### PR TITLE
feat(replay): add mobile platforms to onboarding sidebar

### DIFF
--- a/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
@@ -334,6 +334,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
     ) {
       return 'feedbackOnboardingNpm';
     }
+    // TODO: update this when we add feedback to the loader
     return 'replayOnboardingJsLoader';
   }
 

--- a/static/app/components/onboarding/gettingStartedDoc/types.ts
+++ b/static/app/components/onboarding/gettingStartedDoc/types.ts
@@ -86,9 +86,8 @@ export interface Docs<PlatformOptions extends BasePlatformOptions = BasePlatform
   feedbackOnboardingCrashApi?: OnboardingConfig<PlatformOptions>;
   feedbackOnboardingNpm?: OnboardingConfig<PlatformOptions>;
   platformOptions?: PlatformOptions;
+  replayOnboarding?: OnboardingConfig<PlatformOptions>;
   replayOnboardingJsLoader?: OnboardingConfig<PlatformOptions>;
-  replayOnboardingMobile?: OnboardingConfig<PlatformOptions>;
-  replayOnboardingNpm?: OnboardingConfig<PlatformOptions>;
 }
 
 export type ConfigType =
@@ -96,7 +95,6 @@ export type ConfigType =
   | 'feedbackOnboardingNpm'
   | 'feedbackOnboardingCrashApi'
   | 'crashReportOnboarding'
-  | 'replayOnboardingNpm'
+  | 'replayOnboarding'
   | 'replayOnboardingJsLoader'
-  | 'replayOnboardingMobile'
   | 'customMetricsOnboarding';

--- a/static/app/components/onboarding/gettingStartedDoc/types.ts
+++ b/static/app/components/onboarding/gettingStartedDoc/types.ts
@@ -87,6 +87,7 @@ export interface Docs<PlatformOptions extends BasePlatformOptions = BasePlatform
   feedbackOnboardingNpm?: OnboardingConfig<PlatformOptions>;
   platformOptions?: PlatformOptions;
   replayOnboardingJsLoader?: OnboardingConfig<PlatformOptions>;
+  replayOnboardingMobile?: OnboardingConfig<PlatformOptions>;
   replayOnboardingNpm?: OnboardingConfig<PlatformOptions>;
 }
 
@@ -97,4 +98,5 @@ export type ConfigType =
   | 'crashReportOnboarding'
   | 'replayOnboardingNpm'
   | 'replayOnboardingJsLoader'
+  | 'replayOnboardingMobile'
   | 'customMetricsOnboarding';

