### PR TITLE
chore (anomaly detection): create proxy API endpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -80,6 +80,9 @@ from sentry.discover.endpoints.discover_saved_query_detail import (
 from sentry.incidents.endpoints.organization_alert_rule_activations import (
     OrganizationAlertRuleActivationsEndpoint,
 )
+from sentry.incidents.endpoints.organization_alert_rule_anomalies import (
+    OrganizationAlertRuleAnomaliesEndpoint,
+)
 from sentry.incidents.endpoints.organization_alert_rule_available_action_index import (
     OrganizationAlertRuleAvailableActionIndexEndpoint,
 )
@@ -1168,6 +1171,11 @@ ORGANIZATION_URLS = [
         r"^(?P<organization_id_or_slug>[^\/]+)/alert-rules/(?P<alert_rule_id>[^\/]+)/activations/$",
         OrganizationAlertRuleActivationsEndpoint.as_view(),
         name="sentry-api-0-organization-alert-rule-activations",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/alert-rules/(?P<alert_rule_id>[^\/]+)/anomalies/$",
+        OrganizationAlertRuleAnomaliesEndpoint.as_view(),
+        name="sentry-api-0-organization-alert-rule-anomalies",
     ),
     re_path(  # fetch combined metric and issue alert rules
         r"^(?P<organization_id_or_slug>[^\/]+)/combined-rules/$",

--- a/src/sentry/apidocs/examples/metric_alert_examples.py
+++ b/src/sentry/apidocs/examples/metric_alert_examples.py
@@ -239,3 +239,19 @@ class MetricAlertExamples:
             ],
         )
     ]
+
+    GET_METRIC_ALERT_ANOMALIES = [
+        OpenApiExample(
+            "Fetch a list of anomalies for a metric alert rule",
+            value=[
+                {
+                    "timestamp": 0.1,
+                    "value": 100.0,
+                    "anomaly": {
+                        "anomaly_type": "anomaly_higher_confidence",
+                        "anomaly_value": 100,
+                    },
+                }
+            ],
+        )
+    ]

--- a/src/sentry/incidents/endpoints/organization_alert_rule_anomalies.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_anomalies.py
@@ -1,0 +1,76 @@
+from drf_spectacular.utils import extend_schema
+from pydantic import BaseModel
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.paginator import OffsetPaginator
+from sentry.api.serializers.base import serialize
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.examples.metric_alert_examples import MetricAlertExamples
+from sentry.apidocs.parameters import GlobalParams, MetricAlertParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.incidents.endpoints.bases import OrganizationAlertRuleEndpoint
+from sentry.incidents.models.alert_rule import AlertRule
+from sentry.models.organization import Organization
+from sentry.seer.anomaly_detection.get_historical_anomalies import (
+    get_historical_anomaly_data_from_seer,
+)
+from sentry.seer.anomaly_detection.types import TimeSeriesPoint
+
+
+class DetectAnomaliesResponse(BaseModel):
+    timeseries: list[TimeSeriesPoint]
+
+
+@region_silo_endpoint
+class OrganizationAlertRuleAnomaliesEndpoint(OrganizationAlertRuleEndpoint):
+    owner = ApiOwner.ALERTS_NOTIFICATIONS
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+
+    @extend_schema(
+        operation_id="Retrieve anomalies for a Metric Alert Rule",
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, MetricAlertParams.METRIC_RULE_ID],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ListAlertRuleAnomalies", DetectAnomaliesResponse
+            ),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+        examples=MetricAlertExamples.GET_METRIC_ALERT_ANOMALIES,
+    )
+    def get(self, request: Request, organization: Organization, alert_rule: AlertRule) -> Response:
+        """
+        Return a list of anomalies for a metric alert rule.
+        """
+        project = alert_rule.projects.first()
+        start = request.GET.get("start", None)
+        end = request.GET.get("end", None)
+
+        if not project or start is None or end is None:
+            return Response(
+                "Unable to get historical anomaly data: missing required argument(s) project, start, and/or end",
+                status=400,
+            )
+
+        anomalies = get_historical_anomaly_data_from_seer(alert_rule, project, start, end)
+        if anomalies is None:
+            return Response("Unable to get historical anomaly data", status=400)
+        return self.paginate(
+            request=request,
+            queryset=anomalies,
+            paginator_cls=OffsetPaginator,
+            on_results=lambda x: serialize(x, request.user),
+        )

