### PR TITLE
fix(features) Fix batch_has not trapping errors

### DIFF
--- a/src/sentry/features/handler.py
+++ b/src/sentry/features/handler.py
@@ -6,14 +6,15 @@ import abc
 from collections.abc import Mapping, MutableSet, Sequence
 from typing import TYPE_CHECKING
 
-from sentry.users.services.user import RpcUser
-
 if TYPE_CHECKING:
+    from django.contrib.auth.models import AnonymousUser
+
     from sentry.features.base import Feature
     from sentry.features.manager import FeatureCheckBatch
     from sentry.models.organization import Organization
     from sentry.models.project import Project
     from sentry.models.user import User
+    from sentry.users.services.user import RpcUser
 
 
 class FeatureHandler:
@@ -37,7 +38,10 @@ class FeatureHandler:
 
     @abc.abstractmethod
     def has(
-        self, feature: Feature, actor: User | RpcUser, skip_entity: bool | None = False
+        self,
+        feature: Feature,
+        actor: User | RpcUser | AnonymousUser | None,
+        skip_entity: bool | None = False,
     ) -> bool | None:
         raise NotImplementedError
 
@@ -52,7 +56,7 @@ class FeatureHandler:
     def batch_has(
         self,
         feature_names: Sequence[str],
-        actor: User,
+        actor: User | RpcUser | AnonymousUser | None,
         projects: Sequence[Project] | None = None,
         organization: Organization | None = None,
         batch: bool = True,

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import logging
 
-from sentry.users.services.user.model import RpcUser
-
 __all__ = ["FeatureManager"]
 
 import abc
@@ -15,6 +13,7 @@ import sentry_sdk
 from django.conf import settings
 
 from sentry.options import FLAG_AUTOMATOR_MODIFIABLE, register
+from sentry.users.services.user.model import RpcUser
 from sentry.utils import metrics
 from sentry.utils.types import Dict
 

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import logging
 
+from sentry.users.services.user.model import RpcUser
+
 __all__ = ["FeatureManager"]
 
 import abc
@@ -305,14 +307,14 @@ class FeatureManager(RegisteredFeatureManager):
                 )
 
                 return False
-        except Exception:
-            logger.exception("Failed to run feature check")
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
             return False
 
     def batch_has(
         self,
         feature_names: Sequence[str],
-        actor: User | AnonymousUser | None = None,
+        actor: User | RpcUser | AnonymousUser | None = None,
         projects: Sequence[Project] | None = None,
         organization: Organization | None = None,
     ) -> Mapping[str, Mapping[str, bool | None]] | None:
@@ -323,40 +325,47 @@ class FeatureManager(RegisteredFeatureManager):
         Will only accept one type of feature, either all ProjectFeatures or all
         OrganizationFeatures.
         """
-        if self._entity_handler:
-            with metrics.timer("features.entity_batch_has", sample_rate=0.01):
-                return self._entity_handler.batch_has(
-                    feature_names, actor, projects=projects, organization=organization
+        try:
+            if self._entity_handler:
+                with metrics.timer("features.entity_batch_has", sample_rate=0.01):
+                    return self._entity_handler.batch_has(
+                        feature_names, actor, projects=projects, organization=organization
+                    )
+            else:
+                # Fall back to default handler if no entity handler available.
+                project_features = [name for name in feature_names if name.startswith("projects:")]
+                if projects and project_features:
+                    results: MutableMapping[str, Mapping[str, bool]] = {}
+                    for project in projects:
+                        proj_results = results[f"project:{project.id}"] = {}
+                        for feature_name in project_features:
+                            proj_results[feature_name] = self.has(
+                                feature_name, project, actor=actor
+                            )
+                    return results
+
+                org_features = filter(lambda name: name.startswith("organizations:"), feature_names)
+                if organization and org_features:
+                    org_results = {}
+                    for feature_name in org_features:
+                        org_results[feature_name] = self.has(
+                            feature_name, organization, actor=actor
+                        )
+                    return {f"organization:{organization.id}": org_results}
+
+                unscoped_features = filter(
+                    lambda name: not name.startswith("organizations:")
+                    and not name.startswith("projects:"),
+                    feature_names,
                 )
-
-        else:
-            # Fall back to default handler if no entity handler available.
-            project_features = [name for name in feature_names if name.startswith("projects:")]
-            if projects and project_features:
-                results: MutableMapping[str, Mapping[str, bool]] = {}
-                for project in projects:
-                    proj_results = results[f"project:{project.id}"] = {}
-                    for feature_name in project_features:
-                        proj_results[feature_name] = self.has(feature_name, project, actor=actor)
-                return results
-
-            org_features = filter(lambda name: name.startswith("organizations:"), feature_names)
-            if organization and org_features:
-                org_results = {}
-                for feature_name in org_features:
-                    org_results[feature_name] = self.has(feature_name, organization, actor=actor)
-                return {f"organization:{organization.id}": org_results}
-
-            unscoped_features = filter(
-                lambda name: not name.startswith("organizations:")
-                and not name.startswith("projects:"),
-                feature_names,
-            )
-            if unscoped_features:
-                unscoped_results = {}
-                for feature_name in unscoped_features:
-                    unscoped_results[feature_name] = self.has(feature_name, actor=actor)
-                return {"unscoped": unscoped_results}
+                if unscoped_features:
+                    unscoped_results = {}
+                    for feature_name in unscoped_features:
+                        unscoped_results[feature_name] = self.has(feature_name, actor=actor)
+                    return {"unscoped": unscoped_results}
+                return None
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
             return None
 
     @staticmethod

--- a/tests/sentry/features/test_manager.py
+++ b/tests/sentry/features/test_manager.py
@@ -271,6 +271,17 @@ class FeatureManagerTest(TestCase):
         assert ret is not None
         assert ret[f"project:{self.project.id}"]["projects:feature"]
 
+    def test_batch_has_error(self):
+        manager = features.FeatureManager()
+        manager.add("organizations:feature", OrganizationFeature)
+        manager.add("projects:feature", ProjectFeature)
+        handler = mock.Mock(spec=features.FeatureHandler)
+        handler.batch_has.side_effect = Exception("something bad")
+        manager.add_entity_handler(handler)
+
+        ret = manager.batch_has(["auth:register"], actor=self.user)
+        assert ret is None
+
     def test_batch_has_no_entity(self):
         manager = features.FeatureManager()
         manager.add("auth:register")

--- a/tests/sentry/features/test_manager.py
+++ b/tests/sentry/features/test_manager.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import pytest
 from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
 from django.test import override_settings
 
 from sentry import features
@@ -25,7 +26,7 @@ class MockBatchHandler(features.BatchFeatureHandler):
     def has(
         self,
         feature: Feature,
-        actor: User | RpcUser,
+        actor: User | RpcUser | AnonymousUser | None,
         skip_entity: bool | None = False,
     ) -> bool:
         return True


### PR DESCRIPTION
If a FeatureHandler.batch_has() is faulty, errors should not bubble up to the application logic. Instead features system should trap errors and return a none decision.