### PR TITLE
fix(uptime): Fix downtime duration calculation from activity

### DIFF
--- a/static/app/components/events/interfaces/uptime/uptimeDataSection.spec.tsx
+++ b/static/app/components/events/interfaces/uptime/uptimeDataSection.spec.tsx
@@ -20,17 +20,17 @@ describe('Uptime Data Section', function () {
     const activity: GroupActivity[] = [
       {
         data: {},
-        id: '1',
-        dateCreated: '2024-06-20T20:36:51.884284Z',
-        project,
-        type: GroupActivityType.FIRST_SEEN,
-      },
-      {
-        data: {},
         id: '2',
         dateCreated: '2024-06-21T20:36:51.884284Z',
         project,
         type: GroupActivityType.SET_RESOLVED,
+      },
+      {
+        data: {},
+        id: '1',
+        dateCreated: '2024-06-20T20:36:51.884284Z',
+        project,
+        type: GroupActivityType.FIRST_SEEN,
       },
     ];
 
@@ -52,6 +52,66 @@ describe('Uptime Data Section', function () {
     render(<UptimeDataSection event={event} group={group} project={project} />);
 
     expect(screen.getByText('1 day')).toBeInTheDocument();
+
+    expect(screen.getByRole('button', {name: 'Uptime Alert Rule'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/alerts/rules/uptime/project-slug/1234/details/'
+    );
+  });
+
+  it('displays downtime according to multiple activities', function () {
+    const project = ProjectFixture();
+
+    const activity: GroupActivity[] = [
+      {
+        data: {},
+        id: '4',
+        dateCreated: '2024-06-22T22:36:51.884284Z',
+        project,
+        type: GroupActivityType.SET_RESOLVED,
+      },
+      {
+        data: {},
+        id: '3',
+        dateCreated: '2024-06-22T20:36:51.884284Z',
+        project,
+        type: GroupActivityType.SET_REGRESSION,
+      },
+      {
+        data: {},
+        id: '2',
+        dateCreated: '2024-06-21T20:36:51.884284Z',
+        project,
+        type: GroupActivityType.SET_RESOLVED,
+      },
+      {
+        data: {},
+        id: '1',
+        dateCreated: '2024-06-20T20:36:51.884284Z',
+        project,
+        type: GroupActivityType.FIRST_SEEN,
+      },
+    ];
+
+    const group = GroupFixture({
+      status: GroupStatus.RESOLVED,
+      issueCategory: IssueCategory.UPTIME,
+      activity,
+    });
+
+    const event = EventFixture({
+      tags: [
+        {
+          key: 'uptime_rule',
+          value: '1234',
+        },
+      ],
+    });
+
+    render(<UptimeDataSection event={event} group={group} project={project} />);
+
+    // Shows the second downtime duration
+    expect(screen.getByText('2 hours')).toBeInTheDocument();
 
     expect(screen.getByRole('button', {name: 'Uptime Alert Rule'})).toHaveAttribute(
       'href',

--- a/static/app/components/events/interfaces/uptime/uptimeDataSection.tsx
+++ b/static/app/components/events/interfaces/uptime/uptimeDataSection.tsx
@@ -24,6 +24,7 @@ interface Props {
 const DOWNTIME_START_TYPES = [
   GroupActivityType.SET_UNRESOLVED,
   GroupActivityType.FIRST_SEEN,
+  GroupActivityType.SET_REGRESSION,
 ];
 
 const DOWNTIME_TERMINAL_TYPES = [GroupActivityType.SET_RESOLVED];
@@ -31,10 +32,10 @@ const DOWNTIME_TERMINAL_TYPES = [GroupActivityType.SET_RESOLVED];
 export function UptimeDataSection({group, event, project}: Props) {
   const organization = useOrganization();
   const nowRef = useRef(new Date());
-  const downtimeStartActivity = group.activity.findLast(activity =>
+  const downtimeStartActivity = group.activity.find(activity =>
     DOWNTIME_START_TYPES.includes(activity.type)
   );
-  const downtimeEndActivity = group.activity.findLast(activity =>
+  const downtimeEndActivity = group.activity.find(activity =>
     DOWNTIME_TERMINAL_TYPES.includes(activity.type)
   );
 


### PR DESCRIPTION
A couple things were wrong here from before:

1. The activity is sorted in descending order by timestamp so I should be using `.find` not `.findLast`.
2. I also forgot to account for the regression activity which is the one that would automatically be created when a new uptime event is added to the uptime issue.