### PR TITLE
ref(compact-select): Use key instead of value for hidden/disabled options

### DIFF
--- a/static/app/components/charts/optionSelector.tsx
+++ b/static/app/components/charts/optionSelector.tsx
@@ -8,6 +8,7 @@ import type {
   SingleSelectProps,
 } from 'sentry/components/compactSelect';
 import {CompactSelect} from 'sentry/components/compactSelect';
+import type {SelectOptionWithKey} from 'sentry/components/compactSelect/types';
 import Truncate from 'sentry/components/truncate';
 import {defined} from 'sentry/utils';
 
@@ -82,14 +83,14 @@ function OptionSelector({
     };
   }, [multiple, selected, defaultValue, onChange, closeOnSelect]);
 
-  function isOptionDisabled(option) {
-    return (
+  function isOptionDisabled(option: SelectOptionWithKey<string>) {
+    return Boolean(
       // Option is explicitly marked as disabled
       // The user has reached the maximum number of selections (3), and the option hasn't
       // yet been selected. These options should be disabled to visually indicate that the
       // user has reached the max.
       option.disabled ||
-      (multiple && selected.length === 3 && !selected.includes(option.value))
+        (multiple && selected.length === 3 && !selected.includes(option.value))
     );
   }
 

--- a/static/app/components/comboBox/index.tsx
+++ b/static/app/components/comboBox/index.tsx
@@ -7,7 +7,7 @@ import {Item, Section} from '@react-stately/collections';
 import {type ComboBoxStateOptions, useComboBoxState} from '@react-stately/combobox';
 import omit from 'lodash/omit';
 
-import type {SelectOption} from 'sentry/components/compactSelect';
+import type {SelectKey, SelectOption} from 'sentry/components/compactSelect';
 import {ListBox} from 'sentry/components/compactSelect/listBox';
 import {
   getDisabledOptions,
@@ -42,7 +42,7 @@ interface ComboBoxProps<Value extends string>
   disabled?: boolean;
   growingInput?: boolean;
   hasSearch?: boolean;
-  hiddenOptions?: Set<string>;
+  hiddenOptions?: Set<SelectKey>;
   isLoading?: boolean;
   loadingMessage?: string;
   /**
@@ -294,7 +294,7 @@ function ControlledComboBox<Value extends string>({
   );
 
   const disabledKeys = useMemo(
-    () => [...getDisabledOptions(items), ...hiddenOptions].map(getEscapedKey),
+    () => [...getDisabledOptions(items), ...hiddenOptions],
     [hiddenOptions, items]
   );
 

--- a/static/app/components/compactSelect/gridList/index.tsx
+++ b/static/app/components/compactSelect/gridList/index.tsx
@@ -98,12 +98,10 @@ function GridList({
     () =>
       [...listState.collection].filter(node => {
         if (node.type === 'section') {
-          return ![...node.childNodes].every(child =>
-            hiddenOptions.has(child.props.value)
-          );
+          return ![...node.childNodes].every(child => hiddenOptions.has(child.key));
         }
 
-        return !hiddenOptions.has(node.props.value);
+        return !hiddenOptions.has(node.key);
       }),
     [listState.collection, hiddenOptions]
   );

--- a/static/app/components/compactSelect/gridList/section.tsx
+++ b/static/app/components/compactSelect/gridList/section.tsx
@@ -40,7 +40,7 @@ export function GridListSection({node, listState, onToggle, size}: GridListSecti
 
   const hiddenOptions = useContext(SelectFilterContext);
   const childNodes = useMemo(
-    () => [...node.childNodes].filter(child => !hiddenOptions.has(child.props.value)),
+    () => [...node.childNodes].filter(child => !hiddenOptions.has(child.key)),
     [node.childNodes, hiddenOptions]
   );
 

--- a/static/app/components/compactSelect/list.tsx
+++ b/static/app/components/compactSelect/list.tsx
@@ -23,6 +23,7 @@ import type {
   SelectKey,
   SelectOption,
   SelectOptionOrSectionWithKey,
+  SelectOptionWithKey,
   SelectSection,
 } from './types';
 import {
@@ -72,7 +73,7 @@ interface BaseListProps<Value extends SelectKey>
    * Custom function to determine whether an option is disabled. By default, an option
    * is considered disabled when it has {disabled: true}.
    */
-  isOptionDisabled?: (opt: SelectOption<Value>) => boolean;
+  isOptionDisabled?: (opt: SelectOptionWithKey<Value>) => boolean;
   /**
    * Text label to be rendered as heading on top of grid list.
    */
@@ -160,7 +161,7 @@ function List<Value extends SelectKey>({
     const disabledKeys = [
       ...getDisabledOptions(items, isOptionDisabled),
       ...hiddenOptions,
-    ].map(getEscapedKey);
+    ];
 
     if (multiple) {
       return {
@@ -345,7 +346,7 @@ function List<Value extends SelectKey>({
           // This is a section
           item.type === 'section' &&
           // Options inside the section haven't been all filtered out
-          ![...item.childNodes].every(child => hiddenOptions.has(child.props.value))
+          ![...item.childNodes].every(child => hiddenOptions.has(child.key))
       ),
 
     [listState.collection, hiddenOptions]

--- a/static/app/components/compactSelect/listBox/index.tsx
+++ b/static/app/components/compactSelect/listBox/index.tsx
@@ -139,12 +139,10 @@ const ListBox = forwardRef<HTMLUListElement, ListBoxProps>(function ListBox(
     () =>
       [...listState.collection].filter(node => {
         if (node.type === 'section') {
-          return ![...node.childNodes].every(child =>
-            hiddenOptions.has(child.props.value)
-          );
+          return ![...node.childNodes].every(child => hiddenOptions.has(child.key));
         }
 
-        return !hiddenOptions.has(node.props.value);
+        return !hiddenOptions.has(node.key);
       }),
     [listState.collection, hiddenOptions]
   );

--- a/static/app/components/compactSelect/listBox/section.tsx
+++ b/static/app/components/compactSelect/listBox/section.tsx
@@ -52,7 +52,7 @@ export function ListBoxSection({
     item.value.showToggleAllButton;
 
   const childItems = useMemo(
-    () => [...item.childNodes].filter(child => !hiddenOptions.has(child.props.value)),
+    () => [...item.childNodes].filter(child => !hiddenOptions.has(child.key)),
     [item.childNodes, hiddenOptions]
   );
 

--- a/static/app/components/compactSelect/utils.tsx
+++ b/static/app/components/compactSelect/utils.tsx
@@ -139,7 +139,7 @@ export function getHiddenOptions<Value extends SelectKey>(
         return item;
       }
 
-      hiddenOptionsSet.add(item.value);
+      hiddenOptionsSet.add(item.key);
       return null;
     })
     .filter((item): item is SelectOptionOrSectionWithKey<Value> => !!item);

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -25,7 +25,6 @@ import type {
 } from 'sentry/components/compactSelect/types';
 import {
   getDisabledOptions,
-  getEscapedKey,
   getHiddenOptions,
 } from 'sentry/components/compactSelect/utils';
 import {GrowingInput} from 'sentry/components/growingInput';
@@ -187,8 +186,8 @@ function useHiddenItems<T extends SelectOptionOrSectionWithKey<string>>({
     return getHiddenOptions(items, shouldFilterResults ? filterValue : '', maxOptions);
   }, [items, shouldFilterResults, filterValue, maxOptions]);
 
-  const disabledKeys: string[] = useMemo(
-    () => [...getDisabledOptions(items), ...hiddenOptions].map(getEscapedKey),
+  const disabledKeys = useMemo(
+    () => [...getDisabledOptions(items), ...hiddenOptions],
     [hiddenOptions, items]
   );
 


### PR DESCRIPTION
CompactSelect uses `hiddenOptions` and `disabledOptions` to determine which options are hidden or disabled. Currently, they track the option `value`, not the option `key`. For most use cases, the key is an escaped version of the value.

I want to change this to track the `key` for a couple reasons:
1. Because keys are guaranteed to be unique, it makes more sense to use that instead of the value
2. For the search bar, I want options that have the same `value`, but different `key`s, which is not possible with the current implementation of these utils.