### PR TITLE
ref(similarity): Add postgres query retry with decreased batch size

### DIFF
--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -3,6 +3,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict
 from datetime import UTC, datetime, timedelta
+from sqlite3 import OperationalError
 from typing import Any, TypedDict
 
 import sentry_sdk
@@ -118,6 +119,46 @@ def initialize_backfill(
     return project, last_processed_group_id, last_processed_project_index_ret
 
 
+def _make_postgres_call(group_id_filter: Q, project_id: int, batch_size: int):
+    groups_to_backfill_batch_raw = (
+        Group.objects.filter(
+            group_id_filter,
+            project_id=project_id,
+            type=ErrorGroupType.type_id,
+            times_seen__gt=1,
+        )
+        .values_list("id", "data", "status", "last_seen")
+        .order_by("-id")[:batch_size]
+    )
+    return groups_to_backfill_batch_raw
+
+
+def _make_postgres_call_with_retry(group_id_filter: Q, project_id: int, batch_size: int):
+    """
+    Try making postgres query. If it has an operational error, retry with a decreased batch size.
+    """
+    try:
+        groups_to_backfill_batch_raw = _make_postgres_call(group_id_filter, project_id, batch_size)
+    except OperationalError:
+        batch_size = batch_size // 2
+        try:
+            logger.info(
+                "tasks.backfill_seer_grouping_records.postgres_query_retry",
+                extra={"project_id": project_id, "batch_size": batch_size},
+            )
+            groups_to_backfill_batch_raw = _make_postgres_call(
+                group_id_filter, project_id, batch_size
+            )
+        except OperationalError:
+            logger.exception(
+                "tasks.backfill_seer_grouping_records.postgres_query_operational_error",
+                extra={"project_id": project_id, "batch_size": batch_size},
+            )
+            raise
+
+    return (groups_to_backfill_batch_raw, batch_size)
+
+
 @sentry_sdk.tracing.trace
 def get_current_batch_groups_from_postgres(
     project, last_processed_group_id, batch_size, enable_ingestion: bool = False
@@ -126,16 +167,10 @@ def get_current_batch_groups_from_postgres(
     if last_processed_group_id is not None:
         group_id_filter = Q(id__lt=last_processed_group_id)
 
-    groups_to_backfill_batch_raw = (
-        Group.objects.filter(
-            group_id_filter,
-            project_id=project.id,
-            type=ErrorGroupType.type_id,
-            times_seen__gt=1,
-        )
-        .values_list("id", "data", "status", "last_seen")
-        .order_by("-id")[:batch_size]
+    (groups_to_backfill_batch_raw, batch_size) = _make_postgres_call_with_retry(
+        group_id_filter, project.id, batch_size
     )
+
     total_groups_to_backfill_length = len(groups_to_backfill_batch_raw)
     batch_end_group_id = (
         groups_to_backfill_batch_raw[total_groups_to_backfill_length - 1][0]

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -3,11 +3,11 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict
 from datetime import UTC, datetime, timedelta
-from sqlite3 import OperationalError
 from typing import Any, TypedDict
 
 import sentry_sdk
 from django.db.models import Q
+from django.db.utils import OperationalError
 from google.api_core.exceptions import DeadlineExceeded, ServiceUnavailable
 from snuba_sdk import Column, Condition, Entity, Limit, Op, Query, Request
 

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -3,6 +3,7 @@ import time
 from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
 from random import choice
+from sqlite3 import OperationalError
 from string import ascii_uppercase
 from typing import Any
 from unittest.mock import ANY, call, patch
@@ -1724,3 +1725,26 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
             call("backfill finished, no cohort", extra={"project_id": self.project.id}),
         ]
         assert mock_logger.info.call_args_list == expected_call_args_list
+
+    @with_feature("projects:similarity-embeddings-backfill")
+    @patch("sentry.tasks.embeddings_grouping.utils.logger")
+    @patch("sentry.tasks.embeddings_grouping.utils._make_postgres_call")
+    def test_backfill_seer_grouping_records_postgres_exception(
+        self, mock_make_postgres_call, mock_logger
+    ):
+        """
+        Test log after postgres query retries with decreased batch size
+        """
+        mock_make_postgres_call.side_effect = OperationalError
+        batch_size = options.get("embeddings-grouping.seer.backfill-batch-size")
+        with pytest.raises(Exception), TaskRunner():
+            backfill_seer_grouping_records_for_project(self.project.id, None)
+
+        mock_logger.info.assert_called_with(
+            "tasks.backfill_seer_grouping_records.postgres_query_retry",
+            extra={"project_id": self.project.id, "batch_size": batch_size // 2},
+        )
+        mock_logger.exception.assert_called_with(
+            "tasks.backfill_seer_grouping_records.postgres_query_operational_error",
+            extra={"project_id": self.project.id, "batch_size": batch_size // 2},
+        )

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -3,12 +3,12 @@ import time
 from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
 from random import choice
-from sqlite3 import OperationalError
 from string import ascii_uppercase
 from typing import Any
 from unittest.mock import ANY, call, patch
 
 import pytest
+from django.db.utils import OperationalError
 from django.test import override_settings
 from google.api_core.exceptions import DeadlineExceeded, ServiceUnavailable
 from snuba_sdk import Column, Condition, Entity, Limit, Op, Query, Request

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -1728,14 +1728,15 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
 
     @with_feature("projects:similarity-embeddings-backfill")
     @patch("sentry.tasks.embeddings_grouping.utils.logger")
-    @patch("sentry.tasks.embeddings_grouping.utils._make_postgres_call")
+    @patch(
+        "sentry.tasks.embeddings_grouping.utils._make_postgres_call", side_effect=OperationalError
+    )
     def test_backfill_seer_grouping_records_postgres_exception(
         self, mock_make_postgres_call, mock_logger
     ):
         """
         Test log after postgres query retries with decreased batch size
         """
-        mock_make_postgres_call.side_effect = OperationalError
         batch_size = options.get("embeddings-grouping.seer.backfill-batch-size")
         with pytest.raises(Exception), TaskRunner():
             backfill_seer_grouping_records_for_project(self.project.id, None)


### PR DESCRIPTION
Postgres query in similarity backfill is sometimes timing out
The first time this exception occurs, retry with a smaller batch size
If it occurs again, raise it