### PR TITLE
feat(eap): Use new schema for the MQL EAP bridge

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -67,7 +67,7 @@ rfc3986-validator>=0.1.1
 sentry-arroyo>=2.16.5
 sentry-kafka-schemas>=0.1.106
 sentry-ophio==0.2.7
-sentry-protos>=0.1.14
+sentry-protos>=0.1.15
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.9.1
 sentry-sdk>=2.12.0

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -67,7 +67,7 @@ rfc3986-validator>=0.1.1
 sentry-arroyo>=2.16.5
 sentry-kafka-schemas>=0.1.106
 sentry-ophio==0.2.7
-sentry-protos>=0.1.3
+sentry-protos>=0.1.14
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.9.1
 sentry-sdk>=2.12.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -185,7 +185,7 @@ sentry-forked-django-stubs==5.0.4.post1
 sentry-forked-djangorestframework-stubs==3.15.0.post1
 sentry-kafka-schemas==0.1.106
 sentry-ophio==0.2.7
-sentry-protos==0.1.14
+sentry-protos==0.1.15
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.1
 sentry-sdk==2.12.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -185,7 +185,7 @@ sentry-forked-django-stubs==5.0.4.post1
 sentry-forked-djangorestframework-stubs==3.15.0.post1
 sentry-kafka-schemas==0.1.106
 sentry-ophio==0.2.7
-sentry-protos==0.1.3
+sentry-protos==0.1.14
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.1
 sentry-sdk==2.12.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -126,7 +126,7 @@ s3transfer==0.10.0
 sentry-arroyo==2.16.5
 sentry-kafka-schemas==0.1.106
 sentry-ophio==0.2.7
-sentry-protos==0.1.14
+sentry-protos==0.1.15
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.1
 sentry-sdk==2.12.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -126,7 +126,7 @@ s3transfer==0.10.0
 sentry-arroyo==2.16.5
 sentry-kafka-schemas==0.1.106
 sentry-ophio==0.2.7
-sentry-protos==0.1.3
+sentry-protos==0.1.14
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.1
 sentry-sdk==2.12.0


### PR DESCRIPTION
This standardizes things between graphing and samples in such a way that a lot of logic can be reused in snuba