### PR TITLE
fix(issues): Remove extra wrapper for threaded stacktrace

### DIFF
--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -2,7 +2,6 @@ import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
-import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import {StacktraceBanners} from 'sentry/components/events/interfaces/crashContent/exception/banners/stacktraceBanners';
 import {getLockReason} from 'sentry/components/events/interfaces/threads/threadSelector/lockReason';
 import {
@@ -225,15 +224,20 @@ export function Threads({data, event, projectSlug, groupingCurrentLevel}: Props)
   const hideThreadTags = activeThreadId === undefined || !activeThreadName;
 
   const threadComponent = (
-    <Fragment>
+    <ThreadTraceWrapper
+      style={{
+        // TODO(issues): Remove on streamline issues ui GA
+        padding:
+          !hasMoreThanOneThread || hasStreamlinedUI
+            ? undefined
+            : `${space(1)} ${space(4)}`,
+      }}
+    >
       {hasMoreThanOneThread && (
         <Fragment>
           <Grid>
-            <EventDataSection
-              type="threads"
-              title={t('Threads')}
-              showPermalink={!hasStreamlinedUI}
-            >
+            <div>
+              <ThreadHeading>{t('Threads')}</ThreadHeading>
               {activeThread && (
                 <Wrapper>
                   <ThreadSelector
@@ -247,13 +251,10 @@ export function Threads({data, event, projectSlug, groupingCurrentLevel}: Props)
                   />
                 </Wrapper>
               )}
-            </EventDataSection>
+            </div>
             {activeThread?.state && (
-              <EventDataSection
-                title={t('Thread State')}
-                type="thread-state"
-                showPermalink={!hasStreamlinedUI}
-              >
+              <div>
+                <ThreadHeading>{t('Thread State')}</ThreadHeading>
                 <ThreadStateWrapper>
                   {getThreadStateIcon(threadStateDisplay)}
                   <ThreadState>{threadStateDisplay}</ThreadState>
@@ -267,17 +268,14 @@ export function Threads({data, event, projectSlug, groupingCurrentLevel}: Props)
                   )}
                   <LockReason>{getLockReason(activeThread?.heldLocks)}</LockReason>
                 </ThreadStateWrapper>
-              </EventDataSection>
+              </div>
             )}
           </Grid>
           {!hideThreadTags && (
-            <EventDataSection
-              title={t('Thread Tags')}
-              type={'thread-tags'}
-              showPermalink={!hasStreamlinedUI}
-            >
+            <div>
+              <ThreadHeading>{t('Thread Tags')}</ThreadHeading>
               {renderPills()}
-            </EventDataSection>
+            </div>
           )}
         </Fragment>
       )}
@@ -356,9 +354,10 @@ export function Threads({data, event, projectSlug, groupingCurrentLevel}: Props)
           );
         }}
       </TraceEventDataSection>
-    </Fragment>
+    </ThreadTraceWrapper>
   );
 
+  // If there is only one thread, we expect the stacktrace to wrap itself in a section
   return hasMoreThanOneThread && hasStreamlinedUI ? (
     <InterimSection
       title={tn('Stack Trace', 'Stack Traces', threads.length)}
@@ -400,4 +399,17 @@ const Wrapper = styled('div')`
   flex-wrap: wrap;
   flex-grow: 1;
   justify-content: flex-start;
+`;
+
+const ThreadTraceWrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(2)};
+`;
+
+const ThreadHeading = styled('h3')`
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeMedium};
+  font-weight: ${p => p.theme.fontWeightBold};
+  margin-bottom: ${space(1)};
 `;

--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -289,7 +289,7 @@ export function Threads({data, event, projectSlug, groupingCurrentLevel}: Props)
         fullStackTrace={stackView === StackView.FULL}
         title={hasMoreThanOneThread ? t('Thread Stack Trace') : t('Stack Trace')}
         platform={platform}
-        isNestedSection
+        isNestedSection={hasMoreThanOneThread}
         hasMinified={
           !!exception?.values?.find(value => value.rawStacktrace) ||
           !!activeThread?.rawStacktrace
@@ -359,7 +359,7 @@ export function Threads({data, event, projectSlug, groupingCurrentLevel}: Props)
     </Fragment>
   );
 
-  return hasStreamlinedUI ? (
+  return hasMoreThanOneThread && hasStreamlinedUI ? (
     <InterimSection
       title={tn('Stack Trace', 'Stack Traces', threads.length)}
       type={SectionKey.STACKTRACE}

--- a/static/app/components/events/traceEventDataSection.tsx
+++ b/static/app/components/events/traceEventDataSection.tsx
@@ -1,13 +1,14 @@
 import {createContext, useCallback, useState} from 'react';
+import styled from '@emotion/styled';
 
 import {LinkButton} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {CompactSelect} from 'sentry/components/compactSelect';
-import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import {SegmentedControl} from 'sentry/components/segmentedControl';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconEllipsis, IconSort} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {PlatformKey, Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -354,7 +355,7 @@ export function TraceEventDataSection({
     fullStackTrace: state.fullStackTrace,
   };
 
-  const SectionComponent = isNestedSection ? EventDataSection : InterimSection;
+  const SectionComponent = isNestedSection ? InlineThreadSection : InterimSection;
 
   return (
     <SectionComponent
@@ -443,3 +444,39 @@ export function TraceEventDataSection({
     </SectionComponent>
   );
 }
+
+function InlineThreadSection({
+  children,
+  title,
+  actions,
+}: {
+  actions: React.ReactNode;
+  children: React.ReactNode;
+  title: React.ReactNode;
+}) {
+  return (
+    <Wrapper>
+      <InlineSectionHeaderWrapper>
+        <ThreadHeading>{title}</ThreadHeading>
+        {actions}
+      </InlineSectionHeaderWrapper>
+      {children}
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled('div')``;
+
+const ThreadHeading = styled('h3')`
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeMedium};
+  font-weight: ${p => p.theme.fontWeightBold};
+  margin-bottom: ${space(1)};
+`;
+
+const InlineSectionHeaderWrapper = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: ${space(1)};
+`;


### PR DESCRIPTION
fixes an issue with extra padding on stacktrace

example issue with one stacktrace https://sentry.sentry.io/issues/5621794158/events/2cb7aa51702e4dc389cfb2bbdd7b73dd/?project=300688&query=is%3Aunresolved&referrer=issues_trace_timeline&sort=date&stream_index=13

example issue with multiple threads https://demo.sentry.io/issues/5399336660/?project=6249899&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&sort=date&statsPeriod=24h&stream_index=0

example of extra padding
![image](https://github.com/user-attachments/assets/4581a9a6-75b3-4b80-81cf-d388167b8f04)
