### PR TITLE
fix(crons): Correct cursor behavior upon filtering on monitor overview page

### DIFF
--- a/static/app/views/monitors/overview.spec.tsx
+++ b/static/app/views/monitors/overview.spec.tsx
@@ -1,0 +1,76 @@
+import {TeamFixture} from 'sentry-fixture/team';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import OrganizationStore from 'sentry/stores/organizationStore';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import Monitors from 'sentry/views/monitors/overview';
+
+jest.mock('sentry/utils/useNavigate', () => ({
+  useNavigate: jest.fn(),
+}));
+
+const mockUseNavigate = jest.mocked(useNavigate);
+const mockNavigate = jest.fn();
+mockUseNavigate.mockReturnValue(mockNavigate);
+
+describe('Monitors Overview', function () {
+  const team = TeamFixture();
+
+  beforeEach(function () {
+    OrganizationStore.init();
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/monitors/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/processing-errors/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/members/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/teams/',
+      body: [team],
+    });
+  });
+
+  it('renders', async function () {
+    const {organization, router} = initializeOrg();
+    OrganizationStore.onUpdate(organization);
+
+    render(<Monitors />, {organization, router});
+    expect(await screen.findByText('Cron Monitors')).toBeInTheDocument();
+  });
+
+  it('correctly filters on owner', async function () {
+    const {organization, router} = initializeOrg({
+      router: {location: {query: {cursor: 'test-cursor'}}},
+    });
+    OrganizationStore.onUpdate(organization);
+
+    render(<Monitors />, {organization, router});
+    expect(await screen.findByText('Cron Monitors')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Filter Owners'}));
+    await userEvent.click(screen.getByRole('option', {name: '#team-slug'}));
+
+    expect(mockNavigate).toHaveBeenLastCalledWith(
+      {
+        query: {
+          cursor: undefined, // Confirm that the cursor is reset
+          owner: ['team:1'],
+        },
+      },
+      {replace: true}
+    );
+  });
+});

--- a/static/app/views/monitors/overview.tsx
+++ b/static/app/views/monitors/overview.tsx
@@ -144,7 +144,7 @@ export default function Monitors() {
                   navigate(
                     {
                       ...location,
-                      query: {...location.query, owner},
+                      query: {...location.query, owner, cursor: undefined},
                     },
                     {replace: true}
                   );
@@ -153,7 +153,7 @@ export default function Monitors() {
               <PageFilterBar>
                 <ProjectPageFilter resetParamsOnChange={['cursor']} />
                 <EnvironmentPageFilter resetParamsOnChange={['cursor']} />
-                <DatePageFilter resetParamsOnChange={['cursor']} />
+                <DatePageFilter />
               </PageFilterBar>
               <SearchBar
                 query={decodeScalar(qs.parse(location.search)?.query, '')}


### PR DESCRIPTION
Corrects two behaviors to reach the following state:

1. When changing the owner, reset the cursor (since changing the owner filter affects the list of monitors returned)
2. When changing the time field, does NOT reset the cursor (since changing the date time should not affect the quantity of results returned)


Fixes: https://github.com/getsentry/sentry/issues/76862