### PR TITLE
fix(discover): Split count_if default parameters by dataset

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -199,6 +199,8 @@ const getDocsAndOutputType = (key: AggregationKey) => {
 
 // Refer to src/sentry/search/events/fields.py
 // Try to keep functions logically sorted, ie. all the count functions are grouped together
+// When dealing with errors or transactions datasets, use getAggregations() instead because
+// there are dataset-specific overrides
 export const AGGREGATIONS = {
   [AggregationKey.COUNT]: {
     ...getDocsAndOutputType(AggregationKey.COUNT),

--- a/static/app/views/dashboards/datasetConfig/errors.tsx
+++ b/static/app/views/dashboards/datasetConfig/errors.tsx
@@ -15,9 +15,9 @@ import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQue
 import type {MetaType} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {
-  AGGREGATIONS,
   ERROR_FIELDS,
   ERRORS_AGGREGATION_FUNCTIONS,
+  getAggregations,
   isEquation,
   isEquationAlias,
 } from 'sentry/utils/discover/fields';
@@ -122,13 +122,14 @@ function getEventsTableFieldOptions(
   tags?: TagCollection,
   _customMeasurements?: CustomMeasurementCollection
 ) {
+  const aggregates = getAggregations(DiscoverDatasets.ERRORS);
   return generateFieldOptions({
     organization,
     tagKeys: Object.values(tags ?? {}).map(({key}) => key),
-    aggregations: Object.keys(AGGREGATIONS)
+    aggregations: Object.keys(aggregates)
       .filter(key => ERRORS_AGGREGATION_FUNCTIONS.includes(key as AggregationKey))
       .reduce((obj, key) => {
-        obj[key] = AGGREGATIONS[key];
+        obj[key] = aggregates;
         return obj;
       }, {}),
     fieldKeys: ERROR_FIELDS,

--- a/static/app/views/dashboards/datasetConfig/errors.tsx
+++ b/static/app/views/dashboards/datasetConfig/errors.tsx
@@ -129,7 +129,7 @@ function getEventsTableFieldOptions(
     aggregations: Object.keys(aggregates)
       .filter(key => ERRORS_AGGREGATION_FUNCTIONS.includes(key as AggregationKey))
       .reduce((obj, key) => {
-        obj[key] = aggregates;
+        obj[key] = aggregates[key];
         return obj;
       }, {}),
     fieldKeys: ERROR_FIELDS,

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
@@ -1831,6 +1831,80 @@ describe('WidgetBuilder', function () {
         expect(screen.getByText('transaction.duration')).toBeInTheDocument();
         expect(screen.getByText('testFilter:value')).toBeInTheDocument();
       });
+
+      it('sets the correct default count_if parameters for the errors dataset', async function () {
+        dashboard = mockDashboard({
+          widgets: [
+            WidgetFixture({
+              displayType: DisplayType.TABLE,
+              widgetType: WidgetType.ERRORS,
+              queries: [
+                {
+                  name: 'Test Widget',
+                  fields: ['count()'],
+                  columns: [],
+                  aggregates: ['count()'],
+                  conditions: '',
+                  orderby: '',
+                },
+              ],
+            }),
+          ],
+        });
+
+        renderTestComponent({
+          orgFeatures: [...defaultOrgFeatures, 'performance-discover-dataset-selector'],
+          dashboard,
+          params: {
+            widgetIndex: '0',
+          },
+        });
+
+        await userEvent.click(await screen.findByTestId('label'));
+        await userEvent.click(screen.getByText(/count_if/));
+
+        const fieldLabels = screen.getAllByTestId('label');
+        expect(fieldLabels[0]).toHaveTextContent(/count_if/);
+        expect(fieldLabels[1]).toHaveTextContent('event.type');
+        expect(screen.getByDisplayValue('error')).toBeInTheDocument();
+      });
+
+      it('sets the correct default count_if parameters for the transactions dataset', async function () {
+        dashboard = mockDashboard({
+          widgets: [
+            WidgetFixture({
+              displayType: DisplayType.TABLE,
+              widgetType: WidgetType.TRANSACTIONS,
+              queries: [
+                {
+                  name: 'Test Widget',
+                  fields: ['count()'],
+                  columns: [],
+                  aggregates: ['count()'],
+                  conditions: '',
+                  orderby: '',
+                },
+              ],
+            }),
+          ],
+        });
+
+        renderTestComponent({
+          orgFeatures: [...defaultOrgFeatures, 'performance-discover-dataset-selector'],
+          dashboard,
+          params: {
+            widgetIndex: '0',
+          },
+        });
+
+        await userEvent.click(await screen.findByTestId('label'));
+        await userEvent.click(screen.getByText(/count_if/));
+
+        const fieldLabels = screen.getAllByTestId('label');
+        expect(fieldLabels[0]).toHaveTextContent(/count_if/);
+        expect(fieldLabels[1]).toHaveTextContent('transaction.duration');
+        expect(screen.getByDisplayValue('300')).toBeInTheDocument();
+      });
     });
 
     describe('events-stats', function () {
@@ -1969,6 +2043,80 @@ describe('WidgetBuilder', function () {
         expect(await screen.findByText(/p99\(…\)/i)).toBeInTheDocument();
         expect(screen.getByText('transaction.duration')).toBeInTheDocument();
         expect(screen.getByText('testFilter:value')).toBeInTheDocument();
+      });
+
+      it('sets the correct default count_if parameters for the errors dataset', async function () {
+        dashboard = mockDashboard({
+          widgets: [
+            WidgetFixture({
+              displayType: DisplayType.LINE,
+              widgetType: WidgetType.ERRORS,
+              queries: [
+                {
+                  name: 'Test Widget',
+                  fields: ['count()'],
+                  columns: [],
+                  aggregates: ['count()'],
+                  conditions: '',
+                  orderby: '',
+                },
+              ],
+            }),
+          ],
+        });
+
+        renderTestComponent({
+          orgFeatures: [...defaultOrgFeatures, 'performance-discover-dataset-selector'],
+          dashboard,
+          params: {
+            widgetIndex: '0',
+          },
+        });
+
+        await userEvent.click(await screen.findByTestId('label'));
+        await userEvent.click(screen.getByText(/count_if/));
+
+        const fieldLabels = screen.getAllByTestId('label');
+        expect(fieldLabels[0]).toHaveTextContent(/count_if/);
+        expect(fieldLabels[1]).toHaveTextContent('event.type');
+        expect(screen.getByDisplayValue('error')).toBeInTheDocument();
+      });
+
+      it('sets the correct default count_if parameters for the transactions dataset', async function () {
+        dashboard = mockDashboard({
+          widgets: [
+            WidgetFixture({
+              displayType: DisplayType.LINE,
+              widgetType: WidgetType.TRANSACTIONS,
+              queries: [
+                {
+                  name: 'Test Widget',
+                  fields: ['count()'],
+                  columns: [],
+                  aggregates: ['count()'],
+                  conditions: '',
+                  orderby: '',
+                },
+              ],
+            }),
+          ],
+        });
+
+        renderTestComponent({
+          orgFeatures: [...defaultOrgFeatures, 'performance-discover-dataset-selector'],
+          dashboard,
+          params: {
+            widgetIndex: '0',
+          },
+        });
+
+        await userEvent.click(await screen.findByTestId('label'));
+        await userEvent.click(screen.getByText(/count_if/));
+
+        const fieldLabels = screen.getAllByTestId('label');
+        expect(fieldLabels[0]).toHaveTextContent(/count_if/);
+        expect(fieldLabels[1]).toHaveTextContent('transaction.duration');
+        expect(screen.getByDisplayValue('300')).toBeInTheDocument();
       });
     });
 

--- a/static/app/views/discover/table/columnEditModal.spec.tsx
+++ b/static/app/views/discover/table/columnEditModal.spec.tsx
@@ -605,7 +605,7 @@ describe('Discover -> ColumnEditModal', function () {
       expect(screen.getByDisplayValue('error')).toBeInTheDocument();
     });
 
-    it('chooses the correct default parameters for the transactions dataset', async function () {
+    it('chooses the correct default count_if parameters for the transactions dataset', async function () {
       mountModal(
         {
           columns: [

--- a/static/app/views/discover/table/columnEditModal.spec.tsx
+++ b/static/app/views/discover/table/columnEditModal.spec.tsx
@@ -13,11 +13,23 @@ import {
 import {makeCloseButton} from 'sentry/components/globalModal/components';
 import TagStore from 'sentry/stores/tagStore';
 import type {QueryFieldValue} from 'sentry/utils/discover/fields';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import ColumnEditModal from 'sentry/views/discover/table/columnEditModal';
 
 const stubEl = styled(p => p.children);
 
-function mountModal({columns, onApply, customMeasurements}, initialData) {
+function mountModal(
+  {
+    columns,
+    onApply,
+    customMeasurements,
+    dataset,
+  }: Pick<
+    React.ComponentProps<typeof ColumnEditModal>,
+    'columns' | 'onApply' | 'customMeasurements' | 'dataset'
+  >,
+  initialData
+) {
   return render(
     <ColumnEditModal
       CloseButton={makeCloseButton(() => {})}
@@ -30,6 +42,7 @@ function mountModal({columns, onApply, customMeasurements}, initialData) {
       closeModal={jest.fn()}
       measurementKeys={null}
       customMeasurements={customMeasurements}
+      dataset={dataset}
     />,
     {router: initialData.router}
   );
@@ -153,7 +166,10 @@ describe('Discover -> ColumnEditModal', function () {
       mountModal(
         {
           columns: [
-            {kind: 'function', function: ['count_unique', 'user-defined']},
+            {
+              kind: 'function',
+              function: ['count_unique', 'user-defined', undefined, undefined],
+            },
             {kind: 'field', field: 'user-def'},
           ],
           onApply: jest.fn(),
@@ -226,9 +242,12 @@ describe('Discover -> ColumnEditModal', function () {
       mountModal(
         {
           columns: [
-            {kind: 'function', function: ['count', 'id']},
-            {kind: 'function', function: ['count_unique', 'title']},
-            {kind: 'function', function: ['percentile', 'transaction.duration', '0.66']},
+            {kind: 'function', function: ['count', 'id', undefined, undefined]},
+            {kind: 'function', function: ['count_unique', 'title', undefined, undefined]},
+            {
+              kind: 'function',
+              function: ['percentile', 'transaction.duration', '0.66', undefined],
+            },
           ],
           onApply: jest.fn(),
           customMeasurements: {},
@@ -560,6 +579,56 @@ describe('Discover -> ColumnEditModal', function () {
         },
       ]);
     });
+
+    it('chooses the correct default parameters for the errors dataset', async function () {
+      mountModal(
+        {
+          columns: [
+            {
+              kind: 'function',
+              function: ['count', '', undefined, undefined],
+            },
+          ],
+          onApply,
+          customMeasurements: {},
+          dataset: DiscoverDatasets.ERRORS,
+        },
+        initialData
+      );
+
+      expect(await screen.findByText('count()')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByText('count()'));
+      await userEvent.click(screen.getByText(/count_if/));
+
+      expect(screen.getByText('event.type')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('error')).toBeInTheDocument();
+    });
+
+    it('chooses the correct default parameters for the transactions dataset', async function () {
+      mountModal(
+        {
+          columns: [
+            {
+              kind: 'function',
+              function: ['count', '', undefined, undefined],
+            },
+          ],
+          onApply,
+          customMeasurements: {},
+          dataset: DiscoverDatasets.TRANSACTIONS,
+        },
+        initialData
+      );
+
+      expect(await screen.findByText('count()')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByText('count()'));
+      await userEvent.click(screen.getByText(/count_if/));
+
+      expect(screen.getByText('transaction.duration')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('300')).toBeInTheDocument();
+    });
   });
 
   describe('equation automatic update', function () {
@@ -573,11 +642,11 @@ describe('Discover -> ColumnEditModal', function () {
           columns: [
             {
               kind: 'function',
-              function: ['count_unique', 'user'],
+              function: ['count_unique', 'user', undefined, undefined],
             },
             {
               kind: 'function',
-              function: ['p95', ''],
+              function: ['p95', '', undefined, undefined],
             },
             {
               kind: 'equation',
@@ -608,7 +677,7 @@ describe('Discover -> ColumnEditModal', function () {
           columns: [
             {
               kind: 'function',
-              function: ['count_unique', 'user'],
+              function: ['count_unique', 'user', undefined, undefined],
             },
             {
               kind: 'equation',

--- a/static/app/views/discover/table/columnEditModal.tsx
+++ b/static/app/views/discover/table/columnEditModal.tsx
@@ -13,10 +13,10 @@ import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import {
-  AGGREGATIONS,
   type Column,
   ERROR_FIELDS,
   ERRORS_AGGREGATION_FUNCTIONS,
+  getAggregations,
   TRANSACTION_FIELDS,
 } from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
@@ -74,10 +74,10 @@ function ColumnEditModal(props: Props) {
       organization,
       tagKeys,
       fieldKeys: ERROR_FIELDS,
-      aggregations: Object.keys(AGGREGATIONS)
+      aggregations: Object.keys(getAggregations(DiscoverDatasets.ERRORS))
         .filter(key => ERRORS_AGGREGATION_FUNCTIONS.includes(key as AggregationKey))
         .reduce((obj, key) => {
-          obj[key] = AGGREGATIONS[key];
+          obj[key] = getAggregations(DiscoverDatasets.ERRORS)[key];
           return obj;
         }, {}),
     });

--- a/static/app/views/discover/table/columnEditModal.tsx
+++ b/static/app/views/discover/table/columnEditModal.tsx
@@ -70,14 +70,15 @@ function ColumnEditModal(props: Props) {
   let fieldOptions: ReturnType<typeof generateFieldOptions>;
 
   if (dataset === DiscoverDatasets.ERRORS) {
+    const aggregations = getAggregations(DiscoverDatasets.ERRORS);
     fieldOptions = generateFieldOptions({
       organization,
       tagKeys,
       fieldKeys: ERROR_FIELDS,
-      aggregations: Object.keys(getAggregations(DiscoverDatasets.ERRORS))
+      aggregations: Object.keys(aggregations)
         .filter(key => ERRORS_AGGREGATION_FUNCTIONS.includes(key as AggregationKey))
         .reduce((obj, key) => {
-          obj[key] = getAggregations(DiscoverDatasets.ERRORS)[key];
+          obj[key] = aggregations[key];
           return obj;
         }, {}),
     });


### PR DESCRIPTION
Updates the default parameters for the `count_if` function in Discover and Dashboards for the errors and transactions datasets.

The current default of `transaction.duration` errors out for the Errors dataset, so switch it to something more relevant to errors. I'm open to a different default. I wanted to use `error.handled` but it doesn't look like we expose that in dashboard. I could hold off on this PR to introduce `error.handled` if we think that it's valuable enough to do so.