### PR TITLE
Set local clickhouse container's hostname to clickhouse.dev.local

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2323,6 +2323,7 @@ SENTRY_DEVSERVICES: dict[str, Callable[[Any, Any], dict[str, Any]]] = {
             "image": (
                 "ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:23.3.19.33.altinitystable"
             ),
+            "hostname": "clickhouse.dev.local",
             "ports": {"9000/tcp": 9000, "9009/tcp": 9009, "8123/tcp": 8123},
             "ulimits": [{"name": "nofile", "soft": 262144, "hard": 262144}],
             # The arm image does not properly load the MAX_MEMORY_USAGE_RATIO


### PR DESCRIPTION
Currently, when a clickhouse container is running locally, its hostname is randomly picked up by docker runtime. This hostname which also happens to be the container-id is 12 characters long and composed solely of hexadecimal digits. This makes the hostname resolution a problem because the id is dynamically generated and can be only controlled by docker runtime. This PR sets clickhouse container's hostname to `clickhouse.dev.local`. 

In Snuba developement environment, snuba admin is often not run as a docker container on Mac. To resolve the hostnmae from Snuba admin, you have an entry `127.0.0.1	clickhouse.dev.local` in `/etc/hosts` and then `clickhouse.dev.local` can resolve to `127.0.0.1`. On Mac, `127.0.0.1`'s port `9000` is forwarded to the clickhouse container, thus making it possible to connect to that container.

The corresponding changes in Snuba admin are in https://github.com/getsentry/snuba/pull/6268. 

**Testing done**

```
onkardeshpande@G260FHW6HW sentry % docker exec -it sentry_clickhouse /bin/bash
root@clickhouse:/# set | grep -i hostname
HOSTNAME=clickhouse.dev.local
```