### PR TITLE
fix(discord): Fix Bot Command Timeout

### DIFF
--- a/src/sentry/middleware/integrations/parsers/discord.py
+++ b/src/sentry/middleware/integrations/parsers/discord.py
@@ -9,10 +9,12 @@ from rest_framework import status
 from rest_framework.request import Request
 
 from sentry.hybridcloud.outbox.category import WebhookProviderIdentifier
+from sentry.integrations.discord.message_builder.base.flags import EPHEMERAL_FLAG
 from sentry.integrations.discord.requests.base import DiscordRequest, DiscordRequestError
 from sentry.integrations.discord.views.link_identity import DiscordLinkIdentityView
 from sentry.integrations.discord.views.unlink_identity import DiscordUnlinkIdentityView
 from sentry.integrations.discord.webhooks.base import DiscordInteractionsEndpoint
+from sentry.integrations.discord.webhooks.types import DiscordResponseTypes
 from sentry.integrations.middleware.hybrid_cloud.parser import (
     BaseRequestParser,
     create_async_request_payload,
@@ -43,7 +45,10 @@ class DiscordRequestParser(BaseRequestParser):
     _discord_request: DiscordRequest | None = None
 
     # https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-type
-    async_response_data = {"type": 5, "data": {"flags": 64}}
+    async_response_data = {
+        "type": DiscordResponseTypes.DEFERRED_MESSAGE,
+        "data": {"flags": EPHEMERAL_FLAG},
+    }
 
     @property
     def discord_request(self) -> DiscordRequest | None:

--- a/src/sentry/middleware/integrations/parsers/discord.py
+++ b/src/sentry/middleware/integrations/parsers/discord.py
@@ -43,7 +43,7 @@ class DiscordRequestParser(BaseRequestParser):
     _discord_request: DiscordRequest | None = None
 
     # https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-type
-    async_response_data = {"type": 5, "flags": 64}
+    async_response_data = {"type": 5, "data": {"flags": 64}}
 
     @property
     def discord_request(self) -> DiscordRequest | None:
@@ -65,7 +65,7 @@ class DiscordRequestParser(BaseRequestParser):
                 }
             )
 
-        return JsonResponse(data=self.async_response_data, status=status.HTTP_202_ACCEPTED)
+        return JsonResponse(data=self.async_response_data, status=status.HTTP_200_OK)
 
     def get_integration_from_request(self) -> Integration | None:
         if self.view_class in self.control_classes:

--- a/tests/sentry/middleware/integrations/parsers/test_discord.py
+++ b/tests/sentry/middleware/integrations/parsers/test_discord.py
@@ -207,7 +207,7 @@ class DiscordRequestParserTest(TestCase):
                 "response_url": response_url,
             }
         )
-        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert response.status_code == status.HTTP_200_OK
         assert json.loads(response.content) == parser.async_response_data
 
 


### PR DESCRIPTION
Fixes https://sentry.sentry.io/issues/5131244670/events/a169bd4760e9408f86f40822285b804f/ & Discord Bot Commands that are currently failing:
![image](https://github.com/user-attachments/assets/9ef653d3-72f1-4ec2-a679-a7d148518128)

What went wrong?

Discord expects us to respond to a webhook within 3 seconds, which is difficult to do when we are making RPC calls between region and control.

Currently the way handle the latency induced by RPC calls is to send a discord a response to a webhook, which tells it that we are processing. this buys us 15 minutes to respond with the new data, which is more enough.

However, we didn't follow the Discord API spec correctly, and out response was not formatted & we sent the incorrect status code. 
> When responding to an interaction received via webhook, your server can simply respond to the received POST request. You'll want to respond with a 200 status code (if everything went well), as well as specifying a type and data....
(https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-messages)

What this meant is in reality, we only had 3 seconds to respond and when the RPC call didn't finish in time, Discord believed we didn't respond. In this pr, i actually send the correct response, which ultimately gives us the full 15 minutes.

In the video below, i exaggerated how long it would take to respond to show the functionality. Notice how it says, the bot is thinking, which shows we told Discord that we are working on a response.

https://github.com/user-attachments/assets/ae7ad9bb-8ff2-4c34-bb01-30d8d22c1190


Note: We run through this async logic only when running on silo mode, which means testing this locally on monolith won't surface this issue. 
