### PR TITLE
fix(priority-alerts): Update project rules configuration

### DIFF
--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -7,7 +7,6 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.constants import MIGRATED_CONDITIONS, SENTRY_APP_ACTIONS, TICKET_ACTIONS
-from sentry.receivers.rules import has_high_priority_issue_alerts
 from sentry.rules import rules
 
 
@@ -75,11 +74,6 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
                 continue
 
             if rule_type.startswith("condition/"):
-                if not has_high_priority_issue_alerts(project=project) and context["id"] in (
-                    "sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition",
-                    "sentry.rules.conditions.high_priority_issue.ExistingHighPriorityIssueCondition",
-                ):
-                    continue
                 condition_list.append(context)
             elif rule_type.startswith("filter/"):
                 if (

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -7,6 +7,7 @@ from sentry.rules import rules as default_rules
 from sentry.rules.filters.issue_category import IssueCategoryFilter
 from sentry.rules.registry import RuleRegistry
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 
 EMAIL_ACTION = "sentry.mail.actions.NotifyEmailAction"
 APP_ACTION = "sentry.rules.actions.notify_event_service.NotifyEventServiceAction"
@@ -19,6 +20,7 @@ if GitHubEnterpriseCreateTicketAction.id not in default_rules:
     default_rules.add(GitHubEnterpriseCreateTicketAction)
 
 
+@apply_feature_flag_on_cls("organizations:priority-ga-features")
 class ProjectRuleConfigurationTest(APITestCase):
     endpoint = "sentry-api-0-project-rules-configuration"
 
@@ -33,7 +35,7 @@ class ProjectRuleConfigurationTest(APITestCase):
 
         response = self.get_success_response(self.organization.slug, project1.slug)
         assert len(response.data["actions"]) == 12
-        assert len(response.data["conditions"]) == 7
+        assert len(response.data["conditions"]) == 9
         assert len(response.data["filters"]) == 8
 
     @property
@@ -148,7 +150,7 @@ class ProjectRuleConfigurationTest(APITestCase):
                 "service": {"type": "choice", "choices": [[sentry_app.slug, sentry_app.name]]}
             },
         } in response.data["actions"]
-        assert len(response.data["conditions"]) == 7
+        assert len(response.data["conditions"]) == 9
         assert len(response.data["filters"]) == 8
 
     @patch("sentry.sentry_apps.components.SentryAppComponentPreparer.run")
@@ -179,28 +181,26 @@ class ProjectRuleConfigurationTest(APITestCase):
             "formFields": settings_schema["settings"],
             "sentryAppInstallationUuid": str(install.uuid),
         } in response.data["actions"]
-        assert len(response.data["conditions"]) == 7
+        assert len(response.data["conditions"]) == 9
         assert len(response.data["filters"]) == 8
 
     def test_issue_type_and_category_filter_feature(self):
         response = self.get_success_response(self.organization.slug, self.project.slug)
         assert len(response.data["actions"]) == 12
-        assert len(response.data["conditions"]) == 7
+        assert len(response.data["conditions"]) == 9
         assert len(response.data["filters"]) == 8
 
         filter_ids = {f["id"] for f in response.data["filters"]}
         assert IssueCategoryFilter.id in filter_ids
 
     def test_high_priority_issue_condition(self):
-        with self.feature({"organizations:priority-ga-features": True}):
-            response = self.get_success_response(self.organization.slug, self.project.slug)
-            assert "sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition" in [
-                filter["id"] for filter in response.data["conditions"]
-            ]
-            assert (
-                "sentry.rules.conditions.high_priority_issue.ExistingHighPriorityIssueCondition"
-                in [filter["id"] for filter in response.data["conditions"]]
-            )
+        response = self.get_success_response(self.organization.slug, self.project.slug)
+        assert "sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition" in [
+            filter["id"] for filter in response.data["conditions"]
+        ]
+        assert "sentry.rules.conditions.high_priority_issue.ExistingHighPriorityIssueCondition" in [
+            filter["id"] for filter in response.data["conditions"]
+        ]
 
     def test_is_in_feature(self):
         response = self.get_success_response(self.organization.slug, self.project.slug)


### PR DESCRIPTION
The feature is in GA and there are some calls to this endpoint that are timing out and causing users to not be able to create issue alerts. Removing the high priority alert condition check in case that's responsible for the errors/retries.