### PR TITLE
feat(issue-details): Allow setting preferred UI for issue details

### DIFF
--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -80,7 +80,7 @@ class UserOptionsSerializer(serializers.Serializer):
         ),
         required=False,
     )
-    issueDetailsNewExperienceQ42023 = serializers.BooleanField(required=False)
+    prefersIssueDetailsStreamlinedUI = serializers.BooleanField(required=False)
 
 
 class BaseUserSerializer(CamelSnakeModelSerializer):
@@ -238,7 +238,7 @@ class UserDetailsEndpoint(UserEndpoint):
             "stacktraceOrder": "stacktrace_order",
             "defaultIssueEvent": "default_issue_event",
             "clock24Hours": "clock_24_hours",
-            "issueDetailsNewExperienceQ42023": "issue_details_new_experience_q4_2023",
+            "prefersIssueDetailsStreamlinedUI": "prefers_issue_details_streamlined_ui",
         }
 
         options_result = serializer_options.validated_data

--- a/src/sentry/api/serializers/models/user.py
+++ b/src/sentry/api/serializers/models/user.py
@@ -76,7 +76,7 @@ class _UserOptions(TypedDict):
     defaultIssueEvent: str
     timezone: str
     clock24Hours: bool
-    issueDetailsNewExperienceQ42023: bool
+    prefersIssueDetailsStreamlinedUI: bool
 
 
 class UserSerializerResponseOptional(TypedDict, total=False):
@@ -201,10 +201,9 @@ class UserSerializer(Serializer):
                 "defaultIssueEvent": options.get("default_issue_event") or "recommended",
                 "timezone": options.get("timezone") or settings.SENTRY_DEFAULT_TIME_ZONE,
                 "clock24Hours": options.get("clock_24_hours") or False,
-                "issueDetailsNewExperienceQ42023": options.get(
-                    "issue_details_new_experience_q4_2023"
-                )
-                or False,
+                "prefersIssueDetailsStreamlinedUI": options.get(
+                    "prefers_issue_details_streamlined_ui", False
+                ),
             }
 
             d["flags"] = {"newsletter_consent_prompt": bool(obj.flags.newsletter_consent_prompt)}

--- a/src/sentry/models/options/user_option.py
+++ b/src/sentry/models/options/user_option.py
@@ -163,8 +163,8 @@ class UserOption(Model):
         - unused
      - issues:defaults:jira_server
         - unused
-    - issue_details_new_experience_q4_2023
-        - Whether the user has opted into the new issue details experience (boolean)
+    - prefers_issue_details_streamlined_ui
+        - Whether the user prefers the new issue details experience (boolean)
      - language
         - which language to display the app in
      - mail:email

--- a/tests/sentry/api/endpoints/test_user_details.py
+++ b/tests/sentry/api/endpoints/test_user_details.py
@@ -45,7 +45,7 @@ class UserDetailsGetTest(UserDetailsTest):
         assert resp.data["options"]["language"] == "en"
         assert resp.data["options"]["stacktraceOrder"] == -1
         assert not resp.data["options"]["clock24Hours"]
-        assert not resp.data["options"]["issueDetailsNewExperienceQ42023"]
+        assert not resp.data["options"]["prefersIssueDetailsStreamlinedUI"]
 
     def test_superuser_simple(self):
         self.login_as(user=self.superuser, superuser=True)
@@ -115,7 +115,7 @@ class UserDetailsUpdateTest(UserDetailsTest):
                 "language": "fr",
                 "clock24Hours": True,
                 "extra": True,
-                "issueDetailsNewExperienceQ42023": True,
+                "prefersIssueDetailsStreamlinedUI": True,
             },
         )
 

--- a/tests/sentry/api/endpoints/test_user_details.py
+++ b/tests/sentry/api/endpoints/test_user_details.py
@@ -133,7 +133,7 @@ class UserDetailsUpdateTest(UserDetailsTest):
         assert UserOption.objects.get_value(user=self.user, key="language") == "fr"
         assert UserOption.objects.get_value(user=self.user, key="clock_24_hours")
         assert UserOption.objects.get_value(
-            user=self.user, key="issue_details_new_experience_q4_2023"
+            user=self.user, key="prefers_issue_details_streamlined_ui"
         )
 
         assert not UserOption.objects.get_value(user=self.user, key="extra")


### PR DESCRIPTION
Adds a new user option for setting the streamlined UI as a preference. Follow up PR will have it reflected in the frontend.