### PR TITLE
feat(releases): allow resolving in an upcoming release in the ui

### DIFF
--- a/static/app/components/actions/resolve.spec.tsx
+++ b/static/app/components/actions/resolve.spec.tsx
@@ -247,9 +247,7 @@ describe('ResolveActions', function () {
   });
 
   it('does render in upcoming release', async function () {
-    const organization = OrganizationFixture({
-      features: ['resolve-in-upcoming-release'],
-    });
+    const organization = OrganizationFixture({});
     const onUpdate = jest.fn();
     MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/releases/',

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -206,10 +206,6 @@ function ResolveActions({
       });
     };
 
-    const hasUpcomingRelease = organization.features.includes(
-      'resolve-in-upcoming-release'
-    );
-
     const isSemver = latestRelease ? isSemverRelease(latestRelease.version) : false;
     const items: MenuItemProps[] = [
       {
@@ -219,7 +215,6 @@ function ResolveActions({
           ? actionTitle
           : t('The next release that is not yet released'),
         onAction: () => onActionOrConfirm(handleUpcomingReleaseResolution),
-        hidden: !hasUpcomingRelease,
       },
       {
         key: 'next-release',


### PR DESCRIPTION
Now that the backend for resolving in an upcoming release is now ungated as of this [PR](https://github.com/getsentry/sentry/pull/75901), we can do the same in the UI. This feature is relatively low risk to just roll out to everyone because not many people will use it an it's well validated at Sentry (it was enabled while I was still a full time empoyee, lol). 

<img width="1247" alt="Screenshot 2024-08-18 at 11 51 03 AM" src="https://github.com/user-attachments/assets/3470c669-243d-449d-9560-b15ade82cb09">
<img width="1234" alt="Screenshot 2024-08-18 at 11 51 49 AM" src="https://github.com/user-attachments/assets/97a12c9b-8f04-4d50-b134-e1a471284fcd">

I'm also going to update the docs for this new feature.