### PR TITLE
feat(dashboards): Allow cancelling a zoom selection

### DIFF
--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -102,8 +102,8 @@ class ChartZoom extends Component<Props> {
   }
 
   componentWillUnmount(): void {
-    document.removeEventListener('keydown', this.handleKeyDown);
-    document.removeEventListener('mouseup', this.handleMouseUp);
+    document.body.removeEventListener('keydown', this.handleKeyDown);
+    document.body.removeEventListener('mouseup', this.handleMouseUp);
     this.$chart?.removeEventListener('mousedown', this.handleMouseDown);
   }
 
@@ -257,13 +257,13 @@ class ChartZoom extends Component<Props> {
     // Register `mouseup` and `keydown` listeners on mouse down
     // This ensures that there is only one live listener at a time
     // regardless of how many charts are rendered
-    window.addEventListener('mouseup', this.handleMouseUp);
-    window.addEventListener('keydown', this.handleKeyDown);
+    document.body.addEventListener('mouseup', this.handleMouseUp);
+    document.body.addEventListener('keydown', this.handleKeyDown);
   };
 
   handleMouseUp = () => {
-    window.removeEventListener('mouseup', this.handleMouseUp);
-    window.removeEventListener('keydown', this.handleKeyDown);
+    document.body.removeEventListener('mouseup', this.handleMouseUp);
+    document.body.removeEventListener('keydown', this.handleKeyDown);
   };
 
   handleDataZoom = (evt, chart) => {

--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -2,6 +2,7 @@ import {Component} from 'react';
 import type {InjectedRouter} from 'react-router';
 import type {
   DataZoomComponentOption,
+  ECharts,
   InsideDataZoomComponentOption,
   ToolboxComponentOption,
   XAXisComponentOption,
@@ -100,6 +101,7 @@ class ChartZoom extends Component<Props> {
     this.saveCurrentPeriod(this.props);
   }
 
+  chart?: ECharts;
   history: Period[];
   currentPeriod?: Period;
   zooming: (() => void) | null = null;
@@ -186,6 +188,7 @@ class ChartZoom extends Component<Props> {
    */
   handleChartReady = chart => {
     this.props.onChartReady?.(chart);
+    this.chart = chart;
   };
 
   /**

--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -256,14 +256,17 @@ class ChartZoom extends Component<Props> {
   handleMouseDown = () => {
     // Register `mouseup` and `keydown` listeners on mouse down
     // This ensures that there is only one live listener at a time
-    // regardless of how many charts are rendered
+    // regardless of how many charts are rendered. NOTE: It's
+    // important to set `useCapture: true` in the `"keydown"` handler
+    // otherwise the Escape will close whatever modal or panel the
+    // chart is in. Those elements register their handlers _earlier_.
     document.body.addEventListener('mouseup', this.handleMouseUp);
-    document.body.addEventListener('keydown', this.handleKeyDown);
+    document.body.addEventListener('keydown', this.handleKeyDown, true);
   };
 
   handleMouseUp = () => {
     document.body.removeEventListener('mouseup', this.handleMouseUp);
-    document.body.removeEventListener('keydown', this.handleKeyDown);
+    document.body.removeEventListener('keydown', this.handleKeyDown, true);
   };
 
   handleDataZoom = (evt, chart) => {

--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -215,6 +215,7 @@ class ChartZoom extends Component<Props> {
     // This handler only exists if mouse down was caught inside the chart.
     // Therefore, no need to check any other state.
     if (evt.key === 'Escape') {
+      evt.stopPropagation();
       // Mark the component as currently cancelling a zoom selection. This allows
       // us to prevent "restore" handlers from running
       this.isCancellingZoom = true;


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/44723. Pressing the "Escape" key while making a drag selection on a chart will cancel the selection! Makes it possible to change your mind halfway through.

**e.g.,**

https://github.com/user-attachments/assets/f4d52ddd-dec7-41d9-aaa9-c8b1dc10f6b2


## Context

The code's a little wacky looking, so here are a few of the important circumstances:

- I don't want to fire a `"restore"` event to all charts, just the one that was selected! It's probably safe to fire `"restore"` everywhere, but it feels sloppy
- I chose a janky `querySelector` way to get the chart DOM element. It's hard to do any other way because `ChartZoom` renders an arbitrary child, so it's hard for it to get at the chart's `ref`
- ECharts does not have any `mousedown` or `mouseup` handlers _for the chart area_, only for the actual data lines. There's a feature request to add those handlers, but they don't exist. Therefore I have to add them manually
- Even if ECharts _had_ those events, `ChartZoom` would have to hijack them, and there wouldn't be a nice way to pass them down to the `BaseChart` so that approach is moot
- Some dashboards have a lot of charts. I didn't want to register an event handler for every chart. Instead, only the `"mousedown"` handler is registered at mount. The other handlers are registered in `"mousedown"`!
- The `"restore"` handler currently jumps to the _earliest_ point in the chart zoom history. Why does it do that, and not the most recent one? I don't know! I chose to avoid that history logic altogether and not run any `"restore"` handlers at all if it's for the sake of cancelling a zoom
