### PR TITLE
fix(replay): replay queries should respect location statsPeriod

### DIFF
--- a/static/app/components/events/eventReplay/replayClipSection.tsx
+++ b/static/app/components/events/eventReplay/replayClipSection.tsx
@@ -14,8 +14,10 @@ import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import {getAnalyticsDataForEvent, getAnalyticsDataForGroup} from 'sentry/utils/events';
+import {decodeScalar} from 'sentry/utils/queryString';
 import useReplayCountForIssues from 'sentry/utils/replayCount/useReplayCountForIssues';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
 import {FoldSectionKey} from 'sentry/views/issueDetails/streamline/foldSection';
@@ -38,8 +40,11 @@ const ReplayClipPreview = lazy(() => import('./replayClipPreview'));
 export function ReplayClipSection({event, group, replayId}: Props) {
   const organization = useOrganization();
   const hasStreamlinedUI = useHasStreamlinedUI();
+  const location = useLocation();
   const router = useRouter();
-  const {getReplayCountForIssue} = useReplayCountForIssues();
+  const {getReplayCountForIssue} = useReplayCountForIssues({
+    statsPeriod: decodeScalar(location.query.statsPeriod) ?? '90d',
+  });
 
   const startTimestampMS =
     'startTimestamp' in event ? event.startTimestamp * 1000 : undefined;

--- a/static/app/components/group/issueReplayCount.tsx
+++ b/static/app/components/group/issueReplayCount.tsx
@@ -6,8 +6,10 @@ import {IconPlay} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
+import {decodeScalar} from 'sentry/utils/queryString';
 import useReplayCountForIssues from 'sentry/utils/replayCount/useReplayCountForIssues';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface Props {
@@ -19,7 +21,10 @@ interface Props {
  */
 function IssueReplayCount({group}: Props) {
   const organization = useOrganization();
-  const {getReplayCountForIssue} = useReplayCountForIssues();
+  const location = useLocation();
+  const {getReplayCountForIssue} = useReplayCountForIssues({
+    statsPeriod: decodeScalar(location.query.statsPeriod) ?? '90d',
+  });
   const count = getReplayCountForIssue(group.id, group.issueCategory);
 
   if (count === undefined || count === 0) {

--- a/static/app/utils/replayCount/useReplayCountForIssues.tsx
+++ b/static/app/utils/replayCount/useReplayCountForIssues.tsx
@@ -1,7 +1,9 @@
 import {useMemo} from 'react';
 
 import {IssueCategory} from 'sentry/types/group';
+import {decodeScalar} from 'sentry/utils/queryString';
 import useReplayCount from 'sentry/utils/replayCount/useReplayCount';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface Props {
@@ -14,9 +16,10 @@ interface Props {
  */
 export default function useReplayCountForIssues({
   bufferLimit = 25,
-  statsPeriod = '14d',
+  statsPeriod,
 }: Props = {}) {
   const organization = useOrganization();
+  const location = useLocation();
   const {
     getOne: getOneError,
     getMany: getManyError,
@@ -27,7 +30,7 @@ export default function useReplayCountForIssues({
     dataSource: 'discover',
     fieldName: 'issue.id',
     organization,
-    statsPeriod,
+    statsPeriod: statsPeriod ?? decodeScalar(location.query.statsPeriod) ?? '90d',
   });
   const {
     getOne: getOneIssue,
@@ -39,7 +42,7 @@ export default function useReplayCountForIssues({
     dataSource: 'search_issues',
     fieldName: 'issue.id',
     organization,
-    statsPeriod,
+    statsPeriod: statsPeriod ?? decodeScalar(location.query.statsPeriod) ?? '90d',
   });
 
   return useMemo(

--- a/static/app/utils/replayCount/useReplayCountForIssues.tsx
+++ b/static/app/utils/replayCount/useReplayCountForIssues.tsx
@@ -1,9 +1,7 @@
 import {useMemo} from 'react';
 
 import {IssueCategory} from 'sentry/types/group';
-import {decodeScalar} from 'sentry/utils/queryString';
 import useReplayCount from 'sentry/utils/replayCount/useReplayCount';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface Props {
@@ -16,10 +14,9 @@ interface Props {
  */
 export default function useReplayCountForIssues({
   bufferLimit = 25,
-  statsPeriod,
+  statsPeriod = '90d',
 }: Props = {}) {
   const organization = useOrganization();
-  const location = useLocation();
   const {
     getOne: getOneError,
     getMany: getManyError,
@@ -30,7 +27,7 @@ export default function useReplayCountForIssues({
     dataSource: 'discover',
     fieldName: 'issue.id',
     organization,
-    statsPeriod: statsPeriod ?? decodeScalar(location.query.statsPeriod) ?? '90d',
+    statsPeriod,
   });
   const {
     getOne: getOneIssue,
@@ -42,7 +39,7 @@ export default function useReplayCountForIssues({
     dataSource: 'search_issues',
     fieldName: 'issue.id',
     organization,
-    statsPeriod: statsPeriod ?? decodeScalar(location.query.statsPeriod) ?? '90d',
+    statsPeriod,
   });
 
   return useMemo(

--- a/static/app/utils/replayCount/useReplayCountForTransactions.tsx
+++ b/static/app/utils/replayCount/useReplayCountForTransactions.tsx
@@ -1,8 +1,6 @@
 import {useMemo} from 'react';
 
-import {decodeScalar} from 'sentry/utils/queryString';
 import useReplayCount from 'sentry/utils/replayCount/useReplayCount';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface Props {
@@ -15,16 +13,15 @@ interface Props {
  */
 export default function useReplayCountForTransactions({
   bufferLimit = 25,
-  statsPeriod,
+  statsPeriod = '90d',
 }: Props = {}) {
   const organization = useOrganization();
-  const location = useLocation();
   const {getOne, getMany, hasOne, hasMany} = useReplayCount({
     bufferLimit,
     dataSource: 'discover',
     fieldName: 'transaction',
     organization,
-    statsPeriod: statsPeriod ?? decodeScalar(location.query.statsPeriod) ?? '90d',
+    statsPeriod,
   });
 
   return useMemo(

--- a/static/app/utils/replayCount/useReplayCountForTransactions.tsx
+++ b/static/app/utils/replayCount/useReplayCountForTransactions.tsx
@@ -1,6 +1,8 @@
 import {useMemo} from 'react';
 
+import {decodeScalar} from 'sentry/utils/queryString';
 import useReplayCount from 'sentry/utils/replayCount/useReplayCount';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface Props {
@@ -13,15 +15,16 @@ interface Props {
  */
 export default function useReplayCountForTransactions({
   bufferLimit = 25,
-  statsPeriod = '14d',
+  statsPeriod,
 }: Props = {}) {
   const organization = useOrganization();
+  const location = useLocation();
   const {getOne, getMany, hasOne, hasMany} = useReplayCount({
     bufferLimit,
     dataSource: 'discover',
     fieldName: 'transaction',
     organization,
-    statsPeriod,
+    statsPeriod: statsPeriod ?? decodeScalar(location.query.statsPeriod) ?? '90d',
   });
 
   return useMemo(

--- a/static/app/views/issueDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.tsx
@@ -14,6 +14,7 @@ import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import type EventView from 'sentry/utils/discover/eventView';
+import {decodeScalar} from 'sentry/utils/queryString';
 import useReplayCountForIssues from 'sentry/utils/replayCount/useReplayCountForIssues';
 import useReplayList from 'sentry/utils/replays/hooks/useReplayList';
 import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
@@ -175,7 +176,7 @@ function GroupReplaysTable({
   const location = useLocation();
   const urlParams = useUrlParams();
   const {getReplayCountForIssue} = useReplayCountForIssues({
-    statsPeriod: '90d',
+    statsPeriod: decodeScalar(location.query.statsPeriod) ?? '90d',
   });
 
   const replayListData = useReplayList({

--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
@@ -50,7 +50,7 @@ export default function useReplaysFromIssue({
       Sentry.captureException(error);
       setFetchError(error);
     }
-  }, [api, organization.slug, group.id, dataSource, location]);
+  }, [api, organization.slug, group.id, dataSource, location.query]);
 
   const eventView = useMemo(() => {
     if (!replayIds || !replayIds.length) {

--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
@@ -39,7 +39,7 @@ export default function useReplaysFromIssue({
             returnIds: true,
             query: `issue.id:[${group.id}]`,
             data_source: dataSource,
-            statsPeriod: '90d',
+            statsPeriod: location.query.statsPeriod,
             environment: location.query.environment,
             project: ALL_ACCESS_PROJECTS,
           },
@@ -50,7 +50,7 @@ export default function useReplaysFromIssue({
       Sentry.captureException(error);
       setFetchError(error);
     }
-  }, [api, organization.slug, group.id, dataSource, location.query.environment]);
+  }, [api, organization.slug, group.id, dataSource, location]);
 
   const eventView = useMemo(() => {
     if (!replayIds || !replayIds.length) {

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -23,6 +23,7 @@ import type {Event, Group, Organization, Project} from 'sentry/types';
 import {IssueCategory, IssueType} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
+import {decodeScalar} from 'sentry/utils/queryString';
 import useReplayCountForIssues from 'sentry/utils/replayCount/useReplayCountForIssues';
 import {projectCanLinkToReplay} from 'sentry/utils/replays/projectSupportsReplay';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
@@ -60,7 +61,7 @@ export function GroupHeaderTabs({
   const location = useLocation();
 
   const {getReplayCountForIssue} = useReplayCountForIssues({
-    statsPeriod: '90d',
+    statsPeriod: decodeScalar(location.query.statsPeriod) ?? '90d',
   });
   const replaysCount = getReplayCountForIssue(group.id, group.issueCategory);
 

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -21,6 +21,7 @@ import type EventView from 'sentry/utils/discover/eventView';
 import type {MetricsCardinalityContext} from 'sentry/utils/performance/contexts/metricsCardinality';
 import HasMeasurementsQuery from 'sentry/utils/performance/vitals/hasMeasurementsQuery';
 import {isProfilingSupportedOrProjectHasProfiles} from 'sentry/utils/profiling/platforms';
+import {decodeScalar} from 'sentry/utils/queryString';
 import useReplayCountForTransactions from 'sentry/utils/replayCount/useReplayCountForTransactions';
 import projectSupportsReplay from 'sentry/utils/replays/projectSupportsReplay';
 import Breadcrumb from 'sentry/views/performance/breadcrumb';
@@ -113,7 +114,7 @@ function TransactionHeader({
   );
 
   const {getReplayCountForTransaction} = useReplayCountForTransactions({
-    statsPeriod: '90d',
+    statsPeriod: decodeScalar(location.query.statsPeriod) ?? '90d',
   });
   const replaysCount = getReplayCountForTransaction(transactionName);
 

--- a/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
@@ -36,12 +36,7 @@ function TransactionReplays() {
 
   return (
     <PageLayout
-      location={{
-        ...location,
-        query: {
-          ...location.query,
-        },
-      }}
+      location={location}
       organization={organization}
       projects={projects}
       tab={Tab.REPLAYS}

--- a/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
@@ -11,6 +11,7 @@ import {
   SPAN_OP_BREAKDOWN_FIELDS,
   SPAN_OP_RELATIVE_BREAKDOWN_FIELD,
 } from 'sentry/utils/discover/fields';
+import {decodeScalar} from 'sentry/utils/queryString';
 import useReplayList from 'sentry/utils/replays/hooks/useReplayList';
 import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
@@ -84,6 +85,7 @@ function generateEventView({
     name: `Replay events within a transaction`,
     version: 2,
     fields,
+    range: decodeScalar(location.query.statsPeriod),
     query: `event.type:transaction transaction:"${transactionName}" !replayId:""`,
     projects: [Number(location.query.project)],
   });

--- a/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
@@ -39,7 +39,6 @@ function TransactionReplays() {
         ...location,
         query: {
           ...location.query,
-          statsPeriod: '90d',
         },
       }}
       organization={organization}


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry/issues/75973

### before: 24h -> replay tab -> 90d

https://github.com/user-attachments/assets/5f430390-2bd1-4e52-aebf-f26f9152c747

### after: 1h -> replay tab -> still 1h

https://github.com/user-attachments/assets/b0e35acb-9760-4b0d-8d60-ba63f87c139f

also fixed an error where the issue details replay tab query wasn't respecting the location `statsPeriod` either.

### before: tab says `6` replays but there are way more than 6 replays:
<img width="766" alt="SCR-20240812-kpbj" src="https://github.com/user-attachments/assets/9b479b32-27b5-4d6b-9859-36abca89ae78">

<img width="1117" alt="SCR-20240812-kovl" src="https://github.com/user-attachments/assets/c1e64db4-6f28-46cf-94a9-42b8743acb1a">




### after: tab says `17` replays which is the correct amount:
<img width="727" alt="SCR-20240812-kozx" src="https://github.com/user-attachments/assets/1ff05c6d-f179-434e-adf9-b99e3369752c">
<img width="792" alt="SCR-20240812-koxv" src="https://github.com/user-attachments/assets/88ce6aff-8e08-4077-924d-5f0bd99c660c">


also fixed a bug where the transactions summary tab count didn't match the replay list in the tab. fetching the replay list didn't respect the location query; it seems to always default to 14d. the default `eventView` was hardcoding 14d:

<img width="283" alt="a14048c7-3193-4d2d-8db3-2831378316f0" src="https://github.com/user-attachments/assets/1e25a8ab-6aab-4679-a154-fecb0d81d9e6">

https://github.com/getsentry/sentry/blob/d3c2b01801a5c28be02caaca75677cf658e617ab/static/app/views/performance/transactionSummary/transactionReplays/useReplaysFromTransaction.tsx#L64-L69

### before: 
<img width="778" alt="de461924-406a-4485-bd4c-b718ca3f216a" src="https://github.com/user-attachments/assets/d72798ff-5b3b-46d1-af7c-1582ddbbe908">

### after:
<img width="932" alt="SCR-20240812-lfmn" src="https://github.com/user-attachments/assets/0a520a38-e4d7-4be9-845c-7930dc6d2fc8">

