### PR TITLE
feat(onboarding): disable button for below team plan

### DIFF
--- a/static/app/views/alerts/rules/issue/messagingIntegrationModal.spec.tsx
+++ b/static/app/views/alerts/rules/issue/messagingIntegrationModal.spec.tsx
@@ -32,15 +32,14 @@ describe('MessagingIntegrationModal', function () {
     jest.clearAllMocks();
   });
 
-  const getComponent = (closeModal?, props = {}) => (
+  const getComponent = (closeModal = jest.fn(), props = {}) => (
     <MessagingIntegrationModal
-      closeModal={closeModal ? closeModal : jest.fn()}
+      closeModal={closeModal}
       Header={makeClosableHeader(() => {})}
       Body={ModalBody}
       headerContent={t('Connect with a messaging tool')}
       bodyContent={t('Receive alerts and digests right where you work.')}
       providerKeys={providerKeys}
-      organization={org}
       project={project}
       CloseButton={makeCloseButton(() => {})}
       Footer={ModalFooter}
@@ -58,7 +57,7 @@ describe('MessagingIntegrationModal', function () {
         })
       );
     });
-    render(getComponent());
+    render(getComponent(), {organization: org});
 
     mockResponses.forEach(mock => {
       expect(mock).toHaveBeenCalled();
@@ -86,7 +85,7 @@ describe('MessagingIntegrationModal', function () {
       );
     });
 
-    render(getComponent(closeModal));
+    render(getComponent(closeModal), {organization: org});
 
     mockResponses.forEach(mock => {
       expect(mock).toHaveBeenCalled();

--- a/static/app/views/alerts/rules/issue/messagingIntegrationModal.tsx
+++ b/static/app/views/alerts/rules/issue/messagingIntegrationModal.tsx
@@ -6,15 +6,14 @@ import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {IntegrationProvider} from 'sentry/types/integrations';
-import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {useApiQueries} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
 import AddIntegrationRow from 'sentry/views/alerts/rules/issue/addIntegrationRow';
 import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations/integrationContext';
 
 type Props = ModalRenderProps & {
   headerContent: React.ReactNode;
-  organization: Organization;
   project: Project;
   providerKeys: string[];
   bodyContent?: React.ReactNode;
@@ -28,10 +27,10 @@ function MessagingIntegrationModal({
   headerContent,
   bodyContent,
   providerKeys,
-  organization,
   project,
   onAddIntegration,
 }: Props) {
+  const organization = useOrganization();
   const queryResults = useApiQueries<{providers: IntegrationProvider[]}>(
     providerKeys.map((providerKey: string) => [
       `/organizations/${organization.slug}/config/integrations/?provider_key=${providerKey}`,

--- a/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.spec.tsx
+++ b/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.spec.tsx
@@ -5,6 +5,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {openModal} from 'sentry/actionCreators/modal';
+import HookStore from 'sentry/stores/hookStore';
 import SetupMessagingIntegrationButton from 'sentry/views/alerts/rules/issue/setupMessagingIntegrationButton';
 
 jest.mock('sentry/actionCreators/modal');
@@ -73,7 +74,7 @@ describe('SetupAlertIntegrationButton', function () {
     expect(openModal).toHaveBeenCalled();
   });
 
-  it('returns null if project is loading', function () {
+  it('does not render button if project is loading', function () {
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/`,
       statusCode: 400,
@@ -81,5 +82,32 @@ describe('SetupAlertIntegrationButton', function () {
     });
     render(getComponent(), {organization: organization});
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('disables button if user does not have integration feature', async function () {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/`,
+      body: {
+        ...project,
+        hasAlertIntegrationInstalled: false,
+      },
+    });
+
+    HookStore.add('integrations:feature-gates', () => {
+      return {
+        IntegrationFeatures: p =>
+          p.children({
+            disabled: true,
+            disabledReason: 'some reason',
+            ungatedFeatures: p.features,
+            gatedFeatureGroups: [],
+          }),
+        FeatureList: p => (p.provider = providers[0]),
+      };
+    });
+
+    render(getComponent(), {organization: organization});
+    await screen.findByRole('button', {name: /connect to messaging/i});
+    expect(screen.getByRole('button')).toBeDisabled();
   });
 });

--- a/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
+++ b/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
@@ -6,8 +6,10 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import PluginIcon from 'sentry/plugins/components/pluginIcon';
 import {space} from 'sentry/styles/space';
+import type {IntegrationProvider} from 'sentry/types/integrations';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {getIntegrationFeatureGate} from 'sentry/utils/integrationUtil';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -27,16 +29,11 @@ function SetupMessagingIntegrationButton({projectSlug, refetchConfigs}: Props) {
   const organization = useOrganization();
 
   const onAddIntegration = () => {
-    refetch();
+    projectQuery.refetch();
     refetchConfigs();
   };
 
-  const {
-    data: project,
-    isLoading,
-    isError,
-    refetch,
-  } = useApiQuery<ProjectWithAlertIntegrationInfo>(
+  const projectQuery = useApiQuery<ProjectWithAlertIntegrationInfo>(
     [
       `/projects/${organization.slug}/${projectSlug}/`,
       {query: {expand: 'hasAlertIntegration'}},
@@ -44,13 +41,30 @@ function SetupMessagingIntegrationButton({projectSlug, refetchConfigs}: Props) {
     {staleTime: Infinity}
   );
 
-  const shouldRenderSetupButton = project && !project.hasAlertIntegrationInstalled;
+  const integrationQuery = useApiQuery<{providers: IntegrationProvider[]}>(
+    [
+      `/organizations/${organization.slug}/config/integrations/?provider_key=${providerKeys[0]}`,
+    ],
+    {staleTime: Infinity}
+  );
+
+  const {IntegrationFeatures} = getIntegrationFeatureGate();
+
+  const shouldRenderSetupButton =
+    projectQuery.data &&
+    !projectQuery.data.hasAlertIntegrationInstalled &&
+    integrationQuery.data;
 
   useRouteAnalyticsParams({
     setup_message_integration_button_shown: shouldRenderSetupButton,
   });
 
-  if (isLoading || isError) {
+  if (
+    projectQuery.isLoading ||
+    projectQuery.isError ||
+    integrationQuery.isLoading ||
+    integrationQuery.isError
+  ) {
     return null;
   }
 
@@ -58,46 +72,56 @@ function SetupMessagingIntegrationButton({projectSlug, refetchConfigs}: Props) {
     return null;
   }
 
-  // TODO(Mia): only render if organization has team plan and above
   return (
-    <Tooltip
-      title={t('Send alerts to your messaging service. Install the integration now.')}
+    <IntegrationFeatures
+      organization={organization}
+      features={integrationQuery.data.providers[0].metadata.features}
     >
-      <Button
-        size="sm"
-        icon={
-          <IconWrapper>
-            {providerKeys.map((value: string) => {
-              return <PluginIcon key={value} pluginId={value} size={16} />;
-            })}
-          </IconWrapper>
-        }
-        onClick={() => {
-          openModal(
-            deps => (
-              <MessagingIntegrationModal
-                {...deps}
-                headerContent={t('Connect with a messaging tool')}
-                bodyContent={t('Receive alerts and digests right where you work.')}
-                providerKeys={providerKeys}
-                organization={organization}
-                project={project}
-                onAddIntegration={onAddIntegration}
-              />
-            ),
-            {
-              closeEvents: 'escape-key',
+      {({disabled, disabledReason}) => (
+        <Tooltip
+          title={
+            disabled
+              ? disabledReason
+              : t('Send alerts to your messaging service. Install the integration now.')
+          }
+        >
+          <Button
+            size="sm"
+            icon={
+              <IconWrapper>
+                {providerKeys.map((value: string) => {
+                  return <PluginIcon key={value} pluginId={value} size={16} />;
+                })}
+              </IconWrapper>
             }
-          );
-          trackAnalytics('onboarding.messaging_integration_modal_rendered', {
-            project_id: project.id,
-            organization,
-          });
-        }}
-      >
-        {t('Connect to messaging')}
-      </Button>
-    </Tooltip>
+            disabled={disabled}
+            onClick={() => {
+              openModal(
+                deps => (
+                  <MessagingIntegrationModal
+                    {...deps}
+                    headerContent={t('Connect with a messaging tool')}
+                    bodyContent={t('Receive alerts and digests right where you work.')}
+                    providerKeys={providerKeys}
+                    project={projectQuery.data}
+                    onAddIntegration={onAddIntegration}
+                  />
+                ),
+                {
+                  closeEvents: 'escape-key',
+                }
+              );
+              trackAnalytics('onboarding.messaging_integration_modal_rendered', {
+                project_id: projectQuery.data.id,
+                organization,
+              });
+            }}
+          >
+            {t('Connect to messaging')}
+          </Button>
+        </Tooltip>
+      )}
+    </IntegrationFeatures>
   );
 }
 

--- a/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
+++ b/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
@@ -41,6 +41,7 @@ function SetupMessagingIntegrationButton({projectSlug, refetchConfigs}: Props) {
     {staleTime: Infinity}
   );
 
+  // Only need to fetch the first provider to check if the feature is enabled, as all providers will return the same response
   const integrationQuery = useApiQuery<{providers: IntegrationProvider[]}>(
     [
       `/organizations/${organization.slug}/config/integrations/?provider_key=${providerKeys[0]}`,


### PR DESCRIPTION
disabled setup messaging integration button for users without a team plan or above

![Screenshot 2024-08-07 at 2 09 48 PM](https://github.com/user-attachments/assets/a4e25b49-f69a-4674-a6de-320373eeefa2)
