### PR TITLE
chore: Bump React error codes cache TTL to 3 days

### DIFF
--- a/src/sentry/lang/javascript/errormapping.py
+++ b/src/sentry/lang/javascript/errormapping.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 SOFT_TIMEOUT = 600
 SOFT_TIMEOUT_FUZZINESS = 10
-HARD_TIMEOUT = 7200
+HARD_TIMEOUT = 3 * 24 * 60 * 60  # 3 days = 259200 seconds
 
 REACT_MAPPING_URL = (
     "https://raw.githubusercontent.com/facebook/react/master/scripts/error-codes/codes.json"


### PR DESCRIPTION
Bump TTL of storing the [React error codes](https://github.com/facebook/react/commits/main/scripts/error-codes/codes.json) to 3 days from 2 hours.

Based on the commit history, this file does not change often: https://github.com/facebook/react/commits/main/scripts/error-codes/codes.json

This relies on GitHub's outage to recover within 3 days instead of within 2 hours.
