### PR TITLE
fix(metrics-extraction): Include extraction state in on-demand check

### DIFF
--- a/static/app/utils/performance/contexts/onDemandControl.tsx
+++ b/static/app/utils/performance/contexts/onDemandControl.tsx
@@ -104,6 +104,12 @@ export function isOnDemandMetricWidget(widget: Widget): boolean {
 const doesWidgetHaveReleaseConditions = (widget: Widget) =>
   widget.queries.some(q => q.conditions.includes('release:'));
 
+/**
+ * Check the extraction state for any widgets exceeding spec limit / cardinality limit etc.
+ */
+const doesWidgetHaveDisabledOnDemand = (widget: Widget) =>
+  widget.queries.some(q => q.onDemand?.some(d => !d.enabled));
+
 export const shouldUseOnDemandMetrics = (
   organization: Organization,
   widget: Widget,
@@ -118,6 +124,10 @@ export const shouldUseOnDemandMetrics = (
   }
 
   if (doesWidgetHaveReleaseConditions(widget)) {
+    return false;
+  }
+
+  if (doesWidgetHaveDisabledOnDemand(widget)) {
     return false;
   }
 


### PR DESCRIPTION
### Summary
This adds a check for any on-demand state being 'disabled' (eg. spec limit, cardinality limit) for a widget, and stops it from querying on-demand metrics on the backend. 

#### Other
- This can also be handled by the backend, but since that requires determining the widget id in question it leaks dashboard domain into our events/event-stats endpoints. 
- Closes #76050 