### PR TITLE
style(toolbar): update toolbar headings to match new design

### DIFF
--- a/static/app/components/devtoolbar/components/alerts/alertsPanel.tsx
+++ b/static/app/components/devtoolbar/components/alerts/alertsPanel.tsx
@@ -3,13 +3,11 @@ import {css} from '@emotion/react';
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
 import AlertBadge from 'sentry/components/badge/alertBadge';
 import AnalyticsProvider from 'sentry/components/devtoolbar/components/analyticsProvider';
-import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import Placeholder from 'sentry/components/placeholder';
 import TextOverflow from 'sentry/components/textOverflow';
 import TimeSince from 'sentry/components/timeSince';
 import type {Actor} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
-import type {PlatformKey} from 'sentry/types/project';
 import ActivatedMetricAlertRuleStatus from 'sentry/views/alerts/list/rules/activatedMetricAlertRuleStatus';
 import type {Incident, MetricAlert} from 'sentry/views/alerts/types';
 import {CombinedAlertType} from 'sentry/views/alerts/types';
@@ -23,7 +21,7 @@ import {
   listItemPlaceholderWrapperCss,
 } from '../../styles/listItem';
 import {panelInsetContentCss, panelSectionCss} from '../../styles/panel';
-import {resetFlexColumnCss, resetFlexRowCss} from '../../styles/reset';
+import {resetFlexColumnCss} from '../../styles/reset';
 import {smallCss, xSmallCss} from '../../styles/typography';
 import InfiniteListItems from '../infiniteListItems';
 import InfiniteListState from '../infiniteListState';
