### PR TITLE
chore(priority-alerts): Remove priority feature flags from frontend

### DIFF
--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -322,16 +322,7 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
     if (!ruleId && !this.isDuplicateRule) {
       // now that we've loaded all the possible conditions, we can populate the
       // value of conditions for a new alert
-      const hasSeerBasedPriority =
-        this.props.organization.features.includes('priority-ga-features');
-      const hasHighPriorityIssueAlerts =
-        this.props.organization.features.includes('default-high-priority-alerts') ||
-        this.props.project.features.includes('high-priority-alerts');
-      const isValidPlatform =
-        this.props.project.platform?.startsWith('javascript') ||
-        this.props.project.platform?.startsWith('python');
-
-      if (hasSeerBasedPriority || (hasHighPriorityIssueAlerts && isValidPlatform)) {
+      if (this.props.organization.features.includes('priority-ga-features')) {
         this.handleChange('conditions', [
           {id: IssueAlertConditionType.NEW_HIGH_PRIORITY_ISSUE},
           {id: IssueAlertConditionType.EXISTING_HIGH_PRIORITY_ISSUE},

--- a/static/app/views/projectInstall/issueAlertOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertOptions.tsx
@@ -6,7 +6,7 @@ import DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent
 import RadioGroup from 'sentry/components/forms/controls/radioGroup';
 import SelectControl from 'sentry/components/forms/controls/selectControl';
 import Input from 'sentry/components/input';
-import {SupportedLanguages} from 'sentry/components/onboarding/frameworkSuggestionModal';
+import type {SupportedLanguages} from 'sentry/components/onboarding/frameworkSuggestionModal';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {IssueAlertRuleAction} from 'sentry/types/alerts';
@@ -193,15 +193,7 @@ class IssueAlertOptions extends DeprecatedAsyncComponent<Props, State> {
   }
 
   shouldUseNewDefaultSetting(): boolean {
-    if (this.props.organization.features.includes('priority-ga-features')) {
-      return true;
-    }
-
-    return (
-      this.props.organization.features.includes('default-high-priority-alerts') &&
-      (this.props.platformLanguage === SupportedLanguages.PYTHON ||
-        this.props.platformLanguage === SupportedLanguages.JAVASCRIPT)
-    );
+    return this.props.organization.features.includes('priority-ga-features');
   }
 
   getUpdatedData(): RequestDataFragment {


### PR DESCRIPTION
Remove feature flag checks for priority alerts. The feature is now gated by `organizations:priority-ga-features` in flagpole.