### PR TITLE
fix(custom-views): Make add view button and temporary tab animate with tab bar

### DIFF
--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -7,7 +7,7 @@ import {ListCollection} from '@react-stately/list';
 import type {TabListStateOptions} from '@react-stately/tabs';
 import {useTabListState} from '@react-stately/tabs';
 import type {Node, Orientation} from '@react-types/shared';
-import {Reorder} from 'framer-motion';
+import {motion, Reorder} from 'framer-motion';
 
 import {Button} from 'sentry/components/button';
 import type {SelectOption} from 'sentry/components/compactSelect';
@@ -120,6 +120,7 @@ function BaseDraggableTabList({
         values={[...state.collection]}
         onReorder={onReorder}
         as="div"
+        layoutRoot
       >
         <TabListWrap
           {...tabListProps}
@@ -136,6 +137,7 @@ function BaseDraggableTabList({
                 value={item}
                 style={{display: 'flex', flexDirection: 'row'}}
                 as="div"
+                layout
               >
                 <Tab
                   key={item.key}
@@ -152,29 +154,33 @@ function BaseDraggableTabList({
               {(state.selectedKey === 'temporary-tab' ||
                 (state.selectedKey !== item.key &&
                   state.collection.getKeyAfter(item.key) !== state.selectedKey)) && (
-                <TabDivider />
+                <TabDivider layout />
               )}
             </Fragment>
           ))}
-          <AddViewButton borderless size="zero" onClick={onAddView}>
-            <StyledIconAdd size="xs" />
-            {t('Add View')}
-          </AddViewButton>
-          <TabDivider />
-          {showTempTab && tempTab && (
-            <Tab
-              key={tempTab.key}
-              item={tempTab}
-              state={state}
-              orientation={orientation}
-              overflowing={
-                orientation === 'horizontal' && overflowTabs.includes(tempTab.key)
-              }
-              ref={element => (tabItemsRef.current[tempTab.key] = element)}
-              variant={tabVariant}
-              borderStyle="dashed"
-            />
-          )}
+          <MotionWrapper layout>
+            <AddViewButton borderless size="zero" onClick={onAddView}>
+              <StyledIconAdd size="xs" />
+              {t('Add View')}
+            </AddViewButton>
+          </MotionWrapper>
+          <TabDivider layout />
+          <MotionWrapper layout>
+            {showTempTab && tempTab && (
+              <Tab
+                key={tempTab.key}
+                item={tempTab}
+                state={state}
+                orientation={orientation}
+                overflowing={
+                  orientation === 'horizontal' && overflowTabs.includes(tempTab.key)
+                }
+                ref={element => (tabItemsRef.current[tempTab.key] = element)}
+                variant={tabVariant}
+                borderStyle="dashed"
+              />
+            )}
+          </MotionWrapper>
         </TabListWrap>
       </Reorder.Group>
 
@@ -244,7 +250,7 @@ export function DraggableTabList({
 
 DraggableTabList.Item = Item;
 
-const TabDivider = styled('div')`
+const TabDivider = styled(motion.div)`
   height: 50%;
   width: 1px;
   border-radius: 6px;
@@ -289,13 +295,19 @@ const TabListWrap = styled('ul', {
 `;
 
 const AddViewButton = styled(Button)`
+  display: flex;
   color: ${p => p.theme.gray300};
   padding-right: ${space(0.5)};
-  margin: 3px 2px 2px 2px;
+  margin: 4px 2px 2px 2px;
   font-weight: normal;
 `;
 
 const StyledIconAdd = styled(IconAdd)`
   margin-right: 4px;
   margin-left: 2px;
+`;
+
+const MotionWrapper = styled(motion.div)`
+  display: flex;
+  position: relative;
 `;


### PR DESCRIPTION
This PR makes subtle improvements to the animations in the draggable tab bar. Specifically, it fixes the issue where the Add View Button would jump to its new position anytime the tab bar width changed, rather than animating with the other elements:

Before: 

https://github.com/user-attachments/assets/7e2a3d98-3472-4ef0-984a-e9646d8cb1be

After: 

https://github.com/user-attachments/assets/3ac87819-9ac9-4a20-83a6-27483be47ea7
