### PR TITLE
fix(ecosystem): Adds special handling for team custom field in Jira

### DIFF
--- a/fixtures/integrations/jira/stubs/createmeta_response.json
+++ b/fixtures/integrations/jira/stubs/createmeta_response.json
@@ -101,6 +101,21 @@
                 {"id": 10101, "label": "happy"}
               ]
             },
+            "customfield_10001": {
+              "required": false,
+              "schema": {
+                "type": "team",
+                "custom": "com.atlassian.jira.plugin.system.customfieldtypes:atlassian-team",
+                "customId": 10001,
+                "configuration": {
+                  "com.atlassian.jira.plugin.system.customfieldtypes:atlassian-team": true
+                }
+              },
+              "name": "Team",
+              "key": "customfield_10001",
+              "hasDefaultValue": false,
+              "operations": ["set"]
+            },
             "customfield_10300": {
               "required": false,
               "schema": {

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -115,6 +115,7 @@ JIRA_CUSTOM_FIELD_TYPES = {
     "tempo_account": "com.tempoplugin.tempo-accounts:accounts.customfield",
     "sprint": "com.pyxis.greenhopper.jira:gh-sprint",
     "epic": "com.pyxis.greenhopper.jira:gh-epic-link",
+    "team": "com.atlassian.jira.plugin.system.customfieldtypes:atlassian-team",
 }
 
 
@@ -860,6 +861,8 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                     elif schema["type"] == "issuelink":  # used by Parent field
                         v = {"key": v}
                     elif schema.get("custom") == JIRA_CUSTOM_FIELD_TYPES["epic"]:
+                        v = v
+                    elif schema.get("custom") == JIRA_CUSTOM_FIELD_TYPES["team"]:
                         v = v
                     elif schema.get("custom") == JIRA_CUSTOM_FIELD_TYPES["sprint"]:
                         try:

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -148,6 +148,7 @@ class RegionJiraIntegrationTest(APITestCase):
                     "label": "Issue Type",
                     "type": "select",
                 },
+                {"label": "Team", "name": "customfield_10001", "required": False, "type": "text"},
                 {
                     "name": "customfield_10200",
                     "default": "",
@@ -303,6 +304,7 @@ class RegionJiraIntegrationTest(APITestCase):
                 "title",
                 "description",
                 "issuetype",
+                "customfield_10001",
                 "customfield_10200",
                 "customfield_10300",
                 "customfield_10400",
@@ -325,6 +327,7 @@ class RegionJiraIntegrationTest(APITestCase):
                 "title",
                 "description",
                 "issuetype",
+                "customfield_10001",
                 "customfield_10300",
                 "customfield_10400",
                 "customfield_10500",


### PR DESCRIPTION
Adds special handling for Jira's `team` custom field, which was previously passing invalid data to the issue create endpoint.

This is mostly a quick-fix to allow users to provide a Team ID, where previously, nothing would work. Ideally this should be turned into a validated field which queries available teams, but this work will be handled in a follow-up PR.