### PR TITLE
feat(seer grouping): Add project-specific killswitch to Seer calls

### DIFF
--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -217,7 +217,7 @@ ALL_KILLSWITCH_OPTIONS = {
         """,
         fields={"organization_id": "An organization ID to disable check-ins for."},
     ),
-    "embeddings-grouping.use-embeddings": KillswitchInfo(
+    "seer.similarity.grouping_killswitch_projects": KillswitchInfo(
         description="""
         Prevent project from using LLM embeddings for grouping new hashes.
         In case project has too many new events, spike of events from that

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -833,6 +833,12 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "seer.similarity.grouping_killswitch_projects",
+    default=[],
+    type=Sequence,
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "seer.severity-killswitch.enabled",
     default=False,
     type=Bool,
@@ -977,7 +983,6 @@ register(
 register(
     "store.load-shed-process-event-projects", type=Any, default=[], flags=FLAG_AUTOMATOR_MODIFIABLE
 )
-register("embeddings-grouping.use-embeddings", type=Sequence, default=[])
 register(
     "store.load-shed-process-event-projects-gradual",
     type=Dict,

--- a/tests/sentry/grouping/ingest/test_seer.py
+++ b/tests/sentry/grouping/ingest/test_seer.py
@@ -93,6 +93,17 @@ class ShouldCallSeerTest(TestCase):
                 )
 
     @with_feature("projects:similarity-embeddings-grouping")
+    def test_obeys_project_specific_killswitch(self):
+        for blocked_projects, expected_result in [([self.project.id], False), ([], True)]:
+            with override_options(
+                {"seer.similarity.grouping_killswitch_projects": blocked_projects}
+            ):
+                assert (
+                    should_call_seer_for_grouping(self.event, self.primary_hashes)
+                    is expected_result
+                )
+
+    @with_feature("projects:similarity-embeddings-grouping")
     def test_obeys_global_ratelimit(self):
         for ratelimit_enabled, expected_result in [(True, False), (False, True)]:
             with patch(


### PR DESCRIPTION
This adds a project-specific killswitch (to go along with the similarity-service-specific and global Seer killswitches) to the checks performed in `should_call_seer_for_grouping` (via the `killswitch_enabled` helper). 

It turns out we already had a killswitch in place that we weren't using, which I renamed both for clarity and so the naming more closely mirrors our other killswitches. (I also moved it to be with said killswitches in `defaults.py`.) Once this is deployed, we'll be able to prevent a given project from using Seer grouping by adding its id to the `seer.similarity.grouping_killswitch_projects` option in the options automator.