### PR TITLE
ref(uptime): Hide uptime autodetection setting

### DIFF
--- a/static/app/data/forms/organizationGeneralSettings.tsx
+++ b/static/app/data/forms/organizationGeneralSettings.tsx
@@ -63,7 +63,11 @@ const formGroups: JsonFormObject[] = [
         type: 'boolean',
         label: t('Automatically Configure Uptime Alerts'),
         help: t('Detect most-used URLs for uptime monitoring.'),
-        visible: ({features}) => features.has('uptime-settings'),
+        // TOOD(epurkhiser): Currently there's no need for users to change this
+        // setting as it will just be confusing. In the future when
+        // autodetection is used for suggested URLs it will make more sense to
+        // for users to have the option to disable this.
+        visible: false,
       },
     ],
   },


### PR DESCRIPTION
In the current EA beta world, by the time a user realizes what this
setting is for, we'll have already done auto-detection and there's no
reason for a user to disable this.

I'm keeping this setting here instead of removing it completely as there
is a near-future world where autodetection will instead be used for
suggesting what URLs you may want to configure with uptime monitoring.
In which case, it would make sense that customers could disable thismonitor.