### PR TITLE
fix(discord): Verify User Bot Installation Permission

### DIFF
--- a/src/sentry/integrations/discord/client.py
+++ b/src/sentry/integrations/discord/client.py
@@ -112,10 +112,8 @@ class DiscordClient(ApiClient):
         # TODO(iamrajjoshi): Eventually, we should use `/users/@me/guilds/{guild.id}/member`
         params = {"before": str(int(guild_id) + 1), "after": str(int(guild_id) - 1), "limit": 1}
 
-        response: list[dict[str, Any]] = self.get(
-            "/users/@me/guilds", headers=headers, params=params
-        )
-        if not response:
+        response = self.get("/users/@me/guilds", headers=headers, params=params)
+        if not response or not isinstance(response, list):
             return False
 
         # We will only get one guild back, so we can just grab the first one

--- a/src/sentry/integrations/discord/integration.py
+++ b/src/sentry/integrations/discord/integration.py
@@ -120,7 +120,7 @@ class DiscordIntegrationProvider(IntegrationProvider):
 
     # https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes
     oauth_scopes = frozenset(["applications.commands", "bot", "identify"])
-    access_token = None
+    access_token = ""
 
     bot_permissions = (
         DiscordPermissions.VIEW_CHANNEL.value

--- a/src/sentry/integrations/discord/integration.py
+++ b/src/sentry/integrations/discord/integration.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from enum import Enum
 from typing import Any
 from urllib.parse import urlencode
 
@@ -17,6 +16,7 @@ from sentry.integrations.base import (
     IntegrationProvider,
 )
 from sentry.integrations.discord.client import DiscordClient
+from sentry.integrations.discord.types import DiscordPermissions
 from sentry.integrations.models.integration import Integration
 from sentry.organizations.services.organization.model import RpcOrganizationSummary
 from sentry.pipeline.views.base import PipelineView
@@ -111,19 +111,6 @@ class DiscordIntegration(IntegrationInstallation):
             return
 
 
-class DiscordPermissions(Enum):
-    # https://discord.com/developers/docs/topics/permissions#permissions
-    VIEW_CHANNEL = 1 << 10
-    SEND_MESSAGES = 1 << 11
-    SEND_TTS_MESSAGES = 1 << 12
-    EMBED_LINKS = 1 << 14
-    ATTACH_FILES = 1 << 15
-    MANAGE_THREADS = 1 << 34
-    CREATE_PUBLIC_THREADS = 1 << 35
-    CREATE_PRIVATE_THREADS = 1 << 36
-    SEND_MESSAGES_IN_THREADS = 1 << 38
-
-
 class DiscordIntegrationProvider(IntegrationProvider):
     key = "discord"
     name = "Discord"
@@ -132,7 +119,8 @@ class DiscordIntegrationProvider(IntegrationProvider):
     features = frozenset([IntegrationFeatures.CHAT_UNFURL, IntegrationFeatures.ALERT_RULE])
 
     # https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes
-    oauth_scopes = frozenset(["applications.commands", "bot", "identify"])
+    oauth_scopes = frozenset(["applications.commands", "bot", "identify", "guilds.members.read"])
+    access_token = None
 
     bot_permissions = (
         DiscordPermissions.VIEW_CHANNEL.value
@@ -175,6 +163,10 @@ class DiscordIntegrationProvider(IntegrationProvider):
         auth_code = str(state.get("code"))
         if auth_code:
             discord_user_id = self._get_discord_user_id(auth_code, url)
+            if not self.client.check_user_bot_installation_permission(
+                access_token=self.access_token, guild_id=guild_id
+            ):
+                raise IntegrationError("User does not have permissions to install bot.")
         else:
             raise IntegrationError("Missing code from state.")
 
@@ -238,13 +230,13 @@ class DiscordIntegrationProvider(IntegrationProvider):
 
         """
         try:
-            access_token = self.client.get_access_token(auth_code, url)
+            self.access_token = self.client.get_access_token(auth_code, url)
         except ApiError:
             raise IntegrationError("Failed to get Discord access token from API.")
         except KeyError:
             raise IntegrationError("Failed to get Discord access token from key.")
         try:
-            user_id = self.client.get_user_id(access_token)
+            user_id = self.client.get_user_id(self.access_token)
         except ApiError:
             raise IntegrationError("Failed to get Discord user ID from API.")
         except KeyError:

--- a/src/sentry/integrations/discord/integration.py
+++ b/src/sentry/integrations/discord/integration.py
@@ -119,7 +119,7 @@ class DiscordIntegrationProvider(IntegrationProvider):
     features = frozenset([IntegrationFeatures.CHAT_UNFURL, IntegrationFeatures.ALERT_RULE])
 
     # https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes
-    oauth_scopes = frozenset(["applications.commands", "bot", "identify", "guilds.members.read"])
+    oauth_scopes = frozenset(["applications.commands", "bot", "identify"])
     access_token = None
 
     bot_permissions = (

--- a/src/sentry/integrations/discord/types.py
+++ b/src/sentry/integrations/discord/types.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+
+class DiscordPermissions(Enum):
+    # https://discord.com/developers/docs/topics/permissions#permissions
+    VIEW_CHANNEL = 1 << 10
+    SEND_MESSAGES = 1 << 11
+    SEND_TTS_MESSAGES = 1 << 12
+    EMBED_LINKS = 1 << 14
+    ATTACH_FILES = 1 << 15
+    MANAGE_THREADS = 1 << 34
+    CREATE_PUBLIC_THREADS = 1 << 35
+    CREATE_PRIVATE_THREADS = 1 << 36
+    SEND_MESSAGES_IN_THREADS = 1 << 38
+
+    MANAGE_GUILD = 1 << 5
+    ADMINISTRATOR = 1 << 3

--- a/tests/sentry/integrations/discord/test_integration.py
+++ b/tests/sentry/integrations/discord/test_integration.py
@@ -9,6 +9,7 @@ from sentry import audit_log, options
 from sentry.api.client import ApiError
 from sentry.integrations.discord.client import APPLICATION_COMMANDS_URL, GUILD_URL, DiscordClient
 from sentry.integrations.discord.integration import COMMANDS, DiscordIntegrationProvider
+from sentry.integrations.discord.types import DiscordPermissions
 from sentry.integrations.models.integration import Integration
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.shared_integrations.exceptions import IntegrationError
@@ -70,6 +71,12 @@ class DiscordSetupTestCase(IntegrationTestCase):
             url=f"{DiscordClient.base_url}{APPLICATION_COMMANDS_URL.format(application_id=self.application_id)}",
             match=[header_matcher({"Authorization": f"Bot {self.bot_token}"})],
             json=[] if command_response_empty else COMMANDS,
+        )
+
+        responses.add(
+            responses.GET,
+            url=f"{DiscordClient.base_url}/users/@me/guilds",
+            json=[{"id": guild_id, "permissions": str(DiscordPermissions.MANAGE_GUILD.value)}],
         )
 
         if command_response_empty:
@@ -160,6 +167,13 @@ class DiscordSetupTestCase(IntegrationTestCase):
                 "access_token": "access_token",
             },
         )
+
+        responses.add(
+            responses.GET,
+            url=f"{DiscordClient.base_url}/users/@me/guilds",
+            json=[{"id": guild_id, "permissions": str(DiscordPermissions.MANAGE_GUILD.value)}],
+        )
+
         responses.add(
             responses.GET, url=f"{DiscordClient.base_url}/users/@me", json={"id": "user_1234"}
         )
@@ -237,19 +251,22 @@ class DiscordSetupIntegrationTest(DiscordSetupTestCase):
 
 
 class DiscordIntegrationTest(DiscordSetupTestCase):
+    def setUp(self):
+        super().setUp()
+        self.user_id = "user1234"
+        self.guild_id = "12345"
+        self.guild_name = "guild_name"
+
     @responses.activate
     def test_get_guild_name(self):
         provider = self.provider()
-        user_id = "user1234"
-        guild_id = "guild_id"
-        guild_name = "guild_name"
         responses.add(
             responses.GET,
-            url=f"{DiscordClient.base_url}{GUILD_URL.format(guild_id=guild_id)}",
+            url=f"{DiscordClient.base_url}{GUILD_URL.format(guild_id=self.guild_id)}",
             match=[header_matcher({"Authorization": f"Bot {self.bot_token}"})],
             json={
-                "id": guild_id,
-                "name": guild_name,
+                "id": self.guild_id,
+                "name": self.guild_name,
             },
         )
         responses.add(
@@ -262,21 +279,26 @@ class DiscordIntegrationTest(DiscordSetupTestCase):
         responses.add(
             responses.GET, url=f"{DiscordClient.base_url}/users/@me", json={"id": "user_1234"}
         )
-        result = provider.build_integration({"guild_id": "guild_id", "code": user_id})
-        assert result["name"] == guild_name
+
+        responses.add(
+            responses.GET,
+            url=f"{DiscordClient.base_url}/users/@me/guilds",
+            json=[{"id": self.guild_id, "permissions": str(DiscordPermissions.MANAGE_GUILD.value)}],
+        )
+
+        result = provider.build_integration({"guild_id": self.guild_id, "code": self.user_id})
+        assert result["name"] == self.guild_name
 
     @responses.activate
     def test_build_integration_no_code_in_state(self):
         provider = self.provider()
-        guild_id = "guild_id"
-        guild_name = "guild_name"
         responses.add(
             responses.GET,
-            url=f"{DiscordClient.base_url}{GUILD_URL.format(guild_id=guild_id)}",
+            url=f"{DiscordClient.base_url}{GUILD_URL.format(guild_id=self.guild_id)}",
             match=[header_matcher({"Authorization": f"Bot {self.bot_token}"})],
             json={
-                "id": guild_id,
-                "name": guild_name,
+                "id": self.guild_id,
+                "name": self.guild_name,
             },
         )
         with pytest.raises(IntegrationError):
@@ -285,9 +307,8 @@ class DiscordIntegrationTest(DiscordSetupTestCase):
     @responses.activate
     def test_get_guild_name_failure(self):
         provider = self.provider()
-        user_id = "user1234"
-        guild_id = "guild_id"
-        responses.add(responses.GET, "https://discord.com/api/v10/guilds/guild_name", status=500)
+
+        responses.add(responses.GET, "https://discord.com/api/v10/guilds/guild_name", status=500),
         responses.add(
             responses.POST,
             url="https://discord.com/api/v10/oauth2/token",
@@ -296,15 +317,52 @@ class DiscordIntegrationTest(DiscordSetupTestCase):
             },
         )
         responses.add(
-            responses.GET, url=f"{DiscordClient.base_url}/users/@me", json={"id": user_id}
+            responses.GET, url=f"{DiscordClient.base_url}/users/@me", json={"id": self.user_id}
         )
-        result = provider.build_integration({"guild_id": guild_id, "code": user_id})
-        assert result["name"] == guild_id
+        responses.add(
+            responses.GET,
+            url=f"{DiscordClient.base_url}/users/@me/guilds",
+            json=[{"id": self.guild_id, "permissions": str(DiscordPermissions.MANAGE_GUILD.value)}],
+        )
+
+        result = provider.build_integration({"guild_id": self.guild_id, "code": self.user_id})
+        assert result["name"] == self.guild_id
+
+    @responses.activate
+    def test_get_user_insufficient_permission(self):
+        provider = self.provider()
+
+        responses.add(
+            responses.GET,
+            url=f"{DiscordClient.base_url}{GUILD_URL.format(guild_id=self.guild_id)}",
+            match=[header_matcher({"Authorization": f"Bot {self.bot_token}"})],
+            json={
+                "id": self.guild_id,
+                "name": self.guild_name,
+            },
+        )
+        responses.add(
+            responses.POST,
+            url="https://discord.com/api/v10/oauth2/token",
+            json={
+                "access_token": "access_token",
+            },
+        )
+        responses.add(
+            responses.GET, url=f"{DiscordClient.base_url}/users/@me", json={"id": self.user_id}
+        )
+        responses.add(
+            responses.GET,
+            url=f"{DiscordClient.base_url}/users/@me/guilds",
+            json=[{"id": self.guild_id, "permissions": str(DiscordPermissions.VIEW_CHANNEL.value)}],
+        )
+
+        with pytest.raises(IntegrationError):
+            provider.build_integration({"guild_id": self.guild_id, "code": self.user_id})
 
     @responses.activate
     def test_get_discord_user_id(self):
         provider = self.provider()
-        user_id = "user1234"
 
         responses.add(
             responses.POST,
@@ -314,12 +372,12 @@ class DiscordIntegrationTest(DiscordSetupTestCase):
             },
         )
         responses.add(
-            responses.GET, url=f"{DiscordClient.base_url}/users/@me", json={"id": user_id}
+            responses.GET, url=f"{DiscordClient.base_url}/users/@me", json={"id": self.user_id}
         )
 
         result = provider._get_discord_user_id("auth_code", "1")
 
-        assert result == user_id
+        assert result == self.user_id
 
     @responses.activate
     def test_get_discord_user_id_oauth_failure(self):


### PR DESCRIPTION
Addresses https://getsentry.atlassian.net/browse/SECURITY-4486

currently, we don't verify that the guild/server the user has permissions to actually the bot, so someone can modify the request and install the bot somewhere they shouldn't be able to. 

here, i check if the user has adequate permission to actually do so. i wanted to use the [Get User Member Endpoint](https://discord.com/developers/docs/resources/user#get-current-user-guild-member), but the api doesn't provide permissions field when using the scope we are using. this has been documented https://github.com/discord/discord-api-docs/discussions/6846.

because of that, i have to use the query parameters to get the permissions 😞 .