### PR TITLE
feat(query-builder): Add FormattedQuery component for rendering a formatted query 

### DIFF
--- a/static/app/components/searchQueryBuilder/formattedQuery.spec.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.spec.tsx
@@ -1,0 +1,64 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
+
+import {
+  FormattedQuery,
+  type FormattedQueryProps,
+} from 'sentry/components/searchQueryBuilder/formattedQuery';
+import type {TagCollection} from 'sentry/types/group';
+
+const FILTER_KEYS: TagCollection = {
+  lastSeen: {
+    key: 'lastSeen',
+    name: 'Last Seen',
+  },
+};
+
+describe('FormattedQuery', function () {
+  const defaultProps: Partial<FormattedQueryProps> = {
+    filterKeys: FILTER_KEYS,
+  };
+
+  it('renders aggregate filters correctly', function () {
+    render(<FormattedQuery {...defaultProps} query="count():>1" />);
+
+    expect(screen.getByText(textWithMarkupMatcher('count() > 1'))).toBeInTheDocument();
+  });
+
+  it('renders filters with multiple values correctly', function () {
+    render(<FormattedQuery {...defaultProps} query="browser.name:[Firefox,Chrome]" />);
+
+    expect(
+      screen.getByText(textWithMarkupMatcher('browser.name is Firefox or Chrome'))
+    ).toBeInTheDocument();
+  });
+
+  it('renders "is" filter correctly', function () {
+    render(<FormattedQuery {...defaultProps} query="is:unresolved" />);
+
+    expect(screen.getByText(textWithMarkupMatcher('is unresolved'))).toBeInTheDocument();
+  });
+
+  it('renders relative date filter correctly', function () {
+    render(<FormattedQuery {...defaultProps} query="lastSeen:-7d" />);
+
+    expect(
+      screen.getByText(textWithMarkupMatcher('lastSeen is after 7d ago'))
+    ).toBeInTheDocument();
+  });
+
+  it('renders absolute date filter correctly', function () {
+    render(<FormattedQuery {...defaultProps} query="lastSeen:>2024-01-01" />);
+
+    expect(
+      screen.getByText(textWithMarkupMatcher('lastSeen is after Jan 1, 2024'))
+    ).toBeInTheDocument();
+  });
+
+  it('renders boolean logic correctly', function () {
+    render(<FormattedQuery {...defaultProps} query="(a OR b)" />);
+
+    expect(screen.getByText('OR')).toBeInTheDocument();
+    expect(screen.getAllByTestId('icon-parenthesis')).toHaveLength(2);
+  });
+});

--- a/static/app/components/searchQueryBuilder/formattedQuery.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.tsx
@@ -25,7 +25,7 @@ type TokenProps = {
   token: ParseResultToken;
 };
 
