### PR TITLE
ref: squash index_together operation for ArtifactBundleIndex model

### DIFF
--- a/src/sentry/migrations/0504_add_artifact_bundle_index.py
+++ b/src/sentry/migrations/0504_add_artifact_bundle_index.py
@@ -59,9 +59,6 @@ class Migration(CheckedMigration):
             ],
             options={
                 "db_table": "sentry_artifactbundleindex",
-                "index_together": {
-                    ("organization_id", "release_name", "dist_name", "url", "artifact_bundle")
-                },
             },
         ),
     ]

--- a/src/sentry/migrations/0518_cleanup_bundles_indexes.py
+++ b/src/sentry/migrations/0518_cleanup_bundles_indexes.py
@@ -51,9 +51,11 @@ class Migration(CheckedMigration):
             name="releaseartifactbundle",
             unique_together=set(),
         ),
-        migrations.AlterIndexTogether(
-            name="artifactbundleindex",
-            index_together={("url", "artifact_bundle")},
+        migrations.AddIndex(
+            model_name="artifactbundleindex",
+            index=models.Index(
+                fields=["url", "artifact_bundle"], name="sentry_arti_url_7e628a_idx"
+            ),
         ),
         migrations.AddIndex(
             model_name="debugidartifactbundle",

--- a/src/sentry/migrations/0640_index_together.py
+++ b/src/sentry/migrations/0640_index_together.py
@@ -24,11 +24,6 @@ class Migration(CheckedMigration):
 
     operations = [
         migrations.RenameIndex(
-            model_name="artifactbundleindex",
-            new_name="sentry_arti_url_7e628a_idx",
-            old_fields=("url", "artifact_bundle"),
-        ),
-        migrations.RenameIndex(
             model_name="controloutbox",
             new_name="sentry_cont_region__0c4512_idx",
             old_fields=("region_name", "shard_scope", "shard_identifier", "scheduled_for"),


### PR DESCRIPTION
index_together is removed in django 5.1 so this is necessary to upgrade

hard-stop is already in place for self-hosted

<!-- Describe your PR here. -->