### PR TITLE
chore(issue-platform): Include occurrence type in stats when updating group status

### DIFF
--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -211,7 +211,10 @@ def process_status_change_message(
             return None
         txn.set_tag("group_id", group.id)
 
-    with metrics.timer("occurrence_consumer._process_message.status_change.update_group_status"):
+    with metrics.timer(
+        "occurrence_consumer._process_message.status_change.update_group_status",
+        tags={"occurrence_type": group.issue_type.type_id},
+    ):
         update_status(group, status_change_data)
 
     return group


### PR DESCRIPTION
We'd like to differentiate between these messages in Uptime, and this seems generally useful

<!-- Describe your PR here. -->