### PR TITLE
ref(alerts): Add anomaly detection metrics

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -659,6 +659,8 @@ def create_alert_rule(
             except (ValidationError):
                 alert_rule.delete()
                 raise
+            else:
+                metrics.incr("anomaly_detection_alert.created")
 
         if user:
             create_audit_entry_from_user(

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -562,7 +562,7 @@ class SubscriptionProcessor:
                         ) and not self.check_trigger_matches_status(trigger, TriggerStatus.ACTIVE):
                             metrics.incr(
                                 "incidents.alert_rules.threshold.alert",
-                                tags={"type": detection_type},
+                                tags={"detection_type": detection_type},
                             )
                             incident_trigger = self.trigger_alert_threshold(
                                 trigger, aggregation_value
@@ -579,7 +579,7 @@ class SubscriptionProcessor:
                         ):
                             metrics.incr(
                                 "incidents.alert_rules.threshold.resolve",
-                                tags={"type": detection_type},
+                                tags={"detection_type": detection_type},
                             )
                             incident_trigger = self.trigger_resolve_threshold(
                                 trigger, aggregation_value
@@ -596,7 +596,8 @@ class SubscriptionProcessor:
                         # If the value has breached our threshold (above/below)
                         # And the trigger is not yet active
                         metrics.incr(
-                            "incidents.alert_rules.threshold.alert", tags={"type": detection_type}
+                            "incidents.alert_rules.threshold.alert",
+                            tags={"detection_type": detection_type},
                         )
                         # triggering a threshold will create an incident and set the status to active
                         incident_trigger = self.trigger_alert_threshold(trigger, aggregation_value)
@@ -613,7 +614,8 @@ class SubscriptionProcessor:
                         and self.check_trigger_matches_status(trigger, TriggerStatus.ACTIVE)
                     ):
                         metrics.incr(
-                            "incidents.alert_rules.threshold.resolve", tags={"type": detection_type}
+                            "incidents.alert_rules.threshold.resolve",
+                            tags={"detection_type": detection_type},
                         )
                         incident_trigger = self.trigger_resolve_threshold(
                             trigger, aggregation_value

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -563,6 +563,7 @@ class SubscriptionProcessor:
                             potential_anomaly, trigger.label
                         ) and not self.check_trigger_matches_status(trigger, TriggerStatus.ACTIVE):
                             metrics.incr("incidents.alert_rules.threshold", tags={"type": "alert"})
+                            metrics.incr("anomaly_detection_alert.fire")
                             incident_trigger = self.trigger_alert_threshold(
                                 trigger, aggregation_value
                             )
@@ -576,6 +577,7 @@ class SubscriptionProcessor:
                             and self.active_incident
                             and self.check_trigger_matches_status(trigger, TriggerStatus.ACTIVE)
                         ):
+                            metrics.incr("anomaly_detection_alert.resolve")
                             metrics.incr(
                                 "incidents.alert_rules.threshold", tags={"type": "resolve"}
                             )


### PR DESCRIPTION
Update the metric alert rule fired and resolved metric to have the action in the name and the tag is now the detection type. There don't seem to be any other dashboards using this metric (besides the one I just created). 

Closes https://getsentry.atlassian.net/browse/ALRT-148