### PR TITLE
chore(hybridcloud) Add sentryapp RPC for use in ratelimiting

### DIFF
--- a/src/sentry/sentry_apps/services/app/impl.py
+++ b/src/sentry/sentry_apps/services/app/impl.py
@@ -76,6 +76,17 @@ class DatabaseBackedAppService(AppService):
         except SentryAppInstallation.DoesNotExist:
             return None
 
+    def get_installation_org_id_by_token_id(self, token_id: int) -> int | None:
+        filters: SentryAppInstallationFilterArgs = {
+            "status": SentryAppInstallationStatus.INSTALLED,
+            "api_installation_token_id": str(token_id),
+        }
+        queryset = self._FQ.apply_filters(SentryAppInstallation.objects.all(), filters)
+        install = queryset.first()
+        if not install:
+            return None
+        return install.organization_id
+
     def get_sentry_app_by_slug(self, *, slug: str) -> RpcSentryApp | None:
         try:
             sentry_app = SentryApp.objects.get(slug=slug)

--- a/src/sentry/sentry_apps/services/app/service.py
+++ b/src/sentry/sentry_apps/services/app/service.py
@@ -94,6 +94,16 @@ class AppService(RpcService):
 
     @rpc_method
     @abc.abstractmethod
+    def get_installation_org_id_by_token_id(self, token_id: int) -> int | None:
+        """
+        Get the organization id for an installation by installation token_id
+
+        This is a specialized RPC call used by ratelimit middleware
+        """
+        pass
+
+    @rpc_method
+    @abc.abstractmethod
     def get_installation_token(self, *, organization_id: int, provider: str) -> str | None:
         pass
 


### PR DESCRIPTION
Within ratelimiting we need to resolve the organization id from the installation's api_token.id. Currently this involves fetching the installation, app, and api token across RPC. From this result we only use the `organization_id`. Having a dedicated RPC method means we can trim out db queries to load the sentryapp, apiapplication, and serialize a much smaller result.

By fetching and serializing less data, I'm hoping to see an improvement in this trace segment:

![Screenshot 2024-08-13 at 12 37 29 PM](https://github.com/user-attachments/assets/21424025-7336-4888-af27-311dbbe16c6d)