### PR TITLE
nit(api): Skip adding choice name to bullet point

### DIFF
--- a/src/sentry/apidocs/spectacular_ports.py
+++ b/src/sentry/apidocs/spectacular_ports.py
@@ -38,6 +38,7 @@ from typing import Any, Literal, Union
 from typing import get_type_hints as _get_type_hints
 from typing import is_typeddict
 
+import drf_spectacular
 from drf_spectacular.drainage import get_override
 from drf_spectacular.plumbing import (
     UnableToProceedError,
@@ -81,6 +82,20 @@ def get_type_hints(hint, **kwargs):
 
 def _get_type_hint_origin(hint):
     return typing.get_origin(hint), typing.get_args(hint)
+
+
+def build_choice_description_list(choices) -> str:
+    """
+    Override the default generated description for choicefields if the value and
+    label are identical to be (* `value`) instead of (* `value` - `label`).
+    """
+    return "\n".join(
+        f"* `{value}` - {label}" if value != label else f"* `{value}`" for value, label in choices
+    )
+
+
+# Monkey patch build_choice_description_list
+drf_spectacular.plumbing.build_choice_description_list = build_choice_description_list
 
 
 def resolve_type_hint(hint) -> Any:

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1419,25 +1419,28 @@ if os.environ.get("OPENAPIGENERATE", False):
     from sentry.apidocs.build import OPENAPI_TAGS, get_old_json_components, get_old_json_paths
 
     SPECTACULAR_SETTINGS = {
-        "DEFAULT_GENERATOR_CLASS": "sentry.apidocs.hooks.CustomGenerator",
-        "PREPROCESSING_HOOKS": ["sentry.apidocs.hooks.custom_preprocessing_hook"],
-        "POSTPROCESSING_HOOKS": ["sentry.apidocs.hooks.custom_postprocessing_hook"],
-        "DISABLE_ERRORS_AND_WARNINGS": False,
-        "COMPONENT_SPLIT_REQUEST": False,
-        "COMPONENT_SPLIT_PATCH": False,
+        "APPEND_COMPONENTS": get_old_json_components(OLD_OPENAPI_JSON_PATH),
+        "APPEND_PATHS": get_old_json_paths(OLD_OPENAPI_JSON_PATH),
         "AUTHENTICATION_WHITELIST": ["sentry.api.authentication.UserAuthTokenAuthentication"],
+        "COMPONENT_SPLIT_PATCH": False,
+        "COMPONENT_SPLIT_REQUEST": False,
+        "CONTACT": {"email": "partners@sentry.io"},
+        "DEFAULT_GENERATOR_CLASS": "sentry.apidocs.hooks.CustomGenerator",
+        "DESCRIPTION": "Sentry Public API",
+        "DISABLE_ERRORS_AND_WARNINGS": False,
+        # We override the default behavior to skip adding the choice name to the bullet point if
+        # it's identical to the choice value by monkey patching build_choice_description_list.
+        "ENUM_GENERATE_CHOICE_DESCRIPTION": True,
+        "LICENSE": {"name": "Apache 2.0", "url": "http://www.apache.org/licenses/LICENSE-2.0.html"},
+        "PARSER_WHITELIST": ["rest_framework.parsers.JSONParser"],
+        "POSTPROCESSING_HOOKS": ["sentry.apidocs.hooks.custom_postprocessing_hook"],
+        "PREPROCESSING_HOOKS": ["sentry.apidocs.hooks.custom_preprocessing_hook"],
+        "SERVERS": [{"url": "https://sentry.io"}],
+        "SORT_OPERATION_PARAMETERS": custom_parameter_sort,
         "TAGS": OPENAPI_TAGS,
         "TITLE": "API Reference",
-        "DESCRIPTION": "Sentry Public API",
         "TOS": "http://sentry.io/terms/",
-        "CONTACT": {"email": "partners@sentry.io"},
-        "LICENSE": {"name": "Apache 2.0", "url": "http://www.apache.org/licenses/LICENSE-2.0.html"},
         "VERSION": "v0",
-        "SERVERS": [{"url": "https://sentry.io"}],
-        "PARSER_WHITELIST": ["rest_framework.parsers.JSONParser"],
-        "APPEND_PATHS": get_old_json_paths(OLD_OPENAPI_JSON_PATH),
-        "APPEND_COMPONENTS": get_old_json_components(OLD_OPENAPI_JSON_PATH),
-        "SORT_OPERATION_PARAMETERS": custom_parameter_sort,
     }
 
 CRISPY_TEMPLATE_PACK = "bootstrap3"


### PR DESCRIPTION
For choicefields, DRF has a setting called [ENUM_GENERATE_CHOICE_DESCRIPTION](https://drf-spectacular.readthedocs.io/en/latest/settings.html) where in that field description, it adds a bullet point for each choice like
`* (choice value) - (choice name)`

This is nice and helpful, but often times in the choicefield code we either don't use the second name part of the tuple and don't pass a list of tuples to the choicefield, or have the name be identical to the value.

This PR fixes this by omitting the choice name from the bullet point in such cases, so that it looks like
`* (choice value)`

Closes [ALRT-194](https://getsentry.atlassian.net/browse/ALRT-194?atlOrigin=eyJpIjoiNzBjMTk5M2ZiMzc2NDA0NzhlZWZkYTYzMjA5MWZhNDAiLCJwIjoiaiJ9)

[ALRT-194]: https://getsentry.atlassian.net/browse/ALRT-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