### PR TITLE
fix(spans): Add duration to eap spans

### DIFF
--- a/src/sentry/search/events/builder/spans_indexed.py
+++ b/src/sentry/search/events/builder/spans_indexed.py
@@ -4,7 +4,10 @@ from snuba_sdk import Column, Function
 from sentry.search.events import constants
 from sentry.search.events.builder.base import BaseQueryBuilder
 from sentry.search.events.builder.discover import TimeseriesQueryBuilder, TopEventsQueryBuilder
-from sentry.search.events.datasets.spans_indexed import SpansIndexedDatasetConfig
+from sentry.search.events.datasets.spans_indexed import (
+    SpansEAPDatasetConfig,
+    SpansIndexedDatasetConfig,
+)
 from sentry.search.events.fields import custom_time_processor
 from sentry.search.events.types import SelectType
 from sentry.snuba.dataset import Dataset
@@ -60,7 +63,7 @@ class SpansEAPQueryBuilder(SpansIndexedQueryBuilderMixin, BaseQueryBuilder):
     requires_organization_condition = True
     uuid_fields = SPAN_UUID_FIELDS
     span_id_fields = SPAN_ID_FIELDS
-    config_class = SpansIndexedDatasetConfig
+    config_class = SpansEAPDatasetConfig
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -518,3 +518,30 @@ class SpansIndexedDatasetConfig(DatasetConfig):
                 index,
             ],
         )
+
+
+class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
+    """Eventually should just write the eap dataset from scratch, but inheriting for now to move fast"""
+
+    def _resolve_span_duration(self, alias: str) -> SelectType:
+        # In ClickHouse, duration is an UInt32 whereas self time is a Float64.
+        # This creates a situation where a sub-millisecond duration is truncated
+        # to but the self time is not.
+        #
+        # To remedy this, we take the greater of the duration and self time as
+        # this is the only situation where the self time can be greater than
+        # the duration.
+        #
+        # Also avoids strange situations on the frontend where duration is less
+        # than the self time.
+        duration = Column("duration_ms")
+        self_time = self.builder.column("span.self_time")
+        return Function(
+            "if",
+            [
+                Function("greater", [self_time, duration]),
+                self_time,
+                duration,
+            ],
+            alias,
+        )


### PR DESCRIPTION
- This enables the span.duration field for the spans dataset
- For now this is going to continue inheriting the entirety of the dataset config until we do more testing