### PR TITLE
chore(scm): fill in unimplemented get+check_file for Bitbucket and Azure DevOps

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -54,6 +54,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class IntegrationFeatureNotImplementedError(Exception):
+    pass
+
+
 class FeatureDescription(NamedTuple):
     description: str  # A markdown description of the feature
     featureGate: IntegrationFeatures  # A IntegrationFeature that gates this feature

--- a/src/sentry/integrations/bitbucket/client.py
+++ b/src/sentry/integrations/bitbucket/client.py
@@ -7,6 +7,7 @@ from urllib.parse import parse_qs, urlparse, urlsplit
 
 from requests import PreparedRequest
 
+from sentry.integrations.base import IntegrationFeatureNotImplementedError
 from sentry.integrations.client import ApiClient
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.utils import get_query_hash
@@ -178,3 +179,6 @@ class BitbucketApiClient(ApiClient):
                 path=path,
             ),
         )
+
+    def get_file(self, repo: Repository, path: str, version: str, codeowners: bool = False) -> str:
+        raise IntegrationFeatureNotImplementedError

--- a/src/sentry/integrations/bitbucket_server/client.py
+++ b/src/sentry/integrations/bitbucket_server/client.py
@@ -6,8 +6,11 @@ from requests import PreparedRequest
 from requests_oauthlib import OAuth1
 
 from sentry.identity.services.identity.model import RpcIdentity
+from sentry.integrations.base import IntegrationFeatureNotImplementedError
 from sentry.integrations.client import ApiClient
 from sentry.integrations.services.integration.model import RpcIntegration
+from sentry.models.repository import Repository
+from sentry.shared_integrations.client.base import BaseApiResponseX
 from sentry.shared_integrations.exceptions import ApiError
 
 logger = logging.getLogger("sentry.integrations.bitbucket_server")
@@ -251,3 +254,9 @@ class BitbucketServerClient(ApiClient):
             },
         )
         return values
+
+    def check_file(self, repo: Repository, path: str, version: str) -> BaseApiResponseX | None:
+        raise IntegrationFeatureNotImplementedError
+
+    def get_file(self, repo: Repository, path: str, version: str, codeowners: bool = False) -> str:
+        raise IntegrationFeatureNotImplementedError

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -9,6 +9,7 @@ from requests import PreparedRequest
 from rest_framework.response import Response
 
 from sentry.exceptions import InvalidIdentity
+from sentry.integrations.base import IntegrationFeatureNotImplementedError
 from sentry.integrations.client import ApiClient
 from sentry.models.identity import Identity
 from sentry.models.repository import Repository
@@ -278,9 +279,9 @@ class VstsApiClient(IntegrationProxyClient, VstsApiMixin):
                         # TODO(dcramer): this is problematic when the link already exists
                         "op": "replace" if f_name != "link" else "add",
                         "path": FIELD_MAP[f_name],
-                        "value": {"rel": "Hyperlink", "url": f_value}
-                        if f_name == "link"
-                        else f_value,
+                        "value": (
+                            {"rel": "Hyperlink", "url": f_value} if f_name == "link" else f_value
+                        ),
                     }
                 )
 
@@ -432,3 +433,6 @@ class VstsApiClient(IntegrationProxyClient, VstsApiMixin):
                 "versionDescriptor.version": version,
             },
         )
+
+    def get_file(self, repo: Repository, path: str, version: str, codeowners: bool = False) -> str:
+        raise IntegrationFeatureNotImplementedError


### PR DESCRIPTION
"Unimplemented" version of https://github.com/getsentry/sentry/pull/75884

Current state of the SCM APIs implemented related to `RepositoryMixin`:

|  | check_file | get_file |
| --- | --- | --- |
| GitHub | Y | Y |
| GitHub Enterprise | Y | Y |
| Gitlab | Y | Y |
| Bitbucket | Y | N |
| Bitbucket Server | N | N |
| Azure DevOps (VSTS) | Y | N |

To make the abstraction easier, we can define these functions but still raise some kind of error so they are technically "defined". We can fill these in later.

This PR is useful for https://github.com/getsentry/sentry/pull/74908