### PR TITLE
chore(issues): Add logs when substatuses are incorrect

### DIFF
--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -207,7 +207,9 @@ class CorePostProcessGroupTestMixin(BasePostProgressGroupMixin):
             instance=mock.ANY,
             tags={"occurrence_type": mock.ANY},
         )
-        logger_mock.warning.assert_not_called()
+        assert "tasks.post_process.old_time_to_post_process" not in [
+            msg for (msg, _) in logger_mock.warning.call_args_list
+        ]
 
 
 class DeriveCodeMappingsProcessGroupTestMixin(BasePostProgressGroupMixin):


### PR DESCRIPTION
We have logs in place for invalid substatuses or incorrect substatuses for IGNORED groups in the pre_save. This PR adds some logging when we set the group substatus to NEW in post_process to ensure we aren't skipping any issues that have a substatus (which is incorrect since new groups should have no substatus until https://github.com/getsentry/sentry/pull/75471 is merged). 

Fixes https://github.com/getsentry/sentry/issues/75683