### PR TITLE
fix(onboarding): Additional info about feedback integration for remix

### DIFF
--- a/static/app/gettingStartedDocs/javascript/remix.tsx
+++ b/static/app/gettingStartedDocs/javascript/remix.tsx
@@ -202,9 +202,20 @@ const feedbackOnboarding: OnboardingConfig = {
           ],
         },
       ],
-      additionalInfo: crashReportCallout({
-        link: 'https://docs.sentry.io/platforms/javascript/guides/remix/user-feedback/#user-feedback-api',
-      }),
+      additionalInfo: (
+        <Fragment>
+          <p>
+            {tct(
+              'Note: The Feedback integration only needs to be added to your [entryClient:entry.client.tsx] file.',
+              {entryClient: <code />, sentryServer: <code />}
+            )}
+          </p>
+
+          {crashReportCallout({
+            link: 'https://docs.sentry.io/platforms/javascript/guides/remix/user-feedback/#user-feedback-api',
+          })}
+        </Fragment>
+      ),
     },
   ],
   verify: () => [],

--- a/static/app/gettingStartedDocs/javascript/remix.tsx
+++ b/static/app/gettingStartedDocs/javascript/remix.tsx
@@ -206,8 +206,8 @@ const feedbackOnboarding: OnboardingConfig = {
         <Fragment>
           <p>
             {tct(
-              'Note: The Feedback integration only needs to be added to your [entryClient:entry.client.tsx] file.',
-              {entryClient: <code />, sentryServer: <code />}
+              'Note: The Feedback integration only needs to be added to your [code:entry.client.tsx] file.',
+              {code: <code />}
             )}
           </p>
 

--- a/static/app/gettingStartedDocs/javascript/remix.tsx
+++ b/static/app/gettingStartedDocs/javascript/remix.tsx
@@ -136,7 +136,7 @@ const replayOnboarding: OnboardingConfig = {
         {
           code: [
             {
-              label: 'JavaScript',
+              label: 'entry.client.tsx',
               value: 'javascript',
               language: 'javascript',
               code: getReplaySDKSetupSnippet({

--- a/static/app/gettingStartedDocs/javascript/remix.tsx
+++ b/static/app/gettingStartedDocs/javascript/remix.tsx
@@ -190,7 +190,7 @@ const feedbackOnboarding: OnboardingConfig = {
         {
           code: [
             {
-              label: 'JavaScript',
+              label: 'entry.client.tsx',
               value: 'javascript',
               language: 'javascript',
               code: getFeedbackSDKSetupSnippet({


### PR DESCRIPTION
Added additional info about where to add sentry's feedback integration - it should be added only to a client side.

![image](https://github.com/user-attachments/assets/84df57dc-ff18-4f59-9b9d-290071748473)
