### PR TITLE
fix(slack): Send linking message in bot <> user DM if bot doesn't have access to channel

### DIFF
--- a/src/sentry/integrations/slack/message_builder/prompt.py
+++ b/src/sentry/integrations/slack/message_builder/prompt.py
@@ -4,19 +4,30 @@ from sentry.integrations.slack.message_builder.types import SlackBody
 
 from .base.block import BlockSlackMessageBuilder
 
-LINK_IDENTITY_MESSAGE = "Link your Slack identity to Sentry to unfurl Discover charts."
+EPHEMERAL_LINK_IDENTITY_MESSAGE = "Link your Slack identity to Sentry to unfurl Discover charts."
+NON_EPHEMERAL_LINK_IDENTITY_MESSAGE = "You sent an unfurlable link in <#{}>. Please link your Slack identity to Sentry to unfurl Discover charts."
 
 
 class SlackPromptLinkMessageBuilder(BlockSlackMessageBuilder):
-    def __init__(self, url: str) -> None:
+    def __init__(self, url: str, ephemeral: bool = True, channel_name: str | None = None) -> None:
         super().__init__()
         self.url = url
+        # message_channel is the channel the user sent the unfurl link in
+        # if passed, we will add this additional context to the message
+        self.ephemeral = ephemeral
+        self.channel_name = channel_name
 
     def build(self) -> SlackBody:
+        message = (
+            EPHEMERAL_LINK_IDENTITY_MESSAGE
+            if self.ephemeral
+            else NON_EPHEMERAL_LINK_IDENTITY_MESSAGE.format(self.channel_name)
+        )
+
         return {
             "blocks": orjson.dumps(
                 [
-                    self.get_markdown_block(LINK_IDENTITY_MESSAGE),
+                    self.get_markdown_block(message),
                     self.get_action_block([("Link", self.url, "link"), ("Cancel", None, "ignore")]),
                 ],
             ).decode()


### PR DESCRIPTION
fixes [SENTRY-3BTE](https://sentry.sentry.io/issues/5585631410/)

the bot was attempting to send an ephemeral message in a channel that it doesn't have access to, which is why slack was sending us `channel_not_found`. 

the solution here is if we can't send the ephemeral message, we instead send the user a dm to link their identity. because sending them a link to their message would be another slack api call, i instead settled on sending them the channel that they decided to send the link in, so they can jump to it.


