### PR TITLE
fix(insights): Broken search in requests sample panel

### DIFF
--- a/static/app/views/insights/http/components/httpSamplesPanel.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.tsx
@@ -152,12 +152,14 @@ export function HTTPSamplesPanel() {
   const ribbonFilters: SpanMetricsQueryFilters = {
     ...BASE_FILTERS,
     ...ADDITONAL_FILTERS,
+    ...new MutableSearch(query.spanSearchQuery).filters,
   };
 
   // These filters are for the charts and samples tables
   const filters: SpanMetricsQueryFilters = {
     ...BASE_FILTERS,
     ...ADDITONAL_FILTERS,
+    ...new MutableSearch(query.spanSearchQuery).filters,
   };
 
   const responseCodeInRange = query.responseCodeClass


### PR DESCRIPTION
The filter object was not wired up with the search query text so this was not working!