### PR TITLE
ref(seer grouping): Use option to control sample rate of metrics

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -89,7 +89,7 @@ def _has_customized_fingerprint(event: Event, primary_hashes: CalculatedHashes) 
         else:
             metrics.incr(
                 "grouping.similarity.did_call_seer",
-                sample_rate=1.0,
+                sample_rate=options.get("seer.similarity.metrics_sample_rate"),
                 tags={"call_made": False, "blocker": "hybrid-fingerprint"},
             )
             return True
@@ -102,7 +102,7 @@ def _has_customized_fingerprint(event: Event, primary_hashes: CalculatedHashes) 
     if fingerprint_variant:
         metrics.incr(
             "grouping.similarity.did_call_seer",
-            sample_rate=1.0,
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
             tags={"call_made": False, "blocker": fingerprint_variant.type},
         )
         return True
@@ -129,7 +129,7 @@ def _ratelimiting_enabled(event: Event, project: Project) -> bool:
 
         metrics.incr(
             "grouping.similarity.did_call_seer",
-            sample_rate=1.0,
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
             tags={"call_made": False, "blocker": "global-rate-limit"},
         )
 
@@ -143,7 +143,7 @@ def _ratelimiting_enabled(event: Event, project: Project) -> bool:
 
         metrics.incr(
             "grouping.similarity.did_call_seer",
-            sample_rate=1.0,
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
             tags={"call_made": False, "blocker": "project-rate-limit"},
         )
 
@@ -168,7 +168,7 @@ def _circuit_breaker_broken(event: Event, project: Project) -> bool:
         )
         metrics.incr(
             "grouping.similarity.did_call_seer",
-            sample_rate=1.0,
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
             tags={"call_made": False, "blocker": "circuit-breaker"},
         )
 
