### PR TITLE
ref(formatDuration): Fix hh:mm:ss formatting to account for precision

### DIFF
--- a/static/app/utils/duration/formatDuration.spec.tsx
+++ b/static/app/utils/duration/formatDuration.spec.tsx
@@ -1,4 +1,5 @@
 import formatDuration from 'sentry/utils/duration/formatDuration';
+import type {Duration, Unit} from 'sentry/utils/duration/types';
 
 describe('formatDuration', () => {
   describe('parsing', () => {
@@ -24,21 +25,6 @@ describe('formatDuration', () => {
   });
 
   describe('formatting', () => {
-    it.each([
-      {style: 'h:mm:ss' as const, expected: '8:20'},
-      {style: 'hh:mm:ss' as const, expected: '08:20'},
-      {style: 'h:mm:ss.sss' as const, expected: '8:20.012'},
-      {style: 'hh:mm:ss.sss' as const, expected: '08:20.012'},
-    ])('should format according to the selected style', ({style, expected}) => {
-      expect(
-        formatDuration({
-          style,
-          precision: 'sec',
-          duration: [500.012, 'sec'],
-        })
-      ).toBe(expected);
-    });
-
     it('should format the value into a locale specific number', () => {
       expect(
         formatDuration({
@@ -77,35 +63,57 @@ describe('formatDuration', () => {
       ).toBe('8:20');
     });
 
-    it('should truncate ms when formatting as hours & minutes', () => {
-      expect(
-        formatDuration({
-          style: 'h:mm:ss',
-          precision: 'sec',
-          duration: [500012, 'ms'],
-        })
-      ).toBe('8:20');
-    });
+    it.each<{duration: Duration; expected: string; precision: Unit}>([
+      {duration: [500_000, 'ms'], precision: 'ms', expected: '8:20.000'},
+      {duration: [500_000, 'ms'], precision: 'sec', expected: '8:20.000'},
+      {duration: [500_012, 'ms'], precision: 'ms', expected: '8:20.012'},
+      {duration: [500_012, 'ms'], precision: 'sec', expected: '8:20.000'},
+      {duration: [500, 'sec'], precision: 'ms', expected: '8:20.000'},
+      {duration: [500, 'sec'], precision: 'sec', expected: '8:20.000'},
+      {duration: [500, 'sec'], precision: 'ms', expected: '8:20.000'},
+      {duration: [500, 'sec'], precision: 'sec', expected: '8:20.000'},
+      {duration: [500.012, 'sec'], precision: 'ms', expected: '8:20.012'},
+      {duration: [500.012, 'sec'], precision: 'sec', expected: '8:20.000'},
+      {duration: [500.012, 'sec'], precision: 'ms', expected: '8:20.012'},
+      {duration: [500.012, 'sec'], precision: 'sec', expected: '8:20.000'},
+    ])(
+      'should format $duration with precision $precision as h:mm:ss.sss',
+      ({duration, precision, expected}) => {
+        expect(
+          formatDuration({
+            style: 'h:mm:ss.sss',
+            precision,
+            duration,
+          })
+        ).toBe(expected);
+      }
+    );
 
-    it('should add ms when format demands it', () => {
-      expect(
-        formatDuration({
-          style: 'h:mm:ss.sss',
-          precision: 'sec',
-          duration: [500, 'sec'],
-        })
-      ).toBe('8:20.000');
-    });
-
-    it('should include ms when precision includes it', () => {
-      expect(
-        formatDuration({
-          style: 'h:mm:ss.sss',
-          precision: 'sec',
-          duration: [500012, 'ms'],
-        })
-      ).toBe('8:20.012');
-    });
+    it.each<{duration: Duration; precision: Unit}>([
+      {duration: [500_000, 'ms'], precision: 'ms'},
+      {duration: [500_000, 'ms'], precision: 'sec'},
+      {duration: [500_012, 'ms'], precision: 'ms'},
+      {duration: [500_012, 'ms'], precision: 'sec'},
+      {duration: [500, 'sec'], precision: 'ms'},
+      {duration: [500, 'sec'], precision: 'sec'},
+      {duration: [500, 'sec'], precision: 'ms'},
+      {duration: [500, 'sec'], precision: 'sec'},
+      {duration: [500.012, 'sec'], precision: 'ms'},
+      {duration: [500.012, 'sec'], precision: 'sec'},
+      {duration: [500.012, 'sec'], precision: 'ms'},
+      {duration: [500.012, 'sec'], precision: 'sec'},
+    ])(
+      'should format $duration with precision $precision as h:mm:ss, never showing ms',
+      ({duration, precision}) => {
+        expect(
+          formatDuration({
+            style: 'h:mm:ss',
+            precision,
+            duration,
+          })
+        ).toBe('8:20');
+      }
+    );
 
     it('should format the value into an ISO8601 period with ms precision', () => {
       expect(

--- a/static/app/utils/duration/formatDuration.tsx
+++ b/static/app/utils/duration/formatDuration.tsx
@@ -79,13 +79,19 @@ export default function formatDuration({
     case 'hh:mm:ss': // fall-through
     case 'h:mm:ss.sss': // fall-through
     case 'hh:mm:ss.sss':
+      const truncatedValueInMs = normalizeTimespanToMs(
+        Math.floor(valueInUnit),
+        precision
+      );
+      const valueInSec = msToPrecision(truncatedValueInMs, 'sec');
+
+      const padAll = style.startsWith('hh:mm:ss');
       const includeMs = style.endsWith('.sss');
-      const valueInSec = msToPrecision(ms, 'sec');
-      const str = formatSecondsToClock(valueInSec, {
-        padAll: style.startsWith('hh:mm:ss'),
-      });
+      const str = formatSecondsToClock(valueInSec, {padAll});
       const [head, tail] = str.split('.');
-      return includeMs ? [head, tail ?? '000'].join('.') : String(head);
+      return includeMs
+        ? [head, precision === 'ms' ? tail ?? '000' : '000'].join('.')
+        : String(head);
     case 'ISO8601':
       const output = ['P'];
 


### PR DESCRIPTION
This updates `formatDuration` so that the formatting and precision are distinct things.

You've got formatting, like `h:mm:ss.sss` or `hh:mm:ss` which will show milliseconds (former) or pad with leading zeros (latter). Also precision like `sec` or `ms` which controls what the value is that will be formatted. If you want to, now you can have a value like `1,234ms`, which is second, 234 milliseconds, and set the precision to be "sec" (which truncates it to 1,000ms) then format it with "hh:mm:ss.sss" for a final render of `01.000`.

Ok, so some of the combinations are not practical, but this change better reflects what the props are expressing which makes it easier to have a consistent api for any format around the app.

