### PR TITLE
chore(seer grouping): Remove redundant metrics

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -128,10 +128,6 @@ def _ratelimiting_enabled(event: Event, project: Project) -> bool:
         logger.warning("should_call_seer_for_grouping.global_ratelimit_hit", extra=logger_extra)
 
         metrics.incr(
-            "grouping.similarity.global_ratelimit_hit",
-            tags={"limit_per_sec": global_limit_per_sec},
-        )
-        metrics.incr(
             "grouping.similarity.did_call_seer",
             sample_rate=1.0,
             tags={"call_made": False, "blocker": "global-rate-limit"},
@@ -145,10 +141,6 @@ def _ratelimiting_enabled(event: Event, project: Project) -> bool:
         logger_extra["limit_per_sec"] = project_limit_per_sec
         logger.warning("should_call_seer_for_grouping.project_ratelimit_hit", extra=logger_extra)
 
-        metrics.incr(
-            "grouping.similarity.project_ratelimit_hit",
-            tags={"limit_per_sec": project_limit_per_sec},
-        )
         metrics.incr(
             "grouping.similarity.did_call_seer",
             sample_rate=1.0,
@@ -173,9 +165,6 @@ def _circuit_breaker_broken(event: Event, project: Project) -> bool:
                 "project_id": project.id,
                 **breaker_config,
             },
-        )
-        metrics.incr(
-            "grouping.similarity.broken_circuit_breaker",
         )
         metrics.incr(
             "grouping.similarity.did_call_seer",

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -158,7 +158,6 @@ def killswitch_enabled(project_id: int, event: Event | None = None) -> bool:
             "should_call_seer_for_grouping.seer_global_killswitch_enabled",
             extra=logger_extra,
         )
-        metrics.incr("grouping.similarity.seer_global_killswitch_enabled")
         metrics.incr(
             "grouping.similarity.did_call_seer",
             sample_rate=1.0,
@@ -171,7 +170,6 @@ def killswitch_enabled(project_id: int, event: Event | None = None) -> bool:
             "should_call_seer_for_grouping.seer_similarity_killswitch_enabled",
             extra=logger_extra,
         )
-        metrics.incr("grouping.similarity.seer_similarity_killswitch_enabled")
         metrics.incr(
             "grouping.similarity.did_call_seer",
             sample_rate=1.0,


### PR DESCRIPTION
We have a bunch of metrics which were added before the `did_call_seer` metric was added, and which are now duplicated by instances of that metric with tags corresponding to the metrics in question. (For example, where we've been collecting a `grouping.similarity.seer_global_killswitch_enabled` metric, we've also been collecting the `did_call_seer` metric with the tag `blocker: global-killswitch`.) This removes all of the redundant metrics (which, it should be noted, we also haven't even been using).