### PR TITLE
feat(uptime): Add api for creating new uptime monitors

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -257,6 +257,7 @@ from sentry.scim.endpoints.members import OrganizationSCIMMemberDetails, Organiz
 from sentry.scim.endpoints.schemas import OrganizationSCIMSchemaIndex
 from sentry.scim.endpoints.teams import OrganizationSCIMTeamDetails, OrganizationSCIMTeamIndex
 from sentry.uptime.endpoints.project_uptime_alert_details import ProjectUptimeAlertDetailsEndpoint
+from sentry.uptime.endpoints.project_uptime_alert_index import ProjectUptimeAlertIndexEndpoint
 
 from .endpoints.accept_organization_invite import AcceptOrganizationInvite
 from .endpoints.accept_project_transfer import AcceptProjectTransferEndpoint
@@ -2818,6 +2819,11 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/uptime/(?P<uptime_project_subscription_id>[^\/]+)/$",
         ProjectUptimeAlertDetailsEndpoint.as_view(),
         name="sentry-api-0-project-uptime-alert-details",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/uptime/$",
+        ProjectUptimeAlertIndexEndpoint.as_view(),
+        name="sentry-api-0-project-uptime-alert-index",
     ),
 ]
 

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -462,6 +462,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:transaction-name-normalize", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=False)
     # Sanitize transaction names in the ingestion pipeline. # Deprecated
     manager.add("organizations:transaction-name-sanitization", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
+    # Enables creation and full updating of uptime monitors via the api
+    manager.add("organizations:uptime-api-create-update", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables automatic hostname detection in uptime
     manager.add("organizations:uptime-automatic-hostname-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables automatic subscription creation in uptime

--- a/src/sentry/uptime/detectors/tasks.py
+++ b/src/sentry/uptime/detectors/tasks.py
@@ -42,8 +42,6 @@ URL_MIN_TIMES_SEEN = 5
 URL_MIN_PERCENT = 0.05
 # Default value for how often we should run these subscriptions when onboarding them
 ONBOARDING_SUBSCRIPTION_INTERVAL_SECONDS = int(timedelta(minutes=60).total_seconds())
-# Default timeout for subscriptions when we're onboarding them
-ONBOARDING_SUBSCRIPTION_TIMEOUT_MS = 10000
 
 logger = logging.getLogger("sentry.uptime-url-autodetection")
 
@@ -244,9 +242,7 @@ def monitor_url_for_project(project: Project, url: str):
                 ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
             ],
         )
-    subscription = create_uptime_subscription(
-        url, ONBOARDING_SUBSCRIPTION_INTERVAL_SECONDS, ONBOARDING_SUBSCRIPTION_TIMEOUT_MS
-    )
+    subscription = create_uptime_subscription(url, ONBOARDING_SUBSCRIPTION_INTERVAL_SECONDS)
     create_project_uptime_subscription(
         project, subscription, ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING
     )

--- a/src/sentry/uptime/endpoints/project_uptime_alert_index.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_index.py
@@ -24,7 +24,7 @@ from sentry.uptime.endpoints.validators import UptimeMonitorValidator
 @extend_schema(tags=["Uptime Monitors"])
 class ProjectUptimeAlertIndexEndpoint(ProjectEndpoint):
     publish_status = {
-        "POST": ApiPublishStatus.PUBLIC,
+        "POST": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.CRONS
 

--- a/src/sentry/uptime/endpoints/project_uptime_alert_index.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_index.py
@@ -1,0 +1,63 @@
+from drf_spectacular.utils import extend_schema
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases import ProjectEndpoint
+from sentry.api.serializers import serialize
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.parameters import GlobalParams
+from sentry.models.project import Project
+from sentry.uptime.endpoints.serializers import ProjectUptimeSubscriptionSerializer
+from sentry.uptime.endpoints.validators import UptimeMonitorValidator
+
+
+@region_silo_endpoint
+@extend_schema(tags=["Uptime Monitors"])
+class ProjectUptimeAlertIndexEndpoint(ProjectEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.PUBLIC,
+    }
+    owner = ApiOwner.CRONS
+
+    @extend_schema(
+        operation_id="Create an Uptime Monitor",
+        parameters=[GlobalParams.ORG_ID_OR_SLUG],
+        request=UptimeMonitorValidator,
+        responses={
+            201: ProjectUptimeSubscriptionSerializer,
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def post(self, request: Request, project: Project) -> Response:
+        """
+        Create a new monitor.
+        """
+        if not features.has(
+            "organizations:uptime-api-create-update", project.organization, actor=request.user
+        ):
+            return Response(status=404)
+        validator = UptimeMonitorValidator(
+            data=request.data,
+            context={
+                "organization": project.organization,
+                "project": project,
+                "access": request.access,
+                "request": request,
+            },
+        )
+        if not validator.is_valid():
+            return self.respond(validator.errors, status=400)
+
+        return self.respond(serialize(validator.save(), request.user))

--- a/src/sentry/uptime/endpoints/validators.py
+++ b/src/sentry/uptime/endpoints/validators.py
@@ -1,15 +1,25 @@
+from datetime import timedelta
+
 from drf_spectacular.utils import extend_schema_serializer
 from rest_framework import serializers
+from rest_framework.fields import URLField
 
 from sentry import audit_log
 from sentry.api.fields import ActorField
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
+from sentry.auth.superuser import is_active_superuser
+from sentry.uptime.models import ProjectUptimeSubscriptionMode
+from sentry.uptime.subscriptions.subscriptions import (
+    create_project_uptime_subscription,
+    create_uptime_subscription,
+)
 from sentry.utils.audit import create_audit_entry
 
 
 @extend_schema_serializer()
 class UptimeMonitorValidator(CamelSnakeSerializer):
     name = serializers.CharField(
+        required=True,
         max_length=128,
         help_text="Name of the uptime monitor",
     )
@@ -18,6 +28,43 @@ class UptimeMonitorValidator(CamelSnakeSerializer):
         allow_null=True,
         help_text="The ID of the team or user that owns the uptime monitor. (eg. user:51 or team:6)",
     )
+    url = URLField(required=True, max_length=255)
+    interval_seconds = serializers.IntegerField(
+        required=True, min_value=60, max_value=int(timedelta(days=1).total_seconds())
+    )
+    mode = serializers.IntegerField(required=False)
+
+    def validate_mode(self, mode):
+        if not is_active_superuser(self.context["request"]):
+            raise serializers.ValidationError("Only superusers can modify `mode`")
+        try:
+            return ProjectUptimeSubscriptionMode(mode)
+        except ValueError:
+            raise serializers.ValidationError(
+                "Invalid mode, valid values are %s"
+                % [item.value for item in ProjectUptimeSubscriptionMode]
+            )
+
+    def create(self, validated_data):
+        uptime_subscription = create_uptime_subscription(
+            url=validated_data["url"],
+            interval_seconds=validated_data["interval_seconds"],
+        )
+        uptime_monitor = create_project_uptime_subscription(
+            project=self.context["project"],
+            uptime_subscription=uptime_subscription,
+            name=validated_data["name"],
+            mode=validated_data.get("mode", ProjectUptimeSubscriptionMode.MANUAL),
+            owner=validated_data["owner"],
+        )
+        create_audit_entry(
+            request=self.context["request"],
+            organization=self.context["organization"],
+            target_object=uptime_monitor.id,
+            event=audit_log.get_event_id("UPTIME_MONITOR_ADD"),
+            data=uptime_monitor.get_audit_log_data(),
+        )
+        return uptime_monitor
 
     def update(self, instance, validated_data):
         params = {}
@@ -33,6 +80,9 @@ class UptimeMonitorValidator(CamelSnakeSerializer):
                     params["owner_user_id"] = owner.id
                 if owner.is_team:
                     params["owner_team_id"] = owner.id
+
+        if "mode" in validated_data:
+            raise serializers.ValidationError("Mode can only be specified on creation (for now)")
 
         if params:
             instance.update(**params)

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_index.py
@@ -1,0 +1,87 @@
+from rest_framework.exceptions import ErrorDetail
+
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers import with_feature
+from sentry.uptime.models import ProjectUptimeSubscription, ProjectUptimeSubscriptionMode
+from sentry.uptime.subscriptions.subscriptions import DEFAULT_SUBSCRIPTION_TIMEOUT_MS
+
+
+class ProjectUptimeAlertIndexBaseEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-project-uptime-alert-index"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+
+
+class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpointTest):
+    method = "post"
+
+    def test_no_feature(self):
+        self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            name="test",
+            owner=f"user:{self.user.id}",
+            url="http://sentry.io",
+            interval_seconds=60,
+            status_code=404,
+        )
+
+    @with_feature("organizations:uptime-api-create-update")
+    def test(self):
+        resp = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            name="test",
+            owner=f"user:{self.user.id}",
+            url="http://sentry.io",
+            interval_seconds=60,
+        )
+        uptime_monitor = ProjectUptimeSubscription.objects.get(id=resp.data["id"])
+        uptime_subscription = uptime_monitor.uptime_subscription
+        assert uptime_monitor.name == "test"
+        assert uptime_monitor.owner_user_id == self.user.id
+        assert uptime_monitor.owner_team_id is None
+        assert uptime_monitor.mode == ProjectUptimeSubscriptionMode.MANUAL
+        assert uptime_subscription.url == "http://sentry.io"
+        assert uptime_subscription.interval_seconds == 60
+        assert uptime_subscription.timeout_ms == DEFAULT_SUBSCRIPTION_TIMEOUT_MS
+
+    @with_feature("organizations:uptime-api-create-update")
+    def test_mode_no_superadmin(self):
+        resp = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            name="test",
+            owner=f"user:{self.user.id}",
+            url="http://sentry.io",
+            interval_seconds=60,
+            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            status_code=400,
+        )
+        assert resp.data == {
+            "mode": [ErrorDetail(string="Only superusers can modify `mode`", code="invalid")]
+        }
+
+    @with_feature("organizations:uptime-api-create-update")
+    def test_mode_superadmin(self):
+        self.login_as(self.user, superuser=True)
+        resp = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            name="test",
+            owner=f"user:{self.user.id}",
+            url="http://sentry.io",
+            interval_seconds=60,
+            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+        )
+        uptime_monitor = ProjectUptimeSubscription.objects.get(id=resp.data["id"])
+        uptime_subscription = uptime_monitor.uptime_subscription
+        assert uptime_monitor.name == "test"
+        assert uptime_monitor.owner_user_id == self.user.id
+        assert uptime_monitor.owner_team_id is None
+        assert uptime_monitor.mode == ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE
+        assert uptime_subscription.url == "http://sentry.io"
+        assert uptime_subscription.interval_seconds == 60
+        assert uptime_subscription.timeout_ms == DEFAULT_SUBSCRIPTION_TIMEOUT_MS


### PR DESCRIPTION
This api is currently gated behind a feature flag, so that we can just allow this on orgs we want to test on. We shouldn't enable this on other orgs until we have billing related concerns sorted out.

<!-- Describe your PR here. -->