### PR TITLE
feat(query-builder): Add defaultValue and values to the field definition

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -147,7 +147,9 @@ function getPredefinedValues({
     return null;
   }
 
-  if (!key.values?.length) {
+  const definedValues = key.values ?? fieldDefinition?.values;
+
+  if (!definedValues?.length) {
     return getValueSuggestions({
       filterValue,
       token,
@@ -155,17 +157,17 @@ function getPredefinedValues({
     });
   }
 
-  if (isStringFilterValues(key.values)) {
-    return [{sectionText: '', suggestions: key.values.map(value => ({value}))}];
+  if (isStringFilterValues(definedValues)) {
+    return [{sectionText: '', suggestions: definedValues.map(value => ({value}))}];
   }
 
-  const valuesWithoutSection = key.values
+  const valuesWithoutSection = definedValues
     .filter(group => group.type === ItemType.TAG_VALUE && group.value)
     .map(group => ({
       value: group.value as string,
       description: getSuggestionDescription(group),
     }));
-  const sections = key.values
+  const sections = definedValues
     .filter(group => group.type === 'header')
     .map(group => {
       return {
@@ -609,7 +611,7 @@ export function SearchQueryBuilderValueCombobox({
         dispatch({
           type: 'UPDATE_TOKEN_VALUE',
           token: token,
-          value: getDefaultFilterValue({key: keyName, fieldDefinition}),
+          value: getDefaultFilterValue({fieldDefinition}),
         });
         onCommit();
         return;
@@ -649,7 +651,6 @@ export function SearchQueryBuilderValueCombobox({
       canSelectMultipleValues,
       dispatch,
       fieldDefinition,
-      keyName,
       onCommit,
       token,
       updateFilterValue,

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -98,7 +98,7 @@ function getInitialFilterKeyText(key: string, fieldDefinition: FieldDefinition |
 }
 
 function getInitialFilterText(key: string, fieldDefinition: FieldDefinition | null) {
-  const defaultValue = getDefaultFilterValue({key, fieldDefinition});
+  const defaultValue = getDefaultFilterValue({fieldDefinition});
 
   const keyText = getInitialFilterKeyText(key, fieldDefinition);
 

--- a/static/app/components/searchQueryBuilder/tokens/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/utils.tsx
@@ -8,7 +8,8 @@ import type {
   SelectSectionWithKey,
 } from 'sentry/components/compactSelect/types';
 import type {ParseResultToken} from 'sentry/components/searchSyntax/parser';
-import {type FieldDefinition, FieldKey, FieldValueType} from 'sentry/utils/fields';
+import {defined} from 'sentry/utils';
+import {type FieldDefinition, FieldValueType} from 'sentry/utils/fields';
 
 export function shiftFocusToChild(
   element: HTMLElement,
@@ -43,18 +44,16 @@ export function useShiftFocusToChild(
 }
 
 export function getDefaultFilterValue({
-  key,
   fieldDefinition,
 }: {
   fieldDefinition: FieldDefinition | null;
-  key: string;
 }): string {
   if (!fieldDefinition) {
     return '""';
   }
 
-  if (key === FieldKey.IS) {
-    return 'unresolved';
+  if (defined(fieldDefinition.defaultValue)) {
+    return fieldDefinition.defaultValue;
   }
 
   switch (fieldDefinition.valueType) {

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -278,6 +278,10 @@ export interface FieldDefinition {
    */
   allowComparisonOperators?: boolean;
   /**
+   * Default value for the field
+   */
+  defaultValue?: string;
+  /**
    * Is this field being deprecated
    */
   deprecated?: boolean;
@@ -298,6 +302,10 @@ export interface FieldDefinition {
    * Defines the number and type of parameters that the function accepts.
    */
   parameters?: AggregateParameter[];
+  /**
+   * Potential values for the field
+   */
+  values?: string[];
 }
 
 export const AGGREGATION_FIELDS: Record<AggregationKey, FieldDefinition> = {
@@ -870,6 +878,7 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
     keywords: ['ignored', 'assigned', 'for_review', 'unassigned', 'linked', 'unlinked'],
+    defaultValue: 'unresolved',
   },
   [FieldKey.ISSUE]: {
     desc: t('The issue identification short code'),


### PR DESCRIPTION
Allows the default value to be overridden in the field definition. Useful if `100` or `10ms` isn't in the right ballpark. It is already useful for the `is` filter which had a hardcoded `unresolved` as the default value.

Also adds `values` to the field definition. Currently that value is stored in the `Tag`, but I am planning on moving all data to the field definition rather than maintaining the config in two separate places. For now, `values` in the `Tag` overrides anything in the field definition.