### PR TITLE
drop(hierarchical): Drop hierarchical code - part 4

### DIFF
--- a/tests/sentry/event_manager/grouping/test_assign_to_group.py
+++ b/tests/sentry/event_manager/grouping/test_assign_to_group.py
@@ -15,6 +15,7 @@ from sentry.grouping.ingest.hashing import (
     _calculate_primary_hash,
     _calculate_secondary_hash,
     find_existing_grouphash,
+    find_existing_grouphash_new,
 )
 from sentry.grouping.ingest.metrics import record_calculation_metric_with_result
 from sentry.models.grouphash import GroupHash
@@ -32,11 +33,15 @@ pytestmark = [requires_snuba]
 
 LEGACY_CONFIG = "legacy:2019-03-12"
 NEWSTYLE_CONFIG = "newstyle:2023-01-11"
+MOBILE_CONFIG = "mobile:2021-02-12"
 
 
 @contextmanager
 def patch_grouping_helpers(return_values: dict[str, Any]):
     wrapped_find_existing_grouphash = capture_results(find_existing_grouphash, return_values)
+    wrapped_find_existing_grouphash_new = capture_results(
+        find_existing_grouphash_new, return_values
+    )
     wrapped_calculate_primary_hash = capture_results(_calculate_primary_hash, return_values)
     wrapped_calculate_secondary_hash = capture_results(_calculate_secondary_hash, return_values)
 
@@ -45,6 +50,10 @@ def patch_grouping_helpers(return_values: dict[str, Any]):
             "sentry.event_manager.find_existing_grouphash",
             wraps=wrapped_find_existing_grouphash,
         ) as find_existing_grouphash_spy,
