### PR TITLE
fix(substatus): Remove default substatus for UNRESOLVED groups

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -963,28 +963,20 @@ class Group(Model):
 def pre_save_group_default_substatus(instance, sender, *args, **kwargs):
     # TODO(snigdha): Replace the logging with a ValueError once we are confident that this is working as expected.
     if instance:
+        if instance.status == GroupStatus.IGNORED:
+            if instance.substatus not in IGNORED_SUBSTATUS_CHOICES:
+                logger.error(
+                    "Invalid substatus for IGNORED group.", extra={"substatus": instance.substatus}
+                )
+        elif instance.status == GroupStatus.UNRESOLVED:
+            if instance.substatus not in UNRESOLVED_SUBSTATUS_CHOICES:
+                logger.error(
+                    "Invalid substatus for UNRESOLVED group",
+                    extra={"substatus": instance.substatus},
+                )
         # We only support substatuses for UNRESOLVED and IGNORED groups
-        if (
-            instance.status not in [GroupStatus.UNRESOLVED, GroupStatus.IGNORED]
-            and instance.substatus is not None
-        ):
+        elif instance.substatus is not None:
             logger.error(
                 "No substatus allowed for group",
                 extra={"status": instance.status, "substatus": instance.substatus},
-            )
-
-        if (
-            instance.status == GroupStatus.IGNORED
-            and instance.substatus not in IGNORED_SUBSTATUS_CHOICES
-        ):
-            logger.error(
-                "Invalid substatus for IGNORED group.", extra={"substatus": instance.substatus}
-            )
-
-        if (
-            instance.status == GroupStatus.UNRESOLVED
-            and instance.substatus not in UNRESOLVED_SUBSTATUS_CHOICES
-        ):
-            logger.error(
-                "Invalid substatus for UNRESOLVED group", extra={"substatus": instance.substatus}
             )

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -981,17 +981,10 @@ def pre_save_group_default_substatus(instance, sender, *args, **kwargs):
                 "Invalid substatus for IGNORED group.", extra={"substatus": instance.substatus}
             )
 
-        if instance.status == GroupStatus.UNRESOLVED:
-            if instance.substatus is None:
-                logger.warning(
-                    "no_substatus: Found UNRESOLVED group with no substatus",
-                    extra={"group_id": instance.id},
-                )
-                instance.substatus = GroupSubStatus.ONGOING
-
-            # UNRESOLVED groups must have a substatus
-            if instance.substatus not in UNRESOLVED_SUBSTATUS_CHOICES:
-                logger.error(
-                    "Invalid substatus for UNRESOLVED group",
-                    extra={"substatus": instance.substatus},
-                )
+        if (
+            instance.status == GroupStatus.UNRESOLVED
+            and instance.substatus not in UNRESOLVED_SUBSTATUS_CHOICES
+        ):
+            logger.error(
+                "Invalid substatus for UNRESOLVED group", extra={"substatus": instance.substatus}
+            )

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -312,8 +312,12 @@ class GroupTest(TestCase, SnubaTestCase):
 
         assert group2.get_last_release() is None
 
-    def test_group_substatus_defaults(self):
-        assert self.create_group(status=GroupStatus.UNRESOLVED).substatus is GroupSubStatus.ONGOING
+    @patch("sentry.models.group.logger.error")
+    def test_group_substatus_defaults(self, mock_logger):
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+        assert group.substatus is None
+        assert mock_logger.call_count == 1
+
         for nullable_status in (
             GroupStatus.IGNORED,
             GroupStatus.MUTED,


### PR DESCRIPTION
Fixed any instances of missing substatus that were surfaced by the existing warning log. Replacing the warning with an error log and removing the default.

Fixes https://github.com/getsentry/sentry/issues/76077 and https://github.com/getsentry/sentry/issues/76755