### PR TITLE
feat(insights): Formatting for MongoDB queries

### DIFF
--- a/static/app/views/insights/browser/resources/components/tables/resourceSummaryTable.tsx
+++ b/static/app/views/insights/browser/resources/components/tables/resourceSummaryTable.tsx
@@ -27,7 +27,11 @@ import {
   DataTitles,
   getThroughputTitle,
 } from 'sentry/views/insights/common/views/spans/types';
-import {SpanIndexedField, SpanMetricsField} from 'sentry/views/insights/types';
+import {
+  ModuleName,
+  SpanIndexedField,
+  SpanMetricsField,
+} from 'sentry/views/insights/types';
 
 const {
   RESOURCE_RENDER_BLOCKING_STATUS,
@@ -126,7 +130,7 @@ function ResourceSummaryTable() {
                 <TitleWrapper>{t('Example')}</TitleWrapper>
                 <FullSpanDescription
                   group={groupId}
-                  language="http"
+                  moduleName={ModuleName.RESOURCE}
                   filters={{
                     [SpanIndexedField.RESOURCE_RENDER_BLOCKING_STATUS]:
                       row[RESOURCE_RENDER_BLOCKING_STATUS],

--- a/static/app/views/insights/common/components/fullSpanDescription.spec.tsx
+++ b/static/app/views/insights/common/components/fullSpanDescription.spec.tsx
@@ -1,0 +1,138 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
+
+import {EntryType} from 'sentry/types/event';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {FullSpanDescription} from 'sentry/views/insights/common/components/fullSpanDescription';
+import {ModuleName} from 'sentry/views/insights/types';
+
+jest.mock('sentry/utils/usePageFilters');
+
+describe('FullSpanDescription', function () {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const organization = OrganizationFixture();
+
+  const project = ProjectFixture();
+
+  jest.mocked(usePageFilters).mockReturnValue({
+    isReady: true,
+    desyncedFilters: new Set(),
+    pinnedFilters: new Set(),
+    shouldPersist: true,
+    selection: {
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
+      },
+      environments: [],
+      projects: [],
+    },
+  });
+
+  const groupId = '2ed2abf6ce7e3577';
+  const spanId = 'abfed2aabf';
+  const eventId = '65c7d8647b8a76ef8f4c05d41deb7860';
+
+  it('uses the correct code formatting for SQL queries', async function () {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {
+        data: [
+          {
+            'transaction.id': eventId,
+            project: project.slug,
+            span_id: spanId,
+          },
+        ],
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/${project.slug}:${eventId}/`,
+      body: {
+        id: eventId,
+        entries: [
+          {
+            type: EntryType.SPANS,
+            data: [
+              {
+                span_id: spanId,
+                description: 'SELECT users FROM my_table LIMIT 1;',
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(
+      <FullSpanDescription
+        group={groupId}
+        shortDescription={'SELECT users FRO*'}
+        moduleName={ModuleName.DB}
+      />,
+      {organization}
+    );
+
+    await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
+
+    const queryCodeSnippet = await screen.findByText(
+      /select users from my_table limit 1;/i
+    );
+    expect(queryCodeSnippet).toBeInTheDocument();
+    expect(queryCodeSnippet).toHaveClass('language-sql');
+  });
+
+  it('uses the correct code formatting for MongoDB queries', async function () {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {
+        data: [
+          {
+            'transaction.id': eventId,
+            project: project.slug,
+            span_id: spanId,
+          },
+        ],
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/${project.slug}:${eventId}/`,
+      body: {
+        id: eventId,
+        entries: [
+          {
+            type: EntryType.SPANS,
+            data: [
+              {
+                span_id: spanId,
+                description: `{"insert": "my_cool_collection😎", "a": {}}`,
+                data: {'db.system': 'mongodb'},
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(<FullSpanDescription group={groupId} moduleName={ModuleName.DB} />, {
+      organization,
+    });
+
+    await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
+
+    const queryCodeSnippet = screen.getByText(
+      /\{ "insert": "my_cool_collection😎", "a": \{\} \}/i
+    );
+    expect(queryCodeSnippet).toBeInTheDocument();
+    expect(queryCodeSnippet).toHaveClass('language-json');
+  });
+});

--- a/static/app/views/insights/common/components/fullSpanDescription.tsx
+++ b/static/app/views/insights/common/components/fullSpanDescription.tsx
@@ -6,17 +6,36 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {space} from 'sentry/styles/space';
 import {SQLishFormatter} from 'sentry/utils/sqlish/SQLishFormatter';
 import {useFullSpanFromTrace} from 'sentry/views/insights/common/queries/useFullSpanFromTrace';
+import {ModuleName} from 'sentry/views/insights/types';
 
 const formatter = new SQLishFormatter();
 
-export function FullSpanDescription({group, shortDescription, language, filters}: Props) {
+const INDEXED_SPAN_SORT = {
+  field: 'span.self_time',
+  kind: 'desc' as const,
+};
+
+interface Props {
+  moduleName: ModuleName;
+  filters?: Record<string, string>;
+  group?: string;
+  shortDescription?: string;
+}
+
+export function FullSpanDescription({
+  group,
+  shortDescription,
+  filters,
+  moduleName,
+}: Props) {
   const {
     data: fullSpan,
     isLoading,
     isFetching,
-  } = useFullSpanFromTrace(group, undefined, Boolean(group), filters);
+  } = useFullSpanFromTrace(group, [INDEXED_SPAN_SORT], Boolean(group), filters);
 
   const description = fullSpan?.description ?? shortDescription;
+  const system = fullSpan?.data?.['db.system'];
 
   if (isLoading && isFetching) {
     return (
@@ -30,26 +49,31 @@ export function FullSpanDescription({group, shortDescription, language, filters}
     return null;
   }
 
-  if (language === 'sql') {
+  if (moduleName === ModuleName.DB) {
+    if (system === 'mongodb') {
+      return (
+        <CodeSnippet language="json">
+          {JSON.stringify(
+            JSON.parse(fullSpan?.sentry_tags?.description ?? ''),
+            null,
+            4
+          ) ?? ''}
+        </CodeSnippet>
+      );
+    }
+
     return (
-      <CodeSnippet language={language}>
+      <CodeSnippet language="sql">
         {formatter.toString(description, {maxLineLength: LINE_LENGTH})}
       </CodeSnippet>
     );
   }
 
-  if (language) {
-    return <CodeSnippet language={language}>{description}</CodeSnippet>;
+  if (moduleName === ModuleName.RESOURCE) {
+    return <CodeSnippet language="http">{description}</CodeSnippet>;
   }
 
   return <Fragment>{description}</Fragment>;
-}
-
-interface Props {
-  filters?: Record<string, string>;
-  group?: string;
-  language?: 'sql' | 'http';
-  shortDescription?: string;
 }
 
 const LINE_LENGTH = 60;

--- a/static/app/views/insights/common/components/fullSpanDescription.tsx
+++ b/static/app/views/insights/common/components/fullSpanDescription.tsx
@@ -54,7 +54,7 @@ export function FullSpanDescription({
       return (
         <CodeSnippet language="json">
           {JSON.stringify(
-            JSON.parse(fullSpan?.sentry_tags?.description ?? ''),
+            JSON.parse(fullSpan?.sentry_tags?.description ?? fullSpan?.description ?? ''),
             null,
             4
           ) ?? ''}

--- a/static/app/views/insights/common/components/spanDescription.spec.tsx
+++ b/static/app/views/insights/common/components/spanDescription.spec.tsx
@@ -115,7 +115,7 @@ describe('DatabaseSpanDescription', function () {
       isFetching: false,
       isError: false,
       data: {
-        description: undefined,
+        description: 'SELECT users FROM my_table LIMIT 1;',
         data: {'db.operation': 'SELECT', 'db.system': 'postgresql'},
         span_id: '1',
         start_timestamp: 1,
@@ -172,6 +172,25 @@ describe('DatabaseSpanDescription', function () {
             ],
           },
         ],
+      },
+    });
+
+    jest.mocked(useFullSpanFromTrace).mockReturnValue({
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      data: {
+        description: 'SELECT users FROM my_table LIMIT 1;',
+        data: {
+          'db.operation': 'SELECT',
+          'db.system': 'postgresql',
+          'code.filepath': '/app/views/users.py',
+          'code.lineno': 78,
+        },
+        span_id: '1',
+        start_timestamp: 1,
+        timestamp: 10,
+        trace_id: '1',
       },
     });
 

--- a/static/app/views/insights/common/components/spanDescription.tsx
+++ b/static/app/views/insights/common/components/spanDescription.tsx
@@ -78,33 +78,17 @@ export function DatabaseSpanDescription({
     return formatter.toString(rawDescription ?? '');
   }, [preliminaryDescription, rawSpan, indexedSpan, system]);
 
-  const renderQueryDescription = () => {
-    if (areIndexedSpansLoading || !system) {
-      return (
+  return (
+    <Frame>
+      {areIndexedSpansLoading || !system ? (
         <WithPadding>
           <LoadingIndicator mini />
         </WithPadding>
-      );
-    }
-
-    if (system === 'mongodb') {
-      return (
-        <CodeSnippet language="json" isRounded={false}>
+      ) : (
+        <CodeSnippet language={system === 'mongodb' ? 'json' : 'sql'} isRounded={false}>
           {formattedDescription}
         </CodeSnippet>
-      );
-    }
-
-    return (
-      <CodeSnippet language="sql" isRounded={false}>
-        {formattedDescription}
-      </CodeSnippet>
-    );
-  };
-
-  return (
-    <Frame>
-      {renderQueryDescription()}
+      )}
 
       {!areIndexedSpansLoading && !isRawSpanLoading && (
         <Fragment>

--- a/static/app/views/insights/common/components/spanDescription.tsx
+++ b/static/app/views/insights/common/components/spanDescription.tsx
@@ -159,5 +159,4 @@ const WordBreak = styled('div')`
 
 const MongoQuery = styled(StructuredEventData)`
   margin: 0;
-  background: ${p => p.theme.white};
 `;

--- a/static/app/views/insights/common/components/spanDescription.tsx
+++ b/static/app/views/insights/common/components/spanDescription.tsx
@@ -159,4 +159,5 @@ const WordBreak = styled('div')`
 
 const MongoQuery = styled(StructuredEventData)`
   margin: 0;
+  background: ${p => p.theme.white};
 `;

--- a/static/app/views/insights/common/components/spanDescription.tsx
+++ b/static/app/views/insights/common/components/spanDescription.tsx
@@ -70,7 +70,9 @@ export function DatabaseSpanDescription({
       // TODO: We should transform the data a bit for mongodb queries.
       // For example, it would be better if we display the operation on the collection as the
       // first key value pair in the JSON, since this is not guaranteed by the backend
-      return JSON.stringify(JSON.parse(preliminaryDescription ?? ''), null, 4) ?? '';
+      return preliminaryDescription
+        ? JSON.stringify(JSON.parse(preliminaryDescription), null, 4)
+        : '{ ... }';
     }
 
     const rawDescription =

--- a/static/app/views/insights/common/components/spanDescription.tsx
+++ b/static/app/views/insights/common/components/spanDescription.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import StructuredEventData from 'sentry/components/structuredEventData';
 import {space} from 'sentry/styles/space';
 import {SQLishFormatter} from 'sentry/utils/sqlish/SQLishFormatter';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -75,16 +74,6 @@ export function DatabaseSpanDescription({
     return formatter.toString(rawDescription ?? '');
   }, [preliminaryDescription, rawSpan, indexedSpan, system]);
 
-  const mongoQueryConfig = useMemo(
-    () => ({
-      isBoolean: value => typeof value === 'boolean',
-      isNull: value => value === null,
-      isString: value => typeof value === 'string',
-      isNumber: value => typeof value === 'number',
-    }),
-    []
-  );
-
   const renderQueryDescription = () => {
     if (areIndexedSpansLoading || !system) {
       return (
@@ -96,12 +85,9 @@ export function DatabaseSpanDescription({
 
     if (system === 'mongodb') {
       return (
-        <MongoQuery
-          config={mongoQueryConfig}
-          data={JSON.parse(preliminaryDescription || '{}')}
-          forceDefaultExpand
-          maxDefaultDepth={3}
-        />
+        <CodeSnippet language="json" isRounded={false}>
+          {JSON.stringify(JSON.parse(preliminaryDescription ?? ''), null, 4) ?? ''}
+        </CodeSnippet>
       );
     }
 
@@ -155,8 +141,4 @@ const WithPadding = styled('div')`
 
 const WordBreak = styled('div')`
   word-break: break-word;
-`;
-
-const MongoQuery = styled(StructuredEventData)`
-  margin: 0;
 `;

--- a/static/app/views/insights/common/components/spanDescription.tsx
+++ b/static/app/views/insights/common/components/spanDescription.tsx
@@ -96,7 +96,7 @@ export function DatabaseSpanDescription({
 
     if (system === 'mongodb') {
       return (
-        <StructuredEventData
+        <MongoQuery
           config={mongoQueryConfig}
           data={JSON.parse(preliminaryDescription || '{}')}
           forceDefaultExpand
@@ -155,4 +155,8 @@ const WithPadding = styled('div')`
 
 const WordBreak = styled('div')`
   word-break: break-word;
+`;
+
+const MongoQuery = styled(StructuredEventData)`
+  margin: 0;
 `;

--- a/static/app/views/insights/common/components/spanDescription.tsx
+++ b/static/app/views/insights/common/components/spanDescription.tsx
@@ -61,12 +61,16 @@ export function DatabaseSpanDescription({
   const system = rawSpan?.data?.['db.system'];
 
   const formattedDescription = useMemo(() => {
+    if (!system) {
+      return preliminaryDescription ?? '';
+    }
+
     // MongoDB span descriptions are in JSON and should not have SQLish formatting applied
-    if (!system || system === 'mongodb') {
+    if (system === 'mongodb') {
       // TODO: We should transform the data a bit for mongodb queries.
       // For example, it would be better if we display the operation on the collection as the
       // first key value pair in the JSON, since this is not guaranteed by the backend
-      return preliminaryDescription;
+      return JSON.stringify(JSON.parse(preliminaryDescription ?? ''), null, 4) ?? '';
     }
 
     const rawDescription =
@@ -86,14 +90,14 @@ export function DatabaseSpanDescription({
     if (system === 'mongodb') {
       return (
         <CodeSnippet language="json" isRounded={false}>
-          {JSON.stringify(JSON.parse(preliminaryDescription ?? ''), null, 4) ?? ''}
+          {formattedDescription}
         </CodeSnippet>
       );
     }
 
     return (
       <CodeSnippet language="sql" isRounded={false}>
-        {formattedDescription ?? ''}
+        {formattedDescription}
       </CodeSnippet>
     );
   };

--- a/static/app/views/insights/common/components/spanDescription.tsx
+++ b/static/app/views/insights/common/components/spanDescription.tsx
@@ -64,25 +64,24 @@ export function DatabaseSpanDescription({
     try {
       return JSON.stringify(JSON.parse(queryString), null, 4);
     } catch (error) {
-      throw Error('Failed to parse JSON: ', error);
+      throw Error(`Failed to parse JSON: ${queryString}`);
     }
   };
 
   const formattedDescription = useMemo(() => {
-    if (!preliminaryDescription) {
-      return '...';
-    }
+    const rawDescription =
+      rawSpan?.description || indexedSpan?.['span.description'] || preliminaryDescription;
 
     if (!system) {
       // If the span data has not loaded, we can still infer that this is a NoSQL query
       if (
-        preliminaryDescription.startsWith('{') &&
-        preliminaryDescription.endsWith('}')
+        preliminaryDescription?.startsWith('{') &&
+        preliminaryDescription?.endsWith('}')
       ) {
         return formatJsonQuery(preliminaryDescription);
       }
 
-      return preliminaryDescription;
+      return rawDescription;
     }
 
     // MongoDB span descriptions are in JSON and should not have SQLish formatting applied
@@ -90,11 +89,9 @@ export function DatabaseSpanDescription({
       // TODO: We should transform the data a bit for mongodb queries.
       // For example, it would be better if we display the operation on the collection as the
       // first key value pair in the JSON, since this is not guaranteed by the backend
-      return formatJsonQuery(preliminaryDescription);
+      return formatJsonQuery(preliminaryDescription ?? '{}');
     }
 
-    const rawDescription =
-      rawSpan?.description || indexedSpan?.['span.description'] || preliminaryDescription;
     return formatter.toString(rawDescription ?? '');
   }, [preliminaryDescription, rawSpan, indexedSpan, system]);
 
@@ -106,7 +103,7 @@ export function DatabaseSpanDescription({
         </WithPadding>
       ) : (
         <CodeSnippet language={system === 'mongodb' ? 'json' : 'sql'} isRounded={false}>
-          {formattedDescription}
+          {formattedDescription ?? ''}
         </CodeSnippet>
       )}
 

--- a/static/app/views/insights/common/components/tableCells/spanDescriptionCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/spanDescriptionCell.tsx
@@ -61,7 +61,7 @@ export function SpanDescriptionCell({
           <FullSpanDescription
             group={group}
             shortDescription={rawDescription}
-            language="sql"
+            moduleName={moduleName}
           />
         }
       >
@@ -80,7 +80,7 @@ export function SpanDescriptionCell({
             <FullSpanDescription
               group={group}
               shortDescription={rawDescription}
-              language="http"
+              moduleName={moduleName}
               filters={spanOp ? {[SPAN_OP]: spanOp} : undefined}
             />
           </Fragment>

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
@@ -65,6 +65,7 @@ describe('DatabaseSpanSummaryPage', function () {
         data: [
           {
             'span.op': 'db',
+            'span.description': 'SELECT thing FROM my_table;',
           },
         ],
       },


### PR DESCRIPTION
Adds pretty printing for MongoDB queries in the following locations:

### Queries landing page: Tooltip hover
![image](https://github.com/user-attachments/assets/aca367d3-be09-42a4-a2f1-ea1df08d6809)

### Query summary page:
![image](https://github.com/user-attachments/assets/ce4e705b-1e32-47e9-85ff-e20dbec4604f)
