### PR TITLE
fix(replay): Pass pathname & query into ListLink to make react-router6 happy

### DIFF
--- a/static/app/views/replays/detail/network/details/tabs.tsx
+++ b/static/app/views/replays/detail/network/details/tabs.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import queryString from 'query-string';
 
 import ListLink from 'sentry/components/links/listLink';
 import ScrollableTabs from 'sentry/components/replays/scrollableTabs';
@@ -32,7 +31,10 @@ function NetworkDetailsTabs({className, underlined = true}: Props) {
         <ListLink
           key={tab}
           isActive={() => tab === activeTab}
-          to={`${pathname}?${queryString.stringify({...query, t_main: tab})}`}
+          to={{
+            pathname,
+            query: {...query, t_main: tab},
+          }}
           onClick={e => {
             e.preventDefault();
             setParamValue(tab);


### PR DESCRIPTION
Fixes JAVASCRIPT-2VNC

**Test notes:**
enable `organizations:react-router-6` or edit this area to be able to trigger the bug, and see that it's fixed in dev/staging.
https://github.com/getsentry/sentry/blob/d905c55447371e48078c0a1dc1a6c5bd66f60ee5/static/app/index.tsx#L74-L82
