### PR TITLE
fix(slack): Render Loading Modal for Slack

### DIFF
--- a/src/sentry/integrations/slack/metrics.py
+++ b/src/sentry/integrations/slack/metrics.py
@@ -74,3 +74,8 @@ SLACK_UTILS_GET_USER_LIST_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.ut
 SLACK_UTILS_GET_USER_LIST_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.utils.users.failure"
 SLACK_UTILS_CHANNEL_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.utils.channel.success"
 SLACK_UTILS_CHANNEL_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.utils.channel.failure"
+
+
+# Middleware Parsers
+SLACK_MIDDLE_PARSERS_SUCCESS_DATADOG_METRIC = "sentry.middleware.integrations.slack.parsers.success"
+SLACK_MIDDLE_PARSERS_FAILURE_DATADOG_METRIC = "sentry.middleware.integrations.slack.parsers.failure"

--- a/src/sentry/integrations/slack/requests/action.py
+++ b/src/sentry/integrations/slack/requests/action.py
@@ -131,3 +131,16 @@ class SlackActionRequest(SlackRequest):
                 if tag_key.strip().endswith(":"):
                     tags.add(tag_key.strip(": "))
         return tags
+
+    def get_action_ts(self) -> str | None:
+        """
+        Get the action timestamp from the Slack request data.
+
+        Returns:
+            str | None: The action timestamp if available, None otherwise.
+        """
+        actions = self.data.get("actions", [])
+        if actions and isinstance(actions, list) and len(actions) > 0:
+            (action,) = actions
+            return action.get("action_ts")
+        return None

--- a/src/sentry/integrations/slack/utils/errors.py
+++ b/src/sentry/integrations/slack/utils/errors.py
@@ -15,6 +15,7 @@ class SlackSdkErrorCategory:
 SLACK_SDK_ERROR_CATEGORIES = (
     RATE_LIMITED := SlackSdkErrorCategory("ratelimited"),
     CHANNEL_NOT_FOUND := SlackSdkErrorCategory("channel_not_found"),
+    MODAL_NOT_FOUND := SlackSdkErrorCategory("not_found"),
 )
 
 _CATEGORIES_BY_MESSAGE = {c.message: c for c in SLACK_SDK_ERROR_CATEGORIES}

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -393,6 +393,20 @@ class SlackActionEndpoint(Endpoint):
             # If the external_id is not found, Slack we send `not_found` error
             # https://api.slack.com/methods/views.update
             if unpack_slack_api_error(e) == MODAL_NOT_FOUND:
+                metrics.incr(
+                    SLACK_WEBHOOK_GROUP_ACTIONS_FAILURE_DATADOG_METRIC,
+                    sample_rate=1.0,
+                    tags={"type": "update_modal"},
+                )
+                _logger.exception(
+                    "slack.action.update-modal-not-found",
+                    extra={
+                        "organization_id": slack_request.organization.id,
+                        "integration_id": slack_request.integration.id,
+                        "trigger_id": slack_request.data["trigger_id"],
+                        "dialog": "resolve",
+                    },
+                )
                 # The modal was not found, so we need to open a new one
                 self._open_view(slack_client, modal_payload, slack_request)
             else:

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -377,7 +377,7 @@ class SlackActionEndpoint(Endpoint):
             metadata=metadata,
         )
 
