### PR TITLE
feat(ai-issue-summary): Backend endpoint to generate and store summary

### DIFF
--- a/src/sentry/api/endpoints/group_ai_summary.py
+++ b/src/sentry/api/endpoints/group_ai_summary.py
@@ -25,8 +25,6 @@ logger = logging.getLogger(__name__)
 
 from rest_framework.request import Request
 
-TIMEOUT_SECONDS = 60 * 30  # 30 minutes
-
 
 class SummarizeIssueResponse(BaseModel):
     group_id: str
@@ -40,7 +38,6 @@ class GroupAiSummaryEndpoint(GroupEndpoint):
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.ML_AI
-    # go away
     private = True
     enforce_rate_limit = True
     rate_limits = {

--- a/src/sentry/api/endpoints/group_ai_summary.py
+++ b/src/sentry/api/endpoints/group_ai_summary.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import orjson
+import requests
+from django.conf import settings
+from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
+from pydantic import BaseModel
+from rest_framework.response import Response
+
+from sentry import eventstore, features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.group import GroupEndpoint
+from sentry.api.serializers import EventSerializer, serialize
+from sentry.models.group import Group
+from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
+
+logger = logging.getLogger(__name__)
+
+from rest_framework.request import Request
+
+TIMEOUT_SECONDS = 60 * 30  # 30 minutes
+
+
+class SummarizeIssueResponse(BaseModel):
+    group_id: str
+    summary: str
+    impact: str
+
+
+@region_silo_endpoint
+class GroupAiSummaryEndpoint(GroupEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ML_AI
+    # go away
+    private = True
+    enforce_rate_limit = True
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(limit=10, window=60),
+            RateLimitCategory.USER: RateLimit(limit=10, window=60),
+            RateLimitCategory.ORGANIZATION: RateLimit(
+                limit=30, window=60
+            ),  # TODO: Raise this limit when we move out of internal preview
+        }
+    }
+
+    def _get_event(
+        self, group: Group, user: AbstractBaseUser | AnonymousUser
+    ) -> dict[str, Any] | None:
+        event = group.get_recommended_event_for_environments()
+        if not event:
+            event = group.get_latest_event()
+
+        if not event:
+            return None
+
+        event_id = event.event_id
+
+        ready_event = eventstore.backend.get_event_by_id(
+            group.project.id, event_id, group_id=group.id
+        )
+
+        if not ready_event:
+            return None
+
+        return serialize(ready_event, user, EventSerializer())
+
+    def _call_seer(
+        self,
+        group: Group,
+        serialized_event: dict[str, Any],
+    ):
+        path = "/v1/automation/summarize/issue"
+        body = orjson.dumps(
+            {
+                "group_id": group.id,
+                "issue": {
+                    "id": group.id,
+                    "title": group.title,
+                    "short_id": group.qualified_short_id,
+                    "events": [serialized_event],
+                },
+            },
+            option=orjson.OPT_NON_STR_KEYS,
+        )
+        response = requests.post(
+            f"{settings.SEER_AUTOFIX_URL}{path}",
+            data=body,
+            headers={
+                "content-type": "application/json;charset=utf-8",
+                **sign_with_seer_secret(
+                    url=f"{settings.SEER_AUTOFIX_URL}{path}",
+                    body=body,
+                ),
+            },
+        )
+
+        response.raise_for_status()
+
+        return SummarizeIssueResponse.validate(response.json())
+
+    def get(self, request: Request, group: Group) -> Response:
+        if not features.has("organizations:ai-summary", group.organization, actor=request.user):
+            return Response({"detail": "Feature flag not enabled"}, status=400)
+
+        if group.data.get("issue_summary"):
+            return Response(group.data["issue_summary"], status=200)
+
+        serialized_event = self._get_event(group, request.user)
+
+        if not serialized_event:
+            return Response({"detail": "Could not find an event for the issue"}, status=400)
+
+        issue_summary = self._call_seer(group, serialized_event)
+
+        group.data.update({"issue_summary": issue_summary.dict()})
+        group.save()
+
+        return Response(issue_summary.dict(), status=200)