--- a/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
+++ b/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
@@ -1,0 +1,24 @@
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleStatus
+from sentry.models.project import Project
+from sentry.seer.anomaly_detection.types import AnomalyType
+
+
+def get_historical_anomaly_data_from_seer(
+    alert_rule: AlertRule, project: Project, start_string: str, end_string: str
+) -> list | None:
+    """
+    Send time series data to Seer and return anomaly detection response (PLACEHOLDER).
+    """
+    if alert_rule.status == AlertRuleStatus.NOT_ENOUGH_DATA.value:
+        return []
+
+    return [
+        {
+            "timestamp": 0.1,
+            "value": 100.0,
+            "anomaly": {
+                "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
+                "anomaly_value": 100,
+            },
+        }
+    ]

--- a/src/sentry/seer/anomaly_detection/store_data.py
+++ b/src/sentry/seer/anomaly_detection/store_data.py
@@ -1,17 +1,13 @@
 import logging
 from datetime import datetime, timedelta
-from typing import Any
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.utils import timezone
-from django.utils.datastructures import MultiValueDict
 from urllib3.exceptions import MaxRetryError, TimeoutError
 
-from sentry import release_health
 from sentry.conf.server import SEER_ANOMALY_DETECTION_STORE_DATA_URL
 from sentry.incidents.models.alert_rule import AlertRule, AlertRuleStatus
-from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.net.http import connection_from_url
 from sentry.search.events.types import SnubaParams
@@ -20,12 +16,15 @@ from sentry.seer.anomaly_detection.types import (
     AnomalyDetectionConfig,
     StoreDataRequest,
 )
-from sentry.seer.anomaly_detection.utils import format_historical_data, translate_direction
+from sentry.seer.anomaly_detection.utils import (
+    format_historical_data,
+    get_crash_free_historical_data,
+    translate_direction,
+)
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.snuba import metrics_performance
 from sentry.snuba.models import SnubaQuery
 from sentry.snuba.referrer import Referrer
-from sentry.snuba.sessions_v2 import QueryDefinition
 from sentry.snuba.utils import get_dataset
 from sentry.utils import json
 from sentry.utils.snuba import SnubaTSResult

--- a/src/sentry/seer/anomaly_detection/store_data.py
+++ b/src/sentry/seer/anomaly_detection/store_data.py
@@ -19,9 +19,8 @@ from sentry.seer.anomaly_detection.types import (
     AlertInSeer,
     AnomalyDetectionConfig,
     StoreDataRequest,
-    TimeSeriesPoint,
 )
-from sentry.seer.anomaly_detection.utils import translate_direction
+from sentry.seer.anomaly_detection.utils import format_historical_data, translate_direction
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.snuba import metrics_performance
 from sentry.snuba.models import SnubaQuery
@@ -38,81 +37,6 @@ seer_anomaly_detection_connection_pool = connection_from_url(
     timeout=settings.SEER_ANOMALY_DETECTION_TIMEOUT,
 )
 NUM_DAYS = 28
