### PR TITLE
ref(uptime): Store uptime_rule_id over subscription_id

### DIFF
--- a/src/sentry/uptime/issue_platform.py
+++ b/src/sentry/uptime/issue_platform.py
@@ -17,10 +17,11 @@ def create_issue_platform_occurrence(
     result: CheckResult, project_subscription: ProjectUptimeSubscription
 ):
     occurrence = build_occurrence_from_result(result, project_subscription)
+    event_data = build_event_data_for_occurrence(result, project_subscription, occurrence)
     produce_occurrence_to_kafka(
         payload_type=PayloadType.OCCURRENCE,
         occurrence=occurrence,
-        event_data=build_event_data_for_occurrence(result, occurrence),
+        event_data=event_data,
     )
 
 
@@ -82,7 +83,11 @@ def build_occurrence_from_result(
     )
 
 
-def build_event_data_for_occurrence(result: CheckResult, occurrence: IssueOccurrence):
+def build_event_data_for_occurrence(
+    result: CheckResult,
+    project_subscription: ProjectUptimeSubscription,
+    occurrence: IssueOccurrence,
+):
     return {
         "environment": "prod",  # TODO: Include the environment here when we have it
         "event_id": occurrence.event_id,
@@ -93,7 +98,7 @@ def build_event_data_for_occurrence(result: CheckResult, occurrence: IssueOccurr
         "received": datetime.fromtimestamp(result["actual_check_time_ms"] / 1000),
         "sdk": None,
         "tags": {
-            "subscription_id": result["subscription_id"],
+            "uptime_rule": project_subscription.id,
         },
         "timestamp": occurrence.detection_time.isoformat(),
         "contexts": {"trace": {"trace_id": result["trace_id"], "span_id": None}},

--- a/tests/sentry/uptime/test_issue_platform.py
+++ b/tests/sentry/uptime/test_issue_platform.py
@@ -34,7 +34,7 @@ class CreateIssuePlatformOccurrenceTest(UptimeTestCase):
         assert call_kwargs == {
             "payload_type": PayloadType.OCCURRENCE,
             "occurrence": occurrence,
-            "event_data": build_event_data_for_occurrence(result, occurrence),
+            "event_data": build_event_data_for_occurrence(result, project_subscription, occurrence),
         }
 
 
@@ -94,7 +94,8 @@ class BuildEventDataForOccurrenceTest(UptimeTestCase):
             level="error",
             culprit="",
         )
-        event_data = build_event_data_for_occurrence(result, occurrence)
+        project_subscription = self.create_project_uptime_subscription()
+        event_data = build_event_data_for_occurrence(result, project_subscription, occurrence)
         assert event_data == {
             "environment": "prod",
             "event_id": event_id.hex,
@@ -103,7 +104,7 @@ class BuildEventDataForOccurrenceTest(UptimeTestCase):
             "project_id": 1,
             "received": datetime.datetime.now().replace(microsecond=0),
             "sdk": None,
-            "tags": {"subscription_id": result["subscription_id"]},
+            "tags": {"uptime_rule": project_subscription.id},
             "timestamp": occurrence.detection_time.isoformat(),
             "contexts": {"trace": {"trace_id": result["trace_id"], "span_id": None}},
         }


### PR DESCRIPTION
We'll use this to link back to the alert rule details for uptime
subscriptions.