### PR TITLE
chore(uptime): Store duration/delay stats in the result consumer

### DIFF
--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -129,11 +129,12 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                 # Since we process all results for a given uptime monitor in order, we can guarantee that we get the
                 # earliest delay stat for each scheduled check for the monitor here, and so this stat will be a more
                 # accurate measurement of delay/duration.
-                metrics.gauge(
-                    "uptime.result_processor.check_result.duration",
-                    result["duration_ms"],
-                    sample_rate=1.0,
-                )
+                if result["duration_ms"]:
+                    metrics.gauge(
+                        "uptime.result_processor.check_result.duration",
+                        result["duration_ms"],
+                        sample_rate=1.0,
+                    )
                 metrics.gauge(
                     "uptime.result_processor.check_result.delay",
                     result["actual_check_time_ms"] - result["scheduled_check_time_ms"],


### PR DESCRIPTION
Copying comment from the pr:

We log the result stats here after the duplicate check so that we know the "true" duration and delay of each check. Since during deploys we might have checks run from both the old/new checker deployments, there will be overlap of when things run. The new deployment will have artificially inflated delay stats, since it may duplicate checks that already ran on time on the old deployment, but will have run them later.
Since we process all results for a given uptime monitor in order, we can guarantee that we get the earliest delay stat for each scheduled check for the monitor here, and so this stat will be a more accurate measurement of delay/duration.

<!-- Describe your PR here. -->