### PR TITLE
ref(uptime): Always empty uptime alert pages

### DIFF
--- a/static/app/views/alerts/index.tsx
+++ b/static/app/views/alerts/index.tsx
@@ -10,7 +10,9 @@ type Props = {
 function AlertsContainer({children}: Props) {
   const organization = useOrganization();
   const hasMetricAlerts = organization.features.includes('incidents');
-  const hasUptimeAlerts = organization.features.includes('uptime-rule-api');
+
+  // Uptime alerts are not behind a feature flag at the moment
+  const hasUptimeAlerts = true;
 
   const content =
     children && isValidElement(children)


### PR DESCRIPTION
This does not actually expose anything related to uptime rules yet,
since in order to do anything with up time right now a rule will have to
have been generated. So for now just set it to constant true.