### PR TITLE
fix(issues): Adjust resolved gradient for dark mode

### DIFF
--- a/static/app/views/issueDetails/streamline/header.tsx
+++ b/static/app/views/issueDetails/streamline/header.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
+import Color from 'color';
 
 import Feature from 'sentry/components/acl/feature';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
@@ -242,7 +243,7 @@ const InfoWrapper = styled('div')<{isResolvedOrIgnored: boolean}>`
   gap: ${space(1)};
   background: ${p =>
     p.isResolvedOrIgnored
-      ? 'linear-gradient(to right, rgba(235, 250, 246, 0.2) , rgb(235, 250, 246))'
+      ? `linear-gradient(to right, ${Color(p.theme.success).lighten(0.7).alpha(0.05).string()}, ${Color(p.theme.success).lighten(0.5).alpha(0.2).string()})`
       : p.theme.background};
   color: ${p => p.theme.gray300};
   padding: ${space(1)} 24px;

--- a/static/app/views/issueDetails/streamline/header.tsx
+++ b/static/app/views/issueDetails/streamline/header.tsx
@@ -243,7 +243,7 @@ const InfoWrapper = styled('div')<{isResolvedOrIgnored: boolean}>`
   gap: ${space(1)};
   background: ${p =>
     p.isResolvedOrIgnored
-      ? `linear-gradient(to right, ${Color(p.theme.success).lighten(0.7).alpha(0.05).string()}, ${Color(p.theme.success).lighten(0.5).alpha(0.2).string()})`
+      ? `linear-gradient(to right, ${Color(p.theme.success).lighten(0.5).alpha(0.2).string()}, ${Color(p.theme.success).lighten(0.7).alpha(0.05).string()})`
       : p.theme.background};
   color: ${p => p.theme.gray300};
   padding: ${space(1)} 24px;


### PR DESCRIPTION
Attempt to make it less bright in dark mode

before:
![image](https://github.com/user-attachments/assets/5b7096c8-dccf-4274-be63-e44b589c049b)

after:
![image](https://github.com/user-attachments/assets/a7bfceac-67bf-4857-af45-5e9878c42d3e)


before (light):
![image](https://github.com/user-attachments/assets/a9288598-49e6-41b0-8a0a-52e2b71b99e2)

after (light):
![image](https://github.com/user-attachments/assets/c7ff3473-b2fe-4ed1-a578-7232ab362a32)

