### PR TITLE
fix(custom-views): Fix broken back-navigation when hitting issues

### DIFF
--- a/static/app/views/issueList/customViewsHeader.tsx
+++ b/static/app/views/issueList/customViewsHeader.tsx
@@ -165,15 +165,18 @@ function CustomViewsIssueListHeaderTabsContent({
   useEffect(() => {
     // If no query, sort, or viewId is present, set the first tab as the selected tab, update query accordingly
     if (!query && !sort && !viewId) {
-      navigate({
-        ...location,
-        query: {
-          ...queryParams,
-          query: draggableTabs[0].query,
-          sort: draggableTabs[0].querySort,
-          viewId: draggableTabs[0].id,
+      navigate(
+        {
+          ...location,
+          query: {
+            ...queryParams,
+            query: draggableTabs[0].query,
+            sort: draggableTabs[0].querySort,
+            viewId: draggableTabs[0].id,
+          },
         },
-      });
+        {replace: true}
+      );
       tabListState?.setSelectedKey(draggableTabs[0].key);
       return;
     }


### PR DESCRIPTION
This PR fixes an issue where you would not be able to navigate backwards after clicking on "Issues" in the sentry sidebar. 