### PR TITLE
ref(insights): remove performance-sample-panel-search feature

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -269,8 +269,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:performance-queries-mongodb-extraction", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable removing the fallback for metrics compatibility
     manager.add("organizations:performance-remove-metrics-compatibility-fallback", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable span search bar in Insights module sample panels
-    manager.add("organizations:performance-sample-panel-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable platform selector for screens flow
     manager.add("organizations:performance-screens-platform-selector", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable screens view powered by span metrics

--- a/static/app/views/insights/cache/components/samplePanel.tsx
+++ b/static/app/views/insights/cache/components/samplePanel.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import keyBy from 'lodash/keyBy';
 import * as qs from 'query-string';
 
-import Feature from 'sentry/components/acl/feature';
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import {Button} from 'sentry/components/button';
 import {CompactSelect} from 'sentry/components/compactSelect';
@@ -392,20 +391,18 @@ export function CacheSamplePanel() {
             />
           </ModuleLayout.Half>
 
-          <Feature features="performance-sample-panel-search">
-            <ModuleLayout.Full>
-              <SearchBar
-                searchSource={`${ModuleName.CACHE}-sample-panel`}
-                query={query.spanSearchQuery}
-                onSearch={handleSearch}
-                placeholder={t('Search for span attributes')}
-                organization={organization}
-                supportedTags={supportedTags}
-                dataset={DiscoverDatasets.SPANS_INDEXED}
-                projectIds={selection.projects}
-              />
-            </ModuleLayout.Full>
-          </Feature>
+          <ModuleLayout.Full>
+            <SearchBar
+              searchSource={`${ModuleName.CACHE}-sample-panel`}
+              query={query.spanSearchQuery}
+              onSearch={handleSearch}
+              placeholder={t('Search for span attributes')}
+              organization={organization}
+              supportedTags={supportedTags}
+              dataset={DiscoverDatasets.SPANS_INDEXED}
+              projectIds={selection.projects}
+            />
+          </ModuleLayout.Full>
 
           <Fragment>
             <ModuleLayout.Full>

--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
@@ -4,7 +4,6 @@ import debounce from 'lodash/debounce';
 import omit from 'lodash/omit';
 import * as qs from 'query-string';
 
-import Feature from 'sentry/components/acl/feature';
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import SearchBar from 'sentry/components/events/searchBar';
 import {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
@@ -219,18 +218,16 @@ export function SampleList({
           highlightedSpanId={highlightedSpanId}
         />
 
-        <Feature features="performance-sample-panel-search">
-          <StyledSearchBar
-            searchSource={`${moduleName}-sample-panel`}
-            query={spanSearchQuery}
-            onSearch={handleSearch}
-            placeholder={t('Search for span attributes')}
-            organization={organization}
-            supportedTags={supportedTags}
-            dataset={DiscoverDatasets.SPANS_INDEXED}
-            projectIds={selection.projects}
-          />
-        </Feature>
+        <StyledSearchBar
+          searchSource={`${moduleName}-sample-panel`}
+          query={spanSearchQuery}
+          onSearch={handleSearch}
+          placeholder={t('Search for span attributes')}
+          organization={organization}
+          supportedTags={supportedTags}
+          dataset={DiscoverDatasets.SPANS_INDEXED}
+          projectIds={selection.projects}
+        />
 
         <SampleTable
           highlightedSpanId={highlightedSpanId}

--- a/static/app/views/insights/http/components/httpSamplesPanel.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.tsx
@@ -2,7 +2,6 @@ import {Fragment, useCallback} from 'react';
 import styled from '@emotion/styled';
 import * as qs from 'query-string';
 
-import Feature from 'sentry/components/acl/feature';
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import {Button} from 'sentry/components/button';
 import {CompactSelect} from 'sentry/components/compactSelect';
@@ -463,20 +462,18 @@ export function HTTPSamplesPanel() {
             </Fragment>
           )}
 
-          <Feature features="performance-sample-panel-search">
-            <ModuleLayout.Full>
-              <SearchBar
-                searchSource={`${ModuleName.HTTP}-sample-panel`}
-                query={query.spanSearchQuery}
-                onSearch={handleSearch}
-                placeholder={t('Search for span attributes')}
-                organization={organization}
-                supportedTags={supportedTags}
-                dataset={DiscoverDatasets.SPANS_INDEXED}
-                projectIds={selection.projects}
-              />
-            </ModuleLayout.Full>
-          </Feature>
+          <ModuleLayout.Full>
+            <SearchBar
+              searchSource={`${ModuleName.HTTP}-sample-panel`}
+              query={query.spanSearchQuery}
+              onSearch={handleSearch}
+              placeholder={t('Search for span attributes')}
+              organization={organization}
+              supportedTags={supportedTags}
+              dataset={DiscoverDatasets.SPANS_INDEXED}
+              projectIds={selection.projects}
+            />
+          </ModuleLayout.Full>
 
           {query.panel === 'duration' && (
             <Fragment>

--- a/static/app/views/insights/mobile/common/components/spanSamplesPanelContainer.tsx
+++ b/static/app/views/insights/mobile/common/components/spanSamplesPanelContainer.tsx
@@ -2,7 +2,6 @@ import {Fragment, useCallback, useState} from 'react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 
-import Feature from 'sentry/components/acl/feature';
 import SearchBar from 'sentry/components/events/searchBar';
 import {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import Link from 'sentry/components/links/link';
@@ -198,18 +197,17 @@ export function SpanSamplesContainer({
         platform={isProjectCrossPlatform ? selectedPlatform : undefined}
       />
 
-      <Feature features="performance-sample-panel-search">
-        <StyledSearchBar
-          searchSource={`${moduleName}-sample-panel`}
-          query={searchQuery}
-          onSearch={handleSearch}
-          placeholder={t('Search for span attributes')}
-          organization={organization}
-          supportedTags={supportedTags}
-          dataset={DiscoverDatasets.SPANS_INDEXED}
-          projectIds={selection.projects}
-        />
-      </Feature>
+      <StyledSearchBar
+        searchSource={`${moduleName}-sample-panel`}
+        query={searchQuery}
+        onSearch={handleSearch}
+        placeholder={t('Search for span attributes')}
+        organization={organization}
+        supportedTags={supportedTags}
+        dataset={DiscoverDatasets.SPANS_INDEXED}
+        projectIds={selection.projects}
+      />
+
       <SampleTable
         referrer={TraceViewSources.APP_STARTS_MODULE}
         spanSearch={spanSearch}

--- a/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
+++ b/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
@@ -2,7 +2,6 @@ import {useCallback} from 'react';
 import styled from '@emotion/styled';
 import * as qs from 'query-string';
 
-import Feature from 'sentry/components/acl/feature';
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import {Button} from 'sentry/components/button';
 import {CompactSelect, type SelectOption} from 'sentry/components/compactSelect';
@@ -361,20 +360,18 @@ export function MessageSpanSamplesPanel() {
             />
           </ModuleLayout.Full>
 
-          <Feature features="performance-sample-panel-search">
-            <ModuleLayout.Full>
-              <SearchBar
-                searchSource={`${ModuleName.QUEUE}-sample-panel`}
-                query={query.spanSearchQuery}
-                onSearch={handleSearch}
-                placeholder={t('Search for span attributes')}
-                organization={organization}
-                supportedTags={supportedTags}
-                dataset={DiscoverDatasets.SPANS_INDEXED}
-                projectIds={selection.projects}
-              />
-            </ModuleLayout.Full>
-          </Feature>
+          <ModuleLayout.Full>
+            <SearchBar
+              searchSource={`${ModuleName.QUEUE}-sample-panel`}
+              query={query.spanSearchQuery}
+              onSearch={handleSearch}
+              placeholder={t('Search for span attributes')}
+              organization={organization}
+              supportedTags={supportedTags}
+              dataset={DiscoverDatasets.SPANS_INDEXED}
+              projectIds={selection.projects}
+            />
+          </ModuleLayout.Full>
 
           <ModuleLayout.Full>
             <MessageSpanSamplesTable


### PR DESCRIPTION
We GA'd sample panel search a few months ago. Cleans up the feature flag.