### PR TITLE
chore(anomaly detection): no anomaly detection for apdex alerts

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -1173,6 +1173,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
 
     const thresholdTypeForm = (disabled: boolean) => (
       <ThresholdTypeForm
+        alertType={alertType}
         comparisonType={comparisonType}
         dataset={dataset}
         disabled={disabled}

--- a/static/app/views/alerts/rules/metric/thresholdTypeForm.tsx
+++ b/static/app/views/alerts/rules/metric/thresholdTypeForm.tsx
@@ -37,6 +37,19 @@ function ThresholdTypeForm({
   if (isCrashFreeAlert(dataset)) {
     return null;
   }
+  const validAnomalyDetectionAlertTypes = new Set([
+    'num_errors',
+    'users_experiencing_errors',
+    'throughput',
+    'trans_duration',
+    'failure_rate',
+    'lcp',
+    'fid',
+    'cls',
+    'custom_transactions',
+    'custom_metrics',
+    'insights_metrics',
+  ]);
 
   const hasAnomalyDetection = organization.features.includes('anomaly-detection-alerts');
 
@@ -81,10 +94,7 @@ function ThresholdTypeForm({
     ],
   ];
 
-  if (
-    hasAnomalyDetection &&
-    !(alertType === 'apdex' || alertType === 'llm_tokens' || alertType === 'llm_cost')
-  ) {
+  if (hasAnomalyDetection && validAnomalyDetectionAlertTypes.has(alertType)) {
     thresholdTypeChoices.push([
       AlertRuleComparisonType.DYNAMIC,
       'Anomaly: whenever values are outside of expected bounds',

--- a/static/app/views/alerts/rules/metric/thresholdTypeForm.tsx
+++ b/static/app/views/alerts/rules/metric/thresholdTypeForm.tsx
@@ -7,12 +7,14 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import {COMPARISON_DELTA_OPTIONS} from 'sentry/views/alerts/rules/metric/constants';
+import type {MetricAlertType} from 'sentry/views/alerts/wizard/options';
 
 import {isCrashFreeAlert} from './utils/isCrashFreeAlert';
 import type {Dataset} from './types';
 import {AlertRuleComparisonType} from './types';
 
 type Props = {
+  alertType: MetricAlertType;
   comparisonType: AlertRuleComparisonType;
   dataset: Dataset;
   disabled: boolean;
@@ -23,6 +25,7 @@ type Props = {
 };
 
 function ThresholdTypeForm({
+  alertType,
   organization,
   dataset,
   disabled,
@@ -78,7 +81,10 @@ function ThresholdTypeForm({
     ],
   ];
 
-  if (hasAnomalyDetection) {
+  if (
+    hasAnomalyDetection &&
+    !(alertType === 'apdex' || alertType === 'llm_tokens' || alertType === 'llm_cost')
+  ) {
     thresholdTypeChoices.push([
       AlertRuleComparisonType.DYNAMIC,
       'Anomaly: whenever values are outside of expected bounds',


### PR DESCRIPTION
Hide the anomaly detection option if the alert type is apdex/llm.

https://github.com/user-attachments/assets/d869c902-8e74-41e4-b8bc-26cd90424706

