### PR TITLE
fix(stats): Fix usage stats per minute for indexed spans

### DIFF
--- a/static/app/views/organizationStats/usageStatsPerMin.tsx
+++ b/static/app/views/organizationStats/usageStatsPerMin.tsx
@@ -68,7 +68,7 @@ function UsageStatsPerMin({
       const {category, outcome} = group.by;
 
       if (dataCategoryApiName === 'span_indexed') {
-        if (category !== 'span_indexed' || group.by.outcome !== Outcome.ACCEPTED) {
+        if (category !== 'span_indexed' || outcome !== Outcome.ACCEPTED) {
           return count;
         }
       } else {

--- a/static/app/views/organizationStats/usageStatsPerMin.tsx
+++ b/static/app/views/organizationStats/usageStatsPerMin.tsx
@@ -58,9 +58,6 @@ function UsageStatsPerMin({
     return null;
   }
 
-  const category =
-    dataCategoryApiName === 'span_indexed' ? dataCategoryApiName : dataCategory;
-
   const minuteData = (): string | undefined => {
     // The last minute in the series is still "in progress"
     // Read data from 2nd last element for the latest complete minute
@@ -68,12 +65,17 @@ function UsageStatsPerMin({
     const lastMin = Math.max(intervals.length - 2, 0);
 
     const eventsLastMin = groups.reduce((count, group) => {
-      // HACK: The backend enum are singular, but the frontend enums are plural
-      if (
-        !category.includes(`${group.by.category}`) ||
-        group.by.outcome !== Outcome.ACCEPTED
-      ) {
-        return count;
+      const {category, outcome} = group.by;
+
+      if (dataCategoryApiName === 'span_indexed') {
+        if (category !== 'span_indexed' || group.by.outcome !== Outcome.ACCEPTED) {
+          return count;
+        }
+      } else {
+        // HACK: The backend enum are singular, but the frontend enums are plural
+        if (!dataCategory.includes(`${category}`) || outcome !== Outcome.ACCEPTED) {
+          return count;
+        }
       }
 
       count += group.series['sum(quantity)'][lastMin];


### PR DESCRIPTION
The old logic works but not for 'span_indexed' as the string includes 'span'. Now it shall be correct.

We shouldn't sum results from 'span' and 'span_indexed' right? 