### PR TITLE
feat(autofix): Add github links to code context snippets

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -17,7 +17,6 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import EventSerializer, serialize
 from sentry.autofix.utils import get_autofix_repos_from_project_code_mappings, get_autofix_state
-from sentry.integrations.utils.code_mapping import get_sorted_code_mapping_configs
 from sentry.models.group import Group
 from sentry.models.user import User
 from sentry.seer.signed_seer_api import sign_with_seer_secret
@@ -225,22 +224,5 @@ class GroupAutofixEndpoint(GroupEndpoint):
                 users_map = {user["id"]: user for user in users}
 
                 response_state["users"] = users_map
-
-            project = group.project
-            repositories = []
-            if project:
-                code_mappings = get_sorted_code_mapping_configs(project=project)
-                for mapping in code_mappings:
-                    repo = mapping.repository
-                    repositories.append(
-                        {
-                            "url": repo.url,
-                            "external_id": repo.external_id,
-                            "name": repo.name,
-                            "provider": repo.provider,
-                            "default_branch": mapping.default_branch,
-                        }
-                    )
-            response_state["repositories"] = repositories
 
         return Response({"autofix": response_state})

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -17,6 +17,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import EventSerializer, serialize
 from sentry.autofix.utils import get_autofix_repos_from_project_code_mappings, get_autofix_state
+from sentry.integrations.utils.code_mapping import get_sorted_code_mapping_configs
 from sentry.models.group import Group
 from sentry.models.user import User
 from sentry.seer.signed_seer_api import sign_with_seer_secret
@@ -224,5 +225,22 @@ class GroupAutofixEndpoint(GroupEndpoint):
                 users_map = {user["id"]: user for user in users}
 
                 response_state["users"] = users_map
+
+            project = group.project
+            repositories = []
+            if project:
+                code_mappings = get_sorted_code_mapping_configs(project=project)
+                for mapping in code_mappings:
+                    repo = mapping.repository
+                    repositories.append(
+                        {
+                            "url": repo.url,
+                            "external_id": repo.external_id,
+                            "name": repo.name,
+                            "provider": repo.provider,
+                            "default_branch": mapping.default_branch,
+                        }
+                    )
+            response_state["repositories"] = repositories
 
         return Response({"autofix": response_state})

