### PR TITLE
ref(ui): Use object style arguments with react query

### DIFF
--- a/static/app/actionCreators/events.tsx
+++ b/static/app/actionCreators/events.tsx
@@ -298,7 +298,9 @@ export const useDeleteEventAttachmentOptimistic = (
       );
     },
     onMutate: async variables => {
-      await queryClient.cancelQueries(makeFetchEventAttachmentsQueryKey(variables));
+      await queryClient.cancelQueries({
+        queryKey: makeFetchEventAttachmentsQueryKey(variables),
+      });
 
       const previous = getApiQueryData<FetchEventAttachmentResponse>(
         queryClient,

--- a/static/app/components/dynamicSampling/investigationRule.tsx
+++ b/static/app/components/dynamicSampling/investigationRule.tsx
@@ -135,13 +135,13 @@ function useCreateInvestigationRuleMutation() {
     onSuccess: (_data, variables) => {
       addSuccessMessage(t('Successfully created investigation rule'));
       // invalidate the rule-exists query
-      queryClient.invalidateQueries(
-        makeRuleExistsQueryKey(
+      queryClient.invalidateQueries({
+        queryKey: makeRuleExistsQueryKey(
           variables.query,
           variables.projects,
           variables.organization
-        )
-      );
+        ),
+      });
       trackAnalytics('dynamic_sampling.custom_rule_add', {
         organization: variables.organization,
         projects: variables.projects,

--- a/static/app/utils/metrics/useBlockMetric.tsx
+++ b/static/app/utils/metrics/useBlockMetric.tsx
@@ -32,7 +32,7 @@ export const useBlockMetric = (project: Project) => {
   const {slug} = useOrganization();
   const queryClient = useQueryClient();
 
-  const options = {
+  return useMutation({
     mutationFn: (data: BlockMutationData) => {
       return api.requestPromise(`/projects/${slug}/${project.slug}/metrics/visibility/`, {
         method: 'PUT',
@@ -84,7 +84,5 @@ export const useBlockMetric = (project: Project) => {
     onError: () => {
       addErrorMessage(t('An error occurred while updating the metric'));
     },
-  };
-
-  return useMutation(options);
+  });
 };

--- a/static/app/views/issueList/mutations/useDeleteSavedSearch.tsx
+++ b/static/app/views/issueList/mutations/useDeleteSavedSearch.tsx
@@ -44,9 +44,9 @@ export const useDeleteSavedSearchOptimistic = (
       });
     },
     onMutate: async variables => {
-      await queryClient.cancelQueries(
-        makeFetchSavedSearchesForOrgQueryKey({orgSlug: variables.orgSlug})
-      );
+      await queryClient.cancelQueries({
+        queryKey: makeFetchSavedSearchesForOrgQueryKey({orgSlug: variables.orgSlug}),
+      });
 
       const previousSavedSearches = getApiQueryData<SavedSearch[]>(
         queryClient,

--- a/static/app/views/settings/account/accountEmails.tsx
+++ b/static/app/views/settings/account/accountEmails.tsx
@@ -33,7 +33,7 @@ function AccountEmails() {
   const queryClient = useQueryClient();
 
   const handleSubmitSuccess: FormProps['onSubmitSuccess'] = (_change, model, id) => {
-    queryClient.invalidateQueries(makeEmailsEndpointKey());
+    queryClient.invalidateQueries({queryKey: makeEmailsEndpointKey()});
 
     if (id === undefined) {
       return;

--- a/static/app/views/settings/account/accountSecurity/accountSecurityWrapper.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityWrapper.tsx
@@ -37,26 +37,24 @@ function AccountSecurityWrapper({children}: Props) {
     emailsRequest.refetch();
   }, [orgRequest, authenticatorsRequest, emailsRequest]);
 
-  const disableAuthenticatorMutation = useMutation(
-    async (auth: Authenticator) => {
+  const disableAuthenticatorMutation = useMutation({
+    mutationFn: async (auth: Authenticator) => {
       if (!auth || !auth.authId) {
         return;
       }
 
       await api.requestPromise(`${ENDPOINT}${auth.authId}/`, {method: 'DELETE'});
     },
-    {
-      onSuccess: () => {
-        handleRefresh();
-      },
-      onError: (_, auth) => {
-        addErrorMessage(t('Error disabling %s', auth.name));
-      },
-    }
-  );
+    onSuccess: () => {
+      handleRefresh();
+    },
+    onError: (_, auth) => {
+      addErrorMessage(t('Error disabling %s', auth.name));
+    },
+  });
 
-  const regenerateBackupCodesMutation = useMutation(
-    async () => {
+  const regenerateBackupCodesMutation = useMutation({
+    mutationFn: async () => {
       if (!authId) {
         return;
       }
@@ -65,15 +63,13 @@ function AccountSecurityWrapper({children}: Props) {
         method: 'PUT',
       });
     },
-    {
-      onSuccess: () => {
-        handleRefresh();
-      },
-      onError: () => {
-        addErrorMessage(t('Error regenerating backup codes'));
-      },
-    }
-  );
+    onSuccess: () => {
+      handleRefresh();
+    },
+    onError: () => {
+      addErrorMessage(t('Error regenerating backup codes'));
+    },
+  });
 
   if (
     orgRequest.isLoading ||

--- a/static/app/views/settings/account/apiApplications/details.tsx
+++ b/static/app/views/settings/account/apiApplications/details.tsx
@@ -57,36 +57,34 @@ function ApiApplicationsDetails() {
     staleTime: 0,
   });
 
-  const {mutate: rotateClientSecret} = useMutation<RotateClientSecretResponse>(
-    () => {
+  const {mutate: rotateClientSecret} = useMutation<RotateClientSecretResponse>({
+    mutationFn: () => {
       return api.requestPromise(`/api-applications/${appId}/rotate-secret/`, {
         method: 'POST',
       });
     },
-    {
-      onSuccess: data => {
-        openModal(({Body, Header}) => (
-          <Fragment>
-            <Header>{t('Your new Client Secret')}</Header>
-            <Body>
-              <Alert type="info" showIcon>
-                {t('This will be the only time your client secret is visible!')}
-              </Alert>
-              <TextCopyInput aria-label={t('new-client-secret')}>
-                {data.clientSecret}
-              </TextCopyInput>
-            </Body>
-          </Fragment>
-        ));
-      },
-      onError: () => {
-        addErrorMessage(t('Error rotating secret'));
-      },
-      onSettled: () => {
-        queryClient.invalidateQueries(getAppQueryKey(appId));
-      },
-    }
-  );
+    onSuccess: data => {
+      openModal(({Body, Header}) => (
+        <Fragment>
+          <Header>{t('Your new Client Secret')}</Header>
+          <Body>
+            <Alert type="info" showIcon>
+              {t('This will be the only time your client secret is visible!')}
+            </Alert>
+            <TextCopyInput aria-label={t('new-client-secret')}>
+              {data.clientSecret}
+            </TextCopyInput>
+          </Body>
+        </Fragment>
+      ));
+    },
+    onError: () => {
+      addErrorMessage(t('Error rotating secret'));
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({queryKey: getAppQueryKey(appId)});
+    },
+  });
 
   if (isPending) {
     return <LoadingIndicator />;

--- a/static/app/views/settings/organizationTeams/index.tsx
+++ b/static/app/views/settings/organizationTeams/index.tsx
@@ -61,7 +61,7 @@ export function OrganizationTeamsContainer(props: RouteComponentProps<{}, {}>) {
       setApiQueryData(queryClient, queryKey, newRequestList);
 
       // To be safer, trigger a refetch to ensure data is correct
-      queryClient.invalidateQueries(queryKey);
+      queryClient.invalidateQueries({queryKey});
 
       if (isApproved && requestToRemove) {
         const team = requestToRemove.team;

--- a/static/app/views/settings/projectDebugFiles/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/index.tsx
@@ -130,20 +130,20 @@ function ProjectDebugSymbols({organization, project, location, router, params}: 
       addSuccessMessage('Successfully deleted debug file');
 
       // invalidate debug files query
-      queryClient.invalidateQueries(
-        makeDebugFilesQueryKey({
+      queryClient.invalidateQueries({
+        queryKey: makeDebugFilesQueryKey({
           projectSlug: params.projectId,
           orgSlug: organization.slug,
           query,
-        })
-      );
+        }),
+      });
 
       // invalidate symbol sources query
-      queryClient.invalidateQueries(
-        makeSymbolSourcesQueryKey({
+      queryClient.invalidateQueries({
+        queryKey: makeSymbolSourcesQueryKey({
           orgSlug: organization.slug,
-        })
-      );
+        }),
+      });
     },
     onError: () => {
       addErrorMessage('Failed to delete debug file');


### PR DESCRIPTION
passing queryKey or the mutation function as the first argument and options as the 2nd is gone in react query v5

part of https://github.com/getsentry/frontend-tsc/issues/52
