### PR TITLE
chore(custom-views): Add more right margin to add view button

### DIFF
--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -261,6 +261,7 @@ const AddViewButton = styled(Button)`
   font-weight: normal;
   padding: ${space(0.5)};
   transform: translateY(1px);
+  margin-right: ${space(0.5)};
 `;
 
 const StyledIconAdd = styled(IconAdd)`


### PR DESCRIPTION
before:

![image](https://github.com/user-attachments/assets/e95f4a68-273b-4ad2-aed9-ac03c1cba6f9)


after:

![image](https://github.com/user-attachments/assets/60506b09-b744-44b7-bd8a-b9a473d5e35a)


This happened because I removed the tab divider after the add view button. This spacing keeps it in line with the spacing between all the other tabs. 