### PR TITLE
feat: disable span description clustering

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -511,7 +511,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:visibility-explore-dataset", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable minimap in the widget viewer modal in dashboards
     manager.add("organizations:widget-viewer-modal-minimap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    manager.add("projects:record-span-descriptions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enabled unresolved issue webhook for organization
     manager.add("organizations:webhooks-unresolved", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=True)
     # NOTE: Don't add features down here! Add them to their specific group and sort
@@ -547,6 +546,7 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("projects:relay-otel-endpoint", ProjectFeature, FeatureHandlerStrategy.OPTIONS, api_expose=False)
     # EAP: extremely experimental flag that makes DDM page use EAP tables
     manager.add("projects:use-eap-spans-for-metrics-explorer", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("projects:record-span-descriptions", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 
     # Project plugin features
     manager.add("projects:plugins", ProjectPluginFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -511,6 +511,7 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:visibility-explore-dataset", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable minimap in the widget viewer modal in dashboards
     manager.add("organizations:widget-viewer-modal-minimap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("projects:record-span-descriptions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enabled unresolved issue webhook for organization
     manager.add("organizations:webhooks-unresolved", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=True)
     # NOTE: Don't add features down here! Add them to their specific group and sort

--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -1,4 +1,5 @@
 """ Write transactions into redis sets """
+
 import logging
 from collections.abc import Iterator, Mapping
 from typing import Any
@@ -182,6 +183,9 @@ def record_span_descriptions(
     project: Project, event_data: Mapping[str, Any], **kwargs: Any
 ) -> None:
     if not features.has("projects:span-metrics-extraction", project):
+        return
+
+    if not features.has("projects:record-span-descriptions", project):
         return
 
     spans = event_data.get("spans", [])


### PR DESCRIPTION
We're making a lot of redis calls here https://sentry.my.sentry.io/organizations/sentry/performance/trace/2f1fea0659264706bc0f2b4d6807908f/?dataset=transactions&field=title&field=project&field=timestamp&field=transaction.duration&name=All+Errors&node=span-9f7db12a2da2ae00&node=txn-09cd48a7d61d4b8db3cfeb07e4c202a9&query=server_name%3Agetsentry-worker-postprocess-transactions%2A&queryDataset=transaction-like&sort=-transaction.duration&source=discover&statsPeriod=24h&timestamp=1724066865&yAxis=count%28%29
might be hitting resource limits on redis instance