--- a/src/sentry/api/endpoints/group_ai_summary.py
+++ b/src/sentry/api/endpoints/group_ai_summary.py
@@ -35,13 +35,13 @@ class SummarizeIssueResponse(BaseModel):
 @region_silo_endpoint
 class GroupAiSummaryEndpoint(GroupEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.EXPERIMENTAL,
+        "POST": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.ML_AI
     private = True
     enforce_rate_limit = True
     rate_limits = {
-        "GET": {
+        "POST": {
             RateLimitCategory.IP: RateLimit(limit=10, window=60),
             RateLimitCategory.USER: RateLimit(limit=10, window=60),
             RateLimitCategory.ORGANIZATION: RateLimit(
@@ -105,7 +105,7 @@ class GroupAiSummaryEndpoint(GroupEndpoint):
 
         return SummarizeIssueResponse.validate(response.json())
 
-    def get(self, request: Request, group: Group) -> Response:
+    def post(self, request: Request, group: Group) -> Response:
         if not features.has("organizations:ai-summary", group.organization, actor=request.user):
             return Response({"detail": "Feature flag not enabled"}, status=400)
 

--- a/src/sentry/api/endpoints/group_ai_summary.py
+++ b/src/sentry/api/endpoints/group_ai_summary.py
@@ -16,6 +16,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import EventSerializer, serialize
+from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
 from sentry.models.group import Group
 from sentry.seer.signed_seer_api import sign_with_seer_secret
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -112,7 +113,9 @@ class GroupAiSummaryEndpoint(GroupEndpoint):
             return Response({"detail": "Feature flag not enabled"}, status=400)
 
         if group.data.get("issue_summary"):
-            return Response(group.data["issue_summary"], status=200)
+            return Response(
+                convert_dict_key_case(group.data["issue_summary"], snake_to_camel_case), status=200
+            )
 
         serialized_event = self._get_event(group, request.user)
 
@@ -124,4 +127,6 @@ class GroupAiSummaryEndpoint(GroupEndpoint):
         group.data.update({"issue_summary": issue_summary.dict()})
         group.save()
 
-        return Response(issue_summary.dict(), status=200)
+        return Response(
+            convert_dict_key_case(issue_summary.dict(), snake_to_camel_case), status=200
+        )

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from django.conf.urls import include
 from django.urls import URLPattern, URLResolver, re_path
 
+from sentry.api.endpoints.group_ai_summary import GroupAiSummaryEndpoint
 from sentry.api.endpoints.group_autofix_setup_check import GroupAutofixSetupCheck
 from sentry.api.endpoints.group_event_details import GroupEventDetailsEndpoint
 from sentry.api.endpoints.group_integration_details import GroupIntegrationDetailsEndpoint
@@ -816,6 +817,11 @@ def create_group_urls(name_prefix: str) -> list[URLPattern | URLResolver]:
             r"^(?P<issue_id>[^\/]+)/autofix/setup/$",
             GroupAutofixSetupCheck.as_view(),
             name=f"{name_prefix}-group-autofix-setup",
+        ),
+        re_path(
+            r"^(?P<issue_id>[^\/]+)/summarize/$",
+            GroupAiSummaryEndpoint.as_view(),
+            name=f"{name_prefix}-group-ai-summary",
         ),
         # Load plugin group urls
         re_path(

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -44,6 +44,8 @@ def register_temporary_features(manager: FeatureManager):
 
     # Enables activated alert rules
     manager.add("organizations:activated-alert-rules", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable AI Issue Summary feture on the Issue Details page.
+    manager.add("organizations:ai-summary", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables alert creation on indexed events in UI (use for PoC/testing only)
     manager.add("organizations:alert-allow-indexed", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Use metrics as the dataset for crash free metric alerts

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -23,7 +23,10 @@ interface GroupSummaryData {
 const makeGroupSummaryQueryKey = (
   organizationSlug: string,
   groupId: string
-): ApiQueryKey => [`/organizations/${organizationSlug}/issues/${groupId}/summarize/`];
+): ApiQueryKey => [
+  `/organizations/${organizationSlug}/issues/${groupId}/summarize/`,
+  {method: 'POST'},
+];
 
 export function GroupSummary({groupId}: GroupSummaryProps) {
   const organization = useOrganization();

--- a/tests/sentry/api/endpoints/test_group_ai_summary.py
+++ b/tests/sentry/api/endpoints/test_group_ai_summary.py
@@ -1,0 +1,85 @@
+from unittest.mock import ANY, Mock, patch
+
+from sentry.api.endpoints.group_ai_summary import SummarizeIssueResponse
+from sentry.testutils.cases import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.features import apply_feature_flag_on_cls
+from sentry.testutils.skips import requires_snuba
+
+pytestmark = [requires_snuba]
+
+
+@apply_feature_flag_on_cls("organizations:ai-summary")
+class GroupAiSummaryEndpointTest(APITestCase, SnubaTestCase):
+    def _get_url(self, group_id: int):
+        return f"/api/0/issues/{group_id}/summarize/"
+
+    @patch("sentry.api.endpoints.group_ai_summary.GroupAiSummaryEndpoint._call_seer")
+    def test_ai_summary_get_endpoint_with_existing_summary(self, mock_call_seer):
+        group = self.create_group()
+        existing_summary = {
+            "group_id": str(group.id),
+            "summary": "Existing summary",
+            "impact": "Existing impact",
+        }
+        group.data["issue_summary"] = existing_summary
+        group.save()
+
+        self.login_as(user=self.user)
+        response = self.client.get(self._get_url(group.id), format="json")
+
+        assert response.status_code == 200
+        assert response.data == existing_summary
+        mock_call_seer.assert_not_called()
+
+    @patch("sentry.api.endpoints.group_ai_summary.GroupAiSummaryEndpoint._get_event")
+    def test_ai_summary_get_endpoint_without_event(self, mock_get_event):
+        mock_get_event.return_value = None
+        group = self.create_group()
+
+        self.login_as(user=self.user)
+        response = self.client.get(self._get_url(group.id), format="json")
+
+        assert response.status_code == 400
+        assert response.data == {"detail": "Could not find an event for the issue"}
+
+    @patch("sentry.api.endpoints.group_ai_summary.GroupAiSummaryEndpoint._call_seer")
+    @patch("sentry.api.endpoints.group_ai_summary.GroupAiSummaryEndpoint._get_event")
+    def test_ai_summary_get_endpoint_without_existing_summary(self, mock_get_event, mock_call_seer):
+        group = self.create_group()
+        mock_event = {"id": "test_event_id", "data": "test_event_data"}
+        mock_get_event.return_value = mock_event
+        mock_summary = SummarizeIssueResponse(
+            group_id=str(group.id),
+            summary="Test summary",
+            impact="Test impact",
+        )
+        mock_call_seer.return_value = mock_summary
+
+        self.login_as(user=self.user)
+        response = self.client.get(self._get_url(group.id), format="json")
+
+        assert response.status_code == 200
+        assert response.data == mock_summary.dict()
+        mock_get_event.assert_called_once_with(group, ANY)
+        mock_call_seer.assert_called_once_with(group, mock_event)
+
+    @patch("sentry.api.endpoints.group_ai_summary.requests.post")
+    @patch("sentry.api.endpoints.group_ai_summary.GroupAiSummaryEndpoint._get_event")
+    def test_ai_summary_call_seer(self, mock_get_event, mock_post):
+        group = self.create_group()
+        serialized_event = {"id": "test_event_id", "data": "test_event_data"}
+        mock_get_event.return_value = serialized_event
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "group_id": str(group.id),
+            "summary": "Test summary",
+            "impact": "Test impact",
+        }
+        mock_post.return_value = mock_response
+
+        self.login_as(user=self.user)
+        response = self.client.get(self._get_url(group.id), format="json")
+
+        assert response.status_code == 200
+        assert response.data == mock_response.json.return_value
+        mock_post.assert_called_once()

--- a/tests/sentry/api/endpoints/test_group_ai_summary.py
+++ b/tests/sentry/api/endpoints/test_group_ai_summary.py
@@ -1,6 +1,7 @@
 from unittest.mock import ANY, Mock, patch
 
 from sentry.api.endpoints.group_ai_summary import SummarizeIssueResponse
+from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 from sentry.testutils.skips import requires_snuba
@@ -28,7 +29,7 @@ class GroupAiSummaryEndpointTest(APITestCase, SnubaTestCase):
         response = self.client.get(self._get_url(group.id), format="json")
 
         assert response.status_code == 200
-        assert response.data == existing_summary
+        assert response.data == convert_dict_key_case(existing_summary, snake_to_camel_case)
         mock_call_seer.assert_not_called()
 
     @patch("sentry.api.endpoints.group_ai_summary.GroupAiSummaryEndpoint._get_event")
@@ -59,7 +60,7 @@ class GroupAiSummaryEndpointTest(APITestCase, SnubaTestCase):
         response = self.client.get(self._get_url(group.id), format="json")
 
         assert response.status_code == 200
-        assert response.data == mock_summary.dict()
+        assert response.data == convert_dict_key_case(mock_summary.dict(), snake_to_camel_case)
         mock_get_event.assert_called_once_with(group, ANY)
         mock_call_seer.assert_called_once_with(group, mock_event)
 
@@ -81,5 +82,7 @@ class GroupAiSummaryEndpointTest(APITestCase, SnubaTestCase):
         response = self.client.get(self._get_url(group.id), format="json")
 
         assert response.status_code == 200
-        assert response.data == mock_response.json.return_value
+        assert response.data == convert_dict_key_case(
+            mock_response.json.return_value, snake_to_camel_case
+        )
         mock_post.assert_called_once()

--- a/tests/sentry/api/endpoints/test_group_ai_summary.py
+++ b/tests/sentry/api/endpoints/test_group_ai_summary.py
@@ -26,7 +26,7 @@ class GroupAiSummaryEndpointTest(APITestCase, SnubaTestCase):
         group.save()
 
         self.login_as(user=self.user)
-        response = self.client.get(self._get_url(group.id), format="json")
+        response = self.client.post(self._get_url(group.id), format="json")
 
         assert response.status_code == 200
         assert response.data == convert_dict_key_case(existing_summary, snake_to_camel_case)
@@ -38,7 +38,7 @@ class GroupAiSummaryEndpointTest(APITestCase, SnubaTestCase):
         group = self.create_group()
 
         self.login_as(user=self.user)
-        response = self.client.get(self._get_url(group.id), format="json")
+        response = self.client.post(self._get_url(group.id), format="json")
 
         assert response.status_code == 400
         assert response.data == {"detail": "Could not find an event for the issue"}
@@ -57,7 +57,7 @@ class GroupAiSummaryEndpointTest(APITestCase, SnubaTestCase):
         mock_call_seer.return_value = mock_summary
 
         self.login_as(user=self.user)
-        response = self.client.get(self._get_url(group.id), format="json")
+        response = self.client.post(self._get_url(group.id), format="json")
 
         assert response.status_code == 200
         assert response.data == convert_dict_key_case(mock_summary.dict(), snake_to_camel_case)
@@ -79,7 +79,7 @@ class GroupAiSummaryEndpointTest(APITestCase, SnubaTestCase):
         mock_post.return_value = mock_response
 
         self.login_as(user=self.user)
-        response = self.client.get(self._get_url(group.id), format="json")
+        response = self.client.post(self._get_url(group.id), format="json")
 
         assert response.status_code == 200
         assert response.data == convert_dict_key_case(


### PR DESCRIPTION
Guarded behind a feature flag: `organizations:ai-summary`

1. If an issue summary exists, return that
2. If it doesn't, call seer to generate one and store it in the group data

![Screenshot 2024-08-13 at 2 11 13 PM](https://github.com/user-attachments/assets/cbc99ee7-05dc-4856-91e3-d820670a7e94)
![Screenshot 2024-08-13 at 2 10 53 PM](https://github.com/user-attachments/assets/141e88d7-f286-43f9-ab22-d497e8572799)
