### PR TITLE
add anomaly charts to chartcuterie

### DIFF
--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -228,8 +228,11 @@ def build_metric_alert_chart(
             user,
         ),
     }
+    # NOTE: anomaly-detection-alerts-charts flag does not exist
+    # Flag can be enabled IF we want to enable marked lines/areas for anomalies in the future
+    # For now, we defer to incident lines as indicators for anomalies
     if features.has(
-        "organizations:anomaly-detection-alerts",
+        "organizations:anomaly-detection-alerts-charts",
         organization,
     ):
         chart_data["anomalies"] = fetch_metric_alert_anomalies(

--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -15,7 +15,7 @@ from sentry.charts.types import ChartSize, ChartType
 from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializer
 from sentry.incidents.endpoints.serializers.incident import DetailedIncidentSerializer
 from sentry.incidents.logic import translate_aggregate_field
-from sentry.incidents.models.alert_rule import AlertRule
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleDetectionType
 from sentry.incidents.models.incident import Incident
 from sentry.models.apikey import ApiKey
 from sentry.models.organization import Organization
@@ -228,12 +228,15 @@ def build_metric_alert_chart(
             user,
         ),
     }
-    # NOTE: anomaly-detection-alerts-charts flag does not exist
+    # NOTE: 'anomaly-detection-alerts-charts' flag does not exist
     # Flag can be enabled IF we want to enable marked lines/areas for anomalies in the future
     # For now, we defer to incident lines as indicators for anomalies
-    if features.has(
-        "organizations:anomaly-detection-alerts-charts",
-        organization,
+    if (
+        features.has(
+            "organizations:anomaly-detection-alerts-charts",
+            organization,
+        )
+        and alert_rule.detection_type == AlertRuleDetectionType.DYNAMIC
     ):
         chart_data["anomalies"] = fetch_metric_alert_anomalies(
             organization,

--- a/src/sentry/templates/sentry/debug/chart-renderer.html
+++ b/src/sentry/templates/sentry/debug/chart-renderer.html
@@ -22,7 +22,8 @@
     <h2>Chart Renderer Debug</h2>
     <div class="charts">
       {% for chart_url in charts %}
-        <img src="{{ chart_url }}" />
+        <div>{{ chart_url.title }}</div>
+        <img src="{{ chart_url.chart }}" />
       {% endfor %}
     </div>
   </body>

--- a/src/sentry/web/debug_urls.py
+++ b/src/sentry/web/debug_urls.py
@@ -148,12 +148,12 @@ urlpatterns = [
     re_path(r"^debug/mail/sso-linked/$", DebugSsoLinkedEmailView.as_view()),
     re_path(r"^debug/mail/sso-unlinked/$", DebugSsoUnlinkedEmailView.as_view()),
     re_path(
-        r"^debug/mail/sso-unlinked/no-password$", DebugSsoUnlinkedNoPasswordEmailView.as_view()
+        r"^debug/mail/sso-unlinked/no-password/$", DebugSsoUnlinkedNoPasswordEmailView.as_view()
     ),
-    re_path(r"^debug/mail/incident-activity$", DebugIncidentActivityEmailView.as_view()),
-    re_path(r"^debug/mail/incident-trigger$", DebugIncidentTriggerEmailView.as_view()),
+    re_path(r"^debug/mail/incident-activity/$", DebugIncidentActivityEmailView.as_view()),
+    re_path(r"^debug/mail/incident-trigger/$", DebugIncidentTriggerEmailView.as_view()),
     re_path(
-        r"^debug/mail/activated-incident-trigger$",
+        r"^debug/mail/activated-incident-trigger/$",
         DebugIncidentActivatedAlertTriggerEmailView.as_view(),
     ),
     re_path(r"^debug/mail/setup-2fa/$", DebugSetup2faEmailView.as_view()),

--- a/src/sentry/web/frontend/debug/debug_chart_renderer.py
+++ b/src/sentry/web/frontend/debug/debug_chart_renderer.py
@@ -706,7 +706,7 @@ class DebugChartRendererView(View):
                 "chart": charts.generate_chart(
                     ChartType.SLACK_DISCOVER_TOTAL_PERIOD, discover_total_period
                 ),
-                "title": "Slack discover total period",
+                "title": "Slack Discover total period",
             }
         )
         ret.append(
@@ -714,7 +714,7 @@ class DebugChartRendererView(View):
                 "chart": charts.generate_chart(
                     ChartType.SLACK_DISCOVER_TOTAL_PERIOD, discover_multi_y_axis
                 ),
-                "title": "Slack discover total period multi y axis",
+                "title": "Slack Discover total period multi y axis",
             }
         )
         ret.append(
@@ -722,7 +722,7 @@ class DebugChartRendererView(View):
                 "chart": charts.generate_chart(
                     ChartType.SLACK_DISCOVER_TOTAL_PERIOD, discover_empty
                 ),
-                "title": "Slack discover total period empty",
+                "title": "Slack Discover total period empty",
             }
         )
         ret.append(
@@ -752,7 +752,7 @@ class DebugChartRendererView(View):
         ret.append(
             {
                 "chart": charts.generate_chart(ChartType.SLACK_DISCOVER_TOP5_PERIOD, discover_top5),
-                "title": "Slack discover top5 period",
+                "title": "Slack Discover top5 period",
             }
         )
         ret.append(
@@ -760,7 +760,7 @@ class DebugChartRendererView(View):
                 "chart": charts.generate_chart(
                     ChartType.SLACK_DISCOVER_TOP5_PERIOD, discover_empty
                 ),
-                "title": "Slack discover top5 empty",
+                "title": "Slack Discover top5 empty",
             }
         )
         ret.append(
@@ -768,7 +768,7 @@ class DebugChartRendererView(View):
                 "chart": charts.generate_chart(
                     ChartType.SLACK_DISCOVER_TOP5_PERIOD_LINE, discover_top5
                 ),
-                "title": "Slack discover top5 period line",
+                "title": "Slack Discover top5 period line",
             }
         )
         ret.append(
@@ -776,19 +776,19 @@ class DebugChartRendererView(View):
                 "chart": charts.generate_chart(
                     ChartType.SLACK_DISCOVER_TOP5_PERIOD_LINE, discover_empty
                 ),
-                "title": "Slack discover top5 period line empty",
+                "title": "Slack Discover top5 period line empty",
             }
         )
         ret.append(
             {
                 "chart": charts.generate_chart(ChartType.SLACK_DISCOVER_TOP5_DAILY, discover_top5),
-                "title": "Slack discover top5 daily",
+                "title": "Slack Discover top5 daily",
             }
         )
         ret.append(
             {
                 "chart": charts.generate_chart(ChartType.SLACK_DISCOVER_TOP5_DAILY, discover_empty),
-                "title": "Slack discover top5 daily empty",
+                "title": "Slack Discover top5 daily empty",
             }
         )
         ret.append(
@@ -796,7 +796,7 @@ class DebugChartRendererView(View):
                 "chart": charts.generate_chart(
                     ChartType.SLACK_DISCOVER_PREVIOUS_PERIOD, discover_total_period
                 ),
-                "title": "Slack discover previous period",
+                "title": "Slack Discover previous period",
             }
         )
         ret.append(
@@ -804,14 +804,14 @@ class DebugChartRendererView(View):
                 "chart": charts.generate_chart(
                     ChartType.SLACK_DISCOVER_PREVIOUS_PERIOD, discover_multi_y_axis
                 ),
-                "title": "Slack discover previous period multi y axis",
+                "title": "Slack Discover previous period multi y axis",
             }
         )
 
         ret.append(
             {
                 "chart": charts.generate_chart(ChartType.SLACK_METRIC_ALERT_EVENTS, metric_alert),
-                "title": "slack metric alert events",
+                "title": "Slack metric alert events",
             }
         )
         ret.append(
@@ -819,7 +819,7 @@ class DebugChartRendererView(View):
                 "chart": charts.generate_chart(
                     ChartType.SLACK_METRIC_ALERT_SESSIONS, crash_free_metric_alert
                 ),
-                "title": "slack metric alert sessions crash free",
+                "title": "Slack metric alert sessions crash free",
             }
         )
         ret.append(
@@ -827,7 +827,7 @@ class DebugChartRendererView(View):
                 "chart": charts.generate_chart(
                     ChartType.SLACK_METRIC_ALERT_EVENTS, metric_alert_with_anomalies
                 ),
-                "title": "slack metric alert with anomalies",
+                "title": "Slack metric alert with anomalies",
             }
         )
 

