### PR TITLE
feat(alerts): Update Discord and Slack unfurl message builder for dynamic alerts

### DIFF
--- a/tests/sentry/integrations/discord/test_message_builder.py
+++ b/tests/sentry/integrations/discord/test_message_builder.py
@@ -48,7 +48,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
                 {
                     "title": title,
                     "description": "",
-                    "url": f"{link}&referrer=discord&detection_type={self.alert_rule.detection_type}&notification_uuid={uuid}",
+                    "url": f"{link}?detection_type={self.alert_rule.detection_type}&referrer=discord&notification_uuid={uuid}",
                     "color": LEVEL_TO_COLOR["_incident_resolved"],
                 }
             ],
@@ -63,17 +63,14 @@ class BuildMetricAlertAttachmentTest(TestCase):
             alert_rule_trigger=trigger, triggered_for_incident=incident
         )
         title = f"Resolved: {self.alert_rule.name}"
-        link = (
-            absolute_uri(
-                reverse(
-                    "sentry-metric-alert-details",
-                    kwargs={
-                        "organization_slug": self.alert_rule.organization.slug,
-                        "alert_rule_id": self.alert_rule.id,
-                    },
-                )
+        link = absolute_uri(
+            reverse(
+                "sentry-metric-alert-details",
+                kwargs={
+                    "organization_slug": self.alert_rule.organization.slug,
+                    "alert_rule_id": self.alert_rule.id,
+                },
             )
-            + f"?alert={incident.identifier}"
         )
 
         uuid = "uuid"
@@ -86,7 +83,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
                 {
                     "title": title,
                     "description": get_started_at(incident.date_started),
-                    "url": f"{link}&referrer=discord&detection_type={self.alert_rule.detection_type}&notification_uuid={uuid}",
+                    "url": f"{link}?detection_type={self.alert_rule.detection_type}&alert={incident.identifier}&referrer=discord&notification_uuid={uuid}",
                     "color": LEVEL_TO_COLOR["_incident_resolved"],
                 }
             ],
@@ -120,7 +117,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
                     "color": LEVEL_TO_COLOR["fatal"],
                     "title": title,
                     "description": "0 events in the last 10 minutes",
-                    "url": f"{link}&referrer=discord&detection_type={self.alert_rule.detection_type}&notification_uuid={uuid}",
+                    "url": f"{link}?detection_type={self.alert_rule.detection_type}&referrer=discord&notification_uuid={uuid}",
                 }
             ],
             "components": [],
@@ -193,7 +190,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
                 {
                     "title": title,
                     "description": get_started_at(incident.date_started),
-                    "url": f"{link}?alert={incident.identifier}&referrer=discord&detection_type={self.alert_rule.detection_type}&notification_uuid={uuid}",
+                    "url": f"{link}?detection_type={self.alert_rule.detection_type}&alert={incident.identifier}&referrer=discord&notification_uuid={uuid}",
                     "color": LEVEL_TO_COLOR["_incident_resolved"],
                     "image": {"url": "chart_url"},
                 }
@@ -226,7 +223,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
                     "color": LEVEL_TO_COLOR["fatal"],
                     "title": title,
                     "description": "0 events in the last 10 minutes",
-                    "url": f"{link}&referrer=discord&detection_type={self.alert_rule.detection_type}",
+                    "url": f"{link}?detection_type={self.alert_rule.detection_type}&referrer=discord",
                 }
             ],
             "components": [],
@@ -269,7 +266,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
                     "color": LEVEL_TO_COLOR["fatal"],
                     "title": title,
                     "description": f"0 events in the last 30 minutes\nThreshold: {alert_rule.detection_type.title()}",
-                    "url": f"{link}&referrer=discord&detection_type={alert_rule.detection_type}&notification_uuid={uuid}",
+                    "url": f"{link}?detection_type={alert_rule.detection_type}&referrer=discord&notification_uuid={uuid}",
                 }
             ],
             "components": [],

--- a/tests/sentry/integrations/discord/test_message_builder.py
+++ b/tests/sentry/integrations/discord/test_message_builder.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
+from unittest.mock import patch
+
 from django.urls import reverse
+from urllib3.response import HTTPResponse
 
 from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL
