### PR TITLE
fix(cleanup) Remove NotificationMessage before RuleFireHistory

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -211,8 +211,8 @@ def cleanup(
         BULK_QUERY_DELETES = [
             (models.UserReport, "date_added", None),
             (models.GroupEmailThread, "date", None),
-            (RuleFireHistory, "date_added", None),
             (NotificationMessage, "date_added", None),
+            (RuleFireHistory, "date_added", None),
         ] + additional_bulk_query_deletes
 
         # Deletions that use the `deletions` code path (which handles their child relations)


### PR DESCRIPTION
NotificationMessage has a foreign key constraint pointing to RuleFireHistory. Currently cleanup is failing because we have the deletion order incorrect.

Fixes SENTRY-3BW5