### PR TITLE
feat(seer similarity): Use `useReranking` value for `use_reranking` on similar issues tab

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/api/endpoints/group_similar_issues_embeddings.py
@@ -94,6 +94,10 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
         if request.GET.get("threshold"):
             similar_issues_params["threshold"] = float(request.GET["threshold"])
 
+        # Override `use_reranking` value if necessary
+        if request.GET.get("useReranking"):
+            similar_issues_params["use_reranking"] = request.GET["useReranking"] == "true"
+
         extra: dict[str, Any] = dict(similar_issues_params.copy())
         extra["group_message"] = extra.pop("message")
         logger.info("Similar issues embeddings parameters", extra=extra)

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -625,3 +625,14 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             ),
             headers={"content-type": "application/json;charset=utf-8"},
         )
+
+    @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
+    def test_obeys_useReranking_query_param(self, mock_seer_request):
+        for incoming_value, outgoing_value in [("true", True), ("false", False)]:
+            self.client.get(self.path, data={"useReranking": incoming_value})
+
+            assert mock_seer_request.call_count == 1
+            request_params = orjson.loads(mock_seer_request.call_args.kwargs["body"])
+            assert request_params["use_reranking"] == outgoing_value
+
+            mock_seer_request.reset_mock()


### PR DESCRIPTION
We'd like to be able to compare the results Seer sends back both with and without reranking. To that end, this makes the Seer similar issues tab endpoint in Sentry able to handle a `useReranking` query parameter (either `"true"` or `"false"`), which will then set the value of `use_reranking` in the subsequent request to Seer.

To keep front- and backend changes separate, the ability to actually send `useReranking` to the endpoint has been split into [a separate PR](https://github.com/getsentry/sentry/pull/75560).