### PR TITLE
fix(seer grouping): Add db decorator to delete grouping records tests

### DIFF
--- a/tests/sentry/seer/similarity/test_grouping_records.py
+++ b/tests/sentry/seer/similarity/test_grouping_records.py
@@ -15,6 +15,7 @@ from sentry.seer.similarity.grouping_records import (
     delete_grouping_records_by_hash,
     post_bulk_grouping_records,
 )
+from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils import json
 
 DUMMY_POOL = ConnectionPool("dummy")
@@ -157,6 +158,7 @@ def test_post_bulk_grouping_records_use_reranking(
     )
 
 
+@django_db_all
 @mock.patch("sentry.seer.similarity.grouping_records.logger")
 @mock.patch("sentry.seer.similarity.grouping_records.seer_grouping_connection_pool.urlopen")
 def test_delete_grouping_records_by_hash_success(
@@ -200,6 +202,7 @@ def test_delete_grouping_records_by_hash_timeout(
     )
 
 
+@django_db_all
 @mock.patch("sentry.seer.similarity.grouping_records.logger")
 @mock.patch("sentry.seer.similarity.grouping_records.seer_grouping_connection_pool.urlopen")
 def test_delete_grouping_records_by_hash_failure(


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/75564, we switched to using an option to control the sample rate of our Seer metrics. Because options are stored in the database, tests hitting the affected code therefore needed to be marked as needing database access. For some reason, two tests in `test_grouping_records.py` to which this applied did not in fact fail without it... until one CI run of a random, unrelated PR three weeks later. So perhaps it's flaky? It doesn't make a ton of sense - the tests in question fail locally quite consistently, _as they should_.

Regardless, this fixes the problem by marking both tests with the `@django_db_all` decorator.