### PR TITLE
feat(dashboards): Set widgetType with discover split in prebuilt

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboard_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_details.py
@@ -47,7 +47,7 @@ class OrganizationDashboardBase(OrganizationEndpoint):
         return (args, kwargs)
 
     def _get_dashboard(self, request: Request, organization, dashboard_id):
-        prebuilt = Dashboard.get_prebuilt(dashboard_id)
+        prebuilt = Dashboard.get_prebuilt(organization, request.user, dashboard_id)
         sentry_sdk.set_tag("dashboard.is_prebuilt", prebuilt is not None)
         if prebuilt:
             return prebuilt

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -92,7 +92,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         query = request.GET.get("query")
         if query:
             dashboards = dashboards.filter(title__icontains=query)
-        prebuilt = Dashboard.get_prebuilt_list(organization, query)
+        prebuilt = Dashboard.get_prebuilt_list(organization, request.user, query)
 
         sort_by = request.query_params.get("sort")
         if sort_by and sort_by.startswith("-"):

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -62,7 +62,9 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         assert response.status_code == 200, response.content
         assert "default-overview" == response.data[0]["id"]
 
-        default_overview_data = Dashboard.get_prebuilt("default-overview")
+        default_overview_data = Dashboard.get_prebuilt(
+            self.organization, self.user, "default-overview"
+        )
         default_overview = response.data[0]
         assert default_overview["widgetPreview"] == [
             {"displayType": w["displayType"], "layout": None}


### PR DESCRIPTION
There is one dashboard that is prebuilt and sent from the backend. This passes along the organization and user values to determine which dataset to use. It also updates the conditions to drop the `event.type` filter if the user has the split flag, otherwise we send the old conditions

Best viewed with whitespace changes off because a big diff is due to wrapping the constant in a function to handle feature flagging.