### PR TITLE
ref: squash index_together operation for ControlOutbox model

### DIFF
--- a/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
+++ b/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
@@ -8989,17 +8989,26 @@ class Migration(CheckedMigration):
             ],
             options={
                 "db_table": "sentry_controloutbox",
-                "index_together": {
-                    ("region_name", "shard_scope", "shard_identifier", "scheduled_for"),
-                    (
-                        "region_name",
-                        "shard_scope",
-                        "shard_identifier",
-                        "category",
-                        "object_identifier",
+                "indexes": [
+                    models.Index(
+                        fields=[
+                            "region_name",
+                            "shard_scope",
+                            "shard_identifier",
+                            "category",
+                            "object_identifier",
+                        ],
+                        name="sentry_cont_region__1c1c72_idx",
                     ),
-                    ("region_name", "shard_scope", "shard_identifier", "id"),
-                },
+                    models.Index(
+                        fields=["region_name", "shard_scope", "shard_identifier", "scheduled_for"],
+                        name="sentry_cont_region__0c4512_idx",
+                    ),
+                    models.Index(
+                        fields=["region_name", "shard_scope", "shard_identifier", "id"],
+                        name="sentry_cont_region__a95d82_idx",
+                    ),
+                ],
             },
         ),
         migrations.AlterField(

--- a/src/sentry/migrations/0640_index_together.py
+++ b/src/sentry/migrations/0640_index_together.py
@@ -24,27 +24,6 @@ class Migration(CheckedMigration):
 
     operations = [
         migrations.RenameIndex(
-            model_name="controloutbox",
-            new_name="sentry_cont_region__0c4512_idx",
-            old_fields=("region_name", "shard_scope", "shard_identifier", "scheduled_for"),
-        ),
-        migrations.RenameIndex(
-            model_name="controloutbox",
-            new_name="sentry_cont_region__a95d82_idx",
-            old_fields=("region_name", "shard_scope", "shard_identifier", "id"),
-        ),
-        migrations.RenameIndex(
-            model_name="controloutbox",
-            new_name="sentry_cont_region__1c1c72_idx",
-            old_fields=(
-                "region_name",
-                "shard_scope",
-                "shard_identifier",
-                "category",
-                "object_identifier",
-            ),
-        ),
-        migrations.RenameIndex(
             model_name="group",
             new_name="sentry_grou_project_5eb75b_idx",
             old_fields=("project", "status", "substatus", "last_seen", "id"),


### PR DESCRIPTION
index_together is removed in django 5.1 so this is necessary to upgrade

hard-stop is already in place for self-hosted

<!-- Describe your PR here. -->