### PR TITLE
chore(seer grouping): Improve logging of Seer results

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -206,8 +206,9 @@ def get_seer_similar_issues(
 
     # Similar issues are returned with the closest match first
     seer_results = get_similarity_data_from_seer(request_data)
+    seer_results_json = [asdict(result) for result in seer_results]
     similar_issues_metadata = {
-        "results": [asdict(result) for result in seer_results],
+        "results": seer_results_json,
         "similarity_model_version": SEER_SIMILARITY_MODEL_VERSION,
     }
     parent_grouphash = (
@@ -224,7 +225,7 @@ def get_seer_similar_issues(
             "event_id": event.event_id,
             "project_id": event.project.id,
             "hash": event_hash,
-            "results": seer_results,
+            "results": seer_results_json,
             "grouphash_returned": bool(parent_grouphash),
         },
     )

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -40,6 +40,7 @@ def get_similarity_data_from_seer(
     Request similar issues data from seer and normalize the results. Returns similar groups
     sorted in order of descending similarity.
     """
+    event_id = similar_issues_request["event_id"]
     project_id = similar_issues_request["project_id"]
     request_hash = similar_issues_request["hash"]
     referrer = similar_issues_request.get("referrer")
@@ -232,6 +233,7 @@ def get_similarity_data_from_seer(
                     "hash": request_hash,
                     "parent_hash": parent_hash,
                     "project_id": project_id,
+                    "event_id": event_id,
                 },
             )
         except SimilarHashMissingGroupError:
@@ -251,6 +253,7 @@ def get_similarity_data_from_seer(
                     "hash": request_hash,
                     "parent_hash": parent_hash,
                     "project_id": project_id,
+                    "event_id": event_id,
                 },
             )
 

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -427,6 +427,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 "hash": NonNone(self.event.get_primary_hash()),
                 "parent_hash": "not a real hash",
                 "project_id": self.project.id,
+                "event_id": self.event.event_id,
             },
         )
         mock_seer_deletion_request.delay.assert_called_with(self.project.id, ["not a real hash"])
@@ -482,6 +483,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 "hash": NonNone(self.event.get_primary_hash()),
                 "parent_hash": "dogs are great",
                 "project_id": self.project.id,
+                "event_id": self.event.event_id,
             },
         )
 


### PR DESCRIPTION
This makes two small changes to the logs we send when getting results from Seer:

- Send the result data as JSON rather than as a list of `SeerSimilarIssueData` repr strings. (This will make it a little easier to search in GCP.)

- Include the event id when logging problematic Seer responses (ones which point to non-existent or orphan grouphashes).