### PR TITLE
ref(js): Move RouteAnalyticsContext to App

### DIFF
--- a/static/app/main.tsx
+++ b/static/app/main.tsx
@@ -15,18 +15,15 @@ import {
 } from 'sentry/utils/queryClient';
 import {RouteContext} from 'sentry/views/routeContext';
 
-import RouteAnalyticsContextProvider from './views/routeAnalyticsContextProvider';
 /**
  * Renders our compatibility RouteContext.Provider. This will go away with
  * react-router v6.
  */
 function renderRouter(props: any) {
   return (
-    <RouteAnalyticsContextProvider {...props}>
-      <RouteContext.Provider value={props}>
-        <RouterContext {...props} />
-      </RouteContext.Provider>
-    </RouteAnalyticsContextProvider>
+    <RouteContext.Provider value={props}>
+      <RouterContext {...props} />
+    </RouteContext.Provider>
   );
 }
 

--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -31,6 +31,7 @@ import {useUser} from 'sentry/utils/useUser';
 import type {InstallWizardProps} from 'sentry/views/admin/installWizard';
 import {AsyncSDKIntegrationContextProvider} from 'sentry/views/app/asyncSDKIntegrationProvider';
 import {OrganizationContextProvider} from 'sentry/views/organizationContext';
+import RouteAnalyticsContextProvider from 'sentry/views/routeAnalyticsContextProvider';
 
 import SystemAlerts from './systemAlerts';
 
@@ -234,20 +235,22 @@ function App({children, params}: Props) {
 
   return (
     <Profiler id="App" onRender={onRenderCallback}>
-      <OrganizationContextProvider>
-        <AsyncSDKIntegrationContextProvider>
-          <GlobalDrawer>
-            <GlobalFeedbackForm>
-              <MainContainer tabIndex={-1} ref={mainContainerRef}>
-                <GlobalModal onClose={handleModalClose} />
-                <SystemAlerts className="messages-container" />
-                <Indicators className="indicators-container" />
-                <ErrorBoundary>{renderBody()}</ErrorBoundary>
-              </MainContainer>
-            </GlobalFeedbackForm>
-          </GlobalDrawer>
-        </AsyncSDKIntegrationContextProvider>
-      </OrganizationContextProvider>
+      <RouteAnalyticsContextProvider>
+        <OrganizationContextProvider>
+          <AsyncSDKIntegrationContextProvider>
+            <GlobalDrawer>
+              <GlobalFeedbackForm>
+                <MainContainer tabIndex={-1} ref={mainContainerRef}>
+                  <GlobalModal onClose={handleModalClose} />
+                  <SystemAlerts className="messages-container" />
+                  <Indicators className="indicators-container" />
+                  <ErrorBoundary>{renderBody()}</ErrorBoundary>
+                </MainContainer>
+              </GlobalFeedbackForm>
+            </GlobalDrawer>
+          </AsyncSDKIntegrationContextProvider>
+        </OrganizationContextProvider>
+      </RouteAnalyticsContextProvider>
     </Profiler>
   );
 }

--- a/static/app/views/routeAnalyticsContextProvider.tsx
+++ b/static/app/views/routeAnalyticsContextProvider.tsx
@@ -3,6 +3,10 @@ import type {RouteContextInterface} from 'react-router';
 
 import HookStore from 'sentry/stores/hookStore';
 import type {Organization} from 'sentry/types/organization';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useParams} from 'sentry/utils/useParams';
+import useRouter from 'sentry/utils/useRouter';
+import {useRoutes} from 'sentry/utils/useRoutes';
 
 const DEFAULT_CONTEXT = {
   setDisableRouteAnalytics: () => {},
@@ -29,19 +33,27 @@ export const RouteAnalyticsContext = createContext<{
   setRouteAnalyticsParams: (params: Record<string, any>) => void;
 }>(DEFAULT_CONTEXT);
 
-interface Props extends RouteContextInterface {
+interface Props {
   children?: React.ReactNode;
 }
 
-export default function RouteAnalyticsContextProvider({children, ...props}: Props) {
+export default function RouteAnalyticsContextProvider({children}: Props) {
   const useRouteActivatedHook = HookStore.get('react-hook:route-activated')[0];
+
+  const context: RouteContextInterface = {
+    params: useParams(),
+    routes: useRoutes(),
+    router: useRouter(),
+    location: useLocation(),
+  };
+
   const {
     setDisableRouteAnalytics,
     setRouteAnalyticsParams,
     setOrganization,
     setEventNames,
     previousUrl,
-  } = useRouteActivatedHook?.(props) || DEFAULT_CONTEXT;
+  } = useRouteActivatedHook?.(context) || DEFAULT_CONTEXT;
 
   const memoizedValue = useMemo(
     () => ({


### PR DESCRIPTION
Instead of placing this inside the renderRouter we can connect it to the
router hooks to provide the values. This allows it to work with react
router 3 and 6.