### PR TITLE
fix(nodeDocs): fix incorrect DSN parameter to use public DSN

### DIFF
--- a/static/app/utils/gettingStartedDocs/node.ts
+++ b/static/app/utils/gettingStartedDocs/node.ts
@@ -180,7 +180,7 @@ export const getSdkInitSnippet = (
             : ''
 }
 Sentry.init({
-  dsn: "${params.dsn}",
+  dsn: "${params.dsn.public}",
   ${
     params.isProfilingSelected
       ? `integrations: [


### PR DESCRIPTION
The PR: #75969 introduced an error for NodeJS applications:

They're being show as [Object object].

Those we're hapenning at Production / Self-Hosted.

Affected: All 'node' integrations that used: [getSdkInitSnippet()](https://github.com/getsentry/sentry/blob/47bf82cb9dda33364b1545e4b870c4963fefedce/static/app/utils/gettingStartedDocs/node.ts#L149)

The fix was to use the **_.public_** key.



Express example:
![image](https://github.com/user-attachments/assets/7fb8c0ba-db35-4f78-a187-5c18eef135d7)
