### PR TITLE
ref: use the actual real values for digests.backends.test_redis

### DIFF
--- a/tests/sentry/digests/backends/test_redis.py
+++ b/tests/sentry/digests/backends/test_redis.py
@@ -1,39 +1,46 @@
 import time
+import uuid
+from functools import cached_property
 
 import pytest
 
 from sentry.digests.backends.base import InvalidState
 from sentry.digests.backends.redis import RedisBackend
-from sentry.digests.types import Record
+from sentry.digests.types import Notification, Record
 from sentry.testutils.cases import TestCase
 
 
 class RedisBackendTestCase(TestCase):
+    @cached_property
+    def notification(self) -> Notification:
+        rule = self.event.project.rule_set.all()[0]
+        return Notification(self.event, (rule.id,), str(uuid.uuid4()))
+
     def test_basic(self):
         backend = RedisBackend()
 
         # The first item should return "true", indicating that this timeline
         # can be immediately dispatched to be digested.
-        record_1 = Record("record:1", "value", time.time())
+        record_1 = Record("record:1", self.notification, time.time())
         assert backend.add("timeline", record_1) is True
 
         # The second item should return "false", since it's ready to be
         # digested but dispatching again would cause it to be sent twice.
-        record_2 = Record("record:2", "value", time.time())
+        record_2 = Record("record:2", self.notification, time.time())
         assert backend.add("timeline", record_2) is False
 
         # There's nothing to move between sets, so scheduling should return nothing.
         assert set(backend.schedule(time.time())) == set()
 
         with backend.digest("timeline", 0) as records:
-            assert set(records) == {record_1, record_2}
+            assert {record.key for record in records} == {record_1.key, record_2.key}
 
         # The schedule should now contain the timeline.
         assert {entry.key for entry in backend.schedule(time.time())} == {"timeline"}
 
         # We didn't add any new records so there's nothing to do here.
         with backend.digest("timeline", 0) as records:
-            assert set(records) == set()
+            assert not records
 
         # There's nothing to move between sets since the timeline contents no
         # longer exist at this point.
@@ -42,17 +49,17 @@ class RedisBackendTestCase(TestCase):
     def test_truncation(self):
         backend = RedisBackend(capacity=2, truncation_chance=1.0)
 
-        records = [Record(f"record:{i}", "value", time.time()) for i in range(4)]
+        records = [Record(f"record:{i}", self.notification, time.time()) for i in range(4)]
         for record in records:
             backend.add("timeline", record)
 
         with backend.digest("timeline", 0) as records:
-            assert set(records) == set(records[-2:])
+            assert {record.key for record in records} == {"record:2", "record:3"}
 
     def test_maintenance_failure_recovery(self):
         backend = RedisBackend()
 
-        record_1 = Record("record:1", "value", time.time())
+        record_1 = Record("record:1", self.notification, time.time())
         backend.add("timeline", record_1)
 
         try:
@@ -69,7 +76,7 @@ class RedisBackendTestCase(TestCase):
             with backend.digest("timeline", 0) as records:
                 pass
 
-        record_2 = Record("record:2", "value", time.time())
+        record_2 = Record("record:2", self.notification, time.time())
         backend.add("timeline", record_2)
 
         # The schedule should now contain the timeline.
@@ -78,7 +85,7 @@ class RedisBackendTestCase(TestCase):
         # The existing and new record should be there because the timeline
         # contents were merged back into the digest.
         with backend.digest("timeline", 0) as records:
-            assert set(records) == {record_1, record_2}
+            assert {record.key for record in records} == {"record:1", "record:2"}
 
     def test_maintenance_failure_recovery_with_capacity(self):
         backend = RedisBackend(capacity=10, truncation_chance=0.0)
@@ -87,7 +94,7 @@ class RedisBackendTestCase(TestCase):
 
         # Add 10 items to the timeline.
         for i in range(10):
-            backend.add("timeline", Record(f"record:{i}", f"{i}", t + i))
+            backend.add("timeline", Record(f"record:{i}", self.notification, t + i))
 
         try:
             with backend.digest("timeline", 0) as records:
@@ -100,7 +107,7 @@ class RedisBackendTestCase(TestCase):
         # deleted from Redis or removed from the digest set.) If we add 10 more
         # items, they should be added to the timeline set (not the digest set.)
         for i in range(10, 20):
-            backend.add("timeline", Record(f"record:{i}", f"{i}", t + i))
+            backend.add("timeline", Record(f"record:{i}", self.notification, t + i))
 
         # Maintenance should move the timeline back to the waiting state, ...
         backend.maintenance(time.time())
@@ -116,12 +123,12 @@ class RedisBackendTestCase(TestCase):
 
     def test_delete(self):
         backend = RedisBackend()
-        backend.add("timeline", Record("record:1", "value", time.time()))
+        backend.add("timeline", Record("record:1", self.notification, time.time()))
         backend.delete("timeline")
 
         with pytest.raises(InvalidState):
             with backend.digest("timeline", 0) as records:
-                assert set(records) == set()
+                assert not records
 
         assert set(backend.schedule(time.time())) == set()
         assert len(backend._get_connection("timeline").keys("d:*")) == 0
@@ -129,17 +136,17 @@ class RedisBackendTestCase(TestCase):
     def test_missing_record_contents(self):
         backend = RedisBackend()
 
-        record_1 = Record("record:1", "value", time.time())
+        record_1 = Record("record:1", self.notification, time.time())
         backend.add("timeline", record_1)
         backend._get_connection("timeline").delete("d:t:timeline:r:record:1")
 
-        record_2 = Record("record:2", "value", time.time())
+        record_2 = Record("record:2", self.notification, time.time())
         backend.add("timeline", record_2)
 
         # The existing and new record should be there because the timeline
         # contents were merged back into the digest.
         with backend.digest("timeline", 0) as records:
-            assert set(records) == {record_2}
+            assert {record.key for record in records} == {"record:2"}
 
     def test_large_digest(self):
         backend = RedisBackend()
@@ -147,7 +154,7 @@ class RedisBackendTestCase(TestCase):
         n = 8192
         t = time.time()
         for i in range(n):
-            backend.add("timeline", Record(f"record:{i}", f"{i}", t))
+            backend.add("timeline", Record(f"record:{i}", self.notification, t))
 
         with backend.digest("timeline", 0) as records:
-            assert len(set(records)) == n
+            assert len(records) == n


### PR DESCRIPTION
had to adjust the assertions due to `Notification` containing an Event object which when it is retrieved later it is not identical to the original one (same Event though, just different object identity)

split out from my typing of `digests.notifications`

<!-- Describe your PR here. -->