### PR TITLE
fix(issue-details): Omit query from all events tab link

### DIFF
--- a/static/app/views/issueDetails/useIssueDetailsHeader.tsx
+++ b/static/app/views/issueDetails/useIssueDetailsHeader.tsx
@@ -24,7 +24,7 @@ export function useIssueDetailsHeader({
 }: IssueDetailsHeaderProps) {
   const location = useLocation();
   const organization = useOrganization();
-  const {sort: _sort, ...query} = location.query;
+  const {sort: _sort, query: _query, ...query} = location.query;
 
   const disabledTabs = useMemo(() => {
     if (groupReprocessingStatus === ReprocessingStatus.REPROCESSING) {


### PR DESCRIPTION
This was a regression which caused the query from the issue stream to be carried over when clicking on the all events tab.