### PR TITLE
feat(custom-views): Add feedback button to tab menu button

### DIFF
--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabMenuButton.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabMenuButton.tsx
@@ -60,7 +60,7 @@ function FeedbackFooter() {
           openForm({
             messagePlaceholder: t('How can we make custom views better for you?'),
             tags: {
-              source: 'custom_views',
+              ['feedback.source']: 'custom_views',
             },
           })
         }

--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabMenuButton.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabMenuButton.tsx
@@ -1,7 +1,11 @@
 import styled from '@emotion/styled';
 
+import {Button} from 'sentry/components/button';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
-import {IconEllipsis} from 'sentry/icons';
+import {IconEllipsis, IconMegaphone} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 
 interface DraggableTabMenuButtonProps {
   menuOptions: MenuItemProps[];
@@ -33,11 +37,48 @@ export function DraggableTabMenuButton({
         }}
         items={menuOptions}
         offset={[-10, 5]}
+        menuFooter={<FeedbackFooter />}
         usePortal
       />
     </TriggerIconWrap>
   );
 }
+
+function FeedbackFooter() {
+  const openForm = useFeedbackForm();
+
+  if (!openForm) {
+    return null;
+  }
+
+  return (
+    <SectionedOverlayFooter>
+      <Button
+        size="xs"
+        icon={<IconMegaphone />}
+        onClick={() =>
+          openForm({
+            messagePlaceholder: t('How can we make custom views better for you?'),
+            tags: {
+              source: 'custom_views',
+            },
+          })
+        }
+      >
+        {t('Give Feedback')}
+      </Button>
+    </SectionedOverlayFooter>
+  );
+}
+
+const SectionedOverlayFooter = styled('div')`
+  grid-area: footer;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: ${space(1)};
+  border-top: 1px solid ${p => p.theme.innerBorder};
+`;
 
 const StyledDropdownMenu = styled(DropdownMenu)`
   font-weight: ${p => p.theme.fontWeightNormal};

--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabMenuButton.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabMenuButton.tsx
@@ -61,6 +61,7 @@ function FeedbackFooter() {
             messagePlaceholder: t('How can we make custom views better for you?'),
             tags: {
               ['feedback.source']: 'custom_views',
+              ['feedback.owner']: 'issues',
             },
           })
         }


### PR DESCRIPTION
Adds a feedback button to the bottom of the tab menu button (only appears for the Sentry org). definitely not the most graceful, open to design criticism. 

<img width="227" alt="image" src="https://github.com/user-attachments/assets/45b63c08-fc1d-44ca-988d-baf30470a9b6">
