### PR TITLE
fix(codeowners): Fix bug with multiple codeowners 

### DIFF
--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -111,7 +111,7 @@ class GroupOwner(Model):
                 group_id=group_id, project_id=project_id, type__in=autoassignment_types
             )
             .exclude(user_id__isnull=True, team_id__isnull=True)
-            .order_by("type")
+            .order_by("type", "date_added")
             .first()
         )
         # should return False if no owner

--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -106,6 +106,9 @@ class GroupOwner(Model):
         """
         Non-cached read access to find the autoassigned GroupOwner.
         """
+
+        # Ordered by date_added as well to ensure that the first GroupOwner is returned
+        # Multiple GroupOwners can be created but they are created in the correct evaluation order, so the first one takes precedence
         issue_owner = (
             cls.objects.filter(
                 group_id=group_id, project_id=project_id, type__in=autoassignment_types

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -703,7 +703,7 @@ class ProjectOwnershipTestCase(TestCase):
         assignee = GroupAssignee.objects.get(group=self.event.group)
         assert assignee.team_id == self.team.id
 
-    def test_autoassign_multiple_codeowners(self):
+    def test_autoassignment_with_multiple_codeowners(self):
         processing_team = self.create_team(
             organization=self.organization, slug="processing-team", members=[self.user]
         )

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -703,6 +703,75 @@ class ProjectOwnershipTestCase(TestCase):
         assignee = GroupAssignee.objects.get(group=self.event.group)
         assert assignee.team_id == self.team.id
 
+    def test_autoassign_multiple_codeowners(self):
+        processing_team = self.create_team(
+            organization=self.organization, slug="processing-team", members=[self.user]
+        )
+        payment_team = self.create_team(
+            organization=self.organization, slug="payment-team", members=[self.user2]
+        )
+
+        project = self.create_project(
+            organization=self.organization, teams=[processing_team, payment_team], slug="rotation"
+        )
+        data = {
+            "stacktrace": {
+                "frames": [
+                    {"abs_path": "/app/payment_service.rb", "in_app": True},
+                    {"abs_path": "/app/processing_unit.rb", "in_app": True},
+                    {"abs_path": "/app/processing_unit.rb", "in_app": True},
+                ]
+            }
+        }
+
+        event = self.store_event(
+            data=data,
+            project_id=project.id,
+        )
+
+        rules = [
+            Rule(Matcher("codeowners", "*payment*"), [Owner("team", payment_team.slug)]),
+            Rule(
+                Matcher("codeowners", "/app/processing_unit.rb"),
+                [Owner("team", processing_team.slug)],
+            ),
+        ]
+
+        ProjectOwnership.objects.create(
+            project_id=project.id, schema=dump_schema(rules), fallthrough=True
+        )
+
+        assert len(ProjectOwnership.get_issue_owners(project.id, data)) == 2
+
+        # Order of group owners should be determined by `get_issue_owners` which has the correct order
+        group_owners = [
+            GroupOwner(
+                group=event.group,
+                type=GroupOwnerType.CODEOWNERS.value,
+                user_id=None,
+                team_id=processing_team.id,
+                project=project,
+                organization=project.organization,
+                context={"rule": str(rules[1])},
+            ),
+            GroupOwner(
+                group=event.group,
+                type=GroupOwnerType.CODEOWNERS.value,
+                user_id=None,
+                team_id=payment_team.id,
+                project=project,
+                organization=project.organization,
+                context={"rule": str(rules[0])},
+            ),
+        ]
+
+        GroupOwner.objects.bulk_create(group_owners)
+
+        ProjectOwnership.handle_auto_assignment(project.id, event)
+        assert len(GroupAssignee.objects.all()) == 1
+        assignee = GroupAssignee.objects.get(group=event.group)
+        assert assignee.team_id == processing_team.id
+
 
 class ResolveActorsTestCase(TestCase):
     def test_no_actors(self):


### PR DESCRIPTION
this pr fixes a bug with codeowners where the wrong codeowner was selected. this is because `get_issue_owners` returns 2 owners but when auto-assignment happened, it only filtered by type. In the case that there were 2 owners of the same type, it didn't specify which one to pick. Since they are created in the correct order,  we can sort by `date_created` to find the one that's created first which should be the correct one. 


fixes https://github.com/getsentry/sentry/issues/73021
Closes https://github.com/getsentry/sentry/issues/73021
