### PR TITLE
chore(uptime): Include reason for onboarding failure in stat

### DIFF
--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -154,6 +154,14 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                     tags={"failure_reason": result["status_reason"]["type"]},
                     sample_rate=1.0,
                 )
+                logger.info(
+                    "uptime_onboarding_failed",
+                    extra={
+                        "project_id": project_subscription.project_id,
+                        "url": project_subscription.uptime_subscription.url,
+                        **result,
+                    },
+                )
         elif result["status"] == CHECKSTATUS_SUCCESS:
             assert project_subscription.date_added is not None
             scheduled_check_time = datetime.fromtimestamp(
@@ -175,6 +183,14 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                 remove_uptime_subscription_if_unused(onboarding_subscription)
                 metrics.incr(
                     "uptime.result_processor.autodetection.graduated_onboarding", sample_rate=1.0
+                )
+                logger.info(
+                    "uptime_onboarding_graduated",
+                    extra={
+                        "project_id": project_subscription.project_id,
+                        "url": project_subscription.uptime_subscription.url,
+                        **result,
+                    },
                 )
 
     def handle_result_for_project_active_mode(

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -149,9 +149,12 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                 # Mark the url as failed so that we don't attempt to auto-detect it for a while
                 set_failed_url(project_subscription.uptime_subscription.url)
                 redis.delete(key)
+                status_reason = "unknown"
+                if result["status_reason"]:
+                    status_reason = result["status_reason"]["type"]
                 metrics.incr(
                     "uptime.result_processor.autodetection.failed_onboarding",
-                    tags={"failure_reason": result["status_reason"]["type"]},
+                    tags={"failure_reason": status_reason},
                     sample_rate=1.0,
                 )
                 logger.info(

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -150,7 +150,9 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                 set_failed_url(project_subscription.uptime_subscription.url)
                 redis.delete(key)
                 metrics.incr(
-                    "uptime.result_processor.autodetection.failed_onboarding", sample_rate=1.0
+                    "uptime.result_processor.autodetection.failed_onboarding",
+                    tags={"failure_reason": result["status_reason"]["type"]},
+                    sample_rate=1.0,
                 )
         elif result["status"] == CHECKSTATUS_SUCCESS:
             assert project_subscription.date_added is not None

--- a/tests/sentry/uptime/consumers/test_results_consumers.py
+++ b/tests/sentry/uptime/consumers/test_results_consumers.py
@@ -12,6 +12,7 @@ from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
     CHECKSTATUS_FAILURE,
     CHECKSTATUS_MISSED_WINDOW,
     CHECKSTATUS_SUCCESS,
+    CHECKSTATUSREASONTYPE_TIMEOUT,
     CheckResult,
 )
 
@@ -261,7 +262,9 @@ class ProcessResultTest(UptimeTestCase):
                         tags={"status": CHECKSTATUS_FAILURE, "mode": "auto_detected_onboarding"},
                     ),
                     call(
-                        "uptime.result_processor.autodetection.failed_onboarding", sample_rate=1.0
+                        "uptime.result_processor.autodetection.failed_onboarding",
+                        tags={"failure_reason": CHECKSTATUSREASONTYPE_TIMEOUT},
+                        sample_rate=1.0,
                     ),
                 ]
             )


### PR DESCRIPTION
Include failure reason as a tag for `failed_onboarding` so that we can track it.

<!-- Describe your PR here. -->