### PR TITLE
chore(performance): Use search query builder for spans pages

### DIFF
--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -110,7 +110,7 @@ export function SpanSearchQueryBuilder({
       getTagValues={getSpanFilterTagValues}
       disallowFreeText
       disallowUnsupportedFilters
-      recentSearches={SavedSearchType.EVENT}
+      recentSearches={SavedSearchType.SPAN}
     />
   );
 }

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryTable.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useCallback, useMemo} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
@@ -7,6 +7,7 @@ import SearchBar from 'sentry/components/events/searchBar';
 import type {GridColumnHeader} from 'sentry/components/gridEditable';
 import GridEditable, {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import Pagination, {type CursorHandler} from 'sentry/components/pagination';
+import {SpanSearchQueryBuilder} from 'sentry/components/performance/spanSearchQueryBuilder';
 import {ROW_HEIGHT, ROW_PADDING} from 'sentry/components/performance/waterfall/constants';
 import PerformanceDuration from 'sentry/components/performanceDuration';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -109,7 +110,7 @@ export default function SpanSummaryTable(props: Props) {
   const location = useLocation();
   const {transaction} = location.query;
   const spansCursor = decodeScalar(location.query?.[QueryParameterNames.SPANS_CURSOR]);
-  const spansQuery = decodeScalar(location.query.spansQuery);
+  const spansQuery = decodeScalar(location.query.spansQuery, '');
 
   const filters: SpanMetricsQueryFilters = {
     'span.group': groupId,
@@ -118,7 +119,7 @@ export default function SpanSummaryTable(props: Props) {
   };
 
   const sort = useSpanSummarySort();
-  const spanSearchString = new MutableSearch(spansQuery ?? '').formatString();
+  const spanSearchString = new MutableSearch(spansQuery).formatString();
   const search = MutableSearch.fromQueryObject(filters);
   search.addStringMultiFilter(spanSearchString);
 
@@ -209,28 +210,43 @@ export default function SpanSummaryTable(props: Props) {
     });
   };
 
-  const handleSearch = (searchString: string) => {
-    navigate({
-      ...location,
-      query: {
-        ...location.query,
-        spansQuery: new MutableSearch(searchString).formatString(),
-      },
-    });
-  };
+  const handleSearch = useCallback(
+    (searchString: string) => {
+      navigate({
+        ...location,
+        query: {
+          ...location.query,
+          spansQuery: new MutableSearch(searchString).formatString(),
+        },
+      });
+    },
+    [location, navigate]
+  );
+  const projectIds = useMemo(() => eventView.project.slice(), [eventView]);
 
   return (
     <Fragment>
-      <StyledSearchBar
-        organization={organization}
-        projectIds={eventView.project}
-        query={spansQuery}
-        fields={eventView.fields}
-        placeholder={t('Search for span attributes')}
-        supportedTags={supportedTags}
-        dataset={DiscoverDatasets.SPANS_INDEXED}
-        onSearch={handleSearch}
-      />
+      <StyledSearchBarWrapper>
+        {organization.features.includes('search-query-builder-performance') ? (
+          <SpanSearchQueryBuilder
+            projects={projectIds}
+            initialQuery={spansQuery}
+            onSearch={handleSearch}
+            searchSource="transaction_span_summary"
+          />
+        ) : (
+          <SearchBar
+            organization={organization}
+            projectIds={eventView.project}
+            query={spansQuery}
+            fields={eventView.fields}
+            placeholder={t('Search for span attributes')}
+            supportedTags={supportedTags}
+            dataset={DiscoverDatasets.SPANS_INDEXED}
+            onSearch={handleSearch}
+          />
+        )}
+      </StyledSearchBarWrapper>
       <VisuallyCompleteWithData
         id="SpanDetails-SpanDetailsTable"
         hasData={!!mergedData?.length}
@@ -355,6 +371,6 @@ const EmptySpanDurationBar = styled('div')`
   line-height: 1;
 `;
 
-const StyledSearchBar = styled(SearchBar)`
+const StyledSearchBarWrapper = styled('div')`
   margin-bottom: ${space(2)};
 `;


### PR DESCRIPTION
This ports the spans pages within performance to use the new search query builder UX.