### PR TITLE
fix(auth providers): remove fly non partner from auth provider list

### DIFF
--- a/src/sentry/api/endpoints/organization_auth_providers.py
+++ b/src/sentry/api/endpoints/organization_auth_providers.py
@@ -7,6 +7,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationAuthProviderPermission, OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.auth import manager
+from sentry.auth.partnership_configs import ChannelName
 
 
 @region_silo_endpoint
@@ -27,7 +28,7 @@ class OrganizationAuthProvidersEndpoint(OrganizationEndpoint):
         """
         provider_list = []
         for k, v in manager:
-            if not v.is_partner:
+            if not v.is_partner and k != ChannelName.FLY_NON_PARTNER.value:
                 provider_list.append(
                     {"key": k, "name": v.name, "requiredFeature": v.required_feature}
                 )

--- a/src/sentry/auth/partnership_configs.py
+++ b/src/sentry/auth/partnership_configs.py
@@ -6,4 +6,4 @@ class ChannelName(Enum):
     FLY_NON_PARTNER = "fly-non-partner"
 
 
-SPONSOR_OAUTH_NAME = {ChannelName.FLY_IO: "Fly.io", ChannelName.FLY_NON_PARTNER: "Fly.non-partner"}
+SPONSOR_OAUTH_NAME = {ChannelName.FLY_IO: "Fly.io", ChannelName.FLY_NON_PARTNER: "Fly.io"}

--- a/tests/sentry/api/endpoints/test_organization_auth_providers.py
+++ b/tests/sentry/api/endpoints/test_organization_auth_providers.py
@@ -1,7 +1,8 @@
 from django.urls import reverse
 
 from sentry import auth
-from sentry.auth.providers.fly.provider import FlyOAuth2Provider
+from sentry.auth.partnership_configs import ChannelName
+from sentry.auth.providers.fly.provider import FlyOAuth2Provider, NonPartnerFlyOAuth2Provider
 from sentry.testutils.cases import APITestCase, PermissionTestCase
 
 
@@ -30,8 +31,14 @@ class OrganizationAuthProviders(APITestCase):
         auth.register("Fly IO", FlyOAuth2Provider)
         self.addCleanup(auth.unregister, "Fly IO", FlyOAuth2Provider)
 
+        auth.register(ChannelName.FLY_NON_PARTNER.value, NonPartnerFlyOAuth2Provider)
+        self.addCleanup(
+            auth.unregister, ChannelName.FLY_NON_PARTNER.value, NonPartnerFlyOAuth2Provider
+        )
+
     def test_get_list_of_auth_providers(self):
         with self.feature("organizations:sso-basic"):
             response = self.get_success_response(self.organization.slug)
         assert any(d["key"] == "dummy" for d in response.data)
         assert any(d["key"] == "Fly IO" for d in response.data) is False
+        assert any(d["key"] == ChannelName.FLY_NON_PARTNER.value for d in response.data) is False


### PR DESCRIPTION
Removes `fly-non-partner` provider from auth provider list
