### PR TITLE
dev(mocks): empower-mocks v0 WIP

### DIFF
--- a/bin/empower-mocks
+++ b/bin/empower-mocks
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+import os
+import signal
+
 from sentry.runner import configure
 
 configure()
@@ -7,8 +10,10 @@ import hashlib
 import re
 import subprocess
 import sys
+import time
 import uuid
 from argparse import ArgumentParser
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
 import click
@@ -49,20 +54,31 @@ def download_file(url):
         raise Exception(f"An error occurred while downloading the file: {str(e)}")
 
 
-def get_envelopes(project_name):
-    project_id = EMPOWER_PROJECT_IDS[project_name]
+@dataclass
+class Envelope:
+    content: bytes
+    project_name: str
+    latest_timestamp: datetime | None = field(default=None)
+
+
+# we assume that everything in the bucket is a single "batch" - typically meaning a single Replay session
+def get_envelopes(projects) -> list[Envelope]:
     res = []
-    i = 1
-    while True:
-        envelope = download_file(f"http://{GCP_BUCKET}.storage.googleapis.com/{project_id}/{i}")
-        if envelope is None:
-            break
-        res.append(envelope)
-        i += 1
+    for project_name in projects:
+        project_id = EMPOWER_PROJECT_IDS[project_name]
+        i = 1
+        while True:
+            envelope_content = download_file(
+                f"http://{GCP_BUCKET}.storage.googleapis.com/{project_id}/{i}"
+            )
+            if envelope_content is None:
+                break
+            res.append(Envelope(envelope_content, project_name))
+            i += 1
     return res
 
 
-def send_envelope_into_ingest(envelope, project_id, public_key):
+def send_envelope_into_ingest(envelope, project_id, public_key, quiet=True):
 
     # TODO these are part of URL path so should be parsed out of the envelope:
     # &sentry_version=7&sentry_client=sentry.javascript.react%2F8.20.0
@@ -76,9 +92,12 @@ def send_envelope_into_ingest(envelope, project_id, public_key):
             "content-type: text/plain;charset=UTF-8",
             "-d",
             envelope,
-        ]
+        ],
+        stdout=subprocess.DEVNULL if quiet else sys.stdout,
+        stderr=subprocess.DEVNULL if quiet else sys.stderr,
     )
-    click.echo("")
+    if not quiet:
+        click.echo("")
     # click.echo("Sent envelope: " + envelope.decode("utf-8"))
 
 
@@ -106,68 +125,92 @@ def dt2unix(dt):
     return f"{dt.timestamp():.7f}"
 
 
+ISO_8601_RE = rb"(\"(?:start_timestamp|timestamp|started|sent_at)\":\")(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z)(\")"
+UNIX_FRACT_RE = rb"(\"(?:start_timestamp|timestamp|started|sent_at)\":)(\d{10}\.\d{3,9})([^0-9])"
+
+
+def compute_latest_timestamps(envelopes):
+    for envelope in envelopes:
+        timestamps = [
+            iso2dt(m[1].decode("utf-8")) for m in re.findall(ISO_8601_RE, envelope.content)
+        ] + [unix2dt(m[1].decode("utf-8")) for m in re.findall(UNIX_FRACT_RE, envelope.content)]
+        if not timestamps:
+            click.echo(f"[WARNING] No timestamps found in input string: {envelope}")
+        else:
+            envelope.latest_timestamp = max(timestamps)
+
+
 # Shift all timestamps by equal amount so that the latest timestamp found becomes `base_time`
 #
 # NOTE: this can potentially mess up JSON in breadcrumbs, HTTP response bodies, etc.
 # but we don't care if that happens as this is demo data and those values can be anything.
 # What's potentially undesirable is if extraneous timestamps happens to the latest timestamp
 # that's why we try to match keys to reduce the chance of that happening.
-def shift_all_timestamps(envelope, base_time=None):
-    base_time = base_time or datetime.now(timezone.utc)
-    iso_8601_re = rb"(\"(?:start_timestamp|timestamp|started|sent_at)\":\")(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z)(\")"
-    unix_fract_re = (
-        rb"(\"(?:start_timestamp|timestamp|started|sent_at)\":)(\d{10}\.\d{3,9})([^0-9])"
-    )
-
-    datetime_objects = [iso2dt(m[1].decode("utf-8")) for m in re.findall(iso_8601_re, envelope)] + [
-        unix2dt(m[1].decode("utf-8")) for m in re.findall(unix_fract_re, envelope)
-    ]
-    if not datetime_objects:
-        click.echo(f"[WARNING] No timestamps found in input string: {envelope}")
-        return envelope
-    latest_time = max(datetime_objects)
+def shift_all_timestamps(envelopes: list[Envelope], base_time: datetime) -> list[Envelope]:
+    latest_time = max(e.latest_timestamp for e in envelopes)
     offset = base_time - latest_time
 
-    return re.sub(
-        iso_8601_re,
-        lambda m: m.group(1) + dt2iso(iso2dt(m.group(2)) + offset).encode("utf-8") + m.group(3),
-        re.sub(
-            unix_fract_re,
-            lambda m: m.group(1)
-            + dt2unix(unix2dt(m.group(2)) + offset).encode("utf-8")
-            + m.group(3),
-            envelope,
-        ),
-    )
+    new_envelopes = []
+    for envelope in envelopes:
+        new_envelopes.append(
+            Envelope(
+                re.sub(
+                    ISO_8601_RE,
+                    lambda m: m.group(1)
+                    + dt2iso(iso2dt(m.group(2)) + offset).encode("utf-8")
+                    + m.group(3),
+                    re.sub(
+                        UNIX_FRACT_RE,
+                        lambda m: m.group(1)
+                        + dt2unix(unix2dt(m.group(2)) + offset).encode("utf-8")
+                        + m.group(3),
+                        envelope.content,
+                    ),
+                ),
+                envelope.project_name,
+                envelope.latest_timestamp + offset,
+            )
+        )
+    return new_envelopes
 
 
 # Replace all ID with their salted hashes
 # All envelopes in the same Replay session must be treated as a single unit to preserve the relationships
 # between events via replay_id and trace_id
