### PR TITLE
feat(seer grouping): Add metrics for feature flag and eligible content

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -70,6 +70,12 @@ def _project_has_similarity_grouping_enabled(project: Project) -> bool:
     # projects have been backfilled, the option (and this check) can go away.
     has_been_backfilled = project.get_option("sentry:similarity_backfill_completed")
 
+    metrics.incr(
+        "grouping.similarity.event_from_backfilled_project",
+        sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+        tags={"backfilled": has_seer_grouping_flag_on or has_been_backfilled},
+    )
+
     return has_seer_grouping_flag_on or has_been_backfilled
 
 

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -36,13 +36,14 @@ def should_call_seer_for_grouping(event: Event, primary_hashes: CalculatedHashes
 
     project = event.project
 
-    if not _project_has_similarity_grouping_enabled(project):
+    # Check both of these before returning based on either so we can gather metrics on their results
+    content_is_eligible = event_content_is_seer_eligible(event)
+    seer_enabled_for_project = _project_has_similarity_grouping_enabled(project)
+
+    if not (content_is_eligible and seer_enabled_for_project):
         return False
 
     if _has_customized_fingerprint(event, primary_hashes):
-        return False
-
-    if not event_content_is_seer_eligible(event):
         return False
 
     # **Do not add any new checks after this.** The rate limit check MUST remain the last of all the

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -165,11 +165,26 @@ def event_content_is_seer_eligible(event: Event) -> bool:
     """
     # TODO: Determine if we want to filter out non-sourcemapped events
     if not event_content_has_stacktrace(event):
+        metrics.incr(
+            "grouping.similarity.event_content_seer_eligible",
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+            tags={"eligible": False, "blocker": "no-stacktrace"},
+        )
         return False
 
     if event.platform not in SEER_ELIGIBLE_PLATFORMS:
+        metrics.incr(
+            "grouping.similarity.event_content_seer_eligible",
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+            tags={"eligible": False, "blocker": "unsupported-platform"},
+        )
         return False
 
+    metrics.incr(
+        "grouping.similarity.event_content_seer_eligible",
+        sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+        tags={"eligible": True, "blocker": "none"},
+    )
     return True
 
 


### PR DESCRIPTION
This adds two new metrics, `grouping.similarity.event_from_backfilled_project` and `grouping.similarity.event_content_seer_eligible`, to the helpers called in `should_call_seer_for_grouping`. In order that they both always be recorded, the order of checks there has also been rearranged, so failing one of the relevant checks doesn't prevent checking the other.