### PR TITLE
ref(grouping): Improve config transition metrics

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1403,7 +1403,7 @@ def _save_aggregate(
     # hashes, we're free to perform a config update if permitted. Future events will use the new
     # config, but will also be grandfathered into the current config for a month, so as not to
     # erroneously create new groups.
-    update_grouping_config_if_permitted(project)
+    update_grouping_config_if_permitted(project, "ingest")
 
     _materialize_metadata_many([job])
     metadata = dict(job["event_metadata"])
@@ -1761,7 +1761,7 @@ def _save_aggregate_new(
     # hashes, we're free to perform a config update if needed. Future events will use the new
     # config, but will also be grandfathered into the current config for a week, so as not to
     # erroneously create new groups.
-    update_grouping_config_if_permitted(project)
+    update_grouping_config_if_permitted(project, "ingest")
 
     return group_info
 

--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -28,7 +28,7 @@ DO_NOT_UPGRADE_YET = ("legacy:2019-03-12", "newstyle:2019-10-29", "newstyle:2019
 
 # Used by getsentry script. Remove it once the script has been updated to call update_grouping_config_if_permitted
 def _auto_update_grouping(project: Project) -> None:
-    update_grouping_config_if_permitted(project)
+    update_grouping_config_if_permitted(project, "script")
 
 
 def _config_update_happened_recently(project: Project, tolerance: int) -> bool:
@@ -46,7 +46,7 @@ def _config_update_happened_recently(project: Project, tolerance: int) -> bool:
     return time_since_update < 60
 
 
-def update_grouping_config_if_permitted(project: Project) -> None:
+def update_grouping_config_if_permitted(project: Project, source: str) -> None:
     current_config = project.get_option("sentry:grouping_config")
     new_config = DEFAULT_GROUPING_CONFIG
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2405,6 +2405,17 @@ register(
     flags=FLAG_ADMIN_MODIFIABLE | FLAG_AUTOMATOR_MODIFIABLE | FLAG_RATE,
 )
 
+# TODO: For now, only a small number of projects are going through a grouping config transition at
+# any given time, so we're sampling at 100% in order to be able to get good signal. Once we've fully
+# transitioned to the optimized logic, and before the next config change, we probably either want to
+# turn this down or get rid of it in favor of the default 10% sample rate
+register(
+    "grouping.config_transition.metrics_sample_rate",
+    type=Float,
+    default=1.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Sample rate for double writing to experimental dsn
 register(
     "store.experimental-dsn-double-write.sample-rate",


### PR DESCRIPTION
This makes a few small improvements to our metrics tracking the change from the legacy to the new grouping config transition logic:

- Use an option to control the sample rate, so it's uniform across metrics (allowing them to be compared to each other) and easy to change if we want to.

- Set that sample rate to 100% for now, as the number of projects transitioning is small and we want to get good signal.

- Add a new metric, `grouping.config_updated`, tagged with a source, either ingest or the getsentry script. (The script has been updated to pass the `source` parameter in https://github.com/getsentry/getsentry/pull/14839.)