-def make_all_ids_unique(envelopes, batch_salt=""):
+def make_all_ids_unique(envelope_content: bytes, batch_salt: bytes = "") -> bytes:
     uuid32_re = (
         rb'("(?:id|event_id|trace_id|profile_id|replay_id|replayId|message|sid)":")([0-9a-f]{32})"'
     )
     id16_re = rb'("(?:parent_span_id|span_id|__span)":")([0-9a-f]{16})"'
 
-    new_envelopes = []
-    for envelope in envelopes:
-        new_envelopes.append(
-            re.sub(
-                uuid32_re,
-                lambda t: t.group(1)
-                + hashlib.sha256(t.group(2) + batch_salt).hexdigest()[:32].encode("utf-8")
-                + b'"',
-                re.sub(
-                    id16_re,
-                    lambda t: t.group(1)
-                    + hashlib.sha256(t.group(2) + batch_salt).hexdigest()[:16].encode("utf-8")
-                    + b'"',
-                    envelope,
-                ),
-            )
-        )
-    return new_envelopes
+    return re.sub(
+        uuid32_re,
+        lambda t: t.group(1)
+        + hashlib.sha256(t.group(2) + batch_salt).hexdigest()[:32].encode("utf-8")
+        + b'"',
+        re.sub(
+            id16_re,
+            lambda t: t.group(1)
+            + hashlib.sha256(t.group(2) + batch_salt).hexdigest()[:16].encode("utf-8")
+            + b'"',
+            envelope_content,
+        ),
+    )
+
+
+def kill_old_backgrounded_processes():
+    process_name = os.path.basename(__file__)
+    try:
+        # Use the `pgrep` command to find processes by name
+        pids = subprocess.check_output(["pgrep", "-f", process_name]).splitlines()
+        for pid in pids:
+            # Exclude the current process to avoid killing itself
+            if int(pid) != os.getpid():
+                os.kill(int(pid), signal.SIGTERM)
+                click.echo(f"Also terminating old backgrounded process with PID {int(pid)}")
+    except subprocess.CalledProcessError:
+        # If `pgrep` doesn't find any processes, it will raise a CalledProcessError
+        pass
 
 
 if __name__ == "__main__":
@@ -176,11 +219,24 @@ if __name__ == "__main__":
 
         parser = ArgumentParser(description="Load latest mock data from empower")
         parser.add_argument(
-            "-p",
             "--projects",
             default=["react", "flask"],
             nargs="+",
             help="List of empower projects",
+        )
+        parser.add_argument(
+            "--stream",
+            nargs="?",  # Makes the value optional
+            const="5",  # Value assigned if the option is provided without a value
+            default=None,  # Value when the option is not provided at all
+            help="Send new events continuously at given interval in seconds (default: 5)",
+            metavar="INTERVAL_SECONDS",
+        )
+        parser.add_argument(
+            "--quiet",
+            default=False,
+            action="store_true",
+            help="Don't print ingest responses",
         )
         options = parser.parse_args()
 
@@ -202,35 +258,63 @@ if __name__ == "__main__":
         project_map = generate_projects(
             organization, tuple([("Empower Plant", tuple(p for p in options.projects))])
         )
-
-        # [ {envelope: bytes, dev_project_id: int, dev_project_public_key: str} ]
-
-        batch_time = datetime.now(timezone.utc)
-        batch_salt = uuid.uuid4().hex.encode("utf-8")
-
-        for project_name in options.projects:
-            # TODO: first update platform, get envelopes, then send as separate step/loop
-            project = project_map[project_name]
+        for project_name, project in project_map.items():
             project.platform = PROJECT_PLATFORM_MAP[project_name]
             project.save()
-            project_public_key = ProjectKey.get_default(project)
 
-            envelopes = get_envelopes(project_name)
-            envelopes = make_all_ids_unique(envelopes, batch_salt)
-            for envelope in envelopes:
+        template_envelopes = get_envelopes(options.projects)
+        compute_latest_timestamps(template_envelopes)
+        template_envelopes.sort(key=lambda e: e.latest_timestamp)  # why not
+
+        if options.stream:
+            click.echo("")
+            click.echo(f"> Sending new batch of events every {options.stream} seconds")
+            click.echo("")
+            click.echo("^C\tExit")
+            click.echo("^Z\tPause")
+            click.echo("fg\tResume")
+            click.echo("")
+
+            def sigtstp_handler(signum, frame):
+                click.echo("")
+                click.echo("Paused. Use `fg` command to resume")
+                # sys.stdout.flush()  # Ensure the message is printed immediately
+                # Reset the signal handler to the default to allow the process to stop
+                signal.signal(signal.SIGTSTP, signal.SIG_DFL)
+                os.kill(os.getpid(), signal.SIGTSTP)
+
+            signal.signal(signal.SIGTSTP, sigtstp_handler)
+
+        while True:
+            batch_envelopes = shift_all_timestamps(template_envelopes, datetime.now(timezone.utc))
+            batch_salt = uuid.uuid4().hex.encode("utf-8")
+
+            for envelope in batch_envelopes:
+                project = project_map[envelope.project_name]
                 send_envelope_into_ingest(
-                    shift_all_timestamps(envelope, base_time=batch_time),
+                    make_all_ids_unique(envelope.content, batch_salt),
                     project.id,
-                    project_public_key,
+                    ProjectKey.get_default(project),
+                    options.quiet,
                 )
 
-        click.echo("    > Done sending envelopes. Waiting for processing to finish")
+            if not options.stream:
+                click.echo("    > Done sending initial envelopes. Waiting for processing to finish")
+                if hasattr(buffer, "process_pending"):
+                    click.echo("    > Processing pending buffers")
+                    buffer.process_pending()
+                click.echo("    > Processing complete")
+                break
+            else:
+                if not options.quiet:
+                    click.echo("")
+                time.sleep(float(options.stream))
 
-        if hasattr(buffer, "process_pending"):
-            click.echo("    > Processing pending buffers")
-            buffer.process_pending()
-
-        click.echo("    > Processing complete")
+    except KeyboardInterrupt:
+        click.echo("")
+        click.echo("Exiting...")
+        kill_old_backgrounded_processes()
+        sys.exit(0)
 
     except Exception:
         # Avoid reporting any issues recursively back into Sentry

