### PR TITLE
fix(issues): Add back feature flag checks to the backend for upcoming release

### DIFF
--- a/src/sentry/api/helpers/group_index/validators/status_details.py
+++ b/src/sentry/api/helpers/group_index/validators/status_details.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from sentry import features
 from sentry.models.release import Release
 
 from . import InCommitValidator
@@ -58,6 +59,11 @@ class StatusDetailsValidator(serializers.Serializer):
 
     def validate_inUpcomingRelease(self, value: bool) -> "Release":
         project = self.context["project"]
+
+        if not features.has("organizations:resolve-in-upcoming-release", project.organization):
+            raise serializers.ValidationError(
+                "Your organization does not have access to this feature."
+            )
 
         try:
             return (

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -28,7 +28,7 @@ from sentry.models.grouptombstone import GroupTombstone
 from sentry.models.release import Release
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, SnubaTestCase
-from sentry.testutils.helpers import parse_link_header
+from sentry.testutils.helpers import parse_link_header, with_feature
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.activity import ActivityType
@@ -868,6 +868,27 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         )
         assert activity.data["version"] == ""
 
+    def test_upcoming_release_flag_validation(self):
+        release = Release.objects.create(organization_id=self.project.organization_id, version="a")
+        release.add_project(self.project)
+
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+
+        self.login_as(user=self.user)
+
+        url = f"{self.path}?id={group.id}"
+        response = self.client.put(
+            url,
+            data={"status": "resolved", "statusDetails": {"inUpcomingRelease": True}},
+            format="json",
+        )
+        assert response.status_code == 400
+        assert (
+            response.data["statusDetails"]["inUpcomingRelease"][0]
+            == "Your organization does not have access to this feature."
+        )
+
+    @with_feature("organizations:resolve-in-upcoming-release")
     def test_upcoming_release_release_validation(self):
         group = self.create_group(status=GroupStatus.UNRESOLVED)
 

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -830,6 +830,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         )
         assert activity.data["version"] == ""
 
+    @with_feature("organizations:resolve-in-upcoming-release")
     def test_set_resolved_in_upcoming_release(self):
         release = Release.objects.create(organization_id=self.project.organization_id, version="a")
         release.add_project(self.project)


### PR DESCRIPTION
this pr undos the changes in https://github.com/getsentry/sentry/pull/75901 and adds back the feature flag checks