### PR TITLE
fix(js): Fix typing on fieldLabel shouldForwardProp

### DIFF
--- a/static/app/components/forms/fieldGroup/fieldLabel.tsx
+++ b/static/app/components/forms/fieldGroup/fieldLabel.tsx
@@ -7,9 +7,9 @@ import type {FieldGroupProps} from './types';
 
 type FieldLabelProps = Pick<FieldGroupProps, 'disabled'>;
 
-const shouldForwardProp = p => p !== 'disabled' && isPropValid(p);
-
-const FieldLabel = styled('div', {shouldForwardProp})<FieldLabelProps>`
+const FieldLabel = styled('div', {
+  shouldForwardProp: p => p !== 'disabled' && isPropValid(p),
+})<FieldLabelProps>`
   color: ${p => (!p.disabled ? p.theme.textColor : p.theme.disabled)};
   display: flex;
   gap: ${space(0.5)};


### PR DESCRIPTION
By inlining it typescript can just infer the property correctly