### PR TITLE
feat(autofix): Send code repos to Autofix frontend

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -17,6 +17,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import EventSerializer, serialize
 from sentry.autofix.utils import get_autofix_repos_from_project_code_mappings, get_autofix_state
+from sentry.integrations.utils.code_mapping import get_sorted_code_mapping_configs
 from sentry.models.group import Group
 from sentry.models.user import User
 from sentry.seer.signed_seer_api import sign_with_seer_secret
@@ -224,5 +225,22 @@ class GroupAutofixEndpoint(GroupEndpoint):
                 users_map = {user["id"]: user for user in users}
 
                 response_state["users"] = users_map
+
+            project = group.project
+            repositories = []
+            if project:
+                code_mappings = get_sorted_code_mapping_configs(project=project)
+                for mapping in code_mappings:
+                    repo = mapping.repository
+                    repositories.append(
+                        {
+                            "url": repo.url,
+                            "external_id": repo.external_id,
+                            "name": repo.name,
+                            "provider": repo.provider,
+                            "default_branch": mapping.default_branch,
+                        }
+                    )
+            response_state["repositories"] = repositories
 
         return Response({"autofix": response_state})

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, Mock, patch
 
 from sentry.api.endpoints.group_ai_autofix import TIMEOUT_SECONDS
 from sentry.autofix.utils import AutofixState, AutofixStatus
@@ -49,6 +49,38 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert response.data["autofix"] is None
 
         mock_get_autofix_state.assert_called_once_with(group_id=group.id)
+
+    @patch("sentry.api.endpoints.group_ai_autofix.get_autofix_state")
+    @patch("sentry.api.endpoints.group_ai_autofix.get_sorted_code_mapping_configs")
+    def test_ai_autofix_get_endpoint_repositories(
+        self, mock_get_sorted_code_mapping_configs, mock_get_autofix_state
+    ):
+        group = self.create_group()
+        mock_get_autofix_state.return_value = AutofixState(
+            run_id=123,
+            request={"project_id": 456, "issue": {"id": 789}},
+            updated_at=datetime.strptime("2023-07-18T12:00:00Z", "%Y-%m-%dT%H:%M:%SZ"),
+            status=AutofixStatus.PROCESSING,
+        )
+
+        class TestRepo:
+            def __init__(self):
+                self.url = "example.com"
+                self.external_id = "id123"
+                self.name = "test_repo"
+                self.provider = "github"
+
+        mock_get_sorted_code_mapping_configs.return_value = [
+            Mock(repository=TestRepo(), default_branch="main"),
+        ]
+
+        self.login_as(user=self.user)
+        response = self.client.get(self._get_url(group.id), format="json")
+
+        assert response.status_code == 200
+        assert response.data["autofix"] is not None
+        assert len(response.data["autofix"]["repositories"]) == 1
+        assert response.data["autofix"]["repositories"][0]["default_branch"] == "main"
 
     @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_autofix")
     @patch("sentry.tasks.autofix.check_autofix_status.apply_async")


### PR DESCRIPTION
Send information on available code repositories to the Autofix frontend using code mappings. This will be used on the frontend to provide hyperlinks to code files in GitHub.