### PR TITLE
chore(statistical-detectors): Add option to configure timeseries days

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2000,6 +2000,12 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "statistical_detectors.query.functions.timeseries_days",
+    type=Int,
+    default=14,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "statistical_detectors.ratelimit.ema",
     type=Int,
     default=-1,

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -926,10 +926,10 @@ def query_functions_timeseries(
 ) -> Generator[tuple[int, int | str, SnubaTSResult]]:
     projects = [project for project, _ in functions_list]
 
-    # take the last 14 days as our window
+    days_to_query = options.get("statistical_detectors.query.functions.timeseries_days")
     end = start.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
     params = SnubaParams(
-        start=end - timedelta(days=14),
+        start=end - timedelta(days=days_to_query),
         end=end,
         projects=projects,
     )


### PR DESCRIPTION
Looking to experiment with more historical data for breakpoint detection. This will allow us to control the length of the timeseries.