### PR TITLE
ref(scm): abstraction for commit context integrations

### DIFF
--- a/src/sentry/integrations/github/blame.py
+++ b/src/sentry/integrations/github/blame.py
@@ -9,7 +9,11 @@ from typing import Any, TypedDict
 from django.utils.datastructures import OrderedSet
 from isodate import parse_datetime
 
-from sentry.integrations.mixins.commit_context import CommitInfo, FileBlameInfo, SourceLineInfo
+from sentry.integrations.source_code_management.commit_context import (
+    CommitInfo,
+    FileBlameInfo,
+    SourceLineInfo,
+)
 
 logger = logging.getLogger("sentry.integrations.github")
 

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -16,9 +16,13 @@ from sentry.integrations.github.blame import (
     generate_file_path_mapping,
 )
 from sentry.integrations.github.utils import get_jwt, get_next_link
-from sentry.integrations.mixins.commit_context import FileBlameInfo, SourceLineInfo
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration import RpcIntegration
+from sentry.integrations.source_code_management.commit_context import (
+    CommitContextClient,
+    FileBlameInfo,
+    SourceLineInfo,
+)
 from sentry.integrations.types import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.integrations.utils.code_mapping import (
     MAX_CONNECTION_ERRORS,
@@ -183,7 +187,7 @@ class GithubProxyClient(IntegrationProxyClient):
         return super().is_error_fatal(error)
 
 
-class GitHubBaseClient(GithubProxyClient):
+class GitHubBaseClient(GithubProxyClient, CommitContextClient):
     allow_redirects = True
 
     base_url = "https://api.github.com"

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -26,10 +26,10 @@ from sentry.integrations.base import (
 from sentry.integrations.github.constants import RATE_LIMITED_MESSAGE
 from sentry.integrations.github.tasks.link_all_repos import link_all_repos
 from sentry.integrations.mixins import RepositoryMixin
-from sentry.integrations.mixins.commit_context import CommitContextMixin
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.repository import RpcRepository, repository_service
+from sentry.integrations.source_code_management.commit_context import CommitContextIntegration
 from sentry.integrations.tasks.migrate_repo import migrate_repo
 from sentry.integrations.utils.code_mapping import RepoTree
 from sentry.models.repository import Repository
@@ -155,7 +155,7 @@ def get_document_origin(org) -> str:
 # Github App docs and list of available endpoints
 # https://docs.github.com/en/rest/apps/installations
 # https://docs.github.com/en/rest/overview/endpoints-available-for-github-apps
-class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMixin, CommitContextMixin):  # type: ignore[misc]
+class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMixin, CommitContextIntegration):  # type: ignore[misc]
     repo_search = True
     codeowners_locations = ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"]
 

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -21,8 +21,8 @@ from sentry.integrations.github.integration import GitHubIntegrationProvider, bu
 from sentry.integrations.github.issues import GitHubIssueBasic
 from sentry.integrations.github.utils import get_jwt
 from sentry.integrations.mixins import RepositoryMixin
-from sentry.integrations.mixins.commit_context import CommitContextMixin
 from sentry.integrations.models.integration import Integration
+from sentry.integrations.source_code_management.commit_context import CommitContextIntegration
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization import RpcOrganizationSummary
 from sentry.pipeline import NestedPipelineView, PipelineView
