### PR TITLE
ref(ui): Simplify form FieldGroup

### DIFF
--- a/static/app/components/forms/fieldGroup/controlWrapper.tsx
+++ b/static/app/components/forms/fieldGroup/controlWrapper.tsx
@@ -5,7 +5,7 @@ import {space} from 'sentry/styles/space';
 import FieldControlState from './fieldControlState';
 import type {FieldGroupProps} from './types';
 
-interface FieldControlProps
+interface ControlWrapperProps
   extends Pick<
     FieldGroupProps,
     | 'alignRight'
@@ -14,17 +14,17 @@ interface FieldControlProps
     | 'hideControlState'
     | 'inline'
   > {
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }
 
-function FieldControl({
+function ControlWrapper({
   inline,
   alignRight,
   controlState,
   children,
   hideControlState,
   flexibleControlStateSize,
-}: FieldControlProps) {
+}: ControlWrapperProps) {
   return (
     <FieldControlWrapper inline={inline}>
       <FieldControlStyled alignRight={alignRight}>{children}</FieldControlStyled>
@@ -38,7 +38,7 @@ function FieldControl({
   );
 }
 
-export default FieldControl;
+export default ControlWrapper;
 
 const FieldControlWrapper = styled('div')<{inline?: boolean}>`
   display: flex;

--- a/static/app/components/forms/fieldGroup/index.tsx
+++ b/static/app/components/forms/fieldGroup/index.tsx
@@ -1,7 +1,7 @@
 import QuestionTooltip from 'sentry/components/questionTooltip';
 
 import ControlState from './controlState';
-import FieldControl from './fieldControl';
+import ControlWrapper from './controlWrapper';
 import FieldDescription from './fieldDescription';
 import FieldHelp from './fieldHelp';
 import FieldLabel from './fieldLabel';
@@ -33,13 +33,13 @@ function FieldGroup({
   const {
     alignRight,
     children,
-    controlClassName,
-    disabledReason,
     error,
     flexibleControlStateSize,
     help,
     hideLabel,
+    hideControlState,
     highlighted,
+    controlState,
     id,
     isSaved,
     isSaving,
@@ -58,27 +58,12 @@ function FieldGroup({
     return null;
   }
 
+  const controlStateElement = controlState ?? (
+    <ControlState error={error} isSaving={isSaving} isSaved={isSaved} />
+  );
+
   const helpElement = typeof help === 'function' ? help(props) : help;
   const shouldRenderLabel = !hideLabel && !!label;
-
-  const controlWrapperProps = {
-    inline,
-    alignRight,
-    disabledReason,
-    flexibleControlStateSize,
-    controlState: <ControlState error={error} isSaving={isSaving} isSaved={isSaved} />,
-    className: controlClassName,
-    disabled: isDisabled,
-    help: helpElement,
-  };
-
-  // See comments in prop types
-  const control =
-    typeof children === 'function' ? (
-      children({...props, ...controlWrapperProps})
-    ) : (
-      <FieldControl {...controlWrapperProps}>{children}</FieldControl>
-    );
 
   // Provide an `aria-label` to the FieldDescription label if our label is a
   // string value. This helps with testing and accessability. Without this the
@@ -122,7 +107,15 @@ function FieldGroup({
           </FieldHelp>
         )}
       </FieldDescription>
-      {control}
+      <ControlWrapper
+        inline={inline}
+        alignRight={alignRight}
+        flexibleControlStateSize={flexibleControlStateSize}
+        hideControlState={hideControlState}
+        controlState={controlStateElement}
+      >
+        {children}
+      </ControlWrapper>
     </FieldWrapper>
   );
 }

--- a/static/app/components/forms/fieldGroup/types.tsx
+++ b/static/app/components/forms/fieldGroup/types.tsx
@@ -7,18 +7,13 @@ export interface FieldGroupProps {
    */
   alignRight?: boolean;
   /**
-   * The control to render. May be given a function to render with resolved
-   * props.
+   * The control to render
    */
-  children?: React.ReactNode | ((props: ChildRenderProps) => React.ReactNode);
+  children?: React.ReactNode;
   /**
    * The classname of the field
    */
   className?: string;
-  /**
-   * The classname of the field control
-   */
-  controlClassName?: string;
   /**
    * Loading / Saving / Error states of the form. See the ControlState
    */
@@ -115,20 +110,5 @@ export interface FieldGroupProps {
 }
 
 /**
- * The children render props mostly pass down FieldGroupProps, with some slight
- * differences for properities that were resolved.
+ * Proops provided to the FieldGroupProps['controlWrapper']
  */
-interface ChildRenderProps extends Omit<FieldGroupProps, 'className' | 'disabled'> {
-  /**
-   * Same as {@link FieldGroupProps.controlState}, but will always be defined
-   */
-  controlState: React.ReactNode;
-  /**
-   * The rendered help node
-   */
-  help: React.ReactNode;
-  /**
-   * Is the field disabled
-   */
-  disabled?: boolean;
-}

--- a/static/app/components/forms/formField/index.tsx
+++ b/static/app/components/forms/formField/index.tsx
@@ -17,7 +17,6 @@ import {defined} from 'sentry/utils';
 import {sanitizeQuerySelector} from 'sentry/utils/sanitizeQuerySelector';
 
 import FieldGroup from '../fieldGroup';
-import FieldControl from '../fieldGroup/fieldControl';
 import type {FieldGroupProps} from '../fieldGroup/types';
 import FormContext from '../formContext';
 import type FormModel from '../model';
@@ -176,6 +175,7 @@ type ResolvedProps = BaseProps & FieldGroupProps;
 
 type PassthroughProps = Omit<
   ResolvedProps,
+  | 'children'
   | 'className'
   | 'name'
   | 'hideErrorMessage'
@@ -321,10 +321,10 @@ function FormField(props: FormFieldProps) {
         saveMessage,
         saveMessageAlertType,
         selectionInfoFunction,
-        hideControlState,
         // Don't pass `defaultValue` down to input fields, will be handled in
         // form model
         defaultValue: _defaultValue,
+        children: _children,
         ...otherProps
       } = props;
 
@@ -339,52 +339,42 @@ function FormField(props: FormFieldProps) {
             id={id}
             className={className}
             flexibleControlStateSize={flexibleControlStateSize}
+            controlState={
+              <FormFieldControlState
+                model={model}
+                name={name}
+                hideErrorMessage={hideErrorMessage}
+              />
+            }
             {...fieldProps}
           >
-            {({alignRight, disabled, inline}) => (
-              <FieldControl
-                inline={inline}
-                alignRight={alignRight}
-                flexibleControlStateSize={flexibleControlStateSize}
-                hideControlState={hideControlState}
-                controlState={
-                  <FormFieldControlState
-                    model={model}
-                    name={name}
-                    hideErrorMessage={hideErrorMessage}
-                  />
-                }
-              >
-                <Observer>
-                  {() => {
-                    const error = model.getError(name);
-                    const value = model.getValue(name);
+            <Observer>
+              {() => {
+                const error = model.getError(name);
+                const value = model.getValue(name);
 
-                    return (
-                      <Fragment>
-                        {props.children({
-                          ref: handleInputMount,
-                          ...fieldProps,
-                          model,
-                          name,
-                          id,
-                          onKeyDown: handleKeyDown,
-                          onChange: handleChange,
-                          onBlur: handleBlur,
-                          // Fixes react warnings about input switching from controlled to uncontrolled
-                          // So force to empty string for null values
-                          value: value === null ? '' : value,
-                          error,
-                          disabled,
-                          initialData: model.initialData,
-                          'aria-describedby': `${id}_help`,
-                        })}
-                      </Fragment>
-                    );
-                  }}
-                </Observer>
-              </FieldControl>
-            )}
+                return (
+                  <Fragment>
+                    {props.children({
+                      ref: handleInputMount,
+                      ...fieldProps,
+                      model,
+                      name,
+                      id,
+                      onKeyDown: handleKeyDown,
+                      onChange: handleChange,
+                      onBlur: handleBlur,
+                      // Fixes react warnings about input switching from controlled to uncontrolled
+                      // So force to empty string for null values
+                      value: value === null ? '' : value,
+                      error,
+                      initialData: model.initialData,
+                      'aria-describedby': `${id}_help`,
+                    })}
+                  </Fragment>
+                );
+              }}
+            </Observer>
           </FieldGroup>
           {selectionInfoFunction && (
             <Observer>

--- a/static/app/views/sentryAppExternalInstallation/index.tsx
+++ b/static/app/views/sentryAppExternalInstallation/index.tsx
@@ -337,15 +337,13 @@ function MultiOrgView({
         )}
       </p>
       <FieldGroup label={t('Organization')} inline={false} stacked required>
-        {() => (
-          <SelectControl
-            onChange={({value}) => onSelectOrg(value)}
-            value={selectedOrgSlug}
-            placeholder={t('Select an organization')}
-            options={getOrganizationOptions(organizations)}
-            data-test-id="org-select"
-          />
-        )}
+        <SelectControl
+          onChange={({value}) => onSelectOrg(value)}
+          value={selectedOrgSlug}
+          placeholder={t('Select an organization')}
+          options={getOrganizationOptions(organizations)}
+          data-test-id="org-select"
+        />
       </FieldGroup>
     </div>
   );


### PR DESCRIPTION
Remove the option of using a render function as the child of a FieldGroup. There is no need to for this as the only time we use this is in the FormField itself where we use it to render the same ControlWrapper (renamed from FieldControl) but with a different controlState component.

The FieldGroup already had types that allowed for the controlState to be overridden in the FieldGroup.

Now the FormField just passes it's custom FormFieldControlState to the FieldGroup's controlState prop instead of rendering the whole ControlWrapper with the custom control statet pr