### PR TITLE
chore(seer grouping): Default to using reranking in ingest

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -907,7 +907,7 @@ register(
 register(
     "seer.similarity.ingest.use_reranking",
     type=Bool,
-    default=False,
+    default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/tests/sentry/grouping/ingest/test_seer.py
+++ b/tests/sentry/grouping/ingest/test_seer.py
@@ -233,7 +233,7 @@ class GetSeerSimilarIssuesTest(TestCase):
                     "exception_type": "FailedToFetchError",
                     "k": 1,
                     "referrer": "ingest",
-                    "use_reranking": False,
+                    "use_reranking": True,
                 }
             )
 


### PR DESCRIPTION
Reranking in both the backfill and similar issues tab seems to be working fine and not adding a lot of overhead, so we're going to turn it on in ingest as well.