### PR TITLE
feat(spans): Add stats support to spans-eap

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -221,7 +221,7 @@ class TimeseriesQueryBuilder(UnresolvedQuery):
 
     def get_snql_query(self) -> Request:
         return Request(
-            dataset=self.dataset.value,
+            dataset=self._get_dataset_name(),
             app_id="default",
             query=Query(
                 match=Entity(self.dataset.value),

--- a/src/sentry/search/events/builder/spans_indexed.py
+++ b/src/sentry/search/events/builder/spans_indexed.py
@@ -86,6 +86,18 @@ class TimeseriesSpanIndexedQueryBuilder(SpansIndexedQueryBuilderMixin, Timeserie
         )
 
 
+class TimeseriesSpanEAPIndexedQueryBuilder(SpansEAPQueryBuilder, TimeseriesQueryBuilder):
+    config_class = SpansEAPDatasetConfig
+    uuid_fields = SPAN_UUID_FIELDS
+    span_id_fields = SPAN_ID_FIELDS
+
+    @property
+    def time_column(self) -> SelectType:
+        return custom_time_processor(
+            self.interval, Function("toUInt32", [Column("start_timestamp")])
+        )
+
+
 class TopEventsSpanIndexedQueryBuilder(SpansIndexedQueryBuilderMixin, TopEventsQueryBuilder):
     config_class = SpansIndexedDatasetConfig
     uuid_fields = SPAN_UUID_FIELDS

--- a/src/sentry/snuba/spans_eap.py
+++ b/src/sentry/snuba/spans_eap.py
@@ -9,7 +9,7 @@ from sentry.discover.arithmetic import categorize_columns
 from sentry.models.organization import Organization
 from sentry.search.events.builder.spans_indexed import (
     SpansEAPQueryBuilder,
-    TimeseriesSpanIndexedQueryBuilder,
+    TimeseriesSpanEAPIndexedQueryBuilder,
     TopEventsSpanIndexedQueryBuilder,
 )
 from sentry.search.events.types import EventsResponse, QueryBuilderConfig, SnubaParams
@@ -103,7 +103,7 @@ def timeseries_query(
     equations, columns = categorize_columns(selected_columns)
 
     with sentry_sdk.start_span(op="spans_indexed", description="TimeseriesSpanIndexedQueryBuilder"):
-        querybuilder = TimeseriesSpanIndexedQueryBuilder(
+        querybuilder = TimeseriesSpanEAPIndexedQueryBuilder(
             Dataset.SpansEAP,
             {},
             rollup,


### PR DESCRIPTION
- Adds support for stats graphs, which means we can call events-stats with dataset=spans now
- Doesn't support topEvents yet