### PR TITLE
Add OIDC GA project option

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -166,6 +166,7 @@ ORG_OPTIONS = (
     ),
     ("relayPiiConfig", "sentry:relay_pii_config", str, None),
     ("allowJoinRequests", "sentry:join_requests", bool, JOIN_REQUESTS_DEFAULT),
+    ("githubActionOIDC", "sentry:github_action_oidc", str, None),
     ("apdexThreshold", "sentry:apdex_threshold", int, None),
     (
         "aiSuggestedSolution",
@@ -278,6 +279,7 @@ class OrganizationSerializer(BaseOrganizationSerializer):
     requireEmailVerification = serializers.BooleanField(required=False)
     trustedRelays = serializers.ListField(child=TrustedRelaySerializer(), required=False)
     allowJoinRequests = serializers.BooleanField(required=False)
+    githubActionOIDC = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     relayPiiConfig = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     apdexThreshold = serializers.IntegerField(min_value=1, required=False)
     extrapolateMetrics = serializers.BooleanField(required=False)

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -473,6 +473,7 @@ class DetailedOrganizationSerializerResponse(_DetailedOrganizationSerializerResp
     metricsActivateLastForGauges: bool
     extrapolateMetrics: bool
     requiresSso: bool
+    githubActionsOIDC: str | None
 
 
 class DetailedOrganizationSerializer(OrganizationSerializer):
@@ -611,6 +612,7 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
                         METRICS_ACTIVATE_LAST_FOR_GAUGES_DEFAULT,
                     )
                 ),
+                "githubActionOIDC": obj.get_option("sentry:github_action_oidc"),
             }
         )
 

--- a/static/app/data/forms/organizationSecurityAndPrivacyGroups.tsx
+++ b/static/app/data/forms/organizationSecurityAndPrivacyGroups.tsx
@@ -111,6 +111,17 @@ const formGroups: JsonFormObject[] = [
         },
         visible: ({hasSsoEnabled}) => !hasSsoEnabled,
       },
+      {
+        name: 'githubActionOIDC',
+        type: 'string',
+        placeholder: t(
+          '{"organization": "getsentry", "repo": "sentry", "workflow-url": "release.yml"}'
+        ),
+        label: t('GitHub Actions OICD'),
+        help: t(
+          'Configuration for setting up GitHub Action`s OIDC. Format it like a JSON, with the organization and repo names as well as the `workflow-url` being the filename of the release workflow under `.github/workflows/`: i.e: {"organization": "getsentry", "repo": "sentry", "workflow-url": "release.yml"}'
+        ),
+      },
     ],
   },
   {

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -65,6 +65,7 @@ export interface Organization extends OrganizationSummary {
   eventsMemberAdmin: boolean;
   experiments: Partial<OrgExperiments>;
   genAIConsent: boolean;
+  githubActionOIDC: string;
   isDefault: boolean;
   isDynamicallySampled: boolean;
   onboardingTasks: OnboardingTaskStatus[];


### PR DESCRIPTION
This adds an organization option under the Organization -> Security & Privacy -> Security & Privacy for GA OIDC option. 

![Screenshot 2024-08-21 at 11 33 04 AM](https://github.com/user-attachments/assets/7c584bbf-2f08-437c-aebc-366ee5280ef1)


The setting is stored in the `OrganizationOption` model.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
