### PR TITLE
fix(unreal-unboarding): Display unreal crash reporter URL

### DIFF
--- a/static/app/gettingStartedDocs/unreal/unreal.tsx
+++ b/static/app/gettingStartedDocs/unreal/unreal.tsx
@@ -33,7 +33,7 @@ void Verify()
 const getCrashReporterConfigSnippet = (params: Params) => `
 [CrashReportClient]
 CrashReportClientVersion=1.0
-DataRouterUrl="${params.dsn.public}"`;
+DataRouterUrl="${params.dsn.unreal}"`;
 
 const onboarding: OnboardingConfig = {
   install: () => [


### PR DESCRIPTION
Display unreal specific reporter URL.

Closes https://github.com/getsentry/sentry/issues/71733