### PR TITLE
fix(fe): Move Feedback Button on Project Details Page

### DIFF
--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -11,7 +11,7 @@ import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import CreateAlertButton from 'sentry/components/createAlertButton';
-import FloatingFeedbackWidget from 'sentry/components/feedback/widget/floatingFeedbackWidget';
+import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import GlobalEventProcessingAlert from 'sentry/components/globalEventProcessingAlert';
 import IdBadge from 'sentry/components/idBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -177,6 +177,7 @@ export default function ProjectDetail({router, location, organization}: Props) {
 
               <Layout.HeaderActions>
                 <ButtonBar gap={1}>
+                  <FeedbackWidgetButton />
                   <Button
                     size="sm"
                     to={
@@ -206,7 +207,6 @@ export default function ProjectDetail({router, location, organization}: Props) {
 
             <Layout.Body noRowGap>
               {project && <StyledGlobalEventProcessingAlert projects={[project]} />}
-              <FloatingFeedbackWidget />
               <Layout.Main>
                 <ProjectFiltersWrapper>
                   <ProjectFilters


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/c6ec84b7-8341-495e-b105-ea0e565092e6)

Originally the floating widget was hiding "Docs" and "Contribute" links in the footer in a way that makes them unclickable.

I moved the button into the header like the other pages in the UI