### PR TITLE
ref: squash index_together operation for ReleaseProject model

### DIFF
--- a/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
+++ b/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
@@ -7180,10 +7180,6 @@ class Migration(CheckedMigration):
                     field=models.DateTimeField(blank=True, null=True),
                 ),
                 migrations.AlterIndexTogether(
-                    name="releaseproject",
-                    index_together={("project", "adopted"), ("project", "unadopted")},
-                ),
-                migrations.AlterIndexTogether(
                     name="releaseprojectenvironment",
                     index_together={
                         ("project", "adopted", "environment"),
@@ -8711,13 +8707,23 @@ class Migration(CheckedMigration):
             name="first_seen_transaction",
             field=models.DateTimeField(blank=True, null=True),
         ),
-        migrations.AlterIndexTogether(
-            name="releaseproject",
-            index_together={
-                ("project", "adopted"),
-                ("project", "first_seen_transaction"),
-                ("project", "unadopted"),
-            },
+        migrations.AddIndex(
+            model_name="releaseproject",
+            index=models.Index(
+                fields=["project", "adopted"], name="sentry_rele_project_a80825_idx"
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="releaseproject",
+            index=models.Index(
+                fields=["project", "unadopted"], name="sentry_rele_project_2ca122_idx"
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="releaseproject",
+            index=models.Index(
+                fields=["project", "first_seen_transaction"], name="sentry_rele_project_3143eb_idx"
+            ),
         ),
         migrations.SeparateDatabaseAndState(
             database_operations=[

--- a/src/sentry/migrations/0642_index_together_release.py
+++ b/src/sentry/migrations/0642_index_together_release.py
@@ -44,21 +44,6 @@ class Migration(CheckedMigration):
             new_name="sentry_rele_organiz_ffeeb2_idx",
             old_fields=("organization", "build_code"),
         ),
-        migrations.RenameIndex(
-            model_name="releaseproject",
-            new_name="sentry_rele_project_2ca122_idx",
-            old_fields=("project", "unadopted"),
-        ),
-        migrations.RenameIndex(
-            model_name="releaseproject",
-            new_name="sentry_rele_project_3143eb_idx",
-            old_fields=("project", "first_seen_transaction"),
-        ),
-        migrations.RenameIndex(
-            model_name="releaseproject",
-            new_name="sentry_rele_project_a80825_idx",
-            old_fields=("project", "adopted"),
-        ),
         migrations.SeparateDatabaseAndState(
             # fancy noop, we're now defining this index in django words
             database_operations=[],


### PR DESCRIPTION
index_together is removed in django 5.1 so this is necessary to upgrade

hard-stop is already in place for self-hosted

<!-- Describe your PR here. -->