-    def _update_view(
+    def _update_modal(
         self,
         slack_client: SlackSdkClient,
         external_id: str,
@@ -438,7 +438,7 @@ class SlackActionEndpoint(Endpoint):
             external_id = slack_request.data.get("actions")[0].get("action_ts")
 
             if options.get("send-slack-response-from-control-silo"):
-                self._update_view(slack_client, external_id, modal_payload, slack_request)
+                self._update_modal(slack_client, external_id, modal_payload, slack_request)
             else:
                 self._open_view(slack_client, modal_payload, slack_request)
 
@@ -490,7 +490,7 @@ class SlackActionEndpoint(Endpoint):
             external_id = slack_request.data.get("actions")[0].get("action_ts")
 
             if options.get("send-slack-response-from-control-silo"):
-                self._update_view(slack_client, external_id, modal_payload, slack_request)
+                self._update_modal(slack_client, external_id, modal_payload, slack_request)
             else:
                 self._open_view(slack_client, modal_payload, slack_request)
 

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -15,7 +15,7 @@ from slack_sdk.errors import SlackApiError
 from slack_sdk.models.views import View
 from slack_sdk.webhook import WebhookClient
 
-from sentry import analytics
+from sentry import analytics, options
 from sentry.api import client
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
@@ -34,6 +34,7 @@ from sentry.integrations.slack.metrics import (
 from sentry.integrations.slack.requests.action import SlackActionRequest
 from sentry.integrations.slack.requests.base import SlackRequestError
 from sentry.integrations.slack.sdk_client import SlackSdkClient
+from sentry.integrations.slack.utils.errors import MODAL_NOT_FOUND, unpack_slack_api_error
 from sentry.integrations.types import ExternalProviderEnum
 from sentry.integrations.utils.scope import bind_org_context_from_integration
 from sentry.models.activity import ActivityIntegration
@@ -376,6 +377,36 @@ class SlackActionEndpoint(Endpoint):
             metadata=metadata,
         )
 
+    def _update_view(
+        self,
+        slack_client: SlackSdkClient,
+        external_id: str,
+        modal_payload: View,
+        slack_request: SlackActionRequest,
+    ) -> None:
+        try:
+            slack_client.views_update(
+                external_id=external_id,
+                view=modal_payload,
+            )
+        except SlackApiError as e:
+            # If the external_id is not found, Slack we send `not_found` error
+            # https://api.slack.com/methods/views.update
+            if unpack_slack_api_error(e) == MODAL_NOT_FOUND:
+                # The modal was not found, so we need to open a new one
+                self._open_view(slack_client, modal_payload, slack_request)
+            else:
+                raise
+
+    def _open_view(
+        self, slack_client: SlackSdkClient, modal_payload: View, slack_request: SlackActionRequest
+    ) -> None:
+        # Error handling is done in the calling function
+        slack_client.views_open(
+            trigger_id=slack_request.data["trigger_id"],
+            view=modal_payload,
+        )
+
     def open_resolve_dialog(self, slack_request: SlackActionRequest, group: Group) -> None:
         # XXX(epurkhiser): In order to update the original message we have to
         # keep track of the response_url in the callback_id. Definitely hacky,
@@ -402,10 +433,15 @@ class SlackActionEndpoint(Endpoint):
         modal_payload = self.build_resolve_modal_payload(callback_id, metadata=metadata)
         slack_client = SlackSdkClient(integration_id=slack_request.integration.id)
         try:
-            slack_client.views_open(
-                trigger_id=slack_request.data["trigger_id"],
-                view=modal_payload,
-            )
+            # We need to use the action_ts as the external_id to update the modal
+            # We passed this in control when we sent the loading modal to beat the 3 second timeout
+            external_id = slack_request.data.get("actions")[0].get("action_ts")
+
+            if options.get("send-slack-response-from-control-silo"):
+                self._update_view(slack_client, external_id, modal_payload, slack_request)
+            else:
+                self._open_view(slack_client, modal_payload, slack_request)
+
             metrics.incr(
                 SLACK_WEBHOOK_GROUP_ACTIONS_SUCCESS_DATADOG_METRIC,
                 sample_rate=1.0,
@@ -449,10 +485,15 @@ class SlackActionEndpoint(Endpoint):
         modal_payload = self.build_archive_modal_payload(callback_id, metadata=metadata)
         slack_client = SlackSdkClient(integration_id=slack_request.integration.id)
         try:
-            slack_client.views_open(
-                trigger_id=slack_request.data["trigger_id"],
-                view=modal_payload,
-            )
+            # We need to use the action_ts as the external_id to update the modal
+            # We passed this in control when we sent the loading modal to beat the 3 second timeout
+            external_id = slack_request.data.get("actions")[0].get("action_ts")
+
+            if options.get("send-slack-response-from-control-silo"):
+                self._update_view(slack_client, external_id, modal_payload, slack_request)
+            else:
+                self._open_view(slack_client, modal_payload, slack_request)
+
             metrics.incr(
                 SLACK_WEBHOOK_GROUP_ACTIONS_SUCCESS_DATADOG_METRIC,
                 sample_rate=1.0,

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -435,7 +435,7 @@ class SlackActionEndpoint(Endpoint):
         try:
             # We need to use the action_ts as the external_id to update the modal
             # We passed this in control when we sent the loading modal to beat the 3 second timeout
-            external_id = slack_request.data.get("actions")[0].get("action_ts")
+            external_id = slack_request.get_action_ts()
 
             if options.get("send-slack-response-from-control-silo"):
                 self._update_modal(slack_client, external_id, modal_payload, slack_request)
@@ -487,7 +487,7 @@ class SlackActionEndpoint(Endpoint):
         try:
             # We need to use the action_ts as the external_id to update the modal
             # We passed this in control when we sent the loading modal to beat the 3 second timeout
-            external_id = slack_request.data.get("actions")[0].get("action_ts")
+            external_id = slack_request.get_action_ts()
 
             if options.get("send-slack-response-from-control-silo"):
                 self._update_modal(slack_client, external_id, modal_payload, slack_request)

--- a/src/sentry/middleware/integrations/parsers/slack.py
+++ b/src/sentry/middleware/integrations/parsers/slack.py
@@ -210,6 +210,7 @@ class SlackRequestParser(BaseRequestParser):
             }
         )
 
+        # Return a 200 OK response to Slack even if we rendered the modal b/c we are sending an async response
         return HttpResponse(status=status.HTTP_200_OK)
 
     def get_integration_from_request(self) -> Integration | None:

--- a/src/sentry/middleware/integrations/parsers/slack.py
+++ b/src/sentry/middleware/integrations/parsers/slack.py
@@ -122,18 +122,16 @@ class SlackRequestParser(BaseRequestParser):
             # we need to grab the action_ts to use as the external_id for the loading modal
             # https://api.slack.com/reference/interaction-payloads/block-actions
             actions = payload.get("actions", None)
-            if actions and isinstance(actions, list) and len(actions) == 1:
-                (action,) = actions  # we only expect one action in the list
-                action_ts = action.get("action_ts")
-                if action_ts is None:
-                    raise ValueError(
-                        "Error parsing Slack payload: 'action_ts' not found in 'actions'"
-                    )
-                return payload, action_ts
-            else:
-                raise ValueError(
-                    "Error parsing Slack payload: 'actions' not found or not a list of length 1"
-                )
+            if not actions or not isinstance(actions, list):
+                raise ValueError("Error parsing Slack payload: 'actions' not found")
+            if len(actions) != 1:
+                raise ValueError("Error parsing Slack payload: 'actions' not a list of length 1")
+
+            (action,) = actions  # we only expect one action in the list
+            action_ts = action.get("action_ts")
+            if action_ts is None:
+                raise ValueError("Error parsing Slack payload: 'action_ts' not found in 'actions'")
+            return payload, action_ts
 
         except (json.JSONDecodeError, KeyError, IndexError, TypeError) as e:
             raise ValueError(f"Error parsing Slack payload: {str(e)}")

--- a/src/sentry/middleware/integrations/parsers/slack.py
+++ b/src/sentry/middleware/integrations/parsers/slack.py
@@ -106,7 +106,7 @@ class SlackRequestParser(BaseRequestParser):
             ],
         }
 
