### PR TITLE
chore(onboarding): add view param to modal render analytics

### DIFF
--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -69,7 +69,9 @@ import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import withOrganization from 'sentry/utils/withOrganization';
 import withProjects from 'sentry/utils/withProjects';
 import {PreviewIssues} from 'sentry/views/alerts/rules/issue/previewIssues';
-import SetupMessagingIntegrationButton from 'sentry/views/alerts/rules/issue/setupMessagingIntegrationButton';
+import SetupMessagingIntegrationButton, {
+  MessagingIntegrationAnalyticsView,
+} from 'sentry/views/alerts/rules/issue/setupMessagingIntegrationButton';
 import {
   CHANGE_ALERT_CONDITION_IDS,
   CHANGE_ALERT_PLACEHOLDERS_LABELS,
@@ -1228,7 +1230,9 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
                 <SetupMessagingIntegrationButton
                   projectSlug={project.slug}
                   refetchConfigs={this.refetchConfigs}
-                  analyticsParams={{view: 'alert_rule_creation'}}
+                  analyticsParams={{
+                    view: MessagingIntegrationAnalyticsView.ALERT_RULE_CREATION,
+                  }}
                 />
               ) : (
                 <SetupAlertIntegrationButton

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1228,6 +1228,7 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
                 <SetupMessagingIntegrationButton
                   projectSlug={project.slug}
                   refetchConfigs={this.refetchConfigs}
+                  analyticsParams={{view: 'alert_rule_creation'}}
                 />
               ) : (
                 <SetupAlertIntegrationButton

--- a/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.spec.tsx
+++ b/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.spec.tsx
@@ -24,6 +24,7 @@ describe('SetupAlertIntegrationButton', function () {
     <SetupMessagingIntegrationButton
       projectSlug={project.slug}
       refetchConfigs={jest.fn()}
+      analyticsParams={{view: 'alert_rule_creation'}}
     />
   );
 

--- a/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.spec.tsx
+++ b/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.spec.tsx
@@ -6,7 +6,9 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import HookStore from 'sentry/stores/hookStore';
-import SetupMessagingIntegrationButton from 'sentry/views/alerts/rules/issue/setupMessagingIntegrationButton';
+import SetupMessagingIntegrationButton, {
+  MessagingIntegrationAnalyticsView,
+} from 'sentry/views/alerts/rules/issue/setupMessagingIntegrationButton';
 
 jest.mock('sentry/actionCreators/modal');
 
@@ -24,7 +26,7 @@ describe('SetupAlertIntegrationButton', function () {
     <SetupMessagingIntegrationButton
       projectSlug={project.slug}
       refetchConfigs={jest.fn()}
-      analyticsParams={{view: 'alert_rule_creation'}}
+      analyticsParams={{view: MessagingIntegrationAnalyticsView.ALERT_RULE_CREATION}}
     />
   );
 

--- a/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
+++ b/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
@@ -22,9 +22,16 @@ interface ProjectWithAlertIntegrationInfo extends Project {
 type Props = {
   projectSlug: string;
   refetchConfigs: () => void;
+  analyticsParams?: {
+    view: string;
+  };
 };
 
-function SetupMessagingIntegrationButton({projectSlug, refetchConfigs}: Props) {
+function SetupMessagingIntegrationButton({
+  projectSlug,
+  refetchConfigs,
+  analyticsParams,
+}: Props) {
   const providerKeys = ['slack', 'discord', 'msteams'];
   const organization = useOrganization();
 
@@ -115,6 +122,7 @@ function SetupMessagingIntegrationButton({projectSlug, refetchConfigs}: Props) {
               trackAnalytics('onboarding.messaging_integration_modal_rendered', {
                 project_id: projectQuery.data.id,
                 organization,
+                ...analyticsParams,
               });
             }}
           >

--- a/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
+++ b/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
@@ -19,11 +19,15 @@ interface ProjectWithAlertIntegrationInfo extends Project {
   hasAlertIntegrationInstalled: boolean;
 }
 
+export enum MessagingIntegrationAnalyticsView {
+  ALERT_RULE_CREATION = 'alert_rule_creation',
+}
+
 type Props = {
   projectSlug: string;
   refetchConfigs: () => void;
   analyticsParams?: {
-    view: `alert_rule_creation`;
+    view: MessagingIntegrationAnalyticsView;
   };
 };
 

--- a/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
+++ b/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
@@ -23,7 +23,7 @@ type Props = {
   projectSlug: string;
   refetchConfigs: () => void;
   analyticsParams?: {
-    view: string;
+    view: `alert_rule_creation`;
   };
 };
 


### PR DESCRIPTION
adding a `view` param to the `messaging_integration_modal_rendered` analytics for when the modal is added to other product surfaces (ex. project creation)