### PR TITLE
feat(functions): Pass user query to functions table

### DIFF
--- a/static/app/utils/profiling/routes.tsx
+++ b/static/app/utils/profiling/routes.tsx
@@ -254,7 +254,7 @@ export function generateProfileRouteFromProfileReference({
         ...query,
         frameName,
         framePackage,
-        spanId: reference.transaction_id,
+        eventId: reference.transaction_id,
         tid: reference.thread_id as unknown as string,
       }),
     });

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -488,7 +488,7 @@ function ProfilingTransactionsContent(props: ProfilingTabContentProps) {
                 selection={selection}
                 continuousProfilingCompat={continuousProfilingCompat}
               />
-              <SlowestFunctionsTable />
+              <SlowestFunctionsTable userQuery={query} />
             </Fragment>
           ) : organization.features.includes('profiling-global-suspect-functions') ? (
             <Fragment>

--- a/static/app/views/profiling/landing/slowestFunctionsTable.tsx
+++ b/static/app/views/profiling/landing/slowestFunctionsTable.tsx
@@ -83,10 +83,16 @@ function useMemoryPagination(items: any[], size: number) {
   };
 }
 
-export function SlowestFunctionsTable() {
+export function SlowestFunctionsTable({userQuery}: {userQuery?: string}) {
   const {projects} = useProjects();
+
   const query = useAggregateFlamegraphQuery({
-    dataSource: 'profiles',
+    // User query is only permitted when using transactions.
+    // If this is to be reused for strictly continuous profiling,
+    // it'll need to be swapped to use the `profiles` data source
+    // with no user query.
+    dataSource: 'transactions',
+    query: userQuery ?? '',
     metrics: true,
   });
 


### PR DESCRIPTION
Since this is on the transactions tab, we can actually search `transactions` and pass the user query through.