### PR TITLE
styles(explore): Make explore toolbar more compact

### DIFF
--- a/static/app/utils/dedupeArray.tsx
+++ b/static/app/utils/dedupeArray.tsx
@@ -1,0 +1,13 @@
+export function dedupeArray(values: string[]): string[] {
+  const deduped: string[] = [];
+  const seen = new Set();
+  values.forEach(s => {
+    if (seen.has(s)) {
+      return;
+    }
+
+    seen.add(s);
+    deduped.push(s);
+  });
+  return deduped;
+}

--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -6,6 +6,7 @@ import {CompactSelect} from 'sentry/components/compactSelect';
 import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {dedupeArray} from 'sentry/utils/dedupeArray';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -36,20 +37,6 @@ const exploreChartTypeOptions = [
   },
 ];
 
-function dedupe(strings: string[]): string[] {
-  const deduped: string[] = [];
-  const seen = new Set();
-  strings.forEach(s => {
-    if (seen.has(s)) {
-      return;
-    }
-
-    seen.add(s);
-    deduped.push(s);
-  });
-  return deduped;
-}
-
 // TODO: Update to support aggregate mode and multiple queries / visualizations
 export function ExploreCharts({query}: ExploreChartsProps) {
   const pageFilters = usePageFilters();
@@ -58,7 +45,7 @@ export function ExploreCharts({query}: ExploreChartsProps) {
   const [interval, setInterval, intervalOptions] = useChartInterval();
 
   const yAxes = useMemo(() => {
-    const deduped = dedupe(visualizes.flatMap(visualize => visualize.yAxes));
+    const deduped = dedupeArray(visualizes.flatMap(visualize => visualize.yAxes));
     deduped.sort();
     return deduped;
   }, [visualizes]);
@@ -76,7 +63,7 @@ export function ExploreCharts({query}: ExploreChartsProps) {
   return (
     <Fragment>
       {visualizes.map((visualize, index) => {
-        const dedupedYAxes = dedupe(visualize.yAxes);
+        const dedupedYAxes = dedupeArray(visualize.yAxes);
         return (
           <ChartContainer key={index}>
             <ChartPanel>

--- a/static/app/views/explore/hooks/useSampleFields.spec.tsx
+++ b/static/app/views/explore/hooks/useSampleFields.spec.tsx
@@ -33,7 +33,7 @@ describe('useSampleFields', function () {
 
     expect(sampleFields).toEqual([
       'project',
-      'id',
+      'span_id',
       'span.op',
       'span.description',
       'span.duration',
@@ -46,7 +46,7 @@ describe('useSampleFields', function () {
     act(() => setSampleFields([]));
     expect(sampleFields).toEqual([
       'project',
-      'id',
+      'span_id',
       'span.op',
       'span.description',
       'span.duration',

--- a/static/app/views/explore/hooks/useSampleFields.tsx
+++ b/static/app/views/explore/hooks/useSampleFields.tsx
@@ -31,7 +31,14 @@ function useSampleFieldsImpl({
       return fields;
     }
 
-    return ['project', 'id', 'span.op', 'span.description', 'span.duration', 'timestamp'];
+    return [
+      'project',
+      'span_id',
+      'span.op',
+      'span.description',
+      'span.duration',
+      'timestamp',
+    ];
   }, [location.query.field]);
 
   const setSampleFields = useCallback(

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -3,6 +3,7 @@ import {Fragment, useMemo} from 'react';
 import Link from 'sentry/components/links/link';
 import Pagination from 'sentry/components/pagination';
 import type {NewQuery} from 'sentry/types/organization';
+import {dedupeArray} from 'sentry/utils/dedupeArray';
 import type {EventData} from 'sentry/utils/discover/eventView';
 import EventView from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
@@ -37,7 +38,16 @@ export function SpansTable({}: SpansTableProps) {
   const [query] = useUserQuery();
 
   const queryFields = useMemo(() => {
-    return [...fields, 'project', 'trace', 'transaction.id', 'span_id', 'timestamp'];
+    const deduped = dedupeArray([
+      ...fields,
+      'project',
+      'trace',
+      'transaction.id',
+      'span_id',
+      'timestamp',
+    ]);
+    deduped.sort();
+    return deduped;
   }, [fields]);
 
   const eventView = useMemo(() => {

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -3,7 +3,6 @@ import {Fragment, useMemo} from 'react';
 import Link from 'sentry/components/links/link';
 import Pagination from 'sentry/components/pagination';
 import type {NewQuery} from 'sentry/types/organization';
-import {dedupeArray} from 'sentry/utils/dedupeArray';
 import type {EventData} from 'sentry/utils/discover/eventView';
 import EventView from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
@@ -37,20 +36,16 @@ export function SpansTable({}: SpansTableProps) {
   const [sorts] = useSorts({fields});
   const [query] = useUserQuery();
 
-  const queryFields = useMemo(() => {
-    const deduped = dedupeArray([
+  const eventView = useMemo(() => {
+    const queryFields = [
       ...fields,
       'project',
       'trace',
       'transaction.id',
       'span_id',
       'timestamp',
-    ]);
-    deduped.sort();
-    return deduped;
-  }, [fields]);
+    ];
 
-  const eventView = useMemo(() => {
     const discoverQuery: NewQuery = {
       id: undefined,
       name: 'Explore - Span Samples',
@@ -62,7 +57,7 @@ export function SpansTable({}: SpansTableProps) {
     };
 
     return EventView.fromNewQueryWithPageFilters(discoverQuery, selection);
-  }, [dataset, queryFields, sorts, query, selection]);
+  }, [dataset, fields, sorts, query, selection]);
 
   const result = useSpansQuery({
     eventView,

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -219,5 +219,11 @@ describe('ExploreToolbar', function () {
       within(section).getByRole('button', {name: 'span.description'})
     ).toBeInTheDocument();
     expect(groupBys).toEqual(['span.op', 'span.description']);
+
+    await userEvent.click(within(section).getAllByLabelText('Remove')[0]);
+    expect(groupBys).toEqual(['span.description']);
+
+    // only one left so cant be deleted
+    expect(within(section).getByLabelText('Remove')).toBeDisabled();
   });
 });

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -134,13 +134,13 @@ describe('ExploreToolbar', function () {
 
     // this is the default
     expect(within(section).getByRole('button', {name: 'timestamp'})).toBeInTheDocument();
-    expect(within(section).getByRole('button', {name: 'Descending'})).toBeInTheDocument();
+    expect(within(section).getByRole('button', {name: 'Desc'})).toBeInTheDocument();
     expect(sorts).toEqual([{field: 'timestamp', kind: 'desc'}]);
 
     // check the default field options
     const fields = [
       'project',
-      'id',
+      'span_id',
       'span.op',
       'span.description',
       'span.duration',
@@ -156,20 +156,20 @@ describe('ExploreToolbar', function () {
     // try changing the field
     await userEvent.click(within(section).getByRole('option', {name: 'span.op'}));
     expect(within(section).getByRole('button', {name: 'span.op'})).toBeInTheDocument();
-    expect(within(section).getByRole('button', {name: 'Descending'})).toBeInTheDocument();
+    expect(within(section).getByRole('button', {name: 'Desc'})).toBeInTheDocument();
     expect(sorts).toEqual([{field: 'span.op', kind: 'desc'}]);
 
     // check the kind options
-    await userEvent.click(within(section).getByRole('button', {name: 'Descending'}));
+    await userEvent.click(within(section).getByRole('button', {name: 'Desc'}));
     const kindOptions = await within(section).findAllByRole('option');
     expect(kindOptions).toHaveLength(2);
-    expect(kindOptions[0]).toHaveTextContent('Descending');
-    expect(kindOptions[1]).toHaveTextContent('Ascending');
+    expect(kindOptions[0]).toHaveTextContent('Desc');
+    expect(kindOptions[1]).toHaveTextContent('Asc');
 
     // try changing the kind
-    await userEvent.click(within(section).getByRole('option', {name: 'Ascending'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'Asc'}));
     expect(within(section).getByRole('button', {name: 'span.op'})).toBeInTheDocument();
-    expect(within(section).getByRole('button', {name: 'Ascending'})).toBeInTheDocument();
+    expect(within(section).getByRole('button', {name: 'Asc'})).toBeInTheDocument();
     expect(sorts).toEqual([{field: 'span.op', kind: 'asc'}]);
   });
 
@@ -186,6 +186,16 @@ describe('ExploreToolbar', function () {
 
     expect(within(section).getByRole('button', {name: 'None'})).toBeInTheDocument();
     expect(groupBys).toEqual(['']);
+
+    // disabled in the samples mode
+    expect(within(section).getByRole('button', {name: 'None'})).toBeDisabled();
+
+    // click the aggregates mode to enable
+    await userEvent.click(
+      within(screen.getByTestId('section-result-mode')).getByRole('radio', {
+        name: 'Aggregate',
+      })
+    );
 
     await userEvent.click(within(section).getByRole('button', {name: 'None'}));
     const groupByOptions1 = await within(section).findAllByRole('option');

--- a/static/app/views/explore/toolbar/index.tsx
+++ b/static/app/views/explore/toolbar/index.tsx
@@ -46,7 +46,7 @@ export function ExploreToolbar({extras}: ExploreToolbarProps) {
       )}
       <ToolbarResults resultMode={resultMode} setResultMode={setResultMode} />
       <ToolbarVisualize />
-      <ToolbarGroupBy />
+      <ToolbarGroupBy disabled={resultMode !== 'aggregate'} />
       <ToolbarSortBy fields={fields} sorts={sorts} setSorts={setSorts} />
       <ToolbarLimitTo />
     </div>

--- a/static/app/views/explore/toolbar/styles.tsx
+++ b/static/app/views/explore/toolbar/styles.tsx
@@ -1,9 +1,6 @@
-import {useCallback} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
-import {IconDelete} from 'sentry/icons/iconDelete';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 export const ToolbarSection = styled('div')`
@@ -36,45 +33,15 @@ export const ToolbarFooterButton = styled(Button)<{disabled?: boolean}>`
   color: ${p => p.theme.gray300};
 `;
 
-export function ToolbarRow<T>({
-  index = 0,
-  rows = [],
-  setRows,
-  children,
-}: {
-  children: React.ReactNode;
-  index?: number;
-  rows?: T[];
-  setRows?: (rows: T[]) => void;
-}) {
-  const removeRow = useCallback(
-    (i: number) => {
-      const newRow = rows.filter((_, rowIndex) => rowIndex !== i);
-      setRows?.(newRow);
-    },
-    [setRows, rows]
-  );
+export const ToolbarFooter = styled('div')<{disabled?: boolean}>`
+  margin-top: ${space(0.5)};
+`;
 
-  return (
-    <ToolbarRowWrapper>
-      {children}
-      <Button
-        borderless
-        icon={<IconDelete />}
-        size="zero"
-        disabled={rows.length <= 1}
-        onClick={e => {
-          e.preventDefault();
-          removeRow(index);
-        }}
-        aria-label={t('Remove')}
-      />
-    </ToolbarRowWrapper>
-  );
-}
-
-const ToolbarRowWrapper = styled('div')`
+export const ToolbarRow = styled('div')`
   display: flex;
-  align-items: center;
-  gap: ${space(0.5)};
+  justify-content: space-between;
+
+  :not(:first-child) {
+    padding-top: ${space(1)};
+  }
 `;

--- a/static/app/views/explore/toolbar/toolbarDataset.tsx
+++ b/static/app/views/explore/toolbar/toolbarDataset.tsx
@@ -15,7 +15,12 @@ export function ToolbarDataset({dataset, setDataset}: ToolbarDatasetProps) {
       <ToolbarHeader>
         <ToolbarHeading>{t('Dataset')}</ToolbarHeading>
       </ToolbarHeader>
-      <SegmentedControl aria-label={t('Dataset')} value={dataset} onChange={setDataset}>
+      <SegmentedControl
+        size="sm"
+        aria-label={t('Dataset')}
+        value={dataset}
+        onChange={setDataset}
+      >
         <SegmentedControl.Item key={DiscoverDatasets.SPANS_INDEXED}>
           {t('Indexed Spans')}
         </SegmentedControl.Item>

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -1,7 +1,9 @@
 import {useCallback, useMemo} from 'react';
 
+import {Button} from 'sentry/components/button';
 import type {SelectOption} from 'sentry/components/compactSelect';
 import {CompactSelect} from 'sentry/components/compactSelect';
+import {IconDelete} from 'sentry/icons/iconDelete';
 import {t} from 'sentry/locale';
 import {useGroupBys} from 'sentry/views/explore/hooks/useGroupBys';
 import type {Field} from 'sentry/views/explore/hooks/useSampleFields';
@@ -15,7 +17,11 @@ import {
   ToolbarSection,
 } from './styles';
 
-export function ToolbarGroupBy() {
+interface ToolbarGroupByProps {
+  disabled?: boolean;
+}
+
+export function ToolbarGroupBy({disabled}: ToolbarGroupByProps) {
   // TODO: This should be loaded from context to avoid loading tags twice.
   const tags = useSpanFieldSupportedTags();
 
@@ -47,25 +53,49 @@ export function ToolbarGroupBy() {
     [setGroupBys, groupBys]
   );
 
+  const deleteGroupBy = useCallback(
+    (index: number) => {
+      const newGroupBys = groupBys.filter((_, orgIndex) => index !== orgIndex);
+      setGroupBys?.(newGroupBys);
+    },
+    [setGroupBys, groupBys]
+  );
+
   return (
     <ToolbarSection data-test-id="section-group-by">
       <ToolbarHeader>
-        <ToolbarHeading>{t('Group By')}</ToolbarHeading>
-        <ToolbarHeaderButton size="xs" onClick={addGroupBy} borderless>
+        <ToolbarHeading disabled={disabled}>{t('Group By')}</ToolbarHeading>
+        <ToolbarHeaderButton
+          disabled={disabled}
+          size="xs"
+          onClick={addGroupBy}
+          borderless
+        >
           {t('+Add Group By')}
         </ToolbarHeaderButton>
       </ToolbarHeader>
-      {groupBys.map((groupBy, index) => (
-        <ToolbarRow rows={groupBys} setRows={setGroupBys} index={index} key={index}>
-          <CompactSelect
-            searchable
-            size="md"
-            options={options}
-            value={groupBy}
-            onChange={newGroupBy => setGroupBy(index, newGroupBy)}
-          />
-        </ToolbarRow>
-      ))}
+      <div>
+        {groupBys.map((groupBy, index) => (
+          <ToolbarRow key={index}>
+            <CompactSelect
+              searchable
+              disabled={disabled}
+              size="sm"
+              options={options}
+              value={groupBy}
+              onChange={newGroupBy => setGroupBy(index, newGroupBy)}
+            />
+            <Button
+              borderless
+              icon={<IconDelete />}
+              size="zero"
+              disabled={disabled || groupBys.length <= 1}
+              onClick={() => deleteGroupBy(index)}
+              aria-label={t('Remove')}
+            />
+          </ToolbarRow>
+        ))}
+      </div>
     </ToolbarSection>
   );
 }

--- a/static/app/views/explore/toolbar/toolbarResults.tsx
+++ b/static/app/views/explore/toolbar/toolbarResults.tsx
@@ -16,6 +16,7 @@ export function ToolbarResults({resultMode, setResultMode}: ToolbarResultsProps)
         <ToolbarHeading>{t('Results')}</ToolbarHeading>
       </ToolbarHeader>
       <SegmentedControl
+        size="sm"
         aria-label={t('Result Mode')}
         value={resultMode}
         onChange={setResultMode}

--- a/static/app/views/explore/toolbar/toolbarSortBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarSortBy.tsx
@@ -41,11 +41,11 @@ export function ToolbarSortBy({fields, setSorts, sorts}: ToolbarSortByProps) {
   const kindOptions: SelectOption<Sort['kind']>[] = useMemo(() => {
     return [
       {
-        label: 'Descending',
+        label: 'Desc',
         value: 'desc',
       },
       {
-        label: 'Ascending',
+        label: 'Asc',
         value: 'asc',
       },
     ];
@@ -70,20 +70,22 @@ export function ToolbarSortBy({fields, setSorts, sorts}: ToolbarSortByProps) {
       <ToolbarHeader>
         <ToolbarHeading>{t('Sort By')}</ToolbarHeading>
       </ToolbarHeader>
-      <ToolbarRow>
-        <CompactSelect
-          size="md"
-          options={fieldOptions}
-          value={sorts[0]?.field}
-          onChange={newSortField => setSortField(0, newSortField)}
-        />
-        <CompactSelect
-          size="md"
-          options={kindOptions}
-          value={sorts[0]?.kind}
-          onChange={newSortKind => setSortKind(0, newSortKind)}
-        />
-      </ToolbarRow>
+      <div>
+        <ToolbarRow>
+          <CompactSelect
+            size="sm"
+            options={fieldOptions}
+            value={sorts[0]?.field}
+            onChange={newSortField => setSortField(0, newSortField)}
+          />
+          <CompactSelect
+            size="sm"
+            options={kindOptions}
+            value={sorts[0]?.kind}
+            onChange={newSortKind => setSortKind(0, newSortKind)}
+          />
+        </ToolbarRow>
+      </div>
     </ToolbarSection>
   );
 }

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -1,11 +1,9 @@
 import {Fragment, useCallback, useMemo} from 'react';
-import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
 import {CompactSelect, type SelectOption} from 'sentry/components/compactSelect';
 import {IconDelete} from 'sentry/icons/iconDelete';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import type {ParsedFunction} from 'sentry/utils/discover/fields';
 import {parseFunction} from 'sentry/utils/discover/fields';
@@ -19,10 +17,12 @@ import {
 import type {SpanIndexedField} from 'sentry/views/insights/types';
 
 import {
+  ToolbarFooter,
   ToolbarFooterButton,
   ToolbarHeader,
   ToolbarHeaderButton,
   ToolbarHeading,
+  ToolbarRow,
   ToolbarSection,
 } from './styles';
 
@@ -124,15 +124,15 @@ export function ToolbarVisualize({}: ToolbarVisualizeProps) {
           return (
             <Fragment key={group}>
               {parsedVisualizeGroup.map((parsedVisualize, index) => (
-                <VisualizeOption key={index}>
+                <ToolbarRow key={index}>
                   <CompactSelect
-                    size="md"
+                    size="sm"
                     options={fieldOptions}
                     value={parsedVisualize.arguments[0]}
                     onChange={newField => setChartField(group, index, newField)}
                   />
                   <CompactSelect
-                    size="md"
+                    size="sm"
                     options={aggregateOptions}
                     value={parsedVisualize?.name}
                     onChange={newAggregate =>
@@ -147,11 +147,17 @@ export function ToolbarVisualize({}: ToolbarVisualizeProps) {
                     onClick={() => deleteOverlay(group, index)}
                     aria-label={t('Remove')}
                   />
-                </VisualizeOption>
+                </ToolbarRow>
               ))}
-              <ToolbarFooterButton size="xs" onClick={() => addOverlay(group)} borderless>
-                {t('+Add Overlay')}
-              </ToolbarFooterButton>
+              <ToolbarFooter>
+                <ToolbarFooterButton
+                  size="xs"
+                  onClick={() => addOverlay(group)}
+                  borderless
+                >
+                  {t('+Add Overlay')}
+                </ToolbarFooterButton>
+              </ToolbarFooter>
             </Fragment>
           );
         })}
@@ -159,12 +165,3 @@ export function ToolbarVisualize({}: ToolbarVisualizeProps) {
     </ToolbarSection>
   );
 }
-
-const VisualizeOption = styled('div')`
-  display: flex;
-  justify-content: space-between;
-
-  :not(:first-child) {
-    padding-top: ${space(1)};
-  }
-`;


### PR DESCRIPTION
A little bulky right now so make it a bit smaller. And make sure to disable the group by in samples mode.