### PR TITLE
fix(issue/replay): correct replay link if no location.search

### DIFF
--- a/static/app/components/events/eventReplay/replayClipSection.tsx
+++ b/static/app/components/events/eventReplay/replayClipSection.tsx
@@ -55,7 +55,12 @@ export function ReplayClipSection({event, group, replayId}: Props) {
         )
       : normalizeUrl(`/organizations/${organization.slug}/issues/${group.id}/`)
     : '';
-  const replayUrl = baseUrl ? `${baseUrl}replays/${location.search}/` : '';
+  const replayUrl = baseUrl
+    ? location.search.length
+      ? `${baseUrl}replays/${location.search}/`
+      : `${baseUrl}replays/`
+    : '';
+
   const seeAllReplaysButton = replayUrl ? (
     <LinkButton
       size="xs"


### PR DESCRIPTION
attempt to fix issues like this where we have a double `//` in the route:

https://sentry.sentry.io/issues/496412334/events/7ddc281864624bb39e90dbb95e0a683e/?project=11276