### PR TITLE
ref: move ScheduleEntry to the modules which need it

### DIFF
--- a/src/sentry/digests/__init__.py
+++ b/src/sentry/digests/__init__.py
@@ -32,11 +32,6 @@ class Record(NamedTuple):
         return to_datetime(self.timestamp)
 
 
-class ScheduleEntry(NamedTuple):
-    key: str
-    timestamp: float
-
-
 OPTIONS = frozenset(("increment_delay", "maximum_delay", "minimum_delay"))
 
 Digest: TypeAlias = MutableMapping["Rule", MutableMapping["Group", list[Record]]]

--- a/src/sentry/digests/backends/base.py
+++ b/src/sentry/digests/backends/base.py
@@ -1,15 +1,22 @@
+from __future__ import annotations
+
 import logging
 from collections.abc import Iterable, Mapping
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from sentry.utils.imports import import_string
 from sentry.utils.services import Service
 
 if TYPE_CHECKING:
-    from sentry.digests import Record, ScheduleEntry
+    from sentry.digests import Record
     from sentry.models.project import Project
 
 logger = logging.getLogger("sentry.digests")
+
+
+class ScheduleEntry(NamedTuple):
+    key: str
+    timestamp: float
 
 
 def load(options: Mapping[str, str]) -> Any:
@@ -106,7 +113,7 @@ class Backend(Service):
             else:
                 self.truncation_chance = 0.0
 
-    def enabled(self, project: "Project") -> bool:
+    def enabled(self, project: Project) -> bool:
         """
         Check if a project has digests enabled.
         """
@@ -115,7 +122,7 @@ class Backend(Service):
     def add(
         self,
         key: str,
-        record: "Record",
+        record: Record,
         increment_delay: int | None = None,
         maximum_delay: int | None = None,
         timestamp: float | None = None,
@@ -169,9 +176,7 @@ class Backend(Service):
         """
         raise NotImplementedError
 
-    def schedule(
-        self, deadline: float, timestamp: float | None = None
-    ) -> Iterable["ScheduleEntry"]:
+    def schedule(self, deadline: float, timestamp: float | None = None) -> Iterable[ScheduleEntry]:
         """
         Identify timelines that are ready for processing.
 

--- a/src/sentry/digests/backends/dummy.py
+++ b/src/sentry/digests/backends/dummy.py
@@ -2,10 +2,10 @@ from collections.abc import Iterable
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
-from sentry.digests.backends.base import Backend
+from sentry.digests.backends.base import Backend, ScheduleEntry
 
 if TYPE_CHECKING:
-    from sentry.digests import Record, ScheduleEntry
+    from sentry.digests import Record
     from sentry.models.project import Project
 
 

--- a/src/sentry/digests/backends/redis.py
+++ b/src/sentry/digests/backends/redis.py
@@ -7,8 +7,8 @@ from typing import Any
 from rb.clients import LocalClient
 from redis.exceptions import ResponseError
 
-from sentry.digests import Record, ScheduleEntry
-from sentry.digests.backends.base import Backend, InvalidState
+from sentry.digests import Record
+from sentry.digests.backends.base import Backend, InvalidState, ScheduleEntry
 from sentry.utils.locking.backends.redis import RedisLockBackend
 from sentry.utils.locking.lock import Lock
 from sentry.utils.locking.manager import LockManager


### PR DESCRIPTION
fixes one typing cycle

split out from fixing the typing of `sentry.digests.notifications`

<!-- Describe your PR here. -->