### PR TITLE
chore(insights): Upgrade search bar + `useNavigate` in Vitals module

### DIFF
--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -243,7 +243,7 @@ const decodeTeams = (location: Location): ('myteams' | number)[] => {
     .filter(team => team === 'myteams' || !isNaN(team));
 };
 
-const decodeProjects = (location: Location): number[] => {
+export const decodeProjects = (location: Location): number[] => {
   if (!location.query || !location.query.project) {
     return [];
   }


### PR DESCRIPTION
Adds the new `SearchQueryBuilder` component to the Web Vitals page summary:

![image](https://github.com/user-attachments/assets/4d4dfd1d-b732-4180-aa30-475be73c4829)

Also replaces usages of `router.replace` with `useNavigate`, since the former is deprecated