### PR TITLE
ref: squash index_together operation for UserReport model

### DIFF
--- a/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
+++ b/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
@@ -3195,7 +3195,14 @@ class Migration(CheckedMigration):
             options={
                 "db_table": "sentry_userreport",
                 "unique_together": {("project_id", "event_id")},
-                "index_together": {("project_id", "date_added"), ("project_id", "event_id")},
+                "indexes": [
+                    models.Index(
+                        fields=["project_id", "event_id"], name="sentry_user_project_cbfd59_idx"
+                    ),
+                    models.Index(
+                        fields=["project_id", "date_added"], name="sentry_user_project_b8faaf_idx"
+                    ),
+                ],
             },
         ),
         migrations.CreateModel(

--- a/src/sentry/migrations/0640_index_together.py
+++ b/src/sentry/migrations/0640_index_together.py
@@ -254,14 +254,4 @@ class Migration(CheckedMigration):
             new_name="sentry_rule_project_676d0d_idx",
             old_fields=("project", "status", "owner"),
         ),
-        migrations.RenameIndex(
-            model_name="userreport",
-            new_name="sentry_user_project_b8faaf_idx",
-            old_fields=("project_id", "date_added"),
-        ),
-        migrations.RenameIndex(
-            model_name="userreport",
-            new_name="sentry_user_project_cbfd59_idx",
-            old_fields=("project_id", "event_id"),
-        ),
     ]


### PR DESCRIPTION
index_together is removed in django 5.1 so this is necessary to upgrade

we will need a hard stop for self-hosted

<!-- Describe your PR here. -->