### PR TITLE
feat(alerts): Update metric alert rule template for dynamic alerts

### DIFF
--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -5,6 +5,7 @@ from django.db.models import Max
 from django.urls import reverse
 from django.utils.translation import gettext as _
 
+from sentry import features
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS
 from sentry.incidents.logic import get_incident_aggregates
 from sentry.incidents.models.alert_rule import AlertRule, AlertRuleThresholdType
@@ -114,6 +115,9 @@ def incident_attachment_info(
         metric_value = get_metric_count_from_incident(incident)
 
     text = get_incident_status_text(alert_rule, metric_value)
+    if features.has("organizations:anomaly-detection-alerts", incident.organization):
+        text += f"\nThreshold: {alert_rule.detection_type.title()}"
+
     title = f"{status}: {alert_rule.name}"
 
     title_link_params = {

--- a/src/sentry/integrations/slack/message_builder/incidents.py
+++ b/src/sentry/integrations/slack/message_builder/incidents.py
@@ -55,9 +55,6 @@ class SlackIncidentsMessageBuilder(BlockSlackMessageBuilder):
             referrer="metric_alert_slack",
         )
         incident_text = f"{data['text']}\n{get_started_at(data['ts'])}"
-        if features.has("organizations:anomaly-detection-alerts", self.incident.organization):
-            incident_text += f"\nThreshold: {alert_rule.detection_type.title()}"
-
         blocks = [
             self.get_markdown_block(text=incident_text),
         ]

--- a/tests/sentry/incidents/action_handlers/test_msteams.py
+++ b/tests/sentry/incidents/action_handlers/test_msteams.py
@@ -2,13 +2,21 @@ import time
 from unittest.mock import patch
 
 import responses
+from urllib3.response import HTTPResponse
 
-from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
-from sentry.incidents.models.incident import IncidentStatus
+from sentry.incidents.logic import update_incident_status
+from sentry.incidents.models.alert_rule import (
+    AlertRuleDetectionType,
+    AlertRuleSeasonality,
+    AlertRuleSensitivity,
+    AlertRuleTriggerAction,
+)
+from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod
 from sentry.integrations.messaging import MessagingActionHandler
 from sentry.integrations.msteams.spec import MsTeamsMessagingSpec
 from sentry.silo.base import SiloMode
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils import json
 
@@ -72,6 +80,76 @@ class MsTeamsActionHandlerTest(FireTest):
 
         assert data["attachments"][0]["content"] == build_incident_attachment(
             incident, IncidentStatus(incident.status), metric_value
+        )
+
+    @responses.activate
+    def test_build_incident_attachment(self):
+        from sentry.integrations.msteams.card_builder.incident_attachment import (
+            build_incident_attachment,
+        )
+
+        alert_rule = self.create_alert_rule()
+        incident = self.create_incident(alert_rule=alert_rule)
+        update_incident_status(
+            incident, IncidentStatus.CRITICAL, status_method=IncidentStatusMethod.RULE_TRIGGERED
+        )
+        responses.add(
+            method=responses.POST,
+            url="https://smba.trafficmanager.net/amer/v3/conversations/d_s/activities",
+            status=200,
+            json={},
+        )
+        metric_value = 1000
+        data = build_incident_attachment(
+            incident=incident, new_status=IncidentStatus(incident.status), metric_value=metric_value
+        )
+        assert (
+            data["body"][0]["columns"][1]["items"][0]["items"][1]["text"]
+            == "1000 events in the last 10 minutes"
+        )
+        assert alert_rule.name in data["body"][0]["columns"][1]["items"][0]["items"][0]["text"]
+        assert (
+            f"http://testserver/organizations/baz/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}&referrer=metric_alert_msteams&detection_type={alert_rule.detection_type}"
+            in data["body"][0]["columns"][1]["items"][0]["items"][0]["text"]
+        )
+
+    @responses.activate
+    @with_feature("organizations:anomaly-detection-alerts")
+    @patch(
+        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
+    )
+    def test_build_incident_attachment_dynamic_alert(self, mock_seer_request):
+        from sentry.integrations.msteams.card_builder.incident_attachment import (
+            build_incident_attachment,
+        )
+
+        mock_seer_request.return_value = HTTPResponse(status=200)
+        alert_rule = self.create_alert_rule(
+            detection_type=AlertRuleDetectionType.DYNAMIC,
+            time_window=30,
+            sensitivity=AlertRuleSensitivity.LOW,
+            seasonality=AlertRuleSeasonality.AUTO,
+        )
+        incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CRITICAL.value)
+        self.create_alert_rule_trigger(alert_rule=alert_rule, alert_threshold=0)
+        responses.add(
+            method=responses.POST,
+            url="https://smba.trafficmanager.net/amer/v3/conversations/d_s/activities",
+            status=200,
+            json={},
+        )
+        metric_value = 1000
+        data = build_incident_attachment(
+            incident=incident, new_status=IncidentStatus(incident.status), metric_value=metric_value
+        )
+        assert (
+            data["body"][0]["columns"][1]["items"][0]["items"][1]["text"]
+            == f"1000 events in the last 30 minutes\nThreshold: {alert_rule.detection_type.title()}"
+        )
+        assert alert_rule.name in data["body"][0]["columns"][1]["items"][0]["items"][0]["text"]
+        assert (
+            f"http://testserver/organizations/baz/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}&referrer=metric_alert_msteams&detection_type={alert_rule.detection_type}"
+            in data["body"][0]["columns"][1]["items"][0]["items"][0]["text"]
         )
 
     def test_fire_metric_alert(self):

