### PR TITLE
ref(scm): search endpoint abstraction

### DIFF
--- a/src/sentry/integrations/bitbucket/search.py
+++ b/src/sentry/integrations/bitbucket/search.py
@@ -1,73 +1,64 @@
 import logging
 
-from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
-from sentry.integrations.api.bases.integration import IntegrationEndpoint
 from sentry.integrations.bitbucket.integration import BitbucketIntegration
+from sentry.integrations.mixins.issues import IssueBasicIntegration
 from sentry.integrations.models.integration import Integration
+from sentry.integrations.source_code_management.search import SourceCodeSearchEndpoint
 from sentry.shared_integrations.exceptions import ApiError
 
 logger = logging.getLogger("sentry.integrations.bitbucket")
 
 
 @control_silo_endpoint
-class BitbucketSearchEndpoint(IntegrationEndpoint):
+class BitbucketSearchEndpoint(SourceCodeSearchEndpoint):
     owner = ApiOwner.INTEGRATIONS
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def get(self, request: Request, organization, integration_id, **kwds) -> Response:
+    @property
+    def repository_field(self):
+        return "repo"
+
+    @property
+    def integration_provider(self):
+        return "bitbucket"
+
+    @property
+    def installation_class(self):
+        return BitbucketIntegration
+
+    def handle_search_issues(
+        self, installation: IssueBasicIntegration, query: str, repo: str
+    ) -> Response:
+        full_query = f'title~"{query}"'
         try:
-            integration = Integration.objects.get(
-                organizationintegration__organization_id=organization.id,
-                id=integration_id,
-                provider="bitbucket",
-            )
-        except Integration.DoesNotExist:
-            return Response(status=404)
+            resp = installation.search_issues(query=full_query, repo=repo)
+        except ApiError as e:
+            if "no issue tracker" in str(e):
+                logger.info(
+                    "bitbucket.issue-search-no-issue-tracker",
+                    extra={"installation_id": installation.model.id, "repo": repo},
+                )
+                return Response(
+                    {"detail": "Bitbucket Repository has no issue tracker."}, status=400
+                )
+            raise
+        return Response(
+            [
+                {"label": "#{} {}".format(i["id"], i["title"]), "value": i["id"]}
+                for i in resp.get("values", [])
+            ]
+        )
 
-        field = request.GET.get("field")
-        query = request.GET.get("query")
-        if field is None:
-            return Response({"detail": "field is a required parameter"}, status=400)
-        if not query:
-            return Response({"detail": "query is a required parameter"}, status=400)
-
-        installation = integration.get_installation(organization_id=organization.id)
-        assert isinstance(installation, BitbucketIntegration), installation
-
-        if field == "externalIssue":
-            repo = request.GET.get("repo")
-            if not repo:
-                return Response({"detail": "repo is a required parameter"}, status=400)
-
-            full_query = f'title~"{query}"'
-            try:
-                resp = installation.search_issues(query=full_query, repo=repo)
-            except ApiError as e:
-                if "no issue tracker" in str(e):
-                    logger.info(
-                        "bitbucket.issue-search-no-issue-tracker",
-                        extra={"installation_id": installation.model.id, "repo": repo},
-                    )
-                    return Response(
-                        {"detail": "Bitbucket Repository has no issue tracker."}, status=400
-                    )
-                raise
-            return Response(
-                [
-                    {"label": "#{} {}".format(i["id"], i["title"]), "value": i["id"]}
-                    for i in resp.get("values", [])
-                ]
-            )
-
-        if field == "repo":
-            result = installation.get_repositories(query)
-            return Response([{"label": i["name"], "value": i["name"]} for i in result])
-
-        return Response(status=400)
+    # TODO: somehow type installation with installation_class
+    def handle_search_repositories(
+        self, integration: Integration, installation, query: str
+    ) -> Response:
+        result = installation.get_repositories(query)
+        return Response([{"label": i["name"], "value": i["name"]} for i in result])

--- a/src/sentry/integrations/bitbucket/search.py
+++ b/src/sentry/integrations/bitbucket/search.py
@@ -59,7 +59,6 @@ class BitbucketSearchEndpoint(SourceCodeSearchEndpoint):
             ]
         )
 
