### PR TITLE
chore(autofix): Migrate autofix flags to flagpole

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -158,7 +158,10 @@ class GroupAutofixEndpoint(GroupEndpoint):
 
         created_at = datetime.now().isoformat()
 
-        if not features.has("projects:ai-autofix", group.project):
+        if not (
+            features.has("projects:ai-autofix", group.project)
+            or features.has("organizations:autofix", group.organization)
+        ):
             return self._respond_with_error("AI Autofix is not enabled for this project.", 403)
 
         # For now we only send the event that the user is looking at, in the near future we want to send multiple events.

--- a/src/sentry/api/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/api/endpoints/group_autofix_setup_check.py
@@ -106,7 +106,10 @@ class GroupAutofixSetupCheck(GroupEndpoint):
         """
         Checks if we are able to run Autofix on the given group.
         """
-        if not features.has("projects:ai-autofix", group.project):
+        if not (
+            features.has("projects:ai-autofix", group.project)
+            or features.has("organizations:autofix", group.organization)
+        ):
             return Response({"detail": "Feature not enabled for project"}, status=403)
 
         org: Organization = request.organization

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -68,6 +68,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:auto-size-big-number-widget", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables the cron job to auto-enable codecov integrations.
     manager.add("organizations:auto-enable-codecov", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
+    # Enables Autofix
+    manager.add("organizations:autofix", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Autofix use new strategy without codebase indexing
     manager.add("organizations:autofix-disable-codebase-indexing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=True)
     # Enables getting commit sha from git blame for codecov.

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -13,7 +13,7 @@ from sentry.utils.samples import load_data
 pytestmark = [requires_snuba]
 
 
-@apply_feature_flag_on_cls("projects:ai-autofix")
+@apply_feature_flag_on_cls("organizations:autofix")
 class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
     def _get_url(self, group_id: int):
         return f"/api/0/issues/{group_id}/autofix/"

--- a/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
@@ -9,7 +9,7 @@ from sentry.testutils.helpers.features import apply_feature_flag_on_cls, with_fe
 from sentry.testutils.silo import assume_test_silo_mode
 
 
-@apply_feature_flag_on_cls("projects:ai-autofix")
+@apply_feature_flag_on_cls("organizations:autofix")
 class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
     def setUp(self):
         super().setUp()
@@ -140,7 +140,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
         }
 
 
-@apply_feature_flag_on_cls("projects:ai-autofix")
+@apply_feature_flag_on_cls("organizations:autofix")
 class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
     def test_no_gen_ai_consent(self):
         self.organization.update_option("sentry:gen_ai_consent", False)


### PR DESCRIPTION
This PR adds a new `organizations:autofix` flag that is managed by flagpole that is a redundancy with the `projects:ai-autofix` flag. We'll be deleting the latter flag after we enable the new flag via flagpole. 
