### PR TITLE
chore(auth): remove unused url socialauth_associate_complete

### DIFF
--- a/src/social_auth/urls.py
+++ b/src/social_auth/urls.py
@@ -1,12 +1,8 @@
 from django.urls import re_path
 
-from social_auth.views import auth, complete
+from social_auth.views import auth
 
 urlpatterns = [
-    # authentication
-    re_path(
-        r"^associate/complete/(?P<backend>[^/]+)/$", complete, name="socialauth_associate_complete"
-    ),
     re_path(
         r"^associate/(?P<backend>[^/]+)/$",
         auth,


### PR DESCRIPTION
The `socialauth_associate_complete` url has been replaced by `socialauth_associate_complete_auth_sso`.
See: https://github.com/getsentry/sentry/pull/76899
