### PR TITLE
feat(metrics): Add analytics for span based metrics

### DIFF
--- a/static/app/components/metrics/metricQuerySelect.tsx
+++ b/static/app/components/metrics/metricQuerySelect.tsx
@@ -218,6 +218,7 @@ export function CardinalityWarningIcon() {
 }
 
 function QueryFooter({mri, closeOverlay}: {closeOverlay: () => void; mri: MRI}) {
+  const organization = useOrganization();
   const {getExtractionRules} = useVirtualMetricsContext();
   const selectedProjects = useSelectedProjects();
   const extractionRules = getExtractionRules(mri);
@@ -225,9 +226,13 @@ function QueryFooter({mri, closeOverlay}: {closeOverlay: () => void; mri: MRI}) 
   const handleEdit = useCallback(
     (rule: MetricsExtractionRule) => {
       closeOverlay();
-      openExtractionRuleEditModal({metricExtractionRule: rule});
+      openExtractionRuleEditModal({
+        organization,
+        source: 'ddm.condition-select.add-filter',
+        metricExtractionRule: rule,
+      });
     },
-    [closeOverlay]
+    [closeOverlay, organization]
   );
 
   const options = useMemo(

--- a/static/app/components/metrics/mriSelect/index.tsx
+++ b/static/app/components/metrics/mriSelect/index.tsx
@@ -340,7 +340,10 @@ export const MRISelect = memo(function MRISelect({
                     priority="primary"
                     onClick={() => {
                       closeOverlay();
-                      openExtractionRuleCreateModal({});
+                      openExtractionRuleCreateModal({
+                        organization,
+                        source: 'ddm.metric-select.create-metric',
+                      });
                     }}
                     size="xs"
                   >

--- a/static/app/components/metrics/queryBuilder.tsx
+++ b/static/app/components/metrics/queryBuilder.tsx
@@ -209,6 +209,7 @@ export const QueryBuilder = memo(function QueryBuilder({
 
   const handleConditionChange = useCallback(
     (conditionId: number) => {
+      trackAnalytics('ddm.widget.condition', {organization});
       const newAggregates = getAggregations(metricsQuery.mri, conditionId);
 
       const changes: Partial<MetricsQuery> = {
@@ -223,7 +224,7 @@ export const QueryBuilder = memo(function QueryBuilder({
 
       onChange(changes);
     },
-    [getAggregations, metricsQuery.aggregation, metricsQuery.mri, onChange]
+    [getAggregations, metricsQuery.aggregation, metricsQuery.mri, onChange, organization]
   );
 
   const handleMetricTagClick = useCallback(

--- a/static/app/utils/analytics/ddmAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/ddmAnalyticsEvents.tsx
@@ -15,10 +15,29 @@ export type DDMEventParameters = {
     target: 'event-id' | 'description' | 'trace-id' | 'profile';
   };
   'ddm.set-default-query': {};
+  'ddm.span-metric.create.cancel': {};
+  'ddm.span-metric.create.open': {
+    source: string;
+  };
+  'ddm.span-metric.create.success': {
+    hasFilters: boolean;
+  };
+  'ddm.span-metric.delete': {};
+  'ddm.span-metric.edit.cancel': {};
+  'ddm.span-metric.edit.open': {
+    hasFilters: boolean;
+    source: string;
+  };
+  'ddm.span-metric.edit.success': {
+    hasFilters: boolean;
+  };
+  'ddm.span-metric.form.add-filter': {};
+  'ddm.span-metric.form.remove-filter': {};
   'ddm.view_performance_metrics': {};
   'ddm.widget.add': {
     type: 'query' | 'equation';
   };
+  'ddm.widget.condition': {};
   'ddm.widget.duplicate': {};
   'ddm.widget.filter': {};
   'ddm.widget.group': {};
@@ -49,4 +68,14 @@ export const ddmEventMap: Record<keyof DDMEventParameters, string> = {
   'ddm.widget.group': 'DDM: Change query grouping',
   'ddm.widget.metric': 'DDM: Change query metric',
   'ddm.widget.operation': 'DDM: Change query operation',
+  'ddm.widget.condition': 'DDM: Change query condition',
+  'ddm.span-metric.create.cancel': 'DDM: Cancel span metric create',
+  'ddm.span-metric.create.open': 'DDM: Open span metric create',
+  'ddm.span-metric.create.success': 'DDM: Created span metric',
+  'ddm.span-metric.delete': 'DDM: Delete span metric',
+  'ddm.span-metric.edit.cancel': 'DDM: Cancel span metric edit',
+  'ddm.span-metric.edit.open': 'DDM: Open span metric edit',
+  'ddm.span-metric.edit.success': 'DDM: Edited span metric',
+  'ddm.span-metric.form.add-filter': 'DDM: Add filter in span metric form',
+  'ddm.span-metric.form.remove-filter': 'DDM: Remove filter in span metric form',
 };

--- a/static/app/views/metrics/metricQueryContextMenu.tsx
+++ b/static/app/views/metrics/metricQueryContextMenu.tsx
@@ -161,6 +161,8 @@ export function MetricQueryContextMenu({
             );
             if (extractionRule) {
               openExtractionRuleEditModal({
+                organization,
+                source: 'ddm.configure-metric',
                 metricExtractionRule: extractionRule,
                 onSubmitSuccess: data => {
                   // Keep the unit of the MRI in sync with the unit of the extraction rule

--- a/static/app/views/metrics/pageHeaderActions.tsx
+++ b/static/app/views/metrics/pageHeaderActions.tsx
@@ -147,7 +147,12 @@ export function PageHeaderActions({showAddMetricButton, addCustomMetric}: Props)
         (hasCustomMetricsExtractionRules(organization) ? (
           <Button
             priority="primary"
-            onClick={() => openExtractionRuleCreateModal({})}
+            onClick={() =>
+              openExtractionRuleCreateModal({
+                organization,
+                source: 'ddm.header.create-metric',
+              })
+            }
             size="sm"
           >
             {t('Create Metric')}

--- a/static/app/views/monitors/overview.tsx
+++ b/static/app/views/monitors/overview.tsx
@@ -119,7 +119,7 @@ export default function Monitors() {
                 size="sm"
                 onClick={() =>
                   openBulkEditMonitorsModal({
-                    onClose: refetch,
+                    onClose: () => refetch(),
                   })
                 }
                 analyticsEventKey="crons.bulk_edit_modal_button_clicked"

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/keys.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/keys.tsx
@@ -154,7 +154,9 @@ function getNonSizeKeyActionData({
         aria-label={t('Extract as metric')}
         onClick={() =>
           openExtractionRuleCreateModal({
+            organization,
             projectId: projectId,
+            source: 'trace-view.span-attribute',
             initialData: {
               spanAttribute,
             },

--- a/static/app/views/settings/projectMetrics/metricsExtractionRuleCreateModal.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRuleCreateModal.tsx
@@ -13,7 +13,9 @@ import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {MetricsExtractionRule} from 'sentry/types/metrics';
+import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {useCardinalityLimitedMetricVolume} from 'sentry/utils/metrics/useCardinalityLimitedMetricVolume';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -27,7 +29,23 @@ import {
 import {useCreateMetricsExtractionRules} from 'sentry/views/settings/projectMetrics/utils/useMetricsExtractionRules';
 
 interface Props {
+  organization: Organization;
+  /**
+   * Source parameter for analytics
+   */
+  source: string;
+  /**
+   * Initial data to populate the form with
+   */
   initialData?: Partial<FormData>;
+  /**
+   * Callback when the form is submitted successfully
+   */
+  onSubmitSuccess?: (data: FormData) => void;
+  /**
+   * The project to create the metric for
+   * If not provided, the user will be prompted to select a project
+   */
   projectId?: string | number;
 }
 
@@ -46,6 +64,7 @@ export function MetricsExtractionRuleCreateModal({
   CloseButton,
   initialData: initalDataProp = {},
   projectId: projectIdProp,
+  onSubmitSuccess,
 }: Props & ModalRenderProps) {
   const {projects} = useProjects();
   const {selection} = usePageFilters();
@@ -137,6 +156,7 @@ export function MetricsExtractionRuleCreateModal({
             initialData={initialData}
             projectId={projectId}
             closeModal={closeModal}
+            onSubmitSuccess={onSubmitSuccess}
           />
         ) : null}
       </Body>
@@ -148,10 +168,12 @@ function FormWrapper({
   closeModal,
   projectId,
   initialData,
+  onSubmitSuccess: onSubmitSuccessProp,
 }: {
   closeModal: () => void;
   initialData: FormData;
   projectId: string | number;
+  onSubmitSuccess?: (data: FormData) => void;
 }) {
   const organization = useOrganization();
   const createExtractionRuleMutation = useCreateMetricsExtractionRules(
@@ -188,6 +210,7 @@ function FormWrapper({
         },
         {
           onSuccess: () => {
+            onSubmitSuccessProp?.(data);
             onSubmitSuccess(data);
             addSuccessMessage(t('Metric extraction rule created'));
             closeModal();
@@ -203,7 +226,7 @@ function FormWrapper({
       );
       onSubmitSuccess(data);
     },
-    [closeModal, projectId, createExtractionRuleMutation]
+    [projectId, createExtractionRuleMutation, onSubmitSuccessProp, closeModal]
   );
 
   return (
@@ -234,11 +257,40 @@ export const modalCss = css`
 `;
 
 export function openExtractionRuleCreateModal(props: Props, options?: ModalOptions) {
+  const {organization, source, onSubmitSuccess} = props;
+
+  trackAnalytics('ddm.span-metric.create.open', {
+    organization,
+    source,
+  });
+
+  const handleClose: ModalOptions['onClose'] = reason => {
+    if (reason && ['close-button', 'backdrop-click', 'escape-key'].includes(reason)) {
+      trackAnalytics('ddm.span-metric.create.cancel', {organization});
+    }
+    options?.onClose?.(reason);
+  };
+
+  const handleSubmitSuccess: Props['onSubmitSuccess'] = data => {
+    trackAnalytics('ddm.span-metric.create.success', {
+      organization,
+      hasFilters: data.conditions.some(condition => condition.value),
+    });
+    onSubmitSuccess?.(data);
+  };
+
   openModal(
-    modalProps => <MetricsExtractionRuleCreateModal {...props} {...modalProps} />,
+    modalProps => (
+      <MetricsExtractionRuleCreateModal
+        {...props}
+        onSubmitSuccess={handleSubmitSuccess}
+        {...modalProps}
+      />
+    ),
     {
       modalCss,
       ...options,
+      onClose: handleClose,
     }
   );
 }

--- a/static/app/views/settings/projectMetrics/metricsExtractionRuleForm.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRuleForm.tsx
@@ -18,6 +18,7 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {SelectValue} from 'sentry/types/core';
 import type {MetricAggregation, MetricsExtractionCondition} from 'sentry/types/metrics';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {hasDuplicates} from 'sentry/utils/array/hasDuplicates';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -290,7 +291,9 @@ export function MetricsExtractionRuleForm({
                         aria-label={t('Edit %s metric', disabledRule.spanAttribute)}
                         onClick={() => {
                           openExtractionRuleEditModal({
+                            organization,
                             metricExtractionRule: disabledRule,
+                            source: 'span-metric.form.already-in-use',
                           });
                         }}
                       />
@@ -304,7 +307,7 @@ export function MetricsExtractionRuleForm({
         // Sort disabled attributes to bottom
         .sort((a, b) => Number(a.disabled) - Number(b.disabled))
     );
-  }, [allAttributeOptions, extractionRules]);
+  }, [allAttributeOptions, extractionRules, organization]);
 
   const tagOptions = useMemo(() => {
     return allAttributeOptions.map<SelectValue<string>>(option => ({
@@ -613,7 +616,12 @@ export function MetricsExtractionRuleForm({
                           {value.length > 1 && (
                             <Button
                               aria-label={t('Remove Filter')}
-                              onClick={() => onChange(conditions.toSpliced(index, 1), {})}
+                              onClick={() => {
+                                trackAnalytics('ddm.span-metric.form.remove-filter', {
+                                  organization,
+                                });
+                                onChange(conditions.toSpliced(index, 1), {});
+                              }}
                               icon={<IconClose />}
                             />
                           )}
@@ -624,7 +632,10 @@ export function MetricsExtractionRuleForm({
                   <ConditionsButtonBar>
                     <Button
                       size="sm"
-                      onClick={() => onChange([...conditions, createCondition()], {})}
+                      onClick={() => {
+                        trackAnalytics('ddm.span-metric.form.add-filter', {organization});
+                        onChange([...conditions, createCondition()], {});
+                      }}
                       icon={<IconAdd />}
                     >
                       {t('Add Filter')}

--- a/static/app/views/settings/projectMetrics/metricsExtractionRulesTable.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRulesTable.tsx
@@ -73,15 +73,24 @@ export function MetricsExtractionRulesTable({project}: Props) {
     [deleteMetricsExtractionRules]
   );
 
-  const handleEdit = useCallback((rule: MetricsExtractionRule) => {
-    openExtractionRuleEditModal({
-      metricExtractionRule: rule,
-    });
-  }, []);
+  const handleEdit = useCallback(
+    (rule: MetricsExtractionRule) => {
+      openExtractionRuleEditModal({
+        organization,
+        metricExtractionRule: rule,
+        source: 'settings',
+      });
+    },
+    [organization]
+  );
 
   const handleCreate = useCallback(() => {
-    openExtractionRuleCreateModal({projectId: project.id});
-  }, [project]);
+    openExtractionRuleCreateModal({
+      organization,
+      projectId: project.id,
+      source: 'settings',
+    });
+  }, [organization, project.id]);
 
   return (
     <Fragment>

--- a/static/app/views/settings/projectMetrics/metricsExtractionRulesTable.tsx
+++ b/static/app/views/settings/projectMetrics/metricsExtractionRulesTable.tsx
@@ -17,6 +17,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {MetricsExtractionRule} from 'sentry/types/metrics';
 import type {Project} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {useCardinalityLimitedMetricVolume} from 'sentry/utils/metrics/useCardinalityLimitedMetricVolume';
 import {useMembers} from 'sentry/utils/useMembers';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -60,6 +61,7 @@ export function MetricsExtractionRulesTable({project}: Props) {
             {
               onSuccess: () => {
                 addSuccessMessage(t('Metric deleted'));
+                trackAnalytics('metrics_extractions.delete', {organization});
               },
               onError: () => {
                 addErrorMessage(t('Failed to delete metric'));
@@ -70,7 +72,7 @@ export function MetricsExtractionRulesTable({project}: Props) {
         confirmText: t('Delete Metric'),
       });
     },
-    [deleteMetricsExtractionRules]
+    [deleteMetricsExtractionRules, organization]
   );
 
   const handleEdit = useCallback(


### PR DESCRIPTION
Add analytics events for span based metric flows.
Expose close reason in modal's `onClose` callback.

Closes https://github.com/getsentry/sentry/issues/75579