### PR TITLE
ref: squash index_together operation for ReleaseArtifactBundle model

### DIFF
--- a/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
+++ b/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
@@ -9216,6 +9216,17 @@ class Migration(CheckedMigration):
                 "unique_together": {
                     ("organization_id", "release_name", "dist_name", "artifact_bundle")
                 },
+                "indexes": [
+                    models.Index(
+                        fields=[
+                            "organization_id",
+                            "release_name",
+                            "dist_name",
+                            "artifact_bundle",
+                        ],
+                        name="sentry_rele_organiz_291018_idx",
+                    ),
+                ],
             },
         ),
         migrations.CreateModel(

--- a/src/sentry/migrations/0518_cleanup_bundles_indexes.py
+++ b/src/sentry/migrations/0518_cleanup_bundles_indexes.py
@@ -67,8 +67,4 @@ class Migration(CheckedMigration):
             name="projectartifactbundle",
             index_together={("project_id", "artifact_bundle")},
         ),
-        migrations.AlterIndexTogether(
-            name="releaseartifactbundle",
-            index_together={("organization_id", "release_name", "dist_name", "artifact_bundle")},
-        ),
     ]

--- a/src/sentry/migrations/0640_index_together.py
+++ b/src/sentry/migrations/0640_index_together.py
@@ -98,9 +98,4 @@ class Migration(CheckedMigration):
             new_name="sentry_proj_project_f73d36_idx",
             old_fields=("project_id", "artifact_bundle"),
         ),
-        migrations.RenameIndex(
-            model_name="releaseartifactbundle",
-            new_name="sentry_rele_organiz_291018_idx",
-            old_fields=("organization_id", "release_name", "dist_name", "artifact_bundle"),
-        ),
     ]


### PR DESCRIPTION
index_together is removed in django 5.1 so this is necessary to upgrade

hard-stop is already in place for self-hosted

<!-- Describe your PR here. -->