-    # TODO: somehow type installation with installation_class
     def handle_search_repositories(
         self, integration: Integration, installation: T, query: str
     ) -> Response:

--- a/src/sentry/integrations/github/search.py
+++ b/src/sentry/integrations/github/search.py
@@ -1,84 +1,64 @@
-from typing import Any
-
-from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api.api_owners import ApiOwner
-from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
-from sentry.integrations.api.bases.integration import IntegrationEndpoint
 from sentry.integrations.github.integration import GitHubIntegration, build_repository_query
 from sentry.integrations.github_enterprise.integration import GitHubEnterpriseIntegration
+from sentry.integrations.mixins.issues import IssueBasicIntegration
 from sentry.integrations.models.integration import Integration
-from sentry.organizations.services.organization import RpcOrganization
+from sentry.integrations.source_code_management.search import SourceCodeSearchEndpoint
 from sentry.shared_integrations.exceptions import ApiError
 
 
 @control_silo_endpoint
-class GithubSharedSearchEndpoint(IntegrationEndpoint):
-    owner = ApiOwner.ECOSYSTEM
-    publish_status = {
-        "GET": ApiPublishStatus.PRIVATE,
-    }
+class GithubSharedSearchEndpoint(SourceCodeSearchEndpoint):
     """NOTE: This endpoint is a shared search endpoint for Github and Github Enterprise integrations."""
 
-    def get(
-        self, request: Request, organization: RpcOrganization, integration_id: int, **kwds: Any
+    @property
+    def repository_field(self):
+        return "repo"
+
+    @property
+    def integration_provider(self):
+        return None
+
+    @property
+    def installation_class(self):
+        return (GitHubIntegration, GitHubEnterpriseIntegration)
+
+    def handle_search_issues(
+        self, installation: IssueBasicIntegration, query: str, repo: str
     ) -> Response:
         try:
-            integration = Integration.objects.get(
-                organizationintegration__organization_id=organization.id,
-                id=integration_id,
-            )
-        except Integration.DoesNotExist:
-            return Response(status=404)
+            response = installation.search_issues(query=f"repo:{repo} {query}")
+        except ApiError as err:
+            if err.code == 403:
+                return Response({"detail": "Rate limit exceeded"}, status=429)
+            raise
+        return Response(
+            [
+                {"label": "#{} {}".format(i["number"], i["title"]), "value": i["number"]}
+                for i in response.get("items", [])
+            ]
+        )
 
-        field = request.GET.get("field")
-        query = request.GET.get("query")
-        if field is None:
-            return Response({"detail": "field is a required parameter"}, status=400)
-        if not query:
-            return Response({"detail": "query is a required parameter"}, status=400)
-
-        installation = integration.get_installation(organization.id)
-        assert isinstance(
-            installation, (GitHubIntegration, GitHubEnterpriseIntegration)
-        ), installation
-        if field == "externalIssue":
-            repo = request.GET.get("repo")
-            if repo is None:
-                return Response({"detail": "repo is a required parameter"}, status=400)
-
-            try:
-                response = installation.search_issues(query=f"repo:{repo} {query}")
-            except ApiError as err:
-                if err.code == 403:
-                    return Response({"detail": "Rate limit exceeded"}, status=429)
-                raise
-            return Response(
-                [
-                    {"label": "#{} {}".format(i["number"], i["title"]), "value": i["number"]}
-                    for i in response.get("items", [])
-                ]
-            )
-
-        if field == "repo":
-            full_query = build_repository_query(integration.metadata, integration.name, query)
-            try:
-                response = installation.get_client().search_repositories(full_query)
-            except ApiError as err:
-                if err.code == 403:
-                    return Response({"detail": "Rate limit exceeded"}, status=429)
-                if err.code == 422:
-                    return Response(
-                        {
-                            "detail": "Repositories could not be searched because they do not exist, or you do not have access to them."
-                        },
-                        status=404,
-                    )
-                raise
-            return Response(
-                [{"label": i["name"], "value": i["full_name"]} for i in response.get("items", [])]
-            )
-
-        return Response(status=400)
+    # TODO: somehow type installation with installation_class
+    def handle_search_repositories(
+        self, integration: Integration, installation, query: str
+    ) -> Response:
+        full_query = build_repository_query(integration.metadata, integration.name, query)
+        try:
+            response = installation.get_client().search_repositories(full_query)
+        except ApiError as err:
+            if err.code == 403:
+                return Response({"detail": "Rate limit exceeded"}, status=429)
+            if err.code == 422:
+                return Response(
+                    {
+                        "detail": "Repositories could not be searched because they do not exist, or you do not have access to them."
+                    },
+                    status=404,
+                )
+            raise
+        return Response(
+            [{"label": i["name"], "value": i["full_name"]} for i in response.get("items", [])]
+        )

--- a/src/sentry/integrations/github/search.py
+++ b/src/sentry/integrations/github/search.py
@@ -1,11 +1,16 @@
+from typing import TypeVar
+
 from rest_framework.response import Response
 
 from sentry.api.base import control_silo_endpoint
 from sentry.integrations.github.integration import GitHubIntegration, build_repository_query
 from sentry.integrations.github_enterprise.integration import GitHubEnterpriseIntegration
 from sentry.integrations.models.integration import Integration
+from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
 from sentry.integrations.source_code_management.search import SourceCodeSearchEndpoint
 from sentry.shared_integrations.exceptions import ApiError
+
+T = TypeVar("T", bound=SourceCodeIssueIntegration)
 
 
 @control_silo_endpoint
@@ -24,7 +29,7 @@ class GithubSharedSearchEndpoint(SourceCodeSearchEndpoint):
     def installation_class(self):
         return (GitHubIntegration, GitHubEnterpriseIntegration)
 
-    def handle_search_issues(self, installation, query: str, repo: str) -> Response:
+    def handle_search_issues(self, installation: T, query: str, repo: str) -> Response:
         assert isinstance(installation, self.installation_class)
 
         try:
@@ -44,7 +49,7 @@ class GithubSharedSearchEndpoint(SourceCodeSearchEndpoint):
 
     # TODO: somehow type installation with installation_class
     def handle_search_repositories(
-        self, integration: Integration, installation, query: str
+        self, integration: Integration, installation: T, query: str
     ) -> Response:
         assert isinstance(installation, self.installation_class)
 

--- a/src/sentry/integrations/github/search.py
+++ b/src/sentry/integrations/github/search.py
@@ -47,7 +47,6 @@ class GithubSharedSearchEndpoint(SourceCodeSearchEndpoint):
             ]
         )
 
