### PR TITLE
feat(discover): Create Alert sets up the correct alert type

### DIFF
--- a/static/app/views/alerts/rules/metric/incompatibleAlertQuery.spec.tsx
+++ b/static/app/views/alerts/rules/metric/incompatibleAlertQuery.spec.tsx
@@ -1,5 +1,3 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
-
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import EventView from 'sentry/utils/discover/eventView';
@@ -7,10 +5,7 @@ import {IncompatibleAlertQuery} from 'sentry/views/alerts/rules/metric/incompati
 import {ALL_VIEWS, DEFAULT_EVENT_VIEW} from 'sentry/views/discover/data';
 
 function renderComponent(eventView: EventView) {
-  const organization = OrganizationFixture();
-  return render(
-    <IncompatibleAlertQuery orgSlug={organization.slug} eventView={eventView} />
-  );
+  return render(<IncompatibleAlertQuery eventView={eventView} />);
 }
 
 describe('IncompatibleAlertQuery', () => {

--- a/static/app/views/alerts/rules/metric/incompatibleAlertQuery.tsx
+++ b/static/app/views/alerts/rules/metric/incompatibleAlertQuery.tsx
@@ -96,7 +96,6 @@ export function checkMetricAlertCompatiablity(
 
 interface IncompatibleAlertQueryProps {
   eventView: EventView;
-  orgSlug: string;
 }
 
 /**
@@ -110,15 +109,6 @@ export function IncompatibleAlertQuery(props: IncompatibleAlertQueryProps) {
   if (!totalErrors || !isOpen) {
     return null;
   }
-
-  const eventTypeError = props.eventView.clone();
-  eventTypeError.query += ' event.type:error';
-  const eventTypeTransaction = props.eventView.clone();
-  eventTypeTransaction.query += ' event.type:transaction';
-  const eventTypeDefault = props.eventView.clone();
-  eventTypeDefault.query += ' event.type:default';
-  const eventTypeErrorDefault = props.eventView.clone();
-  eventTypeErrorDefault.query += ' event.type:error or event.type:default';
 
   return (
     <StyledAlert

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -1162,9 +1162,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
       <Main fullWidth>
         <PermissionAlert access={['alerts:write']} project={project} />
 
-        {eventView && (
-          <IncompatibleAlertQuery orgSlug={organization.slug} eventView={eventView} />
-        )}
+        {eventView && <IncompatibleAlertQuery eventView={eventView} />}
         <Form
           model={this.form}
           apiMethod={ruleId ? 'PUT' : 'POST'}

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.spec.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.spec.tsx
@@ -138,4 +138,63 @@ describe('Incident Rules Create', () => {
       })
     );
   });
+
+  it('queries the errors dataset if dataset is errors', async () => {
+    const {organization, project, router} = initializeOrg({
+      organization: {features: ['performance-discover-dataset-selector']},
+    });
+
+    render(
+      <TriggersChart
+        api={api}
+        location={router.location}
+        organization={organization}
+        projects={[project]}
+        query="event.type:error"
+        timeWindow={1}
+        aggregate="count()"
+        dataset={Dataset.ERRORS}
+        triggers={[]}
+        environment={null}
+        comparisonType={AlertRuleComparisonType.COUNT}
+        resolveThreshold={null}
+        thresholdType={AlertRuleThresholdType.BELOW}
+        newAlertOrQuery
+        onDataLoaded={() => {}}
+        isQueryValid
+        showTotalCount
+      />
+    );
+
+    expect(await screen.findByTestId('area-chart')).toBeInTheDocument();
+    expect(await screen.findByTestId('alert-total-events')).toBeInTheDocument();
+
+    expect(eventStatsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: {
+          interval: '1m',
+          project: [2],
+          query: 'event.type:error',
+          statsPeriod: '9998m',
+          yAxis: 'count()',
+          referrer: 'api.organization-event-stats',
+          dataset: 'errors',
+        },
+      })
+    );
+
+    expect(eventCountsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: {
+          project: ['2'],
+          query: 'event.type:error',
+          statsPeriod: '9998m',
+          environment: [],
+          dataset: 'errors',
+        },
+      })
+    );
+  });
 });

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -264,7 +264,7 @@ class TriggersChart extends PureComponent<Props, State> {
     let queryDataset = queryExtras.dataset as undefined | DiscoverDatasets;
     const queryOverride = (queryExtras.query as string | undefined) ?? query;
 
-    if (shouldUseErrorsDiscoverDataset(query, dataset)) {
+    if (shouldUseErrorsDiscoverDataset(query, dataset, organization)) {
       queryDataset = DiscoverDatasets.ERRORS;
     }
 
@@ -436,7 +436,7 @@ class TriggersChart extends PureComponent<Props, State> {
         newAlertOrQuery,
       }),
       ...getForceMetricsLayerQueryExtras(organization, dataset),
-      ...(shouldUseErrorsDiscoverDataset(query, dataset)
+      ...(shouldUseErrorsDiscoverDataset(query, dataset, organization)
         ? {dataset: DiscoverDatasets.ERRORS}
         : {}),
     };

--- a/static/app/views/alerts/rules/utils.tsx
+++ b/static/app/views/alerts/rules/utils.tsx
@@ -111,6 +111,5 @@ export function shouldUseErrorsDiscoverDataset(
     return dataset === Dataset.ERRORS && query?.includes('is:unresolved');
   }
 
-  // Why do we need to check for is:unresolved above?
   return dataset === Dataset.ERRORS;
 }

--- a/static/app/views/alerts/rules/utils.tsx
+++ b/static/app/views/alerts/rules/utils.tsx
@@ -7,6 +7,7 @@ import type {Project} from 'sentry/types/project';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
+import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 
 export function getProjectOptions({
   organization,
@@ -101,6 +102,15 @@ export function getAlertRuleActionCategory(rule: MetricRule) {
   }
 }
 
-export function shouldUseErrorsDiscoverDataset(query: string, dataset: Dataset) {
-  return dataset === Dataset.ERRORS && query?.includes('is:unresolved');
+export function shouldUseErrorsDiscoverDataset(
+  query: string,
+  dataset: Dataset,
+  organization: Organization
+) {
+  if (!hasDatasetSelector(organization)) {
+    return dataset === Dataset.ERRORS && query?.includes('is:unresolved');
+  }
+
+  // Why do we need to check for is:unresolved above?
+  return dataset === Dataset.ERRORS;
 }

--- a/static/app/views/discover/savedQuery/index.spec.tsx
+++ b/static/app/views/discover/savedQuery/index.spec.tsx
@@ -470,5 +470,56 @@ describe('Discover > SaveQueryButtonGroup', function () {
         screen.queryByRole('button', {name: /create alert/i})
       ).not.toBeInTheDocument();
     });
+    it('uses the throughput alert type for transaction queries', () => {
+      const metricAlertOrg = {
+        ...organization,
+        features: ['incidents', 'performance-discover-dataset-selector'],
+      };
+      const transactionSavedQuery = {
+        ...savedQuery,
+        queryDataset: SavedQueryDatasets.TRANSACTIONS,
+        query: 'foo:bar',
+      };
+      const transactionView = EventView.fromSavedQuery(transactionSavedQuery);
+      mount(
+        location,
+        metricAlertOrg,
+        router,
+        transactionView,
+        transactionSavedQuery,
+        yAxis
+      );
+
+      const createAlertButton = screen.getByRole('button', {name: /create alert/i});
+      const href = createAlertButton.getAttribute('href')!;
+      const queryParameters = new URLSearchParams(href.split('?')[1]);
+
+      expect(queryParameters.get('query')).toEqual(
+        '(foo:bar) AND (event.type:transaction)'
+      );
+      expect(queryParameters.get('dataset')).toEqual('transactions');
+      expect(queryParameters.get('eventTypes')).toEqual('transaction');
+    });
+    it('uses the num errors alert type for error queries', () => {
+      const metricAlertOrg = {
+        ...organization,
+        features: ['incidents', 'performance-discover-dataset-selector'],
+      };
+      const errorSavedQuery = {
+        ...savedQuery,
+        queryDataset: SavedQueryDatasets.ERRORS,
+        query: 'foo:bar',
+      };
+      const transactionView = EventView.fromSavedQuery(errorSavedQuery);
+      mount(location, metricAlertOrg, router, transactionView, errorSavedQuery, yAxis);
+
+      const createAlertButton = screen.getByRole('button', {name: /create alert/i});
+      const href = createAlertButton.getAttribute('href')!;
+      const queryParameters = new URLSearchParams(href.split('?')[1]);
+
+      expect(queryParameters.get('query')).toEqual('foo:bar');
+      expect(queryParameters.get('dataset')).toEqual('events');
+      expect(queryParameters.get('eventTypes')).toEqual('error');
+    });
   });
 });

--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -406,8 +406,8 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
         : undefined;
 
       if (currentDataset === DiscoverDatasets.TRANSACTIONS) {
-        // We need to inject the event.type:transaction filter for alerts
-        // to avoid triggering the event.type missing banner error
+        // Inject the event.type:transaction filter for to avoid triggering
+        // the event.type missing banner error in the alerts form
         eventView.query = eventView.query
           ? `(${eventView.query}) AND (event.type:transaction)`
           : 'event.type:transaction';

--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -27,16 +27,19 @@ import type {Organization, Project, SavedQuery} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import EventView from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {getDiscoverQueriesUrl} from 'sentry/utils/discover/urls';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOverlay from 'sentry/utils/useOverlay';
 import withApi from 'sentry/utils/withApi';
 import withProjects from 'sentry/utils/withProjects';
+import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import {handleAddQueryToDashboard} from 'sentry/views/discover/utils';
 
 import {DEFAULT_EVENT_VIEW} from '../data';
 
 import {
+  getDatasetFromLocationOrSavedQueryDataset,
   handleCreateQuery,
   handleDeleteQuery,
   handleResetHomepageQuery,
@@ -386,7 +389,13 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
   }
 
   renderButtonCreateAlert() {
-    const {eventView, organization, projects} = this.props;
+    const {eventView, organization, projects, location, savedQuery} = this.props;
+    const currentDataset =
+      getDatasetFromLocationOrSavedQueryDataset(location, savedQuery?.queryDataset) ===
+      DiscoverDatasets.TRANSACTIONS
+        ? 'throughput'
+        : 'num_errors';
+    const alertType = hasDatasetSelector(organization) ? currentDataset : undefined;
 
     return (
       <GuideAnchor target="create_alert_from_discover">
@@ -399,6 +408,7 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
           size="sm"
           aria-label={t('Create Alert')}
           data-test-id="discover2-create-from-discover"
+          alertType={alertType}
         />
       </GuideAnchor>
     );


### PR DESCRIPTION
Clicking the "Create Alert" button should:
- Open up the number of errors alert page if the discover query is "Errors"
- Open up the throughput alert page if the discover query is "Transactions"

The requests to events-stats and events-meta should send along `dataset=errors` if the user has the split dataset feature flag.