### PR TITLE
fix(discover): Fix bad padding around `SearchQueryBuilder`

### DIFF
--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -685,15 +685,17 @@ export class Results extends Component<Props, State> {
 
     if (organization.features.includes('search-query-builder-discover')) {
       return (
-        <StyledResultsSearchQueryBuilder
-          projectIds={eventView.project}
-          query={eventView.query}
-          fields={fields}
-          onSearch={this.handleSearch}
-          customMeasurements={customMeasurements}
-          dataset={eventView.dataset}
-          includeTransactions
-        />
+        <Wrapper>
+          <ResultsSearchQueryBuilder
+            projectIds={eventView.project}
+            query={eventView.query}
+            fields={fields}
+            onSearch={this.handleSearch}
+            customMeasurements={customMeasurements}
+            dataset={eventView.dataset}
+            includeTransactions
+          />
+        </Wrapper>
       );
     }
 
@@ -870,10 +872,6 @@ const Wrapper = styled('div')`
     display: grid;
     grid-auto-flow: row;
   }
-`;
-
-const StyledResultsSearchQueryBuilder = styled(ResultsSearchQueryBuilder)`
-  margin-bottom: ${space(2)};
 `;
 
 const StyledSearchBar = styled(SearchBar)`


### PR DESCRIPTION
Adding a styled variant doesn't actually work in this case, the styles aren't propagated down.

Instead, use the pre-existing `Wrapper` that adds the right padding. Fixes a regression I introduced in https://github.com/getsentry/sentry/pull/76958