--- a/static/app/components/onboarding/gettingStartedDoc/utils/index.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/index.tsx
@@ -75,7 +75,7 @@ export function MobileBetaBanner({link}: {link: string}) {
   return (
     <Alert type="info" showIcon>
       {tct(
-        `Currently, Mobile Replay is in beta. You can [link:read our docs] to learn how to set it up for your project.`,
+        `Currently, Mobile Replay is in beta. To learn more, you can [link:read our docs].`,
         {
           link: <ExternalLink href={link} />,
         }

--- a/static/app/components/onboarding/gettingStartedDoc/utils/replayOnboarding.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/replayOnboarding.tsx
@@ -4,6 +4,15 @@ import {tct} from 'sentry/locale';
 
 export const getReplayConfigureDescription = ({link}: {link: string}) =>
   tct(
+    'The SDK is aggressively redacting all text and images. We plan to add fine controls for redacting, but currently, we just allow either on or off. Learn more about configuring Session Replay by reading the [link:configuration docs].',
+    {
+      code: <code />,
+      link: <ExternalLink href={link} />,
+    }
+  );
+
+export const getReplayMobileConfigureDescription = ({link}: {link: string}) =>
+  tct(
     'Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set using the [code:integrations] constructor. Learn more about configuring Session Replay by reading the [link:configuration docs].',
     {
       code: <code />,

--- a/static/app/components/onboarding/gettingStartedDoc/utils/replayOnboarding.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/replayOnboarding.tsx
@@ -4,7 +4,7 @@ import {tct} from 'sentry/locale';
 
 export const getReplayMobileConfigureDescription = ({link}: {link: string}) =>
   tct(
-    'The SDK is aggressively redacting all text and images. We plan to add fine controls for redacting, but currently, we just allow either on or off. Learn more about configuring Session Replay by reading the [link:configuration docs].',
+    'The SDK aggressively redacts all text and images. We plan to add fine controls for redacting, but currently, we just allow either on or off. Learn more about configuring Session Replay by reading the [link:configuration docs].',
     {
       link: <ExternalLink href={link} />,
     }

--- a/static/app/components/onboarding/gettingStartedDoc/utils/replayOnboarding.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/replayOnboarding.tsx
@@ -2,16 +2,15 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {tct} from 'sentry/locale';
 
-export const getReplayConfigureDescription = ({link}: {link: string}) =>
+export const getReplayMobileConfigureDescription = ({link}: {link: string}) =>
   tct(
     'The SDK is aggressively redacting all text and images. We plan to add fine controls for redacting, but currently, we just allow either on or off. Learn more about configuring Session Replay by reading the [link:configuration docs].',
     {
-      code: <code />,
       link: <ExternalLink href={link} />,
     }
   );
 
-export const getReplayMobileConfigureDescription = ({link}: {link: string}) =>
+export const getReplayConfigureDescription = ({link}: {link: string}) =>
   tct(
     'Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set using the [code:integrations] constructor. Learn more about configuring Session Replay by reading the [link:configuration docs].',
     {

--- a/static/app/components/replaysOnboarding/replayOnboardingLayout.tsx
+++ b/static/app/components/replaysOnboarding/replayOnboardingLayout.tsx
@@ -8,6 +8,7 @@ import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/ty
 import {useSourcePackageRegistries} from 'sentry/components/onboarding/gettingStartedDoc/useSourcePackageRegistries';
 import {useUrlPlatformOptions} from 'sentry/components/onboarding/platformOptionsControl';
 import ReplayConfigToggle from 'sentry/components/replaysOnboarding/replayConfigToggle';
+import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 
 export function ReplayOnboardingLayout({
@@ -25,7 +26,7 @@ export function ReplayOnboardingLayout({
   const selectedOptions = useUrlPlatformOptions(docsConfig.platformOptions);
   const [mask, setMask] = useState(true);
   const [block, setBlock] = useState(true);
-  const {steps} = useMemo(() => {
+  const {introduction, steps} = useMemo(() => {
     const doc = docsConfig[configType] ?? docsConfig.onboarding;
 
     const docParams: DocsParams<any> = {
@@ -78,6 +79,7 @@ export function ReplayOnboardingLayout({
   return (
     <AuthTokenGeneratorProvider projectSlug={projectSlug}>
       <Wrapper>
+        {introduction && <Introduction>{introduction}</Introduction>}
         <Steps>
           {steps.map(step =>
             step.type === StepType.CONFIGURE ? (
@@ -85,14 +87,15 @@ export function ReplayOnboardingLayout({
                 key={step.title ?? step.type}
                 {...{
                   ...step,
-                  codeHeader: (
-                    <ReplayConfigToggle
-                      blockToggle={block}
-                      maskToggle={mask}
-                      onBlockToggle={() => setBlock(!block)}
-                      onMaskToggle={() => setMask(!mask)}
-                    />
-                  ),
+                  codeHeader:
+                    configType === 'replayOnboardingMobile' ? null : (
+                      <ReplayConfigToggle
+                        blockToggle={block}
+                        maskToggle={mask}
+                        onBlockToggle={() => setBlock(!block)}
+                        onMaskToggle={() => setMask(!mask)}
+                      />
+                    ),
                 }}
               />
             ) : (
@@ -123,4 +126,10 @@ const Wrapper = styled('div')`
       margin-bottom: 0;
     }
   }
+`;
+
+const Introduction = styled('div')`
+  display: flex;
+  flex-direction: column;
+  margin: 0 0 ${space(2)} 0;
 `;

--- a/static/app/components/replaysOnboarding/replayOnboardingLayout.tsx
+++ b/static/app/components/replaysOnboarding/replayOnboardingLayout.tsx
@@ -19,7 +19,8 @@ export function ReplayOnboardingLayout({
   projectSlug,
   newOrg,
   configType = 'onboarding',
-}: OnboardingLayoutProps) {
+  hideMaskBlockToggles,
+}: OnboardingLayoutProps & {hideMaskBlockToggles?: boolean}) {
   const organization = useOrganization();
   const {isPending: isLoadingRegistry, data: registryData} =
     useSourcePackageRegistries(organization);
@@ -87,15 +88,14 @@ export function ReplayOnboardingLayout({
                 key={step.title ?? step.type}
                 {...{
                   ...step,
-                  codeHeader:
-                    configType === 'replayOnboardingMobile' ? null : (
-                      <ReplayConfigToggle
-                        blockToggle={block}
-                        maskToggle={mask}
-                        onBlockToggle={() => setBlock(!block)}
-                        onMaskToggle={() => setMask(!mask)}
-                      />
-                    ),
+                  codeHeader: hideMaskBlockToggles ? null : (
+                    <ReplayConfigToggle
+                      blockToggle={block}
+                      maskToggle={mask}
+                      onBlockToggle={() => setBlock(!block)}
+                      onMaskToggle={() => setMask(!mask)}
+                    />
+                  ),
                 }}
               />
             ) : (

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -22,6 +22,7 @@ import TextOverflow from 'sentry/components/textOverflow';
 import {
   replayBackendPlatforms,
   replayFrontendPlatforms,
+  replayJsLoaderInstructionsPlatformList,
   replayMobilePlatforms,
   replayOnboardingPlatforms,
   replayPlatforms,
@@ -191,7 +192,7 @@ function OnboardingContent({
       .filter((p): p is PlatformKey => p !== 'javascript')
       .includes(currentProject.platform);
 
-  const defaultTab = backendPlatform ? 'jsLoader' : mobilePlatform ? 'mobile' : 'npm';
+  const defaultTab = backendPlatform ? 'jsLoader' : 'npm';
   const {getParamValue: setupMode, setParamValue: setSetupMode} = useUrlParams(
     'mode',
     defaultTab
@@ -229,7 +230,9 @@ function OnboardingContent({
     productType: 'replay',
   });
 
-  const showRadioButtons = !!docs?.replayOnboardingJsLoader;
+  const showRadioButtons =
+    currentProject.platform &&
+    replayJsLoaderInstructionsPlatformList.includes(currentProject.platform);
 
   const radioButtons = (
     <Header>
@@ -351,6 +354,7 @@ function OnboardingContent({
     <Fragment>
       {radioButtons}
       <ReplayOnboardingLayout
+        hideMaskBlockToggles={mobilePlatform}
         docsConfig={docs}
         dsn={dsn}
         activeProductSelection={[]}
@@ -358,13 +362,12 @@ function OnboardingContent({
         projectId={currentProject.id}
         projectSlug={currentProject.slug}
         configType={
-          mobilePlatform
-            ? 'replayOnboardingMobile'
-            : setupMode() === 'npm' || // switched to NPM option
-                (!setupMode() && defaultTab === 'npm') || // default value for FE frameworks when ?mode={...} in URL is not set yet
-                npmOnlyFramework // even if '?mode=jsLoader', only show npm instructions for FE frameworks
-              ? 'replayOnboardingNpm'
-              : 'replayOnboardingJsLoader'
+          setupMode() === 'npm' || // switched to NPM option
+          (!setupMode() && defaultTab === 'npm') || // default value for FE frameworks when ?mode={...} in URL is not set yet
+          npmOnlyFramework ||
+          mobilePlatform // even if '?mode=jsLoader', only show npm/default instructions for FE frameworks & mobile platforms
+            ? 'replayOnboarding'
+            : 'replayOnboardingJsLoader'
         }
       />
     </Fragment>

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -22,7 +22,6 @@ import TextOverflow from 'sentry/components/textOverflow';
 import {
   replayBackendPlatforms,
   replayFrontendPlatforms,
-  replayJsLoaderInstructionsPlatformList,
   replayMobilePlatforms,
   replayOnboardingPlatforms,
   replayPlatforms,
@@ -191,9 +190,6 @@ function OnboardingContent({
     replayFrontendPlatforms
       .filter((p): p is PlatformKey => p !== 'javascript')
       .includes(currentProject.platform);
-  const jsLoaderPlatform =
-    currentProject.platform &&
-    replayJsLoaderInstructionsPlatformList.includes(currentProject.platform);
 
   const defaultTab = backendPlatform ? 'jsLoader' : mobilePlatform ? 'mobile' : 'npm';
   const {getParamValue: setupMode, setParamValue: setSetupMode} = useUrlParams(
@@ -202,7 +198,6 @@ function OnboardingContent({
   );
 
   const showJsFrameworkInstructions = backendPlatform && setupMode() === 'npm';
-  const showRadioButtons = jsLoaderPlatform;
 
   const currentPlatform = currentProject.platform
     ? platforms.find(p => p.id === currentProject.platform) ?? otherPlatform
@@ -233,6 +228,8 @@ function OnboardingContent({
     orgSlug: organization.slug,
     productType: 'replay',
   });
+
+  const showRadioButtons = !!docs?.replayOnboardingJsLoader;
 
   const radioButtons = (
     <Header>

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -10,7 +10,6 @@ import {CompactSelect} from 'sentry/components/compactSelect';
 import RadioGroup from 'sentry/components/forms/controls/radioGroup';
 import IdBadge from 'sentry/components/idBadge';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {MobileBetaBanner} from 'sentry/components/onboarding/gettingStartedDoc/utils';
 import useCurrentProjectState from 'sentry/components/onboarding/gettingStartedDoc/utils/useCurrentProjectState';
 import {useLoadGettingStarted} from 'sentry/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted';
 import {PlatformOptionDropdown} from 'sentry/components/replaysOnboarding/platformOptionDropdown';
@@ -21,10 +20,10 @@ import type {CommonSidebarProps} from 'sentry/components/sidebar/types';
 import {SidebarPanelKey} from 'sentry/components/sidebar/types';
 import TextOverflow from 'sentry/components/textOverflow';
 import {
-  backend,
   replayBackendPlatforms,
   replayFrontendPlatforms,
   replayJsLoaderInstructionsPlatformList,
+  replayMobilePlatforms,
   replayOnboardingPlatforms,
   replayPlatforms,
 } from 'sentry/data/platformCategories';
@@ -162,6 +161,8 @@ function OnboardingContent({
   currentProject: Project;
   hasDocs: boolean;
 }) {
+  const organization = useOrganization();
+
   const jsFrameworkSelectOptions = replayJsFrameworkOptions().map(platform => {
     return {
       value: platform.id,
@@ -175,40 +176,33 @@ function OnboardingContent({
     };
   });
 
-  const organization = useOrganization();
   const [jsFramework, setJsFramework] = useState<{
     value: PlatformKey;
     label?: ReactNode;
     textValue?: string;
   }>(jsFrameworkSelectOptions[0]);
 
-  const defaultTab =
-    currentProject.platform && backend.includes(currentProject.platform)
-      ? 'jsLoader'
-      : 'npm';
-
-  const {getParamValue: setupMode, setParamValue: setSetupMode} = useUrlParams(
-    'mode',
-    defaultTab
-  );
-
-  const showJsFrameworkInstructions =
-    currentProject.platform &&
-    replayBackendPlatforms.includes(currentProject.platform) &&
-    setupMode() === 'npm';
-
+  const backendPlatform =
+    currentProject.platform && replayBackendPlatforms.includes(currentProject.platform);
+  const mobilePlatform =
+    currentProject.platform && replayMobilePlatforms.includes(currentProject.platform);
   const npmOnlyFramework =
     currentProject.platform &&
     replayFrontendPlatforms
       .filter((p): p is PlatformKey => p !== 'javascript')
       .includes(currentProject.platform);
-
-  const showRadioButtons =
+  const jsLoaderPlatform =
     currentProject.platform &&
     replayJsLoaderInstructionsPlatformList.includes(currentProject.platform);
 
-  const backendPlatforms =
-    currentProject.platform && replayBackendPlatforms.includes(currentProject.platform);
+  const defaultTab = backendPlatform ? 'jsLoader' : mobilePlatform ? 'mobile' : 'npm';
+  const {getParamValue: setupMode, setParamValue: setSetupMode} = useUrlParams(
+    'mode',
+    defaultTab
+  );
+
+  const showJsFrameworkInstructions = backendPlatform && setupMode() === 'npm';
+  const showRadioButtons = jsLoaderPlatform;
 
   const currentPlatform = currentProject.platform
     ? platforms.find(p => p.id === currentProject.platform) ?? otherPlatform
@@ -248,7 +242,7 @@ function OnboardingContent({
           choices={[
             [
               'npm',
-              backendPlatforms ? (
+              backendPlatform ? (
                 <PlatformSelect key="platform-select">
                   {tct('I use [platformSelect]', {
                     platformSelect: (
@@ -283,6 +277,7 @@ function OnboardingContent({
           onChange={setSetupMode}
         />
       ) : (
+        !mobilePlatform &&
         docs?.platformOptions &&
         !isProjKeysLoading && (
           <PlatformSelect>
@@ -303,22 +298,6 @@ function OnboardingContent({
         {radioButtons}
         <LoadingIndicator />
       </Fragment>
-    );
-  }
-
-  // TODO: remove once we have mobile replay onboarding
-  if (['android', 'react-native'].includes(currentPlatform.language)) {
-    return (
-      <MobileBetaBanner
-        link={`https://docs.sentry.io/platforms/${currentPlatform.language}/session-replay/`}
-      />
-    );
-  }
-  if (currentPlatform.language === 'apple') {
-    return (
-      <MobileBetaBanner
-        link={`https://docs.sentry.io/platforms/apple/guides/ios/session-replay/`}
-      />
     );
   }
 
@@ -382,11 +361,13 @@ function OnboardingContent({
         projectId={currentProject.id}
         projectSlug={currentProject.slug}
         configType={
-          setupMode() === 'npm' || // switched to NPM option
-          (!setupMode() && defaultTab === 'npm') || // default value for FE frameworks when ?mode={...} in URL is not set yet
-          npmOnlyFramework // even if '?mode=jsLoader', only show npm instructions for FE frameworks
-            ? 'replayOnboardingNpm'
-            : 'replayOnboardingJsLoader'
+          mobilePlatform
+            ? 'replayOnboardingMobile'
+            : setupMode() === 'npm' || // switched to NPM option
+                (!setupMode() && defaultTab === 'npm') || // default value for FE frameworks when ?mode={...} in URL is not set yet
+                npmOnlyFramework // even if '?mode=jsLoader', only show npm instructions for FE frameworks
+              ? 'replayOnboardingNpm'
+              : 'replayOnboardingJsLoader'
         }
       />
     </Fragment>

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -466,6 +466,7 @@ export const replayPlatforms: readonly PlatformKey[] = [
 export const replayOnboardingPlatforms: readonly PlatformKey[] = [
   ...replayFrontendPlatforms.filter(p => !['javascript-backbone'].includes(p)),
   ...replayBackendPlatforms,
+  ...replayMobilePlatforms,
 ];
 
 // These are the supported replay platforms that can also be set up using the JS loader.

--- a/static/app/gettingStartedDocs/android/android.tsx
+++ b/static/app/gettingStartedDocs/android/android.tsx
@@ -407,7 +407,7 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
             {
               label: 'Kotlin',
               value: 'kotlin',
-              language: 'kotlin',
+              language: 'java',
               code: getReplayConfigurationSnippet(),
             },
           ],

--- a/static/app/gettingStartedDocs/android/android.tsx
+++ b/static/app/gettingStartedDocs/android/android.tsx
@@ -367,7 +367,7 @@ const docs: Docs<PlatformOptions> = {
   crashReportOnboarding: feedbackOnboardingCrashApiJava,
   customMetricsOnboarding: getAndroidMetricsOnboarding(),
   platformOptions,
-  replayOnboardingMobile: replayOnboarding,
+  replayOnboarding,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/android/android.tsx
+++ b/static/app/gettingStartedDocs/android/android.tsx
@@ -323,7 +323,7 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
               code: getReplaySetupSnippetKotlin(params),
             },
             {
-              label: 'Xml',
+              label: 'XML',
               value: 'xml',
               language: 'xml',
               filename: 'AndroidManifest.xml',

--- a/static/app/gettingStartedDocs/android/android.tsx
+++ b/static/app/gettingStartedDocs/android/android.tsx
@@ -310,16 +310,74 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
   install: (params: Params) => [
     {
       type: StepType.INSTALL,
-      description: t(
-        'Make sure your Sentry Android SDK version is at least 7.12.0. To set up the integration, add the following to your Sentry initialization.'
+      description: tct(
+        "Make sure your Sentry Android SDK version is at least 7.12.0. The easiest way to update through the Sentry Android Gradle plugin to your app module's [code:build.gradle] file.",
+        {code: <code />}
       ),
       configurations: [
         {
           code: [
             {
+              label: 'Groovy',
+              value: 'groovy',
+              language: 'groovy',
+              filename: 'app/build.gradle',
+              code: `plugins {
+  id "com.android.application"
+  id "io.sentry.android.gradle" version "4.11.0"
+}`,
+            },
+            {
               label: 'Kotlin',
               value: 'kotlin',
-              language: 'kotlin',
+              language: 'java',
+              filename: 'app/build.gradle.kts',
+              code: `plugins {
+  id("com.android.application")
+  id("io.sentry.android.gradle") version "4.11.0"
+}`,
+            },
+          ],
+        },
+        {
+          description: tct(
+            'If you have the SDK installed without the Sentry Gradle Plugin, you can update the version directly in the [code:build.gradle] through:',
+            {code: <code />}
+          ),
+        },
+        {
+          code: [
+            {
+              label: 'Groovy',
+              value: 'groovy',
+              language: 'groovy',
+              filename: 'app/build.gradle',
+              code: `dependencies {
+    implementation 'io.sentry:sentry-android:7.14.0'
+}`,
+            },
+            {
+              label: 'Kotlin',
+              value: 'kotlin',
+              language: 'java',
+              filename: 'app/build.gradle.kts',
+              code: `dependencies {
+    implementation("io.sentry:sentry-android:7.14.0")
+}`,
+            },
+          ],
+        },
+        {
+          description: t(
+            'To set up the integration, add the following to your Sentry initialization:'
+          ),
+        },
+        {
+          code: [
+            {
+              label: 'Kotlin',
+              value: 'kotlin',
+              language: 'java',
               code: getReplaySetupSnippetKotlin(params),
             },
             {

--- a/static/app/gettingStartedDocs/android/android.tsx
+++ b/static/app/gettingStartedDocs/android/android.tsx
@@ -12,6 +12,7 @@ import type {
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {MobileBetaBanner} from 'sentry/components/onboarding/gettingStartedDoc/utils';
 import {getAndroidMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
+import {getReplayMobileConfigureDescription} from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
 import {feedbackOnboardingCrashApiJava} from 'sentry/gettingStartedDocs/java/java';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
@@ -336,17 +337,9 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
   configure: () => [
     {
       type: StepType.CONFIGURE,
-      description: tct(
-        'The SDK is aggressively redacting all text and images. We plan to add fine controls for redacting, but currently, we just allow either on or off. Learn more about configuring Session Replay by reading the [link:configuration docs].',
-        {
-          code: <code />,
-          link: (
-            <ExternalLink
-              href={'https://docs.sentry.io/platforms/android/session-replay/#privacy'}
-            />
-          ),
-        }
-      ),
+      description: getReplayMobileConfigureDescription({
+        link: 'https://docs.sentry.io/platforms/android/session-replay/#privacy',
+      }),
       configurations: [
         {
           description: t(

--- a/static/app/gettingStartedDocs/android/android.tsx
+++ b/static/app/gettingStartedDocs/android/android.tsx
@@ -324,17 +324,25 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
               filename: 'app/build.gradle',
               code: `plugins {
   id "com.android.application"
-  id "io.sentry.android.gradle" version "4.11.0"
+  id "io.sentry.android.gradle" version "${getPackageVersion(
+    params,
+    'sentry.java.android.gradle-plugin',
+    '4.11.0'
+  )}"
 }`,
             },
             {
               label: 'Kotlin',
               value: 'kotlin',
-              language: 'java',
+              language: 'kotlin',
               filename: 'app/build.gradle.kts',
               code: `plugins {
   id("com.android.application")
-  id("io.sentry.android.gradle") version "4.11.0"
+  id("io.sentry.android.gradle") version "${getPackageVersion(
+    params,
+    'sentry.java.android.gradle-plugin',
+    '4.11.0'
+  )}"
 }`,
             },
           ],
@@ -353,16 +361,24 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
               language: 'groovy',
               filename: 'app/build.gradle',
               code: `dependencies {
-    implementation 'io.sentry:sentry-android:7.14.0'
+    implementation 'io.sentry:sentry-android:${getPackageVersion(
+      params,
+      'sentry.java.android',
+      '7.14.0'
+    )}'
 }`,
             },
             {
               label: 'Kotlin',
               value: 'kotlin',
-              language: 'java',
+              language: 'kotlin',
               filename: 'app/build.gradle.kts',
               code: `dependencies {
-    implementation("io.sentry:sentry-android:7.14.0")
+    implementation("io.sentry:sentry-android:${getPackageVersion(
+      params,
+      'sentry.java.android',
+      '7.14.0'
+    )}")
 }`,
             },
           ],
@@ -377,7 +393,7 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
             {
               label: 'Kotlin',
               value: 'kotlin',
-              language: 'java',
+              language: 'kotlin',
               code: getReplaySetupSnippetKotlin(params),
             },
             {
@@ -407,7 +423,7 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
             {
               label: 'Kotlin',
               value: 'kotlin',
-              language: 'java',
+              language: 'kotlin',
               code: getReplayConfigurationSnippet(),
             },
           ],

--- a/static/app/gettingStartedDocs/apple/ios.tsx
+++ b/static/app/gettingStartedDocs/apple/ios.tsx
@@ -648,7 +648,11 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
               label: 'SPM',
               value: 'spm',
               language: 'swift',
-              code: `.package(url: "https://github.com/getsentry/sentry-cocoa", from: "8.36.0"),`,
+              code: `.package(url: "https://github.com/getsentry/sentry-cocoa", from: "${getPackageVersion(
+                params,
+                'sentry.cocoa',
+                '8.36.0'
+              )}"),`,
             },
             {
               label: 'CocoaPods',
@@ -660,7 +664,11 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
               label: 'Carthage',
               value: 'carthage',
               language: 'swift',
-              code: `github "getsentry/sentry-cocoa" "8.36.0"`,
+              code: `github "getsentry/sentry-cocoa" "${getPackageVersion(
+                params,
+                'sentry.cocoa',
+                '8.36.0'
+              )}"`,
             },
           ],
         },

--- a/static/app/gettingStartedDocs/apple/ios.tsx
+++ b/static/app/gettingStartedDocs/apple/ios.tsx
@@ -647,19 +647,19 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
             {
               label: 'SPM',
               value: 'spm',
-              language: 'spm',
+              language: 'swift',
               code: `.package(url: "https://github.com/getsentry/sentry-cocoa", from: "8.36.0"),`,
             },
             {
               label: 'Cocoapods',
               value: 'cocoapods',
-              language: 'cocoapods',
+              language: 'ruby',
               code: `pod update`,
             },
             {
               label: 'Carthage',
               value: 'carthage',
-              language: 'carthage',
+              language: 'swift',
               code: `github "getsentry/sentry-cocoa" "8.36.0"`,
             },
           ],

--- a/static/app/gettingStartedDocs/apple/ios.tsx
+++ b/static/app/gettingStartedDocs/apple/ios.tsx
@@ -688,7 +688,7 @@ const docs: Docs<PlatformOptions> = {
   crashReportOnboarding: appleFeedbackOnboarding,
   customMetricsOnboarding: metricsOnboarding,
   platformOptions,
-  replayOnboardingMobile: replayOnboarding,
+  replayOnboarding,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/apple/ios.tsx
+++ b/static/app/gettingStartedDocs/apple/ios.tsx
@@ -11,6 +11,7 @@ import type {
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {MobileBetaBanner} from 'sentry/components/onboarding/gettingStartedDoc/utils';
 import {metricTagsExplanation} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
+import {getReplayMobileConfigureDescription} from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
 import {appleFeedbackOnboarding} from 'sentry/gettingStartedDocs/apple/macos';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
@@ -657,19 +658,9 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
   configure: () => [
     {
       type: StepType.CONFIGURE,
-      description: tct(
-        'The SDK is aggressively redacting all text and images. We plan to add fine controls for redacting, but currently, we just allow either on or off. Learn more about configuring Session Replay by reading the [link:configuration docs].',
-        {
-          code: <code />,
-          link: (
-            <ExternalLink
-              href={
-                'https://docs.sentry.io/platforms/apple/guides/ios/session-replay/#privacy'
-              }
-            />
-          ),
-        }
-      ),
+      description: getReplayMobileConfigureDescription({
+        link: 'https://docs.sentry.io/platforms/apple/guides/ios/session-replay/#privacy',
+      }),
       configurations: [
         {
           description: t(

--- a/static/app/gettingStartedDocs/apple/ios.tsx
+++ b/static/app/gettingStartedDocs/apple/ios.tsx
@@ -639,9 +639,36 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
     {
       type: StepType.INSTALL,
       description: t(
-        'Make sure your Sentry Cocoa SDK version is at least 8.31.1. To set up the integration, add the following to your Sentry initialization.'
+        'Make sure your Sentry Cocoa SDK version is at least 8.31.1. If you already have the SDK installed, you can update it to the latest version with:'
       ),
       configurations: [
+        {
+          code: [
+            {
+              label: 'SPM',
+              value: 'spm',
+              language: 'spm',
+              code: `.package(url: "https://github.com/getsentry/sentry-cocoa", from: "8.36.0"),`,
+            },
+            {
+              label: 'Cocoapods',
+              value: 'cocoapods',
+              language: 'cocoapods',
+              code: `pod update`,
+            },
+            {
+              label: 'Carthage',
+              value: 'carthage',
+              language: 'carthage',
+              code: `github "getsentry/sentry-cocoa" "8.36.0"`,
+            },
+          ],
+        },
+        {
+          description: t(
+            'To set up the integration, add the following to your Sentry initialization:'
+          ),
+        },
         {
           code: [
             {

--- a/static/app/gettingStartedDocs/apple/ios.tsx
+++ b/static/app/gettingStartedDocs/apple/ios.tsx
@@ -651,7 +651,7 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
               code: `.package(url: "https://github.com/getsentry/sentry-cocoa", from: "8.36.0"),`,
             },
             {
-              label: 'Cocoapods',
+              label: 'CocoaPods',
               value: 'cocoapods',
               language: 'ruby',
               code: `pod update`,

--- a/static/app/gettingStartedDocs/capacitor/capacitor.tsx
+++ b/static/app/gettingStartedDocs/capacitor/capacitor.tsx
@@ -487,7 +487,7 @@ const docs: Docs<PlatformOptions> = {
   onboarding,
   platformOptions,
   feedbackOnboardingNpm: feedbackOnboarding,
-  replayOnboardingNpm: replayOnboarding,
+  replayOnboarding,
   crashReportOnboarding,
 };
 

--- a/static/app/gettingStartedDocs/electron/electron.tsx
+++ b/static/app/gettingStartedDocs/electron/electron.tsx
@@ -363,7 +363,7 @@ init({
 const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedbackOnboarding,
-  replayOnboardingNpm: replayOnboarding,
+  replayOnboarding,
   customMetricsOnboarding,
   crashReportOnboarding,
 };

--- a/static/app/gettingStartedDocs/javascript/angular.tsx
+++ b/static/app/gettingStartedDocs/javascript/angular.tsx
@@ -375,7 +375,7 @@ const crashReportOnboarding: OnboardingConfig = {
 const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedbackOnboarding,
-  replayOnboardingNpm: replayOnboarding,
+  replayOnboarding,
   customMetricsOnboarding: getJSMetricsOnboarding({getInstallConfig}),
   crashReportOnboarding,
 };

--- a/static/app/gettingStartedDocs/javascript/astro.tsx
+++ b/static/app/gettingStartedDocs/javascript/astro.tsx
@@ -377,7 +377,7 @@ const crashReportOnboarding: OnboardingConfig = {
 const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedbackOnboarding,
-  replayOnboardingNpm: replayOnboarding,
+  replayOnboarding,
   customMetricsOnboarding: getJSMetricsOnboarding({getInstallConfig}),
   crashReportOnboarding,
 };

--- a/static/app/gettingStartedDocs/javascript/ember.tsx
+++ b/static/app/gettingStartedDocs/javascript/ember.tsx
@@ -288,7 +288,7 @@ const crashReportOnboarding: OnboardingConfig = {
 const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedbackOnboarding,
-  replayOnboardingNpm: replayOnboarding,
+  replayOnboarding,
   customMetricsOnboarding: getJSMetricsOnboarding({getInstallConfig}),
   crashReportOnboarding,
 };

--- a/static/app/gettingStartedDocs/javascript/gatsby.tsx
+++ b/static/app/gettingStartedDocs/javascript/gatsby.tsx
@@ -322,7 +322,7 @@ const crashReportOnboarding: OnboardingConfig = {
 const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedbackOnboarding,
-  replayOnboardingNpm: replayOnboarding,
+  replayOnboarding,
   customMetricsOnboarding: getJSMetricsOnboarding({getInstallConfig}),
   crashReportOnboarding,
 };

--- a/static/app/gettingStartedDocs/javascript/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/javascript.tsx
@@ -289,7 +289,7 @@ const crashReportOnboarding: OnboardingConfig = {
 const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedbackOnboarding,
-  replayOnboardingNpm: replayOnboarding,
+  replayOnboarding,
   replayOnboardingJsLoader,
   customMetricsOnboarding: getJSMetricsOnboarding({getInstallConfig}),
   crashReportOnboarding,

--- a/static/app/gettingStartedDocs/javascript/nextjs.tsx
+++ b/static/app/gettingStartedDocs/javascript/nextjs.tsx
@@ -285,7 +285,7 @@ const crashReportOnboarding: OnboardingConfig = {
 const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedbackOnboarding,
-  replayOnboardingNpm: replayOnboarding,
+  replayOnboarding,
   customMetricsOnboarding: getJSMetricsOnboarding({
     getInstallConfig: getManualInstallConfig,
   }),

--- a/static/app/gettingStartedDocs/javascript/react.tsx
+++ b/static/app/gettingStartedDocs/javascript/react.tsx
@@ -314,7 +314,7 @@ const crashReportOnboarding: OnboardingConfig = {
 const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedbackOnboarding,
-  replayOnboardingNpm: replayOnboarding,
+  replayOnboarding,
   customMetricsOnboarding: getJSMetricsOnboarding({getInstallConfig}),
   crashReportOnboarding,
 };

--- a/static/app/gettingStartedDocs/javascript/remix.tsx
+++ b/static/app/gettingStartedDocs/javascript/remix.tsx
@@ -232,7 +232,7 @@ const crashReportOnboarding: OnboardingConfig = {
 const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedbackOnboarding,
-  replayOnboardingNpm: replayOnboarding,
+  replayOnboarding,
   customMetricsOnboarding: getJSMetricsOnboarding({getInstallConfig}),
   crashReportOnboarding,
 };

--- a/static/app/gettingStartedDocs/javascript/solid.tsx
+++ b/static/app/gettingStartedDocs/javascript/solid.tsx
@@ -314,7 +314,7 @@ const crashReportOnboarding: OnboardingConfig = {
 const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedbackOnboarding,
-  replayOnboardingNpm: replayOnboarding,
+  replayOnboarding,
   customMetricsOnboarding: getJSMetricsOnboarding({getInstallConfig}),
   crashReportOnboarding,
 };

--- a/static/app/gettingStartedDocs/javascript/solidstart.tsx
+++ b/static/app/gettingStartedDocs/javascript/solidstart.tsx
@@ -472,7 +472,7 @@ const crashReportOnboarding: OnboardingConfig = {
 const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedbackOnboarding,
-  replayOnboardingNpm: replayOnboarding,
+  replayOnboarding,
   customMetricsOnboarding: getJSMetricsOnboarding({getInstallConfig}),
   crashReportOnboarding,
 };

--- a/static/app/gettingStartedDocs/javascript/svelte.tsx
+++ b/static/app/gettingStartedDocs/javascript/svelte.tsx
@@ -311,7 +311,7 @@ const crashReportOnboarding: OnboardingConfig = {
 const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedbackOnboarding,
-  replayOnboardingNpm: replayOnboarding,
+  replayOnboarding,
   customMetricsOnboarding: getJSMetricsOnboarding({getInstallConfig}),
   crashReportOnboarding,
 };

--- a/static/app/gettingStartedDocs/javascript/sveltekit.tsx
+++ b/static/app/gettingStartedDocs/javascript/sveltekit.tsx
@@ -208,7 +208,7 @@ const crashReportOnboarding: OnboardingConfig = {
 const docs: Docs = {
   onboarding,
   feedbackOnboardingNpm: feedbackOnboarding,
-  replayOnboardingNpm: replayOnboarding,
+  replayOnboarding,
   customMetricsOnboarding: getJSMetricsOnboarding({getInstallConfig}),
   crashReportOnboarding,
 };

--- a/static/app/gettingStartedDocs/javascript/vue.tsx
+++ b/static/app/gettingStartedDocs/javascript/vue.tsx
@@ -384,7 +384,7 @@ const docs: Docs<PlatformOptions> = {
   onboarding,
   platformOptions,
   feedbackOnboardingNpm: feedbackOnboarding,
-  replayOnboardingNpm: replayOnboarding,
+  replayOnboarding,
   customMetricsOnboarding: getJSMetricsOnboarding({getInstallConfig}),
   crashReportOnboarding,
 };

--- a/static/app/gettingStartedDocs/react-native/react-native.tsx
+++ b/static/app/gettingStartedDocs/react-native/react-native.tsx
@@ -412,9 +412,36 @@ const replayOnboarding: OnboardingConfig = {
     {
       type: StepType.INSTALL,
       description: t(
-        'Make sure your Sentry React Native SDK version is at least 5.26.0. To set up the integration, add the following to your Sentry initialization.'
+        'Make sure your Sentry React Native SDK version is at least 5.26.0. If you already have the SDK installed, you can update it to the latest version with:'
       ),
       configurations: [
+        {
+          code: [
+            {
+              label: 'npm',
+              value: 'npm',
+              language: 'bash',
+              code: `npm install @sentry/react-native --save`,
+            },
+            {
+              label: 'yarn',
+              value: 'yarn',
+              language: 'bash',
+              code: `yarn add @sentry/react-native`,
+            },
+            {
+              label: 'pnpm',
+              value: 'pnpm',
+              language: 'bash',
+              code: `pnpm add @sentry/react-native`,
+            },
+          ],
+        },
+        {
+          description: t(
+            'To set up the integration, add the following to your Sentry initialization:'
+          ),
+        },
         {
           code: [
             {

--- a/static/app/gettingStartedDocs/react-native/react-native.tsx
+++ b/static/app/gettingStartedDocs/react-native/react-native.tsx
@@ -84,10 +84,7 @@ Sentry.init({
     replaysOnErrorSampleRate: 1.0,
   },
   integrations: [
-    Sentry.mobileReplayIntegration({
-      maskAllText: true,
-      maskAllImages: true,
-    }),
+    Sentry.mobileReplayIntegration(),
   ],
 });`;
 

--- a/static/app/gettingStartedDocs/react-native/react-native.tsx
+++ b/static/app/gettingStartedDocs/react-native/react-native.tsx
@@ -460,7 +460,7 @@ const docs: Docs = {
   feedbackOnboardingCrashApi,
   crashReportOnboarding: feedbackOnboardingCrashApi,
   customMetricsOnboarding: getReactNativeMetricsOnboarding({getInstallConfig}),
-  replayOnboardingMobile: replayOnboarding,
+  replayOnboarding,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/react-native/react-native.tsx
+++ b/static/app/gettingStartedDocs/react-native/react-native.tsx
@@ -15,6 +15,7 @@ import {
   getCrashReportInstallDescription,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {getReactNativeMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
+import {getReplayMobileConfigureDescription} from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
@@ -433,19 +434,9 @@ const replayOnboarding: OnboardingConfig = {
   configure: () => [
     {
       type: StepType.CONFIGURE,
-      description: tct(
-        'The SDK is aggressively redacting all text and images. We plan to add fine controls for redacting, but currently, we just allow either on or off. Learn more about configuring Session Replay by reading the [link:configuration docs].',
-        {
-          code: <code />,
-          link: (
-            <ExternalLink
-              href={
-                'https://docs.sentry.io/platforms/react-native/session-replay/#privacy'
-              }
-            />
-          ),
-        }
-      ),
+      description: getReplayMobileConfigureDescription({
+        link: 'https://docs.sentry.io/platforms/react-native/session-replay/#privacy',
+      }),
       configurations: [
         {
           description: t(

--- a/static/app/gettingStartedDocs/react-native/react-native.tsx
+++ b/static/app/gettingStartedDocs/react-native/react-native.tsx
@@ -78,7 +78,7 @@ const getReplaySetupSnippet = (params: Params) => `
 import * as Sentry from '@sentry/react-native';
 
 Sentry.init({
-  dsn = "${params.dsn.public}",
+  dsn: "${params.dsn.public}",
   _experiments: {
     replaysSessionSampleRate: 1.0,
     replaysOnErrorSampleRate: 1.0,


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/67695

### android:

https://github.com/user-attachments/assets/4ba7d3cc-b4a7-4678-8fe6-5c55baed873c


### react native:

https://github.com/user-attachments/assets/bb614c5d-6b55-4a97-b1db-a38e564cf0c1


### apple:

https://github.com/user-attachments/assets/6e30f742-13e2-498f-9d2b-261ad3c9dc18


