### PR TITLE
ref: move Notification tuple test to the test for its module

### DIFF
--- a/tests/sentry/digests/test_types.py
+++ b/tests/sentry/digests/test_types.py
@@ -1,0 +1,16 @@
+import uuid
+from unittest import mock
+
+from sentry.digests.types import Notification
+
+
+class TestNotificationTuple:
+    def test_missing_notification_uuid(self):
+        notification = Notification(mock.sentinel.rule, mock.sentinel.group)
+        assert notification.notification_uuid is None
+
+    def test_notification_uuid(self):
+        notification = Notification(
+            mock.sentinel.rule, mock.sentinel.group, notification_uuid=str(uuid.uuid4())
+        )
+        assert notification.notification_uuid is not None

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -13,7 +13,6 @@ from django.utils import timezone
 from sentry_relay.processing import parse_release
 from slack_sdk.web import SlackResponse
 
-from sentry.digests.types import Notification
 from sentry.event_manager import EventManager
 from sentry.models.activity import Activity
 from sentry.models.group import Group, GroupStatus
@@ -587,17 +586,3 @@ class ActivityNotificationTest(APITestCase):
             notification_uuid=notification_uuid,
             actor_type="User",
         )
-
-
-class NotificationTupleTest(APITestCase):
-    def test_missing_notification_uuid(self):
-        rule = self.create_project_rule()
-        group = self.create_group()
-        notification = Notification(rule, group)
-        assert notification.notification_uuid is None
-
-    def test_notification_uuid(self):
-        rule = self.create_project_rule()
-        group = self.create_group()
-        notification = Notification(rule, group, notification_uuid=str(uuid.uuid4()))
-        assert notification.notification_uuid is not None


### PR DESCRIPTION
missed moving this test because it wasn't in the module I moved the class from!

<!-- Describe your PR here. -->