### PR TITLE
feat(saml2): Redirect to SLO URL on the frontend

### DIFF
--- a/static/app/actionCreators/account.spec.tsx
+++ b/static/app/actionCreators/account.spec.tsx
@@ -1,0 +1,22 @@
+import {redirect} from 'react-router-dom';
+
+import {waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {logout} from './account';
+
+jest.mock('react-router-dom');
+
+describe('logout', () => {
+  it('has can logout', async function () {
+    const mock = MockApiClient.addMockResponse({
+      url: '/auth/',
+      method: 'DELETE',
+    });
+
+    const api = new MockApiClient();
+    logout(api);
+
+    await waitFor(() => expect(mock).toHaveBeenCalled());
+    await waitFor(() => expect(redirect).toHaveBeenCalled());
+  });
+});

--- a/static/app/actionCreators/account.tsx
+++ b/static/app/actionCreators/account.tsx
@@ -50,7 +50,7 @@ export async function logout(api: Client, redirectUrl = '/auth/login/') {
   const data = await api.requestPromise('/auth/', {method: 'DELETE'});
 
   // If there's a URL for SAML Single-logout, redirect back to IdP
-  window.location.replace(data?.sloUrl || redirectUrl);
+  window.location.assign(data?.sloUrl || redirectUrl);
 }
 
 export function removeAuthenticator(api: Client, userId: string, authId: string) {

--- a/static/app/actionCreators/account.tsx
+++ b/static/app/actionCreators/account.tsx
@@ -46,8 +46,11 @@ export function updateUser(user: User | ChangeAvatarUser) {
   ConfigStore.set('user', {...previousUser, ...user, options});
 }
 
-export function logout(api: Client) {
-  return api.requestPromise('/auth/', {method: 'DELETE'});
+export async function logout(api: Client, redirectUrl = '/auth/login/') {
+  const data = await api.requestPromise('/auth/', {method: 'DELETE'});
+
+  // If there's a URL for SAML Single-logout, redirect back to IdP
+  window.location.replace(data?.sloUrl || redirectUrl);
 }
 
 export function removeAuthenticator(api: Client, userId: string, authId: string) {

--- a/static/app/actionCreators/account.tsx
+++ b/static/app/actionCreators/account.tsx
@@ -1,3 +1,5 @@
+import {redirect} from 'react-router-dom';
+
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {Client} from 'sentry/api';
 import ConfigStore from 'sentry/stores/configStore';
@@ -50,7 +52,7 @@ export async function logout(api: Client, redirectUrl = '/auth/login/') {
   const data = await api.requestPromise('/auth/', {method: 'DELETE'});
 
   // If there's a URL for SAML Single-logout, redirect back to IdP
-  window.location.assign(data?.sloUrl || redirectUrl);
+  redirect(data?.sloUrl || redirectUrl);
 }
 
 export function removeAuthenticator(api: Client, userId: string, authId: string) {

--- a/static/app/components/modals/sudoModal.tsx
+++ b/static/app/components/modals/sudoModal.tsx
@@ -222,22 +222,13 @@ function SudoModal({
     return authLoginPath;
   };
 
-  const handleLogout = async () => {
-    try {
-      await logout(api);
-    } catch {
-      // ignore errors
-    }
-    window.location.assign(getAuthLoginPath());
-  };
-
   const renderBodyContent = () => {
     const user = ConfigStore.get('user');
     const isSelfHosted = ConfigStore.get('isSelfHosted');
     const validateSUForm = ConfigStore.get('validateSUForm');
 
     if (errorType === ErrorCodes.INVALID_SSO_SESSION) {
-      handleLogout();
+      logout(api, getAuthLoginPath());
       return null;
     }
 

--- a/static/app/components/narrowLayout.tsx
+++ b/static/app/components/narrowLayout.tsx
@@ -21,6 +21,10 @@ function NarrowLayout({maxWidth, showLogout, children}: Props) {
     return () => document.body.classList.remove('narrow');
   }, []);
 
+  function handleLogout() {
+    logout(api);
+  }
+
   return (
     <div className="app">
       <div className="pattern-bg" />
@@ -31,7 +35,7 @@ function NarrowLayout({maxWidth, showLogout, children}: Props) {
               <IconSentry size="lg" />
             </a>
             {showLogout && (
-              <a className="logout pull-right" onClick={() => logout(api)}>
+              <a className="logout pull-right" onClick={handleLogout}>
                 <Logout>{t('Sign out')}</Logout>
               </a>
             )}

--- a/static/app/components/narrowLayout.tsx
+++ b/static/app/components/narrowLayout.tsx
@@ -21,11 +21,6 @@ function NarrowLayout({maxWidth, showLogout, children}: Props) {
     return () => document.body.classList.remove('narrow');
   }, []);
 
-  async function handleLogout() {
-    await logout(api);
-    window.location.assign('/auth/login');
-  }
-
   return (
     <div className="app">
       <div className="pattern-bg" />
@@ -36,7 +31,7 @@ function NarrowLayout({maxWidth, showLogout, children}: Props) {
               <IconSentry size="lg" />
             </a>
             {showLogout && (
-              <a className="logout pull-right" onClick={handleLogout}>
+              <a className="logout pull-right" onClick={() => logout(api)}>
                 <Logout>{t('Sign out')}</Logout>
               </a>
             )}

--- a/static/app/components/sidebar/index.spec.tsx
+++ b/static/app/components/sidebar/index.spec.tsx
@@ -7,6 +7,7 @@ import {UserFixture} from 'sentry-fixture/user';
 
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {logout} from 'sentry/actionCreators/account';
 import {OnboardingContextProvider} from 'sentry/components/onboarding/onboardingContext';
 import SidebarContainer from 'sentry/components/sidebar';
 import ConfigStore from 'sentry/stores/configStore';
@@ -16,6 +17,7 @@ import localStorage from 'sentry/utils/localStorage';
 import {useLocation} from 'sentry/utils/useLocation';
 import * as incidentsHook from 'sentry/utils/useServiceIncidents';
 
+jest.mock('sentry/actionCreators/account');
 jest.mock('sentry/utils/useServiceIncidents');
 jest.mock('sentry/utils/useLocation');
 
@@ -122,13 +124,6 @@ describe('Sidebar', function () {
   });
 
   it('has can logout', async function () {
-    const mock = MockApiClient.addMockResponse({
-      url: '/auth/',
-      method: 'DELETE',
-      status: 204,
-    });
-    jest.spyOn(window.location, 'assign').mockImplementation(() => {});
-
     renderSidebar({
       organization: OrganizationFixture({access: ['member:read']}),
     });
@@ -136,9 +131,7 @@ describe('Sidebar', function () {
     await userEvent.click(await screen.findByTestId('sidebar-dropdown'));
     await userEvent.click(screen.getByTestId('sidebar-signout'));
 
-    await waitFor(() => expect(mock).toHaveBeenCalled());
-
-    expect(window.location.assign).toHaveBeenCalledWith('/auth/login/');
+    await waitFor(() => expect(logout).toHaveBeenCalled());
   });
 
   it('can toggle help menu', async function () {

--- a/static/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.tsx
@@ -54,6 +54,10 @@ export default function SidebarDropdown({orientation, collapsed, hideOrgLinks}: 
   const hasTeamRead = org?.access?.includes('team:read');
   const canCreateOrg = ConfigStore.get('features').has('organizations:create');
 
+  function handleLogout() {
+    logout(api);
+  }
+
   // Avatar to use: Organization --> user --> Sentry
   const avatar =
     hasOrganization || hasUser ? (
@@ -160,7 +164,7 @@ export default function SidebarDropdown({orientation, collapsed, hideOrgLinks}: 
                       )}
                       <SidebarMenuItem
                         data-test-id="sidebar-signout"
-                        onClick={() => logout(api)}
+                        onClick={handleLogout}
                       >
                         {t('Sign out')}
                       </SidebarMenuItem>

--- a/static/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.tsx
@@ -44,11 +44,6 @@ export default function SidebarDropdown({orientation, collapsed, hideOrgLinks}: 
   const user = useUser();
   const {projects} = useProjects();
 
-  const handleLogout = async () => {
-    await logout(api);
-    window.location.assign('/auth/login/');
-  };
-
   const hasOrganization = !!org;
   const hasUser = !!user;
 
@@ -165,7 +160,7 @@ export default function SidebarDropdown({orientation, collapsed, hideOrgLinks}: 
                       )}
                       <SidebarMenuItem
                         data-test-id="sidebar-signout"
-                        onClick={handleLogout}
+                        onClick={() => logout(api)}
                       >
                         {t('Sign out')}
                       </SidebarMenuItem>

--- a/static/app/components/superuserStaffAccessForm.tsx
+++ b/static/app/components/superuserStaffAccessForm.tsx
@@ -163,21 +163,15 @@ class SuperuserStaffAccessForm extends Component<Props, State> {
     });
   };
 
-  handleLogout = async () => {
-    const {api} = this.props;
-    try {
-      await logout(api);
-    } catch {
-      // ignore errors
-    }
-    const authLoginPath = `/auth/login/?next=${encodeURIComponent(window.location.href)}`;
+  handleLogout = () => {
+    let nextUrl = `/auth/login/?next=${encodeURIComponent(window.location.href)}`;
+
     const {superuserUrl} = window.__initialData.links;
     if (window.__initialData?.customerDomain && superuserUrl) {
-      const redirectURL = `${trimEnd(superuserUrl, '/')}${authLoginPath}`;
-      window.location.assign(redirectURL);
-      return;
+      nextUrl = `${trimEnd(superuserUrl, '/')}${nextUrl}`;
     }
-    window.location.assign(authLoginPath);
+
+    logout(this.props.api, nextUrl);
   };
 
   async getAuthenticators() {

--- a/static/app/components/superuserStaffAccessForm.tsx
+++ b/static/app/components/superuserStaffAccessForm.tsx
@@ -1,6 +1,5 @@
 import React, {Component} from 'react';
 import styled from '@emotion/styled';
-import trimEnd from 'lodash/trimEnd';
 
 import {logout} from 'sentry/actionCreators/account';
 import type {Client} from 'sentry/api';
@@ -164,14 +163,16 @@ class SuperuserStaffAccessForm extends Component<Props, State> {
   };
 
   handleLogout = () => {
-    let nextUrl = `/auth/login/?next=${encodeURIComponent(window.location.href)}`;
+    const {superuserUrl} = window.__initialData?.links;
+    const urlOrigin =
+      window.__initialData?.customerDomain && superuserUrl
+        ? superuserUrl
+        : window.location.origin;
 
-    const {superuserUrl} = window.__initialData.links;
-    if (window.__initialData?.customerDomain && superuserUrl) {
-      nextUrl = `${trimEnd(superuserUrl, '/')}${nextUrl}`;
-    }
+    const nextUrl = new URL('/auth/login/', urlOrigin);
+    nextUrl.searchParams.set('next', window.location.href);
 
-    logout(this.props.api, nextUrl);
+    logout(this.props.api, nextUrl.toString());
   };
 
   async getAuthenticators() {

--- a/static/app/views/acceptOrganizationInvite/index.spec.tsx
+++ b/static/app/views/acceptOrganizationInvite/index.spec.tsx
@@ -245,11 +245,8 @@ describe('AcceptOrganizationInvite', function () {
     );
 
     expect(screen.getByTestId('existing-member')).toBeInTheDocument();
-
     await userEvent.click(screen.getByTestId('existing-member-link'));
-
     await waitFor(() => expect(logout).toHaveBeenCalled());
-    await waitFor(() => expect(window.location.assign).toHaveBeenCalled());
   });
 
   it('shows right options for logged in user and optional SSO', function () {
@@ -294,9 +291,7 @@ describe('AcceptOrganizationInvite', function () {
 
     expect(screen.getByTestId('existing-member')).toBeInTheDocument();
     await userEvent.click(screen.getByTestId('existing-member-link'));
-
     await waitFor(() => expect(logout).toHaveBeenCalled());
-    await waitFor(() => expect(window.location.assign).toHaveBeenCalled());
   });
 
   it('shows 2fa warning', function () {

--- a/static/app/views/acceptOrganizationInvite/index.spec.tsx
+++ b/static/app/views/acceptOrganizationInvite/index.spec.tsx
@@ -248,8 +248,8 @@ describe('AcceptOrganizationInvite', function () {
 
     await userEvent.click(screen.getByTestId('existing-member-link'));
 
-    expect(logout).toHaveBeenCalled();
-    await waitFor(() => expect(window.location.replace).toHaveBeenCalled());
+    await waitFor(() => expect(logout).toHaveBeenCalled());
+    await waitFor(() => expect(window.location.assign).toHaveBeenCalled());
   });
 
   it('shows right options for logged in user and optional SSO', function () {
@@ -295,8 +295,8 @@ describe('AcceptOrganizationInvite', function () {
     expect(screen.getByTestId('existing-member')).toBeInTheDocument();
     await userEvent.click(screen.getByTestId('existing-member-link'));
 
-    expect(logout).toHaveBeenCalled();
-    await waitFor(() => expect(window.location.replace).toHaveBeenCalled());
+    await waitFor(() => expect(logout).toHaveBeenCalled());
+    await waitFor(() => expect(window.location.assign).toHaveBeenCalled());
   });
 
   it('shows 2fa warning', function () {

--- a/static/app/views/acceptOrganizationInvite/index.tsx
+++ b/static/app/views/acceptOrganizationInvite/index.tsx
@@ -61,10 +61,9 @@ class AcceptOrganizationInvite extends DeprecatedAsyncView<Props, State> {
     return t('Accept Organization Invite');
   }
 
-  handleLogout = async (e: React.MouseEvent) => {
+  handleLogout = (e: React.MouseEvent) => {
     e.preventDefault();
-    await logout(this.api);
-    window.location.replace('/auth/login/');
+    logout(this.api);
   };
 
   handleAcceptInvite = async () => {


### PR DESCRIPTION
Related to https://github.com/getsentry/sentry/pull/77033

If a SLO URL is returned by the logout API, we will redirect the browser to that URL. This is needed for Single-Logout to work, because we need the browser to clear the cookies that are attached to the IdP's domain.