### PR TITLE
fix(issues): Supply unique keys to grouping component

### DIFF
--- a/static/app/components/events/groupingInfo/groupingComponentChildren.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentChildren.tsx
@@ -16,10 +16,10 @@ type Props = {
 function GroupingComponentChildren({component, showNonContributing}: Props) {
   return (
     <Fragment>
-      {(component.values as EventGroupComponent[])
+      {component.values
         .filter(value => groupingComponentFilter(value, showNonContributing))
         .map(value => (
-          <GroupingComponentListItem key={value.id}>
+          <GroupingComponentListItem key={typeof value === 'object' ? value.id : value}>
             {typeof value === 'object' ? (
               <GroupingComponent
                 component={value}


### PR DESCRIPTION
- Fixes an error when value is a string and the key is "undefined" for multiple items. 
- Fixes the types that were allowing it

![Screenshot 2024-08-21 at 6 57 14 PM](https://github.com/user-attachments/assets/d36dd652-d1bd-4f44-85d2-6a0beb3387d5)
