### PR TITLE
feat(anomaly detection): add new anomaly detection alert fields to create/update form

### DIFF
--- a/static/app/views/alerts/rules/metric/constants.tsx
+++ b/static/app/views/alerts/rules/metric/constants.tsx
@@ -172,6 +172,7 @@ export function createDefaultRule(
     environment: null,
     resolveThreshold: '',
     thresholdType: AlertRuleThresholdType.ABOVE,
+    detectionType: AlertRuleComparisonType.COUNT,
     ...defaultRuleOptions,
   };
 }

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -69,8 +69,7 @@ import {getProjectOptions} from '../utils';
 
 import {isCrashFreeAlert} from './utils/isCrashFreeAlert';
 import {DEFAULT_AGGREGATE, DEFAULT_TRANSACTION_AGGREGATE} from './constants';
-import type {AlertRuleComparisonType} from './types';
-import {Dataset, Datasource, TimeWindow} from './types';
+import {AlertRuleComparisonType, Dataset, Datasource, TimeWindow} from './types';
 
 const TIME_WINDOW_MAP: Record<TimeWindow, string> = {
   [TimeWindow.ONE_MINUTE]: t('1 minute'),
@@ -264,6 +263,14 @@ class RuleConditionsForm extends PureComponent<Props, State> {
         TimeWindow.TWO_HOURS,
         TimeWindow.FOUR_HOURS,
         TimeWindow.ONE_DAY,
+      ]);
+    }
+
+    if (this.props.comparisonType === AlertRuleComparisonType.DYNAMIC) {
+      options = pick(TIME_WINDOW_MAP, [
+        TimeWindow.FIFTEEN_MINUTES,
+        TimeWindow.THIRTY_MINUTES,
+        TimeWindow.ONE_HOUR,
       ]);
     }
 

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -12,7 +12,11 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import {ActivationConditionType, MonitorType} from 'sentry/types/alerts';
 import {metric} from 'sentry/utils/analytics';
 import RuleFormContainer from 'sentry/views/alerts/rules/metric/ruleForm';
-import {Dataset} from 'sentry/views/alerts/rules/metric/types';
+import {
+  AlertRuleComparisonType,
+  AlertRuleSensitivity,
+  Dataset,
+} from 'sentry/views/alerts/rules/metric/types';
 import {permissionAlertText} from 'sentry/views/settings/project/permissionAlert';
 
 jest.mock('sentry/actionCreators/indicator');
@@ -346,6 +350,52 @@ describe('Incident Rules Form', () => {
             eventTypes: ['transaction'],
             dataset: 'generic_metrics',
             thresholdPeriod: 1,
+          }),
+        })
+      );
+    });
+
+    it('creates an anomaly detection rule', async () => {
+      organization.features = [...organization.features, 'anomaly-detection-alerts'];
+      const rule = MetricRuleFixture({
+        detectionType: AlertRuleComparisonType.PERCENT,
+        sensitivity: AlertRuleSensitivity.MEDIUM,
+        seasonality: 'auto',
+      });
+      createWrapper({
+        rule: {
+          ...rule,
+          id: undefined,
+          aggregate: 'count()',
+          eventTypes: ['error'],
+          dataset: 'events',
+        },
+      });
+      await userEvent.click(
+        screen.getByText('Anomaly: when evaluated values are outside of expected bounds')
+      );
+
+      expect(
+        await screen.findByLabelText(
+          'Anomaly: when evaluated values are outside of expected bounds'
+        )
+      ).toBeChecked();
+      expect(
+        await screen.findByRole('textbox', {name: 'Sensitivity'})
+      ).toBeInTheDocument();
+      await userEvent.click(screen.getByLabelText('Save Rule'));
+
+      expect(createRule).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            aggregate: 'count()',
+            dataset: 'events',
+            environment: null,
+            eventTypes: ['error'],
+            detectionType: AlertRuleComparisonType.DYNAMIC,
+            sensitivity: AlertRuleSensitivity.MEDIUM,
+            seasonality: 'auto',
           }),
         })
       );

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -14,6 +14,7 @@ import {metric} from 'sentry/utils/analytics';
 import RuleFormContainer from 'sentry/views/alerts/rules/metric/ruleForm';
 import {
   AlertRuleComparisonType,
+  AlertRuleSeasonality,
   AlertRuleSensitivity,
   Dataset,
 } from 'sentry/views/alerts/rules/metric/types';
