### PR TITLE
feat(issues): Add lil icons to error event level

### DIFF
--- a/static/app/components/events/errorLevel.tsx
+++ b/static/app/components/events/errorLevel.tsx
@@ -1,42 +1,20 @@
-import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import UnhandledTag from 'sentry/components/group/inboxBadges/unhandledTag';
 import {Tooltip} from 'sentry/components/tooltip';
-import {tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import type {Level} from 'sentry/types/event';
 import {capitalize} from 'sentry/utils/string/capitalize';
-import {Divider} from 'sentry/views/issueDetails/divider';
-import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 const DEFAULT_SIZE = '13px';
 
 type Props = {
   className?: string;
   level?: Level;
-  showUnhandled?: boolean;
   size?: string;
 };
 
-function ErrorLevel({className, showUnhandled, level = 'unknown', size = '11px'}: Props) {
-  const hasStreamlinedUI = useHasStreamlinedUI();
-  const levelLabel = tct('Level: [level]', {level: capitalize(level)});
-
-  if (hasStreamlinedUI) {
-    return (
-      <Fragment>
-        {showUnhandled ? (
-          <Fragment>
-            <UnhandledTag />
-            <Divider />
-          </Fragment>
-        ) : null}
-        {capitalize(level)}
-        <Divider />
-      </Fragment>
-    );
-  }
-
+function ErrorLevel({className, level = 'unknown', size = '11px'}: Props) {
+  const levelLabel = t('Level: %s', capitalize(level));
   return (
     <Tooltip skipWrapper disabled={level === 'unknown'} title={levelLabel}>
       <ColoredCircle className={className} level={level} size={size}>

--- a/static/app/components/events/errorLevelText.tsx
+++ b/static/app/components/events/errorLevelText.tsx
@@ -1,0 +1,57 @@
+import styled from '@emotion/styled';
+
+import {IconClose, IconFatal, IconInfo, IconWarning} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Level} from 'sentry/types/event';
+import type {IconSize} from 'sentry/utils/theme';
+
+const errorLevelMap: Readonly<Record<Level, string>> = {
+  error: t('Error'),
+  fatal: t('Fatal'),
+  info: t('Info'),
+  warning: t('Warning'),
+  sample: t('Sample'),
+  unknown: t('Unknown'),
+};
+
+interface IconWithDefaultProps {
+  Component: React.ComponentType<any> | null;
+  defaultProps: {isCircled?: boolean};
+}
+
+const errorLevelIconMap: Readonly<Record<Level, IconWithDefaultProps>> = {
+  error: {Component: IconClose, defaultProps: {isCircled: true}},
+  fatal: {Component: IconFatal, defaultProps: {}},
+  info: {Component: IconInfo, defaultProps: {}},
+  warning: {Component: IconWarning, defaultProps: {}},
+  sample: {Component: null, defaultProps: {}},
+  unknown: {Component: null, defaultProps: {}},
+};
+
+interface ErrorLevelTextProps {
+  level: Level;
+  iconSize?: IconSize;
+}
+
+export function ErrorLevelText({level, iconSize = 'xs'}: ErrorLevelTextProps) {
+  const Icon = errorLevelIconMap[level]?.Component ?? null;
+  return (
+    <ErrorLevelTextWrapper>
+      {Icon && (
+        <Icon
+          {...errorLevelIconMap[level].defaultProps}
+          size={iconSize}
+          color="subText"
+        />
+      )}
+      {errorLevelMap[level]}
+    </ErrorLevelTextWrapper>
+  );
+}
+
+const ErrorLevelTextWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
+`;

--- a/static/app/components/events/eventMessage.spec.tsx
+++ b/static/app/components/events/eventMessage.spec.tsx
@@ -1,0 +1,57 @@
+import {UserFixture} from 'sentry-fixture/user';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import ConfigStore from 'sentry/stores/configStore';
+import {EventOrGroupType} from 'sentry/types/event';
+
+import EventMessage from './eventMessage';
+
+describe('EventMessage', () => {
+  const defaultUser = UserFixture();
+
+  beforeEach(() => {
+    ConfigStore.init();
+  });
+
+  it('renders error message', () => {
+    render(<EventMessage message="Test message" type={EventOrGroupType.ERROR} />);
+    expect(screen.getByText('Test message')).toBeInTheDocument();
+  });
+
+  it('renders "No error message" when message is not provided', () => {
+    render(<EventMessage message={null} type={EventOrGroupType.ERROR} />);
+    expect(screen.getByText('(No error message)')).toBeInTheDocument();
+  });
+
+  it('renders error level indicator dot', () => {
+    render(
+      <EventMessage message="Test message" type={EventOrGroupType.ERROR} level="error" />
+    );
+    expect(screen.getByText('Level: Error')).toBeInTheDocument();
+  });
+
+  it('renders error level indicator text', () => {
+    ConfigStore.set(
+      'user',
+      UserFixture({
+        ...defaultUser,
+        options: {
+          ...defaultUser.options,
+          prefersIssueDetailsStreamlinedUI: true,
+        },
+      })
+    );
+    render(
+      <EventMessage message="Test message" type={EventOrGroupType.ERROR} level="error" />
+    );
+    expect(screen.getByText('Error')).toBeInTheDocument();
+  });
+
+  it('renders unhandled tag', () => {
+    render(
+      <EventMessage message="Test message" type={EventOrGroupType.ERROR} showUnhandled />
+    );
+    expect(screen.getByText('Unhandled')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/events/eventMessage.tsx
+++ b/static/app/components/events/eventMessage.tsx
@@ -46,7 +46,7 @@ function EventMessage({
     <LevelMessageContainer className={className}>
       {!hasStreamlinedUI ? <ErrorLevel level={level} size={levelIndicatorSize} /> : null}
       {showUnhandled ? <UnhandledTag /> : null}
-      {hasStreamlinedUI && showEventLevel && hasStreamlinedUI ? (
+      {hasStreamlinedUI && showEventLevel ? (
         <Fragment>
           {showUnhandled ? <Divider /> : null}
           <ErrorLevelText level={level} />

--- a/static/app/components/events/eventMessage.tsx
+++ b/static/app/components/events/eventMessage.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import ErrorLevel from 'sentry/components/events/errorLevel';
@@ -5,16 +6,20 @@ import UnhandledTag from 'sentry/components/group/inboxBadges/unhandledTag';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {EventOrGroupType, type Level} from 'sentry/types/event';
+import {capitalize} from 'sentry/utils/string/capitalize';
+import {Divider} from 'sentry/views/issueDetails/divider';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 type Props = {
+  message: React.ReactNode;
   type: EventOrGroupType;
-  annotations?: React.ReactNode;
   className?: string;
-  hasGuideAnchor?: boolean;
   level?: Level;
-  levelIndicatorSize?: string;
-  message?: React.ReactNode;
+  /**
+   * Size of the level indicator.
+   * Text will show the level as text instead of a colored dot.
+   */
+  levelIndicatorSize?: '9px' | '11px' | 'text';
   showUnhandled?: boolean;
 };
 
@@ -28,24 +33,8 @@ const EVENT_TYPES_WITH_LOG_LEVEL = new Set([
   EventOrGroupType.NEL,
 ]);
 
-function EventOrGroupLevel({
-  level,
-  levelIndicatorSize,
-  type,
-  showUnhandled,
-}: Pick<Props, 'level' | 'levelIndicatorSize' | 'type' | 'showUnhandled'>) {
-  if (level && EVENT_TYPES_WITH_LOG_LEVEL.has(type)) {
-    return (
-      <ErrorLevel level={level} size={levelIndicatorSize} showUnhandled={showUnhandled} />
-    );
-  }
-
-  return null;
-}
-
 function EventMessage({
   className,
-  annotations,
   level,
   levelIndicatorSize,
   message,
@@ -53,21 +42,24 @@ function EventMessage({
   showUnhandled = false,
 }: Props) {
   const hasStreamlinedUI = useHasStreamlinedUI();
+  const showEventLevel = level && EVENT_TYPES_WITH_LOG_LEVEL.has(type);
+  const displayLevelAsDot = showEventLevel && levelIndicatorSize !== 'text';
   return (
     <LevelMessageContainer className={className}>
-      <EventOrGroupLevel
-        level={level}
-        levelIndicatorSize={levelIndicatorSize}
-        type={type}
-        showUnhandled={showUnhandled}
-      />
-      {showUnhandled && !hasStreamlinedUI ? <UnhandledTag /> : null}
+      {displayLevelAsDot ? <ErrorLevel level={level} size={levelIndicatorSize} /> : null}
+      {showUnhandled ? <UnhandledTag /> : null}
+      {hasStreamlinedUI && showEventLevel && !displayLevelAsDot ? (
+        <Fragment>
+          {showUnhandled ? <Divider /> : null}
+          {capitalize(level)}
+          <Divider />
+        </Fragment>
+      ) : null}
       {message ? (
         <Message>{message}</Message>
       ) : (
         <NoMessage>({t('No error message')})</NoMessage>
       )}
-      {annotations}
     </LevelMessageContainer>
   );
 }

--- a/static/app/components/events/eventMessage.tsx
+++ b/static/app/components/events/eventMessage.tsx
@@ -2,11 +2,11 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import ErrorLevel from 'sentry/components/events/errorLevel';
+import {ErrorLevelText} from 'sentry/components/events/errorLevelText';
 import UnhandledTag from 'sentry/components/group/inboxBadges/unhandledTag';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {EventOrGroupType, type Level} from 'sentry/types/event';
-import {capitalize} from 'sentry/utils/string/capitalize';
 import {Divider} from 'sentry/views/issueDetails/divider';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
@@ -17,9 +17,8 @@ type Props = {
   level?: Level;
   /**
    * Size of the level indicator.
-   * Text will show the level as text instead of a colored dot.
    */
-  levelIndicatorSize?: '9px' | '11px' | 'text';
+  levelIndicatorSize?: '9px' | '11px';
   showUnhandled?: boolean;
 };
 
@@ -43,15 +42,14 @@ function EventMessage({
 }: Props) {
   const hasStreamlinedUI = useHasStreamlinedUI();
   const showEventLevel = level && EVENT_TYPES_WITH_LOG_LEVEL.has(type);
-  const displayLevelAsDot = showEventLevel && levelIndicatorSize !== 'text';
   return (
     <LevelMessageContainer className={className}>
-      {displayLevelAsDot ? <ErrorLevel level={level} size={levelIndicatorSize} /> : null}
+      {!hasStreamlinedUI ? <ErrorLevel level={level} size={levelIndicatorSize} /> : null}
       {showUnhandled ? <UnhandledTag /> : null}
-      {hasStreamlinedUI && showEventLevel && !displayLevelAsDot ? (
+      {hasStreamlinedUI && showEventLevel && hasStreamlinedUI ? (
         <Fragment>
           {showUnhandled ? <Divider /> : null}
-          {capitalize(level)}
+          <ErrorLevelText level={level} />
           <Divider />
         </Fragment>
       ) : null}

--- a/static/app/views/issueDetails/streamline/header.tsx
+++ b/static/app/views/issueDetails/streamline/header.tsx
@@ -117,7 +117,6 @@ export default function StreamlinedGroupHeader({
           type={group.type}
           level={group.level}
           showUnhandled={group.isUnhandled}
-          levelIndicatorSize={'text'}
         />
         {firstRelease && lastRelease && (
           <Fragment>

--- a/static/app/views/issueDetails/streamline/header.tsx
+++ b/static/app/views/issueDetails/streamline/header.tsx
@@ -117,6 +117,7 @@ export default function StreamlinedGroupHeader({
           type={group.type}
           level={group.level}
           showUnhandled={group.isUnhandled}
+          levelIndicatorSize={'text'}
         />
         {firstRelease && lastRelease && (
           <Fragment>


### PR DESCRIPTION
related to https://github.com/getsentry/sentry/pull/75296
Removes some unused props

(previous) issue stream error level with dot
![image](https://github.com/user-attachments/assets/1787a259-d6e1-4a22-96c1-8b0acf73bd12)

(new) issue details with icon + text
![image](https://github.com/user-attachments/assets/efc74cbe-eaaf-44ab-a2be-82d836edb13d)