--- a/src/sentry/web/frontend/debug/debug_chart_renderer.py
+++ b/src/sentry/web/frontend/debug/debug_chart_renderer.py
@@ -518,41 +518,320 @@ crash_free_metric_alert = {
     },
 }
 
+metric_alert_anomaly = {
+    "timeseries": [
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "none",
+            },
+            "timestamp": "2024-08-29T15:39:00Z",
+            "value": 0.077881957,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "none",
+            },
+            "timestamp": "2024-08-29T15:40:00Z",
+            "value": 0.075652768,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "none",
+            },
+            "timestamp": "2024-08-29T15:41:00Z",
+            "value": 0.073435431,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "anomaly_higher_confidence",
+            },
+            "timestamp": "2024-08-29T15:42:00Z",
+            "value": 0.071145604,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "anomaly_higher_confidence",
+            },
+            "timestamp": "2024-08-29T15:43:00Z",
+            "value": 0.068080257,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "anomaly_higher_confidence",
+            },
+            "timestamp": "2024-08-29T15:44:00Z",
+            "value": 0.065966207,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "anomaly_higher_confidence",
+            },
+            "timestamp": "2024-08-29T15:45:00Z",
+            "value": 0.062053994,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "anomaly_higher_confidence",
+            },
+            "timestamp": "2024-08-29T15:46:00Z",
+            "value": 0.058596638,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "anomaly_higher_confidence",
+            },
+            "timestamp": "2024-08-29T15:47:00Z",
+            "value": 0.056028657,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "anomaly_higher_confidence",
+            },
+            "timestamp": "2024-08-29T15:48:00Z",
+            "value": 0.052905251,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "anomaly_higher_confidence",
+            },
+            "timestamp": "2024-08-29T15:49:00Z",
+            "value": 0.051122719,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "anomaly_higher_confidence",
+            },
+            "timestamp": "2024-08-29T15:50:00Z",
+            "value": 0.050375953,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "anomaly_higher_confidence",
+            },
+            "timestamp": "2024-08-29T15:51:00Z",
+            "value": 0.047727103,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "anomaly_higher_confidence",
+            },
+            "timestamp": "2024-08-29T15:52:00Z",
+            "value": 0.047437386,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "none",
+            },
+            "timestamp": "2024-08-29T15:53:00Z",
+            "value": 0.046208149,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "none",
+            },
+            "timestamp": "2024-08-29T15:54:00Z",
+            "value": 0.044512145,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "none",
+            },
+            "timestamp": "2024-08-29T15:55:00Z",
+            "value": 0.043505737,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "none",
+            },
+            "timestamp": "2024-08-29T15:56:00Z",
+            "value": 0.043147801,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "none",
+            },
+            "timestamp": "2024-08-29T15:57:00Z",
+            "value": 0.041545758,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "none",
+            },
+            "timestamp": "2024-08-29T15:58:00Z",
+            "value": 0.040482494,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "none",
+            },
+            "timestamp": "2024-08-29T15:59:00Z",
+            "value": 0.041155806,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "none",
+            },
+            "timestamp": "2024-08-29T15:60:00Z",
+            "value": 0.042155754,
+        },
+    ],
+}
+
 
 class DebugChartRendererView(View):
     def get(self, request: HttpRequest) -> HttpResponse:
         ret = []
 
         ret.append(
-            charts.generate_chart(ChartType.SLACK_DISCOVER_TOTAL_PERIOD, discover_total_period)
+            {
+                "chart": charts.generate_chart(
+                    ChartType.SLACK_DISCOVER_TOTAL_PERIOD, discover_total_period
+                ),
+                "title": "Slack discover total period",
+            }
         )
         ret.append(
-            charts.generate_chart(ChartType.SLACK_DISCOVER_TOTAL_PERIOD, discover_multi_y_axis)
-        )
-        ret.append(charts.generate_chart(ChartType.SLACK_DISCOVER_TOTAL_PERIOD, discover_empty))
-        ret.append(
-            charts.generate_chart(ChartType.SLACK_DISCOVER_TOTAL_DAILY, discover_total_daily)
-        )
-        ret.append(
-            charts.generate_chart(ChartType.SLACK_DISCOVER_TOTAL_DAILY, discover_total_daily_multi)
-        )
-        ret.append(charts.generate_chart(ChartType.SLACK_DISCOVER_TOTAL_DAILY, discover_empty))
-        ret.append(charts.generate_chart(ChartType.SLACK_DISCOVER_TOP5_PERIOD, discover_top5))
-        ret.append(charts.generate_chart(ChartType.SLACK_DISCOVER_TOP5_PERIOD, discover_empty))
-        ret.append(charts.generate_chart(ChartType.SLACK_DISCOVER_TOP5_PERIOD_LINE, discover_top5))
-        ret.append(charts.generate_chart(ChartType.SLACK_DISCOVER_TOP5_PERIOD_LINE, discover_empty))
-        ret.append(charts.generate_chart(ChartType.SLACK_DISCOVER_TOP5_DAILY, discover_top5))
-        ret.append(charts.generate_chart(ChartType.SLACK_DISCOVER_TOP5_DAILY, discover_empty))
-        ret.append(
-            charts.generate_chart(ChartType.SLACK_DISCOVER_PREVIOUS_PERIOD, discover_total_period)
+            {
+                "chart": charts.generate_chart(
+                    ChartType.SLACK_DISCOVER_TOTAL_PERIOD, discover_multi_y_axis
+                ),
+                "title": "Slack discover total period multi y axis",
+            }
         )
         ret.append(
-            charts.generate_chart(ChartType.SLACK_DISCOVER_PREVIOUS_PERIOD, discover_multi_y_axis)
+            {
+                "chart": charts.generate_chart(
+                    ChartType.SLACK_DISCOVER_TOTAL_PERIOD, discover_empty
+                ),
+                "title": "Slack discover total period empty",
+            }
+        )
+        ret.append(
+            {
+                "chart": charts.generate_chart(
+                    ChartType.SLACK_DISCOVER_TOTAL_DAILY, discover_total_daily
+                ),
+                "title": "Discover total daily",
+            }
+        )
+        ret.append(
+            {
+                "chart": charts.generate_chart(
+                    ChartType.SLACK_DISCOVER_TOTAL_DAILY, discover_total_daily_multi
+                ),
+                "title": "Discover total daily multi",
+            }
+        )
+        ret.append(
+            {
+                "chart": charts.generate_chart(
+                    ChartType.SLACK_DISCOVER_TOTAL_DAILY, discover_empty
+                ),
+                "title": "Discover total daily empty",
+            }
+        )
+        ret.append(
+            {
+                "chart": charts.generate_chart(ChartType.SLACK_DISCOVER_TOP5_PERIOD, discover_top5),
+                "title": "Slack discover top5 period",
+            }
+        )
+        ret.append(
+            {
+                "chart": charts.generate_chart(
+                    ChartType.SLACK_DISCOVER_TOP5_PERIOD, discover_empty
+                ),
+                "title": "Slack discover top5 empty",
+            }
+        )
+        ret.append(
+            {
+                "chart": charts.generate_chart(
+                    ChartType.SLACK_DISCOVER_TOP5_PERIOD_LINE, discover_top5
+                ),
+                "title": "Slack discover top5 period line",
+            }
+        )
+        ret.append(
+            {
+                "chart": charts.generate_chart(
+                    ChartType.SLACK_DISCOVER_TOP5_PERIOD_LINE, discover_empty
+                ),
+                "title": "Slack discover top5 period line empty",
+            }
+        )
+        ret.append(
+            {
+                "chart": charts.generate_chart(ChartType.SLACK_DISCOVER_TOP5_DAILY, discover_top5),
+                "title": "Slack discover top5 daily",
+            }
+        )
+        ret.append(
+            {
+                "chart": charts.generate_chart(ChartType.SLACK_DISCOVER_TOP5_DAILY, discover_empty),
+                "title": "Slack discover top5 daily empty",
+            }
+        )
+        ret.append(
+            {
+                "chart": charts.generate_chart(
+                    ChartType.SLACK_DISCOVER_PREVIOUS_PERIOD, discover_total_period
+                ),
+                "title": "Slack discover previous period",
+            }
+        )
+        ret.append(
+            {
+                "chart": charts.generate_chart(
+                    ChartType.SLACK_DISCOVER_PREVIOUS_PERIOD, discover_multi_y_axis
+                ),
+                "title": "Slack discover previous period multi y axis",
+            }
         )
 
