### PR TITLE
chore(similarity): Remove unused default project option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2699,11 +2699,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "similarity.new_project_seer_grouping.enabled",
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "similarity.backfill_use_reranking",
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/76337 removes the use of this option 
https://github.com/getsentry/sentry-options-automator/pull/2150 removes setting it
Remove setting the default option in sentry