### PR TITLE
fix(issues): Clamp left side of key values at 50% max width

### DIFF
--- a/static/app/components/keyValueData/index.tsx
+++ b/static/app/components/keyValueData/index.tsx
@@ -249,6 +249,7 @@ export const Subject = styled('div')`
   grid-column: span 1;
   font-family: ${p => p.theme.text.familyMono};
   word-break: break-word;
+  min-width: 100px;
 `;
 
 const ValueSection = styled('div')<{hasEmptySubject: boolean; hasErrors: boolean}>`

--- a/static/app/components/keyValueData/index.tsx
+++ b/static/app/components/keyValueData/index.tsx
@@ -216,7 +216,7 @@ export const CardPanel = styled(Panel)`
   padding: ${space(0.75)};
   display: grid;
   column-gap: ${space(1.5)};
-  grid-template-columns: minmax(100px, auto) 1fr;
+  grid-template-columns: fit-content(50%) 1fr;
   font-size: ${p => p.theme.fontSizeSmall};
 `;
 


### PR DESCRIPTION
if you have a really long key minmax(100px, auto) allows the key to take almost the entire width. fit content finds the minimum size or 50% https://developer.mozilla.org/en-US/docs/Web/CSS/fit-content_function

fit-content is new to me so i'm not totally sure if there's a nicer option

before
![image](https://github.com/user-attachments/assets/57ef1505-5444-4757-bfc4-e01f24f3e4cd)



after
![image](https://github.com/user-attachments/assets/e481c14b-e7b5-4451-999f-c3ee157935f4)


