### PR TITLE
feat(onboarding): frontend for disableMemberInvite flag

### DIFF
--- a/static/app/components/modals/inviteMembersModal/useInviteModal.tsx
+++ b/static/app/components/modals/inviteMembersModal/useInviteModal.tsx
@@ -16,6 +16,7 @@ interface Props {
   initialData?: Partial<InviteRow>[];
   source?: string;
 }
+
 function defaultInvite(): InviteRow {
   return {
     emails: new Set<string>(),
@@ -37,7 +38,10 @@ function useLogInviteModalOpened({
     trackAnalytics('invite_modal.opened', {
       organization,
       modal_session: sessionId,
-      can_invite: organization.access?.includes('member:write'),
+      can_invite:
+        organization.access?.includes('member:write') ||
+        (organization.features.includes('organizations:members-invite-teammates') &&
+          organization.allowMemberInvite),
       source,
     });
   }, [organization, sessionId, source]);
@@ -45,7 +49,10 @@ function useLogInviteModalOpened({
 
 export default function useInviteModal({organization, initialData, source}: Props) {
   const api = useApi();
-  const willInvite = organization.access?.includes('member:write');
+  const willInvite =
+    organization.access?.includes('member:write') ||
+    (organization.features.includes('organizations:members-invite-teammates') &&
+      organization.allowMemberInvite);
 
   /**
    * Used for analytics tracking of the modals usage.

--- a/static/app/components/modals/inviteMembersModal/useInviteModal.tsx
+++ b/static/app/components/modals/inviteMembersModal/useInviteModal.tsx
@@ -25,6 +25,14 @@ function defaultInvite(): InviteRow {
   };
 }
 
+function canInvite(organization: Organization) {
+  return (
+    organization.access?.includes('member:write') ||
+    (organization.features.includes('members-invite-teammates') &&
+      organization.allowMemberInvite)
+  );
+}
+
 function useLogInviteModalOpened({
   organization,
   sessionId,
@@ -38,10 +46,7 @@ function useLogInviteModalOpened({
     trackAnalytics('invite_modal.opened', {
       organization,
       modal_session: sessionId,
-      can_invite:
-        organization.access?.includes('member:write') ||
-        (organization.features.includes('members-invite-teammates') &&
-          organization.allowMemberInvite),
+      can_invite: canInvite(organization),
       source,
     });
   }, [organization, sessionId, source]);
@@ -49,10 +54,7 @@ function useLogInviteModalOpened({
 
 export default function useInviteModal({organization, initialData, source}: Props) {
   const api = useApi();
-  const willInvite =
-    organization.access?.includes('member:write') ||
-    (organization.features.includes('members-invite-teammates') &&
-      organization.allowMemberInvite);
+  const willInvite = canInvite(organization);
 
   /**
    * Used for analytics tracking of the modals usage.

--- a/static/app/components/modals/inviteMembersModal/useInviteModal.tsx
+++ b/static/app/components/modals/inviteMembersModal/useInviteModal.tsx
@@ -40,7 +40,7 @@ function useLogInviteModalOpened({
       modal_session: sessionId,
       can_invite:
         organization.access?.includes('member:write') ||
-        (organization.features.includes('organizations:members-invite-teammates') &&
+        (organization.features.includes('members-invite-teammates') &&
           organization.allowMemberInvite),
       source,
     });
@@ -51,7 +51,7 @@ export default function useInviteModal({organization, initialData, source}: Prop
   const api = useApi();
   const willInvite =
     organization.access?.includes('member:write') ||
-    (organization.features.includes('organizations:members-invite-teammates') &&
+    (organization.features.includes('members-invite-teammates') &&
       organization.allowMemberInvite);
 
   /**

--- a/static/app/components/modals/inviteMembersModal/useInviteModal.tsx
+++ b/static/app/components/modals/inviteMembersModal/useInviteModal.tsx
@@ -29,7 +29,8 @@ function canInvite(organization: Organization) {
   return (
     organization.access?.includes('member:write') ||
     (organization.features.includes('members-invite-teammates') &&
-      organization.allowMemberInvite)
+      organization.allowMemberInvite &&
+      organization.access?.includes('member:invite'))
   );
 }
 

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -58,6 +58,7 @@ export const ALLOWED_SCOPES = [
   'event:read',
   'event:write',
   'member:admin',
+  'member:invite',
   'member:read',
   'member:write',
   'org:admin',

--- a/static/app/data/forms/organizationGeneralSettings.tsx
+++ b/static/app/data/forms/organizationGeneralSettings.tsx
@@ -92,6 +92,16 @@ const formGroups: JsonFormObject[] = [
         help: t('Allow organization members to freely join any team'),
       },
       {
+        name: 'allowMemberInvite',
+        type: 'boolean',
+        label: t('Let Members Invite Freely'),
+        help: t(
+          'Allow organization members to invite other members via email without needing org owner or manager approval.'
+        ),
+        visible: ({features}) => features.has('members-invite-teammates'),
+        disabled: ({access}) => !access.has('org:admin'),
+      },
+      {
         name: 'allowMemberProjectCreation',
         type: 'boolean',
         label: t('Let Members Create Projects'),

--- a/static/app/data/forms/organizationGeneralSettings.tsx
+++ b/static/app/data/forms/organizationGeneralSettings.tsx
@@ -99,7 +99,12 @@ const formGroups: JsonFormObject[] = [
           'Allow organization members to invite other members via email without needing org owner or manager approval.'
         ),
         visible: ({features}) => features.has('members-invite-teammates'),
-        disabled: ({access}) => !access.has('org:admin'),
+        disabled: ({features, access}) =>
+          !access.has('org:write') || features.has('team-roles'),
+        disabledReason: ({features}) =>
+          !features.has('team-roles')
+            ? t('You must be on a business plan to toggle this feature.')
+            : undefined,
       },
       {
         name: 'allowMemberProjectCreation',

--- a/static/app/data/forms/organizationGeneralSettings.tsx
+++ b/static/app/data/forms/organizationGeneralSettings.tsx
@@ -100,7 +100,7 @@ const formGroups: JsonFormObject[] = [
         ),
         visible: ({features}) => features.has('members-invite-teammates'),
         disabled: ({features, access}) =>
-          !access.has('org:write') || features.has('team-roles'),
+          !access.has('org:write') || !features.has('team-roles'),
         disabledReason: ({features}) =>
           !features.has('team-roles')
             ? t('You must be on a business plan to toggle this feature.')
@@ -112,7 +112,7 @@ const formGroups: JsonFormObject[] = [
         label: t('Let Members Create Projects'),
         help: t('Allow organization members to create and configure new projects.'),
         disabled: ({features, access}) =>
-          !access.has('org:write') || features.has('team-roles'),
+          !access.has('org:write') || !features.has('team-roles'),
         disabledReason: ({features}) =>
           !features.has('team-roles')
             ? t('You must be on a business plan to toggle this feature.')

--- a/static/app/data/forms/organizationGeneralSettings.tsx
+++ b/static/app/data/forms/organizationGeneralSettings.tsx
@@ -88,7 +88,7 @@ const formGroups: JsonFormObject[] = [
       {
         name: 'openMembership',
         type: 'boolean',
-        label: t('Open Membership'),
+        label: t('Open Team Membership'),
         help: t('Allow organization members to freely join any team'),
       },
       {

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -52,6 +52,7 @@ export interface Organization extends OrganizationSummary {
   aggregatedDataConsent: boolean;
   alertsMemberWrite: boolean;
   allowJoinRequests: boolean;
+  allowMemberInvite: boolean;
   allowMemberProjectCreation: boolean;
   allowSharedIssues: boolean;
   attachmentsRole: string;

--- a/tests/js/fixtures/organization.ts
+++ b/tests/js/fixtures/organization.ts
@@ -40,6 +40,7 @@ export function OrganizationFixture( params: Partial<Organization> = {}): Organi
     aiSuggestedSolution: false,
     alertsMemberWrite: false,
     allowJoinRequests: false,
+    allowMemberInvite: true,
     allowMemberProjectCreation: false,
     allowSharedIssues: false,
     attachmentsRole: '',


### PR DESCRIPTION
add toggle for org admin to allow/disallow members from inviting teammates to their org

Admin view:
<img width="1214" alt="admin_view" src="https://github.com/user-attachments/assets/610f4f67-56a4-43c2-a83c-483709057866">

Toggle is disabled for non-admin members and organizations that are not on a business plan:
<img width="1216" alt="member_view" src="https://github.com/user-attachments/assets/12a990bf-6a2b-4fe3-b89d-4cb97e82df1e">
