### PR TITLE
feat(issues): Add an arbitrary chart data endpoint for issue details

### DIFF
--- a/src/sentry/api/endpoints/group_detailed_stats.py
+++ b/src/sentry/api/endpoints/group_detailed_stats.py
@@ -1,0 +1,89 @@
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features, tagstore, tsdb
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import EnvironmentMixin, region_silo_endpoint
+from sentry.api.bases.group import GroupEndpoint
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.helpers.environments import get_environments
+from sentry.api.utils import get_date_range_from_params
+from sentry.exceptions import InvalidSearchQuery
+from sentry.issues.constants import get_issue_tsdb_group_model
+from sentry.issues.grouptype import GroupCategory
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.utils.dates import get_rollup_from_request
+
+
+@region_silo_endpoint
+class GroupDetailedStatsEndpoint(GroupEndpoint, EnvironmentMixin):
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+    enforce_rate_limit = True
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(limit=5, window=1),
+            RateLimitCategory.USER: RateLimit(limit=5, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
+        }
+    }
+
+    def get(self, request: Request, group) -> Response:
+        if not (
+            features.has(
+                "organizations:issue-details-streamline",
+                group.project.organization,
+                actor=request.user,
+            )
+        ):
+            raise ResourceDoesNotExist
+
+        tenant_ids = {"organization_id": group.project.organization_id}
+        environments = get_environments(request, group.project.organization)
+        environment_ids = [e.id for e in environments]
+        start, end = get_date_range_from_params(request.GET)
+        try:
+            rollup = get_rollup_from_request(
+                request,
+                end - start,
+                default_interval=None,
+                error=InvalidSearchQuery(),
+            )
+        except InvalidSearchQuery:
+            rollup = 3600  # use a default of 1 hour
+        model = get_issue_tsdb_group_model(group.issue_category)
+        event_stats = tsdb.backend.rollup(
+            tsdb.backend.get_range(
+                model=model,
+                keys=[group.id],
+                start=start,
+                end=end,
+                environment_ids=environment_ids,
+                tenant_ids=tenant_ids,
+            ),
+            rollup,
+        )[group.id]
+
+        user_count_func = (
+            tagstore.backend.get_groups_user_counts
+            if group.issue_category == GroupCategory.ERROR
+            else tagstore.backend.get_generic_groups_user_counts
+        )
+        user_count = user_count_func(
+            project_ids=[group.project_id],
+            group_ids=[group.id],
+            environment_ids=environment_ids,
+            start=start,
+            end=end,
+            tenant_ids=tenant_ids,
+        )
+        return Response(
+            {
+                "eventStats": event_stats,
+                "userCount": user_count[group.id],
+                "rollup": rollup,
+                "start": start,
+                "end": end,
+            }
+        )

--- a/src/sentry/api/endpoints/group_detailed_stats.py
+++ b/src/sentry/api/endpoints/group_detailed_stats.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django.conf import settings
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -44,7 +46,9 @@ class GroupDetailedStatsEndpoint(GroupEndpoint, EnvironmentMixin):
 
         environments = get_environments(request, group.project.organization)
         environment_ids = [e.id for e in environments]
-        start, end = get_date_range_from_params(request.GET)
+        start, end = get_date_range_from_params(
+            request.GET, default_stats_period=timedelta(days=14)
+        )
         try:
             rollup = get_rollup_from_request(
                 request,
@@ -53,7 +57,7 @@ class GroupDetailedStatsEndpoint(GroupEndpoint, EnvironmentMixin):
                 error=InvalidSearchQuery(),
             )
         except InvalidSearchQuery:
-            rollup = 3600  # use a default of 1 hour
+            rollup = 3600
 
         event_stats = get_group_stats(
             group=group, environment_ids=environment_ids, start=start, end=end, rollup=rollup
@@ -76,8 +80,5 @@ class GroupDetailedStatsEndpoint(GroupEndpoint, EnvironmentMixin):
             {
                 "eventStats": event_stats,
                 "userCount": user_count[group.id],
-                "rollup": rollup,
-                "start": start,
-                "end": end,
             }
         )

