### PR TITLE
chore(custom-views): Make id required in group serach view response type

### DIFF
--- a/static/app/views/issueList/mutations/useUpdateGroupSearchViews.tsx
+++ b/static/app/views/issueList/mutations/useUpdateGroupSearchViews.tsx
@@ -9,31 +9,26 @@ import {
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 import {makeFetchGroupSearchViewsKey} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
-import type {GroupSearchView} from 'sentry/views/issueList/types';
+import type {
+  GroupSearchView,
+  UpdateGroupSearchViewPayload,
+} from 'sentry/views/issueList/types';
 
 type UpdateGroupSearchViewsVariables = {
-  groupSearchViews: GroupSearchView[]; // Id is not required in request payload
+  groupSearchViews: UpdateGroupSearchViewPayload[]; // Id is not required in request payload
   orgSlug: string;
 };
 
 export const useUpdateGroupSearchViews = (
   options: Omit<
-    UseMutationOptions<
-      Required<GroupSearchView>[],
-      RequestError,
-      UpdateGroupSearchViewsVariables
-    >,
+    UseMutationOptions<GroupSearchView[], RequestError, UpdateGroupSearchViewsVariables>,
     'mutationFn'
   > = {}
 ) => {
   const api = useApi();
   const queryClient = useQueryClient();
 
-  return useMutation<
-    Required<GroupSearchView>[],
-    RequestError,
-    UpdateGroupSearchViewsVariables
-  >({
+  return useMutation<GroupSearchView[], RequestError, UpdateGroupSearchViewsVariables>({
     ...options,
     mutationFn: ({orgSlug, groupSearchViews: data}: UpdateGroupSearchViewsVariables) =>
       api.requestPromise(`/organizations/${orgSlug}/group-search-views/`, {

--- a/static/app/views/issueList/mutations/useUpdateGroupSearchViews.tsx
+++ b/static/app/views/issueList/mutations/useUpdateGroupSearchViews.tsx
@@ -9,20 +9,20 @@ import {
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 import {makeFetchGroupSearchViewsKey} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
-import type {GroupSearchView} from 'sentry/views/issueList/types';
+import type {
+  GroupSearchView,
+  GroupSearchViewResponse,
+} from 'sentry/views/issueList/types';
 
 type UpdateGroupSearchViewsVariables = {
   groupSearchViews: GroupSearchView[];
   orgSlug: string;
 };
 
-// The PUT groupsearchviews endpoint updates the views AND returns the updated views
-type UpdateGroupSearchViewResponse = GroupSearchView[];
-
 export const useUpdateGroupSearchViews = (
   options: Omit<
     UseMutationOptions<
-      UpdateGroupSearchViewResponse,
+      GroupSearchViewResponse[],
       RequestError,
       UpdateGroupSearchViewsVariables
     >,
@@ -33,7 +33,7 @@ export const useUpdateGroupSearchViews = (
   const queryClient = useQueryClient();
 
   return useMutation<
-    UpdateGroupSearchViewResponse,
+    GroupSearchViewResponse[],
     RequestError,
     UpdateGroupSearchViewsVariables
   >({
@@ -44,7 +44,7 @@ export const useUpdateGroupSearchViews = (
         data,
       }),
     onSuccess: (groupSearchViews, parameters, context) => {
-      setApiQueryData<GroupSearchView[]>(
+      setApiQueryData<GroupSearchViewResponse[]>(
         queryClient,
         makeFetchGroupSearchViewsKey({orgSlug: parameters.orgSlug}),
         groupSearchViews // Update the cache with the new groupSearchViews

--- a/static/app/views/issueList/mutations/useUpdateGroupSearchViews.tsx
+++ b/static/app/views/issueList/mutations/useUpdateGroupSearchViews.tsx
@@ -9,20 +9,17 @@ import {
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 import {makeFetchGroupSearchViewsKey} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
-import type {
-  GroupSearchView,
-  GroupSearchViewResponse,
-} from 'sentry/views/issueList/types';
+import type {GroupSearchView} from 'sentry/views/issueList/types';
 
 type UpdateGroupSearchViewsVariables = {
-  groupSearchViews: GroupSearchView[];
+  groupSearchViews: GroupSearchView[]; // Id is not required in request payload
   orgSlug: string;
 };
 
 export const useUpdateGroupSearchViews = (
   options: Omit<
     UseMutationOptions<
-      GroupSearchViewResponse[],
+      Required<GroupSearchView>[],
       RequestError,
       UpdateGroupSearchViewsVariables
     >,
@@ -33,7 +30,7 @@ export const useUpdateGroupSearchViews = (
   const queryClient = useQueryClient();
 
   return useMutation<
-    GroupSearchViewResponse[],
+    Required<GroupSearchView>[],
     RequestError,
     UpdateGroupSearchViewsVariables
   >({
@@ -44,7 +41,7 @@ export const useUpdateGroupSearchViews = (
         data,
       }),
     onSuccess: (groupSearchViews, parameters, context) => {
-      setApiQueryData<GroupSearchViewResponse[]>(
+      setApiQueryData<GroupSearchView[]>(
         queryClient,
         makeFetchGroupSearchViewsKey({orgSlug: parameters.orgSlug}),
         groupSearchViews // Update the cache with the new groupSearchViews

--- a/static/app/views/issueList/queries/useFetchGroupSearchViews.tsx
+++ b/static/app/views/issueList/queries/useFetchGroupSearchViews.tsx
@@ -1,12 +1,10 @@
 import type {UseApiQueryOptions} from 'sentry/utils/queryClient';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import type {GroupSearchView} from 'sentry/views/issueList/types';
+import type {GroupSearchViewResponse} from 'sentry/views/issueList/types';
 
 type FetchGroupSearchViewsParameters = {
   orgSlug: string;
 };
-
-type FetchGroupSearchViewsResponse = GroupSearchView[];
 
 export const makeFetchGroupSearchViewsKey = ({
   orgSlug,
@@ -15,13 +13,10 @@ export const makeFetchGroupSearchViewsKey = ({
 
 export const useFetchGroupSearchViews = (
   {orgSlug}: FetchGroupSearchViewsParameters,
-  options: Partial<UseApiQueryOptions<FetchGroupSearchViewsResponse>> = {}
+  options: Partial<UseApiQueryOptions<GroupSearchViewResponse[]>> = {}
 ) => {
-  return useApiQuery<FetchGroupSearchViewsResponse>(
-    makeFetchGroupSearchViewsKey({orgSlug}),
-    {
-      staleTime: Infinity,
-      ...options,
-    }
-  );
+  return useApiQuery<GroupSearchViewResponse[]>(makeFetchGroupSearchViewsKey({orgSlug}), {
+    staleTime: Infinity,
+    ...options,
+  });
 };

--- a/static/app/views/issueList/queries/useFetchGroupSearchViews.tsx
+++ b/static/app/views/issueList/queries/useFetchGroupSearchViews.tsx
@@ -1,6 +1,6 @@
 import type {UseApiQueryOptions} from 'sentry/utils/queryClient';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import type {GroupSearchViewResponse} from 'sentry/views/issueList/types';
+import type {GroupSearchView} from 'sentry/views/issueList/types';
 
 type FetchGroupSearchViewsParameters = {
   orgSlug: string;
@@ -13,9 +13,9 @@ export const makeFetchGroupSearchViewsKey = ({
 
 export const useFetchGroupSearchViews = (
   {orgSlug}: FetchGroupSearchViewsParameters,
-  options: Partial<UseApiQueryOptions<GroupSearchViewResponse[]>> = {}
+  options: Partial<UseApiQueryOptions<GroupSearchView[]>> = {}
 ) => {
-  return useApiQuery<GroupSearchViewResponse[]>(makeFetchGroupSearchViewsKey({orgSlug}), {
+  return useApiQuery<GroupSearchView[]>(makeFetchGroupSearchViewsKey({orgSlug}), {
     staleTime: Infinity,
     ...options,
   });

--- a/static/app/views/issueList/types.tsx
+++ b/static/app/views/issueList/types.tsx
@@ -21,11 +21,3 @@ export type GroupSearchView = {
   querySort: IssueSortOptions;
   id?: string;
 };
-
-// Id is always returned by the response
-export type GroupSearchViewResponse = {
-  id: string;
-  name: string;
-  query: string;
-  querySort: IssueSortOptions;
-};

--- a/static/app/views/issueList/types.tsx
+++ b/static/app/views/issueList/types.tsx
@@ -16,8 +16,12 @@ export type IssueUpdateData =
   | GroupStatusResolution;
 
 export type GroupSearchView = {
+  id: string;
   name: string;
   query: string;
   querySort: IssueSortOptions;
-  id?: string;
 };
+
+export interface UpdateGroupSearchViewPayload extends Omit<GroupSearchView, 'id'> {
+  id?: string;
+}

--- a/static/app/views/issueList/types.tsx
+++ b/static/app/views/issueList/types.tsx
@@ -21,3 +21,11 @@ export type GroupSearchView = {
   querySort: IssueSortOptions;
   id?: string;
 };
+
+// Id is always returned by the response
+export type GroupSearchViewResponse = {
+  id: string;
+  name: string;
+  query: string;
+  querySort: IssueSortOptions;
+};


### PR DESCRIPTION
This PR makes a minor update to the frontend functions that call the groupsearchviews endpoints. Specifically - it makes the id parameter required in the _response_ type of both the GET and PUT, but leaves it optional in the _request_ type. This did not cause any issues before, but is more correct and will help with the existing custom views work. 