### PR TITLE
feat(seer grouping): Add options to control using reranking

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/api/endpoints/group_similar_issues_embeddings.py
@@ -6,7 +6,7 @@ from django.contrib.auth.models import AnonymousUser
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics
+from sentry import analytics, options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -86,6 +86,7 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
             "exception_type": get_path(latest_event.data, "exception", "values", -1, "type"),
             "read_only": True,
             "referrer": "similar_issues",
+            "use_reranking": options.get("seer.similarity.similar_issues.use_reranking"),
         }
         # Add optional parameters
         if request.GET.get("k"):

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -212,6 +212,7 @@ def get_seer_similar_issues(
         "exception_type": filter_null_from_string(exception_type) if exception_type else None,
         "k": num_neighbors,
         "referrer": "ingest",
+        "use_reranking": options.get("seer.similarity.ingest.use_reranking"),
     }
 
     # Similar issues are returned with the closest match first

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -897,6 +897,19 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "seer.similarity.ingest.use_reranking",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
+    "seer.similarity.similar_issues.use_reranking",
+    type=Bool,
+    default=True,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # seer nearest neighbour endpoint timeout
 register(

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -51,7 +51,7 @@ def get_similarity_data_from_seer(
 
     logger_extra = apply_key_filter(
         similar_issues_request,
-        keep_keys=["event_id", "project_id", "message", "hash", "referrer"],
+        keep_keys=["event_id", "project_id", "message", "hash", "referrer", "use_reranking"],
     )
     # We have to rename the key `message` because it conflicts with the `LogRecord` attribute of the
     # same name

--- a/src/sentry/seer/similarity/types.py
+++ b/src/sentry/seer/similarity/types.py
@@ -28,6 +28,7 @@ class SimilarIssuesEmbeddingsRequest(TypedDict):
     read_only: NotRequired[bool]
     event_id: NotRequired[str]
     referrer: NotRequired[str]
+    use_reranking: NotRequired[bool]
 
 
 class RawSeerSimilarIssueData(TypedDict):

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -227,6 +227,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             "exception_type": "ZeroDivisionError",
             "read_only": True,
             "referrer": "similar_issues",
+            "use_reranking": True,
             "k": 1,
         }
 
@@ -344,6 +345,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                     "exception_type": "ZeroDivisionError",
                     "read_only": True,
                     "referrer": "similar_issues",
+                    "use_reranking": True,
                 },
                 "raw_similar_issue_data": {
                     "message_distance": 0.05,
@@ -559,6 +561,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                     "exception_type": "ZeroDivisionError",
                     "read_only": True,
                     "referrer": "similar_issues",
+                    "use_reranking": True,
                 },
             ),
             headers={"content-type": "application/json;charset=utf-8"},
@@ -587,6 +590,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                     "exception_type": "ZeroDivisionError",
                     "read_only": True,
                     "referrer": "similar_issues",
+                    "use_reranking": True,
                     "k": 1,
                 },
             ),
@@ -616,6 +620,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                     "exception_type": "ZeroDivisionError",
                     "read_only": True,
                     "referrer": "similar_issues",
+                    "use_reranking": True,
                 },
             ),
             headers={"content-type": "application/json;charset=utf-8"},

--- a/tests/sentry/grouping/ingest/test_seer.py
+++ b/tests/sentry/grouping/ingest/test_seer.py
@@ -233,6 +233,7 @@ class GetSeerSimilarIssuesTest(TestCase):
                     "exception_type": "FailedToFetchError",
                     "k": 1,
                     "referrer": "ingest",
+                    "use_reranking": False,
                 }
             )
 


### PR DESCRIPTION
This adds two new options, `seer.similarity.similar_issues.use_reranking` and `seer.similarity.ingest.use_reranking`, to (as the names suggest) control whether we ask Seer to rerank the similarity results before returning them. For now, while we're testing it, reranking is turned on for the similar issues tab (as that's a good way to see the results), but off for ingest (until we're confident it works and improves the results returned by Seer).