### PR TITLE
fix(autofix): Make autofix logs full width

### DIFF
--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -515,6 +515,7 @@ const LogText = styled('div')<{expanded: boolean; isExpandable: boolean}>`
   -webkit-box-orient: vertical;
   overflow-y: hidden;
   max-height: ${props => (props.expanded ? 'none' : '3em')};
+  flex: 1;
 `;
 
 const ExpandableLogRow = styled('div')`
@@ -522,4 +523,5 @@ const ExpandableLogRow = styled('div')`
   display: flex;
   flex-direction: row;
   align-items: flex-start;
+  width: 100%;
 `;


### PR DESCRIPTION
Full width the logs:

![Screenshot 2024-08-07 at 3 12 32 PM](https://github.com/user-attachments/assets/a3a265e4-61b2-4328-92ba-7a6022f5d122)
