### PR TITLE
fix(groupIndex): fix useGroupSnubaDataset url param check

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -171,7 +171,8 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
 
                 def use_group_snuba_dataset() -> bool:
                     # if useGroupSnubaDataset is present, override the flag so we can test the new dataset
-                    if request.GET.get("useGroupSnubaDataset"):
+                    req_param_value: str | None = request.GET.get("useGroupSnubaDataset")
+                    if req_param_value and req_param_value.lower() == "true":
                         return True
 
                     if not features.has("organizations:issue-search-snuba", organization):


### PR DESCRIPTION
Was doing some local testing playing with this param, and it turns out url params are always strings so this condition always evaluates to True.

This should be pretty low-impact since it looks like use_group_snuba_dataset isn't currently used in executors.py. It's not in tests either.