### PR TITLE
fix(metrics): Handle null unit

### DIFF
--- a/static/app/views/settings/projectMetrics/customMetricsTable.tsx
+++ b/static/app/views/settings/projectMetrics/customMetricsTable.tsx
@@ -193,7 +193,7 @@ function MetricsTable({metrics, isLoading, query, project}: MetricsTableProps) {
               <Tag>{getReadableMetricType(type)}</Tag>
             </Cell>
             <Cell right>
-              <Tag>{unit}</Tag>
+              <Tag>{unit ?? 'none'}</Tag>
             </Cell>
             <Cell right>
               <BlockButton


### PR DESCRIPTION
If the `unit` field was `null` in the API response, we would show empty label in the Unit column in the table. Instead we should default to `none`

Before:
![image](https://github.com/user-attachments/assets/9c168ea2-9dee-48c3-9659-7cda0472069d)

After:
![image](https://github.com/user-attachments/assets/2620f646-c931-4d9e-8782-1c3f8967ec6d)
