### PR TITLE
feat(toolbar): Quick highlighting of Deadclicks listed in the toolbar

### DIFF
--- a/static/app/components/devtoolbar/components/deadClicks/deadClicksPanel.tsx
+++ b/static/app/components/devtoolbar/components/deadClicks/deadClicksPanel.tsx
@@ -1,0 +1,160 @@
+import {useCallback, useRef} from 'react';
+
+import AnalyticsProvider from 'sentry/components/devtoolbar/components/analyticsProvider';
+import SentryAppLink from 'sentry/components/devtoolbar/components/sentryAppLink';
+import useConfiguration from 'sentry/components/devtoolbar/hooks/useConfiguration';
+import {
+  badgeWithLabelCss,
+  listItemGridCss,
+  listItemPlaceholderWrapperCss,
+} from 'sentry/components/devtoolbar/styles/listItem';
+import {smallCss} from 'sentry/components/devtoolbar/styles/typography';
+import Placeholder from 'sentry/components/placeholder';
+import TextOverflow from 'sentry/components/textOverflow';
+import type {DeadRageSelectorItem} from 'sentry/views/replays/types';
+
+import {panelInsetContentCss, panelSectionCss} from '../../styles/panel';
+import {resetFlexColumnCss} from '../../styles/reset';
+import InfiniteListItems from '../infiniteListItems';
+import InfiniteListState from '../infiniteListState';
+import PanelLayout from '../panelLayout';
+
+import useInfiniteDeadClicksList from './useInfiniteDeadClicksList';
+
+export default function DeadClicksPanel() {
+  const queryResult = useInfiniteDeadClicksList({
+    sort: '-count_dead_clicks',
+  });
+
+  const estimateSize = 89;
+  const placeholderHeight = `${estimateSize - 8}px`; // The real height of the items, minus the padding-block value
+
+  return (
+    <PanelLayout title="Dead Clicks">
+      <div css={resetFlexColumnCss}>
+        <InfiniteListState
+          queryResult={queryResult}
+          backgroundUpdatingMessage={() => null}
+          loadingMessage={() => (
+            <div
+              css={[
+                resetFlexColumnCss,
+                panelSectionCss,
+                panelInsetContentCss,
+                listItemPlaceholderWrapperCss,
+              ]}
+            >
+              <Placeholder height={placeholderHeight} />
+              <Placeholder height={placeholderHeight} />
+              <Placeholder height={placeholderHeight} />
+              <Placeholder height={placeholderHeight} />
+            </div>
+          )}
+        >
+          <InfiniteListItems
+            estimateSize={() => estimateSize}
+            queryResult={queryResult}
+            itemRenderer={props => <DeadClickListItem {...props} />}
+            emptyMessage={() => <p css={panelInsetContentCss}>No items to show</p>}
+          />
+        </InfiniteListState>
+      </div>
+    </PanelLayout>
+  );
+}
+
+function DeadClickListItem({item}: {item: DeadRageSelectorItem}) {
+  const {projectId} = useConfiguration();
+
+  const {onMouseOver, onMouseOut} = useHighlightMouseEvents({
+    item,
+  });
+  return (
+    <AnalyticsProvider keyVal="issue-list.item" nameVal="issue list item">
+      <div css={listItemGridCss} onMouseOver={onMouseOver} onMouseOut={onMouseOut}>
+        <TextOverflow
+          css={[badgeWithLabelCss, smallCss, 'display: block']}
+          style={{gridArea: 'name'}}
+        >
+          <SentryAppLink
+            to={{
+              url: `/issues/`,
+              query: {project: projectId},
+            }}
+          >
+            <strong>{item.dom_element.selector ?? '<unknown>'}</strong>
+          </SentryAppLink>
+        </TextOverflow>
+
+        <div style={{gridArea: 'message'}}>
+          <TextOverflow css={[smallCss]}>{item.dom_element.querySelector}</TextOverflow>
+        </div>
+      </div>
+    </AnalyticsProvider>
+  );
+}
+
+function useHighlightMouseEvents({
+  item,
+  showAfterMs = 0,
+}: {
+  item: DeadRageSelectorItem;
+  showAfterMs?: number;
+}) {
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>();
+
+  const onMouseOver = useCallback(() => {
+    timeoutRef.current = setTimeout(() => {
+      timeoutRef.current = null;
+      canvasRef.current = highlightNodes(item.dom_element.querySelector);
+    }, showAfterMs);
+  }, [item, showAfterMs]);
+
+  const onMouseOut = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    } else {
+      canvasRef.current?.remove();
+      canvasRef.current = null;
+    }
+  }, []);
+
+  return {onMouseOver, onMouseOut};
+}
+
+function highlightNodes(selector: string) {
+  try {
+    const found = document.querySelectorAll(selector);
+    if (!found.length) {
+      return null;
+    }
+
+    const canvas = document.createElement('canvas');
+    canvas.height = window.innerHeight;
+    canvas.width = window.innerWidth;
+    canvas.style.position = 'absolute';
+    canvas.style.pointerEvents = 'none';
+    canvas.style.inset = String(0);
+    canvas.style.zIndex = '99999';
+    const context = canvas.getContext('2d');
+    if (!context) {
+      return null;
+    }
+
+    context.fillStyle = 'rgba(168, 196, 236, 0.75)';
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    found.forEach(elementToHighlight => {
+      const rect = elementToHighlight.getBoundingClientRect();
+      context?.clearRect(rect.x, rect.y, rect.width, rect.height);
+    });
+
+    document.body.appendChild(canvas);
+    return canvas;
+  } catch {
+    // `querySelectorAll` can throw if the selector is invalid, which
+    // happens because we don't do proper escaping of the attr values yet.
+  }
+  return null;
+}

