### PR TITLE
ref(replay): don't show mobile onboarding if org can't ingest video replays

### DIFF
--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -10,6 +10,7 @@ import {CompactSelect} from 'sentry/components/compactSelect';
 import RadioGroup from 'sentry/components/forms/controls/radioGroup';
 import IdBadge from 'sentry/components/idBadge';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {MobileBetaBanner} from 'sentry/components/onboarding/gettingStartedDoc/utils';
 import useCurrentProjectState from 'sentry/components/onboarding/gettingStartedDoc/utils/useCurrentProjectState';
 import {useLoadGettingStarted} from 'sentry/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted';
 import {PlatformOptionDropdown} from 'sentry/components/replaysOnboarding/platformOptionDropdown';
@@ -348,6 +349,25 @@ function OnboardingContent({
         </div>
       </Fragment>
     );
+  }
+
+  // if the org cannot ingest mobile replay events, don't show the onboarding
+  // TODO: remove once we GA mobile replay
+  if (organization.features.includes('session-replay-video-disabled')) {
+    if (['android', 'react-native'].includes(currentPlatform.language)) {
+      return (
+        <MobileBetaBanner
+          link={`https://docs.sentry.io/platforms/${currentPlatform.language}/session-replay/`}
+        />
+      );
+    }
+    if (currentPlatform.language === 'apple') {
+      return (
+        <MobileBetaBanner
+          link={`https://docs.sentry.io/platforms/apple/guides/ios/session-replay/`}
+        />
+      );
+    }
   }
 
   return (


### PR DESCRIPTION
if the org can't ingest mobile replays, just show this banner for mobile platforms:

<img width="445" alt="SCR-20240903-mhxb" src="https://github.com/user-attachments/assets/6f032000-b8d1-438e-af9e-f81282a90aee">
