### PR TITLE
fix(issue-summary): Hide issue summary on non-error issues

### DIFF
--- a/static/app/components/group/groupSummary.spec.tsx
+++ b/static/app/components/group/groupSummary.spec.tsx
@@ -46,9 +46,7 @@ describe('GroupSummary', function () {
 
     render(<GroupSummary groupId={groupId} groupCategory={IssueCategory.ERROR} />);
 
-    await waitFor(() => {
-      expect(screen.getByText('Issue Summary')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Issue Summary')).toBeInTheDocument();
 
     expect(screen.getByText('Issue Summary')).toBeInTheDocument();
     expect(screen.getByText('Test summary')).toBeInTheDocument();
@@ -90,12 +88,9 @@ describe('GroupSummary', function () {
 
     render(<GroupSummary groupId={groupId} groupCategory={IssueCategory.ERROR} />);
 
-    await waitFor(
-      () => {
-        expect(setupCall).toHaveBeenCalled();
-      },
-      {timeout: 5000}
-    );
+    await waitFor(() => {
+      expect(setupCall).toHaveBeenCalled();
+    });
 
     expect(screen.queryByText('Issue Summary')).not.toBeInTheDocument();
     expect(screen.queryByText('Test summary')).not.toBeInTheDocument();
@@ -184,9 +179,7 @@ describe('GroupSummaryHeader', function () {
 
     render(<GroupSummaryHeader groupId={groupId} groupCategory={IssueCategory.ERROR} />);
 
-    await waitFor(() => {
-      expect(screen.getByText('Test headline')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Test headline')).toBeInTheDocument();
   });
 
   it('does not render the group summary headline if no consent', async function () {
@@ -224,12 +217,9 @@ describe('GroupSummaryHeader', function () {
 
     render(<GroupSummaryHeader groupId={groupId} groupCategory={IssueCategory.ERROR} />);
 
-    await waitFor(
-      () => {
-        expect(setupCall).toHaveBeenCalled();
-      },
-      {timeout: 5000}
-    );
+    await waitFor(() => {
+      expect(setupCall).toHaveBeenCalled();
+    });
 
     expect(screen.queryByText('Test headline')).not.toBeInTheDocument();
   });

--- a/static/app/components/group/groupSummary.spec.tsx
+++ b/static/app/components/group/groupSummary.spec.tsx
@@ -44,13 +44,7 @@ describe('GroupSummary', function () {
       },
     });
 
-    render(
-      <GroupSummary
-        groupId={groupId}
-        groupCategory={IssueCategory.ERROR}
-        groupTitle={'Uh oh.'}
-      />
-    );
+    render(<GroupSummary groupId={groupId} groupCategory={IssueCategory.ERROR} />);
 
     await waitFor(() => {
       expect(screen.getByText('Issue Summary')).toBeInTheDocument();
@@ -94,13 +88,7 @@ describe('GroupSummary', function () {
       },
     });
 
-    render(
-      <GroupSummary
-        groupId={groupId}
-        groupCategory={IssueCategory.ERROR}
-        groupTitle={'Uh oh.'}
-      />
-    );
+    render(<GroupSummary groupId={groupId} groupCategory={IssueCategory.ERROR} />);
 
     await waitFor(
       () => {
@@ -147,59 +135,8 @@ describe('GroupSummary', function () {
       },
     });
 
-    render(
-      <GroupSummary
-        groupId={groupId}
-        groupCategory={IssueCategory.PERFORMANCE}
-        groupTitle={'Uh oh.'}
-      />
-    );
+    render(<GroupSummary groupId={groupId} groupCategory={IssueCategory.PERFORMANCE} />);
 
-    expect(screen.queryByText('Issue Summary')).not.toBeInTheDocument();
-    expect(screen.queryByText('Test summary')).not.toBeInTheDocument();
-    expect(screen.queryByText('Potential Impact')).not.toBeInTheDocument();
-    expect(screen.queryByText('Test impact')).not.toBeInTheDocument();
-  });
-
-  it('does not render the group summary if user feedback', function () {
-    const groupId = '1';
-    const organizationSlug = 'org-slug';
-    MockApiClient.addMockResponse({
-      url: makeGroupSummaryQueryKey(organizationSlug, groupId)[0],
-      method: 'POST',
-      body: {
-        groupId,
-        summary: 'Test summary',
-        impact: 'Test impact',
-      },
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/issues/${groupId}/autofix/setup/`,
-      body: {
-        genAIConsent: {ok: true},
-        integration: {ok: true},
-        githubWriteIntegration: {
-          ok: true,
-          repos: [
-            {
-              provider: 'integrations:github',
-              owner: 'getsentry',
-              name: 'sentry',
-              external_id: '123',
-            },
-          ],
-        },
-      },
-    });
-
-    render(
-      <GroupSummary
-        groupId={groupId}
-        groupCategory={IssueCategory.ERROR}
-        groupTitle={'User Feedback'}
-      />
-    );
     expect(screen.queryByText('Issue Summary')).not.toBeInTheDocument();
     expect(screen.queryByText('Test summary')).not.toBeInTheDocument();
     expect(screen.queryByText('Potential Impact')).not.toBeInTheDocument();
@@ -245,13 +182,7 @@ describe('GroupSummaryHeader', function () {
       },
     });
 
-    render(
-      <GroupSummaryHeader
-        groupId={groupId}
-        groupCategory={IssueCategory.ERROR}
-        groupTitle={'Uh oh.'}
-      />
-    );
+    render(<GroupSummaryHeader groupId={groupId} groupCategory={IssueCategory.ERROR} />);
 
     await waitFor(() => {
       expect(screen.getByText('Test headline')).toBeInTheDocument();
@@ -291,13 +222,7 @@ describe('GroupSummaryHeader', function () {
       },
     });
 
-    render(
-      <GroupSummaryHeader
-        groupId={groupId}
-        groupCategory={IssueCategory.ERROR}
-        groupTitle={'Uh oh.'}
-      />
-    );
+    render(<GroupSummaryHeader groupId={groupId} groupCategory={IssueCategory.ERROR} />);
 
     await waitFor(
       () => {
@@ -343,54 +268,8 @@ describe('GroupSummaryHeader', function () {
     });
 
     render(
-      <GroupSummaryHeader
-        groupId={groupId}
-        groupCategory={IssueCategory.PERFORMANCE}
-        groupTitle={'Uh oh.'}
-      />
+      <GroupSummaryHeader groupId={groupId} groupCategory={IssueCategory.PERFORMANCE} />
     );
-    expect(screen.queryByText('Test headline')).not.toBeInTheDocument();
-  });
-
-  it('does not render the group summary headline if user feedback', function () {
-    const groupId = '1';
-    const organizationSlug = 'org-slug';
-    MockApiClient.addMockResponse({
-      url: makeGroupSummaryQueryKey(organizationSlug, groupId)[0],
-      method: 'POST',
-      body: {
-        groupId,
-        summary: 'Test summary',
-        impact: 'Test impact',
-        headline: 'Test headline',
-      },
-    });
-    MockApiClient.addMockResponse({
-      url: `/issues/${groupId}/autofix/setup/`,
-      body: {
-        genAIConsent: {ok: false},
-        integration: {ok: true},
-        githubWriteIntegration: {
-          ok: true,
-          repos: [
-            {
-              provider: 'integrations:github',
-              owner: 'getsentry',
-              name: 'sentry',
-              external_id: '123',
-            },
-          ],
-        },
-      },
-    });
-    render(
-      <GroupSummaryHeader
-        groupId={groupId}
-        groupCategory={IssueCategory.ERROR}
-        groupTitle="User Feedback"
-      />
-    );
-
     expect(screen.queryByText('Test headline')).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/group/groupSummary.spec.tsx
+++ b/static/app/components/group/groupSummary.spec.tsx
@@ -115,7 +115,7 @@ describe('GroupSummary', function () {
     expect(screen.queryByText('Test impact')).not.toBeInTheDocument();
   });
 
-  it('does not render the group summary if not an error', async function () {
+  it('does not render the group summary if not an error', function () {
     const groupId = '1';
     const organizationSlug = 'org-slug';
     MockApiClient.addMockResponse({
@@ -128,10 +128,10 @@ describe('GroupSummary', function () {
       },
     });
 
-    const setupCall = MockApiClient.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/issues/${groupId}/autofix/setup/`,
       body: {
-        genAIConsent: {ok: false},
+        genAIConsent: {ok: true},
         integration: {ok: true},
         githubWriteIntegration: {
           ok: true,
@@ -155,20 +155,13 @@ describe('GroupSummary', function () {
       />
     );
 
-    await waitFor(
-      () => {
-        expect(setupCall).toHaveBeenCalled();
-      },
-      {timeout: 5000}
-    );
-
     expect(screen.queryByText('Issue Summary')).not.toBeInTheDocument();
     expect(screen.queryByText('Test summary')).not.toBeInTheDocument();
     expect(screen.queryByText('Potential Impact')).not.toBeInTheDocument();
     expect(screen.queryByText('Test impact')).not.toBeInTheDocument();
   });
 
-  it('does not render the group summary if user feedback', async function () {
+  it('does not render the group summary if user feedback', function () {
     const groupId = '1';
     const organizationSlug = 'org-slug';
     MockApiClient.addMockResponse({
@@ -181,10 +174,10 @@ describe('GroupSummary', function () {
       },
     });
 
-    const setupCall = MockApiClient.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/issues/${groupId}/autofix/setup/`,
       body: {
-        genAIConsent: {ok: false},
+        genAIConsent: {ok: true},
         integration: {ok: true},
         githubWriteIntegration: {
           ok: true,
@@ -207,14 +200,6 @@ describe('GroupSummary', function () {
         groupTitle={'User Feedback'}
       />
     );
-
-    await waitFor(
-      () => {
-        expect(setupCall).toHaveBeenCalled();
-      },
-      {timeout: 5000}
-    );
-
     expect(screen.queryByText('Issue Summary')).not.toBeInTheDocument();
     expect(screen.queryByText('Test summary')).not.toBeInTheDocument();
     expect(screen.queryByText('Potential Impact')).not.toBeInTheDocument();
@@ -227,7 +212,7 @@ describe('GroupSummaryHeader', function () {
     MockApiClient.clearMockResponses();
   });
 
-  it('renders the group summary', async function () {
+  it('renders the group summary header', async function () {
     const groupId = '1';
     const organizationSlug = 'org-slug';
     MockApiClient.addMockResponse({
@@ -324,7 +309,7 @@ describe('GroupSummaryHeader', function () {
     expect(screen.queryByText('Test headline')).not.toBeInTheDocument();
   });
 
-  it('does not render the group summary headline if not an error', async function () {
+  it('does not render the group summary headline if not an error', function () {
     const groupId = '1';
     const organizationSlug = 'org-slug';
     MockApiClient.addMockResponse({
@@ -338,10 +323,10 @@ describe('GroupSummaryHeader', function () {
       },
     });
 
-    const setupCall = MockApiClient.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/issues/${groupId}/autofix/setup/`,
       body: {
-        genAIConsent: {ok: false},
+        genAIConsent: {ok: true},
         integration: {ok: true},
         githubWriteIntegration: {
           ok: true,
@@ -364,18 +349,10 @@ describe('GroupSummaryHeader', function () {
         groupTitle={'Uh oh.'}
       />
     );
-
-    await waitFor(
-      () => {
-        expect(setupCall).toHaveBeenCalled();
-      },
-      {timeout: 5000}
-    );
-
     expect(screen.queryByText('Test headline')).not.toBeInTheDocument();
   });
 
-  it('does not render the group summary headline if user feedback', async function () {
+  it('does not render the group summary headline if user feedback', function () {
     const groupId = '1';
     const organizationSlug = 'org-slug';
     MockApiClient.addMockResponse({
@@ -388,8 +365,7 @@ describe('GroupSummaryHeader', function () {
         headline: 'Test headline',
       },
     });
-
-    const setupCall = MockApiClient.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/issues/${groupId}/autofix/setup/`,
       body: {
         genAIConsent: {ok: false},
@@ -407,20 +383,12 @@ describe('GroupSummaryHeader', function () {
         },
       },
     });
-
     render(
       <GroupSummaryHeader
         groupId={groupId}
         groupCategory={IssueCategory.ERROR}
-        groupTitle={'User Feedback'}
+        groupTitle="User Feedback"
       />
-    );
-
-    await waitFor(
-      () => {
-        expect(setupCall).toHaveBeenCalled();
-      },
-      {timeout: 5000}
     );
 
     expect(screen.queryByText('Test headline')).not.toBeInTheDocument();

--- a/static/app/views/issueDetails/groupSidebar.tsx
+++ b/static/app/views/issueDetails/groupSidebar.tsx
@@ -260,11 +260,7 @@ export default function GroupSidebar({
   return (
     <Container>
       <Feature features={['organizations:ai-summary']}>
-        <GroupSummary
-          groupId={group.id}
-          groupCategory={group.issueCategory}
-          groupTitle={group.title}
-        />
+        <GroupSummary groupId={group.id} groupCategory={group.issueCategory} />
       </Feature>
       {hasStreamlinedUI && event && (
         <ErrorBoundary mini>

--- a/static/app/views/issueDetails/groupSidebar.tsx
+++ b/static/app/views/issueDetails/groupSidebar.tsx
@@ -260,7 +260,11 @@ export default function GroupSidebar({
   return (
     <Container>
       <Feature features={['organizations:ai-summary']}>
-        <GroupSummary groupId={group.id} />
+        <GroupSummary
+          groupId={group.id}
+          groupCategory={group.issueCategory}
+          groupTitle={group.title}
+        />
       </Feature>
       {hasStreamlinedUI && event && (
         <ErrorBoundary mini>

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -257,7 +257,11 @@ function GroupHeader({
               showUnhandled={group.isUnhandled}
             />
             <Feature features={['organizations:ai-summary']}>
-              <GroupSummaryHeader groupId={group.id} />
+              <GroupSummaryHeader
+                groupId={group.id}
+                groupCategory={group.issueCategory}
+                groupTitle={group.title}
+              />
             </Feature>
           </TitleWrapper>
           <StatsWrapper>

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -260,7 +260,6 @@ function GroupHeader({
               <GroupSummaryHeader
                 groupId={group.id}
                 groupCategory={group.issueCategory}
-                groupTitle={group.title}
               />
             </Feature>
           </TitleWrapper>

--- a/static/app/views/issueDetails/streamline/header.tsx
+++ b/static/app/views/issueDetails/streamline/header.tsx
@@ -150,11 +150,7 @@ export default function StreamlinedGroupHeader({
         )}
       </MessageWrapper>
       <Feature features={['organizations:ai-summary']}>
-        <GroupSummaryHeader
-          groupId={group.id}
-          groupCategory={group.issueCategory}
-          groupTitle={group.title}
-        />
+        <GroupSummaryHeader groupId={group.id} groupCategory={group.issueCategory} />
       </Feature>
       <StyledBreak />
       <InfoWrapper

--- a/static/app/views/issueDetails/streamline/header.tsx
+++ b/static/app/views/issueDetails/streamline/header.tsx
@@ -150,7 +150,11 @@ export default function StreamlinedGroupHeader({
         )}
       </MessageWrapper>
       <Feature features={['organizations:ai-summary']}>
-        <GroupSummaryHeader groupId={group.id} />
+        <GroupSummaryHeader
+          groupId={group.id}
+          groupCategory={group.issueCategory}
+          groupTitle={group.title}
+        />
       </Feature>
       <StyledBreak />
       <InfoWrapper


### PR DESCRIPTION
Hides issue summary header and card if the issue is not an error issue (i.e. it's a performance, replay, or user feedback issue).