### PR TITLE
fix(slack): fix disappearing tags for issue button actions attempt 2

### DIFF
--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -534,7 +534,7 @@ class SlackActionEndpoint(Endpoint):
 
             view = View(**slack_request.data["view"])
             private_metadata = orjson.loads(view.private_metadata)
-            original_tags_from_request = set(private_metadata["tags"])
+            original_tags_from_request = set(private_metadata.get("tags", {}))
 
             blocks = SlackIssuesMessageBuilder(
                 group,

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -234,7 +234,8 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert resp.data["response_type"] == "ephemeral"
         assert resp.data["text"] == LINK_IDENTITY_MESSAGE.format(associate_url=associate_url)
 
-    def test_archive_issue_until_escalating(self):
+    @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
+    def test_archive_issue_until_escalating(self, mock_tags):
         original_message = self.get_original_message(self.group.id)
         self.archive_issue(original_message, "ignored:archived_until_escalating")
 
@@ -244,13 +245,16 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
 
+        assert mock_tags.call_args.kwargs["tags"] == self.tags
+
         expect_status = f"*Issue archived by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
         assert blocks[2]["text"]["text"].endswith(expect_status)
         assert "via" not in blocks[4]["elements"][0]["text"]
         assert ":white_circle:" in blocks[0]["text"]["text"]
 
-    def test_archive_issue_until_escalating_through_unfurl(self):
+    @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
+    def test_archive_issue_until_escalating_through_unfurl(self, mock_tags):
         original_message = self.get_original_message(self.group.id)
         payload_data = self.get_unfurl_data(original_message["blocks"])
         self.archive_issue(original_message, "ignored:archived_until_escalating", payload_data)
@@ -260,12 +264,14 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.group.substatus == GroupSubStatus.UNTIL_ESCALATING
 
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        assert mock_tags.call_args.kwargs["tags"] == self.tags
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
         assert blocks[2]["text"]["text"].endswith(expect_status)
 
-    def test_archive_issue_until_condition_met(self):
+    @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
+    def test_archive_issue_until_condition_met(self, mock_tags):
         original_message = self.get_original_message(self.group.id)
         self.archive_issue(original_message, "ignored:archived_until_condition_met:10")
 
@@ -276,12 +282,14 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert group_snooze.count == 10
 
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        assert mock_tags.call_args.kwargs["tags"] == self.tags
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
         assert blocks[2]["text"]["text"].endswith(expect_status)
 
-    def test_archive_issue_until_condition_met_through_unfurl(self):
+    @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
+    def test_archive_issue_until_condition_met_through_unfurl(self, mock_tags):
         original_message = self.get_original_message(self.group.id)
         payload_data = self.get_unfurl_data(original_message["blocks"])
         self.archive_issue(
@@ -295,12 +303,14 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert group_snooze.count == 100
 
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        assert mock_tags.call_args.kwargs["tags"] == self.tags
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
         assert blocks[2]["text"]["text"].endswith(expect_status)
 
-    def test_archive_issue_forever_with(self):
+    @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
+    def test_archive_issue_forever(self, mock_tags):
         original_message = self.get_original_message(self.group.id)
         self.archive_issue(original_message, "ignored:archived_forever")
 
@@ -309,6 +319,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.group.substatus == GroupSubStatus.FOREVER
 
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        assert mock_tags.call_args.kwargs["tags"] == self.tags
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
@@ -328,7 +339,8 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.group.get_status() == GroupStatus.UNRESOLVED
         assert self.group.substatus == GroupSubStatus.ONGOING
 
-    def test_archive_issue_forever_through_unfurl(self):
+    @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
+    def test_archive_issue_forever_through_unfurl(self, mock_tags):
         original_message = self.get_original_message(self.group.id)
         payload_data = self.get_unfurl_data(original_message["blocks"])
         self.archive_issue(original_message, "ignored:archived_forever", payload_data)
@@ -338,6 +350,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.group.substatus == GroupSubStatus.FOREVER
 
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        assert mock_tags.call_args.kwargs["tags"] == self.tags
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
@@ -389,7 +402,8 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.notification_text in blocks[1]["text"]["text"]
         assert blocks[2]["text"]["text"].endswith(expect_status)
 
-    def test_unarchive_issue(self):
+    @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
+    def test_unarchive_issue(self, mock_tags):
         self.group.status = GroupStatus.IGNORED
         self.group.substatus = GroupSubStatus.UNTIL_ESCALATING
         self.group.save(update_fields=["status", "substatus"])
@@ -407,12 +421,14 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.group.substatus == GroupSubStatus.NEW  # the issue is less than 7 days old
 
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        assert mock_tags.call_args.kwargs["tags"] == self.tags
 
         expect_status = f"*Issue re-opened by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
         assert blocks[2]["text"]["text"].endswith(expect_status)
 
-    def test_unarchive_issue_through_unfurl(self):
+    @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
+    def test_unarchive_issue_through_unfurl(self, mock_tags):
         self.group.status = GroupStatus.IGNORED
         self.group.substatus = GroupSubStatus.UNTIL_ESCALATING
         self.group.save(update_fields=["status", "substatus"])
@@ -431,6 +447,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.group.substatus == GroupSubStatus.NEW  # the issue is less than 7 days old
 
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        assert mock_tags.call_args.kwargs["tags"] == self.tags
 
         expect_status = f"*Issue re-opened by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
@@ -683,7 +700,8 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.notification_text in blocks[1]["text"]["text"]
         assert blocks[2]["text"]["text"].endswith(expect_status), text
 
-    def test_resolve_issue(self):
+    @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
+    def test_resolve_issue(self, mock_tags):
         original_message = self.get_original_message(self.group.id)
         self.resolve_issue(original_message, "resolved")
 
@@ -692,13 +710,15 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert not GroupResolution.objects.filter(group=self.group)
 
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        assert mock_tags.call_args.kwargs["tags"] == self.tags
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
         assert blocks[2]["text"]["text"] == expect_status
         assert ":white_circle:" in blocks[0]["text"]["text"]
 
-    def test_resolve_perf_issue(self):
+    @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
+    def test_resolve_perf_issue(self, mock_tags):
         group_fingerprint = f"{PerformanceNPlusOneGroupType.type_id}-group1"
 
         event_data_2 = load_data("transaction-n-plus-one", fingerprint=[group_fingerprint])
@@ -720,6 +740,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert not GroupResolution.objects.filter(group=self.group)
 
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        assert mock_tags.call_args.kwargs["tags"] == self.tags
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
         assert (
@@ -729,7 +750,8 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert blocks[3]["text"]["text"] == expect_status
         assert ":white_circle: :chart_with_upwards_trend:" in blocks[0]["text"]["text"]
 
-    def test_resolve_issue_through_unfurl(self):
+    @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
+    def test_resolve_issue_through_unfurl(self, mock_tags):
         original_message = self.get_original_message(self.group.id)
         payload_data = self.get_unfurl_data(original_message["blocks"])
         self.resolve_issue(original_message, "resolved", payload_data)
@@ -739,12 +761,14 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert not GroupResolution.objects.filter(group=self.group)
 
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        assert mock_tags.call_args.kwargs["tags"] == self.tags
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
         assert blocks[2]["text"]["text"] == expect_status
 
-    def test_resolve_issue_in_current_release(self):
+    @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
+    def test_resolve_issue_in_current_release(self, mock_tags):
         release = Release.objects.create(
             organization_id=self.organization.id,
             version="1.0",
@@ -761,12 +785,14 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert resolution.release == release
 
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        assert mock_tags.call_args.kwargs["tags"] == self.tags
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
         assert blocks[2]["text"]["text"].endswith(expect_status)
 
-    def test_resolve_issue_in_current_release_through_unfurl(self):
+    @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
+    def test_resolve_issue_in_current_release_through_unfurl(self, mock_tags):
         release = Release.objects.create(
             organization_id=self.organization.id,
             version="1.0",
@@ -784,12 +810,14 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert resolution.release == release
 
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        assert mock_tags.call_args.kwargs["tags"] == self.tags
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
         assert blocks[2]["text"]["text"].endswith(expect_status)
 
-    def test_resolve_in_next_release(self):
+    @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
+    def test_resolve_in_next_release(self, mock_tags):
         release = Release.objects.create(
             organization_id=self.organization.id,
             version="1.0",
@@ -805,12 +833,14 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert resolution.release == release
 
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        assert mock_tags.call_args.kwargs["tags"] == self.tags
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]
         assert blocks[2]["text"]["text"].endswith(expect_status)
 
-    def test_resolve_in_next_release_through_unfurl(self):
+    @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
+    def test_resolve_in_next_release_through_unfurl(self, mock_tags):
         release = Release.objects.create(
             organization_id=self.organization.id,
             version="1.0",
@@ -827,6 +857,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert resolution.release == release
 
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        assert mock_tags.call_args.kwargs["tags"] == self.tags
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
         assert self.notification_text in blocks[1]["text"]["text"]


### PR DESCRIPTION
See #75789

Adds a fix to the above PR to account for someone clicking on an old message that doesn't have tags in the `View` `metadata`.