### PR TITLE
fix(breadcrumbs): Handle exceedingly large values properly

### DIFF
--- a/static/app/components/events/breadcrumbs/breadcrumbItemContent.spec.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbItemContent.spec.tsx
@@ -17,7 +17,7 @@ describe('BreadcrumbItemContent', function () {
       message: 'my message',
       data: {a: 1, b: 2, c: 3, d: 4, e: 5, f: 6},
     };
-    render(<BreadcrumbItemContent breadcrumb={breadcrumb} />);
+    render(<BreadcrumbItemContent breadcrumb={breadcrumb} fullyExpanded={false} />);
     expect(screen.getByText(breadcrumb.message as string)).toBeInTheDocument();
     expect(screen.getByText('6 items')).toBeInTheDocument();
   });
@@ -35,7 +35,7 @@ describe('BreadcrumbItemContent', function () {
         responseSize: 15080,
       },
     };
-    render(<BreadcrumbItemContent breadcrumb={breadcrumb} />);
+    render(<BreadcrumbItemContent breadcrumb={breadcrumb} fullyExpanded={false} />);
     expect(screen.getByText(breadcrumb.message as string)).toBeInTheDocument();
     // Link is rendered in a span between method and status code
     expect(
@@ -54,7 +54,7 @@ describe('BreadcrumbItemContent', function () {
       message: "SELECT * from 'table'",
       data: {a: 1, b: 2, c: 3, d: 4, e: 5, f: 6},
     };
-    render(<BreadcrumbItemContent breadcrumb={breadcrumb} />);
+    render(<BreadcrumbItemContent breadcrumb={breadcrumb} fullyExpanded={false} />);
     // .token denotes Prism tokens for special formatting
     expect(
       screen.getByText(breadcrumb.message as string, {selector: '.token'})
@@ -78,7 +78,9 @@ describe('BreadcrumbItemContent', function () {
         f: 6,
       },
     };
-    const item = render(<BreadcrumbItemContent breadcrumb={breadcrumb} />);
+    const item = render(
+      <BreadcrumbItemContent breadcrumb={breadcrumb} fullyExpanded={false} />
+    );
     expect(screen.getByText(breadcrumb.message as string)).toBeInTheDocument();
     expect(
       screen.getByText(`${breadcrumb?.data?.type}: ${breadcrumb?.data?.value}`)
@@ -95,6 +97,7 @@ describe('BreadcrumbItemContent', function () {
             type: undefined,
           },
         }}
+        fullyExpanded={false}
       />
     );
     expect(screen.getByText(breadcrumb.message as string)).toBeInTheDocument();
@@ -111,11 +114,32 @@ describe('BreadcrumbItemContent', function () {
             value: undefined,
           },
         }}
+        fullyExpanded={false}
       />
     );
     expect(screen.getByText(breadcrumb.message as string)).toBeInTheDocument();
     expect(screen.getByText(breadcrumb?.data?.type)).toBeInTheDocument();
     expect(screen.getByText('6 items')).toBeInTheDocument();
     itemWithoutValue.unmount();
