### PR TITLE
fix(custom-views): Fix query repopulating upon empty search

### DIFF
--- a/static/app/views/issueList/customViewsHeader.tsx
+++ b/static/app/views/issueList/customViewsHeader.tsx
@@ -210,7 +210,7 @@ function CustomViewsIssueListHeaderTabsContent({
         tabListState?.setSelectedKey(selectedTab.key);
         return;
       }
-      if (selectedTab && !query) {
+      if (selectedTab && query === undefined) {
         navigate({
           query: {
             ...queryParams,


### PR DESCRIPTION
Fixes a bug where deleting all search tokens and hitting "Enter" would repopulate the search bar with the tab's query. 