### PR TITLE
ref: squash index_together operation for ProjectArtifactBundle model

### DIFF
--- a/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
+++ b/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
@@ -9257,6 +9257,12 @@ class Migration(CheckedMigration):
             options={
                 "db_table": "sentry_projectartifactbundle",
                 "unique_together": {("project_id", "artifact_bundle")},
+                "indexes": [
+                    models.Index(
+                        fields=["project_id", "artifact_bundle"],
+                        name="sentry_proj_project_f73d36_idx",
+                    )
+                ],
             },
         ),
         migrations.CreateModel(

--- a/src/sentry/migrations/0518_cleanup_bundles_indexes.py
+++ b/src/sentry/migrations/0518_cleanup_bundles_indexes.py
@@ -63,8 +63,4 @@ class Migration(CheckedMigration):
                 fields=["debug_id", "artifact_bundle"], name="sentry_debu_debug_i_8c6c44_idx"
             ),
         ),
-        migrations.AlterIndexTogether(
-            name="projectartifactbundle",
-            index_together={("project_id", "artifact_bundle")},
-        ),
     ]

--- a/src/sentry/migrations/0640_index_together.py
+++ b/src/sentry/migrations/0640_index_together.py
@@ -93,9 +93,4 @@ class Migration(CheckedMigration):
             new_name="sentry_orga_organiz_7de26b_idx",
             old_fields=("organization_id", "email"),
         ),
-        migrations.RenameIndex(
-            model_name="projectartifactbundle",
-            new_name="sentry_proj_project_f73d36_idx",
-            old_fields=("project_id", "artifact_bundle"),
-        ),
     ]


### PR DESCRIPTION
index_together is removed in django 5.1 so this is necessary to upgrade

hard-stop is already in place for self-hosted

<!-- Describe your PR here. -->