### PR TITLE
ref(integrations): convert issue mixins to ABCs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,7 +262,6 @@ module = [
     "sentry.integrations.jira_server.integration",
     "sentry.integrations.message_builder",
     "sentry.integrations.metric_alerts",
-    "sentry.integrations.mixins.issues",
     "sentry.integrations.mixins.notifications",
     "sentry.integrations.msteams.actions.form",
     "sentry.integrations.msteams.client",

--- a/src/sentry/integrations/api/endpoints/organization_integration_issues.py
+++ b/src/sentry/integrations/api/endpoints/organization_integration_issues.py
@@ -9,7 +9,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.integrations.api.bases.organization_integrations import (
     RegionOrganizationIntegrationBaseEndpoint,
 )
-from sentry.integrations.mixins import IssueSyncMixin
+from sentry.integrations.mixins.issues import IssueSyncIntegration
 from sentry.models.organization import Organization
 
 
@@ -35,7 +35,7 @@ class OrganizationIntegrationIssuesEndpoint(RegionOrganizationIntegrationBaseEnd
         """
         integration = self.get_integration(organization.id, integration_id)
         install = integration.get_installation(organization_id=organization.id)
-        if isinstance(install, IssueSyncMixin):
+        if isinstance(install, IssueSyncIntegration):
             install.migrate_issues()
             return Response(status=204)
         return Response(status=400)

--- a/src/sentry/integrations/api/serializers/models/integration.py
+++ b/src/sentry/integrations/api/serializers/models/integration.py
@@ -103,7 +103,7 @@ class IntegrationConfigSerializer(IntegrationSerializer):
 
             # Query param "action" only attached in TicketRuleForm modal.
             if self.params.get("action") == "create":
-                # This method comes from IssueBasicMixin within the integration's installation class
+                # This method comes from IssueBasicIntegration within the integration's installation class
                 data["createIssueConfig"] = install.get_create_issue_config(  # type: ignore[attr-defined]
                     None, user, params=self.params
                 )

--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -16,6 +16,7 @@ from sentry.integrations.base import (
 )
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.repository import RpcRepository, repository_service
+from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.integrations.tasks.migrate_repo import migrate_repo
 from sentry.integrations.utils import AtlassianConnectValidationError, get_integration_from_request
 from sentry.models.repository import Repository
@@ -25,7 +26,7 @@ from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.http import absolute_uri
 
 from .client import BitbucketApiClient
-from .issues import BitbucketSCMSpec
+from .issues import BitbucketIssuesSpec
 from .repository import BitbucketRepositoryProvider
 
 DESCRIPTION = """
@@ -81,7 +82,7 @@ metadata = IntegrationMetadata(
 scopes = ("issue:write", "pullrequest", "webhook", "repository")
 
 
-class BitbucketIntegration(BitbucketSCMSpec):
+class BitbucketIntegration(RepositoryIntegration, BitbucketIssuesSpec):
     @property
     def integration_name(self) -> str:
         return "bitbucket"

--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -16,7 +16,6 @@ from sentry.integrations.base import (
 )
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.repository import RpcRepository, repository_service
-from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.integrations.tasks.migrate_repo import migrate_repo
 from sentry.integrations.utils import AtlassianConnectValidationError, get_integration_from_request
 from sentry.models.repository import Repository
@@ -26,7 +25,7 @@ from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.http import absolute_uri
 
 from .client import BitbucketApiClient
-from .issues import BitbucketIssueBasicMixin
+from .issues import BitbucketSCMSpec
 from .repository import BitbucketRepositoryProvider
 
 DESCRIPTION = """
@@ -82,7 +81,7 @@ metadata = IntegrationMetadata(
 scopes = ("issue:write", "pullrequest", "webhook", "repository")
 
 
-class BitbucketIntegration(RepositoryIntegration, BitbucketIssueBasicMixin):
+class BitbucketIntegration(BitbucketSCMSpec):
     @property
     def integration_name(self) -> str:
         return "bitbucket"

--- a/src/sentry/integrations/bitbucket/issues.py
+++ b/src/sentry/integrations/bitbucket/issues.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from django.urls import reverse
 
-from sentry.integrations.mixins.issues import IssueBasicIntegration
+from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
 from sentry.models.group import Group
 from sentry.shared_integrations.exceptions import ApiError, IntegrationFormError
 from sentry.silo.base import all_silo_function
@@ -27,7 +27,7 @@ PRIORITIES = (
 )
 
 
-class BitbucketIssueBasicMixin(IssueBasicIntegration):
+class BitbucketSCMSpec(SourceCodeIssueIntegration):
     def get_issue_url(self, key: str) -> str:
         repo, issue_id = key.split("#")
         return f"https://bitbucket.org/{repo}/issues/{issue_id}"

--- a/src/sentry/integrations/bitbucket/issues.py
+++ b/src/sentry/integrations/bitbucket/issues.py
@@ -27,7 +27,7 @@ PRIORITIES = (
 )
 
 
-class BitbucketSCMSpec(SourceCodeIssueIntegration):
+class BitbucketIssuesSpec(SourceCodeIssueIntegration):
     def get_issue_url(self, key: str) -> str:
         repo, issue_id = key.split("#")
         return f"https://bitbucket.org/{repo}/issues/{issue_id}"

--- a/src/sentry/integrations/bitbucket/issues.py
+++ b/src/sentry/integrations/bitbucket/issues.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from django.urls import reverse
 
-from sentry.integrations.mixins import IssueBasicMixin
+from sentry.integrations.mixins.issues import IssueBasicIntegration
 from sentry.models.group import Group
 from sentry.shared_integrations.exceptions import ApiError, IntegrationFormError
 from sentry.silo.base import all_silo_function
@@ -27,7 +27,7 @@ PRIORITIES = (
 )
 
 
-class BitbucketIssueBasicMixin(IssueBasicMixin):
+class BitbucketIssueBasicMixin(IssueBasicIntegration):
     def get_issue_url(self, key: str) -> str:
         repo, issue_id = key.split("#")
         return f"https://bitbucket.org/{repo}/issues/{issue_id}"

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -18,7 +18,7 @@ from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration.serial import serialize_integration
 from sentry.integrations.services.repository.model import RpcRepository
-from sentry.integrations.source_code_management.repository import RepositoryIntegration
+from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
 from sentry.mediators.plugins.migrator import Migrator
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization import RpcOrganizationSummary
@@ -67,7 +67,7 @@ metadata = IntegrationMetadata(
 )
 
 
-class ExampleIntegration(RepositoryIntegration, IssueSyncIntegration):
+class ExampleIntegration(SourceCodeIssueIntegration, IssueSyncIntegration):
     comment_key = "sync_comments"
     outbound_status_key = "sync_status_outbound"
     inbound_status_key = "sync_status_inbound"

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -12,7 +12,8 @@ from sentry.integrations.base import (
     IntegrationMetadata,
     IntegrationProvider,
 )
-from sentry.integrations.mixins import IssueSyncMixin, ResolveSyncAction
+from sentry.integrations.mixins import ResolveSyncAction
+from sentry.integrations.mixins.issues import IssueSyncIntegration
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration.serial import serialize_integration
@@ -66,7 +67,7 @@ metadata = IntegrationMetadata(
 )
 
 
-class ExampleIntegration(RepositoryIntegration, IssueSyncMixin):
+class ExampleIntegration(RepositoryIntegration, IssueSyncIntegration):
     comment_key = "sync_comments"
     outbound_status_key = "sync_status_outbound"
     inbound_status_key = "sync_status_inbound"

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -19,6 +19,7 @@ from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration.serial import serialize_integration
 from sentry.integrations.services.repository.model import RpcRepository
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
+from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.mediators.plugins.migrator import Migrator
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization import RpcOrganizationSummary
@@ -67,7 +68,7 @@ metadata = IntegrationMetadata(
 )
 
 
-class ExampleIntegration(SourceCodeIssueIntegration, IssueSyncIntegration):
+class ExampleIntegration(RepositoryIntegration, SourceCodeIssueIntegration, IssueSyncIntegration):
     comment_key = "sync_comments"
     outbound_status_key = "sync_status_outbound"
     inbound_status_key = "sync_status_inbound"

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -28,7 +28,6 @@ from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.repository import RpcRepository, repository_service
 from sentry.integrations.source_code_management.commit_context import CommitContextIntegration
-from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.integrations.tasks.migrate_repo import migrate_repo
 from sentry.integrations.utils.code_mapping import RepoTree
 from sentry.models.repository import Repository
@@ -42,7 +41,7 @@ from sentry.utils.http import absolute_uri
 from sentry.web.helpers import render_to_response
 
 from .client import GitHubApiClient, GitHubBaseClient
-from .issues import GitHubIssueBasic
+from .issues import GitHubSCMSpec
 from .repository import GitHubRepositoryProvider
 
 logger = logging.getLogger("sentry.integrations.github")
@@ -156,7 +155,7 @@ def get_document_origin(org) -> str:
 # https://docs.github.com/en/rest/overview/endpoints-available-for-github-apps
 
 
-class GitHubIntegration(RepositoryIntegration, CommitContextIntegration, GitHubIssueBasic):  # type: ignore[misc]
+class GitHubIntegration(GitHubSCMSpec, CommitContextIntegration):
     codeowners_locations = ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"]
 
     @property

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -28,6 +28,7 @@ from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.repository import RpcRepository, repository_service
 from sentry.integrations.source_code_management.commit_context import CommitContextIntegration
+from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.integrations.tasks.migrate_repo import migrate_repo
 from sentry.integrations.utils.code_mapping import RepoTree
 from sentry.models.repository import Repository
@@ -41,7 +42,7 @@ from sentry.utils.http import absolute_uri
 from sentry.web.helpers import render_to_response
 
 from .client import GitHubApiClient, GitHubBaseClient
-from .issues import GitHubSCMSpec
+from .issues import GitHubIssuesSpec
 from .repository import GitHubRepositoryProvider
 
 logger = logging.getLogger("sentry.integrations.github")
@@ -155,7 +156,7 @@ def get_document_origin(org) -> str:
 # https://docs.github.com/en/rest/overview/endpoints-available-for-github-apps
 
 
-class GitHubIntegration(GitHubSCMSpec, CommitContextIntegration):
+class GitHubIntegration(RepositoryIntegration, GitHubIssuesSpec, CommitContextIntegration):
     codeowners_locations = ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"]
 
     @property

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -21,7 +21,7 @@ from sentry.utils.http import absolute_uri
 from sentry.utils.strings import truncatechars
 
 
-class GitHubSCMSpec(SourceCodeIssueIntegration):
+class GitHubIssuesSpec(SourceCodeIssueIntegration):
     def make_external_key(self, data: Mapping[str, Any]) -> str:
         return "{}#{}".format(data["repo"], data["key"])
 

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -8,8 +8,9 @@ from typing import Any
 from django.urls import reverse
 
 from sentry.eventstore.models import Event, GroupEvent
-from sentry.integrations.mixins.issues import MAX_CHAR, IssueBasicIntegration
+from sentry.integrations.mixins.issues import MAX_CHAR
 from sentry.integrations.models.external_issue import ExternalIssue
+from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import Group
 from sentry.organizations.services.organization.service import organization_service
@@ -20,7 +21,7 @@ from sentry.utils.http import absolute_uri
 from sentry.utils.strings import truncatechars
 
 
-class GitHubIssueBasic(IssueBasicIntegration):
+class GitHubSCMSpec(SourceCodeIssueIntegration):
     def make_external_key(self, data: Mapping[str, Any]) -> str:
         return "{}#{}".format(data["repo"], data["key"])
 

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -8,7 +8,7 @@ from typing import Any
 from django.urls import reverse
 
 from sentry.eventstore.models import Event, GroupEvent
-from sentry.integrations.mixins.issues import MAX_CHAR, IssueBasicMixin
+from sentry.integrations.mixins.issues import MAX_CHAR, IssueBasicIntegration
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import Group
@@ -20,7 +20,7 @@ from sentry.utils.http import absolute_uri
 from sentry.utils.strings import truncatechars
 
 
-class GitHubIssueBasic(IssueBasicMixin):
+class GitHubIssueBasic(IssueBasicIntegration):
     def make_external_key(self, data: Mapping[str, Any]) -> str:
         return "{}#{}".format(data["repo"], data["key"])
 

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -18,11 +18,12 @@ from sentry.integrations.base import (
     IntegrationMetadata,
 )
 from sentry.integrations.github.integration import GitHubIntegrationProvider, build_repository_query
-from sentry.integrations.github.issues import GitHubSCMSpec
+from sentry.integrations.github.issues import GitHubIssuesSpec
 from sentry.integrations.github.utils import get_jwt
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.repository.model import RpcRepository
 from sentry.integrations.source_code_management.commit_context import CommitContextIntegration
+from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization import RpcOrganizationSummary
 from sentry.pipeline import NestedPipelineView, PipelineView
@@ -130,7 +131,9 @@ API_ERRORS = {
 }
 
 
-class GitHubEnterpriseIntegration(GitHubSCMSpec, CommitContextIntegration):
+class GitHubEnterpriseIntegration(
+    RepositoryIntegration, GitHubIssuesSpec, CommitContextIntegration
+):
     codeowners_locations = ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"]
 
     @property

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -18,12 +18,11 @@ from sentry.integrations.base import (
     IntegrationMetadata,
 )
 from sentry.integrations.github.integration import GitHubIntegrationProvider, build_repository_query
-from sentry.integrations.github.issues import GitHubIssueBasic
+from sentry.integrations.github.issues import GitHubSCMSpec
 from sentry.integrations.github.utils import get_jwt
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.repository.model import RpcRepository
 from sentry.integrations.source_code_management.commit_context import CommitContextIntegration
-from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization import RpcOrganizationSummary
 from sentry.pipeline import NestedPipelineView, PipelineView
@@ -131,9 +130,7 @@ API_ERRORS = {
 }
 
 
-class GitHubEnterpriseIntegration(
-    RepositoryIntegration, GitHubIssueBasic, CommitContextIntegration
-):
+class GitHubEnterpriseIntegration(GitHubSCMSpec, CommitContextIntegration):
     codeowners_locations = ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"]
 
     @property

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -18,7 +18,6 @@ from sentry.integrations.base import (
 )
 from sentry.integrations.services.repository.model import RpcRepository
 from sentry.integrations.source_code_management.commit_context import CommitContextIntegration
-from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.models.identity import Identity
 from sentry.models.repository import Repository
 from sentry.pipeline import NestedPipelineView, PipelineView
@@ -32,7 +31,7 @@ from sentry.utils.http import absolute_uri
 from sentry.web.helpers import render_to_response
 
 from .client import GitLabApiClient, GitLabSetupApiClient
-from .issues import GitlabIssueBasic
+from .issues import GitlabSCMSpec
 from .repository import GitlabRepositoryProvider
 
 DESCRIPTION = """
@@ -92,7 +91,7 @@ metadata = IntegrationMetadata(
 )
 
 
-class GitlabIntegration(RepositoryIntegration, CommitContextIntegration, GitlabIssueBasic):
+class GitlabIntegration(GitlabSCMSpec, CommitContextIntegration):
     codeowners_locations = ["CODEOWNERS", ".gitlab/CODEOWNERS", "docs/CODEOWNERS"]
 
     def __init__(self, *args, **kwargs):

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -18,6 +18,7 @@ from sentry.integrations.base import (
 )
 from sentry.integrations.services.repository.model import RpcRepository
 from sentry.integrations.source_code_management.commit_context import CommitContextIntegration
+from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.models.identity import Identity
 from sentry.models.repository import Repository
 from sentry.pipeline import NestedPipelineView, PipelineView
@@ -31,7 +32,7 @@ from sentry.utils.http import absolute_uri
 from sentry.web.helpers import render_to_response
 
 from .client import GitLabApiClient, GitLabSetupApiClient
-from .issues import GitlabSCMSpec
+from .issues import GitlabIssuesSpec
 from .repository import GitlabRepositoryProvider
 
 DESCRIPTION = """
@@ -91,7 +92,7 @@ metadata = IntegrationMetadata(
 )
 
 
-class GitlabIntegration(GitlabSCMSpec, CommitContextIntegration):
+class GitlabIntegration(RepositoryIntegration, GitlabIssuesSpec, CommitContextIntegration):
     codeowners_locations = ["CODEOWNERS", ".gitlab/CODEOWNERS", "docs/CODEOWNERS"]
 
     def __init__(self, *args, **kwargs):

--- a/src/sentry/integrations/gitlab/issues.py
+++ b/src/sentry/integrations/gitlab/issues.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from django.urls import reverse
 
-from sentry.integrations.mixins import IssueBasicMixin
+from sentry.integrations.mixins.issues import IssueBasicIntegration
 from sentry.models.group import Group
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
 from sentry.silo.base import all_silo_function
@@ -16,7 +16,7 @@ from sentry.utils.http import absolute_uri
 ISSUE_EXTERNAL_KEY_FORMAT = re.compile(r".+:(.+)#(.+)")
 
 
-class GitlabIssueBasic(IssueBasicMixin):
+class GitlabIssueBasic(IssueBasicIntegration):
     def make_external_key(self, data):
         return "{}:{}".format(self.model.metadata["domain_name"], data["key"])
 

--- a/src/sentry/integrations/gitlab/issues.py
+++ b/src/sentry/integrations/gitlab/issues.py
@@ -16,7 +16,7 @@ from sentry.utils.http import absolute_uri
 ISSUE_EXTERNAL_KEY_FORMAT = re.compile(r".+:(.+)#(.+)")
 
 
-class GitlabSCMSpec(SourceCodeIssueIntegration):
+class GitlabIssuesSpec(SourceCodeIssueIntegration):
     def make_external_key(self, data):
         return "{}:{}".format(self.model.metadata["domain_name"], data["key"])
 

--- a/src/sentry/integrations/gitlab/issues.py
+++ b/src/sentry/integrations/gitlab/issues.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from django.urls import reverse
 
-from sentry.integrations.mixins.issues import IssueBasicIntegration
+from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
 from sentry.models.group import Group
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
 from sentry.silo.base import all_silo_function
@@ -16,7 +16,7 @@ from sentry.utils.http import absolute_uri
 ISSUE_EXTERNAL_KEY_FORMAT = re.compile(r".+:(.+)#(.+)")
 
 
-class GitlabIssueBasic(IssueBasicIntegration):
+class GitlabSCMSpec(SourceCodeIssueIntegration):
     def make_external_key(self, data):
         return "{}:{}".format(self.model.metadata["domain_name"], data["key"])
 

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -16,7 +16,6 @@ from sentry.eventstore.models import GroupEvent
 from sentry.integrations.base import (
     FeatureDescription,
     IntegrationFeatures,
-    IntegrationInstallation,
     IntegrationMetadata,
     IntegrationProvider,
 )
@@ -119,7 +118,7 @@ JIRA_CUSTOM_FIELD_TYPES = {
 }
 
 
-class JiraIntegration(IntegrationInstallation, IssueSyncIntegration):
+class JiraIntegration(IssueSyncIntegration):
     comment_key = "sync_comments"
     outbound_status_key = "sync_status_forward"
     inbound_status_key = "sync_status_reverse"

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -21,7 +21,7 @@ from sentry.integrations.base import (
     IntegrationProvider,
 )
 from sentry.integrations.jira.tasks import migrate_issues
-from sentry.integrations.mixins.issues import MAX_CHAR, IssueSyncMixin, ResolveSyncAction
+from sentry.integrations.mixins.issues import MAX_CHAR, IssueSyncIntegration, ResolveSyncAction
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration_external_project import IntegrationExternalProject
 from sentry.integrations.services.integration import integration_service
@@ -119,7 +119,7 @@ JIRA_CUSTOM_FIELD_TYPES = {
 }
 
 
-class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
+class JiraIntegration(IntegrationInstallation, IssueSyncIntegration):
     comment_key = "sync_comments"
     outbound_status_key = "sync_status_forward"
     inbound_status_key = "sync_status_reverse"
@@ -424,7 +424,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
 
     def get_issue(self, issue_id, **kwargs):
         """
-        Jira installation's implementation of IssueSyncMixin's `get_issue`.
+        Jira installation's implementation of IssueSyncIntegration's `get_issue`.
         """
         client = self.get_client()
         issue = client.get_issue(issue_id)

--- a/src/sentry/integrations/jira/utils/api.py
+++ b/src/sentry/integrations/jira/utils/api.py
@@ -12,7 +12,7 @@ from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.utils import sync_group_assignee_inbound
 from sentry.shared_integrations.exceptions import ApiError
 
-from ...mixins import IssueSyncMixin
+from ...mixins.issues import IssueSyncIntegration
 from ..client import JiraCloudClient
 
 logger = logging.getLogger(__name__)
@@ -93,7 +93,7 @@ def handle_status_change(integration, data):
     result = integration_service.organization_contexts(integration_id=integration.id)
     for oi in result.organization_integrations:
         install = integration.get_installation(organization_id=oi.organization_id)
-        if isinstance(install, IssueSyncMixin):
+        if isinstance(install, IssueSyncIntegration):
             install.sync_status_inbound(issue_key, {"changelog": changelog, "issue": data["issue"]})
 
 

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -21,7 +21,6 @@ from sentry import features
 from sentry.integrations.base import (
     FeatureDescription,
     IntegrationFeatures,
-    IntegrationInstallation,
     IntegrationMetadata,
     IntegrationProvider,
 )
@@ -269,7 +268,7 @@ JIRA_CUSTOM_FIELD_TYPES = {
 }
 
 
-class JiraServerIntegration(IntegrationInstallation, IssueSyncIntegration):
+class JiraServerIntegration(IssueSyncIntegration):
     """
     IntegrationInstallation implementation for Jira-Server
     """

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -27,7 +27,8 @@ from sentry.integrations.base import (
 )
 from sentry.integrations.jira.tasks import migrate_issues
 from sentry.integrations.jira_server.utils.choice import build_user_choice
-from sentry.integrations.mixins import IssueSyncMixin, ResolveSyncAction
+from sentry.integrations.mixins import ResolveSyncAction
+from sentry.integrations.mixins.issues import IssueSyncIntegration
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration_external_project import IntegrationExternalProject
 from sentry.integrations.services.integration import integration_service
@@ -268,7 +269,7 @@ JIRA_CUSTOM_FIELD_TYPES = {
 }
 
 
-class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
+class JiraServerIntegration(IntegrationInstallation, IssueSyncIntegration):
     """
     IntegrationInstallation implementation for Jira-Server
     """
@@ -544,7 +545,7 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
 
     def get_issue(self, issue_id, **kwargs):
         """
-        Jira installation's implementation of IssueSyncMixin's `get_issue`.
+        Jira installation's implementation of IssueSyncIntegration's `get_issue`.
         """
         client = self.get_client()
         issue = client.get_issue(issue_id)

--- a/src/sentry/integrations/mixins/__init__.py
+++ b/src/sentry/integrations/mixins/__init__.py
@@ -8,8 +8,6 @@ logic between providers.
 """
 
 __all__ = (
-    "IssueBasicMixin",
-    "IssueSyncMixin",
     "NotifyBasicMixin",
     "ResolveSyncAction",
     "ServerlessMixin",
@@ -17,7 +15,7 @@ __all__ = (
     "SUCCESS_UNLINKED_TEAM_TITLE",
 )
 
-from .issues import IssueBasicMixin, IssueSyncMixin, ResolveSyncAction
+from .issues import ResolveSyncAction
 from .notifications import (
     SUCCESS_UNLINKED_TEAM_MESSAGE,
     SUCCESS_UNLINKED_TEAM_TITLE,

--- a/src/sentry/integrations/mixins/issues.py
+++ b/src/sentry/integrations/mixins/issues.py
@@ -84,12 +84,14 @@ class IssueBasicIntegration(IntegrationInstallation, ABC):
         return "\n\n".join(result)
 
     def get_feedback_issue_body(self, event: GroupEvent) -> str:
-        messages = [
-            evidence for evidence in event.occurrence.evidence_display if evidence.name == "message"
-        ]
-        others = [
-            evidence for evidence in event.occurrence.evidence_display if evidence.name != "message"
-        ]
+        messages = []
+        others = []
+        if event.occurrence:
+            for evidence in event.occurrence.evidence_display:
+                if evidence.name == "message":
+                    messages.append(evidence)
+                else:
+                    others.append(evidence)
 
         body = ""
         for message in messages:

--- a/src/sentry/integrations/mixins/issues.py
+++ b/src/sentry/integrations/mixins/issues.py
@@ -10,6 +10,7 @@ from operator import attrgetter
 from typing import Any, ClassVar
 
 from sentry.eventstore.models import GroupEvent
+from sentry.integrations.base import IntegrationInstallation
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.tasks.sync_status_inbound import (
@@ -21,7 +22,6 @@ from sentry.models.group import Group
 from sentry.models.grouplink import GroupLink
 from sentry.models.project import Project
 from sentry.notifications.utils import get_notification_group_title
-from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.silo.base import all_silo_function
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
@@ -61,7 +61,7 @@ class ResolveSyncAction(enum.Enum):
         return ResolveSyncAction.NOOP
 
 
-class IssueBasicIntegration(ABC):
+class IssueBasicIntegration(IntegrationInstallation, ABC):
     def should_sync(self, attribute):
         return False
 
@@ -213,7 +213,7 @@ class IssueBasicIntegration(ABC):
               differentiation is made between the two field configs.
         """
         persisted_fields = self.get_persisted_default_config_fields()
-        if persisted_fields:
+        if persisted_fields and self.org_integration:
             project_defaults = {k: v for k, v in data.items() if k in persisted_fields}
             new_config = deepcopy(self.org_integration.config)
             new_config.setdefault("project_issue_defaults", {}).setdefault(
@@ -239,7 +239,13 @@ class IssueBasicIntegration(ABC):
                 )
 
     def get_defaults(self, project: Project, user: User):
-        project_defaults = self.get_project_defaults(project.id)
+        project_defaults = (
+            {}
+            if not self.org_integration
+            else self.org_integration.config.get("project_issue_defaults", {}).get(
+                str(project.id), {}
+            )
+        )
 
         user_option_value = get_option_from_list(
             user_option_service.get_many(
@@ -256,12 +262,6 @@ class IssueBasicIntegration(ABC):
         defaults.update(user_defaults)
 
         return defaults
-
-    # TODO(saif): Make private and move all usages over to `get_defaults`
-    def get_project_defaults(self, project_id):
-        return self.org_integration.config.get("project_issue_defaults", {}).get(
-            str(project_id), {}
-        )
 
     @abstractmethod
     def create_issue(self, data, **kwargs):
@@ -323,42 +323,6 @@ class IssueBasicIntegration(ABC):
         does not match the desired display name.
         """
         return ""
-
-    def get_repository_choices(self, group: Group | None, params: Mapping[str, Any], **kwargs):
-        """
-        Returns the default repository and a set/subset of repositories of associated with the installation
-        """
-        try:
-            repos = self.get_repositories()
-        except ApiError:
-            raise IntegrationError("Unable to retrieve repositories. Please try again later.")
-        else:
-            repo_choices = [(repo["identifier"], repo["name"]) for repo in repos]
-
-        defaults = self.get_project_defaults(group.project_id) if group else {}
-        repo = params.get("repo") or defaults.get("repo")
-
-        try:
-            default_repo = repo or repo_choices[0][0]
-        except IndexError:
-            return "", repo_choices
-
-        # If a repo has been selected outside of the default list of
-        # repos, stick it onto the front of the list so that it can be
-        # selected.
-        try:
-            next(True for r in repo_choices if r[0] == default_repo)
-        except StopIteration:
-            repo_choices.insert(0, self.create_default_repo_choice(default_repo))
-
-        return default_repo, repo_choices
-
-    def create_default_repo_choice(self, default_repo):
-        """
-        Helper method for get_repository_choices
-        Returns the choice for the default repo in a tuple to be added to the list of repository choices
-        """
-        return (default_repo, default_repo)
 
     def get_annotations_for_group_list(self, group_list):
         group_links = GroupLink.objects.filter(

--- a/src/sentry/integrations/source_code_management/issues.py
+++ b/src/sentry/integrations/source_code_management/issues.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from abc import ABC
+from collections.abc import Mapping
+from typing import Any
+
+from sentry.integrations.mixins.issues import IssueBasicIntegration
+from sentry.integrations.source_code_management.repository import RepositoryIntegration
+from sentry.models.group import Group
+from sentry.shared_integrations.exceptions import ApiError, IntegrationError
+
+
+class SourceCodeIssueIntegration(IssueBasicIntegration, RepositoryIntegration, ABC):
+    def get_repository_choices(self, group: Group | None, params: Mapping[str, Any], **kwargs):
+        """
+        Returns the default repository and a set/subset of repositories of associated with the installation
+        """
+        try:
+            repos = self.get_repositories()
+        except ApiError:
+            raise IntegrationError("Unable to retrieve repositories. Please try again later.")
+        else:
+            repo_choices = [(repo["identifier"], repo["name"]) for repo in repos]
+
+        defaults = self.get_project_defaults(group.project_id) if group else {}
+        repo = params.get("repo") or defaults.get("repo")
+
+        try:
+            default_repo = repo or repo_choices[0][0]
+        except IndexError:
+            return "", repo_choices
+
+        # If a repo has been selected outside of the default list of
+        # repos, stick it onto the front of the list so that it can be
+        # selected.
+        try:
+            next(True for r in repo_choices if r[0] == default_repo)
+        except StopIteration:
+            repo_choices.insert(0, self.create_default_repo_choice(default_repo))
+
+        return default_repo, repo_choices
+
+    # TODO(saif): Make private and move all usages over to `get_defaults`
+    def get_project_defaults(self, project_id):
+        if not self.org_integration:
+            return {}
+
+        return self.org_integration.config.get("project_issue_defaults", {}).get(
+            str(project_id), {}
+        )
+
+    def create_default_repo_choice(self, default_repo):
+        """
+        Helper method for get_repository_choices
+        Returns the choice for the default repo in a tuple to be added to the list of repository choices
+        """
+        return (default_repo, default_repo)

--- a/src/sentry/integrations/source_code_management/issues.py
+++ b/src/sentry/integrations/source_code_management/issues.py
@@ -5,12 +5,12 @@ from collections.abc import Mapping
 from typing import Any
 
 from sentry.integrations.mixins.issues import IssueBasicIntegration
-from sentry.integrations.source_code_management.repository import RepositoryIntegration
+from sentry.integrations.source_code_management.repository import BaseRepositoryIntegration
 from sentry.models.group import Group
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 
 
-class SourceCodeIssueIntegration(IssueBasicIntegration, RepositoryIntegration, ABC):
+class SourceCodeIssueIntegration(IssueBasicIntegration, BaseRepositoryIntegration, ABC):
     def get_repository_choices(self, group: Group | None, params: Mapping[str, Any], **kwargs):
         """
         Returns the default repository and a set/subset of repositories of associated with the installation

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -19,7 +19,28 @@ REPOSITORY_INTEGRATION_CHECK_FILE_METRIC = "repository_integration.check_file.{r
 REPOSITORY_INTEGRATION_GET_FILE_METRIC = "repository_integration.get_file.{result}"
 
 
-class RepositoryIntegration(IntegrationInstallation, ABC):
+class BaseRepositoryIntegration(ABC):
+    @abstractmethod
+    def get_repositories(self, query: str | None = None) -> Sequence[dict[str, Any]]:
+        """
+        Get a list of available repositories for an installation
+
+        >>> def get_repositories(self):
+        >>>     return self.get_client().get_repositories()
+
+        return [{
+            'name': display_name,
+            'identifier': external_repo_id,
+        }]
+
+        The shape of the `identifier` should match the data
+        returned by the integration's
+        IntegrationRepositoryProvider.repository_external_slug()
+        """
+        raise NotImplementedError
+
+
+class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, ABC):
     @property
     def codeowners_locations(self) -> list[str] | None:
         """
@@ -64,25 +85,6 @@ class RepositoryIntegration(IntegrationInstallation, ABC):
     @abstractmethod
     def has_repo_access(self, repo: RpcRepository) -> bool:
         """Used for migrating repositories. Checks if the installation has access to the repository."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def get_repositories(self, query: str | None = None) -> Sequence[dict[str, Any]]:
-        """
-        Get a list of available repositories for an installation
-
-        >>> def get_repositories(self):
-        >>>     return self.get_client().get_repositories()
-
-        return [{
-            'name': display_name,
-            'identifier': external_repo_id,
-        }]
-
-        The shape of the `identifier` should match the data
-        returned by the integration's
-        IntegrationRepositoryProvider.repository_external_slug()
-        """
         raise NotImplementedError
 
     def get_unmigratable_repositories(self) -> list[RpcRepository]:

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -29,8 +29,9 @@ from sentry.integrations.models.integration_external_project import IntegrationE
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.integration import RpcOrganizationIntegration, integration_service
 from sentry.integrations.services.repository import RpcRepository, repository_service
+from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.integrations.tasks.migrate_repo import migrate_repo
-from sentry.integrations.vsts.issues import VstsSCMSpec
+from sentry.integrations.vsts.issues import VstsIssuesSpec
 from sentry.models.apitoken import generate_token
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization import RpcOrganizationSummary
@@ -113,7 +114,7 @@ metadata = IntegrationMetadata(
 logger = logging.getLogger("sentry.integrations")
 
 
-class VstsIntegration(VstsSCMSpec):
+class VstsIntegration(RepositoryIntegration, VstsIssuesSpec):
     logger = logger
     comment_key = "sync_comments"
     outbound_status_key = "sync_status_forward"

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -29,9 +29,8 @@ from sentry.integrations.models.integration_external_project import IntegrationE
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.integration import RpcOrganizationIntegration, integration_service
 from sentry.integrations.services.repository import RpcRepository, repository_service
-from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.integrations.tasks.migrate_repo import migrate_repo
-from sentry.integrations.vsts.issues import VstsIssueSync
+from sentry.integrations.vsts.issues import VstsSCMSpec
 from sentry.models.apitoken import generate_token
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization import RpcOrganizationSummary
@@ -114,7 +113,7 @@ metadata = IntegrationMetadata(
 logger = logging.getLogger("sentry.integrations")
 
 
-class VstsIntegration(RepositoryIntegration, VstsIssueSync):
+class VstsIntegration(VstsSCMSpec):
     logger = logger
     comment_key = "sync_comments"
     outbound_status_key = "sync_status_forward"

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from sentry.models.group import Group
 
 
-class VstsSCMSpec(IssueSyncIntegration, SourceCodeIssueIntegration):
+class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration):
     description = "Integrate Azure DevOps work items by linking a project."
     slug = "vsts"
     conf_key = slug

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -9,6 +9,7 @@ from rest_framework.response import Response
 from sentry.integrations.mixins import ResolveSyncAction
 from sentry.integrations.mixins.issues import IssueSyncIntegration
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
 from sentry.models.activity import Activity
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized
 from sentry.silo.base import all_silo_function
@@ -20,7 +21,7 @@ if TYPE_CHECKING:
     from sentry.models.group import Group
 
 
-class VstsIssueSync(IssueSyncIntegration):
+class VstsSCMSpec(IssueSyncIntegration, SourceCodeIssueIntegration):
     description = "Integrate Azure DevOps work items by linking a project."
     slug = "vsts"
     conf_key = slug

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -6,7 +6,8 @@ from django.utils.translation import gettext as _
 from mistune import markdown
 from rest_framework.response import Response
 
-from sentry.integrations.mixins import IssueSyncMixin, ResolveSyncAction
+from sentry.integrations.mixins import ResolveSyncAction
+from sentry.integrations.mixins.issues import IssueSyncIntegration
 from sentry.integrations.services.integration import integration_service
 from sentry.models.activity import Activity
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized
@@ -19,7 +20,7 @@ if TYPE_CHECKING:
     from sentry.models.group import Group
 
 
-class VstsIssueSync(IssueSyncMixin):
+class VstsIssueSync(IssueSyncIntegration):
     description = "Integrate Azure DevOps work items by linking a project."
     slug = "vsts"
     conf_key = slug

--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -12,7 +12,7 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
-from sentry.integrations.mixins import IssueSyncMixin
+from sentry.integrations.mixins.issues import IssueSyncIntegration
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.utils import sync_group_assignee_inbound
 from sentry.utils.email import parse_email
@@ -136,7 +136,7 @@ def handle_status_change(
 
     for org_integration in org_integrations:
         installation = integration.get_installation(organization_id=org_integration.organization_id)
-        if isinstance(installation, IssueSyncMixin):
+        if isinstance(installation, IssueSyncIntegration):
             installation.sync_status_inbound(
                 external_issue_key,
                 {

--- a/tests/sentry/api/endpoints/test_group_notes_details.py
+++ b/tests/sentry/api/endpoints/test_group_notes_details.py
@@ -128,7 +128,7 @@ class GroupNotesDetailsTest(APITestCase):
             reason=GroupSubscriptionReason.comment,
         ).exists()
 
-    @patch("sentry.integrations.mixins.IssueBasicMixin.update_comment")
+    @patch("sentry.integrations.mixins.issues.IssueBasicIntegration.update_comment")
     @responses.activate
     def test_put(self, mock_update_comment):
         self.login_as(user=self.user)
@@ -178,7 +178,7 @@ class GroupNotesDetailsTest(APITestCase):
             "text": f"hi **@{self.user.username}**",
         }
 
-    @patch("sentry.integrations.mixins.IssueBasicMixin.update_comment")
+    @patch("sentry.integrations.mixins.issues.IssueBasicIntegration.update_comment")
     def test_put_no_external_id(self, mock_update_comment):
         del self.activity.data["external_id"]
         self.activity.save()

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -11,7 +11,6 @@ from pytest import fixture
 
 from sentry.integrations.github import client
 from sentry.integrations.github.integration import GitHubIntegration
-from sentry.integrations.github.issues import GitHubIssueBasic
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.services.integration import integration_service
 from sentry.issues.grouptype import FeedbackGroup
@@ -239,9 +238,9 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
     def test_performance_issues_content(self):
         """Test that a GitHub issue created from a performance issue has the expected title and description"""
         event = self.create_performance_issue()
-        description = GitHubIssueBasic().get_group_description(event.group, event)
+        description = self.install.get_group_description(event.group, event)
         assert "db - SELECT `books_author`.`id`, `books_author" in description
-        title = GitHubIssueBasic().get_group_title(event.group, event)
+        title = self.install.get_group_title(event.group, event)
         assert title == "N+1 Query"
 
     def test_generic_issues_content(self):
@@ -259,11 +258,11 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
         group_event = event.for_group(event.groups[0])
         group_event.occurrence = occurrence
 
-        description = GitHubIssueBasic().get_group_description(group_event.group, group_event)
+        description = self.install.get_group_description(group_event.group, group_event)
         assert group_event.occurrence.evidence_display[0].value in description
         assert group_event.occurrence.evidence_display[1].value in description
         assert group_event.occurrence.evidence_display[2].value in description
-        title = GitHubIssueBasic().get_group_title(group_event.group, group_event)
+        title = self.install.get_group_title(group_event.group, group_event)
         assert title == group_event.occurrence.issue_title
 
     def test_error_issues_content(self):
@@ -278,9 +277,9 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
         )
         assert event.group is not None
 
-        description = GitHubIssueBasic().get_group_description(event.group, event)
+        description = self.install.get_group_description(event.group, event)
         assert "oh no" in description
-        title = GitHubIssueBasic().get_group_title(event.group, event)
+        title = self.install.get_group_title(event.group, event)
         assert title == event.title
 
     @responses.activate

--- a/tests/sentry/integrations/jira/test_webhooks.py
+++ b/tests/sentry/integrations/jira/test_webhooks.py
@@ -10,7 +10,7 @@ from rest_framework.response import Response
 
 from fixtures.integrations.stub_service import StubService
 from sentry.integrations.jira.webhooks.base import JiraTokenError, JiraWebhookBase
-from sentry.integrations.mixins import IssueSyncMixin
+from sentry.integrations.mixins.issues import IssueSyncIntegration
 from sentry.integrations.services.integration.serial import serialize_integration
 from sentry.integrations.utils import AtlassianConnectValidationError
 from sentry.organizations.services.organization.serial import serialize_rpc_organization
@@ -128,7 +128,7 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
                 self.integration, None, "APP-123", assign=False
             )
 
-    @patch.object(IssueSyncMixin, "sync_status_inbound")
+    @patch.object(IssueSyncIntegration, "sync_status_inbound")
     def test_simple_status_sync_inbound(self, mock_sync_status_inbound):
         with patch(
             "sentry.integrations.jira.webhooks.issue_updated.get_integration_from_jwt",


### PR DESCRIPTION
Old issues mixin organization:
<img width="1112" alt="Screenshot 2024-08-15 at 11 38 17" src="https://github.com/user-attachments/assets/874700f9-637f-4e5d-bcaa-51f2cbd54ff2">

New issues abstract base class organization:
<img width="1044" alt="Screenshot 2024-08-15 at 11 37 10" src="https://github.com/user-attachments/assets/d0f05b76-0b03-4ad6-9f8c-94abeba21678">
Notes about the new organization:
- `BaseRepositoryIntegration` includes the `get_repositories` function, which is present in `SourceCodeIssueIntegration` AND `RepositoryIntegration`.
- The new `SourceCodeIssueIntegration` ABC includes functionality only present in the SCM integrations, which includes searching for repos to create the issue in
- Some of the issues specs are only inherited by their respective integration, which suggests that they could be combined with the integration (e.g. `BitbucketIssuesSpec` + `BitbucketIntegration`). This could be done later, but I personally like that the issue functionality is separated since it's typically a lot of code and the integration classes already include a lot of methods.

The end goal should be that `SourceCodeIssueIntegration` includes all of the features of `IssueSyncIntegration`!