### PR TITLE
fix(ST): Fix comparison direction for old trace

### DIFF
--- a/static/app/views/performance/traceDetails/utils.tsx
+++ b/static/app/views/performance/traceDetails/utils.tsx
@@ -99,7 +99,7 @@ export function shouldForceRouteToOldView(
 
   return (
     organization.extraOptions?.traces.checkSpanExtractionDate &&
-    organization.extraOptions?.traces.spansExtractionDate <= usableTimestamp
+    organization.extraOptions?.traces.spansExtractionDate > usableTimestamp
   );
 }
 


### PR DESCRIPTION
This function needs the other comparison direction, we should show users the old trace view if the trace is older (lower) than the span extraction date.
