### PR TITLE
fix(custom-views): Reduce gap between selected and unselected tab to 1px (down from 4px)

### DIFF
--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -231,9 +231,12 @@ const TabDivider = styled(motion.div, {
     width: 1px;
     border-radius: 6px;
     margin-right: ${space(0.5)};
+    margin-left: ${space(0.5)};
   `}
+
+  ${p => !p.isVisible && `margin-left: 1px;`}
+
   margin-top: 1px;
-  margin-left: ${space(0.5)};
 `;
 
 const TabListOuterWrap = styled('div')<{


### PR DESCRIPTION
Reduces the gap between a selected tab and the hover state of an unselected tab from 4px to 1px. 

Before
![image](https://github.com/user-attachments/assets/a54a67ed-f971-448e-a7f2-d5638510f4c0)


After:
![image](https://github.com/user-attachments/assets/f26fbc68-cfad-4106-8234-6d12f4e874ec)
