### PR TITLE
feat(mobile-onboarding): Add replay verify step

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/utils/replayOnboarding.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/replayOnboarding.tsx
@@ -1,5 +1,9 @@
 import ExternalLink from 'sentry/components/links/externalLink';
-import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import type {
+  DocsParams,
+  OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {tct} from 'sentry/locale';
 
 export const getReplayMobileConfigureDescription = ({link}: {link: string}) =>
@@ -32,6 +36,28 @@ export const getReplayJsLoaderSdkSetupSnippet = (params: DocsParams) => `
     });
   });
 </script>`;
+
+export const getReplayVerifyStep = ({
+  replayOnErrorSampleRateName = 'replaysOnErrorSampleRate',
+  replaySessionSampleRateName = 'replaysSessionSampleRate',
+}: {
+  replayOnErrorSampleRateName?: string;
+  replaySessionSampleRateName?: string;
+} = {}): OnboardingConfig['verify'] => {
+  return () => [
+    {
+      type: StepType.VERIFY,
+      description: tct(
+        "While you're testing, we recommend that you set [codeSampleRate] to [code:1.0]. This ensures that every user session will be sent to Sentry.",
+        {codeSampleRate: <code>{replaySessionSampleRateName}</code>, code: <code />}
+      ),
+      additionalInfo: tct(
+        'Once testing is complete, we recommend lowering this value in production. We still recommend keeping [codeErrorSampleRate] set to [code:1.0].',
+        {codeErrorSampleRate: <code>{replayOnErrorSampleRateName}</code>, code: <code />}
+      ),
+    },
+  ];
+};
 
 export const getReplaySDKSetupSnippet = ({
   importStatement,

--- a/static/app/gettingStartedDocs/android/android.tsx
+++ b/static/app/gettingStartedDocs/android/android.tsx
@@ -431,7 +431,33 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
       ],
     },
   ],
-  verify: () => [],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      description: t(
+        'To verify your Replay setup, trigger an error in your app and watch Sentry capture the event along with a recording of the user interaction.'
+      ),
+      configurations: [
+        {
+          description: tct(
+            "You can simulate an error by adding the following code to your app's [code: MainActivity]:",
+            {code: <code />}
+          ),
+          code: [
+            {
+              label: 'Kotlin',
+              value: 'kotlin',
+              language: 'kotlin',
+              code: getVerifySnippet(),
+            },
+          ],
+          additionalInfo: t(
+            'After clicking the button, wait a few moments, and you\'ll see a new session appear on the "Replays" page.'
+          ),
+        },
+      ],
+    },
+  ],
   nextSteps: () => [],
 };
 

--- a/static/app/gettingStartedDocs/android/android.tsx
+++ b/static/app/gettingStartedDocs/android/android.tsx
@@ -12,7 +12,10 @@ import type {
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {MobileBetaBanner} from 'sentry/components/onboarding/gettingStartedDoc/utils';
 import {getAndroidMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
-import {getReplayMobileConfigureDescription} from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
+import {
+  getReplayMobileConfigureDescription,
+  getReplayVerifyStep,
+} from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
 import {feedbackOnboardingCrashApiJava} from 'sentry/gettingStartedDocs/java/java';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
@@ -431,33 +434,12 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
       ],
     },
   ],
-  verify: () => [
-    {
-      type: StepType.VERIFY,
-      description: t(
-        'To verify your Replay setup, trigger an error in your app and watch Sentry capture the event along with a recording of the user interaction.'
-      ),
-      configurations: [
-        {
-          description: tct(
-            "You can simulate an error by adding the following code to your app's [code: MainActivity]:",
-            {code: <code />}
-          ),
-          code: [
-            {
-              label: 'Kotlin',
-              value: 'kotlin',
-              language: 'kotlin',
-              code: getVerifySnippet(),
-            },
-          ],
-          additionalInfo: t(
-            'After clicking the button, wait a few moments, and you\'ll see a new session appear on the "Replays" page.'
-          ),
-        },
-      ],
-    },
-  ],
+  verify: getReplayVerifyStep({
+    replayOnErrorSampleRateName:
+      'options\u200b.experimental\u200b.sessionReplay\u200b.errorSampleRate',
+    replaySessionSampleRateName:
+      'options\u200b.experimental\u200b.sessionReplay\u200b.sessionSampleRate',
+  }),
   nextSteps: () => [],
 };
 

