### PR TITLE
fix(sentry-sdk): Use existing scope in thread

### DIFF
--- a/src/sentry/utils/concurrent.py
+++ b/src/sentry/utils/concurrent.py
@@ -241,8 +241,8 @@ class ThreadedExecutor(Executor[T]):
         task = PriorityTask(
             priority,
             (
-                sentry_sdk.Scope.get_isolation_scope().fork(),
-                sentry_sdk.Scope.get_current_scope().fork(),
+                sentry_sdk.Scope.get_isolation_scope(),
+                sentry_sdk.Scope.get_current_scope(),
                 callable,
                 future,
             ),

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1097,8 +1097,8 @@ def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
                     _snuba_query,
                     [
                         (
-                            sentry_sdk.Scope.get_isolation_scope().fork(),
-                            sentry_sdk.Scope.get_current_scope().fork(),
+                            sentry_sdk.Scope.get_isolation_scope(),
+                            sentry_sdk.Scope.get_current_scope(),
                             snuba_request,
                         )
                         for snuba_request in snuba_requests_list
@@ -1110,8 +1110,8 @@ def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
             query_results = [
                 _snuba_query(
                     (
-                        sentry_sdk.Scope.get_isolation_scope().fork(),
-                        sentry_sdk.Scope.get_current_scope().fork(),
+                        sentry_sdk.Scope.get_isolation_scope(),
+                        sentry_sdk.Scope.get_current_scope(),
                         snuba_requests_list[0],
                     )
                 )


### PR DESCRIPTION
If the scope is forked, tags set in the forked scope will not be set on the event started on the original scope.