### PR TITLE
feat(explore): Add internal dataset selection to test eap spans

### DIFF
--- a/static/app/utils/discover/types.tsx
+++ b/static/app/utils/discover/types.tsx
@@ -19,6 +19,7 @@ export enum DiscoverDatasets {
   METRICS = 'metrics',
   METRICS_ENHANCED = 'metricsEnhanced',
   ISSUE_PLATFORM = 'issuePlatform',
+  SPANS_EAP = 'spans',
   SPANS_INDEXED = 'spansIndexed',
   SPANS_METRICS = 'spansMetrics',
   TRANSACTIONS = 'transactions',

--- a/static/app/views/explore/content.tsx
+++ b/static/app/views/explore/content.tsx
@@ -29,6 +29,10 @@ export function ExploreContent({}: ExploreContentProps) {
 
   const [userQuery, setUserQuery] = useUserQuery();
 
+  const toolbarExtras = organization.features.includes('visibility-explore-dataset')
+    ? ['dataset toggle' as const]
+    : [];
+
   return (
     <SentryDocumentTitle title={t('Explore')} orgSlug={organization.slug}>
       <PageFiltersContainer>
@@ -53,7 +57,7 @@ export function ExploreContent({}: ExploreContentProps) {
           </Layout.Header>
           <Body>
             <Side>
-              <ExploreToolbar />
+              <ExploreToolbar extras={toolbarExtras} />
             </Side>
             <Main fullWidth>
               <ExploreCharts />

--- a/static/app/views/explore/hooks/useDataset.tsx
+++ b/static/app/views/explore/hooks/useDataset.tsx
@@ -1,0 +1,48 @@
+import {useCallback, useMemo} from 'react';
+import type {Location} from 'history';
+
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+
+interface Options {
+  location: Location;
+  navigate: ReturnType<typeof useNavigate>;
+}
+
+export function useDataset(): [DiscoverDatasets, (dataset: DiscoverDatasets) => void] {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const options = {location, navigate};
+
+  return useDatasetImpl(options);
+}
+
+function useDatasetImpl({
+  location,
+  navigate,
+}: Options): [DiscoverDatasets, (dataset: DiscoverDatasets) => void] {
+  const dataset: DiscoverDatasets = useMemo(() => {
+    const rawDataset = decodeScalar(location.query.dataset);
+    if (rawDataset === 'spans') {
+      return DiscoverDatasets.SPANS_EAP;
+    }
+    return DiscoverDatasets.SPANS_INDEXED;
+  }, [location.query.dataset]);
+
+  const setDataset = useCallback(
+    (newDataset: DiscoverDatasets) => {
+      navigate({
+        ...location,
+        query: {
+          ...location.query,
+          dataset: newDataset,
+        },
+      });
+    },
+    [location, navigate]
+  );
+
+  return [dataset, setDataset];
+}

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -2,8 +2,8 @@ import {useMemo} from 'react';
 
 import type {NewQuery} from 'sentry/types/organization';
 import EventView from 'sentry/utils/discover/eventView';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {useDataset} from 'sentry/views/explore/hooks/useDataset';
 import {useSampleFields} from 'sentry/views/explore/hooks/useSampleFields';
 import {useSorts} from 'sentry/views/explore/hooks/useSorts';
 import {useUserQuery} from 'sentry/views/explore/hooks/useUserQuery';
@@ -14,6 +14,7 @@ interface SpansTableProps {}
 export function SpansTable({}: SpansTableProps) {
   const {selection} = usePageFilters();
 
+  const [dataset] = useDataset();
   const [fields] = useSampleFields();
   const [sorts] = useSorts({fields});
   const [query] = useUserQuery();
@@ -26,11 +27,11 @@ export function SpansTable({}: SpansTableProps) {
       orderby: sorts.map(sort => `${sort.kind === 'desc' ? '-' : ''}${sort.field}`),
       query,
       version: 2,
-      dataset: DiscoverDatasets.SPANS_INDEXED,
+      dataset,
     };
 
     return EventView.fromNewQueryWithPageFilters(discoverQuery, selection);
-  }, [fields, sorts, query, selection]);
+  }, [dataset, fields, sorts, query, selection]);
 
   const result = useSpansQuery({
     eventView,

--- a/static/app/views/explore/toolbar/index.tsx
+++ b/static/app/views/explore/toolbar/index.tsx
@@ -1,22 +1,31 @@
+import {useDataset} from 'sentry/views/explore/hooks/useDataset';
 import {useResultMode} from 'sentry/views/explore/hooks/useResultsMode';
 import {useSampleFields} from 'sentry/views/explore/hooks/useSampleFields';
 import {useSorts} from 'sentry/views/explore/hooks/useSorts';
+import {ToolbarDataset} from 'sentry/views/explore/toolbar/toolbarDataset';
+import {ToolbarGroupBy} from 'sentry/views/explore/toolbar/toolbarGroupBy';
+import {ToolbarLimitTo} from 'sentry/views/explore/toolbar/toolbarLimitTo';
+import {ToolbarResults} from 'sentry/views/explore/toolbar/toolbarResults';
+import {ToolbarSortBy} from 'sentry/views/explore/toolbar/toolbarSortBy';
+import {ToolbarVisualize} from 'sentry/views/explore/toolbar/toolbarVisualize';
 
-import {ToolbarGroupBy} from './toolbarGroupBy';
-import {ToolbarLimitTo} from './toolbarLimitTo';
-import {ToolbarResults} from './toolbarResults';
-import {ToolbarSortBy} from './toolbarSortBy';
-import {ToolbarVisualize} from './toolbarVisualize';
+type Extras = 'dataset toggle';
 
-interface ExploreToolbarProps {}
+interface ExploreToolbarProps {
+  extras?: Extras[];
+}
 
-export function ExploreToolbar({}: ExploreToolbarProps) {
+export function ExploreToolbar({extras}: ExploreToolbarProps) {
+  const [dataset, setDataset] = useDataset();
   const [resultMode, setResultMode] = useResultMode();
   const [sampleFields] = useSampleFields();
   const [sorts, setSorts] = useSorts({fields: sampleFields});
 
   return (
     <div>
+      {extras?.includes('dataset toggle') && (
+        <ToolbarDataset dataset={dataset} setDataset={setDataset} />
+      )}
       <ToolbarResults resultMode={resultMode} setResultMode={setResultMode} />
       <ToolbarVisualize />
       <ToolbarSortBy fields={sampleFields} sorts={sorts} setSorts={setSorts} />

--- a/static/app/views/explore/toolbar/toolbarDataset.tsx
+++ b/static/app/views/explore/toolbar/toolbarDataset.tsx
@@ -1,0 +1,26 @@
+import {SegmentedControl} from 'sentry/components/segmentedControl';
+import {t} from 'sentry/locale';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+
+import {ToolbarHeading, ToolbarSection} from './styles';
+
+interface ToolbarDatasetProps {
+  dataset: DiscoverDatasets;
+  setDataset: (newExploreDataset: DiscoverDatasets) => void;
+}
+
+export function ToolbarDataset({dataset, setDataset}: ToolbarDatasetProps) {
+  return (
+    <ToolbarSection data-test-id="section-dataset">
+      <ToolbarHeading>{t('Dataset')}</ToolbarHeading>
+      <SegmentedControl aria-label={t('Dataset')} value={dataset} onChange={setDataset}>
+        <SegmentedControl.Item key={DiscoverDatasets.SPANS_INDEXED}>
+          {t('Indexed Spans')}
+        </SegmentedControl.Item>
+        <SegmentedControl.Item key={DiscoverDatasets.SPANS_EAP}>
+          {t('EAP Spans')}
+        </SegmentedControl.Item>
+      </SegmentedControl>
+    </ToolbarSection>
+  );
+}


### PR DESCRIPTION
For internal testing, have a toggle to choose between the 2 possible spans tables.
