### PR TITLE
chore: Move function out of receivers

### DIFF
--- a/src/sentry/db/postgres/helpers.py
+++ b/src/sentry/db/postgres/helpers.py
@@ -1,25 +1,5 @@
-import logging
-from functools import wraps
-
 import psycopg2
-from django.db import router, transaction
-from django.db.utils import DatabaseError, InterfaceError, OperationalError, ProgrammingError
-
-
-def handle_db_failure(func, model, wrap_in_transaction: bool = True):
-    @wraps(func)
-    def wrapped(*args, **kwargs):
-        try:
-            if wrap_in_transaction:
-                with transaction.atomic(router.db_for_write(model)):
-                    return func(*args, **kwargs)
-            else:
-                return func(*args, **kwargs)
-        except (ProgrammingError, OperationalError):
-            logging.exception("Failed processing signal %s", func.__name__)
-            return
-
-    return wrapped
+from django.db.utils import DatabaseError, InterfaceError
 
 
 def can_reconnect(exc):

--- a/src/sentry/db/postgres/helpers.py
+++ b/src/sentry/db/postgres/helpers.py
@@ -1,5 +1,25 @@
+import logging
+from functools import wraps
+
 import psycopg2
-from django.db.utils import DatabaseError, InterfaceError
+from django.db import router, transaction
+from django.db.utils import DatabaseError, InterfaceError, OperationalError, ProgrammingError
+
+
+def handle_db_failure(func, model, wrap_in_transaction: bool = True):
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        try:
+            if wrap_in_transaction:
+                with transaction.atomic(router.db_for_write(model)):
+                    return func(*args, **kwargs)
+            else:
+                return func(*args, **kwargs)
+        except (ProgrammingError, OperationalError):
+            logging.exception("Failed processing signal %s", func.__name__)
+            return
+
+    return wrapped
 
 
 def can_reconnect(exc):

