### PR TITLE
feat(replay-onboarding): Add verify step to JS loader docs

### DIFF
--- a/static/app/gettingStartedDocs/javascript/jsLoader/jsLoader.tsx
+++ b/static/app/gettingStartedDocs/javascript/jsLoader/jsLoader.tsx
@@ -82,7 +82,7 @@ const replayOnboardingJsLoader: OnboardingConfig = {
     {
       type: StepType.VERIFY,
       description: t(
-        'To verify your replay setup, trigger an error on your page and watch Sentry capture the event along with a recording of the user interaction.'
+        'To verify your Replay setup, trigger an error on your page and watch Sentry capture the event along with a recording of the user interaction.'
       ),
       configurations: [
         {

--- a/static/app/gettingStartedDocs/javascript/jsLoader/jsLoader.tsx
+++ b/static/app/gettingStartedDocs/javascript/jsLoader/jsLoader.tsx
@@ -50,6 +50,16 @@ const getInstallConfig = (params: Params) => [
   },
 ];
 
+const getVerifySnippet = () => `
+<!-- A button to trigger a test error -->
+<button id="test-error">Trigger Test Error</button>
+<script>
+  const button = document.getElementById('test-error');
+  button.addEventListener('click', () => {
+    throw new Error('This is a test error');
+  });
+</script>`;
+
 const replayOnboardingJsLoader: OnboardingConfig = {
   install: (params: Params) => getInstallConfig(params),
   configure: (params: Params) => [
@@ -68,7 +78,24 @@ const replayOnboardingJsLoader: OnboardingConfig = {
       additionalInfo: <TracePropagationMessage />,
     },
   ],
-  verify: () => [],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      description: t(
+        'To verify your replay setup, trigger an error on your page and watch Sentry capture the event along with a recording of the user interaction.'
+      ),
+      configurations: [
+        {
+          description: t('You can simulate an error by adding the following code:'),
+          language: 'html',
+          code: getVerifySnippet(),
+          additionalInfo: t(
+            'After clicking the button, wait a few moments, and you\'ll see a new session appear on the "Replays" page.'
+          ),
+        },
+      ],
+    },
+  ],
   nextSteps: () => [],
 };
 


### PR DESCRIPTION
Add a verify step to the JS loader docs to give users instructions on how they can test their setup.

<img width="684" alt="Screenshot 2024-09-04 at 07 48 01" src="https://github.com/user-attachments/assets/07f703b4-6781-4a63-b3b7-c38833cb2674">

part of https://github.com/getsentry/sentry/issues/76909