### PR TITLE
fix(deletion) Use a specialized deletion strategy for GroupHistory

### DIFF
--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -126,7 +126,7 @@ def load_defaults():
     default_manager.register(models.GroupEnvironment, BulkModelDeletionTask)
     default_manager.register(models.GroupHash, defaults.GroupHashDeletionTask)
     default_manager.register(models.GroupHashMetadata, BulkModelDeletionTask)
-    default_manager.register(models.GroupHistory, BulkModelDeletionTask)
+    default_manager.register(models.GroupHistory, defaults.GroupHistoryDeletionTask)
     default_manager.register(models.GroupLink, BulkModelDeletionTask)
     default_manager.register(models.GroupMeta, BulkModelDeletionTask)
     default_manager.register(models.GroupRedirect, BulkModelDeletionTask)

--- a/src/sentry/deletions/defaults/__init__.py
+++ b/src/sentry/deletions/defaults/__init__.py
@@ -7,6 +7,7 @@ from .commitauthor import *  # noqa: F401,F403
 from .discoversavedquery import *  # noqa: F401,F403
 from .group import *  # noqa: F401,F403
 from .grouphash import *  # noqa: F401,F403
+from .grouphistory import *  # noqa: F401,F403
 from .monitor import *  # noqa: F401,F403
 from .monitor_environment import *  # noqa: F401,F403
 from .organization import *  # noqa: F401,F403

--- a/src/sentry/deletions/defaults/grouphistory.py
+++ b/src/sentry/deletions/defaults/grouphistory.py
@@ -1,0 +1,26 @@
+from sentry.deletions.base import ModelDeletionTask
+
+
+class GroupHistoryDeletionTask(ModelDeletionTask):
+    """
+    Specialized deletion handling that operates per group
+
+    Operating per group allows us to delete records more efficiently
+    than instance level deletions would, but avoids the constraint
+    issues that can occur when using BulkModelDeletionTask
+    as GroupHistory instances can have prev_history relations that
+    span 10000 ID values.
+    """
+
+    def chunk(self) -> bool:
+        group_ids = self.query.get("group_id__in", [])
+        if not group_ids:
+            # If we don't have group_id conditions
+            # we can't delete by group.
+            return super().chunk()
+
+        for group_id in group_ids:
+            # Delete all history records for a single group
+            self.model.objects.filter(group_id=group_id).delete()
+
+        return False


### PR DESCRIPTION
There are a few deletions stuck for projects because of failures in deleting grouphistory. When removing a project it is possible for groups to have history records that have `prev_history` references that aren't within the same 10000 record batch as their parent. This was not reproducible in tests because tests run within a transaction so all batches are removed in the same transaction.

By deleting history records by group we can ensure that constraints aren't violated. Most groups have fewer than 10k history records so we shouldn't hit query timeouts.

Fixes SENTRY-19BG