### PR TITLE
fix(slack): fix disappearing tags on issue assignment

### DIFF
--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -67,7 +67,7 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
 
         if block_id:
             tags_block_id = block_id.copy()
-            tags_block_id["block"] = "text"
+            tags_block_id["block"] = "tags"
             block["block_id"] = orjson.dumps(tags_block_id).decode()
 
         return block

--- a/src/sentry/integrations/slack/requests/action.py
+++ b/src/sentry/integrations/slack/requests/action.py
@@ -114,12 +114,7 @@ class SlackActionRequest(SlackRequest):
         return logging_data
 
     def get_tags(self) -> set[str]:
-        logger.info("slack.action.get_tags", extra={"data": self.data})
-        message = self.data.get("message", {})
-        if not message:
-            return set()
-
-        blocks = message.get("blocks", [{}])
+        blocks = self.data.get("message", {}).get("blocks", [{}])
         tags = set()
         for block in blocks:
             if "tags" not in block.get("block_id", ""):
@@ -132,6 +127,7 @@ class SlackActionRequest(SlackRequest):
                 # the tags are organized as tag_key: tag_value, so even indexed tags are keys
                 if i % 2 == 1:
                     continue
-                if tag_key.strip(" ").endswith(":"):
+
+                if tag_key.strip().endswith(":"):
                     tags.add(tag_key.strip(": "))
         return tags

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -117,7 +117,7 @@ def build_test_message_blocks(
             tags_text += f"{k}: `{v}`  "
 
         tags_section = {
-            "block_id": f'{{"issue":{group.id},"block":"text"}}',
+            "block_id": f'{{"issue":{group.id},"block":"tags"}}',
             "type": "section",
             "text": {"type": "mrkdwn", "text": tags_text},
         }

--- a/tests/sentry/integrations/slack/webhooks/actions/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/__init__.py
@@ -226,6 +226,7 @@ class BaseEventTest(APITestCase):
             }
             payload["response_urls"] = []
             payload["view"] = view
+            payload["type"] = type
 
         elif type == "block_actions":
             payload["container"] = {
@@ -251,6 +252,7 @@ class BaseEventTest(APITestCase):
             }
             payload["response_url"] = self.response_url
             payload["actions"] = action_data or []
+            payload["type"] = type
 
         if data:
             payload.update(data)


### PR DESCRIPTION
Actually persist the tags when an issue is assigned.

The modal actions (resolve/archive) will require another pass, because there are two calls to the webhook endpoint (open the modal, taken action via the modal) and we need to modify the `private_metadata` that is being passed back so we can extract the tags from the payload.

Fix

https://github.com/user-attachments/assets/d543603a-685a-4793-b943-e6b766f0c15e

Before

https://github.com/user-attachments/assets/9b01534b-ae84-420b-aa5a-17c4193bcd3d