### PR TITLE
feat(replay): implement search bar key sections and fetch tags from IP instead of discover

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1398,6 +1398,7 @@ export enum ReplayFieldKey {
   OS_VERSION = 'os.version',
   SEEN_BY_ME = 'seen_by_me',
   URLS = 'urls',
+  URL = 'url',
   VIEWED_BY_ME = 'viewed_by_me',
 }
 
@@ -1451,6 +1452,7 @@ export const REPLAY_FIELDS = [
   ReplayFieldKey.SEEN_BY_ME,
   FieldKey.TRACE,
   ReplayFieldKey.URLS,
+  ReplayFieldKey.URL,
   FieldKey.USER_EMAIL,
   FieldKey.USER_ID,
   FieldKey.USER_IP,
@@ -1523,6 +1525,11 @@ const REPLAY_FIELD_DEFINITIONS: Record<ReplayFieldKey, FieldDefinition> = {
     desc: t('Whether you have seen this replay before (true/false)'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.BOOLEAN,
+  },
+  [ReplayFieldKey.URL]: {
+    desc: t('A url visited within the replay'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
   },
   [ReplayFieldKey.URLS]: {
     desc: t('List of urls that were visited within the replay'),

--- a/static/app/views/replays/list/replaySearchBar.tsx
+++ b/static/app/views/replays/list/replaySearchBar.tsx
@@ -54,9 +54,11 @@ const REPLAY_FIELDS_AS_TAGS = fieldDefinitionsToTagCollection(REPLAY_FIELDS);
 const REPLAY_CLICK_FIELDS_AS_TAGS = fieldDefinitionsToTagCollection(REPLAY_CLICK_FIELDS);
 
 /**
- * Merges a list of supported tags and replay search fields into one collection.
+ * Merges a list of supported tags and replay search properties
+ * (https://docs.sentry.io/concepts/search/searchable-properties/session-replay/)
+ * into one collection.
  */
-function getReplaySearchTags(supportedTags: TagCollection): TagCollection {
+function getReplayFilterKeys(supportedTags: TagCollection): TagCollection {
   return {
     ...REPLAY_FIELDS_AS_TAGS,
     ...REPLAY_CLICK_FIELDS_AS_TAGS,
@@ -120,8 +122,8 @@ function ReplaySearchBar(props: Props) {
     loadOrganizationTags(api, organization.slug, pageFilters);
   }, [api, organization.slug, pageFilters]);
 
-  const replayTags = useMemo(
-    () => getReplaySearchTags(organizationTags),
+  const filterKeys = useMemo(
+    () => getReplayFilterKeys(organizationTags),
     [organizationTags]
   );
   const filterKeySections = useMemo(() => {
@@ -196,7 +198,7 @@ function ReplaySearchBar(props: Props) {
         disallowLogicalOperators={undefined} // ^
         className={props.className}
         fieldDefinitionGetter={getReplayFieldDefinition}
-        filterKeys={replayTags}
+        filterKeys={filterKeys}
         filterKeySections={filterKeySections}
         getTagValues={getTagValues}
         initialQuery={props.query ?? props.defaultQuery ?? ''}
@@ -215,7 +217,7 @@ function ReplaySearchBar(props: Props) {
     <SmartSearchBar
       {...props}
       onGetTagValues={getTagValues}
-      supportedTags={replayTags}
+      supportedTags={filterKeys}
       placeholder={
         props.placeholder ??
         t('Search for users, duration, clicked elements, count_errors, and more')

--- a/static/app/views/replays/list/replaySearchBar.tsx
+++ b/static/app/views/replays/list/replaySearchBar.tsx
@@ -98,13 +98,18 @@ const getFilterKeySections = (
 
   return [
     {
+      value: 'replay_field',
+      label: t('Suggested'),
+      children: Object.keys(REPLAY_FIELDS_AS_TAGS),
+    },
+    {
       value: 'replay_click_field',
-      label: t('Replay Click Fields'),
+      label: t('Click Fields'),
       children: Object.keys(REPLAY_CLICK_FIELDS_AS_TAGS),
     },
     {
       value: FieldKind.TAG,
-      label: t('Custom Tags'),
+      label: t('Tags'),
       children: orderedTagKeys,
     },
   ];

--- a/static/app/views/replays/list/replaySearchBar.tsx
+++ b/static/app/views/replays/list/replaySearchBar.tsx
@@ -52,6 +52,7 @@ function fieldDefinitionsToTagCollection(fieldKeys: string[]): TagCollection {
 
 const REPLAY_FIELDS_AS_TAGS = fieldDefinitionsToTagCollection(REPLAY_FIELDS);
 const REPLAY_CLICK_FIELDS_AS_TAGS = fieldDefinitionsToTagCollection(REPLAY_CLICK_FIELDS);
+const EXCLUDED_TAGS = ['browser', 'device', 'os', 'user'];
 
 /**
  * Merges a list of supported tags and replay search properties
@@ -63,13 +64,15 @@ function getReplayFilterKeys(supportedTags: TagCollection): TagCollection {
     ...REPLAY_FIELDS_AS_TAGS,
     ...REPLAY_CLICK_FIELDS_AS_TAGS,
     ...Object.fromEntries(
-      Object.keys(supportedTags).map(key => [
-        key,
-        {
-          ...supportedTags[key],
-          kind: getReplayFieldDefinition(key)?.kind ?? FieldKind.TAG,
-        },
-      ])
+      Object.keys(supportedTags)
+        .filter(key => !EXCLUDED_TAGS.includes(key))
+        .map(key => [
+          key,
+          {
+            ...supportedTags[key],
+            kind: getReplayFieldDefinition(key)?.kind ?? FieldKind.TAG,
+          },
+        ])
     ),
   };
 }
@@ -82,10 +85,9 @@ const getFilterKeySections = (
     return [];
   }
 
-  const excludedTags = ['browser', 'device', 'os', 'user'];
   const customTags: Tag[] = Object.values(tags).filter(
     tag =>
-      !excludedTags.includes(tag.key) &&
+      !EXCLUDED_TAGS.includes(tag.key) &&
       !REPLAY_FIELDS.map(String).includes(tag.key) &&
       !REPLAY_CLICK_FIELDS.map(String).includes(tag.key)
   );

--- a/static/app/views/replays/list/replaySearchBar.tsx
+++ b/static/app/views/replays/list/replaySearchBar.tsx
@@ -119,6 +119,14 @@ function ReplaySearchBar(props: Props) {
   const {organization, pageFilters} = props;
   const api = useApi();
   const projectIds = pageFilters.projects;
+  const start = pageFilters.datetime.start
+    ? getUtcDateString(pageFilters.datetime.start)
+    : undefined;
+  const end = pageFilters.datetime.end
+    ? getUtcDateString(pageFilters.datetime.end)
+    : undefined;
+  const statsPeriod = pageFilters.datetime.period;
+
   const tagQuery = useFetchOrganizationTags(
     {
       orgSlug: organization.slug,
@@ -127,13 +135,9 @@ function ReplaySearchBar(props: Props) {
       useCache: true,
       enabled: true,
       keepPreviousData: false,
-      start: pageFilters.datetime.start
-        ? getUtcDateString(pageFilters.datetime.start)
-        : undefined,
-      end: pageFilters.datetime.end
-        ? getUtcDateString(pageFilters.datetime.end)
-        : undefined,
-      statsPeriod: pageFilters.datetime.period,
+      start: start,
+      end: end,
+      statsPeriod: statsPeriod,
     },
     {}
   );
@@ -162,13 +166,9 @@ function ReplaySearchBar(props: Props) {
       }
 
       const endpointParams = {
-        start: pageFilters.datetime.start
-          ? getUtcDateString(pageFilters.datetime.start)
-          : undefined,
-        end: pageFilters.datetime.end
-          ? getUtcDateString(pageFilters.datetime.end)
-          : undefined,
-        statsPeriod: pageFilters.datetime.period,
+        start: start,
+        end: end,
+        statsPeriod: statsPeriod,
       };
 
       return fetchTagValues({
@@ -186,14 +186,7 @@ function ReplaySearchBar(props: Props) {
         }
       );
     },
-    [
-      api,
-      organization.slug,
-      projectIds,
-      pageFilters.datetime.end,
-      pageFilters.datetime.period,
-      pageFilters.datetime.start,
-    ]
+    [api, organization.slug, projectIds, start, end, statsPeriod]
   );
 
   const onSearch = props.onSearch;

--- a/static/app/views/replays/list/replaySearchBar.tsx
+++ b/static/app/views/replays/list/replaySearchBar.tsx
@@ -1,5 +1,5 @@
 import {useCallback, useMemo} from 'react';
-import {orderBy} from 'lodash';
+import orderBy from 'lodash/orderBy';
 
 import {fetchTagValues, useFetchOrganizationTags} from 'sentry/actionCreators/tags';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';

--- a/static/app/views/replays/list/replaySearchBar.tsx
+++ b/static/app/views/replays/list/replaySearchBar.tsx
@@ -52,7 +52,7 @@ function fieldDefinitionsToTagCollection(fieldKeys: string[]): TagCollection {
 
 const REPLAY_FIELDS_AS_TAGS = fieldDefinitionsToTagCollection(REPLAY_FIELDS);
 const REPLAY_CLICK_FIELDS_AS_TAGS = fieldDefinitionsToTagCollection(REPLAY_CLICK_FIELDS);
-const EXCLUDED_TAGS = ['browser', 'device', 'os', 'user'];
+const EXCLUDED_TAGS = ['browser', 'device', 'os', 'user']; // These are excluded from the display but still valid search queries. browser.name, device.name, etc are effectively the same and included from REPLAY_FIELDS. Displaying these would be redundant and confusing.
 
 /**
  * Merges a list of supported tags and replay search properties

--- a/static/app/views/replays/list/replaySearchBar.tsx
+++ b/static/app/views/replays/list/replaySearchBar.tsx
@@ -52,7 +52,12 @@ function fieldDefinitionsToTagCollection(fieldKeys: string[]): TagCollection {
 
 const REPLAY_FIELDS_AS_TAGS = fieldDefinitionsToTagCollection(REPLAY_FIELDS);
 const REPLAY_CLICK_FIELDS_AS_TAGS = fieldDefinitionsToTagCollection(REPLAY_CLICK_FIELDS);
-const EXCLUDED_TAGS = ['browser', 'device', 'os', 'user']; // These are excluded from the display but still valid search queries. browser.name, device.name, etc are effectively the same and included from REPLAY_FIELDS. Displaying these would be redundant and confusing.
+/**
+ * Excluded from the display but still valid search queries. browser.name,
+ * device.name, etc are effectively the same and included from REPLAY_FIELDS.
+ * Displaying these would be redundant and confusing.
+ */
+const EXCLUDED_TAGS = ['browser', 'device', 'os', 'user'];
 
 /**
  * Merges a list of supported tags and replay search properties


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/75552. Implements sections to make the typeahead easier to navigate.
[Screen recording](https://drive.google.com/file/d/1HxV87JgZWaHHuA74EEdIOdbL1sDxNTzd/view?usp=sharing)

"Suggested" and "Click Fields" combined is = to our documented search properties: https://docs.sentry.io/concepts/search/searchable-properties/session-replay. We always want to show these.

"Tags" are tags found in the Issue Platform dataset, sorted by times seen in the dataset (popularity). Previously we were fetching these from the TagStore which queries Discover. IP has a narrower set of more relevant tags. Some more context is at https://github.com/getsentry/sentry/pull/75878