### PR TITLE
feat(lpq): Add a probabilistic rate for lpq symbolication

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1001,6 +1001,13 @@ register(
 register(
     "store.symbolicate-event-lpq-always", type=Sequence, default=[], flags=FLAG_AUTOMATOR_MODIFIABLE
 )
+
+# Rate at which to send eligible projects to LPQ symbolicators. This is
+# intedended to test gradually phasing out the LPQ.
+register(
+    "store.symbolicate-event-lpq-rate", type=Float, default=1.0, flags=FLAG_AUTOMATOR_MODIFIABLE
+)
+
 register(
     "post_process.get-autoassign-owners", type=Sequence, default=[], flags=FLAG_AUTOMATOR_MODIFIABLE
 )

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1003,7 +1003,7 @@ register(
 )
 
 # Rate at which to send eligible projects to LPQ symbolicators. This is
-# intedended to test gradually phasing out the LPQ.
+# intended to test gradually phasing out the LPQ.
 register(
     "store.symbolicate-event-lpq-rate", type=Float, default=1.0, flags=FLAG_AUTOMATOR_MODIFIABLE
 )

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -66,7 +66,9 @@ def should_demote_symbolication(
 
     if always_lowpri:
         return True
-    elif settings.SENTRY_ENABLE_AUTO_LOW_PRIORITY_QUEUE:
+    elif settings.SENTRY_ENABLE_AUTO_LOW_PRIORITY_QUEUE and in_random_rollout(
+        "store.symbolicate-event-lpq-rate"
+    ):
         try:
             return realtime_metrics.is_lpq_project(platform, project_id)
         # realtime_metrics is empty in getsentry


### PR DESCRIPTION
With Symbolicator autoscaling now, we would like to phase out the LPQ. The first step is to gradually send events that should be on the LPQ to normal Symbolicators and see how the system copes.