### PR TITLE
chore(seer grouping): Stop using `similarity-embeddings-grouping` feature flag

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -959,9 +959,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             project.rename_on_pending_deletion()
 
             # Tell seer to delete all the project's grouping records
-            if features.has(
-                "projects:similarity-embeddings-grouping", project
-            ) or project.get_option("sentry:similarity_backfill_completed"):
+            if project.get_option("sentry:similarity_backfill_completed"):
                 call_seer_delete_project_grouping_records.apply_async(args=[project.id])
 
         return Response(status=204)

--- a/src/sentry/tasks/delete_seer_grouping_records.py
+++ b/src/sentry/tasks/delete_seer_grouping_records.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any
 
-from sentry import features, options
+from sentry import options
 from sentry.models.group import Group
 from sentry.models.grouphash import GroupHash
 from sentry.seer.similarity.grouping_records import (
@@ -56,10 +56,7 @@ def call_delete_seer_grouping_records_by_hash(
         project = group.project if group else None
     if (
         project
-        and (
-            features.has("projects:similarity-embeddings-grouping", project)
-            or project.get_option("sentry:similarity_backfill_completed")
-        )
+        and project.get_option("sentry:similarity_backfill_completed")
         and not killswitch_enabled(project.id)
         and not options.get("seer.similarity-embeddings-delete-by-hash-killswitch.enabled")
     ):

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -1591,13 +1591,13 @@ class ProjectDeleteTest(APITestCase):
             model_name="Project", object_id=self.project.id
         ).exists()
 
-    @with_feature("projects:similarity-embeddings-grouping")
     @mock.patch(
         "sentry.tasks.delete_seer_grouping_records.call_seer_delete_project_grouping_records.apply_async"
     )
     def test_delete_project_and_delete_grouping_records(
         self, mock_call_seer_delete_project_grouping_records
     ):
+        self.project.update_option("sentry:similarity_backfill_completed", int(time()))
         self._delete_project_and_assert_deleted()
         mock_call_seer_delete_project_grouping_records.assert_called_with(args=[self.project.id])
 

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime, timedelta
+from time import time
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -1085,7 +1086,6 @@ class DeleteGroupsTest(TestCase):
         )
         assert send_robust.called
 
-    @with_feature("projects:similarity-embeddings-grouping")
     @patch(
         "sentry.tasks.delete_seer_grouping_records.delete_seer_grouping_records_by_hash.apply_async"
     )
@@ -1094,6 +1094,8 @@ class DeleteGroupsTest(TestCase):
     def test_delete_groups_deletes_seer_records_by_hash(
         self, send_robust: Mock, mock_logger: Mock, mock_delete_seer_grouping_records_by_hash
     ):
+        self.project.update_option("sentry:similarity_backfill_completed", int(time()))
+
         groups = [self.create_group(), self.create_group()]
         group_ids = [group.id for group in groups]
         request = self.make_request(user=self.user, method="GET")

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -1,3 +1,4 @@
+from time import time
 from unittest import mock
 from uuid import uuid4
 
@@ -16,7 +17,6 @@ from sentry.models.userreport import UserReport
 from sentry.tasks.deletion.groups import delete_groups
 from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.testutils.helpers.features import with_feature
 
 
 class DeleteGroupTest(TestCase, SnubaTestCase):
@@ -170,13 +170,13 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
 
         assert nodestore_delete_multi.call_count == 0
 
-    @with_feature("projects:similarity-embeddings-grouping")
     @mock.patch(
         "sentry.tasks.delete_seer_grouping_records.delete_seer_grouping_records_by_hash.apply_async"
     )
     def test_delete_groups_delete_grouping_records_by_hash(
         self, mock_delete_seer_grouping_records_by_hash_apply_async
     ):
+        self.project.update_option("sentry:similarity_backfill_completed", int(time()))
         other_event = self.store_event(
             data={
                 "event_id": "d" * 32,

--- a/tests/sentry/tasks/test_delete_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_delete_seer_grouping_records.py
@@ -1,3 +1,4 @@
+from time import time
 from unittest.mock import patch
 
 from sentry.models.grouphash import GroupHash
@@ -7,7 +8,6 @@ from sentry.tasks.delete_seer_grouping_records import (
     delete_seer_grouping_records_by_hash,
 )
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.pytest.fixtures import django_db_all
 
 
@@ -33,9 +33,10 @@ class TestDeleteSeerGroupingRecordsByHash(TestCase):
             "args": [project_id, hashes, 100]
         }
 
-    @with_feature("projects:similarity-embeddings-grouping")
     @patch("sentry.tasks.delete_seer_grouping_records.logger")
     def test_call_delete_seer_grouping_records_by_hash_simple(self, mock_logger):
+        self.project.update_option("sentry:similarity_backfill_completed", int(time()))
+
         group_ids, hashes = [], []
         for i in range(5):
             group = self.create_group(project=self.project)
@@ -50,12 +51,13 @@ class TestDeleteSeerGroupingRecordsByHash(TestCase):
             extra={"project_id": self.project.id, "hashes": hashes},
         )
 
-    @with_feature("projects:similarity-embeddings-grouping")
     @patch("sentry.tasks.delete_seer_grouping_records.delete_seer_grouping_records_by_hash")
     @patch("sentry.tasks.delete_seer_grouping_records.logger")
     def test_call_delete_seer_grouping_records_by_hash_no_hashes(
         self, mock_logger, mock_delete_seer_grouping_records_by_hash
     ):
+        self.project.update_option("sentry:similarity_backfill_completed", int(time()))
+
         group_ids = []
         for _ in range(5):
             group = self.create_group(project=self.project)


### PR DESCRIPTION
This removes all uses of the `projects:similarity-embeddings-grouping` feature flag, which has been superseded by the `sentry:similarity_backfill_completed` project option. The flag itself will be removed in a follow-up PR.