### PR TITLE
chore(dashboards): Add "Give Feedback" buttons

### DIFF
--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -6,6 +6,7 @@ import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import Confirm from 'sentry/components/confirm';
+import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import {Hovercard} from 'sentry/components/hovercard';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconAdd, IconDownload, IconEdit} from 'sentry/icons';
@@ -142,6 +143,7 @@ function Controls({
       <DashboardEditFeature>
         {hasFeature => (
           <Fragment>
+            <FeedbackWidgetButton />
             <Feature features="dashboards-import">
               <Button
                 data-test-id="dashboard-export"

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -12,6 +12,7 @@ import {Alert} from 'sentry/components/alert';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {CompactSelect} from 'sentry/components/compactSelect';
+import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
@@ -317,6 +318,7 @@ class ManageDashboards extends DeprecatedAsyncView<Props, State> {
                         toggle={this.toggleTemplates}
                       />
                     </TemplateSwitch>
+                    <FeedbackWidgetButton />
                     <DashboardImportButton />
                     <Button
                       data-test-id="dashboard-create"

--- a/static/app/views/dashboards/widgetBuilder/header.tsx
+++ b/static/app/views/dashboards/widgetBuilder/header.tsx
@@ -1,7 +1,7 @@
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
-import {FeatureFeedback} from 'sentry/components/featureFeedback';
+import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
 import type {LinkProps} from 'sentry/components/links/link';
 import {t} from 'sentry/locale';
@@ -35,7 +35,7 @@ export function Header({orgSlug, goBackLocation, dashboardTitle}: Props) {
 
       <Layout.HeaderActions>
         <ButtonBar gap={1}>
-          <FeatureFeedback buttonProps={{size: 'sm'}} featureName="widget-builder" />
+          <FeedbackWidgetButton />
           <Button
             external
             size="sm"


### PR DESCRIPTION
Mysteriously, only the "Edit Widget" page had the button! Strange.

![Screenshot 2024-08-08 at 10 33 44 AM](https://github.com/user-attachments/assets/f6ff59c6-ec47-45ee-9a4e-8778eae7a8fe)
![Screenshot 2024-08-08 at 10 33 49 AM](https://github.com/user-attachments/assets/cbd5ce20-91d2-4728-96b4-2dc36447ebbe)
![Screenshot 2024-08-08 at 10 34 37 AM](https://github.com/user-attachments/assets/4df8d6a0-3fc3-43c1-8bfd-bf9aabf85287)
