### PR TITLE
perf(ratelimits): adjust sample rates of ratelimit middleware timing

### DIFF
--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -49,84 +49,86 @@ class RatelimitMiddleware:
     ) -> HttpResponseBase | None:
         """Check if the endpoint call will violate."""
 
-        try:
-            with sentry_sdk.start_span(op="ratelimit.early_return"):
-                # TODO: put these fields into their own object
-                request.will_be_rate_limited = False
-                if settings.SENTRY_SELF_HOSTED:
-                    return None
-                request.rate_limit_category = None
-                request.rate_limit_uid = uuid.uuid4().hex
-                view_class = getattr(view_func, "view_class", None)
-                if not view_class:
-                    return None
+        with metrics.timer("middleware.ratelimit.process_view"):
+            try:
+                with sentry_sdk.start_span(op="ratelimit.early_return"):
+                    # TODO: put these fields into their own object
+                    request.will_be_rate_limited = False
+                    if settings.SENTRY_SELF_HOSTED:
+                        return None
+                    request.rate_limit_category = None
+                    request.rate_limit_uid = uuid.uuid4().hex
+                    view_class = getattr(view_func, "view_class", None)
+                    if not view_class:
+                        return None
 
-                enforce_rate_limit = getattr(view_class, "enforce_rate_limit", False)
-                if enforce_rate_limit is False:
-                    return None
+                    enforce_rate_limit = getattr(view_class, "enforce_rate_limit", False)
+                    if enforce_rate_limit is False:
+                        return None
 
-            with sentry_sdk.start_span(op="ratelimit.determine_limit_config"):
-                rate_limit_config = get_rate_limit_config(
-                    view_class, view_args, {**view_kwargs, "request": request}
-                )
-                rate_limit_group = (
-                    rate_limit_config.group if rate_limit_config else RateLimitConfig().group
-                )
-                request.rate_limit_key = get_rate_limit_key(
-                    view_func, request, rate_limit_group, rate_limit_config
-                )
-                if request.rate_limit_key is None:
-                    return None
+                with sentry_sdk.start_span(op="ratelimit.determine_limit_config"):
+                    rate_limit_config = get_rate_limit_config(
+                        view_class, view_args, {**view_kwargs, "request": request}
+                    )
+                    rate_limit_group = (
+                        rate_limit_config.group if rate_limit_config else RateLimitConfig().group
+                    )
+                    request.rate_limit_key = get_rate_limit_key(
+                        view_func, request, rate_limit_group, rate_limit_config
+                    )
+                    if request.rate_limit_key is None:
+                        return None
 
-                category_str = request.rate_limit_key.split(":", 1)[0]
-                request.rate_limit_category = category_str
+                    category_str = request.rate_limit_key.split(":", 1)[0]
+                    request.rate_limit_category = category_str
 
-                rate_limit = get_rate_limit_value(
-                    http_method=request.method,
-                    category=RateLimitCategory(category_str),
-                    rate_limit_config=rate_limit_config,
-                )
-                if rate_limit is None:
-                    return None
+                    rate_limit = get_rate_limit_value(
+                        http_method=request.method,
+                        category=RateLimitCategory(category_str),
+                        rate_limit_config=rate_limit_config,
+                    )
+                    if rate_limit is None:
+                        return None
 
-            with sentry_sdk.start_span(op="ratelimit.above_rate_limit_check"):
-                request.rate_limit_metadata = above_rate_limit_check(
-                    request.rate_limit_key, rate_limit, request.rate_limit_uid, rate_limit_group
-                )
+                with sentry_sdk.start_span(op="ratelimit.above_rate_limit_check"):
+                    request.rate_limit_metadata = above_rate_limit_check(
+                        request.rate_limit_key, rate_limit, request.rate_limit_uid, rate_limit_group
+                    )
 
-            # TODO: also limit by concurrent window once we have the data
-            rate_limit_cond = (
-                request.rate_limit_metadata.rate_limit_type != RateLimitType.NOT_LIMITED
-                if settings.ENFORCE_CONCURRENT_RATE_LIMITS
-                else request.rate_limit_metadata.rate_limit_type == RateLimitType.FIXED_WINDOW
-            )
-            if rate_limit_cond:
-                request.will_be_rate_limited = True
-                logger.info(
-                    "sentry.api.rate-limit.exceeded",
-                    extra={
-                        "key": request.rate_limit_key,
-                        "url": request.build_absolute_uri(),
-                        "limit": request.rate_limit_metadata.limit,
-                        "window": request.rate_limit_metadata.window,
-                    },
+                # TODO: also limit by concurrent window once we have the data
+                rate_limit_cond = (
+                    request.rate_limit_metadata.rate_limit_type != RateLimitType.NOT_LIMITED
+                    if settings.ENFORCE_CONCURRENT_RATE_LIMITS
+                    else request.rate_limit_metadata.rate_limit_type == RateLimitType.FIXED_WINDOW
                 )
-                response = HttpResponse(
-                    orjson.dumps(
-                        DEFAULT_ERROR_MESSAGE.format(
-                            limit=request.rate_limit_metadata.limit,
-                            window=request.rate_limit_metadata.window,
-                        )
-                    ),
-                    status=429,
+                if rate_limit_cond:
+                    request.will_be_rate_limited = True
+                    logger.info(
+                        "sentry.api.rate-limit.exceeded",
+                        extra={
+                            "key": request.rate_limit_key,
+                            "url": request.build_absolute_uri(),
+                            "limit": request.rate_limit_metadata.limit,
+                            "window": request.rate_limit_metadata.window,
+                        },
+                    )
+                    response = HttpResponse(
+                        orjson.dumps(
+                            DEFAULT_ERROR_MESSAGE.format(
+                                limit=request.rate_limit_metadata.limit,
+                                window=request.rate_limit_metadata.window,
+                            )
+                        ),
+                        status=429,
+                    )
+                    assert request.method is not None
+                    return apply_cors_headers(
+                        request=request, response=response, allowed_methods=[request.method]
+                    )
+            except Exception:
+                logging.exception(
+                    "Error during rate limiting, failing open. THIS SHOULD NOT HAPPEN"
                 )
-                assert request.method is not None
-                return apply_cors_headers(
-                    request=request, response=response, allowed_methods=[request.method]
-                )
-        except Exception:
-            logging.exception("Error during rate limiting, failing open. THIS SHOULD NOT HAPPEN")
-
         return None
 
     def process_response(

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -49,7 +49,7 @@ class RatelimitMiddleware:
     ) -> HttpResponseBase | None:
         """Check if the endpoint call will violate."""
 
-        with metrics.timer("middleware.ratelimit.process_view"):
+        with metrics.timer("middleware.ratelimit.process_view", sample_rate=0.01):
             try:
                 with sentry_sdk.start_span(op="ratelimit.early_return"):
                     # TODO: put these fields into their own object
@@ -134,7 +134,7 @@ class RatelimitMiddleware:
     def process_response(
         self, request: HttpRequest, response: HttpResponseBase
     ) -> HttpResponseBase:
-        with metrics.timer("middleware.ratelimit.process_response"):
+        with metrics.timer("middleware.ratelimit.process_response", sample_rate=0.01):
             try:
                 rate_limit_metadata: RateLimitMeta | None = getattr(
                     request, "rate_limit_metadata", None


### PR DESCRIPTION
observed that the process_view span dropped to almost nothing after https://github.com/getsentry/sentry/pull/76954 was merged. but the `_call__` span increased. not sure if its due to some kind of metrics initialization, or flushing going on when the metrics are emitted. let's try sampling them both at 1% to see if this improves it.