### PR TITLE
fix(rr6): Do not translate `to` to `{pathname: to}`

### DIFF
--- a/static/app/components/links/listLink.tsx
+++ b/static/app/components/links/listLink.tsx
@@ -37,8 +37,7 @@ function ListLink({
 }: ListLinkProps) {
   const router = useRouter();
   const location = useLocation();
-  const targetLocation = typeof to === 'string' ? {pathname: to} : to;
-  const target = normalizeUrl(targetLocation);
+  const target = normalizeUrl(to);
 
   const active =
     isActive?.(target, index) ??


### PR DESCRIPTION
This is a more generalized fix for what GH-77153 was fixing.

In react router 6 you cannot pass a string like `/whatever/?query=value` to the `pathname` attribute of a `To` object. There was no need to do this in the LinkList afaict.