### PR TITLE
feat(nestjs): Update nestjs onboarding with new error monitoring setup

### DIFF
--- a/static/app/gettingStartedDocs/node/nestjs.spec.tsx
+++ b/static/app/gettingStartedDocs/node/nestjs.spec.tsx
@@ -29,11 +29,7 @@ describe('Nest.js onboarding docs', function () {
     renderWithOnboardingLayout(docs);
 
     expect(
-      screen.getByText(
-        textWithMarkupMatcher(
-          /SentryModule\.forRoot\(\)/
-        )
-      )
+      screen.getByText(textWithMarkupMatcher(/SentryModule\.forRoot\(\)/))
     ).toBeInTheDocument();
   });
 

--- a/static/app/gettingStartedDocs/node/nestjs.spec.tsx
+++ b/static/app/gettingStartedDocs/node/nestjs.spec.tsx
@@ -18,20 +18,20 @@ describe('Nest.js onboarding docs', function () {
 
     // Includes import statement
     const allMatches = screen.getAllByText(
-      textWithMarkupMatcher(/import \* as Sentry from "@sentry\/nestjs"/)
+      textWithMarkupMatcher(/import \{ SentryModule } from '@sentry\/nestjs\/setup'/)
     );
     allMatches.forEach(match => {
       expect(match).toBeInTheDocument();
     });
   });
 
