### PR TITLE
chore(am1): Remove span count metric

### DIFF
--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -1,6 +1,6 @@
 import functools
 import logging
-from collections.abc import Mapping, MutableMapping
+from collections.abc import Mapping
 from typing import Any
 
 import orjson
@@ -187,11 +187,6 @@ def process_event(
                 event_id=event_id,
                 project_id=project_id,
             )
-
-            try:
-                collect_span_metrics(project, data)
-            except Exception:
-                pass
         elif data.get("type") == "feedback":
             if features.has("organizations:user-feedback-ingest", project.organization, actor=None):
                 save_event_feedback.delay(
@@ -329,20 +324,3 @@ def process_userreport(message: IngestMessage, project: Project) -> bool:
         # If you want to remove this make sure to have triaged all errors in Sentry
         logger.exception("userreport.save.crash")
         return False
-
-
-def collect_span_metrics(
-    project: Project,
-    data: MutableMapping[str, Any],
-):
-    if not features.has("organizations:am3-tier", project.organization) and not features.has(
-        "organizations:dynamic-sampling", project.organization
-    ):
-        amount = (
-            len(data.get("spans", [])) + 1
-        )  # Segment spans also get added to the total span count.
-        metrics.incr(
-            "event.save_event.unsampled.spans.count",
-            amount=amount,
-            tags={"organization": project.organization.slug},
-        )


### PR DESCRIPTION
### Summary
The span count metrics already collected should be sufficient for AM1->AM3 migration, removing this extraneous metric.