### PR TITLE
feat(insights): add issue list to db module

### DIFF
--- a/static/app/views/insights/common/components/issues.tsx
+++ b/static/app/views/insights/common/components/issues.tsx
@@ -1,0 +1,278 @@
+import styled from '@emotion/styled';
+
+import ActorAvatar from 'sentry/components/avatar/actorAvatar';
+import Count from 'sentry/components/count';
+import EventOrGroupExtraDetails from 'sentry/components/eventOrGroupExtraDetails';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import Panel from 'sentry/components/panels/panel';
+import PanelHeader from 'sentry/components/panels/panelHeader';
+import PanelItem from 'sentry/components/panels/panelItem';
+import {IconWrapper} from 'sentry/components/sidebarSection';
+import GroupChart from 'sentry/components/stream/groupChart';
+import {IconUser} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Group} from 'sentry/types';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {IssueSummary} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/issues/issueSummary';
+
+const TABLE_WIDTH_BREAKPOINTS = {
+  FIRST: 800,
+  SECOND: 600,
+  THIRD: 500,
+  FOURTH: 400,
+};
+
+function Issue({data}: {data: Group}) {
+  const organization = useOrganization();
+
+  return (
+    <StyledPanelItem>
+      <IssueSummaryWrapper>
+        <IssueSummary data={data} organization={organization} event_id={'0'} />
+        <EventOrGroupExtraDetails data={data} />
+      </IssueSummaryWrapper>
+      <ChartWrapper>
+        <GroupChart
+          stats={data.filtered ? data.filtered.stats?.['24h'] : data.stats?.['24h']}
+          secondaryStats={data.filtered ? data.stats?.['24h'] : []}
+          showSecondaryPoints
+          showMarkLine
+        />
+      </ChartWrapper>
+      <EventsWrapper>
+        <PrimaryCount value={data.filtered ? data.filtered.count : data.count} />
+      </EventsWrapper>
+      <UserCountWrapper>
+        <PrimaryCount value={data.filtered ? data.filtered.userCount : data.userCount} />
+      </UserCountWrapper>
+      <AssineeWrapper>
+        {data.assignedTo ? (
+          <ActorAvatar actor={data.assignedTo} hasTooltip size={24} />
+        ) : (
+          <StyledIconWrapper>
+            <IconUser size="md" />
+          </StyledIconWrapper>
+        )}
+      </AssineeWrapper>
+    </StyledPanelItem>
+  );
+}
+
+function IssueListHeader() {
+  return (
+    <StyledPanelHeader>
+      {/* todo: fix plurality */}
+      <IssueHeading>{t('2 Performance issues')}</IssueHeading>
+      <GraphHeading>{t('Graph')}</GraphHeading>
+      <EventsHeading>{t('Events')}</EventsHeading>
+      <UsersHeading>{t('Users')}</UsersHeading>
+      <AssigneeHeading>{t('Assignee')}</AssigneeHeading>
+    </StyledPanelHeader>
+  );
+}
+
+export default function InsightIssuesList({issueTypes}: {issueTypes: string[]}) {
+  // fetch issue ids that have the current issue types, with the given pageFilter settings
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+
+  const query = `issue.type:[${issueTypes.join(',')}]`;
+  const {
+    isLoading,
+    data: fetchedIssues,
+    // isError,
+  } = useApiQuery<Group[]>(
+    [
+      `/organizations/${organization.slug}/issues/`,
+      {
+        query: {
+          collapse: ['stats', 'unhandled'],
+          expand: ['inbox', 'owners'],
+          query,
+          shortIdLookup: 1,
+          limit: 5,
+          project: selection.projects,
+          ...normalizeDateTimeParams(selection.datetime),
+        },
+      },
+    ],
+    {
+      staleTime: 2 * 60 * 1000,
+    }
+  );
+
+  const {data: issuesStats} = useApiQuery<Group[]>(
+    [
+      `/organizations/${organization.slug}/issues-stats/`,
+      {
+        query: {
+          query,
+          groups: fetchedIssues?.map(issue => issue.id),
+          project: selection.projects,
+          ...normalizeDateTimeParams(selection.datetime),
+        },
+      },
+    ],
+    {
+      staleTime: 2 * 60 * 1000,
+    }
+  );
+
+  const enrichedIssues = fetchedIssues?.map(issue => ({
+    ...issue,
+    ...issuesStats?.find(stats => stats.id === issue.id),
+  }));
+
+  // console.log([fetchedIssues?.map(issue => issue.id)]);
+  // console.log('fetched stats data', fetchedIssuesStatsData);
+  // console.log('enriched', enrichedIssues);
+  // pass issue data into <Issue /> (do not refetch the data per issue)
+
+  return (
+    <StyledPanel>
+      <IssueListHeader />
+      {isLoading ? (
+        <LoadingIndicator />
+      ) : enrichedIssues && enrichedIssues?.length > 0 ? (
+        enrichedIssues?.map(issue => <Issue data={issue} key={issue.id} />)
+      ) : (
+        "We couldn't find any issues that matched your filters"
+      )}
+    </StyledPanel>
+  );
+}
+
+const Heading = styled('div')`
+  display: flex;
+  align-self: center;
+  margin: 0 ${space(2)};
+  width: 60px;
+  color: ${p => p.theme.subText};
+`;
+
+const IssueHeading = styled(Heading)`
+  flex: 1;
+  width: 66.66%;
+  margin: 0;
+
+  @media (min-width: ${p => p.theme.breakpoints.medium}) {
+    width: 50%;
+  }
+`;
+
+const GraphHeading = styled(Heading)`
+  width: 160px;
+  display: flex;
+  justify-content: center;
+
+  @container (width < ${TABLE_WIDTH_BREAKPOINTS.FIRST}px) {
+    display: none;
+  }
+`;
+
+const EventsHeading = styled(Heading)`
+  @container (width < ${TABLE_WIDTH_BREAKPOINTS.SECOND}px) {
+    display: none;
+  }
+`;
+
+const UsersHeading = styled(Heading)`
+  display: flex;
+  justify-content: center;
+
+  @container (width < ${TABLE_WIDTH_BREAKPOINTS.THIRD}px) {
+    display: none;
+  }
+`;
+
+const AssigneeHeading = styled(Heading)`
+  @container (width < ${TABLE_WIDTH_BREAKPOINTS.FOURTH}px) {
+    display: none;
+  }
+`;
+
+const StyledPanel = styled(Panel)`
+  container-type: inline-size;
+`;
+
+const StyledPanelHeader = styled(PanelHeader)`
+  padding-top: ${space(1)};
+  padding-bottom: ${space(1)};
+`;
+
+// const StyledLoadingIndicatorWrapper = styled('div')`
+//   display: flex;
+//   justify-content: center;
+//   width: 100%;
+//   padding: ${space(2)} 0;
+//   height: 84px;
+
+//   /* Add a border between two rows of loading issue states */
+//   & + & {
+//     border-top: 1px solid ${p => p.theme.border};
+//   }
+// `;
+
+const StyledIconWrapper = styled(IconWrapper)`
+  margin: 0;
+`;
+
+const IssueSummaryWrapper = styled('div')`
+  overflow: hidden;
+  flex: 1;
+  width: 66.66%;
+
+  @media (min-width: ${p => p.theme.breakpoints.medium}) {
+    width: 50%;
+  }
+`;
+
+const ColumnWrapper = styled('div')`
+  display: flex;
+  justify-content: flex-end;
+  align-self: center;
+  width: 60px;
+  margin: 0 ${space(2)};
+`;
+
+const EventsWrapper = styled(ColumnWrapper)`
+  @container (width < ${TABLE_WIDTH_BREAKPOINTS.SECOND}px) {
+    display: none;
+  }
+`;
+
+const UserCountWrapper = styled(ColumnWrapper)`
+  @container (width < ${TABLE_WIDTH_BREAKPOINTS.THIRD}px) {
+    display: none;
+  }
+`;
+
+const AssineeWrapper = styled(ColumnWrapper)`
+  @container (width < ${TABLE_WIDTH_BREAKPOINTS.FOURTH}px) {
+    display: none;
+  }
+`;
+
+const ChartWrapper = styled('div')`
+  width: 200px;
+  align-self: center;
+
+  @container (width < ${TABLE_WIDTH_BREAKPOINTS.FIRST}px) {
+    display: none;
+  }
+`;
+
+const PrimaryCount = styled(Count)`
+  font-size: ${p => p.theme.fontSizeLarge};
+  font-variant-numeric: tabular-nums;
+`;
+
+const StyledPanelItem = styled(PanelItem)`
+  padding-top: ${space(1)};
+  padding-bottom: ${space(1)};
+  height: 84px;
+`;

