### PR TITLE
fix(tooltip): Default tooltip portal to document.body at runtime

### DIFF
--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -16,12 +16,10 @@ interface TooltipContextProps {
    * This is particularly useful for making the tooltip interactive within specific contexts,
    * such as inside a modal. By default the tooltip is rendered in the 'document.body'.
    */
-  container: Parameters<typeof createPortal>[1];
+  container: Element | DocumentFragment | null;
 }
 
-export const TooltipContext = createContext<TooltipContextProps>({
-  container: document.body,
-});
+export const TooltipContext = createContext<TooltipContextProps>({container: null});
 
 interface TooltipProps extends UseHoverOverlayProps {
   /**
@@ -79,7 +77,10 @@ function Tooltip({
   return (
     <Fragment>
       {wrapTrigger(children)}
-      {createPortal(<AnimatePresence>{tooltipContent}</AnimatePresence>, container)}
+      {createPortal(
+        <AnimatePresence>{tooltipContent}</AnimatePresence>,
+        container ?? document.body
+      )}
     </Fragment>
   );
 }


### PR DESCRIPTION
Refs: [JAVASCRIPT-2NAQ](https://sentry.sentry.io/issues/4322983594/)

Sometimes we're seeing `Target container is not a DOM element.`.
Hopefully this change ensures we always have a DOM element.