### PR TITLE
fix(custom-views): Stop tab width from animating when selected tab changes

### DIFF
--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -106,7 +106,7 @@ function BaseDraggableTabList({
                 dragConstraints={tabListRef} // Sets the container that the tabs can be dragged within
                 dragElastic={0} // Prevents tabs from being dragged outside of the tab bar
                 dragTransition={{bounceStiffness: 400, bounceDamping: 40}} // Recovers spring behavior thats lost when using dragElastic
-                layout
+                layout="position"
               >
                 <Tab
                   key={item.key}
@@ -119,7 +119,7 @@ function BaseDraggableTabList({
                 />
               </Reorder.Item>
               <TabDivider
-                layout
+                layout="position"
                 isVisible={
                   state.selectedKey === 'temporary-tab' ||
                   (state.selectedKey !== item.key &&

--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -98,28 +98,33 @@ function BaseDraggableTabList({
         <TabListWrap {...tabListProps} className={className} ref={tabListRef}>
           {persistentTabs.map(item => (
             <Fragment key={item.key}>
-              <Reorder.Item
-                key={item.key}
-                value={item}
-                style={{display: 'flex', flexDirection: 'row'}}
-                as="div"
-                dragConstraints={tabListRef} // Sets the container that the tabs can be dragged within
-                dragElastic={0} // Prevents tabs from being dragged outside of the tab bar
-                dragTransition={{bounceStiffness: 400, bounceDamping: 40}} // Recovers spring behavior thats lost when using dragElastic
-                layout="position"
-              >
-                <Tab
+              <TabItemWrap isSelected={state.selectedKey === item.key}>
+                <Reorder.Item
                   key={item.key}
-                  item={item}
-                  state={state}
-                  orientation={orientation}
-                  overflowing={false}
-                  ref={element => (tabItemsRef.current[item.key] = element)}
-                  variant={tabVariant}
-                />
-              </Reorder.Item>
+                  value={item}
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                  }}
+                  as="div"
+                  dragConstraints={tabListRef} // Sets the container that the tabs can be dragged within
+                  dragElastic={0} // Prevents tabs from being dragged outside of the tab bar
+                  dragTransition={{bounceStiffness: 400, bounceDamping: 40}} // Recovers spring behavior thats lost when using dragElastic
+                  layout="position"
+                >
+                  <Tab
+                    key={item.key}
+                    item={item}
+                    state={state}
+                    orientation={orientation}
+                    overflowing={false}
+                    ref={element => (tabItemsRef.current[item.key] = element)}
+                    variant={tabVariant}
+                  />
+                </Reorder.Item>
+              </TabItemWrap>
               <TabDivider
-                layout="position"
+                layout
                 isVisible={
                   state.selectedKey === 'temporary-tab' ||
                   (state.selectedKey !== item.key &&
@@ -204,6 +209,12 @@ export function DraggableTabList({items, onAddView, ...props}: DraggableTabListP
 }
 
 DraggableTabList.Item = Item;
+
+const TabItemWrap = styled('div')<{isSelected: boolean}>`
+  display: flex;
+  position: relative;
+  z-index: ${p => (p.isSelected ? 1 : 0)};
+`;
 
 /**
  * TabDividers are only visible around NON-selected tabs. They are not visible around the selected tab,

--- a/static/app/components/tabs/tab.tsx
+++ b/static/app/components/tabs/tab.tsx
@@ -226,12 +226,11 @@ const FilledTabWrap = styled('li', {shouldForwardProp: tabsShouldForwardProp})<{
     `}
   }
 
-  border-radius: 6px 6px 1px 1px;
-
   &[aria-selected='false'] {
     border-top: 1px solid transparent;
   }
 
+  border-radius: 6px 6px 1px 1px;
   padding: ${space(0.75)} ${space(1.5)};
 
   transform: translateY(1px);

--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
@@ -313,7 +313,7 @@ export function DraggableTabBar({
             pathname: `/organizations/${orgSlug}/issues/`,
           })}
         >
-          <TabContentWrap selected={tabListState?.selectedKey === tab.key}>
+          <TabContentWrap>
             <EditableTabTitle
               label={tab.label}
               isEditing={editingTabKey === tab.key}
@@ -435,14 +435,13 @@ const makeTempViewMenuOptions = ({
   ];
 };
 
-const TabContentWrap = styled('span')<{selected: boolean}>`
+const TabContentWrap = styled('span')`
   white-space: nowrap;
   display: flex;
   align-items: center;
   flex-direction: row;
   padding: 0;
   gap: 6px;
-  ${p => (p.selected ? 'z-index: 1;' : 'z-index: 0;')}
 `;
 
 const StyledBadge = styled(Badge)`


### PR DESCRIPTION
While working on overflowing tabs, discovered this setting:

>  If `layout` is set to `"position"`, the size of the component will change instantly and  only its position will animate. If `layout` is set to `"size"`, the position of the component will change instantly but its size will animate.