### PR TITLE
fix(ui): fixes issue with tag facet expand collapse not animating properly

### DIFF
--- a/static/app/components/group/tagFacets/tagFacetsDistributionMeter.tsx
+++ b/static/app/components/group/tagFacets/tagFacetsDistributionMeter.tsx
@@ -147,7 +147,9 @@ function TagFacetsDistributionMeter({
     return (
       <LegendAnimateContainer
         expanded={expanded}
-        animate={expanded ? {height: '100%', opacity: 1} : {height: '0', opacity: 0}}
+        animate={
+          expanded ? {height: ['100%', 'auto'], opacity: 1} : {height: '0', opacity: 0}
+        }
       >
         <LegendContainer>
           {topSegments.map((segment, index) => {


### PR DESCRIPTION
Fixes a regression on the tag facets legend container not properly adjusting height to 0 when collapsed. This was caused due to updating the framer motion package to a newer version ([^11.3.21](https://github.com/getsentry/sentry/pull/75603)). Adding a `height: auto` keyframe helps the container properly adjust between 100% and 0 height.
![image](https://github.com/user-attachments/assets/28347a7e-6ffb-49e8-853d-5de20bfa0ac9)
