### PR TITLE
fix(avatar-list): Show avatar if only 1 is being collapsed

### DIFF
--- a/static/app/components/avatar/avatarList.spec.tsx
+++ b/static/app/components/avatar/avatarList.spec.tsx
@@ -31,7 +31,7 @@ describe('AvatarList', () => {
     expect(screen.queryByTestId('avatarList-collapsedavatars')).not.toBeInTheDocument();
   });
 
-  it('renders with collapsed avatar count if > 5 users', () => {
+  it('renders with all avatars if count is max + 1 users', () => {
     const users = [
       {...user, id: '1', name: 'AB'},
       {...user, id: '2', name: 'BC'},
@@ -39,6 +39,27 @@ describe('AvatarList', () => {
       {...user, id: '4', name: 'DE'},
       {...user, id: '5', name: 'EF'},
       {...user, id: '6', name: 'FG'},
+    ];
+
+    renderComponent({users});
+    expect(screen.getByText(users[0].name.charAt(0))).toBeInTheDocument();
+    expect(screen.getByText(users[1].name.charAt(0))).toBeInTheDocument();
+    expect(screen.getByText(users[2].name.charAt(0))).toBeInTheDocument();
+    expect(screen.getByText(users[3].name.charAt(0))).toBeInTheDocument();
+    expect(screen.getByText(users[4].name.charAt(0))).toBeInTheDocument();
+    expect(screen.getByText(users[5].name.charAt(0))).toBeInTheDocument();
+    expect(screen.queryByTestId('avatarList-collapsedavatars')).not.toBeInTheDocument();
+  });
+
+  it('renders with collapsed avatar count if > max + 1 users', () => {
+    const users = [
+      {...user, id: '1', name: 'AB'},
+      {...user, id: '2', name: 'BC'},
+      {...user, id: '3', name: 'CD'},
+      {...user, id: '4', name: 'DE'},
+      {...user, id: '5', name: 'EF'},
+      {...user, id: '6', name: 'FG'},
+      {...user, id: '7', name: 'GH'},
     ];
 
     renderComponent({users});

--- a/static/app/components/avatar/avatarList.tsx
+++ b/static/app/components/avatar/avatarList.tsx
@@ -70,9 +70,8 @@ function AvatarList({
     } else if (visibleUserAvatars.length < users.length) {
       visibleUserAvatars.unshift(users[users.length - 1]);
     }
+    numCollapsedAvatars = 0;
   }
-
-  numCollapsedAvatars = 1;
 
   if (!tooltipOptions.position) {
     tooltipOptions.position = 'top';

--- a/static/app/components/avatar/avatarList.tsx
+++ b/static/app/components/avatar/avatarList.tsx
@@ -57,11 +57,22 @@ function AvatarList({
   const numVisibleTeams = maxVisibleAvatars - numTeams > 0 ? numTeams : maxVisibleAvatars;
   const maxVisibleUsers =
     maxVisibleAvatars - numVisibleTeams > 0 ? maxVisibleAvatars - numVisibleTeams : 0;
+
   // Reverse the order since css flex-reverse is used to display the avatars
   const visibleTeamAvatars = teams.slice(0, numVisibleTeams).reverse();
   const visibleUserAvatars = users.slice(0, maxVisibleUsers).reverse();
-  const numCollapsedAvatars =
+  let numCollapsedAvatars =
     users.length + teams.length - (visibleUserAvatars.length + visibleTeamAvatars.length);
+
+  if (numCollapsedAvatars === 1) {
+    if (visibleTeamAvatars.length < teams.length) {
+      visibleTeamAvatars.unshift(teams[teams.length - 1]);
+    } else if (visibleUserAvatars.length < users.length) {
+      visibleUserAvatars.unshift(users[users.length - 1]);
+    }
+  }
+
+  numCollapsedAvatars = 1;
 
   if (!tooltipOptions.position) {
     tooltipOptions.position = 'top';


### PR DESCRIPTION
this pr updates `AvatarList` so that if there is only 1 avatar being collapsed, it is just shown