### PR TITLE
fix(issues): Hide device highlight if client_os is present

### DIFF
--- a/static/app/components/events/contexts/index.tsx
+++ b/static/app/components/events/contexts/index.tsx
@@ -29,7 +29,7 @@ export interface ContextItem {
   value: ContextValue;
 }
 
-export function getOrderedContextItems(event): ContextItem[] {
+export function getOrderedContextItems(event: Event): ContextItem[] {
   const {user, contexts} = event;
   const {data: customUserData, ...userContext} = user ?? {};
 
@@ -37,7 +37,7 @@ export function getOrderedContextItems(event): ContextItem[] {
   const orderedContext: [ContextItem['alias'], ContextValue][] = [
     ['response', response],
     ['feedback', feedback],
-    ['user', {...userContext, ...customUserData}],
+    ['user', {...userContext, ...(customUserData as any)}],
     ...Object.entries(otherContexts),
   ];
   // For these context aliases, use the alias as 'type' rather than 'value.type'

--- a/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
@@ -27,4 +27,26 @@ describe('HighlightsIconSummary', function () {
     expect(screen.getByText('Version: 3.8.13')).toBeInTheDocument();
     expect(screen.getAllByRole('img')).toHaveLength(2);
   });
+
+  it('hides device if client_os is present', function () {
+    const eventWithClientOs = EventFixture({
+      contexts: {
+        ...TEST_EVENT_CONTEXTS,
+        device: {
+          type: 'device',
+          name: 'device',
+          version: 'device version',
+        },
+        client_os: {
+          type: 'client_os',
+          name: 'client_os',
+          version: 'client_os version',
+        },
+      },
+    });
+
+    render(<HighlightsIconSummary event={eventWithClientOs} />);
+    expect(screen.queryByText('device')).not.toBeInTheDocument();
+    expect(screen.getByText('client_os')).toBeInTheDocument();
+  });
 });

--- a/static/app/components/events/highlights/highlightsIconSummary.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.tsx
@@ -18,6 +18,7 @@ export function HighlightsIconSummary({event}: HighlightsIconSummaryProps) {
   const items = getOrderedContextItems(event)
     .map(({alias, type, value}) => ({
       ...getContextSummary({type, value}),
+      alias,
       icon: getContextIcon({
         alias,
         type,
@@ -28,6 +29,13 @@ export function HighlightsIconSummary({event}: HighlightsIconSummaryProps) {
       }),
     }))
     .filter(item => item.icon !== null);
+
+  const deviceIndex = items.findIndex(item => item.alias === 'device');
+  const clientOsIndex = items.findIndex(item => item.alias === 'client_os');
+  // Remove device if client_os is also present
+  if (deviceIndex !== -1 && clientOsIndex !== -1) {
+    items.splice(deviceIndex, 1);
+  }
 
   return items.length ? (
     <Fragment>


### PR DESCRIPTION
hides the device highlight if client_os is available. they both come from user agent and display similar information.

https://sentry-sdks.sentry.io/issues/5710397287/events/fb7cbc2f17aa42f5adf764befa6b72af/?project=5572016

before
![image](https://github.com/user-attachments/assets/8401f053-4e74-4132-9ec4-64c0159269fb)

after
![image](https://github.com/user-attachments/assets/17230eee-1285-4a3a-9f84-e8346191a6b9)