+from sentry.incidents.models.alert_rule import (
+    AlertRuleDetectionType,
+    AlertRuleSeasonality,
+    AlertRuleSensitivity,
+)
 from sentry.incidents.models.incident import IncidentStatus
 from sentry.integrations.discord.message_builder import LEVEL_TO_COLOR
 from sentry.integrations.discord.message_builder.metric_alerts import (
@@ -10,6 +18,7 @@ from sentry.integrations.discord.message_builder.metric_alerts import (
     get_started_at,
 )
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.utils.http import absolute_uri
 
 
@@ -39,7 +48,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
                 {
                     "title": title,
                     "description": "",
-                    "url": f"{link}&referrer=discord&notification_uuid={uuid}",
+                    "url": f"{link}&referrer=discord&detection_type={self.alert_rule.detection_type}&notification_uuid={uuid}",
                     "color": LEVEL_TO_COLOR["_incident_resolved"],
                 }
             ],
@@ -77,7 +86,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
                 {
                     "title": title,
                     "description": get_started_at(incident.date_started),
-                    "url": f"{link}&referrer=discord&notification_uuid={uuid}",
+                    "url": f"{link}&referrer=discord&detection_type={self.alert_rule.detection_type}&notification_uuid={uuid}",
                     "color": LEVEL_TO_COLOR["_incident_resolved"],
                 }
             ],
@@ -111,7 +120,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
                     "color": LEVEL_TO_COLOR["fatal"],
                     "title": title,
                     "description": "0 events in the last 10 minutes",
-                    "url": f"{link}&referrer=discord&notification_uuid={uuid}",
+                    "url": f"{link}&referrer=discord&detection_type={self.alert_rule.detection_type}&notification_uuid={uuid}",
                 }
             ],
             "components": [],
@@ -150,7 +159,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
                     "title": title,
                     "color": LEVEL_TO_COLOR["fatal"],
                     "description": f"{metric_value} events in the last 10 minutes{get_started_at(incident.date_started)}",
-                    "url": f"{link}?alert={incident.identifier}&referrer=discord&notification_uuid={uuid}",
+                    "url": f"{link}?detection_type={self.alert_rule.detection_type}&alert={incident.identifier}&referrer=discord&notification_uuid={uuid}",
                 }
             ],
             "components": [],
@@ -184,7 +193,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
                 {
                     "title": title,
                     "description": get_started_at(incident.date_started),
-                    "url": f"{link}?alert={incident.identifier}&referrer=discord&notification_uuid={uuid}",
+                    "url": f"{link}?alert={incident.identifier}&referrer=discord&detection_type={self.alert_rule.detection_type}&notification_uuid={uuid}",
                     "color": LEVEL_TO_COLOR["_incident_resolved"],
                     "image": {"url": "chart_url"},
                 }
@@ -217,7 +226,50 @@ class BuildMetricAlertAttachmentTest(TestCase):
                     "color": LEVEL_TO_COLOR["fatal"],
                     "title": title,
                     "description": "0 events in the last 10 minutes",
-                    "url": f"{link}&referrer=discord",
+                    "url": f"{link}&referrer=discord&detection_type={self.alert_rule.detection_type}",
+                }
+            ],
+            "components": [],
+        }
+
+    @with_feature("organizations:anomaly-detection-alerts")
+    @patch(
+        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
+    )
+    def test_metric_alert_with_anomaly_detection(self, mock_seer_request):
+        mock_seer_request.return_value = HTTPResponse(status=200)
+        alert_rule = self.create_alert_rule(
+            detection_type=AlertRuleDetectionType.DYNAMIC,
+            time_window=30,
+            sensitivity=AlertRuleSensitivity.LOW,
+            seasonality=AlertRuleSeasonality.AUTO,
+        )
+        incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CRITICAL.value)
+        trigger = self.create_alert_rule_trigger(alert_rule=alert_rule, alert_threshold=0)
+        self.create_alert_rule_trigger_action(
+            alert_rule_trigger=trigger, triggered_for_incident=incident
+        )
+        title = f"Critical: {alert_rule.name}"
+        link = absolute_uri(
+            reverse(
+                "sentry-metric-alert-details",
+                kwargs={
+                    "organization_slug": alert_rule.organization.slug,
+                    "alert_rule_id": alert_rule.id,
+                },
+            )
+        )
+        uuid = "uuid"
+        assert DiscordMetricAlertMessageBuilder(alert_rule=alert_rule,).build(
+            notification_uuid=uuid
+        ) == {
+            "content": "",
+            "embeds": [
+                {
+                    "color": LEVEL_TO_COLOR["fatal"],
+                    "title": title,
+                    "description": f"0 events in the last 30 minutes\nThreshold: {alert_rule.detection_type.title()}",
+                    "url": f"{link}&referrer=discord&detection_type={alert_rule.detection_type}&notification_uuid={uuid}",
                 }
             ],
             "components": [],

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -1212,7 +1212,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
                     },
                 )
             )
