### PR TITLE
feat(new-trace): Shouldn't display missing inst. span for react-nativee traces.

### DIFF
--- a/static/app/views/performance/newTraceDetails/guards.tsx
+++ b/static/app/views/performance/newTraceDetails/guards.tsx
@@ -90,6 +90,7 @@ export function shouldAddMissingInstrumentationSpan(sdk: string | undefined): bo
     case 'sentry.javascript.remix':
     case 'sentry.javascript.svelte':
     case 'sentry.javascript.sveltekit':
+    case 'sentry.javascript.react-native':
     case 'sentry.javascript.astro':
       return false;
     case undefined:


### PR DESCRIPTION
There is nothing really missing it’s just empty space between HTTP requests, similar reason as on the web.