### PR TITLE
fix(alerts): Add validation for missing alertThreshold

### DIFF
--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -268,7 +268,6 @@ class AlertRuleSerializer(CamelSnakeModelSerializer[AlertRule]):
         self._translate_thresholds(threshold_type, data.get("comparison_delta"), triggers, data)
 
         critical = triggers[0]
-
         self._validate_trigger_thresholds(threshold_type, critical, data.get("resolve_threshold"))
 
         if len(triggers) == 2:
@@ -413,6 +412,9 @@ class AlertRuleSerializer(CamelSnakeModelSerializer[AlertRule]):
                 )
 
     def _validate_trigger_thresholds(self, threshold_type, trigger, resolve_threshold):
+        if trigger.get("alert_threshold") is None:
+            raise serializers.ValidationError("Trigger must have an alertThreshold")
+
         if resolve_threshold is None:
             return
         is_integer = (


### PR DESCRIPTION
If you forget to add `alertThreshold` to the payload when creating a metric alert through the API we don't currently throw a validation error, but we run into a key error. This PR checks that it's not None and raises an error if so.

Closes https://getsentry.atlassian.net/browse/ALRT-192 and SENTRY-3D4Q