### PR TITLE
fix(issues): Remove duplicate browser highlight

### DIFF
--- a/src/sentry/issues/highlights.py
+++ b/src/sentry/issues/highlights.py
@@ -40,7 +40,7 @@ BACKEND_HIGHLIGHTS: HighlightPreset = {
 }
 FRONTEND_HIGHLIGHTS: HighlightPreset = {
     "tags": SENTRY_TAGS + ["url", "transaction", "browser", "user"],
-    "context": {"browser": ["name"], "user": ["email"]},
+    "context": {"user": ["email"]},
 }
 MOBILE_HIGHLIGHTS: HighlightPreset = {
     "tags": SENTRY_TAGS + ["mobile", "main_thread"],


### PR DESCRIPTION
The browser tag already contains the name/version - this removes the duplicate name which generally is only ever present when the browser tag is also present.

Example with both present: https://sentry.sentry.io/issues/4981240586/