### PR TITLE
ref(jira): Adds field transformer logic for issue creation

### DIFF
--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -108,7 +108,7 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
                     # If we encounter some unexpected exception, we probably
                     # don't want to continue executing more callbacks.
                     logger.warning(
-                        "%s.test_alert.unexpected_exception", callback_name, extra={"exc": exc}
+                        "%s.test_alert.unexpected_exception", callback_name, exc_info=True
                     )
                     break
 

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -528,6 +528,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:webhooks-unresolved", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=True)
     # Display the new 'what's new' experience
     manager.add("organizations:what-is-new-revamp", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable new feature parsing code for Jira integrations
+    manager.add("organizations:new-jira-transformers", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # NOTE: Don't add features down here! Add them to their specific group and sort
     #       them alphabetically! The order features are registered is not important.
 

--- a/src/sentry/integrations/jira/models/create_issue_metadata.py
+++ b/src/sentry/integrations/jira/models/create_issue_metadata.py
@@ -16,6 +16,7 @@ class JiraSchemaTypes(str, Enum):
     date = "date"
     team = "team"
     number = "number"
+    json = "json"
     any = "any"
 
 
@@ -156,8 +157,8 @@ class JiraIssueTypeMetadata:
         )
 
     @classmethod
-    def from_jira_meta_config(cls, meta_config: dict[str, Any]) -> list[JiraIssueTypeMetadata]:
+    def from_jira_meta_config(cls, meta_config: dict[str, Any]) -> dict[str, JiraIssueTypeMetadata]:
         issue_types_list = meta_config.get("issuetypes", {})
         issue_configs = [cls.from_dict(it) for it in issue_types_list]
 
-        return issue_configs
+        return {it.id: it for it in issue_configs}

--- a/src/sentry/integrations/jira/models/create_issue_metadata.py
+++ b/src/sentry/integrations/jira/models/create_issue_metadata.py
@@ -4,6 +4,19 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
+# A list of common builtin custom field types for Jira for easy reference.
+JIRA_CUSTOM_FIELD_TYPES = {
+    "select": "com.atlassian.jira.plugin.system.customfieldtypes:select",
+    "textarea": "com.atlassian.jira.plugin.system.customfieldtypes:textarea",
+    "multiuserpicker": "com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker",
+    "tempo_account": "com.tempoplugin.tempo-accounts:accounts.customfield",
+    "sprint": "com.pyxis.greenhopper.jira:gh-sprint",
+    "epic": "com.pyxis.greenhopper.jira:gh-epic-link",
+    "team": "com.atlassian.jira.plugin.system.customfieldtypes:atlassian-team",
+    "rank": "com.pyxis.greenhopper.jira:gh-lexo-rank",
+    "development": "com.atlassian.jira.plugins.jira-development-integration-plugin:devsummarycf",
+}
+
 
 class JiraSchemaTypes(str, Enum):
     string = "string"

--- a/src/sentry/integrations/jira/models/create_issue_metadata.py
+++ b/src/sentry/integrations/jira/models/create_issue_metadata.py
@@ -40,7 +40,7 @@ class JiraSchema:
     The very long custom field name corresponding to some namespace, plugin,
     and custom field name.
     """
-    custom_id: str | None = None
+    custom_id: int | None = None
     """
     A unique identifier for a field on an issue, in the form of 'customfield_<int>'
     """

--- a/src/sentry/integrations/jira/utils/create_issue_schema_transformers.py
+++ b/src/sentry/integrations/jira/utils/create_issue_schema_transformers.py
@@ -1,16 +1,34 @@
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from typing import Any, TypeVar
 
-from sentry.integrations.jira.integration import JIRA_CUSTOM_FIELD_TYPES
+# A list of common builtin custom field types for Jira for easy reference.
+JIRA_CUSTOM_FIELD_TYPES = {
+    "select": "com.atlassian.jira.plugin.system.customfieldtypes:select",
+    "textarea": "com.atlassian.jira.plugin.system.customfieldtypes:textarea",
+    "multiuserpicker": "com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker",
+    "tempo_account": "com.tempoplugin.tempo-accounts:accounts.customfield",
+    "sprint": "com.pyxis.greenhopper.jira:gh-sprint",
+    "epic": "com.pyxis.greenhopper.jira:gh-epic-link",
+    "team": "com.atlassian.jira.plugin.system.customfieldtypes:atlassian-team",
+    "rank": "com.pyxis.greenhopper.jira:gh-lexo-rank",
+    "development": "com.atlassian.jira.plugins.jira-development-integration-plugin:devsummarycf",
+}
 from sentry.integrations.jira.models.create_issue_metadata import JiraField, JiraSchemaTypes
 from sentry.shared_integrations.exceptions import IntegrationFormError
 
 
-def parse_number_field(num_str: str) -> int | float:
-    if "." in num_str:
-        return float(num_str)
+class JiraSchemaParseError(Exception):
+    pass
 
-    return int(num_str)
+
+def parse_number_field(num_str: str) -> int | float:
+    try:
+        if "." in num_str:
+            return float(num_str)
+
+        return int(num_str)
+    except ValueError:
+        raise JiraSchemaParseError(f"Invalid number value provided for field: '{num_str}'")
 
 
 TransformerType = Mapping[str, Callable[[Any], Any]]
@@ -28,13 +46,12 @@ def id_obj_transformer(input_val: Any) -> dict[str, Any]:
 
 def get_type_transformer_mappings(user_id_field: str) -> TransformerType:
     transformers = {
-        # JiraSchemaTypes.string: identity_transformer,
-        JiraSchemaTypes.user: lambda x: {user_id_field: x},
-        JiraSchemaTypes.issue_type: lambda x: id_obj_transformer,
-        JiraSchemaTypes.option: lambda x: {"value": x},
-        JiraSchemaTypes.issue_link: lambda x: {"key": x},
-        JiraSchemaTypes.project: lambda x: id_obj_transformer,
-        JiraSchemaTypes.number: parse_number_field,
+        JiraSchemaTypes.user.value: lambda x: {user_id_field: x},
+        JiraSchemaTypes.issue_type.value: id_obj_transformer,
+        JiraSchemaTypes.option.value: lambda x: {"value": x},
+        JiraSchemaTypes.issue_link.value: lambda x: {"key": x},
+        JiraSchemaTypes.project.value: id_obj_transformer,
+        JiraSchemaTypes.number.value: parse_number_field,
     }
 
     return transformers
@@ -48,7 +65,6 @@ def get_custom_field_transformer_mappings() -> TransformerType:
         JIRA_CUSTOM_FIELD_TYPES["tempo_account"]: parse_number_field,
         # JIRA_CUSTOM_FIELD_TYPES["sprint"]: identity_transformer,
         # JIRA_CUSTOM_FIELD_TYPES["epic"]: identity_transformer,
-        JIRA_CUSTOM_FIELD_TYPES["development"]: id_obj_transformer,
         JIRA_CUSTOM_FIELD_TYPES["rank"]: id_obj_transformer,
     }
 
@@ -60,11 +76,14 @@ def get_transformer_for_field(
 ) -> Callable[[Any], Any]:
     transformer = None
     if jira_field.is_custom_field():
+        assert jira_field.schema.custom
         transformer = custom_transformers.get(jira_field.schema.custom)
 
     if not transformer:
         field_type = jira_field.get_field_type()
-        transformer = type_transformers.get(field_type)
+
+        if field_type:
+            transformer = type_transformers.get(field_type)
 
     if not transformer:
         transformer = identity_transformer
@@ -72,7 +91,9 @@ def get_transformer_for_field(
     return transformer
 
 
-def transform_fields(user_id_field: str, jira_fields: list[JiraField], **data) -> Mapping[str, Any]:
+def transform_fields(
+    user_id_field: str, jira_fields: Iterable[JiraField], **data
+) -> Mapping[str, Any]:
     transformed_data = {}
 
     # Special handling for fields that don't map cleanly to the transformer logic
@@ -98,13 +119,16 @@ def transform_fields(user_id_field: str, jira_fields: list[JiraField], **data) -
             if field.schema.schema_type.lower() == JiraSchemaTypes.array:
                 transformed_value = []
 
+                if not isinstance(field_data, list):
+                    field_data = [field_data]
+
                 # Bulk transform the individual data fields
                 for val in field_data:
                     transformed_value.append(field_transformer(val))
             else:
                 transformed_value = field_transformer(field_data)
 
-        except ValueError as e:
+        except JiraSchemaParseError as e:
             raise IntegrationFormError(field_errors={field.name: str(e)}) from e
 
         if transformed_value:

--- a/src/sentry/integrations/jira/utils/create_issue_schema_transformers.py
+++ b/src/sentry/integrations/jira/utils/create_issue_schema_transformers.py
@@ -1,19 +1,11 @@
 from collections.abc import Callable, Iterable, Mapping
 from typing import Any, TypeVar
 
-# A list of common builtin custom field types for Jira for easy reference.
-JIRA_CUSTOM_FIELD_TYPES = {
-    "select": "com.atlassian.jira.plugin.system.customfieldtypes:select",
-    "textarea": "com.atlassian.jira.plugin.system.customfieldtypes:textarea",
-    "multiuserpicker": "com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker",
-    "tempo_account": "com.tempoplugin.tempo-accounts:accounts.customfield",
-    "sprint": "com.pyxis.greenhopper.jira:gh-sprint",
-    "epic": "com.pyxis.greenhopper.jira:gh-epic-link",
-    "team": "com.atlassian.jira.plugin.system.customfieldtypes:atlassian-team",
-    "rank": "com.pyxis.greenhopper.jira:gh-lexo-rank",
-    "development": "com.atlassian.jira.plugins.jira-development-integration-plugin:devsummarycf",
-}
-from sentry.integrations.jira.models.create_issue_metadata import JiraField, JiraSchemaTypes
+from sentry.integrations.jira.models.create_issue_metadata import (
+    JIRA_CUSTOM_FIELD_TYPES,
+    JiraField,
+    JiraSchemaTypes,
+)
 from sentry.shared_integrations.exceptions import IntegrationFormError
 
 

--- a/src/sentry/integrations/jira/utils/create_issue_schema_transformers.py
+++ b/src/sentry/integrations/jira/utils/create_issue_schema_transformers.py
@@ -1,0 +1,113 @@
+from collections.abc import Callable, Mapping
+from typing import Any, TypeVar
+
+from sentry.integrations.jira.integration import JIRA_CUSTOM_FIELD_TYPES
+from sentry.integrations.jira.models.create_issue_metadata import JiraField, JiraSchemaTypes
+from sentry.shared_integrations.exceptions import IntegrationFormError
+
+
+def parse_number_field(num_str: str) -> int | float:
+    if "." in num_str:
+        return float(num_str)
+
+    return int(num_str)
+
+
+TransformerType = Mapping[str, Callable[[Any], Any]]
+
+T = TypeVar("T")
+
+
+def identity_transformer(input_val: T) -> T:
+    return input_val
+
+
+def id_obj_transformer(input_val: Any) -> dict[str, Any]:
+    return {"id": input_val}
+
+
+def get_type_transformer_mappings(user_id_field: str) -> TransformerType:
+    transformers = {
+        # JiraSchemaTypes.string: identity_transformer,
+        JiraSchemaTypes.user: lambda x: {user_id_field: x},
+        JiraSchemaTypes.issue_type: lambda x: id_obj_transformer,
+        JiraSchemaTypes.option: lambda x: {"value": x},
+        JiraSchemaTypes.issue_link: lambda x: {"key": x},
+        JiraSchemaTypes.project: lambda x: id_obj_transformer,
+        JiraSchemaTypes.number: parse_number_field,
+    }
+
+    return transformers
+
+
+def get_custom_field_transformer_mappings() -> TransformerType:
+    transformers = {
+        # JIRA_CUSTOM_FIELD_TYPES["select"]: identity_transformer,
+        # JIRA_CUSTOM_FIELD_TYPES["textarea"]: identity_transformer,
+        # JIRA_CUSTOM_FIELD_TYPES["multiuserpicker"]: identity_transformer,
+        JIRA_CUSTOM_FIELD_TYPES["tempo_account"]: parse_number_field,
+        # JIRA_CUSTOM_FIELD_TYPES["sprint"]: identity_transformer,
+        # JIRA_CUSTOM_FIELD_TYPES["epic"]: identity_transformer,
+        JIRA_CUSTOM_FIELD_TYPES["development"]: id_obj_transformer,
+        JIRA_CUSTOM_FIELD_TYPES["rank"]: id_obj_transformer,
+    }
+
+    return transformers
+
+
+def get_transformer_for_field(
+    type_transformers: TransformerType, custom_transformers: TransformerType, jira_field: JiraField
+) -> Callable[[Any], Any]:
+    transformer = None
+    if jira_field.is_custom_field():
+        transformer = custom_transformers.get(jira_field.schema.custom)
+
+    if not transformer:
+        field_type = jira_field.get_field_type()
+        transformer = type_transformers.get(field_type)
+
+    if not transformer:
+        transformer = identity_transformer
+
+    return transformer
+
+
+def transform_fields(user_id_field: str, jira_fields: list[JiraField], **data) -> Mapping[str, Any]:
+    transformed_data = {}
+
+    # Special handling for fields that don't map cleanly to the transformer logic
+    data["summary"] = data.get("title")
+    if labels := data.get("labels"):
+        data["labels"] = [label.strip() for label in labels.split(",") if label.strip()]
+
+    type_transformers = get_type_transformer_mappings(user_id_field)
+    custom_field_transformers = get_custom_field_transformer_mappings()
+
+    for field in jira_fields:
+        field_data = data.get(field.key)
+
+        # We don't have a mapping for this field, so it's probably extraneous
+        if field_data is None:
+            continue
+
+        field_transformer = get_transformer_for_field(
+            type_transformers, custom_field_transformers, field
+        )
+
+        try:
+            if field.schema.schema_type.lower() == JiraSchemaTypes.array:
+                transformed_value = []
+
+                # Bulk transform the individual data fields
+                for val in field_data:
+                    transformed_value.append(field_transformer(val))
+            else:
+                transformed_value = field_transformer(field_data)
+
+        except ValueError as e:
+            raise IntegrationFormError(field_errors={field.name: str(e)}) from e
+
+        if transformed_value:
+            transformed_data[field.key] = transformed_value
+
+    return transformed_data

--- a/src/sentry/integrations/jira/utils/create_issue_schema_transformers.py
+++ b/src/sentry/integrations/jira/utils/create_issue_schema_transformers.py
@@ -100,7 +100,9 @@ def transform_fields(
     for field in jira_fields:
         field_data = data.get(field.key)
 
-        # We don't have a mapping for this field, so it's probably extraneous
+        # We don't have a mapping for this field, so it's probably extraneous.
+        # TODO(Gabe): Explore raising a sentry issue for unmapped fields in
+        #  order for us to properly filter them out.
         if field_data is None:
             continue
 
@@ -111,7 +113,7 @@ def transform_fields(
         try:
             # Handling for array types and their nested subtypes.
             # We have to skip this handling for `sprint` custom fields, as they
-            # are the only `array` type that expects a string, not a list.
+            # are the only `array` type that expects a number, not a list.
             if (
                 field.schema.schema_type.lower() == JiraSchemaTypes.array
                 and field.schema.custom != JIRA_CUSTOM_FIELD_TYPES["sprint"]

--- a/src/sentry/integrations/jira/utils/types.py
+++ b/src/sentry/integrations/jira/utils/types.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DynamicField:
+    type: str
+    url: str | None
+    choices: list[str] | None

--- a/src/sentry/integrations/jira/utils/types.py
+++ b/src/sentry/integrations/jira/utils/types.py
@@ -1,8 +1,0 @@
-from dataclasses import dataclass
-
-
-@dataclass(frozen=True)
-class DynamicField:
-    type: str
-    url: str | None
-    choices: list[str] | None

--- a/tests/sentry/integrations/jira/models/test_jira_schema.py
+++ b/tests/sentry/integrations/jira/models/test_jira_schema.py
@@ -6,7 +6,7 @@ from sentry.testutils.cases import TestCase
 class TestJiraSchema(TestCase):
     def test_schema_parsing(self):
         create_meta = StubJiraApiClient().get_create_meta_for_project("proj-1")
-        issue_configs = JiraIssueTypeMetadata.from_jira_meta_config(create_meta)
+        issue_configs = list(JiraIssueTypeMetadata.from_jira_meta_config(create_meta).values())
         assert len(issue_configs) == 1
         assert issue_configs[0].name == "Bug"
         assert issue_configs[0].id == "1"

--- a/tests/sentry/integrations/jira/utils/test_create_issue_schema_transformers.py
+++ b/tests/sentry/integrations/jira/utils/test_create_issue_schema_transformers.py
@@ -4,14 +4,12 @@ import pytest
 
 from fixtures.integrations.jira.stub_client import StubJiraApiClient
 from sentry.integrations.jira.models.create_issue_metadata import (
+    JIRA_CUSTOM_FIELD_TYPES,
     JiraField,
     JiraSchema,
     JiraSchemaTypes,
 )
-from sentry.integrations.jira.utils.create_issue_schema_transformers import (
-    JIRA_CUSTOM_FIELD_TYPES,
-    transform_fields,
-)
+from sentry.integrations.jira.utils.create_issue_schema_transformers import transform_fields
 from sentry.shared_integrations.exceptions import IntegrationFormError
 from sentry.testutils.cases import TestCase
 

--- a/tests/sentry/integrations/jira/utils/test_create_issue_schema_transformers.py
+++ b/tests/sentry/integrations/jira/utils/test_create_issue_schema_transformers.py
@@ -8,7 +8,10 @@ from sentry.integrations.jira.models.create_issue_metadata import (
     JiraSchema,
     JiraSchemaTypes,
 )
-from sentry.integrations.jira.utils.create_issue_schema_transformers import transform_fields
+from sentry.integrations.jira.utils.create_issue_schema_transformers import (
+    JIRA_CUSTOM_FIELD_TYPES,
+    transform_fields,
+)
 from sentry.shared_integrations.exceptions import IntegrationFormError
 from sentry.testutils.cases import TestCase
 
@@ -134,3 +137,26 @@ class TestDataTransformer(TestCase):
         )
 
         assert transformed_data == {"project": {"id": "abcd"}}
+
+    def test_sprint_custom_field(self):
+        sprint_field = JiraField(
+            schema=JiraSchema(
+                custom_id=1001,
+                custom=JIRA_CUSTOM_FIELD_TYPES["sprint"],
+                schema_type=JiraSchemaTypes.array,
+                items=JiraSchemaTypes.json,
+            ),
+            name="sprint",
+            key="sprint",
+            required=False,
+            has_default_value=False,
+            operations=[],
+        )
+
+        transformed_data = transform_fields(
+            self.client.user_id_field(),
+            jira_fields=[sprint_field],
+            **{"sprint": 2},
+        )
+
+        assert transformed_data == {"sprint": 2}

--- a/tests/sentry/integrations/jira/utils/test_create_issue_schema_transformers.py
+++ b/tests/sentry/integrations/jira/utils/test_create_issue_schema_transformers.py
@@ -1,0 +1,136 @@
+from typing import Any
+
+import pytest
+
+from fixtures.integrations.jira.stub_client import StubJiraApiClient
+from sentry.integrations.jira.models.create_issue_metadata import (
+    JiraField,
+    JiraSchema,
+    JiraSchemaTypes,
+)
+from sentry.integrations.jira.utils.create_issue_schema_transformers import transform_fields
+from sentry.shared_integrations.exceptions import IntegrationFormError
+from sentry.testutils.cases import TestCase
+
+
+class TestDataTransformer(TestCase):
+    def setUp(self):
+        # TODO(Gabe): Add an interface for the Jira client to share among the different impls
+        self.client: Any = StubJiraApiClient()
+
+    def test_transform_with_empty_fields_set(self):
+        transformed_data = transform_fields(
+            self.client.user_id_field(),
+            [],
+            **{"field1": "abcd", "field2": "1234", "field3": "foobar"},
+        )
+
+        assert transformed_data == {}
+
+    def create_standard_field(
+        self,
+        name: str,
+        schema_type: JiraSchemaTypes,
+        is_array: bool = False,
+        key: str | None = None,
+        required: bool = False,
+    ) -> JiraField:
+        if is_array:
+            jira_schema = JiraSchema(
+                schema_type=JiraSchemaTypes.array,
+                items=schema_type,
+            )
+        else:
+            jira_schema = JiraSchema(
+                schema_type=schema_type,
+            )
+        return JiraField(
+            name=name,
+            key=key or name,
+            operations=[],
+            has_default_value=False,
+            required=required,
+            schema=jira_schema,
+        )
+
+    def test_multi_user_array(self):
+        field = self.create_standard_field(
+            name="Foo Bar", key="foobar", schema_type=JiraSchemaTypes.user, is_array=True
+        )
+        transformed_data = transform_fields(
+            self.client.user_id_field(), jira_fields=[field], **{"foobar": "abcd"}
+        )
+        assert transformed_data == {"foobar": [{"accountId": "abcd"}]}
+
+        transformed_data = transform_fields(
+            self.client.user_id_field(), jira_fields=[field], **{"foobar": ["abcd", "efgh"]}
+        )
+        assert transformed_data == {"foobar": [{"accountId": "abcd"}, {"accountId": "efgh"}]}
+
+    def test_transform_single_user(self):
+        field = self.create_standard_field(schema_type=JiraSchemaTypes.user, name="barfoo")
+        transformed_data = transform_fields(
+            self.client.user_id_field(), jira_fields=[field], **{"barfoo": "abcd"}
+        )
+
+        assert transformed_data == {"barfoo": {"accountId": "abcd"}}
+
+    def test_transform_number_field(self):
+        field = self.create_standard_field(schema_type=JiraSchemaTypes.number, name="num_field")
+        with pytest.raises(IntegrationFormError) as exc:
+            transform_fields(
+                self.client.user_id_field(), jira_fields=[field], **{"num_field": "abcd"}
+            )
+
+        assert exc.value.field_errors == {
+            "num_field": "Invalid number value provided for field: 'abcd'"
+        }
+
+        transformed_data = transform_fields(
+            self.client.user_id_field(), jira_fields=[field], **{"num_field": "1.5"}
+        )
+
+        assert transformed_data == {"num_field": 1.5}
+
+        transformed_data = transform_fields(
+            self.client.user_id_field(), jira_fields=[field], **{"num_field": "5"}
+        )
+
+        assert transformed_data == {"num_field": 5}
+
+    def test_transform_issue_type_field(self):
+        field = self.create_standard_field(name="issue", schema_type=JiraSchemaTypes.issue_type)
+        transformed_data = transform_fields(
+            self.client.user_id_field(), jira_fields=[field], **{"issue": "abcd"}
+        )
+        assert transformed_data == {"issue": {"id": "abcd"}}
+
+    def test_transform_option_field(self):
+        field = self.create_standard_field(name="option_thing", schema_type=JiraSchemaTypes.option)
+        transformed_data = transform_fields(
+            self.client.user_id_field(),
+            jira_fields=[field],
+            **{"option_thing": "abcd"},
+        )
+        assert transformed_data == {"option_thing": {"value": "abcd"}}
+
+    def test_transform_issue_link_field(self):
+        field = self.create_standard_field(name="link", schema_type=JiraSchemaTypes.issue_link)
+
+        transformed_data = transform_fields(
+            self.client.user_id_field(),
+            jira_fields=[field],
+            **{"link": "abcd"},
+        )
+
+        assert transformed_data == {"link": {"key": "abcd"}}
+
+    def test_transform_project_field(self):
+        field = self.create_standard_field(name="project", schema_type=JiraSchemaTypes.project)
+        transformed_data = transform_fields(
+            self.client.user_id_field(),
+            jira_fields=[field],
+            **{"project": "abcd"},
+        )
+
+        assert transformed_data == {"project": {"id": "abcd"}}


### PR DESCRIPTION
## Jira Transformers Refactor
The existing logic for creating a new issue via our Jira integration (`/api/0/projects/{org_slug}/{proj_slug}/rule-actions/`) is a bit of a mess, with a lot of duplicated checks and seemingly unnecessary custom field handling.

This PR attempts to clean up the transform logic by using the explicit types passed to us via Jira's Create Issue Metadata endpoint ([jira docs for ref](https://developer.atlassian.com/server/jira/platform/jira-rest-api-example-discovering-meta-data-for-creating-issues-6291669/)).

The new transformer logic is guarded behind a new feature flag `organizations:new-jira-transformers`, with the following deployment plan:
1. LA to Sentry + test organizations, watch failure metrics
2. EA any early adopters, watch failure metrics
3. GA and forward patch remaining bugs
4. Remove the feature flag and officially release the refactors.

## Why bother with this refactor?
I find it easier to reason about a small collection of (mainly) type-based transform functions. In addition, these are individually unit-testable without having to provide a full Jira metadata JSON config like our old testing, as my previous data model changes have moved that responsibility to s different set of Jira integration methods.

## Notable exception
- The `sprint` field in Jira has `type: 'array'`, and `items: 'json'`; however, this is completely different than the expected type for this field and can't cleanly fit into this parsing logic, so it's been special cased. 

I anticipate there are more special cases like this with custom fields, but this is the only issue I managed to encounter during testing.

## Next Steps
Overhaul the Jira Issue Link UI:
-  A number of fields don't currently display properly. 
- There are a couple of field types which are cumbersome, but can be queried/autofilled (team for example). 
- Reopening an issue link dialog doesn't correctly fill every field in the dialog, but retains the state resulting in unusual validation bugs when changing project/task types.