### PR TITLE
ref: squash index_together operation for ProjectDebugFile model

### DIFF
--- a/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
+++ b/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
@@ -3758,7 +3758,14 @@ class Migration(CheckedMigration):
             ],
             options={
                 "db_table": "sentry_projectdsymfile",
-                "index_together": {("project", "debug_id"), ("project", "code_id")},
+                "indexes": [
+                    models.Index(
+                        fields=["project_id", "debug_id"], name="sentry_proj_project_c586ac_idx"
+                    ),
+                    models.Index(
+                        fields=["project_id", "code_id"], name="sentry_proj_project_9b5950_idx"
+                    ),
+                ],
             },
         ),
         migrations.CreateModel(
@@ -7437,10 +7444,6 @@ class Migration(CheckedMigration):
                 migrations.RemoveField(
                     model_name="projectdebugfile",
                     name="project",
-                ),
-                migrations.AlterIndexTogether(
-                    name="projectdebugfile",
-                    index_together={("project_id", "debug_id"), ("project_id", "code_id")},
                 ),
             ],
         ),

--- a/src/sentry/migrations/0640_index_together.py
+++ b/src/sentry/migrations/0640_index_together.py
@@ -155,16 +155,6 @@ class Migration(CheckedMigration):
             old_fields=("project_id", "artifact_bundle"),
         ),
         migrations.RenameIndex(
-            model_name="projectdebugfile",
-            new_name="sentry_proj_project_c586ac_idx",
-            old_fields=("project_id", "debug_id"),
-        ),
-        migrations.RenameIndex(
-            model_name="projectdebugfile",
-            new_name="sentry_proj_project_9b5950_idx",
-            old_fields=("project_id", "code_id"),
-        ),
-        migrations.RenameIndex(
             model_name="regionoutbox",
             new_name="sentry_regi_shard_s_e7412f_idx",
             old_fields=("shard_scope", "shard_identifier", "id"),


### PR DESCRIPTION
index_together is removed in django 5.1 so this is necessary to upgrade

we will need a hard stop for self-hosted (already done!)

<!-- Describe your PR here. -->