### PR TITLE
ref(ui): Switch discover to useQuery object style

### DIFF
--- a/static/app/utils/discover/genericDiscoverQuery.tsx
+++ b/static/app/utils/discover/genericDiscoverQuery.tsx
@@ -422,15 +422,15 @@ export function useGenericDiscoverQuery<T, P>(props: Props<T, P>) {
   const url = `/organizations/${orgSlug}/${route}/`;
   const apiPayload = getPayload<T, P>(props);
 
-  const res = useQuery<[T, string | undefined, ResponseMeta<T> | undefined], QueryError>(
-    [route, apiPayload],
-    ({signal: _signal}) =>
+  const res = useQuery<[T, string | undefined, ResponseMeta<T> | undefined], QueryError>({
+    queryKey: [route, apiPayload],
+    queryFn: ({signal: _signal}) =>
       doDiscoverQuery<T>(api, url, apiPayload, {
         queryBatching: props.queryBatching,
         skipAbort: props.skipAbort,
       }),
-    options
-  );
+    ...options,
+  });
 
   return {
     ...res,


### PR DESCRIPTION
Compatible with react-query v5 instead of multiple arguments.

part of https://github.com/getsentry/frontend-tsc/issues/52
