### PR TITLE
fix(api): Rename to avoid confusion

### DIFF
--- a/.github/workflows/openapi-diff.yml
+++ b/.github/workflows/openapi-diff.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   check-diff:
-    name: Fails to show the difference between the prod schema and dev schema (optional)
+    name: (Optional) Shows the difference between the prod and dev schema
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     steps:

--- a/.github/workflows/openapi-diff.yml
+++ b/.github/workflows/openapi-diff.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   check-diff:
-    name: build api
+    name: Fails to show the difference between the prod schema and dev schema (optional)
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     steps:


### PR DESCRIPTION
There is constant confusion about this workflow action, when it fails people wonder how they can fix it. This is only to display a diff and no action is required.