### PR TITLE
feat(dashboards): On demand should run on transaction widgets

### DIFF
--- a/static/app/utils/performance/contexts/onDemandControl.tsx
+++ b/static/app/utils/performance/contexts/onDemandControl.tsx
@@ -75,7 +75,12 @@ export function OnDemandControlProvider({
  *    can't be on-demand because they are part of errors. (eg. error.type, message, stack, etc.)
  */
 export function isOnDemandMetricWidget(widget: Widget): boolean {
-  if (widget.widgetType !== WidgetType.DISCOVER) {
+  if (
+    !(
+      widget.widgetType === WidgetType.DISCOVER ||
+      widget.widgetType === WidgetType.TRANSACTIONS
+    )
+  ) {
     return false;
   }
 


### PR DESCRIPTION
With the dataset split into errors and transactions
WidgetType.TRANSACTION can also be an on demand type widget