### PR TITLE
chore(uptime): Include status reason in the `handle_result_for_project` stat

### DIFF
--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -99,6 +99,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
         metrics.incr(
             "uptime.result_processor.handle_result_for_project",
             tags={"status_reason": status_reason, **metric_tags},
+            sample_rate=1.0,
         )
         cluster = _get_cluster()
         try:

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -91,7 +91,15 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
             "status": result["status"],
             "mode": ProjectUptimeSubscriptionMode(project_subscription.mode).name.lower(),
         }
-        metrics.incr("uptime.result_processor.handle_result_for_project", tags=metric_tags)
+
+        status_reason = "none"
+        if result["status_reason"]:
+            status_reason = result["status_reason"]["type"]
+
+        metrics.incr(
+            "uptime.result_processor.handle_result_for_project",
+            tags={"status_reason": status_reason, **metric_tags},
+        )
         cluster = _get_cluster()
         try:
             if result["scheduled_check_time_ms"] <= last_update_ms:

--- a/tests/sentry/uptime/consumers/test_results_consumers.py
+++ b/tests/sentry/uptime/consumers/test_results_consumers.py
@@ -73,7 +73,12 @@ class ProcessResultTest(UptimeTestCase):
                 [
                     call(
                         "uptime.result_processor.handle_result_for_project",
-                        tags={"status": CHECKSTATUS_FAILURE, "mode": "auto_detected_active"},
+                        tags={
+                            "status_reason": "timeout",
+                            "status": "failure",
+                            "mode": "auto_detected_active",
+                        },
+                        sample_rate=1.0,
                     ),
                 ]
             )
@@ -92,8 +97,13 @@ class ProcessResultTest(UptimeTestCase):
                 [
                     call(
                         "uptime.result_processor.handle_result_for_project",
-                        tags={"status": CHECKSTATUS_FAILURE, "mode": "auto_detected_active"},
-                    ),
+                        tags={
+                            "status_reason": "timeout",
+                            "status": "failure",
+                            "mode": "auto_detected_active",
+                        },
+                        sample_rate=1.0,
+                    )
                 ]
             )
 
@@ -116,7 +126,12 @@ class ProcessResultTest(UptimeTestCase):
                 [
                     call(
                         "uptime.result_processor.handle_result_for_project",
-                        tags={"status": CHECKSTATUS_FAILURE, "mode": "auto_detected_active"},
+                        tags={
+                            "status_reason": "timeout",
+                            "status": "failure",
+                            "mode": "auto_detected_active",
+                        },
+                        sample_rate=1.0,
                     ),
                 ]
             )
@@ -141,8 +156,13 @@ class ProcessResultTest(UptimeTestCase):
                 [
                     call(
                         "uptime.result_processor.handle_result_for_project",
-                        tags={"status": CHECKSTATUS_SUCCESS, "mode": "auto_detected_active"},
-                    ),
+                        tags={
+                            "status_reason": "timeout",
+                            "status": "success",
+                            "mode": "auto_detected_active",
+                        },
+                        sample_rate=1.0,
+                    )
                 ]
             )
         group.refresh_from_db()
@@ -175,7 +195,12 @@ class ProcessResultTest(UptimeTestCase):
                 [
                     call(
                         "uptime.result_processor.handle_result_for_project",
-                        tags={"status": CHECKSTATUS_FAILURE, "mode": "auto_detected_active"},
+                        tags={
+                            "status_reason": "timeout",
+                            "status": "failure",
+                            "mode": "auto_detected_active",
+                        },
+                        sample_rate=1.0,
                     ),
                     call(
                         "uptime.result_processor.skipping_already_processed_update",
@@ -201,7 +226,12 @@ class ProcessResultTest(UptimeTestCase):
             self.send_result(result)
             metrics.incr.assert_called_once_with(
                 "uptime.result_processor.handle_result_for_project",
-                tags={"status": CHECKSTATUS_MISSED_WINDOW, "mode": "auto_detected_active"},
+                tags={
+                    "status": CHECKSTATUS_MISSED_WINDOW,
+                    "mode": "auto_detected_active",
+                    "status_reason": "timeout",
+                },
+                sample_rate=1.0,
             )
             logger.info.assert_any_call(
                 "handle_result_for_project.missed",
@@ -231,7 +261,12 @@ class ProcessResultTest(UptimeTestCase):
                 [
                     call(
                         "uptime.result_processor.handle_result_for_project",
-                        tags={"status": CHECKSTATUS_FAILURE, "mode": "auto_detected_onboarding"},
+                        tags={
+                            "status": CHECKSTATUS_FAILURE,
+                            "mode": "auto_detected_onboarding",
+                            "status_reason": "timeout",
+                        },
+                        sample_rate=1.0,
                     ),
                 ]
             )
@@ -259,7 +294,12 @@ class ProcessResultTest(UptimeTestCase):
                 [
                     call(
                         "uptime.result_processor.handle_result_for_project",
-                        tags={"status": CHECKSTATUS_FAILURE, "mode": "auto_detected_onboarding"},
+                        tags={
+                            "status": CHECKSTATUS_FAILURE,
+                            "mode": "auto_detected_onboarding",
+                            "status_reason": "timeout",
+                        },
+                        sample_rate=1.0,
                     ),
                     call(
                         "uptime.result_processor.autodetection.failed_onboarding",
@@ -300,7 +340,12 @@ class ProcessResultTest(UptimeTestCase):
                 [
                     call(
                         "uptime.result_processor.handle_result_for_project",
-                        tags={"status": CHECKSTATUS_SUCCESS, "mode": "auto_detected_onboarding"},
+                        tags={
+                            "status_reason": "timeout",
+                            "status": "success",
+                            "mode": "auto_detected_onboarding",
+                        },
+                        sample_rate=1.0,
                     ),
                 ]
             )
@@ -333,7 +378,12 @@ class ProcessResultTest(UptimeTestCase):
                 [
                     call(
                         "uptime.result_processor.handle_result_for_project",
-                        tags={"status": CHECKSTATUS_SUCCESS, "mode": "auto_detected_onboarding"},
+                        tags={
+                            "status_reason": "timeout",
+                            "status": "success",
+                            "mode": "auto_detected_onboarding",
+                        },
+                        sample_rate=1.0,
                     ),
                     call(
                         "uptime.result_processor.autodetection.graduated_onboarding",


### PR DESCRIPTION
This helps us understand the reasons for failures in the result consumer graph
