### PR TITLE
fix(replay/issues): check `issueTypeConfig` before showing onboarding panel

### DIFF
--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -6,6 +6,7 @@ import LazyLoad from 'sentry/components/lazyLoad';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import useEventCanShowReplayUpsell from 'sentry/utils/event/useEventCanShowReplayUpsell';
+import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
 import {useHaveSelectedProjectsSentAnyReplayEvents} from 'sentry/utils/replays/hooks/useReplayOnboarding';
 import useUrlParams from 'sentry/utils/useUrlParams';
@@ -28,6 +29,7 @@ export default function EventReplay({event, group, projectSlug}: Props) {
   });
 
   const {setParamValue: setProjectId} = useUrlParams('project');
+  const issueTypeConfig = getConfigForIssueType(group!, group?.project!);
 
   useEffect(() => {
     if (canShowUpsell) {
@@ -39,7 +41,7 @@ export default function EventReplay({event, group, projectSlug}: Props) {
     return <ReplayClipSection event={event} replayId={replayId} group={group} />;
   }
 
-  if (canShowUpsell && !hasSentOneReplay) {
+  if (canShowUpsell && !hasSentOneReplay && issueTypeConfig.replays.enabled) {
     return (
       <ErrorBoundary mini>
         <LazyLoad

--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -37,7 +37,7 @@ export default function EventReplay({event, group, projectSlug}: Props) {
   }, [upsellProjectId, setProjectId, canShowUpsell]);
 
   if (group) {
-    const issueTypeConfig = getConfigForIssueType(group!, group?.project!);
+    const issueTypeConfig = getConfigForIssueType(group, group?.project);
     if (!issueTypeConfig.replays.enabled) {
       return null;
     }

--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -29,7 +29,6 @@ export default function EventReplay({event, group, projectSlug}: Props) {
   });
 
   const {setParamValue: setProjectId} = useUrlParams('project');
-  const issueTypeConfig = getConfigForIssueType(group!, group?.project!);
 
   useEffect(() => {
     if (canShowUpsell) {
@@ -37,8 +36,11 @@ export default function EventReplay({event, group, projectSlug}: Props) {
     }
   }, [upsellProjectId, setProjectId, canShowUpsell]);
 
-  if (!issueTypeConfig.replays.enabled) {
-    return null;
+  if (group) {
+    const issueTypeConfig = getConfigForIssueType(group!, group?.project!);
+    if (!issueTypeConfig.replays.enabled) {
+      return null;
+    }
   }
 
   if (replayId) {

--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -37,11 +37,15 @@ export default function EventReplay({event, group, projectSlug}: Props) {
     }
   }, [upsellProjectId, setProjectId, canShowUpsell]);
 
+  if (!issueTypeConfig.replays.enabled) {
+    return null;
+  }
+
   if (replayId) {
     return <ReplayClipSection event={event} replayId={replayId} group={group} />;
   }
 
-  if (canShowUpsell && !hasSentOneReplay && issueTypeConfig.replays.enabled) {
+  if (canShowUpsell && !hasSentOneReplay) {
     return (
       <ErrorBoundary mini>
         <LazyLoad

--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -6,7 +6,6 @@ import LazyLoad from 'sentry/components/lazyLoad';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import useEventCanShowReplayUpsell from 'sentry/utils/event/useEventCanShowReplayUpsell';
-import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
 import {useHaveSelectedProjectsSentAnyReplayEvents} from 'sentry/utils/replays/hooks/useReplayOnboarding';
 import useUrlParams from 'sentry/utils/useUrlParams';
@@ -35,13 +34,6 @@ export default function EventReplay({event, group, projectSlug}: Props) {
       setProjectId(upsellProjectId);
     }
   }, [upsellProjectId, setProjectId, canShowUpsell]);
-
-  if (group) {
-    const issueTypeConfig = getConfigForIssueType(group, group?.project);
-    if (!issueTypeConfig.replays.enabled) {
-      return null;
-    }
-  }
 
   if (replayId) {
     return <ReplayClipSection event={event} replayId={replayId} group={group} />;

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -53,7 +53,10 @@ import {EntryType, EventOrGroupType} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import {IssueCategory, IssueType} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
-import {shouldShowCustomErrorResourceConfig} from 'sentry/utils/issueTypeConfig';
+import {
+  getConfigForIssueType,
+  shouldShowCustomErrorResourceConfig,
+} from 'sentry/utils/issueTypeConfig';
 import {QuickTraceContext} from 'sentry/utils/performance/quickTrace/quickTraceContext';
 import QuickTraceQuery from 'sentry/utils/performance/quickTrace/quickTraceQuery';
 import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
@@ -148,6 +151,8 @@ export function DefaultGroupEventDetailsContent({
 
   // default to show on error or isPromptDismissed === undefined
   const showFeedback = !isPromptDismissed || promptError || hasStreamlinedUI;
+
+  const issueTypeConfig = getConfigForIssueType(group, group.project);
 
   return (
     <Fragment>
@@ -291,7 +296,9 @@ export function DefaultGroupEventDetailsContent({
         />
       )}
       <EventHydrationDiff event={event} group={group} />
-      <EventReplay event={event} group={group} projectSlug={project.slug} />
+      {issueTypeConfig.replays.enabled && (
+        <EventReplay event={event} group={group} projectSlug={project.slug} />
+      )}
       <GroupEventEntry
         sectionKey={FoldSectionKey.HPKP}
         entryType={EntryType.HPKP}

--- a/static/app/views/performance/transactionDetails/index.spec.tsx
+++ b/static/app/views/performance/transactionDetails/index.spec.tsx
@@ -70,7 +70,7 @@ describe('EventDetails', () => {
     await act(tick);
   });
 
-  it('does not reender alert if already received transaction', async () => {
+  it('does not render alert if already received transaction', async () => {
     const event = EventFixture();
 
     MockApiClient.addMockResponse({


### PR DESCRIPTION
<img width="388" alt="SCR-20240812-mcaj" src="https://github.com/user-attachments/assets/6280368e-fa04-48ce-bdb7-49596a0a2590">

over slack, we decided to hide the entire `EventReplay` section if `issueTypeConfig.replays.enabled` is false.