@@ -34,43 +32,13 @@ import useTeams from '../teams/useTeams';
 import useInfiniteAlertsList from './useInfiniteAlertsList';
 
 export default function AlertsPanel() {
-  const {projectId, projectSlug, projectPlatform} = useConfiguration();
   const queryResult = useInfiniteAlertsList();
 
   const estimateSize = 84;
   const placeholderHeight = `${estimateSize - 8}px`; // The real height of the items, minus the padding-block value
 
   return (
-    <PanelLayout title="Alerts">
-      <AnalyticsProvider nameVal="header" keyVal="header">
-        <div css={[smallCss, panelSectionCss, panelInsetContentCss]}>
-          <span css={[resetFlexRowCss, {gap: 'var(--space50)'}]}>
-            Active alerts in{' '}
-            <SentryAppLink to={{url: `/projects/${projectSlug}/`}}>
-              <div
-                css={[
-                  resetFlexRowCss,
-                  {display: 'inline-flex', gap: 'var(--space50)', alignItems: 'center'},
-                ]}
-              >
-                <ProjectBadge
-                  css={css({'&& img': {boxShadow: 'none'}})}
-                  project={{
-                    slug: projectSlug,
-                    id: projectId,
-                    platform: projectPlatform as PlatformKey,
-                  }}
-                  avatarSize={16}
-                  hideName
-                  avatarProps={{hasTooltip: false}}
-                />
-                {projectSlug}
-              </div>
-            </SentryAppLink>
-          </span>
-        </div>
-      </AnalyticsProvider>
-
+    <PanelLayout title="Alerts" showProjectBadge>
       <div css={resetFlexColumnCss}>
         <InfiniteListState
           queryResult={queryResult}

--- a/static/app/components/devtoolbar/components/feedback/feedbackPanel.tsx
+++ b/static/app/components/devtoolbar/components/feedback/feedbackPanel.tsx
@@ -21,6 +21,7 @@ import {
   listItemPlaceholderWrapperCss,
 } from '../../styles/listItem';
 import {
+  panelDescCss,
   panelHeadingRightCss,
   panelInsetContentCss,
   panelSectionCss,
@@ -57,6 +58,7 @@ export default function FeedbackPanel() {
 
   return (
     <PanelLayout
+      showProjectBadge
       title="User Feedback"
       titleRight={
         buttonRef ? (
@@ -71,10 +73,8 @@ export default function FeedbackPanel() {
         ) : null
       }
     >
-      <div css={[smallCss, panelSectionCss, panelInsetContentCss]}>
-        <span>
-          Unresolved feedback related to <code>{transactionName}</code>
-        </span>
+      <div css={[smallCss, panelSectionCss, panelDescCss]}>
+        <span>Unresolved feedback related to this page</span>
       </div>
 
       <div css={resetFlexColumnCss}>

--- a/static/app/components/devtoolbar/components/feedback/feedbackPanel.tsx
+++ b/static/app/components/devtoolbar/components/feedback/feedbackPanel.tsx
@@ -7,7 +7,7 @@ import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import Placeholder from 'sentry/components/placeholder';
 import TextOverflow from 'sentry/components/textOverflow';
 import TimeSince from 'sentry/components/timeSince';
-import {IconAdd, IconChat, IconFatal, IconImage, IconPlay} from 'sentry/icons';
+import {IconChat, IconFatal, IconImage, IconMegaphone, IconPlay} from 'sentry/icons';
 import useReplayCount from 'sentry/utils/replayCount/useReplayCount';
 
 import useConfiguration from '../../hooks/useConfiguration';
@@ -68,7 +68,18 @@ export default function FeedbackPanel() {
             ref={buttonRef}
             title="Submit Feedback"
           >
-            <IconAdd size="xs" />
+            <span
+              css={{
+                display: 'flex',
+                gap: 'var(--space75)',
+                alignItems: 'center',
+                color: 'var(--purple300)',
+                fontWeight: 'bold',
+              }}
+            >
+              <IconMegaphone size="xs" />
+              Report Bug
+            </span>
           </button>
         ) : null
       }

--- a/static/app/components/devtoolbar/components/issues/issuesPanel.tsx
+++ b/static/app/components/devtoolbar/components/issues/issuesPanel.tsx
@@ -3,7 +3,7 @@ import Placeholder from 'sentry/components/placeholder';
 
 import useCurrentTransactionName from '../../hooks/useCurrentTransactionName';
 import {listItemPlaceholderWrapperCss} from '../../styles/listItem';
-import {panelInsetContentCss, panelSectionCss} from '../../styles/panel';
+import {panelDescCss, panelInsetContentCss, panelSectionCss} from '../../styles/panel';
 import {resetFlexColumnCss} from '../../styles/reset';
 import {smallCss} from '../../styles/typography';
 import InfiniteListItems from '../infiniteListItems';
@@ -22,11 +22,9 @@ export default function IssuesPanel() {
   const placeholderHeight = `${estimateSize - 8}px`; // The real height of the items, minus the padding-block value
 
   return (
-    <PanelLayout title="Issues">
-      <div css={[smallCss, panelSectionCss, panelInsetContentCss]}>
-        <span>
-          Unresolved issues related to <code>{transactionName}</code>
-        </span>
+    <PanelLayout title="Issues" showProjectBadge>
+      <div css={[smallCss, panelSectionCss, panelDescCss]}>
+        <span>Unresolved issues related to this page</span>
       </div>
 
       <div css={resetFlexColumnCss}>

--- a/static/app/components/devtoolbar/components/panelLayout.tsx
+++ b/static/app/components/devtoolbar/components/panelLayout.tsx
@@ -6,20 +6,18 @@ import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import type {PlatformKey} from 'sentry/types/project';
 
 import {panelCss, panelHeadingCss, panelSectionCss} from '../styles/panel';
-import {resetDialogCss, resetFlexColumnCss} from '../styles/reset';
+import {resetDialogCss, resetFlexColumnCss, resetFlexRowCss} from '../styles/reset';
 
 interface Props {
   children?: React.ReactNode;
   showProjectBadge?: boolean;
   title?: string;
-  titleLeft?: React.ReactNode;
   titleRight?: React.ReactNode;
 }
 
 export default function PanelLayout({
   children,
   title,
-  titleLeft,
   titleRight,
   showProjectBadge,
 }: Props) {
@@ -46,10 +44,15 @@ export default function PanelLayout({
           />
         )}
         {title ? (
-          <header css={panelSectionCss}>
-            {titleLeft}
-            {titleRight}
+          <header
+            css={[
+              panelSectionCss,
+              resetFlexRowCss,
+              {alignItems: 'center', marginRight: 'var(--space100)'},
+            ]}
+          >
             <h1 css={[buttonCss]}>{title}</h1>
+            {titleRight}
           </header>
         ) : null}
       </span>

--- a/static/app/components/devtoolbar/components/panelLayout.tsx
+++ b/static/app/components/devtoolbar/components/panelLayout.tsx
@@ -1,25 +1,58 @@
+import {css} from '@emotion/react';
+
+import useConfiguration from 'sentry/components/devtoolbar/hooks/useConfiguration';
 import {buttonCss} from 'sentry/components/devtoolbar/styles/typography';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
+import type {PlatformKey} from 'sentry/types/project';
 
 import {panelCss, panelHeadingCss, panelSectionCss} from '../styles/panel';
 import {resetDialogCss, resetFlexColumnCss} from '../styles/reset';
 
 interface Props {
   children?: React.ReactNode;
+  showProjectBadge?: boolean;
   title?: string;
   titleLeft?: React.ReactNode;
   titleRight?: React.ReactNode;
 }
 
-export default function PanelLayout({children, title, titleLeft, titleRight}: Props) {
+export default function PanelLayout({
+  children,
+  title,
+  titleLeft,
+  titleRight,
+  showProjectBadge,
+}: Props) {
+  const {projectId, projectSlug, projectPlatform} = useConfiguration();
   return (
     <dialog open css={[resetDialogCss, resetFlexColumnCss, panelCss]}>
-      {title ? (
-        <header css={panelSectionCss}>
-          {titleLeft}
-          {titleRight}
-          <h1 css={[buttonCss, panelHeadingCss]}>{title}</h1>
-        </header>
-      ) : null}
+      <span
+        css={[
+          {display: 'flex', alignItems: 'center', gap: 'var(--space100)'},
+          panelHeadingCss,
+        ]}
+      >
+        {showProjectBadge && (
+          <ProjectBadge
+            css={css({'&& img': {boxShadow: 'none'}})}
+            project={{
+              slug: projectSlug,
+              id: projectId,
+              platform: projectPlatform as PlatformKey,
+            }}
+            avatarSize={16}
+            hideName
+            avatarProps={{hasTooltip: false}}
+          />
+        )}
+        {title ? (
+          <header css={panelSectionCss}>
+            {titleLeft}
+            {titleRight}
+            <h1 css={[buttonCss]}>{title}</h1>
+          </header>
+        ) : null}
+      </span>
       <section css={resetFlexColumnCss} style={{contain: 'strict'}}>
         {children}
       </section>

--- a/static/app/components/devtoolbar/components/releases/releasesPanel.tsx
+++ b/static/app/components/devtoolbar/components/releases/releasesPanel.tsx
@@ -192,7 +192,7 @@ export default function ReleasesPanel() {
   }
 
   return (
-    <PanelLayout title="Latest Release">
+    <PanelLayout title="Latest Release" showProjectBadge>
       <AnalyticsProvider nameVal="header" keyVal="header">
         <span
           css={[

--- a/static/app/components/devtoolbar/components/replay/replayPanel.tsx
+++ b/static/app/components/devtoolbar/components/replay/replayPanel.tsx
@@ -36,7 +36,7 @@ export default function ReplayPanel() {
   const {eventName, eventKey} = useContext(AnalyticsContext);
   const [buttonLoading, setButtonLoading] = useState(false);
   return (
-    <PanelLayout title="Session Replay">
+    <PanelLayout title="Session Replay" showProjectBadge>
       <Button
         size="sm"
         icon={isDisabled ? undefined : isRecordingSession ? <IconPause /> : <IconPlay />}

--- a/static/app/components/devtoolbar/styles/panel.ts
+++ b/static/app/components/devtoolbar/styles/panel.ts
@@ -12,8 +12,9 @@ export const panelCss = css`
 `;
 
 export const panelHeadingCss = css`
-  margin: 0;
-  text-align: center;
+  padding: 0 0 0 var(--space200);
+  text-align: left;
+  border-bottom: 1px solid var(--gray200);
 `;
 
 export const panelHeadingLeftCss = css`
@@ -28,7 +29,7 @@ export const panelHeadingRightCss = css`
 
 export const panelSectionCss = css`
   position: relative;
-  padding-block: var(--space100);
+  padding-block: var(--space75);
   &:not(:last-child) {
     border-bottom: 1px solid var(--gray200);
   }
@@ -36,4 +37,12 @@ export const panelSectionCss = css`
 
 export const panelInsetContentCss = css`
   padding-inline: var(--space150);
+`;
+
+export const panelDescCss = css`
+  color: var(--gray300);
+  font-weight: bold;
+  margin: 0 var(--space150);
+  text-align: left;
+  padding-top: var(--space200);
 `;


### PR DESCRIPTION
- relates to https://github.com/getsentry/sentry/issues/75636
- some initial changes to kick off the toolbar css updates. main changes are 
    - updating the header to be left aligned
    - adding project badge for all panels besides the FF panel
    - updating description css for feedback/issues panel (grey + bold)
    - removing the alerts description
    - also, transaction URLs are removed for feedback/issues
    - change feedback + button to say "report bug"


https://github.com/user-attachments/assets/6dd90d02-1ed4-4cca-a2e3-cea428223e19

<img width="295" alt="SCR-20240813-kdov" src="https://github.com/user-attachments/assets/3132f4a2-c583-42d2-9d4c-4354c159ace0">

