### PR TITLE
ref(integrations): Switch react-query remove for removeQueries

### DIFF
--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -85,7 +85,6 @@ function ConfigureIntegration({params, router, routes, location}: Props) {
     isPending: isLoadingConfig,
     isError: isErrorConfig,
     refetch: refetchConfig,
-    remove: removeConfig,
   } = useApiQuery<{
     providers: IntegrationProvider[];
   }>([`/organizations/${organization.slug}/config/integrations/`], {staleTime: 0});
@@ -94,7 +93,6 @@ function ConfigureIntegration({params, router, routes, location}: Props) {
     isPending: isLoadingIntegration,
     isError: isErrorIntegration,
     refetch: refetchIntegration,
-    remove: removeIntegration,
   } = useApiQuery<OrganizationIntegration>(
     makeIntegrationQuery(organization, integrationId),
     {staleTime: 0}
@@ -104,7 +102,6 @@ function ConfigureIntegration({params, router, routes, location}: Props) {
     isPending: isLoadingPlugins,
     isError: isErrorPlugins,
     refetch: refetchPlugins,
-    remove: removePlugins,
   } = useApiQuery<PluginWithProjectList[] | null>(makePluginQuery(organization), {
     staleTime: 0,
   });
@@ -164,13 +161,17 @@ function ConfigureIntegration({params, router, routes, location}: Props) {
    * Refetch everything, this could be improved to reload only the right thing
    */
   const onUpdateIntegration = () => {
-    removePlugins();
+    queryClient.removeQueries({queryKey: makePluginQuery(organization)});
     refetchPlugins();
 
-    removeConfig();
+    queryClient.removeQueries({
+      queryKey: [`/organizations/${organization.slug}/config/integrations/`],
+    });
     refetchConfig();
 
-    removeIntegration();
+    queryClient.removeQueries({
+      queryKey: makeIntegrationQuery(organization, integrationId),
+    });
     refetchIntegration();
   };
 


### PR DESCRIPTION
remove is gone in v5 but we can still use removeQueries

part of https://github.com/getsentry/frontend-tsc/issues/52