### PR TITLE
ref(grouping): Add data to `GroupHash` and `GroupHashMetadata` reprs

### DIFF
--- a/src/sentry/models/grouphash.py
+++ b/src/sentry/models/grouphash.py
@@ -12,6 +12,7 @@ from sentry.db.models import (
     Model,
     region_silo_model,
 )
+from sentry.db.models.base import sane_repr
 
 if TYPE_CHECKING:
     from sentry.models.grouphashmetadata import GroupHashMetadata
@@ -49,3 +50,5 @@ class GroupHash(Model):
             return self._metadata
         except AttributeError:
             return None
+
+    __repr__ = sane_repr("group_id", "hash")

--- a/src/sentry/models/grouphashmetadata.py
+++ b/src/sentry/models/grouphashmetadata.py
@@ -3,6 +3,7 @@ from django.utils import timezone
 
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import Model, region_silo_model
+from sentry.db.models.base import sane_repr
 
 
 @region_silo_model
@@ -18,3 +19,13 @@ class GroupHashMetadata(Model):
     class Meta:
         app_label = "sentry"
         db_table = "sentry_grouphashmetadata"
+
+    @property
+    def group_id(self) -> int | None:
+        return self.grouphash.group_id
+
+    @property
+    def hash(self) -> str:
+        return self.grouphash.hash
+
+    __repr__ = sane_repr("grouphash_id", "group_id", "hash")


### PR DESCRIPTION
To make debugging easier, this adds group id and hash to the `GroupHash` repr and group id, hash, and grouphash id to the `GroupHashMetadata` repr.