### PR TITLE
fix(suspect-commits): get active integrations

### DIFF
--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -9,6 +9,7 @@ from typing import Any
 from django.utils.datastructures import OrderedSet
 
 from sentry import analytics
+from sentry.constants import ObjectStatus
 from sentry.integrations.base import IntegrationInstallation
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.integrations.services.integration import integration_service
@@ -262,8 +263,9 @@ def _get_blames_from_all_integrations(
     integration_to_install_mapping: dict[str, tuple[IntegrationInstallation, str]] = {}
 
     for integration_organization_id, files in integration_to_files_mapping.items():
+        # find active integrations, otherwise integration proxy will not send request
         integration = integration_service.get_integration(
-            organization_integration_id=integration_organization_id
+            organization_integration_id=integration_organization_id, status=ObjectStatus.ACTIVE
         )
         if not integration:
             continue


### PR DESCRIPTION
Filter for active integrations for suspect commits. If we get any integration and it happens to be inactive, any subsequent outgoing request will fail in the integration proxy because the integration is not active.

https://github.com/getsentry/sentry/blob/630ae72a47bbab18df1633567198481536203e3c/src/sentry/integrations/api/endpoints/integration_proxy.py#L117-L122

Fixes SENTRY-2CY4