### PR TITLE
chore(billing): Remove extra query on RangeQuerySetWrapper

### DIFF
--- a/src/sentry/utils/query.py
+++ b/src/sentry/utils/query.py
@@ -184,6 +184,10 @@ class RangeQuerySetWrapper:
             if cur_value is None:
                 break
 
+            if len(results) < self.step:
+                # we do  not have enough results to completely fill out the current step/page
+                break
+
             has_results = num > start
 
 

--- a/tests/sentry/utils/test_query.py
+++ b/tests/sentry/utils/test_query.py
@@ -60,7 +60,9 @@ class RangeQuerySetWrapperTest(TestCase):
             expected.append(email)
 
         qs = User.objects.all()
-        next_id = qs.order_by("id").first().id
+        first = qs.order_by("id").first()
+        assert first
+        next_id = first.id
 
         with CaptureQueriesContext(connections[router.db_for_read(User)]) as context:
             results = list(self.range_wrapper(qs, step=3))
@@ -154,7 +156,9 @@ class RangeQuerySetWrapperWithProgressBarTest(RangeQuerySetWrapperTest):
             expected.append(email)
 
         qs = User.objects.all()
-        next_id = qs.order_by("id").first().id
+        first = qs.order_by("id").first()
+        assert first
+        next_id = first.id
 
         with CaptureQueriesContext(connections[router.db_for_read(User)]) as context:
             results = list(self.range_wrapper(qs, step=3))
@@ -194,7 +198,9 @@ class RangeQuerySetWrapperWithProgressBarApproxTest(RangeQuerySetWrapperTest):
             expected.append(email)
 
         qs = User.objects.all()
-        next_id = qs.order_by("id").first().id
+        first = qs.order_by("id").first()
+        assert first
+        next_id = first.id
 
         with CaptureQueriesContext(connections[router.db_for_read(User)]) as context:
             results = list(self.range_wrapper(qs, step=3))

--- a/tests/sentry/utils/test_query.py
+++ b/tests/sentry/utils/test_query.py
@@ -1,7 +1,5 @@
-import re
-
 import pytest
-from django.db import connections, router, transaction
+from django.db import connections, router
 from django.test.utils import CaptureQueriesContext
 
 from sentry.db.models.query import in_iexact


### PR DESCRIPTION
While looking at https://github.com/getsentry/getsentry/pull/14901, `RangeQuerySetWrapper` will emit one extra unnecessary query when the length of the current results is less than `step`. 