### PR TITLE
fix(replay): Mobile replay missing pause time

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -468,7 +468,7 @@ export function Provider({
       return;
     }
     if (isPlaying) {
-      replayer.pause();
+      replayer.pause(getCurrentPlayerTime());
       replayer.setConfig({speed: prefs.playbackSpeed});
       replayer.play(getCurrentPlayerTime());
     } else {

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -468,6 +468,7 @@ export function Provider({
       return;
     }
     if (isPlaying) {
+      // we need to pass in the current time when pausing for mobile replays
       replayer.pause(getCurrentPlayerTime());
       replayer.setConfig({speed: prefs.playbackSpeed});
       replayer.play(getCurrentPlayerTime());


### PR DESCRIPTION
When pausing, if the video's current time is not passed in, it defaults to 0. This resulted in a bug where the replayer switched to the first frame after unpausing the video.

Correct play through:

https://github.com/user-attachments/assets/b21798fb-f0f0-4e27-b960-b7ed3b025db0

Before (with bug):

https://github.com/user-attachments/assets/b2ad918b-7f9a-49ed-b7df-8cc21b42517c

After (with fix):

https://github.com/user-attachments/assets/a57753a6-43bf-438d-9368-7503eec814dc



Fixes https://github.com/getsentry/team-replay/issues/465