### PR TITLE
fix(discover): Allow for errors and transactions in data export

### DIFF
--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -29,6 +29,8 @@ from ..tasks import assemble_download
 SUPPORTED_DATASETS = {
     "discover": Dataset.Discover,
     "issuePlatform": Dataset.IssuePlatform,
+    "transactions": Dataset.Transactions,
+    "errors": Dataset.Events,
 }
 
 
@@ -95,7 +97,7 @@ class DataExportQuerySerializer(serializers.Serializer):
             query_info["end"] = end.isoformat()
             dataset = query_info.get("dataset", "discover")
             if dataset not in SUPPORTED_DATASETS:
-                raise serializers.ValidationError(f"{dataset} is not support for csv exports")
+                raise serializers.ValidationError(f"{dataset} is not supported for csv exports")
 
             # validate the query string by trying to parse it
             processor = DiscoverProcessor(
@@ -121,6 +123,7 @@ class DataExportQuerySerializer(serializers.Serializer):
         return data
 
 
+# Must allow the errors and transactions dataset
 @region_silo_endpoint
 class DataExportEndpoint(OrganizationEndpoint, EnvironmentMixin):
     publish_status = {

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -123,7 +123,6 @@ class DataExportQuerySerializer(serializers.Serializer):
         return data
 
 
-# Must allow the errors and transactions dataset
 @region_silo_endpoint
 class DataExportEndpoint(OrganizationEndpoint, EnvironmentMixin):
     publish_status = {

--- a/tests/sentry/data_export/endpoints/test_data_export.py
+++ b/tests/sentry/data_export/endpoints/test_data_export.py
@@ -329,6 +329,34 @@ class DataExportTest(APITestCase):
         assert query_info["field"] == ["title", "count()"]
         assert query_info["dataset"] == "issuePlatform"
 
+    def test_valid_dataset_transactions(self):
+        """
+        Tests that the transactions dataset is valid
+        """
+        payload = self.make_payload(
+            "discover", {"field": ["title", "count()"], "dataset": "transactions"}
+        )
+        with self.feature(["organizations:discover-query"]):
+            response = self.get_success_response(self.org.slug, status_code=201, **payload)
+        data_export = ExportedData.objects.get(id=response.data["id"])
+        query_info = data_export.query_info
+        assert query_info["field"] == ["title", "count()"]
+        assert query_info["dataset"] == "transactions"
+
+    def test_valid_dataset_errors(self):
+        """
+        Tests that the errors dataset is valid
+        """
+        payload = self.make_payload(
+            "discover", {"field": ["title", "count()"], "dataset": "errors"}
+        )
+        with self.feature(["organizations:discover-query"]):
+            response = self.get_success_response(self.org.slug, status_code=201, **payload)
+        data_export = ExportedData.objects.get(id=response.data["id"])
+        query_info = data_export.query_info
+        assert query_info["field"] == ["title", "count()"]
+        assert query_info["dataset"] == "errors"
+
     def test_invalid_dataset(self):
         """
         Ensures that equations are handled

--- a/tests/sentry/data_export/endpoints/test_data_export_details.py
+++ b/tests/sentry/data_export/endpoints/test_data_export_details.py
@@ -130,7 +130,7 @@ class DataExportDetailsTest(APITestCase):
             user_id=self.user.id,
             organization=self.organization,
             query_type=1,
-            query_info={"dataset": "potato"},
+            query_info={"dataset": "transactions"},
         )
 
         with self.feature("organizations:discover-query"):

--- a/tests/sentry/data_export/endpoints/test_data_export_details.py
+++ b/tests/sentry/data_export/endpoints/test_data_export_details.py
@@ -102,3 +102,47 @@ class DataExportDetailsTest(APITestCase):
         with self.feature("organizations:discover-query"):
             response = self.client.get(url)
             assert response.status_code == 404
+
+    def test_content_errors(self):
+        self.data_export = ExportedData.objects.create(
+            user_id=self.user.id,
+            organization=self.organization,
+            query_type=1,
+            query_info={"dataset": "errors"},
+        )
+
+        with self.feature("organizations:discover-query"):
+            response = self.get_success_response(self.organization.slug, self.data_export.id)
+        assert response.data["id"] == self.data_export.id
+        assert response.data["user"] == {
+            "id": str(self.user.id),
+            "email": self.user.email,
+            "username": self.user.username,
+        }
+        assert response.data["dateCreated"] == self.data_export.date_added
+        assert response.data["query"] == {
+            "type": ExportQueryType.as_str(self.data_export.query_type),
+            "info": self.data_export.query_info,
+        }
+
+    def test_content_transactions(self):
+        self.data_export = ExportedData.objects.create(
+            user_id=self.user.id,
+            organization=self.organization,
+            query_type=1,
+            query_info={"dataset": "potato"},
+        )
+
+        with self.feature("organizations:discover-query"):
+            response = self.get_success_response(self.organization.slug, self.data_export.id)
+        assert response.data["id"] == self.data_export.id
+        assert response.data["user"] == {
+            "id": str(self.user.id),
+            "email": self.user.email,
+            "username": self.user.username,
+        }
+        assert response.data["dateCreated"] == self.data_export.date_added
+        assert response.data["query"] == {
+            "type": ExportQueryType.as_str(self.data_export.query_type),
+            "info": self.data_export.query_info,
+        }


### PR DESCRIPTION
Registers the errors and transactions dataset as supported datasets for export for the discover split.