### PR TITLE
fix(stats): Correct displayed names

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -319,14 +319,6 @@ export const DATA_CATEGORY_INFO = {
     titleName: t('Spans'),
     uid: 12,
   },
-  [DataCategoryExact.SPAN_INDEXED]: {
-    name: DataCategoryExact.SPAN_INDEXED,
-    apiName: 'span_indexed',
-    plural: 'indexed spans',
-    displayName: 'indexed span',
-    titleName: t('Spans'),
-    uid: 14,
-  },
   [DataCategoryExact.MONITOR_SEAT]: {
     name: DataCategoryExact.MONITOR_SEAT,
     apiName: 'monitorSeat',

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -100,7 +100,6 @@ export enum DataCategoryExact {
   MONITOR_SEAT = 'monitorSeat',
   PROFILE_DURATION = 'profileDuration',
   SPAN = 'span',
-  SPAN_INDEXED = 'span_indexed',
   METRIC_SECOND = 'metricSecond',
 }
 

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -23,7 +23,11 @@ import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import {t, tct} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
-import type {DataCategoryInfo, PageFilters} from 'sentry/types/core';
+import {
+  DataCategoryExact,
+  type DataCategoryInfo,
+  type PageFilters,
+} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -67,6 +71,16 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
 
     const categories = Object.values(DATA_CATEGORY_INFO);
     const info = categories.find(c => c.plural === dataCategoryPlural);
+
+    if (
+      info?.name === DataCategoryExact.SPAN &&
+      this.props.organization.features.includes('spans-usage-tracking')
+    ) {
+      return {
+        ...info,
+        apiName: 'span_indexed',
+      };
+    }
 
     // Default to errors
     return info ?? DATA_CATEGORY_INFO.error;
@@ -236,13 +250,7 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
         return organization.features.includes('session-replay');
       }
       if (DATA_CATEGORY_INFO.span.plural === opt.value) {
-        return (
-          organization.features.includes('span-stats') &&
-          !organization.features.includes('spans-usage-tracking')
-        );
-      }
-      if (DATA_CATEGORY_INFO.span_indexed.plural === opt.value) {
-        return organization.features.includes('spans-usage-tracking');
+        return organization.features.includes('span-stats');
       }
       if (DATA_CATEGORY_INFO.transaction.plural === opt.value) {
         return !organization.features.includes('spans-usage-tracking');

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -81,12 +81,6 @@ export const CHART_OPTIONS_DATACATEGORY: CategoryOption[] = [
     yAxisMinInterval: 100,
   },
   {
-    label: DATA_CATEGORY_INFO.span_indexed.titleName,
-    value: DATA_CATEGORY_INFO.span_indexed.plural,
-    disabled: false,
-    yAxisMinInterval: 100,
-  },
-  {
     label: DATA_CATEGORY_INFO.profileDuration.titleName,
     value: DATA_CATEGORY_INFO.profileDuration.plural,
     disabled: false,

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -290,7 +290,14 @@ class UsageStatsOrganization<
   }
 
   get cardMetadata() {
-    const {dataCategory, dataCategoryName, organization, projectIds, router} = this.props;
+    const {
+      dataCategory,
+      dataCategoryName,
+      organization,
+      projectIds,
+      router,
+      dataCategoryApiName,
+    } = this.props;
     const {total, accepted, invalid, rateLimited, filtered} = this.chartData.cardStats;
 
     const navigateToInboundFilterSettings = (event: ReactMouseEvent) => {
@@ -314,6 +321,7 @@ class UsageStatsOrganization<
         score: accepted,
         trend: (
           <UsageStatsPerMin
+            dataCategoryApiName={dataCategoryApiName}
             dataCategory={dataCategory}
             organization={organization}
             projectIds={projectIds}

--- a/static/app/views/organizationStats/usageStatsPerMin.tsx
+++ b/static/app/views/organizationStats/usageStatsPerMin.tsx
@@ -11,6 +11,7 @@ import {formatUsageWithUnits, getFormatUsageOptions} from './utils';
 
 type Props = {
   dataCategory: DataCategoryInfo['plural'];
+  dataCategoryApiName: DataCategoryInfo['apiName'];
   organization: Organization;
   projectIds: number[];
 };
@@ -25,7 +26,12 @@ type Props = {
  * We're going with this approach for simplicity sake. By keeping the range
  * as small as possible, this call is quite fast.
  */
-function UsageStatsPerMin({dataCategory, organization, projectIds}: Props) {
+function UsageStatsPerMin({
+  organization,
+  projectIds,
+  dataCategory,
+  dataCategoryApiName,
+}: Props) {
   const {
     data: orgStats,
     isLoading,
@@ -52,6 +58,9 @@ function UsageStatsPerMin({dataCategory, organization, projectIds}: Props) {
     return null;
   }
 
+  const category =
+    dataCategoryApiName === 'span_indexed' ? dataCategoryApiName : dataCategory;
+
   const minuteData = (): string | undefined => {
     // The last minute in the series is still "in progress"
     // Read data from 2nd last element for the latest complete minute
@@ -59,10 +68,11 @@ function UsageStatsPerMin({dataCategory, organization, projectIds}: Props) {
     const lastMin = Math.max(intervals.length - 2, 0);
 
     const eventsLastMin = groups.reduce((count, group) => {
-      const {outcome, category} = group.by;
-
       // HACK: The backend enum are singular, but the frontend enums are plural
-      if (!dataCategory.includes(`${category}`) || outcome !== Outcome.ACCEPTED) {
+      if (
+        !category.includes(`${group.by.category}`) ||
+        group.by.outcome !== Outcome.ACCEPTED
+      ) {
         return count;
       }
 


### PR DESCRIPTION
It is better to return the `apiName` elsewhere for cases where spans should be referred to as either 'span' or 'indexed_spans'. The reasoning behind this decision is that we use plural forms and display names in the UI, and we prefer not to expose whether a span is indexed or not.


before:

![image](https://github.com/user-attachments/assets/c7899755-189a-4bee-906c-d339525e7efd)


after:

![image](https://github.com/user-attachments/assets/e146473e-4720-4937-ae52-85867f54a5e2)
