### PR TITLE
ref: squash index_together operation for GroupHistory model

### DIFF
--- a/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
+++ b/src/sentry/migrations/0001_squashed_0484_break_org_member_user_fk.py
@@ -7695,7 +7695,16 @@ class Migration(CheckedMigration):
             ],
             options={
                 "db_table": "sentry_grouphistory",
-                "index_together": {("project", "status", "release")},
+                "indexes": [
+                    models.Index(
+                        fields=["project", "status", "release"],
+                        name="sentry_grou_project_bbcf30_idx",
+                    ),
+                    models.Index(fields=["group", "status"], name="sentry_grou_group_i_c61acb_idx"),
+                    models.Index(
+                        fields=["project", "date_added"], name="sentry_grou_project_20b3f8_idx"
+                    ),
+                ],
             },
         ),
         migrations.CreateModel(
@@ -7741,10 +7750,6 @@ class Migration(CheckedMigration):
                     hints={"tables": ["sentry_scheduleddeletion"]},
                 ),
             ],
-        ),
-        migrations.AlterIndexTogether(
-            name="grouphistory",
-            index_together={("project", "status", "release"), ("group", "status")},
         ),
         migrations.AlterField(
             model_name="grouphistory",
@@ -7992,14 +7997,6 @@ class Migration(CheckedMigration):
                 name="sentry_release_version_btree",
                 opclasses=["", "text_pattern_ops"],
             ),
-        ),
-        migrations.AlterIndexTogether(
-            name="grouphistory",
-            index_together={
-                ("project", "status", "release"),
-                ("group", "status"),
-                ("project", "date_added"),
-            },
         ),
         migrations.SeparateDatabaseAndState(
             database_operations=[

--- a/src/sentry/migrations/0640_index_together.py
+++ b/src/sentry/migrations/0640_index_together.py
@@ -68,19 +68,4 @@ class Migration(CheckedMigration):
             new_name="sentry_grou_project_17d28d_idx",
             old_fields=("project", "status", "type", "last_seen", "id"),
         ),
-        migrations.RenameIndex(
-            model_name="grouphistory",
-            new_name="sentry_grou_project_bbcf30_idx",
-            old_fields=("project", "status", "release"),
-        ),
-        migrations.RenameIndex(
-            model_name="grouphistory",
-            new_name="sentry_grou_group_i_c61acb_idx",
-            old_fields=("group", "status"),
-        ),
-        migrations.RenameIndex(
-            model_name="grouphistory",
-            new_name="sentry_grou_project_20b3f8_idx",
-            old_fields=("project", "date_added"),
-        ),
     ]


### PR DESCRIPTION
index_together is removed in django 5.1 so this is necessary to upgrade

hard-stop is already in place for self-hosted

<!-- Describe your PR here. -->