-            + f"?alert={incident.identifier}&detection_type={alert_rule.detection_type}"
+            + f"?detection_type={alert_rule.detection_type}&alert={incident.identifier}"
         )
         assert SlackMetricAlertMessageBuilder(alert_rule, incident).build() == {
             "color": LEVEL_TO_COLOR["_incident_resolved"],
@@ -1281,7 +1281,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
                     },
                 )
             )
-            + f"?alert={incident.identifier}&detection_type={alert_rule.detection_type}"
+            + f"?detection_type={alert_rule.detection_type}&alert={incident.identifier}"
         )
         assert SlackMetricAlertMessageBuilder(
             alert_rule, incident, IncidentStatus.CRITICAL, metric_value=metric_value
@@ -1356,7 +1356,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
                     },
                 )
             )
-            + f"?alert={incident.identifier}&detection_type={alert_rule.detection_type}"
+            + f"?detection_type={alert_rule.detection_type}"
         )
         assert SlackMetricAlertMessageBuilder(alert_rule).build() == {
             "color": LEVEL_TO_COLOR["fatal"],

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -1169,14 +1169,17 @@ class BuildMetricAlertAttachmentTest(TestCase):
     def test_metric_alert_without_incidents(self):
         alert_rule = self.create_alert_rule()
         title = f"Resolved: {alert_rule.name}"
-        link = absolute_uri(
-            reverse(
-                "sentry-metric-alert-details",
-                kwargs={
-                    "organization_slug": alert_rule.organization.slug,
-                    "alert_rule_id": alert_rule.id,
-                },
+        link = (
+            absolute_uri(
+                reverse(
+                    "sentry-metric-alert-details",
+                    kwargs={
+                        "organization_slug": alert_rule.organization.slug,
+                        "alert_rule_id": alert_rule.id,
+                    },
+                )
             )
+            + f"?detection_type={alert_rule.detection_type}"
         )
         assert SlackMetricAlertMessageBuilder(alert_rule).build() == {
             "color": LEVEL_TO_COLOR["_incident_resolved"],
@@ -1209,7 +1212,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
                     },
                 )
             )
-            + f"?alert={incident.identifier}"
+            + f"?alert={incident.identifier}&detection_type={alert_rule.detection_type}"
         )
         assert SlackMetricAlertMessageBuilder(alert_rule, incident).build() == {
             "color": LEVEL_TO_COLOR["_incident_resolved"],
@@ -1232,14 +1235,17 @@ class BuildMetricAlertAttachmentTest(TestCase):
             alert_rule_trigger=trigger, triggered_for_incident=incident
         )
         title = f"Critical: {alert_rule.name}"
