### PR TITLE
fix(issues): Avoid issue list cache if projects not updated

### DIFF
--- a/static/app/utils/withSavedSearches.tsx
+++ b/static/app/utils/withSavedSearches.tsx
@@ -39,8 +39,9 @@ function withSavedSearches<P extends InjectedSavedSearchesProps>(
         {...(props as P)}
         savedSearches={props.savedSearches ?? savedSearches}
         savedSearchLoading={
-          !organization.features.includes('issue-stream-custom-views') &&
-          (props.savedSearchLoading ?? isLoading)
+          organization.features.includes('issue-stream-custom-views')
+            ? false
+            : props.savedSearchLoading ?? isLoading
         }
         savedSearch={props.savedSearch ?? selectedSavedSearch}
         selectedSearchId={params.searchId ?? null}


### PR DESCRIPTION
fixes an issue where we load the wrong issues cache because the PageFiltersStore does not reflect the project in the url until after componentDidMount has run.

I did try getting the pageFiltersStore to update sooner but it broke other pages.

to reproduce the issue:
- Go to projects list
- Click "errors: 123" under a project name and load the issues
- Return to projects list and click another "errors: 456" link
- See that issues list is populated with the wrong issues

fixes https://github.com/getsentry/sentry/issues/76387
