### PR TITLE
feat(insights): adds create alert buttons to db and queue modules

### DIFF
--- a/static/app/views/insights/common/components/chartPanel.spec.tsx
+++ b/static/app/views/insights/common/components/chartPanel.spec.tsx
@@ -1,0 +1,34 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import ChartPanel from 'sentry/views/insights/common/components/chartPanel';
+
+describe('chartPanel', function () {
+  const {organization} = initializeOrg({
+    organization: {features: ['insights-alerts', 'insights-initial-modules']},
+  });
+
+  it('should render create alert options', async function () {
+    const alertConfigs = [
+      {
+        aggregate: 'avg(d:spans/duration@millisecond)',
+        query: 'span.module:db has:span.description',
+        name: 'Average DB Duration',
+      },
+      {
+        aggregate: 'spm()',
+        query: 'span.module:db has:span.description',
+        name: 'DB Spans per minute',
+      },
+    ];
+    render(
+      <ChartPanel title="Avg Latency" alertConfigs={alertConfigs}>
+        <div />
+      </ChartPanel>,
+      {organization}
+    );
+    await userEvent.click(screen.getByLabelText('Chart Actions'));
+    screen.getByText('Average DB Duration');
+    screen.getByText('DB Spans per minute');
+  });
+});

--- a/static/app/views/insights/common/components/chartPanel.tsx
+++ b/static/app/views/insights/common/components/chartPanel.tsx
@@ -1,21 +1,68 @@
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {openInsightChartModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/button';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import Panel from 'sentry/components/panels/panel';
-import {IconExpand} from 'sentry/icons';
+import {IconEllipsis, IconExpand} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import useProjects from 'sentry/utils/useProjects';
+import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
+import {hasInsightsAlerts} from 'sentry/views/insights/common/utils/hasInsightsAlerts';
 import {Subtitle} from 'sentry/views/performance/landing/widgets/widgets/singleFieldAreaWidget';
+
+export type AlertConfig = {
+  aggregate: string;
+  name?: string;
+  query?: string;
+};
 
 type Props = {
   children: React.ReactNode;
+  alertConfigs?: AlertConfig[];
   button?: JSX.Element;
   subtitle?: React.ReactNode;
   title?: React.ReactNode;
 };
 
-export default function ChartPanel({title, children, button, subtitle}: Props) {
+export default function ChartPanel({
+  title,
+  children,
+  button,
+  subtitle,
+  alertConfigs,
+}: Props) {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+  const {projects} = useProjects();
+  const project = useMemo(
+    () =>
+      selection.projects.length === 1
+        ? projects.find(p => p.id === `${selection.projects[0]}`)
+        : undefined,
+    [projects, selection.projects]
+  );
+  const alertsUrls =
+    alertConfigs?.map(alertConfig => {
+      // Alerts only support single project selection
+      const alertsUrl =
+        alertConfig && selection.projects.length === 1 && project
+          ? getAlertsUrl({project, ...alertConfig})
+          : undefined;
+      const name = alertConfig.name ?? 'Create Alert';
+      return {
+        key: name,
+        label: name,
+        to: alertsUrl,
+      };
+    }) ?? [];
+
+  const dropdownMenuItems = hasInsightsAlerts(organization) ? alertsUrls : [];
+
   return (
     <PanelWithNoPadding>
       <PanelBody>
@@ -30,16 +77,31 @@ export default function ChartPanel({title, children, button, subtitle}: Props) {
                 )}
               </ChartLabel>
             )}
-            {button}
-            <Button
-              aria-label={t('Expand Insight Chart')}
-              borderless
-              size="xs"
-              icon={<IconExpand />}
-              onClick={() => {
-                openInsightChartModal({title, children});
-              }}
-            />
+            <MenuContainer>
+              {button}
+              <Button
+                aria-label={t('Expand Insight Chart')}
+                borderless
+                size="xs"
+                icon={<IconExpand />}
+                onClick={() => {
+                  openInsightChartModal({title, children});
+                }}
+              />
+              {dropdownMenuItems.length > 0 && (
+                <DropdownMenu
+                  triggerProps={{
+                    'aria-label': t('Chart Actions'),
+                    size: 'xs',
+                    borderless: true,
+                    showChevron: false,
+                    icon: <IconEllipsis direction="down" size="sm" />,
+                  }}
+                  position="bottom-end"
+                  items={dropdownMenuItems}
+                />
+              )}
+            </MenuContainer>
           </Header>
         )}
         {subtitle && (
@@ -78,4 +140,8 @@ const Header = styled('div')`
   display: flex;
   align-items: center;
   justify-content: space-between;
+`;
+
+const MenuContainer = styled('span')`
+  display: flex;
 `;

--- a/static/app/views/insights/common/components/chartPanel.tsx
+++ b/static/app/views/insights/common/components/chartPanel.tsx
@@ -52,7 +52,7 @@ export default function ChartPanel({
       const singleProject = selection.projects.length === 1 && project;
       const alertsUrl =
         alertConfig && singleProject
-          ? getAlertsUrl({project, ...alertConfig})
+          ? getAlertsUrl({project, orgSlug: organization.slug, ...alertConfig})
           : undefined;
       const name = alertConfig.name ?? 'Create Alert';
       const disabled = !singleProject;
@@ -62,7 +62,9 @@ export default function ChartPanel({
         to: alertsUrl,
         disabled,
         tooltip: disabled
-          ? t('Alerts are only available for a single project')
+          ? t(
+              'Alerts are only available for single project selection. Update your project filter to create an alert.'
+            )
           : undefined,
       };
     }) ?? [];

--- a/static/app/views/insights/common/components/chartPanel.tsx
+++ b/static/app/views/insights/common/components/chartPanel.tsx
@@ -49,15 +49,21 @@ export default function ChartPanel({
   const alertsUrls =
     alertConfigs?.map(alertConfig => {
       // Alerts only support single project selection
+      const singleProject = selection.projects.length === 1 && project;
       const alertsUrl =
-        alertConfig && selection.projects.length === 1 && project
+        alertConfig && singleProject
           ? getAlertsUrl({project, ...alertConfig})
           : undefined;
       const name = alertConfig.name ?? 'Create Alert';
+      const disabled = !singleProject;
       return {
         key: name,
         label: name,
         to: alertsUrl,
+        disabled,
+        tooltip: disabled
+          ? t('Alerts are only available for a single project')
+          : undefined,
       };
     }) ?? [];
 

--- a/static/app/views/insights/common/utils/getAlertsUrl.spec.tsx
+++ b/static/app/views/insights/common/utils/getAlertsUrl.spec.tsx
@@ -7,9 +7,10 @@ describe('getAlertsUrl', function () {
   it('should return a url to the alert rule page prepopulated with DB params', function () {
     const aggregate = 'avg(d:spans/duration@millisecond)';
     const query = 'span.module:db';
-    const url = getAlertsUrl({project, aggregate, query});
+    const orgSlug = 'orgSlug';
+    const url = getAlertsUrl({project, aggregate, query, orgSlug});
     expect(url).toEqual(
-      '/alerts/new/metric/?aggregate=avg%28d%3Aspans%2Fduration%40millisecond%29&dataset=generic_metrics&eventTypes=transaction&project=project-slug&query=span.module%3Adb'
+      '/organizations/orgSlug/alerts/new/metric/?aggregate=avg%28d%3Aspans%2Fduration%40millisecond%29&dataset=generic_metrics&eventTypes=transaction&project=project-slug&query=span.module%3Adb'
     );
   });
 });

--- a/static/app/views/insights/common/utils/getAlertsUrl.spec.tsx
+++ b/static/app/views/insights/common/utils/getAlertsUrl.spec.tsx
@@ -1,0 +1,15 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+
+import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
+
+describe('getAlertsUrl', function () {
+  const {project} = initializeOrg();
+  it('should return a url to the alert rule page prepopulated with DB params', function () {
+    const aggregate = 'avg(d:spans/duration@millisecond)';
+    const query = 'span.module:db';
+    const url = getAlertsUrl({project, aggregate, query});
+    expect(url).toEqual(
+      '/alerts/new/metric/?aggregate=avg%28d%3Aspans%2Fduration%40millisecond%29&dataset=generic_metrics&eventTypes=transaction&project=project-slug&query=span.module%3Adb'
+    );
+  });
+});

--- a/static/app/views/insights/common/utils/getAlertsUrl.tsx
+++ b/static/app/views/insights/common/utils/getAlertsUrl.tsx
@@ -1,0 +1,23 @@
+import * as qs from 'query-string';
+
+import type {Project} from 'sentry/types/project';
+import {Dataset} from 'sentry/views/alerts/rules/metric/types';
+
+export function getAlertsUrl({
+  project,
+  query,
+  aggregate,
+}: {
+  aggregate: string;
+  project: Project;
+  query?: string;
+}) {
+  const queryParams = {
+    aggregate: aggregate,
+    dataset: Dataset.GENERIC_METRICS,
+    project: project.slug,
+    eventTypes: 'transaction',
+    query,
+  };
+  return `/alerts/new/metric/?${qs.stringify(queryParams)}`;
+}

--- a/static/app/views/insights/common/utils/getAlertsUrl.tsx
+++ b/static/app/views/insights/common/utils/getAlertsUrl.tsx
@@ -1,14 +1,17 @@
 import * as qs from 'query-string';
 
 import type {Project} from 'sentry/types/project';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 
 export function getAlertsUrl({
   project,
   query,
   aggregate,
+  orgSlug,
 }: {
   aggregate: string;
+  orgSlug: string;
   project: Project;
   query?: string;
 }) {
@@ -19,5 +22,7 @@ export function getAlertsUrl({
     eventTypes: 'transaction',
     query,
   };
-  return `/alerts/new/metric/?${qs.stringify(queryParams)}`;
+  return normalizeUrl(
+    `/organizations/${orgSlug}/alerts/new/metric/?${qs.stringify(queryParams)}`
+  );
 }

--- a/static/app/views/insights/database/alerts.ts
+++ b/static/app/views/insights/database/alerts.ts
@@ -1,0 +1,10 @@
+export const ALERTS = {
+  duration: {
+    aggregate: 'avg(d:spans/exclusive_time@millisecond)',
+    query: 'span.module:db has:span.description',
+  },
+  spm: {
+    aggregate: 'spm()',
+    query: 'span.module:db has:span.description',
+  },
+};

--- a/static/app/views/insights/database/components/charts/durationChart.tsx
+++ b/static/app/views/insights/database/components/charts/durationChart.tsx
@@ -3,17 +3,23 @@ import {AVG_COLOR} from 'sentry/views/insights/colors';
 import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
 import ChartPanel from 'sentry/views/insights/common/components/chartPanel';
 import {getDurationChartTitle} from 'sentry/views/insights/common/views/spans/types';
+import {ALERTS} from 'sentry/views/insights/database/alerts';
 import {CHART_HEIGHT} from 'sentry/views/insights/database/settings';
 
 interface Props {
   isLoading: boolean;
   series: Series[];
   error?: Error | null;
+  groupId?: string;
 }
 
-export function DurationChart({series, isLoading, error}: Props) {
+export function DurationChart({series, isLoading, error, groupId}: Props) {
+  let alertConfig = ALERTS.duration;
+  if (groupId) {
+    alertConfig = {...alertConfig, query: `${alertConfig.query} span.group:${groupId}`};
+  }
   return (
-    <ChartPanel title={getDurationChartTitle('db')}>
+    <ChartPanel title={getDurationChartTitle('db')} alertConfigs={[alertConfig]}>
       <Chart
         height={CHART_HEIGHT}
         grid={{

--- a/static/app/views/insights/database/components/charts/throughputChart.tsx
+++ b/static/app/views/insights/database/components/charts/throughputChart.tsx
@@ -5,17 +5,23 @@ import {THROUGHPUT_COLOR} from 'sentry/views/insights/colors';
 import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
 import ChartPanel from 'sentry/views/insights/common/components/chartPanel';
 import {getThroughputChartTitle} from 'sentry/views/insights/common/views/spans/types';
+import {ALERTS} from 'sentry/views/insights/database/alerts';
 import {CHART_HEIGHT} from 'sentry/views/insights/database/settings';
 
 interface Props {
   isLoading: boolean;
   series: Series;
   error?: Error | null;
+  groupId?: string;
 }
 
-export function ThroughputChart({series, isLoading}: Props) {
+export function ThroughputChart({series, isLoading, groupId}: Props) {
+  let alertConfig = ALERTS.spm;
+  if (groupId) {
+    alertConfig = {...alertConfig, query: `${alertConfig.query} span.group:${groupId}`};
+  }
   return (
-    <ChartPanel title={getThroughputChartTitle('db')}>
+    <ChartPanel title={getThroughputChartTitle('db')} alertConfigs={[alertConfig]}>
       <Chart
         height={CHART_HEIGHT}
         grid={{

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
@@ -272,6 +272,7 @@ export function DatabaseSpanSummaryPage({params}: Props) {
                   series={throughputData['spm()']}
                   isLoading={isThroughputDataLoading}
                   error={throughputError}
+                  groupId={groupId}
                 />
 
                 <DurationChart
@@ -282,6 +283,7 @@ export function DatabaseSpanSummaryPage({params}: Props) {
                   ]}
                   isLoading={isDurationDataLoading}
                   error={durationError}
+                  groupId={groupId}
                 />
               </ChartContainer>
             </ModuleLayout.Full>

--- a/static/app/views/insights/queues/alerts.ts
+++ b/static/app/views/insights/queues/alerts.ts
@@ -1,22 +1,24 @@
+import {t} from 'sentry/locale';
+
 export const ALERTS = {
   latency: {
     aggregate: 'avg(g:spans/messaging.message.receive.latency@millisecond)',
     query: 'span.op:queue.process',
-    name: 'Create Time in Queue Alert',
+    name: t('Create Time in Queue Alert'),
   },
   duration: {
     aggregate: 'avg(d:spans/duration@millisecond)',
     query: 'span.op:queue.process',
-    name: 'Create Processing Time Alert',
+    name: t('Create Processing Time Alert'),
   },
   processed: {
     aggregate: 'spm()',
     query: 'span.op:queue.process',
-    name: 'Create Processed Alert',
+    name: t('Create Processed Alert'),
   },
   published: {
     aggregate: 'spm()',
     query: 'span.op:queue.publish',
-    name: 'Create Published Alert',
+    name: t('Create Published Alert'),
   },
 };

--- a/static/app/views/insights/queues/alerts.ts
+++ b/static/app/views/insights/queues/alerts.ts
@@ -1,0 +1,22 @@
+export const ALERTS = {
+  latency: {
+    aggregate: 'avg(g:spans/messaging.message.receive.latency@millisecond)',
+    query: 'span.op:queue.process',
+    name: 'Create Time in Queue Alert',
+  },
+  duration: {
+    aggregate: 'avg(d:spans/duration@millisecond)',
+    query: 'span.op:queue.process',
+    name: 'Create Processing Time Alert',
+  },
+  processed: {
+    aggregate: 'spm()',
+    query: 'span.op:queue.process',
+    name: 'Create Processed Alert',
+  },
+  published: {
+    aggregate: 'spm()',
+    query: 'span.op:queue.publish',
+    name: 'Create Published Alert',
+  },
+};

--- a/static/app/views/insights/queues/charts/latencyChart.tsx
+++ b/static/app/views/insights/queues/charts/latencyChart.tsx
@@ -2,6 +2,7 @@ import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 import {t} from 'sentry/locale';
 import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
 import ChartPanel from 'sentry/views/insights/common/components/chartPanel';
+import {ALERTS} from 'sentry/views/insights/queues/alerts';
 import {useProcessQueuesTimeSeriesQuery} from 'sentry/views/insights/queues/queries/useProcessQueuesTimeSeriesQuery';
 import type {Referrer} from 'sentry/views/insights/queues/referrers';
 import {CHART_HEIGHT} from 'sentry/views/insights/queues/settings';
@@ -18,8 +19,20 @@ export function LatencyChart({error, destination, referrer}: Props) {
     referrer,
   });
 
+  let {latency, duration} = ALERTS;
+  if (destination) {
+    latency = {
+      ...latency,
+      query: `${latency.query} messaging.destination.name:${destination}`,
+    };
+    duration = {
+      ...duration,
+      query: `${duration.query} messaging.destination.name:${destination}`,
+    };
+  }
+
   return (
-    <ChartPanel title={t('Avg Latency')}>
+    <ChartPanel title={t('Avg Latency')} alertConfigs={[latency, duration]}>
       <Chart
         height={CHART_HEIGHT}
         grid={{

--- a/static/app/views/insights/queues/charts/throughputChart.tsx
+++ b/static/app/views/insights/queues/charts/throughputChart.tsx
@@ -4,6 +4,7 @@ import {RateUnit} from 'sentry/utils/discover/fields';
 import {formatRate} from 'sentry/utils/formatters';
 import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
 import ChartPanel from 'sentry/views/insights/common/components/chartPanel';
+import {ALERTS} from 'sentry/views/insights/queues/alerts';
 import {useProcessQueuesTimeSeriesQuery} from 'sentry/views/insights/queues/queries/useProcessQueuesTimeSeriesQuery';
 import {usePublishQueuesTimeSeriesQuery} from 'sentry/views/insights/queues/queries/usePublishQueuesTimeSeriesQuery';
 import type {Referrer} from 'sentry/views/insights/queues/referrers';
@@ -26,8 +27,19 @@ export function ThroughputChart({error, destination, referrer}: Props) {
       destination,
       referrer,
     });
+  let {processed, published} = ALERTS;
+  if (destination) {
+    processed = {
+      ...processed,
+      query: `${processed.query} messaging.destination.name:${destination}`,
+    };
+    published = {
+      ...published,
+      query: `${published.query} messaging.destination.name:${destination}`,
+    };
+  }
   return (
-    <ChartPanel title={t('Published vs Processed')}>
+    <ChartPanel title={t('Published vs Processed')} alertConfigs={[processed, published]}>
       <Chart
         height={CHART_HEIGHT}
         grid={{


### PR DESCRIPTION
Adds Create Alert menu items to Queue and Database insights module charts that takes users to a prepopulate Create Alert Rule page
![image](https://github.com/user-attachments/assets/93fc8924-0658-4e6b-8e0c-b80c3e07436d)
