### PR TITLE
fix(alerts): Simplify form rendering conditions

### DIFF
--- a/static/app/views/alerts/edit.tsx
+++ b/static/app/views/alerts/edit.tsx
@@ -32,7 +32,7 @@ type Props = RouteComponentProps<RouteParams, {}> & {
 };
 
 function ProjectAlertsEditor(props: Props) {
-  const {hasMetricAlerts, hasUptimeAlerts, members, organization, project} = props;
+  const {members, organization, project} = props;
   const location = useLocation();
 
   const [title, setTitle] = useState('');
@@ -80,7 +80,7 @@ function ProjectAlertsEditor(props: Props) {
       <Layout.Body>
         {!teamsLoading ? (
           <Fragment>
-            {(!hasMetricAlerts || alertType === CombinedAlertType.ISSUE) && (
+            {alertType === CombinedAlertType.ISSUE && (
               <IssueEditor
                 {...props}
                 project={project}
@@ -89,7 +89,7 @@ function ProjectAlertsEditor(props: Props) {
                 members={members}
               />
             )}
-            {hasMetricAlerts && alertType === CombinedAlertType.METRIC && (
+            {alertType === CombinedAlertType.METRIC && (
               <MetricRulesEdit
                 {...props}
                 project={project}
@@ -97,7 +97,7 @@ function ProjectAlertsEditor(props: Props) {
                 userTeamIds={teams.map(({id}) => id)}
               />
             )}
-            {hasUptimeAlerts && alertType === CombinedAlertType.UPTIME && (
+            {alertType === CombinedAlertType.UPTIME && (
               <UptimeRulesEdit
                 {...props}
                 project={project}


### PR DESCRIPTION
We can just render these based on the issue types. This way we will never render two at once.

Fixes a case where uptime alerts AND issue alerts edit form were rendering together like this

![image](https://github.com/user-attachments/assets/49583765-3a0f-4fc5-89d3-bffd9d8a6c01)
