### PR TITLE
ref(ui): Ignore interaction state layer prop types

### DIFF
--- a/static/app/components/interactionStateLayer.tsx
+++ b/static/app/components/interactionStateLayer.tsx
@@ -19,7 +19,8 @@ interface StateLayerProps extends React.HTMLAttributes<HTMLSpanElement> {
 
 const InteractionStateLayer = styled(
   (props: StateLayerProps) => {
-    const {children, as: Element = 'span', ...rest} = props;
+    // Prevent type checking of `rest` as it has hundreds of properties and is slow
+    const {children, as: Element = 'span', ...rest} = props as any;
 
     // Here, using `as` directly doesn't work because it loses the `role` prop. Instead, manually propagating the props does the right thing.
     return (


### PR DESCRIPTION
Destructuring props with `React.HTMLAttributes<HTMLSpanElement>` creates a new type with hundreds of complex properties that takes a while to type check. Casting it to any should be okay.

command used
```
npx tsc -p tsconfig.json --generateTrace traces
```

before
![image](https://github.com/user-attachments/assets/9313e430-ac84-44a2-a7c8-d7d14b06823e)

after
![image](https://github.com/user-attachments/assets/1489ea8a-1840-4aea-8b21-89dcf7a4e947)
