### PR TITLE
fix(ui): Improve spacing on App icon

### DIFF
--- a/static/app/components/modals/sentryAppDetailsModal.tsx
+++ b/static/app/components/modals/sentryAppDetailsModal.tsx
@@ -216,9 +216,10 @@ const Heading = styled('div')`
 `;
 
 const HeadingInfo = styled('div')`
-  display: grid;
-  grid-template-rows: max-content max-content;
+  display: flex;
+  flex-direction: column;
   align-items: start;
+  gap: ${space(0.75)};
 `;
 
 const Name = styled('div')`


### PR DESCRIPTION
After

<img alt="clipboard.png" width="327" src="https://i.imgur.com/El1x290.png" />

Before

<img alt="clipboard.png" width="302" src="https://i.imgur.com/1buHGy4.png" />