### PR TITLE
chore(feedback): add extra source tags to create_feedback_issue metrics

### DIFF
--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -166,7 +166,6 @@ def should_filter_feedback(event, project_id, source: FeedbackCreationSource):
             tags={
                 "reason": "missing_context",
                 "referrer": source.value,
-                "client_source": event["contexts"]["feedback"].get("source"),
             },
         )
         return True
@@ -177,7 +176,6 @@ def should_filter_feedback(event, project_id, source: FeedbackCreationSource):
             tags={
                 "reason": "unreal.unattended",
                 "referrer": source.value,
-                "client_source": event["contexts"]["feedback"].get("source"),
             },
         )
         return True
@@ -188,7 +186,6 @@ def should_filter_feedback(event, project_id, source: FeedbackCreationSource):
             tags={
                 "reason": "empty",
                 "referrer": source.value,
-                "client_source": event["contexts"]["feedback"].get("source"),
             },
         )
         return True

--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -163,26 +163,47 @@ def should_filter_feedback(event, project_id, source: FeedbackCreationSource):
     ):
         metrics.incr(
             "feedback.create_feedback_issue.filtered",
-            tags={"reason": "missing_context"},
+            tags={
+                "reason": "missing_context",
+                "referrer": source.value,
+                "client_source": event["contexts"]["feedback"].get("source"),
+            },
         )
         return True
 
     if event["contexts"]["feedback"]["message"] == UNREAL_FEEDBACK_UNATTENDED_MESSAGE:
         metrics.incr(
             "feedback.create_feedback_issue.filtered",
-            tags={"reason": "unreal.unattended"},
+            tags={
+                "reason": "unreal.unattended",
+                "referrer": source.value,
+                "client_source": event["contexts"]["feedback"].get("source"),
+            },
         )
         return True
 
     if event["contexts"]["feedback"]["message"].strip() == "":
-        metrics.incr("feedback.create_feedback_issue.filtered", tags={"reason": "empty"})
+        metrics.incr(
+            "feedback.create_feedback_issue.filtered",
+            tags={
+                "reason": "empty",
+                "referrer": source.value,
+                "client_source": event["contexts"]["feedback"].get("source"),
+            },
+        )
         return True
 
     return False
 
 
 def create_feedback_issue(event, project_id: int, source: FeedbackCreationSource):
-    metrics.incr("feedback.create_feedback_issue.entered")
+    metrics.incr(
+        "feedback.create_feedback_issue.entered",
+        tags={
+            "referrer": source.value,
+            "client_source": event["contexts"]["feedback"].get("source"),
+        },
+    )
 
     if should_filter_feedback(event, project_id, source):
         return
@@ -200,7 +221,11 @@ def create_feedback_issue(event, project_id: int, source: FeedbackCreationSource
             logger.exception("Error checking if message is spam")
         metrics.incr(
             "feedback.create_feedback_issue.spam_detection",
-            tags={"is_spam": is_message_spam},
+            tags={
+                "is_spam": is_message_spam,
+                "referrer": source.value,
+                "client_source": event["contexts"]["feedback"].get("source"),
+            },
             sample_rate=1.0,
         )
 
@@ -345,7 +370,11 @@ def shim_to_feedback(
             feedback_event["tags"] = [list(item) for item in event.tags]
 
         else:
-            metrics.incr("feedback.user_report.missing_event", sample_rate=1.0)
+            metrics.incr(
+                "feedback.user_report.missing_event",
+                sample_rate=1.0,
+                tags={"referrer": source.value},
+            )
 
             feedback_event["timestamp"] = datetime.utcnow().timestamp()
             feedback_event["platform"] = "other"

--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -198,7 +198,7 @@ def create_feedback_issue(event, project_id: int, source: FeedbackCreationSource
         "feedback.create_feedback_issue.entered",
         tags={
             "referrer": source.value,
-            "client_source": event["contexts"]["feedback"].get("source"),
+            "client_source": get_path(event, "contexts", "feedback", "source"),
         },
     )
 
@@ -221,7 +221,7 @@ def create_feedback_issue(event, project_id: int, source: FeedbackCreationSource
             tags={
                 "is_spam": is_message_spam,
                 "referrer": source.value,
-                "client_source": get_path(event, "contexts", "feedback", "source"),
+                "client_source": event["contexts"]["feedback"].get("source"),
             },
             sample_rate=1.0,
         )

--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -221,7 +221,7 @@ def create_feedback_issue(event, project_id: int, source: FeedbackCreationSource
             tags={
                 "is_spam": is_message_spam,
                 "referrer": source.value,
-                "client_source": event["contexts"]["feedback"].get("source"),
+                "client_source": get_path(event, "contexts", "feedback", "source"),
             },
             sample_rate=1.0,
         )


### PR DESCRIPTION
- `referrer`: identifies the pipeline feedback was ingested/shimmed from. See the enum + architecture doc
- `client_source`: "source" field optionally sent in new feedback envelopes. This is user/SDK-defined, current examples are "widget" vs "api". 