### PR TITLE
ref: squash index_together operation for ReleaseFile model

### DIFF
--- a/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
+++ b/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
@@ -3495,7 +3495,11 @@ class Migration(CheckedMigration):
             options={
                 "db_table": "sentry_releasefile",
                 "unique_together": {("release", "ident")},
-                "index_together": {("release", "name")},
+                "indexes": [
+                    models.Index(
+                        fields=["release_id", "name"], name="sentry_rele_release_bff97c_idx"
+                    ),
+                ],
             },
         ),
         migrations.CreateModel(
@@ -7500,10 +7504,6 @@ class Migration(CheckedMigration):
                 migrations.AlterUniqueTogether(
                     name="releasefile",
                     unique_together={("release_id", "ident")},
-                ),
-                migrations.AlterIndexTogether(
-                    name="releasefile",
-                    index_together={("release_id", "name")},
                 ),
             ],
         ),

--- a/src/sentry/migrations/0640_index_together.py
+++ b/src/sentry/migrations/0640_index_together.py
@@ -235,11 +235,6 @@ class Migration(CheckedMigration):
             old_fields=("organization_id", "release_name", "dist_name", "artifact_bundle"),
         ),
         migrations.RenameIndex(
-            model_name="releasefile",
-            new_name="sentry_rele_release_bff97c_idx",
-            old_fields=("release_id", "name"),
-        ),
-        migrations.RenameIndex(
             model_name="releaseprojectenvironment",
             new_name="sentry_rele_project_922a6a_idx",
             old_fields=("project", "unadopted", "environment"),


### PR DESCRIPTION
index_together is removed in django 5.1 so this is necessary to upgrade

we will need a hard stop for self-hosted

<!-- Describe your PR here. -->