### PR TITLE
chore(grouping): Use optimized grouping logic for 20% of non-transitioning projects

### DIFF
--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -93,7 +93,11 @@ def project_uses_optimized_grouping(project: Project) -> bool:
     if has_mobile_config or options.get("grouping.config_transition.killswitch_enabled"):
         return False
 
-    return features.has(
-        "organizations:grouping-suppress-unnecessary-secondary-hash",
-        project.organization,
-    ) or (is_in_transition(project))
+    return (
+        features.has(
+            "organizations:grouping-suppress-unnecessary-secondary-hash",
+            project.organization,
+        )
+        or (is_in_transition(project))
+        or project.id % 5 < 1  # 20% of all non-transition projects
+    )


### PR DESCRIPTION
This enables using the new grouping logic (`_save_aggregate_new`) for 20% of projects not currently in a grouping config transition. (It's already rolled out to all transitioning projects.) Unlike with transitioning projects, `_save_aggregate_new` doesn't actually do anything different than `_save_aggregate` does with events from non-transitioning projects, so this change is essentially just switching the projects in question to a refactored version of what's already happening.