### PR TITLE
ref(issues): Remove unused profile issue category

### DIFF
--- a/static/app/components/events/profileEventEvidence.spec.tsx
+++ b/static/app/components/events/profileEventEvidence.spec.tsx
@@ -4,7 +4,7 @@ import {GroupFixture} from 'sentry-fixture/group';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {ProfileEventEvidence} from 'sentry/components/events/profileEventEvidence';
-import {IssueCategory, IssueType} from 'sentry/types/group';
+import {IssueType} from 'sentry/types/group';
 
 describe('ProfileEventEvidence', function () {
   const defaultProps = {
@@ -18,6 +18,7 @@ describe('ProfileEventEvidence', function () {
           framePackage: 'something.dll',
           transactionId: 'transaction-id',
           transactionName: 'SomeTransaction',
+          templateName: 'profile',
         },
       },
       contexts: {
@@ -27,7 +28,6 @@ describe('ProfileEventEvidence', function () {
       },
     }),
     group: GroupFixture({
-      issueCategory: IssueCategory.PROFILE,
       issueType: IssueType.PROFILE_FILE_IO_MAIN_THREAD,
     }),
     projectSlug: 'project-slug',

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -384,7 +384,6 @@ function BaseGroupRow({
   const groupCategoryCountTitles: Record<IssueCategory, string> = {
     [IssueCategory.ERROR]: t('Error Events'),
     [IssueCategory.PERFORMANCE]: t('Transaction Events'),
-    [IssueCategory.PROFILE]: t('Profile Events'),
     [IssueCategory.CRON]: t('Cron Events'),
     [IssueCategory.REPLAY]: t('Replay Events'),
     [IssueCategory.UPTIME]: t('Uptime Events'),

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -63,7 +63,6 @@ export enum IssueCategory {
   PERFORMANCE = 'performance',
   ERROR = 'error',
   CRON = 'cron',
-  PROFILE = 'profile',
   REPLAY = 'replay',
   UPTIME = 'uptime',
 }

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -527,9 +527,6 @@ export function eventIsProfilingIssue(event: BaseGroup | Event | GroupTombstoneH
   if (isTombstone(event) || isGroup(event)) {
     return false;
   }
-  if (event.issueCategory === IssueCategory.PROFILE) {
-    return true;
-  }
   const evidenceData = event.occurrence?.evidenceData ?? {};
   return evidenceData.templateName === 'profile';
 }

--- a/static/app/utils/issueTypeConfig/index.tsx
+++ b/static/app/utils/issueTypeConfig/index.tsx
@@ -54,7 +54,6 @@ const BASE_CONFIG: IssueTypeConfig = {
 const issueTypeConfig: Config = {
   [IssueCategory.ERROR]: errorConfig,
   [IssueCategory.PERFORMANCE]: performanceConfig,
-  [IssueCategory.PROFILE]: performanceConfig,
   [IssueCategory.CRON]: cronConfig,
   [IssueCategory.REPLAY]: replayConfig,
   [IssueCategory.UPTIME]: uptimeConfig,


### PR DESCRIPTION
The profile category was merged with performance a while back ([see here](https://github.com/getsentry/sentry/blob/master/src/sentry/issues/grouptype.py#L28)), but the references to it were not removed.