### PR TITLE
feat(postprocess): INC-855 allow to split post_process_* queues

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3522,3 +3522,7 @@ if SILO_DEVSERVER:
         SENTRY_WEB_PORT = int(bind[1])
 
     CELERYBEAT_SCHEDULE_FILENAME = f"celerybeat-schedule-{SILO_MODE}"
+
+
+# tmp(michal): Default configuration for post_process* queueus split
+SENTRY_POST_PROCESS_QUEUE_SPLIT_ROUTER: dict[str, Callable[[], str]] = {}

--- a/tests/sentry/eventstream/test_eventstream.py
+++ b/tests/sentry/eventstream/test_eventstream.py
@@ -380,6 +380,18 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
         headers, body = self.__produce_payload(*insert_args, **insert_kwargs)
         assert body["queue"] == "post_process_transactions-1"
 
+        # test default assignment
+        insert_kwargs = {
+            "event": self.__build_event(timezone.now()),
+            **group_state,
+            "primary_hash": "acbd18db4cc2f85cedef654fccc4a4d8",
+            "skip_consume": False,
+            "received_timestamp": event.data["received"],
+            "group_states": [{"id": event.groups[0].id, **group_state}],
+        }
+        headers, body = self.__produce_payload(*insert_args, **insert_kwargs)
+        assert body["queue"] == "post_process_errors"
+
     @patch("sentry.eventstream.backend.insert", autospec=True)
     def test_issue_platform_queue(self, mock_eventstream_insert):
         event = self.__build_transaction_event()

--- a/tests/sentry/eventstream/test_eventstream.py
+++ b/tests/sentry/eventstream/test_eventstream.py
@@ -1,9 +1,12 @@
+import itertools
 import logging
 import time
 from datetime import timedelta
 from unittest.mock import Mock, patch
 
 import pytest
+from django.conf import settings
+from django.test import override_settings
 from django.utils import timezone
 from snuba_sdk import Column, Condition, Entity, Op, Query, Request
 
@@ -335,6 +338,47 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
         assert ("queue", b"post_process_transactions") in headers
         assert "occurrence_id" not in dict(headers)
         assert body["queue"] == "post_process_transactions"
+
+    @override_settings()
+    @patch("sentry.eventstream.backend.insert", autospec=True)
+    def test_queue_split_router(self, mock_eventstream_insert):
+        queues = [
+            "post_process_transactions-1",
+            "post_process_transactions-2",
+            "post_process_transactions-3",
+        ]
+        queues_gen = itertools.cycle(queues)
+
+        settings.SENTRY_POST_PROCESS_QUEUE_SPLIT_ROUTER = {
+            "post_process_transactions": lambda: next(queues_gen)
+        }
+
+        event = self.__build_transaction_event()
+        event.group_id = None
+        event.groups = [self.group]
+        insert_args = ()
+        group_state = {
+            "is_new_group_environment": True,
+            "is_new": True,
+            "is_regression": False,
+        }
+        insert_kwargs = {
+            "event": event,
+            **group_state,
+            "primary_hash": "acbd18db4cc2f85cedef654fccc4a4d8",
+            "skip_consume": False,
+            "received_timestamp": event.data["received"],
+            "group_states": [{"id": event.groups[0].id, **group_state}],
+        }
+
+        headers, body = self.__produce_payload(*insert_args, **insert_kwargs)
+        assert body["queue"] == "post_process_transactions-1"
+        headers, body = self.__produce_payload(*insert_args, **insert_kwargs)
+        assert body["queue"] == "post_process_transactions-2"
+        headers, body = self.__produce_payload(*insert_args, **insert_kwargs)
+        assert body["queue"] == "post_process_transactions-3"
+        headers, body = self.__produce_payload(*insert_args, **insert_kwargs)
+        assert body["queue"] == "post_process_transactions-1"
 
     @patch("sentry.eventstream.backend.insert", autospec=True)
     def test_issue_platform_queue(self, mock_eventstream_insert):


### PR DESCRIPTION
<!-- Describe your PR here. -->

Add possibility to configure additional routing for the `post_process_group` task. During INC-855 we reached the limits of single queue processing and this aims to be a temporary solution that will allow to split single queue into multiple ones.

An example of a `SENTRY_POST_PROCESS_QUEUE_SPLIT_ROUTER`

```
import itertools
queues = ["post_process_transactions-0", "post_process_transactions-1", "post_process_transactions-2"]
queues_gen = itertools.cycle(queues)

SENTRY_POST_PROCESS_QUEUE_SPLIT_ROUTER = {
    "post_process_transactions": lambda: next(queues_gen),
}
```

NB: Celery allows to configure routers for tasks. See ~ https://docs.celeryq.dev/en/stable/userguide/routing.html#routers
To be able to use the Celery routers code must change to not pass the `queue` argument directly to the `task.apply_async` call as that takes priority over the configured routers.