### PR TITLE
fix(menulistitem): Add scroll-margin styles to menu list item

### DIFF
--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -289,6 +289,7 @@ const MenuItemWrap = styled('li')`
   margin: 0;
   padding: 0 ${space(0.5)};
   cursor: pointer;
+  scroll-margin: ${space(0.5)} 0;
 
   &:focus {
     outline: none;


### PR DESCRIPTION
Prevents dropdown options from hitting the edge of the menu when navigating with the keyboard:

Before:

![CleanShot 2024-08-12 at 08 47 34](https://github.com/user-attachments/assets/7b01426c-d737-40dd-a966-c9e8ffef2c6c)

After:

![CleanShot 2024-08-12 at 08 47 13](https://github.com/user-attachments/assets/92e9a8a6-e5e0-42ed-9a91-40ef2460577a)
