### PR TITLE
ref(seer grouping): Project-specific killswitch pre-work

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2355,7 +2355,9 @@ def _get_severity_metadata_for_group(
     """
     from sentry.receivers.rules import PLATFORMS_WITH_PRIORITY_ALERTS
 
-    if killswitch_matches_context("issues.skip-seer-requests", {"project_id": event.project_id}):
+    if killswitch_matches_context(
+        "issues.severity.skip-seer-requests", {"project_id": event.project_id}
+    ):
         logger.warning(
             "get_severity_metadata_for_group.seer_killswitch_enabled",
             extra={"event_id": event.event_id, "project_id": project_id},

--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -227,7 +227,7 @@ ALL_KILLSWITCH_OPTIONS = {
             "project_id": "A project ID to filter events by.",
         },
     ),
-    "issues.skip-seer-requests": KillswitchInfo(
+    "issues.severity.skip-seer-requests": KillswitchInfo(
         description="""
         Do not make requests to Seer.
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1011,7 +1011,7 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "issues.skip-seer-requests",
+    "issues.severity.skip-seer-requests",
     type=Sequence,
     default=[],
     flags=FLAG_AUTOMATOR_MODIFIABLE,

--- a/tests/sentry/event_manager/test_priority.py
+++ b/tests/sentry/event_manager/test_priority.py
@@ -101,7 +101,7 @@ class TestEventManagerPriority(TestCase):
 
     @patch("sentry.event_manager._get_severity_score", return_value=(0.2, "ml"))
     def test_killswitch_on(self, mock_get_severity_score: MagicMock):
-        options.set("issues.skip-seer-requests", [self.project.id])
+        options.set("issues.severity.skip-seer-requests", [self.project.id])
         event = EventManager(
             make_event(level=logging.WARNING, fingerprint=["def"], platform="python")
         ).save(self.project.id)
@@ -112,7 +112,7 @@ class TestEventManagerPriority(TestCase):
         assert event.group.get_event_metadata()["initial_priority"] == PriorityLevel.MEDIUM
         assert mock_get_severity_score.call_count == 0
 
-        options.set("issues.skip-seer-requests", [])
+        options.set("issues.severity.skip-seer-requests", [])
         event = EventManager(
             make_event(level=logging.WARNING, fingerprint=["abc"], platform="python")
         ).save(self.project.id)

--- a/tests/sentry/event_manager/test_severity.py
+++ b/tests/sentry/event_manager/test_severity.py
@@ -424,7 +424,7 @@ class TestEventManagerSeverity(TestCase):
 
     @patch("sentry.event_manager._get_severity_score")
     def test_killswitch_on(self, mock_get_severity_score: MagicMock):
-        options.set("issues.skip-seer-requests", [self.project.id])
+        options.set("issues.severity.skip-seer-requests", [self.project.id])
         event = EventManager(
             make_event(
                 exception={"values": [{"type": "NopeError", "value": "Nopey McNopeface"}]},


### PR DESCRIPTION
This makes two small changes in preparation for using a project-specific killswitch for seer grouping.

- Rename the `issues.skip-seer-requests` killswitch to `issues.severity.skip-seer-requests`, since it is only used in `_get_severity_metadata_for_group`.

- Do some cleanup of/refactoring to `should_call_seer_for_grouping`.