@@ -131,7 +131,7 @@ API_ERRORS = {
 
 
 class GitHubEnterpriseIntegration(
-    IntegrationInstallation, GitHubIssueBasic, RepositoryMixin, CommitContextMixin
+    IntegrationInstallation, GitHubIssueBasic, RepositoryMixin, CommitContextIntegration
 ):
     repo_search = True
     codeowners_locations = ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"]

--- a/src/sentry/integrations/gitlab/blame.py
+++ b/src/sentry/integrations/gitlab/blame.py
@@ -15,7 +15,11 @@ from sentry.integrations.gitlab.utils import (
     GitLabRateLimitInfo,
     get_rate_limit_info_from_response,
 )
-from sentry.integrations.mixins.commit_context import CommitInfo, FileBlameInfo, SourceLineInfo
+from sentry.integrations.source_code_management.commit_context import (
+    CommitInfo,
+    FileBlameInfo,
+    SourceLineInfo,
+)
 from sentry.shared_integrations.client.base import BaseApiClient
 from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
 from sentry.shared_integrations.response.sequence import SequenceApiResponse

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -11,7 +11,11 @@ from requests import PreparedRequest
 from sentry.identity.services.identity.model import RpcIdentity
 from sentry.integrations.gitlab.blame import fetch_file_blames
 from sentry.integrations.gitlab.utils import GitLabApiClientPath
-from sentry.integrations.mixins.commit_context import FileBlameInfo, SourceLineInfo
+from sentry.integrations.source_code_management.commit_context import (
+    CommitContextClient,
+    FileBlameInfo,
+    SourceLineInfo,
+)
 from sentry.models.repository import Repository
 from sentry.shared_integrations.client.proxy import IntegrationProxyClient
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized
@@ -61,7 +65,7 @@ class GitLabSetupApiClient(IntegrationProxyClient):
         return self.get(path)
 
 
-class GitLabApiClient(IntegrationProxyClient):
+class GitLabApiClient(IntegrationProxyClient, CommitContextClient):
     integration_name = "gitlab"
 
     def __init__(self, installation: GitlabIntegration):

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -18,7 +18,7 @@ from sentry.integrations.base import (
     IntegrationProvider,
 )
 from sentry.integrations.mixins import RepositoryMixin
-from sentry.integrations.mixins.commit_context import CommitContextMixin
+from sentry.integrations.source_code_management.commit_context import CommitContextIntegration
 from sentry.models.identity import Identity
 from sentry.models.repository import Repository
 from sentry.pipeline import NestedPipelineView, PipelineView
@@ -93,7 +93,7 @@ metadata = IntegrationMetadata(
 
 
 class GitlabIntegration(
-    IntegrationInstallation, GitlabIssueBasic, RepositoryMixin, CommitContextMixin
+    IntegrationInstallation, GitlabIssueBasic, RepositoryMixin, CommitContextIntegration
 ):
     repo_search = True
     codeowners_locations = ["CODEOWNERS", ".gitlab/CODEOWNERS", "docs/CODEOWNERS"]

--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -36,10 +36,6 @@ class FileBlameInfo(SourceLineInfo):
 
 
 class CommitContextIntegration(ABC):
-    # whether or not integration has the ability to search through Repositories
-    # dynamically given a search query
-    repo_search = False
-
     @abstractmethod
     def get_client(self) -> CommitContextClient:
         raise NotImplementedError
@@ -77,4 +73,5 @@ class CommitContextClient(ABC):
     def get_blame_for_files(
         self, files: Sequence[SourceLineInfo], extra: Mapping[str, Any]
     ) -> list[FileBlameInfo]:
+        """Get the blame for a list of files. This method should include custom metrics for the specific integration implementation."""
         raise NotImplementedError

--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -10,13 +10,13 @@ from django.utils.datastructures import OrderedSet
 
 from sentry import analytics
 from sentry.integrations.base import IntegrationInstallation
-from sentry.integrations.mixins.commit_context import (
-    CommitContextMixin,
+from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
+from sentry.integrations.services.integration import integration_service
+from sentry.integrations.source_code_management.commit_context import (
+    CommitContextIntegration,
     FileBlameInfo,
     SourceLineInfo,
 )
-from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
-from sentry.integrations.services.integration import integration_service
 from sentry.integrations.utils.code_mapping import convert_stacktrace_frame_path_to_source_path
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
@@ -274,7 +274,7 @@ def _get_blames_from_all_integrations(
             "integration_id": integration.id,
         }
         install = integration.get_installation(organization_id=organization_id)
-        if not isinstance(install, CommitContextMixin):
+        if not isinstance(install, CommitContextIntegration):
             logger.info("process_commit_context_all_frames.unsupported_integration", extra=log_info)
             continue
         integration_to_install_mapping[integration_organization_id] = (

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -16,9 +16,13 @@ from sentry.constants import ObjectStatus
 from sentry.integrations.github.blame import create_blame_query, generate_file_path_mapping
 from sentry.integrations.github.client import GitHubApiClient
 from sentry.integrations.github.integration import GitHubIntegration
-from sentry.integrations.mixins.commit_context import CommitInfo, FileBlameInfo, SourceLineInfo
 from sentry.integrations.notify_disable import notify_disable
 from sentry.integrations.request_buffer import IntegrationRequestBuffer
+from sentry.integrations.source_code_management.commit_context import (
+    CommitInfo,
+    FileBlameInfo,
+    SourceLineInfo,
+)
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
 from sentry.shared_integrations.response.base import BaseApiResponse

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -22,9 +22,13 @@ from sentry.integrations.github import (
     client,
 )
 from sentry.integrations.github.integration import GitHubIntegration
-from sentry.integrations.mixins.commit_context import CommitInfo, FileBlameInfo, SourceLineInfo
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.source_code_management.commit_context import (
+    CommitInfo,
+    FileBlameInfo,
+    SourceLineInfo,
+)
 from sentry.integrations.utils.code_mapping import Repo, RepoTree
 from sentry.models.project import Project
 from sentry.models.repository import Repository

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -7,9 +7,13 @@ import responses
 
 from sentry.integrations.github_enterprise import GitHubEnterpriseIntegrationProvider
 from sentry.integrations.github_enterprise.integration import GitHubEnterpriseIntegration
-from sentry.integrations.mixins.commit_context import CommitInfo, FileBlameInfo, SourceLineInfo
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.source_code_management.commit_context import (
+    CommitInfo,
+    FileBlameInfo,
+    SourceLineInfo,
+)
 from sentry.models.identity import Identity, IdentityProvider, IdentityStatus
 from sentry.models.repository import Repository
 from sentry.silo.base import SiloMode

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -16,9 +16,13 @@ from sentry.auth.exceptions import IdentityNotValid
 from sentry.constants import ObjectStatus
 from sentry.integrations.gitlab.blame import GitLabCommitResponse, GitLabFileBlameResponseItem
 from sentry.integrations.gitlab.utils import get_rate_limit_info_from_response
-from sentry.integrations.mixins.commit_context import CommitInfo, FileBlameInfo, SourceLineInfo
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.request_buffer import IntegrationRequestBuffer
+from sentry.integrations.source_code_management.commit_context import (
+    CommitInfo,
+    FileBlameInfo,
+    SourceLineInfo,
+)
 from sentry.models.identity import Identity
 from sentry.shared_integrations.exceptions import ApiError, ApiHostError, ApiRateLimitedError
 from sentry.testutils.outbox import outbox_runner

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -14,9 +14,13 @@ from sentry.integrations.gitlab import GitlabIntegrationProvider
 from sentry.integrations.gitlab.blame import GitLabCommitResponse, GitLabFileBlameResponseItem
 from sentry.integrations.gitlab.client import GitLabApiClient, GitLabSetupApiClient
 from sentry.integrations.gitlab.integration import GitlabIntegration
-from sentry.integrations.mixins.commit_context import CommitInfo, FileBlameInfo, SourceLineInfo
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.source_code_management.commit_context import (
+    CommitInfo,
+    FileBlameInfo,
+    SourceLineInfo,
+)
 from sentry.models.identity import Identity, IdentityProvider, IdentityStatus
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiUnauthorized

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -9,8 +9,12 @@ from celery.exceptions import Retry
 from django.utils import timezone
 
 from sentry.integrations.github.integration import GitHubIntegrationProvider
-from sentry.integrations.mixins.commit_context import CommitInfo, FileBlameInfo, SourceLineInfo
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.source_code_management.commit_context import (
+    CommitInfo,
+    FileBlameInfo,
+    SourceLineInfo,
+)
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
@@ -36,7 +40,7 @@ from sentry.utils.committers import get_frame_paths
 pytestmark = [requires_snuba]
 
 
-class TestCommitContextMixin(TestCase):
+class TestCommitContextIntegration(TestCase):
     def setUp(self):
         self.project = self.create_project()
         self.repo = Repository.objects.create(
@@ -95,7 +99,7 @@ class TestCommitContextMixin(TestCase):
         )
 
 
-class TestCommitContextAllFrames(TestCommitContextMixin):
+class TestCommitContextAllFrames(TestCommitContextIntegration):
     def setUp(self):
         super().setUp()
         self.blame_recent = FileBlameInfo(
@@ -801,7 +805,7 @@ class TestCommitContextAllFrames(TestCommitContextMixin):
     "sentry.integrations.github.GitHubIntegration.get_commit_context_all_frames", return_value=[]
 )
 @patch("sentry.integrations.github.tasks.pr_comment.github_comment_workflow.delay")
-class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
+class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextIntegration):
     provider = GitHubIntegrationProvider
     base_url = "https://api.github.com"
 

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -19,8 +19,8 @@ from sentry.eventstore.models import Event
 from sentry.eventstore.processing import event_processing_store
 from sentry.feedback.usecases.create_feedback import FeedbackCreationSource
 from sentry.ingest.transaction_clusterer import ClustererNamespace
-from sentry.integrations.mixins.commit_context import CommitInfo, FileBlameInfo
 from sentry.integrations.models.integration import Integration
+from sentry.integrations.source_code_management.commit_context import CommitInfo, FileBlameInfo
 from sentry.issues.grouptype import (
     FeedbackGroup,
     GroupCategory,


### PR DESCRIPTION
Convert `CommitContextMixin` to an abstract base class called `CommitContextIntegration`. Also ties `CommitContextIntegration` to a new `CommitContextClient` abstract base class that represents the expected functionality of a SCM integration client tied to the ABC.