### PR TITLE
feat(remix-onboarding): Remove next steps

### DIFF
--- a/static/app/gettingStartedDocs/javascript/remix.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript/remix.spec.tsx
@@ -11,7 +11,6 @@ describe('javascript-remix onboarding docs', function () {
     // Renders main headings
     expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
-    expect(screen.getByRole('heading', {name: 'Next Steps'})).toBeInTheDocument();
 
     // Includes minimum required Astro version
     expect(screen.getByText(textWithMarkupMatcher(/Remix 1.0.0/))).toBeInTheDocument();

--- a/static/app/gettingStartedDocs/javascript/remix.tsx
+++ b/static/app/gettingStartedDocs/javascript/remix.tsx
@@ -121,24 +121,7 @@ const onboarding: OnboardingConfig = {
     },
   ],
   verify: () => [],
-  nextSteps: () => [
-    {
-      id: 'performance-monitoring',
-      name: t('Performance Monitoring'),
-      description: t(
-        'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/remix/tracing/',
-    },
-    {
-      id: 'session-replay',
-      name: t('Session Replay'),
-      description: t(
-        'Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/remix/session-replay/',
-    },
-  ],
+  nextSteps: () => [],
 };
 
 const replayOnboarding: OnboardingConfig = {


### PR DESCRIPTION
The remix onboarding uses the sentry wizard, which already sets up performance monitoring and session replay.
Displaying those as next steps only creates confusion.