### PR TITLE
fix(issues/replay): if fetchError, don't render replayId in highlights

### DIFF
--- a/static/app/components/events/highlights/highlightsDataSection.spec.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.spec.tsx
@@ -43,6 +43,11 @@ describe('HighlightsDataSection', function () {
       url: `/projects/${organization.slug}/${project.slug}/`,
       body: {...project, highlightTags: [], highlightContext: {}},
     });
+    const replayId = undefined;
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replays/${replayId}/`,
+      body: {},
+    });
     render(
       <HighlightsDataSection
         event={event}
@@ -74,6 +79,12 @@ describe('HighlightsDataSection', function () {
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/`,
       body: {...project, highlightTags, highlightContext},
+    });
+
+    const replayId = undefined;
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replays/${replayId}/`,
+      body: {},
     });
 
     render(<HighlightsDataSection event={event} project={project} />, {

--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -154,16 +154,16 @@ function HighlightsData({
   const contextReplayItem = highlightContextDataItems.find(
     e => e.data[0].key === 'replay_id'
   );
-  const contextReplayId = contextReplayItem?.value ?? '';
+  const contextReplayId = contextReplayItem?.value ?? EMPTY_HIGHLIGHT_DEFAULT;
 
   const tagReplayItem = highlightTagItems.find(e => e.originalTag.key === 'replayId');
-  const tagReplayId = tagReplayItem?.value ?? '';
+  const tagReplayId = tagReplayItem?.value ?? EMPTY_HIGHLIGHT_DEFAULT;
 
   // if the id doesn't exist for either tag or context, it's rendered as '--'
   const replayId =
-    contextReplayId.length > 2
+    contextReplayId !== EMPTY_HIGHLIGHT_DEFAULT
       ? contextReplayId
-      : tagReplayId.length > 2
+      : tagReplayId !== EMPTY_HIGHLIGHT_DEFAULT
         ? tagReplayId
         : undefined;
 

--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -169,16 +169,16 @@ function HighlightsData({
 
   const {fetchError: replayFetchError} = useReplayData({
     orgSlug: organization.slug,
-    replayId: replayId,
+    replayId,
   });
 
-  // if fetchError, replace the replay id so we don't link to an invalid replay
+  // if fetchError, replace the replayId so we don't link to an invalid replay
   if (contextReplayItem && replayFetchError) {
-    contextReplayItem.value = '--';
+    contextReplayItem.value = EMPTY_HIGHLIGHT_DEFAULT;
   }
   if (tagReplayItem && replayFetchError) {
-    tagReplayItem.value = '--';
-    tagReplayItem.originalTag.value = '--';
+    tagReplayItem.value = EMPTY_HIGHLIGHT_DEFAULT;
+    tagReplayItem.originalTag.value = EMPTY_HIGHLIGHT_DEFAULT;
   }
 
   const highlightContextRows = highlightContextDataItems.reduce<React.ReactNode[]>(

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -198,11 +198,17 @@ const mockGroupApis = (
   project: Project,
   group: Group,
   event: Event,
+  replayId: string | undefined,
   trace?: QuickTraceEvent
 ) => {
   MockApiClient.addMockResponse({
     url: `/organizations/${organization.slug}/issues/${group.id}/`,
     body: group,
+  });
+
+  MockApiClient.addMockResponse({
+    url: `/organizations/${organization.slug}/replays/${replayId}/`,
+    body: [],
   });
 
   MockApiClient.addMockResponse({
@@ -358,7 +364,7 @@ describe('groupEventDetails', () => {
 
   it('redirects on switching to an invalid environment selection for event', async function () {
     const props = makeDefaultMockData();
-    mockGroupApis(props.organization, props.project, props.group, props.event);
+    mockGroupApis(props.organization, props.project, props.group, props.event, undefined);
 
     const {rerender} = render(<TestComponent {...props} />);
     expect(browserHistory.replace).not.toHaveBeenCalled();
@@ -370,7 +376,7 @@ describe('groupEventDetails', () => {
 
   it('does not redirect when switching to a valid environment selection for event', async function () {
     const props = makeDefaultMockData();
-    mockGroupApis(props.organization, props.project, props.group, props.event);
+    mockGroupApis(props.organization, props.project, props.group, props.event, undefined);
 
     const {rerender} = render(<TestComponent {...props} />);
 
@@ -397,7 +403,8 @@ describe('groupEventDetails', () => {
         tags: [{key: 'environment', value: 'dev'}],
         previousEventID: 'prev-event-id',
         nextEventID: 'next-event-id',
-      })
+      }),
+      undefined
     );
 
     render(<TestComponent event={undefined} eventError />);
@@ -429,7 +436,8 @@ describe('groupEventDetails', () => {
         tags: [{key: 'environment', value: 'dev'}],
         previousEventID: 'prev-event-id',
         nextEventID: 'next-event-id',
-      })
+      }),
+      undefined
     );
 
     render(<TestComponent group={group} event={transaction} />, {
@@ -477,7 +485,8 @@ describe('groupEventDetails', () => {
         tags: [{key: 'environment', value: 'dev'}],
         previousEventID: 'prev-event-id',
         nextEventID: 'next-event-id',
-      })
+      }),
+      undefined
     );
 
     render(<TestComponent group={group} event={transaction} />, {});
@@ -496,7 +505,7 @@ describe('groupEventDetails', () => {
 
   it('renders event tags ui', async () => {
     const props = makeDefaultMockData();
-    mockGroupApis(props.organization, props.project, props.group, props.event);
+    mockGroupApis(props.organization, props.project, props.group, props.event, undefined);
     render(<TestComponent group={props.group} event={props.event} />, {});
 
     expect(await screen.findByText('Event ID:')).toBeInTheDocument();
@@ -543,7 +552,8 @@ describe('EventCause', () => {
         tags: [{key: 'environment', value: 'dev'}],
         previousEventID: 'prev-event-id',
         nextEventID: 'next-event-id',
-      })
+      }),
+      undefined
     );
 
     MockApiClient.addMockResponse({
@@ -603,7 +613,8 @@ describe('Platform Integrations', () => {
         tags: [{key: 'environment', value: 'dev'}],
         previousEventID: 'prev-event-id',
         nextEventID: 'next-event-id',
-      })
+      }),
+      undefined
     );
 
     const component = SentryAppComponentFixture({
@@ -642,6 +653,7 @@ describe('Platform Integrations', () => {
         props.project,
         props.group,
         props.event,
+        undefined,
         mockedTrace(props.project)
       );
 
@@ -660,10 +672,17 @@ describe('Platform Integrations', () => {
     it('does not render root issues section if related perf issues do not exist', async () => {
       const props = makeDefaultMockData();
       const trace = mockedTrace(props.project);
-      mockGroupApis(props.organization, props.project, props.group, props.event, {
-        ...trace,
-        performance_issues: [],
-      });
+      mockGroupApis(
+        props.organization,
+        props.project,
+        props.group,
+        props.event,
+        undefined,
+        {
+          ...trace,
+          performance_issues: [],
+        }
+      );
 
       render(<TestComponent group={props.group} event={props.event} />, {
         organization: props.organization,

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -198,7 +198,7 @@ const mockGroupApis = (
   project: Project,
   group: Group,
   event: Event,
-  replayId: string | undefined,
+  replayId?: string,
   trace?: QuickTraceEvent
 ) => {
   MockApiClient.addMockResponse({
@@ -364,7 +364,7 @@ describe('groupEventDetails', () => {
 
   it('redirects on switching to an invalid environment selection for event', async function () {
     const props = makeDefaultMockData();
-    mockGroupApis(props.organization, props.project, props.group, props.event, undefined);
+    mockGroupApis(props.organization, props.project, props.group, props.event);
 
     const {rerender} = render(<TestComponent {...props} />);
     expect(browserHistory.replace).not.toHaveBeenCalled();
@@ -376,7 +376,7 @@ describe('groupEventDetails', () => {
 
   it('does not redirect when switching to a valid environment selection for event', async function () {
     const props = makeDefaultMockData();
-    mockGroupApis(props.organization, props.project, props.group, props.event, undefined);
+    mockGroupApis(props.organization, props.project, props.group, props.event);
 
     const {rerender} = render(<TestComponent {...props} />);
 
@@ -403,8 +403,7 @@ describe('groupEventDetails', () => {
         tags: [{key: 'environment', value: 'dev'}],
         previousEventID: 'prev-event-id',
         nextEventID: 'next-event-id',
-      }),
-      undefined
+      })
     );
 
     render(<TestComponent event={undefined} eventError />);
@@ -436,8 +435,7 @@ describe('groupEventDetails', () => {
         tags: [{key: 'environment', value: 'dev'}],
         previousEventID: 'prev-event-id',
         nextEventID: 'next-event-id',
-      }),
-      undefined
+      })
     );
 
     render(<TestComponent group={group} event={transaction} />, {
@@ -485,8 +483,7 @@ describe('groupEventDetails', () => {
         tags: [{key: 'environment', value: 'dev'}],
         previousEventID: 'prev-event-id',
         nextEventID: 'next-event-id',
-      }),
-      undefined
+      })
     );
 
     render(<TestComponent group={group} event={transaction} />, {});
@@ -505,7 +502,7 @@ describe('groupEventDetails', () => {
 
   it('renders event tags ui', async () => {
     const props = makeDefaultMockData();
-    mockGroupApis(props.organization, props.project, props.group, props.event, undefined);
+    mockGroupApis(props.organization, props.project, props.group, props.event);
     render(<TestComponent group={props.group} event={props.event} />, {});
 
     expect(await screen.findByText('Event ID:')).toBeInTheDocument();
@@ -552,8 +549,7 @@ describe('EventCause', () => {
         tags: [{key: 'environment', value: 'dev'}],
         previousEventID: 'prev-event-id',
         nextEventID: 'next-event-id',
-      }),
-      undefined
+      })
     );
 
     MockApiClient.addMockResponse({
@@ -613,8 +609,7 @@ describe('Platform Integrations', () => {
         tags: [{key: 'environment', value: 'dev'}],
         previousEventID: 'prev-event-id',
         nextEventID: 'next-event-id',
-      }),
-      undefined
+      })
     );
 
     const component = SentryAppComponentFixture({

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -208,7 +208,7 @@ const mockGroupApis = (
 
   MockApiClient.addMockResponse({
     url: `/organizations/${organization.slug}/replays/${replayId}/`,
-    body: [],
+    body: {},
   });
 
   MockApiClient.addMockResponse({


### PR DESCRIPTION
redo of https://github.com/getsentry/sentry/pull/76316: 

instead of completely removing the replay ID from the event highlights, we now do an extra check to see if there was a `fetchError` with this replay ID (e.g. whether this ID is actually valid or not). if it's not valid, then don't render the replay ID to avoid linking to an invalid replay. the link will take you to a page like this:

<img width="1126" alt="SCR-20240827-kqxv" src="https://github.com/user-attachments/assets/d5dc991f-e649-4ada-8a64-64db8fc94a50">

before: issue details replay processing error (blue banner shows up) but the event highlights still contains the replay ID
<img width="880" alt="SCR-20240827-krda" src="https://github.com/user-attachments/assets/c4a0cbd6-9143-4043-b3f2-0516704999dd">
<img width="897" alt="SCR-20240827-kqac" src="https://github.com/user-attachments/assets/cb802d18-9dbf-47ee-99ab-dcd4baf5e2e0">


after: replayId is shown as `--` and no link
<img width="795" alt="SCR-20240827-kpwz" src="https://github.com/user-attachments/assets/709d0c64-9779-4e4b-8641-49d1cc3359cb">

