### PR TITLE
fix(dashboards): Fix Big Number rendering in Edit Mode

### DIFF
--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -596,6 +596,7 @@ const BigNumberResizeWrapper = styled('div')`
   flex-grow: 1;
   overflow: hidden;
   position: relative;
+  margin: ${space(1)} ${space(3)} ${space(3)} ${space(3)};
 `;
 
 const BigNumber = styled('div')`
@@ -616,7 +617,7 @@ const BigNumber = styled('div')`
 const AutoResizeParent = styled('div')`
   position: absolute;
   color: ${p => p.theme.headingColor};
-  inset: ${space(1)} ${space(3)} 0 ${space(3)};
+  inset: 0;
 
   * {
     line-height: 1;

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -593,8 +593,7 @@ const LoadingPlaceholder = styled(({className}: PlaceholderProps) => (
 `;
 
 const BigNumberResizeWrapper = styled('div')`
-  height: 100%;
-  width: 100%;
+  flex-grow: 1;
   overflow: hidden;
   position: relative;
 `;


### PR DESCRIPTION
There's a bug with the current approach where the Big Number widget can't render inside the edit modal.

This fixes the bug. The first change is to use `flex-grow` to allow the number container to grow naturally, instead of using 100% width and height, which doesn't make sense in a flex content. The second is to use margin to create space around the number wrapper, so it can create gutter space around itself.
