### PR TITLE
chore(dashboards): Improve `AutoSizedNumber` instrumentation

### DIFF
--- a/static/app/views/dashboards/widgetCard/autoSizedText.tsx
+++ b/static/app/views/dashboards/widgetCard/autoSizedText.tsx
@@ -40,44 +40,48 @@ export function AutoSizedText({children}: Props) {
 
       let iterationCount = 0;
 
-      const span = Sentry.startInactiveSpan({
-        op: 'function',
-        name: 'AutoSizedText.iterate',
-        forceTransaction: true,
-      });
+      Sentry.withScope(scope => {
+        const span = Sentry.startInactiveSpan({
+          op: 'function',
+          name: 'AutoSizedText.iterate',
+          forceTransaction: true,
+        });
 
-      // Run the resize iteration in a loop. This blocks the main UI thread and prevents
-      // visible layout jitter. If this was done through a `ResizeObserver` or React State
-      // each step in the resize iteration would be visible to the user
-      while (iterationCount <= ITERATION_LIMIT) {
-        const childDimensions = getElementDimensions(childElement);
+        // Run the resize iteration in a loop. This blocks the main UI thread and prevents
+        // visible layout jitter. If this was done through a `ResizeObserver` or React State
+        // each step in the resize iteration would be visible to the user
+        while (iterationCount <= ITERATION_LIMIT) {
+          const childDimensions = getElementDimensions(childElement);
 
-        const widthDifference = parentDimensions.width - childDimensions.width;
-        const heightDifference = parentDimensions.height - childDimensions.height;
+          const widthDifference = parentDimensions.width - childDimensions.width;
+          const heightDifference = parentDimensions.height - childDimensions.height;
 
-        const childFitsIntoParent = heightDifference > 0 && widthDifference > 0;
-        const childIsWithinWidthTolerance =
-          Math.abs(widthDifference) <= MAXIMUM_DIFFERENCE;
-        const childIsWithinHeightTolerance =
-          Math.abs(heightDifference) <= MAXIMUM_DIFFERENCE;
+          const childFitsIntoParent = heightDifference > 0 && widthDifference > 0;
+          const childIsWithinWidthTolerance =
+            Math.abs(widthDifference) <= MAXIMUM_DIFFERENCE;
+          const childIsWithinHeightTolerance =
+            Math.abs(heightDifference) <= MAXIMUM_DIFFERENCE;
 
-        if (
-          childFitsIntoParent &&
-          (childIsWithinWidthTolerance || childIsWithinHeightTolerance)
-        ) {
-          // Stop the iteration, we've found a fit!
-          span.setAttribute('widthDifference', widthDifference);
-          span.setAttribute('heightDifference', heightDifference);
-          break;
+          if (
+            childFitsIntoParent &&
+            (childIsWithinWidthTolerance || childIsWithinHeightTolerance)
+          ) {
+            // Stop the iteration, we've found a fit!
+            span.setAttribute('widthDifference', widthDifference);
+            span.setAttribute('heightDifference', heightDifference);
+            break;
+          }
+
+          adjustFontSize(childDimensions, parentDimensions);
+
+          iterationCount += 1;
         }
 
-        adjustFontSize(childDimensions, parentDimensions);
+        scope.setTag('didExceedIterationLimit', iterationCount >= ITERATION_LIMIT);
 
-        iterationCount += 1;
-      }
-
-      span.setAttribute('iterationCount', iterationCount);
-      span.end();
+        span.setAttribute('iterationCount', iterationCount);
+        span.end();
+      });
     });
 
     observer.observe(parentElement);

--- a/static/app/views/dashboards/widgetCard/autoSizedText.tsx
+++ b/static/app/views/dashboards/widgetCard/autoSizedText.tsx
@@ -43,6 +43,7 @@ export function AutoSizedText({children}: Props) {
       const span = Sentry.startInactiveSpan({
         op: 'function',
         name: 'AutoSizedText.iterate',
+        forceTransaction: true,
       });
 
       // Run the resize iteration in a loop. This blocks the main UI thread and prevents


### PR DESCRIPTION
I'm taking a look at the performance, and I need some more info.

Firstly, forcing the span to _always_ be a transaction. Right now it's either a transaction or a span depending on whether the calculation ran during page load or later. That makes it hard to get stats! Transactions have more UI support for finding the performance characteristics and better search support.

Secondly, adding a tag to see whether the iteration limit was exceeded, so I can filter for those.

The feature is in EA, so there are about 2,000 of these transactions a day.
