### PR TITLE
ref(jira): Add data model for Jira create issue metadata

### DIFF
--- a/fixtures/integrations/jira/stubs/createmeta_response.json
+++ b/fixtures/integrations/jira/stubs/createmeta_response.json
@@ -47,10 +47,12 @@
               "name": "Issue Type",
               "key": "issuetype",
               "hasDefaultValue": false,
-              "operations": ["set"]
+              "operations": ["set"],
+              "schema": { "type": "issuetype", "system": "issuetype" }
             },
             "labels": {
               "required": false,
+              "operations": ["add", "set", "remove"],
               "schema": {
                 "type": "array",
                 "items": "string",
@@ -89,6 +91,7 @@
             "customfield_10200": {
               "operations": ["set"],
               "required": false,
+              "key": "customfield_10200",
               "schema": {
                 "type": "option",
                 "custom": "com.codebarrel.jira.iconselectlist:icon-select-cf",
@@ -125,6 +128,7 @@
                 "customId": 10202
               },
               "name": "Feature",
+              "key": "customfield_10300",
               "hasDefaultValue": false,
               "operations": ["add", "set", "remove"],
               "allowedValues": [

--- a/src/sentry/integrations/jira/models/create_issue_metadata.py
+++ b/src/sentry/integrations/jira/models/create_issue_metadata.py
@@ -62,8 +62,8 @@ class JiraSchema:
     )
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "JiraSchema":
-        mapped_field_params = {
+    def from_dict(cls, data: dict[str, Any | None]) -> "JiraSchema":
+        mapped_field_params: dict[str, Any] = {
             new_name: data.get(new_name)
             for old_name, new_name in cls.__jira_schema_parameter_map
             if old_name in data
@@ -106,7 +106,7 @@ class JiraField:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "JiraField":
-        mapped_field_params = {
+        mapped_field_params: dict[str, Any] = {
             new_name: data.get(new_name)
             for old_name, new_name in cls.__jira_field_parameter_map
             if old_name in data
@@ -117,18 +117,8 @@ class JiraField:
         return cls(**mapped_field_params)
 
     @classmethod
-    def from_dict_list(cls, data: dict[dict[str, Any]]) -> list["JiraField"]:
+    def from_dict_list(cls, data: dict[str, dict[str, Any]]) -> list["JiraField"]:
         return [cls.from_dict(item) for item in data.values()]
-
-
-jira_issue_mapped_fields = {
-    "id": "id",
-    "description": "description",
-    "name": "name",
-    "subtask": "subtask",
-    "iconUrl": "icon_url",
-    "self": "url",
-}
 
 
 @dataclass(frozen=True)

--- a/src/sentry/integrations/jira/models/create_issue_metadata.py
+++ b/src/sentry/integrations/jira/models/create_issue_metadata.py
@@ -117,8 +117,8 @@ class JiraField:
         )
 
     @classmethod
-    def from_dict_list(cls, data: dict[str, dict[str, Any]]) -> list["JiraField"]:
-        return [cls.from_dict(item) for item in data.values()]
+    def from_dict_list(cls, data: dict[str, dict[str, Any]]) -> dict[str, "JiraField"]:
+        return {key: cls.from_dict(val) for key, val in data.items()}
 
 
 @dataclass(frozen=True)
@@ -129,7 +129,7 @@ class JiraIssueTypeMetadata:
     subtask: bool
     icon_url: str
     url: str
-    fields: list[JiraField]
+    fields: dict[str, JiraField]
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "JiraIssueTypeMetadata":

--- a/src/sentry/integrations/jira/models/create_issue_metadata.py
+++ b/src/sentry/integrations/jira/models/create_issue_metadata.py
@@ -51,16 +51,6 @@ class JiraSchema:
     non-aggregate types, this will be None
     """
 
-    __jira_schema_parameter_map = frozenset(
-        [
-            ("type", "type"),
-            ("custom", "custom"),
-            ("custom_id", "custom_id"),
-            ("system", "system"),
-            ("items", "items"),
-        ]
-    )
-
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "JiraSchema":
         schema_type = data["type"]
@@ -119,6 +109,16 @@ class JiraField:
     @classmethod
     def from_dict_list(cls, data: dict[str, dict[str, Any]]) -> dict[str, "JiraField"]:
         return {key: cls.from_dict(val) for key, val in data.items()}
+
+    def get_field_type(self) -> JiraSchemaTypes | None:
+        type: str | None = self.schema.schema_type
+        if type == JiraSchemaTypes.array:
+            type = self.schema.items
+
+        if type not in JiraSchemaTypes:
+            return None
+
+        return JiraSchemaTypes(type)
 
 
 @dataclass(frozen=True)

--- a/src/sentry/integrations/jira/models/create_issue_metadata.py
+++ b/src/sentry/integrations/jira/models/create_issue_metadata.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
@@ -52,7 +54,7 @@ class JiraSchema:
     """
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "JiraSchema":
+    def from_dict(cls, data: dict[str, Any]) -> JiraSchema:
         schema_type = data["type"]
         custom = data.get("custom")
         custom_id = data.get("custom_id")
@@ -64,7 +66,7 @@ class JiraSchema:
         )
 
     @classmethod
-    def from_dict_list(cls, data: list[dict[str, Any]]) -> list["JiraSchema"]:
+    def from_dict_list(cls, data: list[dict[str, Any]]) -> list[JiraSchema]:
         return [cls.from_dict(item) for item in data]
 
 
@@ -87,7 +89,7 @@ class JiraField:
         return self.schema.custom is not None
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "JiraField":
+    def from_dict(cls, data: dict[str, Any]) -> JiraField:
         required = data["required"]
         name = data["name"]
         key = data["key"]
@@ -107,7 +109,7 @@ class JiraField:
         )
 
     @classmethod
-    def from_dict_list(cls, data: dict[str, dict[str, Any]]) -> dict[str, "JiraField"]:
+    def from_dict_list(cls, data: dict[str, dict[str, Any]]) -> dict[str, JiraField]:
         return {key: cls.from_dict(val) for key, val in data.items()}
 
     def get_field_type(self) -> JiraSchemaTypes | None:
@@ -132,7 +134,7 @@ class JiraIssueTypeMetadata:
     fields: dict[str, JiraField]
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "JiraIssueTypeMetadata":
+    def from_dict(cls, data: dict[str, Any]) -> JiraIssueTypeMetadata:
         jira_id = data["id"]
         description = data["description"]
         name = data["name"]
@@ -154,7 +156,7 @@ class JiraIssueTypeMetadata:
         )
 
     @classmethod
-    def from_jira_meta_config(cls, meta_config: dict[str, Any]) -> list["JiraIssueTypeMetadata"]:
+    def from_jira_meta_config(cls, meta_config: dict[str, Any]) -> list[JiraIssueTypeMetadata]:
         issue_types_list = meta_config.get("issuetypes", {})
         issue_configs = [cls.from_dict(it) for it in issue_types_list]
 

--- a/src/sentry/integrations/jira/models/create_issue_metadata.py
+++ b/src/sentry/integrations/jira/models/create_issue_metadata.py
@@ -62,8 +62,8 @@ class JiraSchema:
     )
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any | None]) -> "JiraSchema":
-        schema_type = data.get("type")
+    def from_dict(cls, data: dict[str, Any]) -> "JiraSchema":
+        schema_type = data["type"]
         custom = data.get("custom")
         custom_id = data.get("custom_id")
         system = data.get("system")
