### PR TITLE
fix(issue-search): Skip archived releases when using latest alias

### DIFF
--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -15,7 +15,7 @@ from sentry.models.group import STATUS_QUERY_CHOICES, Group
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.project import Project
-from sentry.models.release import Release, follows_semver_versioning_scheme
+from sentry.models.release import Release, ReleaseStatus, follows_semver_versioning_scheme
 from sentry.models.team import Team
 from sentry.search.base import ANY
 from sentry.search.events.constants import MAX_PARAMETERS_IN_ARRAY
@@ -454,6 +454,7 @@ def _run_latest_release_query(
             INNER JOIN "sentry_release_project" srp ON sr.id = srp.release_id
             {env_join}
             WHERE sr.organization_id = %s
+            AND sr.status = {ReleaseStatus.OPEN}
             AND srp.project_id IN %s
             {extra_conditions}
             {env_where}

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -124,7 +124,7 @@ from sentry.models.project import Project
 from sentry.models.projectbookmark import ProjectBookmark
 from sentry.models.projectcodeowners import ProjectCodeOwners
 from sentry.models.projecttemplate import ProjectTemplate
-from sentry.models.release import Release
+from sentry.models.release import Release, ReleaseStatus
 from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.releaseenvironment import ReleaseEnvironment
 from sentry.models.releasefile import ReleaseFile, update_artifact_index
@@ -605,6 +605,7 @@ class Factories:
         date_released: datetime | None = None,
         adopted: datetime | None = None,
         unadopted: datetime | None = None,
+        status: ReleaseStatus | None = None,
     ):
         if version is None:
             version = force_str(hexlify(os.urandom(20)))
@@ -620,6 +621,7 @@ class Factories:
             organization_id=project.organization_id,
             date_added=date_added,
             date_released=date_released,
+            status=status,
         )
 
         release.add_project(project)

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -124,7 +124,7 @@ from sentry.models.project import Project
 from sentry.models.projectbookmark import ProjectBookmark
 from sentry.models.projectcodeowners import ProjectCodeOwners
 from sentry.models.projecttemplate import ProjectTemplate
-from sentry.models.release import Release, ReleaseStatus
+from sentry.models.release import Release
 from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.releaseenvironment import ReleaseEnvironment
 from sentry.models.releasefile import ReleaseFile, update_artifact_index
@@ -605,7 +605,7 @@ class Factories:
         date_released: datetime | None = None,
         adopted: datetime | None = None,
         unadopted: datetime | None = None,
-        status: ReleaseStatus | None = None,
+        status: int | None = None,
     ):
         if version is None:
             version = force_str(hexlify(os.urandom(20)))

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -124,7 +124,7 @@ from sentry.models.project import Project
 from sentry.models.projectbookmark import ProjectBookmark
 from sentry.models.projectcodeowners import ProjectCodeOwners
 from sentry.models.projecttemplate import ProjectTemplate
-from sentry.models.release import Release
+from sentry.models.release import Release, ReleaseStatus
 from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.releaseenvironment import ReleaseEnvironment
 from sentry.models.releasefile import ReleaseFile, update_artifact_index
@@ -605,7 +605,7 @@ class Factories:
         date_released: datetime | None = None,
         adopted: datetime | None = None,
         unadopted: datetime | None = None,
-        status: int | None = None,
+        status: int | None = ReleaseStatus.OPEN,
     ):
         if version is None:
             version = force_str(hexlify(os.urandom(20)))

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -24,6 +24,7 @@ from sentry.api.issue_search import (
 from sentry.exceptions import InvalidSearchQuery
 from sentry.issues.grouptype import GroupCategory, get_group_types_by_category
 from sentry.models.group import GROUP_SUBSTATUS_TO_STATUS_MAP, STATUS_QUERY_CHOICES, GroupStatus
+from sentry.models.release import ReleaseStatus
 from sentry.search.utils import get_teams_for_users
 from sentry.testutils.cases import TestCase
 from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, GroupSubStatus, PriorityLevel
@@ -374,6 +375,16 @@ class ConvertReleaseValueTest(TestCase):
         release = self.create_release(self.project)
         assert convert_release_value(["latest"], [self.project], self.user, None) == release.version
         assert convert_release_value(["14.*"], [self.project], self.user, None) == "14.*"
+
+    def test_latest_archived(self):
+        open_release = self.create_release(self.project, version="1.0", status=ReleaseStatus.OPEN)
+        self.create_release(self.project, version="1.1", status=ReleaseStatus.ARCHIVED)
+
+        # The archived release is more recent, but we should still pick the open one
+        assert (
+            convert_release_value(["latest"], [self.project], self.user, None)
+            == open_release.version
+        )
 
 
 class ConvertFirstReleaseValueTest(TestCase):


### PR DESCRIPTION
Related to https://github.com/getsentry/sentry/issues/76841

Currently, `release:latest` will search for the most recent release regardless of its status. This change adds a where statement to the latest releases query which filters out archived releases.