### PR TITLE
fix(deletions) Remove notification message in order

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -211,7 +211,7 @@ def cleanup(
         BULK_QUERY_DELETES = [
             (models.UserReport, "date_added", None),
             (models.GroupEmailThread, "date", None),
-            (NotificationMessage, "date_added", None),
+            (NotificationMessage, "date_added", "-id"),
             (RuleFireHistory, "date_added", None),
         ] + additional_bulk_query_deletes
 


### PR DESCRIPTION
Remove notificationmessage records from the oldest to the newest. This is required because notificationmessage has a foreign key to earlier records, and without ordering integrity errors are encountered.

Fixes SENTRY-3BW5