### PR TITLE
fix(seer grouping): Handle Seer returning grouphash with no group

### DIFF
--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -218,7 +218,7 @@ def get_similarity_data_from_seer(
             delete_seer_grouping_records_by_hash.delay(project_id, [parent_hash])
 
             # As with the `IncompleteSeerDataError` above, this will mark the entire request as
-            # errored even if it's only one group that we can't find. The extent to which that's
+            # errored even if it's only one grouphash that we can't find. The extent to which that's
             # inaccurate will be quite small, though, as the vast majority of calls to this function
             # come from ingest (where we're only requesting one matching group, making "one's
             # missing" the same thing as "they're all missing"). We should also almost never land
@@ -226,7 +226,7 @@ def get_similarity_data_from_seer(
             # triggered a request to Seer to delete the corresponding hashes.
             metric_tags.update({"outcome": "error", "error": "SimilarHashNotFoundError"})
             logger.warning(
-                "get_similarity_data_from_seer.parent_group_not_found",
+                "get_similarity_data_from_seer.parent_hash_not_found",
                 extra={
                     "hash": request_hash,
                     "parent_hash": parent_hash,

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -15,7 +15,7 @@ from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.seer.similarity.types import (
     IncompleteSeerDataError,
     SeerSimilarIssueData,
-    SimilarGroupNotFoundError,
+    SimilarHashNotFoundError,
     SimilarIssuesEmbeddingsRequest,
 )
 from sentry.tasks.delete_seer_grouping_records import delete_seer_grouping_records_by_hash
@@ -210,7 +210,7 @@ def get_similarity_data_from_seer(
                     "raw_similar_issue_data": raw_similar_issue_data,
                 },
             )
-        except SimilarGroupNotFoundError:
+        except SimilarHashNotFoundError:
             parent_hash = raw_similar_issue_data.get("parent_hash")
 
             # Tell Seer to delete the hash from its database, so it doesn't keep suggesting a group
@@ -224,7 +224,7 @@ def get_similarity_data_from_seer(
             # missing" the same thing as "they're all missing"). We should also almost never land
             # here in any case, since deleting the group on the Sentry side should already have
             # triggered a request to Seer to delete the corresponding hashes.
-            metric_tags.update({"outcome": "error", "error": "SimilarGroupNotFoundError"})
+            metric_tags.update({"outcome": "error", "error": "SimilarHashNotFoundError"})
             logger.warning(
                 "get_similarity_data_from_seer.parent_group_not_found",
                 extra={

--- a/src/sentry/seer/similarity/types.py
+++ b/src/sentry/seer/similarity/types.py
@@ -13,7 +13,7 @@ class IncompleteSeerDataError(Exception):
     pass
 
 
-class SimilarGroupNotFoundError(Exception):
+class SimilarHashNotFoundError(Exception):
     pass
 
 
@@ -70,7 +70,7 @@ class SeerSimilarIssueData:
         similar issue in the Seer response.
 
         Throws an `IncompleteSeerDataError` if given data with any required keys missing, and a
-        `SimilarGroupNotFoundError` if the data points to a group which no longer exists. The latter
+        `SimilarHashNotFoundError` if the data points to a group which no longer exists. The latter
         guarantees that if this successfully returns, the parent group id in the return value points
         to an existing group.
 
@@ -99,7 +99,7 @@ class SeerSimilarIssueData:
 
         if not parent_grouphash:
             # TODO: Report back to seer that the hash has been deleted.
-            raise SimilarGroupNotFoundError("Similar group suggested by Seer does not exist")
+            raise SimilarHashNotFoundError("Similar group suggested by Seer does not exist")
 
         # TODO: The `Any` casting here isn't great, but Python currently has no way to
         # relate typeddict keys to dataclass properties

--- a/src/sentry/seer/similarity/types.py
+++ b/src/sentry/seer/similarity/types.py
@@ -105,6 +105,10 @@ class SeerSimilarIssueData:
             # TODO: Report back to seer that the hash has been deleted.
             raise SimilarHashNotFoundError("Similar hash suggested by Seer does not exist")
 
+        if not parent_grouphash.group_id:
+            # TODO: Report back to seer that the hash has been deleted.
+            raise SimilarHashMissingGroupError("Similar hash suggested by Seer missing group id")
+
         # TODO: The `Any` casting here isn't great, but Python currently has no way to
         # relate typeddict keys to dataclass properties
         similar_issue_data: Any = {

--- a/src/sentry/seer/similarity/types.py
+++ b/src/sentry/seer/similarity/types.py
@@ -42,7 +42,7 @@ class SimilarIssuesEmbeddingsResponse(TypedDict):
     responses: list[RawSeerSimilarIssueData]
 
 
-# Like the data that comes back from seer, but guaranteed to have a parent group id
+# Like the data that comes back from seer, but guaranteed to have an existing parent hash
 @dataclass
 class SeerSimilarIssueData:
     stacktrace_distance: float
@@ -69,11 +69,11 @@ class SeerSimilarIssueData:
         using the parent hash to look up the parent group id. Needs to be run individually on each
         similar issue in the Seer response.
 
-        Throws an `IncompleteSeerDataError` if given data with any required keys missing, and a
-        `SimilarHashNotFoundError` if the data points to a group which no longer exists. The latter
-        guarantees that if this successfully returns, the parent group id in the return value points
-        to an existing group.
-
+        Throws an `IncompleteSeerDataError` if given data with any required keys missing, a
+        `SimilarHashNotFoundError` if the data points to a grouphash which no longer exists, and a
+        `SimilarHashMissingGroupError` if the the data points to a grouphash not assigned to a
+        group. The latter two guarantee that if this successfully returns, the parent group id in the
+        return value points to an existing group.
         """
 
         # Filter out any data we're not expecting, and then make sure what's left isn't missing anything
@@ -99,7 +99,7 @@ class SeerSimilarIssueData:
 
         if not parent_grouphash:
             # TODO: Report back to seer that the hash has been deleted.
-            raise SimilarHashNotFoundError("Similar group suggested by Seer does not exist")
+            raise SimilarHashNotFoundError("Similar hash suggested by Seer does not exist")
 
         # TODO: The `Any` casting here isn't great, but Python currently has no way to
         # relate typeddict keys to dataclass properties

--- a/src/sentry/seer/similarity/types.py
+++ b/src/sentry/seer/similarity/types.py
@@ -17,6 +17,10 @@ class SimilarHashNotFoundError(Exception):
     pass
 
 
+class SimilarHashMissingGroupError(Exception):
+    pass
+
+
 class SimilarIssuesEmbeddingsRequest(TypedDict):
     project_id: int
     stacktrace: str

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -28,7 +28,7 @@ from sentry.seer.similarity.grouping_records import (
 from sentry.seer.similarity.types import (
     IncompleteSeerDataError,
     SeerSimilarIssueData,
-    SimilarGroupNotFoundError,
+    SimilarHashNotFoundError,
 )
 from sentry.seer.similarity.utils import (
     event_content_has_stacktrace,
@@ -496,7 +496,7 @@ def update_groups(project, seer_response, group_id_batch_filtered, group_hashes_
                 ]
             # TODO: if we reach this exception, we need to delete the record from seer or this will always happen
             # we should not update the similarity data for this group cause we'd want to try again once we delete it
-            except (IncompleteSeerDataError, SimilarGroupNotFoundError):
+            except (IncompleteSeerDataError, SimilarHashNotFoundError):
                 logger.exception(
                     "tasks.backfill_seer_grouping_records.invalid_parent_group",
                     extra={

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -28,6 +28,7 @@ from sentry.seer.similarity.grouping_records import (
 from sentry.seer.similarity.types import (
     IncompleteSeerDataError,
     SeerSimilarIssueData,
+    SimilarHashMissingGroupError,
     SimilarHashNotFoundError,
 )
 from sentry.seer.similarity.utils import (
@@ -328,9 +329,9 @@ def get_events_from_nodestore(
                     group_id=group_id,
                     project_id=project.id,
                     message=filter_null_from_string(event.title),
-                    exception_type=filter_null_from_string(exception_type)
-                    if exception_type
-                    else None,
+                    exception_type=(
+                        filter_null_from_string(exception_type) if exception_type else None
+                    ),
                     hash=primary_hash,
                 )
             )
@@ -494,9 +495,13 @@ def update_groups(project, seer_response, group_id_batch_filtered, group_hashes_
                         )
                     )
                 ]
-            # TODO: if we reach this exception, we need to delete the record from seer or this will always happen
+            # TODO: if we get a `SimilarHashNotFoundError`, we need to delete the record from seer or this will always happen
             # we should not update the similarity data for this group cause we'd want to try again once we delete it
-            except (IncompleteSeerDataError, SimilarHashNotFoundError):
+            except (
+                IncompleteSeerDataError,
+                SimilarHashNotFoundError,
+                SimilarHashMissingGroupError,
+            ):
                 logger.exception(
                     "tasks.backfill_seer_grouping_records.invalid_parent_group",
                     extra={

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -373,7 +373,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
     @mock.patch("sentry.seer.similarity.similar_issues.metrics.incr")
     @mock.patch("sentry.seer.similarity.similar_issues.logger")
     @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool.urlopen")
-    def test_nonexistent_group(
+    def test_nonexistent_grouphash(
         self,
         mock_seer_similarity_request,
         mock_logger,
@@ -381,8 +381,8 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         mock_seer_deletion_request,
     ):
         """
-        The seer API can return groups that do not exist if they have been deleted/merged.
-        Test that these groups are not returned.
+        The seer API can return grouphashes that do not exist if their groups have been deleted/merged.
+        Test info about these groups is not returned.
         """
         seer_return_value: SimilarIssuesEmbeddingsResponse = {
             # Two suggested groups, one with valid data, one pointing to a group that doesn't exist.
@@ -421,7 +421,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             [NonNone(self.similar_event.group_id)], [0.95], [0.99], ["Yes"]
         )
         mock_logger.warning.assert_called_with(
-            "get_similarity_data_from_seer.parent_group_not_found",
+            "get_similarity_data_from_seer.parent_hash_not_found",
             extra={
                 "hash": NonNone(self.event.get_primary_hash()),
                 "parent_hash": "not a real hash",

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -413,7 +413,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             tags={
                 "response_status": 200,
                 "outcome": "error",
-                "error": "SimilarGroupNotFoundError",
+                "error": "SimilarHashNotFoundError",
                 "referrer": "similar_issues",
             },
         )

--- a/tests/sentry/seer/similarity/test_similar_issues.py
+++ b/tests/sentry/seer/similarity/test_similar_issues.py
@@ -132,7 +132,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
                         }
                     ]
                 },
-                "SimilarGroupNotFoundError",
+                "SimilarHashNotFoundError",
             ),
         ]
 

--- a/tests/sentry/seer/similarity/test_similar_issues.py
+++ b/tests/sentry/seer/similarity/test_similar_issues.py
@@ -7,6 +7,7 @@ from urllib3.response import HTTPResponse
 
 from sentry import options
 from sentry.conf.server import SEER_SIMILAR_ISSUES_URL
+from sentry.models.grouphash import GroupHash
 from sentry.seer.similarity.similar_issues import (
     get_similarity_data_from_seer,
     seer_grouping_connection_pool,
@@ -105,6 +106,9 @@ class GetSimilarityDataFromSeerTest(TestCase):
         mock_metrics_incr: MagicMock,
         mock_record_circuit_breaker_error: MagicMock,
     ):
+        existing_grouphash = GroupHash.objects.create(hash="dogs are great", project=self.project)
+        assert existing_grouphash.group_id is None
+
         cases: list[tuple[Any, str]] = [
             (None, "AttributeError"),
             ([], "AttributeError"),
@@ -126,6 +130,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
                     "responses": [
                         {
                             "message_distance": 0.05,
+                            # hash value doesn't match the `GroupHash` created above
                             "parent_hash": "04152013090820131121201212312012",
                             "should_group": True,
                             "stacktrace_distance": 0.01,
@@ -133,6 +138,21 @@ class GetSimilarityDataFromSeerTest(TestCase):
                     ]
                 },
                 "SimilarHashNotFoundError",
+            ),
+            (
+                {
+                    "responses": [
+                        {
+                            "message_distance": 0.05,
+                            # hash value matches the `GroupHash` created above, but that `GroupHash`
+                            # has no associated group
+                            "parent_hash": "dogs are great",
+                            "should_group": True,
+                            "stacktrace_distance": 0.01,
+                        }
+                    ]
+                },
+                "SimilarHashMissingGroupError",
             ),
         ]
 

--- a/tests/sentry/seer/similarity/test_types.py
+++ b/tests/sentry/seer/similarity/test_types.py
@@ -101,7 +101,7 @@ class SeerSimilarIssueDataTest(TestCase):
 
             SeerSimilarIssueData.from_raw(self.project.id, raw_similar_issue_data)
 
-    def test_from_raw_nonexistent_group(self):
+    def test_from_raw_nonexistent_grouphash(self):
         with pytest.raises(SimilarHashNotFoundError):
             raw_similar_issue_data = {
                 "parent_hash": "not a real hash",

--- a/tests/sentry/seer/similarity/test_types.py
+++ b/tests/sentry/seer/similarity/test_types.py
@@ -2,10 +2,12 @@ from typing import Any
 
 import pytest
 
+from sentry.models.grouphash import GroupHash
 from sentry.seer.similarity.types import (
     IncompleteSeerDataError,
     RawSeerSimilarIssueData,
     SeerSimilarIssueData,
+    SimilarHashMissingGroupError,
     SimilarHashNotFoundError,
 )
 from sentry.testutils.cases import TestCase
@@ -105,6 +107,20 @@ class SeerSimilarIssueDataTest(TestCase):
         with pytest.raises(SimilarHashNotFoundError):
             raw_similar_issue_data = {
                 "parent_hash": "not a real hash",
+                "message_distance": 0.05,
+                "should_group": True,
+                "stacktrace_distance": 0.01,
+            }
+
+            SeerSimilarIssueData.from_raw(self.project.id, raw_similar_issue_data)
+
+    def test_from_raw_grouphash_with_no_group(self):
+        existing_grouphash = GroupHash.objects.create(hash="dogs are great", project=self.project)
+        assert existing_grouphash.group_id is None
+
+        with pytest.raises(SimilarHashMissingGroupError):
+            raw_similar_issue_data = {
+                "parent_hash": "dogs are great",
                 "message_distance": 0.05,
                 "should_group": True,
                 "stacktrace_distance": 0.01,

--- a/tests/sentry/seer/similarity/test_types.py
+++ b/tests/sentry/seer/similarity/test_types.py
@@ -6,7 +6,7 @@ from sentry.seer.similarity.types import (
     IncompleteSeerDataError,
     RawSeerSimilarIssueData,
     SeerSimilarIssueData,
-    SimilarGroupNotFoundError,
+    SimilarHashNotFoundError,
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.eventprocessing import save_new_event
@@ -102,7 +102,7 @@ class SeerSimilarIssueDataTest(TestCase):
             SeerSimilarIssueData.from_raw(self.project.id, raw_similar_issue_data)
 
     def test_from_raw_nonexistent_group(self):
-        with pytest.raises(SimilarGroupNotFoundError):
+        with pytest.raises(SimilarHashNotFoundError):
             raw_similar_issue_data = {
                 "parent_hash": "not a real hash",
                 "message_distance": 0.05,


### PR DESCRIPTION
We have lately run into [an issue](https://github.com/getsentry/sentry/issues/75860) where Seer is recommending hashes with no group attached to them, which has highlighted a) the fact that this is even a possibility, and b) the fact that though we've been talking about Seer sometimes recommending non-existent _groups_, in fact all we check for is the existence of the grouphash. (The assumption there being that all grouphashes point to a group. If everything else is working correctly that should be true, but clearly stuff happens.)

This PR therefore makes two changes:

- Change the `SimilarGroupNotFoundError` to be a `SimilarHashNotFoundError`, to more accurately reflect the situation when it arises.

- Add a new `SimilarHashMissingGroupError` to denote the case described above, so that we can track it rather than silently swallowing the problem.