### PR TITLE
fix(slack): fix disappearing tags after assignment

### DIFF
--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -5,6 +5,8 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import Any
 
+import orjson
+
 from sentry.integrations.slack.message_builder import SlackBlock
 from sentry.integrations.slack.message_builder.base.base import SlackMessageBuilder
 from sentry.notifications.utils.actions import MessageAction
@@ -47,7 +49,9 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
         return {"type": "section", "text": {"type": "mrkdwn", "text": markdown_text}}
 
     @staticmethod
-    def get_tags_block(tags) -> SlackBlock:
+    def get_tags_block(
+        tags: Sequence[Mapping[str, str | bool]], block_id: dict[str, Any] | None = None
+    ) -> SlackBlock:
         text = ""
         for tag in tags:
             title = tag["title"]
@@ -55,10 +59,17 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
             # remove backticks from value, otherwise it will break the markdown
             value = value.replace("`", "")
             text += f"{title}: `{value}`  "
-        return {
+
+        block = {
             "type": "section",
             "text": {"type": "mrkdwn", "text": text},
         }
+
+        if block_id:
+            block_id["block"] = "text"
+            block["block_id"] = orjson.dumps(block_id).decode()
+
+        return block
 
     @staticmethod
     def get_divider() -> SlackBlock:

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -57,7 +57,7 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
             title = tag["title"]
             value = tag["value"]
             # remove backticks from value, otherwise it will break the markdown
-            value = value.replace("`", "")
+            value = value.replace("`", "") if isinstance(value, str) else value
             text += f"{title}: `{value}`  "
 
         block = {
@@ -66,8 +66,9 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
         }
 
         if block_id:
-            block_id["block"] = "text"
-            block["block_id"] = orjson.dumps(block_id).decode()
+            tags_block_id = block_id.copy()
+            tags_block_id["block"] = "text"
+            block["block_id"] = orjson.dumps(tags_block_id).decode()
 
         return block
 

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -588,10 +588,15 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         if self.actions:
             blocks.append(self.get_markdown_block(action_text))
 
+        # set up block id
+        block_id = {"issue": self.group.id}
+        if rule_id:
+            block_id["rule"] = rule_id
+
         # build tags block
-        tags = get_tags(event_for_tags, self.tags)
+        tags = get_tags(event_for_tags=event_for_tags, tags=self.tags)
         if tags:
-            blocks.append(self.get_tags_block(tags))
+            blocks.append(self.get_tags_block(tags, block_id))
 
         # add event count, user count, substate, first seen
         context = get_context(self.group)
@@ -645,10 +650,6 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         # build footer block
         blocks.append(self.get_footer())
         blocks.append(self.get_divider())
-
-        block_id = {"issue": self.group.id}
-        if rule_id:
-            block_id["rule"] = rule_id
 
         chart_block = ImageBlockBuilder(group=self.group).build_image_block()
         if chart_block:

--- a/src/sentry/integrations/slack/requests/action.py
+++ b/src/sentry/integrations/slack/requests/action.py
@@ -122,10 +122,12 @@ class SlackActionRequest(SlackRequest):
                 continue
 
             text: str = block.get("text", {}).get("text", "")
-            tag_keys = text.split(" ")
-            for tag_key in tag_keys:
-                if not tag_key or tag_key.count("`") == 2:
+            tag_keys = text.split("`")
+
+            for i, tag_key in enumerate(tag_keys):
+                # the tags are organized as tag_key: tag_value, so even indexed tags are keys
+                if i % 2 == 1:
                     continue
-                else:
-                    tags.add(tag_key.strip(":"))
+                if tag_key.strip(" ").endswith(":"):
+                    tags.add(tag_key.strip(": "))
         return tags

--- a/src/sentry/integrations/slack/requests/action.py
+++ b/src/sentry/integrations/slack/requests/action.py
@@ -111,9 +111,21 @@ class SlackActionRequest(SlackRequest):
         return logging_data
 
     def get_tags(self) -> set[str]:
-        attachments = self.data.get("original_message", {}).get("attachments", [{}])
+        message = self.data.get("message", {})
+        if not message:
+            return set()
+
+        blocks = message.get("blocks", [{}])
         tags = set()
-        for attachment in attachments:
-            for field in attachment.get("fields", []):
-                tags.add(field["title"])
+        for block in blocks:
+            if "tags" not in block.get("block_id", ""):
+                continue
+
+            text: str = block.get("text", {}).get("text", "")
+            tag_keys = text.split(" ")
+            for tag_key in tag_keys:
+                if not tag_key or tag_key.count("`") == 2:
+                    continue
+                else:
+                    tags.add(tag_key.strip(":"))
         return tags

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -116,7 +116,11 @@ def build_test_message_blocks(
             v = v.replace("`", "")
             tags_text += f"{k}: `{v}`  "
 
-        tags_section = {"type": "section", "text": {"type": "mrkdwn", "text": tags_text}}
+        tags_section = {
+            "block_id": f'{{"issue":{group.id},"block":"text"}}',
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": tags_text},
+        }
         blocks.append(tags_section)
 
     # add event and user count, state, first seen

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -81,7 +81,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": "escape: `room`  foo: `bar`  release: `<http://testserver/releases/57c9bf0a3e183536ef9d47842e932a9e571b6d04/|57c9bf0a3e18>`  ",
+                        "text": "escape: `room`  foo: `bar baz`  release: `<http://testserver/releases/57c9bf0a3e183536ef9d47842e932a9e571b6d04/|57c9bf0a3e18>`  ",
                     },
                 },
             ],

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -60,27 +60,13 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
                 ]
             },
         }