-
-
-def get_crash_free_historical_data(
-    start: datetime, end: datetime, project: Project, organization: Organization, granularity: int
-):
-    """
-    Fetch the historical metrics data from Snuba for crash free user rate and crash free session rate metrics
-    """
-
-    params = {
-        "start": start,
-        "end": end,
-        "project_id": [project.id],
-        "project_objects": [project],
-        "organization_id": organization.id,
-    }
-    query_params: MultiValueDict[str, Any] = MultiValueDict(
-        {
-            "project": [project.id],
-            "statsPeriod": [f"{NUM_DAYS}d"],
-            "field": ["sum(session)"],
-            "groupBy": ["release"],
-        }
-    )
-    query = QueryDefinition(
-        query=query_params,
-        params=params,
-        offset=None,
-        limit=None,
-        query_config=release_health.backend.sessions_query_config(organization),
-    )
-    result = release_health.backend.run_sessions_query(
-        organization.id, query, span_op="sessions.anomaly_detection"
-    )
-    return SnubaTSResult(
-        {
-            "data": result,
-        },
-        result.get("start"),
-        result.get("end"),
-        granularity,
-    )
-
-
-def format_historical_data(data: SnubaTSResult, dataset: Any) -> list[TimeSeriesPoint]:
-    """
-    Format Snuba data into the format the Seer API expects.
-    For errors data:
-        If there are no results, it's just the timestamp
-        {'time': 1719012000}, {'time': 1719018000}, {'time': 1719024000}
-
-        If there are results, the count is added
-        {'time': 1721300400, 'count': 2}
-
-    For metrics_performance dataset/sessions data:
-        The count is stored separately from the timestamps, if there is no data the count is 0
-    """
-    formatted_data: list[TimeSeriesPoint] = []
-    nested_data = data.data.get("data", [])
-
-    if dataset == metrics_performance:
-        groups = nested_data.get("groups")
-        if not len(groups):
-            return formatted_data
-        series = groups[0].get("series")
-
-        for time, count in zip(nested_data.get("intervals"), series.get("sum(session)")):
-            date = datetime.strptime(time, "%Y-%m-%dT%H:%M:%SZ")
-            ts_point = TimeSeriesPoint(timestamp=date.timestamp(), value=count)
-            formatted_data.append(ts_point)
-    else:
-        for datum in nested_data:
-            ts_point = TimeSeriesPoint(timestamp=datum.get("time"), value=datum.get("count", 0))
-            formatted_data.append(ts_point)
-    return formatted_data
 
 
 def _get_start_and_end_indices(data: SnubaTSResult) -> tuple[int, int]:

--- a/src/sentry/seer/anomaly_detection/types.py
+++ b/src/sentry/seer/anomaly_detection/types.py
@@ -6,6 +6,11 @@ class AlertInSeer(TypedDict):
     id: int
 
 
+class Anomaly(TypedDict):
+    anomaly_type: str
+    anomaly_value: float
+
+
 class TimeSeriesPoint(TypedDict):
     timestamp: float
     value: float

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -1,4 +1,6 @@
 from sentry.incidents.models.alert_rule import AlertRuleThresholdType
+from sentry.seer.anomaly_detection.types import TimeSeriesPoint
+from sentry.utils.snuba import SnubaTSResult
 
 
 def translate_direction(direction: int) -> str:
@@ -11,3 +13,19 @@ def translate_direction(direction: int) -> str:
         AlertRuleThresholdType.ABOVE_AND_BELOW: "both",
     }
     return direction_map[AlertRuleThresholdType(direction)]
+
+
+def format_historical_data(data: SnubaTSResult) -> list[TimeSeriesPoint]:
+    """
+    Format Snuba data into the format the Seer API expects.
+    If there are no results, it's just the timestamp
+    {'time': 1719012000}, {'time': 1719018000}, {'time': 1719024000}
+
+    If there are results, the count is added
+    {'time': 1721300400, 'count': 2}
+    """
+    formatted_data = []
+    for datum in data.data.get("data", []):
+        ts_point = TimeSeriesPoint(timestamp=datum.get("time"), value=datum.get("count", 0))
+        formatted_data.append(ts_point)
+    return formatted_data

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -1,5 +1,15 @@
+from datetime import datetime
+from typing import Any
+
+from django.utils.datastructures import MultiValueDict
+
+from sentry import release_health
 from sentry.incidents.models.alert_rule import AlertRuleThresholdType
+from sentry.models.organization import Organization
+from sentry.models.project import Project
 from sentry.seer.anomaly_detection.types import TimeSeriesPoint
+from sentry.snuba import metrics_performance
+from sentry.snuba.sessions_v2 import QueryDefinition
 from sentry.utils.snuba import SnubaTSResult
 
 
@@ -15,17 +25,79 @@ def translate_direction(direction: int) -> str:
     return direction_map[AlertRuleThresholdType(direction)]
 
 
