### PR TITLE
fix(issues): Re-enable new user issues details guide

### DIFF
--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
+import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -176,43 +177,48 @@ export default function BreadcrumbsDataSection({
   const hasViewAll = summaryCrumbs.length !== enhancedCrumbs.length;
 
   return (
-    <InterimSection
-      key="breadcrumbs"
-      type={SectionKey.BREADCRUMBS}
-      title={t('Breadcrumbs')}
-      data-test-id="breadcrumbs-data-section"
-      actions={actions}
-    >
-      <ErrorBoundary mini message={t('There was an error loading the event breadcrumbs')}>
-        <div ref={setContainer}>
-          <BreadcrumbsTimeline
-            breadcrumbs={summaryCrumbs}
-            startTimeString={startTimeString}
-            // We want the timeline to appear connected to the 'View All' button
-            showLastLine={hasViewAll}
-            fullyExpanded={false}
-            containerElement={container}
-          />
-        </div>
-        {hasViewAll && (
-          <ViewAllContainer>
-            <VerticalEllipsis />
-            <div>
-              <ViewAllButton
-                size="sm"
-                // Since we've disabled the button as an 'outside click' for the drawer we can change
-                // the operation based on the drawer state.
-                onClick={() => (isDrawerOpen ? closeDrawer() : onViewAllBreadcrumbs())}
-                aria-label={t('View All Breadcrumbs')}
-                ref={viewAllButtonRef}
-              >
-                {t('View All')}
-              </ViewAllButton>
-            </div>
-          </ViewAllContainer>
-        )}
-      </ErrorBoundary>
-    </InterimSection>
+    <GuideAnchor target="breadcrumbs" position="top">
+      <InterimSection
+        key="breadcrumbs"
+        type={SectionKey.BREADCRUMBS}
+        title={t('Breadcrumbs')}
+        data-test-id="breadcrumbs-data-section"
+        actions={actions}
+      >
+        <ErrorBoundary
+          mini
+          message={t('There was an error loading the event breadcrumbs')}
+        >
+          <div ref={setContainer}>
+            <BreadcrumbsTimeline
+              breadcrumbs={summaryCrumbs}
+              startTimeString={startTimeString}
+              // We want the timeline to appear connected to the 'View All' button
+              showLastLine={hasViewAll}
+              fullyExpanded={false}
+              containerElement={container}
+            />
+          </div>
+          {hasViewAll && (
+            <ViewAllContainer>
+              <VerticalEllipsis />
+              <div>
+                <ViewAllButton
+                  size="sm"
+                  // Since we've disabled the button as an 'outside click' for the drawer we can change
+                  // the operation based on the drawer state.
+                  onClick={() => (isDrawerOpen ? closeDrawer() : onViewAllBreadcrumbs())}
+                  aria-label={t('View All Breadcrumbs')}
+                  ref={viewAllButtonRef}
+                >
+                  {t('View All')}
+                </ViewAllButton>
+              </div>
+            </ViewAllContainer>
+          )}
+        </ErrorBoundary>
+      </InterimSection>
+    </GuideAnchor>
   );
 }
 


### PR DESCRIPTION
Wrapping new breadcrumbs in a guide instead of using the old data section, because the old data section will go away eventually
