### PR TITLE
fix(custom-views): Custom views bug fixes

### DIFF
--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -136,7 +136,7 @@ function BaseDraggableTabList({
               {t('Add View')}
             </AddViewButton>
           </MotionWrapper>
-          <TabDivider layout active />
+          <TabDivider layout isVisible />
           <MotionWrapper layout>
             {tempTab && (
               <Tab

--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -71,7 +71,7 @@ function BaseDraggableTabList({
   useEffect(() => {
     setTabListState(state);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state.selectedItem, state.selectedKey, props.children]);
+  }, [state.selectedKey]);
 
   // Detect tabs that overflow from the wrapper and put them in an overflow menu
   const tabItemsRef = useRef<Record<string | number, HTMLLIElement | null>>({});

--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -120,7 +120,7 @@ function BaseDraggableTabList({
               </Reorder.Item>
               <TabDivider
                 layout
-                active={
+                isVisible={
                   state.selectedKey === 'temporary-tab' ||
                   (state.selectedKey !== item.key &&
                     state.collection.getKeyAfter(item.key) !== state.selectedKey)
@@ -206,9 +206,9 @@ export function DraggableTabList({items, onAddView, ...props}: DraggableTabListP
 
 DraggableTabList.Item = Item;
 
-const TabDivider = styled(motion.div)<{active: boolean}>`
+const TabDivider = styled(motion.div)<{isVisible: boolean}>`
   ${p =>
-    p.active &&
+    p.isVisible &&
     `
     background-color: ${p.theme.gray200};
     height: 50%;

--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -206,6 +206,10 @@ export function DraggableTabList({items, onAddView, ...props}: DraggableTabListP
 
 DraggableTabList.Item = Item;
 
+/**
+ * TabDividers are only visible around NON-selected tabs. They are not visible around the selected tab,
+ * but they still create some space and act as a gap between tabs.
+ */
 const TabDivider = styled(motion.div)<{isVisible: boolean}>`
   ${p =>
     p.isVisible &&

--- a/static/app/components/tabs/tab.tsx
+++ b/static/app/components/tabs/tab.tsx
@@ -101,7 +101,7 @@ export const BaseTab = forwardRef(
           ref={ref}
         >
           <VariantStyledInteractionStateLayer hasSelectedBackground={false} />
-          <VariantFocusLayer />
+          <FilledFocusLayer />
           {props.children}
         </FilledTabWrap>
       );
@@ -363,6 +363,26 @@ const FocusLayer = styled('div')<{orientation: Orientation}>`
     box-shadow:
       ${p => p.theme.focusBorder} 0 0 0 1px,
       inset ${p => p.theme.focusBorder} 0 0 0 1px;
+  }
+`;
+
+const FilledFocusLayer = styled('div')`
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+
+  pointer-events: none;
+  border-radius: inherit;
+  z-index: 0;
+  transition: border 0.1s ease-out;
+  transition: border 0.1s ease-in;
+
+  li:focus-visible & {
+    border-top: 2px solid ${p => p.theme.focusBorder};
+    border-left: 2px solid ${p => p.theme.focusBorder};
+    border-right: 2px solid ${p => p.theme.focusBorder};
   }
 `;
 

--- a/static/app/views/issueList/customViewsHeader.tsx
+++ b/static/app/views/issueList/customViewsHeader.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useState} from 'react';
+import {useContext, useEffect, useMemo, useState} from 'react';
 import type {InjectedRouter} from 'react-router';
 import styled from '@emotion/styled';
 import {debounce} from 'lodash';
@@ -6,6 +6,7 @@ import {debounce} from 'lodash';
 import GlobalEventProcessingAlert from 'sentry/components/globalEventProcessingAlert';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
+import {Tabs, TabsContext} from 'sentry/components/tabs';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
@@ -32,7 +33,6 @@ type CustomViewsIssueListHeaderTabsContentProps = {
   organization: Organization;
   queryCounts: QueryCounts;
   router: InjectedRouter;
-  setHeaderBorderStyle: (style: 'dashed' | 'solid') => void;
   views: UpdateGroupSearchViewPayload[];
 };
 
@@ -49,12 +49,13 @@ function CustomViewsIssueListHeader({
     orgSlug: props.organization.slug,
   });
 
-  const [headerBorderStyle, setHeaderBorderStyle] = useState<'dashed' | 'solid'>('solid');
-
   return (
     <Layout.Header
       noActionWrap
-      borderStyle={groupSearchViews ? headerBorderStyle : 'solid'}
+      // No viewId in the URL query means that a temp view is selected, which has a dashed border
+      borderStyle={
+        groupSearchViews && !props.router?.location.query.viewId ? 'dashed' : 'solid'
+      }
     >
       <Layout.HeaderContent>
         <Layout.Title>
@@ -70,11 +71,9 @@ function CustomViewsIssueListHeader({
       <Layout.HeaderActions />
       <StyledGlobalEventProcessingAlert projects={selectedProjects} />
       {groupSearchViews ? (
-        <CustomViewsIssueListHeaderTabsContent
-          {...props}
-          setHeaderBorderStyle={setHeaderBorderStyle}
-          views={groupSearchViews}
-        />
+        <Tabs>
+          <CustomViewsIssueListHeaderTabsContent {...props} views={groupSearchViews} />
+        </Tabs>
       ) : (
         <div style={{height: 33}} />
       )}
@@ -87,13 +86,13 @@ function CustomViewsIssueListHeaderTabsContent({
   queryCounts,
   router,
   views,
-  setHeaderBorderStyle,
 }: CustomViewsIssueListHeaderTabsContentProps) {
   // Remove cursor and page when switching tabs
   const navigate = useNavigate();
 
   // TODO: Replace this with useLocation
   const {cursor: _cursor, page: _page, ...queryParams} = router?.location.query;
+  const {query, sort, viewId} = queryParams;
 
   const viewsToTabs = views.map(
     ({id, name, query: viewQuery, querySort: viewQuerySort}, index): Tab => {
@@ -111,7 +110,8 @@ function CustomViewsIssueListHeaderTabsContent({
 
   const [draggableTabs, setDraggableTabs] = useState<Tab[]>(viewsToTabs);
 
-  const {query, sort, viewId} = queryParams;
+  const {tabListState} = useContext(TabsContext);
+
   const getInitialTabKey = () => {
     if (draggableTabs[0].key.startsWith('default')) {
       return draggableTabs[0].key;
@@ -128,8 +128,7 @@ function CustomViewsIssueListHeaderTabsContent({
     return draggableTabs[0].key;
   };
 
-  // TODO: infer selected tab key state from URL params
-  const [selectedTabKey, setSelectedTabKey] = useState<string>(getInitialTabKey());
+  // TODO: Try to remove this state if possible
   const [tempTab, setTempTab] = useState<Tab | undefined>(
     getInitialTabKey() === 'temporary-tab' && query
       ? {
@@ -151,7 +150,8 @@ function CustomViewsIssueListHeaderTabsContent({
           updateViews({
             orgSlug: organization.slug,
             groupSearchViews: newTabs.map(tab => ({
-              // Do not send over an ID if it's a temporary id
+              // Do not send over an ID if it's a temporary or default tab so that
+              // the backend will save these and generate permanent Ids for them
               ...(tab.id[0] !== '_' && !tab.id.startsWith('default') ? {id: tab.id} : {}),
               name: tab.label,
               query: tab.query,
@@ -163,6 +163,7 @@ function CustomViewsIssueListHeaderTabsContent({
     [organization.slug, updateViews]
   );
 
+  // This insane useEffect ensures that the correct tab is selected when the page loads and url updates
   useEffect(() => {
     // If no query, sort, or viewId is present, set the first tab as the selected tab, update query accordingly
     if (!query && !sort && !viewId) {
@@ -175,28 +176,56 @@ function CustomViewsIssueListHeaderTabsContent({
         },
         pathname: `/organizations/${organization.slug}/issues/`,
       });
+      tabListState?.setSelectedKey(draggableTabs[0].key);
       return;
     }
     // if a viewId is present, check if it exists in the existing views.
     if (viewId) {
       const selectedTab = draggableTabs.find(tab => tab.id === viewId);
-      if (
-        selectedTab &&
-        (query !== selectedTab!.query || sort !== selectedTab!.querySort)
-      ) {
+      if (selectedTab && query && sort) {
         // if a viewId exists but the query and sort are not what we expected, set them as unsaved changes
-        setDraggableTabs(
-          draggableTabs.map(tab =>
-            tab.key === selectedTab!.key
-              ? {
-                  ...tab,
-                  unsavedChanges: [query, sort],
-                }
-              : tab
-          )
-        );
-      } else if (!selectedTab) {
+        const isCurrentQuerySortDifferentFromExistingUnsavedChanges =
+          selectedTab.unsavedChanges &&
+          (selectedTab.unsavedChanges[0] !== query ||
+            selectedTab.unsavedChanges[1] !== sort);
+
+        const isCurrentQuerySortDifferentFromSelectedTabQuerySort =
+          query !== selectedTab.query || sort !== selectedTab.querySort;
+
+        if (
+          isCurrentQuerySortDifferentFromExistingUnsavedChanges ||
+          isCurrentQuerySortDifferentFromSelectedTabQuerySort
+        ) {
+          setDraggableTabs(
+            draggableTabs.map(tab =>
+              tab.key === selectedTab!.key
+                ? {
+                    ...tab,
+                    unsavedChanges: [query, sort],
+                  }
+                : tab
+            )
+          );
+        }
+        tabListState?.setSelectedKey(selectedTab.key);
+        return;
+      }
+      if (selectedTab && !query) {
+        navigate({
+          query: {
+            ...queryParams,
+            query: selectedTab.query,
+            sort: selectedTab.querySort,
+            viewId: selectedTab.id,
+          },
+          pathname: `/organizations/${organization.slug}/issues/`,
+        });
+        tabListState?.setSelectedKey(selectedTab.key);
+        return;
+      }
+      if (!selectedTab) {
         // if a viewId does not exist, remove it from the query
+        tabListState?.setSelectedKey('temporary-tab');
         navigate({
           query: {
             ...queryParams,
@@ -204,10 +233,24 @@ function CustomViewsIssueListHeaderTabsContent({
           },
           pathname: `/organizations/${organization.slug}/issues/`,
         });
+        return;
       }
+      return;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    if (query) {
+      tabListState?.setSelectedKey('temporary-tab');
+      return;
+    }
+  }, [
+    tabListState,
+    draggableTabs,
+    navigate,
+    organization.slug,
+    query,
+    queryParams,
+    sort,
+    viewId,
+  ]);
 
   // Update local tabs when new views are received from mutation request
   useEffect(() => {
@@ -239,31 +282,6 @@ function CustomViewsIssueListHeaderTabsContent({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [views]);
 
-  // Updates the tab's hasSavedChanges state
-  useEffect(() => {
-    const currentTab = draggableTabs?.find(tab => tab.key === selectedTabKey);
-    if (currentTab && (query !== currentTab.query || sort !== currentTab.querySort)) {
-      setDraggableTabs(
-        draggableTabs?.map(tab => {
-          return tab.key === selectedTabKey
-            ? {...tab, unsavedChanges: [query, sort]}
-            : tab;
-        })
-      );
-    } else if (
-      currentTab &&
-      query === currentTab.query &&
-      sort === currentTab.querySort
-    ) {
-      setDraggableTabs(
-        draggableTabs?.map(tab => {
-          return tab.key === selectedTabKey ? {...tab, unsavedChanges: undefined} : tab;
-        })
-      );
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query, sort]);
-
   // Loads query counts when they are available
   // TODO: fetch these dynamically instead of getting them from overview.tsx
   useEffect(() => {
@@ -278,18 +296,9 @@ function CustomViewsIssueListHeaderTabsContent({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [queryCounts]);
 
-  useEffect(() => {
-    if (tempTab) {
-      setHeaderBorderStyle('dashed');
-    } else {
-      setHeaderBorderStyle('solid');
-    }
-  }, [tempTab, setHeaderBorderStyle]);
-
   return (
     <DraggableTabBar
-      selectedTabKey={selectedTabKey}
-      setSelectedTabKey={setSelectedTabKey}
+      initialTabKey={getInitialTabKey()}
       tabs={draggableTabs}
       setTabs={setDraggableTabs}
       tempTab={tempTab}

--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.spec.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.spec.tsx
@@ -56,8 +56,7 @@ describe.skip('DraggableTabBar', () => {
     it('should render tabs from props', () => {
       render(
         <DraggableTabBar
-          selectedTabKey="1"
-          setSelectedTabKey={jest.fn()}
+          initialTabKey="1"
           setTempTab={jest.fn()}
           tabs={tabs}
           setTabs={jest.fn()}
@@ -79,8 +78,7 @@ describe.skip('DraggableTabBar', () => {
     it('should render the correct set of actions for changed tabs', async () => {
       render(
         <DraggableTabBar
-          selectedTabKey="1"
-          setSelectedTabKey={jest.fn()}
+          initialTabKey="1"
           setTempTab={jest.fn()}
           tabs={tabs}
           setTabs={jest.fn()}
@@ -114,8 +112,7 @@ describe.skip('DraggableTabBar', () => {
     it('should render the correct set of actions for unchanged tabs', async () => {
       render(
         <DraggableTabBar
-          selectedTabKey="1"
-          setSelectedTabKey={jest.fn()}
+          initialTabKey="1"
           setTempTab={jest.fn()}
           tabs={tabs}
           setTabs={jest.fn()}
@@ -152,8 +149,7 @@ describe.skip('DraggableTabBar', () => {
     it('should render the correct set of actions for a single tab', async () => {
       render(
         <DraggableTabBar
-          selectedTabKey="1"
-          setSelectedTabKey={jest.fn()}
+          initialTabKey="1"
           setTempTab={jest.fn()}
           tabs={[tabs[1]]}
           setTabs={jest.fn()}
@@ -180,8 +176,7 @@ describe.skip('DraggableTabBar', () => {
     it('should render the correct set of actions for temporary tabs', async () => {
       render(
         <DraggableTabBar
-          selectedTabKey="1"
-          setSelectedTabKey={jest.fn()}
+          initialTabKey="1"
           setTempTab={jest.fn()}
           tabs={tabs}
           setTabs={jest.fn()}
@@ -210,8 +205,7 @@ describe.skip('DraggableTabBar', () => {
     it('should allow renaming a tab', async () => {
       render(
         <DraggableTabBar
-          selectedTabKey="1"
-          setSelectedTabKey={jest.fn()}
+          initialTabKey="1"
           setTempTab={jest.fn()}
           tabs={tabs}
           setTabs={jest.fn()}
@@ -238,8 +232,7 @@ describe.skip('DraggableTabBar', () => {
     it('should not allow renaming a tab to empty string', async () => {
       render(
         <DraggableTabBar
-          selectedTabKey="1"
-          setSelectedTabKey={jest.fn()}
+          initialTabKey="1"
           setTempTab={jest.fn()}
           tabs={tabs}
           setTabs={jest.fn()}
@@ -266,8 +259,7 @@ describe.skip('DraggableTabBar', () => {
     it('should discard changes if esc is pressed while renaming', async () => {
       render(
         <DraggableTabBar
-          selectedTabKey="1"
-          setSelectedTabKey={jest.fn()}
+          initialTabKey="1"
           setTempTab={jest.fn()}
           tabs={tabs}
           setTabs={jest.fn()}
@@ -292,8 +284,7 @@ describe.skip('DraggableTabBar', () => {
     it('should fire the onSave callback when save changes is pressed', async () => {
       render(
         <DraggableTabBar
-          selectedTabKey="1"
-          setSelectedTabKey={jest.fn()}
+          initialTabKey="1"
           setTempTab={jest.fn()}
           tabs={tabs}
           setTabs={jest.fn()}
@@ -316,8 +307,7 @@ describe.skip('DraggableTabBar', () => {
     it('should fire the onDiscard callback when discard is pressed', async () => {
       render(
         <DraggableTabBar
-          selectedTabKey="1"
-          setSelectedTabKey={jest.fn()}
+          initialTabKey="1"
           setTempTab={jest.fn()}
           tabs={tabs}
           setTabs={jest.fn()}
@@ -340,8 +330,7 @@ describe.skip('DraggableTabBar', () => {
     it('should fire the onDelete callback when delete is pressed', async () => {
       render(
         <DraggableTabBar
-          selectedTabKey="1"
-          setSelectedTabKey={jest.fn()}
+          initialTabKey="1"
           setTempTab={jest.fn()}
           tabs={tabs}
           setTabs={jest.fn()}
@@ -362,8 +351,7 @@ describe.skip('DraggableTabBar', () => {
     it('should fire the onDuplicate callback when duplicate is pressed', async () => {
       render(
         <DraggableTabBar
-          selectedTabKey="1"
-          setSelectedTabKey={jest.fn()}
+          initialTabKey="1"
           setTempTab={jest.fn()}
           tabs={tabs}
           setTabs={jest.fn()}
@@ -386,8 +374,7 @@ describe.skip('DraggableTabBar', () => {
     it('should fire the onDiscardTempView callback when the discard button is pressed for a temp view', async () => {
       render(
         <DraggableTabBar
-          selectedTabKey="1"
-          setSelectedTabKey={jest.fn()}
+          initialTabKey="1"
           setTempTab={jest.fn()}
           tabs={tabs}
           setTabs={jest.fn()}
@@ -408,8 +395,7 @@ describe.skip('DraggableTabBar', () => {
     it('should fire the onSaveTempView callback when the discard button is pressed for a temp view', async () => {
       render(
         <DraggableTabBar
-          selectedTabKey="1"
-          setSelectedTabKey={jest.fn()}
+          initialTabKey="1"
           setTempTab={jest.fn()}
           tabs={tabs}
           setTabs={jest.fn()}
@@ -432,8 +418,7 @@ describe.skip('DraggableTabBar', () => {
     it('should fire the onAddView callback when the add view button is pressed', async () => {
       render(
         <DraggableTabBar
-          selectedTabKey="1"
-          setSelectedTabKey={jest.fn()}
+          initialTabKey="1"
           setTempTab={jest.fn()}
           tabs={tabs}
           setTabs={jest.fn()}

--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
@@ -1,6 +1,6 @@
 import 'intersection-observer'; // polyfill
 
-import {useState} from 'react';
+import {useContext, useState} from 'react';
 import type {InjectedRouter} from 'react-router';
 import styled from '@emotion/styled';
 import type {Node} from '@react-types/shared';
@@ -10,7 +10,7 @@ import {DraggableTabList} from 'sentry/components/draggableTabs/draggableTabList
 import type {DraggableTabListItemProps} from 'sentry/components/draggableTabs/item';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import QueryCount from 'sentry/components/queryCount';
-import {Tabs} from 'sentry/components/tabs';
+import {TabsContext} from 'sentry/components/tabs';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
@@ -31,10 +31,11 @@ export interface Tab {
 }
 
 export interface DraggableTabBarProps {
+  // selectedTabKey: string;
+  // setSelectedTabKey: (key: string) => void;
+  initialTabKey: string;
   orgSlug: string;
   router: InjectedRouter;
-  selectedTabKey: string;
-  setSelectedTabKey: (key: string) => void;
   setTabs: (tabs: Tab[]) => void;
   setTempTab: (tab: Tab | undefined) => void;
   tabs: Tab[];
@@ -87,8 +88,7 @@ export interface DraggableTabBarProps {
 export const generateTempViewId = () => `_${Math.random().toString().substring(2, 7)}`;
 
 export function DraggableTabBar({
-  selectedTabKey,
-  setSelectedTabKey,
+  initialTabKey,
   tabs,
   setTabs,
   tempTab,
@@ -112,6 +112,8 @@ export function DraggableTabBar({
 
   const {cursor: _cursor, page: _page, ...queryParams} = router?.location?.query ?? {};
 
+  const {tabListState} = useContext(TabsContext);
+
   const handleOnReorder = (newOrder: Node<DraggableTabListItemProps>[]) => {
     const newTabs = newOrder
       .map(node => {
@@ -124,10 +126,10 @@ export function DraggableTabBar({
   };
 
   const handleOnSaveChanges = () => {
-    const originalTab = tabs.find(tab => tab.key === selectedTabKey);
+    const originalTab = tabs.find(tab => tab.key === tabListState?.selectedKey);
     if (originalTab) {
       const newTabs = tabs.map(tab => {
-        return tab.key === selectedTabKey && tab.unsavedChanges
+        return tab.key === tabListState?.selectedKey && tab.unsavedChanges
           ? {
               ...tab,
               query: tab.unsavedChanges[0],
@@ -142,11 +144,13 @@ export function DraggableTabBar({
   };
 
   const handleOnDiscardChanges = () => {
-    const originalTab = tabs.find(tab => tab.key === selectedTabKey);
+    const originalTab = tabs.find(tab => tab.key === tabListState?.selectedKey);
     if (originalTab) {
       setTabs(
         tabs.map(tab => {
-          return tab.key === selectedTabKey ? {...tab, unsavedChanges: undefined} : tab;
+          return tab.key === tabListState?.selectedKey
+            ? {...tab, unsavedChanges: undefined}
+            : tab;
         })
       );
       navigate({
@@ -174,7 +178,7 @@ export function DraggableTabBar({
   };
 
   const handleOnDuplicate = () => {
-    const idx = tabs.findIndex(tb => tb.key === selectedTabKey);
+    const idx = tabs.findIndex(tb => tb.key === tabListState?.selectedKey);
     if (idx !== -1) {
       const tempId = generateTempViewId();
       const duplicatedTab = tabs[idx];
@@ -189,16 +193,16 @@ export function DraggableTabBar({
         ...tabs.slice(idx + 1),
       ];
       setTabs(newTabs);
-      setSelectedTabKey(tempId);
+      tabListState?.setSelectedKey(tempId);
       onDuplicate?.(newTabs);
     }
   };
 
   const handleOnDelete = () => {
     if (tabs.length > 1) {
-      const newTabs = tabs.filter(tb => tb.key !== selectedTabKey);
+      const newTabs = tabs.filter(tb => tb.key !== tabListState?.selectedKey);
       setTabs(newTabs);
-      setSelectedTabKey(newTabs[0].key);
+      tabListState?.setSelectedKey(newTabs[0].key);
       onDelete?.(newTabs);
     }
   };
@@ -215,20 +219,20 @@ export function DraggableTabBar({
       };
       const newTabs = [...tabs, newTab];
       setTabs(newTabs);
-      setSelectedTabKey(tempId);
+      tabListState?.setSelectedKey(tempId);
       onSaveTempView?.(newTabs);
     }
   };
 
   const handleOnDiscardTempView = () => {
-    setSelectedTabKey(tabs[0].key);
+    tabListState?.setSelectedKey(tabs[0].key);
     setTempTab(undefined);
     onDiscardTempView?.();
   };
 
   const handleOnAddView = () => {
     const tempId = generateTempViewId();
-    const currentTab = tabs.find(tab => tab.key === selectedTabKey);
+    const currentTab = tabs.find(tab => tab.key === tabListState?.selectedKey);
     if (currentTab) {
       const newTabs = [
         ...tabs,
@@ -252,7 +256,7 @@ export function DraggableTabBar({
         pathname: `/organizations/${orgSlug}/issues/`,
       });
       setTabs(newTabs);
-      setSelectedTabKey(tempId);
+      tabListState?.setSelectedKey(tempId);
       onAddView?.(newTabs);
     }
   };
@@ -283,57 +287,56 @@ export function DraggableTabBar({
   const allTabs = tempTab ? [...tabs, tempTab] : tabs;
 
   return (
-    <Tabs onChange={setSelectedTabKey}>
-      <DraggableTabList
-        onReorder={handleOnReorder}
-        selectedKey={selectedTabKey}
-        onAddView={handleOnAddView}
-        orientation="horizontal"
-        hideBorder
-      >
-        {allTabs.map(tab => (
-          <DraggableTabList.Item
-            textValue={`${tab.label} tab`}
-            key={tab.key}
-            to={normalizeUrl({
-              query: {
-                ...queryParams,
-                query: tab.unsavedChanges?.[0] ?? tab.query,
-                sort: tab.unsavedChanges?.[1] ?? tab.querySort,
-                ...(tab.id !== 'temporary-tab' ? {viewId: tab.id} : {}),
-              },
-              pathname: `/organizations/${orgSlug}/issues/`,
-            })}
-          >
-            <TabContentWrap selected={selectedTabKey === tab.key}>
-              <EditableTabTitle
-                label={tab.label}
-                isEditing={editingTabKey === tab.key}
-                setIsEditing={isEditing => setEditingTabKey(isEditing ? tab.key : null)}
-                onChange={newLabel => handleOnTabRenamed(newLabel.trim(), tab.key)}
-              />
-              {tab.key !== 'temporary-tab' && tab.queryCount !== undefined && (
-                <StyledBadge>
-                  <QueryCount
-                    hideParens
-                    hideIfEmpty={false}
-                    count={tab.queryCount}
-                    max={1000}
-                  />
-                </StyledBadge>
-              )}
-              {selectedTabKey === tab.key && (
-                <DraggableTabMenuButton
-                  hasUnsavedChanges={!!tab.unsavedChanges}
-                  menuOptions={makeMenuOptions(tab)}
-                  aria-label={`${tab.label} Tab Options`}
+    <DraggableTabList
+      onReorder={handleOnReorder}
+      // selectedKey={tabListState?.selectedKey}
+      defaultSelectedKey={initialTabKey}
+      onAddView={handleOnAddView}
+      orientation="horizontal"
+      hideBorder
+    >
+      {allTabs.map(tab => (
+        <DraggableTabList.Item
+          textValue={`${tab.label} tab`}
+          key={tab.key}
+          to={normalizeUrl({
+            query: {
+              ...queryParams,
+              query: tab.unsavedChanges?.[0] ?? tab.query,
+              sort: tab.unsavedChanges?.[1] ?? tab.querySort,
+              ...(tab.id !== 'temporary-tab' ? {viewId: tab.id} : {}),
+            },
+            pathname: `/organizations/${orgSlug}/issues/`,
+          })}
+        >
+          <TabContentWrap selected={tabListState?.selectedKey === tab.key}>
+            <EditableTabTitle
+              label={tab.label}
+              isEditing={editingTabKey === tab.key}
+              setIsEditing={isEditing => setEditingTabKey(isEditing ? tab.key : null)}
+              onChange={newLabel => handleOnTabRenamed(newLabel.trim(), tab.key)}
+            />
+            {tab.key !== 'temporary-tab' && tab.queryCount !== undefined && (
+              <StyledBadge>
+                <QueryCount
+                  hideParens
+                  hideIfEmpty={false}
+                  count={tab.queryCount}
+                  max={1000}
                 />
-              )}
-            </TabContentWrap>
-          </DraggableTabList.Item>
-        ))}
-      </DraggableTabList>
-    </Tabs>
+              </StyledBadge>
+            )}
+            {tabListState?.selectedKey === tab.key && (
+              <DraggableTabMenuButton
+                hasUnsavedChanges={!!tab.unsavedChanges}
+                menuOptions={makeMenuOptions(tab)}
+                aria-label={`${tab.label} Tab Options`}
+              />
+            )}
+          </TabContentWrap>
+        </DraggableTabList.Item>
+      ))}
+    </DraggableTabList>
   );
 }
 

--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
@@ -31,8 +31,6 @@ export interface Tab {
 }
 
 export interface DraggableTabBarProps {
-  // selectedTabKey: string;
-  // setSelectedTabKey: (key: string) => void;
   initialTabKey: string;
   orgSlug: string;
   router: InjectedRouter;
@@ -296,7 +294,6 @@ export function DraggableTabBar({
   return (
     <DraggableTabList
       onReorder={handleOnReorder}
-      // selectedKey={tabListState?.selectedKey}
       defaultSelectedKey={initialTabKey}
       onAddView={handleOnAddView}
       orientation="horizontal"

--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
@@ -192,6 +192,13 @@ export function DraggableTabBar({
         },
         ...tabs.slice(idx + 1),
       ];
+      navigate({
+        query: {
+          ...queryParams,
+          viewId: tempId,
+        },
+        pathname: `/organizations/${orgSlug}/issues/`,
+      });
       setTabs(newTabs);
       tabListState?.setSelectedKey(tempId);
       onDuplicate?.(newTabs);


### PR DESCRIPTION
Fixes three error that were ocurring with custom views:

1. **Custom views were not saving for new users**: This was because new users were receiving default tabs, and the backend does not attach an Id to these tabs. The frontend attached the id "default" when it was received, but then it sent the "default" id back to the backend, which the backend tried to query the database with. Solution here is to filter out the id of any tabs that have "default" as the id, similar to temp tabs. 
2. "Received 'false' for non boolean attribute active" DOMWarning: This was caused by a styled component using `active` as a prop, which is already used for something else. Solution here is to change the prop name 
3. Header border is showing up as dashed in unexpected situations: Certain actions (like clicking issues in the side bar when already in issues) will trigger a change in the url query, without any other effect. This would trigger the header border to switch to 'dashed' as if it was a temp view. Ideally we'd like to rely on the url query, but as a stop gap solution we can replace it with extra state. 