### PR TITLE
fix(dashboard): Ignore null in error handling

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils.tsx
@@ -7,6 +7,7 @@ import {t} from 'sentry/locale';
 import type {SelectValue} from 'sentry/types/core';
 import type {TagCollection} from 'sentry/types/group';
 import type {OrganizationSummary} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
 import {
   aggregateFunctionOutputType,
   aggregateOutputType,
@@ -98,7 +99,9 @@ export function mapErrors(
       return;
     }
     if (Array.isArray(value) && typeof value[0] === 'object') {
-      update[key] = (value as ValidationError[]).map(item => mapErrors(item, {}));
+      update[key] = (value as ValidationError[])
+        .filter(defined)
+        .map(item => mapErrors(item, {}));
     } else {
       update[key] = mapErrors(value as ValidationError, {});
     }


### PR DESCRIPTION
Sometimes when mapping the errors, the value being applied to the updated array is null, but since the typeof null is object we try to recurse into it and iterate over its keys. This results in an error.

If the value is null, we can just skip it