### PR TITLE
chore(custom-views): Change query param from searchId to viewId

### DIFF
--- a/src/sentry/api/helpers/group_index/index.py
+++ b/src/sentry/api/helpers/group_index/index.py
@@ -95,7 +95,7 @@ def build_query_params_from_request(
         if features.has(
             "organizations:issue-stream-custom-views", organization, actor=request.user
         ):
-            selected_view_id = request.GET.get("searchId")
+            selected_view_id = request.GET.get("viewId")
             if selected_view_id:
                 default_view = GroupSearchView.objects.filter(id=int(selected_view_id)).first()
             else:

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -2400,7 +2400,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             sort_by="date",
             limit=10,
             collapse=["unhandled"],
-            searchId=view.id,
+            viewId=view.id,
             savedSearch=0,
         )
         assert response.status_code == 200


### PR DESCRIPTION
Quick chore just renaming the query param that's checked in group_index to retrieve the default view. I meant to change this in the original PR but forgot. viewId is definitely a more accurate descriptor, and since saved searches will be deprecated soon, we'd want to make this change now and have the frontend stick with `viewId` from the start rather than using `searchId` at first and potentially leaving it forever. 