### PR TITLE
ref(issues/trace): rm replay id from issues and trace tags

### DIFF
--- a/static/app/components/events/eventTags/eventTagsTree.spec.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.spec.tsx
@@ -182,17 +182,6 @@ describe('EventTagsTree', function () {
       },
     },
     {
-      tag: {key: 'replayId', value: 'ghi789'},
-      labelText: 'View this replay',
-      validateLink: () => {
-        const linkElement = screen.getByRole('link', {name: 'ghi789'});
-        expect(linkElement).toHaveAttribute(
-          'href',
-          `/organizations/${organization.slug}/replays/ghi789/?referrer=${referrer}`
-        );
-      },
-    },
-    {
       tag: {key: 'external-link', value: 'https://example.com'},
       labelText: 'Visit this external link',
       validateLink: async () => {

--- a/static/app/components/events/eventTags/index.tsx
+++ b/static/app/components/events/eventTags/index.tsx
@@ -95,9 +95,18 @@ export function EventTags({
 
   const hasCustomTagsBanner = tagFilter === TagFilter.CUSTOM && tags.length === 0;
 
+  // filter out replayId since we no longer want to display this on
+  // trace or issue details
+  const filtered = tags.filter(t => t.key !== 'replayId');
+
   return (
     <Fragment>
-      <EventTagsTree event={event} meta={meta} projectSlug={projectSlug} tags={tags} />
+      <EventTagsTree
+        event={event}
+        meta={meta}
+        projectSlug={projectSlug}
+        tags={filtered}
+      />
       {hasCustomTagsBanner && <EventTagCustomBanner />}
     </Fragment>
   );


### PR DESCRIPTION
remove replay id from the tags in trace & issue details. 

see also
- https://github.com/getsentry/sentry/pull/76302
- https://github.com/getsentry/sentry/pull/76301
- https://github.com/getsentry/sentry/pull/76305

reasoning for removing
- we have the replay preview immediately below if it exists, and replay ID doesn't add much useful context
- sometimes the replay ID link leads to an invalid replay ("replay not found" error) because it was dropped, deleted, etc. and this component doesn't take that into account before rendering the link


### before
<img width="395" alt="SCR-20240815-nxdj" src="https://github.com/user-attachments/assets/c528d62c-b24f-4ef7-9a21-d951ca416d27">


### after
<img width="354" alt="SCR-20240815-nwwk" src="https://github.com/user-attachments/assets/1fd6d549-9d6b-4cc8-90f3-ab1b359b8704">
