### PR TITLE
chore(azure): remove base_url param from get_client

### DIFF
--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -163,9 +163,8 @@ class VstsIntegration(IntegrationInstallation, RepositoryMixin, VstsIssueSync):
             return False
         return True
 
-    def get_client(self, base_url: str | None = None) -> VstsApiClient:
-        if base_url is None:
-            base_url = self.instance
+    def get_client(self, base_url) -> VstsApiClient:
+        base_url = self.instance
         if SiloMode.get_current_mode() != SiloMode.REGION:
             if self.default_identity is None:
                 self.default_identity = self.get_default_identity()

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -163,7 +163,7 @@ class VstsIntegration(IntegrationInstallation, RepositoryMixin, VstsIssueSync):
             return False
         return True
 
-    def get_client(self, base_url) -> VstsApiClient:
+    def get_client(self) -> VstsApiClient:
         base_url = self.instance
         if SiloMode.get_current_mode() != SiloMode.REGION:
             if self.default_identity is None:

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -32,13 +32,13 @@ class VstsIssueSync(IssueSyncMixin):
 
     def create_default_repo_choice(self, default_repo: str) -> tuple[str, str]:
         # default_repo should be the project_id
-        project = self.get_client(base_url=self.instance).get_project(default_repo)
+        project = self.get_client().get_project(default_repo)
         return (project["id"], project["name"])
 
     def get_project_choices(
         self, group: Optional["Group"] = None, **kwargs: Any
     ) -> tuple[str | None, Sequence[tuple[str, str]]]:
-        client = self.get_client(base_url=self.instance)
+        client = self.get_client()
         try:
             projects = client.get_projects()
         except (ApiError, ApiUnauthorized, KeyError) as e:
@@ -78,7 +78,7 @@ class VstsIssueSync(IssueSyncMixin):
     def get_work_item_choices(
         self, project: str, group: Optional["Group"] = None
     ) -> tuple[str | None, Sequence[tuple[str, str]]]:
-        client = self.get_client(base_url=self.instance)
+        client = self.get_client()
         try:
             item_categories = client.get_work_item_categories(project)["value"]
         except (ApiError, ApiUnauthorized, KeyError) as e:
@@ -172,7 +172,7 @@ class VstsIssueSync(IssueSyncMixin):
         if project_id is None:
             raise ValueError("Azure DevOps expects project")
 
-        client = self.get_client(base_url=self.instance)
+        client = self.get_client()
 
         title = data["title"]
         description = data["description"]
@@ -199,7 +199,7 @@ class VstsIssueSync(IssueSyncMixin):
         }
 
     def get_issue(self, issue_id: int, **kwargs: Any) -> Mapping[str, Any]:
-        client = self.get_client(base_url=self.instance)
+        client = self.get_client()
         work_item = client.get_work_item(issue_id)
         return {
             "key": str(work_item["id"]),
@@ -219,7 +219,7 @@ class VstsIssueSync(IssueSyncMixin):
         assign: bool = True,
         **kwargs: Any,
     ) -> None:
-        client = self.get_client(base_url=self.instance)
+        client = self.get_client()
         assignee = None
 
         if user and assign is True:
@@ -324,7 +324,7 @@ class VstsIssueSync(IssueSyncMixin):
         )
 
     def _get_done_statuses(self, project: str) -> set[str]:
-        client = self.get_client(base_url=self.instance)
+        client = self.get_client()
         try:
             all_states = client.get_work_item_states(project)["value"]
         except ApiError as err:

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -264,7 +264,7 @@ class VstsIssueSync(IssueSyncMixin):
     def sync_status_outbound(
         self, external_issue: "ExternalIssue", is_resolved: bool, project_id: int, **kwargs: Any
     ) -> None:
-        client = self.get_client(self.instance)
+        client = self.get_client()
         work_item = client.get_work_item(external_issue.key)
         # For some reason, vsts doesn't include the project id
         # in the work item response.
@@ -341,9 +341,7 @@ class VstsIssueSync(IssueSyncMixin):
     def create_comment(self, issue_id: int, user_id: int, group_note: Activity) -> Response:
         comment = group_note.data["text"]
         quoted_comment = self.create_comment_attribution(user_id, comment)
-        return self.get_client(base_url=self.instance).update_work_item(
-            issue_id, comment=quoted_comment
-        )
+        return self.get_client().update_work_item(issue_id, comment=quoted_comment)
 
     def create_comment_attribution(self, user_id: int, comment_text: str) -> str:
         # VSTS uses markdown or xml

--- a/src/sentry/integrations/vsts/repository.py
+++ b/src/sentry/integrations/vsts/repository.py
@@ -23,8 +23,7 @@ class VstsRepositoryProvider(IntegrationRepositoryProvider):
         self, organization: Organization, config: MutableMapping[str, Any]
     ) -> Mapping[str, str]:
         installation = self.get_installation(config.get("installation"), organization.id)
-        instance = installation.instance
-        client = installation.get_client(base_url=instance)
+        client = installation.get_client()
 
         repo_id = config["identifier"]
 
