### PR TITLE
fix(issue-platform): remove +1 on limit

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1867,7 +1867,7 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
                 groupby=groupby,
                 having=having,
                 orderby=[OrderBy(sort_func, direction=Direction.DESC)],
-                limit=Limit(limit + 1),
+                limit=Limit(limit),
             )
             dataset = Dataset.Events.value if is_errors else Dataset.IssuePlatform.value
             request = Request(


### PR DESCRIPTION
Fixes SENTRY-3D61

its unclear to me why we'd add a +1 onto our LIMIT. we should be able to handle limit=10000 like our other query strategies, but adding plus 1 makes it 10001 which causes it to error.

let's see if any tests break because of this