### PR TITLE
feat(uptime): Mark uptime monitors as failed after two consecutive checks

### DIFF
--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -45,6 +45,12 @@ ONBOARDING_FAILURE_THRESHOLD = 3
 ONBOARDING_FAILURE_REDIS_TTL = ONBOARDING_MONITOR_PERIOD
 # How frequently we should run active auto-detected subscriptions
 AUTO_DETECTED_ACTIVE_SUBSCRIPTION_INTERVAL = timedelta(minutes=5)
+# When in active monitoring mode, how many failures in a row do we need to see to mark the monitor as down, or how many
+# successes in a row do we need to mark it up
+ACTIVE_FAILURE_THRESHOLD = 2
+ACTIVE_RECOVERY_THRESHOLD = 1
+# The TTL of the redis key used to track consecutive statuses
+ACTIVE_THRESHOLD_REDIS_TTL = timedelta(minutes=60)
 
 
 def build_last_update_key(project_subscription: ProjectUptimeSubscription) -> str:
@@ -53,6 +59,12 @@ def build_last_update_key(project_subscription: ProjectUptimeSubscription) -> st
 
 def build_onboarding_failure_key(project_subscription: ProjectUptimeSubscription) -> str:
     return f"project-sub-onboarding_failure:{project_subscription.id}"
+
+
+def build_active_consecutive_status_key(
+    project_subscription: ProjectUptimeSubscription, status: str
+) -> str:
+    return f"project-sub-active:{status}:{project_subscription.id}"
 
 
 class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
@@ -103,7 +115,6 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
             tags={"status_reason": status_reason, **metric_tags},
             sample_rate=1.0,
         )
-        cluster = _get_cluster()
         try:
             if result["scheduled_check_time_ms"] <= last_update_ms:
                 # If the scheduled check time is older than the most recent update then we've already processed it.
@@ -154,6 +165,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
             logger.exception("Failed to process result for uptime project subscription")
 
         # Now that we've processed the result for this project subscription we track the last update date
+        cluster = _get_cluster()
         cluster.set(
             build_last_update_key(project_subscription),
             int(result["scheduled_check_time_ms"]),
@@ -230,10 +242,20 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
     def handle_result_for_project_active_mode(
         self, project_subscription: ProjectUptimeSubscription, result: CheckResult
     ):
+        redis = _get_cluster()
+        delete_status = (
+            CHECKSTATUS_FAILURE if result["status"] == CHECKSTATUS_SUCCESS else CHECKSTATUS_SUCCESS
+        )
+        # Delete any consecutive results we have for the opposing status, since we received this status
+        redis.delete(build_active_consecutive_status_key(project_subscription, delete_status))
+
         if (
             project_subscription.uptime_status == UptimeStatus.OK
             and result["status"] == CHECKSTATUS_FAILURE
         ):
+            if not self.has_reached_status_threshold(project_subscription, result["status"]):
+                return
+
             if features.has(
                 "organizations:uptime-create-issues", project_subscription.project.organization
             ):
@@ -252,6 +274,9 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
             project_subscription.uptime_status == UptimeStatus.FAILED
             and result["status"] == CHECKSTATUS_SUCCESS
         ):
+            if not self.has_reached_status_threshold(project_subscription, result["status"]):
+                return
+
             if features.has(
                 "organizations:uptime-create-issues", project_subscription.project.organization
             ):
@@ -266,6 +291,25 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                     },
                 )
             project_subscription.update(uptime_status=UptimeStatus.OK)
+
+    def has_reached_status_threshold(
+        self, project_subscription: ProjectUptimeSubscription, status: str
+    ) -> bool:
+        pipeline = _get_cluster().pipeline()
+        key = build_active_consecutive_status_key(project_subscription, status)
+        pipeline.incr(key)
+        pipeline.expire(key, ACTIVE_THRESHOLD_REDIS_TTL)
+        status_count = int(pipeline.execute()[0])
+        result = (status == CHECKSTATUS_FAILURE and status_count >= ACTIVE_FAILURE_THRESHOLD) or (
+            status == CHECKSTATUS_SUCCESS and status_count >= ACTIVE_RECOVERY_THRESHOLD
+        )
+        if not result:
+            metrics.incr(
+                "uptime.result_processor.active.under_threshold",
+                sample_rate=1.0,
+                tags={"status": status},
+            )
+        return result
 
 
 class UptimeResultsStrategyFactory(ResultsStrategyFactory[CheckResult, UptimeSubscription]):

--- a/tests/sentry/uptime/consumers/test_results_consumers.py
+++ b/tests/sentry/uptime/consumers/test_results_consumers.py
@@ -65,11 +65,39 @@ class ProcessResultTest(UptimeTestCase, ProducerTestMixin):
             consumer.submit(message)
 
     def test(self):
-        result = self.create_uptime_result(self.subscription.subscription_id)
+        result = self.create_uptime_result(
+            self.subscription.subscription_id,
+            scheduled_check_time=datetime.now() - timedelta(minutes=5),
+        )
         with mock.patch(
             "sentry.uptime.consumers.results_consumer.metrics"
         ) as metrics, self.feature("organizations:uptime-create-issues"):
             self.send_result(result)
