### PR TITLE
ref(replay): Refactor currentTime context field

### DIFF
--- a/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
@@ -20,6 +20,7 @@ import EventView from 'sentry/utils/discover/eventView';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import useMarkReplayViewed from 'sentry/utils/replays/hooks/useMarkReplayViewed';
+import useReplayCurrentTime from 'sentry/utils/replays/playback/hooks/useReplayCurrentTime';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -55,8 +56,10 @@ function ReplayPreviewPlayer({
   const location = useLocation();
   const organization = useOrganization();
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
-  const {replay, currentTime, isFetching, isFinished, isPlaying, isVideoReplay} =
-    useReplayContext();
+  const {replay, isFetching, isFinished, isPlaying, isVideoReplay} = useReplayContext();
+  const [currentTime, setCurrentTime] = useState(0);
+  useReplayCurrentTime({callback: setCurrentTime});
+
   const eventView = EventView.fromLocation(location);
 
   const fullscreenRef = useRef(null);

--- a/static/app/components/performance/waterfall/row.tsx
+++ b/static/app/components/performance/waterfall/row.tsx
@@ -1,10 +1,11 @@
-import {Fragment} from 'react';
+import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {ROW_HEIGHT} from 'sentry/components/performance/waterfall/constants';
 import {getBackgroundColor} from 'sentry/components/performance/waterfall/utils';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import toPercent from 'sentry/utils/number/toPercent';
+import useReplayCurrentTime from 'sentry/utils/replays/playback/hooks/useReplayCurrentTime';
 import useCurrentHoverTime from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 
 interface RowProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -63,7 +64,9 @@ export const RowCell = styled('div')<RowCellProps>`
 `;
 
 export function RowReplayTimeIndicators() {
-  const {currentTime, replay} = useReplayContext();
+  const {replay} = useReplayContext();
+  const [currentTime, setCurrentTime] = useState(0);
+  useReplayCurrentTime({callback: setCurrentTime});
   const [currentHoverTime] = useCurrentHoverTime();
   const durationMs = replay?.getDurationMs();
 

--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -1,4 +1,4 @@
-import {useRef} from 'react';
+import {useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
 import Panel from 'sentry/components/panels/panel';
@@ -16,11 +16,14 @@ import {useReplayContext} from 'sentry/components/replays/replayContext';
 import divide from 'sentry/utils/number/divide';
 import toPercent from 'sentry/utils/number/toPercent';
 import useTimelineScale from 'sentry/utils/replays/hooks/useTimelineScale';
+import useReplayCurrentTime from 'sentry/utils/replays/playback/hooks/useReplayCurrentTime';
 import {useDimensions} from 'sentry/utils/useDimensions';
 import useOrganization from 'sentry/utils/useOrganization';
 
 export default function ReplayTimeline() {
-  const {replay, currentTime} = useReplayContext();
+  const {replay} = useReplayContext();
+  const [currentTime, handleCurrentTime] = useState(0);
+  useReplayCurrentTime({callback: handleCurrentTime});
   const [timelineScale] = useTimelineScale();
   const organization = useOrganization();
 

--- a/static/app/components/replays/player/scrubber.tsx
+++ b/static/app/components/replays/player/scrubber.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import RangeSlider from 'sentry/components/forms/controls/rangeSlider';
@@ -12,6 +12,7 @@ import formatReplayDuration from 'sentry/utils/duration/formatReplayDuration';
 import divide from 'sentry/utils/number/divide';
 import toPercent from 'sentry/utils/number/toPercent';
 import useTimelineScale from 'sentry/utils/replays/hooks/useTimelineScale';
+import useReplayCurrentTime from 'sentry/utils/replays/playback/hooks/useReplayCurrentTime';
 import useCurrentHoverTime from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 
 type Props = {
@@ -20,7 +21,9 @@ type Props = {
 };
 
 function Scrubber({className, showZoomIndicators = false}: Props) {
-  const {replay, currentTime, setCurrentTime} = useReplayContext();
+  const {replay, setCurrentTime} = useReplayContext();
+  const [currentTime, handleCurrentTime] = useState(0);
+  useReplayCurrentTime({callback: handleCurrentTime});
   const [currentHoverTime] = useCurrentHoverTime();
   const [timelineScale] = useTimelineScale();
 

--- a/static/app/components/replays/player/useScrubberMouseTracking.tsx
+++ b/static/app/components/replays/player/useScrubberMouseTracking.tsx
@@ -1,8 +1,9 @@
 import type {RefObject} from 'react';
-import {useCallback} from 'react';
+import {useCallback, useState} from 'react';
 
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import divide from 'sentry/utils/number/divide';
+import useReplayCurrentTime from 'sentry/utils/replays/playback/hooks/useReplayCurrentTime';
 import useCurrentHoverTime from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 import useMouseTracking from 'sentry/utils/useMouseTracking';
 
@@ -45,7 +46,9 @@ export function useTimelineScrubberMouseTracking<T extends Element>(
   {elem}: Opts<T>,
   scale: number
 ) {
-  const {replay, currentTime} = useReplayContext();
+  const {replay} = useReplayContext();
+  const [currentTime, handleCurrentTime] = useState(0);
+  useReplayCurrentTime({callback: handleCurrentTime});
   const [, setCurrentHoverTime] = useCurrentHoverTime();
   const durationMs = replay?.getDurationMs();
 

--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -13,6 +13,7 @@ import {IconNext, IconRewind10} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {getNextReplayFrame} from 'sentry/utils/replays/getReplayEvent';
+import useReplayCurrentTime from 'sentry/utils/replays/playback/hooks/useReplayCurrentTime';
 
 const SECOND = 1000;
 
@@ -25,7 +26,10 @@ interface Props {
 }
 
 function ReplayPlayPauseBar() {
-  const {currentTime, replay, setCurrentTime} = useReplayContext();
+  const {replay, setCurrentTime} = useReplayContext();
+
+  const [currentTime, handleCurrentTime] = useState(0);
+  useReplayCurrentTime({callback: handleCurrentTime});
 
   return (
     <ButtonBar gap={1}>

--- a/static/app/components/replays/replayCurrentScreen.tsx
+++ b/static/app/components/replays/replayCurrentScreen.tsx
@@ -1,14 +1,17 @@
-import {useMemo} from 'react';
+import {useMemo, useState} from 'react';
 import * as Sentry from '@sentry/react';
 
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import TextCopyInput from 'sentry/components/textCopyInput';
 import {t} from 'sentry/locale';
 import getCurrentScreenName from 'sentry/utils/replays/getCurrentScreenName';
+import useReplayCurrentTime from 'sentry/utils/replays/playback/hooks/useReplayCurrentTime';
 
 // Screen name component for video/mobile replays - mirrors replayCurrentUrl.tsx
 function ReplayCurrentScreen() {
-  const {currentTime, replay} = useReplayContext();
+  const {replay} = useReplayContext();
+  const [currentTime, handleCurrentTime] = useState(0);
+  useReplayCurrentTime({callback: handleCurrentTime});
   const frames = replay?.getMobileNavigationFrames();
   const replayRecord = replay?.getReplay();
 

--- a/static/app/components/replays/replayCurrentUrl.tsx
+++ b/static/app/components/replays/replayCurrentUrl.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {useMemo, useState} from 'react';
 import * as Sentry from '@sentry/react';
 
 import ExternalLink from 'sentry/components/links/externalLink';
@@ -8,12 +8,15 @@ import TextCopyInput from 'sentry/components/textCopyInput';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t, tct} from 'sentry/locale';
 import getCurrentUrl from 'sentry/utils/replays/getCurrentUrl';
+import useReplayCurrentTime from 'sentry/utils/replays/playback/hooks/useReplayCurrentTime';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 
 function ReplayCurrentUrl() {
-  const {currentTime, replay} = useReplayContext();
+  const {replay} = useReplayContext();
+  const [currentTime, handleCurrentTime] = useState(0);
+  useReplayCurrentTime({callback: handleCurrentTime});
   const replayRecord = replay?.getReplay();
   const frames = replay?.getNavigationFrames();
   const projId = replayRecord?.project_id;

--- a/static/app/components/replays/timeAndScrubberGrid.tsx
+++ b/static/app/components/replays/timeAndScrubberGrid.tsx
@@ -1,4 +1,4 @@
-import {useRef} from 'react';
+import {useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
@@ -14,6 +14,7 @@ import formatReplayDuration from 'sentry/utils/duration/formatReplayDuration';
 import useTimelineScale, {
   TimelineScaleContextProvider,
 } from 'sentry/utils/replays/hooks/useTimelineScale';
+import useReplayCurrentTime from 'sentry/utils/replays/playback/hooks/useReplayCurrentTime';
 
 type TimeAndScrubberGridProps = {
   isCompact?: boolean;
@@ -58,7 +59,10 @@ export default function TimeAndScrubberGrid({
   isCompact = false,
   showZoom = false,
 }: TimeAndScrubberGridProps) {
-  const {currentTime, replay} = useReplayContext();
+  const {replay} = useReplayContext();
+  const [currentTime, handleCurrentTime] = useState(0);
+  useReplayCurrentTime({callback: handleCurrentTime});
+
   const durationMs = replay?.getDurationMs();
   const elem = useRef<HTMLDivElement>(null);
   const mouseTrackingProps = useScrubberMouseTracking({elem});

--- a/static/app/utils/replays/hooks/useA11yData.tsx
+++ b/static/app/utils/replays/hooks/useA11yData.tsx
@@ -1,9 +1,10 @@
-import {useMemo} from 'react';
+import {useMemo, useState} from 'react';
 
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {useQuery} from 'sentry/utils/queryClient';
 import type {RawA11yResponse} from 'sentry/utils/replays/hydrateA11yFrame';
 import hydrateA11yFrame from 'sentry/utils/replays/hydrateA11yFrame';
+import useReplayCurrentTime from 'sentry/utils/replays/playback/hooks/useReplayCurrentTime';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
@@ -11,7 +12,9 @@ import useProjects from 'sentry/utils/useProjects';
 export default function useA11yData() {
   const api = useApi();
   const organization = useOrganization();
-  const {currentTime, replay} = useReplayContext();
+  const {replay} = useReplayContext();
+  const [currentTime, handleCurrentTime] = useState(0);
+  useReplayCurrentTime({callback: handleCurrentTime});
   const {projects} = useProjects();
   const replayRecord = replay?.getReplay();
   const startTimestampMs = replayRecord?.started_at.getTime();

--- a/static/app/utils/replays/hooks/useShareReplayAtTimestamp.tsx
+++ b/static/app/utils/replays/hooks/useShareReplayAtTimestamp.tsx
@@ -4,13 +4,13 @@ import styled from '@emotion/styled';
 import {openModal} from 'sentry/actionCreators/modal';
 import RadioGroup from 'sentry/components/forms/controls/radioGroup';
 import Input from 'sentry/components/input';
-import {useReplayContext} from 'sentry/components/replays/replayContext';
 import TextCopyInput from 'sentry/components/textCopyInput';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {formatSecondsToClock} from 'sentry/utils/duration/formatSecondsToClock';
 import {parseClockToSeconds} from 'sentry/utils/duration/parseClockToSeconds';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
+import useReplayCurrentTime from 'sentry/utils/replays/playback/hooks/useReplayCurrentTime';
 import {useRoutes} from 'sentry/utils/useRoutes';
 
 function ShareModal({currentTimeSec, Header, Body}) {
@@ -73,14 +73,14 @@ function ShareModal({currentTimeSec, Header, Body}) {
 }
 
 export default function useShareReplayAtTimestamp() {
-  const {currentTime} = useReplayContext();
+  const {get: getCurrentTime} = useReplayCurrentTime();
 
   const handleShare = useCallback(() => {
     // floor() to remove ms level precision. It's a cleaner url by default this way.
-    const currentTimeSec = Math.floor(currentTime / 1000);
+    const currentTimeSec = Math.floor((getCurrentTime() ?? 0) / 1000);
 
     openModal(deps => <ShareModal currentTimeSec={currentTimeSec} {...deps} />);
-  }, [currentTime]);
+  }, [getCurrentTime]);
   return handleShare;
 }
 

--- a/static/app/utils/replays/playback/hooks/useEmitTimestampChanges.tsx
+++ b/static/app/utils/replays/playback/hooks/useEmitTimestampChanges.tsx
@@ -1,6 +1,6 @@
-import {useLayoutEffect} from 'react';
+import {useLayoutEffect, useState} from 'react';
 
-import {useReplayContext} from 'sentry/components/replays/replayContext';
+import useReplayCurrentTime from 'sentry/utils/replays/playback/hooks/useReplayCurrentTime';
 import useCurrentHoverTime from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 import {replayPlayerTimestampEmitter} from 'sentry/utils/replays/replayPlayerTimestampEmitter';
 
@@ -11,7 +11,8 @@ import {replayPlayerTimestampEmitter} from 'sentry/utils/replays/replayPlayerTim
  * <ReplayCurrentTimeContextProvider> ancestor node.
  */
 export default function useEmitTimestampChanges() {
-  const {currentTime} = useReplayContext();
+  const [currentTime, handleCurrentTime] = useState(0);
+  useReplayCurrentTime({callback: handleCurrentTime});
   const [currentHoverTime] = useCurrentHoverTime();
 
   useLayoutEffect(() => {

--- a/static/app/utils/replays/playback/hooks/useReplayCurrentTime.tsx
+++ b/static/app/utils/replays/playback/hooks/useReplayCurrentTime.tsx
@@ -1,0 +1,58 @@
+import {useEffect, useMemo} from 'react';
+
+import useReplayPlayerState from 'sentry/utils/replays/playback/providers/useReplayPlayerState';
+import useRAF from 'sentry/utils/useRAF';
+
+interface Props {
+  callback: (props: number) => void;
+}
+
+/**
+ * The basic way to use this hook+callback is to set state in the component:
+ * ```
+ * const [currentTime, setCurrentTime] = useState(0);
+ * useReplayCurrentTime({callback: setCurrentTime});
+ * ```
+ * or just call the returned getter:
+ * ```
+ * const currentTime = useReplayCurrentTime().get()
+ * ```
+ *
+ * For perf we could/should look at ways to update calculated state values
+ * inside the callback, or manipulate css directly without using react.
+ */
+export default function useReplayCurrentTime(props?: Props) {
+  const callback = props?.callback;
+  const {isFinished, playerState, replayers, startTimeOffsetMs} = useReplayPlayerState();
+  const replayer = replayers.at(0);
+  const state = replayer?.service.state;
+
+  useRAF(
+    () => {
+      if (replayer) {
+        callback?.(replayer.getCurrentTime() - startTimeOffsetMs);
+      }
+    },
+    {enabled: callback && replayer ? playerState === 'playing' : false}
+  );
+
+  useEffect(() => {
+    if (!callback) {
+      return;
+    }
+    if (state?.value === 'paused' && state?.context.timeOffset !== undefined) {
+      if (isFinished && replayer) {
+        callback(replayer.getCurrentTime() - startTimeOffsetMs);
+      } else {
+        callback(state.context.timeOffset - startTimeOffsetMs);
+      }
+    }
+  }, [callback, replayer, state, isFinished, startTimeOffsetMs]);
+
+  return useMemo(
+    () => ({
+      get: () => (replayer ? replayer.getCurrentTime() - startTimeOffsetMs : undefined),
+    }),
+    [replayer, startTimeOffsetMs]
+  );
+}

--- a/static/app/utils/replays/playback/providers/useReplayPlayerState.tsx
+++ b/static/app/utils/replays/playback/providers/useReplayPlayerState.tsx
@@ -1,0 +1,48 @@
+import type {ReactNode} from 'react';
+import {createContext, useContext} from 'react';
+import type {Replayer} from '@sentry-internal/rrweb';
+
+type Context = {
+  isFinished: boolean;
+  playerState: 'playing' | 'paused' | 'live';
+  replayers: Replayer[];
+  startTimeOffsetMs: number;
+};
+
+const ReplayPlayerStateContext = createContext<Context>({
+  isFinished: false,
+  playerState: 'paused',
+  replayers: [],
+  startTimeOffsetMs: 0,
+});
+
+export function ReplayPlayerStateFromContextProvider({
+  children,
+  isFinished,
+  isPlaying,
+  replayer,
+  startTimeOffsetMs,
+}: {
+  children: ReactNode;
+  isFinished: boolean;
+  isPlaying: boolean;
+  replayer: Replayer | undefined;
+  startTimeOffsetMs: number;
+}) {
+  return (
+    <ReplayPlayerStateContext.Provider
+      value={{
+        isFinished,
+        playerState: isPlaying ? 'playing' : 'paused',
+        replayers: replayer ? [replayer] : [],
+        startTimeOffsetMs,
+      }}
+    >
+      {children}
+    </ReplayPlayerStateContext.Provider>
+  );
+}
+
+export default function useReplayPlayerState() {
+  return useContext(ReplayPlayerStateContext);
+}

--- a/static/app/views/replays/detail/accessibility/accessibilityRefetchBanner.tsx
+++ b/static/app/views/replays/detail/accessibility/accessibilityRefetchBanner.tsx
@@ -8,6 +8,7 @@ import Well from 'sentry/components/well';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import formatReplayDuration from 'sentry/utils/duration/formatReplayDuration';
+import useReplayCurrentTime from 'sentry/utils/replays/playback/hooks/useReplayCurrentTime';
 import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 
 interface Props {
@@ -16,8 +17,9 @@ interface Props {
 }
 
 export default function AccessibilityRefetchBanner({initialOffsetMs, refetch}: Props) {
-  const {currentTime, replay, setCurrentTime, isPlaying, togglePlayPause} =
-    useReplayContext();
+  const {replay, setCurrentTime, isPlaying, togglePlayPause} = useReplayContext();
+  const [currentTime, handleCurrentTime] = useState(0);
+  useReplayCurrentTime({callback: handleCurrentTime});
 
   const startTimestampMs = replay?.getReplay()?.started_at?.getTime() ?? 0;
   const [lastOffsetMs, setLastOffsetMs] = useState(initialOffsetMs);

--- a/static/app/views/replays/detail/accessibility/index.tsx
+++ b/static/app/views/replays/detail/accessibility/index.tsx
@@ -5,7 +5,6 @@ import styled from '@emotion/styled';
 
 import Placeholder from 'sentry/components/placeholder';
 import JumpButtons from 'sentry/components/replays/jumpButtons';
-import {useReplayContext} from 'sentry/components/replays/replayContext';
 import useJumpButtons from 'sentry/components/replays/useJumpButtons';
 import {GridTable} from 'sentry/components/replays/virtualizedGrid/gridTable';
 import {OverflowHidden} from 'sentry/components/replays/virtualizedGrid/overflowHidden';
@@ -15,6 +14,7 @@ import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useA11yData from 'sentry/utils/replays/hooks/useA11yData';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
+import useReplayCurrentTime from 'sentry/utils/replays/playback/hooks/useReplayCurrentTime';
 import useCurrentHoverTime from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 import useOrganization from 'sentry/utils/useOrganization';
 import AccessibilityFilters from 'sentry/views/replays/detail/accessibility/accessibilityFilters';
@@ -44,7 +44,8 @@ const cellMeasurer = {
 
 function AccessibilityList() {
   const organization = useOrganization();
-  const {currentTime} = useReplayContext();
+  const [currentTime, handleCurrentTime] = useState(0);
+  useReplayCurrentTime({callback: handleCurrentTime});
   const [currentHoverTime] = useCurrentHoverTime();
   const {onMouseEnter, onMouseLeave, onClickTimestamp} = useCrumbHandlers();
 

--- a/static/app/views/replays/detail/breadcrumbs/breadcrumbRow.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/breadcrumbRow.tsx
@@ -1,11 +1,11 @@
 import type {CSSProperties, MouseEvent} from 'react';
-import {useCallback} from 'react';
+import {useCallback, useState} from 'react';
 import classNames from 'classnames';
 
 import BreadcrumbItem from 'sentry/components/replays/breadcrumbs/breadcrumbItem';
-import {useReplayContext} from 'sentry/components/replays/replayContext';
 import type {Extraction} from 'sentry/utils/replays/extractHtml';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
+import useReplayCurrentTime from 'sentry/utils/replays/playback/hooks/useReplayCurrentTime';
 import useCurrentHoverTime from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 import type {ReplayFrame} from 'sentry/utils/replays/types';
 
@@ -36,7 +36,8 @@ export default function BreadcrumbRow({
   startTimestampMs,
   style,
 }: Props) {
-  const {currentTime} = useReplayContext();
+  const [currentTime, handleCurrentTime] = useState(0);
+  useReplayCurrentTime({callback: handleCurrentTime});
   const [currentHoverTime] = useCurrentHoverTime();
 
   const {onMouseEnter, onMouseLeave} = useCrumbHandlers();

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -9,6 +9,7 @@ import useJumpButtons from 'sentry/components/replays/useJumpButtons';
 import {t} from 'sentry/locale';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import useExtractDomNodes from 'sentry/utils/replays/hooks/useExtractDomNodes';
+import useReplayCurrentTime from 'sentry/utils/replays/playback/hooks/useReplayCurrentTime';
 import useVirtualizedInspector from 'sentry/views/replays/detail//useVirtualizedInspector';
 import BreadcrumbFilters from 'sentry/views/replays/detail/breadcrumbs/breadcrumbFilters';
 import BreadcrumbRow from 'sentry/views/replays/detail/breadcrumbs/breadcrumbRow';
@@ -28,7 +29,9 @@ const cellMeasurer = {
 };
 
 function Breadcrumbs() {
-  const {currentTime, replay} = useReplayContext();
+  const {replay} = useReplayContext();
+  const [currentTime, handleCurrentTime] = useState(0);
+  useReplayCurrentTime({callback: handleCurrentTime});
   const {onClickTimestamp} = useCrumbHandlers();
 
   const {data: frameToExtraction, isFetching: isFetchingExtractions} = useExtractDomNodes(

--- a/static/app/views/replays/detail/breadcrumbs/useScrollToCurrentItem.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/useScrollToCurrentItem.tsx
@@ -1,9 +1,9 @@
 import type {RefObject} from 'react';
-import {useEffect, useMemo} from 'react';
+import {useEffect, useMemo, useState} from 'react';
 import type {List as ReactVirtualizedList} from 'react-virtualized';
 
-import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {getPrevReplayFrame} from 'sentry/utils/replays/getReplayEvent';
+import useReplayCurrentTime from 'sentry/utils/replays/playback/hooks/useReplayCurrentTime';
 import type {ReplayFrame} from 'sentry/utils/replays/types';
 
 interface Opts {
@@ -12,7 +12,9 @@ interface Opts {
 }
 
 function useScrollToCurrentItem({frames, ref}: Opts) {
-  const {currentTime} = useReplayContext();
+  const [currentTime, handleCurrentTime] = useState(0);
+  useReplayCurrentTime({callback: handleCurrentTime});
+
   const currentItem = useMemo(
     () =>
       getPrevReplayFrame({

--- a/static/app/views/replays/detail/console/index.tsx
+++ b/static/app/views/replays/detail/console/index.tsx
@@ -8,6 +8,7 @@ import {useReplayContext} from 'sentry/components/replays/replayContext';
 import useJumpButtons from 'sentry/components/replays/useJumpButtons';
 import {t} from 'sentry/locale';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
+import useReplayCurrentTime from 'sentry/utils/replays/playback/hooks/useReplayCurrentTime';
 import useCurrentHoverTime from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 import ConsoleFilters from 'sentry/views/replays/detail/console/consoleFilters';
 import ConsoleLogRow from 'sentry/views/replays/detail/console/consoleLogRow';
@@ -27,7 +28,9 @@ const cellMeasurer = {
 };
 
 function Console() {
-  const {currentTime, replay} = useReplayContext();
+  const {replay} = useReplayContext();
+  const [currentTime, handleCurrentTime] = useState(0);
+  useReplayCurrentTime({callback: handleCurrentTime});
   const [currentHoverTime] = useCurrentHoverTime();
   const {onMouseEnter, onMouseLeave, onClickTimestamp} = useCrumbHandlers();
 

--- a/static/app/views/replays/detail/errorList/index.tsx
+++ b/static/app/views/replays/detail/errorList/index.tsx
@@ -9,6 +9,7 @@ import {useReplayContext} from 'sentry/components/replays/replayContext';
 import useJumpButtons from 'sentry/components/replays/useJumpButtons';
 import {t} from 'sentry/locale';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
+import useReplayCurrentTime from 'sentry/utils/replays/playback/hooks/useReplayCurrentTime';
 import useCurrentHoverTime from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 import ErrorFilters from 'sentry/views/replays/detail/errorList/errorFilters';
 import ErrorHeaderCell, {
@@ -31,7 +32,9 @@ const cellMeasurer = {
 };
 
 function ErrorList() {
-  const {currentTime, replay} = useReplayContext();
+  const {replay} = useReplayContext();
+  const [currentTime, handleCurrentTime] = useState(0);
+  useReplayCurrentTime({callback: handleCurrentTime});
   const [currentHoverTime] = useCurrentHoverTime();
   const {onMouseEnter, onMouseLeave, onClickTimestamp} = useCrumbHandlers();
 

--- a/static/app/views/replays/detail/memoryPanel/domNodesChart.tsx
+++ b/static/app/views/replays/detail/memoryPanel/domNodesChart.tsx
@@ -18,9 +18,9 @@ import domId from 'sentry/utils/domId';
 import formatReplayDuration from 'sentry/utils/duration/formatReplayDuration';
 import type {DomNodeChartDatapoint} from 'sentry/utils/replays/hooks/useCountDomNodes';
 
-interface Props
-  extends Pick<ReturnType<typeof useReplayContext>, 'currentTime' | 'setCurrentTime'> {
+interface Props extends Pick<ReturnType<typeof useReplayContext>, 'setCurrentTime'> {
   currentHoverTime: undefined | number;
+  currentTime: number;
   datapoints: DomNodeChartDatapoint[];
   durationMs: number;
   setCurrentHoverTime: Dispatch<SetStateAction<number | undefined>>;

--- a/static/app/views/replays/detail/memoryPanel/index.tsx
+++ b/static/app/views/replays/detail/memoryPanel/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import EmptyMessage from 'sentry/components/emptyMessage';
@@ -7,12 +7,15 @@ import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useCountDomNodes from 'sentry/utils/replays/hooks/useCountDomNodes';
+import useReplayCurrentTime from 'sentry/utils/replays/playback/hooks/useReplayCurrentTime';
 import useCurrentHoverTime from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 import DomNodesChart from 'sentry/views/replays/detail/memoryPanel/domNodesChart';
 import MemoryChart from 'sentry/views/replays/detail/memoryPanel/memoryChart';
 
 export default function MemoryPanel() {
-  const {currentTime, isFetching, replay, setCurrentTime} = useReplayContext();
+  const {isFetching, replay, setCurrentTime} = useReplayContext();
+  const [currentTime, handleCurrentTime] = useState(0);
+  useReplayCurrentTime({callback: handleCurrentTime});
   const [currentHoverTime, setCurrentHoverTime] = useCurrentHoverTime();
 
   const memoryFrames = replay?.getMemoryFrames();

--- a/static/app/views/replays/detail/memoryPanel/memoryChart.tsx
+++ b/static/app/views/replays/detail/memoryPanel/memoryChart.tsx
@@ -18,9 +18,9 @@ import domId from 'sentry/utils/domId';
 import formatReplayDuration from 'sentry/utils/duration/formatReplayDuration';
 import type {MemoryFrame} from 'sentry/utils/replays/types';
 
-interface Props
-  extends Pick<ReturnType<typeof useReplayContext>, 'currentTime' | 'setCurrentTime'> {
+interface Props extends Pick<ReturnType<typeof useReplayContext>, 'setCurrentTime'> {
   currentHoverTime: undefined | number;
+  currentTime: number;
   durationMs: number;
   memoryFrames: MemoryFrame[];
   setCurrentHoverTime: Dispatch<SetStateAction<number | undefined>>;

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -13,6 +13,7 @@ import useDetailsSplit from 'sentry/components/replays/virtualizedGrid/useDetail
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
+import useReplayCurrentTime from 'sentry/utils/replays/playback/hooks/useReplayCurrentTime';
 import useCurrentHoverTime from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 import {getFrameMethod, getFrameStatus} from 'sentry/utils/replays/resourceFrame';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -42,7 +43,9 @@ const cellMeasurer = {
 
 function NetworkList() {
   const organization = useOrganization();
-  const {currentTime, replay} = useReplayContext();
+  const {replay} = useReplayContext();
+  const [currentTime, handleCurrentTime] = useState(0);
+  useReplayCurrentTime({callback: handleCurrentTime});
   const [currentHoverTime] = useCurrentHoverTime();
   const {onMouseEnter, onMouseLeave, onClickTimestamp} = useCrumbHandlers();
 


### PR DESCRIPTION
Before we had our `currentTime` stored as state inside ReplayContext. This meant that whenever any state inside ReplayContext changed, everything would re-render. This was bad because there's two kinds of things on the page: those that depend on currentTime, and everything else; they should re-render at different frequencies but` couldn't because of the shared Context and massive state.

So now we have a new hook for accessing `currentTime`, called: `useReplayCurrentTime`. 
- The first thing to notice is that it's moving the state value that we had before out of ReplayContext and into all the callsites around the codebase. This benefits anything that depends on ReplayContext because changes to `currentTime` will not force re-renders. 
- The second thing to notice is that the API for `useReplayCurrentTime` provides a callback, as well as a stable getter function. So we can (in a followup PR) avoid setting state in all the callsites by either: a) calling the getting as needed (see `useShareReplayAtTimestamp` for an example) or b) we can calculate a more complex state that changes less often inside the callback (no example for this right now) and store that instead of a frequently changing timestamp. Using those techniques means we can reduce re-renders for places that depend on `currentTime`.

This PR focuses on changing over the interfaces of things, and is very mechanical. There's no render performance improvement for anything because we still have that `const isBuffering` statement inside of ReplayContext which depends on `useCurrentTime(getCurrentPlayerTime)` which itself has state inside it :(

But! once that `useCurrentTime` internal hook is gone we'll be able to see render improvements. Here's how changes to `useShareReplayAtTimestamp` will result in better re-render perf for the whole header:
| Before | After |
| --- | --- |
| <img width="1006" alt="before" src="https://github.com/user-attachments/assets/dd9c8064-28af-483c-b8eb-b01693d8fc9c"> | <img width="1074" alt="after" src="https://github.com/user-attachments/assets/34916ecd-290d-4af1-a933-fc34c8e77de3"> |
