### PR TITLE
fix(flagpole): Default `rollout` to 100

### DIFF
--- a/src/flagpole/conditions.py
+++ b/src/flagpole/conditions.py
@@ -216,7 +216,7 @@ class Segment:
     conditions: list[ConditionBase] = dataclasses.field(default_factory=list)
     "The list of conditions that the segment must be matched in order for this segment to be active"
 
-    rollout: int | None = dataclasses.field(default=0)
+    rollout: int | None = dataclasses.field(default=100)
     """
     Rollout rate controls how many buckets will be granted a feature when this segment matches.
 
@@ -229,7 +229,7 @@ class Segment:
         conditions = [condition_from_dict(condition) for condition in data.get("conditions", [])]
         return cls(
             name=str(data.get("name", "")),
-            rollout=int(data.get("rollout", 0)),
+            rollout=int(data.get("rollout", 100)),
             conditions=conditions,
         )
 

--- a/tests/flagpole/test_feature.py
+++ b/tests/flagpole/test_feature.py
@@ -37,6 +37,30 @@ class TestParseFeatureConfig:
 
         assert not feature.match(EvaluationContext(dict()))
 
+    def test_feature_with_default_rollout(self):
+        feature = Feature.from_feature_config_json(
+            "foo",
+            """
+            {
+                "owner": "test-user",
+                "created_at": "2023-10-12T00:00:00.000Z",
+                "segments": [{
+                    "name": "always_pass_segment",
+                    "conditions": [{
+                        "name": "Always true",
+                        "property": "is_true",
+                        "operator": "equals",
+                        "value": true
+                    }]
+                }]
+            }
+            """,
+        )
+
+        context_builder = self.get_is_true_context_builder(is_true_value=True)
+        assert feature.segments[0].rollout == 100
+        assert feature.match(context_builder.build(SimpleTestContextData()))
+
     def test_feature_with_rollout_zero(self):
         feature = Feature.from_feature_config_json(
             "foobar",


### PR DESCRIPTION
This fixes the default value of the `rollout` property of Flagpole segments to be 100, which matches what's described in the [docs](https://develop.sentry.dev/application/feature-flags/flagpole/#segments).