### PR TITLE
ref(stats): Update logic to display 'spans' category

### DIFF
--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -236,7 +236,7 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
         return organization.features.includes('session-replay');
       }
       if (DATA_CATEGORY_INFO.span.plural === opt.value) {
-        return organization.features.includes('spans-stats');
+        return organization.features.includes('span-stats');
       }
       if (DATA_CATEGORY_INFO.transaction.plural === opt.value) {
         return !organization.features.includes('spans-usage-tracking');

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -225,6 +225,7 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
 
   renderProjectPageControl = () => {
     const {organization} = this.props;
+
     const isSelfHostedErrorsOnly = ConfigStore.get('isSelfHostedErrorsOnly');
 
     const options = CHART_OPTIONS_DATACATEGORY.filter(opt => {
@@ -235,7 +236,7 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
         return organization.features.includes('session-replay');
       }
       if (DATA_CATEGORY_INFO.span.plural === opt.value) {
-        return organization.features.includes('spans-usage-tracking');
+        return organization.features.includes('spans-stats');
       }
       if (DATA_CATEGORY_INFO.transaction.plural === opt.value) {
         return !organization.features.includes('spans-usage-tracking');


### PR DESCRIPTION
Based on a new feature flag, we would like to conditionally display the 'spans' category on the stats page.

related to https://github.com/getsentry/getsentry/pull/14916