### PR TITLE
ref(issue-details): remove replay id from replay context

### DIFF
--- a/static/app/components/events/contexts/replay/index.spec.tsx
+++ b/static/app/components/events/contexts/replay/index.spec.tsx
@@ -12,13 +12,16 @@ describe('replay event context', function () {
   const replayContext = {
     type: 'default',
     replay_id: replayId,
+    custom_replay_value: 123,
   };
 
-  it('renders replay id with button', function () {
+  it('does not render replay id with button', function () {
+    // we removed replay ID from the replay context
+    // but should still show custom values.
     render(<ReplayEventContext data={replayContext} event={event} />, {organization});
 
-    expect(screen.getByText('Replay ID')).toBeInTheDocument();
-    expect(screen.getByText(replayId)).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: replayId})).toBeInTheDocument();
+    expect(screen.queryByText('Replay ID')).not.toBeInTheDocument();
+    expect(screen.queryByText(replayId)).not.toBeInTheDocument();
+    expect(screen.getByText('custom_replay_value')).toBeInTheDocument();
   });
 });

--- a/static/app/components/events/contexts/replay/index.tsx
+++ b/static/app/components/events/contexts/replay/index.tsx
@@ -1,6 +1,5 @@
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
-import {t} from 'sentry/locale';
 import {type Event, type ReplayContext, ReplayContextKey} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
@@ -73,8 +72,6 @@ export function ReplayEventContext({event, data, meta: propsMeta}: ReplayContext
 }
 
 function getReplayKnownDataDetails({
-  data,
-  organization,
   type,
 }: {
   data: ReplayContext;
@@ -83,18 +80,7 @@ function getReplayKnownDataDetails({
   project?: Project;
 }): KnownDataDetails {
   switch (type) {
-    case ReplayContextKey.REPLAY_ID: {
-      const replayId = data.replay_id || '';
-      if (!replayId) {
-        return undefined;
-      }
-      const link = `/organizations/${organization.slug}/replays/${encodeURIComponent(replayId)}/`;
-      return {
-        subject: t('Replay ID'),
-        value: replayId,
-        action: {link},
-      };
-    }
+    case ReplayContextKey.REPLAY_ID:
     default:
       return undefined;
   }

--- a/static/app/components/events/contexts/replay/index.tsx
+++ b/static/app/components/events/contexts/replay/index.tsx
@@ -1,8 +1,7 @@
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
-import {type Event, type ReplayContext, ReplayContextKey} from 'sentry/types/event';
+import type {Event, ReplayContext, ReplayContextKey} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
-import type {Project} from 'sentry/types/project';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import {
@@ -10,7 +9,6 @@ import {
   getKnownData,
   getKnownStructuredData,
   getUnknownData,
-  type KnownDataDetails,
 } from '../utils';
 
 const REPLAY_KNOWN_DATA_VALUES = ['replay_id'];
@@ -24,7 +22,6 @@ interface ReplayContextProps {
 export function getKnownReplayContextData({
   data,
   meta,
-  organization,
 }: Pick<ReplayContextProps, 'data' | 'meta'> & {
   organization: Organization;
 }) {
@@ -32,7 +29,9 @@ export function getKnownReplayContextData({
     data,
     meta,
     knownDataTypes: REPLAY_KNOWN_DATA_VALUES,
-    onGetKnownDataDetails: v => getReplayKnownDataDetails({...v, organization}),
+    onGetKnownDataDetails: _ => {
+      return undefined;
+    },
   }).map(v => ({
     ...v,
     subjectDataTestId: `replay-context-${v.key.toLowerCase()}-value`,
@@ -69,19 +68,4 @@ export function ReplayEventContext({event, data, meta: propsMeta}: ReplayContext
       <KeyValueList data={unknownData} shouldSort={false} raw={false} isContextData />
     </ErrorBoundary>
   );
-}
-
-function getReplayKnownDataDetails({
-  type,
-}: {
-  data: ReplayContext;
-  organization: Organization;
-  type: ReplayContextKey;
-  project?: Project;
-}): KnownDataDetails {
-  switch (type) {
-    case ReplayContextKey.REPLAY_ID:
-    default:
-      return undefined;
-  }
 }


### PR DESCRIPTION
remove replay ID from the replay context on trace & issue details (removed from both since they use the same component, and we expect the behavior to be the same for both situations).

reasoning for removing
- we have the replay preview immediately below, and replay ID doesn't add much useful context
- sometimes the replay ID link leads to an invalid replay ("replay not found" error) because it was dropped, deleted, etc. and this component doesn't take that into account before rendering the link

will follow up with subsequent removals of replay ID on other parts of issues & trace.

### trace before:

<img width="392" alt="SCR-20240815-myks" src="https://github.com/user-attachments/assets/56ea1769-4b53-4165-8cb1-283898ffcbdf">

### trace after:

<img width="410" alt="SCR-20240815-myju" src="https://github.com/user-attachments/assets/80fddacc-e2c0-42b8-8a3e-5b21eb92cc69">

### issues before:


<img width="951" alt="SCR-20240815-mzem" src="https://github.com/user-attachments/assets/2a3ad9f9-597c-4cb4-8ea8-025ed284e343">



### issues after:



<img width="933" alt="SCR-20240815-mzbl" src="https://github.com/user-attachments/assets/4f802072-5253-47fd-8610-27e3d7235e92">