### PR TITLE
feat(alerts): Default metric alerts on project creation

### DIFF
--- a/static/app/components/modals/projectCreationModal.tsx
+++ b/static/app/components/modals/projectCreationModal.tsx
@@ -27,7 +27,10 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import slugify from 'sentry/utils/slugify';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
-import type {IssueAlertFragment} from 'sentry/views/projectInstall/createProject';
+import {
+  getAlertStepName,
+  type IssueAlertFragment,
+} from 'sentry/views/projectInstall/createProject';
 import IssueAlertOptions from 'sentry/views/projectInstall/issueAlertOptions';
 
 type Props = ModalRenderProps & {
@@ -150,7 +153,7 @@ export default function ProjectCreationModal({
       )}
       {step === 1 && (
         <Fragment>
-          <Subtitle>{t('Set your alert frequency')}</Subtitle>
+          <Subtitle>{getAlertStepName(organization)}</Subtitle>
           <IssueAlertOptions
             platformLanguage={platform?.language as SupportedLanguages}
             onChange={updatedData => setAlertRuleConfig(updatedData)}

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -24,7 +24,7 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {t, tct} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {space} from 'sentry/styles/space';
-import type {OnboardingSelectedSDK, Team} from 'sentry/types';
+import type {OnboardingSelectedSDK, Organization, Team} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import useRouteAnalyticsEventNames from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
@@ -43,6 +43,12 @@ import {GettingStartedWithProjectContext} from 'sentry/views/projects/gettingSta
 export type IssueAlertFragment = Parameters<
   React.ComponentProps<typeof IssueAlertOptions>['onChange']
 >[0];
+
+export function getAlertStepName(organization: Organization) {
+  return organization.features.includes('default-metric-alerts-new-projects')
+    ? t('Set your alerts')
+    : t('Set your alert frequency');
+}
 
 function CreateProject() {
   const api = useApi();
@@ -341,7 +347,7 @@ function CreateProject() {
             showOther
             noAutoFilter
           />
-          <StyledListItem>{t('Set your alert frequency')}</StyledListItem>
+          <StyledListItem>{getAlertStepName(organization)}</StyledListItem>
           <IssueAlertOptions
             {...alertFrequencyDefaultValues}
             platformLanguage={platform?.language as SupportedLanguages}

--- a/static/app/views/projectInstall/issueAlertOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertOptions.tsx
@@ -177,23 +177,29 @@ class IssueAlertOptions extends DeprecatedAsyncComponent<Props, State> {
       </CustomizeAlert>,
     ];
 
-    const default_label = this.shouldUseNewDefaultSetting()
-      ? t('Alert me on high priority issues')
-      : t('Alert me on every new issue');
-
     const options: [string, React.ReactNode][] = [
-      [RuleAction.DEFAULT_ALERT.toString(), default_label],
-      ...(hasProperlyLoadedConditions ? [customizedAlertOption] : []),
       [RuleAction.CREATE_ALERT_LATER.toString(), t("I'll create my own alerts later")],
     ];
+
+    if (this.props.organization.features.includes('default-metric-alerts-new-projects')) {
+      options.unshift([RuleAction.DEFAULT_ALERT.toString(), t('Alert me on issues')]);
+    } else {
+      options.unshift(
+        [RuleAction.DEFAULT_ALERT.toString(), this.getDefaultLabel()],
+        ...(hasProperlyLoadedConditions ? [customizedAlertOption] : [])
+      );
+    }
+
     return options.map(([choiceValue, node]) => [
       choiceValue,
       <RadioItemWrapper key={choiceValue}>{node}</RadioItemWrapper>,
     ]);
   }
 
-  shouldUseNewDefaultSetting(): boolean {
-    return this.props.organization.features.includes('priority-ga-features');
+  getDefaultLabel(): string {
+    return this.props.organization.features.includes('priority-ga-features')
+      ? t('Alert me on high priority issues')
+      : t('Alert me on every new issue');
   }
 
   getUpdatedData(): RequestDataFragment {


### PR DESCRIPTION
Change the alerts step on the project creation page to just toggle alerts on or off.

The on option will create both the default metric alert and alert on every/high priority issues issue alert (the issue alert depends on the platform, as priority issue alerts are not GA'd yet)

I also changed the step name to just `Set your Alerts` and the bullet point to `Alert me on Issues`, although I'm open to other names as I feel like the alerts step looks rather small in the UI compared to the other steps.

### Before
<img width="771" alt="Screenshot 2024-08-12 at 3 24 34 PM" src="https://github.com/user-attachments/assets/6c450643-e6e3-4166-b1f8-7ba8e5097179">

### After
<img width="776" alt="Screenshot 2024-08-12 at 3 25 24 PM" src="https://github.com/user-attachments/assets/cb06a605-89ca-4d72-82dc-6ef753cffb49">

Closes [ALRT-206](https://getsentry.atlassian.net/browse/ALRT-206)

[ALRT-206]: https://getsentry.atlassian.net/browse/ALRT-206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