### PR TITLE
ref(fieldWrapper): Remove padding condition for fields inside modal

### DIFF
--- a/static/app/components/forms/fieldGroup/fieldWrapper.tsx
+++ b/static/app/components/forms/fieldGroup/fieldWrapper.tsx
@@ -58,15 +58,6 @@ const FieldWrapper = styled('div')<FieldWrapperProps>`
     `}
 
 
-  /* Better padding with form inside of a modal */
-  ${p =>
-    !p.hasControlState &&
-    css`
-      [role='document'] & {
-        padding-right: 0;
-      }
-    `}
-
   &:last-child {
     border-bottom: none;
     ${p => (p.stacked ? 'padding-bottom: 0' : '')};


### PR DESCRIPTION
**Before**
<img width="626" alt="Screenshot 2024-09-09 at 23 21 06" src="https://github.com/user-attachments/assets/e6268ec3-e799-4ecf-b0bd-4a09a396defa">




**After**

<img width="624" alt="Screenshot 2024-09-09 at 23 19 40" src="https://github.com/user-attachments/assets/f90aaeed-f1ad-4748-9c3b-a2952cfa0835">
