### PR TITLE
Update uptime checker user agent

### DIFF
--- a/src/sentry/uptime/detectors/tasks.py
+++ b/src/sentry/uptime/detectors/tasks.py
@@ -34,7 +34,7 @@ from sentry.utils import metrics
 from sentry.utils.hashlib import md5_text
 from sentry.utils.locking import UnableToAcquireLock
 
-UPTIME_USER_AGENT = "sentry.io_uptime_checker_v_1"
+UPTIME_USER_AGENT = "Mozilla/5.0 (compatible; SentryUptimeBot/1.0; +http://docs.sentry.io/product/alerts/uptime-monitoring/)"
 LAST_PROCESSED_KEY = "uptime_detector_last_processed"
 SCHEDULER_LOCK_KEY = "uptime_detector_scheduler_lock"
 FAILED_URL_RETRY_FREQ = timedelta(days=7)

--- a/src/sentry/uptime/detectors/tasks.py
+++ b/src/sentry/uptime/detectors/tasks.py
@@ -34,7 +34,7 @@ from sentry.utils import metrics
 from sentry.utils.hashlib import md5_text
 from sentry.utils.locking import UnableToAcquireLock
 
-UPTIME_USER_AGENT = "Mozilla/5.0 (compatible; SentryUptimeBot/1.0; +http://docs.sentry.io/product/alerts/uptime-monitoring/)"
+UPTIME_USER_AGENT = "SentryUptimeBot/1.0 (+http://docs.sentry.io/product/alerts/uptime-monitoring/)"
 LAST_PROCESSED_KEY = "uptime_detector_last_processed"
 SCHEDULER_LOCK_KEY = "uptime_detector_scheduler_lock"
 FAILED_URL_RETRY_FREQ = timedelta(days=7)

--- a/tests/sentry/uptime/detectors/test_tasks.py
+++ b/tests/sentry/uptime/detectors/test_tasks.py
@@ -275,7 +275,7 @@ class ProcessCandidateUrlTest(TestCase):
     def test_failed_robots_txt_user_agent(self):
         url = "https://sentry.io"
         test_robot_parser = RobotFileParser()
-        robots_txt = ["User-agent: sentry.io_uptime_checker_v_1", "Disallow: /"]
+        robots_txt = ["User-agent: SentryUptimeBot", "Disallow: /"]
         test_robot_parser.parse(robots_txt)
         with mock.patch(
             "sentry.uptime.detectors.tasks.get_robots_txt_parser",


### PR DESCRIPTION
Updates the uptime checker `User-Agent` to match what we have described in our [documentation PR.](https://github.com/getsentry/sentry-docs/pull/10810)