### PR TITLE
chore(eap): Add snuba.rpc function that reuses connection pool

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -13,15 +13,17 @@ from contextlib import contextmanager
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from hashlib import sha1
-from typing import Any
+from typing import Any, Protocol, TypeVar
 from urllib.parse import urlparse
 
+import sentry_protos.snuba.v1alpha.request_common_pb2
 import sentry_sdk
 import sentry_sdk.scope
 import urllib3
 from dateutil.parser import parse as parse_datetime
 from django.conf import settings
 from django.core.cache import cache
+from google.protobuf.message import Message as ProtobufMessage
 from snuba_sdk import DeleteQuery, MetricsQuery, Request
 from snuba_sdk.legacy import json_to_snql
 
@@ -1200,6 +1202,66 @@ def _log_request_query(req: Request) -> None:
         message=f"{query_type}_query",
         data={query_type: query_str},
     )
+
+
+RPCResponseType = TypeVar("RPCResponseType", bound=ProtobufMessage)
+
+
+class SnubaRPCRequest(Protocol):
+    def SerializeToString(self, deterministic: bool = ...) -> bytes:
+        ...
+
+    @property
+    def meta(self) -> sentry_protos.snuba.v1alpha.request_common_pb2.RequestMeta:
+        ...
+
+
+def rpc(req: SnubaRPCRequest, resp_type: type[RPCResponseType]) -> RPCResponseType:
+    """
+    You want to call a snuba RPC. Here's how you do it:
+
+    start_time_proto = ProtobufTimestamp()
+    start_time_proto.FromDatetime(start)
+    end_time_proto = ProtobufTimestamp()
+    end_time_proto.FromDatetime(end)
+    aggregate_req = AggregateBucketRequest(
+        meta=RequestMeta(
+            organization_id=organization.id,
+            cogs_category="events_analytics_platform",
+            referrer=referrer,
+            project_ids=[project.id for project in projects],
+            start_timestamp=start_time_proto,
+            end_timestamp=end_time_proto,
+        ),
+        aggregate=AggregateBucketRequest.FUNCTION_SUM,
+        filter=TraceItemFilter(
+            comparison_filter=ComparisonFilter(
+                key=AttributeKey(name="op", type=AttributeKey.Type.TYPE_STRING),
+                value=AttributeValue(val_str="ai.run"),
+            )
+        ),
+        granularity_secs=60,
+        key=AttributeKey(
+            name="duration", type=AttributeKey.TYPE_FLOAT
+        ),
+        attribute_key_transform_context=AttributeKeyTransformContext(),
+    )
+    aggregate_resp = snuba.rpc(aggregate_req, AggregateBucketResponse)
+    """
+    referrer = req.meta.referrer
+    with sentry_sdk.start_span(op="snuba_rpc.run", description=req.__class__.__name__) as span:
+        span.set_tag("snuba.referrer", referrer)
+        http_resp = _snuba_pool.urlopen(
+            "POST",
+            f"/rpc/{req.__class__.__name__}",
+            body=req.SerializeToString(),
+            headers={
+                "referer": referrer,
+            },
+        )
+        resp = resp_type()
+        resp.ParseFromString(http_resp.data)
+        return resp
 
 
 RawResult = tuple[str, urllib3.response.HTTPResponse, Translator, Translator]


### PR DESCRIPTION
This lets you query snuba RPC easily.