### PR TITLE
feat(self-hosted): Add support for `rediss://` scheme

### DIFF
--- a/src/sentry/monitoring/queues.py
+++ b/src/sentry/monitoring/queues.py
@@ -110,6 +110,7 @@ def get_queue_by_name(name: str) -> kombu.Queue:
 
 backends: dict[str, type[_QueueBackend]] = {
     "redis": RedisBackend,
+    "rediss": RedisBackend,
     "amqp": AmqpBackend,
     "amqps": AmqpBackend,
 }


### PR DESCRIPTION
Allows self-hosted users to specify Redis broker URLs with TLS enabled.

I believe this fixes #57788 and is tangentially related to #66917 and #67082. To tests this I deployed self hosted sentry in our AWS environment and pointed it at Elasticache Redis cluster with TLS in transit enabled. Before applying the patch (note that it was applied to Sentry 24.5.1) the following error would be produced:

![Screenshot 2024-08-20 at 11 57 21](https://github.com/user-attachments/assets/525eaf59-5414-4f37-8196-70da6fb100dc)

Applying the patch resolved the issue as far as I can tell.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
