### PR TITLE
feat(uptime): Disable detection for the entire org once we've autodetected a single url

### DIFF
--- a/src/sentry/uptime/detectors/tasks.py
+++ b/src/sentry/uptime/detectors/tasks.py
@@ -221,8 +221,9 @@ def process_candidate_url(
     if features.has("organizations:uptime-automatic-subscription-creation", project.organization):
         # If we hit this point, then the url looks worth monitoring. Create an uptime subscription in monitor mode.
         monitor_url_for_project(project, url)
-        # Disable auto-detection on this project now that we've successfully found a hostname
+        # Disable auto-detection on this project and organization now that we've successfully found a hostname
         project.update_option("sentry:uptime_autodetection", False)
+        project.organization.update_option("sentry:uptime_autodetection", False)
 
     metrics.incr("uptime.detectors.candidate_url.succeeded", sample_rate=1.0)
     return True

--- a/tests/sentry/uptime/detectors/test_tasks.py
+++ b/tests/sentry/uptime/detectors/test_tasks.py
@@ -217,6 +217,7 @@ class ProcessCandidateUrlTest(TestCase):
         assert process_candidate_url(self.project, 100, url, 50)
         assert is_url_auto_monitored_for_project(self.project, url)
         assert self.project.get_option("sentry:uptime_autodetection") is False
+        assert self.organization.get_option("sentry:uptime_autodetection") is False
 
     def test_succeeds_new_no_feature(self):
         with mock.patch(
@@ -225,6 +226,7 @@ class ProcessCandidateUrlTest(TestCase):
             assert process_candidate_url(self.project, 100, "https://sentry.io", 50)
             mock_monitor_url_for_project.assert_not_called()
             assert self.project.get_option("sentry:uptime_autodetection") is None
+            assert self.organization.get_option("sentry:uptime_autodetection") is None
 
     @with_feature("organizations:uptime-automatic-subscription-creation")
     def test_succeeds_existing_subscription_other_project(self):
@@ -240,6 +242,7 @@ class ProcessCandidateUrlTest(TestCase):
         assert process_candidate_url(self.project, 100, url, 50)
         assert is_url_auto_monitored_for_project(self.project, url)
         assert self.project.get_option("sentry:uptime_autodetection") is False
+        assert self.organization.get_option("sentry:uptime_autodetection") is False
 
     @with_feature("organizations:uptime-automatic-subscription-creation")
     def test_succeeds_existing_subscription_this_project(self):
@@ -250,6 +253,7 @@ class ProcessCandidateUrlTest(TestCase):
         new_subscription = get_auto_monitored_subscriptions_for_project(self.project)[0]
         assert subscription.id == new_subscription.id
         assert self.project.get_option("sentry:uptime_autodetection") is False
+        assert self.organization.get_option("sentry:uptime_autodetection") is False
 
     def test_below_thresholds(self):
         assert not process_candidate_url(self.project, 500, "https://sentry.io", 1)


### PR DESCRIPTION
We want to disable autodetection for the whole org once we've detected one url.
