### PR TITLE
feat(insights): map geolocaion fields in discover

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -168,6 +168,8 @@ SPAN_COLUMN_MAP = {
     "messaging.message.id": "sentry_tags[messaging.message.id]",
     "tags.key": "tags.key",
     "tags.value": "tags.value",
+    "user.geo.subregion": "sentry_tags[user.geo.subregion]",
+    "user.geo.country_code": "sentry_tags[user.geo.country_code]",
 }
 
 SPAN_EAP_COLUMN_MAP = {


### PR DESCRIPTION
work towards https://github.com/getsentry/sentry/issues/75230

This allows us to query indexed spans using `user.geo.subregion` instead of `sentry_tags[user.geo.subregion]` in discover.