### PR TITLE
chore(integrations): log invalid integration metric

### DIFF
--- a/src/sentry/integrations/api/endpoints/integration_proxy.py
+++ b/src/sentry/integrations/api/endpoints/integration_proxy.py
@@ -109,6 +109,7 @@ class InternalIntegrationProxyEndpoint(Endpoint):
         )
         if self.org_integration is None:
             logger.info("integration_proxy.invalid_org_integration", extra=self.log_extra)
+            metrics.incr("hybrid_cloud.integration_proxy.failure.invalid_org_integration")
             return False
         self.log_extra["integration_id"] = self.org_integration.integration_id
 
@@ -116,6 +117,8 @@ class InternalIntegrationProxyEndpoint(Endpoint):
         self.integration = self.org_integration.integration
         if not self.integration or self.integration.status is not ObjectStatus.ACTIVE:
             logger.info("integration_proxy.invalid_integration", extra=self.log_extra)
+            if self.integration and self.integration.status is not ObjectStatus.ACTIVE:
+                metrics.incr("hybrid_cloud.integration_proxy.failure.invalid_integration")
             return False
 
         # Get the integration client


### PR DESCRIPTION
We are making some changes that should hopefully reduce the number of calls going through the integration proxy that get rejected because the integration or the org integration is not active. To get a baseline value for how much this is happening, emit a metric now.