--- a/src/sentry/api/endpoints/group_detailed_stats.py
+++ b/src/sentry/api/endpoints/group_detailed_stats.py
@@ -1,7 +1,9 @@
+from django.conf import settings
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features, tagstore
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
@@ -20,7 +22,8 @@ class GroupDetailedStatsEndpoint(GroupEndpoint, EnvironmentMixin):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    enforce_rate_limit = True
+    owner: ApiOwner = ApiOwner.ISSUES
+    enforce_rate_limit: bool = settings.SENTRY_RATELIMITER_ENABLED
     rate_limits = {
         "GET": {
             RateLimitCategory.IP: RateLimit(limit=5, window=1),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -5,6 +5,7 @@ from django.urls import URLPattern, URLResolver, re_path
 
 from sentry.api.endpoints.group_ai_summary import GroupAiSummaryEndpoint
 from sentry.api.endpoints.group_autofix_setup_check import GroupAutofixSetupCheck
+from sentry.api.endpoints.group_detailed_stats import GroupDetailedStatsEndpoint
 from sentry.api.endpoints.group_event_details import GroupEventDetailsEndpoint
 from sentry.api.endpoints.group_integration_details import GroupIntegrationDetailsEndpoint
 from sentry.api.endpoints.group_integrations import GroupIntegrationsEndpoint
@@ -724,6 +725,11 @@ def create_group_urls(name_prefix: str) -> list[URLPattern | URLResolver]:
             r"^(?P<issue_id>[^\/]+)/stats/$",
             GroupStatsEndpoint.as_view(),
             name=f"{name_prefix}-group-stats",
+        ),
+        re_path(
+            r"^(?P<issue_id>[^\/]+)/detailed-stats/$",
+            GroupDetailedStatsEndpoint.as_view(),
+            name=f"{name_prefix}-group-detailed-stats",
         ),
         re_path(
             r"^(?P<issue_id>[^\/]+)/tags/$",

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -242,7 +242,7 @@ def get_oldest_or_latest_event_for_environments(
         filter=_filter,
         limit=1,
         orderby=ordering.value,
-        referrer="Group.get_latest",
+        referrer=Referrer.GROUP_GET_LATEST.value,
         dataset=dataset,
         tenant_ids={"organization_id": group.project.organization_id},
     )
@@ -292,7 +292,7 @@ def get_recommended_event_for_environments(
         conditions=all_conditions,
         limit=1,
         orderby=EventOrdering.MOST_HELPFUL.value,
-        referrer="Group.get_helpful",
+        referrer=Referrer.GROUP_GET_HELPFUL.value,
         dataset=dataset,
         tenant_ids={"organization_id": group.project.organization_id},
     )
@@ -380,7 +380,7 @@ class GroupManager(BaseManager["Group"]):
                 conditions=[["group_id", "IS NOT NULL", None]],
             ),
             limit=max(len(project_ids), 100),
-            referrer="Group.filter_by_event_id",
+            referrer=Referrer.GROUP_FILTER_BY_EVENT_ID.value,
             tenant_ids=tenant_ids,
         )
         return self.filter(id__in={event.group_id for event in events})

