### PR TITLE
feat(custom-views): Add drag barriers to tab bar

### DIFF
--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -215,7 +215,6 @@ const TabDivider = styled(motion.div)`
   width: 1px;
   border-radius: 6px;
   background-color: ${p => p.theme.gray200};
-  margin: 8px 4px;
 `;
 
 const TabListOuterWrap = styled('div')<{
@@ -235,6 +234,7 @@ const AddViewTempTabWrap = styled('div')`
   flex-shrink: 0;
   grid-auto-flow: column;
   justify-content: start;
+  align-items: center;
 `;
 
 const TabListWrap = styled('ul')`
@@ -246,6 +246,7 @@ const TabListWrap = styled('ul')`
   margin: 0;
   list-style-type: none;
   flex-shrink: 0;
+  align-items: center;
 `;
 
 const AddViewButton = styled(Button)`

--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -38,6 +38,8 @@ function BaseDraggableTabList({
   ...props
 }: BaseDraggableTabListProps) {
   const tabListRef = useRef<HTMLUListElement>(null);
+  // This ref is used to define the container that the tabs can be dragged within
+  const dragConstraintsRef = useRef<HTMLDivElement>(null);
   const {rootProps, setTabListState} = useContext(TabsContext);
   const {
     value,
@@ -114,7 +116,7 @@ function BaseDraggableTabList({
   const tempTab = [...state.collection].find(item => item.key === 'temporary-tab');
 
   return (
-    <TabListOuterWrap style={outerWrapStyles}>
+    <TabListOuterWrap style={outerWrapStyles} ref={dragConstraintsRef}>
       <Reorder.Group
         axis="x"
         values={[...state.collection]}
@@ -137,6 +139,9 @@ function BaseDraggableTabList({
                 value={item}
                 style={{display: 'flex', flexDirection: 'row'}}
                 as="div"
+                dragConstraints={dragConstraintsRef} // Sets the container that the tabs can be dragged within
+                dragElastic={0} // Prevents tabs from being dragged outside of the tab bar
+                dragTransition={{bounceStiffness: 400, bounceDamping: 40}} // Recovers spring behavior thats lost when using dragElastic
                 layout
               >
                 <Tab


### PR DESCRIPTION
This PR adds drag constraints to the draggable tablist component. That is, it defines a container that the tabs can be dragged within. ~I've set this container to be the entire bar, including the empty area to the right of the add view button, though dragging the tab beyond the add view button will just snap it back to the last position. If necessary, we can change this container to be just within the section left of the Add View button.~

Update: Due to conflicting behavior with the overflow menu, I have change the behavior to only allow tabs to be dragged within the persistent tabs container (to the left of the add view). I have also removed the overflow menu entirely from this PR due to incompatibility with the draggable tabs component. This logic was copied directly over from the existing tabs component, but it needs to be refactored for this component since there are more elements in the tab bar now. This refactor will come in a future PR. 

Before:  

https://github.com/user-attachments/assets/0bdc21d6-53e0-45ca-850a-1984f02189d1


After: 

https://github.com/user-attachments/assets/6f49218e-3823-426f-bd53-b19e8be8779d
