### PR TITLE
fix(discover): Update measurements.inp field type to duration

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2086,6 +2086,7 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
         "spans.http": "metrics_distributions",
         "user": "metrics_sets",
         "function.duration": "metrics_distributions",
+        "measurements.inp": "metrics_distributions",
     }
     ON_DEMAND_KEY_MAP = {
         "c": TransactionMetricKey.COUNT_ON_DEMAND.value,

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1821,6 +1821,7 @@ def is_duration_measurement(key):
         "measurements.app_start_warm",
         "measurements.time_to_full_display",
         "measurements.time_to_initial_display",
+        "measurements.inp",
     ]
 
 


### PR DESCRIPTION
Fix an issue where `measurements.inp` response field type was number instead of duration.