### PR TITLE
fix(metrics): self time extraction spec

### DIFF
--- a/src/sentry/snuba/metrics/span_attribute_extraction.py
+++ b/src/sentry/snuba/metrics/span_attribute_extraction.py
@@ -11,15 +11,15 @@ from sentry.snuba.metrics.extraction import SearchQueryConverter, TagSpec
 # Matches the top level span attributes defined in Relay
 # https://github.com/getsentry/relay/blob/e59f21d9/relay-event-schema/src/protocol/span.rs#L119
 _TOP_LEVEL_SPAN_ATTRIBUTES = {
-    "span.exclusive_time",
-    "span.description",
-    "span.op",
-    "span.span_id",
-    "span.parent_span_id",
-    "span.trace_id",
-    "span.status",
-    "span.origin",
-    "span.duration",
+    "span.self_time": "span.exclusive_time",
+    "span.description": "span.description",
+    "span.span.op": "span.op",
+    "span.span_id": "span.span_id",
+    "span.parent_span_id": "span.parent_span_id",
+    "span.trace_id": "span.trace_id",
+    "span.status": "span.status",
+    "span.origin": "span.origin",
+    "span.duration": "span.duration",
 }
 
 # Matches the keys stored in span.sentry_tags
@@ -275,7 +275,7 @@ def _get_exists_condition(span_attribute: str) -> RuleCondition:
 
 def _map_span_attribute_name(span_attribute: str) -> str:
     if span_attribute in _TOP_LEVEL_SPAN_ATTRIBUTES:
-        return span_attribute
+        return _TOP_LEVEL_SPAN_ATTRIBUTES[span_attribute]
 
     if span_attribute in _SENTRY_TAGS:
         return f"span.sentry_tags.{span_attribute}"

--- a/static/app/views/metrics/pageHeaderActions.tsx
+++ b/static/app/views/metrics/pageHeaderActions.tsx
@@ -18,7 +18,6 @@ import {
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {isCustomMeasurement} from 'sentry/utils/metrics';
 import {
   hasCustomMetricsExtractionRules,
   hasMetricsNewInputs,

--- a/static/app/views/metrics/pageHeaderActions.tsx
+++ b/static/app/views/metrics/pageHeaderActions.tsx
@@ -18,6 +18,7 @@ import {
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {isCustomMeasurement} from 'sentry/utils/metrics';
 import {
   hasCustomMetricsExtractionRules,
   hasMetricsNewInputs,

--- a/tests/sentry/snuba/metrics/test_span_attribute_extraction.py
+++ b/tests/sentry/snuba/metrics/test_span_attribute_extraction.py
@@ -43,27 +43,27 @@ def test_convert_to_spec():
 
 
 def test_top_level_span_attribute():
-    top_level_attributes = {
-        "span.exclusive_time",
-        "span.description",
-        "span.op",
-        "span.span_id",
-        "span.parent_span_id",
-        "span.trace_id",
-        "span.status",
-        "span.origin",
-        "span.duration",
+    top_level_attribute_mapping = {
+        "span.self_time": "span.exclusive_time",
+        "span.description": "span.description",
+        "span.span.op": "span.op",
+        "span.span_id": "span.span_id",
+        "span.parent_span_id": "span.parent_span_id",
+        "span.trace_id": "span.trace_id",
+        "span.status": "span.status",
+        "span.origin": "span.origin",
+        "span.duration": "span.duration",
     }
 
     # Ensure that all top level attributes are covered
-    assert top_level_attributes == _TOP_LEVEL_SPAN_ATTRIBUTES
+    assert top_level_attribute_mapping == _TOP_LEVEL_SPAN_ATTRIBUTES
 
-    for attribute in top_level_attributes:
+    for key, value in top_level_attribute_mapping.items():
         rule = MetricsExtractionRule(
-            span_attribute=attribute, type="d", unit="none", tags=set(), condition="", id=1
+            span_attribute=key, type="d", unit="none", tags=set(), condition="", id=1
         )
         metric_spec = convert_to_metric_spec(rule)
-        assert metric_spec["field"] == attribute
+        assert metric_spec["field"] == value
 
 
 def test_sentry_tags():
@@ -168,6 +168,18 @@ def test_counter_extends_conditions():
             {"inner": {"name": "span.data.foobar", "op": "eq", "value": None}, "op": "not"},
         ],
     }
+
+
+def test_self_time_counter():
+    rule = MetricsExtractionRule(
+        span_attribute="span.self_time", type="c", unit="none", tags=set(), condition="", id=1
+    )
+
+    metric_spec = convert_to_metric_spec(rule)
+
+    assert not metric_spec["field"]
+    assert metric_spec["mri"] == "c:custom/span_attribute_1@none"
+    assert not metric_spec["condition"]
 
 
 def test_span_duration_counter_not_extends_conditions():


### PR DESCRIPTION
- closes: #75712 

`span.self_time` is an alias for `span.exclusive_time`