### PR TITLE
ref(replay): don't show rage click banner if all mobile proj

### DIFF
--- a/static/app/views/replays/list/listContent.spec.tsx
+++ b/static/app/views/replays/list/listContent.spec.tsx
@@ -8,22 +8,33 @@ import {
   useReplayOnboardingSidebarPanel,
 } from 'sentry/utils/replays/hooks/useReplayOnboarding';
 import useProjectSdkNeedsUpdate from 'sentry/utils/useProjectSdkNeedsUpdate';
+import useAllMobileProj from 'sentry/views/replays/detail/useAllMobileProj';
 import ListPage from 'sentry/views/replays/list/listContent';
 
 jest.mock('sentry/utils/replays/hooks/useDeadRageSelectors');
 jest.mock('sentry/utils/replays/hooks/useReplayOnboarding');
 jest.mock('sentry/utils/replays/hooks/useReplayPageview');
 jest.mock('sentry/utils/useProjectSdkNeedsUpdate');
+jest.mock('sentry/views/replays/detail/useAllMobileProj');
 
 const mockUseDeadRageSelectors = jest.mocked(useDeadRageSelectors);
+mockUseDeadRageSelectors.mockReturnValue({
+  isLoading: false,
+  isError: false,
+  data: [],
+  pageLinks: undefined,
+});
 
 const mockUseHaveSelectedProjectsSentAnyReplayEvents = jest.mocked(
   useHaveSelectedProjectsSentAnyReplayEvents
 );
 const mockUseProjectSdkNeedsUpdate = jest.mocked(useProjectSdkNeedsUpdate);
-const mockUseReplayOnboardingSidebarPanel = jest.mocked(useReplayOnboardingSidebarPanel);
 
+const mockUseReplayOnboardingSidebarPanel = jest.mocked(useReplayOnboardingSidebarPanel);
 mockUseReplayOnboardingSidebarPanel.mockReturnValue({activateSidebar: jest.fn()});
+
+const mockUseAllMobileProj = jest.mocked(useAllMobileProj);
+mockUseAllMobileProj.mockReturnValue({allMobileProj: false});
 
 const AM1_FEATURES = [];
 const AM2_FEATURES = ['session-replay'];
@@ -43,6 +54,7 @@ describe('ReplayList', () => {
     mockUseHaveSelectedProjectsSentAnyReplayEvents.mockClear();
     mockUseProjectSdkNeedsUpdate.mockClear();
     mockUseDeadRageSelectors.mockClear();
+    // mockUseAllMobileProj.mockClear();
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/tags/',
@@ -137,7 +149,7 @@ describe('ReplayList', () => {
     });
 
     await waitFor(() => {
-      expect(screen.queryByText('Introducing Rage and Dead Clicks')).toBeInTheDocument();
+      expect(screen.getByText('Introducing Rage and Dead Clicks')).toBeInTheDocument();
       expect(screen.queryByTestId('replay-table')).toBeInTheDocument();
     });
     expect(mockFetchReplayListRequest).toHaveBeenCalled();

--- a/static/app/views/replays/list/listContent.tsx
+++ b/static/app/views/replays/list/listContent.tsx
@@ -58,7 +58,7 @@ export default function ListContent() {
     );
   }
 
-  if (rageClicksSdkVersion.needsUpdate) {
+  if (rageClicksSdkVersion.needsUpdate && !allMobileProj) {
     return (
       <Fragment>
         <FiltersContainer>


### PR DESCRIPTION
if only mobile projects are selected in the replay index, don't show the rage click SDK update banner:

![image](https://github.com/user-attachments/assets/cbe57773-737f-439c-b929-8fe71247ea0d)