+            metrics.incr.assert_has_calls(
+                [
+                    call(
+                        "uptime.result_processor.handle_result_for_project",
+                        tags={
+                            "status_reason": "timeout",
+                            "status": "failure",
+                            "mode": "auto_detected_active",
+                        },
+                        sample_rate=1.0,
+                    ),
+                    call(
+                        "uptime.result_processor.active.under_threshold",
+                        sample_rate=1.0,
+                        tags={"status": "failure"},
+                    ),
+                ]
+            )
+            metrics.incr.reset_mock()
+            self.send_result(
+                self.create_uptime_result(
+                    self.subscription.subscription_id,
+                    scheduled_check_time=datetime.now() - timedelta(minutes=4),
+                )
+            )
             metrics.incr.assert_has_calls(
                 [
                     call(
@@ -90,9 +118,93 @@ class ProcessResultTest(UptimeTestCase, ProducerTestMixin):
         self.project_subscription.refresh_from_db()
         assert self.project_subscription.uptime_status == UptimeStatus.FAILED
 
+    def test_reset_fail_count(self):
+        with mock.patch(
+            "sentry.uptime.consumers.results_consumer.metrics"
+        ) as metrics, self.feature("organizations:uptime-create-issues"):
+            self.send_result(
+                self.create_uptime_result(
+                    self.subscription.subscription_id,
+                    scheduled_check_time=datetime.now() - timedelta(minutes=5),
+                )
+            )
+            metrics.incr.assert_has_calls(
+                [
+                    call(
+                        "uptime.result_processor.handle_result_for_project",
+                        tags={
+                            "status_reason": "timeout",
+                            "status": "failure",
+                            "mode": "auto_detected_active",
+                        },
+                        sample_rate=1.0,
+                    ),
+                    call(
+                        "uptime.result_processor.active.under_threshold",
+                        sample_rate=1.0,
+                        tags={"status": "failure"},
+                    ),
+                ]
+            )
+            metrics.incr.reset_mock()
+            self.send_result(
+                self.create_uptime_result(
+                    self.subscription.subscription_id,
+                    status=CHECKSTATUS_SUCCESS,
+                    scheduled_check_time=datetime.now() - timedelta(minutes=4),
+                )
+            )
+            metrics.incr.assert_has_calls(
+                [
+                    call(
+                        "uptime.result_processor.handle_result_for_project",
+                        tags={
+                            "status_reason": "timeout",
+                            "status": "success",
+                            "mode": "auto_detected_active",
+                        },
+                        sample_rate=1.0,
+                    ),
+                ]
+            )
+            metrics.incr.reset_mock()
+            self.send_result(
+                self.create_uptime_result(
+                    self.subscription.subscription_id,
+                    scheduled_check_time=datetime.now() - timedelta(minutes=3),
+                )
+            )
+            metrics.incr.assert_has_calls(
+                [
+                    call(
+                        "uptime.result_processor.handle_result_for_project",
+                        tags={
+                            "status_reason": "timeout",
+                            "status": "failure",
+                            "mode": "auto_detected_active",
+                        },
+                        sample_rate=1.0,
+                    ),
+                    call(
+                        "uptime.result_processor.active.under_threshold",
+                        sample_rate=1.0,
+                        tags={"status": "failure"},
+                    ),
+                ]
+            )
+
+        hashed_fingerprint = md5(str(self.project_subscription.id).encode("utf-8")).hexdigest()
+        with pytest.raises(Group.DoesNotExist):
+            Group.objects.get(grouphash__hash=hashed_fingerprint)
+        self.project_subscription.refresh_from_db()
+        assert self.project_subscription.uptime_status == UptimeStatus.OK
+
     def test_no_create_issues_feature(self):
         result = self.create_uptime_result(self.subscription.subscription_id)
-        with mock.patch("sentry.uptime.consumers.results_consumer.metrics") as metrics:
+        with mock.patch("sentry.uptime.consumers.results_consumer.metrics") as metrics, mock.patch(
+            "sentry.uptime.consumers.results_consumer.ACTIVE_FAILURE_THRESHOLD",
+            new=1,
+        ):
             self.send_result(result)
             metrics.incr.assert_has_calls(
                 [
@@ -115,14 +227,35 @@ class ProcessResultTest(UptimeTestCase, ProducerTestMixin):
         assert self.project_subscription.uptime_status == UptimeStatus.FAILED
 
     def test_resolve(self):
-        result = self.create_uptime_result(
-            self.subscription.subscription_id,
-            scheduled_check_time=datetime.now() - timedelta(minutes=5),
-        )
         with mock.patch(
             "sentry.uptime.consumers.results_consumer.metrics"
         ) as metrics, self.feature("organizations:uptime-create-issues"):
-            self.send_result(result)
+            self.send_result(
+                self.create_uptime_result(
+                    self.subscription.subscription_id,
+                    scheduled_check_time=datetime.now() - timedelta(minutes=5),
+                )
+            )
+            metrics.incr.assert_has_calls(
+                [
+                    call(
+                        "uptime.result_processor.handle_result_for_project",
+                        tags={
+                            "status_reason": "timeout",
+                            "status": "failure",
+                            "mode": "auto_detected_active",
+                        },
+                        sample_rate=1.0,
+                    ),
+                ]
+            )
+            metrics.incr.reset_mock()
+            self.send_result(
+                self.create_uptime_result(
+                    self.subscription.subscription_id,
+                    scheduled_check_time=datetime.now() - timedelta(minutes=4),
+                )
+            )
             metrics.incr.assert_has_calls(
                 [
                     call(
@@ -147,7 +280,7 @@ class ProcessResultTest(UptimeTestCase, ProducerTestMixin):
         result = self.create_uptime_result(
             self.subscription.subscription_id,
             status=CHECKSTATUS_SUCCESS,
-            scheduled_check_time=datetime.now() - timedelta(minutes=4),
+            scheduled_check_time=datetime.now() - timedelta(minutes=3),
         )
         with mock.patch(
             "sentry.uptime.consumers.results_consumer.metrics"


### PR DESCRIPTION
This builds the concept of consecutive checks into the uptime results consumer. We'll only mark the monitor failed after we've had two consecutive failed checks. This also adds the ability for consecutive recovery checks into the consumer, but for now we'll just leave this at 1 to avoid making it look like the url is down longer than it really is.