--- a/bin/empower-mocks
+++ b/bin/empower-mocks
@@ -1,0 +1,218 @@
+#!/usr/bin/env python
+from sentry.runner import configure
+
+configure()
+
+from django.conf import settings
+
+from sentry.utils import mockdata
+
+GCP_BUCKET = "empower-mocks-production"
+
+EMPOWER_PROJECT_IDS = {
+    "react": 2,
+    "flask": 3,
+    "ruby": 4,
+}
+
+import requests
+
+
+def download_file(url):
+    try:
+        response = requests.get(url)
+        if response.status_code == 200:
+            return response.content
+        elif response.status_code == 404:
+            return None
+        else:
+            response.raise_for_status()  # This will raise an HTTPError
+    except requests.exceptions.RequestException as e:
+        raise Exception(f"An error occurred while downloading the file: {str(e)}")
+
+
+def get_envelopes(project_name):
+    project_id = EMPOWER_PROJECT_IDS[project_name]
+    res = []
+    i = 1
+    while True:
+        envelope = download_file(f"https://${GCP_BUCKET}.storage.googleapis.com/${project_id}/${i}")
+        if envelope is None:
+            break
+        res.append(envelope)
+        i += 1
+    return res
+
+
+# Example of how to send an envelope to the ingest endpoint:
+
+# curl 'http://dev.getsentry.net:8000/api/1/envelope/?sentry_key=c42483a849febd65cfd8dd6df482e68e&sentry_version=7&sentry_client=sentry.javascript.react%2F8.20.0' \
+#  -H 'accept: */*' \
+#  -H 'accept-language: en-US,en;q=0.9' \
+#  -H 'cache-control: no-cache' \
+#  -H 'content-type: text/plain;charset=UTF-8' \
+#  -H 'origin: https://application-monitoring-react-dot-sales-engineering-sf.appspot.com' \
+#  -H 'pragma: no-cache' \
+#  -H 'priority: u=1, i' \
+#  -H 'referer: https://application-monitoring-react-dot-sales-engineering-sf.appspot.com/' \
+#  -H 'sec-ch-ua: "Not)A;Brand";v="99", "Google Chrome";v="127", "Chromium";v="127"' \
+#  -H 'sec-ch-ua-mobile: ?0' \
+#  -H 'sec-ch-ua-platform: "macOS"' \
+#  -H 'sec-fetch-dest: empty' \
+#  -H 'sec-fetch-mode: cors' \
+#  -H 'sec-fetch-site: cross-site' \
+#  -H 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36' \
+#  --data-raw $'{"event_id":"c59350a64a4841fb96697bd832472b19","sent_at":"2024-08-21T19:53:31.548Z","sdk":{"name":"sentry.javascript.react","version":"8.20.0"},"trace":
+def send_envelope_into_ingest(envelope, project_id, public_key):
+    import subprocess
+
+    # TODO these are part of URL path so should be parsed out of the envelope:
+    # &sentry_version=7&sentry_client=sentry.javascript.react%2F8.20.0
+    subprocess.run(
+        [
+            "curl",
+            "-X",
+            "POST",
+            f"http://dev.getsentry.net:8000/api/${project_id}/envelope/?sentry_key=${public_key}",
+            "-H",
+            "content-type: text/plain;charset=UTF-8",
+            "-d",
+            envelope,
+        ]
+    )
+
+
+import re
+from datetime import datetime, timezone
+
+
+def adjust_timestamp(match, time_difference):
+    original_timestamp = datetime.strptime(match.group(0), "%Y-%m-%dT%H:%M:%S.%fZ").replace(
+        tzinfo=timezone.utc
+    )
+    new_timestamp = original_timestamp + time_difference
+    return new_timestamp.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+# shift all timestamps by equal amount so that the latest timestamp found becomes `base_time`
+def adjust_all_timestamps(input_string, base_time=None):
+    base_time = base_time or datetime.now(timezone.utc)
+    iso_8601_pattern = r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z"
+    timestamps = re.findall(iso_8601_pattern, input_string)
+    datetime_objects = [
+        datetime.strptime(ts, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=timezone.utc)
+        for ts in timestamps
+    ]
+    latest_timestamp = max(datetime_objects)
+    time_difference = base_time - latest_timestamp
+    return re.sub(iso_8601_pattern, lambda t: adjust_timestamp(t, time_difference), input_string)
+
+
+if __name__ == "__main__":
+    try:
+        settings.CELERY_ALWAYS_EAGER = True
+
+        import sys
+        from argparse import ArgumentParser
+
+        parser = ArgumentParser(description="Load latest mock data from empower")
+        parser.add_argument("-p", "--projects", nargs="+", help="List of empower projects")
+        parser.add_argument(
+            "-s",
+            "--stream",
+            default=False,
+            action="store_true",
+            help="Continuously send new events",
+        )
+        parser.add_option("--events", default=1, type=int, help="number of events to generate")
+        parser.add_option(
+            "--skip-default-setup",
+            default=False,
+            action="store_true",
+            help="Skips creating the default project, teams and timeseries, useful when only loading specific transactions",
+        )
+        parser.add_option(
+            "--extra-events",
+            default=False,
+            action="store_true",
+            help="add multiple events for each error group",
+        )
+        parser.add_option(
+            "--load-trends",
+            default=False,
+            action="store_true",
+            help="load multiple transactions for each id to show trends",
+        )
+        parser.add_option(
+            "--load-performance-issues",
+            default=False,
+            action="store_true",
+            help="load transactions with performance issues, still needs options/flags on for issues to appear.",
+        )
+        parser.add_option(
+            "--slow",
+            default=False,
+            action="store_true",
+            help="sleep between each transaction to let clickhouse rest",
+        )
+        options = parser.parse_args()
+
+        if options.stream:
+            raise NotImplementedError("Streaming is not yet supported")
+
+        import subprocess
+
+        ingest_running = subprocess.run(["ls", "-l"]).returncode == 0
+        if not ingest_running:
+            # print(
+            #    "Ingest is not running. Please follow https://develop.sentry.dev/development/environment/#ingestion-pipeline-relay-aka-sending-events-to-your-dev-environment"
+            # )
+            sys.exit(1)
+
+        mock_config = [
+            {"team_name": "Empower Plant", "projects": []},
+        ]
+
+        for project_name in options.projects:
+            proj_conf = {"name": project_name}
+            envelopes = get_envelopes(project_name)
+
+            all_envelopes = "".join(envelopes)
+            release_re = r'"release":"(.*?)"'
+            if re.search(release_re, all_envelopes):
+                proj_conf["release_version"] = re.search(release_re, all_envelopes).group(1)
+            else:
+                pass
+                # print(f"[WARNING] No release version found in envelopes for project '${project_name}'")
+
+            mock_config[0]["projects"].append(proj_conf)
+
+            # TODO !!!! this should not be inside the loop
+            mockdata.main(
+                # TODO implement same CLI as load-mocks and pass these options
+                skip_default_setup=options.skip_default_setup,
+                num_events=options.events,
+                extra_events=options.extra_events,
+                load_trends=options.load_trends,
+                load_performance_issues=options.load_performance_issues,
+                slow=options.slow,
+                mock_config=mock_config,
+                # TODO: add a flag to skip the actual sending of events
+            )
+
+            # TODO now get local project IDs and public keys for project with given name
+            dev_project_id = None
+            dev_project_public_key = None
+
+            for envelope in envelopes:
+                send_envelope_into_ingest(
+                    adjust_all_timestamps(envelope), dev_project_id, dev_project_public_key
+                )
+
+    except Exception:
+        # Avoid reporting any issues recursively back into Sentry
+        import sys
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)

