### PR TITLE
fix: sync should ensure admin user is created

### DIFF
--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -249,6 +249,7 @@ def main(context: dict[str, str]) -> int:
     ):
         return 1
 
+    # faster prerequisite check than starting up sentry and running createuser idempotently
     stdout = proc.run(
         (
             "docker",

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -54,7 +54,7 @@ def run_procs(
                 f"""
 ❌ {name}
 
-failed command (code p.returncode):
+failed command (code {p.returncode}):
     {shlex.join(final_cmd)}
 
 Output:


### PR DESCRIPTION
i forgot to check this in a while ago (i think back when i was cleaning up some of our make related stuff), but this is necessary as `devenv bootstrap` no longer calls `make bootstrap`, it just calls sync - `make apply-migrations` doesn't createuser. We need to do that.