### PR TITLE
ref: digests Record.value is Notification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -426,7 +426,6 @@ module = [
     "tests.sentry.api.test_authentication",
     "tests.sentry.api.test_base",
     "tests.sentry.api.test_event_search",
-    "tests.sentry.digests.test_notifications",
     "tests.sentry.eventstore.test_base",
     "tests.sentry.grouping.test_result",
     "tests.sentry.issues.test_utils",

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -4,11 +4,11 @@ import functools
 import itertools
 import logging
 from collections import defaultdict
-from collections.abc import Mapping, MutableMapping, MutableSequence, Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
 from typing import Any, TypeAlias
 
 from sentry import tsdb
-from sentry.digests.types import Notification, Record
+from sentry.digests.types import Notification, Record, RecordWithRuleObjects
 from sentry.eventstore.models import Event
 from sentry.models.group import Group, GroupStatus
 from sentry.models.project import Project
@@ -19,7 +19,7 @@ from sentry.utils.pipeline import Pipeline
 
 logger = logging.getLogger("sentry.digests")
 
-Digest: TypeAlias = MutableMapping["Rule", MutableMapping["Group", list[Record]]]
+Digest: TypeAlias = dict["Rule", dict["Group", list[RecordWithRuleObjects]]]
 
 
 def split_key(
@@ -136,31 +136,25 @@ def rewrite_record(
     project: Project,
     groups: Mapping[int, Group],
     rules: Mapping[str, Rule],
-) -> Record | None:
+) -> RecordWithRuleObjects | None:
     event = record.value.event
 
     # Reattach the group to the event.
-    group = groups.get(event.group_id)
+    if event.group_id is None:
+        group = None
+    else:
+        group = groups.get(event.group_id)
     if group is not None:
         event.group = group
     else:
         logger.debug("%s could not be associated with a group.", record)
         return None
 
-    return Record(
-        record.key,
-        Notification(
-            event,
-            [_f for _f in [rules.get(id) for id in record.value.rules] if _f],
-            record.value.notification_uuid,
-        ),
-        record.timestamp,
-    )
+    rules = [_f for _f in [rules.get(id) for id in record.value.rules] if _f]
+    return record.with_rules(rules)
 
 
-def group_records(
-    groups: MutableMapping[str, Mapping[str, MutableSequence[Record]]], record: Record
-) -> MutableMapping[str, Mapping[str, MutableSequence[Record]]]:
+def group_records(groups: Digest, record: RecordWithRuleObjects) -> Digest:
     group = record.value.event.group
     rules = record.value.rules
     if not rules:
@@ -172,9 +166,7 @@ def group_records(
     return groups
 
 
-def sort_group_contents(
-    rules: MutableMapping[str, Mapping[Group, Sequence[Record]]]
-) -> Mapping[str, Mapping[Group, Sequence[Record]]]:
+def sort_group_contents(rules: Digest) -> Digest:
     for key, groups in rules.items():
         rules[key] = dict(
             sorted(
@@ -187,7 +179,7 @@ def sort_group_contents(
     return rules
 
 
-def sort_rule_groups(rules: Mapping[str, Rule]) -> Mapping[str, Rule]:
+def sort_rule_groups(rules: Digest) -> Digest:
     return dict(
         sorted(
             rules.items(),

--- a/src/sentry/digests/types.py
+++ b/src/sentry/digests/types.py
@@ -1,19 +1,55 @@
 from __future__ import annotations
 
 import datetime as datetime_mod
-from collections import namedtuple
-from typing import Any, NamedTuple
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, NamedTuple
 
 from sentry.utils.dates import to_datetime
 
-Notification = namedtuple(
-    "Notification", "event rules notification_uuid", defaults=(None, None, None)
-)
+if TYPE_CHECKING:
+    from sentry.eventstore.models import Event
+    from sentry.models.rule import Rule
+
+
+class Notification(NamedTuple):
+    event: Event
+    rules: Sequence[int] = ()
+    notification_uuid: str | None = None
+
+    def with_rules(self, rules: list[Rule]) -> NotificationWithRuleObjects:
+        return NotificationWithRuleObjects(
+            event=self.event,
+            rules=rules,
+            notification_uuid=self.notification_uuid,
+        )
 
 
 class Record(NamedTuple):
     key: str
-    value: Any  # TODO: I think this is `Notification` ?
+    value: Notification
+    timestamp: float
+
+    @property
+    def datetime(self) -> datetime_mod.datetime:
+        return to_datetime(self.timestamp)
+
+    def with_rules(self, rules: list[Rule]) -> RecordWithRuleObjects:
+        return RecordWithRuleObjects(
+            key=self.key,
+            value=self.value.with_rules(rules),
+            timestamp=self.timestamp,
+        )
+
+
+class NotificationWithRuleObjects(NamedTuple):
+    event: Event
+    rules: list[Rule]
+    notification_uuid: str | None
+
+
+class RecordWithRuleObjects(NamedTuple):
+    key: str
+    value: NotificationWithRuleObjects
     timestamp: float
 
     @property

--- a/tests/sentry/digests/test_notifications.py
+++ b/tests/sentry/digests/test_notifications.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import uuid
 from collections import defaultdict
-from collections.abc import Mapping, MutableMapping, MutableSequence
 from functools import cached_property, reduce
 
 from sentry.digests.notifications import (
+    Digest,
     event_to_record,
     group_records,
     rewrite_record,
@@ -14,7 +14,7 @@ from sentry.digests.notifications import (
     split_key,
     unsplit_key,
 )
-from sentry.digests.types import Notification, Record
+from sentry.digests.types import NotificationWithRuleObjects, RecordWithRuleObjects
 from sentry.models.rule import Rule
 from sentry.notifications.types import ActionTargetType, FallthroughChoiceType
 from sentry.testutils.cases import TestCase
@@ -41,11 +41,7 @@ class RewriteRecordTestCase(TestCase):
             project=self.event.project,
             groups={self.event.group.id: self.event.group},
             rules={self.rule.id: self.rule},
-        ) == Record(
-            self.record.key,
-            Notification(self.record.value.event, [self.rule], self.notification_uuid),
-            self.record.timestamp,
-        )
+        ) == self.record.with_rules([self.rule])
 
     def test_without_group(self):
         # If the record can't be associated with a group, it should be returned as None.
@@ -62,11 +58,7 @@ class RewriteRecordTestCase(TestCase):
             project=self.event.project,
             groups={self.event.group.id: self.event.group},
             rules={},
-        ) == Record(
-            self.record.key,
-            Notification(self.record.value.event, [], self.notification_uuid),
-            self.record.timestamp,
-        )
+        ) == self.record.with_rules([])
 
 
 class GroupRecordsTestCase(TestCase):
@@ -84,16 +76,14 @@ class GroupRecordsTestCase(TestCase):
         ]
         group = events[0].group
         records = [
-            Record(
+            RecordWithRuleObjects(
                 event.event_id,
-                Notification(event, [self.rule], self.notification_uuid),
-                event.datetime,
+                NotificationWithRuleObjects(event, [self.rule], self.notification_uuid),
+                event.datetime.timestamp(),
             )
             for event in events
         ]
-        results: MutableMapping[str, Mapping[str, MutableSequence[Record]]] = defaultdict(
-            lambda: defaultdict(list)
-        )
+        results: Digest = defaultdict(lambda: defaultdict(list))
         assert reduce(group_records, records, results) == {self.rule: {group: records}}
 
 
@@ -123,7 +113,7 @@ class SortRecordsTestCase(TestCase):
         groups[2].event_count = 5
         groups[2].user_count = 1
 
-        grouped = {rules[0]: {groups[0]: []}, rules[1]: {groups[1]: [], groups[2]: []}}
+        grouped: Digest = {rules[0]: {groups[0]: []}, rules[1]: {groups[1]: [], groups[2]: []}}
 
         ret = sort_rule_groups(sort_group_contents(grouped))
 


### PR DESCRIPTION
this requires a separate type for a bound rule since the digests.notifications code was stuffing rule objects into rules (which for Record is rule ids)

split out from my branch which fixes `digests.notifications` types

<!-- Describe your PR here. -->