### PR TITLE
fix(alerts): Update AlertMetricsQueryBuilder to accept time_window and update spm to use time_window instead of granularity

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -105,7 +105,8 @@ class MetricsQueryBuilder(BaseQueryBuilder):
         # Dataset.PerformanceMetrics is MEP. TODO: rename Dataset.Metrics to Dataset.ReleaseMetrics or similar
         dataset: Dataset | None = None,
         granularity: int | None = None,
-        time_window: int | None = None,
+        # Alerts queries do not contain a start and end time, so we need to accept a time_range_window in order to calculate functions such as spm/epm/eps
+        time_range_window: int | None = None,
         config: QueryBuilderConfig | None = None,
         **kwargs: Any,
     ):
@@ -131,8 +132,8 @@ class MetricsQueryBuilder(BaseQueryBuilder):
 
         if granularity is not None:
             self._granularity = granularity
-        if time_window is not None:
-            self.time_window = time_window
+        if time_range_window is not None:
+            self._time_range_window = time_range_window
 
         super().__init__(
             # TODO: defaulting to Metrics for now so I don't have to update incidents tests. Should be
@@ -555,6 +556,13 @@ class MetricsQueryBuilder(BaseQueryBuilder):
             return super().aliased_column(name)
         except InvalidSearchQuery:
             raise missing_column
+
+    def resolve_time_range_window(self) -> int:
+        start = self.start or self.params.start
+        end = self.end or self.params.end
+        if self._time_range_window is not None and (start is not None or end is not None):
+            raise InvalidSearchQuery("time_range_window can't be set when start or end is set")
+        return self._time_range_window
 
     def resolve_granularity(self) -> Granularity:
         """Granularity impacts metric queries even when they aren't timeseries because the data needs to be
@@ -1495,11 +1503,11 @@ class AlertMetricsQueryBuilder(MetricsQueryBuilder):
         self,
         *args: Any,
         granularity: int,
-        time_window: int,
+        time_range_window: int,
         **kwargs: Any,
     ):
         self._granularity = granularity
-        self.time_window = time_window
+        self._time_range_window = time_range_window
         super().__init__(*args, **kwargs)
 
     def resolve_limit(self, limit: int | None) -> Limit | None:

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -105,6 +105,7 @@ class MetricsQueryBuilder(BaseQueryBuilder):
         # Dataset.PerformanceMetrics is MEP. TODO: rename Dataset.Metrics to Dataset.ReleaseMetrics or similar
         dataset: Dataset | None = None,
         granularity: int | None = None,
+        time_window: int | None = None,
         config: QueryBuilderConfig | None = None,
         **kwargs: Any,
     ):
@@ -130,6 +131,8 @@ class MetricsQueryBuilder(BaseQueryBuilder):
 
         if granularity is not None:
             self._granularity = granularity
+        if time_window is not None:
+            self.time_window = time_window
 
         super().__init__(
             # TODO: defaulting to Metrics for now so I don't have to update incidents tests. Should be
@@ -1492,9 +1495,11 @@ class AlertMetricsQueryBuilder(MetricsQueryBuilder):
         self,
         *args: Any,
         granularity: int,
+        time_window: int,
         **kwargs: Any,
     ):
         self._granularity = granularity
+        self.time_window = time_window
         super().__init__(*args, **kwargs)
 
     def resolve_limit(self, limit: int | None) -> Limit | None:

--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -2083,9 +2083,7 @@ class MetricsDatasetConfig(DatasetConfig):
             condition = base_condition
 
         default_interval = (
-            self.builder.resolve_granularity().granularity
-            if self.should_skip_interval_calculation
-            else args["interval"]
+            self.builder.time_window if self.should_skip_interval_calculation else args["interval"]
         )
 
         return Function(

--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -2083,7 +2083,9 @@ class MetricsDatasetConfig(DatasetConfig):
             condition = base_condition
 
         query_time_range_interval = (
-            self.builder.time_window if self.should_skip_interval_calculation else args["interval"]
+            self.builder.resolve_time_range_window()
+            if self.should_skip_interval_calculation
+            else args["interval"]
         )
 
         return Function(

--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -2082,7 +2082,7 @@ class MetricsDatasetConfig(DatasetConfig):
         else:
             condition = base_condition
 
-        default_interval = (
+        query_time_range_interval = (
             self.builder.time_window if self.should_skip_interval_calculation else args["interval"]
         )
 
@@ -2097,9 +2097,9 @@ class MetricsDatasetConfig(DatasetConfig):
                     ],
                 ),
                 (
-                    default_interval
+                    query_time_range_interval
                     if interval is None
-                    else Function("divide", [default_interval, interval])
+                    else Function("divide", [query_time_range_interval, interval])
                 ),
             ],
             alias,

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -308,7 +308,7 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
             params=params,
             offset=None,
             granularity=self.get_granularity(),
-            time_window=self.time_window,
+            time_range_window=self.time_window,
             config=QueryBuilderConfig(
                 skip_time_conditions=True,
                 use_metrics_layer=self.use_metrics_layer,

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -308,6 +308,7 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
             params=params,
             offset=None,
             granularity=self.get_granularity(),
+            time_window=self.time_window,
             config=QueryBuilderConfig(
                 skip_time_conditions=True,
                 use_metrics_layer=self.use_metrics_layer,

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -3150,6 +3150,7 @@ class AlertMetricsQueryBuilderTest(MetricBuilderBaseTest):
         query = AlertMetricsQueryBuilder(
             self.params,
             granularity=3600,
+            time_window=3600,
             query=query_s,
             dataset=Dataset.PerformanceMetrics,
             selected_columns=[field],
@@ -3205,6 +3206,7 @@ class AlertMetricsQueryBuilderTest(MetricBuilderBaseTest):
             query = AlertMetricsQueryBuilder(
                 params,
                 granularity=3600,
+                time_window=3600,
                 query=query_s,
                 dataset=Dataset.PerformanceMetrics,
                 selected_columns=[field],
@@ -3257,6 +3259,7 @@ class AlertMetricsQueryBuilderTest(MetricBuilderBaseTest):
         query = AlertMetricsQueryBuilder(
             self.params,
             granularity=3600,
+            time_window=3600,
             query=query_s,
             dataset=Dataset.PerformanceMetrics,
             selected_columns=[field],
@@ -3302,6 +3305,7 @@ class AlertMetricsQueryBuilderTest(MetricBuilderBaseTest):
         query = AlertMetricsQueryBuilder(
             self.params,
             granularity=3600,
+            time_window=3600,
             query=query_s,
             dataset=Dataset.PerformanceMetrics,
             selected_columns=[field],
@@ -3330,6 +3334,7 @@ class AlertMetricsQueryBuilderTest(MetricBuilderBaseTest):
         query = AlertMetricsQueryBuilder(
             params,
             granularity=3600,
+            time_window=3600,
             query="transaction.duration:>=100",
             dataset=Dataset.PerformanceMetrics,
             selected_columns=["count(transaction.duration)"],
@@ -3356,6 +3361,7 @@ class AlertMetricsQueryBuilderTest(MetricBuilderBaseTest):
         query = AlertMetricsQueryBuilder(
             params,
             granularity=3600,
+            time_window=3600,
             query="transaction.duration:>=100",
             dataset=Dataset.PerformanceMetrics,
             selected_columns=["p75(measurements.fp)"],
@@ -3414,6 +3420,7 @@ class AlertMetricsQueryBuilderTest(MetricBuilderBaseTest):
         query = AlertMetricsQueryBuilder(
             self.params,
             granularity=3600,
+            time_window=3600,
             query="transaction.duration:>=100",
             dataset=Dataset.PerformanceMetrics,
             selected_columns=["count(transaction.duration)"],
@@ -3472,7 +3479,8 @@ class AlertMetricsQueryBuilderTest(MetricBuilderBaseTest):
         }
         query = AlertMetricsQueryBuilder(
             params,
-            granularity=3600,
+            granularity=60,
+            time_window=3600,
             query="span.module:db",
             dataset=Dataset.PerformanceMetrics,
             selected_columns=["spm()"],
@@ -3724,6 +3732,7 @@ class CustomMetricsWithMetricsLayerTest(MetricBuilderBaseTest):
             query = AlertMetricsQueryBuilder(
                 {**self.params, "environment": self.environment.name},
                 granularity=3600,
+                time_window=3600,
                 query="phone:iPhone",
                 dataset=Dataset.PerformanceMetrics,
                 selected_columns=[f"{aggregate}({mri})"],

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -3150,7 +3150,7 @@ class AlertMetricsQueryBuilderTest(MetricBuilderBaseTest):
         query = AlertMetricsQueryBuilder(
             self.params,
             granularity=3600,
-            time_window=3600,
+            time_range_window=3600,
             query=query_s,
             dataset=Dataset.PerformanceMetrics,
             selected_columns=[field],
@@ -3206,7 +3206,7 @@ class AlertMetricsQueryBuilderTest(MetricBuilderBaseTest):
             query = AlertMetricsQueryBuilder(
                 params,
                 granularity=3600,
-                time_window=3600,
+                time_range_window=3600,
                 query=query_s,
                 dataset=Dataset.PerformanceMetrics,
                 selected_columns=[field],
@@ -3259,7 +3259,7 @@ class AlertMetricsQueryBuilderTest(MetricBuilderBaseTest):
         query = AlertMetricsQueryBuilder(
             self.params,
             granularity=3600,
-            time_window=3600,
+            time_range_window=3600,
             query=query_s,
             dataset=Dataset.PerformanceMetrics,
             selected_columns=[field],
@@ -3305,7 +3305,7 @@ class AlertMetricsQueryBuilderTest(MetricBuilderBaseTest):
         query = AlertMetricsQueryBuilder(
             self.params,
             granularity=3600,
-            time_window=3600,
+            time_range_window=3600,
             query=query_s,
             dataset=Dataset.PerformanceMetrics,
             selected_columns=[field],
@@ -3334,7 +3334,7 @@ class AlertMetricsQueryBuilderTest(MetricBuilderBaseTest):
         query = AlertMetricsQueryBuilder(
             params,
             granularity=3600,
-            time_window=3600,
+            time_range_window=3600,
             query="transaction.duration:>=100",
             dataset=Dataset.PerformanceMetrics,
             selected_columns=["count(transaction.duration)"],
@@ -3361,7 +3361,7 @@ class AlertMetricsQueryBuilderTest(MetricBuilderBaseTest):
         query = AlertMetricsQueryBuilder(
             params,
             granularity=3600,
-            time_window=3600,
+            time_range_window=3600,
             query="transaction.duration:>=100",
             dataset=Dataset.PerformanceMetrics,
             selected_columns=["p75(measurements.fp)"],
@@ -3420,7 +3420,7 @@ class AlertMetricsQueryBuilderTest(MetricBuilderBaseTest):
         query = AlertMetricsQueryBuilder(
             self.params,
             granularity=3600,
-            time_window=3600,
+            time_range_window=3600,
             query="transaction.duration:>=100",
             dataset=Dataset.PerformanceMetrics,
             selected_columns=["count(transaction.duration)"],
@@ -3480,7 +3480,7 @@ class AlertMetricsQueryBuilderTest(MetricBuilderBaseTest):
         query = AlertMetricsQueryBuilder(
             params,
             granularity=60,
-            time_window=3600,
+            time_range_window=3600,
             query="span.module:db",
             dataset=Dataset.PerformanceMetrics,
             selected_columns=["spm()"],
@@ -3732,7 +3732,7 @@ class CustomMetricsWithMetricsLayerTest(MetricBuilderBaseTest):
             query = AlertMetricsQueryBuilder(
                 {**self.params, "environment": self.environment.name},
                 granularity=3600,
-                time_window=3600,
+                time_range_window=3600,
                 query="phone:iPhone",
                 dataset=Dataset.PerformanceMetrics,
                 selected_columns=[f"{aggregate}({mri})"],


### PR DESCRIPTION
Updates the AlertMetricsQueryBuilder (and MetricsQueryBuilder) to accept a `time_window` arg. Also updates `spm` in the metrics data set to fallback to `time_window` from the builder when a `start` and `end` are not provided. We were using `granularity` as the fallback before, but this is not correct because `granularity` does not match the actual time range that a Snuba subscription query will aggregate over.