### PR TITLE
fix(grouping): Fix project-deletion-triggered `GroupHash` deletion

### DIFF
--- a/src/sentry/deletions/defaults/project.py
+++ b/src/sentry/deletions/defaults/project.py
@@ -20,7 +20,6 @@ class ProjectDeletionTask(ModelDeletionTask):
         from sentry.models.groupassignee import GroupAssignee
         from sentry.models.groupbookmark import GroupBookmark
         from sentry.models.groupemailthread import GroupEmailThread
-        from sentry.models.grouphash import GroupHash
         from sentry.models.grouprelease import GroupRelease
         from sentry.models.grouprulestatus import GroupRuleStatus
         from sentry.models.groupseen import GroupSeen
@@ -54,7 +53,6 @@ class ProjectDeletionTask(ModelDeletionTask):
             GroupAssignee,
             GroupBookmark,
             GroupEmailThread,
-            GroupHash,
             GroupRelease,
             GroupRuleStatus,
             GroupSeen,


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/sentry/pull/76312, fixing another bug with grouphash deletion. Currently, when a project is deleted, its associated `GroupHash` records are deleted directly by the project deletion task, using the `BulkModelDeletionTask`. Unfortunately, that task doesn't take into account any dependent tables, meaning that the corresponding `GroupHashMetadata` records aren't deleted as they should be.

This fixes that by allowing `GroupHash` deletions to cascade from group deletions (which themselves are set off by project deletion), rather than having the project deletion task delete the grouphashes directly. (Group deletions already handle `GroupHash`/`GroupHashMetadata` deletion correctly, using the `GroupHash`-specific deletion task [registered in the deletion module's `__init__.py`](https://github.com/getsentry/sentry/blob/9155480cddb7454bba99ae39ea4caac91261ca26/src/sentry/deletions/__init__.py#L127).)

Note that while the results of this change aren't tested in this PR, they are implicitly tested in https://github.com/getsentry/sentry/pull/76245, which will directly follow this one and which for the first time will actually create `GroupHashMetadata` records. Without the change in this PR, the presence of that PR's new `GroupHashMetadata` records causes the project deletion test to fail, but with this change, they pass.