### PR TITLE
feat(uptime): Add api that allows users to edit basic information about uptime monitors

### DIFF
--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -545,6 +545,31 @@ default_manager.add(
     )
 )
 
+default_manager.add(
+    AuditLogEvent(
+        event_id=200,
+        name="UPTIME_MONITOR_ADD",
+        api_name="uptime_monitor.add",
+        template="added uptime monitor {name}",
+    )
+)
+default_manager.add(
+    AuditLogEvent(
+        event_id=201,
+        name="UPTIME_MONITOR_EDIT",
+        api_name="uptime_monitor.edit",
+        template="edited uptime monitor {name}",
+    )
+)
+default_manager.add(
+    AuditLogEvent(
+        event_id=202,
+        name="UPTIME_MONITOR_REMOVE",
+        api_name="uptime_monitor.remove",
+        template="removed uptime monitor {name}",
+    )
+)
+
 default_manager.add(events.DataSecrecyWaivedAuditLogEvent())
 
 default_manager.add(

--- a/src/sentry/uptime/endpoints/project_uptime_alert_details.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_details.py
@@ -30,6 +30,7 @@ class ProjectUptimeAlertDetailsEndpoint(ProjectUptimeAlertEndpoint):
     # TODO(davidenwang): Flip these to public after EA
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
+        "PUT": ApiPublishStatus.EXPERIMENTAL,
     }
 
     @extend_schema(

--- a/src/sentry/uptime/endpoints/project_uptime_alert_details.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_details.py
@@ -6,7 +6,12 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.serializers import serialize
-from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
 from sentry.apidocs.parameters import GlobalParams, UptimeParams
 from sentry.models.project import Project
 from sentry.uptime.endpoints.bases import ProjectUptimeAlertEndpoint
@@ -14,7 +19,8 @@ from sentry.uptime.endpoints.serializers import (
     ProjectUptimeSubscriptionSerializer,
     ProjectUptimeSubscriptionSerializerResponse,
 )
-from sentry.uptime.models import UptimeSubscription
+from sentry.uptime.endpoints.validators import UptimeMonitorValidator
+from sentry.uptime.models import ProjectUptimeSubscription, UptimeSubscription
 
 
 @region_silo_endpoint
@@ -51,3 +57,40 @@ class ProjectUptimeAlertDetailsEndpoint(ProjectUptimeAlertEndpoint):
             request.user,
         )
         return self.respond(serialized_uptime_alert)
+
+    @extend_schema(
+        operation_id="Update an Uptime Monitor for a Project",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+            UptimeParams.UPTIME_ALERT_ID,
+        ],
+        request=UptimeMonitorValidator,
+        responses={
+            200: ProjectUptimeSubscriptionSerializer,
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def put(
+        self, request: Request, project: Project, uptime_subscription: ProjectUptimeSubscription
+    ) -> Response:
+        """
+        Update an uptime monitor.
+        """
+        validator = UptimeMonitorValidator(
+            data=request.data,
+            partial=True,
+            instance=uptime_subscription,
+            context={
+                "organization": project.organization,
+                "access": request.access,
+                "request": request,
+            },
+        )
+        if not validator.is_valid():
+            return self.respond(validator.errors, status=400)
+
+        return self.respond(serialize(validator.save(), request.user))

--- a/src/sentry/uptime/endpoints/validators.py
+++ b/src/sentry/uptime/endpoints/validators.py
@@ -1,0 +1,47 @@
+from drf_spectacular.utils import extend_schema_serializer
+from rest_framework import serializers
+
+from sentry import audit_log
+from sentry.api.fields import ActorField
+from sentry.api.serializers.rest_framework import CamelSnakeSerializer
+from sentry.utils.audit import create_audit_entry
+
+
+@extend_schema_serializer()
+class UptimeMonitorValidator(CamelSnakeSerializer):
+    name = serializers.CharField(
+        max_length=128,
+        help_text="Name of the uptime monitor",
+    )
+    owner = ActorField(
+        required=False,
+        allow_null=True,
+        help_text="The ID of the team or user that owns the uptime monitor. (eg. user:51 or team:6)",
+    )
+
+    def update(self, instance, validated_data):
+        params = {}
+        if "name" in validated_data:
+            params["name"] = validated_data["name"]
+
+        if "owner" in validated_data:
+            owner = validated_data["owner"]
+            params["owner_user_id"] = None
+            params["owner_team_id"] = None
+            if owner is not None:
+                if owner.is_user:
+                    params["owner_user_id"] = owner.id
+                if owner.is_team:
+                    params["owner_team_id"] = owner.id
+
+        if params:
+            instance.update(**params)
+            create_audit_entry(
+                request=self.context["request"],
+                organization=self.context["organization"],
+                target_object=instance.id,
+                event=audit_log.get_event_id("UPTIME_MONITOR_EDIT"),
+                data=instance.get_audit_log_data(),
+            )
+
+        return instance

--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -112,6 +112,17 @@ class ProjectUptimeSubscription(DefaultFieldsModel):
     def owner(self) -> Actor | None:
         return Actor.from_id(user_id=self.owner_user_id, team_id=self.owner_team_id)
 
+    def get_audit_log_data(self):
+        return {
+            "project": self.project.id,
+            "name": self.name,
+            "owner_user_id": self.owner_user_id,
+            "owner_team_id": self.owner_team_id,
+            "url": self.uptime_subscription.url,
+            "interval_seconds": self.uptime_subscription.interval_seconds,
+            "timeout": self.uptime_subscription.timeout_ms,
+        }
+
 
 def get_org_from_uptime_monitor(uptime_monitor: ProjectUptimeSubscription) -> tuple[Organization]:
     return (uptime_monitor.project.organization,)

--- a/tests/sentry/audit_log/test_register.py
+++ b/tests/sentry/audit_log/test_register.py
@@ -96,6 +96,8 @@ class AuditLogEventRegisterTest(TestCase):
             "issue.delete",
             "data-secrecy.waived",
             "data-secrecy.reinstated",
+            "uptime_monitor.add",
+            "uptime_monitor.edit",
+            "uptime_monitor.remove",
         ]