@@ -360,7 +361,7 @@ describe('Incident Rules Form', () => {
       const rule = MetricRuleFixture({
         detectionType: AlertRuleComparisonType.PERCENT,
         sensitivity: AlertRuleSensitivity.MEDIUM,
-        seasonality: 'auto',
+        seasonality: AlertRuleSeasonality.AUTO,
       });
       createWrapper({
         rule: {
@@ -395,7 +396,7 @@ describe('Incident Rules Form', () => {
             eventTypes: ['error'],
             detectionType: AlertRuleComparisonType.DYNAMIC,
             sensitivity: AlertRuleSensitivity.MEDIUM,
-            seasonality: 'auto',
+            seasonality: AlertRuleSeasonality.AUTO,
           }),
         })
       );

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -85,12 +85,13 @@ import {
   DEFAULT_COUNT_TIME_WINDOW,
 } from './constants';
 import RuleConditionsForm from './ruleConditionsForm';
-import type {
-  EventTypes,
-  MetricActionTemplate,
-  MetricRule,
-  Trigger,
-  UnsavedMetricRule,
+import {
+  AlertRuleSensitivity,
+  type EventTypes,
+  type MetricActionTemplate,
+  type MetricRule,
+  type Trigger,
+  type UnsavedMetricRule,
 } from './types';
 import {
   AlertRuleComparisonType,
@@ -233,6 +234,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
       metricExtractionRules: null,
       triggers: triggersClone,
       resolveThreshold: rule.resolveThreshold,
+      sensitivity: rule.sensitivity || AlertRuleSensitivity.MEDIUM,
       thresholdType: rule.thresholdType,
       thresholdPeriod: rule.thresholdPeriod ?? 1,
       comparisonDelta: rule.comparisonDelta ?? undefined,
@@ -850,6 +852,10 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
     });
   };
 
+  handleSensitivityChange = (sensitivity: AlertRuleSensitivity) => {
+    this.setState({sensitivity});
+  };
+
   handleThresholdTypeChange = (thresholdType: AlertRuleThresholdType) => {
     const {triggers} = this.state;
 
@@ -1096,6 +1102,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
       comparisonDelta,
       comparisonType,
       resolveThreshold,
+      sensitivity,
       loading,
       eventTypes,
       dataset,
@@ -1120,6 +1127,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
         aggregate={aggregate}
         isMigration={isMigration}
         resolveThreshold={resolveThreshold}
+        sensitivity={sensitivity}
         thresholdPeriod={thresholdPeriod}
         thresholdType={thresholdType}
         comparisonType={comparisonType}
@@ -1130,6 +1138,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
         onThresholdTypeChange={this.handleThresholdTypeChange}
         onThresholdPeriodChange={this.handleThresholdPeriodChange}
         onResolveThresholdChange={this.handleResolveThresholdChange}
+        onSensitivityChange={this.handleSensitivityChange}
       />
     );
 

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -843,7 +843,13 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
             ? err?.responseJSON
             : Object.values(err?.responseJSON)
           : [];
-        const apiErrors = errors.length > 0 ? `: ${errors.join(', ')}` : '';
+        let apiErrors = '';
+        if (typeof errors[0] === 'object') {
+          // NOTE: this occurs if we get a TimeoutError when attempting to hit the Seer API
+          apiErrors = ': ' + errors[0].message;
+        } else {
+          apiErrors = errors.length > 0 ? `: ${errors.join(', ')}` : '';
+        }
         this.handleRuleSaveFailure(t('Unable to save alert%s', apiErrors));
       }
     });

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -461,9 +461,16 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
     const {comparisonType} = this.state;
     // If we have an anomaly detection alert, then we don't need to validate the thresholds, but we do need to set them to 0
     if (comparisonType === AlertRuleComparisonType.DYNAMIC) {
-      triggers.forEach(trigger => {
-        trigger.alertThreshold = 0;
-      });
+      // NOTE: we don't support warning triggers for anomaly detection alerts yet
+      // once we do, uncomment this code and delete the next five uncommented lines:
+      // triggers.forEach(trigger => {
+      //   trigger.alertThreshold = 0;
+      // });
+      const criticalTriggerIndex = triggers.findIndex(
+        ({label}) => label === AlertRuleTriggerType.CRITICAL
+      );
+      const criticalTrigger = triggers[criticalTriggerIndex];
+      criticalTrigger.alertThreshold = 0;
       const triggerErrors = new Map();
       return triggerErrors; // return an empty map
     }

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -931,7 +931,9 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
       ? DEFAULT_COUNT_TIME_WINDOW
       : DEFAULT_CHANGE_TIME_WINDOW;
     const sensitivity =
