### PR TITLE
ref(autofix): Remove codebase indexing checks on backend

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -111,13 +111,7 @@ class GroupAutofixEndpoint(GroupEndpoint):
                     if not isinstance(user, AnonymousUser)
                     else None
                 ),
-                "options": {
-                    "disable_codebase_indexing": features.has(
-                        "organizations:autofix-disable-codebase-indexing",
-                        group.organization,
-                        actor=user,
-                    )
-                },
+                "options": {"disable_codebase_indexing": True},
             },
             option=orjson.OPT_NON_STR_KEYS,
         )

--- a/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
@@ -44,11 +44,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
             }
         ],
     )
-    @patch(
-        "sentry.api.endpoints.group_autofix_setup_check.get_project_codebase_indexing_status",
-        return_value=AutofixCodebaseIndexingStatus.UP_TO_DATE,
-    )
-    def test_successful_setup(self, mock_update_codebase_index, mock_get_repos_and_access):
+    def test_successful_setup(self, mock_get_repos_and_access):
         """
         Everything is set up correctly, should respond with OKs.
         """
@@ -78,9 +74,6 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
                         "ok": True,
                     }
                 ],
-            },
-            "codebaseIndexing": {
-                "ok": True,
             },
         }
 
@@ -247,19 +240,4 @@ class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
         assert response.data["githubWriteIntegration"] == {
             "ok": False,
             "repos": [],
-        }
-
-    @patch(
-        "sentry.api.endpoints.group_autofix_setup_check.get_project_codebase_indexing_status",
-        return_value=AutofixCodebaseIndexingStatus.NOT_INDEXED,
-    )
-    def test_codebase_indexing_not_done(self, mock_get_project_codebase_indexing_status):
-        group = self.create_group()
-        self.login_as(user=self.user)
-        url = f"/api/0/issues/{group.id}/autofix/setup/"
-        response = self.client.get(url, format="json")
-
-        assert response.status_code == 200
-        assert response.data["codebaseIndexing"] == {
-            "ok": False,
         }


### PR DESCRIPTION
We will be leaving the codebase indexing check endpoints and utils as we may come back to it, but we no longer need to check for the flag & indexing status during setup nor when we send the request