### PR TITLE
ref(performance): Move PerformanceSearchQueryBuilder into its own com…

### DIFF
--- a/static/app/components/performance/performanceSearchQueryBuilder.tsx
+++ b/static/app/components/performance/performanceSearchQueryBuilder.tsx
@@ -1,0 +1,126 @@
+import {useCallback, useMemo} from 'react';
+
+import {fetchTagValues} from 'sentry/actionCreators/tags';
+import {getHasTag} from 'sentry/components/events/searchBar';
+import {
+  STATIC_FIELD_TAGS_WITHOUT_ERROR_FIELDS,
+  STATIC_SEMVER_TAGS,
+  STATIC_SPAN_TAGS,
+} from 'sentry/components/events/searchBarFieldConstants';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
+import type {CallbackSearchState} from 'sentry/components/searchQueryBuilder/types';
+import type {PageFilters} from 'sentry/types/core';
+import {SavedSearchType, type Tag, type TagCollection} from 'sentry/types/group';
+import {defined} from 'sentry/utils';
+import {
+  ALL_INSIGHTS_FILTER_KEY_SECTIONS,
+  isAggregateField,
+  isMeasurement,
+} from 'sentry/utils/discover/fields';
+import {DEVICE_CLASS_TAG_VALUES, isDeviceClass} from 'sentry/utils/fields';
+import {getMeasurements} from 'sentry/utils/measurements/measurements';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import useTags from 'sentry/utils/useTags';
+
+type SearchSource = 'transaction_summary';
+
+interface PerformanceSearchQueryBuilderProps {
+  initialQuery: string;
+  searchSource: SearchSource;
+  datetime?: PageFilters['datetime'];
+  onSearch?: (query: string, state: CallbackSearchState) => void;
+  projects?: PageFilters['projects'];
+}
+
+export function PerformanceSearchQueryBuilder({
+  initialQuery,
+  searchSource,
+  datetime,
+  onSearch,
+  projects,
+}: PerformanceSearchQueryBuilderProps) {
+  const api = useApi();
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+  const tags = useTags();
+
+  const filterTags = useMemo(() => {
+    const measurements = getMeasurements();
+
+    const combinedTags: TagCollection = {
+      ...STATIC_SPAN_TAGS,
+      ...STATIC_FIELD_TAGS_WITHOUT_ERROR_FIELDS,
+      ...STATIC_SEMVER_TAGS,
+      ...measurements,
+      ...tags,
+    };
+
+    combinedTags.has = getHasTag(combinedTags);
+    return combinedTags;
+  }, [tags]);
+
+  const filterKeySections = useMemo(
+    () => [
+      ...ALL_INSIGHTS_FILTER_KEY_SECTIONS,
+      {
+        value: 'custom_fields',
+        label: 'Custom Tags',
+        children: Object.keys(tags),
+      },
+    ],
+    [tags]
+  );
+
+  // This is adapted from the `getEventFieldValues` function in `events/searchBar.tsx`
+  const getTransactionFilterTagValues = useCallback(
+    async (tag: Tag, queryString: string) => {
+      if (isAggregateField(tag.key) || isMeasurement(tag.key)) {
+        // We can't really auto suggest values for aggregate fields
+        // or measurements, so we simply don't
+        return Promise.resolve([]);
+      }
+      //
+      // device.class is stored as "numbers" in snuba, but we want to suggest high, medium,
+      // and low search filter values because discover maps device.class to these values.
+      if (isDeviceClass(tag.key)) {
+        return Promise.resolve(DEVICE_CLASS_TAG_VALUES);
+      }
+
+      try {
+        const results = await fetchTagValues({
+          api,
+          orgSlug: organization.slug,
+          tagKey: tag.key,
+          search: queryString,
+          projectIds: projects?.map(String) ?? selection.projects?.map(String),
+          includeTransactions: true,
+          includeSessions: true,
+          sort: '-count',
+          endpointParams: normalizeDateTimeParams(datetime ?? selection.datetime),
+        });
+
+        return results.filter(({name}) => defined(name)).map(({name}) => name);
+      } catch (e) {
+        throw new Error(`Unable to fetch event field values: ${e}`);
+      }
+    },
+    [api, organization, datetime, projects, selection.datetime, selection.projects]
+  );
+
+  return (
+    <SearchQueryBuilder
+      filterKeys={filterTags}
+      initialQuery={initialQuery}
+      onSearch={onSearch}
+      searchSource={searchSource}
+      filterKeySections={filterKeySections}
+      getTagValues={getTransactionFilterTagValues}
+      disallowFreeText
+      disallowUnsupportedFilters
+      recentSearches={SavedSearchType.EVENT}
+    />
+  );
+}

--- a/static/app/components/performance/transactionSearchQueryBuilder.tsx
+++ b/static/app/components/performance/transactionSearchQueryBuilder.tsx
@@ -27,7 +27,7 @@ import useTags from 'sentry/utils/useTags';
 
 type SearchSource = 'transaction_summary';
 
-interface PerformanceSearchQueryBuilderProps {
+interface TransactionSearchQueryBuilderProps {
   initialQuery: string;
   searchSource: SearchSource;
   datetime?: PageFilters['datetime'];
@@ -35,13 +35,13 @@ interface PerformanceSearchQueryBuilderProps {
   projects?: PageFilters['projects'];
 }
 
-export function PerformanceSearchQueryBuilder({
+export function TransactionSearchQueryBuilder({
   initialQuery,
   searchSource,
   datetime,
   onSearch,
   projects,
-}: PerformanceSearchQueryBuilderProps) {
+}: TransactionSearchQueryBuilderProps) {
   const api = useApi();
   const organization = useOrganization();
   const {selection} = usePageFilters();

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -11,7 +11,7 @@ import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
-import {PerformanceSearchQueryBuilder} from 'sentry/components/performance/performanceSearchQueryBuilder';
+import {TransactionSearchQueryBuilder} from 'sentry/components/performance/transactionSearchQueryBuilder';
 import {SuspectFunctionsTable} from 'sentry/components/profiling/suspectFunctions/suspectFunctionsTable';
 import type {ActionBarItem} from 'sentry/components/smartSearchBar';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -356,7 +356,7 @@ function SummaryContent({
   function renderSearchBar() {
     if (organization.features.includes('search-query-builder-performance')) {
       return (
-        <PerformanceSearchQueryBuilder
+        <TransactionSearchQueryBuilder
           projects={projectIds}
           initialQuery={query}
           onSearch={handleSearch}


### PR DESCRIPTION
…ponent

This component will be reused anywhere we want to search for transactions.
