### PR TITLE
fix(uptime): Fix sorting by name for uptime rules

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -306,7 +306,7 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
             uptime_rules = uptime_rules.annotate(date_triggered=far_past_date)
         alert_rule_intermediary = CombinedQuerysetIntermediary(alert_rules, sort_key)
         rule_intermediary = CombinedQuerysetIntermediary(issue_rules, rule_sort_key)
-        uptime_intermediary = CombinedQuerysetIntermediary(uptime_rules, rule_sort_key)
+        uptime_intermediary = CombinedQuerysetIntermediary(uptime_rules, sort_key)
         response = self.paginate(
             request,
             paginator_cls=CombinedQuerysetPaginator,


### PR DESCRIPTION
"Label" does not exist on the uptime subscription model, we can just use `sort_key` which specifies `name`

Fixes: SENTRY-3DQX
Fixes: https://github.com/getsentry/sentry/issues/76798