### PR TITLE
feat(query-builder): Support overlapping filter key categories

### DIFF
--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -101,7 +101,7 @@ const FILTER_KEY_SECTIONS: FilterKeySection[] = [
   {
     value: 'cat_4',
     label: 'Category 4',
-    children: [FieldKey.LAST_SEEN],
+    children: [FieldKey.LAST_SEEN, FieldKey.TIMES_SEEN],
   },
   {
     value: 'cat_5',

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -44,16 +44,24 @@ export function createSection(
     key: section.value,
     value: section.value,
     label: section.label,
-    options: section.children.map(key => createItem(keys[key], getFieldDefinition(key))),
+    options: section.children.map(key =>
+      createItem(keys[key], getFieldDefinition(key), section)
+    ),
     type: 'section',
   };
 }
 
-export function createItem(tag: Tag, fieldDefinition: FieldDefinition | null): KeyItem {
+export function createItem(
+  tag: Tag,
+  fieldDefinition: FieldDefinition | null,
+  section?: FilterKeySection
+): KeyItem {
   const description = fieldDefinition?.desc;
 
+  const key = section ? `${section.value}:${tag.key}` : tag.key;
+
   return {
-    key: getEscapedKey(tag.key),
+    key: getEscapedKey(key),
     label: getKeyLabel(tag, fieldDefinition),
     description: description ?? '',
     value: tag.key,


### PR DESCRIPTION
Adds the section value to the item key to allow for categories with overlapping options. Previously, the item keys were only based on the filter key so you could only have one per menu. 

This was requested by the Replays team.

![CleanShot 2024-08-13 at 15 22 29](https://github.com/user-attachments/assets/8575f8ca-eb68-4bc9-ae6e-c8abb87db0d5)
