### PR TITLE
feat(autofix): Allow user to reselect root cause and re-run

### DIFF
--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -410,7 +410,7 @@ function AutofixRootCauseDisplay({
                     size="xs"
                     onClick={() => handleSelectFix({causeId: cause.id})}
                     busy={isLoading}
-                    analyticsEventName="Autofix: Root Cause Fix Selected"
+                    analyticsEventName="Autofix: Root Cause Fix Re-Selected"
                     analyticsEventKey="autofix.root_cause_fix_selected"
                     analyticsParams={{group_id: groupId}}
                   >

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -183,6 +183,7 @@ function SuggestedFixSnippet({
   snippet: AutofixRootCauseCodeContextSnippet;
 }) {
   function getSourceLink() {
+    if (!repos) return undefined;
     const repo = repos.find(
       r => r.name === snippet.repo_name && r.provider === 'integrations:github'
     );
@@ -366,6 +367,7 @@ function AutofixRootCauseDisplay({
   repos,
 }: AutofixRootCauseProps) {
   const [selectedId, setSelectedId] = useState(() => causes[0].id);
+  const {isLoading, mutate: handleSelectFix} = useSelectCause({groupId, runId});
 
   if (rootCauseSelection) {
     if ('custom_root_cause' in rootCauseSelection) {
@@ -398,11 +400,24 @@ function AutofixRootCauseDisplay({
           <AutofixShowMore title={t('Show unselected causes')}>
             {otherCauses.map(cause => (
               <RootCauseOption selected key={cause.id}>
-                <Title
-                  dangerouslySetInnerHTML={{
-                    __html: singleLineRenderer(t('Cause: %s', cause.title)),
-                  }}
-                />
+                <RootCauseOptionHeader>
+                  <Title
+                    dangerouslySetInnerHTML={{
+                      __html: singleLineRenderer(t('Cause: %s', cause.title)),
+                    }}
+                  />
+                  <Button
+                    size="xs"
+                    onClick={() => handleSelectFix({causeId: cause.id})}
+                    busy={isLoading}
+                    analyticsEventName="Autofix: Root Cause Fix Selected"
+                    analyticsEventKey="autofix.root_cause_fix_selected"
+                    analyticsParams={{group_id: groupId}}
+                  >
+                    {t('Fix This Instead')}
+                  </Button>
+                </RootCauseOptionHeader>
+
                 <CauseDescription
                   dangerouslySetInnerHTML={{
                     __html: marked(cause.description),

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -518,7 +518,8 @@ const LogText = styled('div')<{expanded: boolean; isExpandable: boolean}>`
 `;
 
 const ExpandableLogRow = styled('div')`
+  overflow-x: scroll;
   display: flex;
   flex-direction: row;
-  align-items: flex-start; /* Ensure items align to the start of the container */
+  align-items: flex-start;
 `;


### PR DESCRIPTION
Add a button to unselected root causes that re-triggers the root cause selection flow.

<img width="864" alt="Screenshot 2024-08-06 at 1 29 06 PM" src="https://github.com/user-attachments/assets/a071e4ee-7940-4d19-a1c7-aa62346788fd">
