### PR TITLE
fix(query-builder): Cap recent filter keys at 3 max

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useRecentSearchFilters.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useRecentSearchFilters.tsx
@@ -7,7 +7,7 @@ import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils
 import {type ParseResult, Token} from 'sentry/components/searchSyntax/parser';
 import type {RecentSearch, TagCollection} from 'sentry/types/group';
 
-const MAX_RECENT_FILTERS = 5;
+const MAX_RECENT_FILTERS = 3;
 const NO_FILTERS = [];
 
 // If the recent searches are very long, this prevents the parser from taking too long
@@ -88,7 +88,7 @@ export function useRecentSearchFilters() {
   const {data: recentSearchesData} = useFetchRecentSearches(
     {
       savedSearchType: recentSearches ?? null,
-      limit: 10,
+      limit: 5,
     },
     {
       staleTime: 30_000,


### PR DESCRIPTION
5 items takes up too much space, maxing at 3 until we have a better way of displaying these