### PR TITLE
fix(scrollbar): Make sidebar scrollbar nicer

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -865,6 +865,11 @@ const PrimaryItems = styled('div')`
   flex-direction: column;
   gap: 1px;
   -ms-overflow-style: -ms-autohiding-scrollbar;
+
+  scrollbar-color: ${p => p.theme.sidebar.scrollbarThumbColor}
+    ${p => p.theme.sidebar.scrollbarColorTrack};
+  scrollbar-width: ${p => p.theme.sidebar.scrollbarWidth};
+
   @media (max-height: 675px) and (min-width: ${p => p.theme.breakpoints.medium}) {
     border-bottom: 1px solid ${p => p.theme.sidebarBorder};
     padding-bottom: ${space(1)};

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -972,7 +972,7 @@ export const lightTheme = {
     ...commonTheme.sidebar,
     background: sidebarBackground.light,
     scrollbarWidth: 'thin',
-    scrollbarThumbColor: '#A0A0A0 ',
+    scrollbarThumbColor: '#A0A0A0',
     scrollbarColorTrack: 'rgba(45,26,50,92.42)', // end of the gradient which is used for background
   },
   sidebarGradient: `linear-gradient(294.17deg,${sidebarBackground.light} 35.57%,#452650 92.42%,#452650 92.42%)`,
@@ -1003,7 +1003,7 @@ export const darkTheme: Theme = {
     ...commonTheme.sidebar,
     background: sidebarBackground.dark,
     scrollbarWidth: 'thin',
-    scrollbarThumbColor: '#808080 ',
+    scrollbarThumbColor: '#808080',
     scrollbarColorTrack: '#1B1825', // end of the gradient which is used for background
   },
   sidebarGradient: `linear-gradient(180deg, ${sidebarBackground.dark} 0%, #1B1825 100%)`,

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -971,6 +971,9 @@ export const lightTheme = {
   sidebar: {
     ...commonTheme.sidebar,
     background: sidebarBackground.light,
+    scrollbarWidth: 'thin',
+    scrollbarThumbColor: '#A0A0A0 ',
+    scrollbarColorTrack: 'rgba(45,26,50,92.42)', // end of the gradient which is used for background
   },
   sidebarGradient: `linear-gradient(294.17deg,${sidebarBackground.light} 35.57%,#452650 92.42%,#452650 92.42%)`,
   sidebarBorder: 'transparent',
@@ -999,6 +1002,9 @@ export const darkTheme: Theme = {
   sidebar: {
     ...commonTheme.sidebar,
     background: sidebarBackground.dark,
+    scrollbarWidth: 'thin',
+    scrollbarThumbColor: '#808080 ',
+    scrollbarColorTrack: '#1B1825', // end of the gradient which is used for background
   },
   sidebarGradient: `linear-gradient(180deg, ${sidebarBackground.dark} 0%, #1B1825 100%)`,
   sidebarBorder: darkAliases.border,


### PR DESCRIPTION
Scrollbar on sidebar looks quite ugly compared to the rest of the UI. This PR is a fix to make the scrollbar looks nicer on Chrome and Firefox browsers. [Safari browser doesn't support used CSS properties](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color)

Current look
![image](https://github.com/user-attachments/assets/334b8901-9918-415a-bb35-10e772fa3930)

New look after changes
![image](https://github.com/user-attachments/assets/8f7f1de3-eb35-4e94-ba50-0983cca99f2d)
