### PR TITLE
chore(dashboards): Remove declarations for `dashboard-widget-indicators`

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -74,8 +74,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:crons-write-user-feedback", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=False)
     # Enable daily summary
     manager.add("organizations:daily-summary", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
-    # Enable dashboard widget indicators.
-    manager.add("organizations:dashboard-widget-indicators", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=True, api_expose=True)
     # Enables import/export functionality for dashboards
     manager.add("organizations:dashboards-import", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable metrics enhanced performance in dashboards

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -76,7 +76,6 @@ class OrganizationSerializerTest(TestCase):
             "integrations-chat-unfurl",
             "integrations-codeowners",
             "integrations-deployment",
-            "dashboard-widget-indicators",
             "integrations-enterprise-alert-rule",
             "integrations-enterprise-incident-management",
             "integrations-event-hooks",


### PR DESCRIPTION
All usage of the flag was removed in https://github.com/getsentry/sentry/pull/75377
