### PR TITLE
fix(ecosystem): Propagate test alert errors to the UI, behind a flag

### DIFF
--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -91,10 +91,7 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
             try:
                 callback(test_event, futures)
             except Exception as exc:
-                if hasattr(callback, "im_class"):
-                    cls = callback.im_class
-                else:
-                    cls = callback.__class__
+                cls = callback.__class__
                 callback_name = getattr(callback, "__name__", str(callback))
                 cls_name = cls.__name__
                 logger = logging.getLogger(f"sentry.test_rule.{cls_name.lower()}")

--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -1,14 +1,19 @@
+import logging
+
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.serializers.rest_framework import RuleActionSerializer
+from sentry.eventstore.models import Event
 from sentry.models.rule import Rule
 from sentry.rules.processing.processor import activate_downstream_actions
+from sentry.shared_integrations.exceptions import IntegrationFormError
 from sentry.utils.safe import safe_execute
 from sentry.utils.samples import create_sample_event
 
@@ -60,7 +65,66 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
             project, platform=project.platform, default="javascript", tagged=True
         )
 
-        for callback, futures in activate_downstream_actions(rule, test_event).values():
-            safe_execute(callback, test_event, futures)
+        if features.has(
+            "projects:verbose-test-alert-reporting", project=project, user=request.user
+        ):
+            return self.execute_future_on_test_event(test_event, rule)
+        else:
+            # Old existing behavior to wrap this in a handler which buries exceptions
+            for callback, futures in activate_downstream_actions(rule, test_event).values():
+                safe_execute(callback, test_event, futures)
+            return Response()
 
-        return Response()
+    def execute_future_on_test_event(
+        self,
+        test_event: Event | None,
+        rule: Rule,
+    ) -> Response:
+        """
+        A slightly modified version of utils.safe.safe_execute that handles
+        IntegrationFormErrors, and returns a body with `{ actions: [<error info>] }`.
+
+        This is used in our Alert Rule UI to display errors to the user.
+        """
+        action_exceptions = []
+        for callback, futures in activate_downstream_actions(rule, test_event).values():
+            try:
+                callback(test_event, futures)
+            except Exception as exc:
+                if hasattr(callback, "im_class"):
+                    cls = callback.im_class
+                else:
+                    cls = callback.__class__
+                callback_name = getattr(callback, "__name__", str(callback))
+                cls_name = cls.__name__
+                logger = logging.getLogger(f"sentry.test_rule.{cls_name.lower()}")
+
+                # safe_execute logs these as exceptions, which can result in
+                # noisy sentry issues, so log with a warning instead.
+                if isinstance(exc, IntegrationFormError):
+                    logger.warning(
+                        "%s.test_alert.integration_form_error",
+                        callback_name,
+                        extra={"exception": exc},
+                    )
+
+                    # IntegrationFormErrors should be safe to propagate via the API
+                    action_exceptions.append(str(exc))
+                else:
+                    # If we encounter some unexpected exception, we probably
+                    # don't want to continue executing more callbacks.
+                    logger.warning(
+                        "%s.test_alert.unexpected_exception",
+                        callback_name,
+                        extra={"exception": exc},
+                    )
+                    break
+
+        status = None
+        data = None
+        # Presence of "actions" here means we have exceptions to surface to the user
+        if len(action_exceptions) > 0:
+            status = 400
+            data = {"actions": action_exceptions}
+
+        return Response(status=status, data=data)

--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -10,7 +10,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.serializers.rest_framework import RuleActionSerializer
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.models.rule import Rule
 from sentry.rules.processing.processor import activate_downstream_actions
 from sentry.shared_integrations.exceptions import IntegrationError
