### PR TITLE
feat(saml2): Return SLO URL to the frontend

### DIFF
--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -304,5 +304,5 @@ class AuthIndexEndpoint(BaseAuthIndexEndpoint):
         request.user = AnonymousUser()
 
         if slo_url:
-            return Response(status=status.HTTP_200_OK, data={"slo_url": slo_url})
+            return Response(status=status.HTTP_200_OK, data={"sloUrl": slo_url})
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -295,9 +295,14 @@ class AuthIndexEndpoint(BaseAuthIndexEndpoint):
 
         Deauthenticate all active sessions for this user.
         """
-        handle_saml_single_logout(request)
+        # If there is an SLO URL, return it to frontend so the browser can redirect
+        # the user back to the IdP site to delete the IdP session cookie
+        slo_url = handle_saml_single_logout(request)
 
         # For signals to work here, we must promote the request.user to a full user object
         logout(request._request)
         request.user = AnonymousUser()
+
+        if slo_url:
+            return Response(status=status.HTTP_200_OK, data={"slo_url": slo_url})
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/auth/providers/saml2/provider.py
+++ b/src/sentry/auth/providers/saml2/provider.py
@@ -436,6 +436,13 @@ def build_auth(request, saml_config):
 
 
 def handle_saml_single_logout(request):
+    """
+    This method will attempt to call the backend of the IdP. However, not
+    all IdP will invalidate the user session from their end.
+
+    We should get the SLO URL and redirect the user back to the IdP site
+    to delete the IdP session cookie in their browser
+    """
     # Do not handle SLO if a user is in more than 1 organization
     # Propagating it to multiple IdPs results in confusion for the user
     organizations = user_service.get_organizations(user_id=request.user.id)
@@ -450,11 +457,16 @@ def handle_saml_single_logout(request):
     if not provider or not provider.is_saml:
         return
 
-    # Try/catch is needed because IdP may not support SLO (e.g. Okta) and
+    # Try/catch is needed because IdP may not support SLO and
     # will return an error
     try:
         saml_config = build_saml_config(provider.config, org)
         idp_auth = build_auth(request, saml_config)
-        idp_auth.logout()
+        idp_slo_url = idp_auth.get_slo_url()
+
+        # IdP that does not support SLO will usually not provide a URL (e.g. Okta)
+        if idp_slo_url:
+            idp_auth.logout()
+            return idp_slo_url
     except Exception as e:
         sentry_sdk.capture_exception(e)

--- a/src/sentry/auth/providers/saml2/provider.py
+++ b/src/sentry/auth/providers/saml2/provider.py
@@ -465,8 +465,10 @@ def handle_saml_single_logout(request):
         idp_slo_url = idp_auth.get_slo_url()
 
         # IdP that does not support SLO will usually not provide a URL (e.g. Okta)
-        if idp_slo_url:
-            idp_auth.logout()
-            return idp_slo_url
+        if not idp_slo_url:
+            return
+
+        idp_auth.logout()
+        return idp_slo_url
     except Exception as e:
         sentry_sdk.capture_exception(e)


### PR DESCRIPTION
Our original implementation would call the IdP's SLO endpoint, but it seems like some IdPs do not invalidate user sessions and we'd need to redirect the user's browser on the frontend back to the IdP so they can clear their browser cookies.

This PR returns the SLO URL to the frontend, so the frontend can redirect the user to the correct page.