### PR TITLE
chore(scm): fill in get_file and check_file for Bitbucket and Azure DevOps

### DIFF
--- a/src/sentry/integrations/bitbucket/client.py
+++ b/src/sentry/integrations/bitbucket/client.py
@@ -178,3 +178,15 @@ class BitbucketApiClient(ApiClient):
                 path=path,
             ),
         )
+
+    def get_file(self, repo: Repository, path: str, version: str, codeowners: bool = False) -> str:
+        contents = self.get(
+            path=BitbucketAPIPath.source.format(
+                repo=repo.name,
+                sha=version,
+                path=path,
+            ),
+            raw_response=True,
+        )
+        result = contents.content.decode("utf-8")
+        return result

--- a/src/sentry/integrations/bitbucket_server/client.py
+++ b/src/sentry/integrations/bitbucket_server/client.py
@@ -30,6 +30,7 @@ class BitbucketServerAPIPath:
     commit_changes = "/rest/api/1.0/projects/{project}/repos/{repo}/commits/{commit}/changes"
 
     source = "/rest/api/1.0/projects/{project}/repos/{repo}/browse/{path}"
+    source_raw = "/rest/api/1.0/projects/{project}/repos/{repo}/browse/{path}?raw"
 
 
 class BitbucketServerSetupClient(ApiClient):
@@ -267,7 +268,7 @@ class BitbucketServerClient(ApiClient):
 
     def get_file(self, repo: Repository, path: str, version: str, codeowners: bool = False) -> str:
         contents = self.get(
-            path=BitbucketServerAPIPath.source.format(
+            path=BitbucketServerAPIPath.source_raw.format(
                 repo=repo.name,
                 project=repo.config["project"],
                 path=path,

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -278,9 +278,9 @@ class VstsApiClient(IntegrationProxyClient, VstsApiMixin):
                         # TODO(dcramer): this is problematic when the link already exists
                         "op": "replace" if f_name != "link" else "add",
                         "path": FIELD_MAP[f_name],
-                        "value": {"rel": "Hyperlink", "url": f_value}
-                        if f_name == "link"
-                        else f_value,
+                        "value": (
+                            {"rel": "Hyperlink", "url": f_value} if f_name == "link" else f_value
+                        ),
                     }
                 )
 
@@ -432,3 +432,20 @@ class VstsApiClient(IntegrationProxyClient, VstsApiMixin):
                 "versionDescriptor.version": version,
             },
         )
+
+    def get_file(self, repo: Repository, path: str, version: str, codeowners: bool = False) -> str:
+        contents = self.get(
+            path=VstsApiPath.items.format(
+                instance=repo.config["instance"],
+                project=quote(repo.config["project"]),
+                repo_id=quote(repo.config["name"]),
+            ),
+            params={
+                "path": path,
+                "api-version": "7.0",
+                "versionDescriptor.version": version,
+            },
+            raw_response=True,
+        )
+        result = contents.content.decode("utf-8")
+        return result


### PR DESCRIPTION
Current state of the SCM APIs implemented related to `RepositoryMixin`:

|  | check_file | get_file |
| --- | --- | --- |
| GitHub | Y | Y |
| GitHub Enterprise | Y | Y |
| Gitlab | Y | Y |
| Bitbucket | Y | N |
| Bitbucket Server | N | N |
| Azure DevOps (VSTS) | Y | N |

To make the abstraction easier we can fill the rest of these in. Besides Bitbucket Server, the `check_file` function is already implemented. The difference between `check_file` and `get_file` is that we just fully read the file (`self.get` with `raw_response=True`), possibly with a slightly different URL, see example implementation in Gitlab:

https://github.com/getsentry/sentry/blob/a0eca661fa254cb6af507d65bee97b1c999dd345/src/sentry/integrations/gitlab/client.py#L310-L327
https://github.com/getsentry/sentry/blob/a0eca661fa254cb6af507d65bee97b1c999dd345/src/sentry/integrations/gitlab/client.py#L329-L344

Notes
- For Bitbucket, the `check_file` URL already returns the raw file ([docs](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-source/#api-repositories-workspace-repo-slug-src-commit-path-get))
- For Bitbucket Server, I referenced [this](https://techieatom.com/how-to-use-bitbucket-server-apis-to-get-file-contents/) to get the file:  -- it seems that you need to add an extra `?raw` parameter to fetch the raw file (and another reference to the `?raw` part [here](https://stackoverflow.com/questions/14063008/get-raw-file-content-using-stash-rest-api)
- For AzureDevOps, it also looks like the original `check_file` URL works for `get_file`. You can add an extra param to download the file but we don't need that ([docs](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/items/get?view=azure-devops-rest-7.1&tabs=HTTP))

This PR is useful for https://github.com/getsentry/sentry/pull/74908