### PR TITLE
ref: squash index_together operation for Rule model

### DIFF
--- a/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
+++ b/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
@@ -7352,20 +7352,11 @@ class Migration(CheckedMigration):
                 "db_table": "sentry_appconnectbuild",
             },
         ),
-        migrations.SeparateDatabaseAndState(
-            database_operations=[
-                migrations.RunSQL(
-                    sql='\n                    CREATE INDEX CONCURRENTLY  "sentry_rule_project_id_status_owner_id_82f20db5_idx" ON "sentry_rule" ("project_id", "status", "owner_id");\n                    ',
-                    reverse_sql="\n                    DROP INDEX CONCURRENTLY IF EXISTS sentry_rule_project_id_status_owner_id_82f20db5_idx;\n                    ",
-                    hints={"tables": ["sentry_rule"]},
-                ),
-            ],
-            state_operations=[
-                migrations.AlterIndexTogether(
-                    name="rule",
-                    index_together={("project", "status", "owner")},
-                ),
-            ],
+        migrations.AddIndex(
+            model_name="rule",
+            index=models.Index(
+                fields=["project", "status", "owner"], name="sentry_rule_project_676d0d_idx"
+            ),
         ),
         migrations.AddIndex(
             model_name="activity",

--- a/src/sentry/migrations/0640_index_together.py
+++ b/src/sentry/migrations/0640_index_together.py
@@ -159,9 +159,4 @@ class Migration(CheckedMigration):
             new_name="sentry_rele_project_4bea8e_idx",
             old_fields=("project", "adopted", "environment"),
         ),
-        migrations.RenameIndex(
-            model_name="rule",
-            new_name="sentry_rule_project_676d0d_idx",
-            old_fields=("project", "status", "owner"),
-        ),
     ]


### PR DESCRIPTION
index_together is removed in django 5.1 so this is necessary to upgrade

hard-stop is already in place for self-hosted

<!-- Describe your PR here. -->