### PR TITLE
fix(grouping): Fix `GroupHashMetadata` deletion

### DIFF
--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -125,6 +125,7 @@ def load_defaults():
     default_manager.register(models.GroupEmailThread, BulkModelDeletionTask)
     default_manager.register(models.GroupEnvironment, BulkModelDeletionTask)
     default_manager.register(models.GroupHash, defaults.GroupHashDeletionTask)
+    default_manager.register(models.GroupHashMetadata, BulkModelDeletionTask)
     default_manager.register(models.GroupHistory, BulkModelDeletionTask)
     default_manager.register(models.GroupLink, BulkModelDeletionTask)
     default_manager.register(models.GroupMeta, BulkModelDeletionTask)

--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -124,7 +124,7 @@ def load_defaults():
     default_manager.register(models.GroupCommitResolution, BulkModelDeletionTask)
     default_manager.register(models.GroupEmailThread, BulkModelDeletionTask)
     default_manager.register(models.GroupEnvironment, BulkModelDeletionTask)
-    default_manager.register(models.GroupHash, BulkModelDeletionTask)
+    default_manager.register(models.GroupHash, defaults.GroupHashDeletionTask)
     default_manager.register(models.GroupHistory, BulkModelDeletionTask)
     default_manager.register(models.GroupLink, BulkModelDeletionTask)
     default_manager.register(models.GroupMeta, BulkModelDeletionTask)

--- a/src/sentry/deletions/defaults/__init__.py
+++ b/src/sentry/deletions/defaults/__init__.py
@@ -6,6 +6,7 @@ from .commit import *  # noqa: F401,F403
 from .commitauthor import *  # noqa: F401,F403
 from .discoversavedquery import *  # noqa: F401,F403
 from .group import *  # noqa: F401,F403
+from .grouphash import *  # noqa: F401,F403
 from .monitor import *  # noqa: F401,F403
 from .monitor_environment import *  # noqa: F401,F403
 from .organization import *  # noqa: F401,F403

--- a/src/sentry/deletions/defaults/grouphash.py
+++ b/src/sentry/deletions/defaults/grouphash.py
@@ -1,0 +1,10 @@
+from ..base import ModelDeletionTask, ModelRelation
+
+
+class GroupHashDeletionTask(ModelDeletionTask):
+    def get_child_relations(self, instance):
+        from sentry.models.grouphashmetadata import GroupHashMetadata
+
+        return [
+            ModelRelation(GroupHashMetadata, {"grouphash_id": instance.id}),
+        ]

--- a/tests/sentry/tasks/deletion/test_groups.py
+++ b/tests/sentry/tasks/deletion/test_groups.py
@@ -5,6 +5,7 @@ from sentry.eventstore.models import Event
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.grouphash import GroupHash
+from sentry.models.grouphashmetadata import GroupHashMetadata
 from sentry.models.groupmeta import GroupMeta
 from sentry.models.groupredirect import GroupRedirect
 from sentry.tasks.deletion.groups import delete_groups
@@ -47,7 +48,8 @@ class DeleteGroupTest(TestCase):
         group.update(status=GroupStatus.PENDING_DELETION, substatus=None)
 
         GroupAssignee.objects.create(group=group, project=project, user_id=self.user.id)
-        GroupHash.objects.create(project=project, group=group, hash=uuid4().hex)
+        grouphash = GroupHash.objects.create(project=project, group=group, hash=uuid4().hex)
+        GroupHashMetadata.objects.create(grouphash=grouphash)
         GroupMeta.objects.create(group=group, key="foo", value="bar")
         GroupRedirect.objects.create(group_id=group.id, previous_group_id=1)
 
@@ -59,6 +61,7 @@ class DeleteGroupTest(TestCase):
 
         assert not GroupRedirect.objects.filter(group_id=group.id).exists()
         assert not GroupHash.objects.filter(group_id=group.id).exists()
+        assert not GroupHashMetadata.objects.filter(grouphash_id=grouphash.id).exists()
         assert not Group.objects.filter(id=group.id).exists()
         assert not nodestore.backend.get(node_id)
         assert not nodestore.backend.get(node_id_2)


### PR DESCRIPTION
Despite the `on_delete=models.CASCADE` in the one-to-one field linking `GroupHashMetadata` to `GroupHash`, deletion does not, in fact, cascade down to `GroupHashMetadata` (via `GroupHash`) when a `Group` row is deleted. It turns out that to make it work, we have to link `GroupHash` and `GroupHashMetadata` separately in a custom deletion task. This does that, and adds `GroupHashMetadata` to the group deletion test.

Note: This is not just me being a Django novice - we turn out to do this for [all of our model dependencies](https://github.com/getsentry/sentry/tree/master/src/sentry/deletions/defaults).