@@ -91,19 +91,19 @@ class JiraField:
     name: str
     key: str
     operations: list[str]
-    has_default_value: bool = False
+    has_default_value: bool
 
     def is_custom_field(self) -> bool:
         return self.schema.custom is not None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "JiraField":
-        required = data.get("required")
-        name = data.get("name")
-        key = data.get("key")
-        operations = data.get("operations")
-        has_default_value = data.get("hasDefaultValue")
-        raw_schema = data.get("schema")
+        required = data["required"]
+        name = data["name"]
+        key = data["key"]
+        operations = data["operations"]
+        has_default_value = data.get("hasDefaultValue") or False
+        raw_schema = data["schema"]
 
         schema = JiraSchema.from_dict(raw_schema)
 
@@ -133,13 +133,13 @@ class JiraIssueTypeMetadata:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "JiraIssueTypeMetadata":
-        jira_id = data.get("id")
-        description = data.get("description")
-        name = data.get("name")
-        subtask = data.get("subtask")
-        icon_url = data.get("iconUrl")
-        url = data.get("self")
-        raw_fields = data.get("fields")
+        jira_id = data["id"]
+        description = data["description"]
+        name = data["name"]
+        subtask = data["subtask"]
+        icon_url = data["iconUrl"]
+        url = data["self"]
+        raw_fields = data["fields"]
 
         fields = JiraField.from_dict_list(raw_fields)
 

