### PR TITLE
chore(anr): Remove `anr-improvements` flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1444,6 +1444,7 @@ CRISPY_TEMPLATE_PACK = "bootstrap3"
 
 SENTRY_EARLY_FEATURES = {
     "organizations:anr-analyze-frames": "Enable anr frame analysis",
+    "organizations:anr-improvements": "Enable anr improvements ui",
     "organizations:device-classification": "Enable device.class as a selectable column",
     "organizations:gitlab-disable-on-broken": "Enable disabling gitlab integrations when broken is detected",
     "organizations:grouping-stacktrace-ui": "Enable experimental new version of stacktrace component where additional data related to grouping is shown on each frame",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1444,7 +1444,6 @@ CRISPY_TEMPLATE_PACK = "bootstrap3"
 
 SENTRY_EARLY_FEATURES = {
     "organizations:anr-analyze-frames": "Enable anr frame analysis",
-    "organizations:anr-improvements": "Enable anr improvements ui",
     "organizations:device-classification": "Enable device.class as a selectable column",
     "organizations:gitlab-disable-on-broken": "Enable disabling gitlab integrations when broken is detected",
     "organizations:grouping-stacktrace-ui": "Enable experimental new version of stacktrace component where additional data related to grouping is shown on each frame",

--- a/static/app/components/events/eventEntry.tsx
+++ b/static/app/components/events/eventEntry.tsx
@@ -108,7 +108,6 @@ function EventEntryContent({
           projectSlug={projectSlug}
           groupingCurrentLevel={groupingCurrentLevel}
           hasHierarchicalGrouping={hasHierarchicalGrouping}
-          organization={organization as Organization}
         />
       );
 

--- a/static/app/components/events/interfaces/threads.spec.tsx
+++ b/static/app/components/events/interfaces/threads.spec.tsx
@@ -225,7 +225,6 @@ describe('Threads', function () {
         groupingCurrentLevel: 0,
         hasHierarchicalGrouping: true,
         projectSlug: project.slug,
-        organization,
       };
 
       it('renders', async function () {
@@ -878,7 +877,6 @@ describe('Threads', function () {
         groupingCurrentLevel: 0,
         hasHierarchicalGrouping: true,
         projectSlug: project.slug,
-        organization,
       };
 
       it('renders', async function () {
@@ -893,9 +891,9 @@ describe('Threads', function () {
         expect(screen.getByRole('radio', {name: 'Full Stack Trace'})).not.toBeChecked();
         expect(screen.getByRole('button', {name: 'Options'})).toBeInTheDocument();
 
-        expect(screen.queryByText('Threads')).not.toBeInTheDocument();
-        expect(screen.queryByText('Thread State')).not.toBeInTheDocument();
-        expect(screen.queryByText('Thread Tags')).not.toBeInTheDocument();
+        expect(screen.queryByText('Threads')).toBeInTheDocument();
+        expect(screen.queryByText('Thread State')).toBeInTheDocument();
+        expect(screen.queryByText('Thread Tags')).toBeInTheDocument();
 
         // Stack Trace
         expect(screen.getByRole('heading', {name: 'EXC_BAD_ACCESS'})).toBeInTheDocument();
@@ -910,12 +908,8 @@ describe('Threads', function () {
       });
 
       it('renders thread state and lock reason', async function () {
-        const newOrg = {
-          ...organization,
-          features: ['anr-improvements'],
-        };
-        const newProps = {...props, organization: newOrg};
-        render(<Threads {...newProps} />, {organization: newOrg});
+        const newProps = {...props, organization};
+        render(<Threads {...newProps} />, {organization});
         // Title
         expect(await screen.findByTestId('thread-selector')).toBeInTheDocument();
 
@@ -945,10 +939,6 @@ describe('Threads', function () {
       });
 
       it('hides thread tag event entry if none', async function () {
-        const newOrg = {
-          ...organization,
-          features: ['anr-improvements'],
-        };
         const newProps = {
           ...props,
           data: {
@@ -991,9 +981,8 @@ describe('Threads', function () {
               },
             ],
           },
-          organization: newOrg,
         };
-        render(<Threads {...newProps} />, {organization: newOrg});
+        render(<Threads {...newProps} />, {organization});
         expect(await screen.findByTestId('event-section-threads')).toBeInTheDocument();
         expect(screen.queryByText('Thread Tags')).not.toBeInTheDocument();
       });
@@ -1046,12 +1035,8 @@ describe('Threads', function () {
           },
         ];
 
-        const newOrg = {
-          ...organization,
-          features: ['anr-improvements'],
-        };
-        const newProps = {...props, event: newEvent, organization: newOrg};
-        render(<Threads {...newProps} />, {organization: newOrg});
+        const newProps = {...props, event: newEvent};
+        render(<Threads {...newProps} />, {organization});
         // Title
         expect(await screen.findByTestId('thread-selector')).toBeInTheDocument();
 

--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -19,7 +19,6 @@ import {space} from 'sentry/styles/space';
 import {StackType, StackView} from 'sentry/types';
 import type {Event, Thread} from 'sentry/types/event';
 import {EntryType} from 'sentry/types/event';
-import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {FoldSectionKey} from 'sentry/views/issueDetails/streamline/foldSection';
@@ -43,7 +42,6 @@ type Props = Pick<ExceptionProps, 'groupingCurrentLevel' | 'hasHierarchicalGroup
     values?: Array<Thread>;
   };
   event: Event;
-  organization: Organization;
   projectSlug: Project['slug'];
 };
 
@@ -103,7 +101,6 @@ export function Threads({
   projectSlug,
   hasHierarchicalGrouping,
   groupingCurrentLevel,
-  organization,
 }: Props) {
   const threads = data.values ?? [];
 
@@ -234,7 +231,7 @@ export function Threads({
 
   return (
     <Fragment>
-      {hasMoreThanOneThread && organization.features.includes('anr-improvements') && (
+      {hasMoreThanOneThread && (
         <Fragment>
           <Grid>
             <InterimSection type={FoldSectionKey.THREADS} title={t('Threads')}>
@@ -286,26 +283,7 @@ export function Threads({
         eventId={event.id}
         recentFirst={isStacktraceNewestFirst()}
         fullStackTrace={stackView === StackView.FULL}
-        title={
-          hasMoreThanOneThread &&
-          activeThread &&
-          !organization.features.includes('anr-improvements') ? (
-            <ThreadSelector
-              threads={threads}
-              activeThread={activeThread}
-              event={event}
-              onChange={thread => {
-                setActiveThread(thread);
-              }}
-              exception={exception}
-              fullWidth
-            />
-          ) : hasMoreThanOneThread ? (
-            t('Thread Stack Trace')
-          ) : (
-            t('Stack Trace')
-          )
-        }
+        title={hasMoreThanOneThread ? t('Thread Stack Trace') : t('Stack Trace')}
         platform={platform}
         hasMinified={
           !!exception?.values?.find(value => value.rawStacktrace) ||
@@ -363,8 +341,6 @@ export function Threads({
 
           return (
             <Fragment>
-              {!organization.features.includes('anr-improvements') && renderPills()}
-
               {stackTrace && !isRaw && (
                 <ErrorBoundary customComponent={null}>
                   <StacktraceBanners event={event} stacktrace={stackTrace} />

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -633,11 +633,7 @@ describe('Platform Integrations', () => {
       MockApiClient.clearMockResponses();
     });
     it('shows anr root cause', async () => {
-      const {organization} = initializeOrg();
-      const props = makeDefaultMockData({
-        ...organization,
-        features: ['anr-improvements'],
-      });
+      const props = makeDefaultMockData();
       mockGroupApis(
         props.organization,
         props.project,
@@ -659,11 +655,7 @@ describe('Platform Integrations', () => {
     });
 
     it('does not render root issues section if related perf issues do not exist', async () => {
-      const {organization} = initializeOrg();
-      const props = makeDefaultMockData({
-        ...organization,
-        features: ['anr-improvements'],
-      });
+      const props = makeDefaultMockData();
       const trace = mockedTrace(props.project);
       mockGroupApis(props.organization, props.project, props.group, props.event, {
         ...trace,

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -120,7 +120,6 @@ function DefaultGroupEventDetailsContent({
   const hasReplay = Boolean(getReplayIdFromEvent(event));
   const mechanism = event.tags?.find(({key}) => key === 'mechanism')?.value;
   const isANR = mechanism === 'ANR' || mechanism === 'AppExitInfo';
-  const hasAnrImprovementsFeature = organization.features.includes('anr-improvements');
   const showPossibleSolutionsHigher = shouldShowCustomErrorResourceConfig(group, project);
 
   const eventEntryProps = {group, event, project};
@@ -256,7 +255,7 @@ function DefaultGroupEventDetailsContent({
         entryType={EntryType.THREADS}
         {...eventEntryProps}
       />
-      {hasAnrImprovementsFeature && isANR && (
+      {isANR && (
         <QuickTraceQuery
           event={event}
           location={location}


### PR DESCRIPTION
The flag is already GA and this would simplify the refactors that are going to be done for the stack trace sections with threads.

Next PR will be to remove the flag from flagpole, then lastly remove the registration from manager.py.