### PR TITLE
fix(breadcrumbs): Give timestamp min width

### DIFF
--- a/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsTimeline.tsx
@@ -170,6 +170,8 @@ const Timestamp = styled('div')`
   margin-right: ${space(1)};
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
+  min-width: 50px;
+  text-align: right;
   span {
     text-decoration: underline dashed ${p => p.theme.translucentBorder};
   }


### PR DESCRIPTION
aligns these top ones a bit more. this is a worse version of this fix https://github.com/getsentry/sentry/pull/76148 that broke the breadcrumbs for replays.

![image](https://github.com/user-attachments/assets/718c5498-e27e-4523-9418-effae402ff90)
