### PR TITLE
fix(issues): Wrap fold section setState in layout effect

### DIFF
--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -1,4 +1,11 @@
-import {type CSSProperties, forwardRef, Fragment, useCallback, useState} from 'react';
+import {
+  type CSSProperties,
+  forwardRef,
+  Fragment,
+  useCallback,
+  useLayoutEffect,
+  useState,
+} from 'react';
 import styled from '@emotion/styled';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -58,9 +65,11 @@ export const FoldSection = forwardRef<HTMLElement, FoldSectionProps>(function Fo
     initialCollapse
   );
 
-  if (!sectionData.hasOwnProperty(sectionKey)) {
-    dispatch({type: 'UPDATE_SECTION', key: sectionKey, config: {initialCollapse}});
-  }
+  useLayoutEffect(() => {
+    if (!sectionData.hasOwnProperty(sectionKey)) {
+      dispatch({type: 'UPDATE_SECTION', key: sectionKey, config: {initialCollapse}});
+    }
+  }, [sectionData, dispatch, sectionKey, initialCollapse]);
 
   // This controls disabling the InteractionStateLayer when hovering over action items. We don't
   // want selecting an action to appear as though it'll fold/unfold the section.


### PR DESCRIPTION
I guess react doesn't like when a child component attempts to queue up an update in a parent component.
I think originally we thought this would be fine since it should only happen on first render.

![Screenshot 2024-08-21 at 6 57 21 PM](https://github.com/user-attachments/assets/a4a2a0a0-ad23-4589-ac57-a6e0c108f7b6)
