### PR TITLE
Anomaly Charts

### DIFF
--- a/static/app/views/alerts/rules/metric/details/body.tsx
+++ b/static/app/views/alerts/rules/metric/details/body.tsx
@@ -29,7 +29,7 @@ import {Dataset, TimePeriod} from 'sentry/views/alerts/rules/metric/types';
 import {extractEventTypeFilterFromRule} from 'sentry/views/alerts/rules/metric/utils/getEventTypeFilter';
 import {isOnDemandMetricAlert} from 'sentry/views/alerts/rules/metric/utils/onDemandMetricAlert';
 import {getAlertRuleActionCategory} from 'sentry/views/alerts/rules/utils';
-import type {Incident} from 'sentry/views/alerts/types';
+import type {Anomaly, Incident} from 'sentry/views/alerts/types';
 import {AlertRuleStatus} from 'sentry/views/alerts/types';
 import {alertDetailsLink} from 'sentry/views/alerts/utils';
 import {MetricsBetaEndAlert} from 'sentry/views/metrics/metricsBetaEndAlert';
@@ -53,6 +53,7 @@ interface MetricDetailsBodyProps extends RouteComponentProps<{}, {}> {
   location: Location;
   organization: Organization;
   timePeriod: TimePeriodType;
+  anomalies?: Anomaly[];
   incidents?: Incident[];
   project?: Project;
   rule?: MetricRule;
@@ -69,6 +70,7 @@ export default function MetricDetailsBody({
   selectedIncident,
   location,
   router,
+  anomalies,
 }: MetricDetailsBodyProps) {
   function getPeriodInterval() {
     const startDate = moment.utc(timePeriod.start);
@@ -232,6 +234,7 @@ export default function MetricDetailsBody({
             api={api}
             rule={rule}
             incidents={incidents}
+            anomalies={anomalies}
             timePeriod={timePeriod}
             selectedIncident={selectedIncident}
             formattedAggregate={formattedAggregate}

--- a/static/app/views/alerts/rules/metric/details/index.tsx
+++ b/static/app/views/alerts/rules/metric/details/index.tsx
@@ -201,11 +201,14 @@ class MetricAlertDetails extends Component<Props, State> {
     const timePeriod = this.getTimePeriod(selectedIncident);
     const {start, end} = timePeriod;
     try {
-      const [incidents, rule, anomalies] = await Promise.all([
+      const promiseList: Promise<any>[] = [
         fetchIncidentsForRule(organization.slug, ruleId, start, end),
         rulePromise,
-        fetchAnomaliesForRule(organization.slug, ruleId, start, end),
-      ]);
+      ];
+      if (organization.features.includes('anomaly-detection-alerts')) {
+        promiseList.push(fetchAnomaliesForRule(organization.slug, ruleId, start, end));
+      }
+      const [incidents, rule, anomalies] = await Promise.all(promiseList);
       this.setState({
         anomalies,
         incidents,

--- a/static/app/views/alerts/rules/metric/details/index.tsx
+++ b/static/app/views/alerts/rules/metric/details/index.tsx
@@ -78,7 +78,6 @@ class MetricAlertDetails extends Component<Props, State> {
       prevProps.params.ruleId !== this.props.params.ruleId
     ) {
       this.fetchData();
-      this.fetchAnomalies();
       this.trackView();
     }
   }
@@ -235,7 +234,7 @@ class MetricAlertDetails extends Component<Props, State> {
   }
 
   render() {
-    const {rule, incidents, hasError, selectedIncident} = this.state;
+    const {rule, incidents, hasError, selectedIncident, anomalies} = this.state;
     const {organization, projects, loadingProjects} = this.props;
     const timePeriod = this.getTimePeriod(selectedIncident);
 
@@ -269,6 +268,7 @@ class MetricAlertDetails extends Component<Props, State> {
           rule={rule}
           project={project}
           incidents={incidents}
+          anomalies={anomalies}
           timePeriod={timePeriod}
           selectedIncident={selectedIncident}
         />

--- a/static/app/views/alerts/rules/metric/details/index.tsx
+++ b/static/app/views/alerts/rules/metric/details/index.tsx
@@ -201,14 +201,13 @@ class MetricAlertDetails extends Component<Props, State> {
     const timePeriod = this.getTimePeriod(selectedIncident);
     const {start, end} = timePeriod;
     try {
-      const promiseList: Promise<any>[] = [
+      const [incidents, rule, anomalies] = await Promise.all([
         fetchIncidentsForRule(organization.slug, ruleId, start, end),
         rulePromise,
-      ];
-      if (organization.features.includes('anomaly-detection-alerts')) {
-        promiseList.push(fetchAnomaliesForRule(organization.slug, ruleId, start, end));
-      }
-      const [incidents, rule, anomalies] = await Promise.all(promiseList);
+        organization.features.includes('anomaly-detection-alerts')
+          ? fetchAnomaliesForRule(organization.slug, ruleId, start, end)
+          : undefined,
+      ]);
       this.setState({
         anomalies,
         incidents,

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -126,8 +126,6 @@ function getRuleChangeSeries(
     return [];
   }
 
-  // Mark Line - draws a vertical line on the chart
-  // Mark Area - outlines an area on the chart
   return [
     {
       type: 'line',
@@ -300,9 +298,6 @@ class MetricChart extends PureComponent<Props, State> {
       );
     };
 
-    // Chart options....
-    // This constructs the series
-    // anomalies
     const {
       criticalDuration,
       warningDuration,

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -68,7 +68,7 @@ import {AlertWizardAlertNames} from 'sentry/views/alerts/wizard/options';
 import {getAlertTypeFromAggregateDataset} from 'sentry/views/alerts/wizard/utils';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 
-import type {Incident} from '../../../types';
+import type {Anomaly, Incident} from '../../../types';
 import {
   alertDetailsLink,
   alertTooltipValueFormatter,
@@ -93,6 +93,7 @@ type Props = WithRouterProps & {
   query: string;
   rule: MetricRule;
   timePeriod: TimePeriodType;
+  anomalies?: Anomaly[];
   formattedAggregate?: string;
   incidents?: Incident[];
   isOnDemandAlert?: boolean;
@@ -125,6 +126,8 @@ function getRuleChangeSeries(
     return [];
   }
 
+  // Mark Line - draws a vertical line on the chart
+  // Mark Area - outlines an area on the chart
   return [
     {
       type: 'line',
@@ -271,6 +274,7 @@ class MetricChart extends PureComponent<Props, State> {
     comparisonTimeseriesData?: Series[]
   ) {
     const {
+      anomalies,
       router,
       selectedIncident,
       interval,
@@ -296,6 +300,9 @@ class MetricChart extends PureComponent<Props, State> {
       );
     };
 
+    // Chart options....
+    // This constructs the series
+    // anomalies
     const {
       criticalDuration,
       warningDuration,
@@ -307,6 +314,7 @@ class MetricChart extends PureComponent<Props, State> {
       rule,
       seriesName: formattedAggregate,
       incidents,
+      anomalies,
       selectedIncident,
       showWaitingForData:
         shouldShowOnDemandMetricAlertUI(organization) && this.props.isOnDemandAlert,

--- a/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
@@ -16,7 +16,7 @@ import {getCrashFreeRateSeries} from 'sentry/utils/sessions';
 import {lightTheme as theme} from 'sentry/utils/theme';
 import type {MetricRule, Trigger} from 'sentry/views/alerts/rules/metric/types';
 import {AlertRuleTriggerType, Dataset} from 'sentry/views/alerts/rules/metric/types';
-import type {Incident} from 'sentry/views/alerts/types';
+import type {Anomaly, Incident} from 'sentry/views/alerts/types';
 import {IncidentActivityType, IncidentStatus} from 'sentry/views/alerts/types';
 import {
   ALERT_CHART_MIN_MAX_BUFFER,
@@ -139,6 +139,7 @@ function createIncidentSeries(
 export type MetricChartData = {
   rule: MetricRule;
   timeseriesData: Series[];
+  anomalies?: Anomaly[];
   handleIncidentClick?: (incident: Incident) => void;
   incidents?: Incident[];
   selectedIncident?: Incident | null;
@@ -162,6 +163,7 @@ export function getMetricAlertChartOption({
   selectedIncident,
   handleIncidentClick,
   showWaitingForData,
+  anomalies,
 }: MetricChartData): MetricChartOption {
   let criticalTrigger: Trigger | undefined;
   let warningTrigger: Trigger | undefined;
@@ -236,6 +238,7 @@ export function getMetricAlertChartOption({
     series.push(createStatusAreaSeries(theme.gray200, startTime, endTime, minChartValue));
   }
 
+  // TODO: construct segments for anomalies
   if (incidents) {
     // select incidents that fall within the graph range
     incidents

--- a/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
@@ -404,7 +404,7 @@ export function getMetricAlertChartOption({
   }
 
   if (anomalies) {
-    const anomalyBlocks: {xAxis: string; name?: string}[][] = [];
+    const anomalyBlocks: any[] = [];
     let start: string | undefined;
     let end: string | undefined;
     anomalies

--- a/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
@@ -404,7 +404,7 @@ export function getMetricAlertChartOption({
   }
 
   if (anomalies) {
-    const anomalyBlocks: {xAxis: string}[][] = [];
+    const anomalyBlocks: {xAxis: string; name?: string}[][] = [];
     let start: string | undefined;
     let end: string | undefined;
     anomalies

--- a/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
@@ -140,6 +140,48 @@ function createIncidentSeries(
   };
 }
 
+function createAnomalyMarkerSeries(
+  lineColor: string,
+  timestamp: number
+): AreaChartSeries {
+  const formatter = ({value}: any) => {
+    const time = formatTooltipDate(moment(value), 'MMM D, YYYY LT');
+    return [
+      `<div class="tooltip-series"><div>`,
+      `</div>Anomaly Detected</div>`,
+      `<div class="tooltip-footer">${time}</div>`,
+      '<div class="tooltip-arrow"></div>',
+    ].join('');
+  };
+
+  return {
+    seriesName: 'Anomaly Line',
+    type: 'line',
+    markLine: MarkLine({
+      silent: false,
+      lineStyle: {color: lineColor, type: 'dashed'},
+      label: {
+        silent: true,
+        show: false,
+      },
+      data: [
+        {
+          xAxis: timestamp,
+        },
+      ],
+      tooltip: {
+        formatter,
+      },
+    }),
+    data: [],
+    tooltip: {
+      trigger: 'item',
+      alwaysShowContent: true,
+      formatter,
+    },
+  };
+}
+
 export type MetricChartData = {
   rule: MetricRule;
   timeseriesData: Series[];
@@ -384,13 +426,13 @@ export function getMetricAlertChartOption({
           if (start && end) {
             anomalyBlocks.push([
               {
-                name: 'Anomaly Detected',
                 xAxis: start,
               },
               {
                 xAxis: end,
               },
             ]);
+            series.push(createAnomalyMarkerSeries(theme.purple300, start));
           }
           start = undefined;
           end = undefined;
@@ -410,6 +452,7 @@ export function getMetricAlertChartOption({
     }
 
     // NOTE: if timerange is too small - highlighted area will not be visible
+    // Possibly provide a minimum window size if the time range is too large?
     series.push({
       seriesName: '',
       name: 'Anomaly',
@@ -420,7 +463,7 @@ export function getMetricAlertChartOption({
         itemStyle: {
           color: 'rgba(255, 173, 177, 0.4)',
         },
-        silent: true,
+        silent: true, // potentially don't make this silent if we want to render the `anomaly detected` in the tooltip
         data: anomalyBlocks,
       },
     });

--- a/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
@@ -1,5 +1,5 @@
 import color from 'color';
-import type {YAXisComponentOption} from 'echarts';
+import type {MarkAreaComponentOption, YAXisComponentOption} from 'echarts';
 import moment from 'moment-timezone';
 
 import type {AreaChartProps, AreaChartSeries} from 'sentry/components/charts/areaChart';
@@ -404,7 +404,7 @@ export function getMetricAlertChartOption({
   }
 
   if (anomalies) {
-    const anomalyBlocks: any[] = [];
+    const anomalyBlocks: MarkAreaComponentOption['data'] = [];
     let start: string | undefined;
     let end: string | undefined;
     anomalies

--- a/static/app/views/alerts/types.tsx
+++ b/static/app/views/alerts/types.tsx
@@ -113,4 +113,5 @@ export type CombinedMetricIssueAlerts = IssueAlert | MetricAlert;
 export type CombinedAlerts = CombinedMetricIssueAlerts | UptimeAlert;
 
 // TODO: This is a placeholder type for now
+// Assume this is a timestamp of when the anomaly occurred and for how long
 export type Anomaly = {};

--- a/static/app/views/alerts/types.tsx
+++ b/static/app/views/alerts/types.tsx
@@ -114,4 +114,15 @@ export type CombinedAlerts = CombinedMetricIssueAlerts | UptimeAlert;
 
 // TODO: This is a placeholder type for now
 // Assume this is a timestamp of when the anomaly occurred and for how long
-export type Anomaly = {};
+export type Anomaly = {
+  anomaly: {[key: string]: number | string};
+  timestamp: string;
+  value: number;
+};
+
+export const AnomalyType = {
+  high: 'anomaly_higher_confidence',
+  low: 'anomaly_lower_confidence',
+  none: 'none',
+  noData: 'no_data',
+};

--- a/static/app/views/alerts/types.tsx
+++ b/static/app/views/alerts/types.tsx
@@ -111,3 +111,6 @@ export interface UptimeAlert extends UptimeRule {
 export type CombinedMetricIssueAlerts = IssueAlert | MetricAlert;
 
 export type CombinedAlerts = CombinedMetricIssueAlerts | UptimeAlert;
+
+// TODO: This is a placeholder type for now
+export type Anomaly = {};

--- a/static/app/views/alerts/utils/apiCalls.tsx
+++ b/static/app/views/alerts/utils/apiCalls.tsx
@@ -50,7 +50,7 @@ export function fetchAnomaliesForRule(
   end: string
 ): Promise<Anomaly[]> {
   return uncancellableApi.requestPromise(
-    `/organizations/${orgId}/alert-rules/${ruleId}anomalies/`,
+    `/organizations/${orgId}/alert-rules/${ruleId}/anomalies/`,
     {
       query: {
         start,

--- a/static/app/views/alerts/utils/apiCalls.tsx
+++ b/static/app/views/alerts/utils/apiCalls.tsx
@@ -1,7 +1,7 @@
 import {Client} from 'sentry/api';
 import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
 
-import type {Incident} from '../types';
+import type {Anomaly, Incident} from '../types';
 
 // Use this api for requests that are getting cancelled
 const uncancellableApi = new Client();
@@ -19,14 +19,14 @@ export function fetchAlertRule(
 
 export function fetchIncidentsForRule(
   orgId: string,
-  alertRule: string,
+  ruleId: string,
   start: string,
   end: string
 ): Promise<Incident[]> {
   return uncancellableApi.requestPromise(`/organizations/${orgId}/incidents/`, {
     query: {
       project: '-1',
-      alertRule,
+      alertRule: ruleId,
       includeSnapshots: true,
       start,
       end,
@@ -41,4 +41,21 @@ export function fetchIncident(
   alertId: string
 ): Promise<Incident> {
   return api.requestPromise(`/organizations/${orgId}/incidents/${alertId}/`);
+}
+
+export function fetchAnomaliesForRule(
+  orgId: string,
+  ruleId: string,
+  start: string,
+  end: string
+): Promise<Anomaly[]> {
+  return uncancellableApi.requestPromise(
+    `/organizations/${orgId}/alert-rules/${ruleId}anomalies/`,
+    {
+      query: {
+        start,
+        end,
+      },
+    }
+  );
 }


### PR DESCRIPTION
highlights the alert rule details chart if an anomaly is detected

Added a dashed line to highlight when the anomaly started
and removed the label at the top of the chart
<img width="512" alt="Screenshot 2024-09-03 at 3 18 23 PM" src="https://github.com/user-attachments/assets/3a1a04a1-f8a0-4325-8989-f9b9f61d974a">
<img width="284" alt="Screenshot 2024-09-03 at 3 21 35 PM" src="https://github.com/user-attachments/assets/0013642a-cbf1-488e-b88f-739cc2f92256">
