### PR TITLE
fix(issues): Avoid animating tags on initial load

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -1008,11 +1008,18 @@ describe('Performance > TransactionSummary', function () {
 
       await screen.findByText('Tag Summary');
 
+      // Expand environment tag
+      await userEvent.click(await screen.findByText('environment'));
+      // Select dev
       await userEvent.click(
         await screen.findByLabelText(
           'environment, dev, 100% of all events. View events with this tag value.'
         )
       );
+
+      // Expand foo tag
+      await userEvent.click(await screen.findByText('foo'));
+      // Select bar
       await userEvent.click(
         await screen.findByLabelText(
           'foo, bar, 100% of all events. View events with this tag value.'


### PR DESCRIPTION
On page load, the tags animate in and all are rendered regardless of if they're expanded or not. Using AnimatePresence allows us to avoid the initial render animation and skip rendering collapsed tags and their mouse listeners and tooltips.


example of route navigation causing a rerender that causes the tags to animate again even thought the data is unchanged.

https://github.com/user-attachments/assets/cfcda14a-732c-4990-92ef-13d782308e15

