### PR TITLE
fix(profiling): Include last bucket for profiles chart

### DIFF
--- a/static/app/utils/profiling/hooks/useProfileEventsStats.tsx
+++ b/static/app/utils/profiling/hooks/useProfileEventsStats.tsx
@@ -56,6 +56,7 @@ export function useProfileEventsStats<F extends string>({
       yAxis: yAxes,
       interval,
       query,
+      partial: 1,
     },
   };
 


### PR DESCRIPTION
If we exclude the last bucket, recent data won't show up until 1 full interval has elapsed.