-        self.original_message = {
-            "type": "message",
-            "attachments": [
-                {
-                    "id": 1,
-                    "ts": 1681409875,
-                    "color": "E03E2F",
-                    "fallback": "[node] IntegrationError: Identity not found.",
-                    "text": self.notification_text,
-                    "title": "IntegrationError",
-                    "footer": "NODE-F via <http://localhost:8000/organizations/sentry/alerts/rules/node/3/details/|New Issue in #critical channel>",
-                    "mrkdwn_in": ["text"],
-                }
-            ],
-        }
         event = self.store_event(
             data=self.event_data,
             project_id=self.project.id,
         )
         assert event.group
         self.group = Group.objects.get(id=event.group.id)
+        self.tags = {"escape", "foo", "release"}
 
     def get_original_message(self, group_id):
         return {
@@ -89,6 +75,14 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
                     "type": "section",
                     "block_id": orjson.dumps({"issue": group_id}).decode(),
                     "text": {"type": "mrkdwn", "text": "boop", "verbatim": False},
+                },
+                {
+                    "block_id": orjson.dumps({"issue": group_id, "block": "tags"}).decode(),
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "escape: `room`  foo: `bar`  release: `<http://testserver/releases/57c9bf0a3e183536ef9d47842e932a9e571b6d04/|57c9bf0a3e18>`  ",
+                    },
                 },
             ],
         }
@@ -155,52 +149,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert selected_option in ARCHIVE_OPTIONS.values()
         status_action = self.get_archive_status_action()
 
-        # Expect request to open dialog on slack
-        responses.add(
-            method=responses.POST,
-            url="https://slack.com/api/views.open",
-            body='{"ok": true}',
-            status=200,
-            content_type="application/json",
-        )
-        resp = self.post_webhook_block_kit(
-            action_data=[status_action], original_message=original_message, data=payload_data
-        )
-        assert resp.status_code == 200, resp.content
-
-        # Opening dialog should *not* cause the current message to be updated
-        assert resp.content == b""
-
-        data = orjson.loads(responses.calls[0].request.body)
-        assert data["trigger_id"] == self.trigger_id
-        assert "view" in data
-
-        view = orjson.loads(data["view"])
-        private_metadata = orjson.loads(view["private_metadata"])
-        assert int(private_metadata["issue"]) == self.group.id
-        assert private_metadata["orig_response_url"] == self.response_url
-
-        # Completing the dialog will update the message
-        responses.add(
-            method=responses.POST,
-            url=self.response_url,
-            body='{"ok": true}',
-            status=200,
-            content_type="application/json",
-        )
-        resp = self.post_webhook_block_kit(
-            type="view_submission",
-            private_metadata=orjson.dumps(private_metadata).decode(),
-            selected_option=selected_option,
-        )
-
-        assert resp.status_code == 200, resp.content
-        return resp
-
-    def archive_issue_sdk(self, original_message, selected_option, payload_data=None):
-        assert selected_option in ARCHIVE_OPTIONS.values()
-        status_action = self.get_archive_status_action()
-
         resp = self.post_webhook_block_kit(
             action_data=[status_action], original_message=original_message, data=payload_data
         )
@@ -257,49 +205,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
     def resolve_issue(self, original_message, selected_option, payload_data=None):
         status_action = self.get_resolve_status_action()
