### PR TITLE
fix(replay): fix read more link in proj settings

### DIFF
--- a/static/app/views/settings/project/projectReplays.tsx
+++ b/static/app/views/settings/project/projectReplays.tsx
@@ -69,7 +69,7 @@ function ProjectReplaySettings({organization, project, params: {projectId}}: Pro
         action={
           <LinkButton
             external
-            href="https://docs.sentry.io/product/session-replay/replay-page-and-filters/"
+            href="https://docs.sentry.io/product/issues/issue-details/replay-issues/"
           >
             {t('Read the Docs')}
           </LinkButton>


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/72124

linking to https://docs.sentry.io/product/issues/issue-details/replay-issues/ instead. right now the button is linking to https://docs.sentry.io/product/explore/session-replay/replay-page-and-filters/ which is just a generic replay docs page

<img width="901" alt="SCR-20240905-ohbb" src="https://github.com/user-attachments/assets/16815b4d-b05b-4f6b-a7b6-1e699ac0820e">
