### PR TITLE
test(ui): Use built-in test providers

### DIFF
--- a/static/app/views/discover/table/quickContext/issueContext.spec.tsx
+++ b/static/app/views/discover/table/quickContext/issueContext.spec.tsx
@@ -3,12 +3,10 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {RepositoryFixture} from 'sentry-fixture/repository';
 
-import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {GroupStatus} from 'sentry/types/group';
 import type {EventData} from 'sentry/utils/discover/eventView';
-import {QueryClientProvider} from 'sentry/utils/queryClient';
 
 import IssueContext from './issueContext';
 import {defaultRow} from './testUtils';
@@ -32,12 +30,7 @@ const mockedGroup = GroupFixture({
 
 const renderIssueContext = (dataRow: EventData = defaultRow) => {
   const organization = OrganizationFixture();
-  render(
-    <QueryClientProvider client={makeTestQueryClient()}>
-      <IssueContext dataRow={dataRow} organization={organization} />
-    </QueryClientProvider>,
-    {organization}
-  );
+  render(<IssueContext dataRow={dataRow} organization={organization} />, {organization});
 };
 
 describe('Quick Context Content Issue Column', function () {

--- a/static/app/views/performance/landing/metricsDataSwitcher.spec.tsx
+++ b/static/app/views/performance/landing/metricsDataSwitcher.spec.tsx
@@ -2,17 +2,20 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {addMetricsDataMock} from 'sentry-test/performance/addMetricsDataMock';
 import {initializeData} from 'sentry-test/performance/initializePerformanceData';
-import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {act, render, screen} from 'sentry-test/reactTestingLibrary';
 
 import TeamStore from 'sentry/stores/teamStore';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
-import {QueryClientProvider} from 'sentry/utils/queryClient';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 import {generatePerformanceEventView} from 'sentry/views/performance/data';
 import {PerformanceLanding} from 'sentry/views/performance/landing';
 
-function WrappedComponent({data, withStaticFilters = true}) {
+function WrappedComponent({
+  data,
+  withStaticFilters = true,
+}: {
+  data: any;
+  withStaticFilters?: boolean;
+}) {
   const eventView = generatePerformanceEventView(
     data.router.location,
     data.projects,
@@ -23,28 +26,24 @@ function WrappedComponent({data, withStaticFilters = true}) {
   );
 
   return (
-    <QueryClientProvider client={makeTestQueryClient()}>
-      <OrganizationContext.Provider value={data.organization}>
-        <MetricsCardinalityProvider
-          location={data.router.location}
-          organization={data.organization}
-        >
-          <PerformanceLanding
-            router={data.router}
-            organization={data.organization}
-            location={data.router.location}
-            eventView={eventView}
-            projects={data.projects}
-            selection={eventView.getPageFilters()}
-            onboardingProject={undefined}
-            handleSearch={() => {}}
-            handleTrendsClick={() => {}}
-            setError={() => {}}
-            withStaticFilters={withStaticFilters}
-          />
-        </MetricsCardinalityProvider>
-      </OrganizationContext.Provider>
-    </QueryClientProvider>
+    <MetricsCardinalityProvider
+      location={data.router.location}
+      organization={data.organization}
+    >
+      <PerformanceLanding
+        router={data.router}
+        organization={data.organization}
+        location={data.router.location}
+        eventView={eventView}
+        projects={data.projects}
+        selection={eventView.getPageFilters()}
+        onboardingProject={undefined}
+        handleSearch={() => {}}
+        handleTrendsClick={() => {}}
+        setError={() => {}}
+        withStaticFilters={withStaticFilters}
+      />
+    </MetricsCardinalityProvider>
   );
 }
 
@@ -133,7 +132,7 @@ describe('Performance > Landing > MetricsDataSwitcher', function () {
       features,
     });
 
-    wrapper = render(<WrappedComponent data={data} />);
+    wrapper = render(<WrappedComponent data={data} />, {organization: data.organization});
     expect(screen.getByTestId('performance-landing-v3')).toBeInTheDocument();
   });
 
@@ -146,7 +145,7 @@ describe('Performance > Landing > MetricsDataSwitcher', function () {
       features,
     });
 
-    wrapper = render(<WrappedComponent data={data} />);
+    wrapper = render(<WrappedComponent data={data} />, {organization: data.organization});
 
     expect(await screen.findByTestId('transaction-search-bar')).toBeInTheDocument();
   });
@@ -164,7 +163,7 @@ describe('Performance > Landing > MetricsDataSwitcher', function () {
       features,
     });
 
-    wrapper = render(<WrappedComponent data={data} />);
+    wrapper = render(<WrappedComponent data={data} />, {organization: data.organization});
 
     expect(await screen.findByTestId('transaction-search-bar')).toBeInTheDocument();
   });
