### PR TITLE
ref(issues/trace): rm replay id from tag distribution

### DIFF
--- a/static/app/components/group/tagFacets/index.tsx
+++ b/static/app/components/group/tagFacets/index.tsx
@@ -174,7 +174,7 @@ export default function TagFacets({
   }, [data, tagFormatter, isStatisticalDetector]);
 
   // filter out replayId since we no longer want to
-  // display this on issue or trace details
+  // display this on issue details
   const topTagKeys = tagKeys.filter(
     tagKey => Object.keys(tagsData).includes(tagKey) && tagKey !== 'replayId'
   );

--- a/static/app/components/group/tagFacets/index.tsx
+++ b/static/app/components/group/tagFacets/index.tsx
@@ -173,9 +173,14 @@ export default function TagFacets({
     return formatted as Record<string, GroupTagResponseItem>;
   }, [data, tagFormatter, isStatisticalDetector]);
 
-  const topTagKeys = tagKeys.filter(tagKey => Object.keys(tagsData).includes(tagKey));
+  // filter out replayId since we no longer want to
+  // display this on issue or trace details
+  const topTagKeys = tagKeys
+    .filter(tagKey => Object.keys(tagsData).includes(tagKey))
+    .filter(f => f !== 'replayId');
   const remainingTagKeys = Object.keys(tagsData)
     .filter(tagKey => !tagKeys.includes(tagKey))
+    .filter(f => f !== 'replayId')
     .sort();
 
   if (isLoading) {

--- a/static/app/components/group/tagFacets/index.tsx
+++ b/static/app/components/group/tagFacets/index.tsx
@@ -175,12 +175,11 @@ export default function TagFacets({
 
   // filter out replayId since we no longer want to
   // display this on issue or trace details
-  const topTagKeys = tagKeys
-    .filter(tagKey => Object.keys(tagsData).includes(tagKey))
-    .filter(f => f !== 'replayId');
+  const topTagKeys = tagKeys.filter(
+    tagKey => Object.keys(tagsData).includes(tagKey) && tagKey !== 'replayId'
+  );
   const remainingTagKeys = Object.keys(tagsData)
-    .filter(tagKey => !tagKeys.includes(tagKey))
-    .filter(f => f !== 'replayId')
+    .filter(tagKey => !tagKeys.includes(tagKey) && tagKey !== 'replayId')
     .sort();
 
   if (isLoading) {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace/tagsSummary.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace/tagsSummary.tsx
@@ -123,7 +123,9 @@ export function TagsSummary(props: TagSummaryProps) {
     if (!data) {
       return [];
     }
-    return data.pages.flatMap(([pageData]) => (isEmpty(pageData) ? [] : pageData));
+    return data.pages
+      .flatMap(([pageData]) => (isEmpty(pageData) ? [] : pageData))
+      .filter(d => d.key !== 'replayId');
   }, [data]);
 
   return (

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace/tagsSummary.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace/tagsSummary.tsx
@@ -123,6 +123,8 @@ export function TagsSummary(props: TagSummaryProps) {
     if (!data) {
       return [];
     }
+    // filter out replayId since we no longer want to
+    // display this trace details
     return data.pages
       .flatMap(([pageData]) => (isEmpty(pageData) ? [] : pageData))
       .filter(d => d.key !== 'replayId');


### PR DESCRIPTION
remove replay id from the tag distribution chart in trace & issue details. 

see also
- https://github.com/getsentry/sentry/pull/76302
- https://github.com/getsentry/sentry/pull/76301

reasoning for removing
- we have the replay preview immediately below, and replay ID or its distribution doesn't add much useful context
will follow up with subsequent removals of replay ID on other parts of issues & trace.

### before
<img width="414" alt="SCR-20240815-noqc" src="https://github.com/user-attachments/assets/30e3021b-0794-41ec-9d52-1b86c593ebc8">

### after
<img width="344" alt="SCR-20240815-noui" src="https://github.com/user-attachments/assets/58264bf0-968f-465f-99f7-cbbf305cf0f4">
