### PR TITLE
fix(feedback): fix query params

### DIFF
--- a/static/app/components/devtoolbar/components/feedback/useInfiniteFeedbackList.tsx
+++ b/static/app/components/devtoolbar/components/feedback/useInfiniteFeedbackList.tsx
@@ -25,7 +25,6 @@ export default function useInfiniteFeedbackList({query}: Props) {
             project: projectId,
             statsPeriod: '14d',
             mailbox,
-            collapse: ['stats'],
             expand: [
               // 'pluginActions', // Gives us plugin actions available
               // 'pluginIssues', // Gives us plugin issues available

--- a/static/app/components/devtoolbar/components/feedback/useInfiniteFeedbackList.tsx
+++ b/static/app/components/devtoolbar/components/feedback/useInfiniteFeedbackList.tsx
@@ -25,11 +25,8 @@ export default function useInfiniteFeedbackList({query}: Props) {
             project: projectId,
             statsPeriod: '14d',
             mailbox,
-
-            collapse: ['inbox'],
+            collapse: ['stats'],
             expand: [
-              'owners', // Gives us assignment
-              'stats', // Gives us `firstSeen`
               // 'pluginActions', // Gives us plugin actions available
               // 'pluginIssues', // Gives us plugin issues available
               // 'integrationIssues', // Gives us integration issues available

--- a/static/app/components/devtoolbar/components/issues/useInfiniteIssuesList.tsx
+++ b/static/app/components/devtoolbar/components/issues/useInfiniteIssuesList.tsx
@@ -27,14 +27,6 @@ export default function useInfiniteIssuesList({query}: Props) {
             environment: Array.isArray(environment) ? environment : [environment],
             project: projectId,
             statsPeriod: '14d',
-            collapse: ['stats'],
-            expand: [
-              // 'pluginActions', // Gives us plugin actions available
-              // 'pluginIssues', // Gives us plugin issues available
-              // 'integrationIssues', // Gives us integration issues available
-              // 'sentryAppIssues', // Gives us Sentry app issues available
-              // 'latestEventHasAttachments', // Gives us whether the feedback has screenshots
-            ],
             shortIdLookup: 0,
             query: `issue.category:[${IssueCategory.ERROR},${IssueCategory.PERFORMANCE}] status:${mailbox} ${query}`,
           },

--- a/static/app/components/devtoolbar/components/issues/useInfiniteIssuesList.tsx
+++ b/static/app/components/devtoolbar/components/issues/useInfiniteIssuesList.tsx
@@ -27,11 +27,8 @@ export default function useInfiniteIssuesList({query}: Props) {
             environment: Array.isArray(environment) ? environment : [environment],
             project: projectId,
             statsPeriod: '14d',
-
-            collapse: ['inbox'],
+            collapse: ['stats'],
             expand: [
-              'owners', // Gives us assignment
-              'stats', // Gives us `firstSeen`
               // 'pluginActions', // Gives us plugin actions available
               // 'pluginIssues', // Gives us plugin issues available
               // 'integrationIssues', // Gives us integration issues available

--- a/static/app/components/feedback/getFeedbackItemQueryKey.tsx
+++ b/static/app/components/feedback/getFeedbackItemQueryKey.tsx
@@ -17,7 +17,7 @@ export default function getFeedbackItemQueryKey({feedbackId, organization}: Prop
           {
             query: {
               collapse: ['release', 'tags'],
-              expand: ['inbox', 'owners'],
+              expand: ['inbox'],
             },
           },
         ]

--- a/static/app/components/feedback/getFeedbackItemQueryKey.tsx
+++ b/static/app/components/feedback/getFeedbackItemQueryKey.tsx
@@ -17,7 +17,6 @@ export default function getFeedbackItemQueryKey({feedbackId, organization}: Prop
           {
             query: {
               collapse: ['release', 'tags'],
-              expand: ['inbox'],
             },
           },
         ]

--- a/static/app/components/feedback/useFeedbackListQueryKey.tsx
+++ b/static/app/components/feedback/useFeedbackListQueryKey.tsx
@@ -58,7 +58,6 @@ export default function useFeedbackListQueryKey({
       {
         query: {
           ...fixedQueryView,
-          collapse: ['stats'],
           expand: prefetch
             ? []
             : [

--- a/static/app/components/feedback/useFeedbackListQueryKey.tsx
+++ b/static/app/components/feedback/useFeedbackListQueryKey.tsx
@@ -58,12 +58,10 @@ export default function useFeedbackListQueryKey({
       {
         query: {
           ...fixedQueryView,
-          collapse: ['inbox'],
+          collapse: ['stats'],
           expand: prefetch
             ? []
             : [
-                'owners', // Gives us assignment
-                'stats', // Gives us `firstSeen`
                 'pluginActions', // Gives us plugin actions available
                 'pluginIssues', // Gives us plugin issues available
                 'integrationIssues', // Gives us integration issues available


### PR DESCRIPTION
- remove expand `owners` - we don't need it
- remove expand `stats` - it's on by default
- remove collapse `inbox` - doesn't exist
- remove expand `inbox` - we don't need it