### PR TITLE
feat(dashboards): Preserve query between errors and transactions

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/columnsStep/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/columnsStep/index.tsx
@@ -55,7 +55,8 @@ export function ColumnsStep({
     explodedFields.forEach(field => {
       // Inject functions that aren't compatible with the current dataset
       if (field.kind === 'function') {
-        if (!(`function:${field.alias}` in fieldOptions)) {
+        const functionName = field.alias || field.function[0];
+        if (!(`function:${functionName}` in fieldOptions)) {
           const [key, value] = getFieldOptionFormat(field);
           fieldOptions[key] = value;
 

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/columnsStep/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/columnsStep/index.tsx
@@ -6,6 +6,7 @@ import type {QueryFieldValue} from 'sentry/utils/discover/fields';
 import useCustomMeasurements from 'sentry/utils/useCustomMeasurements';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import type {DisplayType, WidgetQuery, WidgetType} from 'sentry/views/dashboards/types';
+import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import {appendFieldIfUnknown} from 'sentry/views/discover/table/queryField';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 
@@ -51,7 +52,10 @@ export function ColumnsStep({
   // for the discover dataset split, so functions that are not compatible with
   // errors should still appear in the field options to gracefully handle incorrect
   // dataset splitting.
-  if ([DataSet.ERRORS, DataSet.TRANSACTIONS].includes(dataSet)) {
+  if (
+    hasDatasetSelector(organization) &&
+    [DataSet.ERRORS, DataSet.TRANSACTIONS].includes(dataSet)
+  ) {
     explodedFields.forEach(field => {
       // Inject functions that aren't compatible with the current dataset
       if (field.kind === 'function') {

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/columnsStep/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/columnsStep/index.tsx
@@ -7,10 +7,8 @@ import useCustomMeasurements from 'sentry/utils/useCustomMeasurements';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import type {DisplayType, WidgetQuery, WidgetType} from 'sentry/views/dashboards/types';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
-import {appendFieldIfUnknown} from 'sentry/views/discover/table/queryField';
-import {FieldValueKind} from 'sentry/views/discover/table/types';
 
-import {DataSet, getFieldOptionFormat} from '../../utils';
+import {addIncompatibleFunctions, DataSet} from '../../utils';
 import {BuildStep} from '../buildStep';
 
 import {ColumnFields} from './columnFields';
@@ -42,7 +40,7 @@ export function ColumnsStep({
   const {customMeasurements} = useCustomMeasurements();
   const datasetConfig = getDatasetConfig(widgetType);
 
-  let fieldOptions = datasetConfig.getTableFieldOptions(
+  const fieldOptions = datasetConfig.getTableFieldOptions(
     organization,
     tags,
     customMeasurements
@@ -56,36 +54,7 @@ export function ColumnsStep({
     hasDatasetSelector(organization) &&
     [DataSet.ERRORS, DataSet.TRANSACTIONS].includes(dataSet)
   ) {
-    explodedFields.forEach(field => {
-      // Inject functions that aren't compatible with the current dataset
-      if (field.kind === 'function') {
-        const functionName = field.alias || field.function[0];
-        if (!(`function:${functionName}` in fieldOptions)) {
-          const formattedField = getFieldOptionFormat(field);
-          if (formattedField) {
-            const [key, value] = formattedField;
-            fieldOptions[key] = value;
-
-            // If the function needs to be injected, inject the parameter as a tag
-            // as well if it isn't already an option
-            if (
-              field.function[1] &&
-              !fieldOptions[`field:${field.function[1]}`] &&
-              !fieldOptions[`tag:${field.function[1]}`]
-            ) {
-              fieldOptions = appendFieldIfUnknown(fieldOptions, {
-                kind: FieldValueKind.TAG,
-                meta: {
-                  dataType: 'string',
-                  name: field.function[1],
-                  unknown: true,
-                },
-              });
-            }
-          }
-        }
-      }
-    });
+    addIncompatibleFunctions(explodedFields, fieldOptions);
   }
 
   return (

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/columnsStep/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/columnsStep/index.tsx
@@ -57,24 +57,27 @@ export function ColumnsStep({
       if (field.kind === 'function') {
         const functionName = field.alias || field.function[0];
         if (!(`function:${functionName}` in fieldOptions)) {
-          const [key, value] = getFieldOptionFormat(field);
-          fieldOptions[key] = value;
+          const formattedField = getFieldOptionFormat(field);
+          if (formattedField) {
+            const [key, value] = formattedField;
+            fieldOptions[key] = value;
 
-          // If the function needs to be injected, inject the parameter as a tag
-          // as well if it isn't already an option
-          if (
-            field.function[1] &&
-            !fieldOptions[`field:${field.function[1]}`] &&
-            !fieldOptions[`tag:${field.function[1]}`]
-          ) {
-            fieldOptions = appendFieldIfUnknown(fieldOptions, {
-              kind: FieldValueKind.TAG,
-              meta: {
-                dataType: 'string',
-                name: field.function[1],
-                unknown: true,
-              },
-            });
+            // If the function needs to be injected, inject the parameter as a tag
+            // as well if it isn't already an option
+            if (
+              field.function[1] &&
+              !fieldOptions[`field:${field.function[1]}`] &&
+              !fieldOptions[`tag:${field.function[1]}`]
+            ) {
+              fieldOptions = appendFieldIfUnknown(fieldOptions, {
+                kind: FieldValueKind.TAG,
+                meta: {
+                  dataType: 'string',
+                  name: field.function[1],
+                  unknown: true,
+                },
+              });
+            }
           }
         }
       }

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/yAxisStep/yAxisSelector/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/yAxisStep/yAxisSelector/index.tsx
@@ -105,27 +105,30 @@ export function YAxisSelector({
       if (field.kind === 'function') {
         const functionName = field.alias || field.function[0];
         if (!(`function:${functionName}` in fieldOptions)) {
-          const [key, value] = getFieldOptionFormat(field);
-          fieldOptions[key] = value;
+          const formattedField = getFieldOptionFormat(field);
+          if (formattedField) {
+            const [key, value] = formattedField;
+            fieldOptions[key] = value;
 
-          // Store the injected function key so we can ensure the aggregate is visible
-          injectedFunctions.add(key);
+            // Store the injected function key so we can ensure the aggregate is visible
+            injectedFunctions.add(key);
 
-          // If the function needs to be injected, inject the parameter as a tag
-          // as well if it isn't already an option
-          if (
-            field.function[1] &&
-            !fieldOptions[`field:${field.function[1]}`] &&
-            !fieldOptions[`tag:${field.function[1]}`]
-          ) {
-            fieldOptions = appendFieldIfUnknown(fieldOptions, {
-              kind: FieldValueKind.TAG,
-              meta: {
-                dataType: 'string',
-                name: field.function[1],
-                unknown: true,
-              },
-            });
+            // If the function needs to be injected, inject the parameter as a tag
+            // as well if it isn't already an option
+            if (
+              field.function[1] &&
+              !fieldOptions[`field:${field.function[1]}`] &&
+              !fieldOptions[`tag:${field.function[1]}`]
+            ) {
+              fieldOptions = appendFieldIfUnknown(fieldOptions, {
+                kind: FieldValueKind.TAG,
+                meta: {
+                  dataType: 'string',
+                  name: field.function[1],
+                  unknown: true,
+                },
+              });
+            }
           }
         }
       }

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/yAxisStep/yAxisSelector/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/yAxisStep/yAxisSelector/index.tsx
@@ -10,8 +10,9 @@ import useCustomMeasurements from 'sentry/utils/useCustomMeasurements';
 import useOrganization from 'sentry/utils/useOrganization';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import type {Widget} from 'sentry/views/dashboards/types';
-import {DisplayType} from 'sentry/views/dashboards/types';
-import {QueryField} from 'sentry/views/discover/table/queryField';
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import {getFieldOptionFormat} from 'sentry/views/dashboards/widgetBuilder/utils';
+import {appendFieldIfUnknown, QueryField} from 'sentry/views/discover/table/queryField';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 
 import {AddButton} from './addButton';
@@ -86,19 +87,63 @@ export function YAxisSelector({
     ([DisplayType.LINE, DisplayType.AREA, DisplayType.BAR].includes(displayType) &&
       aggregates.length === 3);
 
+  const injectedFunctions = new Set();
+
+  let fieldOptions = datasetConfig.getTableFieldOptions(
+    organization,
+    tags,
+    customMeasurements
+  );
+
+  // We need to persist the form values across Errors and Transactions datasets
+  // for the discover dataset split, so functions that are not compatible with
+  // errors should still appear in the field options to gracefully handle incorrect
+  // dataset splitting.
+  if (widgetType && [WidgetType.ERRORS, WidgetType.TRANSACTIONS].includes(widgetType)) {
+    aggregates.forEach(field => {
+      // Inject functions that aren't compatible with the current dataset
+      if (field.kind === 'function') {
+        const functionName = field.alias || field.function[0];
+        if (!(`function:${functionName}` in fieldOptions)) {
+          const [key, value] = getFieldOptionFormat(field);
+          fieldOptions[key] = value;
+
+          // Store the injected function key so we can ensure the aggregate is visible
+          injectedFunctions.add(key);
+
+          // If the function needs to be injected, inject the parameter as a tag
+          // as well if it isn't already an option
+          if (
+            field.function[1] &&
+            !fieldOptions[`field:${field.function[1]}`] &&
+            !fieldOptions[`tag:${field.function[1]}`]
+          ) {
+            fieldOptions = appendFieldIfUnknown(fieldOptions, {
+              kind: FieldValueKind.TAG,
+              meta: {
+                dataType: 'string',
+                name: field.function[1],
+                unknown: true,
+              },
+            });
+          }
+        }
+      }
+    });
+  }
+
   return (
     <FieldGroup inline={false} flexibleControlStateSize error={fieldError} stacked>
       {aggregates.map((fieldValue, i) => (
         <QueryFieldWrapper key={`${fieldValue}:${i}`}>
           <QueryField
             fieldValue={fieldValue}
-            fieldOptions={datasetConfig.getTableFieldOptions(
-              organization,
-              tags,
-              customMeasurements
-            )}
+            fieldOptions={fieldOptions}
             onChange={value => handleChangeQueryField(value, i)}
-            filterPrimaryOptions={datasetConfig.filterYAxisOptions?.(displayType)}
+            filterPrimaryOptions={option =>
+              datasetConfig.filterYAxisOptions?.(displayType)(option) ||
+              injectedFunctions.has(`${option.value.kind}:${option.value.meta.name}`)
+            }
             filterAggregateParameters={datasetConfig.filterYAxisAggregateParams?.(
               fieldValue,
               displayType

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/yAxisStep/yAxisSelector/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/yAxisStep/yAxisSelector/index.tsx
@@ -11,6 +11,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import type {Widget} from 'sentry/views/dashboards/types';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import {getFieldOptionFormat} from 'sentry/views/dashboards/widgetBuilder/utils';
 import {appendFieldIfUnknown, QueryField} from 'sentry/views/discover/table/queryField';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
@@ -99,7 +100,11 @@ export function YAxisSelector({
   // for the discover dataset split, so functions that are not compatible with
   // errors should still appear in the field options to gracefully handle incorrect
   // dataset splitting.
-  if (widgetType && [WidgetType.ERRORS, WidgetType.TRANSACTIONS].includes(widgetType)) {
+  if (
+    hasDatasetSelector(organization) &&
+    widgetType &&
+    [WidgetType.ERRORS, WidgetType.TRANSACTIONS].includes(widgetType)
+  ) {
     aggregates.forEach(field => {
       // Inject functions that aren't compatible with the current dataset
       if (field.kind === 'function') {

--- a/static/app/views/dashboards/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils.tsx
@@ -422,9 +422,9 @@ export function getIsTimeseriesChart(displayType: DisplayType) {
 
 // Handle adding functions to the field options
 // Field and equations are already compatible
-export function getFieldOptionFormat(field: QueryFieldValue): [string, FieldValueOption] {
-  // TODO: handle 'calculated fields' ??
-
+export function getFieldOptionFormat(
+  field: QueryFieldValue
+): [string, FieldValueOption] | null {
   if (field.kind === 'function') {
     // Show the ellipsis if there are parameters that actually have values
     const ellipsis =
@@ -460,5 +460,5 @@ export function getFieldOptionFormat(field: QueryFieldValue): [string, FieldValu
       },
     ];
   }
-  return ['a', {} as any]; // TODO: Remove this
+  return null;
 }

--- a/static/app/views/dashboards/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils.tsx
@@ -467,9 +467,15 @@ export function getFieldOptionFormat(
   return null;
 }
 
-// Adds the incompatible functions (i.e. functions that aren't already
-// in the field options) to the field options. This updates fieldOptions
-// in place and returns the keys that were added for extra validation/filtering
+/**
+ * Adds the incompatible functions (i.e. functions that aren't already
+ * in the field options) to the field options. This updates fieldOptions
+ * in place and returns the keys that were added for extra validation/filtering
+ *
+ * The function depends on the consistent structure of field definition for
+ * functions where the first element is the function name and the second
+ * element is the first argument to the function, which is a field/tag.
+ */
 export function addIncompatibleFunctions(
   fields: QueryFieldValue[],
   fieldOptions: Record<string, SelectValue<FieldValue>>

--- a/static/app/views/dashboards/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils.tsx
@@ -422,7 +422,7 @@ export function getIsTimeseriesChart(displayType: DisplayType) {
 
 // Handle adding functions to the field options
 // Field and equations are already compatible
-export function getFieldOptionFormat(field: QueryFieldValue) {
+export function getFieldOptionFormat(field: QueryFieldValue): [string, FieldValueOption] {
   // TODO: handle 'calculated fields' ??
 
   if (field.kind === 'function') {
@@ -438,7 +438,7 @@ export function getFieldOptionFormat(field: QueryFieldValue) {
         value: {
           kind: FieldValueKind.FUNCTION,
           meta: {
-            name: field.alias,
+            name: functionName,
             parameters: AGGREGATIONS[field.function[0]].parameters.map(param => ({
               ...param,
               columnTypes: props => {

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
@@ -1786,6 +1786,51 @@ describe('WidgetBuilder', function () {
           )
         ).toBeInTheDocument();
       });
+
+      it('persists the query state for tables when switching between errors and transactions', async function () {
+        dashboard = mockDashboard({
+          widgets: [
+            WidgetFixture({
+              displayType: DisplayType.TABLE,
+              widgetType: WidgetType.TRANSACTIONS,
+              queries: [
+                {
+                  name: 'Test Widget',
+                  fields: ['p99(transaction.duration)'],
+                  columns: [],
+                  aggregates: ['p99(transaction.duration)'],
+                  conditions: 'testFilter:value',
+                  orderby: '',
+                },
+              ],
+            }),
+          ],
+        });
+
+        renderTestComponent({
+          orgFeatures: [...defaultOrgFeatures, 'performance-discover-dataset-selector'],
+          dashboard,
+          params: {
+            widgetIndex: '0',
+          },
+        });
+
+        expect(await screen.findByText(/p99\(…\)/i)).toBeInTheDocument();
+        expect(screen.getByText('transaction.duration')).toBeInTheDocument();
+        expect(screen.getByText('testFilter:value')).toBeInTheDocument();
+        expect(screen.getByRole('radio', {name: /transactions/i})).toBeChecked();
+
+        // Switch to errors
+        await userEvent.click(screen.getByRole('radio', {name: /errors/i}));
+
+        expect(screen.getByRole('radio', {name: /transactions/i})).not.toBeChecked();
+        expect(screen.getByRole('radio', {name: /errors/i})).toBeChecked();
+
+        // The state is still the same
+        expect(await screen.findByText(/p99\(…\)/i)).toBeInTheDocument();
+        expect(screen.getByText('transaction.duration')).toBeInTheDocument();
+        expect(screen.getByText('testFilter:value')).toBeInTheDocument();
+      });
     });
 
     describe('events-stats', function () {
@@ -1879,6 +1924,51 @@ describe('WidgetBuilder', function () {
             "We're splitting our datasets up to make it a bit easier to digest. We defaulted this widget to Transactions. Edit as you see fit."
           )
         ).toBeInTheDocument();
+      });
+
+      it('persists the query state for timeseries when switching between errors and transactions', async function () {
+        dashboard = mockDashboard({
+          widgets: [
+            WidgetFixture({
+              displayType: DisplayType.LINE,
+              widgetType: WidgetType.TRANSACTIONS,
+              queries: [
+                {
+                  name: 'Test Widget',
+                  fields: ['p99(transaction.duration)'],
+                  columns: [],
+                  aggregates: ['p99(transaction.duration)'],
+                  conditions: 'testFilter:value',
+                  orderby: '',
+                },
+              ],
+            }),
+          ],
+        });
+
+        renderTestComponent({
+          orgFeatures: [...defaultOrgFeatures, 'performance-discover-dataset-selector'],
+          dashboard,
+          params: {
+            widgetIndex: '0',
+          },
+        });
+
+        expect(await screen.findByText(/p99\(…\)/i)).toBeInTheDocument();
+        expect(screen.getByText('transaction.duration')).toBeInTheDocument();
+        expect(screen.getByText('testFilter:value')).toBeInTheDocument();
+        expect(screen.getByRole('radio', {name: /transactions/i})).toBeChecked();
+
+        // Switch to errors
+        await userEvent.click(screen.getByRole('radio', {name: /errors/i}));
+
+        expect(screen.getByRole('radio', {name: /transactions/i})).not.toBeChecked();
+        expect(screen.getByRole('radio', {name: /errors/i})).toBeChecked();
+
+        // The state is still the same
+        expect(await screen.findByText(/p99\(…\)/i)).toBeInTheDocument();
+        expect(screen.getByText('transaction.duration')).toBeInTheDocument();
+        expect(screen.getByText('testFilter:value')).toBeInTheDocument();
       });
     });
 

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -572,11 +572,18 @@ function WidgetBuilder({
         widgetToBeUpdated?.widgetType &&
         WIDGET_TYPE_TO_DATA_SET[widgetToBeUpdated.widgetType] === newDataSet;
 
-      newState.queries.push(
-        ...(didDatasetChange
-          ? widgetToBeUpdated.queries
-          : [{...config.defaultWidgetQuery}])
-      );
+      if (
+        [DataSet.ERRORS, DataSet.TRANSACTIONS].includes(prevState.dataSet) &&
+        [DataSet.ERRORS, DataSet.TRANSACTIONS].includes(newDataSet as DataSet)
+      ) {
+        newState.queries = prevState.queries;
+      } else {
+        newState.queries.push(
+          ...(didDatasetChange
+            ? widgetToBeUpdated.queries
+            : [{...config.defaultWidgetQuery}])
+        );
+      }
 
       set(newState, 'userHasModified', true);
       return {...newState, errors: undefined};

--- a/static/app/views/discover/table/queryField.tsx
+++ b/static/app/views/discover/table/queryField.tsx
@@ -358,7 +358,7 @@ class QueryField extends Component<Props> {
 
     if (fieldValue?.kind === 'field' || fieldValue?.kind === 'calculatedField') {
       field = this.getFieldOrTagOrMeasurementValue(fieldValue.field);
-      fieldOptions = this.appendFieldIfUnknown(fieldOptions, field);
+      fieldOptions = appendFieldIfUnknown(fieldOptions, field);
     }
 
     let parameterDescriptions: ParameterDescription[] = [];
@@ -376,7 +376,7 @@ class QueryField extends Component<Props> {
               fieldValue.function[1],
               [fieldValue.function[0]]
             );
-            fieldOptions = this.appendFieldIfUnknown(fieldOptions, fieldParameter);
+            fieldOptions = appendFieldIfUnknown(fieldOptions, fieldParameter);
             return {
               kind: 'column',
               value: fieldParameter,
@@ -389,6 +389,7 @@ class QueryField extends Component<Props> {
                     value.kind === FieldValueKind.CUSTOM_MEASUREMENT ||
                     value.kind === FieldValueKind.METRICS ||
                     value.kind === FieldValueKind.BREAKDOWN) &&
+                  // This is blocking my parameter from appearing
                   validateColumnTypes(param.columnTypes as ValidateColumnTypes, value)
               ),
             };
@@ -420,29 +421,6 @@ class QueryField extends Component<Props> {
       );
     }
     return {field, fieldOptions, parameterDescriptions};
-  }
-
-  appendFieldIfUnknown(
-    fieldOptions: FieldOptions,
-    field: FieldValue | null
-  ): FieldOptions {
-    if (!field) {
-      return fieldOptions;
-    }
-
-    if (field && field.kind === FieldValueKind.TAG && field.meta.unknown) {
-      // Clone the options so we don't mutate other rows.
-      fieldOptions = Object.assign({}, fieldOptions);
-      fieldOptions[field.meta.name] = {label: field.meta.name, value: field};
-    } else if (field && field.kind === FieldValueKind.CUSTOM_MEASUREMENT) {
-      fieldOptions = Object.assign({}, fieldOptions);
-      fieldOptions[`measurement:${field.meta.name}`] = {
-        label: field.meta.name,
-        value: field,
-      };
-    }
-
-    return fieldOptions;
   }
 
   renderParameterInputs(parameters: ParameterDescription[]): React.ReactNode[] {
@@ -843,3 +821,26 @@ const ArithmeticError = styled(Tooltip)`
 `;
 
 export {QueryField};
+
+export function appendFieldIfUnknown(
+  fieldOptions: FieldOptions,
+  field: FieldValue | null
+): FieldOptions {
+  if (!field) {
+    return fieldOptions;
+  }
+
+  if (field && field.kind === FieldValueKind.TAG && field.meta.unknown) {
+    // Clone the options so we don't mutate other rows.
+    fieldOptions = Object.assign({}, fieldOptions);
+    fieldOptions[field.meta.name] = {label: field.meta.name, value: field};
+  } else if (field && field.kind === FieldValueKind.CUSTOM_MEASUREMENT) {
+    fieldOptions = Object.assign({}, fieldOptions);
+    fieldOptions[`measurement:${field.meta.name}`] = {
+      label: field.meta.name,
+      value: field,
+    };
+  }
+
+  return fieldOptions;
+}

--- a/static/app/views/discover/table/queryField.tsx
+++ b/static/app/views/discover/table/queryField.tsx
@@ -389,7 +389,6 @@ class QueryField extends Component<Props> {
                     value.kind === FieldValueKind.CUSTOM_MEASUREMENT ||
                     value.kind === FieldValueKind.METRICS ||
                     value.kind === FieldValueKind.BREAKDOWN) &&
-                  // This is blocking my parameter from appearing
                   validateColumnTypes(param.columnTypes as ValidateColumnTypes, value)
               ),
             };


### PR DESCRIPTION
Since we aren't guaranteed that all discover splits will be correct, we need to allow the user to switch between the errors and transactions datasets without having to set the entire widget back up.

This PR persists the settings and injects the field options because they may not be allowed in the other dataset (e.g. p99 in transactions -> errors).

This PR does _not_ handle indicating incompatible functions to the users, nor does it handle gracefully erroring when an incompatible function is selected.