### PR TITLE
ref(metrics): Remove span based metrics from dashboard and metrics page

### DIFF
--- a/static/app/components/metrics/mriSelect/index.tsx
+++ b/static/app/components/metrics/mriSelect/index.tsx
@@ -18,10 +18,7 @@ import {
   isTransactionMeasurement,
 } from 'sentry/utils/metrics';
 import {emptyMetricsQueryWidget} from 'sentry/utils/metrics/constants';
-import {
-  hasCustomMetricsExtractionRules,
-  hasMetricsNewInputs,
-} from 'sentry/utils/metrics/features';
+import {hasMetricsNewInputs} from 'sentry/utils/metrics/features';
 import {getReadableMetricType} from 'sentry/utils/metrics/formatters';
 import {formatMRI, isExtractedCustomMetric, parseMRI} from 'sentry/utils/metrics/mri';
 import {useBreakpoints} from 'sentry/utils/metrics/useBreakpoints';
@@ -164,7 +161,6 @@ export const MRISelect = memo(function MRISelect({
   const {projects} = useProjects();
   const mriMode = useMriMode();
   const [inputValue, setInputValue] = useState('');
-  const hasExtractionRules = hasCustomMetricsExtractionRules(organization);
   const breakpoints = useBreakpoints();
 
   const metricsWithDuplicateNames = useMetricsWithDuplicateNames(metricsMeta);
@@ -248,7 +244,7 @@ export const MRISelect = memo(function MRISelect({
         const parsedMRI = parseMRI(metric.mri);
         const isDuplicateWithDifferentUnit = metricsWithDuplicateNames.has(metric.mri);
         const isUnresolvedExtractedMetric = isExtractedCustomMetric(metric);
-        const showProjectBadge = hasExtractionRules && selectedProjects.length > 1;
+        const showProjectBadge = selectedProjects.length > 1;
         const projectToShow =
           selectedProjects.length > 1 && metric.projectIds.length === 1
             ? projects.find(p => metric.projectIds[0] === parseInt(p.id, 10))
@@ -281,9 +277,7 @@ export const MRISelect = memo(function MRISelect({
           !mriMode
         ) {
           trailingItems.push(
-            <CustomMetricInfoText key="text">
-              {hasExtractionRules ? t('Deprecated') : t('Custom')}
-            </CustomMetricInfoText>
+            <CustomMetricInfoText key="text">{t('Custom')}</CustomMetricInfoText>
           );
         }
         return {
@@ -310,7 +304,6 @@ export const MRISelect = memo(function MRISelect({
       }),
     [
       displayedMetrics,
-      hasExtractionRules,
       metricsWithDuplicateNames,
       mriMode,
       onTagClick,

--- a/static/app/components/modals/metricWidgetViewerModal.tsx
+++ b/static/app/components/modals/metricWidgetViewerModal.tsx
@@ -17,13 +17,9 @@ import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {getMetricsUrl} from 'sentry/utils/metrics';
 import {toDisplayType} from 'sentry/utils/metrics/dashboard';
-import {hasCustomMetricsExtractionRules} from 'sentry/utils/metrics/features';
 import {parseMRI} from 'sentry/utils/metrics/mri';
 import {MetricExpressionType} from 'sentry/utils/metrics/types';
-import {
-  useVirtualMetricsContext,
-  VirtualMetricsContextProvider,
-} from 'sentry/utils/metrics/virtualMetricsContext';
+import {useVirtualMetricsContext} from 'sentry/utils/metrics/virtualMetricsContext';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import type {
   DashboardMetricsEquation,
@@ -375,17 +371,7 @@ function MetricWidgetViewerModal({
   );
 }
 
-function WrappedMetricWidgetViewerModal(props: Props) {
-  return hasCustomMetricsExtractionRules(props.organization) ? (
-    <VirtualMetricsContextProvider>
-      <MetricWidgetViewerModal {...props} />
-    </VirtualMetricsContextProvider>
-  ) : (
-    <MetricWidgetViewerModal {...props} />
-  );
-}
-
-export default WrappedMetricWidgetViewerModal;
+export default MetricWidgetViewerModal;
 
 export const modalCss = css`
   width: 100%;

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -26,11 +26,7 @@ import {getFormattedDate} from 'sentry/utils/dates';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {AggregationOutputType} from 'sentry/utils/discover/fields';
 import {parseFunction} from 'sentry/utils/discover/fields';
-import {
-  hasCustomMetrics,
-  hasCustomMetricsExtractionRules,
-} from 'sentry/utils/metrics/features';
-import {VirtualMetricsContextProvider} from 'sentry/utils/metrics/virtualMetricsContext';
+import {hasCustomMetrics} from 'sentry/utils/metrics/features';
 import {hasOnDemandMetricWidgetFeature} from 'sentry/utils/onDemandMetrics/features';
 import {ExtractedMetricsTag} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {
@@ -282,25 +278,7 @@ class WidgetCard extends Component<Props, State> {
 
     if (widget.widgetType === WidgetType.METRICS) {
       if (hasCustomMetrics(organization)) {
-        return hasCustomMetricsExtractionRules(organization) ? (
-          <VirtualMetricsContextProvider>
-            <MetricWidgetCard
-              index={this.props.index}
-              isEditingDashboard={this.props.isEditingDashboard}
-              onEdit={this.props.onEdit}
-              onDelete={this.props.onDelete}
-              onDuplicate={this.props.onDuplicate}
-              router={this.props.router}
-              location={this.props.location}
-              organization={organization}
-              selection={selection}
-              widget={widget}
-              dashboardFilters={dashboardFilters}
-              renderErrorMessage={renderErrorMessage}
-              showContextMenu={this.props.showContextMenu}
-            />
-          </VirtualMetricsContextProvider>
-        ) : (
+        return (
           <MetricWidgetCard
             index={this.props.index}
             isEditingDashboard={this.props.isEditingDashboard}

--- a/static/app/views/metrics/createAlertModal.tsx
+++ b/static/app/views/metrics/createAlertModal.tsx
@@ -27,7 +27,6 @@ import {
   getMetricsInterval,
   isVirtualMetric,
 } from 'sentry/utils/metrics';
-import {hasCustomMetricsExtractionRules} from 'sentry/utils/metrics/features';
 import {formatMetricUsingUnit} from 'sentry/utils/metrics/formatters';
 import {
   formatMRI,
@@ -37,10 +36,7 @@ import {
 } from 'sentry/utils/metrics/mri';
 import type {MetricsQuery} from 'sentry/utils/metrics/types';
 import {useMetricsQuery} from 'sentry/utils/metrics/useMetricsQuery';
-import {
-  useVirtualMetricsContext,
-  VirtualMetricsContextProvider,
-} from 'sentry/utils/metrics/virtualMetricsContext';
+import {useVirtualMetricsContext} from 'sentry/utils/metrics/virtualMetricsContext';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
@@ -447,12 +443,6 @@ const StyledLoadingIndicator = styled(LoadingIndicator)`
 
 export function openCreateAlertModal(props: Props) {
   openModal(deps => {
-    return hasCustomMetricsExtractionRules(props.organization) ? (
-      <VirtualMetricsContextProvider>
-        <CreateAlertModal {...props} {...deps} />
-      </VirtualMetricsContextProvider>
-    ) : (
-      <CreateAlertModal {...props} {...deps} />
-    );
+    return <CreateAlertModal {...props} {...deps} />;
   });
 }

--- a/static/app/views/metrics/metrics.tsx
+++ b/static/app/views/metrics/metrics.tsx
@@ -5,8 +5,6 @@ import PageFiltersContainer from 'sentry/components/organizations/pageFilters/co
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {hasCustomMetricsExtractionRules} from 'sentry/utils/metrics/features';
-import {VirtualMetricsContextProvider} from 'sentry/utils/metrics/virtualMetricsContext';
 import useOrganization from 'sentry/utils/useOrganization';
 import {MetricsContextProvider, useMetricsContext} from 'sentry/views/metrics/context';
 import {MetricsLayout} from 'sentry/views/metrics/layout';
@@ -33,21 +31,13 @@ function Metrics() {
 
   return (
     <SentryDocumentTitle title={t('Metrics')} orgSlug={organization.slug}>
-      {hasCustomMetricsExtractionRules(organization) ? (
-        <VirtualMetricsContextProvider>
-          <MetricsContextProvider>
-            <WrappedPageFiltersContainer>
-              <MetricsLayout />
-            </WrappedPageFiltersContainer>
-          </MetricsContextProvider>
-        </VirtualMetricsContextProvider>
-      ) : (
+      {
         <MetricsContextProvider>
           <WrappedPageFiltersContainer>
             <MetricsLayout />
           </WrappedPageFiltersContainer>
         </MetricsContextProvider>
-      )}
+      }
     </SentryDocumentTitle>
   );
 }


### PR DESCRIPTION
Remove span based metrics functionality form dashboard and metrics page.
Will remove the `VirtualMetricsContextProvider` + usage in another PR. (As it is a lot)