### PR TITLE
fix(anomaly detection): fix comparison type bug on edit

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -359,7 +359,6 @@ describe('Incident Rules Form', () => {
     it('creates an anomaly detection rule', async () => {
       organization.features = [...organization.features, 'anomaly-detection-alerts'];
       const rule = MetricRuleFixture({
-        detectionType: AlertRuleComparisonType.PERCENT,
         sensitivity: AlertRuleSensitivity.MEDIUM,
         seasonality: AlertRuleSeasonality.AUTO,
       });
@@ -372,10 +371,6 @@ describe('Incident Rules Form', () => {
           dataset: 'events',
         },
       });
-      await userEvent.click(
-        screen.getByText('Anomaly: whenever values are outside of expected bounds')
-      );
-
       expect(
         await screen.findByLabelText(
           'Anomaly: whenever values are outside of expected bounds'

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -237,13 +237,16 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
       metricExtractionRules: null,
       triggers: triggersClone,
       resolveThreshold: rule.resolveThreshold,
-      sensitivity: null,
+      sensitivity: rule.sensitivity ?? undefined,
+      seasonality: rule.seasonality ?? undefined,
       thresholdType: rule.thresholdType,
       thresholdPeriod: rule.thresholdPeriod ?? 1,
       comparisonDelta: rule.comparisonDelta ?? undefined,
       comparisonType: rule.comparisonDelta
         ? AlertRuleComparisonType.CHANGE
-        : AlertRuleComparisonType.COUNT,
+        : rule.sensitivity
+          ? AlertRuleComparisonType.DYNAMIC
+          : AlertRuleComparisonType.COUNT,
       project: this.props.project,
       owner: rule.owner,
       alertType: getAlertTypeFromAggregateDataset({aggregate, dataset}),


### PR DESCRIPTION
Previously, anomaly detection alerts would default to "Static" when going to the edit page. Fix this so that the selected checkbox is "Anomaly". Also fix the relevant test.