### PR TITLE
chore(alerts): Update migrate metric alert comment

### DIFF
--- a/static/app/views/alerts/edit.tsx
+++ b/static/app/views/alerts/edit.tsx
@@ -62,7 +62,8 @@ class ProjectAlertsEditor extends Component<Props, State> {
     const {hasMetricAlerts, organization, project, members, location} = this.props;
     const alertType = this.getAlertType();
 
-    // TODO(telemetry-experience): Remove once the migration is complete
+    //  Used to hide specific fields like actions while migrating metric alert rules.
+    //  Currently used to help people add `is:unresolved` to their metric alert query.
     const isMigration = location?.query?.migration === '1';
 
     return (

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -1107,7 +1107,8 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
     } = this.state;
 
     const wizardBuilderChart = this.renderTriggerChart();
-    // TODO(issues): Remove this and all connected logic once the migration is complete
+    //  Used to hide specific fields like actions while migrating metric alert rules.
+    //  Currently used to help people add `is:unresolved` to their metric alert query.
     const isMigration = location?.query?.migration === '1';
 
     const triggerForm = (disabled: boolean) => (


### PR DESCRIPTION
We're still using migrate metric alerts to get people to add `is:unresolved`
