### PR TITLE
feat(explore): Carry group bys from aggregate to sample columns

### DIFF
--- a/static/app/views/explore/hooks/useResultsMode.spec.tsx
+++ b/static/app/views/explore/hooks/useResultsMode.spec.tsx
@@ -2,14 +2,20 @@ import {createMemoryHistory, Route, Router, RouterContext} from 'react-router';
 
 import {act, render} from 'sentry-test/reactTestingLibrary';
 
+import {useGroupBys} from 'sentry/views/explore/hooks/useGroupBys';
 import {useResultMode} from 'sentry/views/explore/hooks/useResultsMode';
+import {useSampleFields} from 'sentry/views/explore/hooks/useSampleFields';
 import {RouteContext} from 'sentry/views/routeContext';
 
 describe('useResultMode', function () {
   it('allows changing results mode', function () {
     let resultMode, setResultMode;
+    let sampleFields;
+    let setGroupBys;
 
     function TestPage() {
+      [sampleFields] = useSampleFields();
+      [, setGroupBys] = useGroupBys();
       [resultMode, setResultMode] = useResultMode();
       return null;
     }
@@ -32,11 +38,31 @@ describe('useResultMode', function () {
     );
 
     expect(resultMode).toEqual('samples'); // default
+    expect(sampleFields).toEqual([
+      'project',
+      'span_id',
+      'span.op',
+      'span.description',
+      'span.duration',
+      'timestamp',
+    ]); // default
 
     act(() => setResultMode('aggregate'));
     expect(resultMode).toEqual('aggregate');
 
+    act(() => setGroupBys(['release', '']));
+
     act(() => setResultMode('samples'));
     expect(resultMode).toEqual('samples');
+
+    expect(sampleFields).toEqual([
+      'project',
+      'span_id',
+      'span.op',
+      'span.description',
+      'span.duration',
+      'timestamp',
+      'release',
+    ]);
   });
 });

--- a/static/app/views/explore/hooks/useResultsMode.tsx
+++ b/static/app/views/explore/hooks/useResultsMode.tsx
@@ -1,7 +1,6 @@
 import {useCallback, useMemo} from 'react';
 import type {Location} from 'history';
 
-import {dedupeArray} from 'sentry/utils/dedupeArray';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -43,10 +42,14 @@ function useResultModeImpl({
       // When switching from the aggregates to samples mode, carry
       // over any group bys as they are helpful context when looking
       // for examples.
-      const fields =
-        newMode === 'samples'
-          ? dedupeArray([...sampleFields, ...groupBys].filter(Boolean))
-          : sampleFields.slice();
+      const fields = [...sampleFields];
+      if (newMode === 'samples') {
+        for (const groupBy of groupBys) {
+          if (groupBy && !fields.includes(groupBy)) {
+            fields.push(groupBy);
+          }
+        }
+      }
 
       navigate({
         ...location,

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -36,10 +36,12 @@ describe('ExploreToolbar', function () {
   });
 
   it('allows changing results mode', async function () {
-    let resultMode;
+    let resultMode, sampleFields, groupBys;
 
     function Component() {
       [resultMode] = useResultMode();
+      [sampleFields] = useSampleFields();
+      [groupBys] = useGroupBys();
       return <ExploreToolbar />;
     }
 
@@ -53,17 +55,42 @@ describe('ExploreToolbar', function () {
     expect(aggregates).not.toBeChecked();
     expect(resultMode).toEqual('samples');
 
+    expect(sampleFields).toEqual([
+      'project',
+      'span_id',
+      'span.op',
+      'span.description',
+      'span.duration',
+      'timestamp',
+    ]); // default
+
     await userEvent.click(aggregates);
     expect(samples).not.toBeChecked();
     expect(aggregates).toBeChecked();
     expect(resultMode).toEqual('aggregate');
+
+    // Add a group by, and leave one unselected
+    const groupBy = screen.getByTestId('section-group-by');
+    await userEvent.click(within(groupBy).getByRole('button', {name: 'None'}));
+    await userEvent.click(within(groupBy).getByRole('option', {name: 'release'}));
+    expect(groupBys).toEqual(['release']);
+    await userEvent.click(within(groupBy).getByRole('button', {name: '+Add Group By'}));
+    expect(groupBys).toEqual(['release', '']);
 
     await userEvent.click(samples);
     expect(samples).toBeChecked();
     expect(aggregates).not.toBeChecked();
     expect(resultMode).toEqual('samples');
 
-    // TODO: check other parts of page reflects this
+    expect(sampleFields).toEqual([
+      'project',
+      'span_id',
+      'span.op',
+      'span.description',
+      'span.duration',
+      'timestamp',
+      'release',
+    ]);
   });
 
   it('allows changing visualizes', async function () {


### PR DESCRIPTION
This carries all the non aggregate columns from the aggregate mode to the sample mode as context.