### PR TITLE
chore(slack): Removed Expire Url Error Check

### DIFF
--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -36,7 +36,7 @@ class SlackNotifyBasicMixin(NotifyBasicMixin):
             metrics.incr(SLACK_NOTIFY_MIXIN_FAILURE_DATADOG_METRIC, sample_rate=1.0)
 
             # TODO: remove this
-            if unpack_slack_api_error(e) not in (CHANNEL_NOT_FOUND):
+            if unpack_slack_api_error(e) != CHANNEL_NOT_FOUND:
                 logger.exception(
                     "slack.slash-response.error",
                     extra={"error": str(e)},

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -14,11 +14,7 @@ from sentry.integrations.slack.metrics import (
     SLACK_NOTIFY_MIXIN_SUCCESS_DATADOG_METRIC,
 )
 from sentry.integrations.slack.service import SlackService
-from sentry.integrations.slack.utils.errors import (
-    CHANNEL_NOT_FOUND,
-    EXPIRED_URL,
-    unpack_slack_api_error,
-)
+from sentry.integrations.slack.utils.errors import CHANNEL_NOT_FOUND, unpack_slack_api_error
 from sentry.integrations.types import ExternalProviders
 from sentry.notifications.notifications.base import BaseNotification
 from sentry.notifications.notify import register_notification_provider
@@ -40,7 +36,7 @@ class SlackNotifyBasicMixin(NotifyBasicMixin):
             metrics.incr(SLACK_NOTIFY_MIXIN_FAILURE_DATADOG_METRIC, sample_rate=1.0)
 
             # TODO: remove this
-            if unpack_slack_api_error(e) not in (EXPIRED_URL, CHANNEL_NOT_FOUND):
+            if unpack_slack_api_error(e) not in (CHANNEL_NOT_FOUND):
                 logger.exception(
                     "slack.slash-response.error",
                     extra={"error": str(e)},

--- a/src/sentry/integrations/slack/utils/errors.py
+++ b/src/sentry/integrations/slack/utils/errors.py
@@ -42,5 +42,5 @@ def unpack_slack_api_error(exc: SlackApiError | SlackRequestError) -> SlackSdkEr
 
     # Indicate that a new value needs to be added to SLACK_SDK_ERROR_CATEGORIES
     _logger.warning("unrecognized_slack_api_message", extra={"slack_api_message": dump})
-    capture_message("Unrecognized Slack API message. Api Message: %s", dump, level="warning")
+    capture_message("Unrecognized Slack API message. Api Message: %s" % dump, level="warning")
     return None

--- a/src/sentry/integrations/slack/utils/errors.py
+++ b/src/sentry/integrations/slack/utils/errors.py
@@ -1,9 +1,8 @@
 import logging
 from dataclasses import dataclass
 
+from sentry_sdk import capture_message
 from slack_sdk.errors import SlackApiError, SlackRequestError
-
-from sentry.utils import metrics
 
 _logger = logging.getLogger(__name__)
 
@@ -11,13 +10,11 @@ _logger = logging.getLogger(__name__)
 @dataclass(frozen=True, eq=True)
 class SlackSdkErrorCategory:
     message: str
-    check_body: bool = False
 
 
 SLACK_SDK_ERROR_CATEGORIES = (
     RATE_LIMITED := SlackSdkErrorCategory("ratelimited"),
     CHANNEL_NOT_FOUND := SlackSdkErrorCategory("channel_not_found"),
-    EXPIRED_URL := SlackSdkErrorCategory("Expired url", check_body=True),
 )
 
 _CATEGORIES_BY_MESSAGE = {c.message: c for c in SLACK_SDK_ERROR_CATEGORIES}
@@ -26,10 +23,9 @@ _CATEGORIES_BY_MESSAGE = {c.message: c for c in SLACK_SDK_ERROR_CATEGORIES}
 def unpack_slack_api_error(exc: SlackApiError | SlackRequestError) -> SlackSdkErrorCategory | None:
     """Retrieve the Slack API error category from an exception object.
 
-    Check three places in priority order:
+    Check two places in priority order:
     1. the error field of the server response;
-    2. the first line of the message body; and,
-    3. for categories with the `check_body` flag, the rest of the message.
+    2. the first line of the message body
     """
 
     if isinstance(exc, SlackApiError):
@@ -44,15 +40,7 @@ def unpack_slack_api_error(exc: SlackApiError | SlackRequestError) -> SlackSdkEr
     if category:
         return category
 
-    for category in SLACK_SDK_ERROR_CATEGORIES:
-        if category.check_body and category.message in dump:
-            metrics.incr(
-                "sentry.integrations.slack.errors.expired_url",
-                sample_rate=1.0,
-            )
-            _logger.warning("slack_api_error.expired_url", extra={"slack_api_error": dump})
-            return category
-
     # Indicate that a new value needs to be added to SLACK_SDK_ERROR_CATEGORIES
     _logger.warning("unrecognized_slack_api_message", extra={"slack_api_message": dump})
+    capture_message("Unrecognized Slack API message. Api Message: %s", dump, level="warning")
     return None

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -21,7 +21,9 @@ from sentry.integrations.repository.metric_alert import (
     NewMetricAlertNotificationMessage,
 )
 from sentry.integrations.services.integration import integration_service
-from sentry.integrations.slack.message_builder.incidents import SlackIncidentsMessageBuilder
+from sentry.integrations.slack.message_builder.incidents import (
+    SlackIncidentsMessageBuilder,
+)
 from sentry.integrations.slack.metrics import (
     SLACK_LINK_IDENTITY_MSG_FAILURE_DATADOG_METRIC,
     SLACK_LINK_IDENTITY_MSG_SUCCESS_DATADOG_METRIC,
@@ -29,7 +31,6 @@ from sentry.integrations.slack.metrics import (
     SLACK_METRIC_ALERT_SUCCESS_DATADOG_METRIC,
 )
 from sentry.integrations.slack.sdk_client import SlackSdkClient
-from sentry.integrations.slack.utils.errors import EXPIRED_URL, unpack_slack_api_error
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.utils import metrics
 
@@ -194,13 +195,12 @@ def respond_to_slack_command(
                 tags={"type": "webhook", "command": command_response.command},
             )
         except (SlackApiError, SlackRequestError) as e:
-            if unpack_slack_api_error(e) != EXPIRED_URL:
-                metrics.incr(
-                    SLACK_LINK_IDENTITY_MSG_FAILURE_DATADOG_METRIC,
-                    sample_rate=1.0,
-                    tags={"type": "webhook", "command": command_response.command},
-                )
-                _logger.exception(log_msg("error"), extra={"error": str(e)})
+            metrics.incr(
+                SLACK_LINK_IDENTITY_MSG_FAILURE_DATADOG_METRIC,
+                sample_rate=1.0,
+                tags={"type": "webhook", "command": command_response.command},
+            )
+            _logger.exception(log_msg("error"), extra={"error": str(e)})
     else:
         _logger.info(log_msg("respond-ephemeral"))
         try:
@@ -217,10 +217,9 @@ def respond_to_slack_command(
                 tags={"type": "ephemeral", "command": command_response.command},
             )
         except SlackApiError as e:
-            if unpack_slack_api_error(e) != EXPIRED_URL:
-                metrics.incr(
-                    SLACK_LINK_IDENTITY_MSG_FAILURE_DATADOG_METRIC,
-                    sample_rate=1.0,
-                    tags={"type": "ephemeral", "command": command_response.command},
-                )
-                _logger.exception(log_msg("error"), extra={"error": str(e)})
+            metrics.incr(
+                SLACK_LINK_IDENTITY_MSG_FAILURE_DATADOG_METRIC,
+                sample_rate=1.0,
+                tags={"type": "ephemeral", "command": command_response.command},
+            )
+            _logger.exception(log_msg("error"), extra={"error": str(e)})

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -21,9 +21,7 @@ from sentry.integrations.repository.metric_alert import (
     NewMetricAlertNotificationMessage,
 )
 from sentry.integrations.services.integration import integration_service
-from sentry.integrations.slack.message_builder.incidents import (
-    SlackIncidentsMessageBuilder,
-)
+from sentry.integrations.slack.message_builder.incidents import SlackIncidentsMessageBuilder
 from sentry.integrations.slack.metrics import (
     SLACK_LINK_IDENTITY_MSG_FAILURE_DATADOG_METRIC,
     SLACK_LINK_IDENTITY_MSG_SUCCESS_DATADOG_METRIC,

--- a/tests/sentry/integrations/slack/test_link_identity.py
+++ b/tests/sentry/integrations/slack/test_link_identity.py
@@ -141,27 +141,6 @@ class SlackIntegrationLinkIdentityTest(SlackIntegrationLinkIdentityTestBase):
         assert mock_logger.exception.call_count == 1
         assert mock_logger.exception.call_args.args == ("slack.link-identity.error",)
 
-    @patch("sentry.integrations.slack.utils.notifications._logger")
-    def test_basic_flow_with_web_client_expired_url(self, mock_logger):
-        self.mock_post.side_effect = SlackApiError(
-            "", response={"ok": False, "error": "Expired url"}
-        )
-
-        linking_url = build_linking_url(self.integration, self.external_id, self.channel_id, "")
-
-        # Load page.
-        response = self.client.get(linking_url)
-        assert response.status_code == 200
-        self.assertTemplateUsed(response, "sentry/auth-link-identity.html")
-
-        # Link identity of user
-        self.client.post(linking_url)
-
-        identity = Identity.objects.filter(external_id="new-slack-id", user=self.user)
-
-        assert len(identity) == 1
-        assert mock_logger.exception.call_count == 0
-
     def test_overwrites_existing_identities_with_sdk(self):
         external_id_2 = "slack-id2"
 


### PR DESCRIPTION
metric to capture the expired url error has existed for two weeks, but we have never hit that error. here, i am cleaning up the error util and some of the exception capturing since we don't need to worry about it.

also decided to try out the `capture_message` from our sdk to notify us via a sentry issue if there is a new slack error that we haven't handled.