### PR TITLE
styles(profiling): Clean up slowest functions column formatting

### DIFF
--- a/static/app/views/explore/components/table.tsx
+++ b/static/app/views/explore/components/table.tsx
@@ -42,7 +42,7 @@ const MINIMUM_COLUMN_WIDTH = COL_WIDTH_MINIMUM;
 type Item = {
   label: string;
   value: React.ReactNode;
-  width?: 'min-content';
+  width?: number | 'min-content';
 };
 
 interface UseTableStylesOptions {
@@ -58,7 +58,11 @@ export function useTableStyles({
     const columns = new Array(items.length);
 
     for (let i = 0; i < items.length; i++) {
-      columns[i] = items[i].width ?? `minmax(${minimumColumnWidth}px, auto)`;
+      if (typeof items[i].width === 'number') {
+        columns[i] = `${items[i].width}px`;
+      } else {
+        columns[i] = items[i].width ?? `minmax(${minimumColumnWidth}px, auto)`;
+      }
     }
 
     return {


### PR DESCRIPTION
This moves the chevron to expand the row to the far left and moves the project column so the first column is the function name.

# Screenshot

![image](https://github.com/user-attachments/assets/7fded837-7680-4b2c-9c04-488551892017)
