### PR TITLE
fix(spans-eap): use the time column

### DIFF
--- a/src/sentry/search/events/builder/spans_indexed.py
+++ b/src/sentry/search/events/builder/spans_indexed.py
@@ -87,9 +87,7 @@ class TimeseriesSpanIndexedQueryBuilder(SpansIndexedQueryBuilderMixin, Timeserie
 
 
 class TimeseriesSpanEAPIndexedQueryBuilder(SpansEAPQueryBuilder, TimeseriesQueryBuilder):
-    config_class = SpansEAPDatasetConfig
-    uuid_fields = SPAN_UUID_FIELDS
-    span_id_fields = SPAN_ID_FIELDS
+    pass
 
 
 class TopEventsSpanIndexedQueryBuilder(SpansIndexedQueryBuilderMixin, TopEventsQueryBuilder):
@@ -105,6 +103,4 @@ class TopEventsSpanIndexedQueryBuilder(SpansIndexedQueryBuilderMixin, TopEventsQ
 
 
 class TopEventsSpanEAPQueryBuilder(SpansEAPQueryBuilder, TopEventsQueryBuilder):
-    config_class = SpansEAPDatasetConfig
-    uuid_fields = SPAN_UUID_FIELDS
-    span_id_fields = SPAN_ID_FIELDS
+    pass

--- a/src/sentry/search/events/builder/spans_indexed.py
+++ b/src/sentry/search/events/builder/spans_indexed.py
@@ -91,12 +91,6 @@ class TimeseriesSpanEAPIndexedQueryBuilder(SpansEAPQueryBuilder, TimeseriesQuery
     uuid_fields = SPAN_UUID_FIELDS
     span_id_fields = SPAN_ID_FIELDS
 
-    @property
-    def time_column(self) -> SelectType:
-        return custom_time_processor(
-            self.interval, Function("toUInt64", [Column("start_timestamp")])
-        )
-
 
 class TopEventsSpanIndexedQueryBuilder(SpansIndexedQueryBuilderMixin, TopEventsQueryBuilder):
     config_class = SpansIndexedDatasetConfig
@@ -114,9 +108,3 @@ class TopEventsSpanEAPQueryBuilder(SpansEAPQueryBuilder, TopEventsQueryBuilder):
     config_class = SpansEAPDatasetConfig
     uuid_fields = SPAN_UUID_FIELDS
     span_id_fields = SPAN_ID_FIELDS
-
-    @property
-    def time_column(self) -> SelectType:
-        return custom_time_processor(
-            self.interval, Function("toUInt64", [Column("start_timestamp")])
-        )

--- a/src/sentry/search/events/builder/spans_indexed.py
+++ b/src/sentry/search/events/builder/spans_indexed.py
@@ -94,7 +94,7 @@ class TimeseriesSpanEAPIndexedQueryBuilder(SpansEAPQueryBuilder, TimeseriesQuery
     @property
     def time_column(self) -> SelectType:
         return custom_time_processor(
-            self.interval, Function("toUInt32", [Column("start_timestamp")])
+            self.interval, Function("toUInt64", [Column("start_timestamp")])
         )
 
 

--- a/src/sentry/search/events/builder/spans_indexed.py
+++ b/src/sentry/search/events/builder/spans_indexed.py
@@ -118,5 +118,5 @@ class TopEventsSpanEAPQueryBuilder(SpansEAPQueryBuilder, TopEventsQueryBuilder):
     @property
     def time_column(self) -> SelectType:
         return custom_time_processor(
-            self.interval, Function("toUInt32", [Column("start_timestamp")])
+            self.interval, Function("toUInt64", [Column("start_timestamp")])
         )


### PR DESCRIPTION
- Bad copy pasta, we should be using the Time column since the eap
  dataset has the timeseries processor and can handle this for us