### PR TITLE
chore(uptime): Bump ACTIVE_FAILURE_THRESHOLD to 3

### DIFF
--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -47,7 +47,7 @@ ONBOARDING_FAILURE_REDIS_TTL = ONBOARDING_MONITOR_PERIOD
 AUTO_DETECTED_ACTIVE_SUBSCRIPTION_INTERVAL = timedelta(minutes=1)
 # When in active monitoring mode, how many failures in a row do we need to see to mark the monitor as down, or how many
 # successes in a row do we need to mark it up
-ACTIVE_FAILURE_THRESHOLD = 2
+ACTIVE_FAILURE_THRESHOLD = 3
 ACTIVE_RECOVERY_THRESHOLD = 1
 # The TTL of the redis key used to track consecutive statuses
 ACTIVE_THRESHOLD_REDIS_TTL = timedelta(minutes=60)

--- a/tests/sentry/uptime/consumers/test_results_consumers.py
+++ b/tests/sentry/uptime/consumers/test_results_consumers.py
@@ -73,7 +73,10 @@ class ProcessResultTest(UptimeTestCase, ProducerTestMixin):
         )
         with mock.patch(
             "sentry.uptime.consumers.results_consumer.metrics"
-        ) as metrics, self.feature("organizations:uptime-create-issues"):
+        ) as metrics, self.feature("organizations:uptime-create-issues"), mock.patch(
+            "sentry.uptime.consumers.results_consumer.ACTIVE_FAILURE_THRESHOLD",
+            new=2,
+        ):
             self.send_result(result)
             metrics.incr.assert_has_calls(
                 [
@@ -231,7 +234,10 @@ class ProcessResultTest(UptimeTestCase, ProducerTestMixin):
     def test_resolve(self):
         with mock.patch(
             "sentry.uptime.consumers.results_consumer.metrics"
-        ) as metrics, self.feature("organizations:uptime-create-issues"):
+        ) as metrics, self.feature("organizations:uptime-create-issues"), mock.patch(
+            "sentry.uptime.consumers.results_consumer.ACTIVE_FAILURE_THRESHOLD",
+            new=2,
+        ):
             self.send_result(
                 self.create_uptime_result(
                     self.subscription.subscription_id,


### PR DESCRIPTION
Since we're moving to 60 second intervals, we want a slightly higher failure threshold

<!-- Describe your PR here. -->