-        # Expect request to open dialog on slack
-        responses.add(
-            method=responses.POST,
-            url="https://slack.com/api/views.open",
-            body='{"ok": true}',
-            status=200,
-            content_type="application/json",
-        )
-        resp = self.post_webhook_block_kit(
-            action_data=[status_action], original_message=original_message, data=payload_data
-        )
-        assert resp.status_code == 200, resp.content
-
-        # Opening dialog should *not* cause the current message to be updated
-        assert resp.content == b""
-
-        data = orjson.loads(responses.calls[0].request.body)
-        assert data["trigger_id"] == self.trigger_id
-        assert "view" in data
-
-        view = orjson.loads(data["view"])
-        private_metadata = orjson.loads(view["private_metadata"])
-        assert int(private_metadata["issue"]) == self.group.id
-        assert private_metadata["orig_response_url"] == self.response_url
-
-        # Completing the dialog will update the message
-        responses.add(
-            method=responses.POST,
-            url=self.response_url,
-            body='{"ok": true}',
-            status=200,
-            content_type="application/json",
-        )
-        resp = self.post_webhook_block_kit(
-            type="view_submission",
-            private_metadata=orjson.dumps(private_metadata).decode(),
-            selected_option=selected_option,
-        )
-
-        assert resp.status_code == 200, resp.content
-
-    def resolve_issue_sdk(self, original_message, selected_option, payload_data=None):
-        status_action = self.get_resolve_status_action()
         resp = self.post_webhook_block_kit(
             action_data=[status_action], original_message=original_message, data=payload_data
         )
@@ -347,9 +252,9 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert resp.data["text"] == LINK_IDENTITY_MESSAGE.format(associate_url=associate_url)
 
     @responses.activate
-    def test_archive_issue_until_escalating_sdk(self):
+    def test_archive_issue_until_escalating(self):
         original_message = self.get_original_message(self.group.id)
-        self.archive_issue_sdk(original_message, "ignored:archived_until_escalating")
+        self.archive_issue(original_message, "ignored:archived_until_escalating")
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.IGNORED
@@ -367,7 +272,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
     def test_archive_issue_until_escalating_through_unfurl_sdk(self):
         original_message = self.get_original_message(self.group.id)
         payload_data = self.get_unfurl_data(original_message["blocks"])
-        self.archive_issue_sdk(original_message, "ignored:archived_until_escalating", payload_data)
+        self.archive_issue(original_message, "ignored:archived_until_escalating", payload_data)
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.IGNORED
@@ -382,7 +287,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
     @responses.activate
     def test_archive_issue_until_condition_met_sdk(self):
         original_message = self.get_original_message(self.group.id)
-        self.archive_issue_sdk(original_message, "ignored:archived_until_condition_met:10")
+        self.archive_issue(original_message, "ignored:archived_until_condition_met:10")
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.IGNORED
@@ -400,7 +305,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
     def test_archive_issue_until_condition_met_through_unfurl_sdk(self):
         original_message = self.get_original_message(self.group.id)
         payload_data = self.get_unfurl_data(original_message["blocks"])