-      value === AlertRuleComparisonType.DYNAMIC ? this.state.sensitivity : undefined;
+      value === AlertRuleComparisonType.DYNAMIC
+        ? this.state.sensitivity ?? AlertRuleSensitivity.MEDIUM
+        : undefined;
     const seasonality = value === AlertRuleComparisonType.DYNAMIC ? 'auto' : undefined; // TODO: replace "auto" with the correct constant
     this.setState({
       comparisonType: value,

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -86,6 +86,7 @@ import {
 } from './constants';
 import RuleConditionsForm from './ruleConditionsForm';
 import {
+  AlertRuleSeasonality,
   AlertRuleSensitivity,
   type EventTypes,
   type MetricActionTemplate,
@@ -144,7 +145,6 @@ type State = {
   query: string;
   resolveThreshold: UnsavedMetricRule['resolveThreshold'];
   sensitivity: UnsavedMetricRule['sensitivity'];
-  // because it's not passed for now
   thresholdPeriod: UnsavedMetricRule['thresholdPeriod'];
   thresholdType: UnsavedMetricRule['thresholdType'];
   timeWindow: number;
@@ -154,7 +154,7 @@ type State = {
   comparisonDelta?: number;
   isExtrapolatedChartData?: boolean;
   monitorType?: MonitorType;
-  seasonality?: string;
+  seasonality?: AlertRuleSeasonality;
 } & DeprecatedAsyncComponent['state'];
 
 const isEmpty = (str: unknown): boolean => str === '' || !defined(str);
@@ -937,7 +937,8 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
       value === AlertRuleComparisonType.DYNAMIC
         ? this.state.sensitivity || AlertRuleSensitivity.MEDIUM
         : undefined;
-    const seasonality = value === AlertRuleComparisonType.DYNAMIC ? 'auto' : undefined; // TODO: replace "auto" with the correct constant
+    const seasonality =
+      value === AlertRuleComparisonType.DYNAMIC ? AlertRuleSeasonality.AUTO : undefined; // TODO: replace "auto" with the correct constant
     this.setState({
       comparisonType: value,
       comparisonDelta,

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -237,7 +237,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
       metricExtractionRules: null,
       triggers: triggersClone,
       resolveThreshold: rule.resolveThreshold,
-      sensitivity: rule.sensitivity || AlertRuleSensitivity.MEDIUM,
+      sensitivity: null,
       thresholdType: rule.thresholdType,
       thresholdPeriod: rule.thresholdPeriod ?? 1,
       comparisonDelta: rule.comparisonDelta ?? undefined,

--- a/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
@@ -24,11 +24,12 @@ import SentryAppRuleModal from 'sentry/views/alerts/rules/issue/sentryAppRuleMod
 import ActionSpecificTargetSelector from 'sentry/views/alerts/rules/metric/triggers/actionsPanel/actionSpecificTargetSelector';
 import ActionTargetSelector from 'sentry/views/alerts/rules/metric/triggers/actionsPanel/actionTargetSelector';
 import DeleteActionButton from 'sentry/views/alerts/rules/metric/triggers/actionsPanel/deleteActionButton';
-import type {
-  Action,
-  ActionType,
-  MetricActionTemplate,
-  Trigger,
+import {
+  type Action,
+  type ActionType,
+  AlertRuleComparisonType,
+  type MetricActionTemplate,
+  type Trigger,
 } from 'sentry/views/alerts/rules/metric/types';
 import {
   ActionLabel,
@@ -39,6 +40,7 @@ import {
 
 type Props = {
   availableActions: MetricActionTemplate[] | null;
+  comparisonType: AlertRuleComparisonType;
   currentProject: string;
   disabled: boolean;
   error: boolean;
@@ -311,6 +313,7 @@ class ActionsPanel extends PureComponent<Props> {
       organization,
       projects,
       triggers,
+      comparisonType,
     } = this.props;
 
     const project = projects.find(({slug}) => slug === currentProject);
@@ -326,6 +329,10 @@ class ActionsPanel extends PureComponent<Props> {
       {value: 0, label: 'Critical Status'},
       {value: 1, label: 'Warning Status'},
     ];
+
+    // NOTE: we don't support warning triggers for anomaly detection alerts yet
+    // once we do, this can be deleted
+    const anomalyDetectionLevels = [{value: 0, label: 'Critical Status'}];
 
     // Create single array of unsaved and saved trigger actions
     // Sorted by date created ascending
@@ -371,7 +378,11 @@ class ActionsPanel extends PureComponent<Props> {
                         actionIdx
                       )}
                       value={triggerIndex}
-                      options={levels}
+                      options={
+                        comparisonType === AlertRuleComparisonType.DYNAMIC
+                          ? anomalyDetectionLevels
+                          : levels
+                      }
                     />
                     <SelectControl
                       name="select-action"

--- a/static/app/views/alerts/rules/metric/triggers/anomalyAlertsForm.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/anomalyAlertsForm.tsx
@@ -1,10 +1,11 @@
-import {PureComponent} from 'react';
+import {Component, Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import SelectControl from 'sentry/components/forms/controls/selectControl';
 import FieldGroup from 'sentry/components/forms/fieldGroup';
 import {
   AlertRuleSensitivity,
+  AlertRuleThresholdType,
   type UnsavedMetricRule,
 } from 'sentry/views/alerts/rules/metric/types';
 
@@ -15,20 +16,18 @@ type Props = {
   // config: Config;
 
   disabled: boolean;
-  fieldHelp: React.ReactNode;
+  // trigger: Trigger;
+  onSensitivityChange: (sensitivity: AlertRuleSensitivity) => void;
   // onChange: (trigger: Trigger, changeObj: Partial<Trigger>) => void;
   // onThresholdPeriodChange: (value: number) => void;
-  // onThresholdTypeChange: (thresholdType: AlertRuleThresholdType) => void;
+  onThresholdTypeChange: (thresholdType: AlertRuleThresholdType) => void;
+  sensitivity: UnsavedMetricRule['sensitivity'];
   // organization: Organization;
   // placeholder: string;
   // projects: Project[];
   // resolveThreshold: UnsavedMetricRule['resolveThreshold'];
   // thresholdPeriod: UnsavedMetricRule['thresholdPeriod'];
-  // thresholdType: UnsavedMetricRule['thresholdType'];
-  // trigger: Trigger;
-  fieldLabel: React.ReactNode;
-  onSensitivityChange: (sensitivity: AlertRuleSensitivity) => void;
-  sensitivity: UnsavedMetricRule['sensitivity'];
+  thresholdType: UnsavedMetricRule['thresholdType'];
   /**
    * Map of fieldName -> errorMessage
    */
@@ -37,38 +36,122 @@ type Props = {
   hideControl?: boolean;
 };
 
-class AnomalyAlertFormItem extends PureComponent<Props> {
-  handleSensitivityChange = ({value}) => {
-    this.props.onSensitivityChange(value);
+type SensitivityFormItemProps = {
+  onSensitivityChange: (sensitivity: AlertRuleSensitivity) => void;
+  sensitivity: UnsavedMetricRule['sensitivity'];
+};
+
+type DirectionFormItemProps = {
+  onThresholdTypeChange: (thresholdType: AlertRuleThresholdType) => void;
+  thresholdType: UnsavedMetricRule['thresholdType'];
+};
+
+function SensitivityFormItem({
+  sensitivity,
+  onSensitivityChange,
+}: SensitivityFormItemProps) {
+  const handleSensitivityChange = ({value}) => {
+    onSensitivityChange(value);
   };
 
+  return (
+    <StyledField
+      label={<div>{'Sensitivity'}</div>}
+      help={
+        <div>
+          {
+            'Lower sensitivity will alert you only when anomalies are larger, higher sensitivity will alert you and your team for even small deviations.'
+          }
+        </div>
+      }
+      required
+    >
+      <SelectContainer>
+        <SelectControl
+          name="sensitivity"
+          value={sensitivity}
+          options={[
+            {
+              value: AlertRuleSensitivity.LOW,
+              label: 'Low (alert less often)',
+            },
+            {
+              value: AlertRuleSensitivity.MEDIUM,
+              label: 'Medium',
+            },
+            {
+              value: AlertRuleSensitivity.HIGH,
+              label: 'High (alert more often)',
+            },
+          ]}
+          onChange={handleSensitivityChange}
+        />
+      </SelectContainer>
+    </StyledField>
+  );
+}
+
+function DirectionFormItem({
+  thresholdType,
+  onThresholdTypeChange,
+}: DirectionFormItemProps) {
+  const handleThresholdTypeChange = ({value}) => {
+    onThresholdTypeChange(value);
+  };
+
+  return (
+    <StyledField
+      label={<div>{'Direction'}</div>}
+      help={
+        <div>
+          {
+            'Indicate if you want to be alerted of anomalies above your set bounds, below, or both.'
+          }
+        </div>
+      }
+      required
+    >
+      <SelectContainer>
+        <SelectControl
+          name="sensitivity"
+          value={thresholdType}
+          options={[
+            {
+              value: AlertRuleThresholdType.ABOVE_AND_BELOW,
+              label: 'Above and below bounds',
+            },
+            {
+              value: AlertRuleThresholdType.ABOVE,
+              label: 'Above bounds only',
+            },
+            {
+              value: AlertRuleThresholdType.BELOW,
+              label: 'Below bounds only',
+            },
+          ]}
+          onChange={handleThresholdTypeChange}
+        />
+      </SelectContainer>
+    </StyledField>
+  );
+}
+
+class AnomalyDetectionForm extends Component<Props> {
   render() {
-    const {fieldHelp, fieldLabel, sensitivity} = this.props;
+    const {sensitivity, onSensitivityChange, thresholdType, onThresholdTypeChange} =
+      this.props;
 
     return (
-      <StyledField label={fieldLabel} help={fieldHelp} required>
-        <SelectContainer>
-          <SelectControl
-            name="sensitivity"
-            value={sensitivity}
-            options={[
-              {
-                value: AlertRuleSensitivity.LOW,
-                label: 'Low (alert less often)',
-              },
-              {
-                value: AlertRuleSensitivity.MEDIUM,
-                label: 'Medium',
-              },
-              {
-                value: AlertRuleSensitivity.HIGH,
-                label: 'High (alert more often)',
-              },
-            ]}
-            onChange={this.handleSensitivityChange}
-          />
-        </SelectContainer>
-      </StyledField>
+      <Fragment>
+        <SensitivityFormItem
+          sensitivity={sensitivity}
+          onSensitivityChange={onSensitivityChange}
+        />
+        <DirectionFormItem
+          thresholdType={thresholdType}
+          onThresholdTypeChange={onThresholdTypeChange}
+        />
+      </Fragment>
     );
   }
 }
@@ -83,4 +166,4 @@ const StyledField = styled(FieldGroup)`
 const SelectContainer = styled('div')`
   flex: 1;
 `;
-export default AnomalyAlertFormItem;
+export default AnomalyDetectionForm;

--- a/static/app/views/alerts/rules/metric/triggers/anomalyAlertsForm.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/anomalyAlertsForm.tsx
@@ -43,7 +43,7 @@ class AnomalyAlertFormItem extends PureComponent<Props> {
   };
 
   render() {
-    const {fieldHelp, fieldLabel, sensitivity, onSensitivityChange: __} = this.props;
+    const {fieldHelp, fieldLabel, sensitivity} = this.props;
 
     return (
       <StyledField label={fieldLabel} help={fieldHelp} required>

--- a/static/app/views/alerts/rules/metric/triggers/anomalyAlertsForm.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/anomalyAlertsForm.tsx
@@ -1,0 +1,81 @@
+import {PureComponent} from 'react';
+import styled from '@emotion/styled';
+
+import SelectControl from 'sentry/components/forms/controls/selectControl';
+import FieldGroup from 'sentry/components/forms/fieldGroup';
+import {
+  AlertRuleSensitivity,
+  type UnsavedMetricRule,
+} from 'sentry/views/alerts/rules/metric/types';
+
+type Props = {
+  // aggregate: UnsavedMetricRule['aggregate'];
+  // api: Client;
+  // comparisonType: AlertRuleComparisonType;
+  // config: Config;
+
+  disabled: boolean;
+  fieldHelp: React.ReactNode;
+  // onChange: (trigger: Trigger, changeObj: Partial<Trigger>) => void;
+  // onThresholdPeriodChange: (value: number) => void;
+  // onThresholdTypeChange: (thresholdType: AlertRuleThresholdType) => void;
+  // organization: Organization;
+  // placeholder: string;
+  // projects: Project[];
+  // resolveThreshold: UnsavedMetricRule['resolveThreshold'];
+  // thresholdPeriod: UnsavedMetricRule['thresholdPeriod'];
+  // thresholdType: UnsavedMetricRule['thresholdType'];
+  // trigger: Trigger;
+  fieldLabel: React.ReactNode;
+  sensitivity: UnsavedMetricRule['sensitivity'];
+  /**
+   * Map of fieldName -> errorMessage
+   */
+  error?: {[fieldName: string]: string};
+
+  hideControl?: boolean;
+};
+
+class AnomalyAlertFormItem extends PureComponent<Props> {
+  // Probably some stuff to handle value change that I haven't figured out yet
+  render() {
+    const {fieldHelp, fieldLabel, sensitivity} = this.props;
+
+    return (
+      <StyledField label={fieldLabel} help={fieldHelp} required>
+        <SelectContainer>
+          <SelectControl
+            name="sensitivity"
+            value={sensitivity}
+            options={[
+              {
+                value: AlertRuleSensitivity.LOW,
+                label: 'Low (alert less often)',
+              },
+              {
+                value: AlertRuleSensitivity.MEDIUM,
+                label: 'Medium',
+              },
+              {
+                value: AlertRuleSensitivity.HIGH,
+                label: 'High (alert more often)',
+              },
+            ]}
+          />
+        </SelectContainer>
+      </StyledField>
+    );
+  }
+}
+
+const StyledField = styled(FieldGroup)`
+  & > label > div:first-child > span {
+    display: flex;
+    flex-direction: row;
+  }
+`;
+
+const SelectContainer = styled('div')`
+  flex: 1;
+`;
+export default AnomalyAlertFormItem;

--- a/static/app/views/alerts/rules/metric/triggers/anomalyAlertsForm.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/anomalyAlertsForm.tsx
@@ -10,23 +10,10 @@ import {
 } from 'sentry/views/alerts/rules/metric/types';
 
 type Props = {
-  // aggregate: UnsavedMetricRule['aggregate'];
-  // api: Client;
-  // comparisonType: AlertRuleComparisonType;
-  // config: Config;
-
   disabled: boolean;
-  // trigger: Trigger;
   onSensitivityChange: (sensitivity: AlertRuleSensitivity) => void;
-  // onChange: (trigger: Trigger, changeObj: Partial<Trigger>) => void;
-  // onThresholdPeriodChange: (value: number) => void;
   onThresholdTypeChange: (thresholdType: AlertRuleThresholdType) => void;
   sensitivity: UnsavedMetricRule['sensitivity'];
-  // organization: Organization;
-  // placeholder: string;
-  // projects: Project[];
-  // resolveThreshold: UnsavedMetricRule['resolveThreshold'];
-  // thresholdPeriod: UnsavedMetricRule['thresholdPeriod'];
   thresholdType: UnsavedMetricRule['thresholdType'];
   /**
    * Map of fieldName -> errorMessage

--- a/static/app/views/alerts/rules/metric/triggers/anomalyAlertsForm.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/anomalyAlertsForm.tsx
@@ -27,6 +27,7 @@ type Props = {
   // thresholdType: UnsavedMetricRule['thresholdType'];
   // trigger: Trigger;
   fieldLabel: React.ReactNode;
+  onSensitivityChange: (sensitivity: AlertRuleSensitivity) => void;
   sensitivity: UnsavedMetricRule['sensitivity'];
   /**
    * Map of fieldName -> errorMessage
@@ -37,9 +38,12 @@ type Props = {
 };
 
 class AnomalyAlertFormItem extends PureComponent<Props> {
-  // Probably some stuff to handle value change that I haven't figured out yet
+  handleSensitivityChange = ({value}) => {
+    this.props.onSensitivityChange(value);
+  };
+
   render() {
-    const {fieldHelp, fieldLabel, sensitivity} = this.props;
+    const {fieldHelp, fieldLabel, sensitivity, onSensitivityChange: __} = this.props;
 
     return (
       <StyledField label={fieldLabel} help={fieldHelp} required>
@@ -61,6 +65,7 @@ class AnomalyAlertFormItem extends PureComponent<Props> {
                 label: 'High (alert more often)',
               },
             ]}
+            onChange={this.handleSensitivityChange}
           />
         </SelectContainer>
       </StyledField>

--- a/static/app/views/alerts/rules/metric/triggers/anomalyAlertsForm.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/anomalyAlertsForm.tsx
@@ -37,19 +37,11 @@ function SensitivityFormItem({
   sensitivity,
   onSensitivityChange,
 }: SensitivityFormItemProps) {
-  const handleSensitivityChange = ({value}) => {
-    onSensitivityChange(value);
-  };
-
   return (
     <StyledField
-      label={<div>{'Sensitivity'}</div>}
+      label={'Sensitivity'}
       help={
-        <div>
-          {
-            'Lower sensitivity will alert you only when anomalies are larger, higher sensitivity will alert you and your team for even small deviations.'
-          }
-        </div>
+        'Lower sensitivity will alert you only when anomalies are larger, higher sensitivity will alert you and your team for even small deviations.'
       }
       required
     >
@@ -71,7 +63,9 @@ function SensitivityFormItem({
               label: 'High (alert more often)',
             },
           ]}
-          onChange={handleSensitivityChange}
+          onChange={({value}) => {
+            onSensitivityChange(value);
+          }}
         />
       </SelectContainer>
     </StyledField>
@@ -82,19 +76,11 @@ function DirectionFormItem({
   thresholdType,
   onThresholdTypeChange,
 }: DirectionFormItemProps) {
-  const handleThresholdTypeChange = ({value}) => {
-    onThresholdTypeChange(value);
-  };
-
   return (
     <StyledField
-      label={<div>{'Direction'}</div>}
+      label={'Direction'}
       help={
-        <div>
-          {
-            'Indicate if you want to be alerted of anomalies above your set bounds, below, or both.'
-          }
-        </div>
+        'Indicate if you want to be alerted of anomalies above your set bounds, below, or both.'
       }
       required
     >
@@ -116,14 +102,16 @@ function DirectionFormItem({
               label: 'Below bounds only',
             },
           ]}
-          onChange={handleThresholdTypeChange}
+          onChange={({value}) => {
+            onThresholdTypeChange(value);
+          }}
         />
       </SelectContainer>
     </StyledField>
   );
 }
 
-class AnomalyDetectionForm extends Component<Props> {
+class AnomalyDetectionFormField extends Component<Props> {
   render() {
     const {sensitivity, onSensitivityChange, thresholdType, onThresholdTypeChange} =
       this.props;
@@ -153,4 +141,4 @@ const StyledField = styled(FieldGroup)`
 const SelectContainer = styled('div')`
   flex: 1;
 `;
-export default AnomalyDetectionForm;
+export default AnomalyDetectionFormField;

--- a/static/app/views/alerts/rules/metric/triggers/anomalyAlertsForm.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/anomalyAlertsForm.tsx
@@ -40,6 +40,7 @@ function SensitivityFormItem({
   return (
     <StyledField
       label={'Sensitivity'}
+      id={'sensitivity'}
       help={
         'Lower sensitivity will alert you only when anomalies are larger, higher sensitivity will alert you and your team for even small deviations.'
       }
@@ -48,6 +49,7 @@ function SensitivityFormItem({
       <SelectContainer>
         <SelectControl
           name="sensitivity"
+          inputId={'sensitivity'}
           value={sensitivity}
           options={[
             {

--- a/static/app/views/alerts/rules/metric/triggers/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/index.tsx
@@ -164,6 +164,7 @@ class Triggers extends Component<Props> {
             triggers={triggers}
             onChange={this.handleChangeActions}
             onAdd={this.handleAddAction}
+            comparisonType={comparisonType}
           />
         )}
       </Fragment>

--- a/static/app/views/alerts/rules/metric/triggers/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/index.tsx
@@ -7,6 +7,7 @@ import type {Project} from 'sentry/types/project';
 import removeAtArrayIndex from 'sentry/utils/array/removeAtArrayIndex';
 import replaceAtArrayIndex from 'sentry/utils/array/replaceAtArrayIndex';
 import ActionsPanel from 'sentry/views/alerts/rules/metric/triggers/actionsPanel';
+import AnomalyAlertFormItem from 'sentry/views/alerts/rules/metric/triggers/anomalyAlertsForm';
 import TriggerForm from 'sentry/views/alerts/rules/metric/triggers/form';
 
 import {
@@ -39,8 +40,9 @@ type Props = {
   projects: Project[];
   resolveThreshold: UnsavedMetricRule['resolveThreshold'];
 
-  thresholdPeriod: UnsavedMetricRule['thresholdPeriod'];
+  sensitivity: UnsavedMetricRule['sensitivity'];
 
+  thresholdPeriod: UnsavedMetricRule['thresholdPeriod'];
   thresholdType: UnsavedMetricRule['thresholdType'];
   triggers: Trigger[];
   isMigration?: boolean;
@@ -110,6 +112,7 @@ class Triggers extends Component<Props> {
       onThresholdTypeChange,
       onResolveThresholdChange,
       onThresholdPeriodChange,
+      sensitivity,
     } = this.props;
 
     // Note we only support 2 triggers max
@@ -118,7 +121,18 @@ class Triggers extends Component<Props> {
         <Panel>
           <PanelBody>
             {comparisonType === AlertRuleComparisonType.DYNAMIC ? (
-              <div>{'This is where the anomaly detection alert field choices go'}</div>
+              <AnomalyAlertFormItem
+                disabled={disabled}
+                sensitivity={sensitivity}
+                fieldHelp={
+                  <div>
+                    {
+                      'Lower sensitivity will alert you only when anomalies are larger, higher sensitivity will alert you and your team for even small deviations.'
+                    }
+                  </div>
+                }
+                fieldLabel={<div>{'Sensitivity'}</div>}
+              />
             ) : (
               <TriggerForm
                 disabled={disabled}

--- a/static/app/views/alerts/rules/metric/triggers/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/index.tsx
@@ -7,7 +7,7 @@ import type {Project} from 'sentry/types/project';
 import removeAtArrayIndex from 'sentry/utils/array/removeAtArrayIndex';
 import replaceAtArrayIndex from 'sentry/utils/array/replaceAtArrayIndex';
 import ActionsPanel from 'sentry/views/alerts/rules/metric/triggers/actionsPanel';
-import AnomalyAlertFormItem from 'sentry/views/alerts/rules/metric/triggers/anomalyAlertsForm';
+import AnomalyDetectionForm from 'sentry/views/alerts/rules/metric/triggers/anomalyAlertsForm';
 import TriggerForm from 'sentry/views/alerts/rules/metric/triggers/form';
 
 import {
@@ -124,18 +124,12 @@ class Triggers extends Component<Props> {
         <Panel>
           <PanelBody>
             {comparisonType === AlertRuleComparisonType.DYNAMIC ? (
-              <AnomalyAlertFormItem
+              <AnomalyDetectionForm
                 disabled={disabled}
                 sensitivity={sensitivity}
                 onSensitivityChange={onSensitivityChange}
-                fieldHelp={
-                  <div>
-                    {
-                      'Lower sensitivity will alert you only when anomalies are larger, higher sensitivity will alert you and your team for even small deviations.'
-                    }
-                  </div>
-                }
-                fieldLabel={<div>{'Sensitivity'}</div>}
+                thresholdType={thresholdType}
+                onThresholdTypeChange={onThresholdTypeChange}
               />
             ) : (
               <TriggerForm

--- a/static/app/views/alerts/rules/metric/triggers/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/index.tsx
@@ -13,6 +13,7 @@ import TriggerForm from 'sentry/views/alerts/rules/metric/triggers/form';
 import {
   type Action,
   AlertRuleComparisonType,
+  type AlertRuleSensitivity,
   type AlertRuleThresholdType,
   type MetricActionTemplate,
   type Trigger,
@@ -34,6 +35,7 @@ type Props = {
   onResolveThresholdChange: (
     resolveThreshold: UnsavedMetricRule['resolveThreshold']
   ) => void;
+  onSensitivityChange: (sensitivity: AlertRuleSensitivity) => void;
   onThresholdPeriodChange: (value: number) => void;
   onThresholdTypeChange: (thresholdType: AlertRuleThresholdType) => void;
   organization: Organization;
@@ -109,6 +111,7 @@ class Triggers extends Component<Props> {
       comparisonType,
       resolveThreshold,
       isMigration,
+      onSensitivityChange,
       onThresholdTypeChange,
       onResolveThresholdChange,
       onThresholdPeriodChange,
@@ -124,6 +127,7 @@ class Triggers extends Component<Props> {
               <AnomalyAlertFormItem
                 disabled={disabled}
                 sensitivity={sensitivity}
+                onSensitivityChange={onSensitivityChange}
                 fieldHelp={
                   <div>
                     {

--- a/static/app/views/alerts/rules/metric/triggers/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/index.tsx
@@ -7,7 +7,7 @@ import type {Project} from 'sentry/types/project';
 import removeAtArrayIndex from 'sentry/utils/array/removeAtArrayIndex';
 import replaceAtArrayIndex from 'sentry/utils/array/replaceAtArrayIndex';
 import ActionsPanel from 'sentry/views/alerts/rules/metric/triggers/actionsPanel';
-import AnomalyDetectionForm from 'sentry/views/alerts/rules/metric/triggers/anomalyAlertsForm';
+import AnomalyDetectionFormField from 'sentry/views/alerts/rules/metric/triggers/anomalyAlertsForm';
 import TriggerForm from 'sentry/views/alerts/rules/metric/triggers/form';
 
 import {
@@ -124,7 +124,7 @@ class Triggers extends Component<Props> {
         <Panel>
           <PanelBody>
             {comparisonType === AlertRuleComparisonType.DYNAMIC ? (
-              <AnomalyDetectionForm
+              <AnomalyDetectionFormField
                 disabled={disabled}
                 sensitivity={sensitivity}
                 onSensitivityChange={onSensitivityChange}

--- a/static/app/views/alerts/rules/metric/types.tsx
+++ b/static/app/views/alerts/rules/metric/types.tsx
@@ -12,6 +12,7 @@ import type {Incident} from '../../types';
 export enum AlertRuleThresholdType {
   ABOVE = 0,
   BELOW = 1,
+  ABOVE_AND_BELOW = 2,
 }
 
 export enum AlertRuleTriggerType {
@@ -56,6 +57,12 @@ export enum Datasource {
   TRANSACTION = 'transaction',
 }
 
+export enum AlertRuleSensitivity {
+  LOW = 'low',
+  MEDIUM = 'medium',
+  HIGH = 'high',
+}
+
 /**
  * This is not a real aggregate as crash-free sessions/users can be only calculated on frontend by comparing the count of sessions broken down by status
  * It is here nevertheless to shoehorn sessions dataset into existing alerts codebase
@@ -95,6 +102,7 @@ export type Trigger = Partial<SavedTrigger> & UnsavedTrigger;
 export type UnsavedMetricRule = {
   aggregate: string;
   dataset: Dataset;
+  detectionType: AlertRuleComparisonType;
   environment: string | null;
   projects: string[];
   query: string;
@@ -110,6 +118,8 @@ export type UnsavedMetricRule = {
   monitorWindow?: number | null;
   owner?: string | null;
   queryType?: MEPAlertsQueryType | null;
+  seasonality?: string | null;
+  sensitivity?: string | null;
 };
 
 // Form values for updating a metric alert rule

--- a/static/app/views/alerts/rules/metric/types.tsx
+++ b/static/app/views/alerts/rules/metric/types.tsx
@@ -102,7 +102,7 @@ export type Trigger = Partial<SavedTrigger> & UnsavedTrigger;
 export type UnsavedMetricRule = {
   aggregate: string;
   dataset: Dataset;
-  detectionType: AlertRuleComparisonType;
+  detectionType: string;
   environment: string | null;
   projects: string[];
   query: string;

--- a/static/app/views/alerts/rules/metric/types.tsx
+++ b/static/app/views/alerts/rules/metric/types.tsx
@@ -63,6 +63,10 @@ export enum AlertRuleSensitivity {
   HIGH = 'high',
 }
 
+export enum AlertRuleSeasonality {
+  AUTO = 'auto',
+}
+
 /**
  * This is not a real aggregate as crash-free sessions/users can be only calculated on frontend by comparing the count of sessions broken down by status
  * It is here nevertheless to shoehorn sessions dataset into existing alerts codebase
@@ -118,8 +122,8 @@ export type UnsavedMetricRule = {
   monitorWindow?: number | null;
   owner?: string | null;
   queryType?: MEPAlertsQueryType | null;
-  seasonality?: string | null;
-  sensitivity?: string | null;
+  seasonality?: AlertRuleSeasonality | null;
+  sensitivity?: AlertRuleSensitivity | null;
 };
 
 // Form values for updating a metric alert rule

--- a/tests/js/fixtures/metricRule.ts
+++ b/tests/js/fixtures/metricRule.ts
@@ -1,7 +1,7 @@
 import {IncidentTriggerFixture} from 'sentry-fixture/incidentTrigger';
 
 import type {SavedMetricRule as SavedMetricRule} from 'sentry/views/alerts/rules/metric/types';
-import {Dataset} from 'sentry/views/alerts/rules/metric/types';
+import {AlertRuleComparisonType, Dataset} from 'sentry/views/alerts/rules/metric/types';
 
 export function MetricRuleFixture(
   params: Partial<SavedMetricRule> = {}
@@ -24,6 +24,7 @@ export function MetricRuleFixture(
     thresholdType: 0,
     thresholdPeriod: 1,
     environment: null,
+    detectionType: AlertRuleComparisonType.COUNT,
     ...params,
   };
 }


### PR DESCRIPTION
If the anomaly detection alert type is selected, new fields pop up for sensitivity and detection type. Also add the functionality for anomaly detection alert create/update via the frontend.

Fixes https://getsentry.atlassian.net/browse/ALRT-143
Create process:

https://github.com/user-attachments/assets/618787ef-a56a-4a49-9643-05cabb4563a8

Created rule:
<img width="1512" alt="Screenshot 2024-08-14 at 11 56 42 AM" src="https://github.com/user-attachments/assets/31683575-30f5-49e6-8a6b-d9e78380829a">
