### PR TITLE
fix(onboarding): disable invite removal button for members when flag is off

### DIFF
--- a/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
@@ -115,13 +115,14 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
     const showRemoveButton = !isCurrentUser;
     const showLeaveButton = isCurrentUser;
     const isInvite = inviterName !== null;
-    const canRemoveInvite =
+    const isInviteFromCurrentUser = inviterName === currentUser.name;
+    const canRemoveInvites =
       organization.features?.includes('members-invite-teammates') &&
-      access.includes('member:invite') &&
-      inviterName === currentUser.name;
+      organization.allowMemberInvite &&
+      access.includes('member:invite');
     const canRemoveMember =
       (canRemoveMembers && !isCurrentUser && !isIdpProvisioned && !isPartnershipUser) ||
-      canRemoveInvite;
+      (canRemoveInvites && isInviteFromCurrentUser);
     // member has a `user` property if they are registered with sentry
     // i.e. has accepted an invite to join org
     const has2fa = user?.has2fa;
@@ -211,7 +212,7 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
                       )
                     : isPartnershipUser
                       ? t('You cannot make changes to this partner-provisioned user.')
-                      : isInvite
+                      : isInvite && canRemoveInvites && !isInviteFromCurrentUser
                         ? t('Your role cannot modify this invite.')
                         : t('You do not have access to remove members')
                 }

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
@@ -114,6 +114,8 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
     const isCurrentUser = currentUser.email === email;
     const showRemoveButton = !isCurrentUser;
     const showLeaveButton = isCurrentUser;
+    // inviterName is null if this is not a pending invite
+    // i.e. invite has been accepted
     const isInvite = inviterName !== null;
     const isInviteFromCurrentUser = inviterName === currentUser.name;
     const canRemoveInvites =
@@ -122,6 +124,7 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
       access.includes('member:invite');
     const canRemoveMember =
       (canRemoveMembers && !isCurrentUser && !isIdpProvisioned && !isPartnershipUser) ||
+      // members can remove invites they sent if allowMemberInvite is true
       (canRemoveInvites && isInviteFromCurrentUser);
     // member has a `user` property if they are registered with sentry
     // i.e. has accepted an invite to join org
@@ -212,7 +215,8 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
                       )
                     : isPartnershipUser
                       ? t('You cannot make changes to this partner-provisioned user.')
-                      : isInvite && canRemoveInvites && !isInviteFromCurrentUser
+                      : // only show this message if member can remove invites but invite was not sent by them
+                        isInvite && canRemoveInvites && !isInviteFromCurrentUser
                         ? t('Your role cannot modify this invite.')
                         : t('You do not have access to remove members')
                 }


### PR DESCRIPTION
We should disable the Remove button for organization members when "Let Members Invite Others" is turned off (AKA when `allowMemberInvite` is false).

### "Let Members Invite Others" turned OFF
All disabled buttons have the same message ("You do not have access to remove members")

![Screenshot 2024-09-09 at 11 55 58 AM](https://github.com/user-attachments/assets/d8fbd91f-ac07-4316-87f2-03998475c263)

### "Let Members Invite Others" turned ON
Disabled invite buttons have a different message ("Your role cannot modify this invite")

![Screenshot 2024-09-09 at 11 28 26 AM](https://github.com/user-attachments/assets/1d74db4b-4df4-47bf-8cf9-94e5850e1c33)


