### PR TITLE
fix(auth): add /auth/sso to social auth urls

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -51,6 +51,7 @@ from sentry.web.frontend.user_avatar import UserAvatarPhotoView
 
 __all__ = ("urlpatterns",)
 
+from social_auth.views import complete
 
 # Only create one instance of the ReactPageView since it's duplicated everywhere
 generic_react_page_view = GenericReactPageView.as_view()
@@ -391,6 +392,12 @@ urlpatterns += [
                 ),
             ]
         ),
+    ),
+    # GitHub social auth requires the prefix auth/sso
+    re_path(
+        r"^auth/sso/account/settings/social/associate/complete/(?P<backend>[^/]+)/$",
+        complete,
+        name="socialauth_associate_complete_auth_sso",
     ),
     # Onboarding
     re_path(

--- a/src/social_auth/backends/visualstudio.py
+++ b/src/social_auth/backends/visualstudio.py
@@ -79,7 +79,9 @@ class VisualStudioAuth(BaseOAuth2):
             "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
             "client_assertion": secret,
             "grant_type": "refresh_token",
-            "redirect_uri": absolute_uri(reverse("socialauth_associate_complete", args=[provider])),
+            "redirect_uri": absolute_uri(
+                reverse("socialauth_associate_complete_auth_sso", args=[provider])
+            ),
             "assertion": token,
         }
 

--- a/src/social_auth/urls.py
+++ b/src/social_auth/urls.py
@@ -8,6 +8,11 @@ urlpatterns = [
         r"^associate/complete/(?P<backend>[^/]+)/$", complete, name="socialauth_associate_complete"
     ),
     re_path(
+        r"^associate/complete/(?P<backend>[^/]+)/auth/sso/$",
+        complete,
+        name="socialauth_associate_complete_auth_sso",
+    ),
+    re_path(
         r"^associate/(?P<backend>[^/]+)/$",
         auth,
         name="socialauth_associate",

--- a/src/social_auth/urls.py
+++ b/src/social_auth/urls.py
@@ -8,11 +8,6 @@ urlpatterns = [
         r"^associate/complete/(?P<backend>[^/]+)/$", complete, name="socialauth_associate_complete"
     ),
     re_path(
-        r"^associate/complete/(?P<backend>[^/]+)/auth/sso/$",
-        complete,
-        name="socialauth_associate_complete_auth_sso",
-    ),
-    re_path(
         r"^associate/(?P<backend>[^/]+)/$",
         auth,
         name="socialauth_associate",

--- a/src/social_auth/views.py
+++ b/src/social_auth/views.py
@@ -24,7 +24,7 @@ ASSOCIATE_ERROR_URL = setting("SOCIAL_AUTH_ASSOCIATE_ERROR_URL")
 PIPELINE_KEY = setting("SOCIAL_AUTH_PARTIAL_PIPELINE_KEY", "partial_pipeline")
 
 
-@dsa_view(setting("SOCIAL_AUTH_COMPLETE_URL_NAME", "socialauth_associate_complete"))
+@dsa_view(setting("SOCIAL_AUTH_COMPLETE_URL_NAME", "socialauth_associate_complete_auth_sso"))
 def auth(request, backend):
     """Authenticate using social backend"""
     data = request.POST if request.method == "POST" else request.GET


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/FEEDBACK-2276
https://github.com/getsentry/sentry/issues/76399

Github authentication is failing for Education Pack because the redirect url does not include `/auth/sso`