@@ -182,7 +181,7 @@ describe('Performance > Landing > MetricsDataSwitcher', function () {
       features,
     });
 
-    wrapper = render(<WrappedComponent data={data} />);
+    wrapper = render(<WrappedComponent data={data} />, {organization: data.organization});
     expect(await screen.findByTestId('transaction-search-bar')).toBeInTheDocument();
     expect(
       await screen.findByTestId('landing-mep-alert-single-project-incompatible')
@@ -204,7 +203,7 @@ describe('Performance > Landing > MetricsDataSwitcher', function () {
       features,
     });
 
-    wrapper = render(<WrappedComponent data={data} />);
+    wrapper = render(<WrappedComponent data={data} />, {organization: data.organization});
     expect(await screen.findByTestId('transaction-search-bar')).toBeInTheDocument();
     expect(
       await screen.findByTestId('landing-mep-alert-multi-project-incompatible')
@@ -226,7 +225,7 @@ describe('Performance > Landing > MetricsDataSwitcher', function () {
       features,
     });
 
-    wrapper = render(<WrappedComponent data={data} />);
+    wrapper = render(<WrappedComponent data={data} />, {organization: data.organization});
     expect(await screen.findByTestId('transaction-search-bar')).toBeInTheDocument();
     expect(
       await screen.findByTestId('landing-mep-alert-multi-project-all-incompatible')
@@ -246,7 +245,7 @@ describe('Performance > Landing > MetricsDataSwitcher', function () {
       features,
     });
 
-    wrapper = render(<WrappedComponent data={data} />);
+    wrapper = render(<WrappedComponent data={data} />, {organization: data.organization});
     expect(await screen.findByTestId('transaction-search-bar')).toBeInTheDocument();
     expect(
       await screen.findByTestId('landing-mep-alert-unnamed-discover')
@@ -266,7 +265,7 @@ describe('Performance > Landing > MetricsDataSwitcher', function () {
       features,
     });
 
-    wrapper = render(<WrappedComponent data={data} />);
+    wrapper = render(<WrappedComponent data={data} />, {organization: data.organization});
     expect(await screen.findByTestId('transaction-search-bar')).toBeInTheDocument();
     expect(
       await screen.findByTestId('landing-mep-alert-unnamed-discover-or-set')
@@ -286,7 +285,7 @@ describe('Performance > Landing > MetricsDataSwitcher', function () {
       features,
     });
 
-    wrapper = render(<WrappedComponent data={data} />);
+    wrapper = render(<WrappedComponent data={data} />, {organization: data.organization});
     expect(await screen.findByTestId('transaction-search-bar')).toBeInTheDocument();
     expect(
       await screen.findByTestId('landing-mep-alert-unnamed-discover')

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -3,7 +3,6 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {TeamFixture} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {
   render,
   renderGlobalModal,
@@ -24,7 +23,6 @@ import {
   MEPSetting,
   MEPState,
 } from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
-import {QueryClientProvider} from 'sentry/utils/queryClient';
 import TransactionSummary from 'sentry/views/performance/transactionSummary/transactionOverview';
 
 const teams = [
@@ -80,14 +78,12 @@ function TestComponent({
   }
 
   return (
-    <QueryClientProvider client={makeTestQueryClient()}>
-      <MetricsCardinalityProvider
-        organization={props.organization}
-        location={props.location}
-      >
-        <TransactionSummary {...props} />
-      </MetricsCardinalityProvider>
-    </QueryClientProvider>
+    <MetricsCardinalityProvider
+      organization={props.organization}
+      location={props.location}
+    >
+      <TransactionSummary {...props} />
+    </MetricsCardinalityProvider>
   );
 }
 


### PR DESCRIPTION
just removes duplicate test providers that are included in our `render` function