### PR TITLE
feat(insights): Set label for domain selector in DB module to `Collection` for MongoDB

### DIFF
--- a/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
@@ -26,6 +26,8 @@ import {type ModuleName, SpanMetricsField} from 'sentry/views/insights/types';
 type Props = {
   moduleName: ModuleName;
   additionalQuery?: string[];
+  // Optional prop to override the default name of the selector label
+  domainAlias?: string;
   emptyOptionLocation?: 'top' | 'bottom';
   spanCategory?: string;
   value?: string;
@@ -41,6 +43,7 @@ export function DomainSelector({
   spanCategory,
   additionalQuery = [],
   emptyOptionLocation = 'bottom',
+  domainAlias,
 }: Props) {
   const location = useLocation();
   const organization = useOrganization();
@@ -106,7 +109,9 @@ export function DomainSelector({
   const emptyOption = {
     value: EMPTY_OPTION_VALUE,
     label: (
-      <EmptyContainer>{t('(No %s)', LABEL_FOR_MODULE_NAME[moduleName])}</EmptyContainer>
+      <EmptyContainer>
+        {t('(No %s)', domainAlias ?? LABEL_FOR_MODULE_NAME[moduleName])}
+      </EmptyContainer>
     ),
   };
 
@@ -125,7 +130,7 @@ export function DomainSelector({
       emptyMessage={t('No results')}
       loading={isPending}
       searchable
-      menuTitle={LABEL_FOR_MODULE_NAME[moduleName]}
+      menuTitle={domainAlias ?? LABEL_FOR_MODULE_NAME[moduleName]}
       maxMenuWidth={'500px'}
       onSearch={newValue => {
         if (!wasSearchSpaceExhausted) {
@@ -133,7 +138,7 @@ export function DomainSelector({
         }
       }}
       triggerProps={{
-        prefix: LABEL_FOR_MODULE_NAME[moduleName],
+        prefix: domainAlias ?? LABEL_FOR_MODULE_NAME[moduleName],
       }}
       onChange={newValue => {
         trackAnalytics('insight.general.select_domain_value', {

--- a/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
@@ -132,6 +132,7 @@ export function DomainSelector({
       searchable
       menuTitle={domainAlias ?? LABEL_FOR_MODULE_NAME[moduleName]}
       maxMenuWidth={'500px'}
+      data-test-id="domain-selector"
       onSearch={newValue => {
         if (!wasSearchSpaceExhausted) {
           debouncedSetSearch(newValue);

--- a/static/app/views/insights/database/components/useSystemSelectorOptions.tsx
+++ b/static/app/views/insights/database/components/useSystemSelectorOptions.tsx
@@ -2,33 +2,8 @@ import type {SelectOption} from 'sentry/components/compactSelect';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {DATABASE_SYSTEM_TO_LABEL} from 'sentry/views/insights/database/utils/constants';
 import {SpanMetricsField} from 'sentry/views/insights/types';
-
-/**
- * The supported relational database system values are based on what is
- * set in the Sentry Python SDK. The only currently supported NoSQL DBMS is MongoDB.
- *
- * https://github.com/getsentry/sentry-python/blob/master/sentry_sdk/integrations/sqlalchemy.py#L125
- */
-enum SupportedDatabaseSystems {
-  // SQL
-  SQLITE = 'sqlite',
-  POSTGRESQL = 'postgresql',
-  MARIADB = 'mariadb',
-  MYSQL = 'mysql',
-  ORACLE = 'oracle',
-  // NoSQL
-  MONGODB = 'mongodb',
-}
-
-const DATABASE_SYSTEM_TO_LABEL: Record<SupportedDatabaseSystems, string> = {
-  [SupportedDatabaseSystems.SQLITE]: 'SQLite',
-  [SupportedDatabaseSystems.POSTGRESQL]: 'PostgreSQL',
-  [SupportedDatabaseSystems.MARIADB]: 'MariaDB',
-  [SupportedDatabaseSystems.MYSQL]: 'MySQL',
-  [SupportedDatabaseSystems.ORACLE]: 'Oracle',
-  [SupportedDatabaseSystems.MONGODB]: 'MongoDB',
-};
 
 export function useSystemSelectorOptions() {
   const [selectedSystem, setSelectedSystem] = useLocalStorageState<string>(

--- a/static/app/views/insights/database/utils/constants.tsx
+++ b/static/app/views/insights/database/utils/constants.tsx
@@ -1,0 +1,25 @@
+/**
+ * The supported relational database system values are based on what is
+ * set in the Sentry Python SDK. The only currently supported NoSQL DBMS is MongoDB.
+ *
+ * https://github.com/getsentry/sentry-python/blob/master/sentry_sdk/integrations/sqlalchemy.py#L125
+ */
+export enum SupportedDatabaseSystems {
+  // SQL
+  SQLITE = 'sqlite',
+  POSTGRESQL = 'postgresql',
+  MARIADB = 'mariadb',
+  MYSQL = 'mysql',
+  ORACLE = 'oracle',
+  // NoSQL
+  MONGODB = 'mongodb',
+}
+
+export const DATABASE_SYSTEM_TO_LABEL: Record<SupportedDatabaseSystems, string> = {
+  [SupportedDatabaseSystems.SQLITE]: 'SQLite',
+  [SupportedDatabaseSystems.POSTGRESQL]: 'PostgreSQL',
+  [SupportedDatabaseSystems.MARIADB]: 'MariaDB',
+  [SupportedDatabaseSystems.MYSQL]: 'MySQL',
+  [SupportedDatabaseSystems.ORACLE]: 'Oracle',
+  [SupportedDatabaseSystems.MONGODB]: 'MongoDB',
+};

--- a/static/app/views/insights/database/views/databaseLandingPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.spec.tsx
@@ -326,4 +326,52 @@ describe('DatabaseLandingPage', function () {
       })
     );
   });
+
+  it('displays the correct domain label for SQL systems', async function () {
+    jest.mocked(useLocation).mockReturnValue({
+      pathname: '',
+      search: '',
+      query: {
+        statsPeriod: '10d',
+        'span.system': 'postgresql',
+      },
+      hash: '',
+      state: undefined,
+      action: 'PUSH',
+      key: '',
+    });
+
+    jest.spyOn(console, 'error').mockImplementation(jest.fn()); // This silences pointless unique key errors that React throws because of the tokenized query descriptions
+
+    render(<DatabaseLandingPage />, {organization});
+
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
+
+    const domainSelector = await screen.findByTestId('domain-selector');
+    expect(domainSelector).toHaveTextContent('Table');
+  });
+
+  it('displays the correct domain label for NoSQL systems', async function () {
+    jest.mocked(useLocation).mockReturnValue({
+      pathname: '',
+      search: '',
+      query: {
+        statsPeriod: '10d',
+        'span.system': 'mongodb',
+      },
+      hash: '',
+      state: undefined,
+      action: 'PUSH',
+      key: '',
+    });
+
+    jest.spyOn(console, 'error').mockImplementation(jest.fn()); // This silences pointless unique key errors that React throws because of the tokenized query descriptions
+
+    render(<DatabaseLandingPage />, {organization});
+
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
+
+    const domainSelector = await screen.findByTestId('domain-selector');
+    expect(domainSelector).toHaveTextContent('Collection');
+  });
 });

--- a/static/app/views/insights/database/views/databaseLandingPage.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.tsx
@@ -44,7 +44,9 @@ import {
   MODULE_DOC_LINK,
   MODULE_TITLE,
 } from 'sentry/views/insights/database/settings';
+import {SupportedDatabaseSystems} from 'sentry/views/insights/database/utils/constants';
 import {ModuleName, SpanMetricsField} from 'sentry/views/insights/types';
+import {useSystemSelectorOptions} from 'sentry/views/insights/database/components/useSystemSelectorOptions';
 
 export function DatabaseLandingPage() {
   const organization = useOrganization();
@@ -59,6 +61,12 @@ export function DatabaseLandingPage() {
   const spanDomain = decodeScalar(location.query?.['span.domain']);
 
   const sortField = decodeScalar(location.query?.[QueryParameterNames.SPANS_SORT]);
+
+  // If there is no query parameter for the system, retrieve the current value from the hook instead
+  const systemQueryParam = decodeScalar(location.query?.[SpanMetricsField.SPAN_SYSTEM]);
+  const {selectedSystem} = useSystemSelectorOptions();
+
+  const system = systemQueryParam ?? selectedSystem;
 
   let sort = decodeSorts(sortField).filter(isAValidSort)[0];
   if (!sort) {
@@ -85,6 +93,7 @@ export function DatabaseLandingPage() {
     ...BASE_FILTERS,
     'span.action': spanAction,
     'span.domain': spanDomain,
+    'span.system': system,
   };
 
   const tableFilters = {
@@ -92,6 +101,7 @@ export function DatabaseLandingPage() {
     'span.action': spanAction,
     'span.domain': spanDomain,
     'span.description': spanDescription ? `*${spanDescription}*` : undefined,
+    'span.system': system,
   };
 
   const cursor = decodeScalar(location.query?.[QueryParameterNames.SPANS_CURSOR]);
@@ -192,7 +202,15 @@ export function DatabaseLandingPage() {
                     'performance-queries-mongodb-extraction'
                   ) && <DatabaseSystemSelector />}
                   <ActionSelector moduleName={moduleName} value={spanAction ?? ''} />
-                  <DomainSelector moduleName={moduleName} value={spanDomain ?? ''} />
+                  <DomainSelector
+                    moduleName={moduleName}
+                    value={spanDomain ?? ''}
+                    domainAlias={
+                      system === SupportedDatabaseSystems.MONGODB
+                        ? t('Collection')
+                        : t('Table')
+                    }
+                  />
                 </DbFilterWrapper>
               </PageFilterWrapper>
             </ModuleLayout.Full>

--- a/static/app/views/insights/database/views/databaseLandingPage.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.tsx
@@ -37,6 +37,7 @@ import {
   isAValidSort,
   QueriesTable,
 } from 'sentry/views/insights/database/components/tables/queriesTable';
+import {useSystemSelectorOptions} from 'sentry/views/insights/database/components/useSystemSelectorOptions';
 import {
   BASE_FILTERS,
   DEFAULT_DURATION_AGGREGATE,
@@ -46,7 +47,6 @@ import {
 } from 'sentry/views/insights/database/settings';
 import {SupportedDatabaseSystems} from 'sentry/views/insights/database/utils/constants';
 import {ModuleName, SpanMetricsField} from 'sentry/views/insights/types';
-import {useSystemSelectorOptions} from 'sentry/views/insights/database/components/useSystemSelectorOptions';
 
 export function DatabaseLandingPage() {
   const organization = useOrganization();


### PR DESCRIPTION
Dynamically determine the label for the domain selector. If the user has selected MongoDB for the DB system, then the dropdown label will say `Collection`. Otherwise, it will say `Table`.

![image](https://github.com/user-attachments/assets/e0317709-f262-42c6-8915-02d4f484cf4c)
