### PR TITLE
ref(onboarding): kotlin language changes

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/utils/metricsOnboarding.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/metricsOnboarding.tsx
@@ -385,20 +385,20 @@ export const getAndroidMetricsOnboarding = (): OnboardingConfig => ({
           code: [
             {
               label: 'Kotlin',
-              value: 'java',
-              language: 'java',
+              value: 'kotlin',
+              language: 'kotlin',
               code: getAndroidKotlinConfigureSnippet(params),
             },
             {
               label: 'Java',
-              value: 'kotlin',
+              value: 'java',
               language: 'java',
               code: getAndroidJavaConfigureSnippet(params),
             },
             {
               label: 'XML',
               value: 'xml',
-              language: 'java',
+              language: 'xml',
               code: getAndroidXmlConfigureSnippet(params),
             },
           ],
@@ -429,7 +429,7 @@ export const getAndroidMetricsOnboarding = (): OnboardingConfig => ({
             {
               label: 'Kotlin',
               value: 'kotlin',
-              language: 'java',
+              language: 'kotlin',
               code: getJvmKotlinVerifySnippet(),
             },
             {
@@ -490,7 +490,7 @@ export const getJavaMetricsOnboarding = (): OnboardingConfig => ({
             {
               label: 'Kotlin',
               value: 'kotlin',
-              language: 'java',
+              language: 'kotlin',
               code: getJvmKotlinConfigureSnippet(params),
             },
             {
@@ -533,7 +533,7 @@ export const getJavaMetricsOnboarding = (): OnboardingConfig => ({
             {
               label: 'Kotlin',
               value: 'kotlin',
-              language: 'java',
+              language: 'kotlin',
               code: getJvmKotlinVerifySnippet(),
             },
           ],

--- a/static/app/gettingStartedDocs/java/log4j2.tsx
+++ b/static/app/gettingStartedDocs/java/log4j2.tsx
@@ -297,7 +297,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
               code: getVerifyJavaSnippet(),
             },
             {
-              language: 'java',
+              language: 'kotlin',
               label: 'Kotlin',
               value: 'kotlin',
               code: getVerifyKotlinSnippet(),

--- a/static/app/gettingStartedDocs/java/logback.tsx
+++ b/static/app/gettingStartedDocs/java/logback.tsx
@@ -293,7 +293,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
               code: getVerifyJavaSnippet(),
             },
             {
-              language: 'java',
+              language: 'kotlin',
               label: 'Kotlin',
               value: 'kotlin',
               code: getVerifyKotlinSnippet(),

--- a/static/app/gettingStartedDocs/java/spring.tsx
+++ b/static/app/gettingStartedDocs/java/spring.tsx
@@ -302,7 +302,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
                   code: getJavaConfigSnippet(params),
                 },
                 {
-                  language: 'java',
+                  language: 'kotlin',
                   label: 'Kotlin',
                   value: 'kotlin',
                   code: getKotlinConfigSnippet(params),
@@ -330,7 +330,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
               code: getJavaVerifySnippet(),
             },
             {
-              language: 'java',
+              language: 'kotlin',
               label: 'Kotlin',
               value: 'kotlin',
               code: getKotlinVerifySnippet(),


### PR DESCRIPTION
prism supports `kotlin`: https://github.com/PrismJS/prism/blob/gh-pages/components/prism-kotlin.js