### PR TITLE
ref: squash index_together operation for ArtifactBundleFlatFileIndex model

### DIFF
--- a/src/sentry/migrations/0520_add_flat_file_index_table.py
+++ b/src/sentry/migrations/0520_add_flat_file_index_table.py
@@ -52,7 +52,6 @@ class Migration(CheckedMigration):
             ],
             options={
                 "db_table": "sentry_artifactbundleflatfileindex",
-                "index_together": {("project_id", "release_name", "dist_name")},
             },
         ),
         migrations.CreateModel(

--- a/src/sentry/migrations/0533_make_flatfile_unique_again.py
+++ b/src/sentry/migrations/0533_make_flatfile_unique_again.py
@@ -31,8 +31,4 @@ class Migration(CheckedMigration):
             name="flatfileindexstate",
             unique_together={("flat_file_index", "artifact_bundle")},
         ),
-        migrations.AlterIndexTogether(
-            name="artifactbundleflatfileindex",
-            index_together=set(),
-        ),
     ]


### PR DESCRIPTION
index_together is removed in django 5.1 so this is necessary to upgrade

hard-stop is already in place for self-hosted

<!-- Describe your PR here. -->