### PR TITLE
fix(issues): Fix hash -> hashes

### DIFF
--- a/api-docs/paths/events/project-issues.json
+++ b/api-docs/paths/events/project-issues.json
@@ -47,7 +47,7 @@
         }
       },
       {
-        "name": "hash",
+        "name": "hashes",
         "in": "query",
         "description": "A list of hashes of groups to return. Is not compatible with 'query' parameter. The maximum number of hashes that can be sent is 100. If more are sent, only the first 100 will be used.",
         "schema": {

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -27,7 +27,7 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.validators import normalize_event_id
 
 ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', and '14d'"
-ERR_HASHES_AND_OTHER_QUERY = "Cannot use 'hash' with 'query'"
+ERR_HASHES_AND_OTHER_QUERY = "Cannot use 'hashes' with 'query'"
 
 
 @region_silo_endpoint


### PR DESCRIPTION
We use `hashes` value(s) in the endpoint implementation: https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/project_group_index.py#L105