### PR TITLE
ref: only set docker context on macos

### DIFF
--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -216,15 +216,16 @@ def devservices() -> None:
         click.echo("Assuming docker (CI).")
         return
 
-    if USE_DOCKER_DESKTOP:
-        click.echo("Using docker desktop.")
-        ensure_docker_cli_context("desktop-linux")
-    if USE_COLIMA:
-        click.echo("Using colima.")
-        ensure_docker_cli_context("colima")
-    if USE_ORBSTACK:
-        click.echo("Using orbstack.")
-        ensure_docker_cli_context("orbstack")
+    if DARWIN:
+        if USE_DOCKER_DESKTOP:
+            click.echo("Using docker desktop.")
+            ensure_docker_cli_context("desktop-linux")
+        if USE_COLIMA:
+            click.echo("Using colima.")
+            ensure_docker_cli_context("colima")
+        if USE_ORBSTACK:
+            click.echo("Using orbstack.")
+            ensure_docker_cli_context("orbstack")
 
 
 @devservices.command()


### PR DESCRIPTION
otherwise this breaks docker on linux with:

```bash
$ docker ps
Failed to initialize: unable to resolve docker endpoint: context "desktop-linux": context not found: open /home/asottile/.docker/contexts/meta/fe9c6bd7a66301f49ca9b6a70b217107cd1284598bfc254700c989b916da791e/meta.json: no such file or directory
```

<!-- Describe your PR here. -->