### PR TITLE
ref(integrations): add abstract search_issues method for issue integrations

### DIFF
--- a/src/sentry/integrations/bitbucket/issues.py
+++ b/src/sentry/integrations/bitbucket/issues.py
@@ -172,7 +172,9 @@ class BitbucketIssuesSpec(SourceCodeIssueIntegration):
             except ApiError as e:
                 self.raise_error(e)
 
-    def search_issues(self, query: str | None, **kwargs):
+    def search_issues(self, query: str | None, **kwargs) -> dict[str, Any]:
         client = self.get_client()
         repo = kwargs["repo"]
-        return client.search_issues(repo, query)
+        resp = client.search_issues(repo, query)
+        assert isinstance(resp, dict)
+        return resp

--- a/src/sentry/integrations/bitbucket/issues.py
+++ b/src/sentry/integrations/bitbucket/issues.py
@@ -171,3 +171,8 @@ class BitbucketIssuesSpec(SourceCodeIssueIntegration):
                 )
             except ApiError as e:
                 self.raise_error(e)
+
+    def search_issues(self, query: str | None, **kwargs):
+        client = self.get_client()
+        repo = kwargs["repo"]
+        return client.search_issues(repo, query)

--- a/src/sentry/integrations/bitbucket/search.py
+++ b/src/sentry/integrations/bitbucket/search.py
@@ -48,7 +48,7 @@ class BitbucketSearchEndpoint(IntegrationEndpoint):
 
             full_query = f'title~"{query}"'
             try:
