### PR TITLE
fix(incidents): Require non-null target_value for Discord

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule_trigger_action.py
@@ -42,7 +42,7 @@ class AlertRuleTriggerActionSerializer(Serializer):
                     "discord.action.description.no.channel",
                     extra={"target_identifier": action.target_identifier},
                 )
-            return f"Send a Discord notification to {action.target_display or ''}"
+            return f"Send a Discord notification to {action.target_display}"
 
     def get_identifier_from_action(self, action):
         if action.type in [

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1518,6 +1518,8 @@ def get_target_identifier_display_for_integration(
             target_value, integration_id, use_async_lookup, input_channel_id, integrations
         )
 
+    if target_value is None:
+        raise InvalidTriggerActionError(f"{action_type.name} requires non-null target_value")
     return _get_target_identifier_display_from_target_value(
         action_type, target_value, organization, integration_id
     )
@@ -1551,7 +1553,7 @@ def _get_target_identifier_display_for_slack(
 
 def _get_target_identifier_display_from_target_value(
     action_type: ActionService,
-    target_value: str | None,
+    target_value: str,
     organization: Organization,
     integration_id: int | None,
 ) -> AlertTarget:
@@ -1562,8 +1564,6 @@ def _get_target_identifier_display_from_target_value(
         # target_value is the MSTeams username or channel name
         if integration_id is None:
             raise InvalidTriggerActionError("MSTEAMS requires non-null integration_id")
-        if target_value is None:
-            raise InvalidTriggerActionError("MSTEAMS requires non-null target_value")
         return AlertTarget(
             _get_alert_rule_trigger_action_msteams_channel_id(
                 target_value, organization, integration_id
@@ -1581,8 +1581,6 @@ def _get_target_identifier_display_from_target_value(
 
     elif action_type == AlertRuleTriggerAction.Type.PAGERDUTY.value:
         # target_value is the ID of the PagerDuty service
-        if target_value is None:
-            raise InvalidTriggerActionError("PAGERDUTY requires non-null target_value")
         return _get_alert_rule_trigger_action_pagerduty_service(
             target_value, organization, integration_id
         )
@@ -1636,31 +1634,15 @@ def _get_alert_rule_trigger_action_slack_channel_id(
     return channel_data.channel_id
 
 
-def _get_alert_rule_trigger_action_discord_channel_id(
-    name: str | None, integration_id: int
-) -> str | None:
+def _get_alert_rule_trigger_action_discord_channel_id(name: str, integration_id: int) -> str | None:
     from sentry.integrations.discord.utils.channel import validate_channel_id
 
     integration = integration_service.get_integration(integration_id=integration_id)
     if integration is None:
         raise InvalidTriggerActionError("Discord integration not found.")
     try:
-        # TODO(RyanSkonnord): Force this function's `name` param to be non-null.
-        #
-        # AlertRuleTriggerActionSerializerTest.test_discord_channel_id_none covers
-        # the case of `name` being None explicitly. However, from eyeballing
-        # validate_channel_id, it looks like this can only lead to an error. The unit
-        # test case originates in https://github.com/getsentry/sentry/pull/58005,
-        # where it looks like it was targeting a spurious failure mode that occurs
-        # while building the description string.
-        #
-        # I'd like to move the null check upstream, clean up the associated nullable
-        # function params, remove the piecemeal checks from
-        # _get_target_identifier_display_from_target_value, and modify
-        # test_discord_channel_id_none to assert for an explicit null check (or just
-        # delete it).
         validate_channel_id(
-            channel_id=name,  # type: ignore[arg-type]
+            channel_id=name,
             guild_id=integration.external_id,
             guild_name=integration.name,
         )

--- a/tests/sentry/incidents/endpoints/serializers/test_alert_rule_trigger_action.py
+++ b/tests/sentry/incidents/endpoints/serializers/test_alert_rule_trigger_action.py
@@ -1,10 +1,12 @@
 from unittest.mock import patch
 
+import pytest
 import responses
 
 from sentry.api.serializers import serialize
 from sentry.incidents.logic import (
     AlertTarget,
+    InvalidTriggerActionError,
     create_alert_rule_trigger,
     create_alert_rule_trigger_action,
 )
@@ -105,17 +107,14 @@ class AlertRuleTriggerActionSerializerTest(TestCase):
             },
         )
         trigger = create_alert_rule_trigger(alert_rule, "hi", 1000)
-        action = create_alert_rule_trigger_action(
-            trigger,
-            AlertRuleTriggerAction.Type.DISCORD,
-            AlertRuleTriggerAction.TargetType.SPECIFIC,
-            target_identifier=None,
-            integration_id=integration.id,
-        )
-
-        result = serialize(action)
-        self.assert_action_serialized(action, result)
-        assert result["desc"] == "Send a Discord notification to "
+        with pytest.raises(InvalidTriggerActionError):
+            create_alert_rule_trigger_action(
+                trigger,
+                AlertRuleTriggerAction.Type.DISCORD,
+                AlertRuleTriggerAction.TargetType.SPECIFIC,
+                target_identifier=None,
+                integration_id=integration.id,
+            )
 
     @patch(
         "sentry.incidents.logic.get_target_identifier_display_for_integration",


### PR DESCRIPTION
Raise an InvalidTriggerActionError if the target_value is None.

Modify test_discord_channel_id_none to assert for this error. (It appears that the test case's original intent was to test that the serializer doesn't crash, but the case where the target_value is None would inevitably cause an error anyway when we call `DiscordClient.get_channel`.)