### PR TITLE
chore(perf): Adjust Transaction summary searchbar properties

### DIFF
--- a/static/app/components/performance/transactionSearchQueryBuilder.tsx
+++ b/static/app/components/performance/transactionSearchQueryBuilder.tsx
@@ -31,6 +31,7 @@ interface TransactionSearchQueryBuilderProps {
   searchSource: string;
   datetime?: PageFilters['datetime'];
   disableLoadingTags?: boolean;
+  filterKeyMenuWidth?: number;
   onSearch?: (query: string, state: CallbackSearchState) => void;
   placeholder?: string;
   projects?: PageFilters['projects'];
@@ -44,6 +45,7 @@ export function TransactionSearchQueryBuilder({
   placeholder,
   projects,
   disableLoadingTags,
+  filterKeyMenuWidth,
 }: TransactionSearchQueryBuilderProps) {
   const api = useApi();
   const organization = useOrganization();
@@ -134,6 +136,7 @@ export function TransactionSearchQueryBuilder({
       disallowFreeText
       disallowUnsupportedFilters
       recentSearches={SavedSearchType.EVENT}
+      filterKeyMenuWidth={filterKeyMenuWidth}
     />
   );
 }

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -1396,6 +1396,11 @@ export const TRANSACTION_FILTER_FIELDS: FilterKeySection = {
     FieldKey.TRANSACTION_DURATION,
     FieldKey.TRANSACTION_OP,
     FieldKey.TRANSACTION_STATUS,
+    SpanOpBreakdown.SPANS_BROWSER,
+    SpanOpBreakdown.SPANS_DB,
+    SpanOpBreakdown.SPANS_HTTP,
+    SpanOpBreakdown.SPANS_RESOURCE,
+    SpanOpBreakdown.SPANS_UI,
   ],
 };
 
@@ -1414,7 +1419,7 @@ export const USER_FILTER_FIELDS: FilterKeySection = {
 
 export const GEO_FILTER_FIELDS: FilterKeySection = {
   value: 'geo_fields',
-  label: 'Geographical',
+  label: 'Geo',
   children: [
     FieldKey.GEO_CITY,
     FieldKey.GEO_COUNTRY_CODE,
@@ -1431,18 +1436,6 @@ export const HTTP_FILTER_FIELDS: FilterKeySection = {
     FieldKey.HTTP_REFERER,
     FieldKey.HTTP_STATUS_CODE,
     FieldKey.HTTP_URL,
-  ],
-};
-
-export const SPAN_OP_FILTER_FIELDS: FilterKeySection = {
-  value: 'span_duration_fields',
-  label: 'Span Duration',
-  children: [
-    SpanOpBreakdown.SPANS_BROWSER,
-    SpanOpBreakdown.SPANS_DB,
-    SpanOpBreakdown.SPANS_HTTP,
-    SpanOpBreakdown.SPANS_RESOURCE,
-    SpanOpBreakdown.SPANS_UI,
   ],
 };
 
@@ -1524,7 +1517,6 @@ export const MISC_FIELDS: FilterKeySection = {
 
 export const ALL_INSIGHTS_FILTER_KEY_SECTIONS: FilterKeySection[] = [
   TRANSACTION_FILTER_FIELDS,
-  SPAN_OP_FILTER_FIELDS,
   HTTP_FILTER_FIELDS,
   WEB_VITAL_FIELDS,
   RELEASE_FIELDS,

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -362,7 +362,7 @@ function SummaryContent({
           onSearch={handleSearch}
           searchSource="transaction_summary"
           disableLoadingTags // already loaded by the parent component
-          filterKeyMenuWidth={480}
+          filterKeyMenuWidth={420}
         />
       );
     }

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -362,6 +362,7 @@ function SummaryContent({
           onSearch={handleSearch}
           searchSource="transaction_summary"
           disableLoadingTags // already loaded by the parent component
+          filterKeyMenuWidth={480}
         />
       );
     }


### PR DESCRIPTION
- Update the width for the menu, to allow for categories to fit in two rows instead of three
- Rename 'Geographical' category to 'Geo'
- Combine span category into transactions, to save room and since they are technically within the same scope (the cumulative span duration is scoped to a per transaction basis)

### Before
![image](https://github.com/user-attachments/assets/25849cd8-1da9-4f1e-9db9-cdb6fa6f5055)

### After
![image](https://github.com/user-attachments/assets/afee1cbb-4eec-45bd-a382-8e5dd9247665)