-    def parse_slack_payload(self, request) -> str | None:
+    def parse_slack_payload(self, request) -> tuple[dict, str]:
         try:
             decoded_body = parse_qs(request.body.decode(encoding="utf-8"))
             payload_list = decoded_body.get("payload")

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -501,6 +501,10 @@ register("slack.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 register("slack.verification-token", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 register("slack.signing-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 
+
+# Slack Middleware Parser
+register("send-slack-response-from-control-silo", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
 # Discord
 register("discord.validate-user", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 

--- a/tests/sentry/middleware/integrations/parsers/test_slack.py
+++ b/tests/sentry/middleware/integrations/parsers/test_slack.py
@@ -130,7 +130,7 @@ class SlackRequestParserTest(TestCase):
                 "response_url": response_url,
             }
         )
-        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert response.status_code == status.HTTP_200_OK
 
     @patch("sentry.middleware.integrations.parsers.slack.convert_to_async_slack_response")
     @patch.object(


### PR DESCRIPTION
fixes [SENTRY-3BWJ](https://sentry.sentry.io/issues/5590278616/)

the issue is we receive the request in control then send it over to region, which then sends a response to slack. this is a problem b/c we only have 3 seconds to respond.

here, i add a loading modal state, which we send immediately from control, eventually updating the model from region. this method gives us 30 minutes to respond to slack from the initial loading modal render.

i wrote the logic here more extensible, so if we want contractors in the future to implement something similar for the individual options (which are also might be timing out), we can have them do that.

here is a video of the changes (i exaggerated the latency)


https://github.com/user-attachments/assets/80238e35-fd99-4ef0-8c1a-38aa98d0c3ad



