### PR TITLE
feat(dashboards): Add release `SearchQueryBuilder`

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
@@ -32,6 +32,13 @@ const supportedTags = Object.values(SESSIONS_FILTER_TAGS).reduce((acc, key) => {
   return acc;
 }, {});
 
+const invalidMessages = {
+  [InvalidReason.WILDCARD_NOT_ALLOWED]: t("Release queries don't support wildcards."),
+  [InvalidReason.FREE_TEXT_NOT_ALLOWED]: t(
+    "Release queries don't support free text search."
+  ),
+};
+
 const SEARCH_SPECIAL_CHARS_REGEXP = new RegExp(
   `^${NEGATION_OPERATOR}|\\${SEARCH_WILDCARD}`,
   'g'
@@ -98,6 +105,7 @@ export function ReleaseSearchBar({
       disallowWildcard
       disallowUnsupportedFilters
       disallowFreeText
+      invalidMessages={invalidMessages}
       recentSearches={SavedSearchType.SESSION}
     />
   ) : (

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
@@ -27,6 +27,11 @@ const filterKeySections: FilterKeySection[] = [
   {value: 'session_field', label: t('Suggested'), children: SESSIONS_FILTER_TAGS},
 ];
 
+const supportedTags = Object.values(SESSIONS_FILTER_TAGS).reduce((acc, key) => {
+  acc[key] = {key, name: key};
+  return acc;
+}, {});
+
 const SEARCH_SPECIAL_CHARS_REGEXP = new RegExp(
   `^${NEGATION_OPERATOR}|\\${SEARCH_WILDCARD}`,
   'g'
@@ -75,11 +80,6 @@ export function ReleaseSearchBar({
       }
     );
   }
-
-  const supportedTags = Object.values(SESSIONS_FILTER_TAGS).reduce((acc, key) => {
-    acc[key] = {key, name: key};
-    return acc;
-  }, {});
 
   return organization.features.includes('search-query-builder-releases') ? (
     <SearchQueryBuilder

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
@@ -93,10 +93,7 @@ export function ReleaseSearchBar({
       initialQuery={widgetQuery.conditions}
       filterKeySections={filterKeySections}
       filterKeys={supportedTags}
-      getTagValues={memoize(
-        getTagValues,
-        ({key}, searchQuery) => `${key}-${searchQuery}`
-      )}
+      getTagValues={getTagValues}
       placeholder={t('Search for release version, session status, and more')}
       onChange={(query, state) => {
         onClose?.(query, {validSearch: state.queryIsValid});


### PR DESCRIPTION
For the release dataset, if the `'search-query-builder-releases'` is on, show a `SearchQueryBuilder` instead of a regular search bar. Note: This does _not_ use `'search-query-builder-dashboards'` flag by design. This follows how the logic works for `'search-query-builder-issues'`, which, if enabled, changes the issue search bar _everywhere_ including dashboards.

**Before:**
<img width="957" alt="Screenshot 2024-09-04 at 2 13 11 PM" src="https://github.com/user-attachments/assets/6fd84671-f955-47c7-9f3a-b9403cf88a37">

**After:**  
<img width="713" alt="Screenshot 2024-09-04 at 2 24 43 PM" src="https://github.com/user-attachments/assets/b8c761cd-b14f-42a8-807b-13b4a4552374">
