### PR TITLE
fix(custom-views): Fix rename functionality for custom tabs, update growingInput to use MutationObserver

### DIFF
--- a/static/app/components/growingInput.tsx
+++ b/static/app/components/growingInput.tsx
@@ -47,27 +47,10 @@ export const GrowingInput = forwardRef<HTMLInputElement, InputProps>(
 
     // If the input is controlled we resize it when the value prop changes
     useLayoutEffect(() => {
-      // This mutationObserver is used to resize the input if the inputRef's style changes
-      // It's necessary because the refs do not trigger useEffects
-      const observer = new MutationObserver(() => {
-        inputRef.current && resize(inputRef.current);
-      });
-
       if (isControlled && inputRef.current) {
         resize(inputRef.current);
       }
-
-      if (inputRef.current) {
-        observer.observe(inputRef.current, {
-          attributes: true,
-          attributeFilter: ['style'],
-        });
-      }
-
-      return () => {
-        observer.disconnect();
-      };
-    }, [props.value, props.placeholder, isControlled]);
+    }, [props.value, props.placeholder, isControlled, props.className, props.style]);
 
     // If the input is uncontrolled we resize it when the user types
     const handleChange = useCallback(

--- a/static/app/components/growingInput.tsx
+++ b/static/app/components/growingInput.tsx
@@ -47,9 +47,26 @@ export const GrowingInput = forwardRef<HTMLInputElement, InputProps>(
 
     // If the input is controlled we resize it when the value prop changes
     useLayoutEffect(() => {
+      // This mutationObserver is used to resize the input if the inputRef's style changes
+      // It's necessary because the refs do not trigger useEffects
+      const observer = new MutationObserver(() => {
+        inputRef.current && resize(inputRef.current);
+      });
+
       if (isControlled && inputRef.current) {
         resize(inputRef.current);
       }
+
+      if (inputRef.current) {
+        observer.observe(inputRef.current, {
+          attributes: true,
+          attributeFilter: ['style'],
+        });
+      }
+
+      return () => {
+        observer.disconnect();
+      };
     }, [props.value, props.placeholder, isControlled]);
 
     // If the input is uncontrolled we resize it when the user types

--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
@@ -319,6 +319,7 @@ export function DraggableTabBar({
               isEditing={editingTabKey === tab.key}
               setIsEditing={isEditing => setEditingTabKey(isEditing ? tab.key : null)}
               onChange={newLabel => handleOnTabRenamed(newLabel.trim(), tab.key)}
+              isSelected={tabListState?.selectedKey === tab.key}
             />
             {tab.key !== 'temporary-tab' && tab.queryCount !== undefined && (
               <StyledBadge>

--- a/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
@@ -1,25 +1,33 @@
 import {useEffect, useRef, useState} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
+import {FocusScope} from '@react-aria/focus';
 
 import {GrowingInput} from 'sentry/components/growingInput';
+
+interface EditableTabTitleProps {
+  isEditing: boolean;
+  isSelected: boolean;
+  label: string;
+  onChange: (newLabel: string) => void;
+  setIsEditing: (isEditing: boolean) => void;
+}
 
 function EditableTabTitle({
   label,
   onChange,
   isEditing,
+  isSelected,
   setIsEditing,
-}: {
-  isEditing: boolean;
-  label: string;
-  onChange: (newLabel: string) => void;
-  setIsEditing: (isEditing: boolean) => void;
-}) {
+}: EditableTabTitleProps) {
   const [inputValue, setInputValue] = useState(label);
 
+  const theme = useTheme();
   const inputRef = useRef<HTMLInputElement>(null);
   const isEmpty = !inputValue.trim();
 
-  const handleOnBlur = () => {
+  const handleOnBlur = (e: React.FocusEvent<HTMLInputElement, Element>) => {
+    e.preventDefault();
     const trimmedInputValue = inputValue.trim();
     if (!isEditing) {
       return;
@@ -37,9 +45,6 @@ function EditableTabTitle({
   };
 
   const handleOnKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      handleOnBlur();
-    }
     if (e.key === 'Escape') {
       setInputValue(label.trim());
       setIsEditing(false);
@@ -51,9 +56,9 @@ function EditableTabTitle({
 
   useEffect(() => {
     if (isEditing) {
-      setTimeout(() => {
-        inputRef?.current?.focus();
-      }, 0);
+      requestAnimationFrame(() => {
+        inputRef.current?.focus();
+      });
     }
   }, [isEditing, inputRef]);
 
@@ -61,16 +66,17 @@ function EditableTabTitle({
     setInputValue(e.target.value);
   };
 
-  return isEditing ? (
-    <StyledGrowingInput
-      value={inputValue}
-      onChange={handleOnChange}
-      onKeyDown={handleOnKeyDown}
-      onBlur={handleOnBlur}
-      ref={inputRef}
-    />
-  ) : (
-    <div style={{height: '20px'}}> {label}</div>
+  return (
+    <FocusScope>
+      <StyledGrowingInput
+        value={inputValue}
+        onChange={handleOnChange}
+        onKeyDown={handleOnKeyDown}
+        onBlur={handleOnBlur}
+        ref={inputRef}
+        style={{fontWeight: isSelected ? theme.fontWeightBold : theme.fontWeightNormal}}
+      />
+    </FocusScope>
   );
 }
 

--- a/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
@@ -1,7 +1,6 @@
-import {useEffect, useRef, useState} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
-import {FocusScope} from '@react-aria/focus';
 
 import {GrowingInput} from 'sentry/components/growingInput';
 
@@ -25,6 +24,10 @@ function EditableTabTitle({
   const theme = useTheme();
   const inputRef = useRef<HTMLInputElement>(null);
   const isEmpty = !inputValue.trim();
+
+  const memoizedStyles = useMemo(() => {
+    return {fontWeight: isSelected ? theme.fontWeightBold : theme.fontWeightNormal};
+  }, [isSelected, theme.fontWeightBold, theme.fontWeightNormal]);
 
   const handleOnBlur = (e: React.FocusEvent<HTMLInputElement, Element>) => {
     e.preventDefault();
@@ -68,18 +71,16 @@ function EditableTabTitle({
   };
 
   return (
-    <FocusScope>
-      <StyledGrowingInput
-        value={inputValue}
-        onChange={handleOnChange}
-        onKeyDown={handleOnKeyDown}
-        onDoubleClick={() => isSelected && setIsEditing(true)}
-        onBlur={handleOnBlur}
-        ref={inputRef}
-        style={{fontWeight: isSelected ? theme.fontWeightBold : theme.fontWeightNormal}}
-        isSelected={isSelected}
-      />
-    </FocusScope>
+    <StyledGrowingInput
+      value={inputValue}
+      onChange={handleOnChange}
+      onKeyDown={handleOnKeyDown}
+      onDoubleClick={() => isSelected && setIsEditing(true)}
+      onBlur={handleOnBlur}
+      ref={inputRef}
+      style={memoizedStyles}
+      isSelected={isSelected}
+    />
   );
 }
 

--- a/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
@@ -32,6 +32,7 @@ function EditableTabTitle({
     if (!isEditing) {
       return;
     }
+
     if (isEmpty) {
       setInputValue(label);
       setIsEditing(false);
@@ -72,9 +73,11 @@ function EditableTabTitle({
         value={inputValue}
         onChange={handleOnChange}
         onKeyDown={handleOnKeyDown}
+        onDoubleClick={() => isSelected && setIsEditing(true)}
         onBlur={handleOnBlur}
         ref={inputRef}
         style={{fontWeight: isSelected ? theme.fontWeightBold : theme.fontWeightNormal}}
+        isSelected={isSelected}
       />
     </FocusScope>
   );
@@ -82,14 +85,15 @@ function EditableTabTitle({
 
 export default EditableTabTitle;
 
-const StyledGrowingInput = styled(GrowingInput)`
+const StyledGrowingInput = styled(GrowingInput)<{isSelected: boolean}>`
   border: none;
   padding: 0;
   background: transparent;
   min-height: 0px;
   height: 20px;
-  cursor: pointer;
   border-radius: 0px;
+
+  cursor: ${p => (p.isSelected ? 'auto' : 'pointer')};
 
   &,
   &:focus,

--- a/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
@@ -70,7 +70,7 @@ function EditableTabTitle({
     setInputValue(e.target.value);
   };
 
-  return (
+  return isSelected ? (
     <StyledGrowingInput
       value={inputValue}
       onChange={handleOnChange}
@@ -81,6 +81,8 @@ function EditableTabTitle({
       style={memoizedStyles}
       isSelected={isSelected}
     />
+  ) : (
+    <div style={{height: '20px'}}>{label}</div>
   );
 }
 


### PR DESCRIPTION
This PR fixes the following issues with the rename function of tabs: 
1. Renaming worked maybe 10% of the time in safari 
2. Renaming would lose focus randomly sometimes 
3. Renaming would slightly shift the title and create a stutter animation 

Edit:
* Added support for double click to rename 
* There's still a bug where if you attempt to rename a tab before the issues stream has loaded, it will lose focus when the issue stream loads
