### PR TITLE
fix(issue-summary): Check for genai consent

### DIFF
--- a/static/app/components/group/groupSummary.spec.tsx
+++ b/static/app/components/group/groupSummary.spec.tsx
@@ -1,0 +1,103 @@
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {
+  GroupSummary,
+  makeGroupSummaryQueryKey,
+} from 'sentry/components/group/groupSummary';
+
+describe('GroupSummary', function () {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders the group summary', async function () {
+    const groupId = '1';
+    const organizationSlug = 'org-slug';
+    MockApiClient.addMockResponse({
+      url: makeGroupSummaryQueryKey(organizationSlug, groupId)[0],
+      method: 'POST',
+      body: {
+        groupId,
+        summary: 'Test summary',
+        impact: 'Test impact',
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/issues/${groupId}/autofix/setup/`,
+      body: {
+        genAIConsent: {ok: true},
+        integration: {ok: true},
+        githubWriteIntegration: {
+          ok: true,
+          repos: [
+            {
+              provider: 'integrations:github',
+              owner: 'getsentry',
+              name: 'sentry',
+              external_id: '123',
+            },
+          ],
+        },
+      },
+    });
+
+    render(<GroupSummary groupId={groupId} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Issue Summary')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Issue Summary')).toBeInTheDocument();
+    expect(screen.getByText('Test summary')).toBeInTheDocument();
+    expect(screen.getByText('Potential Impact')).toBeInTheDocument();
+    expect(screen.getByText('Test impact')).toBeInTheDocument();
+  });
+
+  it('does not render the group summary if no consent', async function () {
+    const groupId = '1';
+    const organizationSlug = 'org-slug';
+    MockApiClient.addMockResponse({
+      url: makeGroupSummaryQueryKey(organizationSlug, groupId)[0],
+      method: 'POST',
+      body: {
+        groupId,
+        summary: 'Test summary',
+        impact: 'Test impact',
+      },
+    });
+
+    const setupCall = MockApiClient.addMockResponse({
+      url: `/issues/${groupId}/autofix/setup/`,
+      body: {
+        genAIConsent: {ok: false},
+        integration: {ok: true},
+        githubWriteIntegration: {
+          ok: true,
+          repos: [
+            {
+              provider: 'integrations:github',
+              owner: 'getsentry',
+              name: 'sentry',
+              external_id: '123',
+            },
+          ],
+        },
+      },
+    });
+
+    render(<GroupSummary groupId={groupId} />);
+
+    await waitFor(
+      () => {
+        expect(setupCall).toHaveBeenCalled();
+      },
+      {timeout: 5000}
+    );
+
+    expect(screen.queryByText('Issue Summary')).not.toBeInTheDocument();
+    expect(screen.queryByText('Test summary')).not.toBeInTheDocument();
+    expect(screen.queryByText('Potential Impact')).not.toBeInTheDocument();
+    expect(screen.queryByText('Test impact')).not.toBeInTheDocument();
+  });
+});

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 
 import FeatureBadge from 'sentry/components/badge/featureBadge';
 import {Button} from 'sentry/components/button';
+import {useAutofixSetup} from 'sentry/components/events/autofix/useAutofixSetup';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
 import Placeholder from 'sentry/components/placeholder';
@@ -26,7 +27,7 @@ interface GroupSummaryData {
   headline?: string;
 }
 
-const makeGroupSummaryQueryKey = (
+export const makeGroupSummaryQueryKey = (
   organizationSlug: string,
   groupId: string
 ): ApiQueryKey => [
@@ -36,13 +37,29 @@ const makeGroupSummaryQueryKey = (
 
 export function useGroupSummary(groupId: string) {
   const organization = useOrganization();
+  // We piggyback and use autofix's genai consent check for now.
+  const {
+    data: autofixSetupData,
+    isLoading: isAutofixSetupLoading,
+    isError: isAutofixSetupError,
+  } = useAutofixSetup({groupId});
 
-  return useApiQuery<GroupSummaryData>(
+  const queryData = useApiQuery<GroupSummaryData>(
     makeGroupSummaryQueryKey(organization.slug, groupId),
     {
       staleTime: Infinity, // Cache the result indefinitely as it's unlikely to change if it's already computed
+      enabled: autofixSetupData?.genAIConsent.ok ?? false,
     }
   );
+
+  return {
+    ...queryData,
+    isLoading:
+      // isFetchedAfterMount is here so we don't have the split second where genAIConsent is true but the query isn't loading yet.
+      isAutofixSetupLoading || queryData.isLoading || !queryData.isFetchedAfterMount,
+    isError: queryData.isError || isAutofixSetupError,
+    hasGenAIConsent: autofixSetupData?.genAIConsent.ok ?? false,
+  };
 }
 
 function GroupSummaryFeatureBadge() {
@@ -57,10 +74,10 @@ function GroupSummaryFeatureBadge() {
 }
 
 export function GroupSummaryHeader({groupId}: GroupSummaryProps) {
-  const {data, isLoading, isError} = useGroupSummary(groupId);
+  const {data, isLoading, isError, hasGenAIConsent} = useGroupSummary(groupId);
   const isStreamlined = useHasStreamlinedUI();
 
-  if (isError || (!isLoading && !data.headline)) {
+  if (isError || !hasGenAIConsent || (!isLoading && !data?.headline)) {
     // Don't render the summary headline if there's an error, the error is already shown in the sidebar
     // If there is no headline we also don't want to render anything
     return null;
@@ -83,9 +100,14 @@ export function GroupSummaryHeader({groupId}: GroupSummaryProps) {
 }
 
 export function GroupSummary({groupId}: GroupSummaryProps) {
-  const {data, isLoading, isError} = useGroupSummary(groupId);
+  const {data, isLoading, isError, hasGenAIConsent} = useGroupSummary(groupId);
 
   const openForm = useFeedbackForm();
+
+  if (!hasGenAIConsent) {
+    // TODO: Render a banner for needing genai consent
+    return null;
+  }
 
   return (
     <SidebarSection.Wrap>

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -44,21 +44,20 @@ export function useGroupSummary(groupId: string) {
     isError: isAutofixSetupError,
   } = useAutofixSetup({groupId});
 
+  const hasGenAIConsent = autofixSetupData?.genAIConsent.ok ?? false;
+
   const queryData = useApiQuery<GroupSummaryData>(
     makeGroupSummaryQueryKey(organization.slug, groupId),
     {
       staleTime: Infinity, // Cache the result indefinitely as it's unlikely to change if it's already computed
-      enabled: autofixSetupData?.genAIConsent.ok ?? false,
+      enabled: hasGenAIConsent,
     }
   );
-
   return {
     ...queryData,
-    isLoading:
-      // isFetchedAfterMount is here so we don't have the split second where genAIConsent is true but the query isn't loading yet.
-      isAutofixSetupLoading || queryData.isLoading || !queryData.isFetchedAfterMount,
+    isLoading: isAutofixSetupLoading || queryData.isLoading,
     isError: queryData.isError || isAutofixSetupError,
-    hasGenAIConsent: autofixSetupData?.genAIConsent.ok ?? false,
+    hasGenAIConsent,
   };
 }
 


### PR DESCRIPTION
Make sure AI Issue summary checks for genai consent first before showing it. If not it will not render the cards. We're piggybacking off of the autofix setup check for now.

When genai consent is false:
<img width="1259" alt="Screenshot 2024-08-19 at 11 18 18 AM" src="https://github.com/user-attachments/assets/e9e04e02-c177-44bc-8a16-b371447e21f5">

When true, it will flicker the header when loading, but IMO this is better than showing the loading state and hiding it if they didn't have it enabled:
https://github.com/user-attachments/assets/36f35a32-e646-4d50-a3be-5e41e3e9b2a0

