### PR TITLE
feat(eap): Make EAP requests more rugged (A vs a, for example)

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics_query.py
+++ b/src/sentry/api/endpoints/organization_metrics_query.py
@@ -172,8 +172,8 @@ class OrganizationMetricsQueryEndpoint(OrganizationEndpoint):
                 features.has("projects:use-eap-spans-for-metrics-explorer", project)
                 for project in projects
             ):
-                if len(mql_queries) == 1 and "a" in mql_queries[0].sub_queries:
-                    subquery = mql_queries[0].sub_queries["a"]
+                if len(mql_queries) == 1 and len(mql_queries[0].sub_queries) == 1:
+                    subquery = next(iter(mql_queries[0].sub_queries.values()))
                     if "d:eap/" in subquery.mql:
                         res_data = mql_eap_bridge.make_eap_request(
                             subquery.mql,

--- a/src/sentry/sentry_metrics/querying/eap/mql_eap_bridge.py
+++ b/src/sentry/sentry_metrics/querying/eap/mql_eap_bridge.py
@@ -95,10 +95,11 @@ def make_eap_request(
 
     series_data = list(resp.result)
     duration = end - start
-    bucket_size_secs = duration.total_seconds() / len(series_data)
     intervals = []
-    for i in range(len(series_data)):
-        intervals.append((start + timedelta(seconds=bucket_size_secs * i)).isoformat())
+    if len(series_data) > 0:
+        bucket_size_secs = duration.total_seconds() / len(series_data)
+        for i in range(len(series_data)):
+            intervals.append((start + timedelta(seconds=bucket_size_secs * i)).isoformat())
     intervals.append(end.isoformat())
 
     return {


### PR DESCRIPTION
In production, the formula name is $A instead of $a (for some reason)

This just ignores the name of the formula and assumes there's only one