### PR TITLE
ref(ui): Add return types to useNavigate, useRouter

### DIFF
--- a/static/app/utils/useNavigate.tsx
+++ b/static/app/utils/useNavigate.tsx
@@ -24,7 +24,7 @@ interface ReactRouter3Navigate {
  *
  * @see https://reactrouter.com/hooks/use-navigate
  */
-export function useNavigate() {
+export function useNavigate(): ReactRouter3Navigate {
   // When running in test mode we still read from the legacy route context to
   // keep test compatability while we fully migrate to react router 6
   const useReactRouter6 = window.__SENTRY_USING_REACT_ROUTER_SIX && NODE_ENV !== 'test';

--- a/static/app/utils/useRouter.tsx
+++ b/static/app/utils/useRouter.tsx
@@ -17,7 +17,7 @@ import {useRoutes} from './useRoutes';
  *
  * react-router 6 does not include this hook.
  */
-function useRouter() {
+function useRouter(): InjectedRouter<any, any> {
   // When running in test mode we still read from the legacy route context to
   // keep test compatability while we fully migrate to react router 6
   const useReactRouter6 = window.__SENTRY_USING_REACT_ROUTER_SIX && NODE_ENV !== 'test';

--- a/static/app/utils/useRoutes.tsx
+++ b/static/app/utils/useRoutes.tsx
@@ -5,7 +5,7 @@ import {useMatches} from 'react-router-dom';
 import {NODE_ENV} from 'sentry/constants';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 
-export function useRoutes() {
+export function useRoutes(): PlainRoute<any>[] {
   // When running in test mode we still read from the legacy route context to
   // keep test compatability while we fully migrate to react router 6
   const useReactRouter6 = window.__SENTRY_USING_REACT_ROUTER_SIX && NODE_ENV !== 'test';


### PR DESCRIPTION
adding return types avoids circular type checking from the functions depending on each other