### PR TITLE
ref(control_silo): Move slack logic for tasks to new location in integrations module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -373,8 +373,6 @@ module = [
     "sentry.tasks.auth",
     "sentry.tasks.base",
     "sentry.tasks.integrations",
-    "sentry.tasks.integrations.slack.find_channel_id_for_rule",
-    "sentry.tasks.integrations.slack.link_slack_user_identities",
     "sentry.tasks.process_buffer",
     "sentry.tasks.sentry_apps",
     "sentry.templatetags.sentry_assets",

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -28,6 +28,7 @@ from sentry.apidocs.parameters import GlobalParams, IssueAlertParams
 from sentry.constants import ObjectStatus
 from sentry.integrations.jira.actions.create_ticket import JiraCreateTicketAction
 from sentry.integrations.jira_server.actions.create_ticket import JiraServerCreateTicketAction
+from sentry.integrations.slack.tasks.find_channel_id_for_rule import find_channel_id_for_rule
 from sentry.integrations.slack.utils import RedisRuleStatus
 from sentry.mediators.project_rules.updater import Updater
 from sentry.models.rule import NeglectedRule, RuleActivity, RuleActivityType
@@ -35,7 +36,6 @@ from sentry.models.scheduledeletion import RegionScheduledDeletion
 from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.rules.actions.utils import get_changed_data, get_updated_rule_data
 from sentry.signals import alert_rule_edited
-from sentry.tasks.integrations.slack import find_channel_id_for_rule
 from sentry.types.actor import Actor
 from sentry.utils import metrics
 

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -25,6 +25,7 @@ from sentry.apidocs.examples.issue_alert_examples import IssueAlertExamples
 from sentry.apidocs.parameters import GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ObjectStatus
+from sentry.integrations.slack.tasks.find_channel_id_for_rule import find_channel_id_for_rule
 from sentry.integrations.slack.utils import RedisRuleStatus
 from sentry.mediators.project_rules.creator import Creator
 from sentry.models.rule import Rule, RuleActivity, RuleActivityType
@@ -32,7 +33,6 @@ from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.rules.actions.base import instantiate_action
 from sentry.rules.processing.processor import is_condition_slow
 from sentry.signals import alert_rule_created
-from sentry.tasks.integrations.slack import find_channel_id_for_rule
 from sentry.utils import metrics
 
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -773,6 +773,7 @@ CELERY_IMPORTS = (
     "sentry.tasks.files",
     "sentry.tasks.groupowner",
     "sentry.tasks.integrations",
+    "sentry.tasks.integrations.slack",
     "sentry.tasks.merge",
     "sentry.tasks.options",
     "sentry.tasks.ping",

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -30,10 +30,12 @@ from sentry.incidents.logic import (
 )
 from sentry.incidents.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
 from sentry.incidents.utils.sentry_apps import trigger_sentry_app_action_creators_for_incidents
+from sentry.integrations.slack.tasks.find_channel_id_for_alert_rule import (
+    find_channel_id_for_alert_rule,
+)
 from sentry.integrations.slack.utils import RedisRuleStatus
 from sentry.models.rulesnooze import RuleSnooze
 from sentry.sentry_apps.services.app import app_service
-from sentry.tasks.integrations.slack import find_channel_id_for_alert_rule
 from sentry.users.services.user.service import user_service
 
 

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -42,6 +42,9 @@ from sentry.incidents.models.alert_rule import AlertRule
 from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.incidents.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
 from sentry.incidents.utils.sentry_apps import trigger_sentry_app_action_creators_for_incidents
+from sentry.integrations.slack.tasks.find_channel_id_for_alert_rule import (
+    find_channel_id_for_alert_rule,
+)
 from sentry.integrations.slack.utils import RedisRuleStatus
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.project import Project
@@ -50,7 +53,6 @@ from sentry.models.team import Team
 from sentry.sentry_apps.services.app import app_service
 from sentry.signals import alert_rule_created
 from sentry.snuba.dataset import Dataset
-from sentry.tasks.integrations.slack import find_channel_id_for_alert_rule
 from sentry.uptime.models import ProjectUptimeSubscription, UptimeStatus
 from sentry.utils.cursors import Cursor, StringCursor
 

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -25,6 +25,7 @@ from sentry.integrations.base import (
     IntegrationMetadata,
     IntegrationProvider,
 )
+from sentry.integrations.jira.tasks import migrate_issues
 from sentry.integrations.jira_server.utils.choice import build_user_choice
 from sentry.integrations.mixins import IssueSyncMixin, ResolveSyncAction
 from sentry.integrations.models.external_issue import ExternalIssue
@@ -42,7 +43,6 @@ from sentry.shared_integrations.exceptions import (
     IntegrationFormError,
 )
 from sentry.silo.base import all_silo_function
-from sentry.tasks.integrations.migrate_issues import migrate_issues
 from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
 from sentry.utils.hashlib import sha1_text

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -19,10 +19,10 @@ from sentry.integrations.base import (
 )
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.slack.sdk_client import SlackSdkClient
+from sentry.integrations.slack.tasks.link_slack_user_identities import link_slack_user_identities
 from sentry.organizations.services.organization import RpcOrganizationSummary
 from sentry.pipeline import NestedPipelineView
 from sentry.shared_integrations.exceptions import IntegrationError
-from sentry.tasks.integrations.slack import link_slack_user_identities
 from sentry.utils.http import absolute_uri
 
 from .notifications import SlackNotifyBasicMixin

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -331,7 +331,7 @@ class SlackService:
         integration: Integration,
         shared_context: Mapping[str, Any],
     ) -> None:
-        from sentry.tasks.integrations.slack.post_message import post_message, post_message_control
+        from sentry.integrations.slack.tasks.post_message import post_message, post_message_control
 
         """Send an "activity" or "alert rule" notification to a Slack user or team, but NOT to a channel directly.
         This is used in the send_notification_as_slack function."""

--- a/src/sentry/integrations/slack/tasks/find_channel_id_for_alert_rule.py
+++ b/src/sentry/integrations/slack/tasks/find_channel_id_for_alert_rule.py
@@ -1,10 +1,27 @@
+from __future__ import annotations
+
+import logging
 from typing import Any
 
+from rest_framework import serializers
+
+from sentry.auth.access import SystemAccess
+from sentry.incidents.logic import (
+    ChannelLookupTimeoutError,
+    InvalidTriggerActionError,
+    get_slack_channel_ids,
+)
+from sentry.incidents.models.alert_rule import AlertRule
+from sentry.incidents.serializers import AlertRuleSerializer
+from sentry.integrations.slack.utils import SLACK_RATE_LIMITED_MESSAGE, RedisRuleStatus
+from sentry.models.organization import Organization
+from sentry.shared_integrations.exceptions import ApiRateLimitedError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.tasks.integrations.slack.find_channel_id_for_alert_rule import (
-    find_channel_id_for_alert_rule as old_find_channel_id_for_alert_rule,
-)
+from sentry.users.services.user import RpcUser
+from sentry.users.services.user.service import user_service
+
+logger = logging.getLogger("sentry.integrations.slack.tasks")
 
 
 @instrumented_task(
@@ -19,10 +36,83 @@ def find_channel_id_for_alert_rule(
     alert_rule_id: int | None = None,
     user_id: int | None = None,
 ) -> None:
-    old_find_channel_id_for_alert_rule(
-        organization_id=organization_id,
-        uuid=uuid,
+    redis_rule_status = RedisRuleStatus(uuid)
+    try:
+        organization = Organization.objects.get(id=organization_id)
+    except Organization.DoesNotExist:
+        redis_rule_status.set_value("failed")
+        return
+
+    user: RpcUser | None = None
+    if user_id:
+        user = user_service.get_user(user_id=user_id)
+
+    alert_rule = None
+    if alert_rule_id:
+        try:
+            alert_rule = AlertRule.objects.get(organization_id=organization_id, id=alert_rule_id)
+        except AlertRule.DoesNotExist:
+            redis_rule_status.set_value("failed")
+            return
+
+    try:
+        mapped_ids = get_slack_channel_ids(organization, user, data)
+    except (serializers.ValidationError, ChannelLookupTimeoutError, InvalidTriggerActionError) as e:
+        # channel doesn't exist error or validation error
+        logger.info(
+            "get_slack_channel_ids.failed",
+            extra={
+                "exception": e,
+            },
+        )
+        redis_rule_status.set_value("failed")
+        return
+    except ApiRateLimitedError as e:
+        logger.info(
+            "get_slack_channel_ids.rate_limited",
+            extra={
+                "exception": e,
+            },
+        )
+        redis_rule_status.set_value("failed", None, SLACK_RATE_LIMITED_MESSAGE)
+        return
+
+    for trigger in data["triggers"]:
+        for action in trigger["actions"]:
+            if action["type"] == "slack":
+                if action["targetIdentifier"] in mapped_ids:
+                    action["input_channel_id"] = mapped_ids[action["targetIdentifier"]]
+                else:
+                    # We can early exit because we couldn't map this action's slack channel name to a slack id
+                    # This is a fail safe, but I think we shouldn't really hit this.
+                    redis_rule_status.set_value("failed")
+                    return
+
+    # we use SystemAccess here because we can't pass the access instance from the request into the task
+    # this means at this point we won't raise any validation errors associated with permissions
+    # however, we should only be calling this task after we tried saving the alert rule first
+    # which will catch those kinds of validation errors
+    serializer = AlertRuleSerializer(
+        context={
+            "organization": organization,
+            "access": SystemAccess(),
+            "user": user,
+            "use_async_lookup": True,
+            "validate_channel_id": False,
+        },
         data=data,
-        alert_rule_id=alert_rule_id,
-        user_id=user_id,
+        instance=alert_rule,
     )
+    if serializer.is_valid():
+        try:
+            alert_rule = serializer.save()
+            redis_rule_status.set_value("success", alert_rule.id)
+            return
+        # we can still get a validation error for the channel not existing
+        except (serializers.ValidationError, ChannelLookupTimeoutError):
+            # channel doesn't exist error or validation error
+            redis_rule_status.set_value("failed")
+            return
+    # some other error
+    redis_rule_status.set_value("failed")
+    return

--- a/src/sentry/integrations/slack/tasks/find_channel_id_for_rule.py
+++ b/src/sentry/integrations/slack/tasks/find_channel_id_for_rule.py
@@ -1,13 +1,23 @@
+import logging
 from collections.abc import Sequence
 from typing import Any
 
-from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.integrations.services.integration import integration_service
+from sentry.integrations.slack.utils import (
+    SLACK_RATE_LIMITED_MESSAGE,
+    RedisRuleStatus,
+    strip_channel_name,
+)
+from sentry.integrations.slack.utils.channel import SlackChannelIdData, get_channel_id_with_timeout
+from sentry.mediators.project_rules.creator import Creator
+from sentry.mediators.project_rules.updater import Updater
 from sentry.models.project import Project
+from sentry.models.rule import Rule, RuleActivity, RuleActivityType
+from sentry.shared_integrations.exceptions import ApiRateLimitedError, DuplicateDisplayNameError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.tasks.integrations.slack.find_channel_id_for_rule import (
-    find_channel_id_for_rule as old_find_channel_id_for_rule,
-)
+
+logger = logging.getLogger("sentry.integrations.slack.tasks")
 
 
 @instrumented_task(
@@ -17,12 +27,94 @@ from sentry.tasks.integrations.slack.find_channel_id_for_rule import (
 )
 def find_channel_id_for_rule(
     project: Project,
-    actions: Sequence[AlertRuleTriggerAction],
+    actions: Sequence[dict[str, Any]],
     uuid: str,
     rule_id: int | None = None,
     user_id: int | None = None,
     **kwargs: Any,
 ) -> None:
-    old_find_channel_id_for_rule(
-        project=project, actions=actions, uuid=uuid, rule_id=rule_id, user_id=user_id, **kwargs
+    redis_rule_status = RedisRuleStatus(uuid)
+
+    try:
+        project = Project.objects.get(id=project.id)
+    except Project.DoesNotExist:
+        redis_rule_status.set_value("failed")
+        return
+
+    organization = project.organization
+    integration_id: int | None = None
+    channel_name: str | None = None
+
+    # TODO: make work for multiple Slack actions
+    for action in actions:
+        if action.get("workspace") and action.get("channel"):
+            integration_id = action["workspace"]
+            # we need to strip the prefix when searching on the channel name
+            channel_name = strip_channel_name(action["channel"])
+            break
+
+    integrations = integration_service.get_integrations(
+        organization_id=organization.id, providers=["slack"], integration_ids=[integration_id]
     )
+    if not integrations:
+        redis_rule_status.set_value("failed")
+        return
+    integration = integrations[0]
+    logger.info(
+        "rule.slack.search_channel_id",
+        extra={
+            "integration_id": integration.id,
+            "organization_id": organization.id,
+            "rule_id": rule_id,
+        },
+    )
+
+    # We do not know exactly how long it will take to paginate through all of the Slack
+    # endpoints but need some time limit imposed. 3 minutes should be more than enough time,
+    # we can always update later
+    channel_data: SlackChannelIdData | None = None
+    try:
+        channel_data = get_channel_id_with_timeout(
+            integration,
+            channel_name,
+            timeout=3 * 60,
+        )
+    except DuplicateDisplayNameError:
+        # if we find a duplicate display name and nothing else, we
+        # want to set the status to failed. This just lets us skip
+        # over the next block and hit the failed status at the end.
+        redis_rule_status.set_value("failed")
+    except ApiRateLimitedError:
+        redis_rule_status.set_value("failed", None, SLACK_RATE_LIMITED_MESSAGE)
+        return
+
+    if channel_data and channel_data.channel_id:
+        for action in actions:
+            # need to make sure we are adding back the right prefix and also the channel_id
+            action_channel = action.get("channel")
+            if (
+                action_channel
+                and channel_name
+                and strip_channel_name(action_channel) == channel_name
+            ):
+                action["channel"] = channel_data.prefix + channel_name
+                action["channel_id"] = channel_data.channel_id
+                break
+
+        kwargs["actions"] = actions
+        kwargs["project"] = project
+
+        if rule_id:
+            rule = Rule.objects.get(id=rule_id)
+            rule = Updater.run(rule=rule, pending_save=False, **kwargs)
+        else:
+            rule = Creator.run(pending_save=False, **kwargs)
+            if user_id:
+                RuleActivity.objects.create(
+                    rule=rule, user_id=user_id, type=RuleActivityType.CREATED.value
+                )
+
+        redis_rule_status.set_value("success", rule.id)
+        return
+    # if we never find the channel name we failed :(
+    redis_rule_status.set_value("failed")

--- a/src/sentry/integrations/slack/tasks/link_slack_user_identities.py
+++ b/src/sentry/integrations/slack/tasks/link_slack_user_identities.py
@@ -1,8 +1,21 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+
+from django.utils import timezone
+
+from sentry.integrations.services.integration import integration_service
+from sentry.integrations.slack.utils.users import SlackUserData, get_slack_data_by_user
+from sentry.integrations.utils import get_identities_by_user
+from sentry.models.identity import Identity, IdentityProvider, IdentityStatus
+from sentry.models.user import User
+from sentry.models.useremail import UserEmail
+from sentry.organizations.services.organization import organization_service
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.tasks.integrations.slack.link_slack_user_identities import (
-    link_slack_user_identities as old_link_slack_user_identities,
-)
+
+logger = logging.getLogger("sentry.integrations.slack.tasks")
 
 
 @instrumented_task(
@@ -15,4 +28,69 @@ def link_slack_user_identities(
     integration_id: int,
     organization_id: int,
 ) -> None:
-    old_link_slack_user_identities(integration_id=integration_id, organization_id=organization_id)
+    integration = integration_service.get_integration(integration_id=integration_id)
+    organization_context = organization_service.get_organization_by_id(id=organization_id)
+    organization = organization_context.organization if organization_context else None
+    if organization is None or integration is None:
+        logger.error(
+            "slack.post_install.link_identities.invalid_params",
+            extra={"organization": organization_id, "integration": integration_id},
+        )
+        return None
+
+    emails_by_user = UserEmail.objects.get_emails_by_user(organization=organization)
+    idp = IdentityProvider.objects.get(
+        type=integration.provider,
+        external_id=integration.external_id,
+    )
+
+    logger.info(
+        "slack.post_install.link_identities.start",
+        extra={
+            "organization": organization.slug,
+            "integration_id": integration.id,
+        },
+    )
+    slack_data_by_user = get_slack_data_by_user(integration, organization, emails_by_user)
+    for data in slack_data_by_user:
+        logger.info(
+            "slack.post_install.link_identities.paginate",
+            extra={
+                "organization": organization.slug,
+                "integration_id": integration.id,
+                "num_users": len(data),
+            },
+        )
+        update_identities(data, idp)
+
+
+def update_identities(slack_data_by_user: Mapping[User, SlackUserData], idp: IdentityProvider):
+    date_verified = timezone.now()
+    identities_by_user = get_identities_by_user(idp, slack_data_by_user.keys())
+
+    for user, data in slack_data_by_user.items():
+        slack_id = data.slack_id
+        # Identity already exists, the emails match, AND the external ID has changed
+        if user in identities_by_user.keys():
+            if slack_id != identities_by_user[user].external_id:
+                # replace the Identity's external_id with the new one we just got from Slack
+                identities_by_user[user].update(external_id=data.slack_id)
+            continue
+        # the user doesn't already have an Identity and one of their Sentry emails matches their Slack email
+        matched_identity, created = Identity.objects.get_or_create(
+            idp=idp,
+            external_id=slack_id,
+            defaults={"user": user, "status": IdentityStatus.VALID, "date_verified": date_verified},
+        )
+        # the Identity matching that idp/external_id combo is linked to a different user
+        if not created:
+            logger.info(
+                "slack.post_install.identity_linked_different_user",
+                extra={
+                    "idp_id": idp.id,
+                    "external_id": slack_id,
+                    "object_id": matched_identity.id,
+                    "user_id": user.id,
+                    "type": idp.type,
+                },
+            )

--- a/src/sentry/integrations/slack/tasks/post_message.py
+++ b/src/sentry/integrations/slack/tasks/post_message.py
@@ -1,12 +1,14 @@
+from __future__ import annotations
+
+import logging
 from collections.abc import Mapping
 from typing import Any
 
+from sentry.integrations.slack.service import SlackService
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.tasks.integrations.slack.post_message import post_message as old_post_message
-from sentry.tasks.integrations.slack.post_message import (
-    post_message_control as old_post_message_control,
-)
+
+logger = logging.getLogger("sentry.integrations.slack.tasks")
 
 
 @instrumented_task(
@@ -21,7 +23,8 @@ def post_message(
     log_error_message: str,
     log_params: Mapping[str, Any],
 ) -> None:
-    old_post_message(
+    service = SlackService.default()
+    service.send_message_to_slack_channel(
         integration_id=integration_id,
         payload=payload,
         log_error_message=log_error_message,
@@ -41,7 +44,8 @@ def post_message_control(
     log_error_message: str,
     log_params: Mapping[str, Any],
 ) -> None:
-    old_post_message_control(
+    service = SlackService.default()
+    service.send_message_to_slack_channel(
         integration_id=integration_id,
         payload=payload,
         log_error_message=log_error_message,

--- a/src/sentry/integrations/slack/utils/users.py
+++ b/src/sentry/integrations/slack/utils/users.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping, MutableMapping, Sequence
+from collections.abc import Iterable, Mapping, MutableMapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -42,7 +42,7 @@ def format_slack_info_by_email(users: dict[str, Any]) -> dict[str, SlackUserData
 
 
 def format_slack_data_by_user(
-    emails_by_user: Mapping[User, Sequence[str]], users: dict[str, Any]
+    emails_by_user: Mapping[User, Iterable[str]], users: dict[str, Any]
 ) -> Mapping[User, SlackUserData]:
     slack_info_by_email = format_slack_info_by_email(users)
 
@@ -89,7 +89,7 @@ def get_slack_user_list(
 def get_slack_data_by_user(
     integration: Integration | RpcIntegration,
     organization: Organization | RpcOrganization,
-    emails_by_user: Mapping[User, Sequence[str]],
+    emails_by_user: Mapping[User, Iterable[str]],
 ) -> Iterable[Mapping[User, SlackUserData]]:
     all_users = get_slack_user_list(integration, organization)
     yield from (format_slack_data_by_user(emails_by_user, users) for users in all_users)

--- a/src/sentry/tasks/integrations/__init__.py
+++ b/src/sentry/tasks/integrations/__init__.py
@@ -18,12 +18,7 @@ def should_comment_sync(
     return has_issue_sync and installation.should_sync("comment")
 
 
-__all__ = (
-    "logger",
-    "migrate_opsgenie_plugin",
-    "migrate_issues",
-    "sync_metadata",
-)
+__all__ = ("logger",)
 
 settings.CELERY_IMPORTS += (
     "sentry.tasks.integrations.create_comment",
@@ -41,7 +36,3 @@ settings.CELERY_IMPORTS += (
     "sentry.tasks.integrations.vsts.kickoff_subscription_check",
     "sentry.tasks.integrations.vsts.subscription_check",
 )
-
-from .migrate_issues import migrate_issues
-from .migrate_opsgenie_plugins import migrate_opsgenie_plugin
-from .sync_metadata import sync_metadata

--- a/src/sentry/tasks/integrations/slack/find_channel_id_for_alert_rule.py
+++ b/src/sentry/tasks/integrations/slack/find_channel_id_for_alert_rule.py
@@ -1,27 +1,10 @@
-from __future__ import annotations
-
-import logging
 from typing import Any
 
-from rest_framework import serializers
-
-from sentry.auth.access import SystemAccess
-from sentry.incidents.logic import (
-    ChannelLookupTimeoutError,
-    InvalidTriggerActionError,
-    get_slack_channel_ids,
+from sentry.integrations.slack.tasks.find_channel_id_for_alert_rule import (
+    find_channel_id_for_alert_rule as new_find_channel_id_for_alert_rule,
 )
-from sentry.incidents.models.alert_rule import AlertRule
-from sentry.incidents.serializers import AlertRuleSerializer
-from sentry.integrations.slack.utils import SLACK_RATE_LIMITED_MESSAGE, RedisRuleStatus
-from sentry.models.organization import Organization
-from sentry.shared_integrations.exceptions import ApiRateLimitedError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.users.services.user import RpcUser
-from sentry.users.services.user.service import user_service
-
-logger = logging.getLogger("sentry.integrations.slack.tasks")
 
 
 @instrumented_task(
@@ -36,83 +19,10 @@ def find_channel_id_for_alert_rule(
     alert_rule_id: int | None = None,
     user_id: int | None = None,
 ) -> None:
-    redis_rule_status = RedisRuleStatus(uuid)
-    try:
-        organization = Organization.objects.get(id=organization_id)
-    except Organization.DoesNotExist:
-        redis_rule_status.set_value("failed")
-        return
-
-    user: RpcUser | None = None
-    if user_id:
-        user = user_service.get_user(user_id=user_id)
-
-    alert_rule = None
-    if alert_rule_id:
-        try:
-            alert_rule = AlertRule.objects.get(organization_id=organization_id, id=alert_rule_id)
-        except AlertRule.DoesNotExist:
-            redis_rule_status.set_value("failed")
-            return
-
-    try:
-        mapped_ids = get_slack_channel_ids(organization, user, data)
-    except (serializers.ValidationError, ChannelLookupTimeoutError, InvalidTriggerActionError) as e:
-        # channel doesn't exist error or validation error
-        logger.info(
-            "get_slack_channel_ids.failed",
-            extra={
-                "exception": e,
-            },
-        )
-        redis_rule_status.set_value("failed")
-        return
-    except ApiRateLimitedError as e:
-        logger.info(
-            "get_slack_channel_ids.rate_limited",
-            extra={
-                "exception": e,
-            },
-        )
-        redis_rule_status.set_value("failed", None, SLACK_RATE_LIMITED_MESSAGE)
-        return
-
-    for trigger in data["triggers"]:
-        for action in trigger["actions"]:
-            if action["type"] == "slack":
-                if action["targetIdentifier"] in mapped_ids:
-                    action["input_channel_id"] = mapped_ids[action["targetIdentifier"]]
-                else:
-                    # We can early exit because we couldn't map this action's slack channel name to a slack id
-                    # This is a fail safe, but I think we shouldn't really hit this.
-                    redis_rule_status.set_value("failed")
-                    return
-
-    # we use SystemAccess here because we can't pass the access instance from the request into the task
-    # this means at this point we won't raise any validation errors associated with permissions
-    # however, we should only be calling this task after we tried saving the alert rule first
-    # which will catch those kinds of validation errors
-    serializer = AlertRuleSerializer(
-        context={
-            "organization": organization,
-            "access": SystemAccess(),
-            "user": user,
-            "use_async_lookup": True,
-            "validate_channel_id": False,
-        },
+    new_find_channel_id_for_alert_rule(
+        organization_id=organization_id,
+        uuid=uuid,
         data=data,
-        instance=alert_rule,
+        alert_rule_id=alert_rule_id,
+        user_id=user_id,
     )
-    if serializer.is_valid():
-        try:
-            alert_rule = serializer.save()
-            redis_rule_status.set_value("success", alert_rule.id)
-            return
-        # we can still get a validation error for the channel not existing
-        except (serializers.ValidationError, ChannelLookupTimeoutError):
-            # channel doesn't exist error or validation error
-            redis_rule_status.set_value("failed")
-            return
-    # some other error
-    redis_rule_status.set_value("failed")
-    return

--- a/src/sentry/tasks/integrations/slack/find_channel_id_for_rule.py
+++ b/src/sentry/tasks/integrations/slack/find_channel_id_for_rule.py
@@ -1,24 +1,13 @@
-import logging
 from collections.abc import Sequence
 from typing import Any
 
 from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
-from sentry.integrations.services.integration import integration_service
-from sentry.integrations.slack.utils import (
-    SLACK_RATE_LIMITED_MESSAGE,
-    RedisRuleStatus,
-    strip_channel_name,
+from sentry.integrations.slack.tasks.find_channel_id_for_alert_rule import (
+    find_channel_id_for_alert_rule as new_find_channel_id_for_alert_rule,
 )
-from sentry.integrations.slack.utils.channel import get_channel_id_with_timeout
-from sentry.mediators.project_rules.creator import Creator
-from sentry.mediators.project_rules.updater import Updater
 from sentry.models.project import Project
-from sentry.models.rule import Rule, RuleActivity, RuleActivityType
-from sentry.shared_integrations.exceptions import ApiRateLimitedError, DuplicateDisplayNameError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-
-logger = logging.getLogger("sentry.integrations.slack.tasks")
 
 
 @instrumented_task(
@@ -34,82 +23,11 @@ def find_channel_id_for_rule(
     user_id: int | None = None,
     **kwargs: Any,
 ) -> None:
-    redis_rule_status = RedisRuleStatus(uuid)
-
-    try:
-        project = Project.objects.get(id=project.id)
-    except Project.DoesNotExist:
-        redis_rule_status.set_value("failed")
-        return
-
-    organization = project.organization
-    integration_id: int | None = None
-    channel_name: str | None = None
-
-    # TODO: make work for multiple Slack actions
-    for action in actions:
-        if action.get("workspace") and action.get("channel"):
-            integration_id = action["workspace"]
-            # we need to strip the prefix when searching on the channel name
-            channel_name = strip_channel_name(action["channel"])
-            break
-
-    integrations = integration_service.get_integrations(
-        organization_id=organization.id, providers=["slack"], integration_ids=[integration_id]
+    new_find_channel_id_for_alert_rule(
+        project=project,
+        actions=actions,
+        uuid=uuid,
+        rule_id=rule_id,
+        user_id=user_id,
+        **kwargs,
     )
-    if not integrations:
-        redis_rule_status.set_value("failed")
-        return
-    integration = integrations[0]
-    logger.info(
-        "rule.slack.search_channel_id",
-        extra={
-            "integration_id": integration.id,
-            "organization_id": organization.id,
-            "rule_id": rule_id,
-        },
-    )
-
-    # We do not know exactly how long it will take to paginate through all of the Slack
-    # endpoints but need some time limit imposed. 3 minutes should be more than enough time,
-    # we can always update later
-    try:
-        channel_data = get_channel_id_with_timeout(
-            integration,
-            channel_name,
-            timeout=3 * 60,
-        )
-    except DuplicateDisplayNameError:
-        # if we find a duplicate display name and nothing else, we
-        # want to set the status to failed. This just lets us skip
-        # over the next block and hit the failed status at the end.
-        redis_rule_status.set_value("failed")
-    except ApiRateLimitedError:
-        redis_rule_status.set_value("failed", None, SLACK_RATE_LIMITED_MESSAGE)
-        return
-
-    if channel_data.channel_id:
-        for action in actions:
-            # need to make sure we are adding back the right prefix and also the channel_id
-            if action.get("channel") and strip_channel_name(action.get("channel")) == channel_name:
-                action["channel"] = channel_data.prefix + channel_name
-                action["channel_id"] = channel_data.channel_id
-                break
-
-        kwargs["actions"] = actions
-        kwargs["project"] = project
-
-        if rule_id:
-            rule = Rule.objects.get(id=rule_id)
-            rule = Updater.run(rule=rule, pending_save=False, **kwargs)
-        else:
-            rule = Creator.run(pending_save=False, **kwargs)
-            if user_id:
-                RuleActivity.objects.create(
-                    rule=rule, user_id=user_id, type=RuleActivityType.CREATED.value
-                )
-
-        redis_rule_status.set_value("success", rule.id)
-        return
-    # if we never find the channel name we failed :(
-    redis_rule_status.set_value("failed")

--- a/src/sentry/tasks/integrations/slack/link_slack_user_identities.py
+++ b/src/sentry/tasks/integrations/slack/link_slack_user_identities.py
@@ -1,21 +1,8 @@
-from __future__ import annotations
-
-import logging
-from collections.abc import Mapping
-
-from django.utils import timezone
-
-from sentry.integrations.services.integration import integration_service
-from sentry.integrations.slack.utils.users import SlackUserData, get_slack_data_by_user
-from sentry.integrations.utils import get_identities_by_user
-from sentry.models.identity import Identity, IdentityProvider, IdentityStatus
-from sentry.models.user import User
-from sentry.models.useremail import UserEmail
-from sentry.organizations.services.organization import organization_service
+from sentry.integrations.slack.tasks.link_slack_user_identities import (
+    link_slack_user_identities as new_link_slack_user_identities,
+)
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-
-logger = logging.getLogger("sentry.integrations.slack.tasks")
 
 
 @instrumented_task(
@@ -28,68 +15,4 @@ def link_slack_user_identities(
     integration_id: int,
     organization_id: int,
 ) -> None:
-    integration = integration_service.get_integration(integration_id=integration_id)
-    organization = organization_service.get_organization_by_id(id=organization_id).organization
-    if organization is None or integration is None:
-        logger.error(
-            "slack.post_install.link_identities.invalid_params",
-            extra={"organization": organization_id, "integration": integration_id},
-        )
-        return None
-
-    emails_by_user = UserEmail.objects.get_emails_by_user(organization=organization)
-    idp = IdentityProvider.objects.get(
-        type=integration.provider,
-        external_id=integration.external_id,
-    )
-
-    logger.info(
-        "slack.post_install.link_identities.start",
-        extra={
-            "organization": organization.slug,
-            "integration_id": integration.id,
-        },
-    )
-    slack_data_by_user = get_slack_data_by_user(integration, organization, emails_by_user)
-    for data in slack_data_by_user:
-        logger.info(
-            "slack.post_install.link_identities.paginate",
-            extra={
-                "organization": organization.slug,
-                "integration_id": integration.id,
-                "num_users": len(data),
-            },
-        )
-        update_identities(data, idp)
-
-
-def update_identities(slack_data_by_user: Mapping[User, SlackUserData], idp: IdentityProvider):
-    date_verified = timezone.now()
-    identities_by_user = get_identities_by_user(idp, slack_data_by_user.keys())
-
-    for user, data in slack_data_by_user.items():
-        slack_id = data.slack_id
-        # Identity already exists, the emails match, AND the external ID has changed
-        if user in identities_by_user.keys():
-            if slack_id != identities_by_user[user].external_id:
-                # replace the Identity's external_id with the new one we just got from Slack
-                identities_by_user[user].update(external_id=data.slack_id)
-            continue
-        # the user doesn't already have an Identity and one of their Sentry emails matches their Slack email
-        matched_identity, created = Identity.objects.get_or_create(
-            idp=idp,
-            external_id=slack_id,
-            defaults={"user": user, "status": IdentityStatus.VALID, "date_verified": date_verified},
-        )
-        # the Identity matching that idp/external_id combo is linked to a different user
-        if not created:
-            logger.info(
-                "slack.post_install.identity_linked_different_user",
-                extra={
-                    "idp_id": idp.id,
-                    "external_id": slack_id,
-                    "object_id": matched_identity.id,
-                    "user_id": user.id,
-                    "type": idp.type,
-                },
-            )
+    new_link_slack_user_identities(integration_id=integration_id, organization_id=organization_id)

--- a/src/sentry/tasks/integrations/slack/post_message.py
+++ b/src/sentry/tasks/integrations/slack/post_message.py
@@ -1,14 +1,12 @@
-from __future__ import annotations
-
-import logging
 from collections.abc import Mapping
 from typing import Any
 
-from sentry.integrations.slack.service import SlackService
+from sentry.integrations.slack.tasks.post_message import post_message as new_post_message
+from sentry.integrations.slack.tasks.post_message import (
+    post_message_control as new_post_message_control,
+)
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-
-logger = logging.getLogger("sentry.integrations.slack.tasks")
 
 
 # TODO: add retry logic
@@ -24,8 +22,7 @@ def post_message(
     log_error_message: str,
     log_params: Mapping[str, Any],
 ) -> None:
-    service = SlackService.default()
-    service.send_message_to_slack_channel(
+    new_post_message(
         integration_id=integration_id,
         payload=payload,
         log_error_message=log_error_message,
@@ -46,8 +43,7 @@ def post_message_control(
     log_error_message: str,
     log_params: Mapping[str, Any],
 ) -> None:
-    service = SlackService.default()
-    service.send_message_to_slack_channel(
+    new_post_message_control(
         integration_id=integration_id,
         payload=payload,
         log_error_message=log_error_message,

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -14,12 +14,12 @@ from slack_sdk.web import SlackResponse
 
 from sentry.api.endpoints.project_rules import get_max_alerts
 from sentry.constants import ObjectStatus
+from sentry.integrations.slack.tasks.find_channel_id_for_rule import find_channel_id_for_rule
 from sentry.integrations.slack.utils.channel import SlackChannelIdData
 from sentry.models.environment import Environment
 from sentry.models.rule import Rule, RuleActivity, RuleActivityType
 from sentry.models.user import User
 from sentry.silo.base import SiloMode
-from sentry.tasks.integrations.slack.find_channel_id_for_rule import find_channel_id_for_rule
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import install_slack, with_feature
 from sentry.testutils.silo import assume_test_silo_mode

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -35,15 +35,15 @@ from sentry.incidents.models.alert_rule import (
 from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.incidents.serializers import AlertRuleSerializer
 from sentry.incidents.utils.types import AlertRuleActivationConditionType
+from sentry.integrations.slack.tasks.find_channel_id_for_alert_rule import (
+    find_channel_id_for_alert_rule,
+)
 from sentry.integrations.slack.utils.channel import SlackChannelIdData
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.sentry_apps.services.app import app_service
 from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.scheduled import run_scheduled_deletions
-from sentry.tasks.integrations.slack.find_channel_id_for_alert_rule import (
-    find_channel_id_for_alert_rule,
-)
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.outbox import outbox_runner

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -24,6 +24,9 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleTriggerAction,
 )
 from sentry.incidents.utils.types import AlertRuleActivationConditionType
+from sentry.integrations.slack.tasks.find_channel_id_for_alert_rule import (
+    find_channel_id_for_alert_rule,
+)
 from sentry.integrations.slack.utils.channel import SlackChannelIdData
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.organizationmember import OrganizationMember
@@ -33,9 +36,6 @@ from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
-from sentry.tasks.integrations.slack.find_channel_id_for_alert_rule import (
-    find_channel_id_for_alert_rule,
-)
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.factories import EventType

--- a/tests/sentry/integrations/slack/tasks/test_tasks.py
+++ b/tests/sentry/integrations/slack/tasks/test_tasks.py
@@ -8,15 +8,15 @@ import responses
 from sentry.incidents.models.alert_rule import AlertRule, AlertRuleTriggerAction
 from sentry.integrations.services.integration.serial import serialize_integration
 from sentry.integrations.slack.sdk_client import SLACK_DATADOG_METRIC
-from sentry.integrations.slack.utils import RedisRuleStatus
-from sentry.integrations.slack.utils.channel import SlackChannelIdData
-from sentry.models.rule import Rule
-from sentry.receivers.rules import DEFAULT_RULE_LABEL, DEFAULT_RULE_LABEL_NEW
-from sentry.tasks.integrations.slack import (
+from sentry.integrations.slack.tasks import (
     find_channel_id_for_alert_rule,
     find_channel_id_for_rule,
     post_message,
 )
+from sentry.integrations.slack.utils import RedisRuleStatus
+from sentry.integrations.slack.utils.channel import SlackChannelIdData
+from sentry.models.rule import Rule
+from sentry.receivers.rules import DEFAULT_RULE_LABEL, DEFAULT_RULE_LABEL_NEW
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import install_slack
 from sentry.testutils.skips import requires_snuba


### PR DESCRIPTION
Moves logic and updates import routes to the new slack tasks located in sentry/integrations/slack/tasks

ref(issue # here)
Split of (https://github.com/getsentry/sentry/pull/74925)