### PR TITLE
feat(explore): Support results and sort controls

### DIFF
--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -1,0 +1,119 @@
+import {createMemoryHistory, Route, Router, RouterContext} from 'react-router';
+
+import {fireEvent, render, screen, within} from 'sentry-test/reactTestingLibrary';
+
+import {useResultMode} from 'sentry/views/explore/hooks/useResultsMode';
+import {useSampleFields} from 'sentry/views/explore/hooks/useSampleFields';
+import {useSort} from 'sentry/views/explore/hooks/useSort';
+import {ExploreToolbar} from 'sentry/views/explore/toolbar';
+import {RouteContext} from 'sentry/views/routeContext';
+
+function renderWithRouter(component) {
+  const memoryHistory = createMemoryHistory();
+
+  render(
+    <Router
+      history={memoryHistory}
+      render={props => {
+        return (
+          <RouteContext.Provider value={props}>
+            <RouterContext {...props} />
+          </RouteContext.Provider>
+        );
+      }}
+    >
+      <Route path="/" component={component} />
+    </Router>
+  );
+}
+
+describe('ExploreToolbar', function () {
+  beforeEach(function () {
+    // without this the `CompactSelect` component errors with a bunch of async updates
+    jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  it('allows changing results mode', function () {
+    let resultMode;
+
+    function Component() {
+      [resultMode] = useResultMode();
+      return <ExploreToolbar />;
+    }
+
+    renderWithRouter(Component);
+
+    const section = screen.getByTestId('section-result-mode');
+    const samples = within(section).getByRole('radio', {name: 'Samples'});
+    const aggregates = within(section).getByRole('radio', {name: 'Aggregate'});
+
+    expect(samples).toBeChecked();
+    expect(aggregates).not.toBeChecked();
+    expect(resultMode).toEqual('samples');
+
+    fireEvent.click(aggregates);
+    expect(samples).not.toBeChecked();
+    expect(aggregates).toBeChecked();
+    expect(resultMode).toEqual('aggregate');
+
+    fireEvent.click(samples);
+    expect(samples).toBeChecked();
+    expect(aggregates).not.toBeChecked();
+    expect(resultMode).toEqual('samples');
+
+    // TODO: check other parts of page reflects this
+  });
+
+  it('allows changing sort by', async function () {
+    let sort;
+
+    function Component() {
+      const [sampleFields] = useSampleFields();
+      [sort] = useSort({fields: sampleFields});
+      return <ExploreToolbar />;
+    }
+    renderWithRouter(Component);
+
+    const section = screen.getByTestId('section-sort-by');
+
+    // this is the default
+    expect(within(section).getByRole('button', {name: 'timestamp'})).toBeInTheDocument();
+    expect(within(section).getByRole('button', {name: 'Descending'})).toBeInTheDocument();
+    expect(sort).toEqual({field: 'timestamp', direction: 'desc'});
+
+    // check the default field options
+    const fields = [
+      'project',
+      'id',
+      'span.op',
+      'span.description',
+      'span.duration',
+      'timestamp',
+    ];
+    fireEvent.click(within(section).getByRole('button', {name: 'timestamp'}));
+    const fieldOptions = await within(section).findAllByRole('option');
+    expect(fieldOptions).toHaveLength(fields.length);
+    fieldOptions.forEach((option, i) => {
+      expect(option).toHaveTextContent(fields[i]);
+    });
+
+    // try changing the field
+    fireEvent.click(within(section).getByRole('option', {name: 'span.op'}));
+    expect(within(section).getByRole('button', {name: 'span.op'})).toBeInTheDocument();
+    expect(within(section).getByRole('button', {name: 'Descending'})).toBeInTheDocument();
+    expect(sort).toEqual({field: 'span.op', direction: 'desc'});
+
+    // check the direction options
+    fireEvent.click(within(section).getByRole('button', {name: 'Descending'}));
+    const directionOptions = await within(section).findAllByRole('option');
+    expect(directionOptions).toHaveLength(2);
+    expect(directionOptions[0]).toHaveTextContent('Descending');
+    expect(directionOptions[1]).toHaveTextContent('Ascending');
+
+    // try changing the direction
+    fireEvent.click(within(section).getByRole('option', {name: 'Ascending'}));
+    expect(within(section).getByRole('button', {name: 'span.op'})).toBeInTheDocument();
+    expect(within(section).getByRole('button', {name: 'Ascending'})).toBeInTheDocument();
+    expect(sort).toEqual({field: 'span.op', direction: 'asc'});
+  });
+});

--- a/static/app/views/explore/toolbar/index.tsx
+++ b/static/app/views/explore/toolbar/index.tsx
@@ -1,3 +1,7 @@
+import {useResultMode} from 'sentry/views/explore/hooks/useResultsMode';
+import {useSampleFields} from 'sentry/views/explore/hooks/useSampleFields';
+import {useSort} from 'sentry/views/explore/hooks/useSort';
+
 import {ToolbarGroupBy} from './toolbarGroupBy';
 import {ToolbarLimitTo} from './toolbarLimitTo';
 import {ToolbarResults} from './toolbarResults';
@@ -7,11 +11,15 @@ import {ToolbarVisualize} from './toolbarVisualize';
 interface ExploreToolbarProps {}
 
 export function ExploreToolbar({}: ExploreToolbarProps) {
+  const [resultMode, setResultMode] = useResultMode();
+  const [sampleFields] = useSampleFields();
+  const [sort, setSort] = useSort({fields: sampleFields});
+
   return (
     <div>
-      <ToolbarResults />
+      <ToolbarResults resultMode={resultMode} setResultMode={setResultMode} />
       <ToolbarVisualize />
-      <ToolbarSortBy />
+      <ToolbarSortBy fields={sampleFields} sort={sort} setSort={setSort} />
       <ToolbarLimitTo />
       <ToolbarGroupBy disabled />
     </div>

--- a/static/app/views/explore/toolbar/toolbarResults.tsx
+++ b/static/app/views/explore/toolbar/toolbarResults.tsx
@@ -1,13 +1,26 @@
+import {SegmentedControl} from 'sentry/components/segmentedControl';
 import {t} from 'sentry/locale';
+import type {ResultMode} from 'sentry/views/explore/hooks/useResultsMode';
 
 import {ToolbarHeading, ToolbarSection} from './styles';
 
-interface ToolbarResultsProps {}
+interface ToolbarResultsProps {
+  resultMode: ResultMode;
+  setResultMode: (newMode: ResultMode) => void;
+}
 
-export function ToolbarResults({}: ToolbarResultsProps) {
+export function ToolbarResults({resultMode, setResultMode}: ToolbarResultsProps) {
   return (
     <ToolbarSection data-test-id="section-result-mode">
       <ToolbarHeading>{t('Results')}</ToolbarHeading>
+      <SegmentedControl
+        aria-label={t('Result Mode')}
+        value={resultMode}
+        onChange={setResultMode}
+      >
+        <SegmentedControl.Item key="samples">{t('Samples')}</SegmentedControl.Item>
+        <SegmentedControl.Item key="aggregate">{t('Aggregate')}</SegmentedControl.Item>
+      </SegmentedControl>
     </ToolbarSection>
   );
 }

--- a/static/app/views/explore/toolbar/toolbarSortBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarSortBy.tsx
@@ -1,13 +1,84 @@
+import {useCallback, useMemo} from 'react';
+import styled from '@emotion/styled';
+
+import type {SelectOption} from 'sentry/components/compactSelect';
+import {CompactSelect} from 'sentry/components/compactSelect';
 import {t} from 'sentry/locale';
+import type {Field} from 'sentry/views/explore/hooks/useSampleFields';
+import type {Direction, Sort} from 'sentry/views/explore/hooks/useSort';
 
 import {ToolbarHeading, ToolbarSection} from './styles';
 
-interface ToolbarSortByProps {}
+interface ToolbarSortByProps {
+  fields: Field[];
+  setSort: (newSort: Sort) => void;
+  sort: Sort;
+}
 
-export function ToolbarSortBy({}: ToolbarSortByProps) {
+export function ToolbarSortBy({fields, setSort, sort}: ToolbarSortByProps) {
+  const fieldOptions: SelectOption<Field>[] = useMemo(() => {
+    return fields.map(field => {
+      return {
+        label: field,
+        value: field,
+      };
+    });
+  }, [fields]);
+
+  const setSortField = useCallback(
+    ({value}: SelectOption<Field>) => {
+      setSort({
+        field: value,
+        direction: sort.direction,
+      });
+    },
+    [setSort, sort]
+  );
+
+  const directionOptions: SelectOption<Direction>[] = useMemo(() => {
+    return [
+      {
+        label: 'Descending',
+        value: 'desc',
+      },
+      {
+        label: 'Ascending',
+        value: 'asc',
+      },
+    ];
+  }, []);
+
+  const setSortDirection = useCallback(
+    ({value}: SelectOption<Direction>) => {
+      setSort({
+        field: sort.field,
+        direction: value,
+      });
+    },
+    [setSort, sort]
+  );
+
   return (
     <ToolbarSection data-test-id="section-sort-by">
       <ToolbarHeading>{t('Sort By')}</ToolbarHeading>
+      <ToolbarContent>
+        <CompactSelect
+          size="md"
+          options={fieldOptions}
+          value={sort.field}
+          onChange={setSortField}
+        />
+        <CompactSelect
+          size="md"
+          options={directionOptions}
+          value={sort.direction}
+          onChange={setSortDirection}
+        />
+      </ToolbarContent>
     </ToolbarSection>
   );
 }
+
+const ToolbarContent = styled('div')`
+  display: flex;
+`;


### PR DESCRIPTION
This adds the controls to allow the users to pick between samples vs aggregates and change the sort on the samples mode.