### PR TITLE
chore(broadcasts): Remove `border-top` for first element

### DIFF
--- a/static/app/components/sidebar/sidebarPanelItem.tsx
+++ b/static/app/components/sidebar/sidebarPanelItem.tsx
@@ -79,10 +79,13 @@ export default SidebarPanelItem;
 
 const SidebarPanelItemRoot = styled('div')`
   line-height: 1.5;
-  border-top: 1px solid ${p => p.theme.innerBorder};
   background: ${p => p.theme.background};
   font-size: ${p => p.theme.fontSizeMedium};
   padding: ${space(3)};
+
+  :not(:first-child) {
+    border-top: 1px solid ${p => p.theme.innerBorder};
+  }
 `;
 
 const TitleWrapper = styled('div')`


### PR DESCRIPTION
this pr removes the `border-top` for the first item in the what's new section


before: 
![Screenshot 2024-08-05 at 3 22 27 PM](https://github.com/user-attachments/assets/a02a554b-5eb9-413c-9095-62ada62f39b0)


after:
![Screenshot 2024-08-05 at 3 21 14 PM](https://github.com/user-attachments/assets/f27d55bd-70b6-46e8-a6e9-2a087229df51)


