### PR TITLE
chore(insights): Upgrade sample list panel searchbars to `SearchQuery…

### DIFF
--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
@@ -8,6 +8,7 @@ import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import SearchBar from 'sentry/components/events/searchBar';
 import {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import Link from 'sentry/components/links/link';
+import {SpanSearchQueryBuilder} from 'sentry/components/performance/spanSearchQueryBuilder';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -223,16 +224,28 @@ export function SampleList({
           highlightedSpanId={highlightedSpanId}
         />
 
-        <StyledSearchBar
-          searchSource={`${moduleName}-sample-panel`}
-          query={spanSearchQuery}
-          onSearch={handleSearch}
-          placeholder={t('Search for span attributes')}
-          organization={organization}
-          supportedTags={supportedTags}
-          dataset={DiscoverDatasets.SPANS_INDEXED}
-          projectIds={selection.projects}
-        />
+        <StyledSearchBar>
+          {organization.features.includes('search-query-builder-performance') ? (
+            <SpanSearchQueryBuilder
+              projects={selection.projects}
+              initialQuery={spanSearchQuery ?? ''}
+              onSearch={handleSearch}
+              placeholder={t('Search for span attributes')}
+              searchSource={`${moduleName}-sample-panel`}
+            />
+          ) : (
+            <SearchBar
+              searchSource={`${moduleName}-sample-panel`}
+              query={spanSearchQuery}
+              onSearch={handleSearch}
+              placeholder={t('Search for span attributes')}
+              organization={organization}
+              supportedTags={supportedTags}
+              dataset={DiscoverDatasets.SPANS_INDEXED}
+              projectIds={selection.projects}
+            />
+          )}
+        </StyledSearchBar>
 
         <SampleTable
           highlightedSpanId={highlightedSpanId}
@@ -279,6 +292,6 @@ const Title = styled('h4')`
   margin: 0;
 `;
 
-const StyledSearchBar = styled(SearchBar)`
+const StyledSearchBar = styled('div')`
   margin: ${space(2)} 0;
 `;


### PR DESCRIPTION
Upgrades the search bar within the span sample panels in all common insights pages to use the new upgraded `SearchQueryBuilder` component

![image](https://github.com/user-attachments/assets/edf66d47-3ac1-496a-832d-231d6602220c)
