### PR TITLE
feat(issue-summary): Show headline in header + feedback button

### DIFF
--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -4,6 +4,7 @@ import FeatureBadge from 'sentry/components/badge/featureBadge';
 import {Button} from 'sentry/components/button';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
+import Placeholder from 'sentry/components/placeholder';
 import * as SidebarSection from 'sentry/components/sidebarSection';
 import {IconMegaphone} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -51,7 +52,6 @@ function GroupSummaryFeatureBadge() {
       title={t(
         'This feature is experimental and may produce inaccurate results. Please share feedback to help us improve the experience.'
       )}
-      tooltipProps={{isHoverable: true}}
     />
   );
 }
@@ -68,7 +68,7 @@ export function GroupSummaryHeader({groupId}: GroupSummaryProps) {
 
   const renderContent = () => {
     if (isLoading) {
-      return <StyledLoadingIndicator size={16} mini />;
+      return <Placeholder height="19px" width="256px" />;
     }
 
     return <span>{data?.headline}</span>;
@@ -121,7 +121,15 @@ export function GroupSummary({groupId}: GroupSummaryProps) {
           <ButtonContainer>
             <Button
               onClick={() => {
-                openForm();
+                openForm({
+                  messagePlaceholder: t(
+                    'How can we make this issue summary more useful?'
+                  ),
+                  tags: {
+                    ['feedback.source']: 'issue_details_ai_issue_summary',
+                    ['feedback.owner']: 'ml-ai',
+                  },
+                });
               }}
               size="xs"
               icon={<IconMegaphone />}

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -1,14 +1,18 @@
 import styled from '@emotion/styled';
 
 import FeatureBadge from 'sentry/components/badge/featureBadge';
+import {Button} from 'sentry/components/button';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
 import * as SidebarSection from 'sentry/components/sidebarSection';
-import {t, tct} from 'sentry/locale';
+import {IconMegaphone} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import marked from 'sentry/utils/marked';
 import {type ApiQueryKey, useApiQuery} from 'sentry/utils/queryClient';
+import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 interface GroupSummaryProps {
   groupId: string;
@@ -18,6 +22,7 @@ interface GroupSummaryData {
   groupId: string;
   impact: string;
   summary: string;
+  headline?: string;
 }
 
 const makeGroupSummaryQueryKey = (
@@ -28,14 +33,59 @@ const makeGroupSummaryQueryKey = (
   {method: 'POST'},
 ];
 
-export function GroupSummary({groupId}: GroupSummaryProps) {
+export function useGroupSummary(groupId: string) {
   const organization = useOrganization();
-  const {data, isLoading, isError} = useApiQuery<GroupSummaryData>(
+
+  return useApiQuery<GroupSummaryData>(
     makeGroupSummaryQueryKey(organization.slug, groupId),
     {
       staleTime: Infinity, // Cache the result indefinitely as it's unlikely to change if it's already computed
     }
   );
+}
+
+function GroupSummaryFeatureBadge() {
+  return (
+    <StyledFeatureBadge
+      type="experimental"
+      title={t(
+        'This feature is experimental and may produce inaccurate results. Please share feedback to help us improve the experience.'
+      )}
+      tooltipProps={{isHoverable: true}}
+    />
+  );
+}
+
+export function GroupSummaryHeader({groupId}: GroupSummaryProps) {
+  const {data, isLoading, isError} = useGroupSummary(groupId);
+  const isStreamlined = useHasStreamlinedUI();
+
+  if (isError || (!isLoading && !data.headline)) {
+    // Don't render the summary headline if there's an error, the error is already shown in the sidebar
+    // If there is no headline we also don't want to render anything
+    return null;
+  }
+
+  const renderContent = () => {
+    if (isLoading) {
+      return <StyledLoadingIndicator size={16} mini />;
+    }
+
+    return <span>{data?.headline}</span>;
+  };
+
+  return (
+    <SummaryHeaderContainer isStreamlined={isStreamlined}>
+      {renderContent()}
+      <GroupSummaryFeatureBadge />
+    </SummaryHeaderContainer>
+  );
+}
+
+export function GroupSummary({groupId}: GroupSummaryProps) {
+  const {data, isLoading, isError} = useGroupSummary(groupId);
+
+  const openForm = useFeedbackForm();
 
   return (
     <SidebarSection.Wrap>
@@ -43,16 +93,7 @@ export function GroupSummary({groupId}: GroupSummaryProps) {
         <StyledTitleRow>
           <StyledTitle>
             <span>{t('Issue Summary')}</span>
-            <StyledFeatureBadge
-              type="internal"
-              title={tct(
-                'This feature is currently only testing internally. Please let us know your feedback at [channel:#proj-issue-summary].',
-                {
-                  channel: <a href="https://sentry.slack.com/archives/C07GPS55GUC" />,
-                }
-              )}
-              tooltipProps={{isHoverable: true}}
-            />
+            <GroupSummaryFeatureBadge />
           </StyledTitle>
           {isLoading && <StyledLoadingIndicator size={16} mini />}
         </StyledTitleRow>
@@ -76,6 +117,19 @@ export function GroupSummary({groupId}: GroupSummaryProps) {
             </Content>
           )}
         </div>
+        {openForm && !isLoading && (
+          <ButtonContainer>
+            <Button
+              onClick={() => {
+                openForm();
+              }}
+              size="xs"
+              icon={<IconMegaphone />}
+            >
+              Give Feedback
+            </Button>
+          </ButtonContainer>
+        )}
       </Wrapper>
     </SidebarSection.Wrap>
   );
@@ -113,6 +167,7 @@ const StyledFeatureBadge = styled(FeatureBadge)`
 `;
 
 const SummaryContent = styled('div')`
+  overflow-wrap: break-word;
   p {
     margin: 0;
   }
@@ -138,4 +193,16 @@ const Content = styled('div')`
   display: flex;
   flex-direction: column;
   gap: ${space(1)};
+`;
+
+const ButtonContainer = styled('div')`
+  margin-top: ${space(1.5)};
+  margin-bottom: ${space(0.5)};
+`;
+
+const SummaryHeaderContainer = styled('div')<{isStreamlined: boolean}>`
+  display: flex;
+  align-items: center;
+  margin-top: ${space(1)};
+  color: ${p => (p.isStreamlined ? p.theme.subText : p.theme.text)};
 `;

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import type {LocationDescriptor} from 'history';
 import omit from 'lodash/omit';
 
+import Feature from 'sentry/components/acl/feature';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import Badge from 'sentry/components/badge/badge';
 import FeatureBadge from 'sentry/components/badge/featureBadge';
@@ -10,6 +11,7 @@ import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import Count from 'sentry/components/count';
 import EventOrGroupTitle from 'sentry/components/eventOrGroupTitle';
 import EventMessage from 'sentry/components/events/eventMessage';
+import {GroupSummaryHeader} from 'sentry/components/group/groupSummary';
 import {GroupStatusBadge} from 'sentry/components/group/inboxBadges/statusBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import Link from 'sentry/components/links/link';
@@ -254,6 +256,9 @@ function GroupHeader({
               type={group.type}
               showUnhandled={group.isUnhandled}
             />
+            <Feature features={['organizations:ai-summary']}>
+              <GroupSummaryHeader groupId={group.id} />
+            </Feature>
           </TitleWrapper>
           <StatsWrapper>
             {issueTypeConfig.stats.enabled && (

--- a/static/app/views/issueDetails/streamline/header.tsx
+++ b/static/app/views/issueDetails/streamline/header.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
+import Feature from 'sentry/components/acl/feature';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import EventOrGroupTitle from 'sentry/components/eventOrGroupTitle';
 import EventMessage from 'sentry/components/events/eventMessage';
@@ -8,6 +9,7 @@ import {
   AssigneeSelector,
   useHandleAssigneeChange,
 } from 'sentry/components/group/assigneeSelector';
+import {GroupSummaryHeader} from 'sentry/components/group/groupSummary';
 import ParticipantList from 'sentry/components/group/streamlinedParticipantList';
 import Version from 'sentry/components/version';
 import VersionHoverCard from 'sentry/components/versionHoverCard';
@@ -147,6 +149,9 @@ export default function StreamlinedGroupHeader({
           </Fragment>
         )}
       </MessageWrapper>
+      <Feature features={['organizations:ai-summary']}>
+        <GroupSummaryHeader groupId={group.id} />
+      </Feature>
       <StyledBreak />
       <InfoWrapper
         isResolvedOrIgnored={group.status === 'resolved' || group.status === 'ignored'}


### PR DESCRIPTION
Show the new summary headline in the header

<img width="1055" alt="Screenshot 2024-08-16 at 4 05 41 PM" src="https://github.com/user-attachments/assets/1576fc98-d0e3-4a76-ae50-e9063993d1bd">

https://github.com/user-attachments/assets/a8888d75-1ae0-45e2-a0c2-757f80ffa227

<img width="351" alt="Screenshot 2024-08-16 at 4 05 49 PM" src="https://github.com/user-attachments/assets/b99c98cd-b1da-45e0-bd8a-6e159d6096c4">

