### PR TITLE
chore(grouping): Enable optimized logic for all projects in config transition

### DIFF
--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -96,4 +96,4 @@ def project_uses_optimized_grouping(project: Project) -> bool:
     return features.has(
         "organizations:grouping-suppress-unnecessary-secondary-hash",
         project.organization,
-    ) or (is_in_transition(project) and project.id % 2 == 0)
+    ) or (is_in_transition(project))

--- a/tests/sentry/event_manager/grouping/test_assign_to_group.py
+++ b/tests/sentry/event_manager/grouping/test_assign_to_group.py
@@ -531,7 +531,7 @@ def test_uses_regular_or_optimized_grouping_as_appropriate(
         assert mock_save_aggregate.call_count == 1
     elif flag_on:
         assert mock_save_aggregate_new.call_count == 1
-    elif in_transition and id_even:
+    elif in_transition:
         assert mock_save_aggregate_new.call_count == 1
     else:
         assert mock_save_aggregate.call_count == 1


### PR DESCRIPTION
This enables the new, optimized grouping logic for all projects currently in a grouping transition. (It's been running for half of such projects for the last two weeks without incident, and has proved to indeed be faster, so we're taking this first step towards rolling it out to everyone.)

Note: I fixed the relevant test to match this new behavior by changing the expected outcome, but I didn't remove the test code generating project ids to cover the cases where the id is odd, so that it will be there for me to adapt once I use a similar mechanism for rolling the feature out to non-transitioning projects.