--- a/bin/empower-mocks
+++ b/bin/empower-mocks
@@ -3,9 +3,11 @@ from sentry.runner import configure
 
 configure()
 
+import hashlib
 import re
 import subprocess
 import sys
+import uuid
 from argparse import ArgumentParser
 from datetime import datetime, timezone
 
@@ -20,6 +22,7 @@ from sentry.utils.mockdata.core import generate_projects
 
 GCP_BUCKET = "empower-mocks-production"
 
+# TODO: do mapping on empower/mini-relay side as it has control over project ids
 EMPOWER_PROJECT_IDS = {
     "react": 2,
     "flask": 3,
@@ -59,25 +62,6 @@ def get_envelopes(project_name):
     return res
 
 
-# Example of how to send an envelope to the ingest endpoint:
-
-# curl 'http://dev.getsentry.net:8000/api/1/envelope/?sentry_key=c42483a849febd65cfd8dd6df482e68e&sentry_version=7&sentry_client=sentry.javascript.react%2F8.20.0' \
-#  -H 'accept: */*' \
-#  -H 'accept-language: en-US,en;q=0.9' \
-#  -H 'cache-control: no-cache' \
-#  -H 'content-type: text/plain;charset=UTF-8' \
-#  -H 'origin: https://application-monitoring-react-dot-sales-engineering-sf.appspot.com' \
-#  -H 'pragma: no-cache' \
-#  -H 'priority: u=1, i' \
-#  -H 'referer: https://application-monitoring-react-dot-sales-engineering-sf.appspot.com/' \
-#  -H 'sec-ch-ua: "Not)A;Brand";v="99", "Google Chrome";v="127", "Chromium";v="127"' \
-#  -H 'sec-ch-ua-mobile: ?0' \
-#  -H 'sec-ch-ua-platform: "macOS"' \
-#  -H 'sec-fetch-dest: empty' \
-#  -H 'sec-fetch-mode: cors' \
-#  -H 'sec-fetch-site: cross-site' \
-#  -H 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36' \
-#  --data-raw $'{"event_id":"c59350a64a4841fb96697bd832472b19","sent_at":"2024-08-21T19:53:31.548Z","sdk":{"name":"sentry.javascript.react","version":"8.20.0"},"trace":
 def send_envelope_into_ingest(envelope, project_id, public_key):
 
     # TODO these are part of URL path so should be parsed out of the envelope:
@@ -95,77 +79,95 @@ def send_envelope_into_ingest(envelope, project_id, public_key):
         ]
     )
     click.echo("")
