### PR TITLE
chore(pagerduty): Remove 404 of Pagerduty Installation Not Found

### DIFF
--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -15,6 +15,7 @@ from sentry.integrations.services.integration.model import RpcOrganizationIntegr
 from sentry.shared_integrations.client.proxy import infer_org_integration
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import control_silo_function
+from sentry.utils import metrics
 
 logger = logging.getLogger("sentry.integrations.pagerduty")
 
@@ -193,7 +194,10 @@ def send_incident_alert_notification(
                 "target_identifier": action.target_identifier,
             },
         )
-        raise Http404
+        metrics.incr(
+            "pagerduty.metric_alert_rule.integration_removed_after_rule_creation", sample_rate=1.0
+        )
+        return False
 
     attachment = build_incident_attachment(
         incident, client.integration_key, new_status, metric_value, notification_uuid


### PR DESCRIPTION
Addresses [SENTRY-3BK0](https://sentry.sentry.io/issues/5573821542/) 
When this 404 occurs, it means an org deleted the Pagerduty Installation, but still has a metric alert set up for it.

We have been thinking about ways to deal with this, so lets start by collecting metrics on how often this happens, as well as not raising an unhandled error. Returning False will let the handler know we did not send the notification.