### PR TITLE
fix(alerts): Migrate uptime alert off onSuccess callback

### DIFF
--- a/static/app/views/alerts/rules/uptime/edit.tsx
+++ b/static/app/views/alerts/rules/uptime/edit.tsx
@@ -1,3 +1,4 @@
+import {useEffect} from 'react';
 import type {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
@@ -46,14 +47,20 @@ export function UptimeRulesEdit({params, onChangeTitle, organization, project}: 
 
   const {
     isLoading,
+    isSuccess,
     isError,
     data: rule,
     error,
   } = useApiQuery<UptimeAlert>([apiUrl], {
     staleTime: 0,
     retry: false,
-    onSuccess: data => onChangeTitle(data[0]?.name ?? ''),
   });
+
+  useEffect(() => {
+    if (isSuccess && rule) {
+      onChangeTitle(rule.name ?? '');
+    }
+  }, [onChangeTitle, isSuccess, rule]);
 
   if (isLoading) {
     return <LoadingIndicator />;


### PR DESCRIPTION
onSuccess is removed in react-query v5, switches to a useEffect

part of https://github.com/getsentry/frontend-tsc/issues/52
