### PR TITLE
ref(similarity): Skip frames with js base64 filenames in stacktrace

### DIFF
--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -11,7 +11,6 @@ logger = logging.getLogger(__name__)
 MAX_FRAME_COUNT = 30
 FULLY_MINIFIED_STACKTRACE_MAX_FRAME_COUNT = 20
 SEER_ELIGIBLE_PLATFORMS = frozenset(["python", "javascript", "node"])
-BASE64_FILENAME_TRUNCATION_LENGTH = 150
 
 
 def _get_value_if_exists(exception_value: dict[str, Any]) -> str:
@@ -89,7 +88,9 @@ def get_stacktrace_string(data: dict[str, Any]) -> str:
 
                     # We want to skip frames with base64 encoded filenames since they can be large
                     # and not contain any usable information
-                    if frame_dict["filename"].startswith("data:text/html;base64"):
+                    if frame_dict["filename"].startswith("data:text/html;base64") or frame_dict[
+                        "filename"
+                    ].startswith("data:text/javascript;base64"):
                         metrics.incr(
                             "seer.grouping.base64_encoded_filename",
                             sample_rate=1.0,

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -719,8 +719,17 @@ class GetStacktraceStringTest(TestCase):
         assert _is_snipped_context_line("{snip} dogs are great {snip}") is True
         assert _is_snipped_context_line("dogs are great") is False
 
-    def test_only_frame_base64_encoded_filename(self):
+    def test_only_frame_text_base64_encoded_filename(self):
         base64_filename = "data:text/html;base64 extra content that could be long and useless"
+        data_base64_encoded_filename = copy.deepcopy(self.BASE_APP_DATA)
+        data_base64_encoded_filename["app"]["component"]["values"][0]["values"][0]["values"][0][
+            "values"
+        ][1]["values"][0] = base64_filename
+        stacktrace_str = get_stacktrace_string(data_base64_encoded_filename)
+        assert stacktrace_str == "ZeroDivisionError: division by zero"
+
+    def test_only_frame_js_base64_encoded_filename(self):
+        base64_filename = "data:text/javascript;base64 extra content that could be long and useless"
         data_base64_encoded_filename = copy.deepcopy(self.BASE_APP_DATA)
         data_base64_encoded_filename["app"]["component"]["values"][0]["values"][0]["values"][0][
             "values"


### PR DESCRIPTION
Also skip filenames that start with data:text/javascript;base64 in similarity stacktrace parsing
These can be quite long and useless