### PR TITLE
chore(django): Rename `DefaultFieldsModel`

### DIFF
--- a/src/sentry/data_secrecy/models/datasecrecywaiver.py
+++ b/src/sentry/data_secrecy/models/datasecrecywaiver.py
@@ -2,11 +2,16 @@ from django.db import models
 from django.utils import timezone
 
 from sentry.backup.scopes import RelocationScope
-from sentry.db.models import ArrayField, DefaultFieldsModel, FlexibleForeignKey, region_silo_model
+from sentry.db.models import (
+    ArrayField,
+    DefaultFieldsModelExisting,
+    FlexibleForeignKey,
+    region_silo_model,
+)
 
 
 @region_silo_model
-class DataSecrecyWaiver(DefaultFieldsModel):
+class DataSecrecyWaiver(DefaultFieldsModelExisting):
     __relocation_scope__ = RelocationScope.Organization
 
     organization = FlexibleForeignKey("sentry.Organization", unique=True)

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -29,6 +29,7 @@ __all__ = (
     "BaseModel",
     "Model",
     "DefaultFieldsModelExisting",
+    "DefaultFieldsModel",
     "sane_repr",
     "get_model_if_available",
     "control_silo_model",
@@ -334,16 +335,8 @@ class DefaultFieldsModelExisting(Model):
         abstract = True
 
 
-class DefaultFieldsModel(Model):
-    """
-    A base model that adds default date fields to a model and auto updates them.
-    """
-
-    date_added = models.DateTimeField(auto_now_add=True)
-    date_updated = models.DateTimeField(auto_now=True)
-
-    class Meta:
-        abstract = True
+# Temporary mapping so we can fix getsentry
+DefaultFieldsModel = DefaultFieldsModelExisting
 
 
 def __model_pre_save(instance: models.Model, **kwargs: Any) -> None:

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -28,7 +28,7 @@ from .query import update
 __all__ = (
     "BaseModel",
     "Model",
-    "DefaultFieldsModel",
+    "DefaultFieldsModelExisting",
     "sane_repr",
     "get_model_if_available",
     "control_silo_model",
@@ -321,7 +321,12 @@ class Model(BaseModel):
     __repr__ = sane_repr("id")
 
 
-class DefaultFieldsModel(Model):
+class DefaultFieldsModelExisting(Model):
+    """
+    A base model that adds default date fields to existing models. Don't use this on new models, since it makes `date_added`
+    nullable.
+    """
+
     date_updated = models.DateTimeField(default=timezone.now)
     date_added = models.DateTimeField(default=timezone.now, null=True)
 
@@ -329,8 +334,20 @@ class DefaultFieldsModel(Model):
         abstract = True
 
 
+class DefaultFieldsModel(Model):
+    """
+    A base model that adds default date fields to a model and auto updates them.
+    """
+
+    date_added = models.DateTimeField(auto_now_add=True)
+    date_updated = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        abstract = True
+
+
 def __model_pre_save(instance: models.Model, **kwargs: Any) -> None:
-    if not isinstance(instance, DefaultFieldsModel):
+    if not isinstance(instance, DefaultFieldsModelExisting):
         return
     # Only update this field when we're updating the row, not on create.
     if instance.pk is not None:

--- a/src/sentry/integrations/models/integration.py
+++ b/src/sentry/integrations/models/integration.py
@@ -9,7 +9,11 @@ from sentry.backup.dependencies import NormalizedModelName, get_model_name
 from sentry.backup.sanitize import SanitizableField, Sanitizer
 from sentry.backup.scopes import RelocationScope
 from sentry.constants import ObjectStatus
-from sentry.db.models import BoundedPositiveIntegerField, DefaultFieldsModel, control_silo_model
+from sentry.db.models import (
+    BoundedPositiveIntegerField,
+    DefaultFieldsModelExisting,
+    control_silo_model,
+)
 from sentry.db.models.fields.jsonfield import JSONField
 from sentry.db.models.manager.base import BaseManager
 from sentry.hybridcloud.models.outbox import ControlOutbox, outbox_context
@@ -42,7 +46,7 @@ class IntegrationManager(BaseManager["Integration"]):
 
 
 @control_silo_model
-class Integration(DefaultFieldsModel):
+class Integration(DefaultFieldsModelExisting):
     """
     An integration tied to a particular instance of a third-party provider (a single Slack
     workspace, a single GH org, etc.), which can be shared by multiple Sentry orgs.

--- a/src/sentry/integrations/models/repository_project_path_config.py
+++ b/src/sentry/integrations/models/repository_project_path_config.py
@@ -4,7 +4,7 @@ from django.db.models.signals import post_save
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedBigIntegerField,
-    DefaultFieldsModel,
+    DefaultFieldsModelExisting,
     FlexibleForeignKey,
     region_silo_model,
 )
@@ -12,7 +12,7 @@ from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignK
 
 
 @region_silo_model
-class RepositoryProjectPathConfig(DefaultFieldsModel):
+class RepositoryProjectPathConfig(DefaultFieldsModelExisting):
     __relocation_scope__ = RelocationScope.Excluded
 
     repository = FlexibleForeignKey("sentry.Repository")

--- a/src/sentry/models/groupsearchview.py
+++ b/src/sentry/models/groupsearchview.py
@@ -3,14 +3,14 @@ from django.db.models import UniqueConstraint
 
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import region_silo_model
-from sentry.db.models.base import DefaultFieldsModel
+from sentry.db.models.base import DefaultFieldsModelExisting
 from sentry.db.models.fields.foreignkey import FlexibleForeignKey
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.models.savedsearch import SortOptions
 
 
 @region_silo_model
-class GroupSearchView(DefaultFieldsModel):
+class GroupSearchView(DefaultFieldsModelExisting):
     """
     A model for a user's view of the issue stream
     """

--- a/src/sentry/models/importchunk.py
+++ b/src/sentry/models/importchunk.py
@@ -4,11 +4,11 @@ from django.db import models
 
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BoundedBigIntegerField, control_silo_model, region_silo_model
-from sentry.db.models.base import DefaultFieldsModel, sane_repr
+from sentry.db.models.base import DefaultFieldsModelExisting, sane_repr
 from sentry.db.models.fields.uuid import UUIDField
 
 
-class BaseImportChunk(DefaultFieldsModel):
+class BaseImportChunk(DefaultFieldsModelExisting):
     """
     Base class representing the map of import pks to final, post-import database pks.
     """

--- a/src/sentry/models/integrations/sentry_app_installation_for_provider.py
+++ b/src/sentry/models/integrations/sentry_app_installation_for_provider.py
@@ -1,12 +1,12 @@
 from django.db import models
 
 from sentry.backup.scopes import RelocationScope
-from sentry.db.models import DefaultFieldsModel, FlexibleForeignKey, control_silo_model
+from sentry.db.models import DefaultFieldsModelExisting, FlexibleForeignKey, control_silo_model
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 
 
 @control_silo_model
-class SentryAppInstallationForProvider(DefaultFieldsModel):
+class SentryAppInstallationForProvider(DefaultFieldsModelExisting):
     """Connects a sentry app installation to an organization and a provider."""
 
     __relocation_scope__ = RelocationScope.Excluded

--- a/src/sentry/models/notificationsettingbase.py
+++ b/src/sentry/models/notificationsettingbase.py
@@ -3,11 +3,11 @@ from django.conf import settings
 from django.db import models
 
 from sentry.backup.scopes import RelocationScope
-from sentry.db.models import BoundedBigIntegerField, DefaultFieldsModel, FlexibleForeignKey
+from sentry.db.models import BoundedBigIntegerField, DefaultFieldsModelExisting, FlexibleForeignKey
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 
 
-class NotificationSettingBase(DefaultFieldsModel):
+class NotificationSettingBase(DefaultFieldsModelExisting):
     __relocation_scope__ = RelocationScope.Excluded
 
     scope_type = models.CharField(max_length=32, null=False)

--- a/src/sentry/models/projecttemplate.py
+++ b/src/sentry/models/projecttemplate.py
@@ -1,11 +1,16 @@
 from django.db import models
 
 from sentry.backup.scopes import RelocationScope
-from sentry.db.models import DefaultFieldsModel, FlexibleForeignKey, region_silo_model, sane_repr
+from sentry.db.models import (
+    DefaultFieldsModelExisting,
+    FlexibleForeignKey,
+    region_silo_model,
+    sane_repr,
+)
 
 
 @region_silo_model
-class ProjectTemplate(DefaultFieldsModel):
+class ProjectTemplate(DefaultFieldsModelExisting):
     """
     Identifies a project template that can be used to create new projects.
 

--- a/src/sentry/models/relocation.py
+++ b/src/sentry/models/relocation.py
@@ -7,7 +7,7 @@ from django.db import models
 
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BoundedBigIntegerField, region_silo_model
-from sentry.db.models.base import DefaultFieldsModel, sane_repr
+from sentry.db.models.base import DefaultFieldsModelExisting, sane_repr
 from sentry.db.models.fields.foreignkey import FlexibleForeignKey
 from sentry.db.models.fields.uuid import UUIDField
 
@@ -17,7 +17,7 @@ def default_guid():
 
 
 @region_silo_model
-class Relocation(DefaultFieldsModel):
+class Relocation(DefaultFieldsModelExisting):
     """
     Represents a single relocation instance. The relocation may be attempted multiple times, but we
     keep a mapping of 1 `Relocation` model per file upload.
@@ -181,7 +181,7 @@ class Relocation(DefaultFieldsModel):
 
 
 @region_silo_model
-class RelocationFile(DefaultFieldsModel):
+class RelocationFile(DefaultFieldsModelExisting):
     """
     A `RelocationFile` is an association between a `Relocation` and a `File`.
 
@@ -274,7 +274,7 @@ class ValidationStatus(Enum):
 
 
 @region_silo_model
-class RelocationValidation(DefaultFieldsModel):
+class RelocationValidation(DefaultFieldsModelExisting):
     """
     Stores general information about whether or not the associated `Relocation` passed its
     validation run.
@@ -302,7 +302,7 @@ class RelocationValidation(DefaultFieldsModel):
 
 
 @region_silo_model
-class RelocationValidationAttempt(DefaultFieldsModel):
+class RelocationValidationAttempt(DefaultFieldsModelExisting):
     """
     Represents a single Google CloudBuild validation run invocation, and tracks it over its
     lifetime.

--- a/src/sentry/models/transaction_threshold.py
+++ b/src/sentry/models/transaction_threshold.py
@@ -3,7 +3,7 @@ from enum import Enum
 from django.db import models
 
 from sentry.backup.scopes import RelocationScope
-from sentry.db.models import DefaultFieldsModel, FlexibleForeignKey, region_silo_model
+from sentry.db.models import DefaultFieldsModelExisting, FlexibleForeignKey, region_silo_model
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.utils.cache import cache
 from sentry.utils.hashlib import md5_text
@@ -52,7 +52,7 @@ def _filter_and_cache(cls, cache_key, project_ids, organization_id, order_by, va
 
 
 @region_silo_model
-class ProjectTransactionThresholdOverride(DefaultFieldsModel):
+class ProjectTransactionThresholdOverride(DefaultFieldsModelExisting):
     __relocation_scope__ = RelocationScope.Excluded
 
     # max_length here is based on the maximum for transactions in relay
@@ -82,7 +82,7 @@ class ProjectTransactionThresholdOverride(DefaultFieldsModel):
 
 
 @region_silo_model
-class ProjectTransactionThreshold(DefaultFieldsModel):
+class ProjectTransactionThreshold(DefaultFieldsModelExisting):
     __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project", unique=True, db_constraint=False)

--- a/src/sentry/sentry_metrics/models/spanattributeextractionrules.py
+++ b/src/sentry/sentry_metrics/models/spanattributeextractionrules.py
@@ -6,14 +6,19 @@ from django.db import models
 from django.db.models import CASCADE
 
 from sentry.backup.scopes import RelocationScope
-from sentry.db.models import ArrayField, DefaultFieldsModel, FlexibleForeignKey, region_silo_model
+from sentry.db.models import (
+    ArrayField,
+    DefaultFieldsModelExisting,
+    FlexibleForeignKey,
+    region_silo_model,
+)
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.models.project import Project
 from sentry.sentry_metrics.configuration import HARD_CODED_UNITS
 
 
 @region_silo_model
-class SpanAttributeExtractionRuleCondition(DefaultFieldsModel):
+class SpanAttributeExtractionRuleCondition(DefaultFieldsModelExisting):
     __relocation_scope__ = RelocationScope.Organization
 
     created_by_id = HybridCloudForeignKey("sentry.User", on_delete="SET_NULL", null=True)
@@ -34,7 +39,7 @@ class SpanAttributeExtractionRuleCondition(DefaultFieldsModel):
 
 
 @region_silo_model
-class SpanAttributeExtractionRuleConfig(DefaultFieldsModel):
+class SpanAttributeExtractionRuleConfig(DefaultFieldsModelExisting):
     __relocation_scope__ = RelocationScope.Organization
 
     created_by_id = HybridCloudForeignKey("sentry.User", on_delete="SET_NULL", null=True)

--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -7,7 +7,7 @@ from django.db import models
 from django.db.models import Q
 
 from sentry.backup.scopes import RelocationScope
-from sentry.db.models import DefaultFieldsModel, FlexibleForeignKey, region_silo_model
+from sentry.db.models import DefaultFieldsModelExisting, FlexibleForeignKey, region_silo_model
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.db.models.manager.base import BaseManager
 from sentry.models.organization import Organization
@@ -17,7 +17,7 @@ from sentry.utils.function_cache import cache_func_for_models
 
 
 @region_silo_model
-class UptimeSubscription(BaseRemoteSubscription, DefaultFieldsModel):
+class UptimeSubscription(BaseRemoteSubscription, DefaultFieldsModelExisting):
     # TODO: This should be included in export/import, but right now it has no relation to
     # any projects/orgs. Will fix this in a later pr
     __relocation_scope__ = RelocationScope.Excluded
@@ -70,7 +70,7 @@ class UptimeStatus(enum.IntEnum):
 
 
 @region_silo_model
-class ProjectUptimeSubscription(DefaultFieldsModel):
+class ProjectUptimeSubscription(DefaultFieldsModelExisting):
     # TODO: This should be included in export/import, but right now it has no relation to
     # any projects/orgs. Will fix this in a later pr
     __relocation_scope__ = RelocationScope.Excluded

--- a/tests/sentry/backup/test_sanitize.py
+++ b/tests/sentry/backup/test_sanitize.py
@@ -24,7 +24,7 @@ from sentry.backup.sanitize import (
     sanitize,
 )
 from sentry.backup.scopes import RelocationScope
-from sentry.db.models.base import DefaultFieldsModel
+from sentry.db.models.base import DefaultFieldsModelExisting
 from sentry.db.models.fields.jsonfield import JSONField
 from sentry.db.models.fields.slug import SentrySlugField
 from sentry.db.models.fields.uuid import UUIDField
@@ -55,7 +55,7 @@ FAKE_DATE_ADDED = CURR_DATE - timedelta(days=7)
 FAKE_DATE_UPDATED = CURR_DATE - timedelta(days=6)
 
 
-class FakeSanitizableModel(DefaultFieldsModel):
+class FakeSanitizableModel(DefaultFieldsModelExisting):
     __relocation_scope__ = RelocationScope.Excluded
 
     email = models.EmailField(null=True, max_length=75)


### PR DESCRIPTION
The current `DefaultFieldsModel` creates nullable fields for these default columns, which breaks type hinting in some cases.

This renames the model. We can't create the new one yet, since we need to update models in getsentry to rename their base model too