-    # TODO: somehow type installation with installation_class
     def handle_search_repositories(
         self, integration: Integration, installation: T, query: str
     ) -> Response:

--- a/src/sentry/integrations/gitlab/search.py
+++ b/src/sentry/integrations/gitlab/search.py
@@ -1,10 +1,15 @@
+from typing import TypeVar
+
 from rest_framework.response import Response
 
 from sentry.api.base import control_silo_endpoint
 from sentry.integrations.gitlab.integration import GitlabIntegration
 from sentry.integrations.models.integration import Integration
+from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
 from sentry.integrations.source_code_management.search import SourceCodeSearchEndpoint
 from sentry.shared_integrations.exceptions import ApiError
+
+T = TypeVar("T", bound=SourceCodeIssueIntegration)
 
 
 @control_silo_endpoint
@@ -21,7 +26,7 @@ class GitlabIssueSearchEndpoint(SourceCodeSearchEndpoint):
     def installation_class(self):
         return GitlabIntegration
 
-    def handle_search_issues(self, installation, query: str, repo: str) -> Response:
+    def handle_search_issues(self, installation: T, query: str, repo: str) -> Response:
         assert isinstance(installation, self.installation_class)
         full_query: str | None = query
 
@@ -47,9 +52,8 @@ class GitlabIssueSearchEndpoint(SourceCodeSearchEndpoint):
             ]
         )
 
-    # TODO: somehow type installation with installation_class
     def handle_search_repositories(
-        self, integration: Integration, installation, query: str
+        self, integration: Integration, installation: T, query: str
     ) -> Response:
         assert isinstance(installation, self.installation_class)
         try:

