### PR TITLE
fix: increase `utils.signing.salt_compatibility_mode` counter in proper place

### DIFF
--- a/src/sentry/utils/signing.py
+++ b/src/sentry/utils/signing.py
@@ -54,8 +54,8 @@ def unsign(data, salt=SALT, max_age=60 * 60 * 24 * 2):
                 urlsafe_b64decode(data).decode("utf-8"), max_age=max_age
             )
         )
+        metrics.incr("utils.signing.salt_compatibility_mode", tags={"salt": salt})
 
-    metrics.incr("utils.signing.salt_compatibility_mode", tags={"salt": salt})
     return result
 
 


### PR DESCRIPTION
The `utils.signing.salt_compatibility_mode` counter was increased on each unsign with a custom salt value. This small fix will make it count only when the successful unsign was completed with the old salt. Once this metrics is 0 for a day, we can remove this whole compatibility logic.