### PR TITLE
ref(ui): Simplify eventAttachmentActions

### DIFF
--- a/static/app/components/events/eventAttachmentActions.tsx
+++ b/static/app/components/events/eventAttachmentActions.tsx
@@ -1,11 +1,8 @@
-import styled from '@emotion/styled';
-
-import {Button} from 'sentry/components/button';
+import {Button, LinkButton} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import Confirm from 'sentry/components/confirm';
 import {IconDelete, IconDownload, IconShow} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 
 type Props = {
   attachmentId: string;
@@ -48,7 +45,7 @@ function EventAttachmentActions({
         />
       </Confirm>
 
-      <DownloadButton
+      <LinkButton
         size="xs"
         icon={<IconDownload />}
         href={url ? `${url}?download=1` : ''}
@@ -58,7 +55,7 @@ function EventAttachmentActions({
       />
 
       {withPreviewButton && (
-        <DownloadButton
+        <Button
           size="xs"
           disabled={!url || !hasPreview}
           priority={previewIsOpen ? 'primary' : 'default'}
@@ -73,14 +70,10 @@ function EventAttachmentActions({
           }
         >
           {t('Preview')}
-        </DownloadButton>
+        </Button>
       )}
     </ButtonBar>
   );
 }
-
-const DownloadButton = styled(Button)`
-  margin-right: ${space(0.5)};
-`;
 
 export default EventAttachmentActions;


### PR DESCRIPTION
Removes the additional margin and switches to LinkButton

Before

<img alt="clipboard.png" width="338" src="https://i.imgur.com/xRAPLkK.png" />

After

<img alt="clipboard.png" width="327" src="https://i.imgur.com/ZaTEnWD.png" />