### PR TITLE
ref: add hard-stop migration for index_together migrations rebase

### DIFF
--- a/src/sentry/runner/commands/upgrade.py
+++ b/src/sentry/runner/commands/upgrade.py
@@ -25,11 +25,10 @@ def _check_history() -> None:
         raise click.ClickException("Could not determine migration state. Aborting")
 
     # Either of these migrations need to have been run for us to proceed.
-    # The first migration is 'pre-squash' and the other entries are squashes
     migration_heads = (
-        "0200_release_indices",
-        "0001_squashed_0200_release_indices",
-        "0001_squashed_0484_break_org_member_user_fk",
+        # not a squash, but migration history was "rebased" before this to eliminate
+        # `index_together` for django 5.1 upgrade
+        "0642_index_together_release",
     )
 
     # If we haven't run all the migration up to the latest squash abort.


### PR DESCRIPTION
I'm going to be "rebasing" the migrations to eliminate `index_together` such that we can upgrade django (upstream doesn't have a good suggestion on how to do this other than "delete all the migrations and start over" which is pretty messed up)

those PRs look like this: https://github.com/getsentry/sentry/pull/76515 -- I'll essentially be requiring:

- self-hosted has progressed past the last migration that modified `index_together`
- I'll modify the migrations to make it look like they never had `index_together` but still resulted in the same state