-                resp = installation.get_client().search_issues(repo, full_query)
+                resp = installation.search_issues(query=full_query, repo=repo)
             except ApiError as e:
                 if "no issue tracker" in str(e):
                     logger.info(

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -191,6 +191,9 @@ class ExampleIntegration(RepositoryIntegration, SourceCodeIssueIntegration, Issu
     def has_repo_access(self, repo: RpcRepository) -> bool:
         return False
 
+    def search_issues(self, query: str | None, **kwargs):
+        return []
+
 
 class ExampleIntegrationProvider(IntegrationProvider):
     """

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -296,8 +296,10 @@ class GitHubIntegration(RepositoryIntegration, GitHubIssuesSpec, CommitContextIn
 
         return trees
 
-    def search_issues(self, query: str | None, **kwargs):
-        return self.get_client().search_issues(query)
+    def search_issues(self, query: str | None, **kwargs) -> dict[str, Any]:
+        resp = self.get_client().search_issues(query)
+        assert isinstance(resp, dict)
+        return resp
 
 
 class GitHubIntegrationProvider(IntegrationProvider):

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -28,7 +28,6 @@ from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.repository import RpcRepository, repository_service
 from sentry.integrations.source_code_management.commit_context import CommitContextIntegration
-from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.integrations.tasks.migrate_repo import migrate_repo
 from sentry.integrations.utils.code_mapping import RepoTree
 from sentry.models.repository import Repository

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -296,8 +296,7 @@ class GitHubIntegration(RepositoryIntegration, GitHubIssuesSpec, CommitContextIn
 
         return trees
 
-    # TODO(cathy): define in issue ABC
-    def search_issues(self, query: str) -> Mapping[str, Sequence[Mapping[str, Any]]]:
+    def search_issues(self, query: str | None, **kwargs):
         return self.get_client().search_issues(query)
 
 

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -28,6 +28,7 @@ from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.repository import RpcRepository, repository_service
 from sentry.integrations.source_code_management.commit_context import CommitContextIntegration
+from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.integrations.tasks.migrate_repo import migrate_repo
 from sentry.integrations.utils.code_mapping import RepoTree
 from sentry.models.repository import Repository

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -203,7 +203,7 @@ class GitHubEnterpriseIntegration(
     def extract_source_path_from_source_url(self, repo: Repository, url: str) -> str:
         raise IntegrationFeatureNotImplementedError
 
-    def search_issues(self, query):
+    def search_issues(self, query: str | None, **kwargs):
         return self.get_client().search_issues(query)
 
     def has_repo_access(self, repo: RpcRepository) -> bool:

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -23,7 +23,6 @@ from sentry.integrations.github.utils import get_jwt
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.repository.model import RpcRepository
 from sentry.integrations.source_code_management.commit_context import CommitContextIntegration
-from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization import RpcOrganizationSummary
 from sentry.pipeline import NestedPipelineView, PipelineView

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -23,6 +23,7 @@ from sentry.integrations.github.utils import get_jwt
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.repository.model import RpcRepository
 from sentry.integrations.source_code_management.commit_context import CommitContextIntegration
+from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization import RpcOrganizationSummary
 from sentry.pipeline import NestedPipelineView, PipelineView

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any
 from urllib.parse import urlparse
 
 from django import forms
@@ -172,11 +173,13 @@ class GitlabIntegration(RepositoryIntegration, GitlabIssuesSpec, CommitContextIn
         return client.search_projects(group_id, query)
 
     # TODO(cathy): define in issue ABC
-    def search_issues(self, query: str | None, **kwargs):
+    def search_issues(self, query: str | None, **kwargs) -> list[dict[str, Any]]:
         client = self.get_client()
         project_id = kwargs["project_id"]
         iids = kwargs["iids"]
-        return client.search_project_issues(project_id, query, iids)
+        resp = client.search_project_issues(project_id, query, iids)
+        assert isinstance(resp, list)
+        return resp
 
 
 class InstallationForm(forms.Form):

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -172,8 +172,10 @@ class GitlabIntegration(RepositoryIntegration, GitlabIssuesSpec, CommitContextIn
         return client.search_projects(group_id, query)
 
     # TODO(cathy): define in issue ABC
-    def search_issues(self, project_id, query, iids):
+    def search_issues(self, query: str | None, **kwargs):
         client = self.get_client()
+        project_id = kwargs["project_id"]
+        iids = kwargs["iids"]
         return client.search_project_issues(project_id, query, iids)
 
 

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -451,9 +451,11 @@ class JiraIntegration(IssueSyncIntegration):
             issue_id, group_note.data["external_id"], quoted_comment
         )
 
-    def search_issues(self, query: str | None, **kwargs):
+    def search_issues(self, query: str | None, **kwargs) -> dict[str, Any]:
         try:
-            return self.get_client().search_issues(query)
+            resp = self.get_client().search_issues(query)
+            assert isinstance(resp, dict)
+            return resp
         except ApiError as e:
             self.raise_error(e)
 

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -451,7 +451,7 @@ class JiraIntegration(IssueSyncIntegration):
             issue_id, group_note.data["external_id"], quoted_comment
         )
 
-    def search_issues(self, query):
+    def search_issues(self, query: str | None, **kwargs):
         try:
             return self.get_client().search_issues(query)
         except ApiError as e:

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -572,7 +572,7 @@ class JiraServerIntegration(IssueSyncIntegration):
             issue_id, group_note.data["external_id"], quoted_comment
         )
 
-    def search_issues(self, query):
+    def search_issues(self, query: str | None, **kwargs):
         try:
             return self.get_client().search_issues(query)
         except ApiError as e:

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -572,9 +572,11 @@ class JiraServerIntegration(IssueSyncIntegration):
             issue_id, group_note.data["external_id"], quoted_comment
         )
 
-    def search_issues(self, query: str | None, **kwargs):
+    def search_issues(self, query: str | None, **kwargs) -> dict[str, Any]:
         try:
-            return self.get_client().search_issues(query)
+            resp = self.get_client().search_issues(query)
+            assert isinstance(resp, dict)
+            return resp
         except ApiError as e:
             self.raise_error(e)
 

--- a/src/sentry/integrations/jira_server/search.py
+++ b/src/sentry/integrations/jira_server/search.py
@@ -8,6 +8,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.integrations.api.bases.integration import IntegrationEndpoint
+from sentry.integrations.jira_server.integration import JiraServerIntegration
 from sentry.integrations.models.integration import Integration
 from sentry.organizations.services.organization import RpcOrganization
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
@@ -23,7 +24,7 @@ class JiraServerSearchEndpoint(IntegrationEndpoint):
     }
     provider = "jira_server"
 
-    def _get_integration(self, organization, integration_id):
+    def _get_integration(self, organization, integration_id) -> Integration:
         return Integration.objects.get(
             organizationintegration__organization_id=organization.id,
             id=integration_id,
@@ -38,6 +39,8 @@ class JiraServerSearchEndpoint(IntegrationEndpoint):
         except Integration.DoesNotExist:
             return Response(status=404)
         installation = integration.get_installation(organization.id)
+
+        assert isinstance(installation, JiraServerIntegration), installation
         jira_client = installation.get_client()
 
         field = request.GET.get("field")

--- a/src/sentry/integrations/mixins/issues.py
+++ b/src/sentry/integrations/mixins/issues.py
@@ -304,7 +304,7 @@ class IssueBasicIntegration(IntegrationInstallation, ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def search_issues(self, query: str | None, **kwargs):
+    def search_issues(self, query: str | None, **kwargs) -> list[dict[str, Any]] | dict[str, Any]:
         raise NotImplementedError
 
     def after_link_issue(self, external_issue, **kwargs):

--- a/src/sentry/integrations/mixins/issues.py
+++ b/src/sentry/integrations/mixins/issues.py
@@ -303,6 +303,10 @@ class IssueBasicIntegration(IntegrationInstallation, ABC):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def search_issues(self, query: str | None, **kwargs):
+        raise NotImplementedError
+
     def after_link_issue(self, external_issue, **kwargs):
         """
         Takes the external issue that has been linked via `get_issue`.

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -29,6 +29,7 @@ from sentry.integrations.models.integration_external_project import IntegrationE
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.integration import RpcOrganizationIntegration, integration_service
 from sentry.integrations.services.repository import RpcRepository, repository_service
+from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.integrations.tasks.migrate_repo import migrate_repo
 from sentry.integrations.vsts.issues import VstsIssuesSpec
 from sentry.models.apitoken import generate_token

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -29,7 +29,6 @@ from sentry.integrations.models.integration_external_project import IntegrationE
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.integration import RpcOrganizationIntegration, integration_service
 from sentry.integrations.services.repository import RpcRepository, repository_service
-from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.integrations.tasks.migrate_repo import migrate_repo
 from sentry.integrations.vsts.issues import VstsIssuesSpec
 from sentry.models.apitoken import generate_token

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -11,7 +11,7 @@ from sentry.integrations.mixins.issues import IssueSyncIntegration
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
 from sentry.models.activity import Activity
-from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized
+from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
 from sentry.silo.base import all_silo_function
 from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
@@ -356,3 +356,14 @@ class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration):
     def update_comment(self, issue_id: int, user_id: int, group_note: str) -> None:
         # Azure does not support updating comments.
         pass
+
+    def search_issues(self, query: str | None, **kwargs):
+        client = self.get_client()
+
+        integration = integration_service.get_integration(
+            integration_id=self.org_integration.integration_id
+        )
+        if not integration:
+            raise IntegrationError("Azure DevOps integration not found")
+
+        return client.search_issues(query=query, account_name=integration.name)

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -357,7 +357,7 @@ class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration):
         # Azure does not support updating comments.
         pass
 
