### PR TITLE
feat(query-builder): Add ability to customize the filter key menu width

### DIFF
--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -12,6 +12,7 @@ import type {FieldDefinition} from 'sentry/utils/fields';
 interface ContextData {
   disabled: boolean;
   dispatch: Dispatch<QueryBuilderActions>;
+  filterKeyMenuWidth: number;
   filterKeySections: FilterKeySection[];
   filterKeys: TagCollection;
   focusOverride: FocusOverride | null;
@@ -35,6 +36,7 @@ export const SearchQueryBuilerContext = createContext<ContextData>({
   query: '',
   focusOverride: null,
   filterKeys: {},
+  filterKeyMenuWidth: 360,
   filterKeySections: [],
   getFieldDefinition: () => null,
   getTagValues: () => Promise.resolve([]),

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -301,6 +301,18 @@ export default storyBook(SearchQueryBuilder, story => {
           getTagValues={getTagValues}
           searchSource="storybook"
         />
+        <p>
+          If you wish to modify the size of the filter key menu, use
+          <code>filterKeyMenuWidth</code> to define the width in pixels.
+        </p>
+        <SearchQueryBuilder
+          initialQuery=""
+          filterKeySections={FILTER_KEY_SECTIONS}
+          filterKeys={FILTER_KEYS}
+          getTagValues={getTagValues}
+          searchSource="storybook"
+          filterKeyMenuWidth={600}
+        />
       </Fragment>
     );
   });

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -70,6 +70,12 @@ export interface SearchQueryBuilderProps {
    */
   fieldDefinitionGetter?: FieldDefinitionGetter;
   /**
+   * The width of the filter key menu.
+   * Defaults to 360px. May be increased if there are a large number of categories
+   * or long filter key names.
+   */
+  filterKeyMenuWidth?: number;
+  /**
    * When provided, displays a tabbed interface for discovering filter keys.
    * Sections and filter keys are displayed in the order they are provided.
    */
@@ -131,6 +137,7 @@ export function SearchQueryBuilder({
   initialQuery,
   fieldDefinitionGetter = getFieldDefinition,
   filterKeys,
+  filterKeyMenuWidth = 360,
   filterKeySections,
   getTagValues,
   onChange,
@@ -196,6 +203,7 @@ export function SearchQueryBuilder({
       disabled,
       parsedQuery,
       filterKeySections: filterKeySections ?? [],
+      filterKeyMenuWidth,
       filterKeys,
       getTagValues,
       getFieldDefinition: fieldDefinitionGetter,
@@ -213,6 +221,7 @@ export function SearchQueryBuilder({
     disabled,
     parsedQuery,
     filterKeySections,
+    filterKeyMenuWidth,
     filterKeys,
     getTagValues,
     fieldDefinitionGetter,

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -92,8 +92,10 @@ export function FilterKeyListBox<T extends SelectOptionOrSectionWithKey<string>>
   selectedSection,
   setSelectedSection,
 }: FilterKeyListBoxProps<T>) {
+  const {filterKeyMenuWidth} = useSearchQueryBuilder();
+
   return (
-    <SectionedOverlay ref={popoverRef}>
+    <SectionedOverlay ref={popoverRef} width={filterKeyMenuWidth}>
       {isOpen ? (
         <Fragment>
           <SectionedListBoxTabPane>
@@ -139,12 +141,12 @@ export function FilterKeyListBox<T extends SelectOptionOrSectionWithKey<string>>
   );
 }
 
-const SectionedOverlay = styled(Overlay)`
+const SectionedOverlay = styled(Overlay)<{width: number}>`
   display: grid;
   grid-template-rows: auto 1fr auto;
   overflow: hidden;
   height: 400px;
-  width: 360px;
+  width: ${p => p.width}px;
 `;
 
 const SectionedOverlayFooter = styled('div')`


### PR DESCRIPTION
Adds `filterKeyMenuWidth` so that certain usages can adjust the width to make sure everything fits nicely.