### PR TITLE
fix(dashboards): Metrics estimation is transaction-like

### DIFF
--- a/static/app/views/dashboards/datasetConfig/transactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/transactions.tsx
@@ -306,7 +306,7 @@ function getEventsSeriesRequest(
       ...requestData.queryExtras,
       ...{dataset: DiscoverDatasets.METRICS_ENHANCED},
     };
-    return doOnDemandMetricsRequest(api, requestData);
+    return doOnDemandMetricsRequest(api, requestData, widget.widgetType);
   }
 
   return doEventsRequest<true>(api, requestData);


### PR DESCRIPTION
Hardcode split decision as `transaction-like` for
queries that run metrics estimation. Otherwise a
dataset is not selected with the new split