### PR TITLE
style(settings): add gap to identity tags

### DIFF
--- a/static/app/views/settings/account/accountIdentities.tsx
+++ b/static/app/views/settings/account/accountIdentities.tsx
@@ -64,7 +64,7 @@ function IdentityItem({identity, onDisconnect}: IdentityItemProps) {
         </IdentityText>
       </InternalContainer>
       <InternalContainer>
-        <TagWrapper>
+        <TagWrapper css={{gap: space(0.75)}}>
           {identity.category === UserIdentityCategory.SOCIAL_IDENTITY && (
             <Tag type="default">{t('Legacy')}</Tag>
           )}

--- a/static/app/views/settings/account/accountIdentities.tsx
+++ b/static/app/views/settings/account/accountIdentities.tsx
@@ -64,7 +64,7 @@ function IdentityItem({identity, onDisconnect}: IdentityItemProps) {
         </IdentityText>
       </InternalContainer>
       <InternalContainer>
-        <TagWrapper css={{gap: space(0.75)}}>
+        <TagWrapper>
           {identity.category === UserIdentityCategory.SOCIAL_IDENTITY && (
             <Tag type="default">{t('Legacy')}</Tag>
           )}
@@ -254,6 +254,7 @@ const TagWrapper = styled('div')`
   justify-content: flex-start;
   flex-grow: 1;
   margin-right: ${space(1)};
+  gap: ${space(0.75)};
 `;
 
 export default AccountIdentities;


### PR DESCRIPTION
before
<img width="626" alt="SCR-20240828-keuh" src="https://github.com/user-attachments/assets/69151c8f-f4f1-4fce-b542-5b8cad02aca8">

after 
<img width="642" alt="SCR-20240828-kerz" src="https://github.com/user-attachments/assets/472da083-d36e-4392-80db-31e2f2bef085">