### PR TITLE
fix(insights): Use correct mobile screens feature flag

### DIFF
--- a/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
+++ b/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
@@ -37,6 +37,7 @@ import {Referrer} from 'sentry/views/insights/mobile/screens/referrers';
 import {
   MODULE_DESCRIPTION,
   MODULE_DOC_LINK,
+  MODULE_FEATURE,
   MODULE_TITLE,
 } from 'sentry/views/insights/mobile/screens/settings';
 import {
@@ -221,10 +222,7 @@ export function ScreensLandingPage() {
   };
 
   return (
-    <ModulePageProviders
-      moduleName="mobile-screens"
-      features={['insights-addon-modules']}
-    >
+    <ModulePageProviders moduleName="mobile-screens" features={[MODULE_FEATURE]}>
       <Layout.Page>
         <PageAlertProvider>
           <Layout.Header>


### PR DESCRIPTION
The sidebar already uses the `'insights-mobile-screens-module'` feature flag, let's apply the same on the module landing page too.
