### PR TITLE
fix(insights): fix sample panel padding

### DIFF
--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
@@ -278,4 +278,5 @@ const Title = styled('h4')`
 
 const StyledSearchBar = styled(SearchBar)`
   margin-top: ${space(2)};
+  margin-bottom: ${space(2)};
 `;

--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
@@ -277,6 +277,5 @@ const Title = styled('h4')`
 `;
 
 const StyledSearchBar = styled(SearchBar)`
-  margin-top: ${space(2)};
-  margin-bottom: ${space(2)};
+  margin: ${space(2)} 0;
 `;


### PR DESCRIPTION
Fixes spacing on sample panel:
<img width="747" alt="image" src="https://github.com/user-attachments/assets/3458c76d-5424-47a4-b36f-4a5657d30683">
