### PR TITLE
fix(feedback): catch snuba errors in update_user_reports task

### DIFF
--- a/src/sentry/tasks/update_user_reports.py
+++ b/src/sentry/tasks/update_user_reports.py
@@ -65,13 +65,12 @@ def update_user_reports(**kwargs: Any) -> None:
                     filter=snuba_filter, referrer="tasks.update_user_reports"
                 )
                 events.extend(events_chunk)
-            except Exception as e:
+            except Exception:
+                sentry_sdk.set_tag("update_user_reports.eventstore_query_failed", True)
                 logger.exception(
                     "update_user_reports.eventstore_query_failed",
                     extra={"project_id": project_id, "start": start, "end": end},
-                )
-                sentry_sdk.set_tag("update_user_reports.eventstore_query_failed", True)
-                sentry_sdk.capture_exception(e)
+                )  # will also send exc to Sentry
 
         for event in events:
             report = report_by_event.get(event.event_id)

--- a/src/sentry/tasks/update_user_reports.py
+++ b/src/sentry/tasks/update_user_reports.py
@@ -2,6 +2,7 @@ import logging
 from datetime import timedelta
 from typing import Any
 
+import sentry_sdk
 from django.utils import timezone
 
 from sentry import eventstore, features
@@ -59,10 +60,18 @@ def update_user_reports(**kwargs: Any) -> None:
                 start=start - timedelta(days=1),  # we go one extra day back for events
                 end=end,
             )
-            events_chunk = eventstore.backend.get_events(
-                filter=snuba_filter, referrer="tasks.update_user_reports"
-            )
-            events.extend(events_chunk)
+            try:
+                events_chunk = eventstore.backend.get_events(
+                    filter=snuba_filter, referrer="tasks.update_user_reports"
+                )
+                events.extend(events_chunk)
+            except Exception as e:
+                logger.exception(
+                    "update_user_reports.eventstore_query_failed",
+                    extra={"project_id": project_id, "start": start, "end": end},
+                )
+                sentry_sdk.set_tag("update_user_reports.eventstore_query_failed", True)
+                sentry_sdk.capture_exception(e)
 
         for event in events:
             report = report_by_event.get(event.event_id)


### PR DESCRIPTION
Related to, but doesn't fix [SENTRY-163P](https://sentry.sentry.io/issues/4502227101/)

If one query fails in this loop, the whole task fails. We're backlogged to ~16k reports today because of the error in the issue above. https://cloudlogging.app.goo.gl/RSiCipKDsuSRWo2m6

~~Depends on https://github.com/getsentry/sentry/pull/76718~~
