### PR TITLE
feat(alerts): Update metric alert email template for anomaly detection

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -367,6 +367,7 @@ def generate_incident_trigger_email_context(
     elif CRASH_RATE_ALERT_AGGREGATE_ALIAS in aggregate:
         aggregate = aggregate.split(f"AS {CRASH_RATE_ALERT_AGGREGATE_ALIAS}")[0].strip()
 
+    threshold: None | str | float = None
     if alert_rule.detection_type == AlertRuleDetectionType.DYNAMIC:
         threshold_prefix_string = alert_rule.detection_type.title()
         threshold = f"({alert_rule.sensitivity} sensitivity)"

--- a/src/sentry/templates/sentry/emails/incidents/trigger.html
+++ b/src/sentry/templates/sentry/emails/incidents/trigger.html
@@ -64,7 +64,7 @@
         <tr>
           <td width="25%">Threshold</td>
           <td>
-            {{ threshold_direction_string }} {{ threshold }}{% if 'percentage' in aggregate %}%{% endif %}
+            {{ threshold_prefix_string }} {{ threshold }}{% if 'percentage' in aggregate %}%{% endif %}
           </td>
         </tr>
         <tr>

--- a/src/sentry/templates/sentry/emails/incidents/trigger.txt
+++ b/src/sentry/templates/sentry/emails/incidents/trigger.txt
@@ -19,7 +19,7 @@ New Deploy: {{activator}}
 {% endif %}
 Metric: {{ aggregate }}
 Environment: {{ environment }}
-Threshold: {{ threshold_direction_string }} {{ threshold }}
+Threshold: {{ threshold_prefix_string }} {{ threshold }}
 Time Interval: {{ time_window }}
 Query: {{ query }}
 


### PR DESCRIPTION
Update the metric alert email template for an anomaly detection alert. The notable change here is the threshold text. 

<img width="725" alt="Screenshot 2024-08-12 at 1 30 29 PM" src="https://github.com/user-attachments/assets/d06a442d-42fb-45f1-adc3-103fcecdf142">

Partially closes https://getsentry.atlassian.net/browse/ALRT-147 (other integrations to follow)