@@ -240,9 +240,7 @@ def maybe_check_seer_for_matching_grouphash(
     if should_call_seer_for_grouping(event, primary_hashes):
         metrics.incr(
             "grouping.similarity.did_call_seer",
-            # TODO: Consider lowering this (in all the spots this metric is
-            # collected) once we roll Seer grouping out more widely
-            sample_rate=1.0,
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
             tags={"call_made": True, "blocker": "none"},
         )
         try:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -918,6 +918,15 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# TODO: Once Seer grouping is GA-ed, we probably either want to turn this down or get rid of it in
+# favor of the default 10% sample rate
+register(
+    "seer.similarity.metrics_sample_rate",
+    type=Float,
+    default=1.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # seer nearest neighbour endpoint timeout
 register(
     "embeddings-grouping.seer.nearest-neighbour-timeout",

--- a/src/sentry/seer/similarity/grouping_records.py
+++ b/src/sentry/seer/similarity/grouping_records.py
@@ -4,6 +4,7 @@ from typing import NotRequired, TypedDict
 from django.conf import settings
 from urllib3.exceptions import ReadTimeoutError
 
+from sentry import options
 from sentry.conf.server import (
     SEER_GROUPING_RECORDS_URL,
     SEER_HASH_GROUPING_RECORDS_DELETE_URL,
@@ -106,13 +107,21 @@ def delete_project_grouping_records(
             "seer.delete_grouping_records.project.success",
             extra={"project_id": project_id},
         )
-        metrics.incr("grouping.similarity.delete_records_by_project", tags={"success": True})
+        metrics.incr(
+            "grouping.similarity.delete_records_by_project",
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+            tags={"success": True},
+        )
         return True
     else:
         logger.error(
             "seer.delete_grouping_records.project.failure",
         )
-        metrics.incr("grouping.similarity.delete_records_by_project", tags={"success": False})
+        metrics.incr(
+            "grouping.similarity.delete_records_by_project",
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+            tags={"success": False},
+        )
         return False
 
 
@@ -140,9 +149,17 @@ def delete_grouping_records_by_hash(project_id: int, hashes: list[str]) -> bool:
             "seer.delete_grouping_records.hashes.success",
             extra=extra,
         )
-        metrics.incr("grouping.similarity.delete_records_by_hash", tags={"success": True})
+        metrics.incr(
+            "grouping.similarity.delete_records_by_hash",
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+            tags={"success": True},
+        )
         return True
     else:
         logger.error("seer.delete_grouping_records.hashes.failure", extra=extra)
-        metrics.incr("grouping.similarity.delete_records_by_hash", tags={"success": False})
+        metrics.incr(
+            "grouping.similarity.delete_records_by_hash",
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+            tags={"success": False},
+        )
         return False

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -25,11 +25,6 @@ from sentry.utils.json import JSONDecodeError, apply_key_filter
 
 logger = logging.getLogger(__name__)
 
-# TODO: Keeping this at a 100% sample rate for now in order to get good signal as we're rolling out
-# and calls are still comparatively rare. Once traffic gets heavy enough, we should probably ramp
-# this down.
-SIMILARITY_REQUEST_METRIC_SAMPLE_RATE = 1.0
-
 
 seer_grouping_connection_pool = connection_from_url(
     settings.SEER_GROUPING_URL,
@@ -93,7 +88,7 @@ def get_similarity_data_from_seer(
         )
         metrics.incr(
             "seer.similar_issues_request",
-            sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
             tags={
                 **metric_tags,
                 "outcome": "empty_stacktrace",
@@ -119,7 +114,7 @@ def get_similarity_data_from_seer(
         logger.warning("get_seer_similar_issues.request_error", extra=logger_extra)
         metrics.incr(
             "seer.similar_issues_request",
-            sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
             tags={**metric_tags, "outcome": "error", "error": type(e).__name__},
         )
         circuit_breaker.record_error()
@@ -141,7 +136,7 @@ def get_similarity_data_from_seer(
 
         metrics.incr(
             "seer.similar_issues_request",
-            sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
             tags={
                 **metric_tags,
                 "outcome": "error",
@@ -171,7 +166,7 @@ def get_similarity_data_from_seer(
         )
         metrics.incr(
             "seer.similar_issues_request",
-            sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
             tags={**metric_tags, "outcome": "error", "error": type(e).__name__},
         )
         return []
@@ -179,7 +174,7 @@ def get_similarity_data_from_seer(
     if not response_data:
         metrics.incr(
             "seer.similar_issues_request",
-            sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
             tags={**metric_tags, "outcome": "no_similar_groups"},
         )
         return []
@@ -241,7 +236,7 @@ def get_similarity_data_from_seer(
 
     metrics.incr(
         "seer.similar_issues_request",
-        sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+        sample_rate=options.get("seer.similarity.metrics_sample_rate"),
         tags=metric_tags,
     )
     return sorted(

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -121,7 +121,7 @@ def get_stacktrace_string(data: dict[str, Any]) -> str:
 
     metrics.incr(
         "seer.grouping.html_in_stacktrace",
-        sample_rate=1.0,
+        sample_rate=options.get("seer.similarity.metrics_sample_rate"),
         tags={
             "html_frames": (
                 "none"
@@ -173,7 +173,7 @@ def killswitch_enabled(project_id: int, event: Event | None = None) -> bool:
         )
         metrics.incr(
             "grouping.similarity.did_call_seer",
-            sample_rate=1.0,
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
             tags={"call_made": False, "blocker": "global-killswitch"},
         )
         return True
@@ -185,7 +185,7 @@ def killswitch_enabled(project_id: int, event: Event | None = None) -> bool:
         )
         metrics.incr(
             "grouping.similarity.did_call_seer",
-            sample_rate=1.0,
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
             tags={"call_made": False, "blocker": "similarity-killswitch"},
         )
         return True

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -245,7 +245,7 @@ def get_data_from_snuba(project, groups_to_backfill_with_no_embedding):
 
         with metrics.timer(
             f"{BACKFILL_NAME}.bulk_snuba_queries",
-            sample_rate=1.0,
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
         ):
             snuba_results_chunk = _make_snuba_call(
                 project, snuba_requests, Referrer.GROUPING_RECORDS_BACKFILL_REFERRER.value
@@ -387,7 +387,7 @@ def send_group_and_stacktrace_to_seer(
 ):
     with metrics.timer(
         f"{BACKFILL_NAME}.send_group_and_stacktrace_to_seer",
-        sample_rate=1.0,
+        sample_rate=options.get("seer.similarity.metrics_sample_rate"),
     ):
         return _make_seer_call(
             CreateGroupingRecordsRequest(
@@ -419,7 +419,7 @@ def send_group_and_stacktrace_to_seer_multithreaded(
 
     with metrics.timer(
         f"{BACKFILL_NAME}.send_group_and_stacktrace_to_seer",
-        sample_rate=1.0,
+        sample_rate=options.get("seer.similarity.metrics_sample_rate"),
     ):
         chunk_size = options.get("similarity.backfill_seer_chunk_size")
         chunks = [

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -5,13 +5,13 @@ from unittest import mock
 import orjson
 from urllib3.response import HTTPResponse
 
+from sentry import options
 from sentry.api.endpoints.group_similar_issues_embeddings import (
     GroupSimilarIssuesEmbeddingsEndpoint,
 )
 from sentry.api.serializers.base import serialize
 from sentry.conf.server import SEER_SIMILAR_ISSUES_URL
 from sentry.models.group import Group
-from sentry.seer.similarity.similar_issues import SIMILARITY_REQUEST_METRIC_SAMPLE_RATE
 from sentry.seer.similarity.types import SeerSimilarIssueData, SimilarIssuesEmbeddingsResponse
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.eventprocessing import save_new_event
@@ -244,7 +244,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         )
         mock_metrics_incr.assert_any_call(
             "seer.similar_issues_request",
-            sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
             tags={
                 "response_status": 200,
                 "outcome": "matching_group_found",
@@ -356,7 +356,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         )
         mock_metrics_incr.assert_any_call(
             "seer.similar_issues_request",
-            sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
             tags={
                 "response_status": 200,
                 "outcome": "error",
@@ -409,7 +409,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         mock_metrics_incr.assert_any_call(
             "seer.similar_issues_request",
-            sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
             tags={
                 "response_status": 200,
                 "outcome": "error",

--- a/tests/sentry/seer/similarity/test_similar_issues.py
+++ b/tests/sentry/seer/similarity/test_similar_issues.py
@@ -5,9 +5,9 @@ from unittest.mock import MagicMock
 from urllib3.exceptions import MaxRetryError, TimeoutError
 from urllib3.response import HTTPResponse
 
+from sentry import options
 from sentry.conf.server import SEER_SIMILAR_ISSUES_URL
 from sentry.seer.similarity.similar_issues import (
-    SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
     get_similarity_data_from_seer,
     seer_grouping_connection_pool,
 )
@@ -75,7 +75,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
             ]
             mock_metrics_incr.assert_any_call(
                 "seer.similar_issues_request",
-                sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+                sample_rate=options.get("seer.similarity.metrics_sample_rate"),
                 tags={
                     "response_status": 200,
                     "outcome": expected_outcome,
@@ -92,7 +92,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
         assert get_similarity_data_from_seer(self.request_params) == []
         mock_metrics_incr.assert_any_call(
             "seer.similar_issues_request",
-            sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
             tags={"response_status": 200, "outcome": "no_similar_groups"},
         )
 
@@ -142,7 +142,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
             assert get_similarity_data_from_seer(self.request_params) == []
             mock_metrics_incr.assert_any_call(
                 "seer.similar_issues_request",
-                sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+                sample_rate=options.get("seer.similarity.metrics_sample_rate"),
                 tags={"response_status": 200, "outcome": "error", "error": expected_error},
             )
             assert mock_record_circuit_breaker_error.call_count == 0
@@ -170,7 +170,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
         )
         mock_metrics_incr.assert_any_call(
             "seer.similar_issues_request",
-            sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
             tags={"response_status": 308, "outcome": "error", "error": "Redirect"},
         )
         assert mock_record_circuit_breaker_error.call_count == 0
@@ -207,7 +207,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
             )
             mock_metrics_incr.assert_any_call(
                 "seer.similar_issues_request",
-                sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+                sample_rate=options.get("seer.similarity.metrics_sample_rate"),
                 tags={"outcome": "error", "error": expected_error_tag},
             )
             assert mock_record_circuit_breaker_error.call_count == 1
@@ -240,7 +240,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
             )
             mock_metrics_incr.assert_any_call(
                 "seer.similar_issues_request",
-                sample_rate=SIMILARITY_REQUEST_METRIC_SAMPLE_RATE,
+                sample_rate=options.get("seer.similarity.metrics_sample_rate"),
                 tags={"response_status": status, "outcome": "error", "error": "RequestError"},
             )
             assert mock_record_circuit_breaker_error.call_count == (


### PR DESCRIPTION
Right now, while Seer grouping is still in EA, the number of times our various metrics are hit is relatively small. For that reason, we've kicked the sample rate on many up them up to 100%. In order to standardize this (and to be able to change it easly), this PR uses a new option, `seer.similarity.metrics_sample_rate`, to control the sample rate for all of the metrics on our dashboard.

Note: Checking an option in the `@metrics.wraps` calls in `tasks.embeddings_grouping.utils` caused tests to fail in about a dozen different test files (most of them unrelated, weirdly) with a complaint that database access isn't allowed unless marked in the test file. Rather than spend a ton of time chasing that down, I just converted the `@metrics.wraps` calls to `with metrics.timer` calls (which is all `@metrics.wraps` does), which is why the changes seem more extensive in that file than the others.