### PR TITLE
fix(substatus): Set substatus to regressed

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -586,11 +586,15 @@ def update_groups(
         )
         if new_substatus is None and new_status == GroupStatus.UNRESOLVED:
             new_substatus = GroupSubStatus.ONGOING
-            if len(group_list) == 1 and group_list[0].status == GroupStatus.IGNORED:
-                is_new_group = group_list[0].first_seen > datetime.now(timezone.utc) - timedelta(
-                    days=TRANSITION_AFTER_DAYS
-                )
-                new_substatus = GroupSubStatus.NEW if is_new_group else GroupSubStatus.ONGOING
+            if len(group_list) == 1:
+                g = group_list[0]
+                if g.status == GroupStatus.IGNORED:
+                    is_new_group = g.first_seen > datetime.now(timezone.utc) - timedelta(
+                        days=TRANSITION_AFTER_DAYS
+                    )
+                    new_substatus = GroupSubStatus.NEW if is_new_group else GroupSubStatus.ONGOING
+                if g.status == GroupStatus.RESOLVED:
+                    new_substatus = GroupSubStatus.REGRESSED
 
         with transaction.atomic(router.db_for_write(Group)):
             # TODO(gilbert): update() doesn't call pre_save and bypasses any substatus defaulting we have there

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -4767,7 +4767,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
     def test_set_unresolved(self) -> None:
         release = self.create_release(project=self.project, version="abc")
-        group = self.create_group(status=GroupStatus.RESOLVED)
+        group = self.create_group(status=GroupStatus.IGNORED)
         GroupResolution.objects.create(group=group, release=release)
 
         self.login_as(user=self.user)
@@ -5254,7 +5254,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             group=group1, status=GroupHistoryStatus.UNRESOLVED
         ).exists()
         assert GroupHistory.objects.filter(
-            group=group2, status=GroupHistoryStatus.UNRESOLVED
+            group=group2, status=GroupHistoryStatus.REGRESSED
         ).exists()
 
     def test_update_priority(self) -> None:


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/76908, we need to check and set the substatus for regressions if the substatus is not provided. 