--- a/src/sentry/integrations/jira/models/schema_model.py
+++ b/src/sentry/integrations/jira/models/schema_model.py
@@ -1,0 +1,174 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+class JiraSchemaTypes(str, Enum):
+    string = "string"
+    option = "option"
+    array = "array"
+    user = "user"
+    issue_type = "issuetype"
+    issue_link = "issuelink"
+    project = "project"
+    date = "date"
+    team = "team"
+    number = "number"
+    any = "any"
+
+
+@dataclass(frozen=True)
+class JiraSchema:
+    type: str
+    """
+    The Field type. Possible types include:
+    - string
+    - array (has a corresponding `items` field with its subtype)
+    - user
+    - issuetype
+    - issuelink
+    - project (and PROJECT)
+    - date
+    - team
+    - any
+    """
+    custom: str | None = None
+    """
+    The very long custom field name corresponding to some namespace, plugin,
+    and custom field name.
+    """
+    custom_id: str | None = None
+    """
+    A unique identifier for a field on an issue, in the form of 'customfield_<int>'
+    """
+    system: str | None = None
+    """
+    TODO(Gabe): Figure out what this is used for
+    """
+    items: str | None = None
+    """
+    Specifies the subtype for aggregate type, such as `array`. For any
+    non-aggregate types, this will be None
+    """
+
+    __jira_schema_parameter_map = frozenset(
+        [
+            ("type", "type"),
+            ("custom", "custom"),
+            ("custom_id", "custom_id"),
+            ("system", "system"),
+            ("items", "items"),
+        ]
+    )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "JiraSchema":
+        mapped_field_params = {
+            new_name: data.get(new_name)
+            for old_name, new_name in cls.__jira_schema_parameter_map
+            if old_name in data
+        }
+
+        return cls(**mapped_field_params)
+
+    @classmethod
+    def from_dict_list(cls, data: list[dict[str, Any]]) -> list["JiraSchema"]:
+        return [cls.from_dict(item) for item in data]
+
+
+@dataclass(frozen=True)
+class JiraField:
+    """
+    Represents a Jira Issue Field, which is queried directly via Jira's issue
+    creation metadata API:
+    https://developer.atlassian.com/server/jira/platform/rest/v10000/api-group-issue/#api-api-2-issue-createmeta-projectidorkey-issuetypes-issuetypeid-get
+    """
+
+    required: bool
+    schema: JiraSchema
+    name: str
+    key: str
+    operations: list[str]
+    has_default_value: bool = False
+
+    __jira_field_parameter_map = frozenset(
+        [
+            ("required", "required"),
+            ("name", "name"),
+            ("key", "key"),
+            ("operations", "operations"),
+            ("hasDefaultValue", "has_default_value"),
+        ]
+    )
+
+    def is_custom_field(self) -> bool:
+        return self.schema.custom is not None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "JiraField":
+        mapped_field_params = {
+            new_name: data.get(new_name)
+            for old_name, new_name in cls.__jira_field_parameter_map
+            if old_name in data
+        }
+
+        mapped_field_params["schema"] = JiraSchema.from_dict(data["schema"])
+
+        return cls(**mapped_field_params)
+
+    @classmethod
+    def from_dict_list(cls, data: dict[dict[str, Any]]) -> list["JiraField"]:
+        return [cls.from_dict(item) for item in data.values()]
+
+
+jira_issue_mapped_fields = {
+    "id": "id",
+    "description": "description",
+    "name": "name",
+    "subtask": "subtask",
+    "iconUrl": "icon_url",
+    "self": "url",
+}
+
+
+@dataclass(frozen=True)
+class JiraIssueTypeMetadata:
+    id: str
+    description: str
+    name: str
+    subtask: bool
+    icon_url: str
+    url: str
+    fields: list[JiraField]
+    __jira_issue_mapped_fields = frozenset(
+        [
+            ("id", "id"),
+            ("description", "description"),
+            ("name", "name"),
+            ("subtask", "subtask"),
+            ("iconUrl", "icon_url"),
+            ("self", "url"),
+        ]
+    )
+
+    @classmethod
+    def from_jira_meta_config(cls, meta_config: dict[str, Any]) -> list["JiraIssueTypeMetadata"]:
+        issue_configs = []
+        issue_types_list = meta_config.get("issuetypes", {})
+
+        for issue_config in issue_types_list:
+            # Create a shallow copy of the config meta, without the "self" property,
+            # which we need to rename.
+            meta_config_clone = {
+                np: issue_config.get(op)
+                for op, np in cls.__jira_issue_mapped_fields
+                if op in issue_config
+            }
+
+            meta_config_clone["fields"] = []
+            if (fields := issue_config.get("fields")) is not None:
+                meta_config_clone["fields"] = JiraField.from_dict_list(fields)
+
+            issue_configs.append(cls(**meta_config_clone))
+
+        return issue_configs

