### PR TITLE
feat(query-builder): Add trailingItems prop

### DIFF
--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -100,9 +100,14 @@ export interface SearchQueryBuilderProps {
    * If provided, saves and displays recent searches of the given type.
    */
   recentSearches?: SavedSearchType;
+  /**
+   * Render custom content in the trailing section of the search bar, located
+   * to the left of the clear button.
+   */
+  trailingItems?: React.ReactNode;
 }
 
-function ActionButtons() {
+function ActionButtons({trailingItems = null}: {trailingItems?: React.ReactNode}) {
   const {dispatch, handleSearch, disabled} = useSearchQueryBuilder();
 
   if (disabled) {
@@ -111,6 +116,7 @@ function ActionButtons() {
 
   return (
     <ButtonsWrapper>
+      {trailingItems}
       <ActionButton
         aria-label={t('Clear search query')}
         size="zero"
@@ -147,6 +153,7 @@ export function SearchQueryBuilder({
   queryInterface = QueryInterfaceType.TOKENIZED,
   recentSearches,
   searchSource,
+  trailingItems,
 }: SearchQueryBuilderProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const {state, dispatch} = useQueryBuilderState({
@@ -251,7 +258,7 @@ export function SearchQueryBuilder({
           ) : (
             <TokenizedQueryGrid label={label} />
           )}
-          {size !== 'small' && <ActionButtons />}
+          {size !== 'small' && <ActionButtons trailingItems={trailingItems} />}
         </Wrapper>
       </PanelProvider>
     </SearchQueryBuilerContext.Provider>

--- a/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
+++ b/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
@@ -21,10 +21,12 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 interface TokenizedQueryGridProps {
+  actionBarWidth: number;
   label?: string;
 }
 
 interface GridProps extends AriaGridListOptions<ParseResultToken> {
+  actionBarWidth: number;
   children: CollectionChildren<ParseResultToken>;
   items: ParseResultToken[];
 }
@@ -70,7 +72,12 @@ function Grid(props: GridProps) {
   useSelectOnDrag(state);
 
   return (
-    <SearchQueryGridWrapper {...gridProps} ref={ref} size={size}>
+    <SearchQueryGridWrapper
+      {...gridProps}
+      ref={ref}
+      size={size}
+      style={size === 'small' ? undefined : {paddingRight: props.actionBarWidth + 12}}
+    >
       <SelectionKeyHandler ref={selectionKeyHandlerRef} state={state} undo={undo} />
       {[...state.collection].map(item => {
         const token = item.value;
@@ -122,7 +129,7 @@ function Grid(props: GridProps) {
   );
 }
 
-export function TokenizedQueryGrid({label}: TokenizedQueryGridProps) {
+export function TokenizedQueryGrid({label, actionBarWidth}: TokenizedQueryGridProps) {
   const {parsedQuery} = useSearchQueryBuilder();
 
   // Shouldn't ever get here since we will render the plain text input instead
@@ -135,6 +142,7 @@ export function TokenizedQueryGrid({label}: TokenizedQueryGridProps) {
       aria-label={label ?? t('Create a search query')}
       items={parsedQuery}
       selectionMode="multiple"
+      actionBarWidth={actionBarWidth}
     >
       {item => (
         <Item key={makeTokenKey(item, parsedQuery)}>
@@ -146,8 +154,10 @@ export function TokenizedQueryGrid({label}: TokenizedQueryGridProps) {
 }
 
 const SearchQueryGridWrapper = styled('div')<{size: 'small' | 'normal'}>`
-  padding: ${p =>
-    p.size === 'small' ? space(0.75) : `${space(0.75)} 34px ${space(0.75)} 32px`};
+  padding-top: ${space(0.75)};
+  padding-bottom: ${space(0.75)};
+  padding-left: ${p => (p.size === 'small' ? space(0.75) : '32px')};
+  padding-right: ${space(0.75)};
   display: flex;
   align-items: stretch;
   row-gap: ${space(0.5)};


### PR DESCRIPTION
The transaction search bars need to show a warning icon in some situations, which was implemented in the old component using `actionBarItems`. 

This is now named `trailingItems` to be consistent with other components and accepts any JSX so should be flexible enough for any use case.