### PR TITLE
fix(custom-views): Fix unsaved changes not triggering correctly

### DIFF
--- a/static/app/views/issueList/customViewsHeader.tsx
+++ b/static/app/views/issueList/customViewsHeader.tsx
@@ -179,30 +179,26 @@ function CustomViewsIssueListHeaderTabsContent({
     if (viewId) {
       const selectedTab = draggableTabs.find(tab => tab.id === viewId);
       if (selectedTab && query && sort) {
-        // if a viewId exists but the query and sort are not what we expected, set them as unsaved changes
-        const isCurrentQuerySortDifferentFromExistingUnsavedChanges =
-          selectedTab.unsavedChanges &&
-          (selectedTab.unsavedChanges[0] !== query ||
-            selectedTab.unsavedChanges[1] !== sort);
+        const issueSortOption = Object.values(IssueSortOptions).includes(sort)
+          ? sort
+          : IssueSortOptions.DATE;
 
-        const isCurrentQuerySortDifferentFromSelectedTabQuerySort =
-          query !== selectedTab.query || sort !== selectedTab.querySort;
+        const unsavedChanges: [string, IssueSortOptions] | undefined =
+          query === selectedTab.query && sort === selectedTab.querySort
+            ? undefined
+            : [query as string, issueSortOption];
 
-        if (
-          isCurrentQuerySortDifferentFromExistingUnsavedChanges ||
-          isCurrentQuerySortDifferentFromSelectedTabQuerySort
-        ) {
-          setDraggableTabs(
-            draggableTabs.map(tab =>
-              tab.key === selectedTab!.key
-                ? {
-                    ...tab,
-                    unsavedChanges: [query, sort],
-                  }
-                : tab
-            )
-          );
-        }
+        setDraggableTabs(
+          draggableTabs.map(tab =>
+            tab.key === selectedTab!.key
+              ? {
+                  ...tab,
+                  unsavedChanges,
+                }
+              : tab
+          )
+        );
+
         tabListState?.setSelectedKey(selectedTab.key);
         return;
       }


### PR DESCRIPTION
This PR fixes an issue with unsaved changes where manually changing a view's search query from unsaved changes back to the original query would result in the unsaved changes indicator still appearing. If the query matches the views existing query, it should always show up as not having unsaved changes. 
