### PR TITLE
ref: squash index_together operation for DebugIdArtifactBundle model

### DIFF
--- a/src/sentry/migrations/0518_cleanup_bundles_indexes.py
+++ b/src/sentry/migrations/0518_cleanup_bundles_indexes.py
@@ -55,9 +55,11 @@ class Migration(CheckedMigration):
             name="artifactbundleindex",
             index_together={("url", "artifact_bundle")},
         ),
-        migrations.AlterIndexTogether(
-            name="debugidartifactbundle",
-            index_together={("debug_id", "artifact_bundle")},
+        migrations.AddIndex(
+            model_name="debugidartifactbundle",
+            index=models.Index(
+                fields=["debug_id", "artifact_bundle"], name="sentry_debu_debug_i_8c6c44_idx"
+            ),
         ),
         migrations.AlterIndexTogether(
             name="projectartifactbundle",

--- a/src/sentry/migrations/0640_index_together.py
+++ b/src/sentry/migrations/0640_index_together.py
@@ -55,11 +55,6 @@ class Migration(CheckedMigration):
             ),
         ),
         migrations.RenameIndex(
-            model_name="debugidartifactbundle",
-            new_name="sentry_debu_debug_i_8c6c44_idx",
-            old_fields=("debug_id", "artifact_bundle"),
-        ),
-        migrations.RenameIndex(
             model_name="group",
             new_name="sentry_grou_project_5eb75b_idx",
             old_fields=("project", "status", "substatus", "last_seen", "id"),


### PR DESCRIPTION
index_together is removed in django 5.1 so this is necessary to upgrade

hard-stop is already in place for self-hosted

<!-- Describe your PR here. -->