--- a/static/app/components/devtoolbar/components/deadClicks/useInfiniteDeadClicksList.tsx
+++ b/static/app/components/devtoolbar/components/deadClicks/useInfiniteDeadClicksList.tsx
@@ -1,0 +1,53 @@
+import {useMemo} from 'react';
+
+import hydratedSelectorData from 'sentry/utils/replays/hydrateSelectorData';
+import type {
+  DeadRageSelectorItem,
+  DeadRageSelectorListResponse,
+} from 'sentry/views/replays/types';
+
+import useConfiguration from '../../hooks/useConfiguration';
+import useFetchInfiniteApiData from '../../hooks/useFetchInfiniteApiData';
+import type {ApiEndpointQueryKey, ApiResult} from '../../types';
+
+interface Props {
+  sort: '-count_dead_clicks' | '-count_rage_clicks';
+}
+
+export default function useInfiniteDeadClicksList({sort}: Props) {
+  const {environment, organizationSlug, projectId} = useConfiguration();
+
+  return useFetchInfiniteApiData<
+    DeadRageSelectorListResponse,
+    ApiResult<DeadRageSelectorItem[]>
+  >({
+    queryKey: useMemo(
+      (): ApiEndpointQueryKey => [
+        'io.sentry.toolbar',
+        `/organizations/${organizationSlug}/replay-selectors/`,
+        {
+          query: {
+            per_page: 25,
+            queryReferrer: 'devtoolbar',
+            environment: Array.isArray(environment) ? environment : [environment],
+            project: projectId,
+            statsPeriod: '14d',
+            query: '!count_dead_clicks:0',
+            sort,
+          },
+        },
+      ],
+      [environment, organizationSlug, projectId, sort]
+    ),
+
+    select(data) {
+      return {
+        ...data,
+        pages: data.pages.map(page => ({
+          ...page,
+          json: hydratedSelectorData(page.json.data, undefined),
+        })),
+      };
+    },
+  });
+}

--- a/static/app/components/devtoolbar/components/issues/issuesPanel.tsx
+++ b/static/app/components/devtoolbar/components/issues/issuesPanel.tsx
@@ -1,5 +1,6 @@
 import IssueListItem from 'sentry/components/devtoolbar/components/issueListItem';
 import Placeholder from 'sentry/components/placeholder';
+import {IssueCategory} from 'sentry/types/group';
 
 import useCurrentTransactionName from '../../hooks/useCurrentTransactionName';
 import {listItemPlaceholderWrapperCss} from '../../styles/listItem';
@@ -15,7 +16,11 @@ import useInfiniteIssuesList from './useInfiniteIssuesList';
 export default function IssuesPanel() {
   const transactionName = useCurrentTransactionName();
   const queryResult = useInfiniteIssuesList({
-    query: `url:*${transactionName}`,
+    query: [
+      `issue.category:[${IssueCategory.ERROR},${IssueCategory.PERFORMANCE}]',
+      'status:unresolved',
+      'url:*${transactionName}`,
+    ].join(' '),
   });
 
   const estimateSize = 89;

--- a/static/app/components/devtoolbar/components/issues/useInfiniteIssuesList.tsx
+++ b/static/app/components/devtoolbar/components/issues/useInfiniteIssuesList.tsx
@@ -1,7 +1,6 @@
 import {useMemo} from 'react';
 
 import type {Group} from 'sentry/types/group';
-import {IssueCategory} from 'sentry/types/group';
 
 import useConfiguration from '../../hooks/useConfiguration';
 import useFetchInfiniteApiData from '../../hooks/useFetchInfiniteApiData';
@@ -13,7 +12,6 @@ interface Props {
 
 export default function useInfiniteIssuesList({query}: Props) {
   const {environment, organizationSlug, projectId} = useConfiguration();
-  const mailbox = 'unresolved';
 
   return useFetchInfiniteApiData<Group[]>({
     queryKey: useMemo(
@@ -39,11 +37,11 @@ export default function useInfiniteIssuesList({query}: Props) {
               // 'latestEventHasAttachments', // Gives us whether the feedback has screenshots
             ],
             shortIdLookup: 0,
-            query: `issue.category:[${IssueCategory.ERROR},${IssueCategory.PERFORMANCE}] status:${mailbox} ${query}`,
+            query,
           },
         },
       ],
-      [environment, mailbox, organizationSlug, projectId, query]
+      [environment, organizationSlug, projectId, query]
     ),
   });
 }

