### PR TITLE
fix(commits): early return if no groups

### DIFF
--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -207,6 +207,9 @@ def resolved_in_pull_request(instance, created, **kwargs):
         if link.group_id not in group_ids:
             remove_resolved_link(link)
 
+    if len(groups) == 0:
+        return
+
     try:
         repo = Repository.objects.get(id=instance.repository_id)
     except Repository.DoesNotExist:

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -87,6 +87,9 @@ def resolved_in_commit(instance, created, **kwargs):
         if link.group_id not in group_ids:
             remove_resolved_link(link)
 
+    if len(groups) == 0:
+        return
+
     try:
         repo = Repository.objects.get(id=instance.repository_id)
     except Repository.DoesNotExist:


### PR DESCRIPTION
in the receiver for `resolved_in_commit`, we do not early return if there are no groups. Which means we end up doing a lot of unecessary hybrid cloud calls to get the commit author, even if we don't need to. 

This should reduce the number of get_user calls here by a lot.

```
select
  count(*),
  linked_type
from
  sentry_grouplink
group by
  linked_type
  ```
shows we don't have too many "resolved in commits" in our db compared to the number of commits.