### PR TITLE
(seer client): Add warning if secret is not configured

### DIFF
--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -1,5 +1,6 @@
 import hashlib
 import hmac
+import logging
 from random import random
 from typing import Any
 from urllib.parse import urlparse
@@ -9,6 +10,8 @@ from urllib3 import BaseHTTPResponse, HTTPConnectionPool
 
 from sentry import options
 from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
 
 
 def make_signed_seer_api_request(
@@ -40,10 +43,15 @@ def make_signed_seer_api_request(
 
 def sign_with_seer_secret(url: str, body: bytes):
     auth_headers: dict[str, str] = {}
-    if random() < options.get("seer.api.use-shared-secret") and settings.SEER_API_SHARED_SECRET:
-        signature_input = b"%s:%s" % (url.encode("utf8"), body)
-        signature = hmac.new(
-            settings.SEER_API_SHARED_SECRET.encode("utf-8"), signature_input, hashlib.sha256
-        ).hexdigest()
-        auth_headers["Authorization"] = f"Rpcsignature rpc0:{signature}"
+    if random() < options.get("seer.api.use-shared-secret"):
+        if settings.SEER_API_SHARED_SECRET:
+            signature_input = b"%s:%s" % (url.encode("utf8"), body)
+            signature = hmac.new(
+                settings.SEER_API_SHARED_SECRET.encode("utf-8"), signature_input, hashlib.sha256
+            ).hexdigest()
+            auth_headers["Authorization"] = f"Rpcsignature rpc0:{signature}"
+        else:
+            logger.warning(
+                "Seer.api.use-shared-secret is set but secret is not set. Unable to add auth headers for call to Seer."
+            )
     return auth_headers

--- a/tests/sentry/seer/test_signed_seer_api.py
+++ b/tests/sentry/seer/test_signed_seer_api.py
@@ -10,7 +10,7 @@ REQUEST_BODY = b'{"b": 12, "thing": "thing"}'
 PATH = "/v0/some/url"
 
 
-def run_test_case(path: str = PATH, timeout: int | None = None):
+def run_test_case(path: str = PATH, timeout: int | None = None, shared_secret: str = "secret-one"):
     """
     Make a mock connection pool, call `make_signed_seer_api_request` on it, and return the
     pool's `urlopen` method, so we can make assertions on how `make_signed_seer_api_request`
@@ -20,7 +20,7 @@ def run_test_case(path: str = PATH, timeout: int | None = None):
     mock.host = "localhost"
     mock.port = None
     mock.scheme = "http"
-    with override_settings(SEER_API_SHARED_SECRET="secret-one"):
+    with override_settings(SEER_API_SHARED_SECRET=shared_secret):
         make_signed_seer_api_request(
             mock,
             path=path,
@@ -58,6 +58,21 @@ def test_uses_given_timeout():
 def test_uses_shared_secret():
     with override_options({"seer.api.use-shared-secret": 1.0}):
         mock_url_open = run_test_case()
+        mock_url_open.assert_called_once_with(
+            "POST",
+            PATH,
+            body=REQUEST_BODY,
+            headers={
+                "content-type": "application/json;charset=utf-8",
+                "Authorization": "Rpcsignature rpc0:96f23d5b3df807a9dc91f090078a46c00e17fe8b0bc7ef08c9391fa8b37a66b5",
+            },
+        )
+
+
+@pytest.mark.django_db
+def test_uses_shared_secret_missing_secret():
+    with override_options({"seer.api.use-shared-secret": 1.0}):
+        mock_url_open = run_test_case(shared_secret="")
         mock_url_open.assert_called_once_with(
             "POST",
             PATH,


### PR DESCRIPTION
Adds check and logging for the secret key used to sign Seer requests