### PR TITLE
ref(highlights): Make API for highlight fields public

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -168,7 +168,15 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
         allow_null=True,
         help_text="Automatically resolve an issue if it hasn't been seen for this many hours. Set to `0` to disable auto-resolve.",
     )
-
+    highlightContext = HighlightContextField(
+        required=False,
+        help_text="A JSON mapping of context types to lists of strings for their keys. E.g. {'user': ['id', 'email']}",
+    )
+    highlightTags = ListField(
+        child=serializers.CharField(),
+        required=False,
+        help_text="A list of strings with tag keys to highlight on this project's issues. E.g. ['release', 'environment']",
+    )
     # TODO: Add help_text to all the fields for public documentation
     team = serializers.RegexField(r"^[a-z0-9_\-]+$", max_length=50)
     digestsMinDelay = serializers.IntegerField(min_value=60, max_value=3600)
@@ -186,8 +194,6 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
     dataScrubberDefaults = serializers.BooleanField(required=False)
     sensitiveFields = ListField(child=serializers.CharField(), required=False)
     safeFields = ListField(child=serializers.CharField(), required=False)
-    highlightContext = HighlightContextField(required=False)
-    highlightTags = ListField(child=serializers.CharField(), required=False)
     storeCrashReports = serializers.IntegerField(
         min_value=-1, max_value=STORE_CRASH_REPORTS_MAX, required=False, allow_null=True
     )


### PR DESCRIPTION
Makes the API for highlight fields public. Reference: https://github.com/getsentry/sentry/issues/76075