### PR TITLE
ref(relay): Write project config revision to Redis

### DIFF
--- a/src/sentry/relay/projectconfig_cache/redis.py
+++ b/src/sentry/relay/projectconfig_cache/redis.py
@@ -78,10 +78,11 @@ class RedisProjectConfigCache(ProjectConfigCache):
                 rv = zstandard.decompress(rv_b).decode()
             except (TypeError, zstandard.ZstdError):
                 # assume raw json
-                rv = rv_b
+                rv = rv_b.decode()
             return json.loads(rv)
         return None
 
     def get_rev(self, public_key) -> str | None:
         if value := self.cluster_read.get(self.__get_redis_rev_key(public_key)):
-            return value.decode("utf-8")
+            return value.decode()
+        return None

--- a/tests/sentry/api/endpoints/test_admin_project_configs.py
+++ b/tests/sentry/api/endpoints/test_admin_project_configs.py
@@ -35,7 +35,7 @@ class AdminRelayProjectConfigsEndpointTest(APITestCase):
 
         projectconfig_cache.backend.set_many(
             {
-                self.p1_pk.public_key: "proj1 config",
+                self.p1_pk.public_key: {"proj1": "config"},
             }
         )
 
@@ -74,7 +74,7 @@ class AdminRelayProjectConfigsEndpointTest(APITestCase):
         response = self.client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        expected = {"configs": {self.p1_pk.public_key: "proj1 config"}}
+        expected = {"configs": {self.p1_pk.public_key: {"proj1": "config"}}}
         actual = response.json()
         assert actual == expected
 
@@ -89,7 +89,7 @@ class AdminRelayProjectConfigsEndpointTest(APITestCase):
         response = self.client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        expected = {"configs": {self.p1_pk.public_key: "proj1 config"}}
+        expected = {"configs": {self.p1_pk.public_key: {"proj1": "config"}}}
         actual = response.json()
         assert actual == expected
 

--- a/tests/sentry/relay/test_projectconfig_cache.py
+++ b/tests/sentry/relay/test_projectconfig_cache.py
@@ -21,6 +21,16 @@ def test_delete_count(monkeypatch):
 @django_db_all
 def test_read_write():
     cache = redis.RedisProjectConfigCache()
-    my_key = "fake-dsn-1"
-    cache.set_many({my_key: "my-value"})
-    assert cache.get(my_key) == "my-value"
+
+    dsn1 = "fake-dsn-1"
+    value1 = {"my-value": "foo", "rev": "my_rev_123"}
+
+    dsn2 = "fake-dsn-2"
+    value2 = {"my-value": "bar", "has_no_rev": "123"}
+
+    cache.set_many({dsn1: value1, dsn2: value2})
+    assert cache.get(dsn1) == value1
+    assert cache.get(dsn2) == value2
+
+    assert cache.get_rev(dsn1) == "my_rev_123"
+    assert cache.get_rev(dsn2) is None

--- a/tests/sentry/relay/test_projectconfig_cache.py
+++ b/tests/sentry/relay/test_projectconfig_cache.py
@@ -9,7 +9,7 @@ def test_delete_count(monkeypatch):
     cache = redis.RedisProjectConfigCache()
     incr_mock = mock.Mock()
     monkeypatch.setattr(metrics, "incr", incr_mock)
-    cache.set_many({"a": 1})
+    cache.set_many({"a": {"foo": "bar"}})
 
     cache.delete_many(["a", "b"])
 

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -198,7 +198,7 @@ def test_project_update_option(
 ):
     # Put something in the cache, otherwise triggers/the invalidation task won't compute
     # anything.
-    redis_cache.set_many({default_projectkey.public_key: "dummy"})
+    redis_cache.set_many({default_projectkey.public_key: {"dummy": "dummy"}})
 
     # XXX: there should only be one hook triggered, regardless of debouncing
     with emulate_transactions(assert_num_callbacks=4):
@@ -235,7 +235,7 @@ def test_project_delete_option(
 ):
     # Put something in the cache, otherwise triggers/the invalidation task won't compute
     # anything.
-    redis_cache.set_many({default_projectkey.public_key: "dummy"})
+    redis_cache.set_many({default_projectkey.public_key: {"dummy": "dummy"}})
 
     # XXX: there should only be one hook triggered, regardless of debouncing
     with emulate_transactions(assert_num_callbacks=3):
@@ -339,7 +339,7 @@ def test_db_transaction(
 ):
     # Put something in the cache, otherwise triggers/the invalidation task won't compute
     # anything.
-    redis_cache.set_many({default_projectkey.public_key: "dummy"})
+    redis_cache.set_many({default_projectkey.public_key: {"dummy": "dummy"}})
 
     with task_runner(), transaction.atomic(router.db_for_write(ProjectOption)):
         default_project.update_option(
@@ -348,7 +348,7 @@ def test_db_transaction(
 
         # Assert that cache entry hasn't been created yet, only after the
         # transaction has committed.
-        assert redis_cache.get(default_projectkey.public_key) == "dummy"
+        assert redis_cache.get(default_projectkey.public_key) == {"dummy": "dummy"}
 
     assert redis_cache.get(default_projectkey.public_key)["config"]["piiConfig"] == {
         "applications": {"$string": ["@creditcard:mask"]}
@@ -519,7 +519,7 @@ def test_invalidate_hierarchy(
     django_cache,
 ):
     # Put something in the cache, otherwise the invalidation task won't compute anything.
-    redis_cache.set_many({default_projectkey.public_key: "dummy"})
+    redis_cache.set_many({default_projectkey.public_key: {"dummy": "dummy"}})
 
     orig_apply_async = invalidate_project_config.apply_async
     calls = []


### PR DESCRIPTION
See: https://github.com/getsentry/relay/issues/3887

Writes the revision to Redis as a separate key. Allowing for optimized reads by revision.

#skip-changelog