### PR TITLE
fix(insights): project selection tooltip interferes with project selector

### DIFF
--- a/static/app/views/insights/common/components/modulePageFilterBar.tsx
+++ b/static/app/views/insights/common/components/modulePageFilterBar.tsx
@@ -44,9 +44,9 @@ export function ModulePageFilterBar({moduleName, onProjectChange, extraFilters}:
   }, [hasDataWithAllProjects]);
 
   useEffect(() => {
-    document.body.addEventListener('click', handleClickAnywhereOnPage);
+    document.addEventListener('click', handleClickAnywhereOnPage, {capture: true});
     return () => {
-      document.body.removeEventListener('click', handleClickAnywhereOnPage);
+      document.removeEventListener('click', handleClickAnywhereOnPage);
     };
   }, []);
 
@@ -59,8 +59,9 @@ export function ModulePageFilterBar({moduleName, onProjectChange, extraFilters}:
           position="bottom-start"
           disabled={!showTooltip}
         >
-          <ProjectPageFilter onChange={onProjectChange} />
+          <div />
         </Tooltip>
+        <ProjectPageFilter onChange={onProjectChange} />
         <EnvironmentPageFilter />
         <DatePageFilter />
       </PageFilterBar>

--- a/static/app/views/insights/common/components/modulePageFilterBar.tsx
+++ b/static/app/views/insights/common/components/modulePageFilterBar.tsx
@@ -59,6 +59,8 @@ export function ModulePageFilterBar({moduleName, onProjectChange, extraFilters}:
           position="bottom-start"
           disabled={!showTooltip}
         >
+          {/* TODO: Placing a DIV here is a hack, it allows the tooltip to close and the ProjectPageFilter to close at the same time,
+          otherwise two clicks are required */}
           <div />
         </Tooltip>
         <ProjectPageFilter onChange={onProjectChange} />

--- a/static/app/views/insights/common/components/modulePageFilterBar.tsx
+++ b/static/app/views/insights/common/components/modulePageFilterBar.tsx
@@ -60,8 +60,8 @@ export function ModulePageFilterBar({moduleName, onProjectChange, extraFilters}:
           disabled={!showTooltip}
         >
           {/* TODO: Placing a DIV here is a hack, it allows the tooltip to close and the ProjectPageFilter to close at the same time,
-          otherwise two clicks are required */}
-          <div />
+          otherwise two clicks are required because of some rerendering/event propogation issues into the children */}
+          <div style={{width: '100px', position: 'absolute', height: '100%'}} />
         </Tooltip>
         <ProjectPageFilter onChange={onProjectChange} />
         <EnvironmentPageFilter />


### PR DESCRIPTION
The expected behaviour of the "change project" tooltip (see below) is to appear when the selected project does not have data for the given module, but another project does. It is then supposed to disappear after 5 seconds OR after a click anywhere on the screen.

<img width="446" alt="image" src="https://github.com/user-attachments/assets/76175820-e961-4be8-b9f9-b67b79056f8a">


There was a bug where clicking on any of the pagefilter controls did not close the tooltip. This is due to events not propagating to the document level click handler. To fix this two things were done.
1. We add `{capture: true}` which effectively ignores any stop propagation's from any handler.
2. We wrap the tooltip in a invisible div instead of the `ProjectPageFilter`. Without this, changing projects would require 2 clicks, one to close the tooltip, and one to open the panel. I spent a while trying to figure a less hacky way around this, but i figured its best to get a quick fix out the door to improve the experience. But if anyone has any ideas on how to fix this lmk! 