### PR TITLE
feat: Use v8 for Loader by default for new projects

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -164,8 +164,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:issue-search-snuba", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable the new issue stream search bar UI
     manager.add("organizations:issue-stream-search-query-builder", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable v8 support for the Loader Script
-    manager.add("organizations:js-sdk-loader-v8", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:large-debug-files", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enabled latest adopted release filter for issue alerts
     manager.add("organizations:latest-adopted-release-filter", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/loader/browsersdkversion.py
+++ b/src/sentry/loader/browsersdkversion.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from packaging.version import Version
 
 import sentry
-from sentry import features
 
 logger = logging.getLogger("sentry")
 
@@ -98,9 +97,4 @@ def get_default_sdk_version_for_project(project):
 
 
 def get_available_sdk_versions_for_project(project):
-    versions = project.get_option("sentry:loader_available_sdk_versions")
-
-    if features.has("organizations:js-sdk-loader-v8", project.organization, actor=None):
-        return ["8.x"] + versions
-
-    return versions
+    return project.get_option("sentry:loader_available_sdk_versions")

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -2,7 +2,7 @@ from sentry.projectoptions import register
 
 # This controls what sentry:option-epoch value is given to a project when it is created
 # The epoch of a project will determine what options are valid options for that specific project
-LATEST_EPOCH = 12
+LATEST_EPOCH = 13
 
 # grouping related configs
 #
@@ -51,7 +51,8 @@ register(key="sentry:similarity_backfill_completed", default=None)
 # is expected to be never set but the epoch defaults are used if no
 # version is set on a project's DSN.
 register(
-    key="sentry:default_loader_version", epoch_defaults={1: "4.x", 2: "5.x", 7: "6.x", 8: "7.x"}
+    key="sentry:default_loader_version",
+    epoch_defaults={1: "4.x", 2: "5.x", 7: "6.x", 8: "7.x", 13: "8.x"},
 )
 
 # Default symbol sources.  The ios source does not exist by default and
@@ -179,8 +180,7 @@ register(
 )
 
 # The available loader SDK versions
-# todo: v8 add version
 register(
     key="sentry:loader_available_sdk_versions",
-    epoch_defaults={1: ["7.x", "6.x", "5.x", "4.x"], 11: ["7.x"]},
+    epoch_defaults={1: ["8.x", "7.x", "6.x", "5.x", "4.x"], 11: ["8.x", "7.x"]},
 )


### PR DESCRIPTION
This PR removes the loader-v8 feature flag, instead enabling this for all orgs. It also adds a new epoch, so that new projects will get v8 by default for the loader. v7 remains selectable for them.

closes https://github.com/getsentry/sentry-javascript/issues/12187