### PR TITLE
feat(data-secrecy): Implement Data Secrecy Backend

### DIFF
--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -211,6 +211,7 @@ class SentryPermission(ScopedPermission):
         if org_context is None:
             assert False, "Failed to fetch organization in determine_access"
 
+        # TODO(iamrajjoshi): Remove this check once we have fully migrated to the new data secrecy logic
         organization = org_context.organization
         if (
             request.user

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -926,7 +926,7 @@ def from_request_org_and_scopes(
             org_member=member,
         )
 
-        superuser_scopes = get_superuser_scopes(auth_state, request.user)
+        superuser_scopes = get_superuser_scopes(auth_state, request.user, rpc_user_org_context)
         if scopes:
             superuser_scopes = superuser_scopes.union(set(scopes))
 
@@ -1030,7 +1030,7 @@ def from_request(
         )
         sso_state = auth_state.sso_state
 
-        superuser_scopes = get_superuser_scopes(auth_state, request.user)
+        superuser_scopes = get_superuser_scopes(auth_state, request.user, organization)
         if scopes:
             superuser_scopes = superuser_scopes.union(set(scopes))
 

--- a/src/sentry/data_secrecy/data_secrecy_logic.py
+++ b/src/sentry/data_secrecy/data_secrecy_logic.py
@@ -25,7 +25,7 @@ def should_allow_superuser_access(
     if not features.has("organizations:data-secrecy", organization):
         return True
 
-    # If organization's prevent_superuser_access bitflag is not set, return True
+    # If organization's prevent_superuser_access bitflag is False, return True
     if not organization.flags.prevent_superuser_access:
         return True
 

--- a/src/sentry/data_secrecy/data_secrecy_logic.py
+++ b/src/sentry/data_secrecy/data_secrecy_logic.py
@@ -1,0 +1,39 @@
+from django.conf import settings
+from django.utils import timezone
+
+from sentry import features
+from sentry.data_secrecy.service.service import data_secrecy_service
+from sentry.models.organization import Organization
+from sentry.organizations.services.organization import RpcOrganization, RpcUserOrganizationContext
+
+
+def should_allow_superuser_access(
+    organization_context: Organization | RpcUserOrganizationContext,
+) -> bool:
+
+    # If self hosted installation, superuser access is allowed
+    if settings.SENTRY_SELF_HOSTED:
+        return True
+
+    organization: Organization | RpcOrganization
+    if isinstance(organization_context, RpcUserOrganizationContext):
+        organization = organization_context.organization
+    else:
+        organization = organization_context
+
+    # If organization does not have data-secrecy feature, return True
+    if not features.has("organizations:data-secrecy", organization):
+        return True
+
+    # If organization's prevent_superuser_access bitflag is not set, return True
+    if not organization.flags.prevent_superuser_access:
+        return True
+
+    ds = data_secrecy_service.get_data_secrecy_waiver(organization_id=organization.id)
+
+    # If no data secrecy waiver exists, data secrecy is active
+    if ds is None:
+        return False
+
+    # If current time is before the access_end time of the waiver, data secrecy is active
+    return timezone.now() <= ds.access_end

--- a/tests/sentry/api/test_data_secrecy.py
+++ b/tests/sentry/api/test_data_secrecy.py
@@ -38,6 +38,7 @@ class SuperuserDataSecrecyTestCase(APITestCase):
 
 
 class DataSecrecyV2TestCase(APITestCase):
+    # Picked an endpoint with OrganizationAndStaffPermission
     endpoint = "sentry-api-0-organization-minimal-projects"
     method = "get"
 

--- a/tests/sentry/api/test_data_secrecy.py
+++ b/tests/sentry/api/test_data_secrecy.py
@@ -1,4 +1,5 @@
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.features import with_feature
 
 
@@ -55,8 +56,10 @@ class DataSecrecyV2TestCase(APITestCase):
         with self.settings(SENTRY_SELF_HOSTED=False):
             self.get_error_response(self.organization.slug, status_code=401)
 
+    @with_feature("organizations:data-secrecy")
     def test_superuser_has_access(self):
         self.organization.flags.prevent_superuser_access = False
+        self.organization.save()
         superuser = self.create_user(is_superuser=True)
         self.login_as(superuser, superuser=True)
 
@@ -70,5 +73,21 @@ class DataSecrecyV2TestCase(APITestCase):
             self.get_error_response(self.organization.slug, status_code=403)
 
     def test_member_has_access(self):
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            self.get_success_response(self.organization.slug)
+
+    @with_feature("organizations:data-secrecy")
+    @override_options({"staff.ga-rollout": True})
+    def admin_access_when_superuser_no_access(self):
+        # When the superuser has no access, the admin should also still work
+        superuser = self.create_user(is_superuser=True)
+        self.login_as(superuser, superuser=True)
+
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            self.get_error_response(self.organization.slug, status_code=401)
+
+        admin = self.create_user(is_staff=True)
+        self.login_as(admin, staff=True)
+
         with self.settings(SENTRY_SELF_HOSTED=False):
             self.get_success_response(self.organization.slug)

--- a/tests/sentry/api/test_data_secrecy.py
+++ b/tests/sentry/api/test_data_secrecy.py
@@ -34,3 +34,41 @@ class SuperuserDataSecrecyTestCase(APITestCase):
 
     def test_member_has_access(self):
         self.get_success_response(self.organization.slug)
+
+
+class DataSecrecyV2TestCase(APITestCase):
+    endpoint = "sentry-api-0-organization-details"
+    method = "get"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+        self.organization.flags.prevent_superuser_access = True
+        self.organization.save()
+
+    @with_feature("organizations:data-secrecy")
+    def test_superuser_no_access(self):
+        superuser = self.create_user(is_superuser=True)
+        self.login_as(superuser, superuser=True)
+
+        # superuser cannot access orgs with data secrecy
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            self.get_error_response(self.organization.slug, status_code=401)
+
+    def test_superuser_has_access(self):
+        self.organization.flags.prevent_superuser_access = False
+        superuser = self.create_user(is_superuser=True)
+        self.login_as(superuser, superuser=True)
+
+        # superuser can access orgs without data secrecy
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            self.get_success_response(self.organization.slug)
+
+    def test_non_member_no_access(self):
+        self.login_as(self.create_user())
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            self.get_error_response(self.organization.slug, status_code=403)
+
+    def test_member_has_access(self):
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            self.get_success_response(self.organization.slug)

--- a/tests/sentry/api/test_data_secrecy.py
+++ b/tests/sentry/api/test_data_secrecy.py
@@ -38,7 +38,7 @@ class SuperuserDataSecrecyTestCase(APITestCase):
 
 
 class DataSecrecyV2TestCase(APITestCase):
-    endpoint = "sentry-api-0-organization-details"
+    endpoint = "sentry-api-0-organization-minimal-projects"
     method = "get"
 
     def setUp(self):
@@ -78,7 +78,7 @@ class DataSecrecyV2TestCase(APITestCase):
 
     @with_feature("organizations:data-secrecy")
     @override_options({"staff.ga-rollout": True})
-    def admin_access_when_superuser_no_access(self):
+    def test_admin_access_when_superuser_no_access(self):
         # When the superuser has no access, the admin should also still work
         superuser = self.create_user(is_superuser=True)
         self.login_as(superuser, superuser=True)

--- a/tests/sentry/auth/test_superuser.py
+++ b/tests/sentry/auth/test_superuser.py
@@ -472,13 +472,29 @@ class SuperuserTestCase(TestCase):
             sso_state=RpcMemberSsoState(), permissions=["superuser.write"]
         )
 
-        assert get_superuser_scopes(auth_state, user) == SUPERUSER_SCOPES
-        assert get_superuser_scopes(auth_state_with_write, user) == SUPERUSER_SCOPES
+        assert (
+            get_superuser_scopes(auth_state, user, organization_context=self.organization)
+            == SUPERUSER_SCOPES
+        )
+        assert (
+            get_superuser_scopes(
+                auth_state_with_write, user, organization_context=self.organization
+            )
+            == SUPERUSER_SCOPES
+        )
 
         # test scope separation
         with self.options({"superuser.read-write.ga-rollout": True}):
-            assert get_superuser_scopes(auth_state, user) == SUPERUSER_READONLY_SCOPES
-            assert get_superuser_scopes(auth_state_with_write, user) == SUPERUSER_SCOPES
+            assert (
+                get_superuser_scopes(auth_state, user, organization_context=self.organization)
+                == SUPERUSER_READONLY_SCOPES
+            )
+            assert (
+                get_superuser_scopes(
+                    auth_state_with_write, user, organization_context=self.organization
+                )
+                == SUPERUSER_SCOPES
+            )
 
     def test_superuser_scopes_self_hosted(self):
         # self hosted always has superuser write scopes
@@ -490,12 +506,28 @@ class SuperuserTestCase(TestCase):
             sso_state=RpcMemberSsoState(), permissions=["superuser.write"]
         )
 
