### PR TITLE
fix(form): Use displayNone over hidden for the prop

### DIFF
--- a/static/app/components/forms/fieldGroup/fieldDescription.tsx
+++ b/static/app/components/forms/fieldGroup/fieldDescription.tsx
@@ -12,7 +12,7 @@ interface FieldDescriptionProps extends Pick<FieldGroupProps, 'inline'> {
    * for screen-readers since this element is used as the `aria-describedby` of
    * the control input componnt.
    */
-  hidden?: boolean;
+  displayNone?: boolean;
 }
 
 const inlineStyle = (p: FieldDescriptionProps) =>
@@ -28,7 +28,7 @@ const inlineStyle = (p: FieldDescriptionProps) =>
 
 const FieldDescription = styled('label')<FieldDescriptionProps>`
   font-weight: ${p => p.theme.fontWeightNormal};
-  display: ${p => (p.hidden ? 'none' : 'inline')};
+  display: ${p => (p.displayNone ? 'none' : 'inline')};
   margin-bottom: 0;
 
   ${inlineStyle};

--- a/static/app/components/forms/fieldGroup/index.tsx
+++ b/static/app/components/forms/fieldGroup/index.tsx
@@ -98,7 +98,7 @@ function FieldGroup({
       style={style}
     >
       <FieldDescription
-        hidden={!shouldRenderLabel && !helpElement}
+        displayNone={!shouldRenderLabel && !helpElement}
         inline={inline}
         htmlFor={id}
         aria-label={ariaLabel}


### PR DESCRIPTION
`hidden` propagates to the DOM and has side effects we do not want.

Basically when it's `hidden` the aria attributes would not be recognized by the screen reader.