### PR TITLE
nit(tasks): Update jira tasks to use new logger

### DIFF
--- a/src/sentry/integrations/jira/tasks.py
+++ b/src/sentry/integrations/jira/tasks.py
@@ -3,6 +3,7 @@ from django.db import IntegrityError, router, transaction
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration.service import integration_service
+from sentry.integrations.tasks import logger
 from sentry.models.grouplink import GroupLink
 from sentry.models.groupmeta import GroupMeta
 from sentry.models.project import Project
@@ -10,7 +11,6 @@ from sentry.plugins.base import plugins
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
-from sentry.tasks.integrations import logger
 
 
 @instrumented_task(


### PR DESCRIPTION
Updating import to use new logger in sentry/integrations/__init__.py since we're getting rid of the old one.

Separate PR because this'll have to marinate a bit (???) [if it doesn't need marination, I'll just include this in the "getting rid of task shims" branch]

(# issue here)

