### PR TITLE
fix(dashboards): Stop hardcoding widget type in add to dashboard

### DIFF
--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -51,7 +51,7 @@ import {getMeasurements} from 'sentry/utils/measurements/measurements';
 import {getMetricDisplayType, getMetricsUrl} from 'sentry/utils/metrics';
 import {parseField} from 'sentry/utils/metrics/mri';
 import type {MetricsWidget} from 'sentry/utils/metrics/types';
-import {decodeList} from 'sentry/utils/queryString';
+import {decodeList, decodeScalar} from 'sentry/utils/queryString';
 import theme from 'sentry/utils/theme';
 import type {
   DashboardDetails,
@@ -203,6 +203,7 @@ export function constructWidgetFromQuery(query?: Query): Widget | undefined {
     const queryNames = coerceStringToArray(query.queryNames);
     const queryConditions = coerceStringToArray(query.queryConditions);
     const queryFields = coerceStringToArray(query.queryFields);
+    const widgetType = decodeScalar(query.widgetType);
     const queries: WidgetQuery[] = [];
     if (
       queryConditions &&
@@ -229,7 +230,7 @@ export function constructWidgetFromQuery(query?: Query): Widget | undefined {
           interval: string;
           title: string;
         }),
-        widgetType: WidgetType.DISCOVER,
+        widgetType: widgetType ? (widgetType as WidgetType) : WidgetType.DISCOVER,
         queries,
       };
       return newWidget;

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
@@ -509,6 +509,7 @@ describe('WidgetBuilder', function () {
             utc: null,
             project: [],
             environment: [],
+            widgetType: 'discover',
           },
         })
       );
@@ -552,6 +553,7 @@ describe('WidgetBuilder', function () {
             utc: null,
             project: [],
             environment: [],
+            widgetType: 'discover',
           },
         })
       );
@@ -1431,6 +1433,7 @@ describe('WidgetBuilder', function () {
               utc: null,
               project: [],
               environment: [],
+              widgetType: 'discover',
             },
           })
         );
@@ -1463,6 +1466,7 @@ describe('WidgetBuilder', function () {
               utc: null,
               project: [],
               environment: [],
+              widgetType: 'discover',
             },
           })
         );

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -920,6 +920,7 @@ function WidgetBuilder({
       displayType: widgetData.displayType,
       interval: widgetData.interval,
       title: widgetData.title,
+      widgetType: widgetData.widgetType,
       ...queryData,
       // Propagate page filters
       project: pageFilters.projects,

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilderDataset.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilderDataset.spec.tsx
@@ -862,6 +862,7 @@ describe('WidgetBuilder', function () {
                 utc: null,
                 project: [],
                 environment: [],
+                widgetType: 'discover',
               },
             })
           );


### PR DESCRIPTION
A bug with adding error/transaction widgets from discover to dashboards.
To reproduce: create an error widget, add to dashboard (this selects the correct dataset), save dashboard, open the widget, dataset isn't selected properly and split decision has to be made again.

This is because we pass the widget state in url params back to the dashboard and do the post request on the `dashboard/` page as a whole. Here, we were hardcoding widget type to discover.