### PR TITLE
fix(crons): Add padding back to monitor forms

### DIFF
--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -4,7 +4,6 @@ import {Observer} from 'mobx-react';
 
 import Alert from 'sentry/components/alert';
 import AlertLink from 'sentry/components/alertLink';
-import FieldWrapper from 'sentry/components/forms/fieldGroup/fieldWrapper';
 import NumberField from 'sentry/components/forms/fields/numberField';
 import SelectField from 'sentry/components/forms/fields/selectField';
 import SentryMemberTeamSelectorField from 'sentry/components/forms/fields/sentryMemberTeamSelectorField';
@@ -551,9 +550,6 @@ export default MonitorForm;
 
 const StyledList = styled(List)`
   width: 800px;
-  ${FieldWrapper} {
-    padding: 0;
-  }
 `;
 
 const StyledAlert = styled(Alert)`


### PR DESCRIPTION
Before

![clipboard.png](https://i.imgur.com/X7vmEU1.png)

After (ignore the ✅)

![image](https://github.com/user-attachments/assets/6f687a65-8f9d-4935-b098-97011512ab86)