### PR TITLE
build(handle_artifacts): fix bug causing codecovuploads to fail on main

### DIFF
--- a/.github/actions/artifacts/do_upload.py
+++ b/.github/actions/artifacts/do_upload.py
@@ -86,8 +86,13 @@ def main():
     # wait, while showing un-interleaved logs
     jobs.append(Popen(tail_args))
 
+    return_codes = []
+
     for job in jobs:
         job.wait()
+
+    if any(return_codes):
+        raise Exception("Error uploading to codecov")
 
 
 if __name__ == "__main__":

--- a/.github/actions/artifacts/do_upload.py
+++ b/.github/actions/artifacts/do_upload.py
@@ -38,13 +38,14 @@ def main():
     upload_flags = [
         "-t",
         input_token,
-        "--commit-sha",
-        input_commit_sha,
         "--plugin",
         "noop",
         "--flag",
         input_type,
     ]
+
+    if input_commit_sha:
+        upload_flags += ["--commit-sha", input_commit_sha]
 
     upload_coverage_cmd = [*codecov_base_cmd, "upload-process", *upload_flags]
     for file in coverage_files:


### PR DESCRIPTION
if the CI runs on main then all the jobs that rely on ${{ github.event.pull.head.sha }} to the commit_sha param of the handle_artifacts action would fail to upload because we would override the commit-sha to be an empty string.

By not setting this option if the commit_sha param of the handle_artifacts job is empty, the codecov CLI can determine the commit SHA itself.