--- a/src/sentry/receivers/core.py
+++ b/src/sentry/receivers/core.py
@@ -132,20 +132,20 @@ def freeze_option_epoch_for_project(instance, created, app=None, **kwargs):
 # Anything that relies on default objects that may not exist with default
 # fields should be wrapped in handle_db_failure
 post_upgrade.connect(
-    handle_db_failure(create_default_projects, wrap_in_transaction=False),
+    handle_db_failure(create_default_projects, model=Organization, wrap_in_transaction=False),
     dispatch_uid="create_default_project",
     weak=False,
     sender=SiloMode.MONOLITH,
 )
 
 post_save.connect(
-    handle_db_failure(freeze_option_epoch_for_project),
+    handle_db_failure(freeze_option_epoch_for_project, model=Organization),
     sender=Project,
     dispatch_uid="freeze_option_epoch_for_project",
     weak=False,
 )
 post_save.connect(
-    handle_db_failure(create_keys_for_project),
+    handle_db_failure(create_keys_for_project, model=Organization),
     sender=Project,
     dispatch_uid="create_keys_for_project",
     weak=False,

--- a/src/sentry/receivers/core.py
+++ b/src/sentry/receivers/core.py
@@ -1,12 +1,8 @@
-import logging
-from functools import wraps
-
 from click import echo
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.db import connections, router, transaction
 from django.db.models.signals import post_save
-from django.db.utils import OperationalError, ProgrammingError
 
 from sentry.hybridcloud.models.outbox import outbox_context
 from sentry.loader.dynamic_sdk_options import get_default_loader_data
@@ -19,6 +15,7 @@ from sentry.services.organization import organization_provisioning_service
 from sentry.signals import post_upgrade, project_created
 from sentry.silo.base import SiloMode, region_silo_function
 from sentry.users.services.user.service import user_service
+from sentry.utils.db import handle_db_failure
 from sentry.utils.env import in_test_environment
 from sentry.utils.settings import is_self_hosted
 
@@ -28,22 +25,6 @@ SELECT setval('sentry_project_id_seq', (
     FROM sentry_project))
 """
 DEFAULT_SENTRY_PROJECT_ID = 1
-
-
-def handle_db_failure(func, using=None, wrap_in_transaction=True):
-    @wraps(func)
-    def wrapped(*args, **kwargs):
-        try:
-            if wrap_in_transaction:
-                with transaction.atomic(using or router.db_for_write(Organization)):
-                    return func(*args, **kwargs)
-            else:
-                return func(*args, **kwargs)
-        except (ProgrammingError, OperationalError):
-            logging.exception("Failed processing signal %s", func.__name__)
-            return
-
-    return wrapped
 
 
 def create_default_projects(**kwds):

--- a/src/sentry/receivers/core.py
+++ b/src/sentry/receivers/core.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.db import connections, router, transaction
 from django.db.models.signals import post_save
 
+from sentry.db.postgres.helpers import handle_db_failure
 from sentry.hybridcloud.models.outbox import outbox_context
 from sentry.loader.dynamic_sdk_options import get_default_loader_data
 from sentry.models.organization import Organization
@@ -15,7 +16,6 @@ from sentry.services.organization import organization_provisioning_service
 from sentry.signals import post_upgrade, project_created
 from sentry.silo.base import SiloMode, region_silo_function
 from sentry.users.services.user.service import user_service
-from sentry.utils.db import handle_db_failure
 from sentry.utils.env import in_test_environment
 from sentry.utils.settings import is_self_hosted
 
@@ -132,20 +132,20 @@ def freeze_option_epoch_for_project(instance, created, app=None, **kwargs):
 # Anything that relies on default objects that may not exist with default
 # fields should be wrapped in handle_db_failure
 post_upgrade.connect(
-    handle_db_failure(create_default_projects, wrap_in_transaction=False),
+    handle_db_failure(create_default_projects, model=Organization, wrap_in_transaction=False),
     dispatch_uid="create_default_project",
     weak=False,
     sender=SiloMode.MONOLITH,
 )
 
 post_save.connect(
-    handle_db_failure(freeze_option_epoch_for_project),
+    handle_db_failure(freeze_option_epoch_for_project, model=Organization),
     sender=Project,
     dispatch_uid="freeze_option_epoch_for_project",
     weak=False,
 )
 post_save.connect(
-    handle_db_failure(create_keys_for_project),
+    handle_db_failure(create_keys_for_project, model=Organization),
     sender=Project,
     dispatch_uid="create_keys_for_project",
     weak=False,

--- a/src/sentry/receivers/core.py
+++ b/src/sentry/receivers/core.py
@@ -1,8 +1,12 @@
+import logging
+from functools import wraps
+
 from click import echo
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.db import connections, router, transaction
 from django.db.models.signals import post_save
+from django.db.utils import OperationalError, ProgrammingError
 
 from sentry.hybridcloud.models.outbox import outbox_context
 from sentry.loader.dynamic_sdk_options import get_default_loader_data
@@ -15,7 +19,6 @@ from sentry.services.organization import organization_provisioning_service
 from sentry.signals import post_upgrade, project_created
 from sentry.silo.base import SiloMode, region_silo_function
 from sentry.users.services.user.service import user_service
-from sentry.utils.db import handle_db_failure
 from sentry.utils.env import in_test_environment
 from sentry.utils.settings import is_self_hosted
 
@@ -25,6 +28,22 @@ SELECT setval('sentry_project_id_seq', (
     FROM sentry_project))
 """
 DEFAULT_SENTRY_PROJECT_ID = 1
+
+
+def handle_db_failure(func, using=None, wrap_in_transaction=True):
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        try:
+            if wrap_in_transaction:
+                with transaction.atomic(using or router.db_for_write(Organization)):
+                    return func(*args, **kwargs)
+            else:
+                return func(*args, **kwargs)
+        except (ProgrammingError, OperationalError):
+            logging.exception("Failed processing signal %s", func.__name__)
+            return
+
+    return wrapped
 
 
 def create_default_projects(**kwds):

--- a/src/sentry/utils/db.py
+++ b/src/sentry/utils/db.py
@@ -1,9 +1,28 @@
+import logging
 from collections.abc import Sequence
 from contextlib import ExitStack
+from functools import wraps
 
 import sentry_sdk
 from django.db import DEFAULT_DB_ALIAS, connections, transaction
+from django.db.utils import OperationalError, ProgrammingError
 from sentry_sdk.integrations import Integration
+
+
+def handle_db_failure(func, using: str = "default", wrap_in_transaction: bool = True):
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        try:
+            if wrap_in_transaction:
+                with transaction.atomic(using):
+                    return func(*args, **kwargs)
+            else:
+                return func(*args, **kwargs)
+        except (ProgrammingError, OperationalError):
+            logging.exception("Failed processing signal %s", func.__name__)
+            return
+
+    return wrapped
 
 
 def atomic_transaction(

--- a/src/sentry/utils/db.py
+++ b/src/sentry/utils/db.py
@@ -1,28 +1,9 @@
-import logging
 from collections.abc import Sequence
 from contextlib import ExitStack
-from functools import wraps
 
 import sentry_sdk
 from django.db import DEFAULT_DB_ALIAS, connections, transaction
-from django.db.utils import OperationalError, ProgrammingError
 from sentry_sdk.integrations import Integration
-
-
-def handle_db_failure(func, using: str = "default", wrap_in_transaction: bool = True):
-    @wraps(func)
-    def wrapped(*args, **kwargs):
-        try:
-            if wrap_in_transaction:
-                with transaction.atomic(using):
-                    return func(*args, **kwargs)
-            else:
-                return func(*args, **kwargs)
-        except (ProgrammingError, OperationalError):
-            logging.exception("Failed processing signal %s", func.__name__)
-            return
-
-    return wrapped
 
 
 def atomic_transaction(

--- a/src/sentry/utils/db.py
+++ b/src/sentry/utils/db.py
@@ -4,17 +4,17 @@ from contextlib import ExitStack
 from functools import wraps
 
 import sentry_sdk
-from django.db import DEFAULT_DB_ALIAS, connections, transaction
+from django.db import DEFAULT_DB_ALIAS, connections, router, transaction
 from django.db.utils import OperationalError, ProgrammingError
 from sentry_sdk.integrations import Integration
 
 
-def handle_db_failure(func, using: str = "default", wrap_in_transaction: bool = True):
+def handle_db_failure(func, model, wrap_in_transaction: bool = True):
     @wraps(func)
     def wrapped(*args, **kwargs):
         try:
             if wrap_in_transaction:
-                with transaction.atomic(using):
+                with transaction.atomic(router.db_for_write(model)):
                     return func(*args, **kwargs)
             else:
                 return func(*args, **kwargs)


### PR DESCRIPTION
Need to move more imports out of receivers in order for getsentry imports to work with upcoming default metric alert changes