### PR TITLE
ref(metrics): move eap meta from API to sentry_metrics

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics_details.py
+++ b/src/sentry/api/endpoints/organization_metrics_details.py
@@ -1,15 +1,14 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationAndStaffPermission, OrganizationEndpoint
 from sentry.models.organization import Organization
+from sentry.sentry_metrics.querying.eap.metrics_details import get_eap_meta
 from sentry.sentry_metrics.querying.metadata import get_metrics_meta
 from sentry.sentry_metrics.use_case_utils import get_use_case_ids
-from sentry.snuba.metrics.utils import MetricMeta
 
 
 @region_silo_endpoint
@@ -28,26 +27,8 @@ class OrganizationMetricsDetailsEndpoint(OrganizationEndpoint):
             return Response(
                 {"detail": "You must supply at least one project to see its metrics"}, status=404
             )
-
-        eap_spans_project_ids = [
-            project.id
-            for project in projects
-            if features.has("projects:use-eap-spans-for-metrics-explorer", project)
-        ]
-        metrics: list[MetricMeta] = []
-        if len(eap_spans_project_ids) > 0:
-            metrics.append(
-                MetricMeta(
-                    name="eap.measurement",
-                    type="distribution",
-                    unit=None,
-                    operations=["sum", "avg", "p50", "p95", "p99", "count"],
-                    projectIds=eap_spans_project_ids,
-                    mri="d:eap/eap.measurement@none",
-                    blockingStatus=[],
-                )
-            )
-
+        metrics = []
+        metrics += get_eap_meta(projects)
         metrics += get_metrics_meta(
             organization=organization, projects=projects, use_case_ids=get_use_case_ids(request)
         )

--- a/src/sentry/sentry_metrics/querying/eap/metrics_details.py
+++ b/src/sentry/sentry_metrics/querying/eap/metrics_details.py
@@ -1,0 +1,25 @@
+from sentry import features
+from sentry.models.project import Project
+from sentry.snuba.metrics.utils import MetricMeta
+
+
+def get_eap_meta(projects: list[Project]) -> list[MetricMeta]:
+    eap_spans_project_ids = [
+        project.id
+        for project in projects
+        if features.has("projects:use-eap-spans-for-metrics-explorer", project)
+    ]
+    metrics: list[MetricMeta] = []
+    if len(eap_spans_project_ids) > 0:
+        metrics.append(
+            MetricMeta(
+                name="eap.measurement",
+                type="distribution",
+                unit=None,
+                operations=["sum", "avg", "p50", "p95", "p99", "count"],
+                projectIds=eap_spans_project_ids,
+                mri="d:eap/eap.measurement@none",
+                blockingStatus=[],
+            )
+        )
+    return metrics


### PR DESCRIPTION
To avoid mixing abstraction levels, move EAP meta to function in sentry_metrics