@@ -77,7 +77,7 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
 
     def execute_future_on_test_event(
         self,
-        test_event: Event | None,
+        test_event: GroupEvent,
         rule: Rule,
     ) -> Response:
         """

--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -100,9 +100,7 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
                 # noisy sentry issues, so log with a warning instead.
                 if isinstance(exc, IntegrationError):
                     logger.warning(
-                        "%s.test_alert.integration_error",
-                        callback_name,
-                        extra={"exception": exc},
+                        "%s.test_alert.integration_error", callback_name, extra={"exc": exc}
                     )
 
                     # IntegrationFormErrors should be safe to propagate via the API
@@ -111,9 +109,7 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
                     # If we encounter some unexpected exception, we probably
                     # don't want to continue executing more callbacks.
                     logger.warning(
-                        "%s.test_alert.unexpected_exception",
-                        callback_name,
-                        extra={"exception": exc},
+                        "%s.test_alert.unexpected_exception", callback_name, extra={"exc": exc}
                     )
                     break
 

--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -13,7 +13,7 @@ from sentry.api.serializers.rest_framework import RuleActionSerializer
 from sentry.eventstore.models import Event
 from sentry.models.rule import Rule
 from sentry.rules.processing.processor import activate_downstream_actions
-from sentry.shared_integrations.exceptions import IntegrationFormError
+from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils.safe import safe_execute
 from sentry.utils.samples import create_sample_event
 
@@ -98,9 +98,9 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
 
                 # safe_execute logs these as exceptions, which can result in
                 # noisy sentry issues, so log with a warning instead.
-                if isinstance(exc, IntegrationFormError):
+                if isinstance(exc, IntegrationError):
                     logger.warning(
-                        "%s.test_alert.integration_form_error",
+                        "%s.test_alert.integration_error",
                         callback_name,
                         extra={"exception": exc},
                     )

--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -91,9 +91,8 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
             try:
                 callback(test_event, futures)
             except Exception as exc:
-                cls = callback.__class__
                 callback_name = getattr(callback, "__name__", str(callback))
-                cls_name = cls.__name__
+                cls_name = callback.__class__.__name__
                 logger = logging.getLogger(f"sentry.test_rule.{cls_name.lower()}")
 
                 # safe_execute logs these as exceptions, which can result in

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -548,6 +548,9 @@ def register_temporary_features(manager: FeatureManager):
     # EAP: extremely experimental flag that makes DDM page use EAP tables
     manager.add("projects:use-eap-spans-for-metrics-explorer", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 
+    # Ecosystem: Enable verbose alert reporting when triggering test alerts
+    manager.add("projects:verbose-test-alert-reporting", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE,
+                api_expose=False)
     # Project plugin features
     manager.add("projects:plugins", ProjectPluginFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2676,3 +2676,7 @@ register(
     default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+register(
+    "ecosystem:enable_integration_form_error_raise", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE
+)

--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -5,6 +5,7 @@ from collections.abc import Callable, Sequence
 
 from rest_framework.response import Response
 
+from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.eventstore.models import GroupEvent
 from sentry.integrations.base import IntegrationInstallation
@@ -134,7 +135,13 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
                     "provider": provider,
                 },
             )
-            return
+
+            # Testing out if this results in a lot of noisy sentry issues
+            # when enabled.
+            if options.get("ecosystem:enable_integration_form_error_raise"):
+                raise
+            else:
+                return
 
         if not event.get_tag("sample_event") == "yes":
             create_link(integration, installation, event, response)

--- a/tests/sentry/api/endpoints/test_project_rule_actions.py
+++ b/tests/sentry/api/endpoints/test_project_rule_actions.py
@@ -66,7 +66,8 @@ class ProjectRuleActionsEndpointTest(APITestCase):
             )
             self.jira_integration.add_organization(self.organization, self.user)
 
-        mock_create_issue.side_effect = IntegrationFormError("Something went wrong")
+        form_errors = {"broken": "something went wrong"}
+        mock_create_issue.side_effect = IntegrationFormError(form_errors)
         action_data = [
             {
                 "id": "sentry.integrations.jira.notify_action.JiraCreateTicketAction",
@@ -88,7 +89,7 @@ class ProjectRuleActionsEndpointTest(APITestCase):
                 self.organization.slug, self.project.slug, actions=action_data
             )
             assert mock_create_issue.call_count == 2
-            assert response.data == {"actions": ["Something went wrong"]}
+            assert response.data == {"actions": [str(form_errors)]}
 
     @mock.patch.object(JiraIntegration, "create_issue")
     def test_success_response_when_client_raises(self, mock_create_issue):
@@ -98,7 +99,7 @@ class ProjectRuleActionsEndpointTest(APITestCase):
             )
             self.jira_integration.add_organization(self.organization, self.user)
 
-        mock_create_issue.side_effect = IntegrationFormError("Something went wrong")
+        mock_create_issue.side_effect = IntegrationFormError({"broken": "something went wrong"})
         action_data = [
             {
                 "id": "sentry.integrations.jira.notify_action.JiraCreateTicketAction",

--- a/tests/sentry/api/endpoints/test_project_rule_actions.py
+++ b/tests/sentry/api/endpoints/test_project_rule_actions.py
@@ -3,8 +3,10 @@ from unittest import mock
 from sentry.integrations.jira.integration import JiraIntegration
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.rules.actions.notify_event import NotifyEventAction
+from sentry.shared_integrations.exceptions import IntegrationFormError
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 
@@ -50,6 +52,75 @@ class ProjectRuleActionsEndpointTest(APITestCase):
         self.get_success_response(self.organization.slug, self.project.slug, actions=action_data)
         assert mock_create_issue.call_count == 1
         assert ExternalIssue.objects.count() == 0
+
+    @mock.patch.object(JiraIntegration, "create_issue")
+    @with_feature(
+        {
+            "projects:verbose-test-alert-reporting": True,
+        }
+    )
+    def test_sample_event_raises_bad_request_error_when_reporting_flag_set(self, mock_create_issue):
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.jira_integration = self.create_provider_integration(
+                provider="jira", name="Jira", external_id="jira:1"
+            )
+            self.jira_integration.add_organization(self.organization, self.user)
+
+        mock_create_issue.side_effect = IntegrationFormError("Something went wrong")
+        action_data = [
+            {
+                "id": "sentry.integrations.jira.notify_action.JiraCreateTicketAction",
+                "dynamic_form_fields": {
+                    "fake_field": "fake_value",
+                },
+            }
+        ]
+
+        response = self.get_success_response(
+            self.organization.slug, self.project.slug, actions=action_data
+        )
+        assert mock_create_issue.call_count == 1
+        assert response.data is None
+
+        # With error propagation option enabled
+        with self.options({"ecosystem:enable_integration_form_error_raise": True}):
+            response = self.get_error_response(
+                self.organization.slug, self.project.slug, actions=action_data
+            )
+            assert mock_create_issue.call_count == 2
+            assert response.data == {"actions": ["Something went wrong"]}
+
+    @mock.patch.object(JiraIntegration, "create_issue")
+    def test_success_response_when_client_raises(self, mock_create_issue):
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.jira_integration = self.create_provider_integration(
+                provider="jira", name="Jira", external_id="jira:1"
+            )
+            self.jira_integration.add_organization(self.organization, self.user)
+
+        mock_create_issue.side_effect = IntegrationFormError("Something went wrong")
+        action_data = [
+            {
+                "id": "sentry.integrations.jira.notify_action.JiraCreateTicketAction",
+                "dynamic_form_fields": {
+                    "fake_field": "fake_value",
+                },
+            }
+        ]
+
+        response = self.get_success_response(
+            self.organization.slug, self.project.slug, actions=action_data
+        )
+        assert mock_create_issue.call_count == 1
+        assert response.data is None
+
+        # With error propagation option enabled
+        with self.options({"ecosystem:enable_integration_form_error_raise": True}):
+            response = self.get_success_response(
+                self.organization.slug, self.project.slug, actions=action_data
+            )
+            assert mock_create_issue.call_count == 2
+            assert response.data is None
 
     def test_no_events(self):
         response = self.get_response(self.organization.slug, self.project.slug)


### PR DESCRIPTION
Adds error propagation for test alert rules, behind 2 flags:
1. `projects:verbose-test-alert-reporting` - Which opts projects/orgs into verbose error reporting
2. `ecosystem:enable_integration_form_error_raise` - Option check for whether or not to raise errors from `IntegrationFormErrors` when creating tickets.

When both of these flags are enabled, the user will receive explicit error messages in the UI if a test alert rule generates an `IntegrationError`, which typically happens when an API call to the provider fails.

Here are a couple of examples from our Jira integration of failed alert tests, first with an invalid team string:
<img width="1037" alt="image" src="https://github.com/user-attachments/assets/c72bf69f-3a3f-458b-ba33-bbef8dcdf0a5">

And second, with an invalid Date property from another bug with the Jira form:
<img width="1053" alt="image" src="https://github.com/user-attachments/assets/8009ebc0-4ee4-4d01-bbca-3fd61e255b69">

The `customfield_<id>` error is some additional tech debt due to us only surfacing `IntegrationFormErrors` with Jira field ID instead of the display name they provide us, and will be handled in yet another follow-up PR.

