### PR TITLE
feat(nestjs): Update nestjs onboarding with new error monitoring setup

### DIFF
--- a/static/app/gettingStartedDocs/node/nestjs.tsx
+++ b/static/app/gettingStartedDocs/node/nestjs.tsx
@@ -64,6 +64,7 @@ getError() {
 
 const getDecoratedGlobalFilter = () => `import { Catch, ExceptionFilter } from '@nestjs/common';
 import { WithSentry } from '@sentry/nestjs';
+
 @Catch()
 export class YourCatchAllExceptionFilter implements ExceptionFilter {
   @WithSentry()
@@ -76,6 +77,7 @@ export class YourCatchAllExceptionFilter implements ExceptionFilter {
 const getAppModuleSnippetWithSentryGlobalFilter = () => `import { Module } from '@nestjs/common';
 import { APP_FILTER } from '@nestjs/core';
 import { SentryGlobalFilter } from '@sentry/nestjs/setup';
+
 @Module({
   providers: [
     {

--- a/static/app/gettingStartedDocs/node/nestjs.tsx
+++ b/static/app/gettingStartedDocs/node/nestjs.tsx
@@ -62,7 +62,8 @@ getError() {
 }
 `;
 
-const getDecoratedGlobalFilter = () => `import { Catch, ExceptionFilter } from '@nestjs/common';
+const getDecoratedGlobalFilter =
+  () => `import { Catch, ExceptionFilter } from '@nestjs/common';
 import { WithSentry } from '@sentry/nestjs';
 @Catch()
 export class YourCatchAllExceptionFilter implements ExceptionFilter {
@@ -71,9 +72,10 @@ export class YourCatchAllExceptionFilter implements ExceptionFilter {
     // your implementation here
   }
 }
-`
+`;
 
-const getAppModuleSnippetWithSentryGlobalFilter = () => `import { Module } from '@nestjs/common';
+const getAppModuleSnippetWithSentryGlobalFilter =
+  () => `import { Module } from '@nestjs/common';
 import { APP_FILTER } from '@nestjs/core';
 import { SentryGlobalFilter } from '@sentry/nestjs/setup';
 @Module({

--- a/static/app/gettingStartedDocs/node/nestjs.tsx
+++ b/static/app/gettingStartedDocs/node/nestjs.tsx
@@ -62,6 +62,32 @@ getError() {
 }
 `;
 
+const getDecoratedGlobalFilter = () => `import { Catch, ExceptionFilter } from '@nestjs/common';
+import { WithSentry } from '@sentry/nestjs';
+@Catch()
+export class YourCatchAllExceptionFilter implements ExceptionFilter {
+  @WithSentry()
+  catch(exception, host): void {
+    // your implementation here
+  }
+}
+`
+
+const getAppModuleSnippetWithSentryGlobalFilter = () => `import { Module } from '@nestjs/common';
+import { APP_FILTER } from '@nestjs/core';
+import { SentryGlobalFilter } from '@sentry/nestjs/setup';
+@Module({
+  providers: [
+    {
+      provide: APP_FILTER,
+      useClass: SentryGlobalFilter,
+    },
+    // ..other providers
+  ],
+})
+export class AppModule {}
+`;
+
 const onboarding: OnboardingConfig = {
   install: params => [
     {
@@ -117,10 +143,9 @@ const onboarding: OnboardingConfig = {
         },
         {
           description: tct(
-            'Then you can add the [code1:SentryModule] as a root module. The [code2:SentryModule] needs to be registered before any other module that should be instrumented by Sentry.',
+            'Afterwards, add the [code1:SentryModule] as a root module to your main module:',
             {
               code1: <code />,
-              code2: <code />,
               docs: (
                 <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/nestjs/install/" />
               ),
@@ -133,6 +158,44 @@ const onboarding: OnboardingConfig = {
               language: 'javascript',
               filename: 'app.module.(js|ts)',
               code: getAppModuleSnippet(),
+            },
+          ],
+        },
+        {
+          description: tct(
+            'In case you are using a global catch-all exception filter (which is either a filter registered with [code1:app.useGlobalFilters()] or a filter registered in your app module providers annotated with a [code2:@Catch()] decorator without arguments), add a [code3:@WithSentry()] decorator to the [code4:catch()] method of this global error filter. This decorator will report all unexpected errors that are received by your global error filter to Sentry:',
+            {
+              code1: <code />,
+              code2: <code />,
+              code3: <code />,
+              code4: <code />,
+            }
+          ),
+          code: [
+            {
+              label: 'JavaScript',
+              value: 'javascript',
+              language: 'javascript',
+              filename: 'global.filter.(js|ts)',
+              code: getDecoratedGlobalFilter(),
+            },
+          ],
+        },
+        {
+          description: tct(
+            'In case you do not have a global catch-all exception filter, add the [code1:SentryGlobalFilter] to the providers of your main module. This filter will report all unhandled errors to Sentry that are not caught by any other error filter. Important: The [code2:SentryGlobalFilter] needs to be registered before any other exception filters.',
+            {
+              code1: <code />,
+              code2: <code />,
+            }
+          ),
+          code: [
+            {
+              label: 'JavaScript',
+              value: 'javascript',
+              language: 'javascript',
+              filename: 'app.module.(js|ts)',
+              code: getAppModuleSnippetWithSentryGlobalFilter(),
             },
           ],
         },


### PR DESCRIPTION
Users now need to explicitly either add the `SentryGlobalFilter` or decorate existing global filters with `WithSentry()` if they have any.

Note: Should be merged after javascript SDK version `8.27` was released.
