### PR TITLE
fix(metrics) Include projectIds when fetching metrics tags

### DIFF
--- a/static/app/components/metrics/mriSelect/metricListItemDetails.tsx
+++ b/static/app/components/metrics/mriSelect/metricListItemDetails.tsx
@@ -70,7 +70,9 @@ export function MetricListItemDetails({
       return false;
     }
     // We only wnat to disable the query if there is no data in the cache
-    const queryKey = getMetricsTagsQueryKey(organization, metric.mri);
+    const queryKey = getMetricsTagsQueryKey(organization, metric.mri, {
+      projects: projectIds,
+    });
     const data = queryClient.getQueryData(queryKey);
     return !!data;
   });

--- a/static/app/utils/metrics/useMetricsTags.tsx
+++ b/static/app/utils/metrics/useMetricsTags.tsx
@@ -18,10 +18,19 @@ const ALLOWED_SPAN_DURATION_TAGS = [
   'span.op',
 ];
 
-export function getMetricsTagsQueryKey(organization: Organization, mri: MRI | undefined) {
-  const queryParams = {
-    metric: mri,
-  };
+export function getMetricsTagsQueryKey(
+  organization: Organization,
+  mri: MRI | undefined,
+  pageFilters: Partial<PageFilters>
+) {
+  const queryParams = pageFilters.projects?.length
+    ? {
+        metric: mri,
+        project: pageFilters.projects,
+      }
+    : {
+        metric: mri,
+      };
 
   return [
     `/organizations/${organization.slug}/metrics/tags/`,
@@ -41,10 +50,13 @@ export function useMetricsTags(
   const parsedMRI = parseMRI(mri);
   const useCase = parsedMRI?.useCase ?? 'custom';
 
-  const tagsQuery = useApiQuery<MetricTag[]>(getMetricsTagsQueryKey(organization, mri), {
-    enabled: !!mri,
-    staleTime: Infinity,
-  });
+  const tagsQuery = useApiQuery<MetricTag[]>(
+    getMetricsTagsQueryKey(organization, mri, pageFilters),
+    {
+      enabled: !!mri,
+      staleTime: Infinity,
+    }
+  );
 
   const metricMeta = useMetricsMeta(pageFilters, [useCase], false, !blockedTags);
   const blockedTagsData =

--- a/static/app/utils/metrics/useMetricsTags.tsx
+++ b/static/app/utils/metrics/useMetricsTags.tsx
@@ -23,14 +23,10 @@ export function getMetricsTagsQueryKey(
   mri: MRI | undefined,
   pageFilters: Partial<PageFilters>
 ) {
-  const queryParams = pageFilters.projects?.length
-    ? {
-        metric: mri,
-        project: pageFilters.projects,
-      }
-    : {
-        metric: mri,
-      };
+  const queryParams = {
+    metric: mri,
+    project: pageFilters.projects,
+  };
 
   return [
     `/organizations/${organization.slug}/metrics/tags/`,


### PR DESCRIPTION
Fixes the problem of group by not working mentiond in the thread: https://sentry.slack.com/archives/C05TB55ETN1/p1722892801710349

Partially reverts what was done in the this PR: https://github.com/getsentry/sentry/pull/75415
In the PR by accident projectIds were removed from the request.
