### PR TITLE
fix(alerts): Pass time_period as an int

### DIFF
--- a/src/sentry/seer/anomaly_detection/types.py
+++ b/src/sentry/seer/anomaly_detection/types.py
@@ -1,14 +1,15 @@
 from enum import Enum
-from typing import TypedDict
-
-
-class AlertInSeer(TypedDict):
-    id: int
+from typing import NotRequired, TypedDict
 
 
 class TimeSeriesPoint(TypedDict):
     timestamp: float
     value: float
+
+
+class AlertInSeer(TypedDict):
+    id: int
+    cur_window: NotRequired[TimeSeriesPoint]
 
 
 class AnomalyDetectionConfig(TypedDict):
@@ -24,6 +25,13 @@ class StoreDataRequest(TypedDict):
     alert: AlertInSeer
     config: AnomalyDetectionConfig
     timeseries: list[TimeSeriesPoint]
+
+
+class DetectAnomaliesRequest(TypedDict):
+    organization_id: int
+    project_id: int
+    config: AnomalyDetectionConfig
+    context: AlertInSeer | list[TimeSeriesPoint]
 
 
 class AnomalyType(Enum):

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -507,10 +507,9 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         assert deserialized_body["project_id"] == self.sub.project_id
         assert deserialized_body["config"]["time_period"] == rule.snuba_query.time_window / 60
         assert deserialized_body["config"]["sensitivity"] == rule.sensitivity.value
-        assert deserialized_body["config"]["seasonality"] == rule.seasonality.value
         assert deserialized_body["config"]["direction"] == translate_direction(rule.threshold_type)
         assert deserialized_body["context"]["id"] == rule.id
-        assert deserialized_body["context"]["cur_window"]["value"] == 5
+        assert deserialized_body["context"]["cur_window"][0]["value"] == 5
 
         self.assert_trigger_counts(processor, trigger, 0, 0)
         self.assert_trigger_counts(processor, warning_trigger, 0, 0)
@@ -547,10 +546,9 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         assert deserialized_body["project_id"] == self.sub.project_id
         assert deserialized_body["config"]["time_period"] == rule.snuba_query.time_window / 60
         assert deserialized_body["config"]["sensitivity"] == rule.sensitivity.value
-        assert deserialized_body["config"]["seasonality"] == rule.seasonality.value
         assert deserialized_body["config"]["direction"] == translate_direction(rule.threshold_type)
         assert deserialized_body["context"]["id"] == rule.id
-        assert deserialized_body["context"]["cur_window"]["value"] == 10
+        assert deserialized_body["context"]["cur_window"][0]["value"] == 10
 
         self.assert_trigger_counts(processor, trigger, 0, 0)
         self.assert_trigger_counts(processor, warning_trigger, 0, 0)
@@ -584,10 +582,9 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         assert deserialized_body["project_id"] == self.sub.project_id
         assert deserialized_body["config"]["time_period"] == rule.snuba_query.time_window / 60
         assert deserialized_body["config"]["sensitivity"] == rule.sensitivity.value
-        assert deserialized_body["config"]["seasonality"] == rule.seasonality.value
         assert deserialized_body["config"]["direction"] == translate_direction(rule.threshold_type)
         assert deserialized_body["context"]["id"] == rule.id
-        assert deserialized_body["context"]["cur_window"]["value"] == 1
+        assert deserialized_body["context"]["cur_window"][0]["value"] == 1
 
         self.assert_trigger_counts(processor, self.trigger, 0, 0)
         self.assert_trigger_counts(processor, warning_trigger, 0, 0)


### PR DESCRIPTION
We're still seeing a 401 from Seer when hitting this endpoint in prod and it may be because we're passing `time_period` as a float rather than an int. This rewrites it slightly to use the types and adds the `DetectAnomaliesRequest` to match what's defined in [Seer](https://github.com/getsentry/seer/blob/main/src/seer/anomaly_detection/models/external.py#L64-L71).