### PR TITLE
chore(custom-views): Remove tab divider to the right of Add View button

### DIFF
--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -136,7 +136,6 @@ function BaseDraggableTabList({
               {t('Add View')}
             </AddViewButton>
           </MotionWrapper>
-          <TabDivider layout isVisible />
           <MotionWrapper layout>
             {tempTab && (
               <Tab


### PR DESCRIPTION
Removes the tab divider to the right of the "Add View" button. I must have hallucinated this in the mockups because they aren't there. 

Before: 
![image](https://github.com/user-attachments/assets/b663adae-49d4-4aa6-ae9d-00d0df82639d)

After: 
![image](https://github.com/user-attachments/assets/6b5a2c9b-c752-46a2-a7ce-1b7fd886504a)
