### PR TITLE
feat(dashboards): Events `SearchQueryBuilder`

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.tsx
@@ -15,6 +15,7 @@ import {
   MAX_MENU_HEIGHT,
   MAX_SEARCH_ITEMS,
 } from 'sentry/views/dashboards/widgetBuilder/utils';
+import ResultsSearchQueryBuilder from 'sentry/views/discover/resultsSearchQueryBuilder';
 
 interface Props {
   getFilterWarning: SearchBarProps['getFilterWarning'];
@@ -42,7 +43,20 @@ export function EventsSearchBar({
     ? generateAggregateFields(organization, eventView.fields)
     : eventView.fields;
 
-  return (
+  return organization.features.includes('search-query-builder-discover') ? (
+    <ResultsSearchQueryBuilder
+      projectIds={eventView.project}
+      query={widgetQuery.conditions}
+      fields={fields}
+      onChange={(query, state) => {
+        onClose?.(query, {validSearch: state.queryIsValid});
+      }}
+      customMeasurements={customMeasurements}
+      dataset={dataset}
+      includeTransactions={hasDatasetSelector(organization) ? false : true}
+      searchSource="widget_builder"
+    />
+  ) : (
     <Search
       searchSource="widget_builder"
       organization={organization}

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -685,7 +685,7 @@ export class Results extends Component<Props, State> {
 
     if (organization.features.includes('search-query-builder-discover')) {
       return (
-        <ResultsSearchQueryBuilder
+        <StyledResultsSearchQueryBuilder
           projectIds={eventView.project}
           query={eventView.query}
           fields={fields}
@@ -870,6 +870,10 @@ const Wrapper = styled('div')`
     display: grid;
     grid-auto-flow: row;
   }
+`;
+
+const StyledResultsSearchQueryBuilder = styled(ResultsSearchQueryBuilder)`
+  margin-bottom: ${space(2)};
 `;
 
 const StyledSearchBar = styled(SearchBar)`

--- a/static/app/views/discover/resultsSearchQueryBuilder.tsx
+++ b/static/app/views/discover/resultsSearchQueryBuilder.tsx
@@ -124,6 +124,7 @@ type Props = {
   placeholder?: string;
   projectIds?: number[] | Readonly<number[]>;
   query?: string;
+  searchSource?: string;
   supportedTags?: TagCollection | undefined;
 };
 
@@ -284,8 +285,8 @@ function ResultsSearchQueryBuilder(props: Props) {
       filterKeys={getTagList}
       initialQuery={props.query ?? ''}
       onSearch={props.onSearch}
-      searchSource={'eventsv2'}
       onChange={props.onChange}
+      searchSource={props.searchSource || 'eventsv2'}
       filterKeySections={filterKeySections}
       getTagValues={getEventFieldValues}
       recentSearches={SavedSearchType.EVENT}

--- a/static/app/views/discover/resultsSearchQueryBuilder.tsx
+++ b/static/app/views/discover/resultsSearchQueryBuilder.tsx
@@ -1,5 +1,4 @@
 import {useCallback, useMemo} from 'react';
-import styled from '@emotion/styled';
 import omit from 'lodash/omit';
 
 import {fetchSpanFieldValues, fetchTagValues} from 'sentry/actionCreators/tags';
@@ -16,7 +15,6 @@ import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilte
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {SavedSearchType, type TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
@@ -277,7 +275,7 @@ function ResultsSearchQueryBuilder(props: Props) {
   }, [filteredTags, dataset]);
 
   return (
-    <StyledResultsSearchQueryBuilder
+    <SearchQueryBuilder
       placeholder={placeholderText}
       filterKeys={getTagList}
       initialQuery={props.query ?? ''}
@@ -289,9 +287,5 @@ function ResultsSearchQueryBuilder(props: Props) {
     />
   );
 }
-
-const StyledResultsSearchQueryBuilder = styled(SearchQueryBuilder)`
-  margin-bottom: ${space(2)};
-`;
 
 export default ResultsSearchQueryBuilder;

--- a/static/app/views/discover/resultsSearchQueryBuilder.tsx
+++ b/static/app/views/discover/resultsSearchQueryBuilder.tsx
@@ -13,7 +13,10 @@ import {
 } from 'sentry/components/events/searchBarFieldConstants';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
-import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
+import type {
+  CallbackSearchState,
+  FilterKeySection,
+} from 'sentry/components/searchQueryBuilder/types';
 import {t} from 'sentry/locale';
 import {SavedSearchType, type TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
@@ -110,13 +113,14 @@ export const getHasTag = (tags: TagCollection) => ({
 });
 
 type Props = {
-  onSearch: (query: string) => void;
   customMeasurements?: CustomMeasurementCollection;
   dataset?: DiscoverDatasets;
   fields?: Readonly<Field[]>;
   includeSessionTagsValues?: boolean;
   includeTransactions?: boolean;
   omitTags?: string[];
+  onChange?: (query: string, state: CallbackSearchState) => void;
+  onSearch?: (query: string) => void;
   placeholder?: string;
   projectIds?: number[] | Readonly<number[]>;
   query?: string;
@@ -281,6 +285,7 @@ function ResultsSearchQueryBuilder(props: Props) {
       initialQuery={props.query ?? ''}
       onSearch={props.onSearch}
       searchSource={'eventsv2'}
+      onChange={props.onChange}
       filterKeySections={filterKeySections}
       getTagValues={getEventFieldValues}
       recentSearches={SavedSearchType.EVENT}


### PR DESCRIPTION
Follow-up to #76944

I'm using `ResultsSearchQueryBuilder` here because it does everything I'd need to do and more. I had to tweak it a little (accept an `onChange`, allow an optional `onSearch`, remove a bottom margin) but otherwise I'm using it straight as-is.

IMO it probably deserves a more generic name, but to be honest once the dataset splits in the UI are complete this might look pretty different.

Here as in the other PR, the flag that controls the query builder is `'search-query-builder-discover'` so it's in sync with what Discover is doing.

**e.g.,**
<img width="743" alt="Screenshot 2024-09-04 at 4 34 23 PM" src="https://github.com/user-attachments/assets/a23b9d3b-f527-4deb-80b7-a734a17fc8a1">
