### PR TITLE
feat(eap): Add a method that powers metrics explorer with EAP

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -67,6 +67,7 @@ rfc3986-validator>=0.1.1
 sentry-arroyo>=2.16.5
 sentry-kafka-schemas>=0.1.106
 sentry-ophio==0.2.7
+sentry-protos>=0.1.3
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.9.1
 sentry-sdk>=2.12.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -69,6 +69,7 @@ google-resumable-media==2.7.0
 googleapis-common-protos==1.63.2
 grpc-google-iam-v1==0.13.1
 grpc-interceptor==0.15.4
+grpc-stubs==1.53.0.5
 grpcio==1.60.1
 grpcio-status==1.60.1
 h11==0.13.0
@@ -184,6 +185,7 @@ sentry-forked-django-stubs==5.0.4.post1
 sentry-forked-djangorestframework-stubs==3.15.0.post1
 sentry-kafka-schemas==0.1.106
 sentry-ophio==0.2.7
+sentry-protos==0.1.3
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.1
 sentry-sdk==2.12.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -57,6 +57,7 @@ google-resumable-media==2.7.0
 googleapis-common-protos==1.63.2
 grpc-google-iam-v1==0.13.1
 grpc-interceptor==0.15.4
+grpc-stubs==1.53.0.5
 grpcio==1.60.1
 grpcio-status==1.60.1
 h11==0.14.0
@@ -125,6 +126,7 @@ s3transfer==0.10.0
 sentry-arroyo==2.16.5
 sentry-kafka-schemas==0.1.106
 sentry-ophio==0.2.7
+sentry-protos==0.1.3
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.1
 sentry-sdk==2.12.0

--- a/src/sentry/api/endpoints/organization_metrics_query.py
+++ b/src/sentry/api/endpoints/organization_metrics_query.py
@@ -182,7 +182,7 @@ class OrganizationMetricsQueryEndpoint(OrganizationEndpoint):
                             interval,
                             organization,
                             projects,
-                            Referrer.API_ORGANIZATION_METRICS_QUERY.value,
+                            Referrer.API_ORGANIZATION_METRICS_EAP_QUERY.value,
                         )
                         return Response(status=200, data=results)
 

--- a/src/sentry/api/endpoints/organization_metrics_query.py
+++ b/src/sentry/api/endpoints/organization_metrics_query.py
@@ -175,7 +175,7 @@ class OrganizationMetricsQueryEndpoint(OrganizationEndpoint):
                 if len(mql_queries) == 1 and "a" in mql_queries[0].sub_queries:
                     subquery = mql_queries[0].sub_queries["a"]
                     if "d:eap/" in subquery.mql:
