### PR TITLE
feat(issue-resolve): stop using feature flag organizations:resolve-in-upcoming-release on the backend

### DIFF
--- a/src/sentry/api/helpers/group_index/validators/status_details.py
+++ b/src/sentry/api/helpers/group_index/validators/status_details.py
@@ -1,6 +1,5 @@
 from rest_framework import serializers
 
-from sentry import features
 from sentry.models.release import Release
 
 from . import InCommitValidator
@@ -60,10 +59,6 @@ class StatusDetailsValidator(serializers.Serializer):
     def validate_inUpcomingRelease(self, value: bool) -> "Release":
         project = self.context["project"]
 
-        if not features.has("organizations:resolve-in-upcoming-release", project.organization):
-            raise serializers.ValidationError(
-                "Your organization does not have access to this feature."
-            )
         try:
             return (
                 Release.objects.filter(projects=project, organization_id=project.organization_id)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -344,6 +344,7 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:reprocessing-v2", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     manager.add("organizations:required-email-verification", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable resolve in upcoming release
+    # TODO(steve): Remove when we remove the feature from the UI
     manager.add("organizations:resolve-in-upcoming-release", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=True)
     # Enable post create/edit rule confirmation notifications
     manager.add("organizations:rule-create-edit-confirm-notification", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -29,7 +29,7 @@ from sentry.models.options.user_option import UserOption
 from sentry.models.release import Release
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, SnubaTestCase
-from sentry.testutils.helpers import parse_link_header, with_feature
+from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.activity import ActivityType
@@ -795,7 +795,6 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         )
         assert activity.data["version"] == ""
 
-    @with_feature("organizations:resolve-in-upcoming-release")
     def test_set_resolved_in_upcoming_release(self):
         release = Release.objects.create(organization_id=self.project.organization_id, version="a")
         release.add_project(self.project)
@@ -834,27 +833,6 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         )
         assert activity.data["version"] == ""
 
-    def test_upcoming_release_flag_validation(self):
-        release = Release.objects.create(organization_id=self.project.organization_id, version="a")
-        release.add_project(self.project)
-
-        group = self.create_group(status=GroupStatus.UNRESOLVED)
-
-        self.login_as(user=self.user)
-
-        url = f"{self.path}?id={group.id}"
-        response = self.client.put(
-            url,
-            data={"status": "resolved", "statusDetails": {"inUpcomingRelease": True}},
-            format="json",
-        )
-        assert response.status_code == 400
-        assert (
-            response.data["statusDetails"]["inUpcomingRelease"][0]
-            == "Your organization does not have access to this feature."
-        )
-
-    @with_feature("organizations:resolve-in-upcoming-release")
     def test_upcoming_release_release_validation(self):
         group = self.create_group(status=GroupStatus.UNRESOLVED)
 


### PR DESCRIPTION
The feature flag `organizations:resolve-in-upcoming-release` has been there for some time (it was added while I was still a Sentry employee, lol). I'm going to assume it's been rolled out internally at least. But it's time to enable the feature globally so that people can start using it. I've tested it locally and seems to work fine. The purpose of this feature is that `Resolve in Next Release` doesn't work well if the latest event for an issue isn't the current release because if a new event comes on that new release, it automatically regresses. This was done because that sort of logic is needed for semver releases where current release might have different branches (e.x: an issue that appears in release 7.0 shouldn't be marked as resolved if release 6.1 happens, only if 7.1 happens). Here is the rollout plan.


1. Stop gating the `Resolve in Upcoming Release` feature on the backend
2. Stop gating the `Resolve in Upcoming Release` feature on the frontend and update 
3. Remove the feature flag altogether
4. Update docks

Here is what the feature looks like in the UI when it's enabled:
<img width="286" alt="Screenshot 2024-08-09 at 3 10 09 PM" src="https://github.com/user-attachments/assets/60c0d834-5f9d-4c57-b462-c840fc8e7e13">


Here is what happens when you resolve the feature in a release then a new release gets released:
<img width="1271" alt="Screenshot 2024-08-09 at 2 57 46 PM" src="https://github.com/user-attachments/assets/8a4a7242-eb32-4844-b526-a414cedafee5">

Related PR from @roggenkemper: https://github.com/getsentry/sentry/pull/70990

