### PR TITLE
feat(query-builder): Change sections with arrow keys

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderGridItem.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderGridItem.tsx
@@ -35,6 +35,11 @@ export function useQueryBuilderGridItem(
   // Returns true if the default behavior should be used, false if not.
   const handleInputKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>, input: HTMLInputElement): boolean => {
+      // If the focus is within a combobox menu, let the combobox handle the event
+      if (input.hasAttribute('aria-activedescendant')) {
+        return false;
+      }
+
       if (input.selectionStart === 0 && input.selectionEnd === 0) {
         // At start and going left, focus the previous grid cell (default behavior)
         if (e.key === 'ArrowLeft') {

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -275,6 +275,67 @@ describe('SearchQueryBuilder', function () {
     });
   });
 
+  describe('filter key menu', function () {
+    it('breaks keys into sections', async function () {
+      render(<SearchQueryBuilder {...defaultProps} />);
+      await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
+
+      // Should show tab button for each section
+      expect(await screen.findByRole('button', {name: 'All'})).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Category 1'})).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Category 2'})).toBeInTheDocument();
+
+      const menu = screen.getByRole('listbox');
+      const groups = within(menu).getAllByRole('group');
+      expect(groups).toHaveLength(2);
+
+      // First group (Field) should have age, assigned, browser.name
+      const group1 = groups[0];
+      expect(within(group1).getByRole('option', {name: 'age'})).toBeInTheDocument();
+      expect(within(group1).getByRole('option', {name: 'assigned'})).toBeInTheDocument();
+      expect(
+        within(group1).getByRole('option', {name: 'browser.name'})
+      ).toBeInTheDocument();
+
+      // Second group (Tag) should have custom_tag_name
+      const group2 = groups[1];
+      expect(
+        within(group2).getByRole('option', {name: 'custom_tag_name'})
+      ).toBeInTheDocument();
+
+      // Clicking "Category 2" should filter the options to only category 2
+      await userEvent.click(screen.getByRole('button', {name: 'Category 2'}));
+      await waitFor(() => {
+        expect(screen.queryByRole('option', {name: 'age'})).not.toBeInTheDocument();
+      });
+      expect(screen.getByRole('option', {name: 'custom_tag_name'})).toBeInTheDocument();
+    });
+
+    it('can navigate between sections with arrow keys', async function () {
+      render(<SearchQueryBuilder {...defaultProps} />);
+
+      await userEvent.click(getLastInput());
+      expect(screen.getByRole('button', {name: 'All'})).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+
+      // Arrow right while an option is not focused does nothing
+      await userEvent.keyboard('{ArrowRight}');
+      expect(screen.getByRole('button', {name: 'All'})).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+
+      // Arrowing down to an option and arrowing to the right should select the first section
+      await userEvent.keyboard('{ArrowDown}{ArrowDown}{ArrowRight}');
+      expect(screen.getByRole('button', {name: 'Category 1'})).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+    });
+  });
+
   describe('mouse interactions', function () {
     it('can remove a token by clicking the delete button', async function () {
       render(
@@ -495,41 +556,6 @@ describe('SearchQueryBuilder', function () {
       await waitFor(() => {
         expect(getLastInput()).toHaveValue('"Error: foo"');
       });
-    });
-
-    it('breaks keys into sections', async function () {
-      render(<SearchQueryBuilder {...defaultProps} />);
-      await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
-
-      // Should show tab button for each section
-      expect(await screen.findByRole('button', {name: 'All'})).toBeInTheDocument();
-      expect(screen.getByRole('button', {name: 'Category 1'})).toBeInTheDocument();
-      expect(screen.getByRole('button', {name: 'Category 2'})).toBeInTheDocument();
-
-      const menu = screen.getByRole('listbox');
-      const groups = within(menu).getAllByRole('group');
-      expect(groups).toHaveLength(2);
-
-      // First group (Field) should have age, assigned, browser.name
-      const group1 = groups[0];
-      expect(within(group1).getByRole('option', {name: 'age'})).toBeInTheDocument();
-      expect(within(group1).getByRole('option', {name: 'assigned'})).toBeInTheDocument();
-      expect(
-        within(group1).getByRole('option', {name: 'browser.name'})
-      ).toBeInTheDocument();
-
-      // Second group (Tag) should have custom_tag_name
-      const group2 = groups[1];
-      expect(
-        within(group2).getByRole('option', {name: 'custom_tag_name'})
-      ).toBeInTheDocument();
-
-      // Clicking "Category 2" should filter the options to only category 2
-      await userEvent.click(screen.getByRole('button', {name: 'Category 2'}));
-      await waitFor(() => {
-        expect(screen.queryByRole('option', {name: 'age'})).not.toBeInTheDocument();
-      });
-      expect(screen.getByRole('option', {name: 'custom_tag_name'})).toBeInTheDocument();
     });
 
     it('can search by key description', async function () {

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -85,7 +85,11 @@ type SearchQueryBuilderComboboxProps<T extends SelectOptionOrSectionWithKey<stri
   onExit?: () => void;
   onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void;
   onInputChange?: React.ChangeEventHandler<HTMLInputElement>;
-  onKeyDown?: (e: KeyboardEvent) => void;
+  onKeyDown?: (e: KeyboardEvent, extra: {state: ComboBoxState<T>}) => void;
+  onKeyDownCapture?: (
+    e: React.KeyboardEvent<HTMLInputElement>,
+    extra: {state: ComboBoxState<T>}
+  ) => void;
   onKeyUp?: (e: KeyboardEvent) => void;
   onOpenChange?: (newOpenState: boolean) => void;
   onPaste?: (e: React.ClipboardEvent<HTMLInputElement>) => void;
@@ -301,6 +305,7 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
     inputLabel,
     onExit,
     onKeyDown,
+    onKeyDownCapture,
     onKeyUp,
     onInputChange,
     onOpenChange,
@@ -384,7 +389,7 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
         state.close();
       },
       onKeyDown: e => {
-        onKeyDown?.(e);
+        onKeyDown?.(e, {state});
         switch (e.key) {
           case 'Escape':
             state.close();
@@ -515,6 +520,7 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
         tabIndex={tabIndex}
         onPaste={onPaste}
         disabled={disabled}
+        onKeyDownCapture={e => onKeyDownCapture?.(e, {state})}
       />
       {description ? (
         <StyledPositionWrapper

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
@@ -1,4 +1,6 @@
+import type React from 'react';
 import {useCallback, useMemo, useState} from 'react';
+import type {ComboBoxState} from '@react-stately/combobox';
 import type {Key} from '@react-types/shared';
 
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
@@ -9,6 +11,7 @@ import type {
   KeySectionItem,
 } from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/types';
 import {itemIsSection} from 'sentry/components/searchQueryBuilder/tokens/utils';
+import clamp from 'sentry/utils/number/clamp';
 
 const MAX_OPTIONS_WITHOUT_SEARCH = 100;
 const MAX_OPTIONS_WITH_SEARCH = 8;
@@ -21,22 +24,22 @@ export function useFilterKeyListBox({
   items: Array<KeyItem | KeySectionItem>;
 }) {
   const {filterKeySections} = useSearchQueryBuilder();
-  const [selectedSection, setSelectedSection] = useState<Key | null>(null);
+  const [selectedSectionKey, setSelectedSection] = useState<Key | null>(null);
 
   const sections = useMemo(() => {
-    return items.filter(itemIsSection);
+    return items.filter(item => 'options' in item);
   }, [items]);
 
   const shownItems = useMemo(
     () =>
       items.filter(item => {
         if (itemIsSection(item)) {
-          return !selectedSection || item.key === selectedSection;
+          return !selectedSectionKey || item.key === selectedSectionKey;
         }
 
         return true;
       }),
-    [items, selectedSection]
+    [items, selectedSectionKey]
   );
 
   const customMenu: CustomComboboxMenu<KeyItem | KeySectionItem> = useCallback(
@@ -44,22 +47,72 @@ export function useFilterKeyListBox({
       return (
         <FilterKeyListBox
           {...props}
-          selectedSection={selectedSection}
+          selectedSection={selectedSectionKey}
           setSelectedSection={setSelectedSection}
           sections={sections}
         />
       );
     },
-    [sections, selectedSection]
+    [sections, selectedSectionKey]
   );
 
   const shouldShowExplorationMenu =
     filterValue.length === 0 && filterKeySections.length > 0;
+
+  /**
+   * Handles switching between sections with ArrowRight and ArrowLeft.
+   * Only enabled when the special menu is shown and there is a focused option.
+   * This must be implemented with onKeyDownCapture because the focused key gets
+   * reset on ArrowRight and ArrowLeft by default [1], so we must intercept the event
+   * before that happens.
+   *
+   * [1]: https://github.com/adobe/react-spectrum/blob/3691c7fc9c4f4138e268704bb776694018f04259/packages/@react-aria/combobox/src/useComboBox.ts#L171
+   */
+  const onKeyDownCapture = useCallback(
+    (
+      e: React.KeyboardEvent<HTMLInputElement>,
+      {state}: {state: ComboBoxState<KeyItem | KeySectionItem>}
+    ) => {
+      switch (e.key) {
+        case 'ArrowRight':
+        case 'ArrowLeft': {
+          if (state.selectionManager.focusedKey === null) {
+            return;
+          }
+
+          e.preventDefault();
+          e.stopPropagation();
+
+          const sectionKeyOrder = [null, ...sections.map(section => section.key)];
+
+          const selectedSectionIndex = sectionKeyOrder.indexOf(selectedSectionKey);
+          const newIndex = clamp(
+            selectedSectionIndex + (e.key === 'ArrowRight' ? 1 : -1),
+            0,
+            sectionKeyOrder.length - 1
+          );
+          const newSectionKey = sectionKeyOrder[newIndex];
+          setSelectedSection(newSectionKey);
+          const selectedSection =
+            sections.find(section => section.key === newSectionKey) ?? sections[0];
+          state.selectionManager.setFocusedKey(
+            selectedSection?.options?.[0]?.key ?? null
+          );
+
+          return;
+        }
+        default:
+          return;
+      }
+    },
+    [sections, selectedSectionKey]
+  );
 
   return {
     sectionItems: shouldShowExplorationMenu ? shownItems : items,
     customMenu: shouldShowExplorationMenu ? customMenu : undefined,
     maxOptions:
       filterValue.length === 0 ? MAX_OPTIONS_WITHOUT_SEARCH : MAX_OPTIONS_WITH_SEARCH,
+    onKeyDownCapture: shouldShowExplorationMenu ? onKeyDownCapture : undefined,
   };
 }

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
@@ -73,37 +73,30 @@ export function useFilterKeyListBox({
       e: React.KeyboardEvent<HTMLInputElement>,
       {state}: {state: ComboBoxState<KeyItem | KeySectionItem>}
     ) => {
-      switch (e.key) {
-        case 'ArrowRight':
-        case 'ArrowLeft': {
-          if (state.selectionManager.focusedKey === null) {
-            return;
-          }
-
-          e.preventDefault();
-          e.stopPropagation();
-
-          const sectionKeyOrder = [null, ...sections.map(section => section.key)];
-
-          const selectedSectionIndex = sectionKeyOrder.indexOf(selectedSectionKey);
-          const newIndex = clamp(
-            selectedSectionIndex + (e.key === 'ArrowRight' ? 1 : -1),
-            0,
-            sectionKeyOrder.length - 1
-          );
-          const newSectionKey = sectionKeyOrder[newIndex];
-          setSelectedSection(newSectionKey);
-          const selectedSection =
-            sections.find(section => section.key === newSectionKey) ?? sections[0];
-          state.selectionManager.setFocusedKey(
-            selectedSection?.options?.[0]?.key ?? null
-          );
-
-          return;
-        }
-        default:
-          return;
+      if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') {
+        return;
       }
+
+      if (state.selectionManager.focusedKey === null) {
+        return;
+      }
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      const sectionKeyOrder = [null, ...sections.map(section => section.key)];
+
+      const selectedSectionIndex = sectionKeyOrder.indexOf(selectedSectionKey);
+      const newIndex = clamp(
+        selectedSectionIndex + (e.key === 'ArrowRight' ? 1 : -1),
+        0,
+        sectionKeyOrder.length - 1
+      );
+      const newSectionKey = sectionKeyOrder[newIndex];
+      setSelectedSection(newSectionKey);
+      const selectedSection =
+        sections.find(section => section.key === newSectionKey) ?? sections[0];
+      state.selectionManager.setFocusedKey(selectedSection?.options?.[0]?.key ?? null);
     },
     [sections, selectedSectionKey]
   );

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -453,7 +453,7 @@ function SearchQueryBuilderInputInternal({
     updateSelectionIndex();
   }, [updateSelectionIndex]);
 
-  const {customMenu, sectionItems, maxOptions} = useFilterKeyListBox({
+  const {customMenu, sectionItems, maxOptions, onKeyDownCapture} = useFilterKeyListBox({
     items,
     filterValue,
   });
@@ -577,6 +577,7 @@ function SearchQueryBuilderInputInternal({
           setSelectionIndex(e.target.selectionStart ?? 0);
         }}
         onKeyDown={onKeyDown}
+        onKeyDownCapture={onKeyDownCapture}
         onOpenChange={setIsOpen}
         tabIndex={item.key === state.selectionManager.focusedKey ? 0 : -1}
         maxOptions={maxOptions}


### PR DESCRIPTION
If and only if there is a focused item within the filter key menu, arrow left/right will switch sections.

https://github.com/user-attachments/assets/6aa8035a-bf52-44dc-b410-22cb994f7d9e