-                        results = mql_eap_bridge.make_eap_request(
+                        res_data = mql_eap_bridge.make_eap_request(
                             subquery.mql,
                             start,
                             end,
@@ -184,7 +184,7 @@ class OrganizationMetricsQueryEndpoint(OrganizationEndpoint):
                             projects,
                             Referrer.API_ORGANIZATION_METRICS_EAP_QUERY.value,
                         )
-                        return Response(status=200, data=results)
+                        return Response(status=200, data=res_data)
 
             results = run_queries(
                 mql_queries=mql_queries,

--- a/src/sentry/api/endpoints/organization_metrics_query.py
+++ b/src/sentry/api/endpoints/organization_metrics_query.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import options
+from sentry import features, options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -17,6 +17,7 @@ from sentry.sentry_metrics.querying.data import (
     MQLQuery,
     run_queries,
 )
+from sentry.sentry_metrics.querying.eap import mql_eap_bridge
 from sentry.sentry_metrics.querying.errors import (
     InvalidMetricsQueryError,
     LatestReleaseNotFoundError,
@@ -156,6 +157,7 @@ class OrganizationMetricsQueryEndpoint(OrganizationEndpoint):
             start, end = get_date_range_from_params(request.GET)
             interval = self._interval_from_request(request)
             mql_queries = self._mql_queries_from_request(request)
+            projects = self.get_projects(request, organization)
 
             metrics.incr(
                 key="ddm.metrics_api.query",
@@ -166,13 +168,31 @@ class OrganizationMetricsQueryEndpoint(OrganizationEndpoint):
                 },
             )
 
+            if all(
+                features.has("projects:use-eap-spans-for-metrics-explorer", project)
+                for project in projects
+            ):
+                if len(mql_queries) == 1 and "a" in mql_queries[0].sub_queries:
+                    subquery = mql_queries[0].sub_queries["a"]
+                    if "d:eap/" in subquery.mql:
+                        results = mql_eap_bridge.make_eap_request(
+                            subquery.mql,
+                            start,
+                            end,
+                            interval,
+                            organization,
+                            projects,
+                            Referrer.API_ORGANIZATION_METRICS_QUERY.value,
+                        )
+                        return Response(status=200, data=results)
+
             results = run_queries(
                 mql_queries=mql_queries,
                 start=start,
                 end=end,
                 interval=interval,
                 organization=organization,
-                projects=self.get_projects(request, organization),
+                projects=projects,
                 environments=self.get_environments(request, organization),
                 referrer=Referrer.API_ORGANIZATION_METRICS_QUERY.value,
                 query_type=self._get_query_type_from_request(request),

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -539,6 +539,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("projects:span-metrics-extraction", ProjectFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     manager.add("projects:span-metrics-extraction-addons", ProjectFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     manager.add("projects:relay-otel-endpoint", ProjectFeature, FeatureHandlerStrategy.OPTIONS, api_expose=False)
+    # EAP: extremely experimental flag that makes DDM page use EAP tables
+    manager.add("projects:use-eap-spans-for-metrics-explorer", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 
     # Project plugin features
     manager.add("projects:plugins", ProjectPluginFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)

--- a/src/sentry/sentry_metrics/querying/eap/README.md
+++ b/src/sentry/sentry_metrics/querying/eap/README.md
@@ -1,0 +1,5 @@
+We would like to move metrics querying to a span-based system backed by `eap_spans`, part of the Events Analytics Platform work.
+
+This module facilitates some hacky initial MQL -> GRPC logic, used as a POC for those efforts.
+
+You should not consider this to be production-ready yet.

--- a/src/sentry/sentry_metrics/querying/eap/mql_eap_bridge.py
+++ b/src/sentry/sentry_metrics/querying/eap/mql_eap_bridge.py
@@ -35,7 +35,7 @@ def parse_mql_filters(group: ConditionGroup) -> Iterable[TraceItemFilter]:
             )
         elif isinstance(cond, MQLOr):
             yield TraceItemFilter(
-                and_filter=OrFilter(filters=list(parse_mql_filters(cond.conditions)))
+                or_filter=OrFilter(filters=list(parse_mql_filters(cond.conditions)))
             )
         elif isinstance(cond, MQLCondition):
             if cond.op == MQLOp.EQ:
@@ -60,12 +60,12 @@ def make_eap_request(
     ts: Timeseries = snuba_sdk.mql.mql.parse_mql(query_mql)
 
     aggregate_map = {
-        "sum": AggregateBucketRequest.SUM,
-        "avg": AggregateBucketRequest.AVG,
-        "p50": AggregateBucketRequest.P50,
-        "p95": AggregateBucketRequest.P95,
-        "P99": AggregateBucketRequest.P99,
-        "count": AggregateBucketRequest.COUNT,
+        "sum": AggregateBucketRequest.FUNCTION_SUM,
+        "avg": AggregateBucketRequest.FUNCTION_AVG,
+        "p50": AggregateBucketRequest.FUNCTION_P50,
+        "p95": AggregateBucketRequest.FUNCTION_P95,
+        "P99": AggregateBucketRequest.FUNCTION_P99,
+        "count": AggregateBucketRequest.FUNCTION_COUNT,
     }
 
     rpc_filters = None

--- a/src/sentry/sentry_metrics/querying/eap/mql_eap_bridge.py
+++ b/src/sentry/sentry_metrics/querying/eap/mql_eap_bridge.py
@@ -1,0 +1,131 @@
+from collections.abc import Iterable, Sequence
+from datetime import datetime, timedelta
+
+import requests
+import snuba_sdk.mql.mql
+from django.conf import settings
+from google.protobuf.timestamp_pb2 import Timestamp as ProtobufTimestamp
+from snuba_sdk import Timeseries
+from snuba_sdk.conditions import And as MQLAnd
+from snuba_sdk.conditions import Condition as MQLCondition
+from snuba_sdk.conditions import ConditionGroup
+from snuba_sdk.conditions import Op as MQLOp
+from snuba_sdk.conditions import Or as MQLOr
+
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.sentry_metrics.querying.eap.protobufs.AggregateBucket_pb2 import (
+    AggregateBucketRequest,
+    AggregateBucketResponse,
+)
+from sentry.sentry_metrics.querying.eap.protobufs.BaseRequest_pb2 import RequestInfo
+from sentry.sentry_metrics.querying.eap.protobufs.Filters_pb2 import (
+    AndFilter,
+    OrFilter,
+    StringFilter,
+    TraceItemFilter,
+)
+
+
+def parse_mql_filters(group: ConditionGroup) -> Iterable[TraceItemFilter]:
+    for cond in group:
+        if isinstance(cond, MQLAnd):
+            yield TraceItemFilter(
+                and_filter=AndFilter(filters=list(parse_mql_filters(cond.conditions)))
+            )
+        elif isinstance(cond, MQLOr):
+            yield TraceItemFilter(
+                and_filter=OrFilter(filters=list(parse_mql_filters(cond.conditions)))
+            )
+        elif isinstance(cond, MQLCondition):
+            if cond.op == MQLOp.EQ:
+                yield TraceItemFilter(
+                    string_comparison=StringFilter(key=cond.lhs.name, value=cond.rhs)
+                )
+        # TODO: maybe we want to implement other stuff
+
+
+def make_eap_request(
+    query_mql: str,
+    start: datetime,
+    end: datetime,
+    interval: int,
+    organization: Organization,
+    projects: Sequence[Project],
+    referrer: str,
+) -> dict:
+    start_time_proto = ProtobufTimestamp()
+    start_time_proto.FromDatetime(start)
+    end_time_proto = ProtobufTimestamp()
+    end_time_proto.FromDatetime(end)
+
+    ts: Timeseries = snuba_sdk.mql.mql.parse_mql(query_mql)
+
+    aggregate_map = {
+        "sum": AggregateBucketRequest.SUM,
+        "avg": AggregateBucketRequest.AVG,
+        "p50": AggregateBucketRequest.P50,
+        "p95": AggregateBucketRequest.P95,
+        "P99": AggregateBucketRequest.P99,
+        "count": AggregateBucketRequest.COUNT,
+    }
+
+    rpc_filters = None
+    if ts.filters is not None:
+        rpc_filters = TraceItemFilter(
+            and_filter=AndFilter(filters=list(parse_mql_filters(ts.filters)))
+        )
+    req = AggregateBucketRequest(
+        request_info=RequestInfo(
+            start_timestamp=start_time_proto,
+            end_timestamp=end_time_proto,
+            organization_id=organization.id,
+            cogs_category="eap",
+            referrer=referrer,
+            project_ids=[project.id for project in projects],
+        ),
+        aggregate=aggregate_map[ts.aggregate],
+        filter=rpc_filters,
+    )
+    http_resp = requests.post(f"{settings.SENTRY_SNUBA}/timeseries", data=req.SerializeToString())
+    http_resp.raise_for_status()
+
+    resp = AggregateBucketResponse()
+    resp.ParseFromString(http_resp.content)
+
+    series_data = list(resp.result)
+    duration = end - start
+    bucket_size_secs = duration.total_seconds() / len(series_data)
+    intervals = []
+    for i in range(len(series_data)):
+        intervals.append((start + timedelta(seconds=bucket_size_secs * i)).isoformat())
+    intervals.append(end.isoformat())
+
+    return {
+        "data": [
+            [
+                {
+                    "by": {},
+                    "totals": None,
+                    "series": series_data,
+                }
+            ]
+        ],
+        "meta": [
+            [
+                {"name": "aggregate_value", "type": "Float64"},
+                {
+                    "group_bys": [],
+                    "order": "DESC",
+                    "limit": 770,
+                    "has_more": False,
+                    "unit_family": None,
+                    "unit": "none",
+                    "scaling_factor": 1,
+                },
+            ]
+        ],
+        "start": start.isoformat(),
+        "end": end.isoformat(),
+        "intervals": intervals,
+    }

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -164,6 +164,7 @@ class Referrer(Enum):
         "api.organization.metrics-metadata.fetch-metrics-summaries"
     )
     API_ORGANIZATION_METRICS_QUERY = "api.organization.metrics-query"
+    API_ORGANIZATION_METRICS_EAP_QUERY = "api.organization.metrics-eap-query"
     API_ORGANIZATION_METRICS_SAMPLES = "api.organization.metrics-samples"
     API_ORGANIZATION_ISSUE_REPLAY_COUNT = "api.organization-issue-replay-count"
     API_ORGANIZATION_SDK_UPDATES = "api.organization-sdk-updates"


### PR DESCRIPTION
Look, this is pretty gross. It short-circuit returns some things, doesn't implement all of MQL, but it's a way to at least query EAP in production. We can start implementing the rest with net-new RPCs for things like tag discovery later.