-def format_historical_data(data: SnubaTSResult) -> list[TimeSeriesPoint]:
+NUM_DAYS = 28
+
+
+def get_crash_free_historical_data(
+    start: datetime, end: datetime, project: Project, organization: Organization, granularity: int
+):
+    """
+    Fetch the historical metrics data from Snuba for crash free user rate and crash free session rate metrics
+    """
+
+    params = {
+        "start": start,
+        "end": end,
+        "project_id": [project.id],
+        "project_objects": [project],
+        "organization_id": organization.id,
+    }
+    query_params: MultiValueDict[str, Any] = MultiValueDict(
+        {
+            "project": [project.id],
+            "statsPeriod": [f"{NUM_DAYS}d"],
+            "field": ["sum(session)"],
+            "groupBy": ["release"],
+        }
+    )
+    query = QueryDefinition(
+        query=query_params,
+        params=params,
+        offset=None,
+        limit=None,
+        query_config=release_health.backend.sessions_query_config(organization),
+    )
+    result = release_health.backend.run_sessions_query(
+        organization.id, query, span_op="sessions.anomaly_detection"
+    )
+    return SnubaTSResult(
+        {
+            "data": result,
+        },
+        result.get("start"),
+        result.get("end"),
+        granularity,
+    )
+
+
+def format_historical_data(data: SnubaTSResult, dataset: Any) -> list[TimeSeriesPoint]:
     """
     Format Snuba data into the format the Seer API expects.
-    If there are no results, it's just the timestamp
-    {'time': 1719012000}, {'time': 1719018000}, {'time': 1719024000}
+    For errors data:
+        If there are no results, it's just the timestamp
+        {'time': 1719012000}, {'time': 1719018000}, {'time': 1719024000}
 
-    If there are results, the count is added
-    {'time': 1721300400, 'count': 2}
+        If there are results, the count is added
+        {'time': 1721300400, 'count': 2}
+
+    For metrics_performance dataset/sessions data:
+        The count is stored separately from the timestamps, if there is no data the count is 0
     """
-    formatted_data = []
-    for datum in data.data.get("data", []):
-        ts_point = TimeSeriesPoint(timestamp=datum.get("time"), value=datum.get("count", 0))
-        formatted_data.append(ts_point)
+    formatted_data: list[TimeSeriesPoint] = []
+    nested_data = data.data.get("data", [])
+
+    if dataset == metrics_performance:
+        groups = nested_data.get("groups")
+        if not len(groups):
+            return formatted_data
+        series = groups[0].get("series")
+
+        for time, count in zip(nested_data.get("intervals"), series.get("sum(session)")):
+            date = datetime.strptime(time, "%Y-%m-%dT%H:%M:%SZ")
+            ts_point = TimeSeriesPoint(timestamp=date.timestamp(), value=count)
+            formatted_data.append(ts_point)
+    else:
+        for datum in nested_data:
+            ts_point = TimeSeriesPoint(timestamp=datum.get("time"), value=datum.get("count", 0))
+            formatted_data.append(ts_point)
     return formatted_data

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_anomalies.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_anomalies.py
@@ -1,11 +1,9 @@
 from datetime import timedelta
 from unittest.mock import patch
 
-# import orjson
 import pytest
 from urllib3.response import HTTPResponse
 
