### PR TITLE
fix(onboarding) conditionally show minimum version for profiling notice for all python packages

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/types.ts
+++ b/static/app/components/onboarding/gettingStartedDoc/types.ts
@@ -34,6 +34,11 @@ export type SelectedPlatformOptions<
   [key in keyof PlatformOptions]: PlatformOptions[key]['items'][number]['value'];
 };
 
+export enum DocsPageLocation {
+  ISSUES_PAGE = 0,
+  PROFILING_PAGE = 1,
+}
+
 export interface DocsParams<
   PlatformOptions extends BasePlatformOptions = BasePlatformOptions,
 > {
@@ -54,6 +59,10 @@ export interface DocsParams<
     screenshot?: boolean;
   };
   newOrg?: boolean;
+  /**
+   * The page where the docs are being displayed
+   */
+  page?: DocsPageLocation;
   replayOptions?: {
     block?: boolean;
     mask?: boolean;

--- a/static/app/components/onboarding/gettingStartedDoc/types.ts
+++ b/static/app/components/onboarding/gettingStartedDoc/types.ts
@@ -53,16 +53,16 @@ export interface DocsParams<
   projectId: Project['id'];
   projectSlug: Project['slug'];
   sourcePackageRegistries: {isLoading: boolean; data?: ReleaseRegistrySdk};
+  /**
+   * The page where the docs are being displayed
+   */
+  docsLocation?: DocsPageLocation;
   feedbackOptions?: {
     email?: boolean;
     name?: boolean;
     screenshot?: boolean;
   };
   newOrg?: boolean;
-  /**
-   * The page where the docs are being displayed
-   */
-  page?: DocsPageLocation;
   replayOptions?: {
     block?: boolean;
     mask?: boolean;

--- a/static/app/components/onboarding/gettingStartedDoc/types.ts
+++ b/static/app/components/onboarding/gettingStartedDoc/types.ts
@@ -35,7 +35,6 @@ export type SelectedPlatformOptions<
 };
 
 export enum DocsPageLocation {
-  ISSUES_PAGE = 0,
   PROFILING_PAGE = 1,
 }
 

--- a/static/app/components/profiling/profilingOnboardingSidebar.tsx
+++ b/static/app/components/profiling/profilingOnboardingSidebar.tsx
@@ -281,7 +281,7 @@ function ProfilingOnboardingContent(props: ProfilingOnboardingContentProps) {
     /**
      * Page where the docs will be rendered
      */
-    page: DocsPageLocation.PROFILING_PAGE,
+    docsLocation: DocsPageLocation.PROFILING_PAGE,
   };
 
   const steps = [

--- a/static/app/components/profiling/profilingOnboardingSidebar.tsx
+++ b/static/app/components/profiling/profilingOnboardingSidebar.tsx
@@ -7,7 +7,10 @@ import IdBadge from 'sentry/components/idBadge';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Step} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  DocsPageLocation,
+  type DocsParams,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {useLoadGettingStarted} from 'sentry/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted';
 import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 import {TaskSidebar} from 'sentry/components/sidebar/taskSidebar';
@@ -275,6 +278,10 @@ function ProfilingOnboardingContent(props: ProfilingOnboardingContentProps) {
     platformOptions: PROFILING_ONBOARDING_STEPS,
     newOrg: false,
     feedbackOptions: {},
+    /**
+     * Page where the docs will be rendered
+     */
+    page: DocsPageLocation.PROFILING_PAGE,
   };
 
   const steps = [

--- a/static/app/components/updatedEmptyState.tsx
+++ b/static/app/components/updatedEmptyState.tsx
@@ -74,7 +74,7 @@ export default function UpdatedEmptyState({project}: {project?: Project}) {
     platformOptions: {installationMode: 'auto'},
     newOrg: false,
     replayOptions: {block: true, mask: true},
-    page: DocsPageLocation.ISSUES_PAGE,
+    docsLocation: DocsPageLocation.ISSUES_PAGE,
   };
 
   if (currentPlatformKey === 'java' || currentPlatformKey === 'java-spring-boot') {

--- a/static/app/components/updatedEmptyState.tsx
+++ b/static/app/components/updatedEmptyState.tsx
@@ -8,10 +8,7 @@ import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {OnboardingCodeSnippet} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
 import {TabbedCodeSnippet} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import {
-  DocsPageLocation,
-  type DocsParams,
-} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {useSourcePackageRegistries} from 'sentry/components/onboarding/gettingStartedDoc/useSourcePackageRegistries';
 import {useLoadGettingStarted} from 'sentry/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted';
 import platforms from 'sentry/data/platforms';
@@ -74,7 +71,6 @@ export default function UpdatedEmptyState({project}: {project?: Project}) {
     platformOptions: {installationMode: 'auto'},
     newOrg: false,
     replayOptions: {block: true, mask: true},
-    docsLocation: DocsPageLocation.ISSUES_PAGE,
   };
 
   if (currentPlatformKey === 'java' || currentPlatformKey === 'java-spring-boot') {

--- a/static/app/components/updatedEmptyState.tsx
+++ b/static/app/components/updatedEmptyState.tsx
@@ -8,7 +8,10 @@ import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {OnboardingCodeSnippet} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
 import {TabbedCodeSnippet} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  DocsPageLocation,
+  type DocsParams,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {useSourcePackageRegistries} from 'sentry/components/onboarding/gettingStartedDoc/useSourcePackageRegistries';
 import {useLoadGettingStarted} from 'sentry/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted';
 import platforms from 'sentry/data/platforms';
@@ -71,6 +74,7 @@ export default function UpdatedEmptyState({project}: {project?: Project}) {
     platformOptions: {installationMode: 'auto'},
     newOrg: false,
     replayOptions: {block: true, mask: true},
+    page: DocsPageLocation.ISSUES_PAGE,
   };
 
   if (currentPlatformKey === 'java' || currentPlatformKey === 'java-spring-boot') {

--- a/static/app/gettingStartedDocs/python/aiohttp.tsx
+++ b/static/app/gettingStartedDocs/python/aiohttp.tsx
@@ -57,7 +57,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description:
-            params.page === DocsPageLocation.PROFILING_PAGE
+            params.docsLocation === DocsPageLocation.PROFILING_PAGE
               ? tct(
                   'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {

--- a/static/app/gettingStartedDocs/python/aiohttp.tsx
+++ b/static/app/gettingStartedDocs/python/aiohttp.tsx
@@ -59,7 +59,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/aiohttp.tsx
+++ b/static/app/gettingStartedDocs/python/aiohttp.tsx
@@ -59,7 +59,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/aiohttp.tsx
+++ b/static/app/gettingStartedDocs/python/aiohttp.tsx
@@ -1,9 +1,10 @@
 import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import type {
-  Docs,
-  DocsParams,
-  OnboardingConfig,
+import {
+  type Docs,
+  DocsPageLocation,
+  type DocsParams,
+  type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
@@ -55,15 +56,16 @@ const onboarding: OnboardingConfig = {
       }),
       configurations: [
         {
-          description: params.isProfilingSelected
-            ? tct(
-                'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
-                {
-                  codeVersion: <code />,
-                  codePackage: <code />,
-                }
-              )
-            : undefined,
+          description:
+            params.page === DocsPageLocation.PROFILING_PAGE
+              ? tct(
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  {
+                    codeVersion: <code />,
+                    codePackage: <code />,
+                  }
+                )
+              : undefined,
           language: 'bash',
           code: getInstallSnippet(),
         },

--- a/static/app/gettingStartedDocs/python/asgi.tsx
+++ b/static/app/gettingStartedDocs/python/asgi.tsx
@@ -85,7 +85,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/asgi.tsx
+++ b/static/app/gettingStartedDocs/python/asgi.tsx
@@ -1,9 +1,10 @@
 import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import type {
-  Docs,
-  DocsParams,
-  OnboardingConfig,
+import {
+  type Docs,
+  DocsPageLocation,
+  type DocsParams,
+  type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {crashReportOnboardingPython} from 'sentry/gettingStartedDocs/python/python';
@@ -81,15 +82,16 @@ const onboarding: OnboardingConfig = {
       }),
       configurations: [
         {
-          description: params.isProfilingSelected
-            ? tct(
-                'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
-                {
-                  codeVersion: <code />,
-                  codePackage: <code />,
-                }
-              )
-            : undefined,
+          description:
+            params.page === DocsPageLocation.PROFILING_PAGE
+              ? tct(
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  {
+                    codeVersion: <code />,
+                    codePackage: <code />,
+                  }
+                )
+              : undefined,
           language: 'bash',
           code: getInstallSnippet(),
         },

--- a/static/app/gettingStartedDocs/python/asgi.tsx
+++ b/static/app/gettingStartedDocs/python/asgi.tsx
@@ -83,7 +83,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description:
-            params.page === DocsPageLocation.PROFILING_PAGE
+            params.docsLocation === DocsPageLocation.PROFILING_PAGE
               ? tct(
                   'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {

--- a/static/app/gettingStartedDocs/python/asgi.tsx
+++ b/static/app/gettingStartedDocs/python/asgi.tsx
@@ -85,7 +85,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/awslambda.tsx
+++ b/static/app/gettingStartedDocs/python/awslambda.tsx
@@ -70,7 +70,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description:
-            params.page === DocsPageLocation.PROFILING_PAGE
+            params.docsLocation === DocsPageLocation.PROFILING_PAGE
               ? tct(
                   'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {

--- a/static/app/gettingStartedDocs/python/awslambda.tsx
+++ b/static/app/gettingStartedDocs/python/awslambda.tsx
@@ -72,7 +72,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/awslambda.tsx
+++ b/static/app/gettingStartedDocs/python/awslambda.tsx
@@ -3,10 +3,11 @@ import styled from '@emotion/styled';
 import Alert from 'sentry/components/alert';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import type {
-  Docs,
-  DocsParams,
-  OnboardingConfig,
+import {
+  type Docs,
+  DocsPageLocation,
+  type DocsParams,
+  type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {crashReportOnboardingPython} from 'sentry/gettingStartedDocs/python/python';
@@ -68,15 +69,16 @@ const onboarding: OnboardingConfig = {
       description: tct('Install our Python SDK using [code:pip]:', {code: <code />}),
       configurations: [
         {
-          description: params.isProfilingSelected
-            ? tct(
-                'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
-                {
-                  codeVersion: <code />,
-                  codePackage: <code />,
-                }
-              )
-            : undefined,
+          description:
+            params.page === DocsPageLocation.PROFILING_PAGE
+              ? tct(
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  {
+                    codeVersion: <code />,
+                    codePackage: <code />,
+                  }
+                )
+              : undefined,
           language: 'bash',
           code: getInstallSnippet(),
         },

--- a/static/app/gettingStartedDocs/python/awslambda.tsx
+++ b/static/app/gettingStartedDocs/python/awslambda.tsx
@@ -72,7 +72,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/bottle.tsx
+++ b/static/app/gettingStartedDocs/python/bottle.tsx
@@ -56,7 +56,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description:
-            params.page === DocsPageLocation.PROFILING_PAGE
+            params.docsLocation === DocsPageLocation.PROFILING_PAGE
               ? tct(
                   'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {

--- a/static/app/gettingStartedDocs/python/bottle.tsx
+++ b/static/app/gettingStartedDocs/python/bottle.tsx
@@ -58,7 +58,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/bottle.tsx
+++ b/static/app/gettingStartedDocs/python/bottle.tsx
@@ -1,9 +1,10 @@
 import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import type {
-  Docs,
-  DocsParams,
-  OnboardingConfig,
+import {
+  type Docs,
+  DocsPageLocation,
+  type DocsParams,
+  type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
@@ -54,15 +55,16 @@ const onboarding: OnboardingConfig = {
       ),
       configurations: [
         {
-          description: params.isProfilingSelected
-            ? tct(
-                'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
-                {
-                  codeVersion: <code />,
-                  codePackage: <code />,
-                }
-              )
-            : undefined,
+          description:
+            params.page === DocsPageLocation.PROFILING_PAGE
+              ? tct(
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  {
+                    codeVersion: <code />,
+                    codePackage: <code />,
+                  }
+                )
+              : undefined,
           language: 'bash',
           code: getInstallSnippet(),
         },

--- a/static/app/gettingStartedDocs/python/bottle.tsx
+++ b/static/app/gettingStartedDocs/python/bottle.tsx
@@ -58,7 +58,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/celery.tsx
+++ b/static/app/gettingStartedDocs/python/celery.tsx
@@ -61,7 +61,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/celery.tsx
+++ b/static/app/gettingStartedDocs/python/celery.tsx
@@ -59,7 +59,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description:
-            params.page === DocsPageLocation.PROFILING_PAGE
+            params.docsLocation === DocsPageLocation.PROFILING_PAGE
               ? tct(
                   'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {

--- a/static/app/gettingStartedDocs/python/celery.tsx
+++ b/static/app/gettingStartedDocs/python/celery.tsx
@@ -61,7 +61,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/celery.tsx
+++ b/static/app/gettingStartedDocs/python/celery.tsx
@@ -5,10 +5,11 @@ import Alert from 'sentry/components/alert';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import type {
-  Docs,
-  DocsParams,
-  OnboardingConfig,
+import {
+  type Docs,
+  DocsPageLocation,
+  type DocsParams,
+  type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {crashReportOnboardingPython} from 'sentry/gettingStartedDocs/python/python';
@@ -57,15 +58,16 @@ const onboarding: OnboardingConfig = {
       ),
       configurations: [
         {
-          description: params.isProfilingSelected
-            ? tct(
-                'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
-                {
-                  codeVersion: <code />,
-                  codePackage: <code />,
-                }
-              )
-            : undefined,
+          description:
+            params.page === DocsPageLocation.PROFILING_PAGE
+              ? tct(
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  {
+                    codeVersion: <code />,
+                    codePackage: <code />,
+                  }
+                )
+              : undefined,
           language: 'bash',
           code: getInstallSnippet(),
         },

--- a/static/app/gettingStartedDocs/python/chalice.tsx
+++ b/static/app/gettingStartedDocs/python/chalice.tsx
@@ -67,7 +67,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/chalice.tsx
+++ b/static/app/gettingStartedDocs/python/chalice.tsx
@@ -67,7 +67,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/chalice.tsx
+++ b/static/app/gettingStartedDocs/python/chalice.tsx
@@ -1,8 +1,9 @@
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import type {
-  Docs,
-  DocsParams,
-  OnboardingConfig,
+import {
+  type Docs,
+  DocsPageLocation,
+  type DocsParams,
+  type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {crashReportOnboardingPython} from 'sentry/gettingStartedDocs/python/python';
@@ -63,15 +64,16 @@ const onboarding: OnboardingConfig = {
       ),
       configurations: [
         {
-          description: params.isProfilingSelected
-            ? tct(
-                'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
-                {
-                  codeVersion: <code />,
-                  codePackage: <code />,
-                }
-              )
-            : undefined,
+          description:
+            params.page === DocsPageLocation.PROFILING_PAGE
+              ? tct(
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  {
+                    codeVersion: <code />,
+                    codePackage: <code />,
+                  }
+                )
+              : undefined,
           language: 'bash',
           code: getInstallSnippet(),
         },

--- a/static/app/gettingStartedDocs/python/chalice.tsx
+++ b/static/app/gettingStartedDocs/python/chalice.tsx
@@ -65,7 +65,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description:
-            params.page === DocsPageLocation.PROFILING_PAGE
+            params.docsLocation === DocsPageLocation.PROFILING_PAGE
               ? tct(
                   'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {

--- a/static/app/gettingStartedDocs/python/django.tsx
+++ b/static/app/gettingStartedDocs/python/django.tsx
@@ -48,7 +48,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description:
-            params.page === DocsPageLocation.PROFILING_PAGE
+            params.docsLocation === DocsPageLocation.PROFILING_PAGE
               ? tct(
                   'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {

--- a/static/app/gettingStartedDocs/python/django.tsx
+++ b/static/app/gettingStartedDocs/python/django.tsx
@@ -50,7 +50,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/django.tsx
+++ b/static/app/gettingStartedDocs/python/django.tsx
@@ -50,7 +50,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/django.tsx
+++ b/static/app/gettingStartedDocs/python/django.tsx
@@ -1,9 +1,10 @@
 import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import type {
-  Docs,
-  DocsParams,
-  OnboardingConfig,
+import {
+  type Docs,
+  DocsPageLocation,
+  type DocsParams,
+  type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
@@ -38,7 +39,7 @@ sentry_sdk.init(
 `;
 
 const onboarding: OnboardingConfig = {
-  install: () => [
+  install: (params: Params) => [
     {
       type: StepType.INSTALL,
       description: tct('Install [code:sentry-sdk] from PyPI:', {
@@ -46,6 +47,16 @@ const onboarding: OnboardingConfig = {
       }),
       configurations: [
         {
+          description:
+            params.page === DocsPageLocation.PROFILING_PAGE
+              ? tct(
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  {
+                    codeVersion: <code />,
+                    codePackage: <code />,
+                  }
+                )
+              : undefined,
           language: 'bash',
           code: getInstallSnippet(),
         },

--- a/static/app/gettingStartedDocs/python/falcon.tsx
+++ b/static/app/gettingStartedDocs/python/falcon.tsx
@@ -57,7 +57,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description:
-            params.page === DocsPageLocation.PROFILING_PAGE
+            params.docsLocation === DocsPageLocation.PROFILING_PAGE
               ? tct(
                   'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {

--- a/static/app/gettingStartedDocs/python/falcon.tsx
+++ b/static/app/gettingStartedDocs/python/falcon.tsx
@@ -59,7 +59,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/falcon.tsx
+++ b/static/app/gettingStartedDocs/python/falcon.tsx
@@ -59,7 +59,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/falcon.tsx
+++ b/static/app/gettingStartedDocs/python/falcon.tsx
@@ -1,9 +1,10 @@
 import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import type {
-  Docs,
-  DocsParams,
-  OnboardingConfig,
+import {
+  type Docs,
+  DocsPageLocation,
+  type DocsParams,
+  type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
@@ -55,15 +56,16 @@ const onboarding: OnboardingConfig = {
       ),
       configurations: [
         {
-          description: params.isProfilingSelected
-            ? tct(
-                'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
-                {
-                  codeVersion: <code />,
-                  codePackage: <code />,
-                }
-              )
-            : undefined,
+          description:
+            params.page === DocsPageLocation.PROFILING_PAGE
+              ? tct(
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  {
+                    codeVersion: <code />,
+                    codePackage: <code />,
+                  }
+                )
+              : undefined,
           language: 'bash',
           code: getInstallSnippet(),
         },

--- a/static/app/gettingStartedDocs/python/fastapi.tsx
+++ b/static/app/gettingStartedDocs/python/fastapi.tsx
@@ -57,7 +57,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description:
-            params.page === DocsPageLocation.PROFILING_PAGE
+            params.docsLocation === DocsPageLocation.PROFILING_PAGE
               ? tct(
                   'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {

--- a/static/app/gettingStartedDocs/python/fastapi.tsx
+++ b/static/app/gettingStartedDocs/python/fastapi.tsx
@@ -59,7 +59,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/fastapi.tsx
+++ b/static/app/gettingStartedDocs/python/fastapi.tsx
@@ -59,7 +59,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/fastapi.tsx
+++ b/static/app/gettingStartedDocs/python/fastapi.tsx
@@ -1,9 +1,10 @@
 import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import type {
-  Docs,
-  DocsParams,
-  OnboardingConfig,
+import {
+  type Docs,
+  DocsPageLocation,
+  type DocsParams,
+  type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
@@ -55,15 +56,16 @@ const onboarding: OnboardingConfig = {
       ),
       configurations: [
         {
-          description: params.isProfilingSelected
-            ? tct(
-                'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
-                {
-                  codeVersion: <code />,
-                  codePackage: <code />,
-                }
-              )
-            : undefined,
+          description:
+            params.page === DocsPageLocation.PROFILING_PAGE
+              ? tct(
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  {
+                    codeVersion: <code />,
+                    codePackage: <code />,
+                  }
+                )
+              : undefined,
           language: 'bash',
           code: getInstallSnippet(),
         },

--- a/static/app/gettingStartedDocs/python/flask.tsx
+++ b/static/app/gettingStartedDocs/python/flask.tsx
@@ -57,7 +57,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description:
-            params.page === DocsPageLocation.PROFILING_PAGE
+            params.docsLocation === DocsPageLocation.PROFILING_PAGE
               ? tct(
                   'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {

--- a/static/app/gettingStartedDocs/python/flask.tsx
+++ b/static/app/gettingStartedDocs/python/flask.tsx
@@ -59,7 +59,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/flask.tsx
+++ b/static/app/gettingStartedDocs/python/flask.tsx
@@ -59,7 +59,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/flask.tsx
+++ b/static/app/gettingStartedDocs/python/flask.tsx
@@ -1,9 +1,10 @@
 import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import type {
-  Docs,
-  DocsParams,
-  OnboardingConfig,
+import {
+  type Docs,
+  DocsPageLocation,
+  type DocsParams,
+  type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
@@ -55,15 +56,16 @@ const onboarding: OnboardingConfig = {
       ),
       configurations: [
         {
-          description: params.isProfilingSelected
-            ? tct(
-                'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
-                {
-                  codeVersion: <code />,
-                  codePackage: <code />,
-                }
-              )
-            : undefined,
+          description:
+            params.page === DocsPageLocation.PROFILING_PAGE
+              ? tct(
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  {
+                    codeVersion: <code />,
+                    codePackage: <code />,
+                  }
+                )
+              : undefined,
           language: 'bash',
           code: getInstallSnippet(),
         },

--- a/static/app/gettingStartedDocs/python/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/python/gcpfunctions.tsx
@@ -65,7 +65,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/python/gcpfunctions.tsx
@@ -63,7 +63,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description:
-            params.page === DocsPageLocation.PROFILING_PAGE
+            params.docsLocation === DocsPageLocation.PROFILING_PAGE
               ? tct(
                   'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {

--- a/static/app/gettingStartedDocs/python/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/python/gcpfunctions.tsx
@@ -3,10 +3,11 @@ import styled from '@emotion/styled';
 import Alert from 'sentry/components/alert';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import type {
-  Docs,
-  DocsParams,
-  OnboardingConfig,
+import {
+  type Docs,
+  DocsPageLocation,
+  type DocsParams,
+  type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {crashReportOnboardingPython} from 'sentry/gettingStartedDocs/python/python';
@@ -61,15 +62,16 @@ const onboarding: OnboardingConfig = {
       ),
       configurations: [
         {
-          description: params.isProfilingSelected
-            ? tct(
-                'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
-                {
-                  codeVersion: <code />,
-                  codePackage: <code />,
-                }
-              )
-            : undefined,
+          description:
+            params.page === DocsPageLocation.PROFILING_PAGE
+              ? tct(
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  {
+                    codeVersion: <code />,
+                    codePackage: <code />,
+                  }
+                )
+              : undefined,
           language: 'bash',
           code: getInstallSnippet(),
         },

--- a/static/app/gettingStartedDocs/python/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/python/gcpfunctions.tsx
@@ -65,7 +65,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/mongo.tsx
+++ b/static/app/gettingStartedDocs/python/mongo.tsx
@@ -54,7 +54,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/mongo.tsx
+++ b/static/app/gettingStartedDocs/python/mongo.tsx
@@ -54,7 +54,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/mongo.tsx
+++ b/static/app/gettingStartedDocs/python/mongo.tsx
@@ -1,9 +1,10 @@
 import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import type {
-  Docs,
-  DocsParams,
-  OnboardingConfig,
+import {
+  type Docs,
+  DocsPageLocation,
+  type DocsParams,
+  type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {crashReportOnboardingPython} from 'sentry/gettingStartedDocs/python/python';
@@ -50,15 +51,16 @@ const onboarding: OnboardingConfig = {
       ),
       configurations: [
         {
-          description: params.isProfilingSelected
-            ? tct(
-                'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
-                {
-                  codeVersion: <code />,
-                  codePackage: <code />,
-                }
-              )
-            : undefined,
+          description:
+            params.page === DocsPageLocation.PROFILING_PAGE
+              ? tct(
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  {
+                    codeVersion: <code />,
+                    codePackage: <code />,
+                  }
+                )
+              : undefined,
           language: 'bash',
           code: getInstallSnippet(),
         },

--- a/static/app/gettingStartedDocs/python/mongo.tsx
+++ b/static/app/gettingStartedDocs/python/mongo.tsx
@@ -52,7 +52,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description:
-            params.page === DocsPageLocation.PROFILING_PAGE
+            params.docsLocation === DocsPageLocation.PROFILING_PAGE
               ? tct(
                   'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -1,8 +1,9 @@
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import type {
-  Docs,
-  DocsParams,
-  OnboardingConfig,
+import {
+  type Docs,
+  DocsPageLocation,
+  type DocsParams,
+  type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
   getCrashReportBackendInstallStep,
@@ -47,15 +48,16 @@ const onboarding: OnboardingConfig = {
       }),
       configurations: [
         {
-          description: params.isProfilingSelected
-            ? tct(
-                'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
-                {
-                  codeVersion: <code />,
-                  codePackage: <code />,
-                }
-              )
-            : undefined,
+          description:
+            params.page === DocsPageLocation.PROFILING_PAGE
+              ? tct(
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  {
+                    codeVersion: <code />,
+                    codePackage: <code />,
+                  }
+                )
+              : undefined,
           language: 'bash',
           code: getInstallSnippet(),
         },

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -49,7 +49,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description:
-            params.page === DocsPageLocation.PROFILING_PAGE
+            params.docsLocation === DocsPageLocation.PROFILING_PAGE
               ? tct(
                   'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -51,7 +51,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -51,7 +51,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/quart.tsx
+++ b/static/app/gettingStartedDocs/python/quart.tsx
@@ -61,7 +61,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/quart.tsx
+++ b/static/app/gettingStartedDocs/python/quart.tsx
@@ -59,7 +59,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description:
-            params.page === DocsPageLocation.PROFILING_PAGE
+            params.docsLocation === DocsPageLocation.PROFILING_PAGE
               ? tct(
                   'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {

--- a/static/app/gettingStartedDocs/python/quart.tsx
+++ b/static/app/gettingStartedDocs/python/quart.tsx
@@ -61,7 +61,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/quart.tsx
+++ b/static/app/gettingStartedDocs/python/quart.tsx
@@ -1,9 +1,10 @@
 import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import type {
-  Docs,
-  DocsParams,
-  OnboardingConfig,
+import {
+  type Docs,
+  DocsPageLocation,
+  type DocsParams,
+  type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
@@ -57,15 +58,16 @@ const onboarding: OnboardingConfig = {
       ),
       configurations: [
         {
-          description: params.isProfilingSelected
-            ? tct(
-                'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
-                {
-                  codeVersion: <code />,
-                  codePackage: <code />,
-                }
-              )
-            : undefined,
+          description:
+            params.page === DocsPageLocation.PROFILING_PAGE
+              ? tct(
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  {
+                    codeVersion: <code />,
+                    codePackage: <code />,
+                  }
+                )
+              : undefined,
           language: 'bash',
           code: getInstallSnippet(),
         },

--- a/static/app/gettingStartedDocs/python/serverless.tsx
+++ b/static/app/gettingStartedDocs/python/serverless.tsx
@@ -80,7 +80,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/serverless.tsx
+++ b/static/app/gettingStartedDocs/python/serverless.tsx
@@ -2,10 +2,11 @@ import {Fragment} from 'react';
 
 import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import type {
-  Docs,
-  DocsParams,
-  OnboardingConfig,
+import {
+  type Docs,
+  DocsPageLocation,
+  type DocsParams,
+  type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {crashReportOnboardingPython} from 'sentry/gettingStartedDocs/python/python';
@@ -76,15 +77,16 @@ const onboarding: OnboardingConfig = {
       }),
       configurations: [
         {
-          description: params.isProfilingSelected
-            ? tct(
-                'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
-                {
-                  codeVersion: <code />,
-                  codePackage: <code />,
-                }
-              )
-            : undefined,
+          description:
+            params.page === DocsPageLocation.PROFILING_PAGE
+              ? tct(
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  {
+                    codeVersion: <code />,
+                    codePackage: <code />,
+                  }
+                )
+              : undefined,
           language: 'bash',
           code: getInstallSnippet(),
         },

--- a/static/app/gettingStartedDocs/python/serverless.tsx
+++ b/static/app/gettingStartedDocs/python/serverless.tsx
@@ -80,7 +80,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/serverless.tsx
+++ b/static/app/gettingStartedDocs/python/serverless.tsx
@@ -78,7 +78,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description:
-            params.page === DocsPageLocation.PROFILING_PAGE
+            params.docsLocation === DocsPageLocation.PROFILING_PAGE
               ? tct(
                   'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {

--- a/static/app/gettingStartedDocs/python/starlette.tsx
+++ b/static/app/gettingStartedDocs/python/starlette.tsx
@@ -57,7 +57,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description:
-            params.page === DocsPageLocation.PROFILING_PAGE
+            params.docsLocation === DocsPageLocation.PROFILING_PAGE
               ? tct(
                   'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {

--- a/static/app/gettingStartedDocs/python/starlette.tsx
+++ b/static/app/gettingStartedDocs/python/starlette.tsx
@@ -59,7 +59,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/starlette.tsx
+++ b/static/app/gettingStartedDocs/python/starlette.tsx
@@ -59,7 +59,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/starlette.tsx
+++ b/static/app/gettingStartedDocs/python/starlette.tsx
@@ -1,9 +1,10 @@
 import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import type {
-  Docs,
-  DocsParams,
-  OnboardingConfig,
+import {
+  type Docs,
+  DocsPageLocation,
+  type DocsParams,
+  type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
@@ -55,15 +56,16 @@ const onboarding: OnboardingConfig = {
       ),
       configurations: [
         {
-          description: params.isProfilingSelected
-            ? tct(
-                'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
-                {
-                  codeVersion: <code />,
-                  codePackage: <code />,
-                }
-              )
-            : undefined,
+          description:
+            params.page === DocsPageLocation.PROFILING_PAGE
+              ? tct(
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  {
+                    codeVersion: <code />,
+                    codePackage: <code />,
+                  }
+                )
+              : undefined,
           language: 'bash',
           code: getInstallSnippet(),
         },

--- a/static/app/gettingStartedDocs/python/tornado.tsx
+++ b/static/app/gettingStartedDocs/python/tornado.tsx
@@ -55,7 +55,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description:
-            params.page === DocsPageLocation.PROFILING_PAGE
+            params.docsLocation === DocsPageLocation.PROFILING_PAGE
               ? tct(
                   'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {

--- a/static/app/gettingStartedDocs/python/tornado.tsx
+++ b/static/app/gettingStartedDocs/python/tornado.tsx
@@ -1,9 +1,10 @@
 import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import type {
-  Docs,
-  DocsParams,
-  OnboardingConfig,
+import {
+  type Docs,
+  DocsPageLocation,
+  type DocsParams,
+  type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
@@ -53,15 +54,16 @@ const onboarding: OnboardingConfig = {
       ),
       configurations: [
         {
-          description: params.isProfilingSelected
-            ? tct(
-                'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
-                {
-                  codeVersion: <code />,
-                  codePackage: <code />,
-                }
-              )
-            : undefined,
+          description:
+            params.page === DocsPageLocation.PROFILING_PAGE
+              ? tct(
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  {
+                    codeVersion: <code />,
+                    codePackage: <code />,
+                  }
+                )
+              : undefined,
           language: 'bash',
           code: getInstallSnippet(),
         },

--- a/static/app/gettingStartedDocs/python/tornado.tsx
+++ b/static/app/gettingStartedDocs/python/tornado.tsx
@@ -57,7 +57,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/tornado.tsx
+++ b/static/app/gettingStartedDocs/python/tornado.tsx
@@ -57,7 +57,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/wsgi.tsx
+++ b/static/app/gettingStartedDocs/python/wsgi.tsx
@@ -92,7 +92,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,

--- a/static/app/gettingStartedDocs/python/wsgi.tsx
+++ b/static/app/gettingStartedDocs/python/wsgi.tsx
@@ -2,10 +2,11 @@ import {Fragment} from 'react';
 
 import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import type {
-  Docs,
-  DocsParams,
-  OnboardingConfig,
+import {
+  type Docs,
+  DocsPageLocation,
+  type DocsParams,
+  type OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {crashReportOnboardingPython} from 'sentry/gettingStartedDocs/python/python';
@@ -88,15 +89,16 @@ const onboarding: OnboardingConfig = {
       }),
       configurations: [
         {
-          description: params.isProfilingSelected
-            ? tct(
-                'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
-                {
-                  codeVersion: <code />,
-                  codePackage: <code />,
-                }
-              )
-            : undefined,
+          description:
+            params.page === DocsPageLocation.PROFILING_PAGE
+              ? tct(
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  {
+                    codeVersion: <code />,
+                    codePackage: <code />,
+                  }
+                )
+              : undefined,
           language: 'bash',
           code: getInstallSnippet(),
         },

--- a/static/app/gettingStartedDocs/python/wsgi.tsx
+++ b/static/app/gettingStartedDocs/python/wsgi.tsx
@@ -90,7 +90,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           description:
-            params.page === DocsPageLocation.PROFILING_PAGE
+            params.docsLocation === DocsPageLocation.PROFILING_PAGE
               ? tct(
                   'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
                   {

--- a/static/app/gettingStartedDocs/python/wsgi.tsx
+++ b/static/app/gettingStartedDocs/python/wsgi.tsx
@@ -92,7 +92,7 @@ const onboarding: OnboardingConfig = {
           description:
             params.page === DocsPageLocation.PROFILING_PAGE
               ? tct(
-                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-python] SDK for the profiling feature.',
+                  'You need a minimum version [codeVersion:1.18.0] of the [codePackage:sentry-sdk] SDK for the profiling feature.',
                   {
                     codeVersion: <code />,
                     codePackage: <code />,


### PR DESCRIPTION
Conditionally show information about minimal version of SDK needed for profiling at the beginning of the onboarding. information should be shown only if the user has opened onboarding docs inside a profile page, while it should be hidden on issues page.

We are showing that info to the user before they could even realise what is profiling, and since they have just installed the latest version, there is no need to mention info about minimum version at this place.

Example how it used to look for one of the python's framworks:
![image](https://github.com/user-attachments/assets/856522f1-4ff2-4283-9b02-dd60d693596a)

Closes https://github.com/getsentry/sentry/issues/76804