### PR TITLE
fix(seer grouping): Fix metric for events from backfilled projects

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -70,7 +70,7 @@ def _project_has_similarity_grouping_enabled(project: Project) -> bool:
     has_been_backfilled = project.get_option("sentry:similarity_backfill_completed")
 
     metrics.incr(
-        "grouping.similarity.event_from_backfilled_project",
+        "grouping.similarity.event_project_backfill_status",
         sample_rate=options.get("seer.similarity.metrics_sample_rate"),
         tags={"backfilled": has_seer_grouping_flag_on or has_been_backfilled},
     )

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -72,7 +72,7 @@ def _project_has_similarity_grouping_enabled(project: Project) -> bool:
     metrics.incr(
         "grouping.similarity.event_project_backfill_status",
         sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-        tags={"backfilled": has_seer_grouping_flag_on or has_been_backfilled},
+        tags={"backfilled": bool(has_seer_grouping_flag_on or has_been_backfilled)},
     )
 
     return has_seer_grouping_flag_on or has_been_backfilled


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/76639, I added a `grouping.similarity.event_from_backfilled_project` metric, to track what percentage of events without a hash come from projects with Seer grouping turned on. Unfortunately, I forgot that the `sentry:similarity_backfill_completed` project option contains a timestamp rather than a boolean, and as a result, we've been sending a super-high-cardinality tag to DataDog. Whoops.

To fix this, I obviously changed the tag value to be a boolean, but I also renamed the metric, from `event_from_backfilled_project` to `event_project_backfill_status`. This will let us just allow the problematic metric to age out, rather than worrying about selectively enabling tags for it (though I have, in fact, turned off indexing for that tag). As a bonus, it's a clearer name. (I discovered my mistake when adding a graph for the metric to our dashboard, but in that process, I had already confused myself by thinking that `event_from_backfilled_project` was only going to fire when the answer was yes.)