--- a/static/app/components/events/autofix/autofixRootCause.spec.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.spec.tsx
@@ -10,6 +10,7 @@ describe('AutofixRootCause', function () {
     groupId: '1',
     rootCauseSelection: null,
     runId: '101',
+    repos: [],
   };
 
   it('can select a relevant code snippet', async function () {
@@ -32,7 +33,7 @@ describe('AutofixRootCause', function () {
       screen.getByText('This is the description of a relevant code snippet.')
     ).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('button', {name: 'Continue with a fix'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Find a Fix'}));
 
     expect(mockSelectFix).toHaveBeenCalledWith(
       expect.anything(),
@@ -62,8 +63,8 @@ describe('AutofixRootCause', function () {
     await userEvent.keyboard('custom root cause');
     await userEvent.click(
       screen.getByRole('button', {
-        name: 'Continue with a fix',
-        description: 'Continue with a fix',
+        name: 'Find a Fix',
+        description: 'Find a Fix',
       })
     );
 

--- a/static/app/components/events/autofix/autofixRootCause.spec.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.spec.tsx
@@ -107,7 +107,7 @@ describe('AutofixRootCause', function () {
             {
               default_branch: 'main',
               external_id: 'id',
-              name: 'test_owner/test_repo',
+              name: 'owner/repo',
               provider: 'integrations:github',
               url: 'https://github.com/test_owner/test_repo',
             },
@@ -116,7 +116,11 @@ describe('AutofixRootCause', function () {
       />
     );
 
-    expect(screen.getByLabelText('GitHub')).toBeInTheDocument();
+    expect(screen.queryByRole('link', {name: 'GitHub'})).toBeInTheDocument();
+    expect(screen.queryByRole('link', {name: 'GitHub'})).toHaveAttribute(
+      'href',
+      'https://github.com/test_owner/test_repo/blob/main/src/file.py'
+    );
   });
 
   it('shows no hyperlink when no matching GitHub repo available', function () {
@@ -129,6 +133,6 @@ describe('AutofixRootCause', function () {
       />
     );
 
-    expect(screen.getByLabelText('GitHub')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', {name: 'GitHub'})).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/events/autofix/autofixRootCause.spec.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.spec.tsx
@@ -97,4 +97,38 @@ describe('AutofixRootCause', function () {
       screen.getByText('Autofix was not able to find a root cause. Maybe try again?')
     ).toBeInTheDocument();
   });
+
+  it('shows hyperlink when matching GitHub repo available', function () {
+    render(
+      <AutofixRootCause
+        {...{
+          ...defaultProps,
+          repos: [
+            {
+              default_branch: 'main',
+              external_id: 'id',
+              name: 'test_owner/test_repo',
+              provider: 'integrations:github',
+              url: 'https://github.com/test_owner/test_repo',
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(screen.getByLabelText('GitHub')).toBeInTheDocument();
+  });
+
+  it('shows no hyperlink when no matching GitHub repo available', function () {
+    render(
+      <AutofixRootCause
+        {...{
+          ...defaultProps,
+          repos: [],
+        }}
+      />
+    );
+
+    expect(screen.getByLabelText('GitHub')).not.toBeInTheDocument();
+  });
 });

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -1,4 +1,5 @@
 import {type ReactNode, useState} from 'react';
+import {css, keyframes} from '@emotion/react';
 import styled from '@emotion/styled';
 import {AnimatePresence, type AnimationProps, motion} from 'framer-motion';
 
@@ -8,6 +9,7 @@ import {Button} from 'sentry/components/button';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import {AutofixShowMore} from 'sentry/components/events/autofix/autofixShowMore';
 import {
+  type AutofixRepository,
   type AutofixRootCauseCodeContext,
   type AutofixRootCauseCodeContextSnippet,
   type AutofixRootCauseData,
@@ -20,10 +22,13 @@ import {
 } from 'sentry/components/events/autofix/useAutofix';
 import TextArea from 'sentry/components/forms/controls/textarea';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {Tooltip} from 'sentry/components/tooltip';
 import {IconChevron} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {getFileExtension} from 'sentry/utils/fileExtension';
+import {getIntegrationIcon} from 'sentry/utils/integrationUtil';
 import marked, {singleLineRenderer} from 'sentry/utils/marked';
 import {getPrismLanguage} from 'sentry/utils/prism';
 import {setApiQueryData, useMutation, useQueryClient} from 'sentry/utils/queryClient';
@@ -33,6 +38,7 @@ import useApi from 'sentry/utils/useApi';
 type AutofixRootCauseProps = {
   causes: AutofixRootCauseData[];
   groupId: string;
+  repos: AutofixRepository[];
   rootCauseSelection: AutofixRootCauseSelection;
   runId: string;
 };
@@ -170,15 +176,29 @@ function RootCauseContent({
 function SuggestedFixSnippet({
   snippet,
   linesToHighlight,
+  repos,
 }: {
   linesToHighlight: number[];
+  repos: AutofixRepository[];
   snippet: AutofixRootCauseCodeContextSnippet;
 }) {
+  function getSourceLink() {
+    for (const repo of repos) {
+      if (repo.name === snippet.repo_name) {
+        if (repo.provider === 'integrations:github') {
+          const sourceLink = `${repo.url}/blob/${repo.default_branch}/${snippet.file_path}`;
+          return sourceLink;
+        }
+      }
+    }
+    return undefined;
+  }
   const extension = getFileExtension(snippet.file_path);
   const lanugage = extension ? getPrismLanguage(extension) : undefined;
+  const sourceLink = getSourceLink();
 
   return (
-    <div>
+    <CodeSnippetWrapper>
       <StyledCodeSnippet
         filename={snippet.file_path}
         language={lanugage}
@@ -187,7 +207,16 @@ function SuggestedFixSnippet({
       >
         {snippet.snippet}
       </StyledCodeSnippet>
-    </div>
+      {sourceLink && (
+        <CodeLinkWrapper>
+          <Tooltip title={t('Open this file in GitHub')} skipWrapper>
+            <OpenInLink href={sourceLink} openInNewTab aria-label={t('GitHub')}>
+              <StyledIconWrapper>{getIntegrationIcon('github', 'sm')}</StyledIconWrapper>
+            </OpenInLink>
+          </Tooltip>
+        </CodeLinkWrapper>
+      )}
+    </CodeSnippetWrapper>
   );
 }
 
@@ -197,9 +226,11 @@ function CauseOption({
   setSelectedId,
   runId,
   groupId,
+  repos,
 }: {
   cause: AutofixRootCauseData;
   groupId: string;
+  repos: AutofixRepository[];
   runId: string;
   selected: boolean;
   setSelectedId: (id: string) => void;
@@ -224,7 +255,7 @@ function CauseOption({
             analyticsEventKey="autofix.root_cause_fix_selected"
             analyticsParams={{group_id: groupId}}
           >
-            {t('Continue with a fix')}
+            {t('Find a Fix')}
           </Button>
           <Button
             icon={<IconChevron size="xs" direction={selected ? 'down' : 'right'} />}
@@ -242,7 +273,7 @@ function CauseOption({
             __html: marked(cause.description),
           }}
         />
-        <AutofixRootCauseCodeContexts codeContext={cause.code_context} />
+        <AutofixRootCauseCodeContexts codeContext={cause.code_context} repos={repos} />
       </RootCauseContent>
     </RootCauseOption>
   );
@@ -251,8 +282,10 @@ function CauseOption({
 function SelectedRootCauseOption({
   selectedCause,
   codeContext,
+  repos,
 }: {
   codeContext: AutofixRootCauseCodeContext[];
+  repos: AutofixRepository[];
   selectedCause: AutofixRootCauseData;
 }) {
   return (
@@ -267,7 +300,7 @@ function SelectedRootCauseOption({
           __html: marked(selectedCause.description),
         }}
       />
-      <AutofixRootCauseCodeContexts codeContext={codeContext} />
+      <AutofixRootCauseCodeContexts codeContext={codeContext} repos={repos} />
     </RootCauseOption>
   );
 }
@@ -321,7 +354,7 @@ function ProvideYourOwn({
             aria-describedby="continue-custom-root-cause"
             id="continue-custom-root-cause"
           >
-            {t('Continue with a fix')}
+            {t('Find a Fix')}
           </Button>
         </OptionFooter>
       </RootCauseContent>
@@ -334,6 +367,7 @@ function AutofixRootCauseDisplay({
   groupId,
   runId,
   rootCauseSelection,
+  repos,
 }: AutofixRootCauseProps) {
   const [selectedId, setSelectedId] = useState(() => causes[0].id);
 
@@ -362,6 +396,7 @@ function AutofixRootCauseDisplay({
         <SelectedRootCauseOption
           codeContext={selectedCause?.code_context}
           selectedCause={selectedCause}
+          repos={repos}
         />
         {otherCauses.length > 0 && (
           <AutofixShowMore title={t('Show unselected causes')}>
@@ -377,7 +412,10 @@ function AutofixRootCauseDisplay({
                     __html: marked(cause.description),
                   }}
                 />
-                <AutofixRootCauseCodeContexts codeContext={cause.code_context} />
+                <AutofixRootCauseCodeContexts
+                  codeContext={cause.code_context}
+                  repos={repos}
+                />
               </RootCauseOption>
             ))}
           </AutofixShowMore>
@@ -405,6 +443,7 @@ function AutofixRootCauseDisplay({
               setSelectedId={setSelectedId}
               runId={runId}
               groupId={groupId}
+              repos={repos}
             />
           ))}
           <ProvideYourOwn
@@ -435,8 +474,10 @@ export function AutofixRootCause(props: AutofixRootCauseProps) {
 
 export function AutofixRootCauseCodeContexts({
   codeContext,
+  repos,
 }: {
   codeContext: AutofixRootCauseCodeContext[];
+  repos: AutofixRepository[];
 }) {
   return codeContext?.map((fix, index) => (
     <SuggestedFixWrapper key={fix.id}>
@@ -456,6 +497,7 @@ export function AutofixRootCauseCodeContexts({
         <SuggestedFixSnippet
           snippet={fix.snippet}
           linesToHighlight={getLinesToHighlight(fix)}
+          repos={repos}
         />
       )}
     </SuggestedFixWrapper>
@@ -564,4 +606,42 @@ const CustomRootCausePadding = styled('div')`
 const RootCauseOptionsRow = styled('div')`
   display: flex;
   flex-direction: row;
+`;
+
+const fadeIn = keyframes`
+  from { opacity: 0; }
+  to { opacity: 1; }
+`;
+
+const StyledIconWrapper = styled('span')`
+  color: inherit;
+  line-height: 0;
+`;
+
+const LinkStyles = css`
+  align-items: center;
+  gap: ${space(0.75)};
+`;
+
+const OpenInLink = styled(ExternalLink)`
+  ${LinkStyles}
+  color: ${p => p.theme.subText};
+  animation: ${fadeIn} 0.2s ease-in-out forwards;
+  &:hover {
+    color: ${p => p.theme.textColor};
+  }
+`;
+
+const CodeLinkWrapper = styled('div')`
+  gap: ${space(1)};
+  color: ${p => p.theme.subText};
+  font-family: ${p => p.theme.text.family};
+  padding: ${space(0)} ${space(1)};
+  position: absolute;
+  top: 8px;
+  right: 0;
+`;
+
+const CodeSnippetWrapper = styled('div')`
+  position: relative;
 `;

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -632,7 +632,7 @@ const CodeLinkWrapper = styled('div')`
   gap: ${space(1)};
   color: ${p => p.theme.subText};
   font-family: ${p => p.theme.text.family};
-  padding: ${space(0)} ${space(1)};
+  padding: 0 ${space(1)};
   position: absolute;
   top: 8px;
   right: 0;

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -183,15 +183,11 @@ function SuggestedFixSnippet({
   snippet: AutofixRootCauseCodeContextSnippet;
 }) {
   function getSourceLink() {
-    for (const repo of repos) {
-      if (repo.name === snippet.repo_name) {
-        if (repo.provider === 'integrations:github') {
-          const sourceLink = `${repo.url}/blob/${repo.default_branch}/${snippet.file_path}`;
-          return sourceLink;
-        }
-      }
-    }
-    return undefined;
+    const repo = repos.find(
+      r => r.name === snippet.repo_name && r.provider === 'integrations:github'
+    );
+    if (!repo) return undefined;
+    return `${repo.url}/blob/${repo.default_branch}/${snippet.file_path}`;
   }
   const extension = getFileExtension(snippet.file_path);
   const lanugage = extension ? getPrismLanguage(extension) : undefined;

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -10,6 +10,7 @@ import {AutofixRootCause} from 'sentry/components/events/autofix/autofixRootCaus
 import {
   type AutofixData,
   type AutofixProgressItem,
+  type AutofixRepository,
   type AutofixStep,
   AutofixStepType,
   type AutofixUserResponseStep,
@@ -76,6 +77,7 @@ function stepShouldBeginExpanded(step: AutofixStep, isLastStep?: boolean) {
 interface StepProps {
   groupId: string;
   onRetry: () => void;
+  repos: AutofixRepository[];
   runId: string;
   step: AutofixStep;
   isChild?: boolean;
@@ -114,10 +116,12 @@ function Progress({
   groupId,
   runId,
   onRetry,
+  repos,
 }: {
   groupId: string;
   onRetry: () => void;
   progress: AutofixProgressItem | AutofixStep;
+  repos: AutofixRepository[];
   runId: string;
 }) {
   if (isProgressLog(progress)) {
@@ -147,6 +151,7 @@ function Progress({
         groupId={groupId}
         runId={runId}
         onRetry={onRetry}
+        repos={repos}
       />
     </ProgressStepContainer>
   );
@@ -159,6 +164,7 @@ export function ExpandableStep({
   runId,
   isLastStep,
   onRetry,
+  repos,
 }: StepProps) {
   const previousIsLastStep = usePrevious(isLastStep);
   const previousStepStatus = usePrevious(step.status);
@@ -241,6 +247,7 @@ export function ExpandableStep({
                   groupId={groupId}
                   runId={runId}
                   onRetry={onRetry}
+                  repos={repos}
                 />
               ))}
             </ProgressContainer>
@@ -251,6 +258,7 @@ export function ExpandableStep({
               runId={runId}
               causes={step.causes}
               rootCauseSelection={step.selection}
+              repos={repos}
             />
           )}
           {step.type === AutofixStepType.CHANGES && (
@@ -284,7 +292,7 @@ function UserStep({step, groupId}: UserStepProps) {
   );
 }
 
-function Step({step, groupId, runId, onRetry, stepNumber, isLastStep}: StepProps) {
+function Step({step, groupId, runId, onRetry, stepNumber, isLastStep, repos}: StepProps) {
   if (step.type === AutofixStepType.USER_RESPONSE) {
     return (
       <UserStep
@@ -293,6 +301,7 @@ function Step({step, groupId, runId, onRetry, stepNumber, isLastStep}: StepProps
         runId={runId}
         onRetry={onRetry}
         isLastStep={isLastStep}
+        repos={repos}
       />
     );
   }
@@ -305,12 +314,14 @@ function Step({step, groupId, runId, onRetry, stepNumber, isLastStep}: StepProps
       onRetry={onRetry}
       stepNumber={stepNumber}
       isLastStep={isLastStep}
+      repos={repos}
     />
   );
 }
 
 export function AutofixSteps({data, groupId, runId, onRetry}: AutofixStepsProps) {
   const steps = data.steps;
+  const repos = data.repositories;
 
   if (!steps) {
     return null;
@@ -330,6 +341,7 @@ export function AutofixSteps({data, groupId, runId, onRetry}: AutofixStepsProps)
           runId={runId}
           onRetry={onRetry}
           isLastStep={index === steps.length - 1}
+          repos={repos}
         />
       ))}
       {showInputField && <AutofixInputField runId={data.run_id} groupId={groupId} />}

--- a/static/app/components/events/autofix/index.spec.tsx
+++ b/static/app/components/events/autofix/index.spec.tsx
@@ -177,6 +177,7 @@ describe('Autofix', () => {
                       snippet: {
                         file_path: 'test/file/path.py',
                         snippet: 'two = 1 + 1',
+                        repo_name: 'owner/repo',
                       },
                     },
                   ],

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -38,8 +38,17 @@ export type AutofixOptions = {
   iterative_feedback?: boolean;
 };
 
+export type AutofixRepository = {
+  default_branch: string;
+  external_id: string;
+  name: string;
+  provider: string;
+  url: string;
+};
+
 export type AutofixData = {
   created_at: string;
+  repositories: AutofixRepository[];
   run_id: string;
   status:
     | 'PENDING'
@@ -123,6 +132,7 @@ export interface AutofixUserResponseStep extends BaseStep {
 
 export type AutofixRootCauseCodeContextSnippet = {
   file_path: string;
+  repo_name: string;
   snippet: string;
 };
 

--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -39,6 +39,7 @@ const makeInitialAutofixData = (): AutofixResponse => ({
       },
     ],
     created_at: new Date().toISOString(),
+    repositories: [],
   },
 });
 

--- a/tests/js/fixtures/autofixData.ts
+++ b/tests/js/fixtures/autofixData.ts
@@ -1,4 +1,4 @@
-import {AutofixData} from 'sentry/components/events/autofix/types';
+import { AutofixData } from 'sentry/components/events/autofix/types';
 
 export function AutofixDataFixture(params: Partial<AutofixData>): AutofixData {
   return {
@@ -7,6 +7,7 @@ export function AutofixDataFixture(params: Partial<AutofixData>): AutofixData {
     completed_at: '',
     created_at: '',
     steps: [],
+    repositories: [],
     ...params,
   };
 }

--- a/tests/js/fixtures/autofixRootCauseCodeContext.ts
+++ b/tests/js/fixtures/autofixRootCauseCodeContext.ts
@@ -10,6 +10,7 @@ export function AutofixRootCauseCodeContext(
     snippet: {
       file_path: 'src/file.py',
       snippet: 'x = 1 + 1;',
+      repo_name: 'owner/repo'
     },
     ...params,
   };


### PR DESCRIPTION
Add GitHub hyperlinks to code snippets shown in Autofix's root cause analysis.

(We're not doing line numbers as of now as LLMs are usually wrong about exact numbers)

![image](https://github.com/user-attachments/assets/9da7cf16-a4d1-46da-834f-1c8552fd4bf7)