### PR TITLE
feat(alerts): Update Slack metric alert rule builder for dynamic alerts

### DIFF
--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -7,11 +7,7 @@ from django.utils.translation import gettext as _
 
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS
 from sentry.incidents.logic import get_incident_aggregates
-from sentry.incidents.models.alert_rule import (
-    AlertRule,
-    AlertRuleDetectionType,
-    AlertRuleThresholdType,
-)
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleThresholdType
 from sentry.incidents.models.incident import (
     INCIDENT_STATUS,
     Incident,
@@ -118,9 +114,6 @@ def incident_attachment_info(
         metric_value = get_metric_count_from_incident(incident)
 
     text = get_incident_status_text(alert_rule, metric_value)
-    if alert_rule.detection_type == AlertRuleDetectionType.DYNAMIC:
-        text += f"\n Threshold: {alert_rule.detection_type.title()}"
-
     title = f"{status}: {alert_rule.name}"
 
     title_link_params = {

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -7,7 +7,11 @@ from django.utils.translation import gettext as _
 
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS
 from sentry.incidents.logic import get_incident_aggregates
-from sentry.incidents.models.alert_rule import AlertRule, AlertRuleThresholdType
+from sentry.incidents.models.alert_rule import (
+    AlertRule,
+    AlertRuleDetectionType,
+    AlertRuleThresholdType,
+)
 from sentry.incidents.models.incident import (
     INCIDENT_STATUS,
     Incident,
@@ -114,11 +118,15 @@ def incident_attachment_info(
         metric_value = get_metric_count_from_incident(incident)
 
     text = get_incident_status_text(alert_rule, metric_value)
+    if alert_rule.detection_type == AlertRuleDetectionType.DYNAMIC:
+        text += f"\n Threshold: {alert_rule.detection_type.title()}"
+
     title = f"{status}: {alert_rule.name}"
 
     title_link_params = {
         "alert": str(incident.identifier),
         "referrer": referrer,
+        "detection_type": alert_rule.detection_type,
     }
     if notification_uuid:
         title_link_params["notification_uuid"] = notification_uuid

--- a/src/sentry/integrations/slack/message_builder/incidents.py
+++ b/src/sentry/integrations/slack/message_builder/incidents.py
@@ -30,7 +30,7 @@ class SlackIncidentsMessageBuilder(BlockSlackMessageBuilder):
         notification_uuid: str | None = None,
     ) -> None:
         """
-        Builds an incident attachment for slack unfurling.
+        Builds an incident attachment when a metric alert fires or is resolved.
 
         :param incident: The `Incident` for which to build the attachment.
         :param [metric_value]: The value of the metric that triggered this alert to
@@ -46,6 +46,7 @@ class SlackIncidentsMessageBuilder(BlockSlackMessageBuilder):
         self.action = action
 
     def build(self) -> SlackBody:
+        alert_rule = self.action.alert_rule_trigger.alert_rule
         data = incident_attachment_info(
             self.incident,
             self.new_status,
@@ -56,7 +57,6 @@ class SlackIncidentsMessageBuilder(BlockSlackMessageBuilder):
         blocks = [
             self.get_markdown_block(text=f"{data['text']}\n{get_started_at(data['ts'])}"),
         ]
-        alert_rule = self.action.alert_rule_trigger.alert_rule
 
         if (
             alert_rule.description

--- a/src/sentry/integrations/slack/message_builder/incidents.py
+++ b/src/sentry/integrations/slack/message_builder/incidents.py
@@ -14,7 +14,7 @@ from sentry.integrations.slack.utils.escape import escape_slack_text
 
 
 def get_started_at(timestamp: datetime) -> str:
-    return "<!date^{:.0f}^Started {} at {} | Sentry Incident>".format(
+    return "<!date^{:.0f}^Started: {} at {} | Sentry Incident>".format(
         timestamp.timestamp(), "{date_pretty}", "{time}"
     )
 
@@ -54,8 +54,12 @@ class SlackIncidentsMessageBuilder(BlockSlackMessageBuilder):
             self.notification_uuid,
             referrer="metric_alert_slack",
         )
+        incident_text = f"{data['text']}\n{get_started_at(data['ts'])}"
+        if features.has("organizations:anomaly-detection-alerts", self.incident.organization):
+            incident_text += f"\nThreshold: {alert_rule.detection_type.title()}"
+
         blocks = [
-            self.get_markdown_block(text=f"{data['text']}\n{get_started_at(data['ts'])}"),
+            self.get_markdown_block(text=incident_text),
         ]
 
         if (

--- a/tests/sentry/incidents/action_handlers/test_opsgenie.py
+++ b/tests/sentry/incidents/action_handlers/test_opsgenie.py
@@ -91,7 +91,7 @@ class OpsgenieActionHandlerTest(FireTest):
         assert data["priority"] == "P1"
         assert (
             data["details"]["URL"]
-            == f"http://testserver/organizations/baz/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}&referrer=metric_alert_opsgenie"
+            == f"http://testserver/organizations/baz/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}&referrer=metric_alert_opsgenie&detection_type=static"
         )
 
     @responses.activate

--- a/tests/sentry/incidents/action_handlers/test_pagerduty.py
+++ b/tests/sentry/incidents/action_handlers/test_pagerduty.py
@@ -89,7 +89,7 @@ class PagerDutyActionHandlerTest(FireTest):
         assert data["links"][0]["text"] == f"Critical: {alert_rule.name}"
         assert (
             data["links"][0]["href"]
-            == f"http://testserver/organizations/baz/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}&referrer=metric_alert_pagerduty&notification_uuid={notification_uuid}"
+            == f"http://testserver/organizations/baz/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}&referrer=metric_alert_pagerduty&detection_type=static&notification_uuid={notification_uuid}"
         )
 
     @responses.activate

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -854,7 +854,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             alert_rule_trigger=trigger, triggered_for_incident=incident
         )
         title = f"Critical: {alert_rule.name}"
-        timestamp = "<!date^{:.0f}^Started {} at {} | Sentry Incident>".format(
+        timestamp = "<!date^{:.0f}^Started: {} at {} | Sentry Incident>".format(
             incident.date_started.timestamp(), "{date_pretty}", "{time}"
         )
         link = (
@@ -898,7 +898,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             alert_rule_trigger=trigger, triggered_for_incident=incident
         )
         title = f"Critical: {alert_rule.name}"
-        timestamp = "<!date^{:.0f}^Started {} at {} | Sentry Incident>".format(
+        timestamp = "<!date^{:.0f}^Started: {} at {} | Sentry Incident>".format(
             incident.date_started.timestamp(), "{date_pretty}", "{time}"
         )
         link = (
@@ -936,7 +936,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             alert_rule_trigger=trigger, triggered_for_incident=incident
         )
         title = f"Resolved: {alert_rule.name}"
-        timestamp = "<!date^{:.0f}^Started {} at {} | Sentry Incident>".format(
+        timestamp = "<!date^{:.0f}^Started: {} at {} | Sentry Incident>".format(
             incident.date_started.timestamp(), "{date_pretty}", "{time}"
         )
         link = (
@@ -1004,7 +1004,7 @@ class BuildIncidentAttachmentTest(TestCase):
             alert_rule_trigger=trigger, triggered_for_incident=incident
         )
         title = f"Resolved: {alert_rule.name}"
-        timestamp = "<!date^{:.0f}^Started {} at {} | Sentry Incident>".format(
+        timestamp = "<!date^{:.0f}^Started: {} at {} | Sentry Incident>".format(
             incident.date_started.timestamp(), "{date_pretty}", "{time}"
         )
         link = (
@@ -1044,7 +1044,7 @@ class BuildIncidentAttachmentTest(TestCase):
         action = self.create_alert_rule_trigger_action(
             alert_rule_trigger=trigger, triggered_for_incident=incident
         )
-        timestamp = "<!date^{:.0f}^Started {} at {} | Sentry Incident>".format(
+        timestamp = "<!date^{:.0f}^Started: {} at {} | Sentry Incident>".format(
             incident.date_started.timestamp(), "{date_pretty}", "{time}"
         )
         link = (
@@ -1084,7 +1084,7 @@ class BuildIncidentAttachmentTest(TestCase):
             alert_rule_trigger=trigger, triggered_for_incident=incident
         )
         title = f"Resolved: {alert_rule.name}"
-        timestamp = "<!date^{:.0f}^Started {} at {} | Sentry Incident>".format(
+        timestamp = "<!date^{:.0f}^Started: {} at {} | Sentry Incident>".format(
             incident.date_started.timestamp(), "{date_pretty}", "{time}"
         )
         link = (
@@ -1134,7 +1134,7 @@ class BuildIncidentAttachmentTest(TestCase):
             alert_rule_trigger=trigger, triggered_for_incident=incident
         )
         title = f"Critical: {alert_rule.name}"
-        timestamp = "<!date^{:.0f}^Started {} at {} | Sentry Incident>".format(
+        timestamp = "<!date^{:.0f}^Started: {} at {} | Sentry Incident>".format(
             incident.date_started.timestamp(), "{date_pretty}", "{time}"
         )
         detection_type = alert_rule.detection_type
@@ -1150,14 +1150,13 @@ class BuildIncidentAttachmentTest(TestCase):
             )
             + f"?alert={incident.identifier}&referrer=metric_alert_slack&detection_type={detection_type}"
         )
-
         assert SlackIncidentsMessageBuilder(action, incident, IncidentStatus.CRITICAL).build() == {
             "blocks": [
                 {
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": f"0 events in the last 30 minutes\n Threshold: {detection_type.title()}\n{timestamp}",
+                        "text": f"0 events in the last 30 minutes\n{timestamp}\nThreshold: {detection_type.title()}",
                     },
                 },
             ],

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -5,9 +5,15 @@ from typing import Any
 from unittest.mock import Mock, patch
 
 from django.urls import reverse
+from urllib3.response import HTTPResponse
 
 from sentry.eventstore.models import Event
 from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL
+from sentry.incidents.models.alert_rule import (
+    AlertRuleDetectionType,
+    AlertRuleSeasonality,
+    AlertRuleSensitivity,
+)
 from sentry.incidents.models.incident import IncidentStatus
 from sentry.integrations.message_builder import build_attachment_text, build_attachment_title
 from sentry.integrations.slack.message_builder import LEVEL_TO_COLOR
@@ -861,7 +867,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
                     },
                 )
             )
-            + f"?alert={incident.identifier}&referrer=metric_alert_slack"
+            + f"?alert={incident.identifier}&referrer=metric_alert_slack&detection_type={alert_rule.detection_type}"
         )
         assert SlackIncidentsMessageBuilder(action, incident, IncidentStatus.CRITICAL).build() == {
             "blocks": [
@@ -905,7 +911,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
                     },
                 )
             )
-            + f"?alert={incident.identifier}&referrer=metric_alert_slack"
+            + f"?alert={incident.identifier}&referrer=metric_alert_slack&detection_type={alert_rule.detection_type}"
         )
         assert SlackIncidentsMessageBuilder(action, incident, IncidentStatus.CRITICAL).build() == {
             "blocks": [
@@ -943,7 +949,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
                     },
                 )
             )
-            + f"?alert={incident.identifier}&referrer=metric_alert_slack"
+            + f"?alert={incident.identifier}&referrer=metric_alert_slack&detection_type={alert_rule.detection_type}"
         )
         assert SlackIncidentsMessageBuilder(action, incident, IncidentStatus.CLOSED).build() == {
             "blocks": [
@@ -1011,7 +1017,7 @@ class BuildIncidentAttachmentTest(TestCase):
                     },
                 )
             )
-            + f"?alert={incident.identifier}&referrer=metric_alert_slack"
+            + f"?alert={incident.identifier}&referrer=metric_alert_slack&detection_type={alert_rule.detection_type}"
         )
         assert SlackIncidentsMessageBuilder(action, incident, IncidentStatus.CLOSED).build() == {
             "blocks": [
@@ -1051,7 +1057,7 @@ class BuildIncidentAttachmentTest(TestCase):
                     },
                 )
             )
-            + f"?alert={incident.identifier}&referrer=metric_alert_slack"
+            + f"?alert={incident.identifier}&referrer=metric_alert_slack&detection_type={alert_rule.detection_type}"
         )
         # This should fail because it pulls status from `action` instead of `incident`
         assert SlackIncidentsMessageBuilder(
@@ -1091,7 +1097,7 @@ class BuildIncidentAttachmentTest(TestCase):
                     },
                 )
             )
-            + f"?alert={incident.identifier}&referrer=metric_alert_slack"
+            + f"?alert={incident.identifier}&referrer=metric_alert_slack&detection_type={alert_rule.detection_type}"
         )
         assert SlackIncidentsMessageBuilder(
             action, incident, IncidentStatus.CLOSED, chart_url="chart-url"
@@ -1107,6 +1113,55 @@ class BuildIncidentAttachmentTest(TestCase):
                 {"alt_text": "Metric Alert Chart", "image_url": "chart-url", "type": "image"},
             ],
             "color": LEVEL_TO_COLOR["_incident_resolved"],
+            "text": f"<{link}|*{title}*>",
+        }
+
+    @with_feature("organizations:anomaly-detection-alerts")
+    @patch(
+        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
+    )
+    def test_metric_alert_with_anomaly_detection(self, mock_seer_request):
+        mock_seer_request.return_value = HTTPResponse(status=200)
+        alert_rule = self.create_alert_rule(
+            detection_type=AlertRuleDetectionType.DYNAMIC,
+            time_window=30,
+            sensitivity=AlertRuleSensitivity.LOW,
+            seasonality=AlertRuleSeasonality.AUTO,
+        )
+        incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CRITICAL.value)
+        trigger = self.create_alert_rule_trigger(alert_rule=alert_rule, alert_threshold=0)
+        action = self.create_alert_rule_trigger_action(
+            alert_rule_trigger=trigger, triggered_for_incident=incident
+        )
+        title = f"Critical: {alert_rule.name}"
+        timestamp = "<!date^{:.0f}^Started {} at {} | Sentry Incident>".format(
+            incident.date_started.timestamp(), "{date_pretty}", "{time}"
+        )
+        detection_type = alert_rule.detection_type
+        link = (
+            absolute_uri(
+                reverse(
+                    "sentry-metric-alert-details",
+                    kwargs={
+                        "organization_slug": alert_rule.organization.slug,
+                        "alert_rule_id": alert_rule.id,
+                    },
+                )
+            )
+            + f"?alert={incident.identifier}&referrer=metric_alert_slack&detection_type={detection_type}"
+        )
+
+        assert SlackIncidentsMessageBuilder(action, incident, IncidentStatus.CRITICAL).build() == {
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"0 events in the last 30 minutes\n Threshold: {detection_type.title()}\n{timestamp}",
+                    },
+                },
+            ],
+            "color": LEVEL_TO_COLOR["fatal"],
             "text": f"<{link}|*{title}*>",
         }
 

--- a/tests/sentry/integrations/test_metric_alerts.py
+++ b/tests/sentry/integrations/test_metric_alerts.py
@@ -48,7 +48,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         assert data["ts"] == date_started
         assert (
             data["title_link"]
-            == f"http://testserver/organizations/baz/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}&referrer={referrer}&notification_uuid={notification_uuid}"
+            == f"http://testserver/organizations/baz/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}&referrer={referrer}&detection_type=static&notification_uuid={notification_uuid}"
         )
         assert (
             data["logo_url"]
@@ -93,7 +93,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         assert data["ts"] == date_started
         assert (
             data["title_link"]
-            == f"http://testserver/organizations/baz/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}&referrer=metric_alert"
+            == f"http://testserver/organizations/baz/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}&referrer=metric_alert&detection_type=static"
         )
         assert (
             data["logo_url"]
@@ -108,7 +108,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         assert data["ts"] == date_started
         assert (
             data["title_link"]
-            == f"http://testserver/organizations/baz/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}&referrer=metric_alert"
+            == f"http://testserver/organizations/baz/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}&referrer=metric_alert&detection_type=static"
         )
         assert (
             data["logo_url"]
@@ -123,7 +123,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         assert data["ts"] == date_started
         assert (
             data["title_link"]
-            == f"http://testserver/organizations/baz/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}&referrer=metric_alert"
+            == f"http://testserver/organizations/baz/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}&referrer=metric_alert&detection_type=static"
         )
         assert (
             data["logo_url"]


### PR DESCRIPTION
Update the metric alert rule message builder for Slack to show the detection type and to include the detection type in the referrer.

Mockup from block kit builder:
<img width="342" alt="Screenshot 2024-08-12 at 3 54 02 PM" src="https://github.com/user-attachments/assets/36806700-c5c5-42c0-a78a-b042916071cf">

See https://github.com/getsentry/sentry/pull/76009 for email update
Partially closes https://getsentry.atlassian.net/browse/ALRT-147 (other integrations to follow)