### PR TITLE
fix(unmerge): Set status and substatus on unmerge

### DIFF
--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -164,6 +164,7 @@ def get_fingerprint(event: BaseEvent) -> str | None:
 
 
 def migrate_events(
+    source,
     caches,
     project,
     args: UnmergeArgs,
@@ -195,7 +196,7 @@ def migrate_events(
         destination = Group.objects.create(
             project_id=project.id,
             short_id=project.next_short_id(),
-            **get_group_creation_attributes(caches, events),
+            **get_group_creation_attributes(caches, source, events),
         )
 
         destination_id = destination.id
@@ -574,6 +575,7 @@ def unmerge(*posargs, **kwargs):
     for unmerge_key, _destination_events in destination_events.items():
         destination_id, eventstream_state = destinations.get(unmerge_key) or (None, None)
         (destination_id, eventstream_state) = migrate_events(
+            source,
             caches,
             project,
             args,

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -99,7 +99,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
         )
         events = [e1, e2, e3]
 
-        assert get_group_creation_attributes(get_caches(), events) == {
+        assert get_group_creation_attributes(get_caches(), e1.group, events) == {
             "active_at": now,
             "first_seen": now,
             "last_seen": now,
@@ -116,6 +116,8 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
                 "last_received": e1.data["received"],
                 "metadata": {"title": "Hello from JavaScript"},
             },
+            "status": e1.group.status,
+            "substatus": e1.group.substatus,
         }
 
     def test_get_group_backfill_attributes(self):


### PR DESCRIPTION
Explicitly set the status and substatus for new groups when unmerging issues. Today, if you unmerge from a resolved group, the new group is marked unresolved, but that behavior is counterintuitive. 

This also fixes an error where groups are created without an explicit substatus.

Fixes https://github.com/getsentry/sentry/issues/76753