-# from sentry.conf.server import SEER_ANOMALY_DETECTION_ENDPOINT_URL
 from sentry.incidents.models.alert_rule import (
     AlertRuleDetectionType,
     AlertRuleSeasonality,
@@ -34,9 +32,6 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
     @patch(
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
-    # @patch(
-    #     "sentry.seer.anomaly_detection.get_historical_anomalies.seer_anomaly_detection_connection_pool.urlopen"
-    # )
     def test_simple(self, mock_seer_store_request):
         self.create_team(organization=self.organization, members=[self.user])
         two_weeks_ago = before_now(days=14).replace(hour=10, minute=0, second=0, microsecond=0)
@@ -73,28 +68,7 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
 
         self.login_as(self.user)
 
-        # seer_return_value = {
-        #     "anomalies": [
-        #         {
-        #             "anomaly": {
-        #                 "anomaly_score": 0.0,
-        #                 "anomaly_type": AnomalyType.NONE.value,
-        #             },
-        #             "timestamp": 1,
-        #             "value": 1,
-        #         },
-        #         {
-        #             "anomaly": {
-        #                 "anomaly_score": 0.0,
-        #                 "anomaly_type": AnomalyType.NONE.value,
-        #             },
-        #             "timestamp": 2,
-        #             "value": 1,
-        #         },
-        #     ]
-        # }
         mock_seer_store_request.return_value = HTTPResponse(status=200)
-        # mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
         with outbox_runner():
             resp = self.get_success_response(
                 self.organization.slug,
@@ -107,10 +81,6 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
             )
 
         assert mock_seer_store_request.call_count == 1
-        # assert mock_seer_request.call_count == 1
-        # assert mock_seer_request.call_args.args[0] == "POST"
-        # assert mock_seer_request.call_args.args[1] == SEER_ANOMALY_DETECTION_ENDPOINT_URL
-        # assert resp.data == seer_return_value["anomalies"]
         assert resp.data == [
             {
                 "timestamp": 0.1,

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_anomalies.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_anomalies.py
@@ -1,0 +1,153 @@
+from datetime import timedelta
+from unittest.mock import patch
+
+# import orjson
+import pytest
+from urllib3.response import HTTPResponse
+
+# from sentry.conf.server import SEER_ANOMALY_DETECTION_ENDPOINT_URL
+from sentry.incidents.models.alert_rule import (
+    AlertRuleDetectionType,
+    AlertRuleSeasonality,
+    AlertRuleSensitivity,
+)
+from sentry.seer.anomaly_detection.types import AnomalyType
+from sentry.testutils.cases import SnubaTestCase
+from sentry.testutils.factories import EventType
+from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
+from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.outbox import outbox_runner
+from sentry.testutils.skips import requires_snuba
+from tests.sentry.incidents.endpoints.test_organization_alert_rule_index import AlertRuleBase
+
+pytestmark = [pytest.mark.sentry_metrics, requires_snuba]
+
+
+@freeze_time()
+class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
+    endpoint = "sentry-api-0-organization-alert-rule-anomalies"
+
+    method = "get"
+
+    @with_feature("organizations:anomaly-detection-alerts")
+    @with_feature("organizations:incidents")
+    @patch(
+        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
+    )
+    # @patch(
+    #     "sentry.seer.anomaly_detection.get_historical_anomalies.seer_anomaly_detection_connection_pool.urlopen"
+    # )
+    def test_simple(self, mock_seer_store_request):
+        self.create_team(organization=self.organization, members=[self.user])
+        two_weeks_ago = before_now(days=14).replace(hour=10, minute=0, second=0, microsecond=0)
+        with self.options({"issues.group_attributes.send_kafka": True}):
+            self.store_event(
+                data={
+                    "event_id": "a" * 32,
+                    "message": "super duper bad",
+                    "timestamp": iso_format(two_weeks_ago + timedelta(minutes=1)),
+                    "fingerprint": ["group1"],
+                    "tags": {"sentry:user": self.user.email},
+                },
+                event_type=EventType.ERROR,
+                project_id=self.project.id,
+            )
+            self.store_event(
+                data={
+                    "event_id": "b" * 32,
+                    "message": "super bad",
+                    "timestamp": iso_format(two_weeks_ago + timedelta(days=10)),
+                    "fingerprint": ["group2"],
+                    "tags": {"sentry:user": self.user.email},
+                },
+                event_type=EventType.ERROR,
+                project_id=self.project.id,
+            )
+
+        alert_rule = self.create_alert_rule(
+            time_window=15,
+            sensitivity=AlertRuleSensitivity.MEDIUM,
+            seasonality=AlertRuleSeasonality.AUTO,
+            detection_type=AlertRuleDetectionType.DYNAMIC,
+        )
+
+        self.login_as(self.user)
+
+        # seer_return_value = {
+        #     "anomalies": [
+        #         {
+        #             "anomaly": {
+        #                 "anomaly_score": 0.0,
+        #                 "anomaly_type": AnomalyType.NONE.value,
+        #             },
+        #             "timestamp": 1,
+        #             "value": 1,
+        #         },
+        #         {
+        #             "anomaly": {
+        #                 "anomaly_score": 0.0,
+        #                 "anomaly_type": AnomalyType.NONE.value,
+        #             },
+        #             "timestamp": 2,
+        #             "value": 1,
+        #         },
+        #     ]
+        # }
+        mock_seer_store_request.return_value = HTTPResponse(status=200)
+        # mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
+        with outbox_runner():
+            resp = self.get_success_response(
+                self.organization.slug,
+                alert_rule.id,
+                qs_params={
+                    "start": str(two_weeks_ago),
+                    "end": str(two_weeks_ago + timedelta(days=12)),
+                },
+                status_code=200,
+            )
+
+        assert mock_seer_store_request.call_count == 1
+        # assert mock_seer_request.call_count == 1
+        # assert mock_seer_request.call_args.args[0] == "POST"
+        # assert mock_seer_request.call_args.args[1] == SEER_ANOMALY_DETECTION_ENDPOINT_URL
+        # assert resp.data == seer_return_value["anomalies"]
+        assert resp.data == [
+            {
+                "timestamp": 0.1,
+                "value": 100.0,
+                "anomaly": {
+                    "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
+                    "anomaly_value": 100,
+                },
+            }
+        ]
+
+    @with_feature("organizations:anomaly-detection-alerts")
+    @with_feature("organizations:incidents")
+    @patch(
+        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
+    )
+    def test_alert_not_enough_data(self, mock_seer_store_request):
+        self.create_team(organization=self.organization, members=[self.user])
+        two_weeks_ago = before_now(days=14).replace(hour=10, minute=0, second=0, microsecond=0)
+        alert_rule = self.create_alert_rule(
+            time_window=15,
+            sensitivity=AlertRuleSensitivity.MEDIUM,
+            seasonality=AlertRuleSeasonality.AUTO,
+            detection_type=AlertRuleDetectionType.DYNAMIC,
+        )
+
+        self.login_as(self.user)
+        mock_seer_store_request.return_value = HTTPResponse(status=200)
+        with outbox_runner():
+            resp = self.get_success_response(
+                self.organization.slug,
+                alert_rule.id,
+                qs_params={
+                    "start": str(two_weeks_ago),
+                    "end": str(two_weeks_ago + timedelta(days=12)),
+                },
+                status_code=200,
+            )
+
+        assert resp.data == []

--- a/tests/sentry/seer/anomaly_detection/test_store_data.py
+++ b/tests/sentry/seer/anomaly_detection/test_store_data.py
@@ -1,7 +1,12 @@
 from datetime import datetime
 
+import pytest
+
+from sentry.incidents.models.alert_rule import AlertRuleThresholdType
 from sentry.seer.anomaly_detection.store_data import fetch_historical_data
 from sentry.seer.anomaly_detection.utils import format_historical_data
+from sentry.snuba import errors, metrics_performance
+from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import SnubaQuery
 from sentry.testutils.cases import BaseMetricsTestCase
 from sentry.testutils.factories import EventType

--- a/tests/sentry/seer/anomaly_detection/test_store_data.py
+++ b/tests/sentry/seer/anomaly_detection/test_store_data.py
@@ -1,11 +1,7 @@
 from datetime import datetime
 
-import pytest
-
-from sentry.incidents.models.alert_rule import AlertRuleThresholdType
-from sentry.seer.anomaly_detection.store_data import fetch_historical_data, format_historical_data
-from sentry.snuba import errors, metrics_performance
-from sentry.snuba.dataset import Dataset
+from sentry.seer.anomaly_detection.store_data import fetch_historical_data
+from sentry.seer.anomaly_detection.utils import format_historical_data
 from sentry.snuba.models import SnubaQuery
 from sentry.testutils.cases import BaseMetricsTestCase
 from sentry.testutils.factories import EventType


### PR DESCRIPTION
Create a proxy API endpoint for us to query the backend about anomalies. `get_historical_anomaly_data_from_seer` returns a placeholder.