### PR TITLE
ref: omit offset for spans that dont span the width of the trace

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
@@ -174,9 +174,7 @@ describe('VirtualizedViewManger', () => {
       manager.view.setTraceSpace([0, 0, 100, 1]);
       manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
 
-      expect(manager.computeSpanCSSMatrixTransform([0, 100])).toEqual([
-        1, 0, 0, 1, -2, 0,
-      ]);
+      expect(manager.computeSpanCSSMatrixTransform([0, 100])).toEqual([1, 0, 0, 1, 0, 0]);
     });
 
     it('computes x position correctly', () => {
@@ -193,7 +191,7 @@ describe('VirtualizedViewManger', () => {
       manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
 
       expect(manager.computeSpanCSSMatrixTransform([50, 1000])).toEqual([
-        1, 0, 0, 1, 48, 0,
+        1, 0, 0, 1, 50, 0,
       ]);
     });
 
@@ -211,7 +209,7 @@ describe('VirtualizedViewManger', () => {
       manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
 
       expect(manager.computeSpanCSSMatrixTransform([50, 1000])).toEqual([
-        1, 0, 0, 1, 48, 0,
+        1, 0, 0, 1, 50, 0,
       ]);
     });
 
@@ -230,7 +228,7 @@ describe('VirtualizedViewManger', () => {
         manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
 
         expect(manager.computeSpanCSSMatrixTransform([100, 100])).toEqual([
-          1, 0, 0, 1, -2, 0,
+          1, 0, 0, 1, 0, 0,
         ]);
       });
       it('computes x position correctly when view is offset', () => {
@@ -247,7 +245,7 @@ describe('VirtualizedViewManger', () => {
         manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
 
         expect(manager.computeSpanCSSMatrixTransform([100, 100])).toEqual([
-          1, 0, 0, 1, -2, 0,
+          1, 0, 0, 1, 0, 0,
         ]);
       });
     });

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -880,9 +880,10 @@ export class VirtualizedViewManager {
 
     // if span ends less than 1px before the end of the view, we move it back by 1px and prevent it from being clipped
     if (
+      space[0] - this.view.to_origin > this.view.trace_space.width / 2 &&
       (this.view.to_origin + this.view.trace_space.width - space[0] - space[1]) /
         this.span_to_px[0] <=
-      1
+        1
     ) {
       // 1px for the span and 1px for the border
       this.span_matrix[4] = this.span_matrix[4] - 2;


### PR DESCRIPTION
This improves the offset check by ensuring we dont offset very wide spans (as they will be visible anyways)