### PR TITLE
ref(releases): refactor set_commits

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -338,6 +338,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:relay-cardinality-limiter", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable the release details performance section
     manager.add("organizations:release-comparison-performance", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # enable new release set_commits functionality
+    manager.add("organizations:set-commits-updated", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable new release UI
     manager.add("organizations:releases-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:releases-v2-internal", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -1,8 +1,12 @@
+# Sort commit list in reverse order
 from __future__ import annotations
 
+import itertools
 import logging
+import re
 from collections.abc import Mapping, Sequence
-from typing import ClassVar
+from time import time
+from typing import ClassVar, TypedDict
 
 import orjson
 import sentry_sdk
@@ -14,8 +18,9 @@ from django.utils.translation import gettext_lazy as _
 from sentry_relay.exceptions import RelayError
 from sentry_relay.processing import parse_release
 
+from sentry import features
 from sentry.backup.scopes import RelocationScope
-from sentry.constants import BAD_RELEASE_CHARS, COMMIT_RANGE_DELIMITER
+from sentry.constants import BAD_RELEASE_CHARS, COMMIT_RANGE_DELIMITER, ObjectStatus
 from sentry.db.models import (
     ArrayField,
     BoundedBigIntegerField,
@@ -29,22 +34,39 @@ from sentry.db.models import (
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.db.models.indexes import IndexWithPostgresNameLimits
 from sentry.db.models.manager.base import BaseManager
+from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
+from sentry.locks import locks
+from sentry.models.activity import Activity
 from sentry.models.artifactbundle import ArtifactBundle
+from sentry.models.commitauthor import CommitAuthor
+from sentry.models.commitfilechange import CommitFileChange
+from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
+from sentry.models.groupinbox import GroupInbox, GroupInboxRemoveAction, remove_group_from_inbox
 from sentry.models.releases.constants import (
     DB_VERSION_LENGTH,
     ERR_RELEASE_HEALTH_DATA,
     ERR_RELEASE_REFERENCED,
 )
-from sentry.models.releases.exceptions import UnsafeReleaseDeletion
+from sentry.models.releases.exceptions import ReleaseCommitError, UnsafeReleaseDeletion
 from sentry.models.releases.release_project import ReleaseProject
 from sentry.models.releases.util import ReleaseQuerySet, SemverFilter, SemverVersion
+from sentry.signals import issue_resolved
+from sentry.users.services.user import RpcUser
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 from sentry.utils.db import atomic_transaction
 from sentry.utils.hashlib import hash_values, md5_text
 from sentry.utils.numbers import validate_bigint
+from sentry.utils.retries import TimedRetryPolicy
+from sentry.utils.strings import truncatechars
 
 logger = logging.getLogger(__name__)
+
+
+class _CommitDataKwargs(TypedDict, total=False):
+    author: CommitAuthor
+    message: str
+    date_added: str
 
 
 class ReleaseStatus:
@@ -641,9 +663,293 @@ class Release(Model):
         commits.
         """
         sentry_sdk.set_measurement("release.set_commits", len(commit_list))
-        from sentry.models.releases.set_commits import set_commits
+        if features.has("organizations:set-commits-updated", self.organization):
+            from sentry.models.releases.set_commits import set_commits
 
-        set_commits(self, commit_list)
+            set_commits(self, commit_list)
+        else:
+            # old logic that will be deleted after we get rid of the feature flag
+            sentry_sdk.set_measurement("release.set_commits", len(commit_list))
+
+            # Sort commit list in reverse order
+            commit_list.sort(key=lambda commit: commit.get("timestamp", 0), reverse=True)
+
+            # TODO(dcramer): this function could use some cleanup/refactoring as it's a bit unwieldy
+            from sentry.integrations.tasks.kick_off_status_syncs import kick_off_status_syncs
+            from sentry.models.commit import Commit
+            from sentry.models.group import Group, GroupStatus
+            from sentry.models.grouplink import GroupLink
+            from sentry.models.groupresolution import GroupResolution
+            from sentry.models.pullrequest import PullRequest
+            from sentry.models.releasecommit import ReleaseCommit
+            from sentry.models.releaseheadcommit import ReleaseHeadCommit
+            from sentry.models.repository import Repository
+            from sentry.plugins.providers.repository import RepositoryProvider
+
+            # todo(meredith): implement for IntegrationRepositoryProvider
+            commit_list = [
+                c
+                for c in commit_list
+                if not RepositoryProvider.should_ignore_commit(c.get("message", ""))
+            ]
+            lock_key = type(self).get_lock_key(self.organization_id, self.id)
+            lock = locks.get(lock_key, duration=10, name="release_set_commits")
+            if lock.locked():
+                # Signal failure to the consumer rapidly. This aims to prevent the number
+                # of timeouts and prevent web worker exhaustion when customers create
+                # the same release rapidly for different projects.
+                raise ReleaseCommitError
+            with TimedRetryPolicy(10)(lock.acquire):
+                start = time()
+                with (
+                    atomic_transaction(using=router.db_for_write(type(self))),
+                    in_test_hide_transaction_boundary(),
+                ):
+                    # TODO(dcramer): would be good to optimize the logic to avoid these
+                    # deletes but not overly important
+                    ReleaseCommit.objects.filter(release=self).delete()
+
+                    authors = {}
+                    repos = {}
+                    commit_author_by_commit = {}
+                    head_commit_by_repo: dict[int, int] = {}
+                    latest_commit = None
+                    for idx, data in enumerate(commit_list):
+                        repo_name = data.get("repository") or f"organization-{self.organization_id}"
+                        if repo_name not in repos:
+                            repo = (
+                                Repository.objects.filter(
+                                    organization_id=self.organization_id,
+                                    name=repo_name,
+                                    status=ObjectStatus.ACTIVE,
+                                )
+                                .order_by("-pk")
+                                .first()
+                            )
+
+                            if repo is None:
+                                repo = Repository.objects.create(
+                                    organization_id=self.organization_id,
+                                    name=repo_name,
+                                )
+
+                            repos[repo_name] = repo
+                        else:
+                            repo = repos[repo_name]
+
+                        author_email = data.get("author_email")
+                        if author_email is None and data.get("author_name"):
+                            author_email = (
+                                re.sub(r"[^a-zA-Z0-9\-_\.]*", "", data["author_name"]).lower()
+                                + "@localhost"
+                            )
+
+                        author_email = truncatechars(author_email, 75)
+
+                        if not author_email:
+                            author = None
+                        elif author_email not in authors:
+                            author_data = {"name": data.get("author_name")}
+                            author, created = CommitAuthor.objects.get_or_create(
+                                organization_id=self.organization_id,
+                                email=author_email,
+                                defaults=author_data,
+                            )
+                            if author.name != author_data["name"]:
+                                author.update(name=author_data["name"])
+                            authors[author_email] = author
+                        else:
+                            author = authors[author_email]
+
+                        commit_data: _CommitDataKwargs = {}
+
+                        # Update/set message and author if they are provided.
+                        if author is not None:
+                            commit_data["author"] = author
+                        if "message" in data:
+                            commit_data["message"] = data["message"]
+                        if "timestamp" in data:
+                            commit_data["date_added"] = data["timestamp"]
+
+                        commit, created = Commit.objects.get_or_create(
+                            organization_id=self.organization_id,
+                            repository_id=repo.id,
+                            key=data["id"],
+                            defaults=commit_data,
+                        )
+                        if not created and any(
+                            getattr(commit, key) != value for key, value in commit_data.items()
+                        ):
+                            commit.update(**commit_data)
+
+                        if author is None:
+                            author = commit.author
+
+                        commit_author_by_commit[commit.id] = author
+
+                        # Guard against patch_set being None
+                        patch_set = data.get("patch_set") or []
+                        if patch_set:
+                            CommitFileChange.objects.bulk_create(
+                                [
+                                    CommitFileChange(
+                                        organization_id=self.organization.id,
+                                        commit=commit,
+                                        filename=patched_file["path"],
+                                        type=patched_file["type"],
+                                    )
+                                    for patched_file in patch_set
+                                ],
+                                ignore_conflicts=True,
+                                batch_size=100,
+                            )
+
+                        try:
+                            with atomic_transaction(using=router.db_for_write(ReleaseCommit)):
+                                ReleaseCommit.objects.create(
+                                    organization_id=self.organization_id,
+                                    release=self,
+                                    commit=commit,
+                                    order=idx,
+                                )
+                        except IntegrityError:
+                            pass
+
+                        if latest_commit is None:
+                            latest_commit = commit
+
+                        head_commit_by_repo.setdefault(repo.id, commit.id)
+
+                    self.update(
+                        commit_count=len(commit_list),
+                        authors=[
+                            str(a_id)
+                            for a_id in ReleaseCommit.objects.filter(
+                                release=self, commit__author_id__isnull=False
+                            )
+                            .values_list("commit__author_id", flat=True)
+                            .distinct()
+                        ],
+                        last_commit_id=latest_commit.id if latest_commit else None,
+                    )
+                    metrics.timing("release.set_commits.duration", time() - start, sample_rate=1.0)
+
+            # fill any missing ReleaseHeadCommit entries
+            for repo_id, commit_id in head_commit_by_repo.items():
+                try:
+                    with atomic_transaction(using=router.db_for_write(ReleaseHeadCommit)):
+                        ReleaseHeadCommit.objects.create(
+                            organization_id=self.organization_id,
+                            release_id=self.id,
+                            repository_id=repo_id,
+                            commit_id=commit_id,
+                        )
+                except IntegrityError:
+                    pass
+
+            release_commits = list(
+                ReleaseCommit.objects.filter(release=self)
+                .select_related("commit")
+                .values("commit_id", "commit__key")
+            )
+
+            commit_resolutions = list(
+                GroupLink.objects.filter(
+                    linked_type=GroupLink.LinkedType.commit,
+                    linked_id__in=[rc["commit_id"] for rc in release_commits],
+                ).values_list("group_id", "linked_id")
+            )
+
+            commit_group_authors = [
+                (cr[0], commit_author_by_commit.get(cr[1])) for cr in commit_resolutions  # group_id
+            ]
+
+            pr_ids_by_merge_commit = list(
+                PullRequest.objects.filter(
+                    merge_commit_sha__in=[rc["commit__key"] for rc in release_commits],
+                    organization_id=self.organization_id,
+                ).values_list("id", flat=True)
+            )
+
+            pull_request_resolutions = list(
+                GroupLink.objects.filter(
+                    relationship=GroupLink.Relationship.resolves,
+                    linked_type=GroupLink.LinkedType.pull_request,
+                    linked_id__in=pr_ids_by_merge_commit,
+                ).values_list("group_id", "linked_id")
+            )
+
+            pr_authors = list(
+                PullRequest.objects.filter(
+                    id__in=[prr[1] for prr in pull_request_resolutions]
+                ).select_related("author")
+            )
+
+            pr_authors_dict = {pra.id: pra.author for pra in pr_authors}
+
+            pull_request_group_authors = [
+                (prr[0], pr_authors_dict.get(prr[1])) for prr in pull_request_resolutions
+            ]
+
+            user_by_author: dict[CommitAuthor | None, RpcUser | None] = {None: None}
+
+            commits_and_prs = list(
+                itertools.chain(commit_group_authors, pull_request_group_authors)
+            )
+
+            group_project_lookup = dict(
+                Group.objects.filter(
+                    id__in=[group_id for group_id, _ in commits_and_prs]
+                ).values_list("id", "project_id")
+            )
+
+            for group_id, author in commits_and_prs:
+                if author is not None and author not in user_by_author:
+                    try:
+                        user_by_author[author] = author.find_users()[0]
+                    except IndexError:
+                        user_by_author[author] = None
+                actor = user_by_author[author]
+
+                with atomic_transaction(
+                    using=(
+                        router.db_for_write(GroupResolution),
+                        router.db_for_write(Group),
+                        # inside the remove_group_from_inbox
+                        router.db_for_write(GroupInbox),
+                        router.db_for_write(Activity),
+                    )
+                ):
+                    GroupResolution.objects.create_or_update(
+                        group_id=group_id,
+                        values={
+                            "release": self,
+                            "type": GroupResolution.Type.in_release,
+                            "status": GroupResolution.Status.resolved,
+                            "actor_id": actor.id if actor is not None else None,
+                        },
+                    )
+                    group = Group.objects.get(id=group_id)
+                    group.update(status=GroupStatus.RESOLVED, substatus=None)
+                    remove_group_from_inbox(
+                        group, action=GroupInboxRemoveAction.RESOLVED, user=actor
+                    )
+                    record_group_history(group, GroupHistoryStatus.RESOLVED, actor=actor)
+
+                    metrics.incr("group.resolved", instance="in_commit", skip_internal=True)
+
+                issue_resolved.send_robust(
+                    organization_id=self.organization_id,
+                    user=actor,
+                    group=group,
+                    project=group.project,
+                    resolution_type="with_commit",
+                    sender=type(self),
+                )
+
+                kick_off_status_syncs.apply_async(
+                    kwargs={"project_id": group_project_lookup[group_id], "group_id": group_id}
+                )
 
     def safe_delete(self):
         """Deletes a release if possible or raises a `UnsafeReleaseDeletion`

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-import itertools
 import logging
-import re
 from collections.abc import Mapping, Sequence
-from time import time
-from typing import ClassVar, TypedDict
+from typing import ClassVar
 
 import orjson
 import sentry_sdk
@@ -18,7 +15,7 @@ from sentry_relay.exceptions import RelayError
 from sentry_relay.processing import parse_release
 
 from sentry.backup.scopes import RelocationScope
-from sentry.constants import BAD_RELEASE_CHARS, COMMIT_RANGE_DELIMITER, ObjectStatus
+from sentry.constants import BAD_RELEASE_CHARS, COMMIT_RANGE_DELIMITER
 from sentry.db.models import (
     ArrayField,
     BoundedBigIntegerField,
@@ -32,31 +29,20 @@ from sentry.db.models import (
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.db.models.indexes import IndexWithPostgresNameLimits
 from sentry.db.models.manager.base import BaseManager
-from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
-from sentry.locks import locks
-from sentry.models.activity import Activity
 from sentry.models.artifactbundle import ArtifactBundle
-from sentry.models.commitauthor import CommitAuthor
-from sentry.models.commitfilechange import CommitFileChange
-from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
-from sentry.models.groupinbox import GroupInbox, GroupInboxRemoveAction, remove_group_from_inbox
 from sentry.models.releases.constants import (
     DB_VERSION_LENGTH,
     ERR_RELEASE_HEALTH_DATA,
     ERR_RELEASE_REFERENCED,
 )
-from sentry.models.releases.exceptions import ReleaseCommitError, UnsafeReleaseDeletion
+from sentry.models.releases.exceptions import UnsafeReleaseDeletion
 from sentry.models.releases.release_project import ReleaseProject
 from sentry.models.releases.util import ReleaseQuerySet, SemverFilter, SemverVersion
-from sentry.signals import issue_resolved
-from sentry.users.services.user import RpcUser
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 from sentry.utils.db import atomic_transaction
 from sentry.utils.hashlib import hash_values, md5_text
 from sentry.utils.numbers import validate_bigint
-from sentry.utils.retries import TimedRetryPolicy
-from sentry.utils.strings import truncatechars
 
 logger = logging.getLogger(__name__)
 
@@ -177,12 +163,6 @@ class ReleaseModelManager(BaseManager["Release"]):
 
         # Convert the False back into a None.
         return release_version or None
-
-
-class _CommitDataKwargs(TypedDict, total=False):
-    author: CommitAuthor
-    message: str
-    date_added: str
 
 
 @region_silo_model
@@ -661,282 +641,9 @@ class Release(Model):
         commits.
         """
         sentry_sdk.set_measurement("release.set_commits", len(commit_list))
+        from sentry.models.releases.set_commits import set_commits
 
-        # Sort commit list in reverse order
-        commit_list.sort(key=lambda commit: commit.get("timestamp", 0), reverse=True)
-
-        # TODO(dcramer): this function could use some cleanup/refactoring as it's a bit unwieldy
-        from sentry.integrations.tasks.kick_off_status_syncs import kick_off_status_syncs
-        from sentry.models.commit import Commit
-        from sentry.models.group import Group, GroupStatus
-        from sentry.models.grouplink import GroupLink
-        from sentry.models.groupresolution import GroupResolution
-        from sentry.models.pullrequest import PullRequest
-        from sentry.models.releasecommit import ReleaseCommit
-        from sentry.models.releaseheadcommit import ReleaseHeadCommit
-        from sentry.models.repository import Repository
-        from sentry.plugins.providers.repository import RepositoryProvider
-
-        # todo(meredith): implement for IntegrationRepositoryProvider
-        commit_list = [
-            c
-            for c in commit_list
-            if not RepositoryProvider.should_ignore_commit(c.get("message", ""))
-        ]
-        lock_key = type(self).get_lock_key(self.organization_id, self.id)
-        lock = locks.get(lock_key, duration=10, name="release_set_commits")
-        if lock.locked():
-            # Signal failure to the consumer rapidly. This aims to prevent the number
-            # of timeouts and prevent web worker exhaustion when customers create
-            # the same release rapidly for different projects.
-            raise ReleaseCommitError
-        with TimedRetryPolicy(10)(lock.acquire):
-            start = time()
-            with (
-                atomic_transaction(using=router.db_for_write(type(self))),
-                in_test_hide_transaction_boundary(),
-            ):
-                # TODO(dcramer): would be good to optimize the logic to avoid these
-                # deletes but not overly important
-                ReleaseCommit.objects.filter(release=self).delete()
-
-                authors = {}
-                repos = {}
-                commit_author_by_commit = {}
-                head_commit_by_repo: dict[int, int] = {}
-                latest_commit = None
-                for idx, data in enumerate(commit_list):
-                    repo_name = data.get("repository") or f"organization-{self.organization_id}"
-                    if repo_name not in repos:
-                        repo = (
-                            Repository.objects.filter(
-                                organization_id=self.organization_id,
-                                name=repo_name,
-                                status=ObjectStatus.ACTIVE,
-                            )
-                            .order_by("-pk")
-                            .first()
-                        )
-
-                        if repo is None:
-                            repo = Repository.objects.create(
-                                organization_id=self.organization_id,
-                                name=repo_name,
-                            )
-
-                        repos[repo_name] = repo
-                    else:
-                        repo = repos[repo_name]
-
-                    author_email = data.get("author_email")
-                    if author_email is None and data.get("author_name"):
-                        author_email = (
-                            re.sub(r"[^a-zA-Z0-9\-_\.]*", "", data["author_name"]).lower()
-                            + "@localhost"
-                        )
-
-                    author_email = truncatechars(author_email, 75)
-
-                    if not author_email:
-                        author = None
-                    elif author_email not in authors:
-                        author_data = {"name": data.get("author_name")}
-                        author, created = CommitAuthor.objects.get_or_create(
-                            organization_id=self.organization_id,
-                            email=author_email,
-                            defaults=author_data,
-                        )
-                        if author.name != author_data["name"]:
-                            author.update(name=author_data["name"])
-                        authors[author_email] = author
-                    else:
-                        author = authors[author_email]
-
-                    commit_data: _CommitDataKwargs = {}
-
-                    # Update/set message and author if they are provided.
-                    if author is not None:
-                        commit_data["author"] = author
-                    if "message" in data:
-                        commit_data["message"] = data["message"]
-                    if "timestamp" in data:
-                        commit_data["date_added"] = data["timestamp"]
-
-                    commit, created = Commit.objects.get_or_create(
-                        organization_id=self.organization_id,
-                        repository_id=repo.id,
-                        key=data["id"],
-                        defaults=commit_data,
-                    )
-                    if not created and any(
-                        getattr(commit, key) != value for key, value in commit_data.items()
-                    ):
-                        commit.update(**commit_data)
-
-                    if author is None:
-                        author = commit.author
-
-                    commit_author_by_commit[commit.id] = author
-
-                    # Guard against patch_set being None
-                    patch_set = data.get("patch_set") or []
-                    if patch_set:
-                        CommitFileChange.objects.bulk_create(
-                            [
-                                CommitFileChange(
-                                    organization_id=self.organization.id,
-                                    commit=commit,
-                                    filename=patched_file["path"],
-                                    type=patched_file["type"],
-                                )
-                                for patched_file in patch_set
-                            ],
-                            ignore_conflicts=True,
-                            batch_size=100,
-                        )
-
-                    try:
-                        with atomic_transaction(using=router.db_for_write(ReleaseCommit)):
-                            ReleaseCommit.objects.create(
-                                organization_id=self.organization_id,
-                                release=self,
-                                commit=commit,
-                                order=idx,
-                            )
-                    except IntegrityError:
-                        pass
-
-                    if latest_commit is None:
-                        latest_commit = commit
-
-                    head_commit_by_repo.setdefault(repo.id, commit.id)
-
-                self.update(
-                    commit_count=len(commit_list),
-                    authors=[
-                        str(a_id)
-                        for a_id in ReleaseCommit.objects.filter(
-                            release=self, commit__author_id__isnull=False
-                        )
-                        .values_list("commit__author_id", flat=True)
-                        .distinct()
-                    ],
-                    last_commit_id=latest_commit.id if latest_commit else None,
-                )
-                metrics.timing("release.set_commits.duration", time() - start, sample_rate=1.0)
-
-        # fill any missing ReleaseHeadCommit entries
-        for repo_id, commit_id in head_commit_by_repo.items():
-            try:
-                with atomic_transaction(using=router.db_for_write(ReleaseHeadCommit)):
-                    ReleaseHeadCommit.objects.create(
-                        organization_id=self.organization_id,
-                        release_id=self.id,
-                        repository_id=repo_id,
-                        commit_id=commit_id,
-                    )
-            except IntegrityError:
-                pass
-
-        release_commits = list(
-            ReleaseCommit.objects.filter(release=self)
-            .select_related("commit")
-            .values("commit_id", "commit__key")
-        )
-
-        commit_resolutions = list(
-            GroupLink.objects.filter(
-                linked_type=GroupLink.LinkedType.commit,
-                linked_id__in=[rc["commit_id"] for rc in release_commits],
-            ).values_list("group_id", "linked_id")
-        )
-
-        commit_group_authors = [
-            (cr[0], commit_author_by_commit.get(cr[1])) for cr in commit_resolutions  # group_id
-        ]
-
-        pr_ids_by_merge_commit = list(
-            PullRequest.objects.filter(
-                merge_commit_sha__in=[rc["commit__key"] for rc in release_commits],
-                organization_id=self.organization_id,
-            ).values_list("id", flat=True)
-        )
-
-        pull_request_resolutions = list(
-            GroupLink.objects.filter(
-                relationship=GroupLink.Relationship.resolves,
-                linked_type=GroupLink.LinkedType.pull_request,
-                linked_id__in=pr_ids_by_merge_commit,
-            ).values_list("group_id", "linked_id")
-        )
-
-        pr_authors = list(
-            PullRequest.objects.filter(
-                id__in=[prr[1] for prr in pull_request_resolutions]
-            ).select_related("author")
-        )
-
-        pr_authors_dict = {pra.id: pra.author for pra in pr_authors}
-
-        pull_request_group_authors = [
-            (prr[0], pr_authors_dict.get(prr[1])) for prr in pull_request_resolutions
-        ]
-
-        user_by_author: dict[CommitAuthor | None, RpcUser | None] = {None: None}
-
-        commits_and_prs = list(itertools.chain(commit_group_authors, pull_request_group_authors))
-
-        group_project_lookup = dict(
-            Group.objects.filter(id__in=[group_id for group_id, _ in commits_and_prs]).values_list(
-                "id", "project_id"
-            )
-        )
-
-        for group_id, author in commits_and_prs:
-            if author is not None and author not in user_by_author:
-                try:
-                    user_by_author[author] = author.find_users()[0]
-                except IndexError:
-                    user_by_author[author] = None
-            actor = user_by_author[author]
-
-            with atomic_transaction(
-                using=(
-                    router.db_for_write(GroupResolution),
-                    router.db_for_write(Group),
-                    # inside the remove_group_from_inbox
-                    router.db_for_write(GroupInbox),
-                    router.db_for_write(Activity),
-                )
-            ):
-                GroupResolution.objects.create_or_update(
-                    group_id=group_id,
-                    values={
-                        "release": self,
-                        "type": GroupResolution.Type.in_release,
-                        "status": GroupResolution.Status.resolved,
-                        "actor_id": actor.id if actor is not None else None,
-                    },
-                )
-                group = Group.objects.get(id=group_id)
-                group.update(status=GroupStatus.RESOLVED, substatus=None)
-                remove_group_from_inbox(group, action=GroupInboxRemoveAction.RESOLVED, user=actor)
-                record_group_history(group, GroupHistoryStatus.RESOLVED, actor=actor)
-
-                metrics.incr("group.resolved", instance="in_commit", skip_internal=True)
-
-            issue_resolved.send_robust(
-                organization_id=self.organization_id,
-                user=actor,
-                group=group,
-                project=group.project,
-                resolution_type="with_commit",
-                sender=type(self),
-            )
-
-            kick_off_status_syncs.apply_async(
-                kwargs={"project_id": group_project_lookup[group_id], "group_id": group_id}
-            )
+        set_commits(self, commit_list)
 
     def safe_delete(self):
         """Deletes a release if possible or raises a `UnsafeReleaseDeletion`

--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -1,4 +1,3 @@
-# Sort commit list in reverse order
 from __future__ import annotations
 
 import itertools
@@ -65,8 +64,8 @@ def set_commits(release, commit_list):
             head_commit_by_repo, commit_author_by_commit = set_commits_on_release(
                 release, commit_list
             )
-    fill_in_missing_release_head_commits(release, head_commit_by_repo)
 
+    fill_in_missing_release_head_commits(release, head_commit_by_repo)
     update_group_resolutions(release, commit_author_by_commit)
 
 

--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -84,11 +84,12 @@ def set_commits_on_release(release, commit_list):
 
     latest_commit = None
     for idx, data in enumerate(commit_list):
-        commit = set_commit(idx, data, release, head_commit_by_repo)
+        commit = set_commit(idx, data, release)
         if idx == 0:
             latest_commit = commit
 
         commit_author_by_commit[commit.id] = commit.author
+        head_commit_by_repo.setdefault(data["repo_model"].id, commit.id)
 
     release.update(
         commit_count=len(commit_list),
@@ -105,7 +106,7 @@ def set_commits_on_release(release, commit_list):
     return head_commit_by_repo, commit_author_by_commit
 
 
-def set_commit(idx, data, release, head_commit_by_repo):
+def set_commit(idx, data, release):
     repo = data["repo_model"]
     author = data["author_model"]
 
@@ -159,7 +160,6 @@ def set_commit(idx, data, release, head_commit_by_repo):
     except IntegrityError:
         pass
 
-    head_commit_by_repo.setdefault(repo.id, commit.id)
     return commit
 
 

--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -84,12 +84,11 @@ def set_commits_on_release(release, commit_list):
 
     latest_commit = None
     for idx, data in enumerate(commit_list):
+        commit = set_commit(idx, data, release, head_commit_by_repo)
         if idx == 0:
-            latest_commit = set_commit(
-                idx, data, release, commit_author_by_commit, head_commit_by_repo
-            )
-        else:
-            set_commit(idx, data, release, commit_author_by_commit, head_commit_by_repo)
+            latest_commit = commit
+
+        commit_author_by_commit[commit.id] = commit.author
 
     release.update(
         commit_count=len(commit_list),
@@ -106,7 +105,7 @@ def set_commits_on_release(release, commit_list):
     return head_commit_by_repo, commit_author_by_commit
 
 
-def set_commit(idx, data, release, commit_author_by_commit, head_commit_by_repo):
+def set_commit(idx, data, release, head_commit_by_repo):
     repo = data["repo_model"]
     author = data["author_model"]
 
@@ -131,8 +130,6 @@ def set_commit(idx, data, release, commit_author_by_commit, head_commit_by_repo)
 
     if author is None:
         author = commit.author
-
-    commit_author_by_commit[commit.id] = author
 
     # Guard against patch_set being None
     patch_set = data.get("patch_set") or []

--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -137,7 +137,6 @@ def set_commits_on_release(release, commit_list):
             data["author_model"] = author
 
     def set_commit(idx, data):
-        nonlocal latest_commit
 
         repo = data["repo_model"]
         author = data["author_model"]
@@ -194,16 +193,17 @@ def set_commits_on_release(release, commit_list):
         except IntegrityError:
             pass
 
-        if latest_commit is None:
-            latest_commit = commit
-
         head_commit_by_repo.setdefault(repo.id, commit.id)
+        return commit
 
     create_repositories(commit_list)
     create_commit_authors(commit_list)
 
     for idx, data in enumerate(commit_list):
-        set_commit(idx, data)
+        if idx == 0:
+            latest_commit = set_commit(idx, data)
+        else:
+            set_commit(idx, data)
 
     release.update(
         commit_count=len(commit_list),

--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -1,0 +1,307 @@
+# Sort commit list in reverse order
+from __future__ import annotations
+
+import itertools
+import logging
+import re
+from time import time
+from typing import TypedDict
+
+from django.db import IntegrityError, router
+
+from sentry.constants import ObjectStatus
+from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
+from sentry.locks import locks
+from sentry.models.activity import Activity
+from sentry.models.commitauthor import CommitAuthor
+from sentry.models.commitfilechange import CommitFileChange
+from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
+from sentry.models.groupinbox import GroupInbox, GroupInboxRemoveAction, remove_group_from_inbox
+from sentry.models.releases.exceptions import ReleaseCommitError
+from sentry.signals import issue_resolved
+from sentry.users.services.user import RpcUser
+from sentry.utils import metrics
+from sentry.utils.db import atomic_transaction
+from sentry.utils.retries import TimedRetryPolicy
+from sentry.utils.strings import truncatechars
+
+logger = logging.getLogger(__name__)
+from sentry.integrations.tasks.kick_off_status_syncs import kick_off_status_syncs
+from sentry.models.commit import Commit
+from sentry.models.group import Group, GroupStatus
+from sentry.models.grouplink import GroupLink
+from sentry.models.groupresolution import GroupResolution
+from sentry.models.pullrequest import PullRequest
+from sentry.models.releasecommit import ReleaseCommit
+from sentry.models.releaseheadcommit import ReleaseHeadCommit
+from sentry.models.repository import Repository
+from sentry.plugins.providers.repository import RepositoryProvider
+
+
+class _CommitDataKwargs(TypedDict, total=False):
+    author: CommitAuthor
+    message: str
+    date_added: str
+
+
+def set_commits(release, commit_list):
+    commit_list.sort(key=lambda commit: commit.get("timestamp", 0), reverse=True)
+
+    # todo(meredith): implement for IntegrationRepositoryProvider
+    commit_list = [
+        c for c in commit_list if not RepositoryProvider.should_ignore_commit(c.get("message", ""))
+    ]
+    lock_key = type(release).get_lock_key(release.organization_id, release.id)
+    lock = locks.get(lock_key, duration=10, name="release_set_commits")
+    if lock.locked():
+        # Signal failure to the consumer rapidly. This aims to prevent the number
+        # of timeouts and prevent web worker exhaustion when customers create
+        # the same release rapidly for different projects.
+        raise ReleaseCommitError
+    with TimedRetryPolicy(10)(lock.acquire):
+        start = time()
+        with (
+            atomic_transaction(using=router.db_for_write(type(release))),
+            in_test_hide_transaction_boundary(),
+        ):
+            # TODO(dcramer): would be good to optimize the logic to avoid these
+            # deletes but not overly important
+            ReleaseCommit.objects.filter(release=release).delete()
+
+            authors = {}
+            repos = {}
+            commit_author_by_commit = {}
+            head_commit_by_repo: dict[int, int] = {}
+            latest_commit = None
+            for idx, data in enumerate(commit_list):
+                repo_name = data.get("repository") or f"organization-{release.organization_id}"
+                if repo_name not in repos:
+                    repo = (
+                        Repository.objects.filter(
+                            organization_id=release.organization_id,
+                            name=repo_name,
+                            status=ObjectStatus.ACTIVE,
+                        )
+                        .order_by("-pk")
+                        .first()
+                    )
+
+                    if repo is None:
+                        repo = Repository.objects.create(
+                            organization_id=release.organization_id,
+                            name=repo_name,
+                        )
+
+                    repos[repo_name] = repo
+                else:
+                    repo = repos[repo_name]
+
+                author_email = data.get("author_email")
+                if author_email is None and data.get("author_name"):
+                    author_email = (
+                        re.sub(r"[^a-zA-Z0-9\-_\.]*", "", data["author_name"]).lower()
+                        + "@localhost"
+                    )
+
+                author_email = truncatechars(author_email, 75)
+
+                if not author_email:
+                    author = None
+                elif author_email not in authors:
+                    author_data = {"name": data.get("author_name")}
+                    author, created = CommitAuthor.objects.get_or_create(
+                        organization_id=release.organization_id,
+                        email=author_email,
+                        defaults=author_data,
+                    )
+                    if author.name != author_data["name"]:
+                        author.update(name=author_data["name"])
+                    authors[author_email] = author
+                else:
+                    author = authors[author_email]
+
+                commit_data: _CommitDataKwargs = {}
+
+                # Update/set message and author if they are provided.
+                if author is not None:
+                    commit_data["author"] = author
+                if "message" in data:
+                    commit_data["message"] = data["message"]
+                if "timestamp" in data:
+                    commit_data["date_added"] = data["timestamp"]
+
+                commit, created = Commit.objects.get_or_create(
+                    organization_id=release.organization_id,
+                    repository_id=repo.id,
+                    key=data["id"],
+                    defaults=commit_data,
+                )
+                if not created and any(
+                    getattr(commit, key) != value for key, value in commit_data.items()
+                ):
+                    commit.update(**commit_data)
+
+                if author is None:
+                    author = commit.author
+
+                commit_author_by_commit[commit.id] = author
+
+                # Guard against patch_set being None
+                patch_set = data.get("patch_set") or []
+                if patch_set:
+                    CommitFileChange.objects.bulk_create(
+                        [
+                            CommitFileChange(
+                                organization_id=release.organization.id,
+                                commit=commit,
+                                filename=patched_file["path"],
+                                type=patched_file["type"],
+                            )
+                            for patched_file in patch_set
+                        ],
+                        ignore_conflicts=True,
+                        batch_size=100,
+                    )
+
+                try:
+                    with atomic_transaction(using=router.db_for_write(ReleaseCommit)):
+                        ReleaseCommit.objects.create(
+                            organization_id=release.organization_id,
+                            release=release,
+                            commit=commit,
+                            order=idx,
+                        )
+                except IntegrityError:
+                    pass
+
+                if latest_commit is None:
+                    latest_commit = commit
+
+                head_commit_by_repo.setdefault(repo.id, commit.id)
+
+            release.update(
+                commit_count=len(commit_list),
+                authors=[
+                    str(a_id)
+                    for a_id in ReleaseCommit.objects.filter(
+                        release=release, commit__author_id__isnull=False
+                    )
+                    .values_list("commit__author_id", flat=True)
+                    .distinct()
+                ],
+                last_commit_id=latest_commit.id if latest_commit else None,
+            )
+            metrics.timing("release.set_commits.duration", time() - start, sample_rate=1.0)
+
+    # fill any missing ReleaseHeadCommit entries
+    for repo_id, commit_id in head_commit_by_repo.items():
+        try:
+            with atomic_transaction(using=router.db_for_write(ReleaseHeadCommit)):
+                ReleaseHeadCommit.objects.create(
+                    organization_id=release.organization_id,
+                    release_id=release.id,
+                    repository_id=repo_id,
+                    commit_id=commit_id,
+                )
+        except IntegrityError:
+            pass
+
+    release_commits = list(
+        ReleaseCommit.objects.filter(release=release)
+        .select_related("commit")
+        .values("commit_id", "commit__key")
+    )
+
+    commit_resolutions = list(
+        GroupLink.objects.filter(
+            linked_type=GroupLink.LinkedType.commit,
+            linked_id__in=[rc["commit_id"] for rc in release_commits],
+        ).values_list("group_id", "linked_id")
+    )
+
+    commit_group_authors = [
+        (cr[0], commit_author_by_commit.get(cr[1])) for cr in commit_resolutions  # group_id
+    ]
+
+    pr_ids_by_merge_commit = list(
+        PullRequest.objects.filter(
+            merge_commit_sha__in=[rc["commit__key"] for rc in release_commits],
+            organization_id=release.organization_id,
+        ).values_list("id", flat=True)
+    )
+
+    pull_request_resolutions = list(
+        GroupLink.objects.filter(
+            relationship=GroupLink.Relationship.resolves,
+            linked_type=GroupLink.LinkedType.pull_request,
+            linked_id__in=pr_ids_by_merge_commit,
+        ).values_list("group_id", "linked_id")
+    )
+
+    pr_authors = list(
+        PullRequest.objects.filter(
+            id__in=[prr[1] for prr in pull_request_resolutions]
+        ).select_related("author")
+    )
+
+    pr_authors_dict = {pra.id: pra.author for pra in pr_authors}
+
+    pull_request_group_authors = [
+        (prr[0], pr_authors_dict.get(prr[1])) for prr in pull_request_resolutions
+    ]
+
+    user_by_author: dict[CommitAuthor | None, RpcUser | None] = {None: None}
+
+    commits_and_prs = list(itertools.chain(commit_group_authors, pull_request_group_authors))
+
+    group_project_lookup = dict(
+        Group.objects.filter(id__in=[group_id for group_id, _ in commits_and_prs]).values_list(
+            "id", "project_id"
+        )
+    )
+
+    for group_id, author in commits_and_prs:
+        if author is not None and author not in user_by_author:
+            try:
+                user_by_author[author] = author.find_users()[0]
+            except IndexError:
+                user_by_author[author] = None
+        actor = user_by_author[author]
+
+        with atomic_transaction(
+            using=(
+                router.db_for_write(GroupResolution),
+                router.db_for_write(Group),
+                # inside the remove_group_from_inbox
+                router.db_for_write(GroupInbox),
+                router.db_for_write(Activity),
+            )
+        ):
+            GroupResolution.objects.create_or_update(
+                group_id=group_id,
+                values={
+                    "release": release,
+                    "type": GroupResolution.Type.in_release,
+                    "status": GroupResolution.Status.resolved,
+                    "actor_id": actor.id if actor is not None else None,
+                },
+            )
+            group = Group.objects.get(id=group_id)
+            group.update(status=GroupStatus.RESOLVED, substatus=None)
+            remove_group_from_inbox(group, action=GroupInboxRemoveAction.RESOLVED, user=actor)
+            record_group_history(group, GroupHistoryStatus.RESOLVED, actor=actor)
+
+            metrics.incr("group.resolved", instance="in_commit", skip_internal=True)
+
+        issue_resolved.send_robust(
+            organization_id=release.organization_id,
+            user=actor,
+            group=group,
+            project=group.project,
+            resolution_type="with_commit",
+            sender=type(release),
+        )
+
+        kick_off_status_syncs.apply_async(
+            kwargs={"project_id": group_project_lookup[group_id], "group_id": group_id}
+        )

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -28,6 +28,7 @@ from sentry.signals import receivers_raise_on_send
 from sentry.testutils.cases import SetRefsTestCase, TestCase
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 from sentry.utils.strings import truncatechars
 
 
@@ -573,6 +574,11 @@ class SetCommitsTestCase(TestCase):
         commit = Commit.objects.get(repository_id=repo.id, organization_id=org.id, key="a" * 40)
         assert commit.author is not None
         assert commit.author.email == truncatechars(commit_email, 75)
+
+
+@apply_feature_flag_on_cls("organizations:set-commits-updated")
+class SetCommitsTestUpdated(SetCommitsTestCase):
+    ...
 
 
 class SetRefsTest(SetRefsTestCase):

--- a/tests/sentry/tasks/test_commits.py
+++ b/tests/sentry/tasks/test_commits.py
@@ -14,6 +14,7 @@ from sentry.models.repository import Repository
 from sentry.silo.base import SiloMode
 from sentry.tasks.commits import fetch_commits, handle_invalid_identity
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from social_auth.models import UserSocialAuth
 
@@ -286,6 +287,11 @@ class FetchCommitsTest(TestCase):
         assert msg.subject == "Unable to Fetch Commits"
         assert msg.to == [self.user.email]
         assert "Repository not found" in msg.body
+
+
+@apply_feature_flag_on_cls("organizations:set-commits-updated")
+class FetchCommitsTestUpdated(FetchCommitsTest):
+    ...
 
 
 @control_silo_test


### PR DESCRIPTION
- refactors `set_commits`, broken up into functions. The functionality is currently not changed. 
- In a future PR, i intend to break up the database transaction it all lives in to not be so large / do so much stuff.
- i use a feature flag for the new logic so we can roll it out gradually and rollback if any issues are noticed.

please review by taking a look at individual commits, which should be digestible.