### PR TITLE
feat(explore): Add column editor modal

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -388,6 +388,8 @@ export const ORGANIZATION_FETCH_ERROR_TYPES = {
 
 export const CONFIG_DOCS_URL = 'https://develop.sentry.dev/config/';
 export const DISCOVER2_DOCS_URL = 'https://docs.sentry.io/product/discover-queries/';
+export const SPAN_PROPS_DOCS_URL =
+  'https://docs.sentry.io/concepts/search/searchable-properties/spans/';
 
 export const IS_ACCEPTANCE_TEST = !!process.env.IS_ACCEPTANCE_TEST;
 export const NODE_ENV = process.env.NODE_ENV;

--- a/static/app/views/explore/tables/columnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.spec.tsx
@@ -1,0 +1,177 @@
+import {act, renderGlobalModal, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {openModal} from 'sentry/actionCreators/modal';
+import {ColumnEditorModal} from 'sentry/views/explore/tables/columnEditorModal';
+
+const tagOptions = {
+  id: {
+    key: 'id',
+    name: 'ID',
+  },
+  project: {
+    key: 'project',
+    name: 'Project',
+  },
+  'span.op': {
+    key: 'span.op',
+    name: 'Span OP',
+  },
+};
+
+describe('ColumnEditorModal', function () {
+  beforeEach(function () {
+    // without this the `CompactSelect` component errors with a bunch of async updates
+    jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  it('allows closes modal on apply', async function () {
+    const onClose = jest.fn();
+
+    renderGlobalModal();
+
+    act(() => {
+      openModal(
+        modalProps => (
+          <ColumnEditorModal
+            {...modalProps}
+            columns={['id', 'project']}
+            onColumnsChange={() => {}}
+            tags={tagOptions}
+          />
+        ),
+        {onClose}
+      );
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('allows deleting a column', async function () {
+    const onColumnsChange = jest.fn();
+
+    renderGlobalModal();
+
+    act(() => {
+      openModal(
+        modalProps => (
+          <ColumnEditorModal
+            {...modalProps}
+            columns={['id', 'project']}
+            onColumnsChange={onColumnsChange}
+            tags={tagOptions}
+          />
+        ),
+        {onClose: jest.fn()}
+      );
+    });
+
+    const columns1 = ['ID', 'Project'];
+    screen.getAllByTestId('editor-column').forEach((column, i) => {
+      expect(column).toHaveTextContent(columns1[i]);
+    });
+
+    await userEvent.click(screen.getAllByLabelText('Remove Column')[0]);
+
+    const columns2 = ['Project'];
+    screen.getAllByTestId('editor-column').forEach((column, i) => {
+      expect(column).toHaveTextContent(columns2[i]);
+    });
+
+    // only 1 column remaining, disable the delete option
+    expect(screen.getByLabelText('Remove Column')).toBeDisabled();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
+    expect(onColumnsChange).toHaveBeenCalledWith(['project']);
+  });
+
+  it('allows adding a column', async function () {
+    const onColumnsChange = jest.fn();
+
+    renderGlobalModal();
+
+    act(() => {
+      openModal(
+        modalProps => (
+          <ColumnEditorModal
+            {...modalProps}
+            columns={['id', 'project']}
+            onColumnsChange={onColumnsChange}
+            tags={tagOptions}
+          />
+        ),
+        {onClose: jest.fn()}
+      );
+    });
+
+    const columns1 = ['ID', 'Project'];
+    screen.getAllByTestId('editor-column').forEach((column, i) => {
+      expect(column).toHaveTextContent(columns1[i]);
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Add a Column'}));
+
+    const columns2 = ['ID', 'Project', 'None'];
+    screen.getAllByTestId('editor-column').forEach((column, i) => {
+      expect(column).toHaveTextContent(columns2[i]);
+    });
+
+    const options = ['ID', 'Project', 'Span OP'];
+    await userEvent.click(screen.getByRole('button', {name: 'None'}));
+    const columnOptions = await screen.findAllByRole('option');
+    columnOptions.forEach((option, i) => {
+      expect(option).toHaveTextContent(options[i]);
+    });
+
+    await userEvent.click(columnOptions[2]);
+    const columns3 = ['ID', 'Project', 'Span OP'];
+    screen.getAllByTestId('editor-column').forEach((column, i) => {
+      expect(column).toHaveTextContent(columns3[i]);
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
+    expect(onColumnsChange).toHaveBeenCalledWith(['id', 'project', 'span.op']);
+  });
+
+  it('allows changing a column', async function () {
+    const onColumnsChange = jest.fn();
+
+    renderGlobalModal();
+
+    act(() => {
+      openModal(
+        modalProps => (
+          <ColumnEditorModal
+            {...modalProps}
+            columns={['id', 'project']}
+            onColumnsChange={onColumnsChange}
+            tags={tagOptions}
+          />
+        ),
+        {onClose: jest.fn()}
+      );
+    });
+
+    const columns1 = ['ID', 'Project'];
+    screen.getAllByTestId('editor-column').forEach((column, i) => {
+      expect(column).toHaveTextContent(columns1[i]);
+    });
+
+    const options = ['ID', 'Project', 'Span OP'];
+    await userEvent.click(screen.getByRole('button', {name: 'Project'}));
+    const columnOptions = await screen.findAllByRole('option');
+    columnOptions.forEach((option, i) => {
+      expect(option).toHaveTextContent(options[i]);
+    });
+
+    await userEvent.click(columnOptions[2]);
+    const columns2 = ['ID', 'Span OP'];
+    screen.getAllByTestId('editor-column').forEach((column, i) => {
+      expect(column).toHaveTextContent(columns2[i]);
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
+    expect(onColumnsChange).toHaveBeenCalledWith(['id', 'span.op']);
+  });
+});

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -1,0 +1,269 @@
+import {Fragment, useMemo, useState} from 'react';
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import {CSS} from '@dnd-kit/utilities';
+import styled from '@emotion/styled';
+
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {Button, LinkButton} from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
+import type {SelectKey, SelectOption} from 'sentry/components/compactSelect';
+import {CompactSelect} from 'sentry/components/compactSelect';
+import {SPAN_PROPS_DOCS_URL} from 'sentry/constants';
+import {IconAdd} from 'sentry/icons/iconAdd';
+import {IconDelete} from 'sentry/icons/iconDelete';
+import {IconGrabbable} from 'sentry/icons/iconGrabbable';
+import {t} from 'sentry/locale';
+import type {TagCollection} from 'sentry/types/group';
+import {defined} from 'sentry/utils';
+
+type Column = {
+  column: string | undefined;
+  id: number;
+};
+
+interface ColumnEditorModalProps extends ModalRenderProps {
+  columns: string[];
+  onColumnsChange: (fields: string[]) => void;
+  tags: TagCollection;
+}
+
+export function ColumnEditorModal({
+  Header,
+  Body,
+  Footer,
+  closeModal,
+  columns,
+  onColumnsChange,
+  tags,
+}: ColumnEditorModalProps) {
+  const [editableColumns, setEditableColumns] = useState<Column[]>(
+    // falsey ids are not draggable in dndkit
+    columns.map((column, i) => ({id: i + 1, column}))
+  );
+
+  const [nextId, setNextId] = useState(columns.length + 1);
+
+  const tagOptions = useMemo(() => {
+    return Object.values(tags).map(tag => {
+      return {
+        label: tag.name,
+        value: tag.key,
+      };
+    });
+  }, [tags]);
+
+  function handleApply() {
+    onColumnsChange(editableColumns.map(({column}) => column).filter(defined));
+    closeModal();
+  }
+
+  function insertColumn() {
+    setEditableColumns(oldEditableColumns => {
+      const newEditableColumns = oldEditableColumns.slice();
+      newEditableColumns.push({id: nextId, column: undefined});
+
+      setNextId(nextId + 1); // make sure to increment the id for the next time
+
+      return newEditableColumns;
+    });
+  }
+
+  function updateColumnAtIndex(i: number, column: string) {
+    setEditableColumns(oldEditableColumns => {
+      const newEditableColumns = [...oldEditableColumns];
+      newEditableColumns[i].column = column;
+      return newEditableColumns;
+    });
+  }
+
+  function deleteColumnAtIndex(i: number) {
+    setEditableColumns(oldEditableColumns => {
+      return [...oldEditableColumns.slice(0, i), ...oldEditableColumns.slice(i + 1)];
+    });
+  }
+
+  function swapColumnsAtIndex(i: number, j: number) {
+    setEditableColumns(oldEditableColumns => {
+      return arrayMove(oldEditableColumns, i, j);
+    });
+  }
+
+  return (
+    <Fragment>
+      <Header closeButton data-test-id="editor-header">
+        <h4>{t('Edit Columns')}</h4>
+      </Header>
+      <Body data-test-id="editor-body">
+        <ColumnEditor
+          columns={editableColumns}
+          onColumnChange={updateColumnAtIndex}
+          onColumnDelete={deleteColumnAtIndex}
+          onColumnSwap={swapColumnsAtIndex}
+          tags={tagOptions}
+        />
+        <RowContainer>
+          <ButtonBar gap={1}>
+            <Button
+              size="sm"
+              aria-label={t('Add a Column')}
+              onClick={insertColumn}
+              icon={<IconAdd isCircled />}
+            >
+              {t('Add a Column')}
+            </Button>
+          </ButtonBar>
+        </RowContainer>
+      </Body>
+      <Footer data-test-id="editor-footer">
+        <ButtonBar gap={1}>
+          <LinkButton priority="default" href={SPAN_PROPS_DOCS_URL} external>
+            {t('Read the Docs')}
+          </LinkButton>
+          <Button aria-label={t('Apply')} priority="primary" onClick={handleApply}>
+            {t('Apply')}
+          </Button>
+        </ButtonBar>
+      </Footer>
+    </Fragment>
+  );
+}
+
+interface ColumnEditorProps {
+  columns: Column[];
+  onColumnChange: (i: number, column: string) => void;
+  onColumnDelete: (i: number) => void;
+  onColumnSwap: (i: number, j: number) => void;
+  tags: SelectOption<string>[];
+}
+
+function ColumnEditor({
+  columns,
+  onColumnChange,
+  onColumnDelete,
+  onColumnSwap,
+  tags,
+}: ColumnEditorProps) {
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  function handleDragEnd(event) {
+    const {active, over} = event;
+
+    if (active.id !== over.id) {
+      const oldIndex = columns.findIndex(({id}) => id === active.id);
+      const newIndex = columns.findIndex(({id}) => id === over.id);
+      onColumnSwap(oldIndex, newIndex);
+    }
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext items={columns} strategy={verticalListSortingStrategy}>
+        {columns.map((column, i) => {
+          return (
+            <ColumnEditorRow
+              key={column.id}
+              canDelete={columns.length > 1}
+              column={column}
+              tags={tags}
+              onColumnChange={c => onColumnChange(i, c)}
+              onColumnDelete={() => onColumnDelete(i)}
+            />
+          );
+        })}
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+interface ColumnEditorRowProps {
+  canDelete: boolean;
+  column: Column;
+  onColumnChange: (column: string) => void;
+  onColumnDelete: () => void;
+  tags: SelectOption<string>[];
+}
+
+function ColumnEditorRow({
+  canDelete,
+  column,
+  tags,
+  onColumnChange,
+  onColumnDelete,
+}: ColumnEditorRowProps) {
+  const {attributes, listeners, setNodeRef, transform, transition} = useSortable({
+    id: column.id,
+  });
+
+  function handleColumnChange(option: SelectOption<SelectKey>) {
+    if (defined(option) && typeof option.value === 'string') {
+      onColumnChange(option.value);
+    }
+  }
+
+  return (
+    <RowContainer
+      key={column.id}
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+      }}
+      {...attributes}
+    >
+      <Button
+        aria-label={t('Drag to reorder')}
+        borderless
+        size="sm"
+        icon={<IconGrabbable size="sm" />}
+        {...listeners}
+      />
+      <StyledCompactSelect
+        data-test-id="editor-column"
+        options={tags}
+        value={column.column ?? ''}
+        onChange={handleColumnChange}
+        searchable
+      />
+      <Button
+        aria-label={t('Remove Column')}
+        borderless
+        disabled={!canDelete}
+        size="sm"
+        icon={<IconDelete size="sm" />}
+        onClick={() => onColumnDelete()}
+      />
+    </RowContainer>
+  );
+}
+
+const RowContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+`;
+
+const StyledCompactSelect = styled(CompactSelect)`
+  flex-grow: 1;
+`;

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -1,9 +1,16 @@
-import {Fragment, useState} from 'react';
+import {Fragment, useCallback, useState} from 'react';
+import styled from '@emotion/styled';
 
+import {openModal} from 'sentry/actionCreators/modal';
+import {Button} from 'sentry/components/button';
 import {TabList, Tabs} from 'sentry/components/tabs';
+import {IconTable} from 'sentry/icons/iconTable';
 import {t} from 'sentry/locale';
 import {useResultMode} from 'sentry/views/explore/hooks/useResultsMode';
+import {useSampleFields} from 'sentry/views/explore/hooks/useSampleFields';
+import {useSpanFieldSupportedTags} from 'sentry/views/performance/utils/useSpanFieldSupportedTags';
 
+import {ColumnEditorModal} from './columnEditorModal';
 import {SpansTable} from './spansTable';
 import {TracesTable} from './tracesTable';
 
@@ -32,16 +39,50 @@ function ExploreAggregateTable() {
 function ExploreSamplesTable() {
   const [tab, setTab] = useState(Tab.SPAN);
 
+  const [fields, setFields] = useSampleFields();
+  // TODO: This should be loaded from context to avoid loading tags twice.
+  const tags = useSpanFieldSupportedTags();
+
+  const openColumnEditor = useCallback(() => {
+    openModal(
+      modalProps => (
+        <ColumnEditorModal
+          {...modalProps}
+          columns={fields}
+          onColumnsChange={setFields}
+          tags={tags}
+        />
+      ),
+      {closeEvents: 'escape-key'}
+    );
+  }, [fields, setFields, tags]);
+
   return (
     <Fragment>
-      <Tabs value={tab} onChange={setTab}>
-        <TabList hideBorder>
-          <TabList.Item key={Tab.SPAN}>{t('Span Samples')}</TabList.Item>
-          <TabList.Item key={Tab.TRACE}>{t('Trace Samples')}</TabList.Item>
-        </TabList>
-      </Tabs>
+      <SamplesTableHeader>
+        <Tabs value={tab} onChange={setTab}>
+          <TabList hideBorder>
+            <TabList.Item key={Tab.SPAN}>{t('Span Samples')}</TabList.Item>
+            <TabList.Item key={Tab.TRACE}>{t('Trace Samples')}</TabList.Item>
+          </TabList>
+        </Tabs>
+        <Button
+          size="sm"
+          disabled={tab !== Tab.SPAN}
+          onClick={openColumnEditor}
+          icon={<IconTable />}
+        >
+          {t('Columns')}
+        </Button>
+      </SamplesTableHeader>
       {tab === Tab.SPAN && <SpansTable />}
       {tab === Tab.TRACE && <TracesTable />}
     </Fragment>
   );
 }
+
+const SamplesTableHeader = styled('div')`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`;

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -1,6 +1,6 @@
 import {createMemoryHistory, Route, Router, RouterContext} from 'react-router';
 
-import {fireEvent, render, screen, within} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import {useResultMode} from 'sentry/views/explore/hooks/useResultsMode';
 import {useSampleFields} from 'sentry/views/explore/hooks/useSampleFields';
@@ -33,7 +33,7 @@ describe('ExploreToolbar', function () {
     jest.spyOn(console, 'error').mockImplementation();
   });
 
-  it('allows changing results mode', function () {
+  it('allows changing results mode', async function () {
     let resultMode;
 
     function Component() {
@@ -51,12 +51,12 @@ describe('ExploreToolbar', function () {
     expect(aggregates).not.toBeChecked();
     expect(resultMode).toEqual('samples');
 
-    fireEvent.click(aggregates);
+    await userEvent.click(aggregates);
     expect(samples).not.toBeChecked();
     expect(aggregates).toBeChecked();
     expect(resultMode).toEqual('aggregate');
 
-    fireEvent.click(samples);
+    await userEvent.click(samples);
     expect(samples).toBeChecked();
     expect(aggregates).not.toBeChecked();
     expect(resultMode).toEqual('samples');
@@ -90,7 +90,7 @@ describe('ExploreToolbar', function () {
       'span.duration',
       'timestamp',
     ];
-    fireEvent.click(within(section).getByRole('button', {name: 'timestamp'}));
+    await userEvent.click(within(section).getByRole('button', {name: 'timestamp'}));
     const fieldOptions = await within(section).findAllByRole('option');
     expect(fieldOptions).toHaveLength(fields.length);
     fieldOptions.forEach((option, i) => {
@@ -98,20 +98,20 @@ describe('ExploreToolbar', function () {
     });
 
     // try changing the field
-    fireEvent.click(within(section).getByRole('option', {name: 'span.op'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'span.op'}));
     expect(within(section).getByRole('button', {name: 'span.op'})).toBeInTheDocument();
     expect(within(section).getByRole('button', {name: 'Descending'})).toBeInTheDocument();
     expect(sorts).toEqual([{field: 'span.op', kind: 'desc'}]);
 
     // check the kind options
-    fireEvent.click(within(section).getByRole('button', {name: 'Descending'}));
+    await userEvent.click(within(section).getByRole('button', {name: 'Descending'}));
     const kindOptions = await within(section).findAllByRole('option');
     expect(kindOptions).toHaveLength(2);
     expect(kindOptions[0]).toHaveTextContent('Descending');
     expect(kindOptions[1]).toHaveTextContent('Ascending');
 
     // try changing the kind
-    fireEvent.click(within(section).getByRole('option', {name: 'Ascending'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'Ascending'}));
     expect(within(section).getByRole('button', {name: 'span.op'})).toBeInTheDocument();
     expect(within(section).getByRole('button', {name: 'Ascending'})).toBeInTheDocument();
     expect(sorts).toEqual([{field: 'span.op', kind: 'asc'}]);

--- a/static/app/views/traces/content.tsx
+++ b/static/app/views/traces/content.tsx
@@ -39,7 +39,7 @@ const DEFAULT_PER_PAGE = 50;
 export default function Wrapper(props) {
   const organization = useOrganization();
 
-  if (false && organization.features.includes('visibility-explore-view')) {
+  if (organization.features.includes('visibility-explore-view')) {
     return <ExploreContent {...props} />;
   }
 

--- a/static/app/views/traces/tracesTable.tsx
+++ b/static/app/views/traces/tracesTable.tsx
@@ -7,6 +7,7 @@ import EmptyStateWarning, {EmptyStreamWrapper} from 'sentry/components/emptyStat
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import PerformanceDuration from 'sentry/components/performanceDuration';
+import {SPAN_PROPS_DOCS_URL} from 'sentry/constants';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {IconWarning} from 'sentry/icons/iconWarning';
 import {t, tct} from 'sentry/locale';
@@ -40,9 +41,6 @@ import {
   WrappingText,
 } from './styles';
 import {areQueriesEmpty} from './utils';
-
-const SPAN_PROPS_DOCS_URL =
-  'https://docs.sentry.io/concepts/search/searchable-properties/spans/';
 
 interface TracesTableProps {
   isEmpty: boolean;


### PR DESCRIPTION
This adds a basic column editor to explore that allows for adding/removing/changing/reordering of columns.