### PR TITLE
chore(visibility): Re-split CODEOWNERS among Visibility teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -232,36 +232,36 @@ yarn.lock                                                @getsentry/owners-js-de
 /src/sentry/snuba/metrics_performance.py                                    @getsentry/visibility
 /src/sentry/snuba/metrics_enhanced_performance.py                           @getsentry/visibility
 
-/tests/snuba/search/test_backend.py      @getsentry/visibility
+/tests/snuba/search/test_backend.py                                         @getsentry/visibility
 
 /src/sentry/search/events/                                                  @getsentry/visibility @getsentry/issues
 
-/src/sentry/utils/performance_issues/                                     @getsentry/visibility
+/src/sentry/utils/performance_issues/                                       @getsentry/performance
 
-/static/app/components/events/eventStatisticalDetector/                    @getsentry/visibility @getsentry/profiling
+/static/app/components/events/eventStatisticalDetector/                     @getsentry/visibility @getsentry/profiling
 
-/src/sentry/statistical_detectors                                         @getsentry/visibility @getsentry/profiling
-/tests/sentry/statistical_detectors                                       @getsentry/visibility @getsentry/profiling
+/src/sentry/statistical_detectors                                           @getsentry/visibility @getsentry/profiling
+/tests/sentry/statistical_detectors                                         @getsentry/visibility @getsentry/profiling
 
 /src/sentry/tasks/statistical_detectors.py                                @getsentry/visibility @getsentry/profiling
 /tests/sentry/tasks/test_statistical_detectors.py                         @getsentry/visibility @getsentry/profiling
 
 /src/sentry/api/bases/organization_events.py                         @getsentry/visibility
 
-/src/sentry/api/endpoints/organization_dashboards.py                 @getsentry/visibility
-/src/sentry/api/endpoints/organization_dashboard_details.py          @getsentry/visibility
-/src/sentry/api/endpoints/organization_dashboard_widget_details.py   @getsentry/visibility
+/src/sentry/api/endpoints/organization_dashboards.py                         @getsentry/dashboards
+/src/sentry/api/endpoints/organization_dashboard_details.py                  @getsentry/dashboards
+/src/sentry/api/endpoints/organization_dashboard_widget_details.py           @getsentry/dashboards
 
-tests/sentry/api/endpoints/test_organization_dashboards.py                   @getsentry/visibility
-tests/sentry/api/endpoints/test_organization_dashboard_details.py            @getsentry/visibility
-tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @getsentry/visibility
+tests/sentry/api/endpoints/test_organization_dashboards.py                   @getsentry/dashboards
+tests/sentry/api/endpoints/test_organization_dashboard_details.py            @getsentry/dashboards
+tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @getsentry/dashboards
 
-/src/sentry/api/serializers/models/dashboard.py                      @getsentry/visibility
+/src/sentry/api/serializers/models/dashboard.py                      @getsentry/dashboards
 /src/sentry/api/serializers/models/discoversavedquery.py             @getsentry/visibility
-/src/sentry/api/serializers/rest_framework/dashboard.py              @getsentry/visibility
+/src/sentry/api/serializers/rest_framework/dashboard.py              @getsentry/dashboards
 
-/src/sentry/discover/                                                @getsentry/visibility
-/tests/sentry/snuba/test_discover.py                                 @getsentry/visibility
+/src/sentry/discover/                                                @getsentry/explore
+/tests/sentry/snuba/test_discover.py                                 @getsentry/explore
 
 /src/sentry/api/event_search.py                                      @getsentry/visibility
 /tests/sentry/api/test_event_search.py                               @getsentry/visibility
@@ -274,26 +274,27 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /src/sentry/api/endpoints/organization_spans_fields.py                              @getsentry/visibility
 /tests/sentry/api/endpoints/test_organization_spans_fields.py                       @getsentry/visibility
 
-/src/sentry/api/endpoints/organization_traces.py                                    @getsentry/visibility
-/tests/sentry/api/endpoints/test_organization_traces.py                             @getsentry/visibility
+/src/sentry/api/endpoints/organization_traces.py                                    @getsentry/explore
+/tests/sentry/api/endpoints/test_organization_traces.py                             @getsentry/explore
 
-/static/app/views/traces/                                                 @getsentry/visibility
-/static/app/components/quickTrace/                                        @getsentry/visibility
+/static/app/views/traces/                                                 @getsentry/explore
+/static/app/components/quickTrace/                                        @getsentry/explore
 
