### PR TITLE
feat(discover):Update discover metrics dataset to not use hardcoded list of default tags if span metrics are detected

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -163,6 +163,8 @@ class MetricsQueryBuilder(BaseQueryBuilder):
 
     @property
     def use_default_tags(self) -> bool:
+        if self.is_spans_metrics_query:
+            return False
         if self._use_default_tags is None:
             if self.params.organization is not None:
                 self._use_default_tags = features.has(


### PR DESCRIPTION
Update discover metrics dataset to not use hardcoded list of default tags if span metrics are detected.
This is the same behaviour as the discover spansMetrics dataset.