### PR TITLE
feat(search): Recent searches should be valid filter keys.

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -353,8 +353,8 @@ describe('SearchQueryBuilder', function () {
           url: '/organizations/org-slug/recent-searches/',
           body: [
             {query: 'assigned:me'},
-            {query: 'assigned:me browser:firefox'},
-            {query: 'assigned:me browser:firefox is:unresolved'},
+            {query: 'assigned:me browser.name:firefox'},
+            {query: 'assigned:me browser.name:firefox is:unresolved'},
           ],
         });
       });
@@ -394,6 +394,36 @@ describe('SearchQueryBuilder', function () {
         expect(recentFilterKeys).toHaveLength(2);
         expect(recentFilterKeys[0]).toHaveTextContent('browser');
         expect(recentFilterKeys[1]).toHaveTextContent('is');
+      });
+
+      it('does not display recent filters that are not valid filter keys', async function () {
+        MockApiClient.addMockResponse({
+          url: '/organizations/org-slug/recent-searches/',
+          body: [
+            {query: 'assigned:me'},
+            {query: 'assigned:me browser.name:firefox'},
+            {query: 'assigned:me browser.name:firefox is:unresolved'},
+            // Level is not a valid filter key
+            {query: 'assigned:me browser.name:firefox is:unresolved level:error'},
+          ],
+        });
+
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            recentSearches={SavedSearchType.ISSUE}
+            initialQuery=""
+          />
+        );
+
+        await userEvent.click(getLastInput());
+
+        // Should not show "level" in the recent filter keys
+        const recentFilterKeys = await screen.findAllByTestId('recent-filter-key');
+        expect(recentFilterKeys).toHaveLength(3);
+        expect(recentFilterKeys[0]).toHaveTextContent('assigned');
+        expect(recentFilterKeys[1]).toHaveTextContent('browser');
+        expect(recentFilterKeys[2]).toHaveTextContent('is');
       });
 
       it('can navigate between filters with arrow keys', async function () {

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useRecentSearchFilters.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useRecentSearchFilters.tsx
@@ -6,6 +6,7 @@ import type {FieldDefinitionGetter} from 'sentry/components/searchQueryBuilder/t
 import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
 import {type ParseResult, Token} from 'sentry/components/searchSyntax/parser';
 import type {RecentSearch, TagCollection} from 'sentry/types/group';
+import {isAggregateFieldOrEquation} from 'sentry/utils/discover/fields';
 
 const MAX_RECENT_FILTERS = 5;
 const NO_FILTERS = [];
@@ -64,7 +65,14 @@ function getFiltersFromRecentSearches(
     .flatMap(search =>
       getFiltersFromQuery({query: search.query, getFieldDefinition, filterKeys})
     )
-    .filter(filter => !filtersInCurrentQuery.includes(filter))
+    .filter(filter => {
+      if (isAggregateFieldOrEquation(filter)) {
+        return !filtersInCurrentQuery.includes(filter);
+      }
+
+      // If the filter is not an aggregate field or equation, we only want to show it if it's a valid filter key.
+      return !filtersInCurrentQuery.includes(filter) && !!filterKeys[filter];
+    })
     .reduce((acc, filter) => {
       acc[filter] = (acc[filter] ?? 0) + 1;
       return acc;


### PR DESCRIPTION
Example:
- In discover the filters keys are dataset aware, so we want the recent searches to follow.
- Introducing this change allows us to keep the filterKeys prop as the sole controller for such logic. 