### PR TITLE
fix(issues): Collapse grouping info by default

### DIFF
--- a/static/app/components/events/groupingInfo/index.tsx
+++ b/static/app/components/events/groupingInfo/index.tsx
@@ -162,6 +162,7 @@ export function EventGroupingInfo({
         )
       }
       type={SectionKey.GROUPING_INFO}
+      initialCollapse
     >
       {!openState ? <GroupInfoSummary groupInfo={groupInfo} /> : null}
       {openState ? (

--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -22,7 +22,7 @@ export function getFoldSectionKey(key: SectionKey) {
   return `'issue-details-fold-section-collapse:${key}`;
 }
 
-interface FoldSectionProps {
+export interface FoldSectionProps {
   children: React.ReactNode;
   sectionKey: SectionKey;
   /**

--- a/static/app/views/issueDetails/streamline/interimSection.tsx
+++ b/static/app/views/issueDetails/streamline/interimSection.tsx
@@ -5,7 +5,10 @@ import {
   type EventDataSectionProps,
 } from 'sentry/components/events/eventDataSection';
 import type {SectionKey} from 'sentry/views/issueDetails/streamline/context';
-import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
+import {
+  FoldSection,
+  type FoldSectionProps,
+} from 'sentry/views/issueDetails/streamline/foldSection';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 /**
@@ -13,26 +16,28 @@ import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
  * for issue details is being developed. Once GA'd, all occurances should be replaced
  * with just <FoldSection />
  */
-export const InterimSection = forwardRef<HTMLElement, EventDataSectionProps>(
-  function InterimSection(
-    {children, title, type, actions = null, ...props}: EventDataSectionProps,
-    ref
-  ) {
-    const hasStreamlinedUI = useHasStreamlinedUI();
+export const InterimSection = forwardRef<
+  HTMLElement,
+  EventDataSectionProps & Pick<FoldSectionProps, 'initialCollapse'>
+>(function InterimSection(
+  {children, title, type, actions = null, initialCollapse, ...props},
+  ref
+) {
+  const hasStreamlinedUI = useHasStreamlinedUI();
 
-    return hasStreamlinedUI ? (
-      <FoldSection
-        sectionKey={type as SectionKey}
-        title={title}
-        actions={actions}
-        ref={ref}
-      >
-        {children}
-      </FoldSection>
-    ) : (
-      <EventDataSection title={title} actions={actions} type={type} {...props}>
-        {children}
-      </EventDataSection>
-    );
-  }
-);
+  return hasStreamlinedUI ? (
+    <FoldSection
+      sectionKey={type as SectionKey}
+      title={title}
+      actions={actions}
+      ref={ref}
+      initialCollapse={initialCollapse}
+    >
+      {children}
+    </FoldSection>
+  ) : (
+    <EventDataSection title={title} actions={actions} type={type} {...props}>
+      {children}
+    </EventDataSection>
+  );
+});


### PR DESCRIPTION
Currently, the grouping data is expanded by default in the streamline issues ui. It isn't super interesting.
