### PR TITLE
chore(slack): Remove Slack SDK Related Options

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -500,19 +500,6 @@ register("slack.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 # signing-secret is preferred, but need to keep verification-token for apps that use it
 register("slack.verification-token", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 register("slack.signing-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
-# Use Slack SDK in SlackEventEndpoint
-register(
-    "slack.event-endpoint-sdk",
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-# Integration Ids to LA for Using Slack SDK in SlackEventEndpoint
-register(
-    "slack.event-endpoint-sdk-integration-ids",
-    type=Sequence,
-    default=[],
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Codecov Integration
 register("codecov.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)


### PR DESCRIPTION
found some options we don't use anymore, since we gave GAed for a while.