--- a/static/app/views/insights/common/components/issues.tsx
+++ b/static/app/views/insights/common/components/issues.tsx
@@ -202,19 +202,6 @@ const StyledPanelHeader = styled(PanelHeader)`
   padding-bottom: ${space(1)};
 `;
 
-// const StyledLoadingIndicatorWrapper = styled('div')`
-//   display: flex;
-//   justify-content: center;
-//   width: 100%;
-//   padding: ${space(2)} 0;
-//   height: 84px;
-
-//   /* Add a border between two rows of loading issue states */
-//   & + & {
-//     border-top: 1px solid ${p => p.theme.border};
-//   }
-// `;
-
 const StyledIconWrapper = styled(IconWrapper)`
   margin: 0;
 `;

--- a/static/app/views/insights/common/components/issues.tsx
+++ b/static/app/views/insights/common/components/issues.tsx
@@ -30,7 +30,7 @@ function Issue({data}: {data: Group}) {
   const organization = useOrganization();
 
   return (
-    <StyledPanelItem>
+    <StyledPanelItem as="tr">
       <IssueSummaryWrapper>
         <IssueSummary data={data} organization={organization} event_id={'0'} />
         <EventOrGroupExtraDetails data={data} />
@@ -64,7 +64,7 @@ function Issue({data}: {data: Group}) {
 
 function IssueListHeader({issues}: {issues?: Group[]}) {
   return (
-    <StyledPanelHeader>
+    <StyledPanelHeader as="tr">
       <IssueHeading>
         {tct(`[count] [text]`, {
           count: issues?.length ?? 0,
@@ -145,7 +145,7 @@ export default function InsightIssuesList({
   );
 }
 
-const Heading = styled('div')`
+const Heading = styled('th')`
   display: flex;
   align-self: center;
   margin: 0 ${space(2)};
@@ -207,7 +207,7 @@ const StyledIconWrapper = styled(IconWrapper)`
   margin: 0;
 `;
 
-const IssueSummaryWrapper = styled('div')`
+const IssueSummaryWrapper = styled('td')`
   overflow: hidden;
   flex: 1;
   width: 66.66%;
@@ -217,7 +217,7 @@ const IssueSummaryWrapper = styled('div')`
   }
 `;
 
-const ColumnWrapper = styled('div')`
+const ColumnWrapper = styled('td')`
   display: flex;
   justify-content: flex-end;
   align-self: center;
@@ -243,7 +243,7 @@ const AssineeWrapper = styled(ColumnWrapper)`
   }
 `;
 
-const ChartWrapper = styled('div')`
+const ChartWrapper = styled('td')`
   width: 200px;
   align-self: center;
 

--- a/static/app/views/insights/common/components/issues.tsx
+++ b/static/app/views/insights/common/components/issues.tsx
@@ -91,9 +91,7 @@ function fetchIssues(
   // note: backend supports a maximum number of characters for message (seems to vary).
   // so, we query the first 200 characters of `message`, then filter for exact `message`
   // matches in application code
-  if (message) {
-    query += ` message:"${message?.slice(0, 200).replaceAll('"', '\\"')}"`;
-  }
+  query += ` message:"${message?.slice(0, 200).replaceAll('"', '\\"')}"`;
 
   const {isLoading, data: maybeMatchingIssues} = useApiQuery<Group[]>(
     [

--- a/static/app/views/insights/common/components/issues.tsx
+++ b/static/app/views/insights/common/components/issues.tsx
@@ -107,6 +107,7 @@ function fetchIssues(
           // even though we only search for the first 200 characters of the message
           limit: 100,
           project: selection.projects,
+          environment: selection.environments,
           ...normalizeDateTimeParams(selection.datetime),
         },
       },

--- a/static/app/views/insights/common/components/issues.tsx
+++ b/static/app/views/insights/common/components/issues.tsx
@@ -114,8 +114,13 @@ function fetchIssues(
     ],
     {
       staleTime: 2 * 60 * 1000,
+      enabled: !!message,
     }
   );
+
+  if (!message) {
+    return {isLoading: false, issues: []};
+  }
 
   // the api response contains issues that match the first 200 characters of the message. now,
   // filter by the issues that match the exact message the user is searching for

--- a/static/app/views/insights/database/views/databaseLandingPage.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.tsx
@@ -15,6 +15,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useSynchronizeCharts} from 'sentry/views/insights/common/components/chart';
+import InsightIssuesList from 'sentry/views/insights/common/components/issues';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
@@ -198,6 +199,14 @@ export function DatabaseLandingPage() {
                 />
               </ModuleLayout.Half>
 
+              <ModuleLayout.Full>
+                <InsightIssuesList
+                  issueTypes={[
+                    'performance_slow_db_query',
+                    'performance_n_plus_one_db_queries',
+                  ]}
+                />
+              </ModuleLayout.Full>
               <ModuleLayout.Full>
                 <ToolRibbon>
                   <ActionSelector moduleName={moduleName} value={spanAction ?? ''} />

--- a/static/app/views/insights/database/views/databaseLandingPage.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.tsx
@@ -15,7 +15,6 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useSynchronizeCharts} from 'sentry/views/insights/common/components/chart';
-import InsightIssuesList from 'sentry/views/insights/common/components/issues';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
@@ -199,14 +198,6 @@ export function DatabaseLandingPage() {
                 />
               </ModuleLayout.Half>
 
-              <ModuleLayout.Full>
-                <InsightIssuesList
-                  issueTypes={[
-                    'performance_slow_db_query',
-                    'performance_n_plus_one_db_queries',
-                  ]}
-                />
-              </ModuleLayout.Full>
               <ModuleLayout.Full>
                 <ToolRibbon>
                   <ActionSelector moduleName={moduleName} value={spanAction ?? ''} />

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
@@ -79,7 +79,7 @@ export function DatabaseSpanSummaryPage({params}: Props) {
 
   const sort = decodeSorts(sortField).filter(isAValidSort).at(0) ?? DEFAULT_SORT;
 
-  const {data: indexedSpansByGroupId, isFetching: areIndexedSpansByGroupIdLoading} =
+  const {data: indexedSpansByGroupId, isLoading: areIndexedSpansByGroupIdLoading} =
     useSpansIndexed(
       {
         search: MutableSearch.fromQueryObject({'span.group': params.groupId}),

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import type {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
+import Feature from 'sentry/components/acl/feature';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import ButtonBar from 'sentry/components/buttonBar';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
@@ -251,17 +252,19 @@ export function DatabaseSpanSummaryPage({params}: Props) {
               </DescriptionContainer>
             )}
 
-            {!areIndexedSpansByGroupIdLoading && (
-              <ModuleLayout.Full>
-                <InsightIssuesList
-                  issueTypes={[
-                    'performance_slow_db_query',
-                    'performance_n_plus_one_db_queries',
-                  ]}
-                  message={indexedSpansByGroupId[0]['span.description']}
-                />
-              </ModuleLayout.Full>
-            )}
+            <Feature features="insights-related-issues-table">
+              {!areIndexedSpansByGroupIdLoading && (
+                <ModuleLayout.Full>
+                  <InsightIssuesList
+                    issueTypes={[
+                      'performance_slow_db_query',
+                      'performance_n_plus_one_db_queries',
+                    ]}
+                    message={indexedSpansByGroupId[0]['span.description']}
+                  />
+                </ModuleLayout.Full>
+              )}
+            </Feature>
 
             <ModuleLayout.Full>
               <ChartContainer>

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
@@ -260,7 +260,7 @@ export function DatabaseSpanSummaryPage({params}: Props) {
                       'performance_slow_db_query',
                       'performance_n_plus_one_db_queries',
                     ]}
-                    message={indexedSpansByGroupId[0]['span.description']}
+                    message={indexedSpansByGroupId[0]?.['span.description']}
                   />
                 </ModuleLayout.Full>
               )}


### PR DESCRIPTION
Adds a "Related Issues" table to query-specific pages. Specifically, this table surfaces all `Slow DB Query` and `N + 1 Query` issues due to the given query.

<img width="1507" alt="image" src="https://github.com/user-attachments/assets/ff99ccd8-79bc-4e77-be4e-4588a3b8fb10">
