### PR TITLE
feat(replay): support replay dataset in snuba tagstore.get_tag_keys

### DIFF
--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -197,12 +197,14 @@ def query_replays_dataset_tag_keys(
     referrer: str | None = None,
     include_values_seen: bool = False,
     **kwargs,
-):
+) -> dict[str, int] | dict[str, dict[str, int]]:
     """
     @param tag_keys  Optionally used to check if a list of tag keys exist in the dataset, and their values_seen.
     """
     # TODO:
-    return {}
+    if include_values_seen:
+        return {"fruit": {"count": 4, "values_seen": 2}}
+    return {"fruit": 4}
 
 
 def query_replays_dataset_tagkey_values(

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -186,6 +186,25 @@ def query_replays_count(
     )
 
 
+def query_replays_dataset_tag_keys(
+    start: datetime,
+    end: datetime,
+    project_ids: list[int],
+    environments: list[str] | None = None,
+    query_keys: Sequence[str] = None,
+    limit: int = 1000,
+    orderby: str = "-count",
+    referrer: str | None = None,
+    include_values_seen: bool = False,
+    **kwargs,
+):
+    """
+    @param tag_keys  Optionally used to check if a list of tag keys exist in the dataset, and their values_seen.
+    """
+    # TODO:
+    return {}
+
+
 def query_replays_dataset_tagkey_values(
     project_ids: list[int],
     start: datetime,


### PR DESCRIPTION
A change to the backend of the organization_tags endpoint allowing it to support replays. Context at https://github.com/getsentry/sentry/pull/75878