### PR TITLE
fix(breadcrumbs): Use subgrid to align log levels

### DIFF
--- a/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
@@ -144,6 +144,7 @@ const Subtitle = styled('p')`
 
 const Timestamp = styled('div')`
   margin-right: ${space(1)};
+  text-align: right;
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
   span {

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -66,14 +66,9 @@ const Row = styled('div')<{showLastLine?: boolean}>`
   display: grid;
   grid-template-columns: subgrid;
   grid-column: 1/-1;
-  grid-column-gap: ${space(1)};
+  grid-row-gap: ${space(0.5)};
 
-  margin: ${space(1)} 0;
-  &:first-child {
-    margin-top: 0;
-  }
   &:last-child {
-    margin-bottom: 0;
     /* Show/hide connecting line from the last element of the timeline */
     background: ${p => (p.showLastLine ? 'transparent' : p.theme.background)};
   }
@@ -140,6 +135,8 @@ export const Container = styled('div')`
   position: relative;
   display: grid;
   grid-template: auto auto / 22px 1fr auto;
+  grid-row-gap: ${space(1)};
+  grid-column-gap: ${space(1)};
   /* vertical line connecting items */
   &::before {
     content: '';

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -62,10 +62,12 @@ export const Item = forwardRef(function _Item(
 const Row = styled('div')<{showLastLine?: boolean}>`
   position: relative;
   color: ${p => p.theme.subText};
-  display: grid;
   align-items: start;
-  grid-template: auto auto / 22px 1fr auto;
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1/-1;
   grid-column-gap: ${space(1)};
+
   margin: ${space(1)} 0;
   &:first-child {
     margin-top: 0;
@@ -136,6 +138,8 @@ export const Data = styled('div')`
 
 export const Container = styled('div')`
   position: relative;
+  display: grid;
+  grid-template: auto auto / 22px 1fr auto;
   /* vertical line connecting items */
   &::before {
     content: '';


### PR DESCRIPTION
attempts to fix this but i think it might drive the virtual scroll crazy https://www.notion.so/sentry/Breadcrumb-level-horizontal-alignment-f7e13defa53d40d7a0af8aa6c73ea085
![image](https://github.com/user-attachments/assets/dbd5f277-493a-49b8-b989-c2e71db42348)
