### PR TITLE
fix(metrics) Make fuzzy search work with only 1 char

### DIFF
--- a/static/app/components/metrics/mriSelect/index.tsx
+++ b/static/app/components/metrics/mriSelect/index.tsx
@@ -117,6 +117,7 @@ const SEARCH_OPTIONS: Fuse.IFuseOptions<any> = {
   ignoreLocation: true,
   includeScore: false,
   includeMatches: false,
+  minMatchCharLength: 1,
 };
 
 function useFilteredMRIs(


### PR DESCRIPTION
Fuzzy search didn't work when only one char was entered, min num of chars required was 2, now it is switched to 1

Before
![image](https://github.com/user-attachments/assets/f376b09c-df06-4636-9038-7efb352119ea)

After
![image](https://github.com/user-attachments/assets/a70f2682-190e-4fc5-923e-c81b5d7b2482)
