### PR TITLE
ref: squash index_together operation for RegressionGroup model

### DIFF
--- a/src/sentry/migrations/0611_add_regression_group_model.py
+++ b/src/sentry/migrations/0611_add_regression_group_model.py
@@ -50,7 +50,12 @@ class Migration(CheckedMigration):
             ],
             options={
                 "unique_together": {("type", "project_id", "fingerprint", "version")},
-                "index_together": {("type", "project_id", "fingerprint", "active")},
+                "indexes": [
+                    models.Index(
+                        fields=["type", "project_id", "fingerprint", "active"],
+                        name="sentry_regr_type_3a29e7_idx",
+                    ),
+                ],
             },
         ),
     ]

--- a/src/sentry/migrations/0640_index_together.py
+++ b/src/sentry/migrations/0640_index_together.py
@@ -160,11 +160,6 @@ class Migration(CheckedMigration):
             old_fields=("shard_scope", "shard_identifier", "scheduled_for"),
         ),
         migrations.RenameIndex(
-            model_name="regressiongroup",
-            new_name="sentry_regr_type_3a29e7_idx",
-            old_fields=("type", "project_id", "fingerprint", "active"),
-        ),
-        migrations.RenameIndex(
             model_name="releaseartifactbundle",
             new_name="sentry_rele_organiz_291018_idx",
             old_fields=("organization_id", "release_name", "dist_name", "artifact_bundle"),


### PR DESCRIPTION
index_together is removed in django 5.1 so this is necessary to upgrade

hard-stop is already in place for self-hosted

<!-- Describe your PR here. -->