### PR TITLE
fix(issues): Hide user avatar if missing properties

### DIFF
--- a/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
@@ -45,7 +45,7 @@ describe('HighlightsIconSummary', function () {
 
     render(<HighlightsIconSummary event={eventWithUser} />);
     expect(screen.getByText('user email')).toBeInTheDocument();
-    expect(screen.getByText('user username')).toBeInTheDocument();
+    expect(screen.getByText('Username: user username')).toBeInTheDocument();
   });
 
   it('renders appropriate icons and text', function () {

--- a/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
@@ -19,6 +19,35 @@ describe('HighlightsIconSummary', function () {
     tags: TEST_EVENT_TAGS,
   });
 
+  it('hides user if there is no id, email, username, etc', function () {
+    const eventWithoutUser = EventFixture({
+      contexts: {
+        user: {
+          customProperty: 'customValue',
+        },
+      },
+    });
+
+    const {container} = render(<HighlightsIconSummary event={eventWithoutUser} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders user if there is id, email, username, etc', function () {
+    const eventWithUser = EventFixture({
+      contexts: {
+        user: {
+          id: 'user id',
+          email: 'user email',
+          username: 'user username',
+        },
+      },
+    });
+
+    render(<HighlightsIconSummary event={eventWithUser} />);
+    expect(screen.getByText('user email')).toBeInTheDocument();
+    expect(screen.getByText('user username')).toBeInTheDocument();
+  });
+
   it('renders appropriate icons and text', function () {
     render(<HighlightsIconSummary event={event} />);
     expect(screen.getByText('Mac OS X')).toBeInTheDocument();

--- a/static/app/components/events/highlights/highlightsIconSummary.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.tsx
@@ -28,7 +28,7 @@ export function HighlightsIconSummary({event}: HighlightsIconSummaryProps) {
         },
       }),
     }))
-    .filter(item => item.icon !== null);
+    .filter(item => item.icon !== null && Boolean(item.title || item.subtitle));
 
   const deviceIndex = items.findIndex(item => item.alias === 'device');
   const clientOsIndex = items.findIndex(item => item.alias === 'client_os');


### PR DESCRIPTION
People can add their own properties to the user object (eg `hardwareId`) and we'd display an empty avatar with nothing else. This hides it if it isn't interesting.

fixes https://www.notion.so/sentry/Empty-user-shown-c921cd9910c3488ba69c5c19f0c930ac?pvs=23