### PR TITLE
chore(substatus): Cleanup constants defined for issue substatus

### DIFF
--- a/src/sentry/models/groupsnooze.py
+++ b/src/sentry/models/groupsnooze.py
@@ -39,8 +39,6 @@ class GroupSnooze(Model):
     - If ``user_count`` is set, the snooze is lfited when unique users match.
     - If ``user_window`` is set (in addition to count), the snooze is lifted
       when the rate unique users matches.
-    - If ``until_escalating`` is set, the snooze is lifted when the Group's occurrences
-      exceeds the forecasted counts.
 
     NOTE: `window` and `user_window` are specified in minutes
     """

--- a/src/sentry/types/group.py
+++ b/src/sentry/types/group.py
@@ -40,12 +40,6 @@ SUBSTATUS_UPDATE_CHOICES: Mapping[str, int] = {
     "ongoing": GroupSubStatus.ONGOING,
     "regressed": GroupSubStatus.REGRESSED,
     "new": GroupSubStatus.NEW,
-    # Deprecated
-    "until_escalating": GroupSubStatus.UNTIL_ESCALATING,
-    # Deprecated
-    "until_condition_met": GroupSubStatus.UNTIL_CONDITION_MET,
-    # Deprecated
-    "forever": GroupSubStatus.FOREVER,
 }
 
 SUBSTATUS_TO_STR: Mapping[int, str] = {

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -250,7 +250,7 @@ class ConvertSubStatusValueTest(TestCase):
     def test_mixed_substatus(self):
         filters = [
             SearchFilter(SearchKey("substatus"), "=", SearchValue(["ongoing"])),
-            SearchFilter(SearchKey("substatus"), "=", SearchValue(["until_escalating"])),
+            SearchFilter(SearchKey("substatus"), "=", SearchValue(["archived_until_escalating"])),
         ]
         result = convert_query_values(filters, [self.project], self.user, None)
         assert [(sf.key.name, sf.operator, sf.value.raw_value) for sf in result] == [
@@ -263,7 +263,7 @@ class ConvertSubStatusValueTest(TestCase):
         filters = [
             SearchFilter(SearchKey("substatus"), "=", SearchValue(["ongoing"])),
             SearchFilter(SearchKey("status"), "=", SearchValue(["unresolved"])),
-            SearchFilter(SearchKey("substatus"), "=", SearchValue(["until_escalating"])),
+            SearchFilter(SearchKey("substatus"), "=", SearchValue(["archived_until_escalating"])),
         ]
         result = convert_query_values(filters, [self.project], self.user, None)
         assert [(sf.key.name, sf.operator, sf.value.raw_value) for sf in result] == [
@@ -275,7 +275,7 @@ class ConvertSubStatusValueTest(TestCase):
     def test_mixed_incl_excl_substatus(self):
         filters = [
             SearchFilter(SearchKey("substatus"), "=", SearchValue(["ongoing"])),
-            SearchFilter(SearchKey("substatus"), "!=", SearchValue(["until_escalating"])),
+            SearchFilter(SearchKey("substatus"), "!=", SearchValue(["archived_until_escalating"])),
         ]
         result = convert_query_values(filters, [self.project], self.user, None)
         assert [(sf.key.name, sf.operator, sf.value.raw_value) for sf in result] == [
@@ -287,7 +287,7 @@ class ConvertSubStatusValueTest(TestCase):
     def test_mixed_incl_excl_substatus_with_status(self):
         filters = [
             SearchFilter(SearchKey("substatus"), "=", SearchValue(["ongoing"])),
-            SearchFilter(SearchKey("substatus"), "!=", SearchValue(["until_escalating"])),
+            SearchFilter(SearchKey("substatus"), "!=", SearchValue(["archived_until_escalating"])),
             SearchFilter(SearchKey("status"), "=", SearchValue(["ignored"])),
         ]
         result = convert_query_values(filters, [self.project], self.user, None)
@@ -300,7 +300,7 @@ class ConvertSubStatusValueTest(TestCase):
     def test_mixed_excl_excl_substatus(self):
         filters = [
             SearchFilter(SearchKey("substatus"), "!=", SearchValue(["ongoing"])),
-            SearchFilter(SearchKey("substatus"), "!=", SearchValue(["until_escalating"])),
+            SearchFilter(SearchKey("substatus"), "!=", SearchValue(["archived_until_escalating"])),
         ]
         result = convert_query_values(filters, [self.project], self.user, None)
         assert [(sf.key.name, sf.operator, sf.value.raw_value) for sf in result] == [

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -2459,8 +2459,8 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             query="!is:regressed is:unresolved"
         )  # (status=unresolved, substatus=(!regressed))
         response6 = get_query_response(
-            query="!is:until_escalating"
-        )  # (status=(!unresolved), substatus=(!until_escalating))
+            query="!is:archived_until_escalating"
+        )  # (status=(!unresolved), substatus=(!archived_until_escalating))
 
         assert (
             response0.status_code
@@ -2498,9 +2498,9 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         response1 = get_query_response(query="is:escalating")
         response2 = get_query_response(query="is:new")
         response3 = get_query_response(query="is:regressed")
-        response4 = get_query_response(query="is:forever")
-        response5 = get_query_response(query="is:until_condition_met")
-        response6 = get_query_response(query="is:until_escalating")
+        response4 = get_query_response(query="is:archived_forever")
+        response5 = get_query_response(query="is:archived_until_condition_met")
+        response6 = get_query_response(query="is:archived_until_escalating")
         response7 = get_query_response(query="is:resolved")
         response8 = get_query_response(query="is:ignored")
         response9 = get_query_response(query="is:muted")

--- a/tests/sentry/receivers/test_sentry_apps.py
+++ b/tests/sentry/receivers/test_sentry_apps.py
@@ -72,7 +72,7 @@ class TestIssueWorkflowNotifications(APITestCase):
     @with_feature("organizations:webhooks-unresolved")
     def test_notify_after_bulk_ongoing(self, delay):
         # First we need to have an ignored issue
-        self.update_issue({"status": "ignored", "substatus": "until_escalating"})
+        self.update_issue({"status": "ignored", "substatus": "archived_until_escalating"})
         bulk_transition_group_to_ongoing(
             from_status=GroupStatus.IGNORED,
             from_substatus=GroupSubStatus.UNTIL_ESCALATING,
@@ -90,7 +90,7 @@ class TestIssueWorkflowNotifications(APITestCase):
     @with_feature("organizations:webhooks-unresolved")
     def test_notify_after_escalating(self, delay):
         # First we need to have an ignored issue
-        self.update_issue({"status": "ignored", "substatus": "until_escalating"})
+        self.update_issue({"status": "ignored", "substatus": "archived_until_escalating"})
         event = self.issue.get_latest_event()
         manage_issue_states(
             group=self.issue,


### PR DESCRIPTION
These fields were deprecated during development of the feature and never cleaned up. We have no saved searches using the deprecated fields so this is safe to remove.