### PR TITLE
fix(query-builder): Suggest True/False instead of true/false for boolean filters

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/boolean.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/boolean.tsx
@@ -3,6 +3,6 @@ import type {SuggestionSection} from 'sentry/components/searchQueryBuilder/token
 export const DEFAULT_BOOLEAN_SUGGESTIONS: SuggestionSection[] = [
   {
     sectionText: '',
-    suggestions: [{value: 'true'}, {value: 'false'}],
+    suggestions: [{value: 'True'}, {value: 'False'}],
   },
 ];


### PR DESCRIPTION
While `true` and `false` are accepted for certain filters like `error.handled`, others like `app.in_foreground` only accept `True` and `False`. This looks like it's due to how Snuba deserialized context data ([see here](https://github.com/getsentry/snuba/blob/63b577bce27afb119799d61beef29a3467995eb3/rust_snuba/src/processors/errors.rs#L828-L830)).

`True` and `False` work for both types of filters, so I'm changing the suggestions to match.