### PR TITLE
fix(insights): Escape release names

### DIFF
--- a/static/app/views/insights/common/utils/releaseComparison.tsx
+++ b/static/app/views/insights/common/utils/releaseComparison.tsx
@@ -14,7 +14,7 @@ export function appendReleaseFilters(
   ) {
     queryString = query
       .copy()
-      .addStringFilter(`release:[${primaryRelease},${secondaryRelease}]`)
+      .addDisjunctionFilterValues('release', [primaryRelease, secondaryRelease])
       .formatString();
   } else if (defined(primaryRelease)) {
     queryString = query

--- a/static/app/views/insights/mobile/screenload/components/tables/screenLoadSpansTable.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/components/tables/screenLoadSpansTable.spec.tsx
@@ -88,7 +88,7 @@ describe('ScreenLoadSpansTable', function () {
           per_page: 25,
           project: [],
           query:
-            'transaction.op:ui.load transaction:MainActivity span.op:[file.read,file.write,ui.load,http.client,db,db.sql.room,db.sql.query,db.sql.transaction] has:span.description release:[io.sentry.samples.android@7.0.0+2,io.sentry.samples.android@6.27.0+2]',
+            'transaction.op:ui.load transaction:MainActivity span.op:[file.read,file.write,ui.load,http.client,db,db.sql.room,db.sql.query,db.sql.transaction] has:span.description ( release:io.sentry.samples.android@7.0.0+2 OR release:io.sentry.samples.android@6.27.0+2 )',
           referrer: 'api.starfish.get-span-operations',
           statsPeriod: '14d',
         }),
@@ -119,7 +119,7 @@ describe('ScreenLoadSpansTable', function () {
           per_page: 25,
           project: [],
           query:
-            'transaction.op:ui.load transaction:MainActivity has:span.description span.op:[file.read,file.write,ui.load,http.client,db,db.sql.room,db.sql.query,db.sql.transaction] release:[io.sentry.samples.android@7.0.0+2,io.sentry.samples.android@6.27.0+2]',
+            'transaction.op:ui.load transaction:MainActivity has:span.description span.op:[file.read,file.write,ui.load,http.client,db,db.sql.room,db.sql.query,db.sql.transaction] ( release:io.sentry.samples.android@7.0.0+2 OR release:io.sentry.samples.android@6.27.0+2 )',
           referrer: 'api.starfish.mobile-span-table',
           sort: '-time_spent_percentage()',
           statsPeriod: '14d',

--- a/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.spec.tsx
@@ -170,7 +170,7 @@ describe('Screen Summary', function () {
             query: expect.objectContaining({
               dataset: 'spansMetrics',
               query:
-                'transaction.op:ui.load transaction:MainActivity has:span.description span.op:[file.read,file.write,ui.load,http.client,db,db.sql.room,db.sql.query,db.sql.transaction] os.name:Android release:[com.example.vu.android@2.10.5,com.example.vu.android@2.10.3+42]',
+                'transaction.op:ui.load transaction:MainActivity has:span.description span.op:[file.read,file.write,ui.load,http.client,db,db.sql.room,db.sql.query,db.sql.transaction] os.name:Android ( release:com.example.vu.android@2.10.5 OR release:com.example.vu.android@2.10.3+42 )',
             }),
           })
         );
@@ -184,7 +184,7 @@ describe('Screen Summary', function () {
             query: expect.objectContaining({
               dataset: 'metrics',
               query:
-                'event.type:transaction transaction.op:ui.load transaction:MainActivity os.name:Android release:[com.example.vu.android@2.10.5,com.example.vu.android@2.10.3+42]',
+                'event.type:transaction transaction.op:ui.load transaction:MainActivity os.name:Android ( release:com.example.vu.android@2.10.5 OR release:com.example.vu.android@2.10.3+42 )',
             }),
           })
         );
@@ -196,7 +196,7 @@ describe('Screen Summary', function () {
             query: expect.objectContaining({
               dataset: 'metrics',
               query:
-                'event.type:transaction transaction.op:ui.load transaction:MainActivity os.name:Android release:[com.example.vu.android@2.10.5,com.example.vu.android@2.10.3+42]',
+                'event.type:transaction transaction.op:ui.load transaction:MainActivity os.name:Android ( release:com.example.vu.android@2.10.5 OR release:com.example.vu.android@2.10.3+42 )',
             }),
           })
         );
@@ -263,7 +263,7 @@ describe('Screen Summary', function () {
             query: expect.objectContaining({
               dataset: 'spansMetrics',
               query:
-                'transaction.op:ui.load transaction:MainActivity has:span.description span.op:[file.read,file.write,ui.load,http.client,db,db.sql.room,db.sql.query,db.sql.transaction] release:[com.example.vu.android@2.10.5,com.example.vu.android@2.10.3+42]',
+                'transaction.op:ui.load transaction:MainActivity has:span.description span.op:[file.read,file.write,ui.load,http.client,db,db.sql.room,db.sql.query,db.sql.transaction] ( release:com.example.vu.android@2.10.5 OR release:com.example.vu.android@2.10.3+42 )',
             }),
           })
         );
@@ -277,7 +277,7 @@ describe('Screen Summary', function () {
             query: expect.objectContaining({
               dataset: 'metrics',
               query:
-                'event.type:transaction transaction.op:ui.load transaction:MainActivity release:[com.example.vu.android@2.10.5,com.example.vu.android@2.10.3+42]',
+                'event.type:transaction transaction.op:ui.load transaction:MainActivity ( release:com.example.vu.android@2.10.5 OR release:com.example.vu.android@2.10.3+42 )',
             }),
           })
         );
@@ -290,7 +290,7 @@ describe('Screen Summary', function () {
             query: expect.objectContaining({
               dataset: 'metrics',
               query:
-                'event.type:transaction transaction.op:ui.load transaction:MainActivity release:[com.example.vu.android@2.10.5,com.example.vu.android@2.10.3+42]',
+                'event.type:transaction transaction.op:ui.load transaction:MainActivity ( release:com.example.vu.android@2.10.5 OR release:com.example.vu.android@2.10.3+42 )',
             }),
           })
         );

--- a/static/app/views/insights/mobile/ui/components/uiScreens.spec.tsx
+++ b/static/app/views/insights/mobile/ui/components/uiScreens.spec.tsx
@@ -143,7 +143,7 @@ describe('Performance Mobile UI Screens', () => {
             'avg(mobile.frames_delay)',
           ],
           query:
-            'release:[com.example.vu.android@2.10.5,com.example.vu.android@2.10.3+42] transaction:["top 1","top 2","top 3","top 4","top 5"]',
+            '( release:com.example.vu.android@2.10.5 OR release:com.example.vu.android@2.10.3+42 ) transaction:["top 1","top 2","top 3","top 4","top 5"]',
         }),
       })
     );


### PR DESCRIPTION
Use addDisjunctionFilterValues to add release conditions,
since it escapes release names correctly