### PR TITLE
feat(custom_views): Make tabs animate better when selected

### DIFF
--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -107,10 +107,11 @@ function BaseDraggableTabList({
                     flexDirection: 'row',
                   }}
                   as="div"
-                  dragConstraints={tabListRef} // Sets the container that the tabs can be dragged within
-                  dragElastic={0} // Prevents tabs from being dragged outside of the tab bar
-                  dragTransition={{bounceStiffness: 400, bounceDamping: 40}} // Recovers spring behavior thats lost when using dragElastic
-                  layout="position"
+                  dragConstraints={tabListRef} // The container that the tabs can be dragged within
+                  dragElastic={0} // Prevents the tab from being dragged outside of the dragConstraints (w/o this you can drag it outside but it'll spring back)
+                  dragTransition={{bounceStiffness: 400, bounceDamping: 40}} // Recovers spring behavior thats lost when using dragElastic=0
+                  transition={{delay: -0.1}} // Skips the first few frames of the animation that make the tab appear to shrink before growing
+                  layout
                 >
                   <Tab
                     key={item.key}
@@ -230,8 +231,6 @@ const TabDivider = styled(motion.div, {
     height: 50%;
     width: 1px;
     border-radius: 6px;
-    margin-right: ${space(0.5)};
-    margin-left: ${space(0.5)};
   `}
 
   ${p => !p.isVisible && `margin-left: 1px;`}


### PR DESCRIPTION
This PR changes the tab animation when selected to (hopefully) something a little smoother and better. It also removes any left/right margin that the tab divider has, as per Vu's request. 

Animation Before: 

https://github.com/user-attachments/assets/a8a56788-5ae9-4383-bfcd-3cb3f55dfb75

Animation After:

https://github.com/user-attachments/assets/c652c446-a8ff-4a5a-b27b-2f16b66d52b3


Tab Divider Before: 

![image](https://github.com/user-attachments/assets/1f444699-8d33-4e2f-baec-b2a15a3031be)

Tab Divider After:

![image](https://github.com/user-attachments/assets/a3f7b876-13b2-460f-b119-2f35a7630590)

