### PR TITLE
chore(similarity): Turn on AI grouping for all new projects

### DIFF
--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -222,7 +222,6 @@ class TeamProjectsEndpoint(TeamEndpoint, EnvironmentMixin):
             is_seer_eligible_platform = project.platform in SEER_ELIGIBLE_PLATFORMS
             if (
                 hasattr(project.organization, "flags")
-                and project.organization.flags.early_adopter
                 and is_seer_eligible_platform
                 and options.get("similarity.new_project_seer_grouping.enabled")
             ):

--- a/tests/sentry/api/endpoints/test_team_projects.py
+++ b/tests/sentry/api/endpoints/test_team_projects.py
@@ -68,14 +68,6 @@ class TeamProjectsCreateTest(APITestCase, TestCase):
         assert project.platform == "python"
         assert project.teams.first() == self.team
 
-        # Assert project option is not set for non-EA organizations
-        assert (
-            ProjectOption.objects.get_value(
-                project=project, key="sentry:similarity_backfill_completed"
-            )
-            is None
-        )
-
     def test_invalid_numeric_slug(self):
         response = self.get_error_response(
             self.organization.slug,
@@ -243,11 +235,9 @@ class TeamProjectsCreateTest(APITestCase, TestCase):
     @override_options({"similarity.new_project_seer_grouping.enabled": True})
     def test_similarity_project_option_valid(self):
         """
-        Test that project option for similarity grouping is created for EA organizations
-        where the project platform is Seer-eligible.
+        Test that project option for similarity grouping is created when the project platform is
+        Seer-eligible.
         """
-        self.organization.flags.early_adopter = True
-        self.organization.save()
         response = self.get_success_response(
             self.organization.slug,
             self.team.slug,
@@ -270,12 +260,9 @@ class TeamProjectsCreateTest(APITestCase, TestCase):
 
     def test_similarity_project_option_invalid(self):
         """
-        Test that project option for similarity grouping is not created for EA organizations
-        where the project platform is not seer eligible.
+        Test that project option for similarity grouping is not created when the project platform
+        is not seer eligible.
         """
-
-        self.organization.flags.early_adopter = True
-        self.organization.save()
         response = self.get_success_response(
             self.organization.slug,
             self.team.slug,


### PR DESCRIPTION
Remove EA org check before adding project option on project creation
The project option will enable the ai similarity embedding feature to be used for grouping new groups