### PR TITLE
ref: squash index_together operation for ReleaseProjectEnvironment model

### DIFF
--- a/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
+++ b/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
@@ -7149,16 +7149,6 @@ class Migration(CheckedMigration):
                     reverse_sql="DROP INDEX CONCURRENTLY IF EXISTS sentry_release_project_proj_id_unadopted_8h5g84ee",
                     hints={"tables": ["sentry_release_project"]},
                 ),
-                migrations.RunSQL(
-                    sql='\n                    CREATE INDEX CONCURRENTLY IF NOT EXISTS "sentry_releaseprojectenvironment_proj_id_env_id_adopted_j6h89s3" ON "sentry_releaseprojectenvironment" ("project_id", "adopted", "environment_id");\n                    ',
-                    reverse_sql="DROP INDEX CONCURRENTLY IF EXISTS sentry_releaseprojectenvironment_proj_id_env_id_adopted_j6h89s3",
-                    hints={"tables": ["sentry_releaseprojectenvironment"]},
-                ),
-                migrations.RunSQL(
-                    sql='\n                    CREATE INDEX CONCURRENTLY IF NOT EXISTS "sentry_releaseprojectenvironment_proj_id_env_id_unadopted_kyh5m" ON "sentry_releaseprojectenvironment" ("project_id", "unadopted", "environment_id");\n                    ',
-                    reverse_sql="DROP INDEX CONCURRENTLY IF EXISTS sentry_releaseprojectenvironment_proj_id_env_id_unadopted_kyh5m",
-                    hints={"tables": ["sentry_releaseprojectenvironment"]},
-                ),
             ],
             state_operations=[
                 migrations.AddField(
@@ -7181,14 +7171,20 @@ class Migration(CheckedMigration):
                     name="unadopted",
                     field=models.DateTimeField(blank=True, null=True),
                 ),
-                migrations.AlterIndexTogether(
-                    name="releaseprojectenvironment",
-                    index_together={
-                        ("project", "adopted", "environment"),
-                        ("project", "unadopted", "environment"),
-                    },
-                ),
             ],
+        ),
+        migrations.AddIndex(
+            model_name="releaseprojectenvironment",
+            index=models.Index(
+                fields=["project", "adopted", "environment"], name="sentry_rele_project_4bea8e_idx"
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="releaseprojectenvironment",
+            index=models.Index(
+                fields=["project", "unadopted", "environment"],
+                name="sentry_rele_project_922a6a_idx",
+            ),
         ),
         migrations.SeparateDatabaseAndState(
             database_operations=[

--- a/src/sentry/migrations/0640_index_together.py
+++ b/src/sentry/migrations/0640_index_together.py
@@ -139,14 +139,4 @@ class Migration(CheckedMigration):
             new_name="sentry_rele_organiz_291018_idx",
             old_fields=("organization_id", "release_name", "dist_name", "artifact_bundle"),
         ),
-        migrations.RenameIndex(
-            model_name="releaseprojectenvironment",
-            new_name="sentry_rele_project_922a6a_idx",
-            old_fields=("project", "unadopted", "environment"),
-        ),
-        migrations.RenameIndex(
-            model_name="releaseprojectenvironment",
-            new_name="sentry_rele_project_4bea8e_idx",
-            old_fields=("project", "adopted", "environment"),
-        ),
     ]


### PR DESCRIPTION
index_together is removed in django 5.1 so this is necessary to upgrade

hard-stop is already in place for self-hosted

<!-- Describe your PR here. -->