### PR TITLE
feat(recent-search): Add errors and transaction datasets

### DIFF
--- a/src/sentry/models/search_common.py
+++ b/src/sentry/models/search_common.py
@@ -8,3 +8,5 @@ class SearchType(IntEnum):
     REPLAY = 3
     METRIC = 4
     SPAN = 5
+    ERROR = 6
+    TRANSACTION = 7

--- a/tests/sentry/api/endpoints/test_organization_recent_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_recent_searches.py
@@ -102,11 +102,29 @@ class RecentSearchesListTest(APITestCase):
                 date_added=timezone.now() - timedelta(hours=1),
             ),
         ]
+        error_recent_search = RecentSearch.objects.create(
+            organization=self.organization,
+            user_id=self.user.id,
+            type=SearchType.ERROR.value,
+            query="some test",
+            last_seen=timezone.now(),
+            date_added=timezone.now(),
+        )
+        transaction_recent_search = RecentSearch.objects.create(
+            organization=self.organization,
+            user_id=self.user.id,
+            type=SearchType.TRANSACTION.value,
+            query="some test",
+            last_seen=timezone.now(),
+            date_added=timezone.now(),
+        )
         self.check_results(issue_recent_searches, search_type=SearchType.ISSUE)
         self.check_results([event_recent_search], search_type=SearchType.EVENT)
         self.check_results([session_recent_search], search_type=SearchType.SESSION)
         self.check_results([metric_recent_search], search_type=SearchType.METRIC)
         self.check_results([span_recent_search], search_type=SearchType.SPAN)
+        self.check_results([error_recent_search], search_type=SearchType.ERROR)
+        self.check_results([transaction_recent_search], search_type=SearchType.TRANSACTION)
 
     def test_param_validation(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
We want to keep the recent search for errors and transactions datasets separate as we split the discover dataset