### PR TITLE
fix(custom-views): Allow view's query field to be empty

### DIFF
--- a/src/sentry/api/serializers/rest_framework/groupsearchview.py
+++ b/src/sentry/api/serializers/rest_framework/groupsearchview.py
@@ -20,7 +20,7 @@ class GroupSearchViewValidatorResponse(TypedDict):
 class ViewValidator(serializers.Serializer):
     id = serializers.CharField(required=False)
     name = serializers.CharField(required=True)
-    query = serializers.CharField(required=True)
+    query = serializers.CharField(required=True, allow_blank=True)
     querySort = serializers.ChoiceField(
         choices=SortOptions.as_choices(), default=SortOptions.DATE, required=False
     )


### PR DESCRIPTION
Views containing an empty query failed validation, and I can't think of a reason to disallow empty queries. 