### PR TITLE
ref(grouping): Always pull grouping config from project

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1747,7 +1747,7 @@ def _save_aggregate_new(
     maybe_run_background_grouping(project, job)
 
     record_hash_calculation_metrics(
-        project, primary.config, primary.hashes, secondary.config, secondary.hashes
+        primary.config, primary.hashes, secondary.config, secondary.hashes
     )
     # TODO: Once the legacy `_save_aggregate` goes away, the logic inside of
     # `record_calculation_metric_with_result` can be pulled into `record_hash_calculation_metrics`

--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -32,21 +32,6 @@ def _auto_update_grouping(project: Project) -> None:
     update_grouping_config_if_permitted(project, "script")
 
 
-def _config_update_happened_recently(project: Project, tolerance: int) -> bool:
-    """
-    Determine whether an auto-upate happened within the last `tolerance` seconds.
-
-    We can use this test to compensate for the delay between config getting updated and Relay
-    picking up the change.
-    """
-    project_transition_expiry = project.get_option("sentry:secondary_grouping_expiry") or 0
-    last_config_update = project_transition_expiry - settings.SENTRY_GROUPING_UPDATE_MIGRATION_PHASE
-    now = int(time.time())
-    time_since_update = now - last_config_update
-
-    return time_since_update < 60
-
-
 def update_grouping_config_if_permitted(project: Project, source: str) -> None:
     current_config = project.get_option("sentry:grouping_config")
     new_config = DEFAULT_GROUPING_CONFIG

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -328,7 +328,6 @@ def get_hash_values(
     primary_grouping_config, primary_hashes = run_primary_grouping(project, job, metric_tags)
 
     record_hash_calculation_metrics(
-        project,
         primary_grouping_config,
         primary_hashes,
         secondary_grouping_config,

--- a/src/sentry/grouping/ingest/metrics.py
+++ b/src/sentry/grouping/ingest/metrics.py
@@ -22,7 +22,6 @@ Job = MutableMapping[str, Any]
 
 
 def record_hash_calculation_metrics(
-    project: Project,
     primary_config: GroupingConfig,
     primary_hashes: CalculatedHashes,
     secondary_config: GroupingConfig,

--- a/src/sentry/grouping/ingest/metrics.py
+++ b/src/sentry/grouping/ingest/metrics.py
@@ -34,31 +34,24 @@ def record_hash_calculation_metrics(
             "primary_config": primary_config["id"],
             "secondary_config": secondary_config["id"],
         }
+        current_values = primary_hashes.hashes
+        secondary_values = secondary_hashes.hashes
+        hashes_match = current_values == secondary_values
 
-        # If the configs are the same, *of course* the values are going to match, so no point in
-        # recording a metric
-        #
-        # TODO: If we fix the issue outlined in https://github.com/getsentry/sentry/pull/65116, we
-        # can ditch this check
-        if tags["primary_config"] != tags["secondary_config"]:
-            current_values = primary_hashes.hashes
-            secondary_values = secondary_hashes.hashes
-            hashes_match = current_values == secondary_values
-
-            if hashes_match:
-                tags["result"] = "no change"
+        if hashes_match:
+            tags["result"] = "no change"
+        else:
+            shared_hashes = set(current_values) & set(secondary_values)
+            if len(shared_hashes) > 0:
+                tags["result"] = "partial change"
             else:
-                shared_hashes = set(current_values) & set(secondary_values)
-                if len(shared_hashes) > 0:
-                    tags["result"] = "partial change"
-                else:
-                    tags["result"] = "full change"
+                tags["result"] = "full change"
 
-            metrics.incr(
-                "grouping.hash_comparison",
-                sample_rate=options.get("grouping.config_transition.metrics_sample_rate"),
-                tags=tags,
-            )
+        metrics.incr(
+            "grouping.hash_comparison",
+            sample_rate=options.get("grouping.config_transition.metrics_sample_rate"),
+            tags=tags,
+        )
 
 
 # TODO: Once the legacy `_save_aggregate` goes away, this logic can be pulled into

--- a/src/sentry/grouping/ingest/metrics.py
+++ b/src/sentry/grouping/ingest/metrics.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from sentry import features, options
 from sentry.grouping.api import GroupingConfig
-from sentry.grouping.ingest.config import _config_update_happened_recently, is_in_transition
+from sentry.grouping.ingest.config import is_in_transition
 from sentry.grouping.ingest.utils import extract_hashes
 from sentry.grouping.result import CalculatedHashes
 from sentry.models.project import Project
@@ -40,7 +40,7 @@ def record_hash_calculation_metrics(
         # recording a metric
         #
         # TODO: If we fix the issue outlined in https://github.com/getsentry/sentry/pull/65116, we
-        # can ditch both this check and the logging below
+        # can ditch this check
         if tags["primary_config"] != tags["secondary_config"]:
             current_values = primary_hashes.hashes
             secondary_values = secondary_hashes.hashes
@@ -60,15 +60,6 @@ def record_hash_calculation_metrics(
                 sample_rate=options.get("grouping.config_transition.metrics_sample_rate"),
                 tags=tags,
             )
-        else:
-            if not _config_update_happened_recently(project, 30):
-                logger.info(
-                    "Equal primary and secondary configs",
-                    extra={
-                        "project": project.id,
-                        "primary_config": primary_config["id"],
-                    },
-                )
 
 
 # TODO: Once the legacy `_save_aggregate` goes away, this logic can be pulled into

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -46,7 +46,7 @@ from sentry.event_manager import (
 )
 from sentry.eventstore.models import Event
 from sentry.exceptions import HashDiscarded
-from sentry.grouping.api import GroupingConfig, load_grouping_config
+from sentry.grouping.api import load_grouping_config
 from sentry.grouping.utils import hash_from_values
 from sentry.ingest.inbound_filters import FilterStatKeys
 from sentry.integrations.models.external_issue import ExternalIssue
@@ -991,43 +991,52 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
     def test_culprit_after_stacktrace_processing(self) -> None:
         from sentry.grouping.enhancer import Enhancements
 
-        enhancement = Enhancements.from_config_string(
+        enhancements_str = Enhancements.from_config_string(
             """
             function:in_app_function +app
             function:not_in_app_function -app
-            """,
-        )
+            """
+        ).dumps()
 
-        manager = EventManager(
-            make_event(
-                platform="native",
-                exception={
-                    "values": [
-                        {
-                            "type": "Hello",
-                            "stacktrace": {
-                                "frames": [
-                                    {
-                                        "function": "not_in_app_function",
-                                    },
-                                    {
-                                        "function": "in_app_function",
-                                    },
-                                ]
-                            },
-                        }
-                    ]
-                },
-            )
-        )
-        manager.normalize()
-        manager.get_data()["grouping_config"] = {
-            "enhancements": enhancement.dumps(),
-            "id": "legacy:2019-03-12",
+        # TODO: Really we should use DEFAULT_GROUPING_CONFIG here as the id (so that we don't have
+        # to update the test every time we change the default), but there's something about the
+        # mobile config, over and above the enhancements hardcoded above, that makes this test pass.
+        # We'll have to figure this out before we can delete the config.
+        grouping_config = {
+            "id": "mobile:2021-02-12",
+            "enhancements": enhancements_str,
         }
-        event1 = manager.save(self.project.id)
-        assert event1.transaction is None
-        assert event1.culprit == "in_app_function"
+
+        with patch(
+            "sentry.grouping.ingest.hashing.get_grouping_config_dict_for_project",
+            return_value=grouping_config,
+        ):
+            manager = EventManager(
+                make_event(
+                    platform="native",
+                    exception={
+                        "values": [
+                            {
+                                "type": "Hello",
+                                "stacktrace": {
+                                    "frames": [
+                                        {
+                                            "function": "not_in_app_function",
+                                        },
+                                        {
+                                            "function": "in_app_function",
+                                        },
+                                    ]
+                                },
+                            }
+                        ]
+                    },
+                )
+            )
+            manager.normalize()
+            event1 = manager.save(self.project.id)
+            assert event1.transaction is None
+            assert event1.culprit == "in_app_function"
 
     def test_inferred_culprit_from_empty_stacktrace(self) -> None:
         manager = EventManager(make_event(stacktrace={"frames": []}))
@@ -2050,72 +2059,81 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         """
         from sentry.grouping.enhancer import Enhancements
 
-        enhancement = Enhancements.from_config_string(
+        enhancements_str = Enhancements.from_config_string(
             """
             function:foo category=bar
             function:foo2 category=bar
             category:bar -app
-            """,
-        )
+            """
+        ).dumps()
 
-        event_params = make_event(
-            platform="native",
-            exception={
-                "values": [
-                    {
-                        "type": "Hello",
-                        "stacktrace": {
-                            "frames": [
-                                {
-                                    "function": "foo",
-                                    "in_app": True,
-                                },
-                                {"function": "bar"},
-                            ]
-                        },
-                    }
-                ]
-            },
-        )
-
-        manager = EventManager(event_params)
-        manager.normalize()
-        manager.get_data()["grouping_config"] = {
-            "enhancements": enhancement.dumps(),
+        # TODO: Really we should use DEFAULT_GROUPING_CONFIG here as the id (so that we don't have
+        # to update the test every time we change the default), but there's something about the
+        # mobile config, over and above the enhancements hardcoded above, that makes this test pass.
+        # We'll have to figure this out before we can delete the config.
+        grouping_config = {
             "id": "mobile:2021-02-12",
+            "enhancements": enhancements_str,
         }
-        event1 = manager.save(self.project.id)
-        assert event1.data["exception"]["values"][0]["stacktrace"]["frames"][0]["in_app"] is False
 
-        event_params = make_event(
-            platform="native",
-            exception={
-                "values": [
-                    {
-                        "type": "Hello",
-                        "stacktrace": {
-                            "frames": [
-                                {
-                                    "function": "foo2",
-                                    "in_app": True,
-                                },
-                                {"function": "bar"},
-                            ]
-                        },
-                    }
-                ]
-            },
-        )
+        with patch(
+            "sentry.grouping.ingest.hashing.get_grouping_config_dict_for_project",
+            return_value=grouping_config,
+        ):
+            event_params = make_event(
+                platform="native",
+                exception={
+                    "values": [
+                        {
+                            "type": "Hello",
+                            "stacktrace": {
+                                "frames": [
+                                    {
+                                        "function": "foo",
+                                        "in_app": True,
+                                    },
+                                    {"function": "bar"},
+                                ]
+                            },
+                        }
+                    ]
+                },
+            )
 
-        manager = EventManager(event_params)
-        manager.normalize()
-        manager.get_data()["grouping_config"] = {
-            "enhancements": enhancement.dumps(),
-            "id": "mobile:2021-02-12",
-        }
-        event2 = manager.save(self.project.id)
-        assert event2.data["exception"]["values"][0]["stacktrace"]["frames"][0]["in_app"] is False
-        assert event1.group_id == event2.group_id
+            manager = EventManager(event_params)
+            manager.normalize()
+            event1 = manager.save(self.project.id)
+            assert (
+                event1.data["exception"]["values"][0]["stacktrace"]["frames"][0]["in_app"] is False
+            )
+
+            event_params = make_event(
+                platform="native",
+                exception={
+                    "values": [
+                        {
+                            "type": "Hello",
+                            "stacktrace": {
+                                "frames": [
+                                    {
+                                        "function": "foo2",
+                                        "in_app": True,
+                                    },
+                                    {"function": "bar"},
+                                ]
+                            },
+                        }
+                    ]
+                },
+            )
+
+            manager = EventManager(event_params)
+            manager.normalize()
+            event2 = manager.save(self.project.id)
+            assert (
+                event2.data["exception"]["values"][0]["stacktrace"]["frames"][0]["in_app"] is False
+            )
+            assert event1.group_id == event2.group_id
 
     def test_category_match_group(self) -> None:
         """
@@ -2124,54 +2142,64 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         """
         from sentry.grouping.enhancer import Enhancements
 
-        enhancement = Enhancements.from_config_string(
+        enhancements_str = Enhancements.from_config_string(
             """
             function:foo category=foo_like
             category:foo_like -group
-            """,
-        )
+            """
+        ).dumps()
 
-        event_params = make_event(
-            platform="native",
-            exception={
-                "values": [
-                    {
-                        "type": "Hello",
-                        "stacktrace": {
-                            "frames": [
-                                {
-                                    "function": "foo",
-                                },
-                                {
-                                    "function": "bar",
-                                },
-                            ]
-                        },
-                    }
-                ]
-            },
-        )
-
-        manager = EventManager(event_params)
-        manager.normalize()
-
-        grouping_config: GroupingConfig = {
-            "enhancements": enhancement.dumps(),
+        # TODO: Really we should use DEFAULT_GROUPING_CONFIG here as the id (so that we don't have
+        # to update the test every time we change the default), but there's something about the
+        # mobile config, over and above the enhancements hardcoded above, that makes this test pass.
+        # We'll have to figure this out before we can delete the config.
+        grouping_config = {
             "id": "mobile:2021-02-12",
+            "enhancements": enhancements_str,
         }
 
-        manager.get_data()["grouping_config"] = grouping_config
-        event1 = manager.save(self.project.id)
+        with patch(
+            "sentry.grouping.ingest.hashing.get_grouping_config_dict_for_project",
+            return_value=grouping_config,
+        ):
+            event_params = make_event(
+                platform="native",
+                exception={
+                    "values": [
+                        {
+                            "type": "Hello",
+                            "stacktrace": {
+                                "frames": [
+                                    {
+                                        "function": "foo",
+                                    },
+                                    {
+                                        "function": "bar",
+                                    },
+                                ]
+                            },
+                        }
+                    ]
+                },
+            )
 
-        event2 = Event(event1.project_id, event1.event_id, data=event1.data)
+            manager = EventManager(event_params)
+            manager.normalize()
 
-        assert (
-            event1.get_hashes().hashes
-            == event2.get_hashes(load_grouping_config(grouping_config)).hashes
-        )
+            event1 = manager.save(self.project.id)
+            event2 = Event(event1.project_id, event1.event_id, data=event1.data)
+
+            assert (
+                event1.get_hashes().hashes
+                == event2.get_hashes(load_grouping_config(grouping_config)).hashes
+            )
 
     def test_write_none_tree_labels(self) -> None:
         """Write tree labels even if None"""
+        # This suffers from the same "has to be mobile" situation as other tests, but here it
+        # doesn't matter, because this test will go away along with hierarchical grouping and the
+        # mobile config
+        self.project.update_option("sentry:grouping_config", "mobile:2021-02-12")
 
         event_params = make_event(
             platform="native",
@@ -2196,15 +2224,17 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
 
         manager = EventManager(event_params)
         manager.normalize()
-
-        manager.get_data()["grouping_config"] = {
-            "id": "mobile:2021-02-12",
-        }
         event = manager.save(self.project.id)
 
         assert event.data["hierarchical_tree_labels"] == [None]
 
     def test_synthetic_exception_detection(self) -> None:
+        # TODO: Really we should use DEFAULT_GROUPING_CONFIG here as the id (so that we don't have
+        # to update the test every time we change the default), but there's something about the
+        # mobile config, over and above the enhancements hardcoded above, that makes this test pass.
+        # We'll have to figure this out before we can delete the config.
+        self.project.update_option("sentry:grouping_config", "mobile:2021-02-12")
+
         manager = EventManager(
             make_event(
                 message="foo",
@@ -2222,10 +2252,6 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             project=self.project,
         )
         manager.normalize()
-
-        manager.get_data()["grouping_config"] = {
-            "id": "mobile:2021-02-12",
-        }
         event = manager.save(self.project.id)
 
         mechanism = event.interfaces["exception"].values[0].mechanism


### PR DESCRIPTION
Currently, when deciding what grouping config to use for an event, we pull the primary config off of the event itself (where it's been added by Relay) and the secondary config from the event's project... unless the event is being reprocessed, in which case we grab both configs from the project.  A while back, [I added a log](https://github.com/getsentry/sentry/pull/65116) so we could see if anything would be different if we were to always just grab both configs from the project, and lo and behold, it's exactly the same. This means we can simplify the logic (and remove the log), which this PR does.

As a bonus, it also solves another problem: Sometimes we calculate the primary and secondary hashes using the same config, totally negating the point of the secondary. This happens when a config update causes the project options cached in Relay to become out of date - Relay still thinks config A is primary (and adds that information to the event), whereas the project now thinks of config A as the secondary and the newer config B as the primary. We then use A for calculating the primary hash (because we read it off of the event), and A for calculating the secondary hash (because we pulled it from the project). Whoops. This fixes that problem by always getting both the primary and secondary configs from the same single source of truth, which then allows us to remove all of the logic (and logging) handling the problem (which this PR also does).

Fixes (the issues discussed in) https://github.com/getsentry/sentry/pull/65116.