### PR TITLE
ref(control_silo): Move UserRole model to users module

### DIFF
--- a/src/sentry/api/endpoints/user_role_details.py
+++ b/src/sentry/api/endpoints/user_role_details.py
@@ -11,7 +11,7 @@ from sentry.api.bases.user import UserEndpoint
 from sentry.api.decorators import sudo_required
 from sentry.api.permissions import SuperuserPermission
 from sentry.api.serializers import serialize
-from sentry.models.userrole import UserRole, UserRoleUser
+from sentry.users.models.userrole import UserRole, UserRoleUser
 
 audit_logger = logging.getLogger("sentry.audit.user")
 

--- a/src/sentry/api/endpoints/user_roles.py
+++ b/src/sentry/api/endpoints/user_roles.py
@@ -6,7 +6,7 @@ from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.permissions import SuperuserPermission
 from sentry.api.serializers import serialize
-from sentry.models.userrole import UserRole
+from sentry.users.models.userrole import UserRole
 
 
 @control_silo_endpoint

--- a/src/sentry/api/endpoints/userroles_details.py
+++ b/src/sentry/api/endpoints/userroles_details.py
@@ -10,7 +10,7 @@ from sentry.api.decorators import sudo_required
 from sentry.api.permissions import SuperuserPermission
 from sentry.api.serializers import serialize
 from sentry.api.validators.userrole import UserRoleValidator
-from sentry.models.userrole import UserRole
+from sentry.users.models.userrole import UserRole
 
 audit_logger = logging.getLogger("sentry.audit.user")
 

--- a/src/sentry/api/endpoints/userroles_index.py
+++ b/src/sentry/api/endpoints/userroles_index.py
@@ -10,7 +10,7 @@ from sentry.api.decorators import sudo_required
 from sentry.api.permissions import SuperuserPermission
 from sentry.api.serializers import serialize
 from sentry.api.validators.userrole import UserRoleValidator
-from sentry.models.userrole import UserRole
+from sentry.users.models.userrole import UserRole
 
 audit_logger = logging.getLogger("sentry.audit.user")
 

--- a/src/sentry/api/serializers/models/user.py
+++ b/src/sentry/api/serializers/models/user.py
@@ -25,10 +25,10 @@ from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.models.useremail import UserEmail
 from sentry.models.userpermission import UserPermission
-from sentry.models.userrole import UserRoleUser
 from sentry.organizations.services.organization import RpcOrganizationSummary
 from sentry.users.models.authenticator import Authenticator
 from sentry.users.models.user import User
+from sentry.users.models.userrole import UserRoleUser
 from sentry.users.services.user import RpcUser
 from sentry.utils.avatar import get_gravatar_url
 

--- a/src/sentry/api/serializers/models/userrole.py
+++ b/src/sentry/api/serializers/models/userrole.py
@@ -1,5 +1,5 @@
 from sentry.api.serializers import Serializer, register
-from sentry.models.userrole import UserRole
+from sentry.users.models.userrole import UserRole
 
 
 @register(UserRole)

--- a/src/sentry/backup/services/import_export/impl.py
+++ b/src/sentry/backup/services/import_export/impl.py
@@ -48,9 +48,9 @@ from sentry.hybridcloud.models.outbox import outbox_context
 from sentry.models.importchunk import ControlImportChunk, RegionImportChunk
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.userpermission import UserPermission
-from sentry.models.userrole import UserRoleUser
 from sentry.silo.base import SiloMode
 from sentry.users.models.user import User
+from sentry.users.models.userrole import UserRoleUser
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/models/__init__.py
+++ b/src/sentry/models/__init__.py
@@ -1,6 +1,7 @@
 from sentry.users.models.authenticator import *  # NOQA
 from sentry.users.models.email import *  # NOQA
 from sentry.users.models.user import *  # NOQA
+from sentry.users.models.userrole import *  # NOQA
 
 from .activity import *  # NOQA
 from .apiapplication import *  # NOQA
@@ -123,4 +124,3 @@ from .useremail import *  # NOQA
 from .userip import *  # NOQA
 from .userpermission import *  # NOQA
 from .userreport import *  # NOQA
-from .userrole import *  # NOQA

