### PR TITLE
feat(alerts): Updates snuba subscription functions to support discover spm() function

### DIFF
--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -4,8 +4,10 @@ import re
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Any, TypedDict, Union
 
+from django.utils import timezone
 from snuba_sdk import Column, Condition, Entity, Join, Op, Request
 
 from sentry import features
@@ -619,11 +621,13 @@ def get_entity_key_from_snuba_query(
         snuba_query,
         organization_id,
     )
+    end = timezone.now()
+    start = end - timedelta(minutes=10)
     query_builder = entity_subscription.build_query_builder(
         snuba_query.query,
         [project_id],
         snuba_query.environment,
-        {"organization_id": organization_id},
+        {"organization_id": organization_id, "start": start, "end": end},
         skip_field_validation_for_entity_subscription_deletion=skip_field_validation_for_entity_subscription_deletion,
     )
     return get_entity_key_from_query_builder(query_builder)

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -123,12 +123,18 @@ def update_subscription_in_snuba(
                 "event_types": subscription.snuba_query.event_types,
             },
         )
+        end = timezone.now()
+        start = end - timedelta(minutes=10)
         old_entity_key = get_entity_key_from_query_builder(
             old_entity_subscription.build_query_builder(
                 query,
                 [subscription.project_id],
                 None,
-                {"organization_id": subscription.project.organization_id},
+                {
+                    "organization_id": subscription.project.organization_id,
+                    "start": start,
+                    "end": end,
+                },
             ),
         )
         _delete_from_snuba(
@@ -216,6 +222,8 @@ def _create_in_snuba(subscription: QuerySubscription) -> str:
             subscription.project.organization_id,
         )
         query_string = build_query_strings(subscription, snuba_query).query_string
+        end = timezone.now()
+        start = end - timedelta(minutes=10)
         snql_query = entity_subscription.build_query_builder(
             query=query_string,
             project_ids=[subscription.project_id],
@@ -223,6 +231,8 @@ def _create_in_snuba(subscription: QuerySubscription) -> str:
             params={
                 "organization_id": subscription.project.organization_id,
                 "project_id": [subscription.project_id],
+                "start": start,
+                "end": end,
             },
         ).get_snql_query()
 


### PR DESCRIPTION
The discover `spm()` function takes a `start` and `end` from the query parameters time to compute a result.

Since the create, update, and delete snuba subscription functions call `entity_subscription.build_query_builder(...)` without providing a `start` and `end` parameter, the query builder fails for `spm()` aggregates.

This updates `entity_subscription.build_query_builder(...)` calls to pass in a start and end time to avoid failing.
Since the `start` and `end` times aren't actually used for anything else in these code paths, it should be safe to just pass in any time range, similar to how we're doing it here:
https://github.com/getsentry/sentry/blob/9941c4b3b6121e4e42ac28978c661b6c61e2bfb3/src/sentry/incidents/serializers/alert_rule.py#L345