-const EMPTY_TAGS_COLLECTION = {};
+const EMPTY_FILTER_KEYS: TagCollection = {};
 
 function Filter({token}: {token: TokenResult<Token.FILTER>}) {
   return (
@@ -71,7 +71,7 @@ function QueryToken({token}: TokenProps) {
 export function FormattedQuery({
   query,
   fieldDefinitionGetter = getFieldDefinition,
-  filterKeys = EMPTY_TAGS_COLLECTION,
+  filterKeys = EMPTY_FILTER_KEYS,
 }: FormattedQueryProps) {
   const parsedQuery = useMemo(() => {
     return parseQueryBuilderValue(query, fieldDefinitionGetter, {filterKeys});

--- a/static/app/components/searchQueryBuilder/formattedQuery.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.tsx
@@ -1,0 +1,125 @@
+import {useMemo} from 'react';
+import styled from '@emotion/styled';
+
+import {FilterValueText} from 'sentry/components/searchQueryBuilder/tokens/filter/filter';
+import {FilterKeyOperatorVisual} from 'sentry/components/searchQueryBuilder/tokens/filter/filterKeyOperator';
+import {SearchQueryBuilderParenIcon} from 'sentry/components/searchQueryBuilder/tokens/paren';
+import type {FieldDefinitionGetter} from 'sentry/components/searchQueryBuilder/types';
+import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
+import {
+  type ParseResultToken,
+  Token,
+  type TokenResult,
+} from 'sentry/components/searchSyntax/parser';
+import {space} from 'sentry/styles/space';
+import type {TagCollection} from 'sentry/types/group';
+import {getFieldDefinition} from 'sentry/utils/fields';
+
+export type FormattedQueryProps = {
+  query: string;
+  fieldDefinitionGetter?: FieldDefinitionGetter;
+  filterKeys?: TagCollection;
+};
+
+type TokenProps = {
+  token: ParseResultToken;
+};
+
+const EMPTY_TAGS_COLLECTION = {};
+
+function Filter({token}: {token: TokenResult<Token.FILTER>}) {
+  return (
+    <FilterWrapper aria-label={token.text}>
+      <FilterKeyOperatorVisual token={token} />{' '}
+      <FilterValue>
+        <FilterValueText token={token} />
+      </FilterValue>
+    </FilterWrapper>
+  );
+}
+
+function QueryToken({token}: TokenProps) {
+  switch (token.type) {
+    case Token.FILTER:
+      return <Filter token={token} />;
+    case Token.FREE_TEXT:
+      if (token.value.trim()) {
+        return <span>{token.value.trim()}</span>;
+      }
+      return null;
+    case Token.L_PAREN:
+    case Token.R_PAREN:
+      return (
+        <Boolean>
+          <SearchQueryBuilderParenIcon token={token} />
+        </Boolean>
+      );
+    case Token.LOGIC_BOOLEAN:
+      return <Boolean>{token.text}</Boolean>;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Renders a formatted query string similar to how it appears in the search bar,
+ * but without all the interactivity.
+ *
+ * Accepts `filterKeys` and `fieldDefinitionGetter`, but is only necessary for
+ * rendering some filter types such as dates.
+ */
+export function FormattedQuery({
+  query,
+  fieldDefinitionGetter = getFieldDefinition,
+  filterKeys = EMPTY_TAGS_COLLECTION,
+}: FormattedQueryProps) {
+  const parsedQuery = useMemo(() => {
+    return parseQueryBuilderValue(query, fieldDefinitionGetter, {filterKeys});
+  }, [fieldDefinitionGetter, filterKeys, query]);
+
+  if (!parsedQuery) {
+    return <QueryWrapper />;
+  }
+
+  return (
+    <QueryWrapper>
+      {parsedQuery.map((token, index) => {
+        return <QueryToken key={index} token={token} />;
+      })}
+    </QueryWrapper>
+  );
+}
+
+const QueryWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  row-gap: ${space(0.5)};
+  column-gap: ${space(1)};
+`;
+
+const FilterWrapper = styled('div')`
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: ${space(0.5)};
+  background: ${p => p.theme.background};
+  padding: ${space(0.25)} ${space(0.5)};
+  border: 1px solid ${p => p.theme.innerBorder};
+  border-radius: ${p => p.theme.borderRadius};
+  height: 24px;
+  white-space: nowrap;
+  overflow: hidden;
+`;
+
+const FilterValue = styled('div')`
+  width: 100%;
+  max-width: 300px;
+  color: ${p => p.theme.purple400};
+  ${p => p.theme.overflowEllipsis};
+`;
+
+const Boolean = styled('div')`
+  display: flex;
+  align-items: center;
+  color: ${p => p.theme.subText};
+`;

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -2,6 +2,7 @@ import {Fragment, useState} from 'react';
 
 import MultipleCheckbox from 'sentry/components/forms/controls/multipleCheckbox';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
+import {FormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
 import type {
   FieldDefinitionGetter,
   FilterKeySection,
@@ -652,6 +653,21 @@ export default storyBook(SearchQueryBuilder, story => {
         searchSource="storybook"
         disabled
       />
+    );
+  });
+
+  story('FormattedQuery', () => {
+    return (
+      <Fragment>
+        <p>
+          If you just need to render a formatted query outside of the search bar,{' '}
+          <JSXNode name="FormattedQuery" /> is exported for this purpose:
+        </p>
+        <FormattedQuery
+          query="count():>1 AND (browser.name:[Firefox,Chrome] OR lastSeen:-7d) TypeError"
+          filterKeys={FILTER_KEYS}
+        />
+      </Fragment>
     );
   });
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/aggregateKey.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/aggregateKey.tsx
@@ -1,4 +1,4 @@
-import {useLayoutEffect, useRef, useState} from 'react';
+import {Fragment, useLayoutEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {useFocusWithin} from '@react-aria/interactions';
 import {mergeProps} from '@react-aria/utils';
@@ -25,6 +25,20 @@ type AggregateKeyProps = {
   state: ListState<ParseResultToken>;
   token: AggregateFilter;
 };
+
+export function AggregateKeyVisual({token}: {token: AggregateFilter}) {
+  const fnName = getKeyName(token.key);
+  const fnParams = token.key.args?.text ?? '';
+
+  return (
+    <Fragment>
+      <FnName>{fnName}</FnName>
+      {'('}
+      <Parameters>{fnParams}</Parameters>
+      {')'}
+    </Fragment>
+  );
+}
 
 export function AggregateKey({
   item,
@@ -60,7 +74,6 @@ export function AggregateKey({
   const filterButtonProps = useFilterButtonProps({state, item});
 
   const fnName = getKeyName(token.key);
-  const fnParams = token.key.args?.text ?? '';
 
   if (isEditing) {
     return (
@@ -105,10 +118,7 @@ export function AggregateKey({
       {...filterButtonProps}
     >
       <InteractionStateLayer />
-      <FnName>{fnName}</FnName>
-      {'('}
-      <Parameters>{fnParams}</Parameters>
-      {')'}
+      <AggregateKeyVisual token={token} />
     </KeyButton>
   );
 }

--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -37,7 +37,7 @@ interface FilterValueProps extends SearchQueryTokenProps {
   onActiveChange: (active: boolean) => void;
 }
 
-function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
+export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
   const {size} = useSearchQueryBuilder();
 
   switch (token.value.type) {
@@ -63,7 +63,7 @@ function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
                 {formatFilterValue(item.value)}
               </FilterMultiValueTruncated>
               {index !== items.length - 1 && index < maxItems - 1 ? (
-                <FilterValueOr>or</FilterValueOr>
+                <FilterValueOr> or </FilterValueOr>
               ) : null}
             </Fragment>
           ))}

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyOperator.tsx
@@ -7,7 +7,10 @@ import type {DOMAttributes, FocusableElement, Node} from '@react-types/shared';
 import {CompactSelect, type SelectOption} from 'sentry/components/compactSelect';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
-import {AggregateKey} from 'sentry/components/searchQueryBuilder/tokens/filter/aggregateKey';
+import {
+  AggregateKey,
+  AggregateKeyVisual,
+} from 'sentry/components/searchQueryBuilder/tokens/filter/aggregateKey';
 import {UnstyledButton} from 'sentry/components/searchQueryBuilder/tokens/filter/unstyledButton';
 import {useFilterButtonProps} from 'sentry/components/searchQueryBuilder/tokens/filter/useFilterButtonProps';
 import {getValidOpsForFilter} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
@@ -99,7 +102,7 @@ function getTermOperatorFromToken(token: TokenResult<Token.FILTER>) {
   return token.operator;
 }
 
-function FilterKeyOperatorLabel({
+export function FilterKeyOperatorLabel({
   keyLabel,
   opLabel,
   includeKeyLabel,
@@ -115,7 +118,7 @@ function FilterKeyOperatorLabel({
   return (
     <KeyOpLabelWrapper>
       <span>{keyLabel}</span>
-      {opLabel ? <OpLabel>{opLabel}</OpLabel> : null}
+      {opLabel ? <OpLabel> {opLabel}</OpLabel> : null}
     </KeyOpLabelWrapper>
   );
 }
@@ -348,6 +351,30 @@ function AggregateFilterKeyOperator({
       </GridCell>
     </Fragment>
   );
+}
+
+export function FilterKeyOperatorVisual({token}: {token: TokenResult<Token.FILTER>}) {
+  switch (token.filter) {
+    case FilterType.AGGREGATE_DATE:
+    case FilterType.AGGREGATE_DURATION:
+    case FilterType.AGGREGATE_NUMERIC:
+    case FilterType.AGGREGATE_PERCENTAGE:
+    case FilterType.AGGREGATE_RELATIVE_DATE:
+    case FilterType.AGGREGATE_SIZE: {
+      const {label} = getOperatorInfo(token, false);
+
+      return (
+        <KeyOpLabelWrapper>
+          <div>
+            <AggregateKeyVisual token={token} /> {label}
+          </div>
+        </KeyOpLabelWrapper>
+      );
+    }
+    default:
+      const {label} = getOperatorInfo(token, true);
+      return label;
+  }
 }
 
 export function FilterKeyOperator({

--- a/static/app/components/searchQueryBuilder/tokens/paren.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/paren.tsx
@@ -15,6 +15,14 @@ type SearchQueryBuilderParenProps = {
   token: TokenResult<Token.L_PAREN | Token.R_PAREN>;
 };
 
+export function SearchQueryBuilderParenIcon({
+  token,
+}: Pick<SearchQueryBuilderParenProps, 'token'>) {
+  return (
+    <IconParenthesis side={token.type === Token.L_PAREN ? 'left' : 'right'} height={26} />
+  );
+}
+
 export function SearchQueryBuilderParen({
   item,
   state,
@@ -28,10 +36,7 @@ export function SearchQueryBuilderParen({
       label={token.value}
       invalid={token.invalid}
     >
-      <IconParenthesis
-        side={token.type === Token.L_PAREN ? 'left' : 'right'}
-        height={26}
-      />
+      <SearchQueryBuilderParenIcon token={token} />
     </DeletableToken>
   );
 }


### PR DESCRIPTION
Renders a query similar to how it appears in the searchbar, but without any interactivity. This will be used in the recent searches UI and perhaps in other locations as well.

![CleanShot 2024-08-12 at 12 31 48](https://github.com/user-attachments/assets/e660092c-a8bb-408e-891e-5acf4eb260f0)
