### PR TITLE
chore(slack): temporarily track snuba user count queries round 2

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -101,7 +101,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_group_users_count(group: Group) -> int:
-    metrics.incr("slack.get_group_users_count", tags={"group": group.id}, sample_rate=1.0)
+    metrics.incr("slack.get_group_users_count", tags={"group_id": group.id}, sample_rate=1.0)
     return group.count_users_seen(
         referrer=Referrer.TAGSTORE_GET_GROUPS_USER_COUNTS_SLACK_ISSUE_NOTIFICATION.value
     )


### PR DESCRIPTION
Try with `group_id` as a tag instead of `group`, `group` appears to be some kind of reserved word.