### PR TITLE
feat(query-builder): Use new design for filter key menu

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -501,6 +501,11 @@ describe('SearchQueryBuilder', function () {
       render(<SearchQueryBuilder {...defaultProps} />);
       await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
 
+      // Should show tab button for each section
+      expect(await screen.findByRole('button', {name: 'All'})).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Category 1'})).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Category 2'})).toBeInTheDocument();
+
       const menu = screen.getByRole('listbox');
       const groups = within(menu).getAllByRole('group');
       expect(groups).toHaveLength(2);
@@ -518,6 +523,13 @@ describe('SearchQueryBuilder', function () {
       expect(
         within(group2).getByRole('option', {name: 'custom_tag_name'})
       ).toBeInTheDocument();
+
+      // Clicking "Category 2" should filter the options to only category 2
+      await userEvent.click(screen.getByRole('button', {name: 'Category 2'}));
+      await waitFor(() => {
+        expect(screen.queryByRole('option', {name: 'age'})).not.toBeInTheDocument();
+      });
+      expect(screen.getByRole('option', {name: 'custom_tag_name'})).toBeInTheDocument();
     });
 
     it('can search by key description', async function () {

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -86,13 +86,7 @@ const FITLER_KEY_SECTIONS: FilterKeySection[] = [
   {
     value: 'cat_1',
     label: 'Category 1',
-    children: [
-      FieldKey.ASSIGNED,
-      FieldKey.BROWSER_NAME,
-      FieldKey.IS,
-      FieldKey.LAST_SEEN,
-      FieldKey.TIMES_SEEN,
-    ],
+    children: [FieldKey.ASSIGNED, FieldKey.BROWSER_NAME, FieldKey.IS],
   },
   {
     value: 'cat_2',
@@ -102,6 +96,16 @@ const FITLER_KEY_SECTIONS: FilterKeySection[] = [
   {
     value: 'cat_3',
     label: 'Category 3',
+    children: [FieldKey.TIMES_SEEN],
+  },
+  {
+    value: 'cat_4',
+    label: 'Category 4',
+    children: [FieldKey.LAST_SEEN],
+  },
+  {
+    value: 'cat_5',
+    label: 'Category 5',
     children: ['custom_tag_name'],
   },
 ];

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -8,7 +8,6 @@ import {
   useLayoutEffect,
   useMemo,
   useRef,
-  useState,
 } from 'react';
 import {usePopper} from 'react-popper';
 import styled from '@emotion/styled';
@@ -164,7 +163,7 @@ function menuIsOpen({
     return openState;
   }
 
-  // When the tabbed menu is not being displayed and we aren't loading anything,
+  // When a custom menu is not being displayed and we aren't loading anything,
   // only show when there is something to select from.
   return openState && totalOptions > hiddenOptions.size;
 }
@@ -249,8 +248,6 @@ function OverlayContent<T extends SelectOptionOrSectionWithKey<string>>({
   listBoxProps: AriaListBoxOptions<any>;
   listBoxRef: React.RefObject<HTMLUListElement>;
   popoverRef: React.RefObject<HTMLDivElement>;
-  selectedSection: Key | null;
-  setSelectedSection: (section: Key | null) => void;
   state: ComboBoxState<any>;
   totalOptions: number;
   customMenu?: CustomComboboxMenu<T>;
@@ -326,7 +323,6 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
   const listBoxRef = useRef<HTMLUListElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
-  const [selectedSection, setSelectedSection] = useState<Key | null>(null);
   const descriptionRef = useRef<HTMLDivElement>(null);
 
   const {hiddenOptions, disabledKeys} = useHiddenItems({
@@ -362,7 +358,7 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
     children,
     allowsEmptyCollection: true,
     // We handle closing on blur ourselves to prevent the combobox from closing
-    // when the user clicks inside the tabbed menu
+    // when the user clicks inside the custom menu
     shouldCloseOnBlur: false,
     ...comboBoxProps,
   });
@@ -491,8 +487,8 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
   });
 
   // useCombobox will hide outside elements with aria-hidden="true" when it is open [1].
-  // Because we switch elements when the custom or tabbed menu is displayed, we need to
-  // manually call this function an extra time to ensure the correct elements are hidden.
+  // Because we switch elements when a custom menu is displayed, we need to manually
+  // call this function an extra time to ensure the correct elements are hidden.
   //
   // [1]: https://github.com/adobe/react-spectrum/blob/main/packages/%40react-aria/combobox/src/useComboBox.ts#L337C3-L341C44
   useEffect(() => {
@@ -541,8 +537,6 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
           listBoxProps={listBoxProps}
           listBoxRef={listBoxRef}
           popoverRef={popoverRef}
-          selectedSection={selectedSection}
-          setSelectedSection={setSelectedSection}
           state={state}
           totalOptions={totalOptions}
         />

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -172,7 +172,7 @@ const SectionButton = styled(Button)`
   text-align: left;
   font-weight: ${p => p.theme.fontWeightNormal};
   font-size: ${p => p.theme.fontSizeSmall};
-  padding: 0 ${space(1)};
+  padding: 0 ${space(1.5)};
   color: ${p => p.theme.subText};
   border: 0;
 

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -140,13 +140,9 @@ export function FilterKeyListBox<T extends SelectOptionOrSectionWithKey<string>>
 }
 
 const SectionedOverlay = styled(Overlay)`
-  overflow: hidden;
   display: grid;
-  grid-template-columns: 120px 240px;
-  grid-template-rows: 1fr auto;
-  grid-template-areas:
-    'left right'
-    'footer footer';
+  grid-template-rows: auto 1fr auto;
+  overflow: hidden;
   height: 400px;
   width: 360px;
 `;
@@ -155,37 +151,34 @@ const SectionedOverlayFooter = styled('div')`
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  grid-area: footer;
   padding: ${space(1)};
   border-top: 1px solid ${p => p.theme.innerBorder};
 `;
 
 const SectionedListBoxPane = styled('div')`
   overflow-y: auto;
+  border-top: 1px solid ${p => p.theme.innerBorder};
 `;
 
 const SectionedListBoxTabPane = styled(SectionedListBoxPane)`
-  padding: ${space(1)};
+  padding: ${space(0.5)};
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   gap: ${space(0.25)};
-  border-right: 1px solid ${p => p.theme.innerBorder};
 `;
 
 const SectionButton = styled(Button)`
-  display: block;
-  height: 32px;
-  width: 100%;
+  height: 20px;
   text-align: left;
   font-weight: ${p => p.theme.fontWeightNormal};
+  font-size: ${p => p.theme.fontSizeSmall};
   padding: 0 ${space(1)};
-
-  span {
-    justify-content: flex-start;
-  }
+  color: ${p => p.theme.subText};
+  border: 0;
 
   &[aria-selected='true'] {
     background-color: ${p => p.theme.purple100};
+    box-shadow: inset 0 0 0 1px ${p => p.theme.purple100};
     color: ${p => p.theme.purple300};
     font-weight: ${p => p.theme.fontWeightBold};
   }

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -71,7 +71,7 @@ const getFilterKeySections = (
   return [
     {
       value: FieldKind.ISSUE_FIELD,
-      label: t('Issue Filters'),
+      label: t('Issues'),
       children: issueFields,
     },
     {


### PR DESCRIPTION
Matches designs [in this Figma file](https://www.figma.com/design/qLPE7uSdRZMOJloVumv8rA/Q1-Smart-Search?node-id=1014-2210&t=rK6LQbRJDaYW2u4F-0) which will allow us to add recent searches/fitlers.



Before:

![CleanShot 2024-08-05 at 12 50 56](https://github.com/user-attachments/assets/30dc2879-73cf-4522-ae35-d599b3549aac)

After:

![CleanShot 2024-08-05 at 12 51 13](https://github.com/user-attachments/assets/27e3b6d6-fb26-4a1e-98d4-9124a2d8e9c8)
