### PR TITLE
ref: move digests Digest / Notification / Record types

### DIFF
--- a/src/sentry/digests/__init__.py
+++ b/src/sentry/digests/__init__.py
@@ -1,40 +1,18 @@
 from __future__ import annotations
 
-import datetime as datetime_mod
-from collections.abc import MutableMapping
-from typing import TYPE_CHECKING, Any, NamedTuple, TypeAlias
-
 from django.conf import settings
 
-from sentry.utils.dates import to_datetime
 from sentry.utils.services import LazyServiceWrapper
 
 from .backends.base import Backend
 from .backends.dummy import DummyBackend
-
-if TYPE_CHECKING:
-    from sentry.models.group import Group
-    from sentry.models.rule import Rule
 
 backend = LazyServiceWrapper(
     Backend, settings.SENTRY_DIGESTS, settings.SENTRY_DIGESTS_OPTIONS, (DummyBackend,)
 )
 backend.expose(locals())
 
-
-class Record(NamedTuple):
-    key: str
-    value: Any  # TODO: I think this is `Notification` ?
-    timestamp: float
-
-    @property
-    def datetime(self) -> datetime_mod.datetime:
-        return to_datetime(self.timestamp)
-
-
 OPTIONS = frozenset(("increment_delay", "maximum_delay", "minimum_delay"))
-
-Digest: TypeAlias = MutableMapping["Rule", MutableMapping["Group", list[Record]]]
 
 
 def get_option_key(plugin: str, option: str) -> str:

--- a/src/sentry/digests/backends/base.py
+++ b/src/sentry/digests/backends/base.py
@@ -4,11 +4,11 @@ import logging
 from collections.abc import Iterable, Mapping
 from typing import TYPE_CHECKING, Any, NamedTuple
 
+from sentry.digests.types import Record
 from sentry.utils.imports import import_string
 from sentry.utils.services import Service
 
 if TYPE_CHECKING:
-    from sentry.digests import Record
     from sentry.models.project import Project
 
 logger = logging.getLogger("sentry.digests")

--- a/src/sentry/digests/backends/dummy.py
+++ b/src/sentry/digests/backends/dummy.py
@@ -3,9 +3,9 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
 from sentry.digests.backends.base import Backend, ScheduleEntry
+from sentry.digests.types import Record
 
 if TYPE_CHECKING:
-    from sentry.digests import Record
     from sentry.models.project import Project
 
 

--- a/src/sentry/digests/backends/redis.py
+++ b/src/sentry/digests/backends/redis.py
@@ -7,8 +7,8 @@ from typing import Any
 from rb.clients import LocalClient
 from redis.exceptions import ResponseError
 
-from sentry.digests import Record
 from sentry.digests.backends.base import Backend, InvalidState, ScheduleEntry
+from sentry.digests.types import Record
 from sentry.utils.locking.backends.redis import RedisLockBackend
 from sentry.utils.locking.lock import Lock
 from sentry.utils.locking.manager import LockManager

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import functools
 import itertools
 import logging
-from collections import defaultdict, namedtuple
+from collections import defaultdict
 from collections.abc import Mapping, MutableMapping, MutableSequence, Sequence
-from typing import Any
+from typing import Any, TypeAlias
 
 from sentry import tsdb
-from sentry.digests import Digest, Record
+from sentry.digests.types import Notification, Record
 from sentry.eventstore.models import Event
 from sentry.models.group import Group, GroupStatus
 from sentry.models.project import Project
@@ -19,9 +19,7 @@ from sentry.utils.pipeline import Pipeline
 
 logger = logging.getLogger("sentry.digests")
 