@@ -34,7 +33,7 @@ class VstsRepositoryProvider(IntegrationRepositoryProvider):
             raise installation.raise_error(e)
         config.update(
             {
-                "instance": instance,
+                "instance": installation.instance,
                 "project": repo["project"]["name"],
                 "name": repo["name"],
                 "external_id": str(repo["id"]),
@@ -76,18 +75,7 @@ class VstsRepositoryProvider(IntegrationRepositoryProvider):
         self, repo: Repository, commit_list: Sequence[Commit], organization_id: int
     ) -> Sequence[Commit]:
         installation = self.get_installation(repo.integration_id, organization_id)
-        instance = repo.config["instance"]
-        if installation.instance != instance:
-            logger.info(
-                "integrations.vsts.mismatched_instance",
-                extra={
-                    "repo_instance": instance,
-                    "installation_instance": installation.instance,
-                    "org_integration_id": repo.integration_id,
-                    "repo_id": repo.id,
-                },
-            )
-        client = installation.get_client(base_url=instance)
+        client = installation.get_client()
         n = 0
         for commit in commit_list:
             # Azure will truncate commit comments to only the first line.
@@ -113,18 +101,7 @@ class VstsRepositoryProvider(IntegrationRepositoryProvider):
     ) -> Sequence[Mapping[str, str]]:
         """TODO(mgaeta): This function is kinda a mess."""
         installation = self.get_installation(repo.integration_id, repo.organization_id)
-        instance = repo.config["instance"]
-        if installation.instance != instance:
-            logger.info(
-                "integrations.vsts.mismatched_instance",
-                extra={
-                    "repo_instance": instance,
-                    "installation_instance": installation.instance,
-                    "org_integration_id": repo.integration_id,
-                    "repo_id": repo.id,
-                },
-            )
-        client = installation.get_client(base_url=instance)
+        client = installation.get_client()
 
         try:
             if start_sha is None:

--- a/src/sentry/integrations/vsts/tasks/subscription_check.py
+++ b/src/sentry/integrations/vsts/tasks/subscription_check.py
@@ -25,7 +25,7 @@ def vsts_subscription_check(integration_id: int, organization_id: int) -> None:
     installation = integration.get_installation(organization_id=organization_id)
     assert isinstance(installation, VstsIntegration), installation
     try:
-        client = installation.get_client(base_url=installation.instance)
+        client = installation.get_client()
     except ObjectDoesNotExist:
         return
 

--- a/tests/sentry/integrations/vsts/test_client.py
+++ b/tests/sentry/integrations/vsts/test_client.py
@@ -47,7 +47,7 @@ class VstsApiClientTest(VstsIntegrationTestCase):
         self._stub_vsts()
 
         # Make a request with expired token
-        installation.get_client(base_url=self.vsts_base_url).get_projects()
+        installation.get_client().get_projects()
 
         # Second to last request, before the Projects request, was to refresh
         # the Access Token.
@@ -91,7 +91,7 @@ class VstsApiClientTest(VstsIntegrationTestCase):
         self._stub_vsts()
 
         # Make a request
-        installation.get_client(base_url=self.vsts_base_url).get_projects()
+        installation.get_client().get_projects()
         assert len(responses.calls) == 1
         assert (
             responses.calls[0].request.url
@@ -122,7 +122,7 @@ class VstsApiClientTest(VstsIntegrationTestCase):
             callback=request_callback,
         )
 
-        projects = installation.get_client(base_url=self.vsts_base_url).get_projects()
+        projects = installation.get_client().get_projects()
         assert len(projects) == 220
 
     @responses.activate
@@ -150,7 +150,7 @@ class VstsApiClientTest(VstsIntegrationTestCase):
                 external_id="albertos-apples",
             )
 
-        client = installation.get_client(base_url=self.vsts_base_url)
+        client = installation.get_client()
 
         responses.calls.reset()
         assert repo.external_id is not None
@@ -206,7 +206,7 @@ class VstsApiClientTest(VstsIntegrationTestCase):
                 external_id="albertos-apples",
             )
 
-        client = installation.get_client(base_url=self.vsts_base_url)
+        client = installation.get_client()
 
         path = "src/sentry/integrations/vsts/client.py"
         version = "master"
@@ -239,7 +239,7 @@ class VstsApiClientTest(VstsIntegrationTestCase):
                 external_id="albertos-apples",
             )
 
-        client = installation.get_client(base_url=self.vsts_base_url)
+        client = installation.get_client()
 
         path = "src/sentry/integrations/vsts/client.py"
         version = "master"


### PR DESCRIPTION
The logger merged in this PR https://github.com/getsentry/sentry/pull/75277 [has not fired](https://cloudlogging.app.goo.gl/y6wBUPCpW7VFJgSr8). According to the code, `repo.config["instance"]` is only ever set to the installation instance, so I believe the extra `base_url` parameter from the VSTS Integration (Azure DevOps) can be removed. We also emitted the logger to check if this these two are ever mismatched and it hasn't fired.

https://github.com/getsentry/sentry/blob/76160de98ae0655baffa6a45388ea1dbc110884f/src/sentry/integrations/vsts/repository.py#L26-L43