### PR TITLE
feat(discover): Update events and events-stats endpoints to skip metrics layer on insights based queries

### DIFF
--- a/src/sentry/snuba/metrics_performance.py
+++ b/src/sentry/snuba/metrics_performance.py
@@ -77,6 +77,7 @@ def query(
                 use_metrics_layer=use_metrics_layer,
                 on_demand_metrics_enabled=on_demand_metrics_enabled,
                 on_demand_metrics_type=on_demand_metrics_type,
+                insights_metrics_override_metric_layer=True,
             ),
         )
         metrics_referrer = referrer + ".metrics-enhanced"
@@ -285,6 +286,7 @@ def timeseries_query(
                     use_metrics_layer=use_metrics_layer,
                     on_demand_metrics_enabled=on_demand_metrics_enabled,
                     on_demand_metrics_type=on_demand_metrics_type,
+                    insights_metrics_override_metric_layer=True,
                 ),
             )
             metrics_referrer = referrer + ".metrics-enhanced"


### PR DESCRIPTION
Sets `insights_metrics_override_metric_layer` to true on discover `metrics_performance` events and events-stats endpoints which allows skipping the metrics layer when an unsupported query (insights) is detected