### PR TITLE
ref(relay): Only update internal state when it changed

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -132,7 +132,6 @@ def relay_from_id(request: Request, relay_id: str) -> tuple[Relay | None, bool]:
     else:
         try:
             relay = Relay.objects.get(relay_id=relay_id)
-            relay.is_internal = is_internal_relay(request, relay.public_key)
             return relay, False  # a Relay from the database
         except Relay.DoesNotExist:
             return None, False  # no Relay found
@@ -222,6 +221,9 @@ class RelayAuthentication(BasicAuthentication):
 
         if relay is None:
             raise AuthenticationFailed("Unknown relay")
+
+        if not static:
+            relay.is_internal = is_internal_relay(request, relay.public_key)
 
         try:
             data = relay.public_key_object.unpack(request.body, relay_sig, max_age=60 * 5)

--- a/src/sentry/api/endpoints/relay/register_response.py
+++ b/src/sentry/api/endpoints/relay/register_response.py
@@ -90,7 +90,7 @@ class RelayRegisterResponseEndpoint(Endpoint):
                 relay = Relay.objects.create(
                     relay_id=relay_id, public_key=public_key, is_internal=is_internal
                 )
-            elif not relay.is_internal == is_internal:
+            elif relay.is_internal != is_internal:
                 # update the internal flag in case it is changed
                 relay.is_internal = is_internal
                 relay.save()

--- a/src/sentry/api/endpoints/relay/register_response.py
+++ b/src/sentry/api/endpoints/relay/register_response.py
@@ -90,7 +90,7 @@ class RelayRegisterResponseEndpoint(Endpoint):
                 relay = Relay.objects.create(
                     relay_id=relay_id, public_key=public_key, is_internal=is_internal
                 )
-            else:
+            elif not relay.is_internal == is_internal:
                 # update the internal flag in case it is changed
                 relay.is_internal = is_internal
                 relay.save()


### PR DESCRIPTION
Removes the `is_internal` update from the `relay_from_id` function, to move the check to the endpoint (where it already was anyways). All additional uses of `relay_from_id` don't seem to care about the internal state, except authentication. 
So that seems fine, also this behaviour does seem more consistent.
