### PR TITLE
log(replay): capture message if mobile replay has mismatching touch events

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -431,6 +431,10 @@ export function Provider({
         events: events ?? [],
         // common to both
         root,
+        context: {
+          sdkName: replay?.getReplay().sdk.name,
+          sdkVersion: replay?.getReplay().sdk.version,
+        },
       });
       // `.current` is marked as readonly, but it's safe to set the value from
       // inside a `useEffect` hook.

--- a/static/app/components/replays/videoReplayerWithInteractions.tsx
+++ b/static/app/components/replays/videoReplayerWithInteractions.tsx
@@ -137,7 +137,7 @@ export class VideoReplayerWithInteractions {
             tags: {
               sdk_name: context.sdkName,
               sdk_version: context.sdkVersion,
-              type: typeof t,
+              touch_event_type: typeof t,
             },
           }
         );

--- a/static/app/components/replays/videoReplayerWithInteractions.tsx
+++ b/static/app/components/replays/videoReplayerWithInteractions.tsx
@@ -134,7 +134,11 @@ export class VideoReplayerWithInteractions {
         Sentry.captureMessage(
           'Mobile replay has mismatching touch start and end events',
           {
-            tags: {sdk_name: context.sdkName, sdk_version: context.sdkVersion},
+            tags: {
+              sdk_name: context.sdkName,
+              sdk_version: context.sdkVersion,
+              type: typeof t,
+            },
           }
         );
       }

--- a/static/app/components/replays/videoReplayerWithInteractions.tsx
+++ b/static/app/components/replays/videoReplayerWithInteractions.tsx
@@ -1,4 +1,5 @@
 import type {Theme} from '@emotion/react';
+import * as Sentry from '@sentry/react';
 import {type eventWithTime, Replayer} from '@sentry-internal/rrweb';
 
 import {
@@ -10,6 +11,7 @@ import type {ClipWindow, VideoEvent} from 'sentry/utils/replays/types';
 type RootElem = HTMLDivElement | null;
 
 interface VideoReplayerWithInteractionsOptions {
+  context: {sdkName: string | undefined | null; sdkVersion: string | undefined | null};
   durationMs: number;
   events: eventWithTime[];
   onBuffer: (isBuffering: boolean) => void;
@@ -46,6 +48,7 @@ export class VideoReplayerWithInteractions {
     durationMs,
     theme,
     speed,
+    context,
   }: VideoReplayerWithInteractionsOptions) {
     this.config = {
       skipInactive: false,
@@ -118,6 +121,22 @@ export class VideoReplayerWithInteractions {
           timestamp: e.timestamp,
         };
         eventsWithSnapshots.push(fullSnapshotEvent);
+      }
+    });
+
+    // log instances where we have a pointer touchStart without a touchEnd
+    const touchEvents = eventsWithSnapshots.filter(
+      (e: eventWithTime) => isTouchEnd(e) || isTouchStart(e)
+    );
+    const grouped = Object.groupBy(touchEvents, (t: any) => t.data.pointerId);
+    Object.values(grouped).forEach(t => {
+      if (t?.length !== 2) {
+        Sentry.captureMessage(
+          'Mobile replay has mismatching touch start and end events',
+          {
+            tags: {sdk_name: context.sdkName, sdk_version: context.sdkVersion},
+          }
+        );
       }
     });
 


### PR DESCRIPTION
log the sdk version & name if we have mismatching touch events (e.g. start without an end or vice versa) to help us debug https://github.com/getsentry/team-replay/issues/466