### PR TITLE
chore(priority-alerts): Remove priority feature flags

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -94,8 +94,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:custom-metrics-extraction-rule-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables metrics extrapolation feature
     manager.add("organizations:metrics-extrapolation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable the default alert at project creation to be the high priority alert
-    manager.add("organizations:default-high-priority-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enables automatically deriving of code mappings
     manager.add("organizations:derive-code-mappings", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True)
     # Enables synthesis of device.class in ingest
@@ -510,8 +508,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("projects:first-event-severity-calculation", ProjectFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable escalation detection for new issues
     manager.add("projects:first-event-severity-new-escalation", ProjectFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=False)
-    # Enable severity alerts for new issues based on severity and escalation
-    manager.add("projects:high-priority-alerts", ProjectFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enable functionality for attaching  minidumps to events and displaying
     # them in the group UI.
     manager.add("projects:minidump", ProjectFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)

--- a/src/sentry/receivers/rules.py
+++ b/src/sentry/receivers/rules.py
@@ -44,22 +44,7 @@ PLATFORMS_WITH_PRIORITY_ALERTS = ["python", "javascript"]
 
 def has_high_priority_issue_alerts(project: Project) -> bool:
     # Seer-based priority is enabled if the organization has the feature flag
-    seer_based_priority_enabled = features.has(
-        "organizations:priority-ga-features", project.organization
-    )
-    if seer_based_priority_enabled:
-        return True
-
-    # High priority alerts are enabled if the project has the feature flag
-    # or for python/javascript projects in organization that have the feature flag
-    return features.has("projects:high-priority-alerts", project) or (
-        features.has("organizations:default-high-priority-alerts", project.organization)
-        and project.platform is not None
-        and any(
-            project.platform.startswith(base_platform)
-            for base_platform in PLATFORMS_WITH_PRIORITY_ALERTS
-        )
-    )
+    return features.has("organizations:priority-ga-features", project.organization)
 
 
 def create_default_rules(project, default_rules=True, RuleModel=Rule, **kwargs):

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -191,21 +191,8 @@ class ProjectRuleConfigurationTest(APITestCase):
         filter_ids = {f["id"] for f in response.data["filters"]}
         assert IssueCategoryFilter.id in filter_ids
 
-    def test_high_priority_issue_condition_feature(self):
-        # Hide the high priority issue condition when high-priority-alerts is off
-        with self.feature({"projects:high-priority-alerts": False}):
-            response = self.get_success_response(self.organization.slug, self.project.slug)
-            assert (
-                "sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition"
-                not in [filter["id"] for filter in response.data["conditions"]]
-            )
-            assert (
-                "sentry.rules.conditions.high_priority_issue.ExistingHighPriorityIssueCondition"
-                not in [filter["id"] for filter in response.data["conditions"]]
-            )
-
-        # Show the high priority issue condition when high-priority-alerts is on
-        with self.feature({"projects:high-priority-alerts": True}):
+    def test_high_priority_issue_condition(self):
+        with self.feature({"projects:priority-ga-features": True}):
             response = self.get_success_response(self.organization.slug, self.project.slug)
             assert "sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition" in [
                 filter["id"] for filter in response.data["conditions"]

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -192,7 +192,7 @@ class ProjectRuleConfigurationTest(APITestCase):
         assert IssueCategoryFilter.id in filter_ids
 
     def test_high_priority_issue_condition(self):
-        with self.feature({"projects:priority-ga-features": True}):
+        with self.feature({"organizations:priority-ga-features": True}):
             response = self.get_success_response(self.organization.slug, self.project.slug)
             assert "sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition" in [
                 filter["id"] for filter in response.data["conditions"]

--- a/tests/sentry/rules/conditions/test_existing_high_priority_issue.py
+++ b/tests/sentry/rules/conditions/test_existing_high_priority_issue.py
@@ -14,7 +14,7 @@ class ExistingHighPriorityIssueConditionTest(RuleTestCase):
     def setUp(self):
         self.rule = Rule(environment_id=1, project=self.project, label="label")
 
-    @with_feature("projects:priority-ga-features")
+    @with_feature("organizations:priority-ga-features")
     def test_applies_correctly(self):
         rule = self.get_rule(rule=self.rule)
 

--- a/tests/sentry/rules/conditions/test_existing_high_priority_issue.py
+++ b/tests/sentry/rules/conditions/test_existing_high_priority_issue.py
@@ -14,7 +14,7 @@ class ExistingHighPriorityIssueConditionTest(RuleTestCase):
     def setUp(self):
         self.rule = Rule(environment_id=1, project=self.project, label="label")
 
-    @with_feature("projects:high-priority-alerts")
+    @with_feature("projects:priority-ga-features")
     def test_applies_correctly(self):
         rule = self.get_rule(rule=self.rule)
 

--- a/tests/sentry/rules/conditions/test_new_high_priority_issue.py
+++ b/tests/sentry/rules/conditions/test_new_high_priority_issue.py
@@ -14,7 +14,7 @@ class NewHighPriorityIssueConditionTest(RuleTestCase):
     def setUp(self):
         self.rule = Rule(environment_id=1, project=self.project, label="label")
 
-    @with_feature("projects:priority-ga-features")
+    @with_feature("organizations:priority-ga-features")
     def test_applies_correctly_with_high_priority_alerts(self):
         self.project.flags.has_high_priority_alerts = True
         self.project.save()
@@ -34,7 +34,7 @@ class NewHighPriorityIssueConditionTest(RuleTestCase):
         self.event.group.update(priority=PriorityLevel.LOW)
         self.assertDoesNotPass(rule, is_new_group_environment=True)
 
-    @with_feature("projects:priority-ga-features")
+    @with_feature("organizations:priority-ga-features")
     def test_applies_correctly_without_high_priority_alerts(self):
         self.project.flags.has_high_priority_alerts = False
         self.project.save()

--- a/tests/sentry/rules/conditions/test_new_high_priority_issue.py
+++ b/tests/sentry/rules/conditions/test_new_high_priority_issue.py
@@ -14,7 +14,7 @@ class NewHighPriorityIssueConditionTest(RuleTestCase):
     def setUp(self):
         self.rule = Rule(environment_id=1, project=self.project, label="label")
 
-    @with_feature("projects:high-priority-alerts")
+    @with_feature("projects:priority-ga-features")
     def test_applies_correctly_with_high_priority_alerts(self):
         self.project.flags.has_high_priority_alerts = True
         self.project.save()
@@ -34,7 +34,7 @@ class NewHighPriorityIssueConditionTest(RuleTestCase):
         self.event.group.update(priority=PriorityLevel.LOW)
         self.assertDoesNotPass(rule, is_new_group_environment=True)
 
-    @with_feature("projects:high-priority-alerts")
+    @with_feature("projects:priority-ga-features")
     def test_applies_correctly_without_high_priority_alerts(self):
         self.project.flags.has_high_priority_alerts = False
         self.project.save()


### PR DESCRIPTION
Remove feature flag checks for priority alerts. The feature is now gated by `organizations:priority-ga-features` in flagpole.