-        assert get_superuser_scopes(auth_state, user) == SUPERUSER_SCOPES
-        assert get_superuser_scopes(auth_state_with_write, user) == SUPERUSER_SCOPES
+        assert (
+            get_superuser_scopes(auth_state, user, organization_context=self.organization)
+            == SUPERUSER_SCOPES
+        )
+        assert (
+            get_superuser_scopes(
+                auth_state_with_write, user, organization_context=self.organization
+            )
+            == SUPERUSER_SCOPES
+        )
 
         with self.feature({"superuser.read-write.ga-rollout": True}):
-            assert get_superuser_scopes(auth_state, user) == SUPERUSER_SCOPES
-            assert get_superuser_scopes(auth_state_with_write, user) == SUPERUSER_SCOPES
+            assert (
+                get_superuser_scopes(auth_state, user, organization_context=self.organization)
+                == SUPERUSER_SCOPES
+            )
+            assert (
+                get_superuser_scopes(
+                    auth_state_with_write, user, organization_context=self.organization
+                )
+                == SUPERUSER_SCOPES
+            )
 
     @override_settings(SENTRY_SELF_HOSTED=False)
     def test_superuser_has_permission(self):

--- a/tests/sentry/data_secrecy/test_data_secrecy_logic.py
+++ b/tests/sentry/data_secrecy/test_data_secrecy_logic.py
@@ -1,0 +1,90 @@
+from datetime import datetime, timezone
+
+from sentry.data_secrecy.data_secrecy_logic import should_allow_superuser_access
+from sentry.data_secrecy.models.datasecrecywaiver import DataSecrecyWaiver
+from sentry.organizations.services.organization import (
+    RpcOrganization,
+    RpcOrganizationMember,
+    RpcUserOrganizationContext,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import with_feature
+from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.silo import (
+    SiloMode,
+    all_silo_test,
+    assume_test_silo_mode,
+    create_test_regions,
+)
+
+
+@all_silo_test(regions=create_test_regions("us"))
+class DataSecrecyTest(TestCase):
+    def setUp(self):
+        self.user = self.create_user()
+        self.organization.flags.prevent_superuser_access = True
+        self.rpc_org = RpcOrganization(id=self.organization.id)
+        self.rpc_org.flags.prevent_superuser_access = True
+
+        self.rpc_orgmember = RpcOrganizationMember(
+            organization_id=self.organization.id,
+            role="admin",
+            user_id=self.user.id,
+        )
+        self.rpc_context = RpcUserOrganizationContext(
+            user_id=self.user.id, organization=self.rpc_org, member=self.rpc_orgmember
+        )
+
+    def test_self_hosted(self):
+        with self.settings(SENTRY_SELF_HOSTED=True):
+            assert should_allow_superuser_access(self.organization) is True
+            assert should_allow_superuser_access(self.rpc_context) is True
+            assert should_allow_superuser_access(self.rpc_org) is True
+
+    def test_feature_flag_disabled(self):
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            assert should_allow_superuser_access(self.organization) is True
+            assert should_allow_superuser_access(self.rpc_context) is True
+            assert should_allow_superuser_access(self.rpc_org) is True
+
+    def test_bit_flag_disabled(self):
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            self.organization.flags.prevent_superuser_access = False
+            assert should_allow_superuser_access(self.organization) is True
+            assert should_allow_superuser_access(self.rpc_context) is True
+            assert should_allow_superuser_access(self.rpc_org) is True
+
+    @with_feature("organizations:data-secrecy")
+    def test_no_waiver_exists(self):
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            assert should_allow_superuser_access(self.organization) is False
+            assert should_allow_superuser_access(self.rpc_context) is False
+            assert should_allow_superuser_access(self.rpc_org) is False
+
+    @freeze_time(datetime(2024, 7, 18, 0, 0, 0, tzinfo=timezone.utc))
+    @with_feature("organizations:data-secrecy")
+    def test_waiver_expired(self):
+        with assume_test_silo_mode(SiloMode.REGION):
+            DataSecrecyWaiver.objects.create(
+                organization=self.organization,
+                access_start=datetime(2024, 7, 17, 0, 0, 0, tzinfo=timezone.utc),
+                access_end=datetime(2024, 7, 17, 23, 59, 59, tzinfo=timezone.utc),
+            )
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            assert should_allow_superuser_access(self.organization) is False
+            assert should_allow_superuser_access(self.rpc_context) is False
+            assert should_allow_superuser_access(self.rpc_org) is False
+
+    @freeze_time(datetime(2024, 7, 18, 0, 0, 0, tzinfo=timezone.utc))
+    @with_feature("organizations:data-secrecy")
+    def test_waiver_active(self):
+        with assume_test_silo_mode(SiloMode.REGION):
+            DataSecrecyWaiver.objects.create(
+                organization=self.organization,
+                access_start=datetime(2024, 7, 18, 0, 0, 0, tzinfo=timezone.utc),
+                access_end=datetime(2024, 7, 19, 0, 0, 0, tzinfo=timezone.utc),
+            )
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            assert should_allow_superuser_access(self.organization) is True
+            assert should_allow_superuser_access(self.rpc_context) is True
+            assert should_allow_superuser_access(self.rpc_org) is True

--- a/tests/sentry/data_secrecy/test_data_secrecy_logic.py
+++ b/tests/sentry/data_secrecy/test_data_secrecy_logic.py
@@ -7,15 +7,11 @@ from sentry.organizations.services.organization import (
     RpcOrganizationMember,
     RpcUserOrganizationContext,
 )
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.testutils.silo import (
-    SiloMode,
-    all_silo_test,
-    assume_test_silo_mode,
-    create_test_regions,
-)
+from sentry.testutils.silo import all_silo_test, assume_test_silo_mode, create_test_regions
 
 
 @all_silo_test(regions=create_test_regions("us"))
@@ -39,27 +35,23 @@ class DataSecrecyTest(TestCase):
         with self.settings(SENTRY_SELF_HOSTED=True):
             assert should_allow_superuser_access(self.organization) is True
             assert should_allow_superuser_access(self.rpc_context) is True
-            assert should_allow_superuser_access(self.rpc_org) is True
 
     def test_feature_flag_disabled(self):
         with self.settings(SENTRY_SELF_HOSTED=False):
             assert should_allow_superuser_access(self.organization) is True
             assert should_allow_superuser_access(self.rpc_context) is True
-            assert should_allow_superuser_access(self.rpc_org) is True
 
     def test_bit_flag_disabled(self):
         with self.settings(SENTRY_SELF_HOSTED=False):
             self.organization.flags.prevent_superuser_access = False
             assert should_allow_superuser_access(self.organization) is True
             assert should_allow_superuser_access(self.rpc_context) is True
-            assert should_allow_superuser_access(self.rpc_org) is True
 
     @with_feature("organizations:data-secrecy")
     def test_no_waiver_exists(self):
         with self.settings(SENTRY_SELF_HOSTED=False):
             assert should_allow_superuser_access(self.organization) is False
             assert should_allow_superuser_access(self.rpc_context) is False
-            assert should_allow_superuser_access(self.rpc_org) is False
 
     @freeze_time(datetime(2024, 7, 18, 0, 0, 0, tzinfo=timezone.utc))
     @with_feature("organizations:data-secrecy")
@@ -73,7 +65,6 @@ class DataSecrecyTest(TestCase):
         with self.settings(SENTRY_SELF_HOSTED=False):
             assert should_allow_superuser_access(self.organization) is False
             assert should_allow_superuser_access(self.rpc_context) is False
-            assert should_allow_superuser_access(self.rpc_org) is False
 
     @freeze_time(datetime(2024, 7, 18, 0, 0, 0, tzinfo=timezone.utc))
     @with_feature("organizations:data-secrecy")
@@ -87,4 +78,3 @@ class DataSecrecyTest(TestCase):
         with self.settings(SENTRY_SELF_HOSTED=False):
             assert should_allow_superuser_access(self.organization) is True
             assert should_allow_superuser_access(self.rpc_context) is True
-            assert should_allow_superuser_access(self.rpc_org) is True


### PR DESCRIPTION
Sentry Version of https://github.com/getsentry/getsentry/pull/14779

Here, I create a new function to determine if we should prevent superuser access based on the new data secrecy logic. It lives behind the `organizations:data-secrecy` feature flag. I add it to `get_superuser_scopes` since if the person is accessing via superuser, it will go into the function.

[spec](https://www.notion.so/sentry/Superuser-Data-Secrecy-Mode-b9f7fdfd8b564615ae1f91d3d981bc1a) 