--- a/static/app/gettingStartedDocs/apple/ios.tsx
+++ b/static/app/gettingStartedDocs/apple/ios.tsx
@@ -11,7 +11,10 @@ import type {
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {MobileBetaBanner} from 'sentry/components/onboarding/gettingStartedDoc/utils';
 import {metricTagsExplanation} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
-import {getReplayMobileConfigureDescription} from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
+import {
+  getReplayMobileConfigureDescription,
+  getReplayVerifyStep,
+} from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
 import {appleFeedbackOnboarding} from 'sentry/gettingStartedDocs/apple/macos';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
@@ -713,33 +716,12 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
       ],
     },
   ],
-  verify: () => [
-    {
-      type: StepType.VERIFY,
-      description: t(
-        'To verify your Replay setup, trigger an error in your app and watch Sentry capture the event along with a recording of the user interaction.'
-      ),
-      configurations: [
-        {
-          description: tct(
-            'You can simulate an error by adding the following code to your main [code: ViewController]:',
-            {code: <code />}
-          ),
-          code: [
-            {
-              label: 'Swift',
-              value: 'swift',
-              language: 'swift',
-              code: getVerifySnippet(),
-            },
-          ],
-          additionalInfo: t(
-            'After clicking the button, wait a few moments, and you\'ll see a new session appear on the "Replays" page.'
-          ),
-        },
-      ],
-    },
-  ],
+  verify: getReplayVerifyStep({
+    replayOnErrorSampleRateName:
+      'options\u200b.experimental\u200b.sessionReplay\u200b.onErrorSampleRate',
+    replaySessionSampleRateName:
+      'options\u200b.experimental\u200b.sessionReplay\u200b.sessionSampleRate',
+  }),
   nextSteps: () => [],
 };
 

--- a/static/app/gettingStartedDocs/apple/ios.tsx
+++ b/static/app/gettingStartedDocs/apple/ios.tsx
@@ -713,7 +713,33 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
       ],
     },
   ],
-  verify: () => [],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      description: t(
+        'To verify your Replay setup, trigger an error in your app and watch Sentry capture the event along with a recording of the user interaction.'
+      ),
+      configurations: [
+        {
+          description: tct(
+            'You can simulate an error by adding the following code to your main [code: ViewController]:',
+            {code: <code />}
+          ),
+          code: [
+            {
+              label: 'Swift',
+              value: 'swift',
+              language: 'swift',
+              code: getVerifySnippet(),
+            },
+          ],
+          additionalInfo: t(
+            'After clicking the button, wait a few moments, and you\'ll see a new session appear on the "Replays" page.'
+          ),
+        },
+      ],
+    },
+  ],
   nextSteps: () => [],
 };
 

--- a/static/app/gettingStartedDocs/capacitor/capacitor.tsx
+++ b/static/app/gettingStartedDocs/capacitor/capacitor.tsx
@@ -63,6 +63,12 @@ const platformOptions: Record<PlatformOptionKey, PlatformOption> = {
 type PlatformOptions = typeof platformOptions;
 type Params = DocsParams<PlatformOptions>;
 
+const getVerifyReplaySnippet = () => `
+setTimeout(() => {
+  throw new Error("Sentry Test Error");
+});
+`;
+
 function getIntegrations(params: Params, siblingOption: string) {
   const integrations: string[] = ['SentrySibling.browserTracingIntegration()'];
 
@@ -436,7 +442,26 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
       additionalInfo: <TracePropagationMessage />,
     },
   ],
-  verify: () => [],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      description: t(
+        'Session replays with errors, will always be captured with the settings above. You can verify this by adding the following snippet anywhere in your code and running it:'
+      ),
+      configurations: [
+        {
+          code: [
+            {
+              label: 'JavaScript',
+              value: 'javascript',
+              language: 'javascript',
+              code: getVerifyReplaySnippet(),
+            },
+          ],
+        },
+      ],
+    },
+  ],
   nextSteps: () => [],
 };
 

