### PR TITLE
feat(uptime): Change default interval for active uptime monitors to one minute

### DIFF
--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -44,7 +44,7 @@ ONBOARDING_FAILURE_THRESHOLD = 3
 # ONBOARDING_MONITOR_PERIOD.
 ONBOARDING_FAILURE_REDIS_TTL = ONBOARDING_MONITOR_PERIOD
 # How frequently we should run active auto-detected subscriptions
-AUTO_DETECTED_ACTIVE_SUBSCRIPTION_INTERVAL = timedelta(minutes=5)
+AUTO_DETECTED_ACTIVE_SUBSCRIPTION_INTERVAL = timedelta(minutes=1)
 # When in active monitoring mode, how many failures in a row do we need to see to mark the monitor as down, or how many
 # successes in a row do we need to mark it up
 ACTIVE_FAILURE_THRESHOLD = 2

--- a/tests/sentry/uptime/consumers/test_results_consumers.py
+++ b/tests/sentry/uptime/consumers/test_results_consumers.py
@@ -42,7 +42,9 @@ class ProcessResultTest(UptimeTestCase, ProducerTestMixin):
     def setUp(self):
         super().setUp()
         self.partition = Partition(Topic("test"), 0)
-        self.subscription = self.create_uptime_subscription(subscription_id=uuid.uuid4().hex)
+        self.subscription = self.create_uptime_subscription(
+            subscription_id=uuid.uuid4().hex, interval_seconds=300
+        )
         self.project_subscription = self.create_project_uptime_subscription(
             uptime_subscription=self.subscription
         )


### PR DESCRIPTION
We'd like to check these more frequently, so that we're able to notify customers faster when their urls are down.
