### PR TITLE
chore(github): better installation error details + logging

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -131,7 +131,10 @@ def error(
     error_short="Invalid installation request.",
     error_long=ERR_INTEGRATION_INVALID_INSTALLATION_REQUEST,
 ):
-    logger.error("github.installation_error", extra={"org_id": org.id, "error_short": error_short})
+    logger.error(
+        "github.installation_error",
+        extra={"org_id": org.organization.id, "error_short": error_short},
+    )
 
     return render_to_response(
         "sentry/integrations/github-integration-failed.html",

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -514,7 +514,7 @@ class GitHubInstallation(PipelineView):
             return error(
                 request,
                 self.active_organization,
-                error_short="Authenticated user is not the same as who installated the app",
+                error_short="Authenticated user is not the same as who installed the app",
             )
 
         return pipeline.next_step()

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -511,6 +511,10 @@ class GitHubInstallation(PipelineView):
             pipeline.fetch_state("github_authenticated_user")
             != integration.metadata["sender"]["login"]
         ):
-            return error(request, self.active_organization)
+            return error(
+                request,
+                self.active_organization,
+                error_short="Authenticated user is not the same as who installated the app",
+            )
 
         return pipeline.next_step()

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -131,6 +131,8 @@ def error(
     error_short="Invalid installation request.",
     error_long=ERR_INTEGRATION_INVALID_INSTALLATION_REQUEST,
 ):
+    logger.error("github.installation_error", extra={"org_id": org.id, "error_short": error_short})
+
     return render_to_response(
         "sentry/integrations/github-integration-failed.html",
         context={
@@ -417,7 +419,7 @@ class OAuthLoginView(PipelineView):
 
         # At this point, we are past the GitHub "authorize" step
         if request.GET.get("state") != pipeline.signature:
-            return error(request, self.active_organization)
+            return error(request, self.active_organization, error_short="Invalid state")
 
         # similar to OAuth2CallbackView.get_token_params
         data = {
@@ -436,11 +438,11 @@ class OAuthLoginView(PipelineView):
             payload = {}
 
         if "access_token" not in payload:
-            return error(request, self.active_organization)
+            return error(request, self.active_organization, error_short="Missing access token")
 
         authenticated_user_info = get_user_info(payload["access_token"])
         if "login" not in authenticated_user_info:
-            return error(request, self.active_organization)
+            return error(request, self.active_organization, error_short="Missing login info")
 
         pipeline.bind_state("github_authenticated_user", authenticated_user_info["login"])
         return pipeline.next_step()

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -400,7 +400,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
                 ),
             )
         )
-        assert b"Invalid installation request." in resp.content
+        assert b"Invalid state" in resp.content
 
     @responses.activate
     @override_options({"github-app.webhook-secret": ""})
@@ -459,7 +459,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             self.assertTemplateUsed(resp, "sentry/integrations/github-integration-failed.html")
             assert resp.status_code == 200
             assert b'window.opener.postMessage({"success":false' in resp.content
-            assert b"Invalid installation request." in resp.content
+            assert b"Authenticated user is not the same as who installed the app" in resp.content
 
     @responses.activate
     def test_disable_plugin_when_fully_migrated(self):


### PR DESCRIPTION
For https://github.com/getsentry/sentry/issues/76018

My hunch is that the error is happening because the user trying to add the integration in Sentry is not the same user that installed the Github app on the Github org, but the error messages need to be improved in order to determine the exact cause.