### PR TITLE
feat(query-builder): Add recent search queries when searchbar is empty

### DIFF
--- a/static/app/components/searchQueryBuilder/formattedQuery.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.tsx
@@ -82,7 +82,7 @@ export function FormattedQuery({
   }
 
   return (
-    <QueryWrapper>
+    <QueryWrapper aria-label={query}>
       {parsedQuery.map((token, index) => {
         return <QueryToken key={index} token={token} />;
       })}

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -406,11 +406,7 @@ describe('SearchQueryBuilder', function () {
         });
 
         render(
-          <SearchQueryBuilder
-            {...defaultProps}
-            recentSearches={SavedSearchType.ISSUE}
-            initialQuery=""
-          />
+          <SearchQueryBuilder {...defaultProps} recentSearches={SavedSearchType.ISSUE} />
         );
 
         await userEvent.click(getLastInput());
@@ -421,9 +417,13 @@ describe('SearchQueryBuilder', function () {
         expect(recentFilterKeys[0]).toHaveTextContent('assigned');
       });
 
-      it('can navigate between filters with arrow keys', async function () {
+      it('can navigate up/down from recent filter gutter to other search keys', async function () {
         render(
-          <SearchQueryBuilder {...defaultProps} recentSearches={SavedSearchType.ISSUE} />
+          <SearchQueryBuilder
+            {...defaultProps}
+            recentSearches={SavedSearchType.ISSUE}
+            initialQuery="is:unresolved"
+          />
         );
 
         await userEvent.click(getLastInput());
@@ -465,6 +465,71 @@ describe('SearchQueryBuilder', function () {
             recentFilterKeys[0].id
           );
         });
+      });
+    });
+
+    describe('recent searches', function () {
+      beforeEach(() => {
+        MockApiClient.addMockResponse({
+          url: '/organizations/org-slug/recent-searches/',
+          body: [{query: 'assigned:me'}, {query: 'some recent query'}],
+        });
+      });
+
+      it('displays recent search queries when query is empty', async function () {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            recentSearches={SavedSearchType.ISSUE}
+            initialQuery=""
+          />
+        );
+
+        await userEvent.click(getLastInput());
+
+        // Should have a "Recent" category
+        expect(await screen.findByRole('button', {name: 'Recent'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: 'assigned:me'})).toBeInTheDocument();
+        expect(
+          screen.getByRole('option', {name: 'some recent query'})
+        ).toBeInTheDocument();
+      });
+
+      it('when selecting a recent search, should reset query and call onSearch', async function () {
+        const mockOnSearch = jest.fn();
+        const mockCreateRecentSearch = MockApiClient.addMockResponse({
+          url: '/organizations/org-slug/recent-searches/',
+          method: 'POST',
+        });
+
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            recentSearches={SavedSearchType.ISSUE}
+            initialQuery=""
+            onSearch={mockOnSearch}
+          />
+        );
+
+        await userEvent.click(getLastInput());
+
+        await userEvent.click(await screen.findByRole('option', {name: 'assigned:me'}));
+        await waitFor(() => {
+          expect(mockOnSearch).toHaveBeenCalledWith('assigned:me', expect.anything());
+        });
+
+        // Focus should be at the end of the query
+        await waitFor(() => {
+          expect(getLastInput()).toHaveFocus();
+        });
+
+        // Should call the endpoint to add this as a recent search
+        expect(mockCreateRecentSearch).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            data: {query: 'assigned:me', type: SavedSearchType.ISSUE},
+          })
+        );
       });
     });
   });

