### PR TITLE
feat(query-builder): Add easy multi-select while holding ctrl/cmd

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -1524,6 +1524,55 @@ describe('SearchQueryBuilder', function () {
         expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveFocus();
       });
 
+      it('keeps focus inside value when multi-selecting with ctrl+enter', async function () {
+        render(
+          <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+        );
+
+        // Arrow down two places to "Chrome" option
+        await userEvent.keyboard('{ArrowDown}{ArrowDown}');
+        // Pressing ctrl+enter should toggle the option and keep focus inside the input
+        await userEvent.keyboard('{Control>}{Enter}');
+        expect(
+          await screen.findByRole('row', {name: 'browser.name:[firefox,Chrome]'})
+        ).toBeInTheDocument();
+        await waitFor(() => {
+          expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveValue(
+            'firefox,Chrome,'
+          );
+        });
+        expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveFocus();
+      });
+
+      it('keeps focus inside value when multi-selecting with ctrl+click', async function () {
+        render(
+          <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />
+        );
+
+        const user = userEvent.setup();
+
+        await user.click(
+          screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+        );
+
+        // Clicking option while holding Ctrl should toggle the option and keep focus inside the input
+        await user.keyboard('{Control>}');
+        await user.click(screen.getByRole('option', {name: 'Chrome'}));
+        expect(
+          await screen.findByRole('row', {name: 'browser.name:[firefox,Chrome]'})
+        ).toBeInTheDocument();
+        await waitFor(() => {
+          expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveValue(
+            'firefox,Chrome,'
+          );
+        });
+        expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveFocus();
+      });
+
       it('collapses many selected options', function () {
         render(
           <SearchQueryBuilder

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -110,6 +110,7 @@ type SearchQueryBuilderComboboxProps<T extends SelectOptionOrSectionWithKey<stri
 type OverlayProps = ReturnType<typeof useOverlay>['overlayProps'];
 
 export type CustomComboboxMenuProps<T> = {
+  filterValue: string;
   hiddenOptions: Set<SelectKey>;
   isOpen: boolean;
   listBoxProps: AriaListBoxOptions<T>;
@@ -277,6 +278,7 @@ function OverlayContent<T extends SelectOptionOrSectionWithKey<string>>({
       listBoxProps,
       state,
       overlayProps,
+      filterValue,
     });
   }
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
@@ -1,0 +1,85 @@
+import styled from '@emotion/styled';
+import {isMac} from '@react-aria/utils';
+
+import {ListBox} from 'sentry/components/compactSelect/listBox';
+import type {SelectOptionOrSectionWithKey} from 'sentry/components/compactSelect/types';
+import {Overlay} from 'sentry/components/overlay';
+import type {CustomComboboxMenuProps} from 'sentry/components/searchQueryBuilder/tokens/combobox';
+import {itemIsSection} from 'sentry/components/searchQueryBuilder/tokens/utils';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+interface ValueListBoxProps<T> extends CustomComboboxMenuProps<T> {
+  isMultiSelect: boolean;
+  items: T[];
+}
+
+export function ValueListBox<T extends SelectOptionOrSectionWithKey<string>>({
+  hiddenOptions,
+  isOpen,
+  listBoxProps,
+  listBoxRef,
+  popoverRef,
+  state,
+  overlayProps,
+  filterValue,
+  isMultiSelect,
+  items,
+}: ValueListBoxProps<T>) {
+  const totalOptions = items.reduce(
+    (acc, item) => acc + (itemIsSection(item) ? item.options.length : 1),
+    0
+  );
+  const anyItemsShowing = totalOptions > hiddenOptions.size;
+
+  if (!isOpen || !anyItemsShowing) {
+    return null;
+  }
+
+  return (
+    <StyledPositionWrapper {...overlayProps} visible={isOpen}>
+      <SectionedOverlay ref={popoverRef}>
+        <StyledListBox
+          {...listBoxProps}
+          ref={listBoxRef}
+          listState={state}
+          hasSearch={!!filterValue}
+          hiddenOptions={hiddenOptions}
+          keyDownHandler={() => true}
+          overlayIsOpen={isOpen}
+          showSectionHeaders={!filterValue}
+          size="sm"
+          style={{maxWidth: overlayProps.style.maxWidth}}
+        />
+        {isMultiSelect ? (
+          <Label>{t('Hold %s to select multiple', isMac() ? '⌘' : 'Ctrl')}</Label>
+        ) : null}
+      </SectionedOverlay>
+    </StyledPositionWrapper>
+  );
+}
+
+const SectionedOverlay = styled(Overlay)`
+  display: grid;
+  grid-template-rows: 1fr auto;
+  overflow: hidden;
+  max-height: 300px;
+  width: min-content;
+`;
+
+const StyledListBox = styled(ListBox)`
+  width: min-content;
+  min-width: 200px;
+`;
+
+const StyledPositionWrapper = styled('div')<{visible?: boolean}>`
+  display: ${p => (p.visible ? 'block' : 'none')};
+  z-index: ${p => p.theme.zIndex.tooltip};
+`;
+
+const Label = styled('div')`
+  padding: ${space(1)} ${space(2)};
+  color: ${p => p.theme.subText};
+  border-top: 1px solid ${p => p.theme.innerBorder};
+  font-size: ${p => p.theme.fontSizeSmall};
+`;

--- a/static/app/utils/useKeyPress.tsx
+++ b/static/app/utils/useKeyPress.tsx
@@ -5,7 +5,7 @@ import {useEffect, useState} from 'react';
  */
 const useKeyPress = (
   targetKey: string,
-  target?: HTMLElement,
+  target?: HTMLElement | null,
   captureAndStop: boolean = false
 ) => {
   const [keyPressed, setKeyPressed] = useState(false);


### PR DESCRIPTION
This adds the "Hold Ctrl/⌘ to select multiple" text and behavior that was in the Figma designs. You could already click the checkbox for this behavior, this makes it possible to do with the keyboard now as well.

![CleanShot 2024-08-27 at 10 32 11@2x](https://github.com/user-attachments/assets/17e1a242-ef81-454d-b605-51720d876d58)

https://github.com/user-attachments/assets/22fce3ec-089e-45a2-b040-1781f9867839