--- a/src/sentry/runner/commands/createuser.py
+++ b/src/sentry/runner/commands/createuser.py
@@ -53,7 +53,7 @@ def _set_superadmin(user: User) -> None:
     superadmin role approximates superuser (model attribute) but leveraging
     Sentry's role system.
     """
-    from sentry.models.userrole import UserRole, UserRoleUser
+    from sentry.users.models.userrole import UserRole, UserRoleUser
 
     role = UserRole.objects.get(name="Super Admin")
     UserRoleUser.objects.create(user=user, role=role)

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -141,7 +141,6 @@ from sentry.models.team import Team
 from sentry.models.useremail import UserEmail
 from sentry.models.userpermission import UserPermission
 from sentry.models.userreport import UserReport
-from sentry.models.userrole import UserRole
 from sentry.organizations.services.organization import RpcOrganization, RpcUserOrganizationContext
 from sentry.sentry_apps.apps import SentryAppCreator
 from sentry.sentry_apps.installations import (
@@ -168,6 +167,7 @@ from sentry.uptime.models import (
     UptimeSubscription,
 )
 from sentry.users.models.user import User
+from sentry.users.models.userrole import UserRole
 from sentry.users.services.user import RpcUser
 from sentry.utils import loremipsum
 from sentry.utils.performance_issues.performance_problem import PerformanceProblem

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -97,7 +97,6 @@ from sentry.models.rule import NeglectedRule, RuleActivity, RuleActivityType
 from sentry.models.savedsearch import SavedSearch, Visibility
 from sentry.models.search_common import SearchType
 from sentry.models.userip import UserIP
-from sentry.models.userrole import UserRole, UserRoleUser
 from sentry.monitors.models import Monitor, MonitorType, ScheduleType
 from sentry.nodestore.django.models import Node
 from sentry.sentry_apps.apps import SentryAppUpdater
@@ -114,6 +113,7 @@ from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.token import AuthTokenType
 from sentry.users.models.authenticator import Authenticator
 from sentry.users.models.user import User
+from sentry.users.models.userrole import UserRole, UserRoleUser
 from sentry.utils import json
 
 __all__ = [

--- a/src/sentry/users/models/userrole.py
+++ b/src/sentry/users/models/userrole.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Any
 
 from django.conf import settings
 from django.db import models
@@ -81,7 +82,7 @@ class UserRoleUser(ControlOutboxProducingModel):
 
 
 # this must be idempotent because it executes on every upgrade
-def manage_default_super_admin_role(**kwargs):
+def manage_default_super_admin_role(**kwargs: Any) -> None:
     role, _ = UserRole.objects.get_or_create(
         name="Super Admin", defaults={"permissions": settings.SENTRY_USER_PERMISSIONS}
     )

--- a/tests/relay_integration/test_sdk.py
+++ b/tests/relay_integration/test_sdk.py
@@ -8,7 +8,6 @@ from sentry_sdk import isolation_scope
 
 from sentry import eventstore
 from sentry.eventstore.models import Event
-from sentry.models.userrole import manage_default_super_admin_role
 from sentry.receivers import create_default_projects
 from sentry.silo.base import SiloMode
 from sentry.testutils.asserts import assert_mock_called_once_with_partial
@@ -16,6 +15,7 @@ from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.pytest.relay import adjust_settings_for_relay_tests
 from sentry.testutils.silo import assume_test_silo_mode, no_silo_test
 from sentry.testutils.skips import requires_kafka
+from sentry.users.models.userrole import manage_default_super_admin_role
 from sentry.utils.sdk import bind_organization_context, configure_sdk
 
 pytestmark = [requires_kafka]

--- a/tests/sentry/api/endpoints/test_user_details.py
+++ b/tests/sentry/api/endpoints/test_user_details.py
@@ -6,7 +6,6 @@ from sentry.models.options.user_option import UserOption
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.userpermission import UserPermission
-from sentry.models.userrole import UserRole
 from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.testutils.cases import APITestCase
@@ -15,6 +14,7 @@ from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.users.models.user import User
+from sentry.users.models.userrole import UserRole
 
 
 class UserDetailsTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_user_role_details.py
+++ b/tests/sentry/api/endpoints/test_user_role_details.py
@@ -1,6 +1,6 @@
-from sentry.models.userrole import UserRole
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
+from sentry.users.models.userrole import UserRole
 
 
 @control_silo_test

--- a/tests/sentry/api/endpoints/test_user_roles.py
+++ b/tests/sentry/api/endpoints/test_user_roles.py
@@ -1,6 +1,6 @@
-from sentry.models.userrole import UserRole
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
+from sentry.users.models.userrole import UserRole
 
 
 @control_silo_test

--- a/tests/sentry/api/endpoints/test_userroles_details.py
+++ b/tests/sentry/api/endpoints/test_userroles_details.py
@@ -1,6 +1,6 @@
-from sentry.models.userrole import UserRole
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
+from sentry.users.models.userrole import UserRole
 
 
 @control_silo_test

--- a/tests/sentry/api/endpoints/test_userroles_index.py
+++ b/tests/sentry/api/endpoints/test_userroles_index.py
@@ -1,6 +1,6 @@
-from sentry.models.userrole import UserRole
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
+from sentry.users.models.userrole import UserRole
 
 
 @control_silo_test

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -16,7 +16,6 @@ from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider
 from sentry.models.organization import Organization
 from sentry.models.team import TeamStatus
-from sentry.models.userrole import UserRole
 from sentry.organizations.services.organization import organization_service
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
@@ -24,6 +23,7 @@ from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode, no_silo_test
 from sentry.users.models.user import User
+from sentry.users.models.userrole import UserRole
 
 
 def silo_from_user(

--- a/tests/sentry/backup/test_exports.py
+++ b/tests/sentry/backup/test_exports.py
@@ -16,7 +16,6 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.models.orgauthtoken import OrgAuthToken
 from sentry.models.useremail import UserEmail
 from sentry.models.userpermission import UserPermission
-from sentry.models.userrole import UserRole, UserRoleUser
 from sentry.testutils.helpers.backups import (
     BackupTransactionTestCase,
     ValidationError,
@@ -26,6 +25,7 @@ from sentry.testutils.helpers.backups import (
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.users.models.email import Email
 from sentry.users.models.user import User
+from sentry.users.models.userrole import UserRole, UserRoleUser
 from tests.sentry.backup import get_matching_exportable_models
 
 

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -60,7 +60,6 @@ from sentry.models.team import Team
 from sentry.models.useremail import UserEmail
 from sentry.models.userip import UserIP
 from sentry.models.userpermission import UserPermission
-from sentry.models.userrole import UserRole, UserRoleUser
 from sentry.monitors.models import Monitor
 from sentry.receivers import create_default_projects
 from sentry.silo.base import SiloMode
@@ -81,6 +80,7 @@ from sentry.testutils.silo import assume_test_silo_mode
 from sentry.users.models.authenticator import Authenticator
 from sentry.users.models.email import Email
 from sentry.users.models.user import User
+from sentry.users.models.userrole import UserRole, UserRoleUser
 from tests.sentry.backup import (
     expect_models,
     get_matching_exportable_models,

--- a/tests/sentry/runner/commands/test_createuser.py
+++ b/tests/sentry/runner/commands/test_createuser.py
@@ -1,13 +1,13 @@
 from sentry import roles
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
-from sentry.models.userrole import manage_default_super_admin_role
 from sentry.receivers import create_default_projects
 from sentry.runner.commands.createuser import createuser
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import CliTestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.users.models.user import User
+from sentry.users.models.userrole import manage_default_super_admin_role
 from sentry.users.services.user.service import user_service
 
 

--- a/tests/sentry/users/models/test_userrole.py
+++ b/tests/sentry/users/models/test_userrole.py
@@ -1,8 +1,8 @@
 from django.conf import settings
 
-from sentry.models.userrole import UserRole, manage_default_super_admin_role
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
+from sentry.users.models.userrole import UserRole, manage_default_super_admin_role
 
 
 @control_silo_test


### PR DESCRIPTION
Part of moving control silo user related resources into the users module, this PR does not include an old UserRole import shim as it's not used in getsentry. Includes adding of types for functions.

Apart of (#73856)