-  it('includes error handler', () => {
+  it('includes root module', () => {
     renderWithOnboardingLayout(docs);
 
     expect(
       screen.getByText(
         textWithMarkupMatcher(
-          /Sentry\.setupNestErrorHandler\(app, new BaseExceptionFilter\(httpAdapter\)\)/
+          /SentryModule\.forRoot\(\)/
         )
       )
     ).toBeInTheDocument();

--- a/static/app/gettingStartedDocs/node/nestjs.tsx
+++ b/static/app/gettingStartedDocs/node/nestjs.tsx
@@ -96,7 +96,7 @@ const onboarding: OnboardingConfig = {
         },
         {
           description: tct(
-            'Make sure to import [code1:instrument.js/mjs] at the top of your [code2:main.ts/js] file.',
+            'Import [code1:instrument.js/mjs] in your [code2:main.ts/js] file.',
             {
               code1: <code />,
               code2: <code />,

--- a/static/app/gettingStartedDocs/node/nestjs.tsx
+++ b/static/app/gettingStartedDocs/node/nestjs.tsx
@@ -96,7 +96,7 @@ const onboarding: OnboardingConfig = {
         },
         {
           description: tct(
-            'Import [code1:instrument.js/mjs] in your [code2:main.ts/js] file.',
+            'Import [code1:instrument.js/mjs] in your [code2:main.ts/js] file:',
             {
               code1: <code />,
               code2: <code />,

--- a/static/app/gettingStartedDocs/node/nestjs.tsx
+++ b/static/app/gettingStartedDocs/node/nestjs.tsx
@@ -19,7 +19,6 @@ import {
   getImportInstrumentSnippet,
   getInstallConfig,
   getSdkInitSnippet,
-  getSentryImportSnippet,
 } from 'sentry/utils/gettingStartedDocs/node';
 
 type Params = DocsParams;

--- a/static/app/gettingStartedDocs/node/nestjs.tsx
+++ b/static/app/gettingStartedDocs/node/nestjs.tsx
@@ -28,26 +28,39 @@ const getSdkSetupSnippet = () => `
 ${getImportInstrumentSnippet('esm')}
 
 // All other imports below
-${getSentryImportSnippet('nestjs', 'esm')}
-import { BaseExceptionFilter, HttpAdapterHost, NestFactory } from '@nestjs/core';
-import { AppModule } from './app.module';
+import { NestFactory } from "@nestjs/core";
+import { AppModule } from "./app.module";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-
-  const { httpAdapter } = app.get(HttpAdapterHost);
-  Sentry.setupNestErrorHandler(app, new BaseExceptionFilter(httpAdapter));
-
   await app.listen(3000);
 }
 
 bootstrap();
 `;
 
+const getAppModuleSnippet = () => `
+import { Module } from "@nestjs/common";
+import { SentryModule } from "@sentry/nestjs/setup";
+import { AppController } from "./app.controller";
+import { AppService } from "./app.service";
+
+@Module({
+  imports: [
+    SentryModule.forRoot(),
+    // ...other modules
+  ],
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {}
+`
+
 const getVerifySnippet = () => `
-app.use(async function () {
+@Get("/debug-sentry")
+getError() {
   throw new Error("My first Sentry error!");
-});
+}
 `;
 
 const onboarding: OnboardingConfig = {
@@ -84,11 +97,10 @@ const onboarding: OnboardingConfig = {
         },
         {
           description: tct(
-            'Make sure to import [code1:instrument.js/mjs] at the top of your [code2:main.ts/js] file. Set up the error handler by passing the [code3:BaseExceptionFilter].',
+            'Make sure to import [code1:instrument.js/mjs] at the top of your [code2:main.ts/js] file.',
             {
               code1: <code />,
               code2: <code />,
-              code3: <code />,
               docs: (
                 <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/nestjs/install/" />
               ),
@@ -101,6 +113,27 @@ const onboarding: OnboardingConfig = {
               language: 'javascript',
               filename: 'main.(js|ts)',
               code: getSdkSetupSnippet(),
+            },
+          ],
+        },
+        {
+          description: tct(
+            'Then you can add the [code1:SentryModule] as a root module. The [code2:SentryModule] needs to be registered before any other module that should be instrumented by Sentry.',
+            {
+              code1: <code />,
+              code2: <code />,
+              docs: (
+                <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/nestjs/install/" />
+              ),
+            }
+          ),
+          code: [
+            {
+              label: 'JavaScript',
+              value: 'javascript',
+              language: 'javascript',
+              filename: 'app.module.(js|ts)',
+              code: getAppModuleSnippet(),
             },
           ],
         },

--- a/static/app/gettingStartedDocs/node/nestjs.tsx
+++ b/static/app/gettingStartedDocs/node/nestjs.tsx
@@ -27,8 +27,8 @@ const getSdkSetupSnippet = () => `
 ${getImportInstrumentSnippet('esm')}
 
 // All other imports below
-import { NestFactory } from "@nestjs/core";
-import { AppModule } from "./app.module";
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -39,10 +39,10 @@ bootstrap();
 `;
 
 const getAppModuleSnippet = () => `
-import { Module } from "@nestjs/common";
-import { SentryModule } from "@sentry/nestjs/setup";
-import { AppController } from "./app.controller";
-import { AppService } from "./app.service";
+import { Module } from '@nestjs/common';
+import { SentryModule } from '@sentry/nestjs/setup';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
 
 @Module({
   imports: [

--- a/static/app/gettingStartedDocs/node/nestjs.tsx
+++ b/static/app/gettingStartedDocs/node/nestjs.tsx
@@ -54,7 +54,7 @@ import { AppService } from "./app.service";
   providers: [AppService],
 })
 export class AppModule {}
-`
+`;
 
 const getVerifySnippet = () => `
 @Get("/debug-sentry")

--- a/static/app/gettingStartedDocs/node/nestjs.tsx
+++ b/static/app/gettingStartedDocs/node/nestjs.tsx
@@ -55,6 +55,34 @@ import { AppService } from './app.service';
 export class AppModule {}
 `;
 
+const getDecoratedGlobalFilter = () => `import { Catch, ExceptionFilter } from '@nestjs/common';
+import { WithSentry } from '@sentry/nestjs';
+
+@Catch()
+export class YourCatchAllExceptionFilter implements ExceptionFilter {
+  @WithSentry()
+  catch(exception, host): void {
+    // your implementation here
+  }
+}
+`
+
+const getAppModuleSnippetWithSentryGlobalFilter = () => `import { Module } from '@nestjs/common';
+import { APP_FILTER } from '@nestjs/core';
+import { SentryGlobalFilter } from '@sentry/nestjs/setup';
+
+@Module({
+  providers: [
+    {
+      provide: APP_FILTER,
+      useClass: SentryGlobalFilter,
+    },
+    // ..other providers
+  ],
+})
+export class AppModule {}
+`;
+
 const getVerifySnippet = () => `
 @Get("/debug-sentry")
 getError() {
@@ -117,10 +145,9 @@ const onboarding: OnboardingConfig = {
         },
         {
           description: tct(
-            'Then you can add the [code1:SentryModule] as a root module. The [code2:SentryModule] needs to be registered before any other module that should be instrumented by Sentry.',
+            'Afterwards, add the [code1:SentryModule] as a root module to your main module:',
             {
               code1: <code />,
-              code2: <code />,
               docs: (
                 <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/nestjs/install/" />
               ),
@@ -133,6 +160,44 @@ const onboarding: OnboardingConfig = {
               language: 'javascript',
               filename: 'app.module.(js|ts)',
               code: getAppModuleSnippet(),
+            },
+          ],
+        },
+        {
+          description: tct(
+            'In case you are using a global catch-all exception filter (which is either a filter registered with [code1:app.useGlobalFilters()] or a filter registered in your app module providers annotated with a [code2:@Catch()] decorator without arguments), add a [code3:@WithSentry()] decorator to the [code4:catch()] method of this global error filter. This decorator will report all unexpected errors that are received by your global error filter to Sentry:',
+            {
+              code1: <code />,
+              code2: <code />,
+              code3: <code />,
+              code4: <code />,
+            }
+          ),
+          code: [
+            {
+              label: 'JavaScript',
+              value: 'javascript',
+              language: 'javascript',
+              filename: 'global.filter.(js|ts)',
+              code: getDecoratedGlobalFilter(),
+            },
+          ],
+        },
+        {
+          description: tct(
+            'In case you do not have a global catch-all exception filter, add the [code1:SentryGlobalFilter] to the providers of your main module. This filter will report all unhandled errors to Sentry that are not caught by any other error filter. Important: The [code2:SentryGlobalFilter] needs to be registered before any other exception filters.',
+            {
+              code1: <code />,
+              code2: <code />,
+            }
+          ),
+          code: [
+            {
+              label: 'JavaScript',
+              value: 'javascript',
+              language: 'javascript',
+              filename: 'app.module.(js|ts)',
+              code: getAppModuleSnippetWithSentryGlobalFilter(),
             },
           ],
         },


### PR DESCRIPTION
Users now need to explicitly either add the `SentryGlobalFilter` or decorate existing global filters with `WithSentry()` if they have any.

Note: Should be merged after javascript SDK version `8.27` was released.