### PR TITLE
fix: sanitize org auth token name

### DIFF
--- a/src/sentry/templates/sentry/emails/org-auth-token-created.html
+++ b/src/sentry/templates/sentry/emails/org-auth-token-created.html
@@ -6,7 +6,7 @@
 
 {% block main %}
   <h3>Security Notice</h3>
-  <p>User {{ actor.email }} has created a new Organization Auth Token "{{ token_name }}" for your Sentry organization {{ organization.name|sanitize_periods }}.</p>
+  <p>User {{ actor.email }} has created a new Organization Auth Token "{{ token_name|sanitize_periods }}" for your Sentry organization {{ organization.name|sanitize_periods }}.</p>
   <table>
     <tr>
       <td style="width:36px;vertical-align:top;padding-right:15px;">


### PR DESCRIPTION
Attempt to prevent mail clients from auto-linking organization auth token names that look or contain a domain name by inserting the word _joiner_ unicode character before each period.