### PR TITLE
chore(issues): Remove logs for substatus changes

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -819,16 +819,11 @@ def process_inbox_adds(job: PostProcessJob) -> None:
             not is_reprocessed and not has_reappeared
         ):  # If true, we added the .ONGOING reason already
             if is_new:
-                group = Group.objects.filter(id=event.group.id).exclude(
-                    substatus=GroupSubStatus.NEW
+                updated = (
+                    Group.objects.filter(id=event.group.id)
+                    .exclude(substatus=GroupSubStatus.NEW)
+                    .update(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.NEW)
                 )
-                if group.exists() and group.exclude(substatus=None).exists():
-                    logger.warning(
-                        "no_substatus: Found NEW group with incorrect substatus",
-                        extra={"group_id": event.group.id, "substatus": event.group.substatus},
-                    )
-
-                updated = group.update(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.NEW)
                 if updated:
                     event.group.status = GroupStatus.UNRESOLVED
                     event.group.substatus = GroupSubStatus.NEW

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -207,9 +207,7 @@ class CorePostProcessGroupTestMixin(BasePostProgressGroupMixin):
             instance=mock.ANY,
             tags={"occurrence_type": mock.ANY},
         )
-        assert "tasks.post_process.old_time_to_post_process" not in [
-            msg for (msg, _) in logger_mock.warning.call_args_list
-        ]
+        logger_mock.warning.assert_not_called()
 
 
 class DeriveCodeMappingsProcessGroupTestMixin(BasePostProgressGroupMixin):


### PR DESCRIPTION
Removing these logs since they are fairly noisy. I've seen enough evidence from these logs to understand the state of substatuses for NEW issues. 