### PR TITLE
chore(derived_code_mappings): Report known issues as non-errors

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 import orjson
 import sentry_sdk
 from requests import PreparedRequest
+from sentry_sdk import capture_exception, capture_message
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.github.blame import (
@@ -427,7 +428,9 @@ class GitHubBaseClient(GithubProxyClient, RepositoryClient, CommitContextClient)
         else:
             # We do not raise the exception so we can keep iterating through the repos.
             # Nevertheless, investigate the error to determine if we should abort the processing
-            logger.error("Continuing execution. Investigate: %s", error_message, extra=extra)
+            capture_message(
+                "Continuing execution. Investigate: %s", error_message, extra=extra, level="warning"
+            )
 
         return should_count_error
 
@@ -448,7 +451,8 @@ class GitHubBaseClient(GithubProxyClient, RepositoryClient, CommitContextClient)
         except ApiError:
             only_use_cache = True
             # Report so we can investigate
-            logger.exception("Loading trees from cache. Execution will continue. Check logs.")
+            logger.warning("Loading trees from cache. Execution will continue. Check logs.")
+            capture_exception(level="warning")
 
         for index, repo_info in enumerate(repositories):
             repo_full_name = repo_info["full_name"]

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -428,9 +428,7 @@ class GitHubBaseClient(GithubProxyClient, RepositoryClient, CommitContextClient)
         else:
             # We do not raise the exception so we can keep iterating through the repos.
             # Nevertheless, investigate the error to determine if we should abort the processing
-            capture_message(
-                "Continuing execution. Investigate: %s", error_message, extra=extra, level="warning"
-            )
+            capture_message("Continuing execution. Investigate: %s", error_message, extra=extra)
 
         return should_count_error
 


### PR DESCRIPTION
This reports the exceptions as warning-level errors rather than error-level.

Deployments do not get paused if the error is [warning or lower](https://github.com/getsentry/getsentry/blob/b08907d9da3e8856c6cbedbd86d4a722c6f89dd9/gocd/templates/bash/backend/check-sentry-new-errors.sh#L12):
```
--additional-query="issue.type:error !level:info !level:warning"
```

Rendering of a warning-level exception:
<img width="265" alt="image" src="https://github.com/user-attachments/assets/cd630c9b-9ac7-4894-aa33-736789c17c0b">

PS: This is a redo of #76212 but without passing a level, thus, making it an info-level message.