-/static/app/views/performance/                                            @getsentry/visibility
-/static/app/components/performance/                                       @getsentry/visibility
-/static/app/utils/performance/                                            @getsentry/visibility
-/static/app/components/events/interfaces/spans/                           @getsentry/visibility
-/static/app/components/events/viewHierarchy/*                             @getsentry/visibility
+/static/app/views/performance/                                            @getsentry/performance
+/static/app/components/performance/                                       @getsentry/performance
+/static/app/utils/performance/                                            @getsentry/performance
+/static/app/components/events/interfaces/spans/                           @getsentry/performance
+/static/app/components/events/viewHierarchy/*                             @getsentry/performance
+
 /static/app/components/charts/                                            @getsentry/visibility
 
-/static/app/views/insights/                                               @getsentry/visibility
+/static/app/views/insights/                                               @getsentry/insights
 
-/static/app/views/dashboards/                                             @getsentry/visibility
-/static/app/components/dashboards/                                        @getsentry/visibility
+/static/app/views/dashboards/                                             @getsentry/dashboards
+/static/app/components/dashboards/                                        @getsentry/dashboards
 
-/static/app/views/discover/                                               @getsentry/visibility
-/static/app/utils/discover/                                               @getsentry/visibility
+/static/app/views/discover/                                               @getsentry/explore
+/static/app/utils/discover/                                               @getsentry/explore
 ## Endof Visibility
 
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,7 @@
 /src/sentry/eventstream/                                 @getsentry/owners-snuba
 /src/sentry/consumers/                                   @getsentry/ops @getsentry/owners-snuba
 /src/sentry/post_process_forwarder/                      @getsentry/owners-snuba
-/src/sentry/utils/snuba.py                               @getsentry/owners-snuba @getsentry/performance
+/src/sentry/utils/snuba.py                               @getsentry/owners-snuba @getsentry/visibility
 /src/sentry/utils/snql.py                                @getsentry/owners-snuba
 /src/sentry/utils/arroyo.py                              @getsentry/owners-snuba
 /src/sentry/utils/arroyo_producer.py                     @getsentry/owners-snuba
@@ -192,94 +192,94 @@ yarn.lock                                                @getsentry/owners-js-de
 
 
 ## Performance
-/src/sentry/api/endpoints/organization_tags.py                              @getsentry/performance
-/src/sentry/api/endpoints/organization_events_histogram.py                  @getsentry/performance
+/src/sentry/api/endpoints/organization_tags.py                              @getsentry/visibility
+/src/sentry/api/endpoints/organization_events_histogram.py                  @getsentry/visibility
 
-/tests/snuba/api/endpoints/*                                                @getsentry/performance
-/tests/snuba/api/endpoints/test_organization_events_histogram.py            @getsentry/performance
-/tests/snuba/api/endpoints/test_organization_events_facets_performance.py   @getsentry/performance
-/tests/snuba/api/endpoints/test_organization_events_spans_performance.py    @getsentry/performance
-/tests/snuba/api/endpoints/test_organization_events_spans_histogram.py      @getsentry/performance
-/tests/snuba/api/endpoints/test_organization_events_trace.py                @getsentry/performance
-/tests/snuba/api/endpoints/test_organization_events_trends.py               @getsentry/performance
-/tests/snuba/api/endpoints/test_organization_events_vitals.py               @getsentry/performance
-/tests/snuba/api/endpoints/test_organization_tagkey_values.py               @getsentry/performance
-/tests/snuba/api/endpoints/test_organization_tags.py                        @getsentry/performance
-/tests/sentry/spans/                                                        @getsentry/performance
-/static/app/components/events/viewHierarchy/*                               @getsentry/performance
+/tests/snuba/api/endpoints/*                                                @getsentry/visibility
+/tests/snuba/api/endpoints/test_organization_events_histogram.py            @getsentry/visibility
+/tests/snuba/api/endpoints/test_organization_events_facets_performance.py   @getsentry/visibility
+/tests/snuba/api/endpoints/test_organization_events_spans_performance.py    @getsentry/visibility
+/tests/snuba/api/endpoints/test_organization_events_spans_histogram.py      @getsentry/visibility
+/tests/snuba/api/endpoints/test_organization_events_trace.py                @getsentry/visibility
+/tests/snuba/api/endpoints/test_organization_events_trends.py               @getsentry/visibility
+/tests/snuba/api/endpoints/test_organization_events_vitals.py               @getsentry/visibility
+/tests/snuba/api/endpoints/test_organization_tagkey_values.py               @getsentry/visibility
+/tests/snuba/api/endpoints/test_organization_tags.py                        @getsentry/visibility
+/tests/sentry/spans/                                                        @getsentry/visibility
+/static/app/components/events/viewHierarchy/*                               @getsentry/visibility
 
-/src/sentry/api/serializers/snuba.py                                        @getsentry/performance
-/src/sentry/snuba/discover.py                                               @getsentry/performance
-/src/sentry/snuba/metrics_performance.py                                    @getsentry/performance
-/src/sentry/snuba/metrics_enhanced_performance.py                           @getsentry/performance
+/src/sentry/api/serializers/snuba.py                                        @getsentry/visibility
+/src/sentry/snuba/discover.py                                               @getsentry/visibility
+/src/sentry/snuba/metrics_performance.py                                    @getsentry/visibility
+/src/sentry/snuba/metrics_enhanced_performance.py                           @getsentry/visibility
 
-/src/sentry/search/events/                                                  @getsentry/performance @getsentry/issues
-/tests/snuba/search/test_backend.py                                         @getsentry/performance
-/static/app/utils/discover/                                                 @getsentry/performance
-/static/app/components/charts/                                              @getsentry/performance
+/src/sentry/search/events/                                                  @getsentry/visibility @getsentry/issues
+/tests/snuba/search/test_backend.py                                         @getsentry/visibility
+/static/app/utils/discover/                                                 @getsentry/visibility
+/static/app/components/charts/                                              @getsentry/visibility
 
-/src/sentry/api/endpoints/organization_events_facets_performance.py       @getsentry/performance
-/src/sentry/api/endpoints/organization_events_spans_performance.py        @getsentry/performance
-/src/sentry/api/endpoints/organization_events_spans_histogram.py          @getsentry/performance
-/src/sentry/api/endpoints/organization_events_trace.py                    @getsentry/performance
-/src/sentry/api/endpoints/organization_events_trends.py                   @getsentry/performance
-/src/sentry/api/endpoints/organization_events_trends_v2.py                @getsentry/performance
-/src/sentry/api/endpoints/organization_events_vitals.py                   @getsentry/performance
+/src/sentry/api/endpoints/organization_events_facets_performance.py       @getsentry/visibility
+/src/sentry/api/endpoints/organization_events_spans_performance.py        @getsentry/visibility
+/src/sentry/api/endpoints/organization_events_spans_histogram.py          @getsentry/visibility
+/src/sentry/api/endpoints/organization_events_trace.py                    @getsentry/visibility
+/src/sentry/api/endpoints/organization_events_trends.py                   @getsentry/visibility
+/src/sentry/api/endpoints/organization_events_trends_v2.py                @getsentry/visibility
+/src/sentry/api/endpoints/organization_events_vitals.py                   @getsentry/visibility
 /src/sentry/api/endpoints/organization_transaction_anomaly_detection.py   @getsentry/data
-/src/sentry/utils/performance_issues/                                     @getsentry/performance
-/src/sentry/spans/                                                        @getsentry/performance
+/src/sentry/utils/performance_issues/                                     @getsentry/visibility
+/src/sentry/spans/                                                        @getsentry/visibility
 
-/static/app/views/traces/                                                 @getsentry/performance
-/static/app/views/performance/                                            @getsentry/performance
-/static/app/utils/performance/                                            @getsentry/performance
-/static/app/components/events/interfaces/spans/                           @getsentry/performance
-/static/app/components/performance/                                       @getsentry/performance
-/static/app/components/quickTrace/                                        @getsentry/performance
+/static/app/views/traces/                                                 @getsentry/visibility
+/static/app/views/performance/                                            @getsentry/visibility
+/static/app/utils/performance/                                            @getsentry/visibility
+/static/app/components/events/interfaces/spans/                           @getsentry/visibility
+/static/app/components/performance/                                       @getsentry/visibility
+/static/app/components/quickTrace/                                        @getsentry/visibility
 
-static/app/components/events/eventStatisticalDetector/                    @getsentry/performance @getsentry/profiling
-/src/sentry/statistical_detectors                                         @getsentry/performance @getsentry/profiling
-/src/sentry/tasks/statistical_detectors.py                                @getsentry/performance @getsentry/profiling
-/tests/sentry/statistical_detectors                                       @getsentry/performance @getsentry/profiling
-/tests/sentry/tasks/test_statistical_detectors.py                         @getsentry/performance @getsentry/profiling
+static/app/components/events/eventStatisticalDetector/                    @getsentry/visibility @getsentry/profiling
+/src/sentry/statistical_detectors                                         @getsentry/visibility @getsentry/profiling
+/src/sentry/tasks/statistical_detectors.py                                @getsentry/visibility @getsentry/profiling
+/tests/sentry/statistical_detectors                                       @getsentry/visibility @getsentry/profiling
+/tests/sentry/tasks/test_statistical_detectors.py                         @getsentry/visibility @getsentry/profiling
 
-/src/sentry/api/endpoints/organization_dashboards.py                 @getsentry/performance
-/src/sentry/api/endpoints/organization_dashboard_details.py          @getsentry/performance
-/src/sentry/api/endpoints/organization_dashboard_widget_details.py   @getsentry/performance
-/src/sentry/api/bases/organization_events.py                         @getsentry/performance
-/src/sentry/api/endpoints/organization_event_details.py              @getsentry/performance
-/src/sentry/api/endpoints/organization_events.py                     @getsentry/performance
-/src/sentry/api/endpoints/organization_events_facets.py              @getsentry/performance
-/src/sentry/api/endpoints/organization_events_meta.py                @getsentry/performance
-/src/sentry/api/endpoints/organization_events_stats.py               @getsentry/performance
-/src/sentry/api/endpoints/organization_measurements_meta.py          @getsentry/performance
-/src/sentry/api/serializers/models/dashboard.py                      @getsentry/performance
-/src/sentry/api/serializers/models/discoversavedquery.py             @getsentry/performance
-/src/sentry/api/serializers/rest_framework/dashboard.py              @getsentry/performance
+/src/sentry/api/endpoints/organization_dashboards.py                 @getsentry/visibility
+/src/sentry/api/endpoints/organization_dashboard_details.py          @getsentry/visibility
+/src/sentry/api/endpoints/organization_dashboard_widget_details.py   @getsentry/visibility
+/src/sentry/api/bases/organization_events.py                         @getsentry/visibility
+/src/sentry/api/endpoints/organization_event_details.py              @getsentry/visibility
+/src/sentry/api/endpoints/organization_events.py                     @getsentry/visibility
+/src/sentry/api/endpoints/organization_events_facets.py              @getsentry/visibility
+/src/sentry/api/endpoints/organization_events_meta.py                @getsentry/visibility
+/src/sentry/api/endpoints/organization_events_stats.py               @getsentry/visibility
+/src/sentry/api/endpoints/organization_measurements_meta.py          @getsentry/visibility
+/src/sentry/api/serializers/models/dashboard.py                      @getsentry/visibility
+/src/sentry/api/serializers/models/discoversavedquery.py             @getsentry/visibility
+/src/sentry/api/serializers/rest_framework/dashboard.py              @getsentry/visibility
 
-/src/sentry/discover/                                                @getsentry/performance
-/tests/sentry/snuba/test_discover.py                                 @getsentry/performance
+/src/sentry/discover/                                                @getsentry/visibility
+/tests/sentry/snuba/test_discover.py                                 @getsentry/visibility
 
-/src/sentry/api/event_search.py                                      @getsentry/performance
-/tests/sentry/api/test_event_search.py                               @getsentry/performance
+/src/sentry/api/event_search.py                                      @getsentry/visibility
+/tests/sentry/api/test_event_search.py                               @getsentry/visibility
 
-/src/sentry/data_export/                                             @getsentry/performance
-/tests/sentry/data_export/                                           @getsentry/performance
+/src/sentry/data_export/                                             @getsentry/visibility
+/tests/sentry/data_export/                                           @getsentry/visibility
 
-/static/app/views/eventsV2/                                          @getsentry/performance
-/static/app/views/discover/                                          @getsentry/performance
-/static/app/views/dashboardsV2/                                      @getsentry/performance
-/static/app/components/dashboards/                                   @getsentry/performance
+/static/app/views/eventsV2/                                          @getsentry/visibility
+/static/app/views/discover/                                          @getsentry/visibility
+/static/app/views/dashboardsV2/                                      @getsentry/visibility
+/static/app/components/dashboards/                                   @getsentry/visibility
 
-/src/sentry/api/endpoints/organization_events_facets_stats_performance.py           @getsentry/performance
-/src/sentry/api/endpoints/organization_spans_aggregation.py                         @getsentry/performance
-/src/sentry/api/endpoints/organization_events_starfish.py                           @getsentry/performance
-/tests/snuba/api/endpoints/test_organization_events_facets_stats_performance.py     @getsentry/performance
-/src/sentry/api/endpoints/organization_spans_fields.py                              @getsentry/performance
-/tests/sentry/api/endpoints/test_organization_spans_fields.py                       @getsentry/performance
-/src/sentry/api/endpoints/organization_traces.py                                    @getsentry/performance
-/tests/sentry/api/endpoints/test_organization_traces.py                             @getsentry/performance
+/src/sentry/api/endpoints/organization_events_facets_stats_performance.py           @getsentry/visibility
+/src/sentry/api/endpoints/organization_spans_aggregation.py                         @getsentry/visibility
+/src/sentry/api/endpoints/organization_events_starfish.py                           @getsentry/visibility
+/tests/snuba/api/endpoints/test_organization_events_facets_stats_performance.py     @getsentry/visibility
+/src/sentry/api/endpoints/organization_spans_fields.py                              @getsentry/visibility
+/tests/sentry/api/endpoints/test_organization_spans_fields.py                       @getsentry/visibility
+/src/sentry/api/endpoints/organization_traces.py                                    @getsentry/visibility
+/tests/sentry/api/endpoints/test_organization_traces.py                             @getsentry/visibility
 
-/static/app/views/insights/                                                         @getsentry/performance
+/static/app/views/insights/                                                         @getsentry/visibility
 ## Endof Performance
 
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -215,6 +215,7 @@ yarn.lock                                                @getsentry/owners-js-de
 /tests/snuba/api/endpoints/test_organization_events_vitals.py               @getsentry/visibility
 /tests/snuba/api/endpoints/test_organization_tagkey_values.py               @getsentry/visibility
 
+/src/sentry/spans/                                                        @getsentry/visibility
 /tests/sentry/spans/                                                        @getsentry/visibility
 
 /static/app/components/events/viewHierarchy/*                               @getsentry/visibility
@@ -232,7 +233,6 @@ yarn.lock                                                @getsentry/owners-js-de
 /src/sentry/api/endpoints/organization_transaction_anomaly_detection.py     @getsentry/data
 
 /src/sentry/utils/performance_issues/                                     @getsentry/visibility
-/src/sentry/spans/                                                        @getsentry/visibility
 
 static/app/components/events/eventStatisticalDetector/                    @getsentry/visibility @getsentry/profiling
 /src/sentry/statistical_detectors                                         @getsentry/visibility @getsentry/profiling

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -234,13 +234,6 @@ yarn.lock                                                @getsentry/owners-js-de
 /src/sentry/utils/performance_issues/                                     @getsentry/visibility
 /src/sentry/spans/                                                        @getsentry/visibility
 
-/static/app/views/traces/                                                 @getsentry/visibility
-/static/app/views/performance/                                            @getsentry/visibility
-/static/app/utils/performance/                                            @getsentry/visibility
-/static/app/components/events/interfaces/spans/                           @getsentry/visibility
-/static/app/components/performance/                                       @getsentry/visibility
-/static/app/components/quickTrace/                                        @getsentry/visibility
-
 static/app/components/events/eventStatisticalDetector/                    @getsentry/visibility @getsentry/profiling
 /src/sentry/statistical_detectors                                         @getsentry/visibility @getsentry/profiling
 /src/sentry/tasks/statistical_detectors.py                                @getsentry/visibility @getsentry/profiling
@@ -270,16 +263,26 @@ static/app/components/events/eventStatisticalDetector/                    @getse
 /src/sentry/data_export/                                             @getsentry/visibility
 /tests/sentry/data_export/                                           @getsentry/visibility
 
-/static/app/views/discover/                                          @getsentry/visibility
-/static/app/components/dashboards/                                   @getsentry/visibility
-
 /src/sentry/api/endpoints/organization_spans_aggregation.py                         @getsentry/visibility
 /src/sentry/api/endpoints/organization_spans_fields.py                              @getsentry/visibility
 /tests/sentry/api/endpoints/test_organization_spans_fields.py                       @getsentry/visibility
 /src/sentry/api/endpoints/organization_traces.py                                    @getsentry/visibility
 /tests/sentry/api/endpoints/test_organization_traces.py                             @getsentry/visibility
 
-/static/app/views/insights/                                                         @getsentry/visibility
+/static/app/views/traces/                                                 @getsentry/visibility
+/static/app/components/quickTrace/                                        @getsentry/visibility
+
+/static/app/views/performance/                                            @getsentry/visibility
+/static/app/components/performance/                                       @getsentry/visibility
+/static/app/utils/performance/                                            @getsentry/visibility
+/static/app/components/events/interfaces/spans/                           @getsentry/visibility
+
+/static/app/views/insights/                                               @getsentry/visibility
+
+/static/app/views/dashboards/                                             @getsentry/visibility
+/static/app/components/dashboards/                                        @getsentry/visibility
+
+/static/app/views/discover/                                               @getsentry/visibility
 ## Endof Performance
 
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -265,15 +265,10 @@ static/app/components/events/eventStatisticalDetector/                    @getse
 /src/sentry/data_export/                                             @getsentry/visibility
 /tests/sentry/data_export/                                           @getsentry/visibility
 
-/static/app/views/eventsV2/                                          @getsentry/visibility
 /static/app/views/discover/                                          @getsentry/visibility
-/static/app/views/dashboardsV2/                                      @getsentry/visibility
 /static/app/components/dashboards/                                   @getsentry/visibility
 
-/src/sentry/api/endpoints/organization_events_facets_stats_performance.py           @getsentry/visibility
 /src/sentry/api/endpoints/organization_spans_aggregation.py                         @getsentry/visibility
-/src/sentry/api/endpoints/organization_events_starfish.py                           @getsentry/visibility
-/tests/snuba/api/endpoints/test_organization_events_facets_stats_performance.py     @getsentry/visibility
 /src/sentry/api/endpoints/organization_spans_fields.py                              @getsentry/visibility
 /tests/sentry/api/endpoints/test_organization_spans_fields.py                       @getsentry/visibility
 /src/sentry/api/endpoints/organization_traces.py                                    @getsentry/visibility

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -194,18 +194,29 @@ yarn.lock                                                @getsentry/owners-js-de
 ## Performance
 /src/sentry/api/endpoints/organization_tags.py                              @getsentry/visibility
 /src/sentry/api/endpoints/organization_events_histogram.py                  @getsentry/visibility
+/src/sentry/api/endpoints/organization_events_facets_performance.py         @getsentry/visibility
+/src/sentry/api/endpoints/organization_events_spans_performance.py          @getsentry/visibility
+/src/sentry/api/endpoints/organization_events_spans_histogram.py            @getsentry/visibility
+/src/sentry/api/endpoints/organization_events_trace.py                      @getsentry/visibility
+/src/sentry/api/endpoints/organization_events_trends.py                     @getsentry/visibility
+/src/sentry/api/endpoints/organization_events_trends_v2.py                  @getsentry/visibility
+/src/sentry/api/endpoints/organization_events_vitals.py                     @getsentry/visibility
+/src/sentry/api/endpoints/organization_tagkey_values.py                     @getsentry/visibility
 
 /tests/snuba/api/endpoints/*                                                @getsentry/visibility
+/tests/snuba/api/endpoints/test_organization_tags.py                        @getsentry/visibility
 /tests/snuba/api/endpoints/test_organization_events_histogram.py            @getsentry/visibility
 /tests/snuba/api/endpoints/test_organization_events_facets_performance.py   @getsentry/visibility
 /tests/snuba/api/endpoints/test_organization_events_spans_performance.py    @getsentry/visibility
 /tests/snuba/api/endpoints/test_organization_events_spans_histogram.py      @getsentry/visibility
 /tests/snuba/api/endpoints/test_organization_events_trace.py                @getsentry/visibility
 /tests/snuba/api/endpoints/test_organization_events_trends.py               @getsentry/visibility
+/tests/snuba/api/endpoints/test_organization_events_trends_v2.py            @getsentry/visibility
 /tests/snuba/api/endpoints/test_organization_events_vitals.py               @getsentry/visibility
 /tests/snuba/api/endpoints/test_organization_tagkey_values.py               @getsentry/visibility
-/tests/snuba/api/endpoints/test_organization_tags.py                        @getsentry/visibility
+
 /tests/sentry/spans/                                                        @getsentry/visibility
+
 /static/app/components/events/viewHierarchy/*                               @getsentry/visibility
 
 /src/sentry/api/serializers/snuba.py                                        @getsentry/visibility
@@ -218,14 +229,8 @@ yarn.lock                                                @getsentry/owners-js-de
 /static/app/utils/discover/                                                 @getsentry/visibility
 /static/app/components/charts/                                              @getsentry/visibility
 
-/src/sentry/api/endpoints/organization_events_facets_performance.py       @getsentry/visibility
-/src/sentry/api/endpoints/organization_events_spans_performance.py        @getsentry/visibility
-/src/sentry/api/endpoints/organization_events_spans_histogram.py          @getsentry/visibility
-/src/sentry/api/endpoints/organization_events_trace.py                    @getsentry/visibility
-/src/sentry/api/endpoints/organization_events_trends.py                   @getsentry/visibility
-/src/sentry/api/endpoints/organization_events_trends_v2.py                @getsentry/visibility
-/src/sentry/api/endpoints/organization_events_vitals.py                   @getsentry/visibility
-/src/sentry/api/endpoints/organization_transaction_anomaly_detection.py   @getsentry/data
+/src/sentry/api/endpoints/organization_transaction_anomaly_detection.py     @getsentry/data
+
 /src/sentry/utils/performance_issues/                                     @getsentry/visibility
 /src/sentry/spans/                                                        @getsentry/visibility
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -191,7 +191,7 @@ yarn.lock                                                @getsentry/owners-js-de
 ## Endof Alerts & Notifications
 
 
-## Performance
+## Visibility
 /src/sentry/api/endpoints/organization_tags.py                              @getsentry/visibility
 /src/sentry/api/endpoints/organization_events_histogram.py                  @getsentry/visibility
 /src/sentry/api/endpoints/organization_events_facets_performance.py         @getsentry/visibility
@@ -202,6 +202,12 @@ yarn.lock                                                @getsentry/owners-js-de
 /src/sentry/api/endpoints/organization_events_trends_v2.py                  @getsentry/visibility
 /src/sentry/api/endpoints/organization_events_vitals.py                     @getsentry/visibility
 /src/sentry/api/endpoints/organization_tagkey_values.py                     @getsentry/visibility
+/src/sentry/api/endpoints/organization_event_details.py                     @getsentry/visibility
+/src/sentry/api/endpoints/organization_events.py                            @getsentry/visibility
+/src/sentry/api/endpoints/organization_events_facets.py                     @getsentry/visibility
+/src/sentry/api/endpoints/organization_events_meta.py                       @getsentry/visibility
+/src/sentry/api/endpoints/organization_events_stats.py                      @getsentry/visibility
+/src/sentry/api/endpoints/organization_measurements_meta.py                 @getsentry/visibility
 
 /tests/snuba/api/endpoints/*                                                @getsentry/visibility
 /tests/snuba/api/endpoints/test_organization_tags.py                        @getsentry/visibility
@@ -215,41 +221,41 @@ yarn.lock                                                @getsentry/owners-js-de
 /tests/snuba/api/endpoints/test_organization_events_vitals.py               @getsentry/visibility
 /tests/snuba/api/endpoints/test_organization_tagkey_values.py               @getsentry/visibility
 
-/src/sentry/spans/                                                        @getsentry/visibility
+/src/sentry/api/endpoints/organization_transaction_anomaly_detection.py     @getsentry/data
+
+/src/sentry/spans/                                                          @getsentry/visibility
 /tests/sentry/spans/                                                        @getsentry/visibility
 
-/static/app/components/events/viewHierarchy/*                               @getsentry/visibility
-
 /src/sentry/api/serializers/snuba.py                                        @getsentry/visibility
+
 /src/sentry/snuba/discover.py                                               @getsentry/visibility
 /src/sentry/snuba/metrics_performance.py                                    @getsentry/visibility
 /src/sentry/snuba/metrics_enhanced_performance.py                           @getsentry/visibility
 
-/src/sentry/search/events/                                                  @getsentry/visibility @getsentry/issues
-/tests/snuba/search/test_backend.py                                         @getsentry/visibility
-/static/app/utils/discover/                                                 @getsentry/visibility
-/static/app/components/charts/                                              @getsentry/visibility
+/tests/snuba/search/test_backend.py      @getsentry/visibility
 
-/src/sentry/api/endpoints/organization_transaction_anomaly_detection.py     @getsentry/data
+/src/sentry/search/events/                                                  @getsentry/visibility @getsentry/issues
 
 /src/sentry/utils/performance_issues/                                     @getsentry/visibility
 
-static/app/components/events/eventStatisticalDetector/                    @getsentry/visibility @getsentry/profiling
+/static/app/components/events/eventStatisticalDetector/                    @getsentry/visibility @getsentry/profiling
+
 /src/sentry/statistical_detectors                                         @getsentry/visibility @getsentry/profiling
-/src/sentry/tasks/statistical_detectors.py                                @getsentry/visibility @getsentry/profiling
 /tests/sentry/statistical_detectors                                       @getsentry/visibility @getsentry/profiling
+
+/src/sentry/tasks/statistical_detectors.py                                @getsentry/visibility @getsentry/profiling
 /tests/sentry/tasks/test_statistical_detectors.py                         @getsentry/visibility @getsentry/profiling
+
+/src/sentry/api/bases/organization_events.py                         @getsentry/visibility
 
 /src/sentry/api/endpoints/organization_dashboards.py                 @getsentry/visibility
 /src/sentry/api/endpoints/organization_dashboard_details.py          @getsentry/visibility
 /src/sentry/api/endpoints/organization_dashboard_widget_details.py   @getsentry/visibility
-/src/sentry/api/bases/organization_events.py                         @getsentry/visibility
-/src/sentry/api/endpoints/organization_event_details.py              @getsentry/visibility
-/src/sentry/api/endpoints/organization_events.py                     @getsentry/visibility
-/src/sentry/api/endpoints/organization_events_facets.py              @getsentry/visibility
-/src/sentry/api/endpoints/organization_events_meta.py                @getsentry/visibility
-/src/sentry/api/endpoints/organization_events_stats.py               @getsentry/visibility
-/src/sentry/api/endpoints/organization_measurements_meta.py          @getsentry/visibility
+
+tests/sentry/api/endpoints/test_organization_dashboards.py                   @getsentry/visibility
+tests/sentry/api/endpoints/test_organization_dashboard_details.py            @getsentry/visibility
+tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @getsentry/visibility
+
 /src/sentry/api/serializers/models/dashboard.py                      @getsentry/visibility
 /src/sentry/api/serializers/models/discoversavedquery.py             @getsentry/visibility
 /src/sentry/api/serializers/rest_framework/dashboard.py              @getsentry/visibility
@@ -264,8 +270,10 @@ static/app/components/events/eventStatisticalDetector/                    @getse
 /tests/sentry/data_export/                                           @getsentry/visibility
 
 /src/sentry/api/endpoints/organization_spans_aggregation.py                         @getsentry/visibility
+
 /src/sentry/api/endpoints/organization_spans_fields.py                              @getsentry/visibility
 /tests/sentry/api/endpoints/test_organization_spans_fields.py                       @getsentry/visibility
+
 /src/sentry/api/endpoints/organization_traces.py                                    @getsentry/visibility
 /tests/sentry/api/endpoints/test_organization_traces.py                             @getsentry/visibility
 
@@ -276,6 +284,8 @@ static/app/components/events/eventStatisticalDetector/                    @getse
 /static/app/components/performance/                                       @getsentry/visibility
 /static/app/utils/performance/                                            @getsentry/visibility
 /static/app/components/events/interfaces/spans/                           @getsentry/visibility
+/static/app/components/events/viewHierarchy/*                             @getsentry/visibility
+/static/app/components/charts/                                            @getsentry/visibility
 
 /static/app/views/insights/                                               @getsentry/visibility
 
@@ -283,7 +293,8 @@ static/app/components/events/eventStatisticalDetector/                    @getse
 /static/app/components/dashboards/                                        @getsentry/visibility
 
 /static/app/views/discover/                                               @getsentry/visibility
-## Endof Performance
+/static/app/utils/discover/                                               @getsentry/visibility
+## Endof Visibility
 
 
 ## Profiling


### PR DESCRIPTION
Updates CODEOWNERS to match the team topology from [Notion](https://www.notion.so/sentry/Visibility-f1627478dcf7422aa14d0549c2033ce1?pvs=4).

- "Visibility" as the top-level grouping of spans+transactions UIs (same as it ever was)
- sub-teams and matching CODEOWNERS lines for UIs of the subgroups (Performance, Explore, Insights, Dashboards)
- shared code (API endpoints) are owned by Visibility (i.e., shared ownership)
- unowned (or loosely owned) code is owned by Visibility
