### PR TITLE
feat(performance): track has data on performance table

### DIFF
--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -79,8 +79,7 @@ export type PerformanceEventParameters = {
     metric: string;
   };
   'performance_views.overview.has_data': {
-    // either "has_data", "no_data", or "empty" (when the user only sees the onboarding screen)
-    table_data_state: string;
+    table_data_state: 'has_data' | 'no_data' | 'onboarding';
     tab?: LandingDisplayField;
   };
   'performance_views.overview.navigate.summary': {

--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -3,6 +3,7 @@
 // analytics/insightAnalyticsEvents.tsx
 import type {FieldValue} from 'sentry/components/forms/model';
 import type {Organization, PlatformKey} from 'sentry/types';
+import type {LandingDisplayField} from 'sentry/views/performance/landing/utils';
 
 type SampleTransactionParam = {
   platform?: PlatformKey;
@@ -76,6 +77,11 @@ export type PerformanceEventParameters = {
   'performance_views.overview.cellaction': {action?: string};
   'performance_views.overview.change_chart': {
     metric: string;
+  };
+  'performance_views.overview.has_data': {
+    // either "has_data", "no_data", or "empty" (when the user only sees the onboarding screen)
+    table_data_state: string;
+    tab?: LandingDisplayField;
   };
   'performance_views.overview.navigate.summary': {
     project_platforms: string;
@@ -260,6 +266,8 @@ export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
   'performance_views.landingv3.table_pagination':
     'Performance Views: Landing Page Transactions Table Page Changed',
   'performance_views.overview.change_chart': 'Performance Views: Change Overview Chart',
+  'performance_views.overview.has_data':
+    'Performance Views: Transaction overview with data present',
   'performance_views.sample_spans.opened': 'Performance Views: Sample spans panel opened',
   'performance_views.sample_spans.span_clicked': 'Performance Views: Sample span clicked',
   'performance_views.sample_spans.try_different_samples_clicked':

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -20,6 +20,7 @@ import {TabList, TabPanels, Tabs} from 'sentry/components/tabs';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization, PageFilters, Project} from 'sentry/types';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import type EventView from 'sentry/utils/discover/eventView';
 import {GenericQueryBatcher} from 'sentry/utils/performance/contexts/genericQueryBatcher';
@@ -112,6 +113,16 @@ export function PerformanceLanding(props: Props) {
   useEffect(() => {
     hasMounted.current = true;
   }, []);
+
+  useEffect(() => {
+    if (showOnboarding) {
+      trackAnalytics('performance_views.overview.has_data', {
+        table_data_state: 'empty',
+        tab: paramLandingDisplay?.field,
+        organization,
+      });
+    }
+  }, [showOnboarding, paramLandingDisplay, organization]);
 
   const getFreeTextFromQuery = (query: string) => {
     const conditions = new MutableSearch(query);

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -117,7 +117,7 @@ export function PerformanceLanding(props: Props) {
   useEffect(() => {
     if (showOnboarding) {
       trackAnalytics('performance_views.overview.has_data', {
-        table_data_state: 'empty',
+        table_data_state: 'onboarding',
         tab: paramLandingDisplay?.field,
         organization,
       });


### PR DESCRIPTION
Tracks whether the transactions table on the performance overview page contains data. The metric is in one of 3 states:
- `has_data`: table has data
- `no_data`: table loads but is empty
- `empty`: the selected project(s) have no data and we display the empty state screen