### PR TITLE
fix(release): Use latest release commit when dupes are present

### DIFF
--- a/src/sentry/api/endpoints/project_release_commits.py
+++ b/src/sentry/api/endpoints/project_release_commits.py
@@ -54,23 +54,31 @@ class ProjectReleaseCommitsEndpoint(ProjectEndpoint):
         repo_name = request.query_params.get("repo_name")
 
         # prefer repo external ID to name
+        # NOTE: We filter on Repository here instead of using get b/c sometimes,
+        # we may have multiple repos with the same external_id/name but diff
+        # provider names due to plugins vs integrations.
+        # (e.g "bitbucket" for the plugin vs "integrations:bitbucket" for the integration).
         if repo_id:
-            try:
-                repo = Repository.objects.get(
-                    organization_id=organization_id, external_id=repo_id, status=ObjectStatus.ACTIVE
-                )
-                queryset = queryset.filter(commit__repository_id=repo.id)
-            except Repository.DoesNotExist:
+            repos = Repository.objects.filter(
+                organization_id=organization_id, external_id=repo_id, status=ObjectStatus.ACTIVE
+            ).order_by("-date_added")
+
+            if not repos.exists():
                 raise ResourceDoesNotExist
 
-        elif repo_name:
-            try:
-                repo = Repository.objects.get(
-                    organization_id=organization_id, name=repo_name, status=ObjectStatus.ACTIVE
-                )
-                queryset = queryset.filter(commit__repository_id=repo.id)
-            except Repository.DoesNotExist:
+            latest_repo = repos.first()
+            queryset = queryset.filter(commit__repository_id=latest_repo.id)
+
+        if repo_name:
+            repos = Repository.objects.filter(
+                organization_id=organization_id, name=repo_name, status=ObjectStatus.ACTIVE
+            ).order_by("-date_added")
+
+            if not repos.exists():
                 raise ResourceDoesNotExist
+
+            latest_repo = repos.first()
+            queryset = queryset.filter(commit__repository_id=latest_repo.id)
 
         return self.paginate(
             request=request,

--- a/src/sentry/api/endpoints/project_release_commits.py
+++ b/src/sentry/api/endpoints/project_release_commits.py
@@ -55,18 +55,17 @@ class ProjectReleaseCommitsEndpoint(ProjectEndpoint):
 
         # prefer repo external ID to name
         # NOTE: We filter on Repository here instead of using get b/c sometimes,
-        # we may have multiple repos with the same external_id/name but diff
-        # provider names due to plugins vs integrations.
-        # (e.g "bitbucket" for the plugin vs "integrations:bitbucket" for the integration).
+        # we have have multiple repos for the same external_id/name that differ
+        # in other fields that differ such as 'provider' or 'config'.
         if repo_id:
             repos = Repository.objects.filter(
                 organization_id=organization_id, external_id=repo_id, status=ObjectStatus.ACTIVE
             ).order_by("-date_added")
 
-            if not repos.exists():
+            latest_repo = repos.first()
+            if latest_repo is None:
                 raise ResourceDoesNotExist
 
-            latest_repo = repos.first()
             queryset = queryset.filter(commit__repository_id=latest_repo.id)
 
         if repo_name:
@@ -74,10 +73,10 @@ class ProjectReleaseCommitsEndpoint(ProjectEndpoint):
                 organization_id=organization_id, name=repo_name, status=ObjectStatus.ACTIVE
             ).order_by("-date_added")
 
-            if not repos.exists():
+            latest_repo = repos.first()
+            if latest_repo is None:
                 raise ResourceDoesNotExist
 
-            latest_repo = repos.first()
             queryset = queryset.filter(commit__repository_id=latest_repo.id)
 
         return self.paginate(


### PR DESCRIPTION
See comment for explanation

Closes https://github.com/getsentry/sentry/issues/75964
Fixes [SENTRY-390Z](https://sentry.sentry.io/issues/5319784997/)