### PR TITLE
ref: squash index_together operation for AuditLogEntry model

### DIFF
--- a/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
+++ b/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
@@ -7514,27 +7514,11 @@ class Migration(CheckedMigration):
             name="uploaded_to_appstore",
             field=models.DateTimeField(default=django.utils.timezone.now),
         ),
-        migrations.SeparateDatabaseAndState(
-            database_operations=[
-                migrations.RunSQL(
-                    sql='\n                    CREATE INDEX CONCURRENTLY "sentry_audi_organiz_c8bd18_idx" ON "sentry_auditlogentry" ("organization_id", "datetime");\n                    ',
-                    reverse_sql="\n                    DROP INDEX CONCURRENTLY IF EXISTS sentry_audi_organiz_c8bd18_idx;\n                    ",
-                    hints={"tables": ["sentry_auditlogentry"]},
-                ),
-            ],
-            state_operations=[
-                migrations.AlterIndexTogether(
-                    name="auditlogentry",
-                    index_together=set(),
-                ),
-                migrations.AddIndex(
-                    model_name="auditlogentry",
-                    index=models.Index(
-                        fields=["organization_id", "datetime"],
-                        name="sentry_audi_organiz_c8bd18_idx",
-                    ),
-                ),
-            ],
+        migrations.AddIndex(
+            model_name="auditlogentry",
+            index=models.Index(
+                fields=["organization_id", "datetime"], name="sentry_audi_organiz_c8bd18_idx"
+            ),
         ),
         migrations.AlterField(
             model_name="project",
@@ -7628,23 +7612,12 @@ class Migration(CheckedMigration):
                 ),
             ],
         ),
-        migrations.SeparateDatabaseAndState(
-            database_operations=[
-                migrations.RunSQL(
-                    sql='\n                    CREATE INDEX CONCURRENTLY "sentry_audi_organiz_588b1e_idx" ON "sentry_auditlogentry" ("organization_id", "event", "datetime");\n                    ',
-                    reverse_sql="\n                    DROP INDEX CONCURRENTLY IF EXISTS sentry_audi_organiz_588b1e_idx;\n                    ",
-                    hints={"tables": ["sentry_auditlogentry"]},
-                ),
-            ],
-            state_operations=[
-                migrations.AddIndex(
-                    model_name="auditlogentry",
-                    index=models.Index(
-                        fields=["organization_id", "event", "datetime"],
-                        name="sentry_audi_organiz_588b1e_idx",
-                    ),
-                ),
-            ],
+        migrations.AddIndex(
+            model_name="auditlogentry",
+            index=models.Index(
+                fields=["organization_id", "event", "datetime"],
+                name="sentry_audi_organiz_588b1e_idx",
+            ),
         ),
         migrations.RunSQL(
             sql='\n                DROP TABLE IF EXISTS "jira_ac_tenant";\n                ',


### PR DESCRIPTION
index_together is removed in django 5.1 so this is necessary to upgrade

hard-stop is already in place for self-hosted

<!-- Describe your PR here. -->