### PR TITLE
feat(new-trace): Passing the correct timestamp to trace meta endpoint.

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -200,7 +200,7 @@ export function TraceView() {
     });
   }, [queryParams, traceSlug]);
 
-  const meta = useTraceMeta([traceSlug]);
+  const meta = useTraceMeta([{traceSlug, timestamp: queryParams.timestamp}]);
 
   const preferences = useMemo(
     () =>

--- a/static/app/views/performance/newTraceDetails/traceApi/useReplayTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useReplayTraceMeta.tsx
@@ -6,14 +6,10 @@ import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
+import type {ReplayTrace} from 'sentry/views/replays/detail/trace/useReplayTraces';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
 import {type TraceMetaQueryResults, useTraceMeta} from './useTraceMeta';
-
-export type TraceDataRow = {
-  timestamp: number | undefined;
-  traceSlug: string;
-};
 
 // Fetches the meta data for all the traces in a replay and combines the results.
 export function useReplayTraceMeta(
@@ -72,7 +68,7 @@ export function useReplayTraceMeta(
   );
 
   const traceDataRows = useMemo(() => {
-    const rows: TraceDataRow[] = [];
+    const rows: ReplayTrace[] = [];
 
     for (const row of eventsData?.data ?? []) {
       if (row.trace) {

--- a/static/app/views/performance/newTraceDetails/traceApi/useReplayTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useReplayTraceMeta.tsx
@@ -67,22 +67,22 @@ export function useReplayTraceMeta(
     }
   );
 
-  const traceDataRows = useMemo(() => {
-    const rows: ReplayTrace[] = [];
+  const replayTraces = useMemo(() => {
+    const traces: ReplayTrace[] = [];
 
     for (const row of eventsData?.data ?? []) {
       if (row.trace) {
-        rows.push({
+        traces.push({
           traceSlug: String(row.trace),
           timestamp: getTimeStampFromTableDateField(row['min(timestamp)']),
         });
       }
     }
 
-    return rows;
+    return traces;
   }, [eventsData]);
 
-  const meta = useTraceMeta(traceDataRows);
+  const meta = useTraceMeta(replayTraces);
 
   const metaResults = useMemo(() => {
     return {

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
@@ -5,11 +5,27 @@ import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import * as useOrganization from 'sentry/utils/useOrganization';
+import type {ReplayTrace} from 'sentry/views/replays/detail/trace/useReplayTraces';
 
 import {useTraceMeta} from './useTraceMeta';
 
 const organization = OrganizationFixture();
 const queryClient = makeTestQueryClient();
+
+const mockedReplayTraces: ReplayTrace[] = [
+  {
+    traceSlug: 'slug1',
+    timestamp: 1,
+  },
+  {
+    traceSlug: 'slug2',
+    timestamp: 2,
+  },
+  {
+    traceSlug: 'slug3',
+    timestamp: 3,
+  },
+];
 
 describe('useTraceMeta', () => {
   beforeEach(function () {
@@ -19,8 +35,6 @@ describe('useTraceMeta', () => {
   });
 
   it('Returns merged metaResults', async () => {
-    const traceSlugs = ['slug1', 'slug2', 'slug3'];
-
     // Mock the API calls
     MockApiClient.addMockResponse({
       method: 'GET',
@@ -60,7 +74,7 @@ describe('useTraceMeta', () => {
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     );
 
-    const {result} = renderHook(() => useTraceMeta(traceSlugs), {wrapper});
+    const {result} = renderHook(() => useTraceMeta(mockedReplayTraces), {wrapper});
 
     expect(result.current).toEqual({
       data: undefined,
@@ -89,8 +103,6 @@ describe('useTraceMeta', () => {
   });
 
   it('Collects errors from rejected api calls', async () => {
-    const traceSlugs = ['slug1', 'slug2', 'slug3'];
-
     // Mock the API calls
     const mockRequest1 = MockApiClient.addMockResponse({
       method: 'GET',
@@ -112,7 +124,7 @@ describe('useTraceMeta', () => {
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     );
 
-    const {result} = renderHook(() => useTraceMeta(traceSlugs), {wrapper});
+    const {result} = renderHook(() => useTraceMeta(mockedReplayTraces), {wrapper});
 
     expect(result.current).toEqual({
       data: undefined,
@@ -142,8 +154,6 @@ describe('useTraceMeta', () => {
   });
 
   it('Accumulates metaResults and collects errors from rejected api calls', async () => {
-    const traceSlugs = ['slug1', 'slug2', 'slug3'];
-
     // Mock the API calls
     const mockRequest1 = MockApiClient.addMockResponse({
       method: 'GET',
@@ -177,7 +187,7 @@ describe('useTraceMeta', () => {
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     );
 
-    const {result} = renderHook(() => useTraceMeta(traceSlugs), {wrapper});
+    const {result} = renderHook(() => useTraceMeta(mockedReplayTraces), {wrapper});
 
     expect(result.current).toEqual({
       data: undefined,

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
@@ -44,11 +44,11 @@ function getMetaQueryParams(
 async function fetchSingleTraceMetaNew(
   api: Client,
   organization: Organization,
-  row: ReplayTrace,
+  replayTrace: ReplayTrace,
   queryParams: any
 ) {
   const data = await api.requestPromise(
-    `/organizations/${organization.slug}/events-trace-meta/${row.traceSlug}/`,
+    `/organizations/${organization.slug}/events-trace-meta/${replayTrace.traceSlug}/`,
     {
       method: 'GET',
       data: queryParams,
@@ -60,11 +60,11 @@ async function fetchSingleTraceMetaNew(
 async function fetchTraceMetaInBatches(
   api: Client,
   organization: Organization,
-  traceDataRows: ReplayTrace[],
+  replayTraces: ReplayTrace[],
   normalizedParams: any,
   filters: Partial<PageFilters> = {}
 ) {
-  const clonedTraceIds = [...traceDataRows];
+  const clonedTraceIds = [...replayTraces];
   const metaResults: TraceMeta = {
     errors: 0,
     performance_issues: 0,
@@ -78,9 +78,9 @@ async function fetchTraceMetaInBatches(
   while (clonedTraceIds.length > 0) {
     const batch = clonedTraceIds.splice(0, 3);
     const results = await Promise.allSettled(
-      batch.map(row => {
-        const queryParams = getMetaQueryParams(row, normalizedParams, filters);
-        return fetchSingleTraceMetaNew(api, organization, row, queryParams);
+      batch.map(replayTrace => {
+        const queryParams = getMetaQueryParams(replayTrace, normalizedParams, filters);
+        return fetchSingleTraceMetaNew(api, organization, replayTrace, queryParams);
       })
     );
 
@@ -130,7 +130,7 @@ export type TraceMetaQueryResults = {
   status: QueryStatus;
 };
 
-export function useTraceMeta(traceDataRows: ReplayTrace[]): TraceMetaQueryResults {
+export function useTraceMeta(replayTraces: ReplayTrace[]): TraceMetaQueryResults {
   const filters = usePageFilters();
   const api = useApi();
   const organization = useOrganization();
@@ -154,17 +154,17 @@ export function useTraceMeta(traceDataRows: ReplayTrace[]): TraceMetaQueryResult
     },
     Error
   >(
-    ['traceData', traceDataRows],
+    ['traceData', replayTraces],
     () =>
       fetchTraceMetaInBatches(
         api,
         organization,
-        traceDataRows,
+        replayTraces,
         normalizedParams,
         filters.selection
       ),
     {
-      enabled: traceDataRows.length > 0,
+      enabled: replayTraces.length > 0,
     }
   );
 

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
@@ -13,8 +13,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-
-import type {TraceDataRow} from './useReplayTraceMeta';
+import type {ReplayTrace} from 'sentry/views/replays/detail/trace/useReplayTraces';
 
 type TraceMetaQueryParams =
   | {
@@ -27,7 +26,7 @@ type TraceMetaQueryParams =
     };
 
 function getMetaQueryParams(
-  row: TraceDataRow,
+  row: ReplayTrace,
   normalizedParams: any,
   filters: Partial<PageFilters> = {}
 ): TraceMetaQueryParams {
@@ -45,7 +44,7 @@ function getMetaQueryParams(
 async function fetchSingleTraceMetaNew(
   api: Client,
   organization: Organization,
-  row: TraceDataRow,
+  row: ReplayTrace,
   queryParams: any
 ) {
   const data = await api.requestPromise(
@@ -61,7 +60,7 @@ async function fetchSingleTraceMetaNew(
 async function fetchTraceMetaInBatches(
   api: Client,
   organization: Organization,
-  traceDataRows: TraceDataRow[],
+  traceDataRows: ReplayTrace[],
   normalizedParams: any,
   filters: Partial<PageFilters> = {}
 ) {
@@ -131,7 +130,7 @@ export type TraceMetaQueryResults = {
   status: QueryStatus;
 };
 
-export function useTraceMeta(traceDataRows: TraceDataRow[]): TraceMetaQueryResults {
+export function useTraceMeta(traceDataRows: ReplayTrace[]): TraceMetaQueryResults {
   const filters = usePageFilters();
   const api = useApi();
   const organization = useOrganization();


### PR DESCRIPTION
There is a mismatch between the number of events reflected by the `events-trace` endpoint and the `events-trace-meta` endpoint. The latter reports less events. This is a bigger issue now since we use the response from the `events-trace-meta` endpoint to determine the `canFetch` property of a txn in the trace waterfall (i.e. to determine if there are embedded span children and if we should render the '+' icon). 

We query for the `traceId`and `min(timestamp)` of the traces associated with a replay. We weren't passing  `timestamp: min(timestamp)` as a param to the events-trace-meta endpoint from replay trace tab.  

This doesn't solve the problem, the mismatch still exists, but this is the right thing to do and lets us narrow down the issue to the Backend. 

