### PR TITLE
fix(issues): Truncate long release versions

### DIFF
--- a/static/app/components/actions/resolve.spec.tsx
+++ b/static/app/components/actions/resolve.spec.tsx
@@ -177,7 +177,8 @@ describe('ResolveActions', function () {
 
     await userEvent.click(screen.getByLabelText('More resolve options'));
     expect(screen.getByText('The current release')).toBeInTheDocument();
-    expect(screen.getByText('1.2.3 (semver)')).toBeInTheDocument();
+    expect(screen.getByText('1.2.3')).toBeInTheDocument();
+    expect(screen.getByText('(semver)')).toBeInTheDocument();
   });
 
   it('displays prompt to setup releases when there are no releases', async function () {

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -236,10 +236,12 @@ function ResolveActions({
               actionTitle
             ) : latestRelease ? (
               <Fragment>
-                <MaxReleaseWidthWrapper>
-                  {formatVersion(latestRelease.version)}
-                </MaxReleaseWidthWrapper>{' '}
-                {isSemver ? t('semver') : t('non-semver')}
+                <div>
+                  <MaxReleaseWidthWrapper>
+                    {formatVersion(latestRelease.version)}
+                  </MaxReleaseWidthWrapper>
+                </div>{' '}
+                ({isSemver ? t('semver') : t('non-semver')})
               </Fragment>
             ) : null}
           </CurrentReleaseWrapper>
@@ -413,6 +415,7 @@ const SetupReleasesHeader = styled('h6')`
 const CurrentReleaseWrapper = styled('div')`
   display: flex;
   align-items: center;
+  gap: ${space(0.25)};
 `;
 
 const MaxReleaseWidthWrapper = styled('div')`

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -229,13 +230,20 @@ function ResolveActions({
       {
         key: 'current-release',
         label: t('The current release'),
-        details: actionTitle
-          ? actionTitle
-          : latestRelease
-            ? `${formatVersion(latestRelease.version)} (${
-                isSemver ? t('semver') : t('non-semver')
-              })`
-            : null,
+        details: (
+          <CurrentReleaseWrapper>
+            {actionTitle ? (
+              actionTitle
+            ) : latestRelease ? (
+              <Fragment>
+                <MaxReleaseWidthWrapper>
+                  {formatVersion(latestRelease.version)}
+                </MaxReleaseWidthWrapper>{' '}
+                {isSemver ? t('semver') : t('non-semver')}
+              </Fragment>
+            ) : null}
+          </CurrentReleaseWrapper>
+        ),
         onAction: () => onActionOrConfirm(handleCurrentReleaseResolution),
       },
       {
@@ -400,4 +408,14 @@ const SetupReleases = styled('div')`
 const SetupReleasesHeader = styled('h6')`
   font-size: ${p => p.theme.fontSizeMedium};
   margin-bottom: ${space(1)};
+`;
+
+const CurrentReleaseWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+const MaxReleaseWidthWrapper = styled('div')`
+  ${p => p.theme.overflowEllipsis};
+  max-width: 250px;
 `;

--- a/static/app/views/issueDetails/streamlinedHeader.tsx
+++ b/static/app/views/issueDetails/streamlinedHeader.tsx
@@ -125,7 +125,7 @@ export default function StreamlinedGroupHeader({
                 projectSlug={project.slug}
                 releaseVersion={firstRelease.version}
               >
-                <Version version={firstRelease.version} projectId={project.id} />
+                <Version version={firstRelease.version} projectId={project.id} truncate />
               </VersionHoverCard>
               {firstRelease.id === lastRelease.id ? null : (
                 <Fragment>
@@ -135,7 +135,11 @@ export default function StreamlinedGroupHeader({
                     projectSlug={project.slug}
                     releaseVersion={lastRelease.version}
                   >
-                    <Version version={lastRelease.version} projectId={project.id} />
+                    <Version
+                      version={lastRelease.version}
+                      projectId={project.id}
+                      truncate
+                    />
                   </VersionHoverCard>
                 </Fragment>
               )}
@@ -256,6 +260,7 @@ const Wrapper = styled('div')`
 const ReleaseWrapper = styled('div')`
   display: flex;
   align-items: center;
+  max-width: 40%;
   gap: ${space(0.25)};
   a {
     color: ${p => p.theme.gray300};


### PR DESCRIPTION
- truncate long release names in the resolve dropdown
- truncate long release names in the issue header

header 
![image](https://github.com/user-attachments/assets/690e4d0b-062d-44b5-b6a7-f7029d7ec95c)

dropdown
![image](https://github.com/user-attachments/assets/646b3545-4bfa-4505-b1a2-e912a132ce0e)

fixes https://www.notion.so/sentry/Header-collapsing-issues-with-large-releases-messages-a636f245c79a468c9d11206c57cb2894