### PR TITLE
feat(uptime): Implement delete endpoint for uptime monitors

### DIFF
--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -27,7 +27,7 @@ from sentry.uptime.models import (
 )
 from sentry.uptime.subscriptions.subscriptions import (
     create_uptime_subscription,
-    delete_project_uptime_subscription,
+    delete_uptime_subscriptions_for_project,
     remove_uptime_subscription_if_unused,
 )
 from sentry.utils import metrics
@@ -150,7 +150,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
             failure_count = pipeline.execute()[0]
             if failure_count >= ONBOARDING_FAILURE_THRESHOLD:
                 # If we've hit too many failures during the onboarding period we stop monitoring
-                delete_project_uptime_subscription(
+                delete_uptime_subscriptions_for_project(
                     project_subscription.project,
                     project_subscription.uptime_subscription,
                     modes=[ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING],

--- a/src/sentry/uptime/detectors/tasks.py
+++ b/src/sentry/uptime/detectors/tasks.py
@@ -26,7 +26,7 @@ from sentry.uptime.models import ProjectUptimeSubscriptionMode
 from sentry.uptime.subscriptions.subscriptions import (
     create_project_uptime_subscription,
     create_uptime_subscription,
-    delete_project_uptime_subscription,
+    delete_uptime_subscriptions_for_project,
     get_auto_monitored_subscriptions_for_project,
     is_url_auto_monitored_for_project,
 )
@@ -234,7 +234,7 @@ def monitor_url_for_project(project: Project, url: str):
     it. Also deletes any other auto-detected monitors since this one should replace them.
     """
     for monitored_subscription in get_auto_monitored_subscriptions_for_project(project):
-        delete_project_uptime_subscription(
+        delete_uptime_subscriptions_for_project(
             project,
             monitored_subscription.uptime_subscription,
             modes=[

--- a/src/sentry/uptime/endpoints/project_uptime_alert_details.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_details.py
@@ -125,8 +125,8 @@ class ProjectUptimeAlertDetailsEndpoint(ProjectUptimeAlertEndpoint):
         audit_log_data = uptime_subscription.get_audit_log_data()
         delete_project_uptime_subscription(uptime_subscription)
         create_audit_entry(
-            request=self.context["request"],
-            organization=self.context["organization"],
+            request=request,
+            organization=project.organization,
             target_object=uptime_subscription_id,
             event=audit_log.get_event_id("UPTIME_MONITOR_REMOVE"),
             data=audit_log_data,

--- a/src/sentry/uptime/endpoints/project_uptime_alert_details.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_details.py
@@ -2,6 +2,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import audit_log
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -23,6 +24,7 @@ from sentry.uptime.endpoints.serializers import (
 from sentry.uptime.endpoints.validators import UptimeMonitorValidator
 from sentry.uptime.models import ProjectUptimeSubscription, UptimeSubscription
 from sentry.uptime.subscriptions.subscriptions import delete_project_uptime_subscription
+from sentry.utils.audit import create_audit_entry
 
 
 @region_silo_endpoint
@@ -33,6 +35,7 @@ class ProjectUptimeAlertDetailsEndpoint(ProjectUptimeAlertEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
         "PUT": ApiPublishStatus.EXPERIMENTAL,
+        "DELETE": ApiPublishStatus.EXPERIMENTAL,
     }
 
     @extend_schema(
@@ -99,13 +102,12 @@ class ProjectUptimeAlertDetailsEndpoint(ProjectUptimeAlertEndpoint):
         return self.respond(serialize(validator.save(), request.user))
 
     @extend_schema(
-        operation_id="Update an Uptime Monitor for a Project",
+        operation_id="Delete an Uptime Monitor for a Project",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             UptimeParams.UPTIME_ALERT_ID,
         ],
-        request=UptimeMonitorValidator,
         responses={
             202: RESPONSE_ACCEPTED,
             401: RESPONSE_UNAUTHORIZED,
@@ -119,5 +121,15 @@ class ProjectUptimeAlertDetailsEndpoint(ProjectUptimeAlertEndpoint):
         """
         Delete an uptime monitor.
         """
+        uptime_subscription_id = uptime_subscription.id
+        audit_log_data = uptime_subscription.get_audit_log_data()
         delete_project_uptime_subscription(uptime_subscription)
+        create_audit_entry(
+            request=self.context["request"],
+            organization=self.context["organization"],
+            target_object=uptime_subscription_id,
+            event=audit_log.get_event_id("UPTIME_MONITOR_REMOVE"),
+            data=audit_log_data,
+        )
+
         return self.respond(status=202)

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -82,7 +82,7 @@ def create_project_uptime_subscription(
     )[0]
 
 
-def delete_project_uptime_subscription(
+def delete_uptime_subscriptions_for_project(
     project: Project,
     uptime_subscription: UptimeSubscription,
     modes: list[ProjectUptimeSubscriptionMode],
@@ -98,6 +98,12 @@ def delete_project_uptime_subscription(
     ):
         uptime_project_subscription.delete()
 
+    remove_uptime_subscription_if_unused(uptime_subscription)
+
+
+def delete_project_uptime_subscription(subscription: ProjectUptimeSubscription):
+    uptime_subscription = subscription.uptime_subscription
+    subscription.delete()
     remove_uptime_subscription_if_unused(uptime_subscription)
 
 


### PR DESCRIPTION
This implements an api for deleting uptime monitors. Also renames `delete_project_uptime_subscription` since it wasn't well named