### PR TITLE
chore(issues): Remove CODEOWNER middleware entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -513,8 +513,6 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /src/sentry/event_manager.py                                @getsentry/issues
 /src/sentry/grouping/                                       @getsentry/issues
 /src/sentry/mediators/                                      @getsentry/issues
-/src/sentry/middleware/ratelimit.py                         @getsentry/issues
-/src/sentry/middleware/access_log.py                        @getsentry/issues
 /src/sentry/ratelimits/                                     @getsentry/issues
 /src/sentry/seer/similarity/                                @getsentry/issues
 /src/sentry/tasks/auto_remove_inbox.py                      @getsentry/issues


### PR DESCRIPTION
These are likely a relic of past issues team responsibilities.