### PR TITLE
feat(perf): Add metrics warning trailing items to new Transaction Summary search

### DIFF
--- a/static/app/components/performance/transactionSearchQueryBuilder.tsx
+++ b/static/app/components/performance/transactionSearchQueryBuilder.tsx
@@ -35,6 +35,7 @@ interface TransactionSearchQueryBuilderProps {
   onSearch?: (query: string, state: CallbackSearchState) => void;
   placeholder?: string;
   projects?: PageFilters['projects'];
+  trailingItems?: React.ReactNode;
 }
 
 export function TransactionSearchQueryBuilder({
@@ -46,6 +47,7 @@ export function TransactionSearchQueryBuilder({
   projects,
   disableLoadingTags,
   filterKeyMenuWidth,
+  trailingItems,
 }: TransactionSearchQueryBuilderProps) {
   const api = useApi();
   const organization = useOrganization();
@@ -137,6 +139,7 @@ export function TransactionSearchQueryBuilder({
       disallowUnsupportedFilters
       recentSearches={SavedSearchType.EVENT}
       filterKeyMenuWidth={filterKeyMenuWidth}
+      trailingItems={trailingItems}
     />
   );
 }

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -222,6 +222,26 @@ function SummaryContent({
     return items;
   }
 
+  const generateTrailingItems = useCallback(() => {
+    if (!canUseTransactionMetricsData(organization, mepDataContext)) {
+      return (
+        <Tooltip
+          title={t(
+            'Based on your search criteria and sample rate, the events available may be limited.'
+          )}
+        >
+          <StyledIconWarning
+            data-test-id="search-metrics-fallback-warning"
+            size="sm"
+            color="warningText"
+          />
+        </Tooltip>
+      );
+    }
+
+    return null;
+  }, [organization, mepDataContext]);
+
   const hasPerformanceChartInterpolation = organization.features.includes(
     'performance-chart-interpolation'
   );
@@ -363,6 +383,7 @@ function SummaryContent({
           searchSource="transaction_summary"
           disableLoadingTags // already loaded by the parent component
           filterKeyMenuWidth={420}
+          trailingItems={generateTrailingItems()}
         />
       );
     }

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -210,7 +210,7 @@ function SummaryContent({
     return items;
   }
 
-  const generateTrailingItems = useCallback(() => {
+  const trailingItems = useMemo(() => {
     if (!canUseTransactionMetricsData(organization, mepDataContext)) {
       return <MetricsWarningIcon />;
     }
@@ -359,7 +359,7 @@ function SummaryContent({
           searchSource="transaction_summary"
           disableLoadingTags // already loaded by the parent component
           filterKeyMenuWidth={420}
-          trailingItems={generateTrailingItems()}
+          trailingItems={trailingItems}
         />
       );
     }

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -198,19 +198,7 @@ function SummaryContent({
         {
           key: 'alert',
           makeAction: () => ({
-            Button: () => (
-              <Tooltip
-                title={t(
-                  'Based on your search criteria and sample rate, the events available may be limited.'
-                )}
-              >
-                <StyledIconWarning
-                  data-test-id="search-metrics-fallback-warning"
-                  size="sm"
-                  color="warningText"
-                />
-              </Tooltip>
-            ),
+            Button: () => <MetricsWarningIcon />,
             menuItem: {
               key: 'alert',
             },
@@ -224,19 +212,7 @@ function SummaryContent({
 
   const generateTrailingItems = useCallback(() => {
     if (!canUseTransactionMetricsData(organization, mepDataContext)) {
-      return (
-        <Tooltip
-          title={t(
-            'Based on your search criteria and sample rate, the events available may be limited.'
-          )}
-        >
-          <StyledIconWarning
-            data-test-id="search-metrics-fallback-warning"
-            size="sm"
-            color="warningText"
-          />
-        </Tooltip>
-      );
+      return <MetricsWarningIcon />;
     }
 
     return null;
@@ -608,6 +584,22 @@ function getTransactionsListSort(
   );
   const selectedSort = sortOptions.find(opt => opt.value === urlParam) || sortOptions[0];
   return {selected: selectedSort, options: sortOptions};
+}
+
+function MetricsWarningIcon() {
+  return (
+    <Tooltip
+      title={t(
+        'Based on your search criteria and sample rate, the events available may be limited.'
+      )}
+    >
+      <StyledIconWarning
+        data-test-id="search-metrics-fallback-warning"
+        size="sm"
+        color="warningText"
+      />
+    </Tooltip>
+  );
 }
 
 const FilterActions = styled('div')`


### PR DESCRIPTION
Adds back the warning icon action bar elements to the new `SearchQueryBuilder` component on the transaction summary page, using the new `trailingItems` prop

![image](https://github.com/user-attachments/assets/13c01a57-4bae-4259-9a78-65cd800b7b1b)