-        ret.append(charts.generate_chart(ChartType.SLACK_METRIC_ALERT_EVENTS, metric_alert))
         ret.append(
-            charts.generate_chart(ChartType.SLACK_METRIC_ALERT_SESSIONS, crash_free_metric_alert)
+            {
+                "chart": charts.generate_chart(ChartType.SLACK_METRIC_ALERT_EVENTS, metric_alert),
+                "title": "slack metric alert events",
+            }
         )
+        ret.append(
+            {
+                "chart": charts.generate_chart(
+                    ChartType.SLACK_METRIC_ALERT_SESSIONS, crash_free_metric_alert
+                ),
+                "title": "slack metric alert sessions crash free",
+            }
+        )
+        # ret.append(
+        #     {
+        #         "chart": charts.generate_chart(
+        #             ChartType.SLACK_METRIC_ALERT_ANOMALIES, metric_alert_anomaly
+        #         ),
+        #         "title": "slack metric alert anomalies",
+        #     }
+        # )
 
         return render_to_response("sentry/debug/chart-renderer.html", context={"charts": ret})

--- a/src/sentry/web/frontend/debug/debug_chart_renderer.py
+++ b/src/sentry/web/frontend/debug/debug_chart_renderer.py
@@ -448,186 +448,184 @@ metric_alert = {
     "selectedIncident": None,
 }
 metric_alert_with_anomalies = metric_alert.copy()
