### PR TITLE
fix(router): Redirect to pathname instead

### DIFF
--- a/static/app/views/projectEventRedirect.tsx
+++ b/static/app/views/projectEventRedirect.tsx
@@ -51,15 +51,14 @@ function ProjectEventRedirect({router}: Props) {
       // after following any redirects. It _should_ be the page we're trying
       // to reach; use the router to go there.
       //
-      // Here we assume that the responseURL is on the same domain as the
-      // as the window.location.origin, so we simply take the pathname.
-      //
       // Use `replace` so that hitting the browser back button will skip all
       // this redirect business.
       const url = new URL(xhr.responseURL);
       if (url.origin === window.location.origin) {
         router.replace(url.pathname);
       } else {
+        // If the origin has changed, we cannot do a simple replace with the router.
+        // Instead, we opt to do a full redirect.
         window.location.replace(xhr.responseURL);
       }
     };

--- a/static/app/views/projectEventRedirect.tsx
+++ b/static/app/views/projectEventRedirect.tsx
@@ -57,7 +57,11 @@ function ProjectEventRedirect({router}: Props) {
       // Use `replace` so that hitting the browser back button will skip all
       // this redirect business.
       const url = new URL(xhr.responseURL);
-      router.replace(url.pathname);
+      if (url.origin === window.location.origin) {
+        router.replace(url.pathname);
+      } else {
+        window.location.replace(xhr.responseURL);
+      }
     };
     xhr.onerror = () => {
       setError(t('Could not load the requested event'));

--- a/static/app/views/projectEventRedirect.tsx
+++ b/static/app/views/projectEventRedirect.tsx
@@ -50,10 +50,14 @@ function ProjectEventRedirect({router}: Props) {
       // responseURL is the URL of the document the browser ultimately loaded,
       // after following any redirects. It _should_ be the page we're trying
       // to reach; use the router to go there.
-
+      //
+      // Here we assume that the responseURL is on the same domain as the
+      // as the window.location.origin, so we simply take the pathname.
+      //
       // Use `replace` so that hitting the browser back button will skip all
       // this redirect business.
-      router.replace(xhr.responseURL);
+      const url = new URL(xhr.responseURL);
+      router.replace(url.pathname);
     };
     xhr.onerror = () => {
       setError(t('Could not load the requested event'));


### PR DESCRIPTION
React Router 3 was able to handle the redirect to an absolute path but React Router 6 assumes the redirect is either a pathname or a relative path. So the absolute url was being treated as a relative path and was concatenated to the end of the current route. To get around this, parse the url and only pass the pathname component to the redirect.