-
         assert set(audit_log.get_api_names()) == set(audit_log_api_name_list)

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_details.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_details.py
@@ -1,14 +1,18 @@
+from rest_framework.exceptions import ErrorDetail
+
 from sentry.api.serializers import serialize
 from sentry.testutils.cases import APITestCase
 
 
-class ProjectUptimeAlertDetailsEndpointTest(APITestCase):
+class ProjectUptimeAlertDetailsBaseEndpointTest(APITestCase):
     endpoint = "sentry-api-0-project-uptime-alert-details"
 
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)
 
+
+class ProjectUptimeAlertDetailsGetEndpointTest(ProjectUptimeAlertDetailsBaseEndpointTest):
     def test_simple(self):
         uptime_subscription = self.create_project_uptime_subscription()
 
@@ -16,6 +20,73 @@ class ProjectUptimeAlertDetailsEndpointTest(APITestCase):
             self.organization.slug, uptime_subscription.project.slug, uptime_subscription.id
         )
         assert resp.data == serialize(uptime_subscription, self.user)
+
+    def test_not_found(self):
+        resp = self.get_error_response(self.organization.slug, self.project.slug, 3)
+        assert resp.status_code == 404
+
+
+class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndpointTest):
+    method = "put"
+
+    def test_simple(self):
+        uptime_subscription = self.create_project_uptime_subscription()
+
+        resp = self.get_success_response(
+            self.organization.slug,
+            uptime_subscription.project.slug,
+            uptime_subscription.id,
+            name="test",
+            owner=f"user:{self.user.id}",
+        )
+        uptime_subscription.refresh_from_db()
+        assert resp.data == serialize(uptime_subscription, self.user)
+        assert uptime_subscription.name == "test"
+        assert uptime_subscription.owner_user_id == self.user.id
+        assert uptime_subscription.owner_team_id is None
+
+        resp = self.get_success_response(
+            self.organization.slug,
+            uptime_subscription.project.slug,
+            uptime_subscription.id,
+            name="test_2",
+            owner=f"team:{self.team.id}",
+        )
+        uptime_subscription.refresh_from_db()
+        assert resp.data == serialize(uptime_subscription, self.user)
+        assert uptime_subscription.name == "test_2"
+        assert uptime_subscription.owner_user_id is None
+        assert uptime_subscription.owner_team_id == self.team.id
+
+    def test_invalid_owner(self):
+        uptime_subscription = self.create_project_uptime_subscription()
+        bad_user = self.create_user()
+
+        resp = self.get_error_response(
+            self.organization.slug,
+            uptime_subscription.project.slug,
+            uptime_subscription.id,
+            owner=f"user:{bad_user.id}",
+        )
+        assert resp.data == {
+            "owner": [
+                ErrorDetail(string="User is not a member of this organization", code="invalid")
+            ]
+        }
+
+        bad_team = self.create_team(organization=self.create_organization())
+
+        resp = self.get_error_response(
+            self.organization.slug,
+            uptime_subscription.project.slug,
+            uptime_subscription.id,
+            owner=f"team:{bad_team.id}",
+        )
+        assert resp.data == {
+            "owner": [
+                ErrorDetail(string="Team is not a member of this organization", code="invalid")
+            ]
+        }
 
     def test_not_found(self):
         resp = self.get_error_response(self.organization.slug, self.project.slug, 3)

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_details.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_details.py
@@ -29,7 +29,7 @@ class ProjectUptimeAlertDetailsGetEndpointTest(ProjectUptimeAlertDetailsBaseEndp
 class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndpointTest):
     method = "put"
 
-    def test_simple(self):
+    def test_user(self):
         uptime_subscription = self.create_project_uptime_subscription()
 
         resp = self.get_success_response(
@@ -45,6 +45,8 @@ class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndp
         assert uptime_subscription.owner_user_id == self.user.id
         assert uptime_subscription.owner_team_id is None
 
+    def test_team(self):
+        uptime_subscription = self.create_project_uptime_subscription()
         resp = self.get_success_response(
             self.organization.slug,
             uptime_subscription.project.slug,


### PR DESCRIPTION
This just allows owner and name to be modified for now. We'll add more to this api as we allow people to create their own uptime monitors.