--- a/src/sentry/integrations/gitlab/search.py
+++ b/src/sentry/integrations/gitlab/search.py
@@ -1,82 +1,62 @@
-from typing import Any
-
-from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api.api_owners import ApiOwner
-from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
-from sentry.integrations.api.bases.integration import IntegrationEndpoint
 from sentry.integrations.gitlab.integration import GitlabIntegration
+from sentry.integrations.mixins.issues import IssueBasicIntegration
 from sentry.integrations.models.integration import Integration
-from sentry.organizations.services.organization import RpcOrganization
+from sentry.integrations.source_code_management.search import SourceCodeSearchEndpoint
 from sentry.shared_integrations.exceptions import ApiError
 
 
 @control_silo_endpoint
-class GitlabIssueSearchEndpoint(IntegrationEndpoint):
-    owner = ApiOwner.INTEGRATIONS
-    publish_status = {
-        "GET": ApiPublishStatus.PRIVATE,
-    }
+class GitlabIssueSearchEndpoint(SourceCodeSearchEndpoint):
+    @property
+    def repository_field(self):
+        return "project"
 
-    def get(
-        self, request: Request, organization: RpcOrganization, integration_id: int, **kwds: Any
+    @property
+    def integration_provider(self):
+        return "gitlab"
+
+    @property
+    def installation_class(self):
+        return GitlabIntegration
+
+    def handle_search_issues(
+        self, installation: IssueBasicIntegration, query: str, repo: str
     ) -> Response:
         try:
-            integration = Integration.objects.get(
-                organizationintegration__organization_id=organization.id,
-                id=integration_id,
-                provider="gitlab",
-            )
-        except Integration.DoesNotExist:
-            return Response(status=404)
+            iids = [int(query)]
+            query = None
+        except ValueError:
+            iids = None
 
-        field = request.GET.get("field")
-        query = request.GET.get("query")
-        if field is None:
-            return Response({"detail": "field is a required parameter"}, status=400)
-        if query is None:
-            return Response({"detail": "query is a required parameter"}, status=400)
+        try:
+            response = installation.search_issues(query=query, project_id=repo, iids=iids)
+        except ApiError as e:
+            return Response({"detail": str(e)}, status=400)
 
-        installation = integration.get_installation(organization.id)
-        assert isinstance(installation, GitlabIntegration), installation
+        return Response(
+            [
+                {
+                    "label": "(#{}) {}".format(i["iid"], i["title"]),
+                    "value": "{}#{}".format(i["project_id"], i["iid"]),
+                }
+                for i in response
+            ]
+        )
 
-        if field == "externalIssue":
-            project = request.GET.get("project")
-            if project is None:
-                return Response({"detail": "project is a required parameter"}, status=400)
-            try:
-                iids = [int(query)]
-                query = None
-            except ValueError:
-                iids = None
-
-            try:
-                response = installation.search_issues(query=query, project_id=project, iids=iids)
-            except ApiError as e:
-                return Response({"detail": str(e)}, status=400)
-
-            return Response(
-                [
-                    {
-                        "label": "(#{}) {}".format(i["iid"], i["title"]),
-                        "value": "{}#{}".format(i["project_id"], i["iid"]),
-                    }
-                    for i in response
-                ]
-            )
-
-        elif field == "project":
-            try:
-                response = installation.search_projects(query)
-            except ApiError as e:
-                return Response({"detail": str(e)}, status=400)
-            return Response(
-                [
-                    {"label": project["name_with_namespace"], "value": project["id"]}
-                    for project in response
-                ]
-            )
-
-        return Response({"detail": "invalid field value"}, status=400)
+    # TODO: somehow type installation with installation_class
+    def handle_search_repositories(
+        self, integration: Integration, installation, query: str
+    ) -> Response:
+        try:
+            response = installation.search_projects(query)
+        except ApiError as e:
+            return Response({"detail": str(e)}, status=400)
+        return Response(
+            [
+                {"label": project["name_with_namespace"], "value": project["id"]}
+                for project in response
+            ]
+        )

--- a/src/sentry/integrations/source_code_management/search.py
+++ b/src/sentry/integrations/source_code_management/search.py
@@ -84,10 +84,7 @@ class SourceCodeSearchEndpoint(IntegrationEndpoint, Generic[T], ABC):
 
         installation = integration.get_installation(organization.id)
         if not isinstance(installation, self.installation_class):
-            integration_provider = (
-                self.integration_provider if self.integration_provider else "github"
-            )
-            raise NotFound(f"Integration by that id is not of type {integration_provider}.")
+            raise NotFound(f"Integration by that id is not of type {self.integration_provider}.")
 
         if field == self.issue_field:
             repo = request.GET.get(self.repository_field)
@@ -100,4 +97,4 @@ class SourceCodeSearchEndpoint(IntegrationEndpoint, Generic[T], ABC):
         if self.repository_field and field == self.repository_field:
             return self.handle_search_repositories(integration, installation, query)
 
-        return Response(status=400)
+        return Response({"detail": "Invalid field"}, status=400)

--- a/src/sentry/integrations/source_code_management/search.py
+++ b/src/sentry/integrations/source_code_management/search.py
@@ -1,0 +1,104 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+from django.db.models import Q
+from rest_framework import serializers
+from rest_framework.exceptions import NotFound
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import control_silo_endpoint
+from sentry.integrations.api.bases.integration import IntegrationEndpoint
+from sentry.integrations.mixins.issues import IssueBasicIntegration
+from sentry.integrations.models.integration import Integration
+from sentry.integrations.source_code_management.repository import RepositoryIntegration
+from sentry.organizations.services.organization import RpcOrganization
+
+
+class SourceCodeSearchSerializer(serializers.Serializer):
+    field = serializers.CharField(required=True)
+    query = serializers.CharField(required=True)
+
+
+@control_silo_endpoint
+class SourceCodeSearchEndpoint(IntegrationEndpoint, ABC):
+    owner = ApiOwner.ECOSYSTEM
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+
+    @property
+    def issue_field(self) -> str:
+        return "externalIssue"
+
+    # not used in VSTS
+    @property
+    def repository_field(self) -> str:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def integration_provider(self) -> str | None:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def installation_class(
+        self,
+    ) -> (
+        type[IssueBasicIntegration | RepositoryIntegration]
+        | tuple[type[IssueBasicIntegration | RepositoryIntegration]]
+    ):
+        raise NotImplementedError
+
+    @abstractmethod
+    def handle_search_issues(
+        self, installation: IssueBasicIntegration, query: str, repo: str
+    ) -> Response:
+        raise NotImplementedError
+
+    # not used in VSTS
+    def handle_search_repositories(
+        self, integration: Integration, installation: IssueBasicIntegration, query: str
+    ) -> Response:
+        pass
+
+    def get(
+        self, request: Request, organization: RpcOrganization, integration_id: int, **kwds: Any
+    ) -> Response:
+        integration_query = Q(
+            organizationintegration__organization_id=organization.id, id=integration_id
+        )
+
+        if self.integration_provider:
+            integration_query &= Q(provider=self.integration_provider)
+        try:
+            integration: Integration = Integration.objects.get(integration_query)
+        except Integration.DoesNotExist:
+            return Response(status=404)
+
+        serializer = SourceCodeSearchSerializer(data=request.query_params)
+        if not serializer.is_valid():
+            return self.respond(serializer.errors, status=400)
+
+        field = serializer.validated_data["field"]
+        query = serializer.validated_data["query"]
+
+        installation = integration.get_installation(organization.id)
+        if not isinstance(installation, self.installation_class):
+            raise NotFound(f"Integration by that id is not a {self.installation_class.__name__}.")
+
+        if field == self.issue_field:
+            repo = request.GET.get(self.repository_field)
+            if repo is None:
+                return Response(
+                    {"detail": f"{self.repository_field} is a required parameter"}, status=400
+                )
+            return self.handle_search_issues(installation, query, repo)
+
+        if self.repository_field and field == self.repository_field:
+            return self.handle_search_repositories(integration, installation, query)
+
+        return Response(status=400)

--- a/src/sentry/integrations/vsts/search.py
+++ b/src/sentry/integrations/vsts/search.py
@@ -1,60 +1,31 @@
-from typing import Any
-
-from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api.api_owners import ApiOwner
-from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
-from sentry.hybridcloud.rpc import coerce_id_from
-from sentry.integrations.api.bases.integration import IntegrationEndpoint
-from sentry.integrations.models.integration import Integration
+from sentry.integrations.source_code_management.search import SourceCodeSearchEndpoint
 from sentry.integrations.vsts.integration import VstsIntegration
-from sentry.organizations.services.organization import RpcOrganization
 
 
 @control_silo_endpoint
-class VstsSearchEndpoint(IntegrationEndpoint):
-    owner = ApiOwner.UNOWNED
-    publish_status = {
-        "GET": ApiPublishStatus.PRIVATE,
-    }
+class VstsSearchEndpoint(SourceCodeSearchEndpoint):
+    @property
+    def integration_provider(self):
+        return "vsts"
 
-    def get(
-        self, request: Request, organization: RpcOrganization, integration_id: int, **kwds: Any
-    ) -> Response:
-        try:
-            integration = Integration.objects.get(
-                organizationintegration__organization_id=coerce_id_from(organization),
-                id=integration_id,
-                provider="vsts",
-            )
-        except Integration.DoesNotExist:
-            return Response(status=404)
+    @property
+    def installation_class(self):
+        return VstsIntegration
 
-        field = request.GET.get("field")
-        query = request.GET.get("query")
-        if field is None:
-            return Response({"detail": "field is a required parameter"}, status=400)
+    def handle_search_issues(self, installation, query: str, repo: str) -> Response:
         if not query:
-            return Response({"detail": "query is a required parameter"}, status=400)
+            return Response([])
 
-        installation = integration.get_installation(organization.id)
-        assert isinstance(installation, VstsIntegration), installation
-
-        if field == "externalIssue":
-            if not query:
-                return Response([])
-
-            resp = installation.search_issues(query=query)
-            return Response(
-                [
-                    {
-                        "label": f'({i["fields"]["system.id"]}) {i["fields"]["system.title"]}',
-                        "value": i["fields"]["system.id"],
-                    }
-                    for i in resp.get("results", [])
-                ]
-            )
-
-        return Response(status=400)
+        resp = installation.search_issues(query=query)
+        return Response(
+            [
+                {
+                    "label": f'({i["fields"]["system.id"]}) {i["fields"]["system.title"]}',
+                    "value": i["fields"]["system.id"],
+                }
+                for i in resp.get("results", [])
+            ]
+        )

--- a/src/sentry/integrations/vsts/search.py
+++ b/src/sentry/integrations/vsts/search.py
@@ -1,8 +1,13 @@
+from typing import TypeVar
+
 from rest_framework.response import Response
 
 from sentry.api.base import control_silo_endpoint
+from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
 from sentry.integrations.source_code_management.search import SourceCodeSearchEndpoint
 from sentry.integrations.vsts.integration import VstsIntegration
+
+T = TypeVar("T", bound=SourceCodeIssueIntegration)
 
 
 @control_silo_endpoint
@@ -15,7 +20,7 @@ class VstsSearchEndpoint(SourceCodeSearchEndpoint):
     def installation_class(self):
         return VstsIntegration
 
-    def handle_search_issues(self, installation, query: str, repo: str) -> Response:
+    def handle_search_issues(self, installation: T, query: str, repo: str) -> Response:
         if not query:
             return Response([])
 

--- a/src/sentry/integrations/vsts/search.py
+++ b/src/sentry/integrations/vsts/search.py
@@ -19,6 +19,7 @@ class VstsSearchEndpoint(SourceCodeSearchEndpoint):
         if not query:
             return Response([])
 
+        assert isinstance(installation, self.installation_class)
         resp = installation.search_issues(query=query)
         return Response(
             [


### PR DESCRIPTION
Search endpoints do two things: search issues and search repositories (optional; not used in VSTS).

The shared logic for all SCMs is the following:

1. Find the integration (also using a specific `provider` string for everything except GH/GH Enterprise)
2. Validate the incoming payload
    1. `field` (str)
    2. `query` (str)
3. Get integration installation, assert the type
4. If `field == “externalIssue”`, search for the repo field in `request.GET`
    1. Search issues for the installation with the `query` and the `repo`
    2. Note: there is some variation in this due to the response from the specific integration
5. If `field` == the repo field (usually `repo`, but Gitlab uses `project`)
    1. Search repos for the installation with the `query`
    2. Note: there is some variation in this due to the response from the specific integration