-metric_alert_with_anomalies["anomalies"] = (
-    [
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "none",
-            },
-            "timestamp": "2022-04-21T15:30:00Z",
-            "value": 0.077881957,
+metric_alert_with_anomalies["anomalies"] = [
+    {
+        "anomaly": {
+            "anomaly_score": 0,
+            "anomaly_type": "none",
         },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2022-04-21T15:40:00Z",
-            "value": 0.075652768,
+        "timestamp": "2022-04-21T15:30:00Z",
+        "value": 0.077881957,
+    },
+    {
+        "anomaly": {
+            "anomaly_score": 0,
+            "anomaly_type": "anomaly_higher_confidence",
         },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2022-04-21T15:41:00Z",
-            "value": 0.073435431,
+        "timestamp": "2022-04-21T15:40:00Z",
+        "value": 0.075652768,
+    },
+    {
+        "anomaly": {
+            "anomaly_score": 0,
+            "anomaly_type": "anomaly_higher_confidence",
         },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2022-04-21T16:42:00Z",
-            "value": 0.071145604,
+        "timestamp": "2022-04-21T15:41:00Z",
+        "value": 0.073435431,
+    },
+    {
+        "anomaly": {
+            "anomaly_score": 0,
+            "anomaly_type": "anomaly_higher_confidence",
         },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2022-04-21T17:43:00Z",
-            "value": 0.068080257,
+        "timestamp": "2022-04-21T16:42:00Z",
+        "value": 0.071145604,
+    },
+    {
+        "anomaly": {
+            "anomaly_score": 0,
+            "anomaly_type": "anomaly_higher_confidence",
         },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2022-04-21T18:44:00Z",
-            "value": 0.065966207,
+        "timestamp": "2022-04-21T17:43:00Z",
+        "value": 0.068080257,
+    },
+    {
+        "anomaly": {
+            "anomaly_score": 0,
+            "anomaly_type": "anomaly_higher_confidence",
         },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2022-04-21T19:45:00Z",
-            "value": 0.062053994,
+        "timestamp": "2022-04-21T18:44:00Z",
+        "value": 0.065966207,
+    },
+    {
+        "anomaly": {
+            "anomaly_score": 0,
+            "anomaly_type": "anomaly_higher_confidence",
         },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2022-04-21T20:46:00Z",
-            "value": 0.058596638,
+        "timestamp": "2022-04-21T19:45:00Z",
+        "value": 0.062053994,
+    },
+    {
+        "anomaly": {
+            "anomaly_score": 0,
+            "anomaly_type": "anomaly_higher_confidence",
         },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2022-04-21T21:47:00Z",
-            "value": 0.056028657,
+        "timestamp": "2022-04-21T20:46:00Z",
+        "value": 0.058596638,
+    },
+    {
+        "anomaly": {
+            "anomaly_score": 0,
+            "anomaly_type": "anomaly_higher_confidence",
         },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2022-04-21T22:48:00Z",
-            "value": 0.052905251,
+        "timestamp": "2022-04-21T21:47:00Z",
+        "value": 0.056028657,
+    },
+    {
+        "anomaly": {
+            "anomaly_score": 0,
+            "anomaly_type": "anomaly_higher_confidence",
         },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2022-04-21T23:49:00Z",
-            "value": 0.051122719,
+        "timestamp": "2022-04-21T22:48:00Z",
+        "value": 0.052905251,
+    },
+    {
+        "anomaly": {
+            "anomaly_score": 0,
+            "anomaly_type": "anomaly_higher_confidence",
         },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "none",
-            },
-            "timestamp": "2022-04-22T00:50:00Z",
-            "value": 0.050375953,
+        "timestamp": "2022-04-21T23:49:00Z",
+        "value": 0.051122719,
+    },
+    {
+        "anomaly": {
+            "anomaly_score": 0,
+            "anomaly_type": "none",
         },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "none",
-            },
-            "timestamp": "2022-04-22T01:51:00Z",
-            "value": 0.047727103,
+        "timestamp": "2022-04-22T00:50:00Z",
+        "value": 0.050375953,
+    },
+    {
+        "anomaly": {
+            "anomaly_score": 0,
+            "anomaly_type": "none",
         },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "none",
-            },
-            "timestamp": "2022-04-22T02:52:00Z",
-            "value": 0.047437386,
+        "timestamp": "2022-04-22T01:51:00Z",
+        "value": 0.047727103,
+    },
+    {
+        "anomaly": {
+            "anomaly_score": 0,
+            "anomaly_type": "none",
         },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "none",
-            },
-            "timestamp": "2022-04-22T03:53:00Z",
-            "value": 0.046208149,
+        "timestamp": "2022-04-22T02:52:00Z",
+        "value": 0.047437386,
+    },
+    {
+        "anomaly": {
+            "anomaly_score": 0,
+            "anomaly_type": "none",
         },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2022-04-22T04:54:00Z",
-            "value": 0.044512145,
+        "timestamp": "2022-04-22T03:53:00Z",
+        "value": 0.046208149,
+    },
+    {
+        "anomaly": {
+            "anomaly_score": 0,
+            "anomaly_type": "anomaly_higher_confidence",
         },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2022-04-22T05:55:00Z",
-            "value": 0.043505737,
+        "timestamp": "2022-04-22T04:54:00Z",
+        "value": 0.044512145,
+    },
+    {
+        "anomaly": {
+            "anomaly_score": 0,
+            "anomaly_type": "anomaly_higher_confidence",
         },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2022-04-22T06:56:00Z",
-            "value": 0.043147801,
+        "timestamp": "2022-04-22T05:55:00Z",
+        "value": 0.043505737,
+    },
+    {
+        "anomaly": {
+            "anomaly_score": 0,
+            "anomaly_type": "anomaly_higher_confidence",
         },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2022-04-22T07:57:00Z",
-            "value": 0.041545758,
+        "timestamp": "2022-04-22T06:56:00Z",
+        "value": 0.043147801,
+    },
+    {
+        "anomaly": {
+            "anomaly_score": 0,
+            "anomaly_type": "anomaly_higher_confidence",
         },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2022-04-22T08:58:00Z",
-            "value": 0.040482494,
+        "timestamp": "2022-04-22T07:57:00Z",
+        "value": 0.041545758,
+    },
+    {
+        "anomaly": {
+            "anomaly_score": 0,
+            "anomaly_type": "anomaly_higher_confidence",
         },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2022-04-22T09:59:00Z",
-            "value": 0.041155806,
+        "timestamp": "2022-04-22T08:58:00Z",
+        "value": 0.040482494,
+    },
+    {
+        "anomaly": {
+            "anomaly_score": 0,
+            "anomaly_type": "anomaly_higher_confidence",
         },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "none",
-            },
-            "timestamp": "2022-04-22T10:60:00Z",
-            "value": 0.042155754,
+        "timestamp": "2022-04-22T09:59:00Z",
+        "value": 0.041155806,
+    },
+    {
+        "anomaly": {
+            "anomaly_score": 0,
+            "anomaly_type": "none",
         },
-    ],
-)
+        "timestamp": "2022-04-22T10:60:00Z",
+        "value": 0.042155754,
+    },
+]
 
 crash_free_metric_alert = {
     "sessionResponse": {

--- a/src/sentry/web/frontend/debug/debug_chart_renderer.py
+++ b/src/sentry/web/frontend/debug/debug_chart_renderer.py
@@ -447,7 +447,187 @@ metric_alert = {
     "incidents": [incident],
     "selectedIncident": None,
 }
-
+metric_alert_with_anomalies = metric_alert.copy()
+metric_alert_with_anomalies["anomalies"] = (
+    [
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "none",
+            },
+            "timestamp": "2022-04-21T15:39:00Z",
+            "value": 0.077881957,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "none",
+            },
+            "timestamp": "2022-04-21T15:40:00Z",
+            "value": 0.075652768,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "none",
+            },
+            "timestamp": "2022-04-21T15:41:00Z",
+            "value": 0.073435431,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "anomaly_higher_confidence",
+            },
+            "timestamp": "2022-04-21T15:42:00Z",
+            "value": 0.071145604,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "anomaly_higher_confidence",
+            },
+            "timestamp": "2022-04-21T15:43:00Z",
+            "value": 0.068080257,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "anomaly_higher_confidence",
+            },
+            "timestamp": "2022-04-21T15:44:00Z",
+            "value": 0.065966207,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "anomaly_higher_confidence",
+            },
+            "timestamp": "2022-04-21T15:45:00Z",
+            "value": 0.062053994,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "anomaly_higher_confidence",
+            },
+            "timestamp": "2022-04-21T15:46:00Z",
+            "value": 0.058596638,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "anomaly_higher_confidence",
+            },
+            "timestamp": "2022-04-21T15:47:00Z",
+            "value": 0.056028657,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "anomaly_higher_confidence",
+            },
+            "timestamp": "2022-04-21T15:48:00Z",
+            "value": 0.052905251,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "anomaly_higher_confidence",
+            },
+            "timestamp": "2022-04-21T15:49:00Z",
+            "value": 0.051122719,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "anomaly_higher_confidence",
+            },
+            "timestamp": "2022-04-21T15:50:00Z",
+            "value": 0.050375953,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "anomaly_higher_confidence",
+            },
+            "timestamp": "2022-04-21T15:51:00Z",
+            "value": 0.047727103,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "anomaly_higher_confidence",
+            },
+            "timestamp": "2022-04-21T15:52:00Z",
+            "value": 0.047437386,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "none",
+            },
+            "timestamp": "2022-04-21T15:53:00Z",
+            "value": 0.046208149,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "none",
+            },
+            "timestamp": "2022-04-21T15:54:00Z",
+            "value": 0.044512145,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "none",
+            },
+            "timestamp": "2022-04-21T15:55:00Z",
+            "value": 0.043505737,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "none",
+            },
+            "timestamp": "2022-04-21T15:56:00Z",
+            "value": 0.043147801,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "none",
+            },
+            "timestamp": "2022-04-21T15:57:00Z",
+            "value": 0.041545758,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "none",
+            },
+            "timestamp": "2022-04-21T15:58:00Z",
+            "value": 0.040482494,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "none",
+            },
+            "timestamp": "2022-04-21T15:59:00Z",
+            "value": 0.041155806,
+        },
+        {
+            "anomaly": {
+                "anomaly_score": 0,
+                "anomaly_type": "none",
+            },
+            "timestamp": "2022-04-21T15:60:00Z",
+            "value": 0.042155754,
+        },
+    ],
+)
 
 crash_free_metric_alert = {
     "sessionResponse": {
@@ -516,187 +696,6 @@ crash_free_metric_alert = {
         "dateCreated": "2022-02-28T10:41:09.742215Z",
         "eventTypes": ["transaction"],
     },
-}
-
-metric_alert_anomaly = {
-    "timeseries": [
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "none",
-            },
-            "timestamp": "2024-08-29T15:39:00Z",
-            "value": 0.077881957,
-        },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "none",
-            },
-            "timestamp": "2024-08-29T15:40:00Z",
-            "value": 0.075652768,
-        },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "none",
-            },
-            "timestamp": "2024-08-29T15:41:00Z",
-            "value": 0.073435431,
-        },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2024-08-29T15:42:00Z",
-            "value": 0.071145604,
-        },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2024-08-29T15:43:00Z",
-            "value": 0.068080257,
-        },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2024-08-29T15:44:00Z",
-            "value": 0.065966207,
-        },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2024-08-29T15:45:00Z",
-            "value": 0.062053994,
-        },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2024-08-29T15:46:00Z",
-            "value": 0.058596638,
-        },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2024-08-29T15:47:00Z",
-            "value": 0.056028657,
-        },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2024-08-29T15:48:00Z",
-            "value": 0.052905251,
-        },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2024-08-29T15:49:00Z",
-            "value": 0.051122719,
-        },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2024-08-29T15:50:00Z",
-            "value": 0.050375953,
-        },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2024-08-29T15:51:00Z",
-            "value": 0.047727103,
-        },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
-            },
-            "timestamp": "2024-08-29T15:52:00Z",
-            "value": 0.047437386,
-        },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "none",
-            },
-            "timestamp": "2024-08-29T15:53:00Z",
-            "value": 0.046208149,
-        },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "none",
-            },
-            "timestamp": "2024-08-29T15:54:00Z",
-            "value": 0.044512145,
-        },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "none",
-            },
-            "timestamp": "2024-08-29T15:55:00Z",
-            "value": 0.043505737,
-        },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "none",
-            },
-            "timestamp": "2024-08-29T15:56:00Z",
-            "value": 0.043147801,
-        },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "none",
-            },
-            "timestamp": "2024-08-29T15:57:00Z",
-            "value": 0.041545758,
-        },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "none",
-            },
-            "timestamp": "2024-08-29T15:58:00Z",
-            "value": 0.040482494,
-        },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "none",
-            },
-            "timestamp": "2024-08-29T15:59:00Z",
-            "value": 0.041155806,
-        },
-        {
-            "anomaly": {
-                "anomaly_score": 0,
-                "anomaly_type": "none",
-            },
-            "timestamp": "2024-08-29T15:60:00Z",
-            "value": 0.042155754,
-        },
-    ],
 }
 
 
