### PR TITLE
ref(issue-stream): Pull IssueListBody into its own component

### DIFF
--- a/static/app/views/issueList/issueListBody.tsx
+++ b/static/app/views/issueList/issueListBody.tsx
@@ -1,4 +1,9 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
 import type {IndexedMembersByProject} from 'sentry/actionCreators/members';
+import type {CursorHandler} from 'sentry/components/pagination';
+import Pagination from 'sentry/components/pagination';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import type {PageFilters} from 'sentry/types/core';
@@ -15,9 +20,13 @@ interface IssueListBodyProps {
   issuesLoading: boolean;
   memberList: IndexedMembersByProject;
   onActionTaken: (itemIds: string[], data: IssueUpdateData) => void;
+  onCursor: CursorHandler;
   onDelete: () => void;
   onSelectStatsPeriod: (period: string) => void;
   onSortChange: (sort: string) => void;
+  pageLinks: string;
+  paginationAnalyticsEvent: (direction: string) => void;
+  paginationCaption: React.ReactNode;
   query: string;
   queryCount: number;
   refetchGroups: (fetchAllCounts?: boolean) => void;
@@ -44,47 +53,63 @@ function IssueListBody({
   memberList,
   refetchGroups,
   error,
+  paginationCaption,
+  pageLinks,
+  onCursor,
+  paginationAnalyticsEvent,
 }: IssueListBodyProps) {
   return (
-    <Panel>
-      {groupIds.length !== 0 && (
-        <IssueListActions
-          selection={selection}
-          query={query}
-          queryCount={queryCount}
-          onSelectStatsPeriod={onSelectStatsPeriod}
-          onActionTaken={onActionTaken}
-          onDelete={onDelete}
-          statsPeriod={statsPeriod}
-          groupIds={groupIds}
-          allResultsVisible={allResultsVisible}
-          displayReprocessingActions={displayReprocessingActions}
-          sort={sort}
-          onSortChange={onSortChange}
-        />
-      )}
-      <PanelBody>
-        <VisuallyCompleteWithData
-          hasData={groupIds.length > 0}
-          id="IssueList-Body"
-          isLoading={issuesLoading}
-        >
-          <GroupListBody
-            memberList={memberList}
-            groupStatsPeriod={statsPeriod}
-            groupIds={groupIds}
-            displayReprocessingLayout={displayReprocessingActions}
+    <Fragment>
+      <Panel>
+        {groupIds.length !== 0 && (
+          <IssueListActions
+            selection={selection}
             query={query}
-            selectedProjectIds={selection.projects}
-            loading={issuesLoading}
-            error={error}
-            refetchGroups={refetchGroups}
+            queryCount={queryCount}
+            onSelectStatsPeriod={onSelectStatsPeriod}
             onActionTaken={onActionTaken}
+            onDelete={onDelete}
+            statsPeriod={statsPeriod}
+            groupIds={groupIds}
+            allResultsVisible={allResultsVisible}
+            displayReprocessingActions={displayReprocessingActions}
+            sort={sort}
+            onSortChange={onSortChange}
           />
-        </VisuallyCompleteWithData>
-      </PanelBody>
-    </Panel>
+        )}
+        <PanelBody>
+          <VisuallyCompleteWithData
+            hasData={groupIds.length > 0}
+            id="IssueList-Body"
+            isLoading={issuesLoading}
+          >
+            <GroupListBody
+              memberList={memberList}
+              groupStatsPeriod={statsPeriod}
+              groupIds={groupIds}
+              displayReprocessingLayout={displayReprocessingActions}
+              query={query}
+              selectedProjectIds={selection.projects}
+              loading={issuesLoading}
+              error={error}
+              refetchGroups={refetchGroups}
+              onActionTaken={onActionTaken}
+            />
+          </VisuallyCompleteWithData>
+        </PanelBody>
+      </Panel>
+      <StyledPagination
+        caption={paginationCaption}
+        pageLinks={pageLinks}
+        onCursor={onCursor}
+        paginationAnalyticsEvent={paginationAnalyticsEvent}
+      />
+    </Fragment>
   );
 }
+
+const StyledPagination = styled(Pagination)`
+  margin-top: 0;
+`;
 
 export default IssueListBody;

--- a/static/app/views/issueList/issueListBody.tsx
+++ b/static/app/views/issueList/issueListBody.tsx
@@ -1,0 +1,90 @@
+import type {IndexedMembersByProject} from 'sentry/actionCreators/members';
+import Panel from 'sentry/components/panels/panel';
+import PanelBody from 'sentry/components/panels/panelBody';
+import type {PageFilters} from 'sentry/types/core';
+import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
+import IssueListActions from 'sentry/views/issueList/actions';
+import GroupListBody from 'sentry/views/issueList/groupListBody';
+import type {IssueUpdateData} from 'sentry/views/issueList/types';
+
+interface IssueListBodyProps {
+  allResultsVisible: boolean;
+  displayReprocessingActions: boolean;
+  error: string | null;
+  groupIds: string[];
+  issuesLoading: boolean;
+  memberList: IndexedMembersByProject;
+  onActionTaken: (itemIds: string[], data: IssueUpdateData) => void;
+  onDelete: () => void;
+  onSelectStatsPeriod: (period: string) => void;
+  onSortChange: (sort: string) => void;
+  query: string;
+  queryCount: number;
+  refetchGroups: (fetchAllCounts?: boolean) => void;
+  selectedProjectIds: number[];
+  selection: PageFilters;
+  sort: string;
+  statsPeriod: string;
+}
+
+function IssueListBody({
+  allResultsVisible,
+  displayReprocessingActions,
+  groupIds,
+  onDelete,
+  onSelectStatsPeriod,
+  onSortChange,
+  query,
+  queryCount,
+  selection,
+  sort,
+  statsPeriod,
+  onActionTaken,
+  issuesLoading,
+  memberList,
+  refetchGroups,
+  error,
+}: IssueListBodyProps) {
+  return (
+    <Panel>
+      {groupIds.length !== 0 && (
+        <IssueListActions
+          selection={selection}
+          query={query}
+          queryCount={queryCount}
+          onSelectStatsPeriod={onSelectStatsPeriod}
+          onActionTaken={onActionTaken}
+          onDelete={onDelete}
+          statsPeriod={statsPeriod}
+          groupIds={groupIds}
+          allResultsVisible={allResultsVisible}
+          displayReprocessingActions={displayReprocessingActions}
+          sort={sort}
+          onSortChange={onSortChange}
+        />
+      )}
+      <PanelBody>
+        <VisuallyCompleteWithData
+          hasData={groupIds.length > 0}
+          id="IssueList-Body"
+          isLoading={issuesLoading}
+        >
+          <GroupListBody
+            memberList={memberList}
+            groupStatsPeriod={statsPeriod}
+            groupIds={groupIds}
+            displayReprocessingLayout={displayReprocessingActions}
+            query={query}
+            selectedProjectIds={selection.projects}
+            loading={issuesLoading}
+            error={error}
+            refetchGroups={refetchGroups}
+            onActionTaken={onActionTaken}
+          />
+        </VisuallyCompleteWithData>
+      </PanelBody>
+    </Panel>
+  );
+}
+
+export default IssueListBody;

--- a/static/app/views/issueList/issueListTable.tsx
+++ b/static/app/views/issueList/issueListTable.tsx
@@ -12,7 +12,7 @@ import IssueListActions from 'sentry/views/issueList/actions';
 import GroupListBody from 'sentry/views/issueList/groupListBody';
 import type {IssueUpdateData} from 'sentry/views/issueList/types';
 
-interface IssueListBodyProps {
+interface IssueListTableProps {
   allResultsVisible: boolean;
   displayReprocessingActions: boolean;
   error: string | null;
@@ -36,7 +36,7 @@ interface IssueListBodyProps {
   statsPeriod: string;
 }
 
-function IssueListBody({
+function IssueListTable({
   allResultsVisible,
   displayReprocessingActions,
   groupIds,
@@ -57,7 +57,7 @@ function IssueListBody({
   pageLinks,
   onCursor,
   paginationAnalyticsEvent,
-}: IssueListBodyProps) {
+}: IssueListTableProps) {
   return (
     <Fragment>
       <Panel>
@@ -112,4 +112,4 @@ const StyledPagination = styled(Pagination)`
   margin-top: 0;
 `;
 
-export default IssueListBody;
+export default IssueListTable;

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -20,7 +20,6 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {extractSelectionParameters} from 'sentry/components/organizations/pageFilters/utils';
 import type {CursorHandler} from 'sentry/components/pagination';
-import Pagination from 'sentry/components/pagination';
 import QueryCount from 'sentry/components/queryCount';
 import {DEFAULT_QUERY, DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {t, tct} from 'sentry/locale';
@@ -1265,9 +1264,7 @@ class IssueListOverview extends Component<Props, State> {
               issuesLoading={issuesLoading}
               error={error}
               refetchGroups={this.fetchData}
-            />
-            <StyledPagination
-              caption={
+              paginationCaption={
                 !issuesLoading && modifiedQueryCount > 0
                   ? tct('[start]-[end] of [total]', {
                       start: numPreviousIssues + 1,
@@ -1331,10 +1328,6 @@ const StyledMain = styled('section')`
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
     padding: ${space(3)} ${space(4)};
   }
-`;
-
-const StyledPagination = styled(Pagination)`
-  margin-top: 0;
 `;
 
 const StyledQueryCount = styled(QueryCount)`

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -57,7 +57,7 @@ import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import withSavedSearches from 'sentry/utils/withSavedSearches';
 import CustomViewsIssueListHeader from 'sentry/views/issueList/customViewsHeader';
-import IssueListBody from 'sentry/views/issueList/issueListBody';
+import IssueListTable from 'sentry/views/issueList/issueListTable';
 import SavedIssueSearches from 'sentry/views/issueList/savedIssueSearches';
 import type {IssueUpdateData} from 'sentry/views/issueList/types';
 import {parseIssuePrioritySearch} from 'sentry/views/issueList/utils/parseIssuePrioritySearch';
@@ -1246,7 +1246,7 @@ class IssueListOverview extends Component<Props, State> {
           <StyledMain>
             <DataConsentBanner source="issues" />
             <IssueListFilters query={query} onSearch={this.onSearch} />
-            <IssueListBody
+            <IssueListTable
               selection={selection}
               query={query}
               queryCount={modifiedQueryCount}

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -21,8 +21,6 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {extractSelectionParameters} from 'sentry/components/organizations/pageFilters/utils';
 import type {CursorHandler} from 'sentry/components/pagination';
 import Pagination from 'sentry/components/pagination';
-import Panel from 'sentry/components/panels/panel';
-import PanelBody from 'sentry/components/panels/panelBody';
 import QueryCount from 'sentry/components/queryCount';
 import {DEFAULT_QUERY, DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {t, tct} from 'sentry/locale';
@@ -49,10 +47,7 @@ import {getUtcDateString} from 'sentry/utils/dates';
 import getCurrentSentryReactRootSpan from 'sentry/utils/getCurrentSentryReactRootSpan';
 import parseApiError from 'sentry/utils/parseApiError';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
-import {
-  makeIssuesINPObserver,
-  VisuallyCompleteWithData,
-} from 'sentry/utils/performanceForSentry';
+import {makeIssuesINPObserver} from 'sentry/utils/performanceForSentry';
 import {decodeScalar} from 'sentry/utils/queryString';
 import type {WithRouteAnalyticsProps} from 'sentry/utils/routeAnalytics/withRouteAnalytics';
 import withRouteAnalytics from 'sentry/utils/routeAnalytics/withRouteAnalytics';
@@ -63,13 +58,12 @@ import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import withSavedSearches from 'sentry/utils/withSavedSearches';
 import CustomViewsIssueListHeader from 'sentry/views/issueList/customViewsHeader';
+import IssueListBody from 'sentry/views/issueList/issueListBody';
 import SavedIssueSearches from 'sentry/views/issueList/savedIssueSearches';
 import type {IssueUpdateData} from 'sentry/views/issueList/types';
 import {parseIssuePrioritySearch} from 'sentry/views/issueList/utils/parseIssuePrioritySearch';
 
-import IssueListActions from './actions';
 import IssueListFilters from './filters';
-import GroupListBody from './groupListBody';
 import IssueListHeader from './header';
 import type {QueryCounts} from './utils';
 import {
@@ -1253,45 +1247,25 @@ class IssueListOverview extends Component<Props, State> {
           <StyledMain>
             <DataConsentBanner source="issues" />
             <IssueListFilters query={query} onSearch={this.onSearch} />
-
-            <Panel>
-              {groupIds.length !== 0 && (
-                <IssueListActions
-                  selection={selection}
-                  query={query}
-                  queryCount={modifiedQueryCount}
-                  onSelectStatsPeriod={this.onSelectStatsPeriod}
-                  onActionTaken={this.onActionTaken}
-                  onDelete={this.onDelete}
-                  statsPeriod={this.getGroupStatsPeriod()}
-                  groupIds={groupIds}
-                  allResultsVisible={this.allResultsVisible()}
-                  displayReprocessingActions={displayReprocessingActions}
-                  sort={this.getSort()}
-                  onSortChange={this.onSortChange}
-                />
-              )}
-              <PanelBody>
-                <VisuallyCompleteWithData
-                  hasData={this.state.groupIds.length > 0}
-                  id="IssueList-Body"
-                  isLoading={this.state.issuesLoading}
-                >
-                  <GroupListBody
-                    memberList={this.state.memberList}
-                    groupStatsPeriod={this.getGroupStatsPeriod()}
-                    groupIds={groupIds}
-                    displayReprocessingLayout={displayReprocessingActions}
-                    query={query}
-                    selectedProjectIds={selection.projects}
-                    loading={issuesLoading}
-                    error={error}
-                    refetchGroups={this.fetchData}
-                    onActionTaken={this.onActionTaken}
-                  />
-                </VisuallyCompleteWithData>
-              </PanelBody>
-            </Panel>
+            <IssueListBody
+              selection={selection}
+              query={query}
+              queryCount={modifiedQueryCount}
+              onSelectStatsPeriod={this.onSelectStatsPeriod}
+              onActionTaken={this.onActionTaken}
+              onDelete={this.onDelete}
+              statsPeriod={this.getGroupStatsPeriod()}
+              groupIds={groupIds}
+              allResultsVisible={this.allResultsVisible()}
+              displayReprocessingActions={displayReprocessingActions}
+              sort={this.getSort()}
+              onSortChange={this.onSortChange}
+              memberList={this.state.memberList}
+              selectedProjectIds={selection.projects}
+              issuesLoading={issuesLoading}
+              error={error}
+              refetchGroups={this.fetchData}
+            />
             <StyledPagination
               caption={
                 !issuesLoading && modifiedQueryCount > 0


### PR DESCRIPTION
This PR pulls the Issue Stream's body into a separate component, `<IssueListBody/>`. This is necessary to allow a context provider to wrap the issue stream's body component, which is will be needed to support custom view's add view flow feature. Since this refactors the second highest traffic page in Sentry, I think it's better that this change is made in its own PR.  

Reviewers: please triple check that I have passed the correct props to this new component. AFAICT, the issue stream appears to work perfectly fine after this change, but I definitely want to be absolutely sure that's the case. 