### PR TITLE
chore(dashboards): Remove usage of `dashboards-rh-widget` flag

### DIFF
--- a/static/app/views/dashboards/addWidget.tsx
+++ b/static/app/views/dashboards/addWidget.tsx
@@ -148,14 +148,12 @@ export function AddWidgetButton({onAddWidget, ...buttonProps}: Props & ButtonPro
       onAction: () => handleAction(DataSet.ISSUES),
     });
 
-    if (organization.features.includes('dashboards-rh-widget')) {
-      menuItems.push({
-        key: DataSet.RELEASES,
-        label: t('Releases'),
-        details: t('Sessions, Crash rates, etc.'),
-        onAction: () => handleAction(DataSet.RELEASES),
-      });
-    }
+    menuItems.push({
+      key: DataSet.RELEASES,
+      label: t('Releases'),
+      details: t('Sessions, Crash rates, etc.'),
+      onAction: () => handleAction(DataSet.RELEASES),
+    });
 
     if (hasCustomMetrics(organization)) {
       menuItems.push({

--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -516,17 +516,7 @@ class Dashboard extends Component<Props, State> {
     const {layouts, isMobile} = this.state;
     const {isEditingDashboard, dashboard, widgetLimitReached, organization, isPreview} =
       this.props;
-    let {widgets} = dashboard;
-    // Filter out any issue/release widgets if the user does not have the feature flag
-    widgets = widgets.filter(({widgetType}) => {
-      if (widgetType === WidgetType.RELEASE) {
-        return organization.features.includes('dashboards-rh-widget');
-      }
-      if (widgetType === WidgetType.METRICS) {
-        return hasCustomMetrics(organization);
-      }
-      return true;
-    });
+    const {widgets} = dashboard;
 
     const columnDepths = calculateColumnDepths(layouts[DESKTOP]);
 

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -516,6 +516,7 @@ describe('Dashboards > Detail', function () {
         'Errors',
         'Transactions',
         'Issues',
+        'Releases',
         'Metrics',
       ]);
     });
@@ -552,6 +553,7 @@ describe('Dashboards > Detail', function () {
       expect(menuOptions.map(e => e.textContent)).toEqual([
         'Errors and Transactions',
         'Issues',
+        'Releases',
         'Metrics',
       ]);
     });

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
@@ -49,7 +49,6 @@ function DiscoverSplitAlert({onDismiss, splitDecision}) {
 interface Props {
   dataSet: DataSet;
   displayType: DisplayType;
-  hasReleaseHealthFeature: boolean;
   onChange: (dataSet: DataSet) => void;
   source?: DatasetSource;
   splitDecision?: WidgetType;
@@ -58,7 +57,6 @@ interface Props {
 export function DataSetStep({
   dataSet,
   onChange,
-  hasReleaseHealthFeature,
   displayType,
   splitDecision,
   source,
@@ -94,9 +92,7 @@ export function DataSetStep({
   }
   datasetChoices.set(DataSet.ISSUES, t('Issues (States, Assignment, Time, etc.)'));
 
-  if (hasReleaseHealthFeature) {
-    datasetChoices.set(DataSet.RELEASES, t('Releases (Sessions, Crash rates)'));
-  }
+  datasetChoices.set(DataSet.RELEASES, t('Releases (Sessions, Crash rates)'));
 
   return (
     <BuildStep

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -190,20 +190,11 @@ function WidgetBuilder({
     defaultTableColumns = [defaultTableColumns];
   }
 
-  const hasReleaseHealthFeature = organization.features.includes('dashboards-rh-widget');
-
-  const filteredDashboardWidgets = dashboard.widgets.filter(({widgetType}) => {
-    if (widgetType === WidgetType.RELEASE) {
-      return hasReleaseHealthFeature;
-    }
-    return true;
-  });
-
   const isEditing = defined(widgetIndex);
   const widgetIndexNum = Number(widgetIndex);
   const isValidWidgetIndex =
     widgetIndexNum >= 0 &&
-    widgetIndexNum < filteredDashboardWidgets.length &&
+    widgetIndexNum < dashboard.widgets.length &&
     Number.isInteger(widgetIndexNum);
   const orgSlug = organization.slug;
 
@@ -316,7 +307,7 @@ function WidgetBuilder({
     }
 
     if (isEditing && isValidWidgetIndex) {
-      const widgetFromDashboard = filteredDashboardWidgets[widgetIndexNum];
+      const widgetFromDashboard = dashboard.widgets[widgetIndexNum];
 
       let queries;
       let newDisplayType = widgetFromDashboard.displayType;
@@ -1190,7 +1181,6 @@ function WidgetBuilder({
                                     dataSet={state.dataSet}
                                     displayType={state.displayType}
                                     onChange={handleDataSetChange}
-                                    hasReleaseHealthFeature={hasReleaseHealthFeature}
                                     splitDecision={
                                       splitDecision ??
                                       // The original widget type is used for a forced split decision

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilderDataset.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilderDataset.spec.tsx
@@ -31,7 +31,6 @@ const defaultOrgFeatures = [
   'dashboards-edit',
   'global-views',
   'dashboards-mep',
-  'dashboards-rh-widget',
 ];
 
 function mockDashboard(dashboard: Partial<DashboardDetails>): DashboardDetails {

--- a/static/app/views/dashboards/widgetBuilder/widgetLibrary/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetLibrary/index.tsx
@@ -7,7 +7,7 @@ import type {OverwriteWidgetModalProps} from 'sentry/components/modals/widgetBui
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
-import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import {DisplayType} from 'sentry/views/dashboards/types';
 import type {WidgetTemplate} from 'sentry/views/dashboards/widgetLibrary/data';
 import {getTopNConvertedDefaultWidgets} from 'sentry/views/dashboards/widgetLibrary/data';
 
@@ -29,12 +29,7 @@ export function WidgetLibrary({
   organization,
 }: Props) {
   const theme = useTheme();
-  let defaultWidgets = getTopNConvertedDefaultWidgets(organization);
-  if (!organization.features.includes('dashboards-rh-widget')) {
-    defaultWidgets = defaultWidgets.filter(
-      widget => !(widget.widgetType === WidgetType.RELEASE)
-    );
-  }
+  const defaultWidgets = getTopNConvertedDefaultWidgets(organization);
 
   function getLibrarySelectionHandler(
     widget: OverwriteWidgetModalProps['widget'],


### PR DESCRIPTION
This PR removes the UI flag added in https://github.com/getsentry/sentry/pull/45828/. The "Release Health" widgets were gated behind a feature because the ingestion of Session metrics wasn't turned on for everyone. As of https://github.com/getsentry/sentry/pull/69860 the feature that controls Session metrics ingestion (`organizations:metrics-extraction`) doesn't even exist anymore, the logic is enabled for everyone. So, it's safe to show everyone release health widgets!
