### PR TITLE
ref: squash index_together operation for GroupInbox model

### DIFF
--- a/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
+++ b/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
@@ -6414,9 +6414,11 @@ class Migration(CheckedMigration):
             name="display_type",
             field=sentry.db.models.fields.bounded.BoundedPositiveIntegerField(),
         ),
-        migrations.AlterIndexTogether(
-            name="groupinbox",
-            index_together={("project", "date_added")},
+        migrations.AddIndex(
+            model_name="groupinbox",
+            index=models.Index(
+                fields=["project", "date_added"], name="sentry_grou_project_a9fe16_idx"
+            ),
         ),
         migrations.AddField(
             model_name="dashboardwidgetquery",

--- a/src/sentry/migrations/0640_index_together.py
+++ b/src/sentry/migrations/0640_index_together.py
@@ -120,11 +120,6 @@ class Migration(CheckedMigration):
             old_fields=("project", "date_added"),
         ),
         migrations.RenameIndex(
-            model_name="groupinbox",
-            new_name="sentry_grou_project_a9fe16_idx",
-            old_fields=("project", "date_added"),
-        ),
-        migrations.RenameIndex(
             model_name="incidenttrigger",
             new_name="sentry_inci_alert_r_33da01_idx",
             old_fields=("alert_rule_trigger", "incident_id"),


### PR DESCRIPTION
index_together is removed in django 5.1 so this is necessary to upgrade

hard-stop is already in place for self-hosted

<!-- Describe your PR here. -->