### PR TITLE
feat(explore): Setup explore table boiler plate

### DIFF
--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -1,5 +1,5 @@
 interface ExploreChartsProps {}
 
 export function ExploreCharts({}: ExploreChartsProps) {
-  return <div>Charts</div>;
+  return <div>TODO: visualize charts</div>;
 }

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -1,6 +1,46 @@
+import {Fragment, useState} from 'react';
+
+import {TabList, Tabs} from 'sentry/components/tabs';
+import {t} from 'sentry/locale';
+import {useResultMode} from 'sentry/views/explore/hooks/useResultsMode';
+
+import {SpansTable} from './spansTable';
+import {TracesTable} from './tracesTable';
+
+enum Tab {
+  SPAN = 'span',
+  TRACE = 'trace',
+}
+
 interface ExploreTablesProps {}
 
 export function ExploreTables({}: ExploreTablesProps) {
-  // TODO
-  return <div>Tables</div>;
+  const [resultMode] = useResultMode();
+
+  if (resultMode === 'aggregate') {
+    return <ExploreAggregateTable />;
+  }
+
+  return <ExploreSamplesTable />;
+}
+
+function ExploreAggregateTable() {
+  return <div>TODO: aggregate table</div>;
+}
+
+function ExploreSamplesTable() {
+  const [tab, setTab] = useState(Tab.SPAN);
+
+  return (
+    <Fragment>
+      <Tabs value={tab} onChange={setTab}>
+        <TabList hideBorder>
+          <TabList.Item key={Tab.SPAN}>{t('Span Samples')}</TabList.Item>
+          <TabList.Item key={Tab.TRACE}>{t('Trace Samples')}</TabList.Item>
+        </TabList>
+      </Tabs>
+      {tab === Tab.SPAN && <SpansTable />}
+      {tab === Tab.TRACE && <TracesTable />}
+    </Fragment>
+  );
 }

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -1,0 +1,5 @@
+interface SpansTableProps {}
+
+export function SpansTable({}: SpansTableProps) {
+  return <div>TODO: span table</div>;
+}

--- a/static/app/views/explore/tables/tracesTable.tsx
+++ b/static/app/views/explore/tables/tracesTable.tsx
@@ -1,0 +1,5 @@
+interface TracesTableProps {}
+
+export function TracesTable({}: TracesTableProps) {
+  return <div>TODO: trace table</div>;
+}


### PR DESCRIPTION
This setups stubs for where the spans and traces samples tables will go.