### PR TITLE
chore(dashboards): Guard against missing chart DOM element

### DIFF
--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -108,7 +108,7 @@ class ChartZoom extends Component<Props> {
   }
 
   chart?: ECharts;
-  $chart?: Element;
+  $chart?: HTMLElement;
   isCancellingZoom?: boolean;
   history: Period[];
   currentPeriod?: Period;

--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -1,5 +1,4 @@
 import {Component} from 'react';
-import * as Sentry from '@sentry/react';
 import type {
   DataZoomComponentOption,
   ECharts,
@@ -195,27 +194,13 @@ class ChartZoom extends Component<Props> {
   /**
    * Enable zoom immediately instead of having to toggle to zoom
    */
-  handleChartReady = chart => {
+  handleChartReady = (chart: ECharts) => {
     this.props.onChartReady?.(chart);
 
-    // The DOM element is also available via chart._dom but TypeScript hates that, since
-    // _dom is technically private. Instead, use `querySelector` to get the element
     this.chart = chart;
+    this.$chart = chart.getDom();
 
-    const $chart = document.querySelector(`div[_echarts_instance_="${chart.id}"]`);
-
-    if ($chart) {
-      $chart.addEventListener('mousedown', this.handleMouseDown);
-      this.$chart = $chart;
-    } else {
-      Sentry.withScope(scope => {
-        scope.setContext('ECharts', {
-          id: chart.id,
-        });
-
-        Sentry.captureException(new Error(`No DOM element for ECharts instance`));
-      });
-    }
+    this.$chart.addEventListener('mousedown', this.handleMouseDown);
   };
 
   handleKeyDown = evt => {

--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -208,7 +208,13 @@ class ChartZoom extends Component<Props> {
       $chart.addEventListener('mousedown', this.handleMouseDown);
       this.$chart = $chart;
     } else {
-      Sentry.captureException(new Error(`No DOM element for chart with ID ${chart.id}`));
+      Sentry.withScope(scope => {
+        scope.setContext('ECharts', {
+          id: chart.id,
+        });
+
+        Sentry.captureException(new Error(`No DOM element for ECharts instance`));
+      });
     }
   };
 


### PR DESCRIPTION
In some cases (unclear when), the DOM element for the chart is not actually present at the time of chart ready. The `as HTMLDivElement` coersion hid this case (my bad, I knew that lying to TypeScript is bad).

Instead use the `getDOM` function that I didn't see before! Should be much safer, if the TypeScript type is to be believed.

Closes JAVASCRIPT-2VNV