--- a/static/app/gettingStartedDocs/capacitor/capacitor.tsx
+++ b/static/app/gettingStartedDocs/capacitor/capacitor.tsx
@@ -19,6 +19,7 @@ import {
 import {
   getReplayConfigOptions,
   getReplayConfigureDescription,
+  getReplayVerifyStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
 import {t, tct} from 'sentry/locale';
 
@@ -62,12 +63,6 @@ const platformOptions: Record<PlatformOptionKey, PlatformOption> = {
 
 type PlatformOptions = typeof platformOptions;
 type Params = DocsParams<PlatformOptions>;
-
-const getVerifyReplaySnippet = () => `
-setTimeout(() => {
-  throw new Error("Sentry Test Error");
-});
-`;
 
 function getIntegrations(params: Params, siblingOption: string) {
   const integrations: string[] = ['SentrySibling.browserTracingIntegration()'];
@@ -442,26 +437,7 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
       additionalInfo: <TracePropagationMessage />,
     },
   ],
-  verify: () => [
-    {
-      type: StepType.VERIFY,
-      description: t(
-        'Session replays with errors, will always be captured with the settings above. You can verify this by adding the following snippet anywhere in your code and running it:'
-      ),
-      configurations: [
-        {
-          code: [
-            {
-              label: 'JavaScript',
-              value: 'javascript',
-              language: 'javascript',
-              code: getVerifyReplaySnippet(),
-            },
-          ],
-        },
-      ],
-    },
-  ],
+  verify: getReplayVerifyStep(),
   nextSteps: () => [],
 };
 

--- a/static/app/gettingStartedDocs/react-native/react-native.tsx
+++ b/static/app/gettingStartedDocs/react-native/react-native.tsx
@@ -478,7 +478,19 @@ const replayOnboarding: OnboardingConfig = {
       ],
     },
   ],
-  verify: () => [],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      description: tct(
+        "While you're testing, we recommend that you set [code:replaysSessionSampleRate] to [code:1.0]. This ensures that every user session will be sent to Sentry.",
+        {code: <code />}
+      ),
+      additionalInfo: tct(
+        'Once testing is complete, we recommend lowering this value in production. We still recommend keeping [code:replaysOnErrorSampleRate] set to [code:1.0].',
+        {code: <code />}
+      ),
+    },
+  ],
   nextSteps: () => [],
 };
 

--- a/static/app/gettingStartedDocs/react-native/react-native.tsx
+++ b/static/app/gettingStartedDocs/react-native/react-native.tsx
@@ -15,7 +15,10 @@ import {
   getCrashReportInstallDescription,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {getReactNativeMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
-import {getReplayMobileConfigureDescription} from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
+import {
+  getReplayMobileConfigureDescription,
+  getReplayVerifyStep,
+} from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
@@ -478,19 +481,7 @@ const replayOnboarding: OnboardingConfig = {
       ],
     },
   ],
-  verify: () => [
-    {
-      type: StepType.VERIFY,
-      description: tct(
-        "While you're testing, we recommend that you set [code:replaysSessionSampleRate] to [code:1.0]. This ensures that every user session will be sent to Sentry.",
-        {code: <code />}
-      ),
-      additionalInfo: tct(
-        'Once testing is complete, we recommend lowering this value in production. We still recommend keeping [code:replaysOnErrorSampleRate] set to [code:1.0].',
-        {code: <code />}
-      ),
-    },
-  ],
+  verify: getReplayVerifyStep(),
   nextSteps: () => [],
 };
 


### PR DESCRIPTION
Add a verify step for the replay onboarding of mobile platforms.

### iOS & Android
<img width="535" alt="Screenshot 2024-09-09 at 09 20 56" src="https://github.com/user-attachments/assets/ac379b0c-cd3e-4136-9bb5-b0a33ae4f87b">


### React-Native & Capacitor
<img width="535" alt="Screenshot 2024-09-09 at 09 20 45" src="https://github.com/user-attachments/assets/21e0f504-c3e2-4d49-a1c9-838ffcee84e7">
