### PR TITLE
feat(flagpole): Allow created_at to be a date

### DIFF
--- a/src/flagpole/flagpole-schema.json
+++ b/src/flagpole/flagpole-schema.json
@@ -32,7 +32,7 @@
       "title": "Created At",
       "description": "The datetime when this feature was created.",
       "type": "string",
-      "format": "date-time"
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}(?:T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?)?$"
     }
   },
   "required": [

--- a/src/sentry/runner/commands/createflag.py
+++ b/src/sentry/runner/commands/createflag.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date
 
 import click
 
@@ -129,7 +129,7 @@ def createflag(
             name=f"feature.{scope}:{name}",
             owner=owner,
             segments=segments,
-            created_at=datetime.now().isoformat(),
+            created_at=date.today().isoformat(),
         )
     except Exception as err:
         raise click.ClickException(f"{err}")

--- a/tests/flagpole/test_feature.py
+++ b/tests/flagpole/test_feature.py
@@ -153,6 +153,7 @@ class TestParseFeatureConfig:
         config = """
         {
             "owner": "sentry",
+            "created_at": "2024-05-14",
             "segments": [
                 {
                     "name": "",
@@ -170,6 +171,7 @@ class TestParseFeatureConfig:
         config = """
         {
             "owner": "sentry",
+            "created_at": "2024-05-14",
             "segments": [
                 {
                     "name": "allowed orgs",
@@ -194,6 +196,7 @@ class TestParseFeatureConfig:
         config = """
         {
             "owner": "sentry",
+            "created_at": "2024-05-14",
             "segments": [
                 {
                     "name": "ga",


### PR DESCRIPTION
Having to set the time and timezone for a feature created_at is tedious. We're mostly interested in the date, so allow dates or datetimes. The new pattern doesn't prevent invalid date values but does prevent invalid shapes.

Refs getsentry/sentry-options-automator#2237