### PR TITLE
ref(js): Remove ActionButton

### DIFF
--- a/static/app/components/actions/actionLink.tsx
+++ b/static/app/components/actions/actionLink.tsx
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 
-import ActionButton from './button';
+import {Button} from 'sentry/components/button';
+
 import ConfirmableAction from './confirmableAction';
 
 const StyledAction = styled('a')<{disabled?: boolean}>`
@@ -10,7 +11,7 @@ const StyledAction = styled('a')<{disabled?: boolean}>`
   ${p => p.disabled && 'cursor: not-allowed;'}
 `;
 
-const StyledActionButton = styled(ActionButton)<{
+const StyledButton = styled(Button)<{
   disabled?: boolean;
   hasDropdown?: boolean;
 }>`
@@ -39,7 +40,7 @@ type CommonProps = Omit<
 
 type Props = CommonProps &
   ({type?: 'button'} & Partial<
-    Omit<React.ComponentProps<typeof StyledActionButton>, 'as' | 'children'>
+    Omit<React.ComponentProps<typeof StyledButton>, 'as' | 'children' | 'ref'>
   >);
 
 export default function ActionLink({
@@ -65,7 +66,7 @@ export default function ActionLink({
 
   const action =
     type === 'button' ? (
-      <StyledActionButton {...actionCommonProps} />
+      <StyledButton size="xs" {...actionCommonProps} />
     ) : (
       <StyledAction {...actionCommonProps} />
     );

--- a/static/app/components/actions/button.tsx
+++ b/static/app/components/actions/button.tsx
@@ -1,8 +1,0 @@
-import type {ButtonProps} from 'sentry/components/button';
-import {Button} from 'sentry/components/button';
-
-function ActionButton(props: ButtonProps): React.ReactElement {
-  return <Button size="xs" {...props} />;
-}
-
-export default ActionButton;

--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/candidate/actions.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/candidate/actions.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 
 import Access from 'sentry/components/acl/access';
 import {Role} from 'sentry/components/acl/role';
-import ActionButton from 'sentry/components/actions/button';
 import MenuItemActionLink from 'sentry/components/actions/menuItemActionLink';
 import {Button, LinkButton} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
@@ -63,7 +62,8 @@ function Actions({
               <StyledDropdownLink
                 caret={false}
                 customTitle={
-                  <ActionButton
+                  <Button
+                    size="xs"
                     aria-label={t('Actions')}
                     disabled={deleted}
                     icon={<IconEllipsis />}

--- a/static/app/components/feedback/feedbackItem/feedbackActions.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackActions.tsx
@@ -1,7 +1,7 @@
 import type {CSSProperties} from 'react';
 import {Fragment} from 'react';
 
-import Button from 'sentry/components/actions/button';
+import {Button} from 'sentry/components/button';
 import {Flex} from 'sentry/components/container/flex';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -53,13 +53,17 @@ function LargeWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
 
   return (
     <Fragment>
-      <Button priority={isResolved ? 'danger' : 'primary'} onClick={onResolveClick}>
+      <Button
+        size="xs"
+        priority={isResolved ? 'danger' : 'primary'}
+        onClick={onResolveClick}
+      >
         {isResolved ? t('Unresolve') : t('Resolve')}
       </Button>
-      <Button priority="default" onClick={onSpamClick}>
+      <Button size="xs" priority="default" onClick={onSpamClick}>
         {isSpam ? t('Move to Inbox') : t('Mark as Spam')}
       </Button>
-      <Button onClick={onMarkAsReadClick}>
+      <Button size="xs" onClick={onMarkAsReadClick}>
         {hasSeen ? t('Mark Unread') : t('Mark Read')}
       </Button>
     </Fragment>
@@ -72,7 +76,11 @@ function MediumWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
 
   return (
     <Fragment>
-      <Button priority={isResolved ? 'danger' : 'primary'} onClick={onResolveClick}>
+      <Button
+        size="xs"
+        priority={isResolved ? 'danger' : 'primary'}
+        onClick={onResolveClick}
+      >
         {isResolved ? t('Unresolve') : t('Resolve')}
       </Button>
 

--- a/static/app/components/feedback/list/feedbackListBulkSelection.tsx
+++ b/static/app/components/feedback/list/feedbackListBulkSelection.tsx
@@ -1,4 +1,4 @@
-import Button from 'sentry/components/actions/button';
+import {Button} from 'sentry/components/button';
 import {Flex} from 'sentry/components/container/flex';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -47,12 +47,16 @@ export default function FeedbackListBulkSelection({
       </span>
       <Flex gap={space(1)} justify="flex-end">
         <ErrorBoundary mini>
-          <Button onClick={() => onToggleResovled({newMailbox: newMailboxResolve})}>
+          <Button
+            size="xs"
+            onClick={() => onToggleResovled({newMailbox: newMailboxResolve})}
+          >
             {mailbox === 'resolved' ? t('Unresolve') : t('Resolve')}
           </Button>
         </ErrorBoundary>
         <ErrorBoundary mini>
           <Button
+            size="xs"
             onClick={() =>
               onToggleResovled({
                 newMailbox: newMailboxSpam,

--- a/static/app/components/modals/debugFileCustomRepository/http.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/http.tsx
@@ -2,7 +2,6 @@ import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import ActionButton from 'sentry/components/actions/button';
 import {Button} from 'sentry/components/button';
 import FieldGroup from 'sentry/components/forms/fieldGroup';
 import SelectField from 'sentry/components/forms/fields/selectField';
@@ -265,7 +264,7 @@ const PasswordInput = styled(Input)`
     p.theme.formPadding.md.paddingRight + CLEAR_PASSWORD_BUTTON_SIZE}px;
 `;
 
-const ClearPasswordButton = styled(ActionButton)`
+const ClearPasswordButton = styled(Button)`
   background: transparent;
   height: ${CLEAR_PASSWORD_BUTTON_SIZE}px;
   width: ${CLEAR_PASSWORD_BUTTON_SIZE}px;

--- a/static/app/views/integrationPipeline/awsLambdaCloudformation.tsx
+++ b/static/app/views/integrationPipeline/awsLambdaCloudformation.tsx
@@ -4,7 +4,7 @@ import debounce from 'lodash/debounce';
 import * as qs from 'query-string';
 
 import {addErrorMessage, addLoadingMessage} from 'sentry/actionCreators/indicator';
-import Button from 'sentry/components/actions/button';
+import {Button} from 'sentry/components/button';
 import SelectField from 'sentry/components/forms/fields/selectField';
 import TextField from 'sentry/components/forms/fields/textField';
 import List from 'sentry/components/list';
@@ -200,6 +200,7 @@ export default class AwsLambdaCloudformation extends Component<Props, State> {
           <ListItem>
             <h3>{t("Add Sentry's CloudFormation")}</h3>
             <StyledButton
+              size="xs"
               priority="primary"
               onClick={this.trackOpenCloudFormation}
               external

--- a/static/app/views/integrationPipeline/components/footerWithButtons.tsx
+++ b/static/app/views/integrationPipeline/components/footerWithButtons.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
-import Button from 'sentry/components/actions/button';
 import type {ButtonProps} from 'sentry/components/button';
+import {Button} from 'sentry/components/button';
 import {space} from 'sentry/styles/space';
 
 interface FooterWithButtonsProps

--- a/static/app/views/integrationPipeline/components/headerWithHelp.tsx
+++ b/static/app/views/integrationPipeline/components/headerWithHelp.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import Button from 'sentry/components/actions/button';
+import {Button} from 'sentry/components/button';
 import LogoSentry from 'sentry/components/logoSentry';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -11,7 +11,6 @@ import type {Client} from 'sentry/api';
 import Feature from 'sentry/components/acl/feature';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import ArchiveActions, {getArchiveActions} from 'sentry/components/actions/archive';
-import ActionButton from 'sentry/components/actions/button';
 import ResolveActions from 'sentry/components/actions/resolve';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import {Button} from 'sentry/components/button';
@@ -373,7 +372,7 @@ export function Actions(props: Props) {
               {isResolved ? t('Resolved') : t('Archived')}
             </ResolvedWrapper>
             <Divider />
-            <ActionButton
+            <Button
               size="sm"
               disabled={disabled || isAutoResolved}
               onClick={() =>
@@ -387,7 +386,7 @@ export function Actions(props: Props) {
               }
             >
               {isResolved ? t('Unresolve') : t('Unarchive')}
-            </ActionButton>
+            </Button>
           </ResolvedActionWapper>
         ) : (
           <Fragment>
@@ -530,7 +529,7 @@ export function Actions(props: Props) {
               features="discover-basic"
               organization={organization}
             >
-              <ActionButton
+              <Button
                 className="hidden-xs"
                 disabled={disabled}
                 to={disabled ? '' : getDiscoverUrl()}
@@ -540,11 +539,11 @@ export function Actions(props: Props) {
                 <GuideAnchor target="open_in_discover">
                   {t('Open in Discover')}
                 </GuideAnchor>
-              </ActionButton>
+              </Button>
             </Feature>
           )}
           {isResolved || isIgnored ? (
-            <ActionButton
+            <Button
               priority="primary"
               title={
                 isAutoResolved
@@ -564,7 +563,7 @@ export function Actions(props: Props) {
               }
             >
               {isIgnored ? t('Archived') : t('Resolved')}
-            </ActionButton>
+            </Button>
           ) : (
             <Fragment>
               <ArchiveActions

--- a/static/app/views/issueDetails/actions/subscribeAction.tsx
+++ b/static/app/views/issueDetails/actions/subscribeAction.tsx
@@ -1,4 +1,4 @@
-import ActionButton from 'sentry/components/actions/button';
+import {Button} from 'sentry/components/button';
 import {IconSubscribed} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
@@ -30,7 +30,7 @@ function SubscribeAction({
   const disabledNotifications = group.subscriptionDetails?.disabled ?? false;
 
   return (
-    <ActionButton
+    <Button
       className={className}
       disabled={disabled || disabledNotifications}
       title={getSubscriptionReason(group)}

--- a/static/app/views/settings/account/apiApplications/details.tsx
+++ b/static/app/views/settings/account/apiApplications/details.tsx
@@ -4,8 +4,8 @@ import styled from '@emotion/styled';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {openModal} from 'sentry/actionCreators/modal';
-import Button from 'sentry/components/actions/button';
 import {Alert} from 'sentry/components/alert';
+import {Button} from 'sentry/components/button';
 import Confirm from 'sentry/components/confirm';
 import Form from 'sentry/components/forms/form';
 import FormField from 'sentry/components/forms/formField';
@@ -113,7 +113,9 @@ class ApiApplicationsDetails extends DeprecatedAsyncView<Props, State> {
                           'Are you sure you want to rotate the client secret? The current one will not be usable anymore, and this cannot be undone.'
                         )}
                       >
-                        <Button priority="danger">Rotate client secret</Button>
+                        <Button size="xs" priority="danger">
+                          Rotate client secret
+                        </Button>
                       </Confirm>
                     </ClientSecret>
                   )

--- a/static/app/views/settings/projectDebugFiles/sources/customRepositories/actions.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/customRepositories/actions.tsx
@@ -1,7 +1,6 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import ActionButton from 'sentry/components/actions/button';
 import MenuItemActionLink from 'sentry/components/actions/menuItemActionLink';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
@@ -106,7 +105,8 @@ function Actions({
           caret={false}
           disabled={actionsDisabled}
           customTitle={
-            <StyledActionButton
+            <StyledButton
+              size="xs"
               aria-label={t('Actions')}
               disabled={actionsDisabled}
               title={
@@ -133,7 +133,7 @@ function Actions({
 
 export default Actions;
 
-const StyledActionButton = styled(ActionButton)`
+const StyledButton = styled(Button)`
   height: 32px;
 `;
 


### PR DESCRIPTION
This was intended to just be used within `components/actions` but
likely because of the filename it was imported and used in a number of
places as just `Button`.

It only set `size="xs"` so we can just replace all usages with regular
button and set size="xs" when appropriate (most usages were already
setting size anyway).