### PR TITLE
chore: Preserve timestamp of empty transactions in SDK setup

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -132,14 +132,15 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
       addExtraMeasurements(event);
       addUIElementTag(event);
 
-      event.spans = event.spans?.filter(span => {
+      const filteredSpans = event.spans?.filter(span => {
         return IGNORED_SPANS_BY_DESCRIPTION.every(
           partialDesc => !span.description?.includes(partialDesc)
         );
       });
 
       // If we removed any spans at the end above, the end timestamp needs to be adjusted again.
-      if (event.spans) {
+      if (filteredSpans && filteredSpans?.length !== event.spans?.length) {
+        event.spans = filteredSpans;
         const newEndTimestamp = Math.max(...event.spans.map(span => span.timestamp ?? 0));
         event.timestamp = newEndTimestamp;
       }


### PR DESCRIPTION
If the transaction had no spans (e.g., a custom transaction), the filtered span logic assigns it a `"timestamp"` of `-Infinity` because it iterates an empty array. Instead, only apply the timestamp adjustment logic iff (sic) any spans were filtered out. If not, do nothing. Otherwise, `-Infinite` is normalized into `null`, and Relay appends an incorrect `"timestamp"` at ingestion time.
