### PR TITLE
ref(custom-views): Refactor draggable tab bar to use query as single source of truth

### DIFF
--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.spec.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.spec.tsx
@@ -1,9 +1,12 @@
+import {RouterFixture} from 'sentry-fixture/routerFixture';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {
   DraggableTabBar,
   type Tab,
 } from 'sentry/views/issueList/groupSearchViewTabs/draggableTabBar';
+import {IssueSortOptions} from 'sentry/views/issueList/utils';
 
 describe('DraggableTabBar', () => {
   const mockOnTabRenamed = jest.fn();
@@ -15,28 +18,37 @@ describe('DraggableTabBar', () => {
   const mockOnDiscardTempView = jest.fn();
   const mockOnSaveTempView = jest.fn();
 
-  const defaultNewTab: Tab = {
-    key: 'new-view',
-    label: 'New View',
-    content: <div>This is a New View</div>,
-  };
-
-  const tempTab: Tab = {
-    key: 'temporary-tab',
-    label: 'Unsaved',
-    content: <div>This is the Temporary view</div>,
-  };
+  const router = RouterFixture({
+    location: {
+      pathname: 'test',
+    },
+  });
 
   const tabs: Tab[] = [
     {
+      id: '1',
       key: '1',
       label: 'Prioritized',
       queryCount: 20,
-      hasUnsavedChanges: true,
-      content: <div>Tab 1 Content</div>,
+      query: 'priority:high',
+      querySort: IssueSortOptions.DATE,
+      unsavedChanges: ['priority:low', IssueSortOptions.DATE],
     },
-    {key: '2', label: 'For Review', queryCount: 1001, content: <div>Tab 2 Content</div>},
-    {key: '3', label: 'Regressed', content: <div>Tab 3 Content</div>},
+    {
+      id: '2',
+      key: '2',
+      label: 'For Review',
+      queryCount: 1001,
+      query: 'is:unassigned',
+      querySort: IssueSortOptions.DATE,
+    },
+    {
+      id: '3',
+      key: '3',
+      label: 'Regressed',
+      query: 'is:regressed',
+      querySort: IssueSortOptions.DATE,
+    },
   ];
 
   describe('Tabs render as expected', () => {
@@ -46,9 +58,8 @@ describe('DraggableTabBar', () => {
           tabs={tabs}
           setTabs={jest.fn()}
           onTabRenamed={mockOnTabRenamed}
-          showTempTab={false}
-          tempTab={tempTab}
-          defaultNewTab={defaultNewTab}
+          orgSlug={'test-org'}
+          router={router}
         />
       );
       expect(screen.getAllByRole('tab').length).toBe(tabs.length);
@@ -56,22 +67,6 @@ describe('DraggableTabBar', () => {
       expect(screen.getByRole('tab', {name: 'Prioritized 20'})).toBeInTheDocument();
       expect(screen.getByRole('tab', {name: 'For Review 1000+'})).toBeInTheDocument();
       expect(screen.getByRole('tab', {name: 'Regressed'})).toBeInTheDocument();
-
-      expect(screen.getByRole('tabpanel')).toHaveTextContent('Tab 1 Content');
-    });
-
-    it('should render temp tab if showTempTab = true', () => {
-      render(
-        <DraggableTabBar
-          tabs={tabs}
-          setTabs={jest.fn()}
-          onTabRenamed={mockOnTabRenamed}
-          showTempTab
-          tempTab={tempTab}
-          defaultNewTab={defaultNewTab}
-        />
-      );
-      expect(screen.getByRole('tab', {name: 'Unsaved'})).toBeInTheDocument();
     });
   });
   // Skipping this and next tests due to excessive unexplainable flakiness
@@ -83,9 +78,8 @@ describe('DraggableTabBar', () => {
           tabs={tabs}
           setTabs={jest.fn()}
           onTabRenamed={mockOnTabRenamed}
-          showTempTab
-          tempTab={tempTab}
-          defaultNewTab={defaultNewTab}
+          orgSlug={'test-org'}
+          router={router}
         />
       );
 
@@ -116,9 +110,8 @@ describe('DraggableTabBar', () => {
           tabs={tabs}
           setTabs={jest.fn()}
           onTabRenamed={mockOnTabRenamed}
-          showTempTab
-          tempTab={tempTab}
-          defaultNewTab={defaultNewTab}
+          orgSlug={'test-org'}
+          router={router}
         />
       );
       // We need to explicitly click on the For Review tab since it is not the default (first) tab in props
@@ -152,9 +145,8 @@ describe('DraggableTabBar', () => {
           tabs={[tabs[1]]}
           setTabs={jest.fn()}
           onTabRenamed={mockOnTabRenamed}
-          showTempTab
-          tempTab={tempTab}
-          defaultNewTab={defaultNewTab}
+          orgSlug={'test-org'}
+          router={router}
         />
       );
 
@@ -178,9 +170,8 @@ describe('DraggableTabBar', () => {
           tabs={tabs}
           setTabs={jest.fn()}
           onTabRenamed={mockOnTabRenamed}
-          showTempTab
-          tempTab={tempTab}
-          defaultNewTab={defaultNewTab}
+          orgSlug={'test-org'}
+          router={router}
         />
       );
       // We need to explicitly click on the For Review tab since it is not the default (first) tab in props
@@ -206,9 +197,8 @@ describe('DraggableTabBar', () => {
           tabs={tabs}
           setTabs={jest.fn()}
           onTabRenamed={mockOnTabRenamed}
-          showTempTab
-          tempTab={tempTab}
-          defaultNewTab={defaultNewTab}
+          orgSlug={'test-org'}
+          router={router}
         />
       );
       await userEvent.click(screen.getByRole('tab', {name: 'For Review 1000+'}));
@@ -232,9 +222,8 @@ describe('DraggableTabBar', () => {
           tabs={tabs}
           setTabs={jest.fn()}
           onTabRenamed={mockOnTabRenamed}
-          showTempTab
-          tempTab={tempTab}
-          defaultNewTab={defaultNewTab}
+          orgSlug={'test-org'}
+          router={router}
         />
       );
       await userEvent.click(screen.getByRole('tab', {name: 'For Review 1000+'}));
@@ -258,9 +247,8 @@ describe('DraggableTabBar', () => {
           tabs={tabs}
           setTabs={jest.fn()}
           onTabRenamed={mockOnTabRenamed}
-          showTempTab
-          tempTab={tempTab}
-          defaultNewTab={defaultNewTab}
+          orgSlug={'test-org'}
+          router={router}
         />
       );
       await userEvent.click(screen.getByRole('tab', {name: 'For Review 1000+'}));
@@ -282,9 +270,8 @@ describe('DraggableTabBar', () => {
           tabs={tabs}
           setTabs={jest.fn()}
           onSave={mockOnSave}
-          showTempTab
-          tempTab={tempTab}
-          defaultNewTab={defaultNewTab}
+          orgSlug={'test-org'}
+          router={router}
         />
       );
       await userEvent.click(screen.getByRole('tab', {name: 'Prioritized 20'}));
@@ -304,9 +291,8 @@ describe('DraggableTabBar', () => {
           tabs={tabs}
           setTabs={jest.fn()}
           onDiscard={mockOnDiscard}
-          showTempTab
-          tempTab={tempTab}
-          defaultNewTab={defaultNewTab}
+          orgSlug={'test-org'}
+          router={router}
         />
       );
       await userEvent.click(screen.getByRole('tab', {name: 'Prioritized 20'}));
@@ -326,9 +312,8 @@ describe('DraggableTabBar', () => {
           tabs={tabs}
           setTabs={jest.fn()}
           onDelete={mockOnDelete}
-          showTempTab
-          tempTab={tempTab}
-          defaultNewTab={defaultNewTab}
+          orgSlug={'test-org'}
+          router={router}
         />
       );
       await userEvent.click(screen.getByRole('tab', {name: 'For Review 1000+'}));
@@ -346,9 +331,8 @@ describe('DraggableTabBar', () => {
           tabs={tabs}
           setTabs={jest.fn()}
           onDuplicate={mockOnDuplicate}
-          showTempTab
-          tempTab={tempTab}
-          defaultNewTab={defaultNewTab}
+          orgSlug={'test-org'}
+          router={router}
         />
       );
       await userEvent.click(screen.getByRole('tab', {name: 'For Review 1000+'}));
@@ -368,9 +352,8 @@ describe('DraggableTabBar', () => {
           tabs={tabs}
           setTabs={jest.fn()}
           onDiscardTempView={mockOnDiscardTempView}
-          showTempTab
-          tempTab={tempTab}
-          defaultNewTab={defaultNewTab}
+          orgSlug={'test-org'}
+          router={router}
         />
       );
       await userEvent.click(screen.getByRole('tab', {name: 'Unsaved'}));
@@ -388,9 +371,8 @@ describe('DraggableTabBar', () => {
           tabs={tabs}
           setTabs={jest.fn()}
           onSaveTempView={mockOnSaveTempView}
-          showTempTab
-          tempTab={tempTab}
-          defaultNewTab={defaultNewTab}
+          orgSlug={'test-org'}
+          router={router}
         />
       );
       await userEvent.click(screen.getByRole('tab', {name: 'Unsaved'}));
@@ -410,9 +392,8 @@ describe('DraggableTabBar', () => {
           tabs={tabs}
           setTabs={jest.fn()}
           onAddView={mockOnAddView}
-          showTempTab
-          tempTab={tempTab}
-          defaultNewTab={defaultNewTab}
+          orgSlug={'test-org'}
+          router={router}
         />
       );
       await userEvent.click(screen.getByRole('button', {name: 'Add View'}));

--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.stories.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.stories.tsx
@@ -10,6 +10,7 @@ import {
   DraggableTabBar,
   type Tab,
 } from 'sentry/views/issueList/groupSearchViewTabs/draggableTabBar';
+import {IssueSortOptions} from 'sentry/views/issueList/utils';
 
 const TabPanelContainer = styled('div')`
   width: 90%;
@@ -18,25 +19,31 @@ const TabPanelContainer = styled('div')`
 `;
 const TABS: Tab[] = [
   {
+    id: 'one',
     key: 'one',
     label: 'Inbox',
     content: <TabPanelContainer>This is the Inbox view</TabPanelContainer>,
     queryCount: 1001,
-    hasUnsavedChanges: true,
+    query: '',
+    querySort: IssueSortOptions.DATE,
   },
   {
+    id: 'two',
     key: 'two',
     label: 'For Review',
     content: <TabPanelContainer>This is the For Review view</TabPanelContainer>,
     queryCount: 50,
-    hasUnsavedChanges: false,
+    query: '',
+    querySort: IssueSortOptions.DATE,
   },
   {
+    id: 'three',
     key: 'three',
     label: 'Regressed',
     content: <TabPanelContainer>This is the Regressed view</TabPanelContainer>,
     queryCount: 100,
-    hasUnsavedChanges: false,
+    query: '',
+    querySort: IssueSortOptions.DATE,
   },
 ];
 
@@ -44,17 +51,6 @@ export default storyBook(DraggableTabBar, story => {
   story('Default', () => {
     const [showTempTab, setShowTempTab] = useState(false);
     const [tabs, setTabs] = useState(TABS);
-
-    const tempTab = {
-      key: 'temporary-tab',
-      label: 'Unsaved',
-      content: <TabPanelContainer>This is the Temporary view</TabPanelContainer>,
-    };
-    const defaultNewTab = {
-      key: `view-${tabs.length + 1}`,
-      label: `New View`,
-      content: <TabPanelContainer>This is the a New View</TabPanelContainer>,
-    };
 
     return (
       <Fragment>
@@ -76,15 +72,11 @@ export default storyBook(DraggableTabBar, story => {
             <DraggableTabBar
               tabs={tabs}
               setTabs={setTabs}
-              showTempTab={showTempTab}
-              tempTabContent={
-                <TabPanelContainer>This is a Temporary view</TabPanelContainer>
-              }
-              defaultNewTab={defaultNewTab}
-              tempTab={tempTab}
               onDiscardTempView={() => {
                 setShowTempTab(false);
               }}
+              orgSlug={'sentry'}
+              router={{} as any}
             />
           </TabBarContainer>
         </SizingWindow>

--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
@@ -31,11 +31,6 @@ export interface Tab {
 }
 
 export interface DraggableTabBarProps {
-  /**
-   * Callback function to be called when the user reorders the tabs. Returns the
-   * new order of the tabs along with their props.
-   */
-  onReorder: (newTabs: Tab[]) => void;
   orgSlug: string;
   router: InjectedRouter;
   setTabs: (tabs: Tab[]) => void;
@@ -64,6 +59,11 @@ export interface DraggableTabBarProps {
    * Note: The `Duplicate` button only appears for persistent views
    */
   onDuplicate?: (newTabs: Tab[]) => void;
+  /**
+   * Callback function to be called when the user reorders the tabs. Returns the
+   * new order of the tabs along with their props.
+   */
+  onReorder?: (newTabs: Tab[]) => void;
   /**
    * Callback function to be called when user clicks the 'Save' button.
    * Note: The `Save` button only appears for persistent views when `isChanged=true`

--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
@@ -1,47 +1,59 @@
 import 'intersection-observer'; // polyfill
 
-import {useEffect, useState} from 'react';
+import {useCallback, useState} from 'react';
+import type {InjectedRouter} from 'react-router';
 import styled from '@emotion/styled';
-import type {Key, Node} from '@react-types/shared';
-import type {LocationDescriptor} from 'history';
+import type {Node} from '@react-types/shared';
 
 import Badge from 'sentry/components/badge/badge';
 import {DraggableTabList} from 'sentry/components/draggableTabs/draggableTabList';
 import type {DraggableTabListItemProps} from 'sentry/components/draggableTabs/item';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import QueryCount from 'sentry/components/queryCount';
-import {TabPanels, Tabs} from 'sentry/components/tabs';
+import {Tabs} from 'sentry/components/tabs';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {DraggableTabMenuButton} from 'sentry/views/issueList/groupSearchViewTabs/draggableTabMenuButton';
 import EditableTabTitle from 'sentry/views/issueList/groupSearchViewTabs/editableTabTitle';
+import type {IssueSortOptions} from 'sentry/views/issueList/utils';
 
+// TODO(michaelsun): Move params that aren't necessary to draggableTabBar to parent
 export interface Tab {
+  id: string;
   key: string;
   label: string;
+  query: string;
+  querySort: IssueSortOptions;
   content?: React.ReactNode;
-  hasUnsavedChanges?: boolean;
   queryCount?: number;
-  to?: LocationDescriptor;
+  unsavedChanges?: [string, IssueSortOptions];
 }
 
 export interface DraggableTabBarProps {
+  /**
+   * Callback function to be called when the user reorders the tabs. Returns the
+   * new order of the tabs along with their props.
+   */
+  onReorder: (newTabs: Tab[]) => void;
+  orgSlug: string;
+  router: InjectedRouter;
   setTabs: (tabs: Tab[]) => void;
-  showTempTab: boolean;
   tabs: Tab[];
-  tempTab: Tab;
-  defaultNewTab?: Tab;
-  onAddView?: React.MouseEventHandler;
+  /**
+   * Callback function to be called when user clicks the `Add View` button.
+   */
+  onAddView?: () => void;
   /**
    * Callback function to be called when user clicks the `Delete` button.
    * Note: The `Delete` button only appears for persistent views
    */
-  onDelete?: (key: MenuItemProps['key']) => void;
+  onDelete?: (newTabs: Tab[]) => void;
   /**
    * Callback function to be called when user clicks on the `Discard Changes` button.
    * Note: The `Discard Changes` button only appears for persistent views when `isChanged=true`
    */
-  onDiscard?: (key: MenuItemProps['key']) => void;
+  onDiscard?: () => void;
   /**
    * Callback function to be called when user clicks on the `Discard` button for temporary views.
    * Note: The `Discard` button only appears for temporary views
@@ -51,31 +63,31 @@ export interface DraggableTabBarProps {
    * Callback function to be called when user clicks the 'Duplicate' button.
    * Note: The `Duplicate` button only appears for persistent views
    */
-  onDuplicate?: (key: MenuItemProps['key']) => void;
+  onDuplicate?: (newTabs: Tab[]) => void;
   /**
    * Callback function to be called when user clicks the 'Save' button.
    * Note: The `Save` button only appears for persistent views when `isChanged=true`
    */
-  onSave?: (key: MenuItemProps['key']) => void;
+  onSave?: (newTabs: Tab[]) => void;
   /**
    * Callback function to be called when user clicks the 'Save View' button for temporary views.
    */
-  onSaveTempView?: () => void;
+  onSaveTempView?: (newTabs: Tab[]) => void;
   /**
    * Callback function to be called when user renames a tab.
    * Note: The `Rename` button only appears for persistent views
    */
-  onTabRenamed?: (key: MenuItemProps['key'], newLabel: string) => void;
-  tempTabContent?: React.ReactNode;
-  tempTabLabel?: string;
+  onTabRenamed?: (newTabs: Tab[], newLabel: string) => void;
 }
+
+const generateTempViewId = () => `_${Math.random().toString().substring(2, 7)}`;
 
 export function DraggableTabBar({
   tabs,
   setTabs,
-  tempTab,
-  defaultNewTab,
-  showTempTab,
+  orgSlug,
+  router,
+  onReorder,
   onAddView,
   onDelete,
   onDiscard,
@@ -85,106 +97,230 @@ export function DraggableTabBar({
   onDiscardTempView,
   onSaveTempView,
 }: DraggableTabBarProps) {
-  const [selectedTabKey, setSelectedTabKey] = useState<Key>(tabs[0].key);
   // TODO: Extract this to a separate component encompassing Tab.Item in the future
   const [editingTabKey, setEditingTabKey] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!showTempTab && selectedTabKey === 'temporary-tab') {
-      setSelectedTabKey(tabs[0].key);
-    }
-  }, [showTempTab, selectedTabKey, tabs]);
-
-  const onReorder: (newOrder: Node<DraggableTabListItemProps>[]) => void = newOrder => {
-    setTabs(
-      newOrder
-        .map(node => {
-          const foundTab = tabs.find(tab => tab.key === node.key);
-          return foundTab?.key === node.key ? foundTab : null;
-        })
-        .filter(defined)
-    );
-  };
-
-  const handleOnDelete = (tab: Tab) => {
-    if (tabs.length > 1) {
-      setTabs(tabs.filter(tb => tb.key !== tab.key));
-      onDelete?.(tab.key);
-    }
-  };
-
-  const handleOnDuplicate = (tab: Tab) => {
-    const idx = tabs.findIndex(tb => tb.key === tab.key);
-    if (idx !== -1) {
-      setTabs([
-        ...tabs.slice(0, idx + 1),
-        {
-          ...tab,
-          key: `${tab.key}-copy`,
-          label: `${tab.label} (Copy)`,
-          hasUnsavedChanges: false,
+  const {cursor: _cursor, page: _page, ...queryParams} = router.location?.query ?? {};
+  const selectedTabKey = queryParams.viewId ?? 'temporary-tab';
+  const setSelectedTabKey = useCallback(
+    (key: string) => {
+      router.replace({
+        query: {
+          ...queryParams,
+          viewId: key,
         },
-        ...tabs.slice(idx + 1),
-      ]);
-      onDuplicate?.(tab.key);
+        pathname: `/organizations/${orgSlug}/issues/`,
+      });
+    },
+    [orgSlug, queryParams, router]
+  );
+
+  const [tempTab, setTempTab] = useState<Tab | undefined>(
+    selectedTabKey === 'temporary-tab' && queryParams.query
+      ? {
+          id: 'temporary-tab',
+          key: 'temporary-tab',
+          label: 'Unsaved',
+          query: queryParams.query,
+          querySort: queryParams.sort,
+          queryCount: undefined,
+        }
+      : undefined
+  );
+
+  const handleOnReorder = (newOrder: Node<DraggableTabListItemProps>[]) => {
+    const newTabs = newOrder
+      .map(node => {
+        const foundTab = tabs.find(tab => tab.key === node.key);
+        return foundTab?.key === node.key ? foundTab : null;
+      })
+      .filter(defined);
+    setTabs(newTabs);
+    onReorder?.(newTabs);
+  };
+
+  const handleOnSaveChanges = () => {
+    const originalTab = tabs.find(tab => tab.key === selectedTabKey);
+    if (originalTab) {
+      const newTabs = tabs.map(tab => {
+        if (tab.key === selectedTabKey && tab.unsavedChanges) {
+          tab.query = tab.unsavedChanges[0];
+          tab.querySort = tab.unsavedChanges[1];
+          tab.unsavedChanges = undefined;
+        }
+        return tab;
+      });
+      setTabs(newTabs);
+      onSave?.(newTabs);
     }
   };
 
-  const handleOnAddView = (e: React.MouseEvent<Element, MouseEvent>) => {
-    if (defaultNewTab) {
-      setTabs([...tabs, defaultNewTab]);
+  const handleOnDiscardChanges = () => {
+    const originalTab = tabs.find(tab => tab.key === selectedTabKey);
+    if (originalTab) {
+      setTabs(
+        tabs.map(tab => {
+          if (tab.key === selectedTabKey) {
+            tab.unsavedChanges = undefined;
+          }
+          return tab;
+        })
+      );
+      router.push(
+        normalizeUrl({
+          query: {
+            ...queryParams,
+            query: originalTab.query,
+            sort: originalTab.querySort,
+            ...(originalTab.id ? {viewId: originalTab.id} : {}),
+          },
+          pathname: `/organizations/${orgSlug}/issues/`,
+        })
+      );
+      onDiscard?.();
     }
-    onAddView?.(e);
   };
 
   const handleOnTabRenamed = (newLabel: string, tabKey: string) => {
-    const tab = tabs.find(tb => tb.key === tabKey);
-    if (tab && newLabel !== tab.label) {
-      setTabs(tabs.map(tb => (tb.key === tab.key ? {...tb, label: newLabel} : tb)));
-      onTabRenamed?.(tab.key, newLabel);
+    const renamedTab = tabs.find(tb => tb.key === tabKey);
+    if (renamedTab && newLabel !== renamedTab.label) {
+      const newTabs = tabs.map(tab =>
+        tab.key === renamedTab.key ? {...tab, label: newLabel} : tab
+      );
+      setTabs(newTabs);
+      onTabRenamed?.(newTabs, newLabel);
+    }
+  };
+
+  const handleOnDuplicate = () => {
+    const idx = tabs.findIndex(tb => tb.key === selectedTabKey);
+    if (idx !== -1) {
+      const tempId = generateTempViewId();
+      const duplicatedTab = tabs[idx];
+      const newTabs = [
+        ...tabs.slice(0, idx + 1),
+        {
+          ...duplicatedTab,
+          id: tempId,
+          key: tempId,
+          label: `${duplicatedTab.label} (Copy)`,
+        },
+        ...tabs.slice(idx + 1),
+      ];
+      setTabs(newTabs);
+      setSelectedTabKey(duplicatedTab.key);
+      onDuplicate?.(newTabs);
+    }
+  };
+
+  const handleOnDelete = () => {
+    if (tabs.length > 1) {
+      const newTabs = tabs.filter(tb => tb.key !== selectedTabKey);
+      setTabs(newTabs);
+      setSelectedTabKey(newTabs[0].key);
+      onDelete?.(newTabs);
+    }
+  };
+
+  const handleOnSaveTempView = () => {
+    if (tempTab) {
+      const tempId = generateTempViewId();
+      const newTab: Tab = {
+        id: tempId,
+        key: tempId,
+        label: 'New View',
+        query: tempTab.query,
+        querySort: tempTab.querySort,
+      };
+      const newTabs = [...tabs, newTab];
+      setTabs(newTabs);
+      setSelectedTabKey(tempId);
+      onSaveTempView?.(newTabs);
+    }
+  };
+
+  const handleOnDiscardTempView = () => {
+    setSelectedTabKey(tabs[0].key);
+    setTempTab(undefined);
+    onDiscardTempView?.();
+  };
+
+  const handleOnAddView = () => {
+    const tempId = generateTempViewId();
+    const currentTab = tabs.find(tab => tab.key === selectedTabKey);
+    if (currentTab) {
+      const newTabQuery = currentTab.unsavedChanges
+        ? currentTab.unsavedChanges[0]
+        : currentTab.query;
+      const newTabSort = currentTab.unsavedChanges
+        ? currentTab.unsavedChanges[1]
+        : currentTab.querySort;
+      const newTabs = [
+        ...tabs,
+        {
+          id: tempId,
+          key: tempId,
+          label: 'New View',
+          query: newTabQuery,
+          querySort: newTabSort,
+        },
+      ];
+      setTabs(newTabs);
+      setSelectedTabKey(tempId);
+      onAddView?.();
     }
   };
 
   const makeMenuOptions = (tab: Tab): MenuItemProps[] => {
     if (tab.key === 'temporary-tab') {
       return makeTempViewMenuOptions({
-        onSave: () => onSaveTempView?.(),
-        onDiscard: () => onDiscardTempView?.(),
+        onSaveTempView: handleOnSaveTempView,
+        onDiscardTempView: handleOnDiscardTempView,
       });
     }
-    if (tab.hasUnsavedChanges) {
+    if (tab.unsavedChanges) {
       return makeUnsavedChangesMenuOptions({
         onRename: () => setEditingTabKey(tab.key),
-        onDuplicate: () => handleOnDuplicate(tab),
-        onDelete: tabs.length > 1 ? () => handleOnDelete(tab) : undefined,
-        onSave: () => onSave?.(tab.key),
-        onDiscard: () => onDiscard?.(tab.key),
+        onDuplicate: handleOnDuplicate,
+        onDelete: tabs.length > 1 ? handleOnDelete : undefined,
+        onSave: handleOnSaveChanges,
+        onDiscard: handleOnDiscardChanges,
       });
     }
     return makeDefaultMenuOptions({
       onRename: () => setEditingTabKey(tab.key),
-      onDuplicate: () => handleOnDuplicate(tab),
-      onDelete: tabs.length > 1 ? () => handleOnDelete(tab) : undefined,
+      onDuplicate: handleOnDuplicate,
+      onDelete: tabs.length > 1 ? handleOnDelete : undefined,
     });
   };
+
+  const allTabs = tempTab ? [...tabs, tempTab] : tabs;
 
   return (
     <Tabs value={selectedTabKey} onChange={setSelectedTabKey}>
       <DraggableTabList
-        onReorder={onReorder}
+        onReorder={handleOnReorder}
         selectedKey={selectedTabKey}
-        showTempTab={showTempTab}
-        onAddView={e => handleOnAddView(e)}
+        showTempTab={!!tempTab}
+        onAddView={handleOnAddView}
         orientation="horizontal"
+        hideBorder
       >
-        {[...tabs, tempTab].map(tab => (
+        {allTabs.map(tab => (
           <DraggableTabList.Item
             textValue={`${tab.label} tab`}
             key={tab.key}
-            hidden={tab.key === 'temporary-tab' && !showTempTab}
-            to={tab.to}
+            to={normalizeUrl({
+              query: {
+                ...queryParams,
+                query: tab.unsavedChanges?.[0] ?? tab.query,
+                sort: tab.unsavedChanges?.[1] ?? tab.querySort,
+                ...(tab.id !== 'temporary-tab' ? {id: tab.id} : {}),
+              },
+              pathname: `/organizations/${orgSlug}/issues/`,
+            })}
           >
-            <TabContentWrap>
+            <TabContentWrap selected={selectedTabKey === tab.key}>
               <EditableTabTitle
                 label={tab.label}
                 isEditing={editingTabKey === tab.key}
@@ -203,7 +339,7 @@ export function DraggableTabBar({
               )}
               {selectedTabKey === tab.key && (
                 <DraggableTabMenuButton
-                  hasUnsavedChanges={tab.hasUnsavedChanges}
+                  hasUnsavedChanges={!!tab.unsavedChanges}
                   menuOptions={makeMenuOptions(tab)}
                   aria-label={`${tab.label} Tab Options`}
                 />
@@ -212,11 +348,6 @@ export function DraggableTabBar({
           </DraggableTabList.Item>
         ))}
       </DraggableTabList>
-      <TabPanels>
-        {[...tabs, tempTab].map(tab => (
-          <TabPanels.Item key={tab.key}>{tab.content}</TabPanels.Item>
-        ))}
-      </TabPanels>
     </Tabs>
   );
 }
@@ -291,34 +422,35 @@ const makeUnsavedChangesMenuOptions = ({
 };
 
 const makeTempViewMenuOptions = ({
-  onSave,
-  onDiscard,
+  onSaveTempView,
+  onDiscardTempView,
 }: {
-  onDiscard: () => void;
-  onSave: () => void;
+  onDiscardTempView: () => void;
+  onSaveTempView: () => void;
 }): MenuItemProps[] => {
   return [
     {
       key: 'save-changes',
       label: t('Save View'),
       priority: 'primary',
-      onAction: onSave,
+      onAction: onSaveTempView,
     },
     {
       key: 'discard-changes',
       label: t('Discard'),
-      onAction: onDiscard,
+      onAction: onDiscardTempView,
     },
   ];
 };
 
-const TabContentWrap = styled('span')`
+const TabContentWrap = styled('span')<{selected: boolean}>`
   white-space: nowrap;
   display: flex;
   align-items: center;
   flex-direction: row;
   padding: 0;
   gap: 6px;
+  ${p => (p.selected ? 'z-index: 1;' : 'z-index: 0;')}
 `;
 
 const StyledBadge = styled(Badge)`


### PR DESCRIPTION
This PR refactors the draggableTabBar in a couple of ways in response to some challenges and issues that came up when trying to integrate it into the issue stream. These changes include:

1. All tab menu options that alter the tab state is now handled directly within draggableTabBar, rather than relying on the parent component to handle some menu options and not others. 
2. All _persistent_ tabs will now have a viewId assigned. Newly created tabs will have a "temporary" view id (a randomly generated 5 digit number preceded by an underscore). This is to ensure that temporary tabs can be distinguished from persistent tabs directly from the url (no viewId = temp tab). The parent component will be responsible for fetching the real viewId from the backend and repopulating it correctly. 
3. The `to` parameter for a tab has been eliminated. It can be generated dynamically based on the tab's query, querySort, and viewId parameters. This should reduce some repetitive code in the parent component 