### PR TITLE
feat(buffers): Assign dedicated Celery queue to a model for RedisBuffers

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -148,6 +148,20 @@ class RedisBuffer(Buffer):
         ).hexdigest()
         return f"b:k:{model._meta}:{md5}"
 
+    def _extract_model_from_key(self, key: str) -> str | None:
+        """
+        Extracts the model metadata from a Redis key.
+        """
+        try:
+            parts = key.split(":")
+
+            if len(parts) != 4 or parts[0] != "b" or parts[1] != "k":
+                return None
+
+            return parts[2]
+        except Exception:
+            return None
+
     def _make_lock_key(self, key: str) -> str:
         return f"l:{key}"
 

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import pickle
-import threading
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
@@ -27,9 +26,6 @@ from sentry.utils.redis import (
     is_instance_redis_cluster,
     validate_dynamic_cluster,
 )
-
-_local_buffers = None
-_local_buffers_lock = threading.Lock()
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -515,10 +515,14 @@ class RedisBuffer(Buffer):
             # model associated with the model_key.
             process_incr_kwargs: dict[str, Any] = dict()
             if model_key is None:
+                metrics.incr("buffer.process-incr.model-key-missing")
                 return process_incr_kwargs
             queue = pending_buffers_router.queue(model_key=model_key)
             if queue is not None:
                 process_incr_kwargs["queue"] = queue
+                metrics.incr("buffer.process-incr-queue", tags={"queue": queue})
+            else:
+                metrics.incr("buffer.process-incr-default-queue")
             return process_incr_kwargs
 
         try:


### PR DESCRIPTION
Fixes https://getsentry.atlassian.net/browse/RV-1753

The `process_incr` task and the default assigned queue for it is shared among multiple models (i.e. `counters-0` queue).

If any backlogs or slowdowns occur when incrementing counts for any specific model, other models will be affected. To alleviate this, we can assign a dedicated queue for any given model. If a dedicated queue is assigned, the `process_incr` task will be processed in the assigned queue. On the other hand, if no dedicated queue is assigned, the `process_incr` task will be processed in the default queue (i.e. `counters-0` queue).

The queue to be used for the `process_incr` task is determined in the following order of precedence:

1. The queue argument passed to `process_incr.apply_async()` (we pass in any dedicated Celery queue for a given Django model in the `queue` keyword argument in this step)
2. The queue defined on the `process_incr` task (set to `counters-0`)
3. Any defined routes in `CELERY_ROUTES` (currently un-used)

See: https://docs.celeryq.dev/en/latest/userguide/routing.html#specifying-task-destination

Hence, we override the default queue of the `process_incr` task by passing in any assigned queue to the `process_incr.apply_async()` call.

An example of how this will be used to assign a Celery queue to a Django model is in: https://github.com/getsentry/getsentry/pull/14897