### PR TITLE
fix(dashboard): Pass down user in widget serializer

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -269,7 +269,8 @@ class DashboardDetailsModelSerializer(Serializer):
                 DashboardWidget.objects.filter(dashboard_id__in=[i.id for i in item_list]).order_by(
                     "order"
                 )
-            )
+            ),
+            user=user,
         )
 
         for dashboard in item_list:


### PR DESCRIPTION
The downstream serializer was missing the user object so a feature check in the dashboard widget was failing