### PR TITLE
feat(dashboards): Add y-axis pointer

### DIFF
--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -424,6 +424,9 @@ class WidgetCardChart extends Component<WidgetCardChartProps, State> {
       },
       tooltip: {
         trigger: 'axis',
+        axisPointer: {
+          type: 'cross',
+        },
         formatter: (params, asyncTicket) => {
           const {chartGroup} = this.props;
           const isInGroup =
@@ -457,6 +460,17 @@ class WidgetCardChart extends Component<WidgetCardChartProps, State> {
               );
             }
             return axisLabelFormatter(value, aggregateOutputType(axisLabel), true);
+          },
+        },
+        axisPointer: {
+          type: 'line',
+          snap: false,
+          lineStyle: {
+            type: 'solid',
+            width: 0.5,
+          },
+          label: {
+            show: false,
           },
         },
         minInterval: durationUnit ?? 0,


### PR DESCRIPTION
Borrows a feature from Insights! On hover, shows a y-axis pointer line, that shows where the cursor intersects with the y-axis. This is really useful for things like:

- comparing multiple peaks to see if they're the same
- eyeballing whether a line is going up or down
- etc.

**e.g.,**

https://github.com/user-attachments/assets/6e6541ca-9381-44af-acbb-5d95b124898f

