### PR TITLE
fix(issues): Show exception for issues with threads

### DIFF
--- a/static/app/components/events/interfaces/exception.tsx
+++ b/static/app/components/events/interfaces/exception.tsx
@@ -26,15 +26,6 @@ export function Exception({
   hasHierarchicalGrouping,
   groupingCurrentLevel,
 }: Props) {
-  const eventHasThreads = !!event.entries.some(entry => entry.type === EntryType.THREADS);
-
-  // in case there are threads in the event data, we don't render the
-  // exception block.  Instead the exception is contained within the
-  // thread interface.
-  if (eventHasThreads) {
-    return null;
-  }
-
   const entryIndex = event.entries.findIndex(
     eventEntry => eventEntry.type === EntryType.EXCEPTION
   );


### PR DESCRIPTION
In #29532, we decided not to show the stack trace when threads are shown in the issue.

We want to add it back since events are grouped by the stack trace.

The original comment says that the stack trace should be found within the threads but the case I investigated did not reflect this.