### PR TITLE
chore(grouping): Use optimized grouping logic for 100% of non-transitioning projects

### DIFF
--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -99,5 +99,6 @@ def project_uses_optimized_grouping(project: Project) -> bool:
             project.organization,
         )
         or (is_in_transition(project))
-        or project.id % 5 < 4  # 80% of all non-transition projects
+        # TODO: Yes, this is everyone - this check will soon be removed entirely
+        or project.id % 5 < 5  # 100% of all non-transition projects
     )

--- a/tests/sentry/event_manager/grouping/test_assign_to_group.py
+++ b/tests/sentry/event_manager/grouping/test_assign_to_group.py
@@ -496,9 +496,7 @@ def test_existing_group_new_hash_exists(
 @pytest.mark.parametrize(
     "mobile_config", (True, False), ids=(" mobile_config: True ", " mobile_config: False ")
 )
-@pytest.mark.parametrize(
-    "id_qualifies", (True, False), ids=(" id_qualifies: True ", " id_qualifies: False ")
-)
+@pytest.mark.parametrize("id_qualifies", (True,), ids=(" id_qualifies: True ",))
 @patch("sentry.event_manager._save_aggregate_new", wraps=_save_aggregate_new)
 @patch("sentry.event_manager._save_aggregate", wraps=_save_aggregate)
 def test_uses_regular_or_optimized_grouping_as_appropriate(

--- a/tests/sentry/event_manager/grouping/test_assign_to_group.py
+++ b/tests/sentry/event_manager/grouping/test_assign_to_group.py
@@ -518,7 +518,7 @@ def test_uses_regular_or_optimized_grouping_as_appropriate(
         # Keep making projects until we get an id which matches `id_qualifies`
         org = Factories.create_organization()
         project = Factories.create_project(organization=org)
-        while (project.id % 5 >= 4) if id_qualifies else (project.id % 5 < 4):
+        while (project.id % 5 >= 5) if id_qualifies else (project.id % 5 < 5):
             project = Factories.create_project(organization=org)
 
     with (


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/sentry/pull/76614, https://github.com/getsentry/sentry/pull/76679, https://github.com/getsentry/sentry/pull/76758, and https://github.com/getsentry/sentry/pull/76890, enabling the updated grouping transition logic for the final 20% of non-transitioning projects.

Once this is merged, we'll be able to start cleaning up the old logic in `_save_aggregate`, the checks for which path to use, etc. I didn't do that in this PR because I want to wait and let this run for a few days to make sure there are no issues before I go ripping out a bunch of code.