### PR TITLE
fix(query-builder): Filter out function columns from potential suggestions

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
@@ -10,7 +10,7 @@ import {FunctionDescription} from 'sentry/components/searchQueryBuilder/tokens/f
 import {replaceCommaSeparatedValue} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
 import type {AggregateFilter} from 'sentry/components/searchSyntax/parser';
 import {t} from 'sentry/locale';
-import {FieldValueType} from 'sentry/utils/fields';
+import {FieldKind, FieldValueType} from 'sentry/utils/fields';
 
 type ParametersComboboxProps = {
   onCommit: () => void;
@@ -112,7 +112,12 @@ function useParameterSuggestions({
   const parameterSuggestions = useMemo<SuggestionItem[]>(() => {
     switch (parameterDefinition?.kind) {
       case 'column': {
-        const potentialColumns = Object.values(filterKeys);
+        const potentialColumns = Object.values(filterKeys).filter(filterKey => {
+          const fieldDef = getFieldDefinition(filterKey.key);
+          return (
+            fieldDef?.kind !== FieldKind.EQUATION && fieldDef?.kind !== FieldKind.FUNCTION
+          );
+        });
         const {columnTypes} = parameterDefinition;
 
         if (typeof columnTypes === 'function') {


### PR DESCRIPTION
Relates to https://github.com/getsentry/sentry/pull/76175

This prevents function and equation filters from being suggested as function parameters. 