--- a/static/app/components/devtoolbar/components/navigation.tsx
+++ b/static/app/components/devtoolbar/components/navigation.tsx
@@ -5,6 +5,7 @@ import SessionStatusBadge from 'sentry/components/devtoolbar/components/releases
 import useConfiguration from 'sentry/components/devtoolbar/hooks/useConfiguration';
 import {
   IconClose,
+  IconCursorArrow,
   IconFlag,
   IconIssues,
   IconMegaphone,
@@ -52,6 +53,7 @@ export default function Navigation({
       <hr style={{margin: 0, width: '100%'}} />
 
       <NavButton panelName="issues" label="Issues" icon={<IconIssues />} />
+      <NavButton panelName="deadClicks" label="Dead Clicks" icon={<IconCursorArrow />} />
       <NavButton panelName="feedback" label="User Feedback" icon={<IconMegaphone />} />
       <NavButton panelName="alerts" label="Active Alerts" icon={<IconSiren />}>
         <AlertCountBadge />

--- a/static/app/components/devtoolbar/components/panelRouter.tsx
+++ b/static/app/components/devtoolbar/components/panelRouter.tsx
@@ -5,6 +5,7 @@ import AnalyticsProvider from 'sentry/components/devtoolbar/components/analytics
 import useToolbarRoute from '../hooks/useToolbarRoute';
 
 const PanelAlerts = lazy(() => import('./alerts/alertsPanel'));
+const PanelDeadClicks = lazy(() => import('./deadClicks/deadClicksPanel'));
 const PanelFeedback = lazy(() => import('./feedback/feedbackPanel'));
 const PanelIssues = lazy(() => import('./issues/issuesPanel'));
 const PanelFeatureFlags = lazy(() => import('./featureFlags/featureFlagsPanel'));
@@ -18,6 +19,12 @@ export default function PanelRouter() {
       return (
         <AnalyticsProvider keyVal="alerts-panel" nameVal="Alerts panel">
           <PanelAlerts />
+        </AnalyticsProvider>
+      );
+    case 'deadClicks':
+      return (
+        <AnalyticsProvider keyVal="dead-clicks-panel" nameVal="Dead Clicks panel">
+          <PanelDeadClicks />
         </AnalyticsProvider>
       );
     case 'feedback':

--- a/static/app/components/devtoolbar/hooks/useFetchApiData.tsx
+++ b/static/app/components/devtoolbar/hooks/useFetchApiData.tsx
@@ -13,10 +13,10 @@ export default function useFetchApiData<
 ) {
   const {fetchFn} = useApiEndpoint();
 
-  const infiniteQueryResult = useQuery<ApiEndpointQueryKey, Error, SelectFnData, any>({
+  const queryResult = useQuery<ApiEndpointQueryKey, Error, SelectFnData, any>({
     queryFn: fetchFn<QueryFnData>,
     ...props,
   });
 
-  return infiniteQueryResult;
+  return queryResult;
 }

--- a/static/app/components/devtoolbar/hooks/useFetchInfiniteApiData.tsx
+++ b/static/app/components/devtoolbar/hooks/useFetchInfiniteApiData.tsx
@@ -5,18 +5,27 @@ import type {ApiEndpointQueryKey, ApiResult} from '../types';
 
 import useApiEndpoint from './useApiEndpoint';
 
-export default function useFetchInfiniteApiData<Data extends Array<unknown>>(
-  props: UseInfiniteQueryOptions<ApiEndpointQueryKey, Error, ApiResult<Data>, any>
+export default function useFetchInfiniteApiData<
+  QueryFnData,
+  SelectFnData = ApiResult<QueryFnData>,
+>(
+  props: UseInfiniteQueryOptions<
+    ApiResult<QueryFnData>,
+    Error,
+    SelectFnData,
+    ApiResult<QueryFnData>,
+    ApiEndpointQueryKey
+  >
 ) {
   const {fetchInfiniteFn, getNextPageParam, getPreviousPageParam} = useApiEndpoint();
 
   const infiniteQueryResult = useInfiniteQuery<
     ApiEndpointQueryKey,
     Error,
-    ApiResult<Data>,
+    SelectFnData,
     any
   >({
-    queryFn: fetchInfiniteFn<Data>,
+    queryFn: fetchInfiniteFn<QueryFnData>,
     getNextPageParam,
     getPreviousPageParam,
     ...props,

--- a/static/app/components/devtoolbar/hooks/useToolbarRoute.tsx
+++ b/static/app/components/devtoolbar/hooks/useToolbarRoute.tsx
@@ -1,7 +1,14 @@
 import {createContext, useCallback, useContext, useState} from 'react';
 
 type State = {
-  activePanel: null | 'alerts' | 'feedback' | 'issues' | 'featureFlags' | 'releases';
+  activePanel:
+    | null
+    | 'alerts'
+    | 'deadClicks'
+    | 'featureFlags'
+    | 'feedback'
+    | 'issues'
+    | 'releases';
 };
 
 const context = createContext<{

--- a/static/app/utils/replays/hooks/useDeadRageSelectors.tsx
+++ b/static/app/utils/replays/hooks/useDeadRageSelectors.tsx
@@ -36,7 +36,7 @@ export default function useDeadRageSelectors(params: DeadRageSelectorQueryParams
     isError,
     data: hydratedSelectorData(
       data ? data.data : [],
-      params.isWidgetData ? params.sort?.replace(/^-/, '') : null
+      params.isWidgetData ? params.sort?.replace(/^-/, '') : undefined
     ),
     pageLinks: getResponseHeader?.('Link') ?? undefined,
   };

--- a/static/app/utils/replays/hydrateSelectorData.tsx
+++ b/static/app/utils/replays/hydrateSelectorData.tsx
@@ -1,8 +1,14 @@
 import constructSelector from 'sentry/views/replays/deadRageClick/constructSelector';
 import getAriaLabel from 'sentry/views/replays/deadRageClick/getAriaLabel';
-import type {DeadRageSelectorItem} from 'sentry/views/replays/types';
+import type {
+  DeadRageSelectorItem,
+  DeadRageSelectorListResponse,
+} from 'sentry/views/replays/types';
 
-export default function hydratedSelectorData(data, clickType?): DeadRageSelectorItem[] {
+export default function hydratedSelectorData(
+  data: DeadRageSelectorListResponse['data'],
+  clickType: string | undefined
+): DeadRageSelectorItem[] {
   return data.map(d => ({
     ...(clickType
       ? {[clickType]: d[clickType]}
@@ -11,11 +17,11 @@ export default function hydratedSelectorData(data, clickType?): DeadRageSelector
           count_rage_clicks: d.count_rage_clicks,
         }),
     dom_element: {
-      fullSelector: constructSelector(d.element).fullSelector,
-      selector: constructSelector(d.element).selector,
+      ...constructSelector(d.element),
       projectId: d.project_id,
     },
     element: d.dom_element.split(/[#.[]+/)[0],
+    elementAttrs: d.element,
     aria_label: getAriaLabel(d.dom_element),
     project_id: d.project_id,
   }));

--- a/static/app/views/replays/deadRageClick/constructSelector.tsx
+++ b/static/app/views/replays/deadRageClick/constructSelector.tsx
@@ -32,6 +32,7 @@ export default function constructSelector(element: ReplayClickElement) {
   const title = trimAttribute(element.title, fullTitle);
 
   const fullComponentName = '[data-sentry-component="' + element.component_name + '"]';
+  const dataSentryElement = '[data-sentry-element="' + element.component_name + '"]';
   const componentName = trimAttribute(element.component_name, fullComponentName);
 
   const fullSelector =
@@ -52,5 +53,21 @@ export default function constructSelector(element: ReplayClickElement) {
     alt +
     title;
 
-  return {fullSelector, selector};
+  const nativeSelector = tag + id + classes + role + ariaLabel + testId + alt + title;
+
+  const querySelector =
+    tag +
+    id +
+    (role ? fullRole : '') +
+    (componentName
+      ? dataSentryElement
+      : testId
+        ? fullTestId
+        : alt
+          ? fullAlt
+          : ariaLabel
+            ? fullAriaLabel
+            : '');
+
+  return {fullSelector, selector, nativeSelector, querySelector};
 }

--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -181,7 +181,9 @@ export type DeadRageSelectorItem = {
   aria_label: string;
   dom_element: {
     fullSelector: string;
+    nativeSelector: string;
     projectId: number;
+    querySelector: string;
     selector: string;
   };
   element: string;


### PR DESCRIPTION
The selector's themselves are not amazing, but I'm trying to get the idea across and also build out some helpers for highlighting CLS as well.

Here's an image with the panel open, and the Replay Play/Pause button in a spotlight:

<img width="1375" alt="SCR-20240805-opns" src="https://github.com/user-attachments/assets/9d9cc62f-c4a7-4cac-a193-6453271d3860">