--- a/tests/sentry/integrations/jira/models/test_jira_schema.py
+++ b/tests/sentry/integrations/jira/models/test_jira_schema.py
@@ -1,0 +1,13 @@
+from fixtures.integrations.jira.stub_client import StubJiraApiClient
+from sentry.integrations.jira.models.schema_model import JiraIssueTypeMetadata
+from sentry.testutils.cases import TestCase
+
+
+class TestJiraSchema(TestCase):
+    def test_schema_parsing(self):
+        create_meta = StubJiraApiClient().get_create_meta_for_project("proj-1")
+        issue_configs = JiraIssueTypeMetadata.from_jira_meta_config(create_meta)
+        assert len(issue_configs) == 1
+        assert issue_configs[0].name == "Bug"
+        assert issue_configs[0].id == "1"
+        assert len(issue_configs[0].fields) > 1

--- a/tests/sentry/integrations/jira/models/test_jira_schema.py
+++ b/tests/sentry/integrations/jira/models/test_jira_schema.py
@@ -1,5 +1,5 @@
 from fixtures.integrations.jira.stub_client import StubJiraApiClient
-from sentry.integrations.jira.models.schema_model import JiraIssueTypeMetadata
+from sentry.integrations.jira.models.create_issue_metadata import JiraIssueTypeMetadata
 from sentry.testutils.cases import TestCase
 
 


### PR DESCRIPTION
Adds Jira [Create Issue Metadata](https://developer.atlassian.com/server/jira/platform/jira-rest-api-example-discovering-meta-data-for-creating-issues-6291669/) specific classes to make our Jira integration code more type safe. This is a precursor to a refactor of our `create_issue` method, which is currently frail and often raises errors when attempting to create new issues due to incorrect data transformations for some custom fields, such as `Date`, `Development`, and `Team`.

I've verified this works on a full Jira configuration I've pulled from a test Jira instance with some of the custom fields described above.

## Next Steps:
- [ ] Wrap our `create_issue` flows in metrics to gather current failure rates
- [ ] Implement a new transform strategy that simplifies our current one
- [ ] Wrap the new `create_issue` transform implementation in a feature flag and monitor the metrics for failures when toggling it on
