### PR TITLE
ref(js): Make profilingBreadcrumbs compatible with react-router 6

### DIFF
--- a/static/app/components/globalSelectionLink.tsx
+++ b/static/app/components/globalSelectionLink.tsx
@@ -42,12 +42,20 @@ function GlobalSelectionLink(props: Props) {
   const query =
     typeof to === 'object' && to.query ? {...globalQuery, ...to.query} : globalQuery;
 
+  if (typeof to === 'object' && to.query && Object.keys(to.query).length === 0) {
+    delete to.query;
+  }
+
   if (location) {
     const toWithGlobalQuery: LocationDescriptor = !hasGlobalQuery
       ? {}
       : typeof to === 'string'
         ? {pathname: to, query}
         : {...to, query};
+
+    if (toWithGlobalQuery.query && Object.keys(toWithGlobalQuery.query).length === 0) {
+      delete toWithGlobalQuery.query;
+    }
 
     const routerProps = hasGlobalQuery
       ? {...props, to: toWithGlobalQuery}

--- a/static/app/components/profiling/profilingBreadcrumbs.spec.tsx
+++ b/static/app/components/profiling/profilingBreadcrumbs.spec.tsx
@@ -27,7 +27,7 @@ describe('Breadcrumb', function () {
     expect(screen.getByText('Profiling')).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Profiling'})).toHaveAttribute(
       'href',
-      `/organizations/${organization.slug}/profiling/?`
+      `/organizations/${organization.slug}/profiling/`
     );
     expect(screen.getByText('foo')).toBeInTheDocument();
   });


### PR DESCRIPTION
Helps with react-router 6 upgrade. We can clean this up later in react-router 6