### PR TITLE
chore: Add additional spans to ratelimit middleware

### DIFF
--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -5,6 +5,7 @@ import uuid
 from collections.abc import Callable
 
 import orjson
+import sentry_sdk
 from django.conf import settings
 from django.http.request import HttpRequest
 from django.http.response import HttpResponse, HttpResponseBase
@@ -69,9 +70,10 @@ class RatelimitMiddleware:
                 rate_limit_group = (
                     rate_limit_config.group if rate_limit_config else RateLimitConfig().group
                 )
-                request.rate_limit_key = get_rate_limit_key(
-                    view_func, request, rate_limit_group, rate_limit_config
-                )
+                with sentry_sdk.start_span(op="ratelimit.get_rate_limit_key"):
+                    request.rate_limit_key = get_rate_limit_key(
+                        view_func, request, rate_limit_group, rate_limit_config
+                    )
                 if request.rate_limit_key is None:
                     return None
 
@@ -86,9 +88,11 @@ class RatelimitMiddleware:
                 if rate_limit is None:
                     return None
 
-                request.rate_limit_metadata = above_rate_limit_check(
-                    request.rate_limit_key, rate_limit, request.rate_limit_uid, rate_limit_group
-                )
+                with sentry_sdk.start_span(op="ratelimit.above_rate_limit_check"):
+                    request.rate_limit_metadata = above_rate_limit_check(
+                        request.rate_limit_key, rate_limit, request.rate_limit_uid, rate_limit_group
+                    )
+
                 # TODO: also limit by concurrent window once we have the data
                 rate_limit_cond = (
                     request.rate_limit_metadata.rate_limit_type != RateLimitType.NOT_LIMITED


### PR DESCRIPTION
I've seen several examples of the the automatically generated span for this middleware reaching multiple seconds of duration which impacts endpoint response times. I've added spans around what I think could be the slower parts of ratelimiting to get more data on what is going wrong.

Refs HC-1198