### PR TITLE
ref(similarity): Rollout similarity delete record to 20% EA

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2698,6 +2698,11 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "similarity.delete_task_EA_rollout_percentage",
+    default=20,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "delayed_processing.batch_size",
     default=10000,
     flags=FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/tasks/delete_seer_grouping_records.py
+++ b/src/sentry/tasks/delete_seer_grouping_records.py
@@ -14,7 +14,6 @@ from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 
 logger = logging.getLogger(__name__)
-EA_ROLLOUT_PERCENTAGE = 20
 
 
 @instrumented_task(

--- a/src/sentry/tasks/delete_seer_grouping_records.py
+++ b/src/sentry/tasks/delete_seer_grouping_records.py
@@ -62,7 +62,7 @@ def call_delete_seer_grouping_records_by_hash(
             features.has("projects:similarity-embeddings-grouping", project)
             or (
                 project.get_option("sentry:similarity_backfill_completed")
-                and randint(1, 100) <= EA_ROLLOUT_PERCENTAGE
+                and randint(1, 100) <= options.get("similarity.delete_task_EA_rollout_percentage")
             )
         )
         and not killswitch_enabled(project.id)


### PR DESCRIPTION
Project option `sentry:similarity_backfill_completed` is `True` for all EA projects
Rollout delete record by hash feature to 20% of these projects