+    # click.echo("Sent envelope: " + envelope.decode("utf-8"))
 
 
-def adjust_timestamp_str_iso(time_str, time_difference):
-    original_timestamp = datetime.strptime(time_str, "%Y-%m-%dT%H:%M:%S.%fZ").replace(
+def decode_if_needed(str_or_bytes):
+    if type(str_or_bytes) is not str:
+        return str_or_bytes.decode("utf-8")
+    return str_or_bytes
+
+
+def iso2dt(iso_str):
+    return datetime.strptime(decode_if_needed(iso_str), "%Y-%m-%dT%H:%M:%S.%fZ").replace(
         tzinfo=timezone.utc
     )
-    new_timestamp = original_timestamp + time_difference
-    return new_timestamp.strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
 
 
-def adjust_timestamp_str_unix(time_str, time_difference):
-    original_timestamp = datetime.fromtimestamp(float(time_str)).replace(tzinfo=timezone.utc)
-    new_timestamp = original_timestamp + time_difference
-    return f"{new_timestamp.timestamp():.7f}"
+def dt2iso(dt):
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
+
+
+def unix2dt(unix_str):
+    return datetime.fromtimestamp(float(decode_if_needed(unix_str))).replace(tzinfo=timezone.utc)
+
+
+def dt2unix(dt):
+    return f"{dt.timestamp():.7f}"
 
 
 # Shift all timestamps by equal amount so that the latest timestamp found becomes `base_time`
-#
-# sample timestamps:
-# "start_timestamp":"2024-08-21T20:28:13.449378Z"
-# "started":"2024-08-21T20:28:00.000000Z"
-# "sent_at":"2024-08-21T20:28:13.468774Z"
-# "timestamp":"2024-08-21T20:28:13.460543Z"
-# "timestamp":1724272105.1860375
 #
 # NOTE: this can potentially mess up JSON in breadcrumbs, HTTP response bodies, etc.
 # but we don't care if that happens as this is demo data and those values can be anything.
 # What's potentially undesirable is if extraneous timestamps happens to the latest timestamp
 # that's why we try to match keys to reduce the chance of that happening.
-def adjust_all_timestamps(input_string, base_time=None):
+def shift_all_timestamps(envelope, base_time=None):
     base_time = base_time or datetime.now(timezone.utc)
-    iso_8601_re = (
-        rb"(?<=(?:started|sent_at|mestamp)\":\")\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z(?=\")"
+    iso_8601_re = rb"(\"(?:start_timestamp|timestamp|started|sent_at)\":\")(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z)(\")"
+    unix_fract_re = (
+        rb"(\"(?:start_timestamp|timestamp|started|sent_at)\":)(\d{10}\.\d{3,9})([^0-9])"
     )
-    unix_fract_re = rb"(?<=(?:started|sent_at|mestamp)\":)\d{10}\.\d{3,9}"
 
-    datetime_objects = [
-        datetime.strptime(ts.decode("utf-8"), "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=timezone.utc)
-        for ts in re.findall(iso_8601_re, input_string)
-    ] + [
-        datetime.fromtimestamp(float(ts.decode("utf-8"))).replace(tzinfo=timezone.utc)
-        for ts in re.findall(unix_fract_re, input_string)
+    datetime_objects = [iso2dt(m[1].decode("utf-8")) for m in re.findall(iso_8601_re, envelope)] + [
+        unix2dt(m[1].decode("utf-8")) for m in re.findall(unix_fract_re, envelope)
     ]
     if not datetime_objects:
-        click.echo(f"[WARNING] No timestamps found in input string: {input_string}")
-        return input_string
-    latest_timestamp = max(datetime_objects)
-    time_difference = base_time - latest_timestamp
+        click.echo(f"[WARNING] No timestamps found in input string: {envelope}")
+        return envelope
+    latest_time = max(datetime_objects)
+    offset = base_time - latest_time
+
     return re.sub(
         iso_8601_re,
-        lambda t: adjust_timestamp_str_iso(t.group(0).decode("utf-8"), time_difference).encode(
-            "utf-8"
-        ),
+        lambda m: m.group(1) + dt2iso(iso2dt(m.group(2)) + offset).encode("utf-8") + m.group(3),
         re.sub(
             unix_fract_re,
-            lambda t: adjust_timestamp_str_unix(t.group(0).decode("utf-8"), time_difference).encode(
-                "utf-8"
-            ),
-            input_string,
+            lambda m: m.group(1)
+            + dt2unix(unix2dt(m.group(2)) + offset).encode("utf-8")
+            + m.group(3),
+            envelope,
         ),
     )
 
 
-def extract_release_from_envelopes(envelopes):
-    all_envelopes = "".join(envelopes)
-    release_re = rb'"release":"(.*?)"'
-    search_res = re.search(release_re, all_envelopes)
-    if search_res:
-        return search_res.group(1)  # first match
-    else:
-        click.echo(f"[WARNING] No release version found in envelopes for project '${project_name}'")
+# Replace all ID with their salted hashes
+# All envelopes in the same Replay session must be treated as a single unit to preserve the relationships
+# between events via replay_id and trace_id
+def make_all_ids_unique(envelopes, batch_salt=""):
+    uuid32_re = (
+        rb'("(?:id|event_id|trace_id|profile_id|replay_id|replayId|message|sid)":")([0-9a-f]{32})"'
+    )
+    id16_re = rb'("(?:parent_span_id|span_id|__span)":")([0-9a-f]{16})"'
+
+    new_envelopes = []
+    for envelope in envelopes:
+        new_envelopes.append(
+            re.sub(
+                uuid32_re,
+                lambda t: t.group(1)
+                + hashlib.sha256(t.group(2) + batch_salt).hexdigest()[:32].encode("utf-8")
+                + b'"',
+                re.sub(
+                    id16_re,
+                    lambda t: t.group(1)
+                    + hashlib.sha256(t.group(2) + batch_salt).hexdigest()[:16].encode("utf-8")
+                    + b'"',
+                    envelope,
+                ),
+            )
+        )
+    return new_envelopes
 
 
 if __name__ == "__main__":
@@ -196,27 +198,30 @@ if __name__ == "__main__":
             )
             sys.exit(1)
 
-        # owner = get_superuser()
-        # user = create_user()
         organization = get_organization()
-        # create_owner(organization, owner)
-        # member = create_member(organization, user, role=roles.get_default().id)
         project_map = generate_projects(
             organization, tuple([("Empower Plant", tuple(p for p in options.projects))])
         )
 
+        # [ {envelope: bytes, dev_project_id: int, dev_project_public_key: str} ]
+
+        batch_time = datetime.now(timezone.utc)
+        batch_salt = uuid.uuid4().hex.encode("utf-8")
+
         for project_name in options.projects:
-            envelopes = get_envelopes(project_name)
+            # TODO: first update platform, get envelopes, then send as separate step/loop
             project = project_map[project_name]
             project.platform = PROJECT_PLATFORM_MAP[project_name]
             project.save()
+            project_public_key = ProjectKey.get_default(project)
 
-            dev_project_id = project.id
-            dev_project_public_key = ProjectKey.get_default(project)
-
+            envelopes = get_envelopes(project_name)
+            envelopes = make_all_ids_unique(envelopes, batch_salt)
             for envelope in envelopes:
                 send_envelope_into_ingest(
-                    adjust_all_timestamps(envelope), dev_project_id, dev_project_public_key
+                    shift_all_timestamps(envelope, base_time=batch_time),
+                    project.id,
+                    project_public_key,
                 )
 
         click.echo("    > Done sending envelopes. Waiting for processing to finish")

--- a/bin/empower-mocks
+++ b/bin/empower-mocks
@@ -3,9 +3,20 @@ from sentry.runner import configure
 
 configure()
 
+import re
+import subprocess
+import sys
+from argparse import ArgumentParser
+from datetime import datetime, timezone
+
+import click
+import requests
 from django.conf import settings
 
-from sentry.utils import mockdata
+from sentry import buffer
+from sentry.models.projectkey import ProjectKey
+from sentry.utils.mockdata import get_organization
+from sentry.utils.mockdata.core import generate_projects
 
 GCP_BUCKET = "empower-mocks-production"
 
@@ -15,7 +26,11 @@ EMPOWER_PROJECT_IDS = {
     "ruby": 4,
 }
 
-import requests
+PROJECT_PLATFORM_MAP = {
+    "react": "javascript-react",
+    "flask": "python-flask",
+    "ruby": "ruby",
+}
 
 
 def download_file(url):
@@ -36,7 +51,7 @@ def get_envelopes(project_name):
     res = []
     i = 1
     while True:
-        envelope = download_file(f"https://${GCP_BUCKET}.storage.googleapis.com/${project_id}/${i}")
+        envelope = download_file(f"http://{GCP_BUCKET}.storage.googleapis.com/{project_id}/{i}")
         if envelope is None:
             break
         res.append(envelope)
@@ -64,7 +79,6 @@ def get_envelopes(project_name):
 #  -H 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36' \
 #  --data-raw $'{"event_id":"c59350a64a4841fb96697bd832472b19","sent_at":"2024-08-21T19:53:31.548Z","sdk":{"name":"sentry.javascript.react","version":"8.20.0"},"trace":
 def send_envelope_into_ingest(envelope, project_id, public_key):
-    import subprocess
 
     # TODO these are part of URL path so should be parsed out of the envelope:
     # &sentry_version=7&sentry_client=sentry.javascript.react%2F8.20.0
@@ -73,141 +87,145 @@ def send_envelope_into_ingest(envelope, project_id, public_key):
             "curl",
             "-X",
             "POST",
-            f"http://dev.getsentry.net:8000/api/${project_id}/envelope/?sentry_key=${public_key}",
+            f"http://dev.getsentry.net:8000/api/{project_id}/envelope/?sentry_key={public_key}",
             "-H",
             "content-type: text/plain;charset=UTF-8",
             "-d",
             envelope,
         ]
     )
+    click.echo("")
 
 
-import re
-from datetime import datetime, timezone
-
-
-def adjust_timestamp(match, time_difference):
-    original_timestamp = datetime.strptime(match.group(0), "%Y-%m-%dT%H:%M:%S.%fZ").replace(
+def adjust_timestamp_str_iso(time_str, time_difference):
+    original_timestamp = datetime.strptime(time_str, "%Y-%m-%dT%H:%M:%S.%fZ").replace(
         tzinfo=timezone.utc
     )
     new_timestamp = original_timestamp + time_difference
-    return new_timestamp.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+    return new_timestamp.strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
 
 
-# shift all timestamps by equal amount so that the latest timestamp found becomes `base_time`
+def adjust_timestamp_str_unix(time_str, time_difference):
+    original_timestamp = datetime.fromtimestamp(float(time_str)).replace(tzinfo=timezone.utc)
+    new_timestamp = original_timestamp + time_difference
+    return f"{new_timestamp.timestamp():.7f}"
+
+
+# Shift all timestamps by equal amount so that the latest timestamp found becomes `base_time`
+#
+# sample timestamps:
+# "start_timestamp":"2024-08-21T20:28:13.449378Z"
+# "started":"2024-08-21T20:28:00.000000Z"
+# "sent_at":"2024-08-21T20:28:13.468774Z"
+# "timestamp":"2024-08-21T20:28:13.460543Z"
+# "timestamp":1724272105.1860375
+#
+# NOTE: this can potentially mess up JSON in breadcrumbs, HTTP response bodies, etc.
+# but we don't care if that happens as this is demo data and those values can be anything.
+# What's potentially undesirable is if extraneous timestamps happens to the latest timestamp
+# that's why we try to match keys to reduce the chance of that happening.
 def adjust_all_timestamps(input_string, base_time=None):
     base_time = base_time or datetime.now(timezone.utc)
-    iso_8601_pattern = r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z"
-    timestamps = re.findall(iso_8601_pattern, input_string)
+    iso_8601_re = (
+        rb"(?<=(?:started|sent_at|mestamp)\":\")\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z(?=\")"
+    )
+    unix_fract_re = rb"(?<=(?:started|sent_at|mestamp)\":)\d{10}\.\d{3,9}"
+
     datetime_objects = [
-        datetime.strptime(ts, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=timezone.utc)
-        for ts in timestamps
+        datetime.strptime(ts.decode("utf-8"), "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=timezone.utc)
+        for ts in re.findall(iso_8601_re, input_string)
+    ] + [
+        datetime.fromtimestamp(float(ts.decode("utf-8"))).replace(tzinfo=timezone.utc)
+        for ts in re.findall(unix_fract_re, input_string)
     ]
+    if not datetime_objects:
+        click.echo(f"[WARNING] No timestamps found in input string: {input_string}")
+        return input_string
     latest_timestamp = max(datetime_objects)
     time_difference = base_time - latest_timestamp
-    return re.sub(iso_8601_pattern, lambda t: adjust_timestamp(t, time_difference), input_string)
+    return re.sub(
+        iso_8601_re,
+        lambda t: adjust_timestamp_str_iso(t.group(0).decode("utf-8"), time_difference).encode(
+            "utf-8"
+        ),
+        re.sub(
+            unix_fract_re,
+            lambda t: adjust_timestamp_str_unix(t.group(0).decode("utf-8"), time_difference).encode(
+                "utf-8"
+            ),
+            input_string,
+        ),
+    )
+
+
+def extract_release_from_envelopes(envelopes):
+    all_envelopes = "".join(envelopes)
+    release_re = rb'"release":"(.*?)"'
+    search_res = re.search(release_re, all_envelopes)
+    if search_res:
+        return search_res.group(1)  # first match
+    else:
+        click.echo(f"[WARNING] No release version found in envelopes for project '${project_name}'")
 
 
 if __name__ == "__main__":
     try:
         settings.CELERY_ALWAYS_EAGER = True
 
-        import sys
-        from argparse import ArgumentParser
-
         parser = ArgumentParser(description="Load latest mock data from empower")
-        parser.add_argument("-p", "--projects", nargs="+", help="List of empower projects")
         parser.add_argument(
-            "-s",
-            "--stream",
-            default=False,
-            action="store_true",
-            help="Continuously send new events",
-        )
-        parser.add_option("--events", default=1, type=int, help="number of events to generate")
-        parser.add_option(
-            "--skip-default-setup",
-            default=False,
-            action="store_true",
-            help="Skips creating the default project, teams and timeseries, useful when only loading specific transactions",
-        )
-        parser.add_option(
-            "--extra-events",
-            default=False,
-            action="store_true",
-            help="add multiple events for each error group",
-        )
-        parser.add_option(
-            "--load-trends",
-            default=False,
-            action="store_true",
-            help="load multiple transactions for each id to show trends",
-        )
-        parser.add_option(
-            "--load-performance-issues",
-            default=False,
-            action="store_true",
-            help="load transactions with performance issues, still needs options/flags on for issues to appear.",
-        )
-        parser.add_option(
-            "--slow",
-            default=False,
-            action="store_true",
-            help="sleep between each transaction to let clickhouse rest",
+            "-p",
+            "--projects",
+            default=["react", "flask"],
+            nargs="+",
+            help="List of empower projects",
         )
         options = parser.parse_args()
 
-        if options.stream:
-            raise NotImplementedError("Streaming is not yet supported")
-
-        import subprocess
-
-        ingest_running = subprocess.run(["ls", "-l"]).returncode == 0
+        ingest_running = (
+            subprocess.run(
+                ["pgrep", "-fl", "sentry run consumer ingest-events"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            ).returncode
+            == 0
+        )
         if not ingest_running:
-            # print(
-            #    "Ingest is not running. Please follow https://develop.sentry.dev/development/environment/#ingestion-pipeline-relay-aka-sending-events-to-your-dev-environment"
-            # )
+            click.echo(
+                "Ingest is required for empower-mocks but is not running. Please follow https://develop.sentry.dev/development/environment/#ingestion-pipeline-relay-aka-sending-events-to-your-dev-environment"
+            )
             sys.exit(1)
 
-        mock_config = [
-            {"team_name": "Empower Plant", "projects": []},
-        ]
+        # owner = get_superuser()
+        # user = create_user()
+        organization = get_organization()
+        # create_owner(organization, owner)
+        # member = create_member(organization, user, role=roles.get_default().id)
+        project_map = generate_projects(
+            organization, tuple([("Empower Plant", tuple(p for p in options.projects))])
+        )
 
         for project_name in options.projects:
-            proj_conf = {"name": project_name}
             envelopes = get_envelopes(project_name)
+            project = project_map[project_name]
+            project.platform = PROJECT_PLATFORM_MAP[project_name]
+            project.save()
 
-            all_envelopes = "".join(envelopes)
-            release_re = r'"release":"(.*?)"'
-            if re.search(release_re, all_envelopes):
-                proj_conf["release_version"] = re.search(release_re, all_envelopes).group(1)
-            else:
-                pass
-                # print(f"[WARNING] No release version found in envelopes for project '${project_name}'")
-
-            mock_config[0]["projects"].append(proj_conf)
-
-            # TODO !!!! this should not be inside the loop
-            mockdata.main(
-                # TODO implement same CLI as load-mocks and pass these options
-                skip_default_setup=options.skip_default_setup,
-                num_events=options.events,
-                extra_events=options.extra_events,
-                load_trends=options.load_trends,
-                load_performance_issues=options.load_performance_issues,
-                slow=options.slow,
-                mock_config=mock_config,
-                # TODO: add a flag to skip the actual sending of events
-            )
-
-            # TODO now get local project IDs and public keys for project with given name
-            dev_project_id = None
-            dev_project_public_key = None
+            dev_project_id = project.id
+            dev_project_public_key = ProjectKey.get_default(project)
 
             for envelope in envelopes:
                 send_envelope_into_ingest(
                     adjust_all_timestamps(envelope), dev_project_id, dev_project_public_key
                 )
+
+        click.echo("    > Done sending envelopes. Waiting for processing to finish")
+
+        if hasattr(buffer, "process_pending"):
+            click.echo("    > Processing pending buffers")
+            buffer.process_pending()
+
+        click.echo("    > Processing complete")
 
     except Exception:
         # Avoid reporting any issues recursively back into Sentry

--- a/src/sentry/utils/mockdata/core.py
+++ b/src/sentry/utils/mockdata/core.py
@@ -393,16 +393,15 @@ def create_access_request(member: OrganizationMember, team: Team) -> None:
     OrganizationAccessRequest.objects.create_or_update(member=member, team=team)
 
 
-# e.g.
-# teams_projects = (
-#   ("Massive Dynamic", ("Ludic Science",)),
-#   ("Captain Planet", ("Earth", "Fire", "Wind", "Water", "Heart")),
-# )
-def generate_projects(organization: Organization, teams_projects) -> Mapping[str, Any]:
+def generate_projects(organization: Organization, mocks=None) -> Mapping[str, Any]:
+    mocks = mocks or (
+        ("Massive Dynamic", ("Ludic Science",)),
+        ("Captain Planet", ("Earth", "Fire", "Wind", "Water", "Heart")),
+    )
     project_map = {}
 
     # Quickly fetch/create the teams and projects
-    for team_name, project_names in teams_projects:
+    for team_name, project_names in mocks:
         click.echo(f"> Mocking team {team_name}")
         team, _ = Team.objects.get_or_create(
             name=team_name, defaults={"organization": organization}
@@ -458,10 +457,10 @@ def create_monitor(project: Project, environment: Environment) -> None:
     )
 
 
-def create_release(project: Project, release_version=None) -> Release:
+def create_release(project: Project) -> Release:
     with transaction.atomic(using=router.db_for_write(Release)):
         release, _ = Release.objects.get_or_create(
-            version=release_version or sha1(uuid4().bytes).hexdigest(),
+            version=sha1(uuid4().bytes).hexdigest(),
             organization_id=project.organization_id,
         )
         release.add_project(project)
@@ -1319,24 +1318,6 @@ def create_mock_user_feedback(project, has_attachment=True):
         create_mock_attachment(event["event_id"], project)
 
 
-DEFAULT_MOCK_CONFIG = [
-    {
-        "team_name": "Massive Dynamic",
-        "projects": [{"name": "Ludic Science"}],  # 'release_version': "1.0.0"
-    },
-    {
-        "team_name": "Captain Planet",
-        "projects": [
-            {"name": "Earth"},
-            {"name": "Fire"},
-            {"name": "Wind"},
-            {"name": "Water"},
-            {"name": "Heart"},
-        ],
-    },
-]
-
-
 def main(
     skip_default_setup=False,
     num_events=1,
@@ -1344,8 +1325,6 @@ def main(
     load_trends=False,
     load_performance_issues=False,
     slow=False,
-    generate_events=True,
-    mock_config=None,
 ):
     owner = get_superuser()
     user = create_user()
@@ -1355,23 +1334,15 @@ def main(
     create_owner(organization, owner)
     member = create_member(organization, user, role=roles.get_default().id)
 
-    mock_config_map = {p["name"]: p for team in mock_config for p in team["projects"]}
-
-    project_map = generate_projects(
-        organization,
-        mock_config
-        and tuple(
-            (team["team_name"], tuple(p["name"] for p in team["projects"])) for team in mock_config
-        ),
-    )
+    project_map = generate_projects(organization)
     if not skip_default_setup:
-        for project_name, project in project_map.items():
-            environment = create_environment(project)  # TODO match env from empower-mocks
+        for project in project_map.values():
+            environment = create_environment(project)
             create_monitor(project, environment)
             create_access_request(member, project.teams.first())
 
             generate_tombstones(project, user)
-            release = create_release(project, mock_config_map[project_name].get("release_version"))
+            release = create_release(project)
             repo = create_repository(organization)
             raw_commits = generate_commit_data(user)
             populate_release(
@@ -1383,25 +1354,22 @@ def main(
                 commits=raw_commits,
             )
             create_metric_alert_rule(organization, project)
-            if generate_events:
-                events = generate_events(
-                    project=project,
-                    release=release,
-                    repository=repo,
-                    user=user,
-                    num_events=num_events,
-                    extra_events=extra_events,
-                )
-                for event in events:
-                    create_sample_time_series(event, release=release)
+            events = generate_events(
+                project=project,
+                release=release,
+                repository=repo,
+                user=user,
+                num_events=num_events,
+                extra_events=extra_events,
+            )
+            for event in events:
+                create_sample_time_series(event, release=release)
 
-                if hasattr(buffer, "process_pending"):
-                    click.echo("    > Processing pending buffers")
-                    buffer.process_pending()
+            if hasattr(buffer, "process_pending"):
+                click.echo("    > Processing pending buffers")
+                buffer.process_pending()
 
-                # TODO: do tests depend on standard captain planet events? should we be merging
-                # mock_config with DEFAULT_MOCK_CONFIG?
-                mocks_loaded.send(project=project, sender=__name__)
+            mocks_loaded.send(project=project, sender=__name__)
 
     create_mock_user_feedback(project_map["Wind"])
     create_mock_transactions(project_map, load_trends, load_performance_issues, slow)


### PR DESCRIPTION
Use latest real events from Empower Plant in your dev environment, with distributed tracing and linked Replays preserved.

### This PR
This PR ships a dev environment script, `empower-mocks` similar to `load-mocks` that takes previously captured envelopes stored in a public GCP bucket, tweaks them to have latest timestamps and unique IDs and sends into locally running ingest pipeline.

```
./bin/empower-mocks --help
usage: empower-mocks [-h] [--projects [PROJECTS ...]] [--stream [INTERVAL_SECONDS]] [--quiet]

Load latest mock data from empower

options:
  -h, --help            show this help message and exit
  --projects [PROJECTS ...]
                        Space-separated list of empower projects (default: react flask)
  --stream [INTERVAL_SECONDS]
                        Send new events continuously at given interval in seconds (default: 5)
  --quiet               Don't print ingest responses
```

Second part, currently being built, is event capture using mini-relay integrated into Empower CI and will allow `empower-mocks` script to have the most recent events, e.g. ones using latest SDK. The goal of it is to provide high-quality real data for local debugging. "Mocks" therefore is a bit of misnomer as this is actual E2E test data.

### --stream option
Instead of ingesting just 1 sample set of events `--stream [INTERVAL_SECONDS]` option will use captured Empower events as a template to generate new events every `INTERVAL_SECONDS` (default: 5) with adjusted timestamps and new IDs.

### Empower

Empower Plant (https://demo.sentry.io/) offers a variety of SDKs and backends, has rich context and good-looking trace waterfall graphs. Its code lives in [sentry-demos/empower](https://github.com/sentry-demos/empower) monorepo and is co-owned by SE and SDK Engineering teams. It has CI and will build, deploy and stream all new merged changes to our `demo` org. You can learn more in [#discuss-demo](https://sentry.slack.com/archives/C05FA9D2PDM) channel on Slack which has documentation links at the top.

### Event capture

The part that captures events from `empower` and stores them in GCP bucket is still work in progress: 
[design doc](https://www.notion.so/sentry/mock-data-for-development-environments-00545d35622f41d9a122eacf8156302b) 
[work already done](https://github.com/sentry-demos/empower/pulls?q=is%3Apr+author%3Aasottile-sentry)

# Implementation details

We chose not to parse envelopes for simplicity and low maintenance burden. Instead whenever possible we search-and-replace values that need to be adjusted. We accept the risk of those accidentally modifying unrelated keys in the event context because this is only test data.

### Expected bucket structure
Note: relies on sequential digit filenames (1,2,3,...) instead of current 3629.173098407 and like. GCP doesn't seem to have a way to browse the bucket via public HTTP. In the future we also want project folders in the bucket to match project names in empower to eliminate the need to hardcode the mapping.

# Testing
```
./bin/empower-mocks
Mocking org Sentry
> Mocking team Empower Plant
  > Mocking project react
  > Mocking project flask
{}
{"id":"aedbad1aaf2ada9a4400c4baa5a70ec5"}
{}
{}
    > Done sending envelopes. Waiting for processing to finish
    > Processing pending buffers
    > Processing complete
```
<img width="1264" alt="Screenshot 2024-08-24 at 12 04 24 AM" src="https://github.com/user-attachments/assets/c5a6da33-1ffd-4ba7-8fc9-19f6ac60df05">


```
./bin/empower-mocks --stream
Mocking org Sentry
> Mocking team Empower Plant
  > Mocking project react
  > Mocking project flask

> Sending new batch of events every 5 seconds

^C	Exit
^Z	Pause
fg	Resume

{}
{}
{"id":"e20479bc8b571bf4d64ad23bd96a7d2f"}
{}

{}
{}
{"id":"3fc5f4fec379770efe9ae2d04c4385ce"}
{}

^Z
Paused. Use `fg` command to resume

zsh: suspended  ./bin/empower-mocks --stream
fg
[1]  + continued  ./bin/empower-mocks --stream
{}
{}
{"id":"1d0ceb4195340601993797f9649e38b7"}
{}

{}
{}
{"id":"4cc3ecc28cae14ed196aa894b04be75f"}
{}

^C
Exiting...
```