### PR TITLE
feat(anomaly detection): Add check for seven days of data to update_alert_rule

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -911,12 +911,18 @@ def update_alert_rule(
                     setattr(alert_rule, k, v)
 
                 try:
-                    send_historical_data_to_seer(
+                    rule_status = send_historical_data_to_seer(
                         alert_rule=alert_rule,
                         project=projects[0] if projects else alert_rule.projects.get(),
                     )
+                    if rule_status == AlertRuleStatus.NOT_ENOUGH_DATA:
+                        # if we don't have at least seven days worth of data, then the dynamic alert won't fire
+                        alert_rule.update(status=AlertRuleStatus.NOT_ENOUGH_DATA.value)
                 except (TimeoutError, MaxRetryError):
                     raise TimeoutError("Failed to send data to Seer - cannot update alert rule.")
+                except (ValidationError):
+                    # If there's no historical data available—something went wrong when querying snuba
+                    raise ValidationError("Failed to send data to Seer - cannot update alert rule.")
 
         alert_rule.update(**updated_fields)
         AlertRuleActivity.objects.create(

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -656,7 +656,7 @@ def create_alert_rule(
             except (TimeoutError, MaxRetryError):
                 alert_rule.delete()
                 raise TimeoutError
-            except (ValidationError):
+            except ValidationError:
                 alert_rule.delete()
                 raise ValidationError
 
@@ -920,7 +920,7 @@ def update_alert_rule(
                         alert_rule.update(status=AlertRuleStatus.NOT_ENOUGH_DATA.value)
                 except (TimeoutError, MaxRetryError):
                     raise TimeoutError("Failed to send data to Seer - cannot update alert rule.")
-                except (ValidationError):
+                except ValidationError:
                     # If there's no historical data available—something went wrong when querying snuba
                     raise ValidationError("Failed to send data to Seer - cannot update alert rule.")
 

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1692,7 +1692,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
     def test_update_alert_rule_static_to_dynamic_not_enough_data(self, mock_seer_request):
-        # assert that the status is PENDING if enough data exists
+        # assert that the status is NOT_ENOUGH_DATA if we don't have 7 days of data
         mock_seer_request.return_value = HTTPResponse(status=200)
 
         two_days_ago = before_now(days=2).replace(hour=10, minute=0, second=0, microsecond=0)

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1666,6 +1666,56 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
     @patch(
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
+    def test_update_alert_rule_static_to_dynamic_enough_data(self, mock_seer_request):
+        # assert that the status is PENDING if enough data exists
+        mock_seer_request.return_value = HTTPResponse(status=200)
+
+        two_weeks_ago = before_now(days=14).replace(hour=10, minute=0, second=0, microsecond=0)
+        self.create_event(two_weeks_ago + timedelta(minutes=1))
+        self.create_event(two_weeks_ago + timedelta(days=10))
+
+        alert_rule = self.create_alert_rule(
+            time_window=30, detection_type=AlertRuleDetectionType.STATIC
+        )
+        update_alert_rule(
+            alert_rule,
+            time_window=30,
+            sensitivity=AlertRuleSensitivity.HIGH,
+            seasonality=AlertRuleSeasonality.AUTO,
+            detection_type=AlertRuleDetectionType.DYNAMIC,
+        )
+        assert mock_seer_request.call_count == 1
+        assert alert_rule.status == AlertRuleStatus.PENDING.value
+
+    @with_feature("organizations:anomaly-detection-alerts")
+    @patch(
+        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
+    )
+    def test_update_alert_rule_static_to_dynamic_not_enough_data(self, mock_seer_request):
+        # assert that the status is PENDING if enough data exists
+        mock_seer_request.return_value = HTTPResponse(status=200)
+
+        two_days_ago = before_now(days=2).replace(hour=10, minute=0, second=0, microsecond=0)
+        self.create_event(two_days_ago + timedelta(minutes=1))
+        self.create_event(two_days_ago + timedelta(days=1))
+
+        alert_rule = self.create_alert_rule(
+            time_window=30, detection_type=AlertRuleDetectionType.STATIC
+        )
+        update_alert_rule(
+            alert_rule,
+            time_window=30,
+            sensitivity=AlertRuleSensitivity.HIGH,
+            seasonality=AlertRuleSeasonality.AUTO,
+            detection_type=AlertRuleDetectionType.DYNAMIC,
+        )
+        assert mock_seer_request.call_count == 1
+        assert alert_rule.status == AlertRuleStatus.NOT_ENOUGH_DATA.value
+
+    @with_feature("organizations:anomaly-detection-alerts")
+    @patch(
+        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
+    )
     @patch("sentry.seer.anomaly_detection.store_data.logger")
     def test_update_alert_rule_anomaly_detection_seer_timeout_max_retry(
         self, mock_logger, mock_seer_request

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1667,7 +1667,9 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
     def test_update_alert_rule_static_to_dynamic_enough_data(self, mock_seer_request):
-        # assert that the status is PENDING if enough data exists
+        """
+        Assert that the status is PENDING if enough data exists.
+        """
         mock_seer_request.return_value = HTTPResponse(status=200)
 
         two_weeks_ago = before_now(days=14).replace(hour=10, minute=0, second=0, microsecond=0)
@@ -1692,7 +1694,9 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
     def test_update_alert_rule_static_to_dynamic_not_enough_data(self, mock_seer_request):
-        # assert that the status is NOT_ENOUGH_DATA if we don't have 7 days of data
+        """
+        Assert that the status is NOT_ENOUGH_DATA if we don't have 7 days of data.
+        """
         mock_seer_request.return_value = HTTPResponse(status=200)
 
         two_days_ago = before_now(days=2).replace(hour=10, minute=0, second=0, microsecond=0)


### PR DESCRIPTION
Updates the alert rule status to NOT_ENOUGH_DATA in `update_alert_rule` if changing to a dynamic detection type and 7+ days of data are not present.

Closes https://getsentry.atlassian.net/browse/ALRT-191