### PR TITLE
chore(profiling): Clean up continuous profiling flags

### DIFF
--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -474,7 +474,6 @@ function ProfilingDurationRegressionIssueDetailsContent({
   event,
   project,
 }: Required<EventDetailsContentProps>) {
-  const organization = useOrganization();
   return (
     <RegressionEventContainer>
       <TransactionsDeltaProvider event={event} project={project}>
@@ -485,11 +484,9 @@ function ProfilingDurationRegressionIssueDetailsContent({
           <ErrorBoundary mini>
             <EventFunctionBreakpointChart event={event} />
           </ErrorBoundary>
-          {!organization.features.includes('continuous-profiling-compat') && (
-            <ErrorBoundary mini>
-              <EventAffectedTransactions event={event} group={group} project={project} />
-            </ErrorBoundary>
-          )}
+          <ErrorBoundary mini>
+            <EventAffectedTransactions event={event} group={group} project={project} />
+          </ErrorBoundary>
           <ErrorBoundary mini>
             <InterimSection
               type={SectionKey.REGRESSION_FLAMEGRAPH}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -472,16 +472,17 @@ function NodeActions(props: {
         (typeof eventSize === 'number' ? ` (${formatBytesBase10(eventSize, 0)})` : ''),
     };
 
-    const continuousProfileLink: MenuItemProps | null = profileLink
-      ? {
-          key: 'continuous-profile',
-          onAction: () => {
-            traceAnalytics.trackViewContinuousProfile(props.organization);
-            browserHistory.push(profileLink!);
-          },
-          label: t('Continuous Profile'),
-        }
-      : null;
+    const continuousProfileLink: MenuItemProps | null =
+      organization.features.includes('continuous-profiling-ui') && !profileLink
+        ? {
+            key: 'continuous-profile',
+            onAction: () => {
+              traceAnalytics.trackViewContinuousProfile(props.organization);
+              browserHistory.push(profileLink!);
+            },
+            label: t('Continuous Profile'),
+          }
+        : null;
 
     if (isTransactionNode(props.node)) {
       return [showInView, jsonDetails, continuousProfileLink].filter(TypeSafeBoolean);
@@ -503,7 +504,7 @@ function NodeActions(props: {
     }
 
     return [showInView];
-  }, [props, profileLink]);
+  }, [props, profileLink, organization.features]);
 
   return (
     <ActionsContainer>

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -419,17 +419,13 @@ function ProfilingTransactionsContent(props: ProfilingTabContentProps) {
   const cursor = decodeScalar(location.query.cursor);
   const query = decodeScalar(location.query.query, '');
 
-  const continuousProfilingCompat = organization.features.includes(
-    'continuous-profiling-compat'
-  );
-
   const transactions = useProfileEvents<FieldType>({
     cursor,
     fields,
     query,
     sort,
     referrer: 'api.profiling.landing-table',
-    continuousProfilingCompat,
+    continuousProfilingCompat: true,
   });
 
   const transactionsError =
@@ -484,14 +480,14 @@ function ProfilingTransactionsContent(props: ProfilingTabContentProps) {
         <ProfilingOnboardingCTA />
       ) : (
         <Fragment>
-          {organization.features.includes('continuous-profiling-compat') ? (
+          {organization.features.includes('continuous-profiling-ui') ? (
             <Fragment>
               <ProfilesChartWidget
                 chartHeight={150}
                 referrer="api.profiling.landing-chart"
                 userQuery={query}
                 selection={selection}
-                continuousProfilingCompat={continuousProfilingCompat}
+                continuousProfilingCompat
               />
               <SlowestFunctionsTable userQuery={query} />
             </Fragment>
@@ -502,7 +498,7 @@ function ProfilingTransactionsContent(props: ProfilingTabContentProps) {
                 referrer="api.profiling.landing-chart"
                 userQuery={query}
                 selection={selection}
-                continuousProfilingCompat={continuousProfilingCompat}
+                continuousProfilingCompat
               />
               <WidgetsContainer>
                 <LandingWidgetSelector


### PR DESCRIPTION
This cleans up the 2 feature flags for continuous profiling flags
- `continuous-profiling-compat` will be enabled for all orgs without continuous profiling to give them a UX compatible with both profiling modes
- `continuous-profiling-ui` will bee enabled for only orgs with continuous profiling to give them a UX compatible with continuous profiling