### PR TITLE
chore(seer grouping): Log when seer event creates a group

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1931,6 +1931,17 @@ def _create_group(
     first_release: Release | None = None,
     **group_creation_kwargs: Any,
 ) -> Group:
+    # Temporary log to debug events seeming to disappear after being sent to Seer
+    if event.data.get("seer_similarity"):
+        logger.info(
+            "seer.similarity.pre_create_group",
+            extra={
+                "event_id": event.event_id,
+                "hash": event.get_primary_hash(),
+                "project": project.id,
+            },
+        )
+
     short_id = _get_next_short_id(project)
 
     # it's possible the release was deleted between
@@ -2003,6 +2014,18 @@ def _create_group(
             # Maybe the stuck counter was hiding some other error
             logger.exception("Error after unsticking project counter")
             raise
+
+    # Temporary log to debug events seeming to disappear after being sent to Seer
+    if event.data.get("seer_similarity"):
+        logger.info(
+            "seer.similarity.post_create_group",
+            extra={
+                "event_id": event.event_id,
+                "hash": event.get_primary_hash(),
+                "project": project.id,
+                "group_id": group.id,
+            },
+        )
 
     return group
 


### PR DESCRIPTION
As part of debugging https://github.com/getsentry/sentry/issues/75860 (wherein events get sent to Seer and then seemingly disappear before they can be saved in the DB), this adds logs to the beginning and end of `_create_group`, so we can see how far such disappearing events make it before vanishing. Volume-wise this shouldn't be an issue, as it only affects events which are both sent to Seer and for which Seer doesn't find a match, which ends up being < 1/sec.