--- a/tests/sentry/incidents/action_handlers/test_pagerduty.py
+++ b/tests/sentry/incidents/action_handlers/test_pagerduty.py
@@ -4,14 +4,21 @@ from unittest.mock import patch
 import pytest
 import responses
 from django.http import Http404
+from urllib3.response import HTTPResponse
 
 from sentry.incidents.action_handlers import PagerDutyActionHandler
 from sentry.incidents.logic import update_incident_status
-from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.incidents.models.alert_rule import (
+    AlertRuleDetectionType,
+    AlertRuleSeasonality,
+    AlertRuleSensitivity,
+    AlertRuleTriggerAction,
+)
 from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod
 from sentry.integrations.pagerduty.utils import add_service
 from sentry.silo.base import SiloMode
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils import json
 
@@ -89,7 +96,59 @@ class PagerDutyActionHandlerTest(FireTest):
         assert data["links"][0]["text"] == f"Critical: {alert_rule.name}"
         assert (
             data["links"][0]["href"]
-            == f"http://testserver/organizations/baz/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}&referrer=metric_alert_pagerduty&detection_type=static&notification_uuid={notification_uuid}"
+            == f"http://testserver/organizations/baz/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}&referrer=metric_alert_pagerduty&detection_type={alert_rule.detection_type}&notification_uuid={notification_uuid}"
+        )
+
+    @with_feature("organizations:anomaly-detection-alerts")
+    @patch(
+        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
+    )
+    def test_build_incident_attachment_dynamic_alert(self, mock_seer_request):
+        from sentry.integrations.pagerduty.utils import build_incident_attachment
+
+        mock_seer_request.return_value = HTTPResponse(status=200)
+        alert_rule = self.create_alert_rule(
+            detection_type=AlertRuleDetectionType.DYNAMIC,
+            time_window=30,
+            sensitivity=AlertRuleSensitivity.LOW,
+            seasonality=AlertRuleSeasonality.AUTO,
+        )
+        incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.CRITICAL.value)
+        trigger = self.create_alert_rule_trigger(alert_rule=alert_rule, alert_threshold=0)
+        update_incident_status(
+            incident, IncidentStatus.CRITICAL, status_method=IncidentStatusMethod.RULE_TRIGGERED
+        )
+        self.create_alert_rule_trigger_action(
+            target_identifier=self.service["id"],
+            type=AlertRuleTriggerAction.Type.PAGERDUTY,
+            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC,
+            integration=self.integration,
+            alert_rule_trigger=trigger,
+            triggered_for_incident=incident,
+        )
+        metric_value = 1000
+        notification_uuid = str(uuid.uuid4())
+        data = build_incident_attachment(
+            incident,
+            self.integration_key,
+            IncidentStatus(incident.status),
+            metric_value,
+            notification_uuid,
+        )
+
+        assert data["routing_key"] == self.integration_key
+        assert data["event_action"] == "trigger"
+        assert data["dedup_key"] == f"incident_{incident.organization_id}_{incident.identifier}"
+        assert data["payload"]["summary"] == alert_rule.name
+        assert data["payload"]["severity"] == "critical"
+        assert data["payload"]["source"] == str(incident.identifier)
+        assert data["payload"]["custom_details"] == {
+            "details": f"1000 events in the last 30 minutes\nThreshold: {alert_rule.detection_type.title()}"
+        }
+        assert data["links"][0]["text"] == f"Critical: {alert_rule.name}"
+        assert (
+            data["links"][0]["href"]
+            == f"http://testserver/organizations/baz/alerts/rules/details/{alert_rule.id}/?alert={incident.identifier}&referrer=metric_alert_pagerduty&detection_type={alert_rule.detection_type}&notification_uuid={notification_uuid}"
         )
 
     @responses.activate

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -1156,7 +1156,7 @@ class BuildIncidentAttachmentTest(TestCase):
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": f"0 events in the last 30 minutes\n{timestamp}\nThreshold: {detection_type.title()}",
+                        "text": f"0 events in the last 30 minutes\nThreshold: {detection_type.title()}\n{timestamp}",
                     },
                 },
             ],


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/76030/ which moves the code into a shared location that updates Slack, MSTeams, OpsGenie, and Pagerduty. I had it the other way before to control the order of the content in the Slack notification, but it's easier this way. This updates all the aforementioned metric alert notifications to include the threshold text.