### PR TITLE
fix(alerts): Send epoch timestamp

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -684,7 +684,7 @@ class SubscriptionProcessor:
             context = {
                 "id": self.alert_rule.id,
                 "cur_window": {
-                    "timestamp": self.last_update,
+                    "timestamp": self.last_update.timestamp(),
                     "value": aggregation_value,
                 },
             }


### PR DESCRIPTION
Seer expects the epoch timestamp as a float here 