### PR TITLE
fix(alerts): Clean up querysubscription and snubaquery when alert is deleted

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -58,7 +58,7 @@ from sentry.snuba.entity_subscription import (
     get_entity_key_from_query_builder,
     get_entity_subscription_from_snuba_query,
 )
-from sentry.snuba.models import QuerySubscription, SnubaQuery
+from sentry.snuba.models import QuerySubscription
 from sentry.snuba.subscriptions import delete_snuba_subscription
 from sentry.utils import json, metrics, redis
 from sentry.utils.dates import to_datetime
@@ -487,9 +487,6 @@ class SubscriptionProcessor:
             # If the alert rule has been removed then clean up associated tables and return
             metrics.incr("incidents.alert_rules.no_alert_rule_for_subscription")
             delete_snuba_subscription(self.subscription)
-            query_subscription = QuerySubscription.objects.get(id=self.subscription.id)
-            SnubaQuery.objects.filter(id=query_subscription.snuba_query.id).delete()
-            query_subscription.delete()
             return
 
         if subscription_update["timestamp"] <= self.last_update:

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -192,9 +192,8 @@ def delete_subscription_from_snuba(query_subscription_id, **kwargs):
         except SnubaQuery.DoesNotExist:
             return
 
-        if snuba_query:
-            if not QuerySubscription.objects.filter(snuba_query=snuba_query).count():
-                snuba_query.delete()
+        if snuba_query and not QuerySubscription.objects.filter(snuba_query=snuba_query).count():
+            snuba_query.delete()
     else:
         subscription.update(subscription_id=None)
 


### PR DESCRIPTION
We have a huge number of events on https://sentry.sentry.io/issues/2382970109 which happens when an alert rule has been deleted but the associated `QuerySubscription` and `SnubaQuery` are not deleted. This PR cleans up those rows when we find that the alert rule is missing. I left the metric so we can see it drop and even out (I expect it'll drop since we won't be repeatedly receiving subscription updates for a rule that doesn't exist anymore, and then even out at a much lower rate when we are just receiving an update right after a rule is deleted). Once it evens out we could move this logic to the deletions flow for the `AlertRule` model, but first we need to remove all the old stuff.

Closes https://sentry.sentry.io/issues/2382970109