### PR TITLE
feat(insights): add geo region filter to http module

### DIFF
--- a/static/app/views/insights/http/components/httpSamplesPanel.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.tsx
@@ -14,7 +14,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {DurationUnit, RateUnit} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
-import {decodeScalar} from 'sentry/utils/queryString';
+import {decodeList, decodeScalar} from 'sentry/utils/queryString';
 import {
   EMPTY_OPTION_VALUE,
   escapeFilterValue,
@@ -79,6 +79,7 @@ export function HTTPSamplesPanel() {
       panel: decodePanel,
       responseCodeClass: decodeResponseCodeClass,
       spanSearchQuery: decodeScalar,
+      [SpanMetricsField.USER_GEO_SUBREGION]: decodeList,
     },
   });
 
@@ -136,20 +137,27 @@ export function HTTPSamplesPanel() {
 
   const isPanelOpen = Boolean(detailKey);
 
-  // The ribbon is above the data selectors, and not affected by them. So, it has its own filters.
-  const ribbonFilters: SpanMetricsQueryFilters = {
-    ...BASE_FILTERS,
+  const ADDITONAL_FILTERS = {
     'span.domain':
       query.domain === '' ? EMPTY_OPTION_VALUE : escapeFilterValue(query.domain),
     transaction: query.transaction,
+    ...(query[SpanMetricsField.USER_GEO_SUBREGION].length > 0
+      ? {
+          [SpanMetricsField.USER_GEO_SUBREGION]: `[${query[SpanMetricsField.USER_GEO_SUBREGION].join(',')}]`,
+        }
+      : {}),
+  };
+
+  // The ribbon is above the data selectors, and not affected by them. So, it has its own filters.
+  const ribbonFilters: SpanMetricsQueryFilters = {
+    ...BASE_FILTERS,
+    ...ADDITONAL_FILTERS,
   };
 
   // These filters are for the charts and samples tables
   const filters: SpanMetricsQueryFilters = {
     ...BASE_FILTERS,
-    'span.domain':
-      query.domain === '' ? EMPTY_OPTION_VALUE : escapeFilterValue(query.domain),
-    transaction: query.transaction,
+    ...ADDITONAL_FILTERS,
   };
 
   const responseCodeInRange = query.responseCodeClass

--- a/static/app/views/insights/http/views/httpLandingPage.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.tsx
@@ -9,7 +9,7 @@ import SearchBar from 'sentry/components/searchBar';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
-import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
+import {decodeList, decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -19,10 +19,12 @@ import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLay
 import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModulesOnboarding} from 'sentry/views/insights/common/components/modulesOnboarding';
+import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
 import {useSpanMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {useModuleBreadcrumbs} from 'sentry/views/insights/common/utils/useModuleBreadcrumbs';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
+import SubregionSelector from 'sentry/views/insights/common/views/spans/selectors/subregionSelector';
 import {DurationChart} from 'sentry/views/insights/http/components/charts/durationChart';
 import {ResponseRateChart} from 'sentry/views/insights/http/components/charts/responseRateChart';
 import {ThroughputChart} from 'sentry/views/insights/http/components/charts/throughputChart';
@@ -37,7 +39,7 @@ import {
   MODULE_DOC_LINK,
   MODULE_TITLE,
 } from 'sentry/views/insights/http/settings';
-import {ModuleName} from 'sentry/views/insights/types';
+import {ModuleName, SpanMetricsField} from 'sentry/views/insights/types';
 
 export function HTTPLandingPage() {
   const organization = useOrganization();
@@ -51,15 +53,26 @@ export function HTTPLandingPage() {
   const query = useLocationQuery({
     fields: {
       'span.domain': decodeScalar,
+      [SpanMetricsField.USER_GEO_SUBREGION]: decodeList,
     },
   });
 
+  const ADDITONAL_FILTERS = {
+    ...(query[SpanMetricsField.USER_GEO_SUBREGION].length > 0
+      ? {
+          [SpanMetricsField.USER_GEO_SUBREGION]: `[${query[SpanMetricsField.USER_GEO_SUBREGION].join(',')}]`,
+        }
+      : {}),
+  };
+
   const chartFilters = {
     ...BASE_FILTERS,
+    ...ADDITONAL_FILTERS,
   };
 
   const tableFilters = {
     ...BASE_FILTERS,
+    ...ADDITONAL_FILTERS,
     'span.domain': query['span.domain'] ? `*${query['span.domain']}*` : undefined,
   };
 
@@ -168,7 +181,12 @@ export function HTTPLandingPage() {
         <Layout.Main fullWidth>
           <ModuleLayout.Layout>
             <ModuleLayout.Full>
-              <ModulePageFilterBar moduleName={ModuleName.HTTP} />
+              <ToolRibbon>
+                <ModulePageFilterBar
+                  moduleName={ModuleName.HTTP}
+                  extraFilters={<SubregionSelector />}
+                />
+              </ToolRibbon>
             </ModuleLayout.Full>
 
             <ModulesOnboarding moduleName={ModuleName.HTTP}>

--- a/static/app/views/insights/http/views/httpLandingPage.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.tsx
@@ -57,11 +57,11 @@ export function HTTPLandingPage() {
     },
   });
 
-
   const ADDITIONAL_FILTERS = {};
-  
+
   if (query[SpanMetricsField.USER_GEO_SUBREGION].length > 0) {
-    ADDITIONAL_FILTERS[SpanMetricsField.USER_GEO_SUBREGION] = `[${query[SpanMetricsField.USER_GEO_SUBREGION].join(',')}]`
+    ADDITIONAL_FILTERS[SpanMetricsField.USER_GEO_SUBREGION] =
+      `[${query[SpanMetricsField.USER_GEO_SUBREGION].join(',')}]`;
   }
 
   const chartFilters = {

--- a/static/app/views/insights/http/views/httpLandingPage.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.tsx
@@ -66,12 +66,12 @@ export function HTTPLandingPage() {
 
   const chartFilters = {
     ...BASE_FILTERS,
-    ...ADDITONAL_FILTERS,
+    ...ADDITIONAL_FILTERS,
   };
 
   const tableFilters = {
     ...BASE_FILTERS,
-    ...ADDITONAL_FILTERS,
+    ...ADDITIONAL_FILTERS,
     'span.domain': query['span.domain'] ? `*${query['span.domain']}*` : undefined,
   };
 

--- a/static/app/views/insights/http/views/httpLandingPage.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.tsx
@@ -57,13 +57,12 @@ export function HTTPLandingPage() {
     },
   });
 
-  const ADDITONAL_FILTERS = {
-    ...(query[SpanMetricsField.USER_GEO_SUBREGION].length > 0
-      ? {
-          [SpanMetricsField.USER_GEO_SUBREGION]: `[${query[SpanMetricsField.USER_GEO_SUBREGION].join(',')}]`,
-        }
-      : {}),
-  };
+
+  const ADDITIONAL_FILTERS = {};
+  
+  if (query[SpanMetricsField.USER_GEO_SUBREGION].length > 0) {
+    ADDITIONAL_FILTERS[SpanMetricsField.USER_GEO_SUBREGION] = `[${query[SpanMetricsField.USER_GEO_SUBREGION].join(',')}]`
+  }
 
   const chartFilters = {
     ...BASE_FILTERS,


### PR DESCRIPTION
work towards https://github.com/getsentry/sentry/issues/75230


add geo region selector to http module, we may or may not want to show this for backend projects, but we can hide it in another PR if necessary

<img width="694" alt="image" src="https://github.com/user-attachments/assets/79cee178-2a85-4515-9380-4a02513354d6">
