### PR TITLE
ref(relay): Remove sentry:relay-rev for project configs

### DIFF
--- a/fixtures/backup/fresh-install.json
+++ b/fixtures/backup/fresh-install.json
@@ -412,24 +412,6 @@
 },
 {
   "model": "sentry.projectoption",
-  "pk": 1,
-  "fields": {
-    "project": 1,
-    "key": "sentry:relay-rev",
-    "value": "\"883653e754e441f9aa54052b52482bdb\""
-  }
-},
-{
-  "model": "sentry.projectoption",
-  "pk": 2,
-  "fields": {
-    "project": 1,
-    "key": "sentry:relay-rev-lastchange",
-    "value": "\"2023-06-22T22:54:29.060271Z\""
-  }
-},
-{
-  "model": "sentry.projectoption",
   "pk": 3,
   "fields": {
     "project": 1,

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -16,7 +16,6 @@ from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
 
 from bitfield import TypedClassBitField
-from sentry import projectoptions
 from sentry.backup.dependencies import PrimaryKeyMap
 from sentry.backup.helpers import ImportFlags
 from sentry.backup.scopes import ImportScope, RelocationScope
@@ -385,7 +384,6 @@ class Project(Model, PendingDeletionMixin):
             )
         else:
             super().save(*args, **kwargs)
-        self.update_rev_for_option()
 
     def get_absolute_url(self, params=None):
         path = f"/organizations/{self.organization.slug}/issues/"
@@ -424,15 +422,10 @@ class Project(Model, PendingDeletionMixin):
         return self.option_manager.get_value(self, key, default, validate)
 
     def update_option(self, key: str, value: Any) -> bool:
-        projectoptions.update_rev_for_option(self)
         return self.option_manager.set_value(self, key, value)
 
     def delete_option(self, key: str) -> None:
-        projectoptions.update_rev_for_option(self)
         self.option_manager.unset_value(self, key)
-
-    def update_rev_for_option(self):
-        return projectoptions.update_rev_for_option(self)
 
     @property
     def color(self):

--- a/src/sentry/projectoptions/__init__.py
+++ b/src/sentry/projectoptions/__init__.py
@@ -12,7 +12,6 @@ register = default_manager.register
 all = default_manager.all
 isset = default_manager.isset
 lookup_well_known_key = default_manager.lookup_well_known_key
-update_rev_for_option = default_manager.update_rev_for_option
 
 
 def get_well_known_default(key, project=None, epoch=None):

--- a/src/sentry/projectoptions/manager.py
+++ b/src/sentry/projectoptions/manager.py
@@ -1,8 +1,4 @@
 import bisect
-import uuid
-from datetime import datetime, timezone
-
-from sentry.utils import json
 
 
 class WellKnownProjectOption:
@@ -52,7 +48,6 @@ class ProjectOptionsManager:
     def set(self, project, key, value):
         from sentry.models.options.project_option import ProjectOption
 
-        self.update_rev_for_option(project)
         return ProjectOption.objects.set_value(project, key, value)
 
     def isset(self, project, key):
@@ -64,18 +59,7 @@ class ProjectOptionsManager:
     def delete(self, project, key):
         from sentry.models.options.project_option import ProjectOption
 
-        self.update_rev_for_option(project)
         return ProjectOption.objects.unset_value(project, key)
-
-    def update_rev_for_option(self, project):
-        from sentry.models.options.project_option import ProjectOption
-
-        ProjectOption.objects.set_value(project, "sentry:relay-rev", uuid.uuid4().hex)
-        ProjectOption.objects.set_value(
-            project,
-            "sentry:relay-rev-lastchange",
-            json.datetime_to_str(datetime.now(timezone.utc)),
-        )
 
     def register(self, key, default=None, epoch_defaults=None):
         self.registry[key] = WellKnownProjectOption(

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -1013,8 +1013,8 @@ def _get_project_config(
             "disabled": False,
             "slug": project.slug,
             "lastFetch": now,
-            "lastChange": project.get_option("sentry:relay-rev-lastchange", now),
-            "rev": project.get_option("sentry:relay-rev", uuid.uuid4().hex),
+            "lastChange": now,
+            "rev": uuid.uuid4().hex,
             "publicKeys": public_keys,
             "config": {
                 "allowedDomains": list(get_origins(project)),

--- a/tests/sentry/backup/snapshots/ReleaseTests/test_at_head.pysnap
+++ b/tests/sentry/backup/snapshots/ReleaseTests/test_at_head.pysnap
@@ -1,18 +1,18 @@
 ---
-created: '2024-07-22T20:47:04.755966+00:00'
+created: '2024-08-05T06:07:32.555605+00:00'
 creator: sentry
 source: tests/sentry/backup/test_releases.py
 ---
 - fields:
     key: bar
-    last_updated: '2024-07-22T20:47:04.419Z'
+    last_updated: '2024-08-05T06:07:32.042Z'
     last_updated_by: unknown
     value: '"b"'
   model: sentry.controloption
   pk: 1
 - fields:
-    date_added: '2024-07-22T20:47:03.836Z'
-    date_updated: '2024-07-22T20:47:03.836Z'
+    date_added: '2024-08-05T06:07:31.097Z'
+    date_updated: '2024-08-05T06:07:31.097Z'
     external_id: slack:test-org
     metadata: {}
     name: Slack for test-org
@@ -22,13 +22,13 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     key: foo
-    last_updated: '2024-07-22T20:47:04.418Z'
+    last_updated: '2024-08-05T06:07:32.039Z'
     last_updated_by: unknown
     value: '"a"'
   model: sentry.option
   pk: 1
 - fields:
-    date_added: '2024-07-22T20:47:03.188Z'
+    date_added: '2024-08-05T06:07:29.985Z'
     default_role: member
     flags: '1'
     is_test: false
@@ -36,40 +36,40 @@ source: tests/sentry/backup/test_releases.py
     slug: test-org
     status: 0
   model: sentry.organization
-  pk: 4554395455258624
+  pk: 4554471269007360
 - fields:
-    date_added: '2024-07-22T20:47:04.016Z'
+    date_added: '2024-08-05T06:07:31.446Z'
     default_role: member
     flags: '1'
     is_test: false
-    name: Stirred Pika
-    slug: stirred-pika
+    name: Suited Spider
+    slug: suited-spider
     status: 0
   model: sentry.organization
-  pk: 4554395455324160
+  pk: 4554471269138433
 - fields:
     config:
       hello: hello
-    date_added: '2024-07-22T20:47:03.836Z'
-    date_updated: '2024-07-22T20:47:03.836Z'
+    date_added: '2024-08-05T06:07:31.100Z'
+    date_updated: '2024-08-05T06:07:31.100Z'
     default_auth_id: null
     grace_period_end: null
     integration: 1
-    organization_id: 4554395455258624
+    organization_id: 4554471269007360
     status: 0
   model: sentry.organizationintegration
   pk: 1
 - fields:
     key: sentry:account-rate-limit
-    organization: 4554395455258624
+    organization: 4554471269007360
     value: 0
   model: sentry.organizationoption
   pk: 1
 - fields:
-    date_added: '2024-07-22T20:47:03.691Z'
-    date_updated: '2024-07-22T20:47:03.691Z'
+    date_added: '2024-08-05T06:07:30.829Z'
+    date_updated: '2024-08-05T06:07:30.829Z'
     name: template-test-org
-    organization: 4554395455258624
+    organization: 4554471269007360
   model: sentry.projecttemplate
   pk: 1
 - fields:
@@ -82,44 +82,44 @@ source: tests/sentry/backup/test_releases.py
     first_seen: null
     is_internal: true
     last_seen: null
-    public_key: sfH_uHULQr5mqLTmmjiWLkhNQ5Xy04vjK7zt9uVYVbg
-    relay_id: 3d729ba3-0195-409a-93d6-69901d961dad
+    public_key: xpLjHve2gpLuHMrkbOe97o7AI-cKjBUBg8BKv_HGVt4
+    relay_id: ad29e5de-23c1-48ed-8aef-aeb9d8b0d629
   model: sentry.relay
   pk: 1
 - fields:
-    first_seen: '2024-07-22T20:47:04.417Z'
-    last_seen: '2024-07-22T20:47:04.417Z'
-    public_key: sfH_uHULQr5mqLTmmjiWLkhNQ5Xy04vjK7zt9uVYVbg
-    relay_id: 3d729ba3-0195-409a-93d6-69901d961dad
+    first_seen: '2024-08-05T06:07:32.037Z'
+    last_seen: '2024-08-05T06:07:32.037Z'
+    public_key: xpLjHve2gpLuHMrkbOe97o7AI-cKjBUBg8BKv_HGVt4
+    relay_id: ad29e5de-23c1-48ed-8aef-aeb9d8b0d629
     version: 0.0.1
   model: sentry.relayusage
   pk: 1
 - fields:
     config: {}
-    date_added: '2024-07-22T20:47:03.986Z'
+    date_added: '2024-08-05T06:07:31.386Z'
     external_id: https://git.example.com:1234
     integration_id: 1
     languages: '[]'
     name: getsentry/getsentry
-    organization_id: 4554395455258624
+    organization_id: 4554471269007360
     provider: integrations:github
     status: 0
     url: https://github.com/getsentry/getsentry
   model: sentry.repository
   pk: 1
 - fields:
-    date_added: '2024-07-22T20:47:03.639Z'
+    date_added: '2024-08-05T06:07:30.723Z'
     idp_provisioned: false
     name: test_team_in_test-org
-    organization: 4554395455258624
+    organization: 4554471269007360
     slug: test_team_in_test-org
     status: 0
   model: sentry.team
-  pk: 4554395455258625
+  pk: 4554471269072896
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-07-22T20:47:02.075Z'
+    date_joined: '2024-08-05T06:07:29.798Z'
     email: superadmin
     flags: '0'
     is_active: true
@@ -129,11 +129,11 @@ source: tests/sentry/backup/test_releases.py
     is_staff: true
     is_superuser: true
     is_unclaimed: false
-    last_active: '2024-07-22T20:47:02.075Z'
+    last_active: '2024-08-05T06:07:29.798Z'
     last_login: null
-    last_password_change: '2024-07-22T20:47:02.075Z'
+    last_password_change: '2024-08-05T06:07:29.798Z'
     name: ''
-    password: md5$BuKd41LhI8FJO71UDZGKm9$c4a141b50bd4a5ce7410269ab0944869
+    password: md5$5k4ANgBqy7r4g5Aa0kAodX$dc9760a6c76e9a89503dbb8ccb3ce86b
     session_nonce: null
     username: superadmin
   model: sentry.user
@@ -141,7 +141,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-07-22T20:47:03.107Z'
+    date_joined: '2024-08-05T06:07:29.887Z'
     email: owner
     flags: '0'
     is_active: true
@@ -151,11 +151,11 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2024-07-22T20:47:03.107Z'
+    last_active: '2024-08-05T06:07:29.887Z'
     last_login: null
-    last_password_change: '2024-07-22T20:47:03.107Z'
+    last_password_change: '2024-08-05T06:07:29.887Z'
     name: ''
-    password: md5$tcq75UcjaqU2mrR4zkgU3H$cb409eb8ce18f394f2a01ef141d16360
+    password: md5$twgxOcyAr8k8Pw9wevO30U$81f305d6a84dd93cf9c21816e45fd315
     session_nonce: null
     username: owner
   model: sentry.user
@@ -163,7 +163,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-07-22T20:47:03.123Z'
+    date_joined: '2024-08-05T06:07:29.907Z'
     email: member
     flags: '0'
     is_active: true
@@ -173,11 +173,11 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2024-07-22T20:47:03.123Z'
+    last_active: '2024-08-05T06:07:29.907Z'
     last_login: null
-    last_password_change: '2024-07-22T20:47:03.123Z'
+    last_password_change: '2024-08-05T06:07:29.907Z'
     name: ''
-    password: md5$uu7xVJtwBH8nvW126Byl6I$1bb2dc1a88ca5fb767fa40fe2aa1c033
+    password: md5$sA3bpRoHVXBliK8m67n19i$1b953794796c33240deaf98320d3c426
     session_nonce: null
     username: member
   model: sentry.user
@@ -185,7 +185,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-07-22T20:47:03.140Z'
+    date_joined: '2024-08-05T06:07:29.927Z'
     email: added-by-superadmin-not-in-org
     flags: '0'
     is_active: true
@@ -195,11 +195,11 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2024-07-22T20:47:03.140Z'
+    last_active: '2024-08-05T06:07:29.927Z'
     last_login: null
-    last_password_change: '2024-07-22T20:47:03.140Z'
+    last_password_change: '2024-08-05T06:07:29.927Z'
     name: ''
-    password: md5$lC3yLTTqElf3IVuGPJOfcz$da28ad00e3464e4ec58fb65d3de69cc7
+    password: md5$vPGYpq5dFPI6Q7aoUbD2GY$13110adcfb6b2a13665768aa923076f2
     session_nonce: null
     username: added-by-superadmin-not-in-org
   model: sentry.user
@@ -207,7 +207,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-07-22T20:47:03.156Z'
+    date_joined: '2024-08-05T06:07:29.947Z'
     email: added-by-org-owner
     flags: '0'
     is_active: true
@@ -217,11 +217,11 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2024-07-22T20:47:03.156Z'
+    last_active: '2024-08-05T06:07:29.947Z'
     last_login: null
-    last_password_change: '2024-07-22T20:47:03.156Z'
+    last_password_change: '2024-08-05T06:07:29.947Z'
     name: ''
-    password: md5$DKsmuXnffp6nNxP6ZdTmc3$52e8452d8de79af7efdde0bcc77b70e8
+    password: md5$Kwl1cvHj21ZEedO7bQffTx$048ea5aa78452187d09736f1e1951cca
     session_nonce: null
     username: added-by-org-owner
   model: sentry.user
@@ -229,7 +229,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-07-22T20:47:03.172Z'
+    date_joined: '2024-08-05T06:07:29.966Z'
     email: added-by-org-member
     flags: '0'
     is_active: true
@@ -239,11 +239,11 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2024-07-22T20:47:03.172Z'
+    last_active: '2024-08-05T06:07:29.966Z'
     last_login: null
-    last_password_change: '2024-07-22T20:47:03.172Z'
+    last_password_change: '2024-08-05T06:07:29.966Z'
     name: ''
-    password: md5$lmtlWSWqCGdnKbE7Ffbqfi$ad4034fc70044884301917d0ff342cc6
+    password: md5$qM7RQHtETYr9pODoqzbmO1$a7261303ec7fa3b9b5ac1aed86779e97
     session_nonce: null
     username: added-by-org-member
   model: sentry.user
@@ -251,7 +251,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-07-22T20:47:03.927Z'
+    date_joined: '2024-08-05T06:07:31.257Z'
     email: admin@localhost
     flags: '0'
     is_active: true
@@ -261,11 +261,11 @@ source: tests/sentry/backup/test_releases.py
     is_staff: true
     is_superuser: true
     is_unclaimed: false
-    last_active: '2024-07-22T20:47:03.927Z'
+    last_active: '2024-08-05T06:07:31.257Z'
     last_login: null
-    last_password_change: '2024-07-22T20:47:03.927Z'
+    last_password_change: '2024-08-05T06:07:31.257Z'
     name: ''
-    password: md5$hHqCmR4F4Xw4B1UagIG1mM$f1f56635a3c4c3f5578fa1612e4737a5
+    password: md5$Fq0yNtwIDkzPZmvSf1LvdR$fd158f7f683a5190df8d88bd81ce2023
     session_nonce: null
     username: admin@localhost
   model: sentry.user
@@ -273,8 +273,8 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-07-22T20:47:04.006Z'
-    email: cec349d460644538987e967c3f41b363@example.com
+    date_joined: '2024-08-05T06:07:31.427Z'
+    email: 3676e32de33a4fc7a3567b338bd2b41a@example.com
     flags: '0'
     is_active: true
     is_managed: false
@@ -283,19 +283,19 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2024-07-22T20:47:04.006Z'
+    last_active: '2024-08-05T06:07:31.427Z'
     last_login: null
-    last_password_change: '2024-07-22T20:47:04.006Z'
+    last_password_change: '2024-08-05T06:07:31.427Z'
     name: ''
-    password: md5$V2A8AnrpWscJEXMc0FVCnM$4135f9059587218e5f924af9ce9a09a0
+    password: md5$j9mw2wouysiswDHiDJ8b5j$8517766dd970d0bb92b2455d75395d9c
     session_nonce: null
-    username: cec349d460644538987e967c3f41b363@example.com
+    username: 3676e32de33a4fc7a3567b338bd2b41a@example.com
   model: sentry.user
   pk: 8
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-07-22T20:47:04.073Z'
+    date_joined: '2024-08-05T06:07:31.544Z'
     email: ''
     flags: '0'
     is_active: true
@@ -305,20 +305,20 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2024-07-22T20:47:04.073Z'
+    last_active: '2024-08-05T06:07:31.544Z'
     last_login: null
     last_password_change: null
     name: ''
     password: ''
     session_nonce: null
-    username: test-app-9ca2e3cf-b5a5-419b-8c7a-3bdc18011961
+    username: test-app-a517f03c-c945-4636-8f16-064fbfdf8f50
   model: sentry.user
   pk: 9
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2024-07-22T20:47:04.330Z'
-    email: 0109fb91d16c48df97dab7c5ba8ace6b@example.com
+    date_joined: '2024-08-05T06:07:31.907Z'
+    email: d94298ab914b4376be499f5792e324eb@example.com
     flags: '0'
     is_active: true
     is_managed: false
@@ -327,13 +327,13 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2024-07-22T20:47:04.330Z'
+    last_active: '2024-08-05T06:07:31.907Z'
     last_login: null
-    last_password_change: '2024-07-22T20:47:04.330Z'
+    last_password_change: '2024-08-05T06:07:31.907Z'
     name: ''
-    password: md5$qeKRpUCwjZ0nvgycetP8Ol$b921a0b7ea39f53ea9ea7c5c9ab44979
+    password: md5$4g43rhH8SxmlsGqvTXhV6c$c2adb23d879b0472ba2e8b2f1e200767
     session_nonce: null
-    username: 0109fb91d16c48df97dab7c5ba8ace6b@example.com
+    username: d94298ab914b4376be499f5792e324eb@example.com
   model: sentry.user
   pk: 10
 - fields:
@@ -396,24 +396,24 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.userpermission
   pk: 1
 - fields:
-    date_added: '2024-07-22T20:47:02.100Z'
-    date_updated: '2024-07-22T20:47:02.100Z'
+    date_added: '2024-08-05T06:07:29.841Z'
+    date_updated: '2024-08-05T06:07:29.841Z'
     name: test-admin-role
     permissions: '[]'
   model: sentry.userrole
   pk: 1
 - fields:
-    date_added: '2024-07-22T20:47:02.105Z'
-    date_updated: '2024-07-22T20:47:02.105Z'
+    date_added: '2024-08-05T06:07:29.847Z'
+    date_updated: '2024-08-05T06:07:29.847Z'
     role: 1
     user: 1
   model: sentry.userroleuser
   pk: 1
 - fields:
-    date_added: '2024-07-22T20:47:03.980Z'
+    date_added: '2024-08-05T06:07:31.371Z'
     is_global: false
     name: Saved query for test-org
-    organization: 4554395455258624
+    organization: 4554471269007360
     owner_id: 2
     query: saved query for test-org
     sort: date
@@ -422,9 +422,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.savedsearch
   pk: 1
 - fields:
-    date_added: '2024-07-22T20:47:03.979Z'
-    last_seen: '2024-07-22T20:47:03.979Z'
-    organization: 4554395455258624
+    date_added: '2024-08-05T06:07:31.369Z'
+    last_seen: '2024-08-05T06:07:31.369Z'
+    organization: 4554471269007360
     query: some query for test-org
     query_hash: 7c69362cd42207b83f80087bc15ebccb
     type: 0
@@ -432,82 +432,82 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.recentsearch
   pk: 1
 - fields:
-    date_added: '2024-07-22T20:47:03.694Z'
+    date_added: '2024-08-05T06:07:30.835Z'
     first_event: null
     flags: '10'
     forced_color: null
     name: project-test-org
-    organization: 4554395455258624
+    organization: 4554471269007360
     platform: null
     public: false
     slug: project-test-org
     status: 0
     template: null
   model: sentry.project
-  pk: 4554395455258626
+  pk: 4554471269072897
 - fields:
-    date_added: '2024-07-22T20:47:03.865Z'
+    date_added: '2024-08-05T06:07:31.174Z'
     first_event: null
     flags: '10'
     forced_color: null
     name: other-project-test-org
-    organization: 4554395455258624
+    organization: 4554471269007360
     platform: null
     public: false
     slug: other-project-test-org
     status: 0
     template: null
   model: sentry.project
-  pk: 4554395455258627
+  pk: 4554471269138432
 - fields:
-    date_added: '2024-07-22T20:47:04.094Z'
+    date_added: '2024-08-05T06:07:31.576Z'
     first_event: null
     flags: '10'
     forced_color: null
-    name: Accepted Leech
-    organization: 4554395455258624
+    name: Concise Reptile
+    organization: 4554471269007360
     platform: null
     public: false
-    slug: accepted-leech
+    slug: concise-reptile
     status: 0
     template: null
   model: sentry.project
-  pk: 4554395455324161
+  pk: 4554471269138434
 - fields:
-    date_added: '2024-07-22T20:47:04.341Z'
+    date_added: '2024-08-05T06:07:31.928Z'
     first_event: null
     flags: '10'
     forced_color: null
-    name: True Salmon
-    organization: 4554395455258624
+    name: Eager Krill
+    organization: 4554471269007360
     platform: null
     public: false
-    slug: true-salmon
+    slug: eager-krill
     status: 0
     template: null
   model: sentry.project
-  pk: 4554395455324162
+  pk: 4554471269138435
 - fields:
     created_by: 2
-    date_added: '2024-07-22T20:47:03.815Z'
+    date_added: '2024-08-05T06:07:31.050Z'
     date_deactivated: null
     date_last_used: null
     name: token 1 for test-org
-    organization_id: 4554395455258624
-    project_last_used_id: 4554395455258626
+    organization_id: 4554471269007360
+    project_last_used_id: 4554471269072897
     scope_list: '[''org:ci'']'
     token_hashed: ABCDEFtest-org
     token_last_characters: xyz1
   model: sentry.orgauthtoken
   pk: 1
 - fields:
-    date_added: '2024-07-22T20:47:03.255Z'
+    date_added: '2024-08-05T06:07:30.052Z'
     email: null
     flags: '0'
     has_global_access: true
     invite_status: 0
     inviter_id: null
-    organization: 4554395455258624
+    organization: 4554471269007360
     role: owner
     token: null
     token_expires_at: null
@@ -518,13 +518,13 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.organizationmember
   pk: 1
 - fields:
-    date_added: '2024-07-22T20:47:03.316Z'
+    date_added: '2024-08-05T06:07:30.135Z'
     email: null
     flags: '0'
     has_global_access: true
     invite_status: 0
     inviter_id: null
-    organization: 4554395455258624
+    organization: 4554471269007360
     role: member
     token: null
     token_expires_at: null
@@ -535,13 +535,13 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.organizationmember
   pk: 2
 - fields:
-    date_added: '2024-07-22T20:47:03.377Z'
+    date_added: '2024-08-05T06:07:30.237Z'
     email: invited-by-superadmin-not-in-org@example.com
     flags: '0'
     has_global_access: true
     invite_status: 1
     inviter_id: 1
-    organization: 4554395455258624
+    organization: 4554471269007360
     role: member
     token: null
     token_expires_at: null
@@ -552,13 +552,13 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.organizationmember
   pk: 3
 - fields:
-    date_added: '2024-07-22T20:47:03.400Z'
+    date_added: '2024-08-05T06:07:30.281Z'
     email: invited-by-org-owner@example.com
     flags: '0'
     has_global_access: true
     invite_status: 1
     inviter_id: 2
-    organization: 4554395455258624
+    organization: 4554471269007360
     role: member
     token: null
     token_expires_at: null
@@ -569,13 +569,13 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.organizationmember
   pk: 4
 - fields:
-    date_added: '2024-07-22T20:47:03.423Z'
+    date_added: '2024-08-05T06:07:30.323Z'
     email: invited-by-org-member@example.com
     flags: '0'
     has_global_access: true
     invite_status: 1
     inviter_id: 3
-    organization: 4554395455258624
+    organization: 4554471269007360
     role: member
     token: null
     token_expires_at: null
@@ -586,13 +586,13 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.organizationmember
   pk: 5
 - fields:
-    date_added: '2024-07-22T20:47:03.446Z'
+    date_added: '2024-08-05T06:07:30.367Z'
     email: null
     flags: '0'
     has_global_access: true
     invite_status: 0
     inviter_id: 1
-    organization: 4554395455258624
+    organization: 4554471269007360
     role: member
     token: null
     token_expires_at: null
@@ -603,13 +603,13 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.organizationmember
   pk: 6
 - fields:
-    date_added: '2024-07-22T20:47:03.502Z'
+    date_added: '2024-08-05T06:07:30.485Z'
     email: null
     flags: '0'
     has_global_access: true
     invite_status: 0
     inviter_id: 2
-    organization: 4554395455258624
+    organization: 4554471269007360
     role: member
     token: null
     token_expires_at: null
@@ -620,13 +620,13 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.organizationmember
   pk: 7
 - fields:
-    date_added: '2024-07-22T20:47:03.558Z'
+    date_added: '2024-08-05T06:07:30.606Z'
     email: null
     flags: '0'
     has_global_access: true
     invite_status: 0
     inviter_id: 3
-    organization: 4554395455258624
+    organization: 4554471269007360
     role: member
     token: null
     token_expires_at: null
@@ -639,31 +639,31 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     member: 2
     requester_id: 2
-    team: 4554395455258625
+    team: 4554471269072896
   model: sentry.organizationaccessrequest
   pk: 1
 - fields:
     config:
       schedule: '* * * * *'
       schedule_type: 1
-    date_added: '2024-07-22T20:47:03.861Z'
-    guid: 85acec3a-3e9c-4bd1-9c80-cfc5a89fbd3b
+    date_added: '2024-08-05T06:07:31.164Z'
+    guid: 0f2068ac-fe56-4208-b216-17ba6fa869c5
     is_muted: false
     name: ''
-    organization_id: 4554395455258624
+    organization_id: 4554471269007360
     owner_team_id: null
     owner_user_id: 2
-    project_id: 4554395455258626
-    slug: 7128d56453d9
+    project_id: 4554471269072897
+    slug: cfce1242679f
     status: 0
     type: 3
   model: sentry.monitor
   pk: 1
 - fields:
-    date_added: '2024-07-22T20:47:03.995Z'
-    date_updated: '2024-07-22T20:47:03.995Z'
+    date_added: '2024-08-05T06:07:31.402Z'
+    date_updated: '2024-08-05T06:07:31.402Z'
     name: View 1 for test-org
-    organization: 4554395455258624
+    organization: 4554471269007360
     position: 0
     query: some query for test-org
     query_sort: date
@@ -671,107 +671,107 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.groupsearchview
   pk: 1
 - fields:
-    date_added: '2024-07-22T20:47:03.858Z'
-    name: ghastly square corgi
-    organization_id: 4554395455258624
+    date_added: '2024-08-05T06:07:31.156Z'
+    name: scarcely obliging pony
+    organization_id: 4554471269007360
   model: sentry.environment
   pk: 1
 - fields:
-    date_added: '2024-07-22T20:47:02.080Z'
+    date_added: '2024-08-05T06:07:29.810Z'
     email: superadmin
   model: sentry.email
   pk: 1
 - fields:
-    date_added: '2024-07-22T20:47:03.111Z'
+    date_added: '2024-08-05T06:07:29.892Z'
     email: owner
   model: sentry.email
   pk: 2
 - fields:
-    date_added: '2024-07-22T20:47:03.127Z'
+    date_added: '2024-08-05T06:07:29.913Z'
     email: member
   model: sentry.email
   pk: 3
 - fields:
-    date_added: '2024-07-22T20:47:03.144Z'
+    date_added: '2024-08-05T06:07:29.932Z'
     email: added-by-superadmin-not-in-org
   model: sentry.email
   pk: 4
 - fields:
-    date_added: '2024-07-22T20:47:03.160Z'
+    date_added: '2024-08-05T06:07:29.951Z'
     email: added-by-org-owner
   model: sentry.email
   pk: 5
 - fields:
-    date_added: '2024-07-22T20:47:03.176Z'
+    date_added: '2024-08-05T06:07:29.971Z'
     email: added-by-org-member
   model: sentry.email
   pk: 6
 - fields:
-    date_added: '2024-07-22T20:47:03.932Z'
+    date_added: '2024-08-05T06:07:31.267Z'
     email: admin@localhost
   model: sentry.email
   pk: 7
 - fields:
-    date_added: '2024-07-22T20:47:04.010Z'
-    email: cec349d460644538987e967c3f41b363@example.com
+    date_added: '2024-08-05T06:07:31.435Z'
+    email: 3676e32de33a4fc7a3567b338bd2b41a@example.com
   model: sentry.email
   pk: 8
 - fields:
-    date_added: '2024-07-22T20:47:04.078Z'
+    date_added: '2024-08-05T06:07:31.550Z'
     email: ''
   model: sentry.email
   pk: 9
 - fields:
-    date_added: '2024-07-22T20:47:04.334Z'
-    email: 0109fb91d16c48df97dab7c5ba8ace6b@example.com
+    date_added: '2024-08-05T06:07:31.915Z'
+    email: d94298ab914b4376be499f5792e324eb@example.com
   model: sentry.email
   pk: 10
 - fields:
-    date_added: '2024-07-22T20:47:03.979Z'
-    organization: 4554395455258624
+    date_added: '2024-08-05T06:07:31.367Z'
+    organization: 4554471269007360
     slug: test-tombstone-in-test-org
   model: sentry.dashboardtombstone
   pk: 1
 - fields:
     created_by_id: 2
-    date_added: '2024-07-22T20:47:03.974Z'
+    date_added: '2024-08-05T06:07:31.356Z'
     filters: null
-    last_visited: '2024-07-22T20:47:03.974Z'
-    organization: 4554395455258624
+    last_visited: '2024-08-05T06:07:31.356Z'
+    organization: 4554471269007360
     title: Dashboard 1 for test-org
     visits: 1
   model: sentry.dashboard
   pk: 1
 - fields:
     condition: '{"op":"equals","name":"environment","value":"prod"}'
-    condition_hash: 601df603003944159df3e9b60d4a2427d261db9e
+    condition_hash: c6968a2d503539a9f7d7c7cee094132bcb351a72
     created_by_id: 2
-    date_added: '2024-07-22T20:47:03.850Z'
-    end_date: '2024-07-22T21:47:03.846Z'
+    date_added: '2024-08-05T06:07:31.136Z'
+    end_date: '2024-08-05T07:07:31.128Z'
     is_active: true
     is_org_level: false
     notification_sent: false
     num_samples: 100
-    organization: 4554395455258624
+    organization: 4554471269007360
     query: environment:prod event.type:transaction
     rule_id: 1
     sample_rate: 0.5
-    start_date: '2024-07-22T20:47:03.846Z'
+    start_date: '2024-08-05T06:07:31.128Z'
   model: sentry.customdynamicsamplingrule
   pk: 1
 - fields:
-    project: 4554395455258626
+    project: 4554471269072897
     value: 2
   model: sentry.counter
   pk: 1
 - fields:
     config: {}
-    date_added: '2024-07-22T20:47:03.768Z'
+    date_added: '2024-08-05T06:07:30.951Z'
     default_global_access: true
     default_role: 50
     flags: '0'
     last_sync: null
-    organization_id: 4554395455258624
+    organization_id: 4554471269007360
     provider: sentry
     sync_time: null
   model: sentry.authprovider
@@ -787,16 +787,16 @@ source: tests/sentry/backup/test_releases.py
       - 3
       key4:
         nested_key: nested_value
-    date_added: '2024-07-22T20:47:03.791Z'
+    date_added: '2024-08-05T06:07:31.000Z'
     ident: 123456789test-org
-    last_synced: '2024-07-22T20:47:03.791Z'
-    last_verified: '2024-07-22T20:47:03.791Z'
+    last_synced: '2024-08-05T06:07:31.000Z'
+    last_verified: '2024-08-05T06:07:31.000Z'
     user: 2
   model: sentry.authidentity
   pk: 1
 - fields:
     config: '""'
-    created_at: '2024-07-22T20:47:02.090Z'
+    created_at: '2024-08-05T06:07:29.829Z'
     last_used_at: null
     type: 1
     user: 1
@@ -804,7 +804,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     config: '""'
-    created_at: '2024-07-22T20:47:03.120Z'
+    created_at: '2024-08-05T06:07:29.902Z'
     last_used_at: null
     type: 1
     user: 2
@@ -812,7 +812,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 2
 - fields:
     config: '""'
-    created_at: '2024-07-22T20:47:03.136Z'
+    created_at: '2024-08-05T06:07:29.922Z'
     last_used_at: null
     type: 1
     user: 3
@@ -820,7 +820,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 3
 - fields:
     config: '""'
-    created_at: '2024-07-22T20:47:03.152Z'
+    created_at: '2024-08-05T06:07:29.942Z'
     last_used_at: null
     type: 1
     user: 4
@@ -828,7 +828,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 4
 - fields:
     config: '""'
-    created_at: '2024-07-22T20:47:03.168Z'
+    created_at: '2024-08-05T06:07:29.962Z'
     last_used_at: null
     type: 1
     user: 5
@@ -836,7 +836,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 5
 - fields:
     config: '""'
-    created_at: '2024-07-22T20:47:03.184Z'
+    created_at: '2024-08-05T06:07:29.980Z'
     last_used_at: null
     type: 1
     user: 6
@@ -844,10 +844,10 @@ source: tests/sentry/backup/test_releases.py
   pk: 6
 - fields:
     allowed_origins: null
-    date_added: '2024-07-22T20:47:03.746Z'
-    key: 8bd32235129d40959cd12baaff804257
+    date_added: '2024-08-05T06:07:30.903Z'
+    key: 71295f5c19c0443faab431f78a92f247
     label: Default
-    organization_id: 4554395455258624
+    organization_id: 4554471269007360
     scope_list: '[]'
     scopes: '0'
     status: 0
@@ -855,11 +855,11 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     allowed_origins: ''
-    client_id: c3eb0a96b7f407b28983dc172478b508716b4d27050333577bf2095a55bca597
-    client_secret: 0442ce08d9ae3322b2ef71c6b408a586e4fc24e4c1e88a61ab641d4e21360c9a
-    date_added: '2024-07-22T20:47:04.083Z'
+    client_id: c273714ebdc4ff35f3a2a7846ba6d521ed53267934c0bc4cbd433313fd9c8406
+    client_secret: 72ce1a83a8afc6a0e3fc447e6616011f9914c8a734a5a0a5d10b4a63ba44deab
+    date_added: '2024-08-05T06:07:31.560Z'
     homepage_url: null
-    name: On Marlin
+    name: Ruling Fish
     owner: 9
     privacy_url: null
     redirect_uris: ''
@@ -916,92 +916,92 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.useroption
   pk: 6
 - fields:
-    date_hash_added: '2024-07-22T20:47:02.078Z'
+    date_hash_added: '2024-08-05T06:07:29.806Z'
     email: superadmin
     is_verified: true
     user: 1
-    validation_hash: qAEwYHQQFpbPrymNHfc5bA0U7bXxZQmU
+    validation_hash: UIQn51fZi3aOT900CJ97Cm0t7wHvmnkF
   model: sentry.useremail
   pk: 1
 - fields:
-    date_hash_added: '2024-07-22T20:47:03.109Z'
+    date_hash_added: '2024-08-05T06:07:29.890Z'
     email: owner
     is_verified: true
     user: 2
-    validation_hash: mJuQoCV3tAok2oz0ifGcD9wowI9FMK4q
+    validation_hash: rcxvKA28pw4rCHfCkw0pJvU1unzO7xYO
   model: sentry.useremail
   pk: 2
 - fields:
-    date_hash_added: '2024-07-22T20:47:03.125Z'
+    date_hash_added: '2024-08-05T06:07:29.909Z'
     email: member
     is_verified: true
     user: 3
-    validation_hash: FLI7xQOnf1T3gAIZU3LazKPIvuh6iHxE
+    validation_hash: nwgYW5P128ocxtlkxBQuANFWAAZSibpi
   model: sentry.useremail
   pk: 3
 - fields:
-    date_hash_added: '2024-07-22T20:47:03.141Z'
+    date_hash_added: '2024-08-05T06:07:29.929Z'
     email: added-by-superadmin-not-in-org
     is_verified: true
     user: 4
-    validation_hash: FssVfMGsmFdYcs1aIWYBiXv1wbleywkn
+    validation_hash: HUMvzGh4TFNxaPxBB7UP7FMM0dycHjuJ
   model: sentry.useremail
   pk: 4
 - fields:
-    date_hash_added: '2024-07-22T20:47:03.158Z'
+    date_hash_added: '2024-08-05T06:07:29.949Z'
     email: added-by-org-owner
     is_verified: true
     user: 5
-    validation_hash: yRFzqXkXp9OFpjWnIUyPoU9ApOXctsRX
+    validation_hash: BWf086nmX0CMGcGjndP9HvX7i1msJm6C
   model: sentry.useremail
   pk: 5
 - fields:
-    date_hash_added: '2024-07-22T20:47:03.173Z'
+    date_hash_added: '2024-08-05T06:07:29.968Z'
     email: added-by-org-member
     is_verified: true
     user: 6
-    validation_hash: YNc85N39idjOWhvZPtI2YWdqUc10g8VX
+    validation_hash: Buiu8zBleCg79VHfL1JwhZnPQjdzdJZo
   model: sentry.useremail
   pk: 6
 - fields:
-    date_hash_added: '2024-07-22T20:47:03.929Z'
+    date_hash_added: '2024-08-05T06:07:31.262Z'
     email: admin@localhost
     is_verified: true
     user: 7
-    validation_hash: 8hwqKV1YAGFWKrT0AjroJUgBsnCjypiC
+    validation_hash: MYQY9IIgOeQL7i76283GiCIFXKYjMr1E
   model: sentry.useremail
   pk: 7
 - fields:
-    date_hash_added: '2024-07-22T20:47:04.008Z'
-    email: cec349d460644538987e967c3f41b363@example.com
+    date_hash_added: '2024-08-05T06:07:31.431Z'
+    email: 3676e32de33a4fc7a3567b338bd2b41a@example.com
     is_verified: true
     user: 8
-    validation_hash: FoKntuDSvHR6P9xPf16zeVTTbismpMwR
+    validation_hash: oVZgNl85m1zMkjb229x1spD2XGaibsDz
   model: sentry.useremail
   pk: 8
 - fields:
-    date_hash_added: '2024-07-22T20:47:04.075Z'
+    date_hash_added: '2024-08-05T06:07:31.547Z'
     email: ''
     is_verified: false
     user: 9
-    validation_hash: E18Hc6eMXIrtJX9VqX1FdV8YJOP5kDJf
+    validation_hash: Ye9aN4eq49dSuefiwOBgjpz5ZhtgfgId
   model: sentry.useremail
   pk: 9
 - fields:
-    date_hash_added: '2024-07-22T20:47:04.332Z'
-    email: 0109fb91d16c48df97dab7c5ba8ace6b@example.com
+    date_hash_added: '2024-08-05T06:07:31.910Z'
+    email: d94298ab914b4376be499f5792e324eb@example.com
     is_verified: true
     user: 10
-    validation_hash: oxNUskCU8kQPrSTNElyx5AWeF5DmwGpt
+    validation_hash: 7gmxTQTxMdwOnQhBbjbYgJhTCxMx6JrT
   model: sentry.useremail
   pk: 10
 - fields:
     aggregates: '[''count'', ''sum'', ''avg'', ''min'', ''max'', ''p50'', ''p75'',
       ''p90'', ''p95'', ''p99'']'
     created_by_id: 2
-    date_added: '2024-07-22T20:47:03.856Z'
-    date_updated: '2024-07-22T20:47:03.856Z'
-    project: 4554395455258626
+    date_added: '2024-08-05T06:07:31.151Z'
+    date_updated: '2024-08-05T06:07:31.151Z'
+    project: 4554471269072897
     span_attribute: my_attribute
     tags: '[''tag1'', ''tag2'']'
     unit: none
@@ -1010,15 +1010,15 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     config: 1
     created_by_id: 2
-    date_added: '2024-07-22T20:47:03.857Z'
-    date_updated: '2024-07-22T20:47:03.857Z'
+    date_added: '2024-08-05T06:07:31.153Z'
+    date_updated: '2024-08-05T06:07:31.153Z'
     value: key:value
   model: sentry.spanattributeextractionrulecondition
   pk: 1
 - fields:
     aggregate: count()
     dataset: events
-    date_added: '2024-07-22T20:47:03.904Z'
+    date_added: '2024-08-05T06:07:31.215Z'
     environment: null
     query: level:error
     resolution: 60
@@ -1029,7 +1029,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     aggregate: count()
     dataset: events
-    date_added: '2024-07-22T20:47:03.940Z'
+    date_added: '2024-08-05T06:07:31.285Z'
     environment: null
     query: level:error
     resolution: 60
@@ -1040,7 +1040,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     aggregate: count()
     dataset: events
-    date_added: '2024-07-22T20:47:03.956Z'
+    date_added: '2024-08-05T06:07:31.317Z'
     environment: null
     query: test query
     resolution: 60
@@ -1051,18 +1051,18 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     application: 1
     author: A Company
-    creator_label: cec349d460644538987e967c3f41b363@example.com
+    creator_label: 3676e32de33a4fc7a3567b338bd2b41a@example.com
     creator_user: 8
-    date_added: '2024-07-22T20:47:04.084Z'
+    date_added: '2024-08-05T06:07:31.562Z'
     date_deleted: null
     date_published: null
-    date_updated: '2024-07-22T20:47:04.289Z'
+    date_updated: '2024-08-05T06:07:31.833Z'
     events: '[]'
     is_alertable: false
     metadata: {}
     name: test app
     overview: A sample description
-    owner_id: 4554395455258624
+    owner_id: 4554471269007360
     popularity: 1
     proxy_user: 9
     redirect_url: https://example.com/sentry-app/redirect/
@@ -1103,27 +1103,27 @@ source: tests/sentry/backup/test_releases.py
     scopes: '0'
     slug: test-app
     status: 0
-    uuid: d0a08088-3a6e-4922-ba44-5e9c0cf661af
+    uuid: 43aca2de-507f-4528-9892-9a51f9e7d26d
     verify_install: true
     webhook_url: https://example.com/sentry-app/webhook/
   model: sentry.sentryapp
   pk: 1
 - fields:
     data: '{"conditions":[{"id":"sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"},{"id":"sentry.rules.conditions.every_event.EveryEventCondition"}],"action_match":"all","filter_match":"all","actions":[{"id":"sentry.rules.actions.notify_event.NotifyEventAction"},{"id":"sentry.rules.actions.notify_event_service.NotifyEventServiceAction","service":"mail"}]}'
-    date_added: '2024-07-22T20:47:03.842Z'
+    date_added: '2024-08-05T06:07:31.116Z'
     environment_id: null
     label: ''
     owner_team: null
     owner_user_id: 2
-    project: 4554395455258626
+    project: 4554471269072897
     source: 0
     status: 0
   model: sentry.rule
   pk: 1
 - fields:
-    date_added: '2024-07-22T20:47:03.916Z'
-    date_updated: '2024-07-22T20:47:03.916Z'
-    project: 4554395455258626
+    date_added: '2024-08-05T06:07:31.235Z'
+    date_updated: '2024-08-05T06:07:31.235Z'
+    project: 4554471269072897
     query_extra: null
     snuba_query: 1
     status: 1
@@ -1132,9 +1132,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 1
 - fields:
-    date_added: '2024-07-22T20:47:03.947Z'
-    date_updated: '2024-07-22T20:47:03.947Z'
-    project: 4554395455258626
+    date_added: '2024-08-05T06:07:31.299Z'
+    date_updated: '2024-08-05T06:07:31.299Z'
+    project: 4554471269072897
     query_extra: null
     snuba_query: 2
     status: 1
@@ -1143,9 +1143,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 2
 - fields:
-    date_added: '2024-07-22T20:47:03.961Z'
-    date_updated: '2024-07-22T20:47:03.961Z'
-    project: 4554395455258626
+    date_added: '2024-08-05T06:07:31.324Z'
+    date_updated: '2024-08-05T06:07:31.324Z'
+    project: 4554471269072897
     query_extra: null
     snuba_query: 3
     status: 1
@@ -1154,9 +1154,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 3
 - fields:
-    date_added: '2024-07-22T20:47:04.098Z'
-    date_updated: '2024-07-22T20:47:04.098Z'
-    project: 4554395455324161
+    date_added: '2024-08-05T06:07:31.583Z'
+    date_updated: '2024-08-05T06:07:31.583Z'
+    project: 4554471269138434
     query_extra: null
     snuba_query: 1
     status: 1
@@ -1165,9 +1165,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 4
 - fields:
-    date_added: '2024-07-22T20:47:04.344Z'
-    date_updated: '2024-07-22T20:47:04.344Z'
-    project: 4554395455324162
+    date_added: '2024-08-05T06:07:31.941Z'
+    date_updated: '2024-08-05T06:07:31.941Z'
+    project: 4554471269138435
     query_extra: null
     snuba_query: 1
     status: 1
@@ -1176,30 +1176,30 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 5
 - fields:
-    project: 4554395455258626
-    team: 4554395455258625
+    project: 4554471269072897
+    team: 4554471269072896
   model: sentry.projectteam
   pk: 1
 - fields:
-    project: 4554395455258627
-    team: 4554395455258625
+    project: 4554471269138432
+    team: 4554471269072896
   model: sentry.projectteam
   pk: 2
 - fields:
-    date_added: '2024-07-22T20:47:03.739Z'
-    organization: 4554395455258624
-    project: 4554395455258626
+    date_added: '2024-08-05T06:07:30.888Z'
+    organization: 4554471269007360
+    project: 4554471269072897
     redirect_slug: project_slug_in_test-org
   model: sentry.projectredirect
   pk: 1
 - fields:
     auto_assignment: true
     codeowners_auto_sync: true
-    date_created: '2024-07-22T20:47:03.734Z'
+    date_created: '2024-08-05T06:07:30.878Z'
     fallthrough: true
     is_active: true
-    last_updated: '2024-07-22T20:47:03.734Z'
-    project: 4554395455258626
+    last_updated: '2024-08-05T06:07:30.878Z'
+    project: 4554471269072897
     raw: '{"hello":"hello"}'
     schema:
       hello: hello
@@ -1207,90 +1207,42 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.projectownership
   pk: 1
 - fields:
-    key: sentry:relay-rev
-    project: 4554395455258626
-    value: '"220ce3946a9149c8a3c05b4199b29e40"'
+    key: sentry:option-epoch
+    project: 4554471269072897
+    value: 12
   model: sentry.projectoption
   pk: 1
 - fields:
-    key: sentry:relay-rev-lastchange
-    project: 4554395455258626
-    value: '"2024-07-22T20:47:03.718228Z"'
+    key: sentry:option-epoch
+    project: 4554471269138432
+    value: 12
   model: sentry.projectoption
   pk: 2
 - fields:
     key: sentry:option-epoch
-    project: 4554395455258626
+    project: 4554471269138434
     value: 12
   model: sentry.projectoption
   pk: 3
 - fields:
-    key: sentry:relay-rev
-    project: 4554395455258627
-    value: '"9110b6f5e6d34af69388a576d1f208e3"'
+    key: sentry:option-epoch
+    project: 4554471269138435
+    value: 12
   model: sentry.projectoption
   pk: 4
 - fields:
-    key: sentry:relay-rev-lastchange
-    project: 4554395455258627
-    value: '"2024-07-22T20:47:03.890791Z"'
-  model: sentry.projectoption
-  pk: 5
-- fields:
-    key: sentry:option-epoch
-    project: 4554395455258627
-    value: 12
-  model: sentry.projectoption
-  pk: 6
-- fields:
-    key: sentry:relay-rev
-    project: 4554395455324161
-    value: '"33dffeacd1e04a969d9d1378b5f13c91"'
-  model: sentry.projectoption
-  pk: 7
-- fields:
-    key: sentry:relay-rev-lastchange
-    project: 4554395455324161
-    value: '"2024-07-22T20:47:04.124582Z"'
-  model: sentry.projectoption
-  pk: 8
-- fields:
-    key: sentry:option-epoch
-    project: 4554395455324161
-    value: 12
-  model: sentry.projectoption
-  pk: 9
-- fields:
-    key: sentry:relay-rev
-    project: 4554395455324162
-    value: '"9b0b0250246e463cb0fe465abd1fbc64"'
-  model: sentry.projectoption
-  pk: 10
-- fields:
-    key: sentry:relay-rev-lastchange
-    project: 4554395455324162
-    value: '"2024-07-22T20:47:04.369058Z"'
-  model: sentry.projectoption
-  pk: 11
-- fields:
-    key: sentry:option-epoch
-    project: 4554395455324162
-    value: 12
-  model: sentry.projectoption
-  pk: 12
-- fields:
     data:
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2024-07-22T20:47:03.712Z'
+    date_added: '2024-08-05T06:07:30.854Z'
     label: Default
-    project: 4554395455258626
-    public_key: f5458d808e3a391d0aeead97724c7f68
+    project: 4554471269072897
+    public_key: 9ec7ef88da1da08ff2b423c45342e079
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: 5ff807b8e309ec93526c37e3b0e51077
+    secret_key: 867112cd18471443bf1f98fcaec2d748
     status: 0
     use_case: user
   model: sentry.projectkey
@@ -1300,14 +1252,14 @@ source: tests/sentry/backup/test_releases.py
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2024-07-22T20:47:03.884Z'
+    date_added: '2024-08-05T06:07:31.193Z'
     label: Default
-    project: 4554395455258627
-    public_key: d8e3cc8316d1f697570111d1374a84ee
+    project: 4554471269138432
+    public_key: 73987e3bdad2b217147601fc4bfec6ff
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: a9c5f2acea9ff7f2cc4d70081ac57d18
+    secret_key: 936ff9a709dc4c22b157489d4e28b1a2
     status: 0
     use_case: user
   model: sentry.projectkey
@@ -1317,14 +1269,14 @@ source: tests/sentry/backup/test_releases.py
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2024-07-22T20:47:04.118Z'
+    date_added: '2024-08-05T06:07:31.597Z'
     label: Default
-    project: 4554395455324161
-    public_key: f4cd5dc48cf6055e3b52b948fb95548e
+    project: 4554471269138434
+    public_key: 2d46b4cd87b7acae07c865fcb7d4c1db
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: 25cf674fd464fa24c7aef9135b21fed0
+    secret_key: 52ae7a4fc26e41776ef23c405ceede80
     status: 0
     use_case: user
   model: sentry.projectkey
@@ -1334,14 +1286,14 @@ source: tests/sentry/backup/test_releases.py
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2024-07-22T20:47:04.363Z'
+    date_added: '2024-08-05T06:07:31.956Z'
     label: Default
-    project: 4554395455324162
-    public_key: 8a35cab3cd7f0e91a05c11377ebc8a6f
+    project: 4554471269138435
+    public_key: a1885f8480149ceb1ddbda6838807760
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: 3d4268e02373ecd0e5c78b88f69dc73b
+    secret_key: dcbb3bb931ae10abbf9c22be12b9b7b7
     status: 0
     use_case: user
   model: sentry.projectkey
@@ -1350,12 +1302,12 @@ source: tests/sentry/backup/test_releases.py
     config:
       hello: hello
     integration_id: 1
-    project: 4554395455258626
+    project: 4554471269072897
   model: sentry.projectintegration
   pk: 1
 - fields:
-    date_added: '2024-07-22T20:47:03.733Z'
-    project: 4554395455258626
+    date_added: '2024-08-05T06:07:30.875Z'
+    project: 4554471269072897
     user_id: 2
   model: sentry.projectbookmark
   pk: 1
@@ -1363,12 +1315,12 @@ source: tests/sentry/backup/test_releases.py
     is_active: true
     organizationmember: 1
     role: null
-    team: 4554395455258625
+    team: 4554471269072896
   model: sentry.organizationmemberteam
   pk: 1
 - fields:
     integration_id: null
-    organization: 4554395455258624
+    organization: 4554471269007360
     sentry_app_id: null
     target_display: Sentry User
     target_identifier: '1'
@@ -1379,7 +1331,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     integration_id: null
-    organization: 4554395455258624
+    organization: 4554471269007360
     sentry_app_id: 1
     target_display: Sentry User
     target_identifier: '1'
@@ -1389,24 +1341,24 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.notificationaction
   pk: 2
 - fields:
-    disable_date: '2024-07-22T20:47:03.845Z'
+    disable_date: '2024-08-05T06:07:31.124Z'
     opted_out: false
-    organization: 4554395455258624
+    organization: 4554471269007360
     rule: 1
-    sent_final_email_date: '2024-07-22T20:47:03.845Z'
-    sent_initial_email_date: '2024-07-22T20:47:03.845Z'
+    sent_final_email_date: '2024-08-05T06:07:31.124Z'
+    sent_initial_email_date: '2024-08-05T06:07:31.124Z'
   model: sentry.neglectedrule
   pk: 1
 - fields:
     environment: 1
     is_hidden: null
-    project: 4554395455258626
+    project: 4554471269072897
   model: sentry.environmentproject
   pk: 1
 - fields:
     dashboard: 1
     dataset_source: 0
-    date_added: '2024-07-22T20:47:03.976Z'
+    date_added: '2024-08-05T06:07:31.359Z'
     description: null
     detail: null
     discover_widget_split: null
@@ -1421,60 +1373,60 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     custom_dynamic_sampling_rule: 1
-    project: 4554395455258626
+    project: 4554471269072897
   model: sentry.customdynamicsamplingruleproject
   pk: 1
 - fields:
     application: 1
-    date_added: '2024-07-22T20:47:04.230Z'
-    expires_at: '2024-07-23T04:47:04.230Z'
-    hashed_refresh_token: 0a7fde173c31a781a9ffe172e89410278cae009768fe555044d51e415841a43e
-    hashed_token: c2632d59e2ce99109f7e051f00ce1c1371f74f81be2a754ee76dda99692e33b5
+    date_added: '2024-08-05T06:07:31.736Z'
+    expires_at: '2024-08-05T14:07:31.736Z'
+    hashed_refresh_token: 5a076176b5c13b64777883ebcd21bf92900e44e25287d23477bf445aa446958a
+    hashed_token: 86d36e946b088e9e0047924b433e84c361e572beeded03ffa5b1ed4f093e9d9e
     name: null
-    refresh_token: 297aea2d3e040fb04d50c2dd0b1c279fd895df2e2aff970225f02951a20e68e2
+    refresh_token: f5f0ac2e0832f6e1a00c03f2f908c699d03fb47df3ccee6fe453931f5518b883
     scope_list: '[]'
     scopes: '0'
-    token: 6e05a150c10b31c97bf8d41dcc71d6017bc76ae58a568f24853b1494a0077243
-    token_last_characters: '7243'
+    token: 57d91f46fdf75b64cc20b90098be7be61a9e886bc30b774fedfb19231f7021c0
+    token_last_characters: 21c0
     token_type: null
     user: 9
   model: sentry.apitoken
   pk: 1
 - fields:
     application: 1
-    date_added: '2024-07-22T20:47:04.304Z'
+    date_added: '2024-08-05T06:07:31.860Z'
     expires_at: null
-    hashed_refresh_token: 7654718c5b093f4e35de44df8ecd463ed646a3ed83463731780f12ca76e81a95
-    hashed_token: 90927e9256dee2dc4fae30edc5bddf71f26ec457cba79e316b4f93c2e34d9a33
+    hashed_refresh_token: 7077bf0a16021461ae3dfaf8f95726b9103e70aa9bc31b13bacdc50a7da8139f
+    hashed_token: 7c99f437e1f27b36dadb0b8c4e07415455ab6696d88f562392e31a0525b8e52f
     name: create_exhaustive_sentry_app
-    refresh_token: a89a87e30af7602c0b61c94c6ceec871033b18552e278f0f70b6facab1cde8f0
+    refresh_token: e9cc71a20db3dc0994bcb904a4080ea8b696713ac4e6ebb86153000059674ee8
     scope_list: '[]'
     scopes: '0'
-    token: 69b98594f127c02b044f9076c51978411d98443f90bbc2fb9e9ea42d6d2dfd4c
-    token_last_characters: fd4c
+    token: 958ceb232f7229097b89a9c7ad1ade6641387793fb19b6c17fa4a4be2a2c0b4d
+    token_last_characters: 0b4d
     token_type: null
     user: 2
   model: sentry.apitoken
   pk: 2
 - fields:
     application: null
-    date_added: '2024-07-22T20:47:04.393Z'
+    date_added: '2024-08-05T06:07:31.991Z'
     expires_at: null
     hashed_refresh_token: null
-    hashed_token: ebcec67c96a9a62ce6f542600d83b128e13333498c9071e425a19dcbfa229e3c
+    hashed_token: 67f87dfd761a2f788dee405e7704052d76524c9eed1101523b72b5dc719e3c98
     name: create_exhaustive_global_configs_for_
     refresh_token: null
     scope_list: '[]'
     scopes: '0'
-    token: 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
-    token_last_characters: bd55
+    token: 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
+    token_last_characters: f848
     token_type: sntryu_
     user: 2
   model: sentry.apitoken
   pk: 3
 - fields:
     application: 1
-    code: cca8a56075dda6632fa66832ad8e31fc53ab5bfffb9bd5e6aaaa8b86ca1e4204
+    code: 27527f818bb8e9b3be70ac1202ece597e78b5f2c6052ebca6dae9dc705739fea
     expires_at: '2022-01-01T11:11:00.000Z'
     redirect_uri: https://example.com
     scope_list: '[''openid'', ''profile'', ''email'']'
@@ -1484,7 +1436,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 2
 - fields:
     application: 1
-    date_added: '2024-07-22T20:47:04.303Z'
+    date_added: '2024-08-05T06:07:31.857Z'
     scope_list: '[]'
     scopes: '0'
     user: 2
@@ -1492,7 +1444,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     application: null
-    date_added: '2024-07-22T20:47:04.392Z'
+    date_added: '2024-08-05T06:07:31.988Z'
     scope_list: '[]'
     scopes: '0'
     user: 2
@@ -1500,14 +1452,14 @@ source: tests/sentry/backup/test_releases.py
   pk: 2
 - fields:
     comparison_delta: null
-    date_added: '2024-07-22T20:47:03.906Z'
-    date_modified: '2024-07-22T20:47:03.906Z'
+    date_added: '2024-08-05T06:07:31.219Z'
+    date_modified: '2024-08-05T06:07:31.219Z'
     description: null
     detection_type: static
     include_all_projects: true
     monitor_type: 0
-    name: Present Dinosaur
-    organization: 4554395455258624
+    name: Cheerful Dolphin
+    organization: 4554471269007360
     resolve_threshold: null
     seasonality: null
     sensitivity: null
@@ -1521,14 +1473,14 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     comparison_delta: null
-    date_added: '2024-07-22T20:47:03.942Z'
-    date_modified: '2024-07-22T20:47:03.942Z'
+    date_added: '2024-08-05T06:07:31.288Z'
+    date_modified: '2024-08-05T06:07:31.288Z'
     description: null
     detection_type: static
     include_all_projects: false
     monitor_type: 1
-    name: Pet Dove
-    organization: 4554395455258624
+    name: Top Burro
+    organization: 4554471269007360
     resolve_threshold: null
     seasonality: null
     sensitivity: null
@@ -1542,14 +1494,14 @@ source: tests/sentry/backup/test_releases.py
   pk: 2
 - fields:
     comparison_delta: null
-    date_added: '2024-07-22T20:47:03.958Z'
-    date_modified: '2024-07-22T20:47:03.958Z'
+    date_added: '2024-08-05T06:07:31.320Z'
+    date_modified: '2024-08-05T06:07:31.320Z'
     description: null
     detection_type: static
     include_all_projects: false
     monitor_type: 0
-    name: Divine Dane
-    organization: 4554395455258624
+    name: Elegant Sunbeam
+    organization: 4554471269007360
     resolve_threshold: null
     seasonality: null
     sensitivity: null
@@ -1579,13 +1531,13 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     api_grant: null
     api_token: 1
-    date_added: '2024-07-22T20:47:04.141Z'
+    date_added: '2024-08-05T06:07:31.617Z'
     date_deleted: null
-    date_updated: '2024-07-22T20:47:04.198Z'
-    organization_id: 4554395455258624
+    date_updated: '2024-08-05T06:07:31.694Z'
+    organization_id: 4554471269007360
     sentry_app: 1
     status: 1
-    uuid: fc6935f3-cfd9-4d08-8d54-c4642ea81040
+    uuid: 227b213c-c7dc-4cf4-8f65-68c4a124cf8f
   model: sentry.sentryappinstallation
   pk: 1
 - fields:
@@ -1623,12 +1575,12 @@ source: tests/sentry/backup/test_releases.py
       type: alert-rule-action
     sentry_app: 1
     type: alert-rule-action
-    uuid: a71e6212-2e68-4607-a570-316dfbbdac5d
+    uuid: d466ca9e-1d30-4a2e-851f-bbb9886a51e1
   model: sentry.sentryappcomponent
   pk: 1
 - fields:
     alert_rule: null
-    date_added: '2024-07-22T20:47:03.845Z'
+    date_added: '2024-08-05T06:07:31.122Z'
     owner_id: 2
     rule: 1
     until: null
@@ -1636,7 +1588,7 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.rulesnooze
   pk: 1
 - fields:
-    date_added: '2024-07-22T20:47:03.844Z'
+    date_added: '2024-08-05T06:07:31.119Z'
     rule: 1
     type: 1
     user_id: 2
@@ -1644,20 +1596,20 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     action: 1
-    project: 4554395455258626
+    project: 4554471269072897
   model: sentry.notificationactionproject
   pk: 1
 - fields:
     action: 2
-    project: 4554395455258626
+    project: 4554471269072897
   model: sentry.notificationactionproject
   pk: 2
 - fields:
     aggregates: null
     columns: null
     conditions: ''
-    date_added: '2024-07-22T20:47:03.977Z'
-    date_modified: '2024-07-22T20:47:03.977Z'
+    date_added: '2024-08-05T06:07:31.361Z'
+    date_modified: '2024-08-05T06:07:31.361Z'
     field_aliases: null
     fields: '[]'
     is_hidden: false
@@ -1670,8 +1622,8 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     alert_rule: 1
     alert_threshold: 100.0
-    date_added: '2024-07-22T20:47:03.924Z'
-    label: Many Deer
+    date_added: '2024-08-05T06:07:31.251Z'
+    label: Helpful Kiwi
     resolve_threshold: null
     threshold_type: null
   model: sentry.alertruletrigger
@@ -1679,39 +1631,39 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     alert_rule: 2
     alert_threshold: 100.0
-    date_added: '2024-07-22T20:47:03.953Z'
-    label: Improved Drum
+    date_added: '2024-08-05T06:07:31.310Z'
+    label: Emerging Python
     resolve_threshold: null
     threshold_type: null
   model: sentry.alertruletrigger
   pk: 2
 - fields:
     alert_rule: 1
-    date_added: '2024-07-22T20:47:03.915Z'
-    project: 4554395455258626
+    date_added: '2024-08-05T06:07:31.233Z'
+    project: 4554471269072897
   model: sentry.alertruleprojects
   pk: 1
 - fields:
     alert_rule: 2
-    date_added: '2024-07-22T20:47:03.945Z'
-    project: 4554395455258626
+    date_added: '2024-08-05T06:07:31.292Z'
+    project: 4554471269072897
   model: sentry.alertruleprojects
   pk: 2
 - fields:
     alert_rule: 3
-    date_added: '2024-07-22T20:47:03.960Z'
-    project: 4554395455258626
+    date_added: '2024-08-05T06:07:31.323Z'
+    project: 4554471269072897
   model: sentry.alertruleprojects
   pk: 3
 - fields:
     alert_rule: 1
-    date_added: '2024-07-22T20:47:03.913Z'
-    project: 4554395455258627
+    date_added: '2024-08-05T06:07:31.224Z'
+    project: 4554471269138432
   model: sentry.alertruleexcludedprojects
   pk: 1
 - fields:
     alert_rule: 1
-    date_added: '2024-07-22T20:47:03.918Z'
+    date_added: '2024-08-05T06:07:31.238Z'
     previous_alert_rule: null
     type: 1
     user_id: 2
@@ -1719,7 +1671,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     alert_rule: 2
-    date_added: '2024-07-22T20:47:03.946Z'
+    date_added: '2024-08-05T06:07:31.294Z'
     previous_alert_rule: null
     type: 1
     user_id: null
@@ -1727,7 +1679,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 2
 - fields:
     alert_rule: 3
-    date_added: '2024-07-22T20:47:03.962Z'
+    date_added: '2024-08-05T06:07:31.326Z'
     previous_alert_rule: null
     type: 1
     user_id: null
@@ -1736,20 +1688,20 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     alert_rule: 2
     condition_type: 0
-    date_added: '2024-07-22T20:47:03.944Z'
+    date_added: '2024-08-05T06:07:31.291Z'
     label: ''
   model: sentry.alertruleactivationcondition
   pk: 1
 - fields:
     actor_id: 1
     application_id: 1
-    date_added: '2024-07-22T20:47:04.195Z'
+    date_added: '2024-08-05T06:07:31.689Z'
     events: '[]'
-    guid: 9afc81f06d734048879e5b137457f044
+    guid: df1f23b7852d4aad92afa243e45ab81a
     installation_id: 1
-    organization_id: 4554395455258624
+    organization_id: 4554471269007360
     project_id: null
-    secret: 412219532c8bc892c9a7e8d4e4a9579dfe96674f709d6de957247ead51fa92dd
+    secret: f8c3b1081e4caa8f09d001962bbfada2daa282eddbabbd14851cf8c8b6799c3a
     status: 0
     url: https://example.com/sentry-app/webhook/
     version: 0
@@ -1758,13 +1710,13 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     actor_id: 10
     application_id: 1
-    date_added: '2024-07-22T20:47:04.380Z'
+    date_added: '2024-08-05T06:07:31.969Z'
     events: '[''event.created'']'
-    guid: 38127786ae3d4a879ba71d2289cb2ab0
+    guid: 8937eb9ffc5f407b8e31229efc8f472b
     installation_id: 1
-    organization_id: 4554395455258624
-    project_id: 4554395455324162
-    secret: eed336ff5956866708fdd67ee4d0a9c4e14b19b97ef1cea6109dfbd62cdc7093
+    organization_id: 4554471269007360
+    project_id: 4554471269138435
+    secret: e5df62b2323a6ab526e697a3c8d9fccfe19c4c35b2f5f02cab5102d117244ef6
     status: 0
     url: https://example.com/sentry/webhook
     version: 0
@@ -1773,24 +1725,24 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     activation: null
     alert_rule: 3
-    date_added: '2024-07-22T20:47:03.965Z'
+    date_added: '2024-08-05T06:07:31.335Z'
     date_closed: null
-    date_detected: '2024-07-22T20:47:03.964Z'
-    date_started: '2024-07-22T20:47:03.964Z'
+    date_detected: '2024-08-05T06:07:31.332Z'
+    date_started: '2024-08-05T06:07:31.332Z'
     detection_uuid: null
     identifier: 1
-    organization: 4554395455258624
+    organization: 4554471269007360
     status: 1
     status_method: 3
     subscription: null
-    title: Magnetic Goose
+    title: Working Caiman
     type: 2
   model: sentry.incident
   pk: 1
 - fields:
     dashboard_widget_query: 1
-    date_added: '2024-07-22T20:47:03.978Z'
-    date_modified: '2024-07-22T20:47:03.978Z'
+    date_added: '2024-08-05T06:07:31.364Z'
+    date_modified: '2024-08-05T06:07:31.364Z'
     extraction_state: disabled:not-applicable
     spec_hashes: '[]'
     spec_version: null
@@ -1798,13 +1750,13 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     alert_rule_trigger: 1
-    date_added: '2024-07-22T20:47:03.925Z'
+    date_added: '2024-08-05T06:07:31.253Z'
     query_subscription: 1
   model: sentry.alertruletriggerexclusion
   pk: 1
 - fields:
     alert_rule_trigger: 1
-    date_added: '2024-07-22T20:47:03.939Z'
+    date_added: '2024-08-05T06:07:31.281Z'
     integration_id: null
     sentry_app_config: null
     sentry_app_id: null
@@ -1817,7 +1769,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     alert_rule_trigger: 2
-    date_added: '2024-07-22T20:47:03.955Z'
+    date_added: '2024-08-05T06:07:31.314Z'
     integration_id: null
     sentry_app_config: null
     sentry_app_id: null
@@ -1829,35 +1781,35 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.alertruletriggeraction
   pk: 2
 - fields:
-    date_added: '2024-07-22T20:47:03.970Z'
-    end: '2024-07-22T20:47:03.970Z'
+    date_added: '2024-08-05T06:07:31.346Z'
+    end: '2024-08-05T06:07:31.346Z'
     period: 1
-    start: '2024-07-21T20:47:03.970Z'
+    start: '2024-08-04T06:07:31.346Z'
     values: '[[1.0, 2.0, 3.0], [1.5, 2.5, 3.5]]'
   model: sentry.timeseriessnapshot
   pk: 1
 - fields:
-    date_added: '2024-07-22T20:47:03.973Z'
+    date_added: '2024-08-05T06:07:31.354Z'
     incident: 1
-    target_run_date: '2024-07-23T00:47:03.973Z'
+    target_run_date: '2024-08-05T10:07:31.354Z'
   model: sentry.pendingincidentsnapshot
   pk: 1
 - fields:
     alert_rule_trigger: 1
-    date_added: '2024-07-22T20:47:03.972Z'
-    date_modified: '2024-07-22T20:47:03.972Z'
+    date_added: '2024-08-05T06:07:31.352Z'
+    date_modified: '2024-08-05T06:07:31.352Z'
     incident: 1
     status: 1
   model: sentry.incidenttrigger
   pk: 1
 - fields:
-    date_added: '2024-07-22T20:47:03.971Z'
+    date_added: '2024-08-05T06:07:31.350Z'
     incident: 1
     user_id: 2
   model: sentry.incidentsubscription
   pk: 1
 - fields:
-    date_added: '2024-07-22T20:47:03.971Z'
+    date_added: '2024-08-05T06:07:31.348Z'
     event_stats_snapshot: 1
     incident: 1
     total_events: 1
@@ -1866,7 +1818,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 1
 - fields:
     comment: hello test-org
-    date_added: '2024-07-22T20:47:03.969Z'
+    date_added: '2024-08-05T06:07:31.343Z'
     incident: 1
     notification_uuid: null
     previous_value: null

--- a/tests/sentry/backup/snapshots/SanitizationExhaustiveTests/test_clean_pks.pysnap
+++ b/tests/sentry/backup/snapshots/SanitizationExhaustiveTests/test_clean_pks.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-07-01T10:57:26.660720+00:00'
+created: '2024-08-05T07:13:33.857381+00:00'
 creator: sentry
 source: tests/sentry/backup/test_sanitize.py
 ---
@@ -593,30 +593,6 @@ source: tests/sentry/backup/test_sanitize.py
   sanitized_fields: []
 - model_name: sentry.projectoption
   ordinal: 4
-  sanitized_fields: []
-- model_name: sentry.projectoption
-  ordinal: 5
-  sanitized_fields: []
-- model_name: sentry.projectoption
-  ordinal: 6
-  sanitized_fields: []
-- model_name: sentry.projectoption
-  ordinal: 7
-  sanitized_fields: []
-- model_name: sentry.projectoption
-  ordinal: 8
-  sanitized_fields: []
-- model_name: sentry.projectoption
-  ordinal: 9
-  sanitized_fields: []
-- model_name: sentry.projectoption
-  ordinal: 10
-  sanitized_fields: []
-- model_name: sentry.projectoption
-  ordinal: 11
-  sanitized_fields: []
-- model_name: sentry.projectoption
-  ordinal: 12
   sanitized_fields: []
 - model_name: sentry.projectkey
   ordinal: 1

--- a/tests/sentry/backup/snapshots/SanitizationIntegrationTests/test_fresh_install.pysnap
+++ b/tests/sentry/backup/snapshots/SanitizationIntegrationTests/test_fresh_install.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-05-28T16:45:51.971601+00:00'
+created: '2024-08-05T07:13:26.420228+00:00'
 creator: sentry
 source: tests/sentry/backup/test_sanitize.py
 ---
@@ -169,12 +169,6 @@ source: tests/sentry/backup/test_sanitize.py
   sanitized_fields: []
 - model_name: sentry.projectoption
   ordinal: 2
-  sanitized_fields: []
-- model_name: sentry.projectoption
-  ordinal: 3
-  sanitized_fields: []
-- model_name: sentry.projectoption
-  ordinal: 4
   sanitized_fields: []
 - model_name: sentry.apiapplication
   ordinal: 1

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -693,9 +693,7 @@ class SignalingTests(ImportTestCase):
         assert Project.objects.filter(name="other-project-some-org").exists()
 
         assert ProjectKey.objects.count() == 2
-        assert ProjectOption.objects.count() == 6
-        assert ProjectOption.objects.filter(key="sentry:relay-rev").exists()
-        assert ProjectOption.objects.filter(key="sentry:relay-rev-lastchange").exists()
+        assert ProjectOption.objects.count() == 2
         assert ProjectOption.objects.filter(key="sentry:option-epoch").exists()
 
         with assume_test_silo_mode(SiloMode.CONTROL):

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -201,7 +201,7 @@ def test_project_update_option(
     redis_cache.set_many({default_projectkey.public_key: "dummy"})
 
     # XXX: there should only be one hook triggered, regardless of debouncing
-    with emulate_transactions(assert_num_callbacks=4):
+    with emulate_transactions(assert_num_callbacks=2):
         default_project.update_option(
             "sentry:relay_pii_config", '{"applications": {"$string": ["@creditcard:mask"]}}'
         )
@@ -238,7 +238,7 @@ def test_project_delete_option(
     redis_cache.set_many({default_projectkey.public_key: "dummy"})
 
     # XXX: there should only be one hook triggered, regardless of debouncing
-    with emulate_transactions(assert_num_callbacks=3):
+    with emulate_transactions(assert_num_callbacks=1):
         default_project.delete_option("sentry:relay_pii_config")
 
     assert redis_cache.get(default_projectkey)["config"]["piiConfig"] == {}
@@ -280,7 +280,7 @@ def test_invalidation_project_deleted(
     project_id = default_project.id
 
     # Delete the project normally, this will delete it from the cache
-    with emulate_transactions(assert_num_callbacks=6):
+    with emulate_transactions(assert_num_callbacks=4):
         default_project.delete()
     assert redis_cache.get(project_key)["disabled"]
 


### PR DESCRIPTION
See: https://github.com/getsentry/relay/issues/3887

Replaces the `sentry:relay-rev` with just a unique id per generation.

#skip-changelog