-        self.archive_issue_sdk(
+        self.archive_issue(
             original_message, "ignored:archived_until_condition_met:100", payload_data
         )
 
@@ -419,7 +324,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
     @responses.activate
     def test_archive_issue_forever_with_sdk(self):
         original_message = self.get_original_message(self.group.id)
-        self.archive_issue_sdk(original_message, "ignored:archived_forever")
+        self.archive_issue(original_message, "ignored:archived_forever")
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.IGNORED
@@ -436,7 +341,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
     def test_archive_issue_forever_error_sdk(self, mock_access):
         original_message = self.get_original_message(self.group.id)
 
-        resp = self.archive_issue_sdk(original_message, "ignored:archived_forever")
+        resp = self.archive_issue(original_message, "ignored:archived_forever")
         expected_text = f"Looks like this Slack identity is linked to the Sentry user *{self.user.email}* who is not a member of organization *{self.organization.slug}* used with this Slack integration. "
         assert expected_text in resp.data["text"]
         assert resp.data["response_type"] == "ephemeral"
@@ -450,7 +355,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
     def test_archive_issue_forever_through_unfurl_sdk(self):
         original_message = self.get_original_message(self.group.id)
         payload_data = self.get_unfurl_data(original_message["blocks"])
-        self.archive_issue_sdk(original_message, "ignored:archived_forever", payload_data)
+        self.archive_issue(original_message, "ignored:archived_forever", payload_data)
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.IGNORED
@@ -474,7 +379,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             AuthIdentity.objects.create(auth_provider=auth_idp, user=self.user)
 
         original_message = self.get_original_message(self.group.id)
-        self.archive_issue_sdk(original_message, "ignored:archived_forever")
+        self.archive_issue(original_message, "ignored:archived_forever")
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.IGNORED
@@ -498,7 +403,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             AuthIdentity.objects.create(auth_provider=auth_idp, user=self.user)
         original_message = self.get_original_message(self.group.id)
         payload_data = self.get_unfurl_data(original_message["blocks"])
-        self.archive_issue_sdk(original_message, "ignored:archived_forever", payload_data)
+        self.archive_issue(original_message, "ignored:archived_forever", payload_data)
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.IGNORED
@@ -557,7 +462,8 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.notification_text in blocks[1]["text"]["text"]
         assert blocks[2]["text"]["text"].endswith(expect_status)
 
-    def test_assign_issue(self):
+    @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
+    def test_assign_issue(self, mock_tags):
         user2 = self.create_user(is_superuser=False)
         self.create_member(user=user2, organization=self.organization, teams=[self.team])
         original_message = self.get_original_message(self.group.id)
@@ -565,6 +471,8 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         # Assign to user
         self.assign_issue(original_message, user2)
         assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
+        assert mock_tags.call_args.kwargs["tags"] == self.tags
+
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
         text = self.mock_post.call_args.kwargs["text"]
         expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
@@ -575,6 +483,8 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         # Assign to team
         self.assign_issue(original_message, self.team)
         assert GroupAssignee.objects.filter(group=self.group, team=self.team).exists()
+        assert mock_tags.call_args.kwargs["tags"] == self.tags
+
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
         text = self.mock_post.call_args.kwargs["text"]
         expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
@@ -802,7 +712,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
     @responses.activate
     def test_resolve_issue(self):
         original_message = self.get_original_message(self.group.id)
-        self.resolve_issue_sdk(original_message, "resolved")
+        self.resolve_issue(original_message, "resolved")
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.RESOLVED
@@ -831,7 +741,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.group
 
         original_message = self.get_original_message(self.group.id)
-        self.resolve_issue_sdk(original_message, "resolved")
+        self.resolve_issue(original_message, "resolved")
 
         self.group.refresh_from_db()
         assert self.group.get_status() == GroupStatus.RESOLVED
@@ -851,7 +761,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
     def test_resolve_issue_through_unfurl_sdk(self):
         original_message = self.get_original_message(self.group.id)
         payload_data = self.get_unfurl_data(original_message["blocks"])
-        self.resolve_issue_sdk(original_message, "resolved", payload_data)
+        self.resolve_issue(original_message, "resolved", payload_data)
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.RESOLVED
@@ -872,7 +782,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         release.add_project(self.project)
 
         original_message = self.get_original_message(self.group.id)
-        self.resolve_issue_sdk(original_message, "resolved:inCurrentRelease")
+        self.resolve_issue(original_message, "resolved:inCurrentRelease")
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.RESOLVED
@@ -896,7 +806,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
         original_message = self.get_original_message(self.group.id)
         payload_data = self.get_unfurl_data(original_message["blocks"])
-        self.resolve_issue_sdk(original_message, "resolved:inCurrentRelease", payload_data)
+        self.resolve_issue(original_message, "resolved:inCurrentRelease", payload_data)
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.RESOLVED
@@ -918,7 +828,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         )
         release.add_project(self.project)
         original_message = self.get_original_message(self.group.id)
-        self.resolve_issue_sdk(original_message, "resolved:inNextRelease")
+        self.resolve_issue(original_message, "resolved:inNextRelease")
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.RESOLVED
@@ -941,7 +851,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         release.add_project(self.project)
         original_message = self.get_original_message(self.group.id)
         payload_data = self.get_unfurl_data(original_message["blocks"])
-        self.resolve_issue_sdk(original_message, "resolved:inNextRelease", payload_data)
+        self.resolve_issue(original_message, "resolved:inNextRelease", payload_data)
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.RESOLVED


### PR DESCRIPTION
Updates https://github.com/getsentry/sentry/pull/40587 to work for block kit -- we need to parse the tags differently.

Fixes https://github.com/getsentry/sentry/issues/69373

Adds a custom `block_id` to the tags block to be able to pull it out easily when a user interacts with the Slack message (when we get a Slack webhook), and parses the tag keys from the tags block to pass to the issues message builder. There is already a function that does this, but it needs to be updated to parse blocks instead of attachments.

In the future, perhaps we don't need to regenerate the whole message and can insert / replace the appropriate block after taking an action on the message.

Fix

https://github.com/user-attachments/assets/72d1c54d-4783-48c2-aa6c-d142271da6b0

Before

https://github.com/user-attachments/assets/e7f2d82c-887b-4605-9a6e-53114cf3017f

