### PR TITLE
feat(issue-platform): handle edge case where api populates a default value

### DIFF
--- a/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.tsx
@@ -23,6 +23,7 @@ export type FieldFromSchema = Omit<Field, 'choices' | 'type'> & {
   choices?: Array<[any, string]>;
   default?: 'issue.title' | 'issue.description';
   depends_on?: string[];
+  skip_load_on_open?: boolean;
   uri?: string;
 };
 
@@ -125,7 +126,33 @@ export class SentryAppExternalForm extends Component<Props, State> {
         uri: config.uri,
       });
     }
+    // let the state update before we try and load the dependent options
+    setTimeout(() => {
+      this.tryAndLoadDependentOptions();
+    }, 0);
   }
+
+  tryAndLoadDependentOptions = () => {
+    const {required_fields, optional_fields} = this.state;
+
+    // first find every field where we don't load the values on open
+    const fieldsToLoad = [...(required_fields || []), ...(optional_fields || [])].filter(
+      field => field.skip_load_on_open
+    );
+
+    fieldsToLoad.forEach(field => {
+      if (field.depends_on && field.depends_on.length > 0) {
+        // check that we can load this field
+        const isReadyToLoad = field.depends_on.every(dependentField => {
+          return !!this.model.getValue(dependentField);
+        });
+        // if ready to load, trigger a field change to trigger the api request to load options
+        if (isReadyToLoad) {
+          this.handleFieldChange(field.depends_on[0]);
+        }
+      }
+    });
+  };
 
   onSubmitError = () => {
     const {action, appName} = this.props;


### PR DESCRIPTION
This fixes a bug where when we have a default value we don't load dependent fields on page load. To get the values to appear, the user has to re-select the field. Before:


https://github.com/user-attachments/assets/f8f6f863-c102-4ec5-b51e-ef0d1529b40a


After:

https://github.com/user-attachments/assets/6a717613-067f-45df-9f06-b43d42ed44d8

For Linear, this matters when there is only one team and sets that as a default.

Resolves issue: https://github.com/getsentry/sentry/issues/60097