### PR TITLE
chore(derived_code_mappings): Report errors with warning level

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -427,7 +427,9 @@ class GitHubBaseClient(GithubProxyClient, RepositoryClient, CommitContextClient)
         else:
             # We do not raise the exception so we can keep iterating through the repos.
             # Nevertheless, investigate the error to determine if we should abort the processing
-            logger.error("Continuing execution. Investigate: %s", error_message, extra=extra)
+            logger.error(
+                "Continuing execution. Investigate: %s", error_message, extra=extra, level="info"
+            )
 
         return should_count_error
 
@@ -448,7 +450,9 @@ class GitHubBaseClient(GithubProxyClient, RepositoryClient, CommitContextClient)
         except ApiError:
             only_use_cache = True
             # Report so we can investigate
-            logger.exception("Loading trees from cache. Execution will continue. Check logs.")
+            logger.exception(
+                "Loading trees from cache. Execution will continue. Check logs.", level="info"
+            )
 
         for index, repo_info in enumerate(repositories):
             repo_full_name = repo_info["full_name"]
@@ -476,7 +480,9 @@ class GitHubBaseClient(GithubProxyClient, RepositoryClient, CommitContextClient)
             except Exception:
                 # Report for investigation but do not stop processing
                 logger.exception(
-                    "Failed to populate_tree. Investigate. Contining execution.", extra=extra
+                    "Failed to populate_tree. Investigate. Contining execution.",
+                    extra=extra,
+                    level="info",
                 )
 
             if connection_error_count >= MAX_CONNECTION_ERRORS:

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -427,9 +427,7 @@ class GitHubBaseClient(GithubProxyClient, RepositoryClient, CommitContextClient)
         else:
             # We do not raise the exception so we can keep iterating through the repos.
             # Nevertheless, investigate the error to determine if we should abort the processing
-            logger.error(
-                "Continuing execution. Investigate: %s", error_message, extra=extra, level="info"
-            )
+            logger.error("Continuing execution. Investigate: %s", error_message, extra=extra)
 
         return should_count_error
 
@@ -450,9 +448,7 @@ class GitHubBaseClient(GithubProxyClient, RepositoryClient, CommitContextClient)
         except ApiError:
             only_use_cache = True
             # Report so we can investigate
-            logger.exception(
-                "Loading trees from cache. Execution will continue. Check logs.", level="info"
-            )
+            logger.exception("Loading trees from cache. Execution will continue. Check logs.")
 
         for index, repo_info in enumerate(repositories):
             repo_full_name = repo_info["full_name"]
@@ -480,9 +476,7 @@ class GitHubBaseClient(GithubProxyClient, RepositoryClient, CommitContextClient)
             except Exception:
                 # Report for investigation but do not stop processing
                 logger.exception(
-                    "Failed to populate_tree. Investigate. Contining execution.",
-                    extra=extra,
-                    level="info",
+                    "Failed to populate_tree. Investigate. Contining execution.", extra=extra
                 )
 
             if connection_error_count >= MAX_CONNECTION_ERRORS:

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -428,7 +428,9 @@ class GitHubBaseClient(GithubProxyClient, RepositoryClient, CommitContextClient)
         else:
             # We do not raise the exception so we can keep iterating through the repos.
             # Nevertheless, investigate the error to determine if we should abort the processing
-            capture_message("Continuing execution. Investigate: %s", error_message, extra=extra)
+            capture_message(
+                "Continuing execution. Investigate: %s", error_message, extra=extra, level="warning"
+            )
 
         return should_count_error
 

--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -66,6 +66,7 @@ def process_error(error: ApiError, extra: dict[str, str]) -> None:
     logger.error(
         "Unhandled ApiError occurred. Nothing is broken. Investigate. Multiple issues grouped.",
         extra=extra,
+        level="info",
     )
 
 
@@ -127,7 +128,9 @@ def derive_code_mappings(
         logger.warning("derive_code_mappings.getting_lock_failed", extra=extra)
         return
     except Exception:
-        logger.exception("Unexpected error type while calling `get_trees_for_org()`.", extra=extra)
+        logger.exception(
+            "Unexpected error type while calling `get_trees_for_org()`.", extra=extra, level="info"
+        )
         return
 
     if not trees:
@@ -155,7 +158,7 @@ def identify_stacktrace_paths(data: NodeData) -> list[str]:
             }
             stacktrace_paths.update(paths)
         except Exception:
-            logger.exception("Error getting filenames for project.")
+            logger.exception("Error getting filenames for project.", level="info")
     return list(stacktrace_paths)
 
 

--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -66,7 +66,6 @@ def process_error(error: ApiError, extra: dict[str, str]) -> None:
     logger.error(
         "Unhandled ApiError occurred. Nothing is broken. Investigate. Multiple issues grouped.",
         extra=extra,
-        level="info",
     )
 
 
@@ -128,9 +127,7 @@ def derive_code_mappings(
         logger.warning("derive_code_mappings.getting_lock_failed", extra=extra)
         return
     except Exception:
-        logger.exception(
-            "Unexpected error type while calling `get_trees_for_org()`.", extra=extra, level="info"
-        )
+        logger.exception("Unexpected error type while calling `get_trees_for_org()`.", extra=extra)
         return
 
     if not trees:
@@ -158,7 +155,7 @@ def identify_stacktrace_paths(data: NodeData) -> list[str]:
             }
             stacktrace_paths.update(paths)
         except Exception:
-            logger.exception("Error getting filenames for project.", level="info")
+            logger.exception("Error getting filenames for project.")
     return list(stacktrace_paths)
 
 


### PR DESCRIPTION
This reports the exceptions as warning-level errors rather than error-level.

Deployments do not get paused if the error is [warning or lower](https://github.com/getsentry/getsentry/blob/b08907d9da3e8856c6cbedbd86d4a722c6f89dd9/gocd/templates/bash/backend/check-sentry-new-errors.sh#L12):
```
--additional-query="issue.type:error !level:info !level:warning"
```

Rendering of a warning-level exception:
<img width="265" alt="image" src="https://github.com/user-attachments/assets/cd630c9b-9ac7-4894-aa33-736789c17c0b">
