### PR TITLE
ref(alerts): Add support for dynamic crash rate alert

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -651,7 +651,7 @@ def create_alert_rule(
                 )
 
             try:
-                # XXX: if adding a new metric alert type, take care to check that it's handled here
+                # NOTE: if adding a new metric alert type, take care to check that it's handled here
                 rule_status = send_historical_data_to_seer(
                     alert_rule=alert_rule, project=projects[0]
                 )
@@ -918,7 +918,7 @@ def update_alert_rule(
                     setattr(alert_rule, k, v)
 
                 try:
-                    # XXX: if adding a new metric alert type, take care to check that it's handled here
+                    # NOTE: if adding a new metric alert type, take care to check that it's handled here
                     rule_status = send_historical_data_to_seer(
                         alert_rule=alert_rule,
                         project=projects[0] if projects else alert_rule.projects.get(),

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -651,6 +651,7 @@ def create_alert_rule(
                 )
 
             try:
+                # XXX: if adding a new metric alert type, take care to check that it's handled here
                 rule_status = send_historical_data_to_seer(
                     alert_rule=alert_rule, project=projects[0]
                 )
@@ -917,6 +918,7 @@ def update_alert_rule(
                     setattr(alert_rule, k, v)
 
                 try:
+                    # XXX: if adding a new metric alert type, take care to check that it's handled here
                     rule_status = send_historical_data_to_seer(
                         alert_rule=alert_rule,
                         project=projects[0] if projects else alert_rule.projects.get(),

--- a/src/sentry/seer/anomaly_detection/store_data.py
+++ b/src/sentry/seer/anomaly_detection/store_data.py
@@ -102,7 +102,6 @@ def send_historical_data_to_seer(alert_rule: AlertRule, project: Project) -> Ale
     if not historical_data:
         raise ValidationError("No historical data available.")
 
-    assert dataset
     formatted_data = format_historical_data(historical_data, dataset)
     if not formatted_data:
         raise ValidationError("Unable to get historical data for this alert.")

--- a/src/sentry/seer/anomaly_detection/store_data.py
+++ b/src/sentry/seer/anomaly_detection/store_data.py
@@ -4,8 +4,10 @@ from datetime import datetime, timedelta
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.utils import timezone
+from django.utils.datastructures import MultiValueDict
 from urllib3.exceptions import MaxRetryError, TimeoutError
 
+from sentry import release_health
 from sentry.conf.server import SEER_ANOMALY_DETECTION_STORE_DATA_URL
 from sentry.incidents.models.alert_rule import AlertRule, AlertRuleStatus
 from sentry.models.project import Project
@@ -19,8 +21,11 @@ from sentry.seer.anomaly_detection.types import (
 )
 from sentry.seer.anomaly_detection.utils import translate_direction
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
+from sentry.snuba import metrics_performance
+from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import SnubaQuery
 from sentry.snuba.referrer import Referrer
+from sentry.snuba.sessions_v2 import QueryDefinition
 from sentry.snuba.utils import get_dataset
 from sentry.utils import json
 from sentry.utils.snuba import SnubaTSResult
@@ -33,19 +38,32 @@ seer_anomaly_detection_connection_pool = connection_from_url(
 )
 
 
-def format_historical_data(data: SnubaTSResult) -> list[TimeSeriesPoint]:
+def format_historical_data(data: SnubaTSResult, dataset: Dataset) -> list[TimeSeriesPoint]:
     """
     Format Snuba data into the format the Seer API expects.
-    If there are no results, it's just the timestamp
-    {'time': 1719012000}, {'time': 1719018000}, {'time': 1719024000}
+    For errors data:
+        If there are no results, it's just the timestamp
+        {'time': 1719012000}, {'time': 1719018000}, {'time': 1719024000}
 
-    If there are results, the count is added
-    {'time': 1721300400, 'count': 2}
+        If there are results, the count is added
+        {'time': 1721300400, 'count': 2}
+
+    For metrics dataset data:
+        The count is stored separately from the timestamps, if there is no data the count is 0
     """
     formatted_data = []
-    for datum in data.data.get("data", []):
-        ts_point = TimeSeriesPoint(timestamp=datum.get("time"), value=datum.get("count", 0))
-        formatted_data.append(ts_point)
+
+    if dataset == metrics_performance:
+        for time, count in zip(
+            data.get("intervals"), data.get("groups")[0].get("series").get("sum(session)")
+        ):
+            date = datetime.strptime(time, "%Y-%m-%dT%H:%M:%SZ")
+            ts_point = TimeSeriesPoint(timestamp=date.timestamp(), value=count)
+            formatted_data.append(ts_point)
+    else:
+        for datum in data.data.get("data", []):
+            ts_point = TimeSeriesPoint(timestamp=datum.get("time"), value=datum.get("count", 0))
+            formatted_data.append(ts_point)
     return formatted_data
 
 
@@ -74,12 +92,13 @@ def send_historical_data_to_seer(alert_rule: AlertRule, project: Project) -> Ale
     """
     snuba_query = SnubaQuery.objects.get(id=alert_rule.snuba_query_id)
     window_min = int(snuba_query.time_window / 60)
+    dataset = get_dataset(snuba_query.dataset)
     historical_data = fetch_historical_data(alert_rule, snuba_query, project)
 
     if not historical_data:
         raise ValidationError("No historical data available.")
 
-    formatted_data = format_historical_data(historical_data)
+    formatted_data = format_historical_data(historical_data, dataset)
     if (
         not alert_rule.sensitivity
         or not alert_rule.seasonality
@@ -154,17 +173,47 @@ def fetch_historical_data(
     if not project or not dataset or not alert_rule.organization:
         return None
 
-    historical_data = dataset.timeseries_query(
-        selected_columns=[snuba_query.aggregate],
-        query=snuba_query.query,
-        snuba_params=SnubaParams(
-            organization=alert_rule.organization,
-            projects=[project],
-            start=start,
-            end=end,
-        ),
-        rollup=granularity,
-        referrer=Referrer.ANOMALY_DETECTION_HISTORICAL_DATA_QUERY.value,
-        zerofill_results=True,
-    )
+    if dataset == metrics_performance:
+        # do alerts other than crash rate ones use the metrics_perf dataset?
+        params = {
+            "start": start,
+            "end": end,
+            "project_id": [project.id],
+            "project_objects": [project],
+            "organization_id": alert_rule.organization.id,
+        }
+        query_params = MultiValueDict(
+            {
+                "project": [project.id],
+                "statsPeriod": [f"{NUM_DAYS}d"],
+                "field": ["sum(session)"],
+                "groupBy": ["release"],
+            }
+        )
+        query = QueryDefinition(
+            query=query_params,
+            params=params,
+            offset=None,
+            limit=None,
+            query_config=release_health.backend.sessions_query_config(alert_rule.organization),
+        )
+        # can I somehow push this through as a SnubaTSResult?
+        historical_data = release_health.backend.run_sessions_query(
+            alert_rule.organization.id, query, span_op="sessions.endpoint"
+        )
+
+    else:
+        historical_data = dataset.timeseries_query(
+            selected_columns=[snuba_query.aggregate],
+            query=snuba_query.query,
+            snuba_params=SnubaParams(
+                organization=alert_rule.organization,
+                projects=[project],
+                start=start,
+                end=end,
+            ),
+            rollup=granularity,
+            referrer=Referrer.ANOMALY_DETECTION_HISTORICAL_DATA_QUERY.value,
+            zerofill_results=True,
+        )
     return historical_data

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -2930,6 +2930,90 @@ class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetrics
             incident, [action_critical], [(85.0, IncidentStatus.CLOSED, mock.ANY)]
         )
 
+    @with_feature("organizations:anomaly-detection-alerts")
+    @mock.patch(
+        "sentry.incidents.subscription_processor.SubscriptionProcessor.seer_anomaly_detection_connection_pool.urlopen"
+    )
+    def test_dynamic_crash_rate_alert_for_sessions_with_auto_resolve_critical(
+        self, mock_seer_request
+    ):
+        """
+        Test that ensures that a dynamic critical alert is triggered when `crash_free_percentage` falls
+        below the Critical threshold and then is Resolved once `crash_free_percentage` goes above
+        the threshold (when no resolve_threshold is set)
+        """
+        # hellboy
+        rule = self.crash_rate_alert_rule
+        rule.update(
+            detection_type=AlertRuleDetectionType.DYNAMIC,
+            sensitivity=AlertRuleSensitivity.HIGH,
+            seasonality=AlertRuleSeasonality.AUTO,
+        )
+        trigger = self.crash_rate_alert_critical_trigger
+        trigger.update(alert_threshold=0)
+        # dynamic alert rules have a threshold of 0.0
+        rule.snuba_query.update(time_window=15 * 60)
+        action_critical = self.crash_rate_alert_critical_action
+
+        # Send Critical Update
+        seer_return_value = {
+            "anomalies": [
+                {
+                    "anomaly": {
+                        "anomaly_score": 0.7,
+                        "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
+                    },
+                    "timestamp": 1,
+                    "value": 10,
+                }
+            ]
+        }
+
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
+        update_value = (1 - trigger.alert_threshold / 100) + 0.05
+        processor = self.send_crash_rate_alert_update(
+            rule=rule,
+            value=update_value,
+            time_delta=timedelta(minutes=-2),
+            subscription=rule.snuba_query.subscriptions.filter(project=self.project).get(),
+        )
+        assert mock_seer_request.call_count == 1
+        assert rule.status == AlertRuleStatus.PENDING.value
+        self.assert_trigger_counts(processor, trigger, 0, 0)
+        incident = self.assert_active_incident(rule)
+        self.assert_actions_fired_for_incident(
+            incident, [action_critical], [(-5.0, IncidentStatus.CRITICAL, mock.ANY)]
+        )
+        self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.ACTIVE)
+
+        # Close the metric alert
+        seer_return_value = {
+            "anomalies": [
+                {
+                    "anomaly": {
+                        "anomaly_score": 0.2,
+                        "anomaly_type": AnomalyType.NONE.value,
+                    },
+                    "timestamp": 1,
+                    "value": 5,
+                }
+            ]
+        }
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
+        update_value = (1 - trigger.alert_threshold / 100) - 0.05
+        self.send_crash_rate_alert_update(
+            rule=rule,
+            value=update_value,
+            time_delta=timedelta(minutes=-1),
+            subscription=rule.snuba_query.subscriptions.filter(project=self.project).get(),
+        )
+        assert mock_seer_request.call_count == 2
+        assert rule.status == AlertRuleStatus.PENDING.value
+        self.assert_no_active_incident(rule)
+        self.assert_actions_resolved_for_incident(
+            incident, [action_critical], [(5.0, IncidentStatus.CLOSED, mock.ANY)]
+        )
+
     def test_crash_rate_alert_for_sessions_with_auto_resolve_warning(self):
         """
         Test that ensures that a Warning alert is triggered when `crash_free_percentage` falls

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -2942,7 +2942,6 @@ class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetrics
         below the Critical threshold and then is Resolved once `crash_free_percentage` goes above
         the threshold (when no resolve_threshold is set)
         """
-        # hellboy
         rule = self.crash_rate_alert_rule
         rule.update(
             detection_type=AlertRuleDetectionType.DYNAMIC,

--- a/tests/sentry/seer/anomaly_detection/test_store_data.py
+++ b/tests/sentry/seer/anomaly_detection/test_store_data.py
@@ -1,15 +1,31 @@
+import time
 from datetime import datetime
 
+import pytest
+
+from sentry.incidents.models.alert_rule import AlertRuleThresholdType
 from sentry.seer.anomaly_detection.store_data import fetch_historical_data, format_historical_data
+from sentry.snuba import errors, metrics_performance
+from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import SnubaQuery
-from sentry.testutils.cases import SnubaTestCase
+from sentry.testutils.cases import BaseMetricsTestCase
 from sentry.testutils.factories import EventType
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.utils.snuba import SnubaTSResult
 from tests.sentry.incidents.endpoints.test_organization_alert_rule_index import AlertRuleBase
 
+pytestmark = pytest.mark.sentry_metrics
 
-class AnomalyDetectionStoreDataTest(AlertRuleBase, SnubaTestCase):
+
+class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase):
+    def setUp(self):
+        super().setUp()
+        self.received = time.time()
+        self.session_started = time.time() // 60 * 60
+        self.session_release = "foo@1.0.0"
+        self.session_1 = "5d52fd05-fcc9-4bf3-9dc9-267783670341"
+        self.user_1 = "39887d89-13b2-4c84-8c23-5d13d2102666"
+
     def test_anomaly_detection_format_historical_data(self):
         time_1 = datetime.timestamp(
             before_now(days=1).replace(hour=10, minute=0, second=0, microsecond=0)
@@ -23,7 +39,7 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, SnubaTestCase):
         ]
         snuba_raw_data = [{"time": time_1}, {"time": time_2, "count": 1}]
         data = SnubaTSResult({"data": snuba_raw_data}, time_1, time_2, 3600)
-        result = format_historical_data(data)
+        result = format_historical_data(data, errors)
         assert result == expected_return_value
 
     def test_anomaly_detection_fetch_historical_data(self):
@@ -60,3 +76,57 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, SnubaTestCase):
         assert result
         assert {"time": int(datetime.timestamp(time_1)), "count": 1} in result.data.get("data")
         assert {"time": int(datetime.timestamp(time_2)), "count": 1} in result.data.get("data")
+
+    def test_anomaly_detection_format_historical_data_crash_rate_alert(self):
+        time_1 = "2024-08-29T00:00:00Z"
+        time_2 = "2024-08-29T02:00:00Z"
+        time_1_ts = datetime(2024, 8, 29, 0, 0).timestamp()
+        time_2_ts = datetime(2024, 8, 29, 2, 0).timestamp()
+        expected_return_value = [
+            {"timestamp": time_1_ts, "value": 0},
+            {"timestamp": time_2_ts, "value": 1},
+        ]
+        snuba_raw_data = {
+            "groups": [
+                {
+                    "by": {"release": self.session_release},
+                    "totals": {"sum(session)": 1},
+                    "series": {"sum(session)": [0, 1]},
+                }
+            ],
+            "start": time_1,
+            "end": time_2,
+            "intervals": [time_1, time_2],
+        }
+        # data = SnubaTSResult({"data": snuba_raw_data}, time_1, time_2, 3600)
+        result = format_historical_data(snuba_raw_data, metrics_performance)
+        assert result == expected_return_value
+
+    def test_anomaly_detection_fetch_historical_data_crash_rate_alert(self):
+        self.store_session(
+            self.build_session(
+                distinct_id=self.user_1,
+                session_id=self.session_1,
+                status="exited",
+                release=self.session_release,
+                environment="prod",
+                started=self.session_started,
+                received=self.received,
+            )
+        )
+
+        alert_rule = self.create_alert_rule(
+            projects=[self.project],
+            dataset=Dataset.Metrics,
+            name="JustAValidRule",
+            query="",
+            aggregate="percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
+            time_window=1,
+            threshold_type=AlertRuleThresholdType.BELOW,
+            threshold_period=1,
+        )
+        snuba_query = SnubaQuery.objects.get(id=alert_rule.snuba_query_id)
+        result = fetch_historical_data(alert_rule, snuba_query, self.project)
+        assert result
+        assert "2024-08-02T01:00:00Z" in result.get("intervals")  # this might be flaky
+        assert 1 in result.get("groups")[0].get("series").get("sum(session)")


### PR DESCRIPTION
Add support for a crash rate alert using anomaly detection. This requires a different snuba query.

Closes https://getsentry.atlassian.net/browse/ALRT-240