+        mock.patch(
+            "sentry.event_manager.find_existing_grouphash_new",
+            wraps=wrapped_find_existing_grouphash_new,
+        ) as find_existing_grouphash_new_spy,
         mock.patch(
             "sentry.grouping.ingest.hashing._calculate_primary_hash",
             wraps=wrapped_calculate_primary_hash,
@@ -67,6 +76,7 @@ def patch_grouping_helpers(return_values: dict[str, Any]):
     ):
         yield {
             "find_existing_grouphash": find_existing_grouphash_spy,
+            "find_existing_grouphash_new": find_existing_grouphash_new_spy,
             "_calculate_primary_hash": calculate_primary_hash_spy,
             "_calculate_secondary_hash": calculate_secondary_hash_spy,
             "_create_group": create_group_spy,
@@ -135,6 +145,10 @@ def get_results_from_saving_event(
     existing_group_id: int | None = None,
     new_logic_enabled: bool = False,
 ):
+    find_existing_grouphash_fn = (
+        "find_existing_grouphash_new" if new_logic_enabled else "find_existing_grouphash"
+    )
+
     # Whether or not these are assigned a value depends on the values of `in_transition` and
     # `existing_group_id`. Everything else we'll return will definitely get a value and therefore
     # doesn't need to be initialized.
@@ -174,7 +188,10 @@ def get_results_from_saving_event(
             gh.hash: gh.group_id for gh in GroupHash.objects.filter(project_id=project.id)
         }
 
-        hash_search_results = return_values["find_existing_grouphash"]
+        hash_search_results = return_values[find_existing_grouphash_fn]
+        # The current logic wraps the search result in an extra layer which we need to unwrap
+        if not new_logic_enabled:
+            hash_search_results = list(map(lambda result: result[0], hash_search_results))
         # Filter out all the Nones to see if we actually found anything
         filtered_results = list(filter(lambda result: bool(result), hash_search_results))
         hash_search_result = filtered_results[0] if filtered_results else None
@@ -477,6 +494,9 @@ def test_existing_group_new_hash_exists(
     "in_transition", (True, False), ids=(" in_transition: True ", " in_transition: False ")
 )
 @pytest.mark.parametrize(
+    "mobile_config", (True, False), ids=(" mobile_config: True ", " mobile_config: False ")
+)
+@pytest.mark.parametrize(
     "id_qualifies", (True, False), ids=(" id_qualifies: True ", " id_qualifies: False ")
 )
 @patch("sentry.event_manager._save_aggregate_new", wraps=_save_aggregate_new)
@@ -485,6 +505,7 @@ def test_uses_regular_or_optimized_grouping_as_appropriate(
     mock_save_aggregate: MagicMock,
     mock_save_aggregate_new: MagicMock,
     id_qualifies: bool,
+    mobile_config: bool,
     in_transition: bool,
     flag_on: bool,
     killswitch_enabled: bool,
@@ -505,9 +526,12 @@ def test_uses_regular_or_optimized_grouping_as_appropriate(
         patch("sentry.grouping.ingest.config.is_in_transition", return_value=in_transition),
         override_options({"grouping.config_transition.killswitch_enabled": killswitch_enabled}),
     ):
-        save_event_with_grouping_config({"message": "Dogs are great!"}, project, NEWSTYLE_CONFIG)
+        config = MOBILE_CONFIG if mobile_config else NEWSTYLE_CONFIG
+        save_event_with_grouping_config({"message": "Dogs are great!"}, project, config)
 
-    if flag_on:
+    if mobile_config or killswitch_enabled:
+        assert mock_save_aggregate.call_count == 1
+    elif flag_on:
         assert mock_save_aggregate_new.call_count == 1
     elif in_transition:
         assert mock_save_aggregate_new.call_count == 1

--- a/tests/sentry/event_manager/test_hierarchical_hashes.py
+++ b/tests/sentry/event_manager/test_hierarchical_hashes.py
@@ -1,0 +1,163 @@
+import logging
+import time
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from sentry.event_manager import _save_aggregate
+from sentry.eventstore.models import Event
+from sentry.grouping.result import CalculatedHashes
+from sentry.models.group import Group
+from sentry.models.grouphash import GroupHash
+from sentry.testutils.pytest.fixtures import django_db_all
+
+
+@pytest.fixture
+def fast_save(default_project, task_runner):
+    def inner(last_frame):
+        data = {"timestamp": time.time(), "type": "error"}
+        evt = Event(
+            default_project.id,
+            uuid.uuid4().hex,
+            data=data,
+        )
+        group_creation_kwargs = {"level": 10, "culprit": ""}
+        hashes = CalculatedHashes(
+            hashes=["a" * 32, "b" * 32],
+            hierarchical_hashes=["c" * 32, "d" * 32, "e" * 32, last_frame * 32],
+        )
+
+        with task_runner():
+            with patch(
+                "sentry.event_manager.get_hash_values",
+                return_value=(hashes, hashes, hashes),
+            ):
+                with patch(
+                    "sentry.event_manager._get_group_creation_kwargs",
+                    return_value=group_creation_kwargs,
+                ):
+                    with patch("sentry.event_manager._materialize_metadata_many"):
+                        return _save_aggregate(
+                            evt,
+                            job={"event_metadata": {}},
+                            release=None,
+                            received_timestamp=0,
+                            metric_tags={},
+                        )
+
+    return inner
+
+
+def get_hash_values_for_group(group_id):
+    return {gh.hash for gh in GroupHash.objects.filter(group_id=group_id)}
+
+
+def associate_group_with_hash(group, hash):
+    gh = GroupHash.objects.get_or_create(project=group.project, hash=hash)[0]
+    assert gh.group is None or gh.group.id != group.id
+    gh.group = group
+    gh.save()
+
+
+def make_event(**kwargs):
+    result = {
+        "event_id": uuid.uuid1().hex,
+        "level": logging.ERROR,
+        "logger": "default",
+        "tags": [],
+    }
+    result.update(kwargs)
+    return result
+
+
+@django_db_all
+def test_move_all_events(default_project, fast_save):
+    group_info = fast_save("f")
+
+    assert group_info.is_new
+    assert not group_info.is_regression
+
+    new_group_info = fast_save("f")
+    assert not new_group_info.is_new
+    assert not new_group_info.is_regression
+    assert new_group_info.group.id == group_info.group.id
+
+    associate_group_with_hash(group_info.group, "a" * 32)
+    associate_group_with_hash(group_info.group, "b" * 32)
+
+    assert get_hash_values_for_group(group_info.group.id) == {"a" * 32, "b" * 32, "c" * 32}
+    assert Group.objects.get(id=new_group_info.group.id).title == "<unknown>"
+
+    # simulate split operation where all events of group are moved into a more specific hash
+    GroupHash.objects.filter(group=group_info.group).delete()
+    GroupHash.objects.create(project=default_project, hash="f" * 32, group_id=group_info.group.id)
+
+    new_group_info = fast_save("f")
+    assert not new_group_info.is_new
+    assert not new_group_info.is_regression
+    assert new_group_info.group.id == group_info.group.id
+
+    assert {g.hash for g in GroupHash.objects.filter(group=group_info.group)} == {
+        # one hierarchical hash associated
+        # no flat hashes associated when sorting into split group!
+        "f"
+        * 32,
+    }
+
+    assert Group.objects.get(id=new_group_info.group.id).title == "<unknown>"
+
+    new_group_info = fast_save("g")
+    assert new_group_info.is_new
+    assert not new_group_info.is_regression
+    assert new_group_info.group.id != group_info.group.id
+
+    assert get_hash_values_for_group(new_group_info.group.id) == {"c" * 32}
+
+    assert Group.objects.get(id=new_group_info.group.id).title == "<unknown>"
+
+
+@django_db_all
+def test_partial_move(default_project, fast_save):
+    group_info = fast_save("f")
+    assert group_info.is_new
+    assert not group_info.is_regression
+
+    new_group_info = fast_save("g")
+    assert not new_group_info.is_new
+    assert not new_group_info.is_regression
+    assert new_group_info.group.id == group_info.group.id
+
+    assert get_hash_values_for_group(group_info.group.id) == {"c" * 32}
+
+    # simulate split operation where event "f" of group is moved into a more specific hash
+    group2 = Group.objects.create(project=default_project)
+    f_hash = GroupHash.objects.create(project=default_project, hash="f" * 32, group_id=group2.id)
+
+    new_group_info = fast_save("f")
+    assert not new_group_info.is_new
+    assert not new_group_info.is_regression
+    assert new_group_info.group.id == group2.id
+
+    assert get_hash_values_for_group(new_group_info.group.id) == {
+        # one hierarchical hash associated
+        # no flat hashes associated when sorting into split group!
+        "f"
+        * 32,
+    }
+
+    new_group_info = fast_save("g")
+    assert not new_group_info.is_new
+    assert not new_group_info.is_regression
+    assert new_group_info.group.id == group_info.group.id
+
+    assert get_hash_values_for_group(new_group_info.group.id) == {
+        "c" * 32,
+    }
+
+    f_hash.delete()
+
+    new_group_info = fast_save("f")
+    assert not new_group_info.is_new
+    assert not new_group_info.is_regression
+    assert new_group_info.group.id == group_info.group.id

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.241776+00:00'
+created: '2024-09-06T13:24:15.646222+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/android_anr.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.316567+00:00'
+created: '2024-09-06T13:24:15.712025+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/aspnetcore.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:46.846192+00:00'
+created: '2024-09-06T13:24:15.283798+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.804174+00:00'
+created: '2024-09-06T13:24:16.198309+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/bugly.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/bugly.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.412210+00:00'
+created: '2024-09-06T13:24:15.809136+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/callee_guaranteed.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.711244+00:00'
+created: '2024-09-06T13:24:17.189200+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.683519+00:00'
+created: '2024-09-06T13:24:17.161894+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.600639+00:00'
+created: '2024-09-06T13:24:15.987772+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/custom_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/custom_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.612434+00:00'
+created: '2024-09-06T13:24:15.999488+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.247583+00:00'
+created: '2024-09-06T13:24:16.661117+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.141659+00:00'
+created: '2024-09-06T13:24:16.561113+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.688035+00:00'
+created: '2024-09-06T13:24:16.083329+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_compute_hashes_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.563726+00:00'
+created: '2024-09-06T13:24:15.953612+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.634694+00:00'
+created: '2024-09-06T13:24:16.026437+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/fallback_prefix_level_1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.855828+00:00'
+created: '2024-09-06T13:24:16.250524+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_comput_hashes_ignores_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_comput_hashes_ignores_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.780847+00:00'
+created: '2024-09-06T13:24:16.173917+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_empty_list.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_empty_list.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.585575+00:00'
+created: '2024-09-06T13:24:15.976137+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.083344+00:00'
+created: '2024-09-06T13:24:16.497110+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.252513+00:00'
+created: '2024-09-06T13:24:15.658258+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.843966+00:00'
+created: '2024-09-06T13:24:16.238930+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_dartlang_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_dartlang_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.618268+00:00'
+created: '2024-09-06T13:24:17.093515+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.319196+00:00'
+created: '2024-09-06T13:24:16.735449+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.414760+00:00'
+created: '2024-09-06T13:24:16.886658+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_extra_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_extra_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:46.981027+00:00'
+created: '2024-09-06T13:24:15.404335+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_from_url_origin_corner_cases.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_from_url_origin_corner_cases.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.296731+00:00'
+created: '2024-09-06T13:24:15.693218+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_if_abs_path_is_http.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_if_abs_path_is_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.277381+00:00'
+created: '2024-09-06T13:24:15.681593+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_if_blob.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_if_blob.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.942123+00:00'
+created: '2024-09-06T13:24:16.343901+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_if_http.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_if_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.176957+00:00'
+created: '2024-09-06T13:24:16.594870+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_if_https.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_if_https.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:46.924550+00:00'
+created: '2024-09-06T13:24:15.357714+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_flutter_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.484460+00:00'
+created: '2024-09-06T13:24:15.877542+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_hibernate_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_hibernate_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.086990+00:00'
+created: '2024-09-06T13:24:15.503819+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_java8_lambda_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_java8_lambda_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.268287+00:00'
+created: '2024-09-06T13:24:16.683284+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_java8_lambda_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_java8_lambda_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.463121+00:00'
+created: '2024-09-06T13:24:16.935750+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_javassist.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_javassist.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.211397+00:00'
+created: '2024-09-06T13:24:16.626796+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_javassist_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_javassist_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.886080+00:00'
+created: '2024-09-06T13:24:16.283802+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_javassist_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_javassist_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.365273+00:00'
+created: '2024-09-06T13:24:16.842925+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_module_if_page_url.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_module_if_page_url.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.506171+00:00'
+created: '2024-09-06T13:24:15.898881+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_module_if_page_url_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_module_if_page_url_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.654304+00:00'
+created: '2024-09-06T13:24:16.047267+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_safari_native_code.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_safari_native_code.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.464557+00:00'
+created: '2024-09-06T13:24:15.858892+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sentry_dart_packages.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.895729+00:00'
+created: '2024-09-06T13:24:16.294744+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sentry_dart_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.344073+00:00'
+created: '2024-09-06T13:24:16.821366+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sentry_flutter_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.025980+00:00'
+created: '2024-09-06T13:24:16.440700+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sun_java_generated_constructors.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sun_java_generated_constructors.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.355264+00:00'
+created: '2024-09-06T13:24:15.752762+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sun_java_generated_constructors_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sun_java_generated_constructors_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.649678+00:00'
+created: '2024-09-06T13:24:17.128100+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sun_java_generated_methods.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sun_java_generated_methods.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.299471+00:00'
+created: '2024-09-06T13:24:16.715193+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_block_functions.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_block_functions.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.541861+00:00'
+created: '2024-09-06T13:24:15.932211+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_erb_templates.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_erb_templates.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.639131+00:00'
+created: '2024-09-06T13:24:17.117744+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_versioned_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_versioned_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.016273+00:00'
+created: '2024-09-06T13:24:15.437657+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_versioned_filenames_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_versioned_filenames_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.289667+00:00'
+created: '2024-09-06T13:24:16.704347+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_skips_symbol_if_unknown.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_skips_symbol_if_unknown.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.905867+00:00'
+created: '2024-09-06T13:24:16.305182+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_context_line_over_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_context_line_over_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.627514+00:00'
+created: '2024-09-06T13:24:17.103713+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_function_over_lineno.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_function_over_lineno.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.553041+00:00'
+created: '2024-09-06T13:24:15.942703+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_module_over_filename.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_module_over_filename.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.120104+00:00'
+created: '2024-09-06T13:24:16.533095+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_symbol_instead_of_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_symbol_instead_of_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.344502+00:00'
+created: '2024-09-06T13:24:15.743093+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_with_only_required_vars.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_with_only_required_vars.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.061995+00:00'
+created: '2024-09-06T13:24:15.478906+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/go_pkg_mod.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.723659+00:00'
+created: '2024-09-06T13:24:17.201499+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_125_event_126.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:46.880558+00:00'
+created: '2024-09-06T13:24:15.318696+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_200_event_200.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.016301+00:00'
+created: '2024-09-06T13:24:16.429899+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_275_event_275.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.005431+00:00'
+created: '2024-09-06T13:24:15.428034+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_289_event_312.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.954670+00:00'
+created: '2024-09-06T13:24:16.358343+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_294_event_294.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.932538+00:00'
+created: '2024-09-06T13:24:16.333147+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_294_event_329.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.333971+00:00'
+created: '2024-09-06T13:24:16.809955+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_307_event_307.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.267886+00:00'
+created: '2024-09-06T13:24:15.671262+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_307_event_657.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.153744+00:00'
+created: '2024-09-06T13:24:16.573303+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_313_event_313.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.432723+00:00'
+created: '2024-09-06T13:24:16.905601+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_313_event_333.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.452138+00:00'
+created: '2024-09-06T13:24:16.925578+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_319_event_321.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.132483+00:00'
+created: '2024-09-06T13:24:15.545843+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_389_event_389.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.041294+00:00'
+created: '2024-09-06T13:24:15.460003+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_432_event_432.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.207684+00:00'
+created: '2024-09-06T13:24:15.615054+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_432_event_453.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.114067+00:00'
+created: '2024-09-06T13:24:15.528650+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_445_event_445.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:46.833099+00:00'
+created: '2024-09-06T13:24:15.271060+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/in_app_in_ui.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.515183+00:00'
+created: '2024-09-06T13:24:16.983901+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.441402+00:00'
+created: '2024-09-06T13:24:15.836429+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/java_minimal.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.077185+00:00'
+created: '2024-09-06T13:24:15.494097+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_exception_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_exception_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.474534+00:00'
+created: '2024-09-06T13:24:16.948138+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_polyfills.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.548895+00:00'
+created: '2024-09-06T13:24:17.018818+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_regression_tree_labels.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_regression_tree_labels.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.388785+00:00'
+created: '2024-09-06T13:24:16.864948+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_unpkg.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.723094+00:00'
+created: '2024-09-06T13:24:16.119711+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.187669+00:00'
+created: '2024-09-06T13:24:15.600079+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.109519+00:00'
+created: '2024-09-06T13:24:16.521708+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.164788+00:00'
+created: '2024-09-06T13:24:15.577755+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_http_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.368846+00:00'
+created: '2024-09-06T13:24:15.765836+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_http_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_http_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:46.902636+00:00'
+created: '2024-09-06T13:24:15.338940+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_http_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.188000+00:00'
+created: '2024-09-06T13:24:16.605883+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_http_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.029074+00:00'
+created: '2024-09-06T13:24:15.448337+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.517880+00:00'
+created: '2024-09-06T13:24:15.911546+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.098224+00:00'
+created: '2024-09-06T13:24:16.510468+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.608069+00:00'
+created: '2024-09-06T13:24:17.081815+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/laravel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/laravel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.712523+00:00'
+created: '2024-09-06T13:24:16.108586+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/laravel_anonymous.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/laravel_anonymous.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.666507+00:00'
+created: '2024-09-06T13:24:16.061785+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/macos_amd_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.333406+00:00'
+created: '2024-09-06T13:24:15.728327+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/macos_intel_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.821615+00:00'
+created: '2024-09-06T13:24:16.215337+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/malloc_sentinel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.573163+00:00'
+created: '2024-09-06T13:24:17.045932+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/minified_javascript.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.537386+00:00'
+created: '2024-09-06T13:24:17.008253+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.200267+00:00'
+created: '2024-09-06T13:24:16.616504+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_driver_crash1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.280136+00:00'
+created: '2024-09-06T13:24:16.694861+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_driver_crash2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.422924+00:00'
+created: '2024-09-06T13:24:15.819971+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_driver_crash3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.866764+00:00'
+created: '2024-09-06T13:24:16.262511+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_limit_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.994071+00:00'
+created: '2024-09-06T13:24:16.403421+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_malloc_chain.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.051026+00:00'
+created: '2024-09-06T13:24:16.466634+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.965929+00:00'
+created: '2024-09-06T13:24:16.370728+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_unlimited_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.143173+00:00'
+created: '2024-09-06T13:24:15.556360+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_windows_anon_namespace.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.559769+00:00'
+created: '2024-09-06T13:24:17.031260+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_with_function_name.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.677025+00:00'
+created: '2024-09-06T13:24:16.073056+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/node_exception_weird.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.833295+00:00'
+created: '2024-09-06T13:24:16.227834+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/node_low_level_async.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.496196+00:00'
+created: '2024-09-06T13:24:15.887853+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_exception_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.003538+00:00'
+created: '2024-09-06T13:24:16.416091+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.402519+00:00'
+created: '2024-09-06T13:24:16.876952+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_grouping_enhancer_towards_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.746362+00:00'
+created: '2024-09-06T13:24:16.141953+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.623685+00:00'
+created: '2024-09-06T13:24:16.013233+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/react_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.039430+00:00'
+created: '2024-09-06T13:24:16.455039+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_cocoa.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_cocoa.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:46.856016+00:00'
+created: '2024-09-06T13:24:15.293549+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_collapse_recursion.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.233775+00:00'
+created: '2024-09-06T13:24:16.647764+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.130314+00:00'
+created: '2024-09-06T13:24:16.547753+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_discards_seemingly_useless_stack.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_discards_seemingly_useless_stack.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.974990+00:00'
+created: '2024-09-06T13:24:16.382436+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_does_not_discard_non_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_does_not_discard_non_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.072877+00:00'
+created: '2024-09-06T13:24:16.486280+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_does_not_group_different_js_errors.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_does_not_group_different_js_errors.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:46.958725+00:00'
+created: '2024-09-06T13:24:15.385432+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_enforce_min_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.575182+00:00'
+created: '2024-09-06T13:24:15.964837+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_excludes_single_frame_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_excludes_single_frame_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.153606+00:00'
+created: '2024-09-06T13:24:15.566385+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_hash_without_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_hash_without_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.489038+00:00'
+created: '2024-09-06T13:24:16.958874+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_ignores_singular_anonymous_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_ignores_singular_anonymous_frame.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:46.991051+00:00'
+created: '2024-09-06T13:24:15.414555+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_negated_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.594868+00:00'
+created: '2024-09-06T13:24:17.068615+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_rust.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.917617+00:00'
+created: '2024-09-06T13:24:16.317373+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_rust2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.222577+00:00'
+created: '2024-09-06T13:24:16.637766+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_with_minimal_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_with_minimal_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.354716+00:00'
+created: '2024-09-06T13:24:16.833076+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/threads_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:48.257333+00:00'
+created: '2024-09-06T13:24:16.672968+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/unity.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-09-06T11:30:47.098200+00:00'
+created: '2024-09-06T13:24:15.514486+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---


### PR DESCRIPTION
This is a follow-up to #77017

The tests get updated because I removed a rule back in #61675