### PR TITLE
fix(snuba-search): Fix first_seen sort aggregation

### DIFF
--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -2550,7 +2550,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             data={"timestamp": time.timestamp(), "fingerprint": ["group-1"]},
             project_id=self.project.id,
         )
-        # issue 2: events 90 minutes ago 1 minute ago
+        # issue 2: events 90 minutes ago and 1 minute ago
         time = datetime.now() - timedelta(minutes=90)
         event2 = self.store_event(
             data={"timestamp": time.timestamp(), "fingerprint": ["group-2"]},
@@ -2562,6 +2562,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             project_id=self.project.id,
         )
 
+        sleep(1)
         self.login_as(user=self.user)
         response = self.get_success_response(
             sort="new",

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -3255,7 +3255,7 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         sleep(1)
 
         # Request the first page with a limit of 10
-        response = self.get_success_response(limit=10)
+        response = self.get_success_response(limit=10, sort="new")
         assert response.status_code == 200
         assert len(response.data) == 10
         assert response.headers.get("X-Hits") == "30"


### PR DESCRIPTION
Add an aggregation for the first seen sort to convert the `first_seen` value to a uint64. Without the aggregation, the paginator is unable to parse and handle the cursor value which is formatted as a datetime (e.g. 2024-08-08T04:30:09+00:00:0:0). The aggregation converts the value like we do for the `last_seen` sort to have an int cursor instead (e.g. 1723176015000:0:0).

Tested locally to confirm pagination works, and this change (as well as all snuba-search changes) are only enabled for Sentry right now so this is safe to land. 