### PR TITLE
ref: squash index_together operation for RegionOutbox model

### DIFF
--- a/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
+++ b/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
@@ -8957,11 +8957,20 @@ class Migration(CheckedMigration):
             ],
             options={
                 "db_table": "sentry_regionoutbox",
-                "index_together": {
-                    ("shard_scope", "shard_identifier", "id"),
-                    ("shard_scope", "shard_identifier", "scheduled_for"),
-                    ("shard_scope", "shard_identifier", "category", "object_identifier"),
-                },
+                "indexes": [
+                    models.Index(
+                        fields=["shard_scope", "shard_identifier", "id"],
+                        name="sentry_regi_shard_s_e7412f_idx",
+                    ),
+                    models.Index(
+                        fields=["shard_scope", "shard_identifier", "scheduled_for"],
+                        name="sentry_regi_shard_s_cd9995_idx",
+                    ),
+                    models.Index(
+                        fields=["shard_scope", "shard_identifier", "category", "object_identifier"],
+                        name="sentry_regi_shard_s_bfff84_idx",
+                    ),
+                ],
             },
         ),
         migrations.CreateModel(

--- a/src/sentry/migrations/0640_index_together.py
+++ b/src/sentry/migrations/0640_index_together.py
@@ -120,21 +120,6 @@ class Migration(CheckedMigration):
             old_fields=("project_id", "artifact_bundle"),
         ),
         migrations.RenameIndex(
-            model_name="regionoutbox",
-            new_name="sentry_regi_shard_s_e7412f_idx",
-            old_fields=("shard_scope", "shard_identifier", "id"),
-        ),
-        migrations.RenameIndex(
-            model_name="regionoutbox",
-            new_name="sentry_regi_shard_s_bfff84_idx",
-            old_fields=("shard_scope", "shard_identifier", "category", "object_identifier"),
-        ),
-        migrations.RenameIndex(
-            model_name="regionoutbox",
-            new_name="sentry_regi_shard_s_cd9995_idx",
-            old_fields=("shard_scope", "shard_identifier", "scheduled_for"),
-        ),
-        migrations.RenameIndex(
             model_name="releaseartifactbundle",
             new_name="sentry_rele_organiz_291018_idx",
             old_fields=("organization_id", "release_name", "dist_name", "artifact_bundle"),


### PR DESCRIPTION
index_together is removed in django 5.1 so this is necessary to upgrade

hard-stop is already in place for self-hosted

<!-- Describe your PR here. -->