### PR TITLE
fix(grouping): Fix getting group metadata in `_save_aggregate_new`

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -933,6 +933,10 @@ def _get_group_processing_kwargs(job: Job) -> dict[str, Any]:
     """
     Pull together all the metadata used when creating a group or updating a group's metadata based
     on a new event.
+
+    Note: Must be called *after* grouping has run, because the grouping process can affect the title
+    (by setting `main_exception_id` or by setting the title directly using a custom fingerprint
+    rule).
     """
     _materialize_metadata_many([job])
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1696,16 +1696,12 @@ def _save_aggregate_new(
     project = event.project
     secondary = NULL_GROUPHASH_INFO
 
-    group_processing_kwargs = _get_group_processing_kwargs(job)
-
     # Try looking for an existing group using the current grouping config
     primary = get_hashes_and_grouphashes(job, run_primary_grouping, metric_tags)
 
     # If we've found one, great. No need to do any more calculations
     if primary.existing_grouphash:
-        group_info = handle_existing_grouphash(
-            job, primary.existing_grouphash, primary.grouphashes, group_processing_kwargs
-        )
+        group_info = handle_existing_grouphash(job, primary.existing_grouphash, primary.grouphashes)
         result = "found_primary"
     # If we haven't, try again using the secondary config
     else:
@@ -1714,7 +1710,7 @@ def _save_aggregate_new(
 
         if secondary.existing_grouphash:
             group_info = handle_existing_grouphash(
-                job, secondary.existing_grouphash, all_grouphashes, group_processing_kwargs
+                job, secondary.existing_grouphash, all_grouphashes
             )
             result = "found_secondary"
         # If we still haven't found a group, ask Seer for a match (if enabled for the project)
@@ -1722,14 +1718,10 @@ def _save_aggregate_new(
             seer_matched_grouphash = maybe_check_seer_for_matching_grouphash(event, primary.hashes)
 
             if seer_matched_grouphash:
-                group_info = handle_existing_grouphash(
-                    job, seer_matched_grouphash, all_grouphashes, group_processing_kwargs
-                )
+                group_info = handle_existing_grouphash(job, seer_matched_grouphash, all_grouphashes)
             # If we *still* haven't found a group into which to put the event, create a new group
             else:
-                group_info = create_group_with_grouphashes(
-                    job, all_grouphashes, group_processing_kwargs
-                )
+                group_info = create_group_with_grouphashes(job, all_grouphashes)
             result = "no_match"
 
     # From here on out, we're just doing housekeeping
@@ -1794,7 +1786,6 @@ def handle_existing_grouphash(
     job: Job,
     existing_grouphash: GroupHash,
     all_grouphashes: list[GroupHash],
-    group_processing_kwargs: dict[str, Any],
 ) -> GroupInfo | None:
     """
     Handle the case where an incoming event matches an existing group, by assigning the event to the
@@ -1835,19 +1826,16 @@ def handle_existing_grouphash(
     is_regression = _process_existing_aggregate(
         group=group,
         event=job["event"],
-        incoming_group_values=group_processing_kwargs,
+        incoming_group_values=_get_group_processing_kwargs(job),
         release=job["release"],
     )
 
     return GroupInfo(group=group, is_new=False, is_regression=is_regression)
 
 
-def create_group_with_grouphashes(
-    job: Job, grouphashes: list[GroupHash], group_processing_kwargs: dict[str, Any]
-) -> GroupInfo | None:
+def create_group_with_grouphashes(job: Job, grouphashes: list[GroupHash]) -> GroupInfo | None:
     """
-    Create a group from the data in `job` and `group_processing_kwargs` and link it to the given
-    grouphashes.
+    Create a group from the data in `job` and link it to the given grouphashes.
 
     In very rare circumstances, we can end up in a race condition with another process trying to
     create the same group. If the current process loses the race, this function will update the
@@ -1899,7 +1887,7 @@ def create_group_with_grouphashes(
             metrics_timer_tags["outcome"] = "new_group"
             record_new_group_metrics(event)
 
-            group = _create_group(project, event, **group_processing_kwargs)
+            group = _create_group(project, event, **_get_group_processing_kwargs(job))
             add_group_id_to_grouphashes(group, grouphashes)
 
             return GroupInfo(group=group, is_new=True, is_regression=False)
@@ -1909,9 +1897,7 @@ def create_group_with_grouphashes(
         # this function at all)
         else:
             # TODO: should we be setting tags here, too?
-            return handle_existing_grouphash(
-                job, existing_grouphash, grouphashes, group_processing_kwargs
-            )
+            return handle_existing_grouphash(job, existing_grouphash, grouphashes)
 
 
 def _create_group(

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -178,7 +178,6 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
 
         assert materialized["metadata"] == {"title": "<unlabeled event>", "dogs": "are great"}
 
-    @pytest.mark.skip(reason="Flaky test")
     def test_react_error_picks_cause_error_title_subtitle(self) -> None:
         cause_error_value = "Load failed"
         # React 19 hydration error include the hydration error and a cause
@@ -217,7 +216,6 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         assert event.group is not None
         assert event.group.title == f"TypeError: {cause_error_value}"
 
-    @pytest.mark.skip(reason="Flaky test")
     def test_react_hydration_error_picks_cause_error_title_subtitle(self) -> None:
         cause_error_value = "Cannot read properties of undefined (reading 'nodeName')"
         # React 19 hydration error include the hydration error and a cause

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -492,7 +492,6 @@ def test_nodestore_missing(
 
 @django_db_all
 @pytest.mark.snuba
-@pytest.mark.skip(reason="Flaky test")
 def test_apply_new_fingerprinting_rules(
     default_project,
     reset_snuba,


### PR DESCRIPTION
When we gather metadata to use when either creating or updating a group, one of the pieces of data we include is the group's title. Because this title can be affected by the grouping process (either directly, via a custom fingerprint rule, or indirectly, as a result of grouping setting `main_exception_id`), the gathering of the metadata must happen after grouping.

This ordering is correct in `_save_aggregate`, but not in `_save_aggregate_new`. This fixes that by gathering the metadata directly in `_save_aggregate_new`'s helpers, rather than calculating it ahead of time and passing it in to them.

(This problem was discovered when a number of tests involving the group's title started flaking as we've been rolling out `_save_aggregate_new`. This therefore also removes the skips on those tests, since they should now work regardless of which of `_save_aggregate` and `_save_aggregate_new` is running.)