### PR TITLE
feat(seer similarity): Send `useReranking` parameter to similarity embeddings endpoint

### DIFF
--- a/static/app/views/issueDetails/groupSimilarIssues/index.spec.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/index.spec.tsx
@@ -213,7 +213,7 @@ describe('Issues Similar Embeddings View', function () {
 
   beforeEach(function () {
     mock = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/issues/group-id/similar-issues-embeddings/?k=10&threshold=0.01',
+      url: '/organizations/org-slug/issues/group-id/similar-issues-embeddings/?k=10&threshold=0.01&useReranking=true',
       body: mockData.simlarEmbeddings,
     });
   });
@@ -353,7 +353,7 @@ describe('Issues Similar Embeddings View', function () {
     MockApiClient.clearMockResponses();
     jest.clearAllMocks();
     mock = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/issues/group-id/similar-issues-embeddings/?k=10&threshold=0.01',
+      url: '/organizations/org-slug/issues/group-id/similar-issues-embeddings/?k=10&threshold=0.01&useReranking=true',
       body: [],
     });
 

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
@@ -56,6 +56,10 @@ function SimilarStackTrace({params, location, project}: Props) {
   const hasSimilarityEmbeddingsFeature =
     project.features.includes('similarity-embeddings') ||
     location.query.similarityEmbeddings === '1';
+  // Use reranking by default (assuming the `seer.similarity.similar_issues.use_reranking`
+  // backend option is using its default value of `True`). This is just so we can turn it off
+  // on demand to see if/how that changes the results.
+  const useReranking = String(location.query.useReranking !== '0');
 
   const fetchData = useCallback(() => {
     setStatus('loading');
@@ -68,6 +72,7 @@ function SimilarStackTrace({params, location, project}: Props) {
           {
             k: 10,
             threshold: 0.01,
+            useReranking,
           }
         )}`,
         dataKey: 'similar',
@@ -89,6 +94,7 @@ function SimilarStackTrace({params, location, project}: Props) {
     orgId,
     hasSimilarityFeature,
     hasSimilarityEmbeddingsFeature,
+    useReranking,
   ]);
 
   const onGroupingChange = useCallback(


### PR DESCRIPTION
This adds the ability to add `useReranking=0` or `useReranking=1` as a URL query parameter on the similar issues tab in order to add `useReranking=false` or `useReranking=true` as a query parameter on that tab's requests to our backend. (This will in turn [control the value](https://github.com/getsentry/sentry/pull/75559) of the `use_reranking` parameter sent from our backend to Seer.)