### PR TITLE
feat(alerts): Allow 'fake' anomalies for testing

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -55,6 +55,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:alerts-migration-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable anomaly detection alerts
     manager.add("organizations:anomaly-detection-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable anomaly detection alerts
+    manager.add("organizations:fake-anomaly-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable anr frame analysis
     manager.add("organizations:anr-analyze-frames", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable auth provider configuration through api

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -514,6 +514,9 @@ class SubscriptionProcessor:
         self.has_anomaly_detection = features.has(
             "organizations:anomaly-detection-alerts", self.subscription.project.organization
         )
+        fake_anomalies = features.has(
+            "organizations:fake-anomaly-detection", self.subscription.project.organization
+        )
 
         if self.has_anomaly_detection:
             potential_anomalies = self.get_anomaly_data_from_seer(aggregation_value)
@@ -558,7 +561,7 @@ class SubscriptionProcessor:
                                 continue
 
                         if self.has_anomaly(
-                            potential_anomaly, trigger.label
+                            potential_anomaly, trigger.label, fake_anomalies
                         ) and not self.check_trigger_matches_status(trigger, TriggerStatus.ACTIVE):
                             metrics.incr(
                                 "incidents.alert_rules.threshold.alert",
@@ -573,7 +576,7 @@ class SubscriptionProcessor:
                             self.trigger_alert_counts[trigger.id] = 0
 
                         if (
-                            not self.has_anomaly(potential_anomaly, trigger.label)
+                            not self.has_anomaly(potential_anomaly, trigger.label, fake_anomalies)
                             and self.active_incident
                             and self.check_trigger_matches_status(trigger, TriggerStatus.ACTIVE)
                         ):
@@ -640,11 +643,14 @@ class SubscriptionProcessor:
         # before the next one then we might alert twice.
         self.update_alert_rule_stats()
 
-    def has_anomaly(self, anomaly, label: str) -> bool:
+    def has_anomaly(self, anomaly, label: str, fake_anomalies: bool) -> bool:
         """
         Helper function to determine whether we care about an anomaly based on the
         anomaly type and trigger type.
         """
+        if fake_anomalies:
+            return True
+
         anomaly_type = anomaly.get("anomaly", {}).get("anomaly_type")
 
         if anomaly_type == AnomalyType.HIGH_CONFIDENCE.value or (

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -514,7 +514,7 @@ class SubscriptionProcessor:
         self.has_anomaly_detection = features.has(
             "organizations:anomaly-detection-alerts", self.subscription.project.organization
         )
-        fake_anomalies = features.has(
+        has_fake_anomalies = features.has(
             "organizations:fake-anomaly-detection", self.subscription.project.organization
         )
 
@@ -561,7 +561,7 @@ class SubscriptionProcessor:
                                 continue
 
                         if self.has_anomaly(
-                            potential_anomaly, trigger.label, fake_anomalies
+                            potential_anomaly, trigger.label, has_fake_anomalies
                         ) and not self.check_trigger_matches_status(trigger, TriggerStatus.ACTIVE):
                             metrics.incr(
                                 "incidents.alert_rules.threshold.alert",
@@ -576,7 +576,9 @@ class SubscriptionProcessor:
                             self.trigger_alert_counts[trigger.id] = 0
 
                         if (
-                            not self.has_anomaly(potential_anomaly, trigger.label, fake_anomalies)
+                            not self.has_anomaly(
+                                potential_anomaly, trigger.label, has_fake_anomalies
+                            )
                             and self.active_incident
                             and self.check_trigger_matches_status(trigger, TriggerStatus.ACTIVE)
                         ):
@@ -643,12 +645,12 @@ class SubscriptionProcessor:
         # before the next one then we might alert twice.
         self.update_alert_rule_stats()
 
-    def has_anomaly(self, anomaly, label: str, fake_anomalies: bool) -> bool:
+    def has_anomaly(self, anomaly, label: str, has_fake_anomalies: bool) -> bool:
         """
         Helper function to determine whether we care about an anomaly based on the
         anomaly type and trigger type.
         """
-        if fake_anomalies:
+        if has_fake_anomalies:
             return True
 
         anomaly_type = anomaly.get("anomaly", {}).get("anomaly_type")


### PR DESCRIPTION
In order to do end to end testing in production (and because I am not able to get ngrok working to validate notification content changes) we'll allow for a 'fake' anomaly to come through if the flag is turned on so we can see these rules trigger.