@@ -825,13 +824,13 @@ class DebugChartRendererView(View):
                 "title": "slack metric alert sessions crash free",
             }
         )
-        # ret.append(
-        #     {
-        #         "chart": charts.generate_chart(
-        #             ChartType.SLACK_METRIC_ALERT_ANOMALIES, metric_alert_anomaly
-        #         ),
-        #         "title": "slack metric alert anomalies",
-        #     }
-        # )
+        ret.append(
+            {
+                "chart": charts.generate_chart(
+                    ChartType.SLACK_METRIC_ALERT_EVENTS, metric_alert_with_anomalies
+                ),
+                "title": "slack metric alert with anomalies",
+            }
+        )
 
         return render_to_response("sentry/debug/chart-renderer.html", context={"charts": ret})

--- a/src/sentry/web/frontend/debug/debug_chart_renderer.py
+++ b/src/sentry/web/frontend/debug/debug_chart_renderer.py
@@ -3,6 +3,7 @@ from django.views.generic import View
 
 from sentry.charts import backend as charts
 from sentry.charts.types import ChartType
+from sentry.seer.anomaly_detection.types import AnomalyType
 from sentry.web.helpers import render_to_response
 
 discover_total_period = {
@@ -452,7 +453,7 @@ metric_alert_with_anomalies["anomalies"] = [
     {
         "anomaly": {
             "anomaly_score": 0,
-            "anomaly_type": "none",
+            "anomaly_type": AnomalyType.NONE.value,
         },
         "timestamp": "2022-04-21T15:30:00Z",
         "value": 0.077881957,
@@ -460,7 +461,7 @@ metric_alert_with_anomalies["anomalies"] = [
     {
         "anomaly": {
             "anomaly_score": 0,
-            "anomaly_type": "anomaly_higher_confidence",
+            "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
         },
         "timestamp": "2022-04-21T15:40:00Z",
         "value": 0.075652768,
@@ -468,7 +469,7 @@ metric_alert_with_anomalies["anomalies"] = [
     {
         "anomaly": {
             "anomaly_score": 0,
-            "anomaly_type": "anomaly_higher_confidence",
+            "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
         },
         "timestamp": "2022-04-21T15:41:00Z",
         "value": 0.073435431,
@@ -476,7 +477,7 @@ metric_alert_with_anomalies["anomalies"] = [
     {
         "anomaly": {
             "anomaly_score": 0,
-            "anomaly_type": "anomaly_higher_confidence",
+            "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
         },
         "timestamp": "2022-04-21T16:42:00Z",
         "value": 0.071145604,
@@ -484,7 +485,7 @@ metric_alert_with_anomalies["anomalies"] = [
     {
         "anomaly": {
             "anomaly_score": 0,
-            "anomaly_type": "anomaly_higher_confidence",
+            "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
         },
         "timestamp": "2022-04-21T17:43:00Z",
         "value": 0.068080257,
@@ -492,7 +493,7 @@ metric_alert_with_anomalies["anomalies"] = [
     {
         "anomaly": {
             "anomaly_score": 0,
-            "anomaly_type": "anomaly_higher_confidence",
+            "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
         },
         "timestamp": "2022-04-21T18:44:00Z",
         "value": 0.065966207,
@@ -500,7 +501,7 @@ metric_alert_with_anomalies["anomalies"] = [
     {
         "anomaly": {
             "anomaly_score": 0,
-            "anomaly_type": "anomaly_higher_confidence",
+            "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
         },
         "timestamp": "2022-04-21T19:45:00Z",
         "value": 0.062053994,
@@ -508,7 +509,7 @@ metric_alert_with_anomalies["anomalies"] = [
     {
         "anomaly": {
             "anomaly_score": 0,
-            "anomaly_type": "anomaly_higher_confidence",
+            "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
         },
         "timestamp": "2022-04-21T20:46:00Z",
         "value": 0.058596638,
@@ -516,7 +517,7 @@ metric_alert_with_anomalies["anomalies"] = [
     {
         "anomaly": {
             "anomaly_score": 0,
-            "anomaly_type": "anomaly_higher_confidence",
+            "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
         },
         "timestamp": "2022-04-21T21:47:00Z",
         "value": 0.056028657,
@@ -524,7 +525,7 @@ metric_alert_with_anomalies["anomalies"] = [
     {
         "anomaly": {
             "anomaly_score": 0,
-            "anomaly_type": "anomaly_higher_confidence",
+            "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
         },
         "timestamp": "2022-04-21T22:48:00Z",
         "value": 0.052905251,
@@ -532,7 +533,7 @@ metric_alert_with_anomalies["anomalies"] = [
     {
         "anomaly": {
             "anomaly_score": 0,
-            "anomaly_type": "anomaly_higher_confidence",
+            "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
         },
         "timestamp": "2022-04-21T23:49:00Z",
         "value": 0.051122719,
@@ -540,7 +541,7 @@ metric_alert_with_anomalies["anomalies"] = [
     {
         "anomaly": {
             "anomaly_score": 0,
-            "anomaly_type": "none",
+            "anomaly_type": AnomalyType.NONE.value,
         },
         "timestamp": "2022-04-22T00:50:00Z",
         "value": 0.050375953,
@@ -548,7 +549,7 @@ metric_alert_with_anomalies["anomalies"] = [
     {
         "anomaly": {
             "anomaly_score": 0,
-            "anomaly_type": "none",
+            "anomaly_type": AnomalyType.NONE.value,
         },
         "timestamp": "2022-04-22T01:51:00Z",
         "value": 0.047727103,
@@ -556,7 +557,7 @@ metric_alert_with_anomalies["anomalies"] = [
     {
         "anomaly": {
             "anomaly_score": 0,
-            "anomaly_type": "none",
+            "anomaly_type": AnomalyType.NONE.value,
         },
         "timestamp": "2022-04-22T02:52:00Z",
         "value": 0.047437386,
@@ -564,7 +565,7 @@ metric_alert_with_anomalies["anomalies"] = [
     {
         "anomaly": {
             "anomaly_score": 0,
-            "anomaly_type": "none",
+            "anomaly_type": AnomalyType.NONE.value,
         },
         "timestamp": "2022-04-22T03:53:00Z",
         "value": 0.046208149,
@@ -572,7 +573,7 @@ metric_alert_with_anomalies["anomalies"] = [
     {
         "anomaly": {
             "anomaly_score": 0,
-            "anomaly_type": "anomaly_higher_confidence",
+            "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
         },
         "timestamp": "2022-04-22T04:54:00Z",
         "value": 0.044512145,
@@ -580,7 +581,7 @@ metric_alert_with_anomalies["anomalies"] = [
     {
         "anomaly": {
             "anomaly_score": 0,
-            "anomaly_type": "anomaly_higher_confidence",
+            "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
         },
         "timestamp": "2022-04-22T05:55:00Z",
         "value": 0.043505737,
@@ -588,7 +589,7 @@ metric_alert_with_anomalies["anomalies"] = [
     {
         "anomaly": {
             "anomaly_score": 0,
-            "anomaly_type": "anomaly_higher_confidence",
+            "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
         },
         "timestamp": "2022-04-22T06:56:00Z",
         "value": 0.043147801,
@@ -596,7 +597,7 @@ metric_alert_with_anomalies["anomalies"] = [
     {
         "anomaly": {
             "anomaly_score": 0,
-            "anomaly_type": "anomaly_higher_confidence",
+            "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
         },
         "timestamp": "2022-04-22T07:57:00Z",
         "value": 0.041545758,
@@ -604,7 +605,7 @@ metric_alert_with_anomalies["anomalies"] = [
     {
         "anomaly": {
             "anomaly_score": 0,
-            "anomaly_type": "anomaly_higher_confidence",
+            "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
         },
         "timestamp": "2022-04-22T08:58:00Z",
         "value": 0.040482494,
@@ -612,7 +613,7 @@ metric_alert_with_anomalies["anomalies"] = [
     {
         "anomaly": {
             "anomaly_score": 0,
-            "anomaly_type": "anomaly_higher_confidence",
+            "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
         },
         "timestamp": "2022-04-22T09:59:00Z",
         "value": 0.041155806,
@@ -620,7 +621,7 @@ metric_alert_with_anomalies["anomalies"] = [
     {
         "anomaly": {
             "anomaly_score": 0,
-            "anomaly_type": "none",
+            "anomaly_type": AnomalyType.NONE.value,
         },
         "timestamp": "2022-04-22T10:60:00Z",
         "value": 0.042155754,

--- a/src/sentry/web/frontend/debug/debug_chart_renderer.py
+++ b/src/sentry/web/frontend/debug/debug_chart_renderer.py
@@ -455,13 +455,13 @@ metric_alert_with_anomalies["anomalies"] = (
                 "anomaly_score": 0,
                 "anomaly_type": "none",
             },
-            "timestamp": "2022-04-21T15:39:00Z",
+            "timestamp": "2022-04-21T15:30:00Z",
             "value": 0.077881957,
         },
         {
             "anomaly": {
                 "anomaly_score": 0,
-                "anomaly_type": "none",
+                "anomaly_type": "anomaly_higher_confidence",
             },
             "timestamp": "2022-04-21T15:40:00Z",
             "value": 0.075652768,
@@ -469,7 +469,7 @@ metric_alert_with_anomalies["anomalies"] = (
         {
             "anomaly": {
                 "anomaly_score": 0,
-                "anomaly_type": "none",
+                "anomaly_type": "anomaly_higher_confidence",
             },
             "timestamp": "2022-04-21T15:41:00Z",
             "value": 0.073435431,
@@ -479,7 +479,7 @@ metric_alert_with_anomalies["anomalies"] = (
                 "anomaly_score": 0,
                 "anomaly_type": "anomaly_higher_confidence",
             },
-            "timestamp": "2022-04-21T15:42:00Z",
+            "timestamp": "2022-04-21T16:42:00Z",
             "value": 0.071145604,
         },
         {
@@ -487,7 +487,7 @@ metric_alert_with_anomalies["anomalies"] = (
                 "anomaly_score": 0,
                 "anomaly_type": "anomaly_higher_confidence",
             },
-            "timestamp": "2022-04-21T15:43:00Z",
+            "timestamp": "2022-04-21T17:43:00Z",
             "value": 0.068080257,
         },
         {
@@ -495,7 +495,7 @@ metric_alert_with_anomalies["anomalies"] = (
                 "anomaly_score": 0,
                 "anomaly_type": "anomaly_higher_confidence",
             },
-            "timestamp": "2022-04-21T15:44:00Z",
+            "timestamp": "2022-04-21T18:44:00Z",
             "value": 0.065966207,
         },
         {
@@ -503,7 +503,7 @@ metric_alert_with_anomalies["anomalies"] = (
                 "anomaly_score": 0,
                 "anomaly_type": "anomaly_higher_confidence",
             },
-            "timestamp": "2022-04-21T15:45:00Z",
+            "timestamp": "2022-04-21T19:45:00Z",
             "value": 0.062053994,
         },
         {
@@ -511,7 +511,7 @@ metric_alert_with_anomalies["anomalies"] = (
                 "anomaly_score": 0,
                 "anomaly_type": "anomaly_higher_confidence",
             },
-            "timestamp": "2022-04-21T15:46:00Z",
+            "timestamp": "2022-04-21T20:46:00Z",
             "value": 0.058596638,
         },
         {
@@ -519,7 +519,7 @@ metric_alert_with_anomalies["anomalies"] = (
                 "anomaly_score": 0,
                 "anomaly_type": "anomaly_higher_confidence",
             },
-            "timestamp": "2022-04-21T15:47:00Z",
+            "timestamp": "2022-04-21T21:47:00Z",
             "value": 0.056028657,
         },
         {
@@ -527,7 +527,7 @@ metric_alert_with_anomalies["anomalies"] = (
                 "anomaly_score": 0,
                 "anomaly_type": "anomaly_higher_confidence",
             },
-            "timestamp": "2022-04-21T15:48:00Z",
+            "timestamp": "2022-04-21T22:48:00Z",
             "value": 0.052905251,
         },
         {
@@ -535,31 +535,31 @@ metric_alert_with_anomalies["anomalies"] = (
                 "anomaly_score": 0,
                 "anomaly_type": "anomaly_higher_confidence",
             },
-            "timestamp": "2022-04-21T15:49:00Z",
+            "timestamp": "2022-04-21T23:49:00Z",
             "value": 0.051122719,
         },
         {
             "anomaly": {
                 "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
+                "anomaly_type": "none",
             },
-            "timestamp": "2022-04-21T15:50:00Z",
+            "timestamp": "2022-04-22T00:50:00Z",
             "value": 0.050375953,
         },
         {
             "anomaly": {
                 "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
+                "anomaly_type": "none",
             },
-            "timestamp": "2022-04-21T15:51:00Z",
+            "timestamp": "2022-04-22T01:51:00Z",
             "value": 0.047727103,
         },
         {
             "anomaly": {
                 "anomaly_score": 0,
-                "anomaly_type": "anomaly_higher_confidence",
+                "anomaly_type": "none",
             },
-            "timestamp": "2022-04-21T15:52:00Z",
+            "timestamp": "2022-04-22T02:52:00Z",
             "value": 0.047437386,
         },
         {
@@ -567,55 +567,55 @@ metric_alert_with_anomalies["anomalies"] = (
                 "anomaly_score": 0,
                 "anomaly_type": "none",
             },
-            "timestamp": "2022-04-21T15:53:00Z",
+            "timestamp": "2022-04-22T03:53:00Z",
             "value": 0.046208149,
         },
         {
             "anomaly": {
                 "anomaly_score": 0,
-                "anomaly_type": "none",
+                "anomaly_type": "anomaly_higher_confidence",
             },
-            "timestamp": "2022-04-21T15:54:00Z",
+            "timestamp": "2022-04-22T04:54:00Z",
             "value": 0.044512145,
         },
         {
             "anomaly": {
                 "anomaly_score": 0,
-                "anomaly_type": "none",
+                "anomaly_type": "anomaly_higher_confidence",
             },
-            "timestamp": "2022-04-21T15:55:00Z",
+            "timestamp": "2022-04-22T05:55:00Z",
             "value": 0.043505737,
         },
         {
             "anomaly": {
                 "anomaly_score": 0,
-                "anomaly_type": "none",
+                "anomaly_type": "anomaly_higher_confidence",
             },
-            "timestamp": "2022-04-21T15:56:00Z",
+            "timestamp": "2022-04-22T06:56:00Z",
             "value": 0.043147801,
         },
         {
             "anomaly": {
                 "anomaly_score": 0,
-                "anomaly_type": "none",
+                "anomaly_type": "anomaly_higher_confidence",
             },
-            "timestamp": "2022-04-21T15:57:00Z",
+            "timestamp": "2022-04-22T07:57:00Z",
             "value": 0.041545758,
         },
         {
             "anomaly": {
                 "anomaly_score": 0,
-                "anomaly_type": "none",
+                "anomaly_type": "anomaly_higher_confidence",
             },
-            "timestamp": "2022-04-21T15:58:00Z",
+            "timestamp": "2022-04-22T08:58:00Z",
             "value": 0.040482494,
         },
         {
             "anomaly": {
                 "anomaly_score": 0,
-                "anomaly_type": "none",
+                "anomaly_type": "anomaly_higher_confidence",
             },
-            "timestamp": "2022-04-21T15:59:00Z",
+            "timestamp": "2022-04-22T09:59:00Z",
             "value": 0.041155806,
         },
         {
@@ -623,7 +623,7 @@ metric_alert_with_anomalies["anomalies"] = (
                 "anomaly_score": 0,
                 "anomaly_type": "none",
             },
-            "timestamp": "2022-04-21T15:60:00Z",
+            "timestamp": "2022-04-22T10:60:00Z",
             "value": 0.042155754,
         },
     ],

--- a/static/app/views/alerts/rules/metric/details/index.tsx
+++ b/static/app/views/alerts/rules/metric/details/index.tsx
@@ -206,9 +206,10 @@ class MetricAlertDetails extends Component<Props, State> {
         rulePromise,
         organization.features.includes('anomaly-detection-alerts-charts')
           ? fetchAnomaliesForRule(organization.slug, ruleId, start, end)
-          : undefined,
+          : undefined, // NOTE: there's no way for us to determine the alert rule detection type here.
+        // proxy API will need to determine whether to fetch anomalies or not
       ]);
-      // NOTE: anomaly-detection-alerts-charts flag does not exist
+      // NOTE: 'anomaly-detection-alerts-charts' flag does not exist
       // Flag can be enabled IF we want to enable marked lines/areas for anomalies in the future
       // For now, we defer to incident lines as indicators for anomalies
       this.setState({

--- a/static/app/views/alerts/rules/metric/details/index.tsx
+++ b/static/app/views/alerts/rules/metric/details/index.tsx
@@ -204,10 +204,13 @@ class MetricAlertDetails extends Component<Props, State> {
       const [incidents, rule, anomalies] = await Promise.all([
         fetchIncidentsForRule(organization.slug, ruleId, start, end),
         rulePromise,
-        organization.features.includes('anomaly-detection-alerts')
+        organization.features.includes('anomaly-detection-alerts-charts')
           ? fetchAnomaliesForRule(organization.slug, ruleId, start, end)
           : undefined,
       ]);
+      // NOTE: anomaly-detection-alerts-charts flag does not exist
+      // Flag can be enabled IF we want to enable marked lines/areas for anomalies in the future
+      // For now, we defer to incident lines as indicators for anomalies
       this.setState({
         anomalies,
         incidents,

--- a/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
@@ -402,7 +402,6 @@ export function getMetricAlertChartOption({
         }
       });
   }
-
   if (anomalies) {
     const anomalyBlocks: MarkAreaComponentOption['data'] = [];
     let start: string | undefined;
@@ -445,9 +444,10 @@ export function getMetricAlertChartOption({
       });
     if (start && end) {
       // push in the last block
+      // Create a marker line for the start of the anomaly
+      series.push(createAnomalyMarkerSeries(theme.purple300, start));
       anomalyBlocks.push([
         {
-          name: 'Anomaly Detected',
           xAxis: start,
         },
         {


### PR DESCRIPTION
<img width="92" alt="Screenshot 2024-09-05 at 3 52 14 PM" src="https://github.com/user-attachments/assets/8ecf4050-9c00-4fe5-9828-0605a6ea6b4a">

we now have anomaly lines rendering in chartcuterie charts!

follow up to https://github.com/getsentry/sentry/pull/76889