### PR TITLE
ref(onboarding): Expose DSN object

### DIFF
--- a/static/app/components/feedback/feedbackOnboarding/feedbackOnboardingLayout.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/feedbackOnboardingLayout.tsx
@@ -12,7 +12,6 @@ import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 
 export function FeedbackOnboardingLayout({
-  cdn,
   docsConfig,
   dsn,
   platformKey,
@@ -34,7 +33,6 @@ export function FeedbackOnboardingLayout({
     const doc = docsConfig[configType] ?? docsConfig.onboarding;
 
     const docParams: DocsParams<any> = {
-      cdn,
       dsn,
       organization,
       platformKey,
@@ -62,7 +60,6 @@ export function FeedbackOnboardingLayout({
       steps: [...doc.install(docParams), ...doc.configure(docParams)],
     };
   }, [
-    cdn,
     docsConfig,
     dsn,
     isLoadingRegistry,

--- a/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
@@ -201,7 +201,6 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
     isLoading,
     docs: newDocs,
     dsn,
-    cdn,
   } = useLoadGettingStarted({
     platform:
       showJsFrameworkInstructions && !crashReportOnboarding
@@ -344,7 +343,6 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
       <FeedbackOnboardingLayout
         docsConfig={newDocs}
         dsn={dsn}
-        cdn={cdn}
         activeProductSelection={[]}
         platformKey={currentPlatform.id}
         projectId={currentProject.id}

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -23,7 +23,7 @@ import {
 } from 'sentry/components/onboarding/productSelection';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {PlatformKey, Project} from 'sentry/types';
+import type {PlatformKey, Project, ProjectKey} from 'sentry/types';
 import useOrganization from 'sentry/utils/useOrganization';
 
 const ProductSelectionAvailabilityHook = HookOrDefault({
@@ -33,12 +33,11 @@ const ProductSelectionAvailabilityHook = HookOrDefault({
 
 export type OnboardingLayoutProps = {
   docsConfig: Docs<any>;
-  dsn: string;
+  dsn: ProjectKey['dsn'];
   platformKey: PlatformKey;
   projectId: Project['id'];
   projectSlug: Project['slug'];
   activeProductSelection?: ProductSolution[];
-  cdn?: string;
   configType?: ConfigType;
   newOrg?: boolean;
 };
@@ -46,7 +45,6 @@ export type OnboardingLayoutProps = {
 const EMPTY_ARRAY: never[] = [];
 
 export function OnboardingLayout({
-  cdn,
   docsConfig,
   dsn,
   platformKey,
@@ -66,7 +64,6 @@ export function OnboardingLayout({
     const doc = docsConfig[configType] ?? docsConfig.onboarding;
 
     const docParams: DocsParams<any> = {
-      cdn,
       dsn,
       organization,
       platformKey,
@@ -97,7 +94,6 @@ export function OnboardingLayout({
       nextSteps: doc.nextSteps?.(docParams) || [],
     };
   }, [
-    cdn,
     activeProductSelection,
     docsConfig,
     dsn,

--- a/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
@@ -28,7 +28,7 @@ export function SdkDocumentation({
   configType,
   organization,
 }: SdkDocumentationProps) {
-  const {isLoading, isError, dsn, cdn, docs, refetch} = useLoadGettingStarted({
+  const {isLoading, isError, dsn, docs, refetch} = useLoadGettingStarted({
     orgSlug: organization.slug,
     projSlug: projectSlug,
     platform,
@@ -73,7 +73,6 @@ export function SdkDocumentation({
     <OnboardingLayout
       docsConfig={docs}
       dsn={dsn}
-      cdn={cdn}
       activeProductSelection={activeProductSelection}
       newOrg={newOrg}
       platformKey={platform.id}

--- a/static/app/components/onboarding/gettingStartedDoc/types.ts
+++ b/static/app/components/onboarding/gettingStartedDoc/types.ts
@@ -1,6 +1,6 @@
 import type {StepProps} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import type {ReleaseRegistrySdk} from 'sentry/components/onboarding/gettingStartedDoc/useSourcePackageRegistries';
-import type {Organization, PlatformKey, Project} from 'sentry/types';
+import type {Organization, PlatformKey, Project, ProjectKey} from 'sentry/types';
 
 type GeneratorFunction<T, Params> = (params: Params) => T;
 type WithGeneratorProperties<T extends Record<string, any>, Params> = {
@@ -36,7 +36,7 @@ export type SelectedPlatformOptions<
 export interface DocsParams<
   PlatformOptions extends BasePlatformOptions = BasePlatformOptions,
 > {
-  dsn: string;
+  dsn: ProjectKey['dsn'];
   isFeedbackSelected: boolean;
   isPerformanceSelected: boolean;
   isProfilingSelected: boolean;
@@ -47,7 +47,6 @@ export interface DocsParams<
   projectId: Project['id'];
   projectSlug: Project['slug'];
   sourcePackageRegistries: {isLoading: boolean; data?: ReleaseRegistrySdk};
-  cdn?: string;
   feedbackOptions?: {
     email?: boolean;
     name?: boolean;

--- a/static/app/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding.tsx
@@ -127,7 +127,7 @@ const getCrashReportModalSnippetJavaScript = params => [
         language: 'html',
         code: `<script>
   Sentry.init({
-    dsn: "${params.dsn}",
+    dsn: "${params.dsn.public}",
     beforeSend(event, hint) {
       // Check if it is an exception, and if so, show the report dialog
       if (event.exception && event.event_id) {
@@ -187,7 +187,7 @@ const getGenericScript = params => [
     value: 'html',
     language: 'html',
     code: `<script>
-  Sentry.init({ dsn: "${params.dsn}" });
+  Sentry.init({ dsn: "${params.dsn.public}" });
   Sentry.showReportDialog({
     eventId: "{{ event_id }}",
   });
@@ -297,7 +297,7 @@ export const getCrashReportPHPInstallStep = params => [
             language: 'html',
             code: `<?php if (\Sentry\SentrySdk::getCurrentHub()->getLastEventId()) { ?>
 <script>
-  Sentry.init({ dsn: "${params.dsn}" });
+  Sentry.init({ dsn: "${params.dsn.public}" });
   Sentry.showReportDialog({
     eventId:
       "<?php echo \Sentry\SentrySdk::getCurrentHub()->getLastEventId(); ?>",

--- a/static/app/components/onboarding/gettingStartedDoc/utils/metricsOnboarding.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/metricsOnboarding.tsx
@@ -12,7 +12,7 @@ import {getInstallConfig as getNodeInstallConfig} from 'sentry/utils/gettingStar
 
 const getJSConfigureSnippet = (params: DocsParams) => `
 Sentry.init({
-  dsn: "${params.dsn}",
+  dsn: "${params.dsn.public}",
   // Only needed for SDK versions < 8.0.0
   // integrations: [
   //   Sentry.metrics.metricsAggregatorIntegration(),
@@ -150,7 +150,7 @@ const getJSMetricsOnboardingVerify = ({docsLink}: {docsLink: string}) => [
 
 const getJSServerConfigureSnippet = (params: DocsParams) => `
 Sentry.init({
-  dsn: "${params.dsn}",
+  dsn: "${params.dsn.public}",
   // Only needed for SDK versions < 8.0.0
   // _experiments: {
   //   metricsAggregator: true,
@@ -229,7 +229,7 @@ const getJvmKotlinConfigureSnippet = (params: DocsParams) => `
 import io.sentry.Sentry
 
 Sentry.init(this) { options ->
-  options.dsn = "${params.dsn}",
+  options.dsn = "${params.dsn.public}",
   options.enableMetrics = true
 }`;
 
@@ -237,7 +237,7 @@ const getJvmJavaConfigureSnippet = (params: DocsParams) => `
 import io.sentry.Sentry;
 
 Sentry.init(this, options -> {
-  options.setDsn("${params.dsn}");
+  options.setDsn("${params.dsn.public}");
   options.setEnableMetrics(true);
 });`;
 
@@ -245,7 +245,7 @@ const getAndroidKotlinConfigureSnippet = (params: DocsParams) => `
 import io.sentry.android.core.SentryAndroid
 
 SentryAndroid.init(this) { options ->
-  options.dsn = "${params.dsn}",
+  options.dsn = "${params.dsn.public}",
   options.enableMetrics = true
 }`;
 
@@ -253,14 +253,14 @@ const getAndroidJavaConfigureSnippet = (params: DocsParams) => `
 import io.sentry.android.core.SentryAndroid;
 
 SentryAndroid.init(this, options -> {
-  options.setDsn("${params.dsn}");
+  options.setDsn("${params.dsn.public}");
   options.setEnableMetrics(true);
 });`;
 
 const getAndroidXmlConfigureSnippet = (params: DocsParams) => `
 <manifest>
     <application>
-        <meta-data android:name="io.sentry.dsn" android:value="${params.dsn}" />
+        <meta-data android:name="io.sentry.dsn" android:value="${params.dsn.public}" />
         <meta-data android:name="io.sentry.enable-metrics" android:value="true" />
     </application>
 </manifest>`;
@@ -562,7 +562,7 @@ const getPythonConfigureSnippet = (params: DocsParams) => `
 import sentry_sdk
 
 sentry_sdk.init(
-  dsn="${params.dsn}",
+  dsn="${params.dsn.public}",
   # ...
 )`;
 
@@ -678,7 +678,7 @@ export const getPythonMetricsOnboarding = ({
 const getDotnetConfigureSnippet = (params: DocsParams) => `
 SentrySdk.Init(options =>
 {
-  options.Dsn = "${params.dsn}";
+  options.Dsn = "${params.dsn.public}";
   options.ExperimentalMetrics = new ExperimentalMetricsOptions
   {
     EnableCodeLocations = true

--- a/static/app/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted.tsx
@@ -6,7 +6,7 @@ import {
   feedbackOnboardingPlatforms,
   replayPlatforms,
 } from 'sentry/data/platformCategories';
-import type {Organization, PlatformIntegration, Project} from 'sentry/types';
+import type {Organization, PlatformIntegration, Project, ProjectKey} from 'sentry/types';
 import {getPlatformPath} from 'sentry/utils/gettingStartedDocs/getPlatformPath';
 import {useProjectKeys} from 'sentry/utils/useProjectKeys';
 
@@ -23,9 +23,8 @@ export function useLoadGettingStarted({
   orgSlug,
   projSlug,
 }: Props): {
-  cdn: string | undefined;
   docs: Docs<any> | null;
-  dsn: string | undefined;
+  dsn: ProjectKey['dsn'] | undefined;
   isError: boolean;
   isLoading: boolean;
   refetch: () => void;
@@ -72,7 +71,6 @@ export function useLoadGettingStarted({
     isLoading: projectKeys.isLoading || module === undefined,
     isError: projectKeys.isError,
     docs: module === 'none' ? null : module?.default ?? null,
-    dsn: projectKeys.data?.[0]?.dsn.public,
-    cdn: projectKeys.data?.[0]?.dsn.cdn,
+    dsn: projectKeys.data?.[0]?.dsn,
   };
 }

--- a/static/app/components/profiling/profilingOnboardingSidebar.tsx
+++ b/static/app/components/profiling/profilingOnboardingSidebar.tsx
@@ -217,7 +217,7 @@ interface ProfilingOnboardingContentProps {
 }
 
 function ProfilingOnboardingContent(props: ProfilingOnboardingContentProps) {
-  const {isLoading, isError, dsn, cdn, docs, refetch} = useLoadGettingStarted({
+  const {isLoading, isError, dsn, docs, refetch} = useLoadGettingStarted({
     orgSlug: props.organization.slug,
     projSlug: props.projectSlug,
     platform: props.platform,
@@ -259,7 +259,6 @@ function ProfilingOnboardingContent(props: ProfilingOnboardingContentProps) {
   }
 
   const docParams: DocsParams<any> = {
-    cdn,
     dsn,
     organization: props.organization,
     platformKey: props.platform.id,

--- a/static/app/components/replaysOnboarding/replayOnboardingLayout.tsx
+++ b/static/app/components/replaysOnboarding/replayOnboardingLayout.tsx
@@ -11,7 +11,6 @@ import ReplayConfigToggle from 'sentry/components/replaysOnboarding/replayConfig
 import useOrganization from 'sentry/utils/useOrganization';
 
 export function ReplayOnboardingLayout({
-  cdn,
   docsConfig,
   dsn,
   platformKey,
@@ -30,7 +29,6 @@ export function ReplayOnboardingLayout({
     const doc = docsConfig[configType] ?? docsConfig.onboarding;
 
     const docParams: DocsParams<any> = {
-      cdn,
       dsn,
       organization,
       platformKey,
@@ -62,7 +60,6 @@ export function ReplayOnboardingLayout({
       nextSteps: doc.nextSteps?.(docParams) || [],
     };
   }, [
-    cdn,
     docsConfig,
     dsn,
     isLoadingRegistry,

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -218,7 +218,6 @@ function OnboardingContent({
   const {
     docs,
     dsn,
-    cdn,
     isLoading: isProjKeysLoading,
   } = useLoadGettingStarted({
     platform:
@@ -378,7 +377,6 @@ function OnboardingContent({
       <ReplayOnboardingLayout
         docsConfig={docs}
         dsn={dsn}
-        cdn={cdn}
         activeProductSelection={[]}
         platformKey={currentPlatform.id}
         projectId={currentProject.id}

--- a/static/app/components/updatedEmptyState.tsx
+++ b/static/app/components/updatedEmptyState.tsx
@@ -49,14 +49,12 @@ export default function UpdatedEmptyState({project}: {project?: Project}) {
     loadGettingStarted.isError ||
     loadGettingStarted.isLoading ||
     !loadGettingStarted.docs ||
-    !loadGettingStarted.cdn ||
     !loadGettingStarted.dsn
   ) {
     return null;
   }
 
   const docParams: DocsParams<any> = {
-    cdn: loadGettingStarted.cdn,
     dsn: loadGettingStarted.dsn,
     organization,
     platformKey: currentPlatformKey,

--- a/static/app/gettingStartedDocs/android/android.tsx
+++ b/static/app/gettingStartedDocs/android/android.tsx
@@ -59,7 +59,7 @@ plugins {
 const getConfigurationSnippet = (params: Params) => `
 <application>
   <!-- Required: set your sentry.io project identifier (DSN) -->
-  <meta-data android:name="io.sentry.dsn" android:value="${params.dsn}" />
+  <meta-data android:name="io.sentry.dsn" android:value="${params.dsn.public}" />
 
   <!-- enable automatic breadcrumbs for user interactions (clicks, swipes, scrolls) -->
   <meta-data android:name="io.sentry.traces.user-interaction.enable" android:value="true" />

--- a/static/app/gettingStartedDocs/apple/ios.tsx
+++ b/static/app/gettingStartedDocs/apple/ios.tsx
@@ -64,7 +64,7 @@ func application(_ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
     SentrySDK.start { options in
-        options.dsn = "${params.dsn}"
+        options.dsn = "${params.dsn.public}"
         options.debug = true // Enabling debug when first installing is always helpful${
           params.isPerformanceSelected
             ? `
@@ -94,7 +94,7 @@ import Sentry
 struct SwiftUIApp: App {
     init() {
         SentrySDK.start { options in
-            options.dsn = "${params.dsn}"
+            options.dsn = "${params.dsn.public}"
             options.debug = true // Enabling debug when first installing is always helpful${
               params.isPerformanceSelected
                 ? `
@@ -159,7 +159,7 @@ const getConfigureMetricsSnippetSwift = (params: Params) => `
 import Sentry
 
 SentrySDK.start { options in
-    options.dsn = "${params.dsn}"
+    options.dsn = "${params.dsn.public}"
 
     options.enableMetrics = true
 }`;
@@ -168,7 +168,7 @@ const getConfigureMetricsSnippetObjC = (params: Params) => `
 @import Sentry;
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions * options) {
-    options.Dsn = @"${params.dsn}";
+    options.Dsn = @"${params.dsn.public}";
 
     options.enableMetrics = YES;
 }];`;

--- a/static/app/gettingStartedDocs/apple/macos.tsx
+++ b/static/app/gettingStartedDocs/apple/macos.tsx
@@ -29,7 +29,7 @@ import Sentry
 func applicationDidFinishLaunching(_ aNotification: Notification) {
 
     SentrySDK.start { options in
-        options.dsn = "${params.dsn}"
+        options.dsn = "${params.dsn.public}"
         options.debug = true // Enabling debug when first installing is always helpful${
           params.isPerformanceSelected
             ? `
@@ -59,7 +59,7 @@ import Sentry
 struct SwiftUIApp: App {
     init() {
         SentrySDK.start { options in
-            options.dsn = "${params.dsn}"
+            options.dsn = "${params.dsn.public}"
             options.debug = true // Enabling debug when first installing is always helpful${
               params.isPerformanceSelected
                 ? `
@@ -278,7 +278,7 @@ userFeedback.name = @"John Doe";
               code: `import Sentry
 
 SentrySDK.start { options in
-    options.dsn = "${params.dsn}"
+    options.dsn = "${params.dsn.public}"
     options.onCrashedLastRun = { event in
         // capture user feedback
     }
@@ -292,7 +292,7 @@ SentrySDK.start { options in
               code: `@import Sentry;
 
 [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
-    options.dsn = @"${params.dsn}";
+    options.dsn = @"${params.dsn.public}";
     options.onCrashedLastRun = ^void(SentryEvent * _Nonnull event) {
         // capture user feedback
     };

--- a/static/app/gettingStartedDocs/bun/bun.tsx
+++ b/static/app/gettingStartedDocs/bun/bun.tsx
@@ -30,7 +30,7 @@ const getConfigureSnippet = (params: Params) => `
 import * as Sentry from "@sentry/bun";
 
 Sentry.init({
-  dsn: "${params.dsn}",${
+  dsn: "${params.dsn.public}",${
     params.isPerformanceSelected
       ? `
   // Performance Monitoring
@@ -47,7 +47,7 @@ const getVerifySnippet = () => `try {
 
 const getMetricsConfigureSnippet = (params: DocsParams) => `
 Sentry.init({
-  dsn: "${params.dsn}",
+  dsn: "${params.dsn.public}",
   // Only needed for SDK versions < 8.0.0
   // _experiments: {
   //   metricsAggregator: true,

--- a/static/app/gettingStartedDocs/capacitor/capacitor.tsx
+++ b/static/app/gettingStartedDocs/capacitor/capacitor.tsx
@@ -114,7 +114,7 @@ const getSentryInitLayout = (params: Params, siblingOption: string): string => {
       : siblingOption === SiblingOption.VUE3
         ? 'app,'
         : ''
-  }dsn: "${params.dsn}",
+  }dsn: "${params.dsn.public}",
    integrations: [
     ${getIntegrations(params, siblingOption)}
    ],

--- a/static/app/gettingStartedDocs/cordova/cordova.tsx
+++ b/static/app/gettingStartedDocs/cordova/cordova.tsx
@@ -19,7 +19,7 @@ type Params = DocsParams;
 const getConfigureSnippet = (params: Params) => `
 onDeviceReady: function() {
   var Sentry = cordova.require('sentry-cordova.Sentry');
-  Sentry.init({ dsn: '${params.dsn}' });
+  Sentry.init({ dsn: '${params.dsn.public}' });
 }`;
 
 const onboarding: OnboardingConfig = {

--- a/static/app/gettingStartedDocs/dart/dart.tsx
+++ b/static/app/gettingStartedDocs/dart/dart.tsx
@@ -26,7 +26,7 @@ import 'package:sentry/sentry.dart';
 
 Future<void> main() async {
   await Sentry.init((options) {
-    options.dsn = '${params.dsn}';
+    options.dsn = '${params.dsn.public}';
     // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
     // We recommend adjusting this value in production.
     options.tracesSampleRate = 1.0;
@@ -81,7 +81,7 @@ import 'package:sentry/sentry.dart';
 
 Future<void> main() async {
  await Sentry.init((options) {
-   options.dsn = '${params.dsn}';
+   options.dsn = '${params.dsn.public}';
    options.enableMetrics = true;
  },
 );`;

--- a/static/app/gettingStartedDocs/deno/deno.tsx
+++ b/static/app/gettingStartedDocs/deno/deno.tsx
@@ -32,7 +32,7 @@ const getInstallConfig = () => [
 const getConfigureSnippet = (params: Params) =>
   `
 Sentry.init({
-  dsn: "${params.dsn}",${
+  dsn: "${params.dsn.public}",${
     params.isPerformanceSelected
       ? `
   // enable performance
@@ -50,7 +50,7 @@ setTimeout(() => {
 
 const getMetricsConfigureSnippet = (params: DocsParams) => `;
 Sentry.init({
-  dsn: '${params.dsn}',
+  dsn: '${params.dsn.public}',
   // Only needed for SDK versions < 8.0.0
   // _experiments: {
   //   metricsAggregator: true,

--- a/static/app/gettingStartedDocs/dotnet/aspnet.tsx
+++ b/static/app/gettingStartedDocs/dotnet/aspnet.tsx
@@ -54,7 +54,7 @@ public class MvcApplication : HttpApplication
         _sentry = SentrySdk.Init(o =>
         {
             o.AddAspNet();
-            o.Dsn = "${params.dsn}";
+            o.Dsn = "${params.dsn.public}";
             // When configuring for the first time, to see what the SDK is doing:
             o.Debug = true;${
               params.isPerformanceSelected
@@ -202,7 +202,7 @@ const crashReportOnboarding: OnboardingConfig = {
               language: 'html',
               code: `@if (SentrySdk.LastEventId != SentryId.Empty) {
   <script>
-    Sentry.init({ dsn: "${params.dsn}" });
+    Sentry.init({ dsn: "${params.dsn.public}" });
     Sentry.showReportDialog({ eventId: "@SentrySdk.LastEventId" });
   </script>
 }`,

--- a/static/app/gettingStartedDocs/dotnet/aspnetcore.tsx
+++ b/static/app/gettingStartedDocs/dotnet/aspnetcore.tsx
@@ -57,7 +57,7 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
           // Add the following line:
           webBuilder.UseSentry(o =>
           {
-              o.Dsn = "${params.dsn}";
+              o.Dsn = "${params.dsn.public}";
               // When configuring for the first time, to see what the SDK is doing:
               o.Debug = true;${
                 params.isPerformanceSelected

--- a/static/app/gettingStartedDocs/dotnet/awslambda.tsx
+++ b/static/app/gettingStartedDocs/dotnet/awslambda.tsx
@@ -42,7 +42,7 @@ public class LambdaEntryPoint : Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFu
             // Add Sentry
             .UseSentry(o =>
             {
-              o.Dsn = "${params.dsn}";
+              o.Dsn = "${params.dsn.public}";
               // When configuring for the first time, to see what the SDK is doing:
               o.Debug = true;
               // Required in Serverless environments

--- a/static/app/gettingStartedDocs/dotnet/dotnet.tsx
+++ b/static/app/gettingStartedDocs/dotnet/dotnet.tsx
@@ -66,7 +66,7 @@ SentrySdk.Init(options =>
     // A Sentry Data Source Name (DSN) is required.
     // See https://docs.sentry.io/product/sentry-basics/dsn-explainer/
     // You can set it in the SENTRY_DSN environment variable, or you can set it in code here.
-    options.Dsn = "${params.dsn}";
+    options.Dsn = "${params.dsn.public}";
 
     // When debug is enabled, the Sentry client will emit detailed debugging information to the console.
     // This might be helpful, or might interfere with the normal operation of your application.

--- a/static/app/gettingStartedDocs/dotnet/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/dotnet/gcpfunctions.tsx
@@ -59,7 +59,7 @@ public class Function : IHttpFunction
 const getConfigureJsonSnippet = (params: Params) => `
 {
   "Sentry": {
-    "Dsn": "${params.dsn}",
+    "Dsn": "${params.dsn.public}",
     // Sends Cookies, User Id when one is logged on and user IP address to sentry. It's turned off by default.
     "SendDefaultPii": true,
     // When configuring for the first time, to see what the SDK is doing:

--- a/static/app/gettingStartedDocs/dotnet/maui.tsx
+++ b/static/app/gettingStartedDocs/dotnet/maui.tsx
@@ -64,7 +64,7 @@ public static MauiApp CreateMauiApp()
     // Add this section anywhere on the builder:
     .UseSentry(options => {
       // The DSN is the only required setting.
-      options.Dsn = "${params.dsn}";
+      options.Dsn = "${params.dsn.public}";
 
       // Use debug mode if you want to see what the SDK is doing.
       // Debug messages are written to stdout with Console.Writeline,

--- a/static/app/gettingStartedDocs/dotnet/uwp.tsx
+++ b/static/app/gettingStartedDocs/dotnet/uwp.tsx
@@ -39,7 +39,7 @@ sealed partial class App : Application
         SentrySdk.Init(o =>
         {
             // Tells which project in Sentry to send events to:
-            o.Dsn = "${params.dsn}";
+            o.Dsn = "${params.dsn.public}";
             // When configuring for the first time, to see what the SDK is doing:
             o.Debug = true;${
               params.isPerformanceSelected

--- a/static/app/gettingStartedDocs/dotnet/winforms.tsx
+++ b/static/app/gettingStartedDocs/dotnet/winforms.tsx
@@ -65,7 +65,7 @@ static class Program
         SentrySdk.Init(o =>
         {
             // Tells which project in Sentry to send events to:
-            o.Dsn = "${params.dsn}";
+            o.Dsn = "${params.dsn.public}";
             // When configuring for the first time, to see what the SDK is doing:
             o.Debug = true;${
               params.isPerformanceSelected

--- a/static/app/gettingStartedDocs/dotnet/wpf.tsx
+++ b/static/app/gettingStartedDocs/dotnet/wpf.tsx
@@ -64,7 +64,7 @@ public partial class App : Application
         SentrySdk.Init(o =>
         {
             // Tells which project in Sentry to send events to:
-            o.Dsn = "${params.dsn}";
+            o.Dsn = "${params.dsn.public}";
             // When configuring for the first time, to see what the SDK is doing:
             o.Debug = true;${
               params.isPerformanceSelected

--- a/static/app/gettingStartedDocs/dotnet/xamarin.tsx
+++ b/static/app/gettingStartedDocs/dotnet/xamarin.tsx
@@ -40,7 +40,7 @@ public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompa
         SentryXamarin.Init(options =>
         {
             // Tells which project in Sentry to send events to:
-            options.Dsn = "${params.dsn}";
+            options.Dsn = "${params.dsn.public}";
             // When configuring for the first time, to see what the SDK is doing:
             options.Debug = true;
             // Set TracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
@@ -57,7 +57,7 @@ public partial class AppDelegate : global::Xamarin.Forms.Platform.iOS.FormsAppli
     {
         SentryXamarin.Init(options =>
         {
-            options.Dsn = "${params.dsn}";
+            options.Dsn = "${params.dsn.public}";
             // When configuring for the first time, to see what the SDK is doing:
             options.Debug = true;
             // Set TracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
@@ -73,7 +73,7 @@ sealed partial class App : Application
     {
         SentryXamarin.Init(options =>
         {
-            options.Dsn = "${params.dsn}";
+            options.Dsn = "${params.dsn.public}";
             // When configuring for the first time, to see what the SDK is doing:
             options.Debug = true;
             // Set TracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.

--- a/static/app/gettingStartedDocs/electron/electron.tsx
+++ b/static/app/gettingStartedDocs/electron/electron.tsx
@@ -30,7 +30,7 @@ const getConfigureSnippet = (params: Params) => `
 import * as Sentry from "@sentry/electron";
 
 Sentry.init({
-  dsn: "${params.dsn}",
+  dsn: "${params.dsn.public}",
 });`;
 
 const getMetricsConfigureSnippet = (params: Params) => `
@@ -38,7 +38,7 @@ import * as Sentry from '@sentry/electron/main';
 
 // main process init
 Sentry.init({
-  dsn: "${params.dsn}",
+  dsn: "${params.dsn.public}",
   // Only needed for SDK versions < 8.0.0
   // _experiments: {
   //   metricsAggregator: true,
@@ -157,7 +157,7 @@ const replayOnboarding: OnboardingConfig = {
               language: 'javascript',
               code: getReplaySDKSetupSnippet({
                 importStatement: `import * as Sentry from "@sentry/electron/renderer";`,
-                dsn: params.dsn,
+                dsn: params.dsn.public,
                 mask: params.replayOptions?.mask,
                 block: params.replayOptions?.block,
               }),
@@ -297,7 +297,7 @@ const feedbackOnboarding: OnboardingConfig = {
               language: 'javascript',
               code: getFeedbackSDKSetupSnippet({
                 importStatement: `import * as Sentry from "@sentry/electron/renderer";`,
-                dsn: params.dsn,
+                dsn: params.dsn.public,
                 feedbackOptions: params.feedbackOptions,
               }),
             },
@@ -329,7 +329,7 @@ const crashReportOnboarding: OnboardingConfig = {
               code: `const { init, showReportDialog } = require("@sentry/electron");
 
 init({
-  dsn: "${params.dsn}",
+  dsn: "${params.dsn.public}",
   beforeSend(event) {
     // Check if it is an exception, if so, show the report dialog
     // Note that this only will work in the renderer process, it's a noop on the main process

--- a/static/app/gettingStartedDocs/elixir/elixir.tsx
+++ b/static/app/gettingStartedDocs/elixir/elixir.tsx
@@ -28,7 +28,7 @@ end`;
 
 const getConfigureSnippet = (params: Params) => `
   config :sentry,
-  dsn: "${params.dsn}",
+  dsn: "${params.dsn.public}",
   environment_name: Mix.env(),
   enable_source_code_context: true,
   root_source_code_paths: [File.cwd!()]`;

--- a/static/app/gettingStartedDocs/flutter/flutter.tsx
+++ b/static/app/gettingStartedDocs/flutter/flutter.tsx
@@ -25,7 +25,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 Future<void> main() async {
   await SentryFlutter.init(
     (options) {
-      options.dsn = '${params.dsn}';${
+      options.dsn = '${params.dsn.public}';${
         params.isPerformanceSelected
           ? `
       // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
@@ -94,7 +94,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 Future<void> main() async {
   await SentryFlutter.init(
     (options) {
-      options.dsn = '${params.dsn}';
+      options.dsn = '${params.dsn.public}';
       options.enableMetrics = true;
     },
     appRunner: initApp, // Init your App.

--- a/static/app/gettingStartedDocs/go/echo.tsx
+++ b/static/app/gettingStartedDocs/go/echo.tsx
@@ -32,7 +32,7 @@ import (
 
 // To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 if err := sentry.Init(sentry.ClientOptions{
-  Dsn: "${params.dsn}",${
+  Dsn: "${params.dsn.public}",${
     params.isPerformanceSelected
       ? `
   // Set TracesSampleRate to 1.0 to capture 100%
@@ -112,7 +112,7 @@ app.Logger.Fatal(app.Start(":3000"))`;
 
 const getBeforeSendSnippet = params => `
 sentry.Init(sentry.ClientOptions{
-  Dsn: "${params.dsn}",
+  Dsn: "${params.dsn.public}",
   BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
     if hint.Context != nil {
       if req, ok := hint.Context.Value(sentry.RequestContextKey).(*http.Request); ok {

--- a/static/app/gettingStartedDocs/go/fasthttp.tsx
+++ b/static/app/gettingStartedDocs/go/fasthttp.tsx
@@ -30,7 +30,7 @@ import (
 
 // To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 if err := sentry.Init(sentry.ClientOptions{
-  Dsn: "${params.dsn}",${
+  Dsn: "${params.dsn.public}",${
     params.isPerformanceSelected
       ? `
   EnableTracing: true,
@@ -117,7 +117,7 @@ if err := fasthttp.ListenAndServe(":3000", sentryHandler.Handle(fastHTTPHandler)
 
 const getBeforeSendSnippet = params => `
 sentry.Init(sentry.ClientOptions{
-  Dsn: "${params.dsn}",
+  Dsn: "${params.dsn.public}",
   BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
     if hint.Context != nil {
       if ctx, ok := hint.Context.Value(sentry.RequestContextKey).(*fasthttp.RequestCtx); ok {

--- a/static/app/gettingStartedDocs/go/fiber.tsx
+++ b/static/app/gettingStartedDocs/go/fiber.tsx
@@ -30,7 +30,7 @@ import (
 
 // To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 if err := sentry.Init(sentry.ClientOptions{
-  Dsn: "${params.dsn}",
+  Dsn: "${params.dsn.public}",
   // Set TracesSampleRate to 1.0 to capture 100%
   // of transactions for performance monitoring.
   // We recommend adjusting this value in production,
@@ -122,7 +122,7 @@ if err := app.Listen(":3000"); err != nil {
 
 const getBeforeSendSnippet = params => `
 sentry.Init(sentry.ClientOptions{
-  Dsn: "${params.dsn}",
+  Dsn: "${params.dsn.public}",
   BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
     if hint.Context != nil {
       if req, ok := hint.Context.Value(sentry.RequestContextKey).(*http.Request); ok {

--- a/static/app/gettingStartedDocs/go/gin.tsx
+++ b/static/app/gettingStartedDocs/go/gin.tsx
@@ -31,7 +31,7 @@ import (
 
 // To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 if err := sentry.Init(sentry.ClientOptions{
-  Dsn: "${params.dsn}",${
+  Dsn: "${params.dsn.public}",${
     params.isPerformanceSelected
       ? `
   EnableTracing: true,
@@ -104,7 +104,7 @@ app.Run(":3000")`;
 
 const getBeforeSendSnippet = params => `
 sentry.Init(sentry.ClientOptions{
-  Dsn: "${params.dsn}",
+  Dsn: "${params.dsn.public}",
   BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
     if hint.Context != nil {
       if req, ok := hint.Context.Value(sentry.RequestContextKey).(*http.Request); ok {

--- a/static/app/gettingStartedDocs/go/go.tsx
+++ b/static/app/gettingStartedDocs/go/go.tsx
@@ -25,7 +25,7 @@ import (
 
 func main() {
   err := sentry.Init(sentry.ClientOptions{
-    Dsn: "${params.dsn}",${
+    Dsn: "${params.dsn.public}",${
       params.isPerformanceSelected
         ? `
     // Set TracesSampleRate to 1.0 to capture 100%
@@ -52,7 +52,7 @@ import (
 
 func main() {
   err := sentry.Init(sentry.ClientOptions{
-    Dsn: "${params.dsn}",${
+    Dsn: "${params.dsn.public}",${
       params.isPerformanceSelected
         ? `
     // Set TracesSampleRate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/go/http.tsx
+++ b/static/app/gettingStartedDocs/go/http.tsx
@@ -30,7 +30,7 @@ import (
 
 // To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 if err := sentry.Init(sentry.ClientOptions{
-  Dsn: "${params.dsn}",${
+  Dsn: "${params.dsn.public}",${
     params.isPerformanceSelected
       ? `
   // Set TracesSampleRate to 1.0 to capture 100%
@@ -112,7 +112,7 @@ if err := http.ListenAndServe(":3000", nil); err != nil {
 
 const getBeforeSendSnippet = params => `
 sentry.Init(sentry.ClientOptions{
-  Dsn: "${params.dsn}",
+  Dsn: "${params.dsn.public}",
   BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
     if hint.Context != nil {
       if req, ok := hint.Context.Value(sentry.RequestContextKey).(*http.Request); ok {

--- a/static/app/gettingStartedDocs/go/iris.tsx
+++ b/static/app/gettingStartedDocs/go/iris.tsx
@@ -30,7 +30,7 @@ import (
 
 // To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 if err := sentry.Init(sentry.ClientOptions{
-  Dsn: "${params.dsn}",${
+  Dsn: "${params.dsn.public}",${
     params.isPerformanceSelected
       ? `
   // Set TracesSampleRate to 1.0 to capture 100%
@@ -101,7 +101,7 @@ app.Run(iris.Addr(":3000"))`;
 
 const getBeforeSendSnippet = params => `
 sentry.Init(sentry.ClientOptions{
-  Dsn: "${params.dsn}",
+  Dsn: "${params.dsn.public}",
   BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
     if hint.Context != nil {
       if req, ok := hint.Context.Value(sentry.RequestContextKey).(*http.Request); ok {

--- a/static/app/gettingStartedDocs/go/martini.tsx
+++ b/static/app/gettingStartedDocs/go/martini.tsx
@@ -30,7 +30,7 @@ import (
 
 // To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 if err := sentry.Init(sentry.ClientOptions{
-  Dsn: "${params.dsn}",${
+  Dsn: "${params.dsn.public}",${
     params.isPerformanceSelected
       ? `
   // Set TracesSampleRate to 1.0 to capture 100%
@@ -99,7 +99,7 @@ app.Run()`;
 
 const getBeforeSendSnippet = params => `
 sentry.Init(sentry.ClientOptions{
-  Dsn: "${params.dsn}",
+  Dsn: "${params.dsn.public}",
   BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
     if hint.Context != nil {
       if req, ok := hint.Context.Value(sentry.RequestContextKey).(*http.Request); ok {

--- a/static/app/gettingStartedDocs/go/negroni.tsx
+++ b/static/app/gettingStartedDocs/go/negroni.tsx
@@ -31,7 +31,7 @@ import (
 
 // To initialize Sentry's handler, you need to initialize Sentry itself beforehand
 if err := sentry.Init(sentry.ClientOptions{
-  Dsn: "${params.dsn}",${
+  Dsn: "${params.dsn.public}",${
     params.isPerformanceSelected
       ? `
   // Set TracesSampleRate to 1.0 to capture 100%
@@ -109,7 +109,7 @@ http.ListenAndServe(":3000", app)`;
 
 const getBeforeSendSnippet = params => `
 sentry.Init(sentry.ClientOptions{
-  Dsn: "${params.dsn}",
+  Dsn: "${params.dsn.public}",
   BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
     if hint.Context != nil {
       if req, ok := hint.Context.Value(sentry.RequestContextKey).(*http.Request); ok {

--- a/static/app/gettingStartedDocs/java/java.tsx
+++ b/static/app/gettingStartedDocs/java/java.tsx
@@ -121,7 +121,7 @@ const getConfigureSnippet = (params: Params) => `
 import io.sentry.Sentry;
 
 Sentry.init(options -> {
-  options.setDsn("${params.dsn}");${
+  options.setDsn("${params.dsn.public}");${
     params.isPerformanceSelected
       ? `
   // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.

--- a/static/app/gettingStartedDocs/java/log4j2.tsx
+++ b/static/app/gettingStartedDocs/java/log4j2.tsx
@@ -111,7 +111,7 @@ const getConsoleAppenderSnippet = (params: Params) => `
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
         <Sentry name="Sentry"
-                dsn=${params.dsn}>
+                dsn=${params.dsn.public}>
     </Appenders>
     <Loggers>
         <Root level="info">
@@ -125,7 +125,7 @@ const getLogLevelSnippet = (params: Params) => `
 <!-- Setting minimumBreadcrumbLevel modifies the default minimum level to add breadcrumbs from INFO to DEBUG  -->
 <!-- Setting minimumEventLevel the default minimum level to capture an event from ERROR to WARN  -->
 <Sentry name="Sentry"
-        dsn="${params.dsn}"
+        dsn="${params.dsn.public}"
         minimumBreadcrumbLevel="DEBUG"
         minimumEventLevel="WARN"
 />`;

--- a/static/app/gettingStartedDocs/java/logback.tsx
+++ b/static/app/gettingStartedDocs/java/logback.tsx
@@ -115,7 +115,7 @@ const getConsoleAppenderSnippet = (params: Params) => `
   <!-- Configure the Sentry appender, overriding the logging threshold to the WARN level -->
   <appender name="Sentry" class="io.sentry.logback.SentryAppender">
     <options>
-      <dsn>${params.dsn}</dsn>
+      <dsn>${params.dsn.public}</dsn>
     </options>
   </appender>
 
@@ -130,7 +130,7 @@ const getConsoleAppenderSnippet = (params: Params) => `
 const getLogLevelSnippet = (params: Params) => `
 <appender name="Sentry" class="io.sentry.logback.SentryAppender">
   <options>
-    <dsn>${params.dsn}</dsn>
+    <dsn>${params.dsn.public}</dsn>
   </options>
   <!-- Optionally change minimum Event level. Default for Events is ERROR -->
   <minimumEventLevel>WARN</minimumEventLevel>

--- a/static/app/gettingStartedDocs/java/spring-boot.tsx
+++ b/static/app/gettingStartedDocs/java/spring-boot.tsx
@@ -105,7 +105,7 @@ const getMavenInstallSnippet = (params: Params) => `
 </build>`;
 
 const getConfigurationPropertiesSnippet = (params: Params) => `
-sentry.dsn=${params.dsn}${
+sentry.dsn=${params.dsn.public}${
   params.isPerformanceSelected
     ? `
 # Set traces-sample-rate to 1.0 to capture 100% of transactions for performance monitoring.
@@ -116,7 +116,7 @@ sentry.traces-sample-rate=1.0`
 
 const getConfigurationYamlSnippet = (params: Params) => `
 sentry:
-  dsn: ${params.dsn}${
+  dsn: ${params.dsn.public}${
     params.isPerformanceSelected
       ? `
   # Set traces-sample-rate to 1.0 to capture 100% of transactions for performance monitoring.

--- a/static/app/gettingStartedDocs/java/spring.tsx
+++ b/static/app/gettingStartedDocs/java/spring.tsx
@@ -132,7 +132,7 @@ import io.sentry.spring${
   params.platformOptions.springVersion === SpringVersion.V6 ? '.jakarta' : ''
 }.EnableSentry;
 
-@EnableSentry(dsn = "${params.dsn}")
+@EnableSentry(dsn = "${params.dsn.public}")
 @Configuration
 class SentryConfiguration {
 }`;
@@ -144,7 +144,7 @@ import io.sentry.spring${
 import org.springframework.core.Ordered
 
 @EnableSentry(
-  dsn = "${params.dsn}",
+  dsn = "${params.dsn.public}",
   exceptionResolverOrder = Ordered.LOWEST_PRECEDENCE
 )`;
 

--- a/static/app/gettingStartedDocs/javascript/angular.tsx
+++ b/static/app/gettingStartedDocs/javascript/angular.tsx
@@ -197,7 +197,7 @@ function getSdkSetupSnippet(params: Params) {
   import { AppModule } from "./app/app.module";
 
   Sentry.init({
-    dsn: "${params.dsn}",
+    dsn: "${params.dsn.public}",
     integrations: [${
       params.isPerformanceSelected
         ? `

--- a/static/app/gettingStartedDocs/javascript/astro.tsx
+++ b/static/app/gettingStartedDocs/javascript/astro.tsx
@@ -31,7 +31,7 @@ import sentry from "@sentry/astro";
 export default defineConfig({
   integrations: [
     sentry({
-      dsn: "${params.dsn}",${
+      dsn: "${params.dsn.public}",${
         params.isPerformanceSelected
           ? ''
           : `
@@ -253,7 +253,7 @@ import sentry from "@sentry/astro";
 export default defineConfig({
   integrations: [
     sentry({
-      dsn: "${params.dsn}",
+      dsn: "${params.dsn.public}",
       replaysSessionSampleRate: 0.2, // defaults to 0.1
       replaysOnErrorSampleRate: 1.0, // defaults to 1.0
     }),
@@ -280,7 +280,7 @@ export default defineConfig({
                 importStatement: `// This file overrides \`astro.config.mjs\` for the browser-side.
 // SDK options from \`astro.config.mjs\` will not apply.
 import * as Sentry from "@sentry/astro";`,
-                dsn: params.dsn,
+                dsn: params.dsn.public,
                 mask: params.replayOptions?.mask,
                 block: params.replayOptions?.block,
               }),
@@ -337,7 +337,7 @@ const feedbackOnboarding: OnboardingConfig = {
               language: 'javascript',
               code: getFeedbackSDKSetupSnippet({
                 importStatement: `import * as Sentry from "@sentry/astro";`,
-                dsn: params.dsn,
+                dsn: params.dsn.public,
                 feedbackOptions: params.feedbackOptions,
               }),
             },

--- a/static/app/gettingStartedDocs/javascript/ember.tsx
+++ b/static/app/gettingStartedDocs/javascript/ember.tsx
@@ -37,7 +37,7 @@ import config from "./config/environment";
 import * as Sentry from "@sentry/ember";
 
 Sentry.init({
-  dsn: "${params.dsn}",
+  dsn: "${params.dsn.public}",
   integrations: [${
     params.isReplaySelected
       ? `

--- a/static/app/gettingStartedDocs/javascript/gatsby.tsx
+++ b/static/app/gettingStartedDocs/javascript/gatsby.tsx
@@ -34,7 +34,7 @@ const getSdkSetupSnippet = (params: Params) => `
 import * as Sentry from "@sentry/gatsby";
 
 Sentry.init({
-  dsn: "${params.dsn}",
+  dsn: "${params.dsn.public}",
   integrations: [${
     params.isPerformanceSelected
       ? `

--- a/static/app/gettingStartedDocs/javascript/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/javascript.tsx
@@ -33,7 +33,7 @@ const getSdkSetupSnippet = (params: Params) => `
 import * as Sentry from "@sentry/browser";
 
 Sentry.init({
-  dsn: "${params.dsn}",
+  dsn: "${params.dsn.public}",
   integrations: [${
     params.isPerformanceSelected
       ? `

--- a/static/app/gettingStartedDocs/javascript/jsLoader/jsLoader.tsx
+++ b/static/app/gettingStartedDocs/javascript/jsLoader/jsLoader.tsx
@@ -26,7 +26,7 @@ const getInstallConfig = (params: Params) => [
         description: t('Add this script tag to the top of the page:'),
         language: 'html',
         code: beautify.html(
-          `<script src="${params.cdn}" crossorigin="anonymous"></script>`,
+          `<script src="${params.dsn.cdn}" crossorigin="anonymous"></script>`,
           {indent_size: 2, wrap_attributes: 'force-expand-multiline'}
         ),
         additionalInfo: (

--- a/static/app/gettingStartedDocs/javascript/nextjs.tsx
+++ b/static/app/gettingStartedDocs/javascript/nextjs.tsx
@@ -148,7 +148,7 @@ const onboarding: OnboardingConfig = {
                 })
               }
             >
-              {params.dsn}
+              {params.dsn.public}
             </TextCopyInput>
           )}
         </Fragment>
@@ -176,7 +176,7 @@ const replayOnboarding: OnboardingConfig = {
               language: 'javascript',
               code: getReplaySDKSetupSnippet({
                 importStatement: `import * as Sentry from "@sentry/nextjs";`,
-                dsn: params.dsn,
+                dsn: params.dsn.public,
                 mask: params.replayOptions?.mask,
                 block: params.replayOptions?.block,
               }),
@@ -233,7 +233,7 @@ const feedbackOnboarding: OnboardingConfig = {
               language: 'javascript',
               code: getFeedbackSDKSetupSnippet({
                 importStatement: `import * as Sentry from "@sentry/nextjs";`,
-                dsn: params.dsn,
+                dsn: params.dsn.public,
                 feedbackOptions: params.feedbackOptions,
               }),
             },

--- a/static/app/gettingStartedDocs/javascript/react.tsx
+++ b/static/app/gettingStartedDocs/javascript/react.tsx
@@ -33,7 +33,7 @@ const getSdkSetupSnippet = (params: Params) => `
 import * as Sentry from "@sentry/react";
 
 Sentry.init({
-  dsn: "${params.dsn}",
+  dsn: "${params.dsn.public}",
   integrations: [${
     params.isPerformanceSelected
       ? `

--- a/static/app/gettingStartedDocs/javascript/remix.tsx
+++ b/static/app/gettingStartedDocs/javascript/remix.tsx
@@ -158,7 +158,7 @@ const replayOnboarding: OnboardingConfig = {
               language: 'javascript',
               code: getReplaySDKSetupSnippet({
                 importStatement: `import * as Sentry from "@sentry/remix";`,
-                dsn: params.dsn,
+                dsn: params.dsn.public,
                 mask: params.replayOptions?.mask,
                 block: params.replayOptions?.block,
               }),
@@ -212,7 +212,7 @@ const feedbackOnboarding: OnboardingConfig = {
               language: 'javascript',
               code: getFeedbackSDKSetupSnippet({
                 importStatement: `import * as Sentry from "@sentry/remix";`,
-                dsn: params.dsn,
+                dsn: params.dsn.public,
                 feedbackOptions: params.feedbackOptions,
               }),
             },

--- a/static/app/gettingStartedDocs/javascript/solid.tsx
+++ b/static/app/gettingStartedDocs/javascript/solid.tsx
@@ -34,7 +34,7 @@ import { render } from "solid-js/web";
 import App from "./app";
 
 Sentry.init({
-  dsn: "${params.dsn}",
+  dsn: "${params.dsn.public}",
   integrations: [${
     params.isPerformanceSelected
       ? `

--- a/static/app/gettingStartedDocs/javascript/svelte.tsx
+++ b/static/app/gettingStartedDocs/javascript/svelte.tsx
@@ -35,7 +35,7 @@ import App from "./App.svelte";
 import * as Sentry from "@sentry/svelte";
 
 Sentry.init({
-  dsn: "${params.dsn}",
+  dsn: "${params.dsn.public}",
   integrations: [${
     params.isPerformanceSelected
       ? `

--- a/static/app/gettingStartedDocs/javascript/sveltekit.tsx
+++ b/static/app/gettingStartedDocs/javascript/sveltekit.tsx
@@ -125,7 +125,7 @@ const replayOnboarding: OnboardingConfig = {
               language: 'javascript',
               code: getReplaySDKSetupSnippet({
                 importStatement: `import * as Sentry from "@sentry/sveltekit";`,
-                dsn: params.dsn,
+                dsn: params.dsn.public,
                 mask: params.replayOptions?.mask,
                 block: params.replayOptions?.block,
               }),
@@ -171,7 +171,7 @@ const feedbackOnboarding: OnboardingConfig = {
               language: 'javascript',
               code: getFeedbackSDKSetupSnippet({
                 importStatement: `import * as Sentry from "@sentry/sveltekit";`,
-                dsn: params.dsn,
+                dsn: params.dsn.public,
                 feedbackOptions: params.feedbackOptions,
               }),
             },

--- a/static/app/gettingStartedDocs/javascript/vue.tsx
+++ b/static/app/gettingStartedDocs/javascript/vue.tsx
@@ -57,7 +57,7 @@ type Params = DocsParams<PlatformOptions>;
 const getSentryInitLayout = (params: Params, siblingOption: string): string => {
   return `Sentry.init({
     ${siblingOption === VueVersion.VUE2 ? 'Vue,' : 'app,'}
-    dsn: "${params.dsn}",
+    dsn: "${params.dsn.public}",
     integrations: [${
       params.isPerformanceSelected
         ? `
@@ -346,7 +346,7 @@ const feedbackOnboarding: OnboardingConfig<PlatformOptions> = {
               language: 'javascript',
               code: getFeedbackSDKSetupSnippet({
                 importStatement: `import * as Sentry from "@sentry/vue";`,
-                dsn: params.dsn,
+                dsn: params.dsn.public,
                 feedbackOptions: params.feedbackOptions,
               }),
             },

--- a/static/app/gettingStartedDocs/kotlin/kotlin.tsx
+++ b/static/app/gettingStartedDocs/kotlin/kotlin.tsx
@@ -114,7 +114,7 @@ const getConfigureSnippet = (params: Params) => `
 import io.sentry.Sentry
 
 Sentry.init { options ->
-  options.dsn = "${params.dsn}"${
+  options.dsn = "${params.dsn.public}"${
     params.isPerformanceSelected
       ? `
   // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.

--- a/static/app/gettingStartedDocs/minidump/minidump.tsx
+++ b/static/app/gettingStartedDocs/minidump/minidump.tsx
@@ -15,7 +15,7 @@ type Params = DocsParams;
 
 const getCurlSnippet = (params: Params) => `
 curl -X POST \
-'${params.dsn}' \
+'${params.dsn.public}' \
 -F upload_file_minidump=@mini.dmp`;
 
 const onboarding: OnboardingConfig = {

--- a/static/app/gettingStartedDocs/native/native.tsx
+++ b/static/app/gettingStartedDocs/native/native.tsx
@@ -17,7 +17,7 @@ const getConfigureSnippet = (params: Params) => `
 
 int main(void) {
   sentry_options_t *options = sentry_options_new();
-  sentry_options_set_dsn(options, "${params.dsn}");
+  sentry_options_set_dsn(options, "${params.dsn.public}");
   // This is also the default-path. For further information and recommendations:
   // https://docs.sentry.io/platforms/native/configuration/options/#database-path
   sentry_options_set_database_path(options, ".sentry-native");

--- a/static/app/gettingStartedDocs/native/qt.tsx
+++ b/static/app/gettingStartedDocs/native/qt.tsx
@@ -19,7 +19,7 @@ const getConfigureSnippet = (params: Params) => `
 int main(int argc, char *argv[])
 {
     sentry_options_t *options = sentry_options_new();
-    sentry_options_set_dsn(options, "${params.dsn}");
+    sentry_options_set_dsn(options, "${params.dsn.public}");
     // This is also the default-path. For further information and recommendations:
     // https://docs.sentry.io/platforms/native/configuration/options/#database-path
     sentry_options_set_database_path(options, ".sentry-native");

--- a/static/app/gettingStartedDocs/node/awslambda.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.tsx
@@ -32,7 +32,7 @@ exports.handler = Sentry.wrapHandler(async (event, context) => {
 
 const getMetricsConfigureSnippet = (params: DocsParams) => `
 Sentry.init({
-  dsn: "${params.dsn}",
+  dsn: "${params.dsn.public}",
   // Only needed for SDK versions < 8.0.0
   // _experiments: {
   //   metricsAggregator: true,

--- a/static/app/gettingStartedDocs/node/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/node/gcpfunctions.tsx
@@ -47,7 +47,7 @@ exports.helloHttp = Sentry.wrapHttpFunction((req, res) => {
 
 const getMetricsConfigureSnippet = (params: DocsParams) => `
 Sentry.init({
-  dsn: "${params.dsn}",
+  dsn: "${params.dsn.public}",
   // Only needed for SDK versions < 8.0.0
   // _experiments: {
   //   metricsAggregator: true,

--- a/static/app/gettingStartedDocs/php/laravel.tsx
+++ b/static/app/gettingStartedDocs/php/laravel.tsx
@@ -39,7 +39,7 @@ return Application::configure(basePath: dirname(__DIR__))
     })->create();`;
 
 const getConfigureSnippet = (params: Params) =>
-  `SENTRY_LARAVEL_DSN=${params.dsn}${
+  `SENTRY_LARAVEL_DSN=${params.dsn.public}${
     params.isPerformanceSelected
       ? `
 # Specify a fixed sample rate
@@ -121,7 +121,7 @@ const onboarding: OnboardingConfig = {
         {
           description: t('Configure the Sentry DSN with this command:'),
           language: 'shell',
-          code: `php artisan sentry:publish --dsn=${params.dsn}`,
+          code: `php artisan sentry:publish --dsn=${params.dsn.public}`,
         },
         {
           description: tct(
@@ -285,7 +285,7 @@ const crashReportOnboarding: OnboardingConfig = {
   @if(app()->bound('sentry') && app('sentry')->getLastEventId())
   <div class="subtitle">Error ID: {{ app('sentry')->getLastEventId() }}</div>
   <script>
-    Sentry.init({ dsn: '${params.dsn}' });
+    Sentry.init({ dsn: '${params.dsn.public}' });
     Sentry.showReportDialog({
       eventId: '{{ app('sentry')->getLastEventId() }}'
     });

--- a/static/app/gettingStartedDocs/php/php.tsx
+++ b/static/app/gettingStartedDocs/php/php.tsx
@@ -18,7 +18,7 @@ import {t, tct} from 'sentry/locale';
 type Params = DocsParams;
 
 const getConfigureSnippet = (params: Params) => `\\Sentry\\init([
-  'dsn' => '${params.dsn}',${
+  'dsn' => '${params.dsn.public}',${
     params.isPerformanceSelected
       ? `
   // Specify a fixed sample rate

--- a/static/app/gettingStartedDocs/php/symfony.tsx
+++ b/static/app/gettingStartedDocs/php/symfony.tsx
@@ -67,7 +67,7 @@ const onboarding: OnboardingConfig = {
           language: 'shell',
           code: `
 ###> sentry/sentry-symfony ###
-SENTRY_DSN="${params.dsn}"
+SENTRY_DSN="${params.dsn.public}"
 ###< sentry/sentry-symfony ###
           `,
         },

--- a/static/app/gettingStartedDocs/powershell/powershell.tsx
+++ b/static/app/gettingStartedDocs/powershell/powershell.tsx
@@ -30,7 +30,7 @@ Start-Sentry -Debug {
     # A Sentry Data Source Name (DSN) is required.
     # See https://docs.sentry.io/product/sentry-basics/dsn-explainer/
     # You can set it in the SENTRY_DSN environment variable, or you can set it in code here.
-    $_.Dsn = '${params.dsn}'
+    $_.Dsn = '${params.dsn.public}'
 
     # This option will enable Sentry's tracing features. You still need to start transactions and spans.
     # For example, setting the rate to 0.1 would capture 10% of transactions.
@@ -39,7 +39,7 @@ Start-Sentry -Debug {
 
 # Later on in your production script, you should omit the \`-Debug\` flag.:
 Start-Sentry {
-    $_.Dsn = '${params.dsn}'
+    $_.Dsn = '${params.dsn.public}'
     $_.TracesSampleRate = 0.1
 }`;
 

--- a/static/app/gettingStartedDocs/python/aiohttp.tsx
+++ b/static/app/gettingStartedDocs/python/aiohttp.tsx
@@ -20,7 +20,7 @@ from aiohttp import web
 import sentry_sdk
 
 sentry_sdk.init(
-    dsn="${params.dsn}",${
+    dsn="${params.dsn.public}",${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/asgi.tsx
+++ b/static/app/gettingStartedDocs/python/asgi.tsx
@@ -20,7 +20,7 @@ from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from myapp import asgi_app
 
 sentry_sdk.init(
-    dsn="${params.dsn}",${
+    dsn="${params.dsn.public}",${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/awslambda.tsx
+++ b/static/app/gettingStartedDocs/python/awslambda.tsx
@@ -22,7 +22,7 @@ import sentry_sdk
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 
 sentry_sdk.init(
-    dsn="${params.dsn}",
+    dsn="${params.dsn.public}",
     integrations=[AwsLambdaIntegration()],${
       params.isPerformanceSelected
         ? `
@@ -46,7 +46,7 @@ def my_function(event, context):
 
 const getTimeoutWarningSnippet = (params: Params) => `
 sentry_sdk.init(
-  dsn="${params.dsn}",
+  dsn="${params.dsn.public}",
   integrations=[
       AwsLambdaIntegration(timeout_warning=True),
   ],

--- a/static/app/gettingStartedDocs/python/bottle.tsx
+++ b/static/app/gettingStartedDocs/python/bottle.tsx
@@ -18,7 +18,7 @@ const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
 
 sentry_sdk.init(
-    dsn="${params.dsn}",${
+    dsn="${params.dsn.public}",${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/celery.tsx
+++ b/static/app/gettingStartedDocs/python/celery.tsx
@@ -23,7 +23,7 @@ const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
 
 sentry_sdk.init(
-    dsn="${params.dsn}",${
+    dsn="${params.dsn.public}",${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/chalice.tsx
+++ b/static/app/gettingStartedDocs/python/chalice.tsx
@@ -19,7 +19,7 @@ from chalice import Chalice
 from sentry_sdk.integrations.chalice import ChaliceIntegration
 
 sentry_sdk.init(
-    dsn="${params.dsn}",
+    dsn="${params.dsn.public}",
     integrations=[ChaliceIntegration()],${
       params.isPerformanceSelected
         ? `

--- a/static/app/gettingStartedDocs/python/django.tsx
+++ b/static/app/gettingStartedDocs/python/django.tsx
@@ -19,7 +19,7 @@ const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
 
 sentry_sdk.init(
-    dsn="${params.dsn}",${
+    dsn="${params.dsn.public}",${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/falcon.tsx
+++ b/static/app/gettingStartedDocs/python/falcon.tsx
@@ -19,7 +19,7 @@ import falcon
 import sentry_sdk
 
 sentry_sdk.init(
-    dsn="${params.dsn}",${
+    dsn="${params.dsn.public}",${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/fastapi.tsx
+++ b/static/app/gettingStartedDocs/python/fastapi.tsx
@@ -19,7 +19,7 @@ from fastapi import FastAPI
 import sentry_sdk
 
 sentry_sdk.init(
-    dsn="${params.dsn}",${
+    dsn="${params.dsn.public}",${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/flask.tsx
+++ b/static/app/gettingStartedDocs/python/flask.tsx
@@ -19,7 +19,7 @@ import sentry_sdk
 from flask import Flask
 
 sentry_sdk.init(
-    dsn="${params.dsn}",${
+    dsn="${params.dsn.public}",${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/python/gcpfunctions.tsx
@@ -22,7 +22,7 @@ import sentry_sdk
 from sentry_sdk.integrations.gcp import GcpIntegration
 
 sentry_sdk.init(
-    dsn="${params.dsn}",
+    dsn="${params.dsn.public}",
     integrations=[GcpIntegration()],${
       params.isPerformanceSelected
         ? `
@@ -46,7 +46,7 @@ def http_function_entrypoint(request):
 
 const getTimeoutWarningSnippet = (params: Params) => `
 sentry_sdk.init(
-    dsn="${params.dsn}",
+    dsn="${params.dsn.public}",
     integrations=[
         GcpIntegration(timeout_warning=True),
     ],

--- a/static/app/gettingStartedDocs/python/mongo.tsx
+++ b/static/app/gettingStartedDocs/python/mongo.tsx
@@ -17,7 +17,7 @@ from sentry_sdk.integrations.pymongo import PyMongoIntegration
 
 
 sentry_sdk.init(
-    dsn="${params.dsn}",
+    dsn="${params.dsn.public}",
     integrations=[
         PyMongoIntegration(),
     ],

--- a/static/app/gettingStartedDocs/python/pylons.tsx
+++ b/static/app/gettingStartedDocs/python/pylons.tsx
@@ -16,7 +16,7 @@ application = Sentry(application, config)`;
 
 const getConfigurationSnippet = (params: Params) => `
 [sentry]
-dsn=${params.dsn}
+dsn=${params.dsn.public}
 include_paths=my.package,my.other.package,
 exclude_paths=my.package.crud`;
 

--- a/static/app/gettingStartedDocs/python/pyramid.tsx
+++ b/static/app/gettingStartedDocs/python/pyramid.tsx
@@ -19,7 +19,7 @@ from pyramid.config import Configurator
 import sentry_sdk
 
 sentry_sdk.init(
-    dsn="${params.dsn}",
+    dsn="${params.dsn.public}",
 )
 `;
 

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -20,7 +20,7 @@ const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
 
 sentry_sdk.init(
-    dsn="${params.dsn}",${
+    dsn="${params.dsn.public}",${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/quart.tsx
+++ b/static/app/gettingStartedDocs/python/quart.tsx
@@ -20,7 +20,7 @@ from sentry_sdk.integrations.quart import QuartIntegration
 from quart import Quart
 
 sentry_sdk.init(
-    dsn="${params.dsn}",
+    dsn="${params.dsn.public}",
     integrations=[QuartIntegration()],${
       params.isPerformanceSelected
         ? `

--- a/static/app/gettingStartedDocs/python/rq.tsx
+++ b/static/app/gettingStartedDocs/python/rq.tsx
@@ -17,7 +17,7 @@ const getInstallSnippet = () => `pip install --upgrade 'sentry-sdk[rq]'`;
 
 const getInitCallSnippet = (params: Params) => `
 sentry_sdk.init(
-  dsn="${params.dsn}",${
+  dsn="${params.dsn.public}",${
     params.isPerformanceSelected
       ? `
   # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/sanic.tsx
+++ b/static/app/gettingStartedDocs/python/sanic.tsx
@@ -18,7 +18,7 @@ const getSdkSetupSnippet = (params: Params) => `from sanic import Sanic
 import sentry_sdk
 
 sentry_sdk.init(
-    dsn="${params.dsn}",
+    dsn="${params.dsn.public}",
 )
 `;
 

--- a/static/app/gettingStartedDocs/python/serverless.tsx
+++ b/static/app/gettingStartedDocs/python/serverless.tsx
@@ -20,7 +20,7 @@ import sentry_sdk
 from sentry_sdk.integrations.serverless import serverless_function
 
 sentry_sdk.init(
-    dsn="${params.dsn}",${
+    dsn="${params.dsn.public}",${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/starlette.tsx
+++ b/static/app/gettingStartedDocs/python/starlette.tsx
@@ -19,7 +19,7 @@ from starlette.applications import Starlette
 import sentry_sdk
 
 sentry_sdk.init(
-    dsn="${params.dsn}",${
+    dsn="${params.dsn.public}",${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/tornado.tsx
+++ b/static/app/gettingStartedDocs/python/tornado.tsx
@@ -17,7 +17,7 @@ const getInstallSnippet = () => `pip install --upgrade sentry-sdk`;
 const getSdkSetupSnippet = (params: Params) => `import sentry_sdk
 
 sentry_sdk.init(
-    dsn="${params.dsn}",${
+    dsn="${params.dsn.public}",${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/python/tryton.tsx
+++ b/static/app/gettingStartedDocs/python/tryton.tsx
@@ -16,7 +16,7 @@ import sentry_sdk
 from sentry_sdk.integrations.trytond import TrytondWSGIIntegration
 
 sentry_sdk.init(
-    dsn="${params.dsn}",
+    dsn="${params.dsn.public}",
     integrations:[
         sentry_sdk.integrations.trytond.TrytondWSGIIntegration(),
     ],${

--- a/static/app/gettingStartedDocs/python/wsgi.tsx
+++ b/static/app/gettingStartedDocs/python/wsgi.tsx
@@ -22,7 +22,7 @@ from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 from my_wsgi_app import app
 
 sentry_sdk.init(
-    dsn="${params.dsn}",${
+    dsn="${params.dsn.public}",${
       params.isPerformanceSelected
         ? `
     # Set traces_sample_rate to 1.0 to capture 100%

--- a/static/app/gettingStartedDocs/react-native/react-native.tsx
+++ b/static/app/gettingStartedDocs/react-native/react-native.tsx
@@ -22,7 +22,7 @@ const getConfigureSnippet = (params: Params) => `
 import * as Sentry from "@sentry/react-native";
 
 Sentry.init({
-  dsn: "${params.dsn}",${
+  dsn: "${params.dsn.public}",${
     params.isPerformanceSelected
       ? `
   // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.

--- a/static/app/gettingStartedDocs/ruby/rack.tsx
+++ b/static/app/gettingStartedDocs/ruby/rack.tsx
@@ -18,7 +18,7 @@ const getConfigureSnippet = (params: Params) => `
 require 'sentry-ruby'
 
 Sentry.init do |config|
-  config.dsn = '${params.dsn}'${
+  config.dsn = '${params.dsn.public}'${
     params.isPerformanceSelected
       ? `
 

--- a/static/app/gettingStartedDocs/ruby/rails.tsx
+++ b/static/app/gettingStartedDocs/ruby/rails.tsx
@@ -25,7 +25,7 @@ const generatorSnippet = 'bin/rails generate sentry';
 
 const getConfigureSnippet = (params: Params) => `
 Sentry.init do |config|
-  config.dsn = '${params.dsn}'
+  config.dsn = '${params.dsn.public}'
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]${
     params.isPerformanceSelected
       ? `
@@ -173,7 +173,7 @@ const crashReportOnboarding: OnboardingConfig = {
               code: `<% sentry_id = request.env["sentry.error_event_id"] %>
 <% if sentry_id.present? %>
 <script>
-  Sentry.init({ dsn: "${params.dsn}" });
+  Sentry.init({ dsn: "${params.dsn.public}" });
   Sentry.showReportDialog({ eventId: "<%= sentry_id %>" });
 </script>
 <% end %>`,

--- a/static/app/gettingStartedDocs/ruby/ruby.tsx
+++ b/static/app/gettingStartedDocs/ruby/ruby.tsx
@@ -16,7 +16,7 @@ const getInstallSnippet = (params: Params) =>
 
 const getConfigureSnippet = (params: Params) => `
 Sentry.init do |config|
-  config.dsn = '${params.dsn}'${
+  config.dsn = '${params.dsn.public}'${
     params.isPerformanceSelected
       ? `
 

--- a/static/app/gettingStartedDocs/rust/rust.tsx
+++ b/static/app/gettingStartedDocs/rust/rust.tsx
@@ -27,14 +27,14 @@ sentry = { version = "${getPackageVersion(
 )}", features = ["UNSTABLE_metrics"] }`;
 
 const getConfigureSnippet = (params: Params) => `
-let _guard = sentry::init(("${params.dsn}", sentry::ClientOptions {
+let _guard = sentry::init(("${params.dsn.public}", sentry::ClientOptions {
   release: sentry::release_name!(),
   ..Default::default()
 }));`;
 
 const getVerifySnippet = (params: Params) => `
 fn main() {
-  let _guard = sentry::init(("${params.dsn}", sentry::ClientOptions {
+  let _guard = sentry::init(("${params.dsn.public}", sentry::ClientOptions {
     release: sentry::release_name!(),
     ..Default::default()
   }));

--- a/static/app/gettingStartedDocs/unity/unity.tsx
+++ b/static/app/gettingStartedDocs/unity/unity.tsx
@@ -79,7 +79,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'url',
-          code: params.dsn,
+          code: params.dsn.public,
         },
       ],
       additionalInfo: (

--- a/static/app/gettingStartedDocs/unreal/unreal.tsx
+++ b/static/app/gettingStartedDocs/unreal/unreal.tsx
@@ -33,7 +33,7 @@ void Verify()
 const getCrashReporterConfigSnippet = (params: Params) => `
 [CrashReportClient]
 CrashReportClientVersion=1.0
-DataRouterUrl="${params.dsn}"`;
+DataRouterUrl="${params.dsn.public}"`;
 
 const onboarding: OnboardingConfig = {
   install: () => [
@@ -82,7 +82,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'url',
-          code: params.dsn,
+          code: params.dsn.public,
         },
       ],
     },

--- a/tests/js/sentry-test/onboarding/renderWithOnboardingLayout.tsx
+++ b/tests/js/sentry-test/onboarding/renderWithOnboardingLayout.tsx
@@ -47,7 +47,16 @@ export function renderWithOnboardingLayout<
     <OnboardingLayout
       docsConfig={docsConfig}
       projectSlug="test-project-slug"
-      dsn="test-dsn"
+      dsn={{
+        public: 'test-dsn',
+        secret: 'test-secret',
+        cdn: 'test-cdn',
+        crons: 'test-crons',
+        security: 'test-security',
+        csp: 'test-csp',
+        minidump: 'test-minidump',
+        unreal: 'test-unreal',
+      }}
       platformKey="java-spring-boot"
       projectId="test-project-id"
       activeProductSelection={selectedProducts}


### PR DESCRIPTION
Expose the whole `dsn` object in the doc parameters, so all the entries can be accessed if necessary.

Part of https://github.com/getsentry/sentry/issues/71733