### PR TITLE
fix(profiling): Increase vroom requests timeouts

### DIFF
--- a/src/sentry/profiles/utils.py
+++ b/src/sentry/profiles/utils.py
@@ -76,7 +76,7 @@ _profiling_pool = connection_from_url(
         status_forcelist={502},
         allowed_methods={"GET", "POST"},
     ),
-    timeout=10,
+    timeout=15,
     maxsize=10,
     headers={"Accept-Encoding": "br, gzip"},
 )


### PR DESCRIPTION
The new endpoint seems to be slower, so raise the timout while we debug what's going on.