-Notification = namedtuple(
-    "Notification", "event rules notification_uuid", defaults=(None, None, None)
-)
+Digest: TypeAlias = MutableMapping["Rule", MutableMapping["Group", list[Record]]]
 
 
 def split_key(

--- a/src/sentry/digests/types.py
+++ b/src/sentry/digests/types.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import datetime as datetime_mod
+from collections import namedtuple
+from typing import Any, NamedTuple
+
+from sentry.utils.dates import to_datetime
+
+Notification = namedtuple(
+    "Notification", "event rules notification_uuid", defaults=(None, None, None)
+)
+
+
+class Record(NamedTuple):
+    key: str
+    value: Any  # TODO: I think this is `Notification` ?
+    timestamp: float
+
+    @property
+    def datetime(self) -> datetime_mod.datetime:
+        return to_datetime(self.timestamp)

--- a/src/sentry/digests/utils.py
+++ b/src/sentry/digests/utils.py
@@ -7,7 +7,8 @@ from typing import Any
 
 from django.db.models import Q
 
-from sentry.digests import Digest, Record
+from sentry.digests.notifications import Digest
+from sentry.digests.types import Record
 from sentry.eventstore.models import Event
 from sentry.integrations.types import ExternalProviders
 from sentry.models.group import Group

--- a/src/sentry/integrations/slack/message_builder/notifications/digest.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/digest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from sentry.digests import Digest
+from sentry.digests.notifications import Digest
 from sentry.digests.utils import get_groups
 from sentry.integrations.slack.message_builder import SlackBlock
 from sentry.integrations.slack.message_builder.issues import SlackIssuesMessageBuilder

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -4,9 +4,8 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 from sentry import digests
-from sentry.digests import Digest
 from sentry.digests import get_option_key as get_digest_option_key
-from sentry.digests.notifications import event_to_record, unsplit_key
+from sentry.digests.notifications import Digest, event_to_record, unsplit_key
 from sentry.integrations.types import ExternalProviders
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.project import Project

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -8,7 +8,7 @@ from urllib.parse import urlencode
 
 from sentry import analytics, features
 from sentry.db.models import Model
-from sentry.digests import Digest
+from sentry.digests.notifications import Digest
 from sentry.digests.utils import (
     get_digest_as_context,
     get_participants_by_event,

--- a/src/sentry/tasks/digests.py
+++ b/src/sentry/tasks/digests.py
@@ -2,9 +2,10 @@ import logging
 import time
 from datetime import datetime
 
-from sentry.digests import Record, get_option_key
+from sentry.digests import get_option_key
 from sentry.digests.backends.base import InvalidState
 from sentry.digests.notifications import build_digest, split_key
+from sentry.digests.types import Record
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.project import Project
 from sentry.silo.base import SiloMode

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -25,8 +25,8 @@ from django.views.generic import View
 
 from sentry import eventstore
 from sentry.constants import LOG_LEVELS
-from sentry.digests import Record
-from sentry.digests.notifications import Notification, build_digest
+from sentry.digests.notifications import build_digest
+from sentry.digests.types import Notification, Record
 from sentry.digests.utils import get_digest_metadata
 from sentry.event_manager import EventManager, get_event_type
 from sentry.http import get_server_hostname

--- a/tests/sentry/digests/backends/test_redis.py
+++ b/tests/sentry/digests/backends/test_redis.py
@@ -2,9 +2,9 @@ import time
 
 import pytest
 
-from sentry.digests import Record
 from sentry.digests.backends.base import InvalidState
 from sentry.digests.backends.redis import RedisBackend
+from sentry.digests.types import Record
 from sentry.testutils.cases import TestCase
 
 

--- a/tests/sentry/digests/test_notifications.py
+++ b/tests/sentry/digests/test_notifications.py
@@ -5,9 +5,7 @@ from collections import defaultdict
 from collections.abc import Mapping, MutableMapping, MutableSequence
 from functools import cached_property, reduce
 
-from sentry.digests import Record
 from sentry.digests.notifications import (
-    Notification,
     event_to_record,
     group_records,
     rewrite_record,
@@ -16,6 +14,7 @@ from sentry.digests.notifications import (
     split_key,
     unsplit_key,
 )
+from sentry.digests.types import Notification, Record
 from sentry.models.rule import Rule
 from sentry.notifications.types import ActionTargetType, FallthroughChoiceType
 from sentry.testutils.cases import TestCase

--- a/tests/sentry/digests/test_utilities.py
+++ b/tests/sentry/digests/test_utilities.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
 
-from sentry.digests import Digest
-from sentry.digests.notifications import build_digest, event_to_record
+from sentry.digests.notifications import Digest, build_digest, event_to_record
 from sentry.digests.utils import (
     get_event_from_groups_in_digest,
     get_participants_by_event,

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -13,7 +13,7 @@ from django.utils import timezone
 from sentry_relay.processing import parse_release
 from slack_sdk.web import SlackResponse
 
-from sentry.digests.notifications import Notification
+from sentry.digests.types import Notification
 from sentry.event_manager import EventManager
 from sentry.models.activity import Activity
 from sentry.models.group import Group, GroupStatus


### PR DESCRIPTION
splitting out the refactor before fixing the types -- this resolves two import cycles as well!

<!-- Describe your PR here. -->