-    def search_issues(self, query: str | None, **kwargs):
+    def search_issues(self, query: str | None, **kwargs) -> dict[str, Any]:
         client = self.get_client()
 
         integration = integration_service.get_integration(
@@ -366,4 +366,6 @@ class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration):
         if not integration:
             raise IntegrationError("Azure DevOps integration not found")
 
-        return client.search_issues(query=query, account_name=integration.name)
+        resp = client.search_issues(query=query, account_name=integration.name)
+        assert isinstance(resp, dict)
+        return resp

--- a/src/sentry/integrations/vsts/search.py
+++ b/src/sentry/integrations/vsts/search.py
@@ -24,7 +24,7 @@ class VstsSearchEndpoint(IntegrationEndpoint):
         self, request: Request, organization: RpcOrganization, integration_id: int, **kwds: Any
     ) -> Response:
         try:
-            integration: Integration = Integration.objects.get(
+            integration = Integration.objects.get(
                 organizationintegration__organization_id=coerce_id_from(organization),
                 id=integration_id,
                 provider="vsts",


### PR DESCRIPTION
Define an abstract `search_issues` method in `IssueBasicIntegration`. This is used across Jira and SCM integrations -- am currently unsure of the return type, but this unifies the expectation of having issue search functionality across these integrations.

There are also `search_issues` functions in the integration API clients, but we should have the entry point be in `installation.search_issues()`.