--- a/tests/sentry/api/endpoints/test_group_detailed_stats.py
+++ b/tests/sentry/api/endpoints/test_group_detailed_stats.py
@@ -1,0 +1,115 @@
+from rest_framework import status
+
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
+from sentry.testutils.helpers.features import apply_feature_flag_on_cls
+from sentry.testutils.skips import requires_snuba
+
+pytestmark = [requires_snuba]
+
+
+@apply_feature_flag_on_cls("organizations:issue-details-streamline")
+class GroupDetailedStatsTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.fingerprint = "group1"
+        self.group = self.store_event(
+            data={
+                "fingerprint": [self.fingerprint],
+                "timestamp": iso_format(before_now(minutes=5)),
+            },
+            project_id=self.project.id,
+        ).group
+        self.url = f"/api/0/issues/{self.group.id}/detailed-stats/"
+
+    def test_requires_flag(self):
+        with self.feature({"organizations:issue-details-streamline": False}):
+            response = self.client.get(self.url, format="json")
+            assert response.status_code == status.HTTP_404_NOT_FOUND, response.content
+
+    @freeze_time(before_now(days=1))
+    def test_get_14d_stats_by_default(self):
+        for i in range(20):
+            self.store_event(
+                data={
+                    "fingerprint": [self.fingerprint],
+                    "timestamp": iso_format(before_now(days=i)),
+                    "user": {"id": i},
+                },
+                project_id=self.project.id,
+            )
+
+        response = self.client.get(self.url, format="json")
+        assert response.status_code == 200, response.content
+        assert len(response.data["eventStats"]) == 15  # 14 days of data
+        assert response.data["userCount"] == 14  # 14 unique users, 1 per day
+
+    @freeze_time(before_now(days=1))
+    def test_get_stats_from_stats_period(self):
+        for i in range(20):
+            self.store_event(
+                data={
+                    "fingerprint": [self.fingerprint],
+                    "timestamp": iso_format(before_now(days=i)),
+                    "user": {"id": i},
+                },
+                project_id=self.project.id,
+            )
+
+        response = self.client.get(self.url, data={"statsPeriod": "7d"}, format="json")
+        assert response.status_code == 200, response.content
+        assert len(response.data["eventStats"]) == 24 * 7 + 1  # Rolled up per hour
+        assert response.data["userCount"] == 7  # 1 unique user per day
+
+    @freeze_time(before_now(days=1))
+    def test_get_stats_from_specific_range(self):
+        for i in range(20):
+            self.store_event(
+                data={
+                    "fingerprint": [self.fingerprint],
+                    "timestamp": iso_format(before_now(days=i)),
+                    "user": {"id": i},
+                },
+                project_id=self.project.id,
+            )
+
+        start = iso_format(before_now(days=10))
+        end = iso_format(before_now(days=5))
+        response = self.client.get(
+            self.url,
+            data={"start": start, "end": end},
+            format="json",
+        )
+        assert response.status_code == 200, response.content
+        assert len(response.data["eventStats"]) == 24 * 5 + 1  # Rolled up per hour
+        assert response.data["userCount"] == 5  # 1 unique user per day
+
+    @freeze_time(before_now(days=1))
+    def test_get_stats_from_timeframe(self):
+        for i in range(20):
+            self.store_event(
+                data={
+                    "fingerprint": [self.fingerprint],
+                    "timestamp": iso_format(before_now(days=i)),
+                    "user": {"id": i},
+                },
+                project_id=self.project.id,
+            )
+        response = self.client.get(
+            self.url,
+            data={"timeframe": "15d"},
+            format="json",
+        )
+        assert response.status_code == 200, response.content
+        assert len(response.data["eventStats"]) == 15 + 1  # Rolled up per day
+        assert response.data["userCount"] == 15  # 1 unique user per day
+
+        response = self.client.get(
+            self.url,
+            data={"timeframeStart": "8d", "timeframeEnd": "5d"},
+            format="json",
+        )
+        assert response.status_code == 200, response.content
+        assert len(response.data["eventStats"]) == 24 * 3 + 1  # Rolled up per hour
+        assert response.data["userCount"] == 3  # 1 unique user per day


### PR DESCRIPTION
This PR extracts the functionality that is currently serialized into `stats` on the group payload, into its own endpoint for issue details. As we add functionality to filter or manipulate these stats in some way, this will allow us to control the data directly rather than changing how every group gets serialized. 

The reason the generic group endpoint is being modified with the `customStats` query param  is so that the initial load of the graph doesn't require another API call. It'll allow us to render the chart immediately 

**todo**
- [x] Add tests for the new endpoint
- [x] Make a shared function that both endpoints call, rather than a static method