+  });
+
+  it('applies item limits with fullyExpanded', function () {
+    const longMessage = 'longMessage'.repeat(100);
+    const breadcrumb: BreadcrumbTypeDefault = {
+      type: BreadcrumbType.DEBUG,
+      level: BreadcrumbLevelType.INFO,
+      message: longMessage,
+      data: {a: 1, b: 2, c: 3, d: 4, e: 5, f: 6},
+    };
+    const compactItem = render(
+      <BreadcrumbItemContent breadcrumb={breadcrumb} fullyExpanded={false} />
+    );
+    expect(screen.getByText(longMessage.substring(0, 200) + '...')).toBeInTheDocument();
+    expect(screen.getByText('6 items')).toBeInTheDocument();
+    compactItem.unmount();
+
+    render(<BreadcrumbItemContent breadcrumb={breadcrumb} />);
+    expect(screen.getByText(longMessage)).toBeInTheDocument();
+    expect(screen.queryByText('6 items')).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/events/breadcrumbs/breadcrumbItemContent.spec.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbItemContent.spec.tsx
@@ -134,7 +134,9 @@ describe('BreadcrumbItemContent', function () {
     const compactItem = render(
       <BreadcrumbItemContent breadcrumb={breadcrumb} fullyExpanded={false} />
     );
-    expect(screen.getByText(longMessage.substring(0, 200) + '...')).toBeInTheDocument();
+    expect(
+      screen.getByText(longMessage.substring(0, 200) + '\u2026')
+    ).toBeInTheDocument();
     expect(screen.getByText('6 items')).toBeInTheDocument();
     compactItem.unmount();
 

--- a/static/app/components/events/breadcrumbs/breadcrumbItemContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbItemContent.tsx
@@ -19,10 +19,12 @@ import {isUrl} from 'sentry/utils/string/isUrl';
 import {usePrismTokens} from 'sentry/utils/usePrismTokens';
 
 const DEFAULT_STRUCTURED_DATA_PROPS = {
-  maxDefaultDepth: 2,
+  maxDefaultDepth: 1,
   withAnnotatedText: true,
   withOnlyFormattedText: true,
 };
+
+const MESSAGE_PREVIEW_CHAR_LIMIT = 200;
 
 interface BreadcrumbItemContentProps {
   breadcrumb: RawCrumb;
@@ -33,7 +35,7 @@ interface BreadcrumbItemContentProps {
 export default function BreadcrumbItemContent({
   breadcrumb: bc,
   meta,
-  fullyExpanded = false,
+  fullyExpanded = true,
 }: BreadcrumbItemContentProps) {
   const structuredDataProps = {
     ...DEFAULT_STRUCTURED_DATA_PROPS,
@@ -45,7 +47,24 @@ export default function BreadcrumbItemContent({
 
   const defaultMessage = defined(bc.message) ? (
     <BreadcrumbText>
-      <StructuredData value={bc.message} meta={meta?.message} {...structuredDataProps} />
+      {fullyExpanded ? (
+        <StructuredData
+          value={bc.message}
+          meta={meta?.message}
+          {...structuredDataProps}
+        />
+      ) : (
+        <StructuredData
+          value={
+            bc.message.length > MESSAGE_PREVIEW_CHAR_LIMIT
+              ? bc.message.substring(0, MESSAGE_PREVIEW_CHAR_LIMIT) + '...'
+              : bc.message
+          }
+          // Note: Annotations applying to trimmed content will not be applied.
+          meta={meta?.message}
+          {...structuredDataProps}
+        />
+      )}
     </BreadcrumbText>
   ) : null;
   const defaultData = defined(bc.data) ? (

--- a/static/app/components/events/breadcrumbs/breadcrumbItemContent.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbItemContent.tsx
@@ -57,7 +57,7 @@ export default function BreadcrumbItemContent({
         <StructuredData
           value={
             bc.message.length > MESSAGE_PREVIEW_CHAR_LIMIT
-              ? bc.message.substring(0, MESSAGE_PREVIEW_CHAR_LIMIT) + '...'
+              ? bc.message.substring(0, MESSAGE_PREVIEW_CHAR_LIMIT) + '\u2026'
               : bc.message
           }
           // Note: Annotations applying to trimmed content will not be applied.

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -187,6 +187,7 @@ export default function BreadcrumbsDataSection({
           startTimeString={startTimeString}
           // We want the timeline to appear connected to the 'View All' button
           showLastLine={hasViewAll}
+          fullyExpanded={false}
         />
         {hasViewAll && (
           <ViewAllContainer>

--- a/static/app/components/events/breadcrumbs/breadcrumbsDrawer.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDrawer.tsx
@@ -249,7 +249,6 @@ export function BreadcrumbsDrawer({
             <BreadcrumbsTimeline
               breadcrumbs={displayCrumbs}
               startTimeString={startTimeString}
-              fullyExpanded
             />
           )}
         </TimelineContainer>

--- a/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
@@ -35,7 +35,7 @@ interface BreadcrumbsTimelineProps {
 export default function BreadcrumbsTimeline({
   breadcrumbs,
   startTimeString,
-  fullyExpanded = false,
+  fullyExpanded = true,
   showLastLine = false,
 }: BreadcrumbsTimelineProps) {
   const containerRef = useRef<HTMLDivElement>(null);

--- a/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
@@ -87,7 +87,7 @@ export default function BreadcrumbsTimeline({
         title={
           <Header>
             <div>
-              {title}
+              <TextBreak>{title}</TextBreak>
               {isVirtualCrumb && <Subtitle> - {t('This event')}</Subtitle>}
             </div>
             {levelComponent}
@@ -126,8 +126,13 @@ export default function BreadcrumbsTimeline({
 }
 
 const Header = styled('div')`
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 1fr auto;
+`;
+
+const TextBreak = styled('span')`
+  word-wrap: break-word;
+  word-break: break-all;
 `;
 
 const Subtitle = styled('p')`

--- a/static/app/components/events/breadcrumbs/utils.tsx
+++ b/static/app/components/events/breadcrumbs/utils.tsx
@@ -346,6 +346,7 @@ function BreadcrumbIcon({type}: {type?: BreadcrumbType}) {
 const BreadcrumbLevel = styled('div')<{level: BreadcrumbLevelType}>`
   margin: 0 ${space(1)};
   font-weight: normal;
+  font-size: ${p => p.theme.fontSizeSmall};
   border: 0;
   background: none;
   color: ${p => {

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -63,7 +63,7 @@ const Row = styled('div')<{showLastLine?: boolean}>`
   position: relative;
   color: ${p => p.theme.subText};
   display: grid;
-  align-items: center;
+  align-items: start;
   grid-template: auto auto / 22px 1fr auto;
   grid-column-gap: ${space(1)};
   margin: ${space(1)} 0;


### PR DESCRIPTION
Two changes here:
- Long message values would clutter the rest of the page. Now they get trimmed at 200 characters in the issue details page preview. They are still fully accessible in the drawer.
- Long categories would flow outside of their dedicated space causing formatting issues but also obscuring data (like timestamps) in the drawer

**before**

<img width="1015" alt="image" src="https://github.com/user-attachments/assets/1169d309-ec87-42f9-b64c-1d4169866e48">

**after**
<img width="741" alt="image" src="https://github.com/user-attachments/assets/247e117a-2adc-40af-be26-57230c91c0ad">
<img width="652" alt="image" src="https://github.com/user-attachments/assets/ed8fd292-38a3-4bef-9c6d-f0fe16408492">

