### PR TITLE
ref(js): Remove legacy withRouter types

### DIFF
--- a/static/app/types/react-router.d.ts
+++ b/static/app/types/react-router.d.ts
@@ -32,19 +32,4 @@ declare module 'react-router' {
     router: InjectedRouter<P, Q>;
     routes: PlainRoute[];
   }
-
-  type ComponentConstructor<P> =
-    | ComponentClass<P>
-    | FunctionComponent<P>
-    | ComponentType<P>;
-
-  declare function withRouter<P extends WithRouterProps>(
-    component: ComponentConstructor<P>,
-    options?: Options
-  ): ComponentClass<Omit<P, keyof WithRouterProps>>;
-
-  declare function withRouter<P extends WithRouterProps, S>(
-    component: ComponentConstructor<P> & S,
-    options?: Options
-  ): ComponentClass<Omit<P, keyof WithRouterProps>> & S;
 }

--- a/static/app/utils/withSentryRouter.tsx
+++ b/static/app/utils/withSentryRouter.tsx
@@ -5,11 +5,11 @@ import {CUSTOMER_DOMAIN, USING_CUSTOMER_DOMAIN} from 'sentry/constants';
 import useRouter from './useRouter';
 
 /**
- * withSentryRouter is a higher-order component (HOC) that wraps withRouter, and implicitly injects the current customer
- * domain as the orgId parameter. This only happens if a customer domain is currently being used.
+ * withSentryRouter is a higher-order component (HOC) that emulates withRouter,
+ * and implicitly injects the current customer domain as the orgId parameter.
+ * This only happens if a customer domain is currently being used.
  *
- * Since withRouter() is discouraged from being used on new React components, we would use withSentryRouter() on
- * pre-existing React components.
+ * @deprecated only use in legacy react class components
  */
 function withSentryRouter<P extends WithRouterProps>(
   WrappedComponent: React.ComponentType<P>


### PR DESCRIPTION
These are not used anymore as the withSentryRouter is implemented using
hooks.