### PR TITLE
chore(feedback): additional metrics for celery task and shim_to_feedback errors

### DIFF
--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -359,6 +359,7 @@ def shim_to_feedback(
         logger.exception(
             "Error attempting to create new User Feedback from Shiming old User Report"
         )
+        metrics.incr("feedback.shim_to_feedback.failed", tags={"referrer": source.value})
 
 
 def auto_ignore_spam_feedbacks(project, issue_fingerprint):


### PR DESCRIPTION
Gives us visibility on effectiveness+failures of update_user_reports task, and shim failures