--- a/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
+++ b/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
@@ -37,10 +37,15 @@ function useApplyFocusOverride(state: ListState<ParseResultToken>) {
   useLayoutEffect(() => {
     if (focusOverride && !focusOverride.part) {
       state.selectionManager.setFocused(true);
-      state.selectionManager.setFocusedKey(focusOverride.itemKey);
+
+      if (focusOverride.itemKey === 'end') {
+        state.selectionManager.setFocusedKey(state.collection.getLastKey());
+      } else {
+        state.selectionManager.setFocusedKey(focusOverride.itemKey);
+      }
       dispatch({type: 'RESET_FOCUS_OVERRIDE'});
     }
-  }, [dispatch, focusOverride, state.selectionManager]);
+  }, [dispatch, focusOverride, state.collection, state.selectionManager]);
 }
 
 function Grid(props: GridProps) {

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -56,9 +56,9 @@ type SearchQueryBuilderComboboxProps<T extends SelectOptionOrSectionWithKey<stri
   onCustomValueCommitted: (value: string) => void;
   /**
    * Called when the user selects an option from the dropdown.
-   * Passes the value of the selected item.
+   * Passes the selected option.
    */
-  onOptionSelected: (value: string) => void;
+  onOptionSelected: (option: T) => void;
   token: TokenResult<Token>;
   autoFocus?: boolean;
   /**
@@ -136,12 +136,15 @@ const DESCRIPTION_POPPER_OPTIONS = {
   ],
 };
 
-function findItemInSections(items: SelectOptionOrSectionWithKey<string>[], key: Key) {
+function findItemInSections<T extends SelectOptionOrSectionWithKey<string>>(
+  items: T[],
+  key: Key
+): T | null {
   for (const item of items) {
     if (itemIsSection(item)) {
       const option = item.options.find(child => child.key === key);
       if (option) {
-        return option;
+        return option as T;
       }
     } else {
       if (item.key === key) {
@@ -351,10 +354,8 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
   const onSelectionChange = useCallback(
     (key: Key) => {
       const selectedOption = findItemInSections(items, key);
-      if (selectedOption && 'textValue' in selectedOption && selectedOption.textValue) {
-        onOptionSelected(selectedOption.textValue);
-      } else if (key) {
-        onOptionSelected(key.toString());
+      if (selectedOption) {
+        onOptionSelected(selectedOption);
       }
     },
     [items, onOptionSelected]

--- a/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
@@ -209,8 +209,12 @@ export function SearchQueryBuilderParametersCombobox({
   );
 
   const handleOptionSelected = useCallback(
-    (value: string) => {
-      const newValue = replaceCommaSeparatedValue(inputValue, selectionIndex, value);
+    (option: SelectOptionWithKey<string>) => {
+      const newValue = replaceCommaSeparatedValue(
+        inputValue,
+        selectionIndex,
+        option.value
+      );
 
       dispatch({
         type: 'UPDATE_AGGREGATE_ARGS',

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -574,7 +574,9 @@ export function SearchQueryBuilderValueCombobox({
   );
 
   const handleOptionSelected = useCallback(
-    (value: string) => {
+    (option: SelectOptionWithKey<string>) => {
+      const value = option.value;
+
       if (isDateToken(token)) {
         if (value === 'absolute_date') {
           setShowDatePicker(true);

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -291,7 +291,7 @@ export function FilterKeyListBox<T extends SelectOptionOrSectionWithKey<string>>
         style={{position: 'absolute', width: '100%', left: 0, top: 38, right: 0}}
       >
         <SectionedOverlay ref={popoverRef} fullWidth showDetailsPane={showDetailsPane}>
-          {true ? (
+          {isOpen ? (
             <FilterKeyMenuContent
               fullWidth={fullWidth}
               hiddenOptions={hiddenOptionsWithRecentsAdded}

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -17,7 +17,11 @@ import {Overlay} from 'sentry/components/overlay';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import type {CustomComboboxMenuProps} from 'sentry/components/searchQueryBuilder/tokens/combobox';
 import {KeyDescription} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/keyDescription';
-import {createRecentFilterOptionKey} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/utils';
+import type {Section} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/types';
+import {
+  createRecentFilterOptionKey,
+  RECENT_SEARCH_CATEGORY_VALUE,
+} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/utils';
 import {IconMegaphone} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -26,9 +30,9 @@ import usePrevious from 'sentry/utils/usePrevious';
 
 interface FilterKeyListBoxProps<T> extends CustomComboboxMenuProps<T> {
   recentFilters: string[];
-  sections: Array<T>;
-  selectedSection: Key | null;
-  setSelectedSection: (section: Key | null) => void;
+  sections: Section[];
+  selectedSection: string;
+  setSelectedSection: (section: string) => void;
 }
 
 interface FilterKeyMenuContentProps<T>
@@ -41,6 +45,7 @@ interface FilterKeyMenuContentProps<T>
     | 'state'
     | 'selectedSection'
     | 'setSelectedSection'
+    | 'sections'
   > {
   fullWidth: boolean;
 }
@@ -136,12 +141,15 @@ function useHighlightFirstOptionOnSectionChange({
   hiddenOptions,
 }: {
   hiddenOptions: Set<SelectKey>;
-  sections: Array<SelectOptionOrSectionWithKey<string>>;
+  sections: Section[];
   selectedSection: Key | null;
   state: ComboBoxState<SelectOptionOrSectionWithKey<string>>;
 }) {
   const displayedListItems = useMemo(() => {
-    const options = state.collection.getChildren?.(selectedSection ?? sections[0].key);
+    if (selectedSection === RECENT_SEARCH_CATEGORY_VALUE) {
+      return [...state.collection].filter(item => !hiddenOptions.has(item.key));
+    }
+    const options = state.collection.getChildren?.(selectedSection ?? sections[0].value);
     return [...(options ?? [])].filter(option => !hiddenOptions.has(option.key));
   }, [state.collection, selectedSection, sections, hiddenOptions]);
 
@@ -167,12 +175,14 @@ function FilterKeyMenuContent<T extends SelectOptionOrSectionWithKey<string>>({
   hiddenOptions,
   listBoxRef,
   fullWidth,
+  sections,
 }: FilterKeyMenuContentProps<T>) {
-  const {filterKeys, filterKeySections} = useSearchQueryBuilder();
+  const {filterKeys} = useSearchQueryBuilder();
   const focusedItem = state.collection.getItem(state.selectionManager.focusedKey)?.props
     ?.value as string | undefined;
   const focusedKey = focusedItem ? filterKeys[focusedItem] : null;
   const showRecentFilters = recentFilters.length > 0;
+  const showDetailsPane = fullWidth && selectedSection !== RECENT_SEARCH_CATEGORY_VALUE;
 
   return (
     <Fragment>
@@ -184,22 +194,12 @@ function FilterKeyMenuContent<T extends SelectOptionOrSectionWithKey<string>>({
         </RecentFiltersPane>
       ) : null}
       <SectionedListBoxTabPane>
-        <ListBoxSectionButton
-          selected={selectedSection === null}
-          onClick={() => {
-            setSelectedSection(null);
-            state.selectionManager.setFocusedKey(null);
-          }}
-        >
-          {t('All')}
-        </ListBoxSectionButton>
-        {filterKeySections.map(section => (
+        {sections.map(section => (
           <ListBoxSectionButton
             key={section.value}
             selected={selectedSection === section.value}
             onClick={() => {
               setSelectedSection(section.value);
-              state.selectionManager.setFocusedKey(null);
             }}
           >
             {section.label}
@@ -211,7 +211,7 @@ function FilterKeyMenuContent<T extends SelectOptionOrSectionWithKey<string>>({
           {...listBoxProps}
           ref={listBoxRef}
           listState={state}
-          hasSearch={false}
+          hasSearch={selectedSection === RECENT_SEARCH_CATEGORY_VALUE}
           hiddenOptions={hiddenOptions}
           keyDownHandler={() => true}
           overlayIsOpen
@@ -220,7 +220,7 @@ function FilterKeyMenuContent<T extends SelectOptionOrSectionWithKey<string>>({
           showDetails={!fullWidth}
         />
       </SectionedListBoxPane>
-      {fullWidth ? (
+      {showDetailsPane ? (
         <DetailsPane>
           {focusedKey ? <KeyDescription size="md" tag={focusedKey} /> : null}
         </DetailsPane>
@@ -262,6 +262,7 @@ export function FilterKeyListBox<T extends SelectOptionOrSectionWithKey<string>>
   });
 
   const fullWidth = !query;
+  const showDetailsPane = fullWidth && selectedSection !== RECENT_SEARCH_CATEGORY_VALUE;
 
   // Remove bottom border radius of top-level component while the full-width menu is open
   useEffect(() => {
@@ -289,7 +290,7 @@ export function FilterKeyListBox<T extends SelectOptionOrSectionWithKey<string>>
         visible={isOpen}
         style={{position: 'absolute', width: '100%', left: 0, top: 38, right: 0}}
       >
-        <SectionedOverlay ref={popoverRef} fullWidth>
+        <SectionedOverlay ref={popoverRef} fullWidth showDetailsPane={showDetailsPane}>
           {isOpen ? (
             <FilterKeyMenuContent
               fullWidth={fullWidth}
@@ -300,6 +301,7 @@ export function FilterKeyListBox<T extends SelectOptionOrSectionWithKey<string>>
               selectedSection={selectedSection}
               setSelectedSection={setSelectedSection}
               state={state}
+              sections={sections}
             />
           ) : null}
         </SectionedOverlay>
@@ -321,6 +323,7 @@ export function FilterKeyListBox<T extends SelectOptionOrSectionWithKey<string>>
             selectedSection={selectedSection}
             setSelectedSection={setSelectedSection}
             state={state}
+            sections={sections}
           />
         ) : null}
       </SectionedOverlay>
@@ -328,7 +331,11 @@ export function FilterKeyListBox<T extends SelectOptionOrSectionWithKey<string>>
   );
 }
 
-const SectionedOverlay = styled(Overlay)<{fullWidth?: boolean; width?: number}>`
+const SectionedOverlay = styled(Overlay)<{
+  fullWidth?: boolean;
+  showDetailsPane?: boolean;
+  width?: number;
+}>`
   display: grid;
   grid-template-rows: auto auto 1fr auto;
   grid-template-columns: ${p => (p.fullWidth ? '50% 50%' : '1fr')};
@@ -343,7 +350,7 @@ const SectionedOverlay = styled(Overlay)<{fullWidth?: boolean; width?: number}>`
       grid-template-areas:
         'recentFilters recentFilters'
         'tabs tabs'
-        'list details'
+        ${p.showDetailsPane ? "'list details'" : "'list list'"}
         'footer footer';
     `}
   overflow: hidden;
@@ -367,7 +374,7 @@ const RecentFiltersPane = styled('ul')`
   display: flex;
   flex-wrap: wrap;
   background: ${p => p.theme.backgroundSecondary};
-  padding: ${space(1)};
+  padding: ${space(1)} 10px;
   gap: ${space(0.25)};
   border-bottom: 1px solid ${p => p.theme.innerBorder};
   margin: 0;

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -291,7 +291,7 @@ export function FilterKeyListBox<T extends SelectOptionOrSectionWithKey<string>>
         style={{position: 'absolute', width: '100%', left: 0, top: 38, right: 0}}
       >
         <SectionedOverlay ref={popoverRef} fullWidth showDetailsPane={showDetailsPane}>
-          {isOpen ? (
+          {true ? (
             <FilterKeyMenuContent
               fullWidth={fullWidth}
               hiddenOptions={hiddenOptionsWithRecentsAdded}
@@ -331,7 +331,9 @@ export function FilterKeyListBox<T extends SelectOptionOrSectionWithKey<string>>
   );
 }
 
-const SectionedOverlay = styled(Overlay)<{
+const SectionedOverlay = styled(Overlay, {
+  shouldForwardProp: prop => !['fullWidth', 'showDetailsPane', 'width'].includes(prop),
+})<{
   fullWidth?: boolean;
   showDetailsPane?: boolean;
   width?: number;

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
@@ -1,3 +1,5 @@
+import type {ReactNode} from 'react';
+
 import type {
   SelectOptionWithKey,
   SelectSectionWithKey,
@@ -24,4 +26,15 @@ export interface RecentFilterItem extends SelectOptionWithKey<string> {
   value: string;
 }
 
-export type FilterKeyItem = KeyItem | RecentFilterItem | KeySectionItem;
+export interface RecentQueryItem extends SelectOptionWithKey<string> {
+  hideCheck: boolean;
+  type: 'recent-query';
+  value: string;
+}
+
+export type FilterKeyItem = KeyItem | RecentFilterItem | KeySectionItem | RecentQueryItem;
+
+export type Section = {
+  label: ReactNode;
+  value: string;
+};

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox.tsx
@@ -1,43 +1,63 @@
 import type React from 'react';
-import {useCallback, useMemo, useState} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
 import type {ComboBoxState} from '@react-stately/combobox';
-import type {Key, Node} from '@react-types/shared';
+import type {Node} from '@react-types/shared';
 
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import type {CustomComboboxMenu} from 'sentry/components/searchQueryBuilder/tokens/combobox';
 import {FilterKeyListBox} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox';
-import type {FilterKeyItem} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/types';
+import type {
+  FilterKeyItem,
+  RecentQueryItem,
+  Section,
+} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/types';
+import {useRecentSearches} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/useRecentSearches';
 import {useRecentSearchFilters} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/useRecentSearchFilters';
 import {
+  ALL_CATEGORY,
+  ALL_CATEGORY_VALUE,
+  createRecentFilterItem,
   createRecentFilterOptionKey,
+  createRecentQueryItem,
   createSection,
+  RECENT_SEARCH_CATEGORY,
+  RECENT_SEARCH_CATEGORY_VALUE,
 } from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/utils';
 import {itemIsSection} from 'sentry/components/searchQueryBuilder/tokens/utils';
+import type {FieldDefinitionGetter} from 'sentry/components/searchQueryBuilder/types';
+import type {RecentSearch, TagCollection} from 'sentry/types/group';
 import clamp from 'sentry/utils/number/clamp';
+import usePrevious from 'sentry/utils/usePrevious';
 
 const MAX_OPTIONS_WITHOUT_SEARCH = 100;
 const MAX_OPTIONS_WITH_SEARCH = 8;
 
-function addRecentFiltersToItems({
-  items,
+function makeRecentFilterItems({
   recentFilters,
 }: {
-  items: FilterKeyItem[];
   recentFilters: string[];
 }): FilterKeyItem[] {
   if (!recentFilters.length) {
-    return items;
+    return [];
   }
-  return [
-    ...recentFilters.map(filter => ({
-      key: createRecentFilterOptionKey(filter),
-      value: filter,
-      textValue: filter,
-      type: 'recent-filter' as const,
-      label: filter,
-    })),
-    ...items,
-  ];
+  return recentFilters.map(filter => createRecentFilterItem({filter}));
+}
+
+function makeRecentSearchQueryItems({
+  recentSearches,
+  filterKeys,
+  getFieldDefinition,
+}: {
+  filterKeys: TagCollection;
+  getFieldDefinition: FieldDefinitionGetter;
+  recentSearches: RecentSearch[] | undefined;
+}): RecentQueryItem[] {
+  if (!recentSearches) {
+    return [];
+  }
+  return recentSearches.map(search =>
+    createRecentQueryItem({search, filterKeys, getFieldDefinition})
+  );
 }
 
 /**
@@ -98,40 +118,101 @@ function useFilterKeyItems() {
   return {sectionedItems};
 }
 
+function useFilterKeySections({
+  recentSearches,
+}: {
+  recentSearches: RecentSearch[] | undefined;
+}) {
+  const {filterKeySections, query} = useSearchQueryBuilder();
+
+  const sections = useMemo<Section[]>(() => {
+    const definedSections = filterKeySections.map(section => ({
+      value: section.value,
+      label: section.label,
+    }));
+
+    if (!definedSections.length) {
+      return [];
+    }
+
+    if (recentSearches?.length && !query) {
+      return [RECENT_SEARCH_CATEGORY, ALL_CATEGORY, ...definedSections];
+    }
+
+    return [ALL_CATEGORY, ...definedSections];
+  }, [filterKeySections, query, recentSearches?.length]);
+
+  const [selectedSection, setSelectedSection] = useState<string>(
+    sections[0]?.value ?? ''
+  );
+
+  const numSections = sections.length;
+  const previousNumSections = usePrevious(numSections);
+  useEffect(() => {
+    if (previousNumSections !== numSections) {
+      setSelectedSection(sections[0].value);
+    }
+  }, [numSections, previousNumSections, sections]);
+
+  return {sections, selectedSection, setSelectedSection};
+}
 export function useFilterKeyListBox({filterValue}: {filterValue: string}) {
-  const {filterKeySections} = useSearchQueryBuilder();
-  const [selectedSectionKey, setSelectedSection] = useState<Key | null>(null);
-
+  const {filterKeys, getFieldDefinition} = useSearchQueryBuilder();
   const {sectionedItems} = useFilterKeyItems();
-
   const recentFilters = useRecentSearchFilters();
+  const {data: recentSearches} = useRecentSearches();
+  const {sections, selectedSection, setSelectedSection} = useFilterKeySections({
+    recentSearches: recentSearches,
+  });
 
   const filterKeyMenuItems = useMemo(() => {
+    const recentFilterItems = makeRecentFilterItems({recentFilters});
+
+    if (selectedSection === RECENT_SEARCH_CATEGORY_VALUE) {
+      return [
+        ...recentFilterItems,
+        ...makeRecentSearchQueryItems({
+          recentSearches,
+          filterKeys,
+          getFieldDefinition,
+        }),
+      ];
+    }
+
     const filteredByCategory = sectionedItems.filter(item => {
       if (itemIsSection(item)) {
-        return !selectedSectionKey || item.key === selectedSectionKey;
+        if (selectedSection === ALL_CATEGORY_VALUE) {
+          return true;
+        }
+        return item.key === selectedSection;
       }
 
       return true;
     });
 
-    return addRecentFiltersToItems({items: filteredByCategory, recentFilters});
-  }, [recentFilters, sectionedItems, selectedSectionKey]);
+    return [...recentFilterItems, ...filteredByCategory];
+  }, [
+    filterKeys,
+    getFieldDefinition,
+    recentFilters,
+    recentSearches,
+    sectionedItems,
+    selectedSection,
+  ]);
 
   const customMenu: CustomComboboxMenu<FilterKeyItem> = props => {
     return (
       <FilterKeyListBox
         {...props}
-        selectedSection={selectedSectionKey}
+        selectedSection={selectedSection}
         setSelectedSection={setSelectedSection}
-        sections={sectionedItems}
+        sections={sections}
         recentFilters={recentFilters}
       />
     );
   };
 
-  const shouldShowExplorationMenu =
-    filterValue.length === 0 && filterKeySections.length > 0;
+  const shouldShowExplorationMenu = filterValue.length === 0 && sections.length > 0;
 
   // This logic allows us to treat the recent filters as a separate section.
   // If we have 5 recent filters, we want arrow up/down to cylce from the
@@ -170,7 +251,7 @@ export function useFilterKeyListBox({filterValue}: {filterValue: string}) {
           findNextMatchingItem(
             state,
             focusedItem,
-            item => item.props?.type === 'item',
+            item => ['item', 'recent-query'].includes(item.props?.type),
             direction
           )?.key ?? null;
 
@@ -215,11 +296,9 @@ export function useFilterKeyListBox({filterValue}: {filterValue: string}) {
 
   const handleCycleSections = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
-      const sectionKeyOrder = [null, ...filterKeySections.map(section => section.value)];
+      const sectionKeyOrder = sections.map(section => section.value);
 
-      const selectedSectionIndex = sectionKeyOrder.indexOf(
-        selectedSectionKey?.toString() ?? null
-      );
+      const selectedSectionIndex = sectionKeyOrder.indexOf(selectedSection);
       const newIndex = clamp(
         selectedSectionIndex + (e.key === 'ArrowRight' ? 1 : -1),
         0,
@@ -228,7 +307,7 @@ export function useFilterKeyListBox({filterValue}: {filterValue: string}) {
       const newSectionKey = sectionKeyOrder[newIndex];
       setSelectedSection(newSectionKey);
     },
-    [filterKeySections, selectedSectionKey]
+    [sections, selectedSection, setSelectedSection]
   );
 
   /**

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useRecentSearchFilters.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useRecentSearchFilters.tsx
@@ -1,7 +1,7 @@
 import {useMemo} from 'react';
 
-import {useFetchRecentSearches} from 'sentry/actionCreators/savedSearches';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
+import {useRecentSearches} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/useRecentSearches';
 import type {FieldDefinitionGetter} from 'sentry/components/searchQueryBuilder/types';
 import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
 import {type ParseResult, Token} from 'sentry/components/searchSyntax/parser';
@@ -88,18 +88,8 @@ function getFiltersFromRecentSearches(
  * Orders by highest count of filter key occurrences.
  */
 export function useRecentSearchFilters() {
-  const {recentSearches, parsedQuery, filterKeys, getFieldDefinition} =
-    useSearchQueryBuilder();
-
-  const {data: recentSearchesData} = useFetchRecentSearches(
-    {
-      savedSearchType: recentSearches ?? null,
-      limit: 5,
-    },
-    {
-      staleTime: 30_000,
-    }
-  );
+  const {parsedQuery, filterKeys, getFieldDefinition} = useSearchQueryBuilder();
+  const {data: recentSearchesData} = useRecentSearches();
 
   const filters = useMemo(
     () =>

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useRecentSearches.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useRecentSearches.tsx
@@ -1,0 +1,16 @@
+import {useFetchRecentSearches} from 'sentry/actionCreators/savedSearches';
+import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
+
+export function useRecentSearches() {
+  const {recentSearches} = useSearchQueryBuilder();
+
+  return useFetchRecentSearches(
+    {
+      savedSearchType: recentSearches ?? null,
+      limit: 10,
+    },
+    {
+      staleTime: 30_000,
+    }
+  );
+}

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -1,20 +1,37 @@
 import {getEscapedKey} from 'sentry/components/compactSelect/utils';
+import {FormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
 import {KeyDescription} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/keyDescription';
 import type {
   KeyItem,
   KeySectionItem,
+  RecentQueryItem,
 } from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/types';
 import type {
   FieldDefinitionGetter,
   FilterKeySection,
 } from 'sentry/components/searchQueryBuilder/types';
-import type {Tag, TagCollection} from 'sentry/types/group';
+import {t} from 'sentry/locale';
+import type {RecentSearch, Tag, TagCollection} from 'sentry/types/group';
 import {type FieldDefinition, FieldKind} from 'sentry/utils/fields';
 
+export const ALL_CATEGORY_VALUE = '__all' as const;
+export const RECENT_SEARCH_CATEGORY_VALUE = '__recent_searches' as const;
+
+export const ALL_CATEGORY = {value: ALL_CATEGORY_VALUE, label: t('All')};
+export const RECENT_SEARCH_CATEGORY = {
+  value: RECENT_SEARCH_CATEGORY_VALUE,
+  label: t('Recent'),
+};
+
 const RECENT_FILTER_KEY_PREFIX = '__recent_filter_key__';
+const RECENT_QUERY_KEY_PREFIX = '__recent_search__';
 
 export function createRecentFilterOptionKey(filter: string) {
   return getEscapedKey(`${RECENT_FILTER_KEY_PREFIX}${filter}`);
+}
+
+export function createRecentQueryOptionKey(filter: string) {
+  return getEscapedKey(`${RECENT_QUERY_KEY_PREFIX}${filter}`);
 }
 
 export function getKeyLabel(
@@ -70,5 +87,40 @@ export function createItem(
     showDetailsInOverlay: true,
     details: <KeyDescription tag={tag} />,
     type: 'item',
+  };
+}
+
+export function createRecentFilterItem({filter}: {filter: string}) {
+  return {
+    key: createRecentFilterOptionKey(filter),
+    value: filter,
+    textValue: filter,
+    type: 'recent-filter' as const,
+    label: filter,
+  };
+}
+
+export function createRecentQueryItem({
+  search,
+  getFieldDefinition,
+  filterKeys,
+}: {
+  filterKeys: TagCollection;
+  getFieldDefinition: FieldDefinitionGetter;
+  search: RecentSearch;
+}): RecentQueryItem {
+  return {
+    key: createRecentQueryOptionKey(search.query),
+    value: search.query,
+    textValue: search.query,
+    type: 'recent-query' as const,
+    label: (
+      <FormattedQuery
+        query={search.query}
+        filterKeys={filterKeys}
+        fieldDefinitionGetter={getFieldDefinition}
+      />
+    ),
+    hideCheck: true,
   };
 }

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -407,7 +407,19 @@ function SearchQueryBuilderInputInternal({
         ref={inputRef}
         items={items}
         placeholder={query === '' ? placeholder : undefined}
-        onOptionSelected={value => {
+        onOptionSelected={option => {
+          if (option.type === 'recent-query') {
+            dispatch({
+              type: 'UPDATE_QUERY',
+              query: option.value,
+              focusOverride: {itemKey: 'end'},
+            });
+            handleSearch(option.value);
+            return;
+          }
+
+          const value = option.value;
+
           dispatch({
             type: 'UPDATE_FREE_TEXT',
             tokens: [token],

--- a/static/app/components/searchQueryBuilder/types.tsx
+++ b/static/app/components/searchQueryBuilder/types.tsx
@@ -15,7 +15,7 @@ export enum QueryInterfaceType {
 }
 
 export type FocusOverride = {
-  itemKey: string;
+  itemKey: string | 'end';
   part?: 'value' | 'key';
 };
 


### PR DESCRIPTION
Adds a "Recents" tab when the full-width menu is active and some number of recent searches are available.

![CleanShot 2024-08-15 at 16 49 35@2x](https://github.com/user-attachments/assets/d9fd6249-9050-4476-8cea-9fe2b8dfdc1e)
