### PR TITLE
feat(dashboards): Split recent searches for dataset split

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -57,6 +57,8 @@ export enum SavedSearchType {
   REPLAY = 3,
   METRIC = 4,
   SPAN = 5,
+  ERROR = 6,
+  TRANSACTION = 7,
 }
 
 export enum IssueCategory {

--- a/static/app/views/dashboards/datasetConfig/errors.tsx
+++ b/static/app/views/dashboards/datasetConfig/errors.tsx
@@ -4,7 +4,7 @@ import {doEventsRequest} from 'sentry/actionCreators/events';
 import type {Client} from 'sentry/api';
 import type {PageFilters} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
-import type {TagCollection} from 'sentry/types/group';
+import {SavedSearchType, type TagCollection} from 'sentry/types/group';
 import type {
   EventsStats,
   MultiSeriesEventsStats,
@@ -69,7 +69,9 @@ export const ErrorsConfig: DatasetConfig<
   defaultWidgetQuery: DEFAULT_WIDGET_QUERY,
   enableEquations: true,
   getCustomFieldRenderer: getCustomEventsFieldRenderer,
-  SearchBar: EventsSearchBar,
+  SearchBar: props => (
+    <EventsSearchBar savedSearchType={SavedSearchType.ERROR} {...props} />
+  ),
   filterSeriesSortOptions,
   filterYAxisAggregateParams,
   filterYAxisOptions,

--- a/static/app/views/dashboards/datasetConfig/transactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/transactions.tsx
@@ -4,7 +4,7 @@ import {doEventsRequest} from 'sentry/actionCreators/events';
 import type {Client} from 'sentry/api';
 import type {PageFilters} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
-import type {TagCollection} from 'sentry/types/group';
+import {SavedSearchType, type TagCollection} from 'sentry/types/group';
 import type {
   EventsStats,
   MultiSeriesEventsStats,
@@ -73,7 +73,9 @@ export const TransactionsConfig: DatasetConfig<
   defaultWidgetQuery: DEFAULT_WIDGET_QUERY,
   enableEquations: true,
   getCustomFieldRenderer: getCustomEventsFieldRenderer,
-  SearchBar: EventsSearchBar,
+  SearchBar: props => (
+    <EventsSearchBar savedSearchType={SavedSearchType.TRANSACTION} {...props} />
+  ),
   filterSeriesSortOptions,
   filterYAxisAggregateParams,
   filterYAxisOptions,

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.spec.tsx
@@ -1,0 +1,137 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {SavedSearchType} from 'sentry/types/group';
+import {CustomMeasurementsProvider} from 'sentry/utils/customMeasurements/customMeasurementsProvider';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {EventsSearchBar} from 'sentry/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar';
+
+describe('EventsSearchBar', () => {
+  let organization;
+
+  beforeEach(() => {
+    organization = OrganizationFixture();
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/measurements-meta/`,
+      body: {},
+    });
+  });
+
+  it('renders recent searches for errors', async () => {
+    const mockRecentSearchHistory = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/recent-searches/`,
+      body: [
+        {
+          query: 'event.type:error',
+        },
+      ],
+    });
+    render(
+      <CustomMeasurementsProvider organization={organization}>
+        <EventsSearchBar
+          getFilterWarning={undefined}
+          onClose={undefined}
+          organization={organization}
+          pageFilters={{
+            datetime: {
+              end: null,
+              period: null,
+              start: null,
+              utc: null,
+            },
+            environments: [],
+            projects: [],
+          }}
+          widgetQuery={{
+            aggregates: [],
+            columns: [],
+            conditions: '',
+            name: '',
+            orderby: '',
+            fieldAliases: undefined,
+            fields: undefined,
+            isHidden: undefined,
+            onDemand: undefined,
+          }}
+          dataset={DiscoverDatasets.ERRORS}
+          savedSearchType={SavedSearchType.ERROR}
+        />
+      </CustomMeasurementsProvider>
+    );
+
+    await userEvent.click(
+      await screen.findByPlaceholderText('Search for events, users, tags, and more')
+    );
+    expect(await screen.findByTestId('filter-token')).toHaveTextContent(
+      'event.type:error'
+    );
+    expect(mockRecentSearchHistory).toHaveBeenCalledWith(
+      '/organizations/org-slug/recent-searches/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          type: SavedSearchType.ERROR,
+        }),
+      })
+    );
+  });
+
+  it('renders recent searches for transactions', async () => {
+    const mockRecentSearchHistory = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/recent-searches/`,
+      body: [
+        {
+          query: 'transaction.status:ok',
+        },
+      ],
+    });
+    render(
+      <CustomMeasurementsProvider organization={organization}>
+        <EventsSearchBar
+          getFilterWarning={undefined}
+          onClose={undefined}
+          organization={organization}
+          pageFilters={{
+            datetime: {
+              end: null,
+              period: null,
+              start: null,
+              utc: null,
+            },
+            environments: [],
+            projects: [],
+          }}
+          widgetQuery={{
+            aggregates: [],
+            columns: [],
+            conditions: '',
+            name: '',
+            orderby: '',
+            fieldAliases: undefined,
+            fields: undefined,
+            isHidden: undefined,
+            onDemand: undefined,
+          }}
+          dataset={DiscoverDatasets.TRANSACTIONS}
+          savedSearchType={SavedSearchType.TRANSACTION}
+        />
+      </CustomMeasurementsProvider>
+    );
+
+    await userEvent.click(
+      await screen.findByPlaceholderText('Search for events, users, tags, and more')
+    );
+    expect(await screen.findByTestId('filter-token')).toHaveTextContent(
+      'transaction.status:ok'
+    );
+    expect(mockRecentSearchHistory).toHaveBeenCalledWith(
+      '/organizations/org-slug/recent-searches/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          type: SavedSearchType.TRANSACTION,
+        }),
+      })
+    );
+  });
+});

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.tsx
@@ -23,6 +23,7 @@ interface Props {
   pageFilters: PageFilters;
   widgetQuery: WidgetQuery;
   dataset?: DiscoverDatasets;
+  savedSearchType?: SavedSearchType;
 }
 
 export function EventsSearchBar({
@@ -32,6 +33,7 @@ export function EventsSearchBar({
   onClose,
   widgetQuery,
   dataset,
+  savedSearchType = SavedSearchType.EVENT,
 }: Props) {
   const {customMeasurements} = useCustomMeasurements();
   const projectIds = pageFilters.projects;
@@ -53,7 +55,7 @@ export function EventsSearchBar({
       maxQueryLength={MAX_QUERY_LENGTH}
       maxSearchItems={MAX_SEARCH_ITEMS}
       maxMenuHeight={MAX_MENU_HEIGHT}
-      savedSearchType={SavedSearchType.EVENT}
+      savedSearchType={savedSearchType}
       customMeasurements={customMeasurements}
       dataset={dataset}
       includeTransactions={hasDatasetSelector(organization) ? false : true}


### PR DESCRIPTION
The widget builder has distinct datasets for errors and transactions, so the recent search history should also be distinct. Adds the enum entries for the saved search type and passes it along in the respective configs.
