### PR TITLE
chore(insights): Rename `SQL Command` label to generic `Command`

### DIFF
--- a/static/app/views/insights/common/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/actionSelector.tsx
@@ -98,7 +98,7 @@ const HTTP_ACTION_OPTIONS = [
 
 const LABEL_FOR_MODULE_NAME: {[key in ModuleName]: ReactNode} = {
   http: t('HTTP Method'),
-  db: t('SQL Command'),
+  db: t('Command'),
   cache: t('Action'),
   vital: t('Action'),
   queue: t('Action'),


### PR DESCRIPTION
Renames the label in the Queries module for the DB command selector to something more generic, since we will be supporting more than just SQL.

![image](https://github.com/user-attachments/assets/ae991643-196a-49a0-a39f-33bee890d6cd)
