### PR TITLE
feat(onboarding): frontend to allow members to delete sent invites

### DIFF
--- a/static/app/data/forms/organizationGeneralSettings.tsx
+++ b/static/app/data/forms/organizationGeneralSettings.tsx
@@ -94,7 +94,7 @@ const formGroups: JsonFormObject[] = [
       {
         name: 'allowMemberInvite',
         type: 'boolean',
-        label: t('Let Members Invite Freely'),
+        label: t('Let Members Invite Others'),
         help: t(
           'Allow organization members to invite other members via email without needing org owner or manager approval.'
         ),

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
@@ -104,7 +104,8 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
       canAddMembers,
     } = this.props;
 
-    const {id, flags, email, name, pending, user} = member;
+    const {id, flags, email, name, pending, user, inviterName} = member;
+    const {access} = organization;
 
     // if member is not the only owner, they can leave
     const isIdpProvisioned = flags['idp:provisioned'];
@@ -113,8 +114,14 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
     const isCurrentUser = currentUser.email === email;
     const showRemoveButton = !isCurrentUser;
     const showLeaveButton = isCurrentUser;
+    const isInvite = inviterName !== null;
+    const canRemoveInvite =
+      organization.features?.includes('members-invite-teammates') &&
+      access.includes('member:invite') &&
+      inviterName === currentUser.name;
     const canRemoveMember =
-      canRemoveMembers && !isCurrentUser && !isIdpProvisioned && !isPartnershipUser;
+      (canRemoveMembers && !isCurrentUser && !isIdpProvisioned && !isPartnershipUser) ||
+      canRemoveInvite;
     // member has a `user` property if they are registered with sentry
     // i.e. has accepted an invite to join org
     const has2fa = user?.has2fa;
@@ -204,7 +211,9 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
                       )
                     : isPartnershipUser
                       ? t('You cannot make changes to this partner-provisioned user.')
-                      : t('You do not have access to remove members')
+                      : isInvite
+                        ? t('Your role cannot modify this invite.')
+                        : t('You do not have access to remove members')
                 }
                 icon={<IconSubtract isCircled />}
               >


### PR DESCRIPTION
If members have permission to invite members to an organization (the org's `disable_member_invite` flag is false), we also want them to be able to remove invitations that they sent.

Enabled the Remove button for invites sent by the current user and  updated the tooltip message for invites that were sent by another user:
![Screenshot 2024-08-29 at 11 37 04 AM](https://github.com/user-attachments/assets/e7d54a38-ead1-4afb-9acd-6b8bdd1f9c42)
