### PR TITLE
ref: squash index_together operation for PullRequest model

### DIFF
--- a/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
+++ b/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
@@ -1549,10 +1549,16 @@ class Migration(CheckedMigration):
             options={
                 "db_table": "sentry_pull_request",
                 "unique_together": {("repository_id", "key")},
-                "index_together": {
-                    ("repository_id", "date_added"),
-                    ("organization_id", "merge_commit_sha"),
-                },
+                "indexes": [
+                    models.Index(
+                        fields=["repository_id", "date_added"],
+                        name="sentry_pull_reposit_c429a4_idx",
+                    ),
+                    models.Index(
+                        fields=["organization_id", "merge_commit_sha"],
+                        name="sentry_pull_organiz_8aabcf_idx",
+                    ),
+                ],
             },
         ),
         migrations.CreateModel(

--- a/src/sentry/migrations/0640_index_together.py
+++ b/src/sentry/migrations/0640_index_together.py
@@ -200,16 +200,6 @@ class Migration(CheckedMigration):
             old_fields=("project_id", "code_id"),
         ),
         migrations.RenameIndex(
-            model_name="pullrequest",
-            new_name="sentry_pull_reposit_c429a4_idx",
-            old_fields=("repository_id", "date_added"),
-        ),
-        migrations.RenameIndex(
-            model_name="pullrequest",
-            new_name="sentry_pull_organiz_8aabcf_idx",
-            old_fields=("organization_id", "merge_commit_sha"),
-        ),
-        migrations.RenameIndex(
             model_name="regionoutbox",
             new_name="sentry_regi_shard_s_e7412f_idx",
             old_fields=("shard_scope", "shard_identifier", "id"),


### PR DESCRIPTION
index_together is removed in django 5.1 so this is necessary to upgrade

we will need a hard stop for self-hosted

<!-- Describe your PR here. -->