-        link = absolute_uri(
-            reverse(
-                "sentry-metric-alert-details",
-                kwargs={
-                    "organization_slug": alert_rule.organization.slug,
-                    "alert_rule_id": alert_rule.id,
-                },
+        link = (
+            absolute_uri(
+                reverse(
+                    "sentry-metric-alert-details",
+                    kwargs={
+                        "organization_slug": alert_rule.organization.slug,
+                        "alert_rule_id": alert_rule.id,
+                    },
+                )
             )
+            + f"?detection_type={alert_rule.detection_type}"
         )
         assert SlackMetricAlertMessageBuilder(alert_rule).build() == {
             "color": LEVEL_TO_COLOR["fatal"],
@@ -1265,14 +1271,17 @@ class BuildMetricAlertAttachmentTest(TestCase):
         self.create_alert_rule_trigger_action(
             alert_rule_trigger=trigger, triggered_for_incident=incident
         )
-        link = absolute_uri(
-            reverse(
-                "sentry-metric-alert-details",
-                kwargs={
-                    "organization_slug": alert_rule.organization.slug,
-                    "alert_rule_id": alert_rule.id,
-                },
+        link = (
+            absolute_uri(
+                reverse(
+                    "sentry-metric-alert-details",
+                    kwargs={
+                        "organization_slug": alert_rule.organization.slug,
+                        "alert_rule_id": alert_rule.id,
+                    },
+                )
             )
+            + f"?alert={incident.identifier}&detection_type={alert_rule.detection_type}"
         )
         assert SlackMetricAlertMessageBuilder(
             alert_rule, incident, IncidentStatus.CRITICAL, metric_value=metric_value
@@ -1281,7 +1290,7 @@ class BuildMetricAlertAttachmentTest(TestCase):
             "blocks": [
                 {
                     "text": {
-                        "text": f"<{link}?alert={incident.identifier}|*{title}*>  \n"
+                        "text": f"<{link}|*{title}*>  \n"
                         f"{metric_value} events in the last 10 minutes",
                         "type": "mrkdwn",
                     },
@@ -1293,14 +1302,17 @@ class BuildMetricAlertAttachmentTest(TestCase):
     def test_metric_alert_chart(self):
         alert_rule = self.create_alert_rule()
         title = f"Resolved: {alert_rule.name}"
-        link = absolute_uri(
-            reverse(
-                "sentry-metric-alert-details",
-                kwargs={
-                    "organization_slug": alert_rule.organization.slug,
-                    "alert_rule_id": alert_rule.id,
-                },
+        link = (
+            absolute_uri(
+                reverse(
+                    "sentry-metric-alert-details",
+                    kwargs={
+                        "organization_slug": alert_rule.organization.slug,
+                        "alert_rule_id": alert_rule.id,
+                    },
+                )
             )
+            + f"?detection_type={alert_rule.detection_type}"
         )
         assert SlackMetricAlertMessageBuilder(alert_rule, chart_url="chart_url").build() == {
             "color": LEVEL_TO_COLOR["_incident_resolved"],
@@ -1313,6 +1325,49 @@ class BuildMetricAlertAttachmentTest(TestCase):
                     "type": "section",
                 },
                 {"alt_text": "Metric Alert Chart", "image_url": "chart_url", "type": "image"},
+            ],
+        }
+
+    @with_feature("organizations:anomaly-detection-alerts")
+    @patch(
+        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
+    )
+    def test_metric_alert_with_anomaly_detection(self, mock_seer_request):
+        mock_seer_request.return_value = HTTPResponse(status=200)
+        alert_rule = self.create_alert_rule(
+            detection_type=AlertRuleDetectionType.DYNAMIC,
+            time_window=30,
+            sensitivity=AlertRuleSensitivity.LOW,
+            seasonality=AlertRuleSeasonality.AUTO,
+        )
+        incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CRITICAL.value)
+        trigger = self.create_alert_rule_trigger(alert_rule=alert_rule, alert_threshold=0)
+        self.create_alert_rule_trigger_action(
+            alert_rule_trigger=trigger, triggered_for_incident=incident
+        )
+        title = f"Critical: {alert_rule.name}"
+        link = (
+            absolute_uri(
+                reverse(
+                    "sentry-metric-alert-details",
+                    kwargs={
+                        "organization_slug": alert_rule.organization.slug,
+                        "alert_rule_id": alert_rule.id,
+                    },
+                )
+            )
+            + f"?alert={incident.identifier}&detection_type={alert_rule.detection_type}"
+        )
+        assert SlackMetricAlertMessageBuilder(alert_rule).build() == {
+            "color": LEVEL_TO_COLOR["fatal"],
+            "blocks": [
+                {
+                    "text": {
+                        "text": f"<{link}|*{title}*>  \n0 events in the last 30 minutes\nThreshold: {alert_rule.detection_type.title()}",
+                        "type": "mrkdwn",
+                    },
+                    "type": "section",
+                },
             ],
         }
 


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/76030 to update Discord and the Slack unfurl metric alerts message builder (they share the same code) for dynamic alerts. The main change is adding the threshold to the message and the detection type to the url params for tracking the clickthrough rate. 

Screenshot coming soon ~ 