### PR TITLE
fix(spans): Add sampling option for span sample table

### DIFF
--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -5,7 +5,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import search
+from sentry import options, search
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
@@ -176,6 +176,7 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsEndpointBase):
             orderby=["-profile_id"],
             snuba_params=snuba_params,
             query=request.query_params.get("query"),
+            sample=options.get("insights.span-samples-query.sample-rate") or None,
             referrer=Referrer.API_SPAN_SAMPLE_GET_SPAN_IDS.value,
             query_source=(QuerySource.FRONTEND if is_frontend else QuerySource.API),
         )

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1811,8 +1811,8 @@ register(
 )
 register(
     "insights.span-samples-query.sample-rate",
-    type=Int,
-    default=100_000_000,
+    type=Float,
+    default=100_000_000.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1809,6 +1809,12 @@ register(
     type=Int,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "insights.span-samples-query.sample-rate",
+    type=Int,
+    default=100_000_000,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "performance.spans-tags-key.sample-rate",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1812,7 +1812,7 @@ register(
 register(
     "insights.span-samples-query.sample-rate",
     type=Float,
-    default=100_000_000.0,
+    default=0.0,  # 0 acts as 'no sampling'
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -6,6 +6,7 @@ from rest_framework.exceptions import ParseError
 
 from sentry.issues.grouptype import ProfileFileIOGroupType
 from sentry.testutils.cases import APITestCase, SnubaTestCase
+from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from tests.sentry.issues.test_utils import SearchIssueTestMixin
 
@@ -443,3 +444,48 @@ class OrganizationSpansSamplesEndpoint(APITestCase, SnubaTestCase):
             "is_segment = 1" in call_args[0][0].serialize()
             for call_args in mock_raw_snql_query.call_args_list
         )
+
+    def test_is_using_sample_rate(self):
+        self.login_as(user=self.user)
+        project = self.create_project()
+        url = reverse(self.url_name, kwargs={"organization_id_or_slug": project.organization.slug})
+
+        def request():
+
+            return self.client.get(
+                url,
+                {
+                    "query": "span.is_segment:1 transaction:api/0/foo",
+                    "lowerBound": "0",
+                    "firstBound": "10",
+                    "secondBound": "20",
+                    "upperBound": "200",
+                    "column": "span.duration",
+                },
+                format="json",
+                extra={"project": [project.id]},
+            )
+
+        response = request()
+
+        assert response.status_code == 200, response.content
+
+        with mock.patch("sentry.search.events.builder.base.raw_snql_query") as mock_raw_snql_query:
+
+            response = request()
+            assert response.status_code == 200, response.content
+
+            assert (
+                "MATCH (spans SAMPLE 100000000.0)"
+                in mock_raw_snql_query.call_args_list[0][0][0].serialize()
+            )
+
+        with (
+            override_options({"insights.span-samples-query.sample-rate": 0.0}),
+            mock.patch("sentry.search.events.builder.base.raw_snql_query") as mock_raw_snql_query,
+        ):
+
+            response = request()
+            assert response.status_code == 200, response.content
+
+            assert "MATCH (spans)" in mock_raw_snql_query.call_args_list[0][0][0].serialize()

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -475,17 +475,17 @@ class OrganizationSpansSamplesEndpoint(APITestCase, SnubaTestCase):
             response = request()
             assert response.status_code == 200, response.content
 
-            assert (
-                "MATCH (spans SAMPLE 100000000.0)"
-                in mock_raw_snql_query.call_args_list[0][0][0].serialize()
-            )
+            assert "MATCH (spans)" in mock_raw_snql_query.call_args_list[0][0][0].serialize()
 
         with (
-            override_options({"insights.span-samples-query.sample-rate": 0.0}),
+            override_options({"insights.span-samples-query.sample-rate": 100_000_000.0}),
             mock.patch("sentry.search.events.builder.base.raw_snql_query") as mock_raw_snql_query,
         ):
 
             response = request()
             assert response.status_code == 200, response.content
 
-            assert "MATCH (spans)" in mock_raw_snql_query.call_args_list[0][0][0].serialize()
+            assert (
+                "MATCH (spans SAMPLE 100000000.0)"
+                in mock_raw_snql_query.call_args_list[0][0][0].serialize()
+            )


### PR DESCRIPTION
### Summary
This sets an upper bound in the case of massive span sample tables. This should improve performance for customers with projects that contain hundreds of millions or billions of spans within their query. At 100mil it also should be unlikely we miss a sample.