### PR TITLE
feat(ai-issue-summary): Issue summary card in sidebar

### DIFF
--- a/static/app/components/badge/featureBadge.tsx
+++ b/static/app/components/badge/featureBadge.tsx
@@ -12,7 +12,7 @@ import {t} from 'sentry/locale';
 import type {ValidSize} from 'sentry/styles/space';
 import {space} from 'sentry/styles/space';
 
-export type BadgeType = 'alpha' | 'beta' | 'new' | 'experimental';
+export type BadgeType = 'alpha' | 'beta' | 'new' | 'experimental' | 'internal';
 
 type BadgeProps = {
   type: BadgeType;
@@ -32,6 +32,7 @@ const defaultTitles: Record<BadgeType, string> = {
   experimental: t(
     'This feature is experimental! Try it out and let us know what you think. No promises!'
   ),
+  internal: t('This feature is for internal use only'),
 };
 
 const labels: Record<BadgeType, string> = {
@@ -39,6 +40,7 @@ const labels: Record<BadgeType, string> = {
   beta: t('beta'),
   new: t('new'),
   experimental: t('experimental'),
+  internal: t('internal only'),
 };
 
 const shortLabels: Record<BadgeType, string> = {
@@ -46,6 +48,7 @@ const shortLabels: Record<BadgeType, string> = {
   beta: 'B',
   new: 'N',
   experimental: 'E',
+  internal: 'I',
 };
 
 function BaseFeatureBadge({

--- a/static/app/components/badge/featureBadge.tsx
+++ b/static/app/components/badge/featureBadge.tsx
@@ -40,7 +40,7 @@ const labels: Record<BadgeType, string> = {
   beta: t('beta'),
   new: t('new'),
   experimental: t('experimental'),
-  internal: t('internal only'),
+  internal: t('internal'),
 };
 
 const shortLabels: Record<BadgeType, string> = {

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -96,7 +96,7 @@ const StyledTitleRow = styled('div')`
   justify-content: space-between;
 `;
 
-const StyledTitle = styled('span')`
+const StyledTitle = styled('div')`
   margin: 0;
   color: ${p => p.theme.text};
   font-size: ${p => p.theme.fontSizeMedium};

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -6,12 +6,12 @@ import Panel from 'sentry/components/panels/panel';
 import * as SidebarSection from 'sentry/components/sidebarSection';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Group} from 'sentry/types/group';
 import marked from 'sentry/utils/marked';
 import {type ApiQueryKey, useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
 
 interface GroupSummaryProps {
-  group: Group;
+  groupId: string;
 }
 
 interface GroupSummaryData {
@@ -20,18 +20,19 @@ interface GroupSummaryData {
   summary: string;
 }
 
-const makeGroupSummaryQueryKey = (groupId: string): ApiQueryKey => [
-  `/issues/${groupId}/summarize/`,
-];
+const makeGroupSummaryQueryKey = (
+  organizationSlug: string,
+  groupId: string
+): ApiQueryKey => [`/organizations/${organizationSlug}/issues/${groupId}/summarize/`];
 
-const useGroupSummary = (groupId: string) => {
-  return useApiQuery<GroupSummaryData>(makeGroupSummaryQueryKey(groupId), {
-    staleTime: Infinity, // Cache the result indefinitely as it's unlikely to change if it's already computed
-  });
-};
-
-export function GroupSummary({group}: GroupSummaryProps) {
-  const {data, isLoading, error} = useGroupSummary(group.id);
+export function GroupSummary({groupId}: GroupSummaryProps) {
+  const organization = useOrganization();
+  const {data, isLoading, error} = useApiQuery<GroupSummaryData>(
+    makeGroupSummaryQueryKey(organization.slug, groupId),
+    {
+      staleTime: Infinity, // Cache the result indefinitely as it's unlikely to change if it's already computed
+    }
+  );
 
   return (
     <SidebarSection.Wrap>
@@ -91,7 +92,6 @@ const Wrapper = styled(Panel)`
 
 const StyledTitleRow = styled('div')`
   display: flex;
-  flex-direction: row;
   align-items: center;
   justify-content: space-between;
 `;
@@ -103,14 +103,13 @@ const StyledTitle = styled('div')`
   font-weight: 600;
   align-items: center;
   display: flex;
-  flex-direction: row;
 `;
 
 const StyledFeatureBadge = styled(FeatureBadge)`
   margin-top: -1px;
 `;
 
-const StyledContent = styled(SidebarSection.Content)`
+const StyledContent = styled('div')`
   margin: 0;
 `;
 

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -53,7 +53,7 @@ export function GroupSummary({groupId}: GroupSummaryProps) {
           </StyledTitle>
           {isLoading && <StyledLoadingIndicator size={16} mini />}
         </StyledTitleRow>
-        <StyledContent>
+        <div>
           {error ? <div>{t('Error loading summary')}</div> : null}
           {data && (
             <Content>
@@ -72,7 +72,7 @@ export function GroupSummary({groupId}: GroupSummaryProps) {
               </ImpactContent>
             </Content>
           )}
-        </StyledContent>
+        </div>
       </Wrapper>
     </SidebarSection.Wrap>
   );
@@ -109,12 +109,7 @@ const StyledFeatureBadge = styled(FeatureBadge)`
   margin-top: -1px;
 `;
 
-const StyledContent = styled('div')`
-  margin: 0;
-`;
-
 const SummaryContent = styled('div')`
-  margin: 0;
   p {
     margin: 0;
   }

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -8,8 +8,7 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
 import marked from 'sentry/utils/marked';
-import {useQuery} from 'sentry/utils/queryClient';
-import useApi from 'sentry/utils/useApi';
+import {type ApiQueryKey, useApiQuery} from 'sentry/utils/queryClient';
 
 interface GroupSummaryProps {
   group: Group;
@@ -21,14 +20,12 @@ interface GroupSummaryData {
   summary: string;
 }
 
-const useGroupSummary = (groupId: string) => {
-  const api = useApi();
+const makeGroupSummaryQueryKey = (groupId: string): ApiQueryKey => [
+  `/issues/${groupId}/summarize/`,
+];
 
-  return useQuery<GroupSummaryData>({
-    queryKey: ['groupSummary', groupId],
-    queryFn: () => {
-      return api.requestPromise(`/issues/${groupId}/summarize/`);
-    },
+const useGroupSummary = (groupId: string) => {
+  return useApiQuery<GroupSummaryData>(makeGroupSummaryQueryKey(groupId), {
     staleTime: Infinity, // Cache the result indefinitely as it's unlikely to change if it's already computed
   });
 };

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -27,7 +27,7 @@ const makeGroupSummaryQueryKey = (
 
 export function GroupSummary({groupId}: GroupSummaryProps) {
   const organization = useOrganization();
-  const {data, isLoading, error} = useApiQuery<GroupSummaryData>(
+  const {data, isLoading, isError} = useApiQuery<GroupSummaryData>(
     makeGroupSummaryQueryKey(organization.slug, groupId),
     {
       staleTime: Infinity, // Cache the result indefinitely as it's unlikely to change if it's already computed
@@ -54,7 +54,7 @@ export function GroupSummary({groupId}: GroupSummaryProps) {
           {isLoading && <StyledLoadingIndicator size={16} mini />}
         </StyledTitleRow>
         <div>
-          {error ? <div>{t('Error loading summary')}</div> : null}
+          {isError ? <div>{t('Error loading summary')}</div> : null}
           {data && (
             <Content>
               <SummaryContent

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -1,0 +1,144 @@
+import styled from '@emotion/styled';
+
+import FeatureBadge from 'sentry/components/badge/featureBadge';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import Panel from 'sentry/components/panels/panel';
+import * as SidebarSection from 'sentry/components/sidebarSection';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Group} from 'sentry/types/group';
+import marked from 'sentry/utils/marked';
+import {useQuery} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
+
+interface GroupSummaryProps {
+  group: Group;
+}
+
+interface GroupSummaryData {
+  group_id: string;
+  impact: string;
+  summary: string;
+}
+
+const useGroupSummary = (groupId: string) => {
+  const api = useApi();
+
+  return useQuery<GroupSummaryData>({
+    queryKey: ['groupSummary', groupId],
+    queryFn: () => {
+      return api.requestPromise(`/issues/${groupId}/summarize/`);
+    },
+    staleTime: Infinity, // Cache the result indefinitely as it's unlikely to change if it's already computed
+  });
+};
+
+export function GroupSummary({group}: GroupSummaryProps) {
+  const {data, isLoading, error} = useGroupSummary(group.id);
+
+  return (
+    <SidebarSection.Wrap>
+      <Wrapper>
+        <StyledTitleRow>
+          <StyledTitle>
+            <span>{t('Issue Summary')}</span>
+            <StyledFeatureBadge
+              type="internal"
+              title={tct(
+                'This feature is currently only testing internally. Please let us know your feedback at [channel:#proj-issue-summary].',
+                {
+                  channel: <a href="https://sentry.slack.com/archives/C07GPS55GUC" />,
+                }
+              )}
+              tooltipProps={{isHoverable: true}}
+            />
+          </StyledTitle>
+          {isLoading && <StyledLoadingIndicator size={16} mini />}
+        </StyledTitleRow>
+        <StyledContent>
+          {error ? <div>{t('Error loading summary')}</div> : null}
+          {data && (
+            <Content>
+              <SummaryContent
+                dangerouslySetInnerHTML={{
+                  __html: marked(data.summary),
+                }}
+              />
+              <ImpactContent>
+                <StyledTitle>{t('Potential Impact')}</StyledTitle>
+                <SummaryContent
+                  dangerouslySetInnerHTML={{
+                    __html: marked(data.impact),
+                  }}
+                />
+              </ImpactContent>
+            </Content>
+          )}
+        </StyledContent>
+      </Wrapper>
+    </SidebarSection.Wrap>
+  );
+}
+
+const Wrapper = styled(Panel)`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 0;
+  background: linear-gradient(
+    269.35deg,
+    ${p => p.theme.backgroundTertiary} 0.32%,
+    rgba(245, 243, 247, 0) 99.69%
+  );
+  padding: ${space(1.5)} ${space(2)};
+`;
+
+const StyledTitleRow = styled('div')`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const StyledTitle = styled('span')`
+  margin: 0;
+  color: ${p => p.theme.text};
+  font-size: ${p => p.theme.fontSizeMedium};
+  font-weight: 600;
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+`;
+
+const StyledFeatureBadge = styled(FeatureBadge)`
+  margin-top: -1px;
+`;
+
+const StyledContent = styled(SidebarSection.Content)`
+  margin: 0;
+`;
+
+const SummaryContent = styled('div')`
+  margin: 0;
+  p {
+    margin: 0;
+  }
+`;
+
+const StyledLoadingIndicator = styled(LoadingIndicator)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  max-height: 16px;
+`;
+
+const ImpactContent = styled('div')`
+  display: flex;
+  flex-direction: column;
+`;
+
+const Content = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
+`;

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -15,7 +15,7 @@ interface GroupSummaryProps {
 }
 
 interface GroupSummaryData {
-  group_id: string;
+  groupId: string;
   impact: string;
   summary: string;
 }

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -497,6 +497,11 @@ const generateBadgeTheme = (colors: BaseColors) => ({
     indicatorColor: colors.gray100,
     color: colors.gray500,
   },
+  internal: {
+    background: colors.gray100,
+    indicatorColor: colors.gray100,
+    color: colors.gray500,
+  },
   warning: {
     background: colors.yellow300,
     indicatorColor: colors.yellow300,

--- a/static/app/views/issueDetails/groupSidebar.tsx
+++ b/static/app/views/issueDetails/groupSidebar.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import Feature from 'sentry/components/acl/feature';
 import AvatarList from 'sentry/components/avatar/avatarList';
 import {DateTime} from 'sentry/components/dateTime';
 import type {OnAssignCallback} from 'sentry/components/deprecatedAssigneeSelectorDropdown';
@@ -9,6 +10,7 @@ import {EventThroughput} from 'sentry/components/events/eventStatisticalDetector
 import AssignedTo from 'sentry/components/group/assignedTo';
 import ExternalIssueList from 'sentry/components/group/externalIssuesList';
 import {StreamlinedExternalIssueList} from 'sentry/components/group/externalIssuesList/streamlinedExternalIssueList';
+import {GroupSummary} from 'sentry/components/group/groupSummary';
 import GroupReleaseStats from 'sentry/components/group/releaseStats';
 import TagFacets, {
   BACKEND_TAGS,
@@ -262,6 +264,9 @@ export default function GroupSidebar({
 
   return (
     <Container>
+      <Feature features={['organizations:ai-summary']}>
+        <GroupSummary group={group} />
+      </Feature>
       {hasStreamlinedUI && event && (
         <ErrorBoundary mini>
           <StreamlinedExternalIssueList group={group} event={event} project={project} />

--- a/static/app/views/issueDetails/groupSidebar.tsx
+++ b/static/app/views/issueDetails/groupSidebar.tsx
@@ -265,7 +265,7 @@ export default function GroupSidebar({
   return (
     <Container>
       <Feature features={['organizations:ai-summary']}>
-        <GroupSummary group={group} />
+        <GroupSummary groupId={group.id} />
       </Feature>
       {hasStreamlinedUI && event && (
         <ErrorBoundary mini>


### PR DESCRIPTION
Introduces the issue summary card and trigger on the issue details page sidebar guarded by the `organizations:ai-summary` feature flag

<img width="395" alt="Screenshot 2024-08-13 at 9 58 17 AM" src="https://github.com/user-attachments/assets/fb7e1bcf-9ef7-4941-b326-a88bcd05654b">

https://github.com/user-attachments/assets/6057959d-cc20-4582-95f5-cb47df3767e8

