### PR TITLE
fix(issues): fix register sort bug

### DIFF
--- a/static/app/components/events/interfaces/frame/frameRegisters/utils.tsx
+++ b/static/app/components/events/interfaces/frame/frameRegisters/utils.tsx
@@ -1,4 +1,5 @@
 import {
+  REGISTERS_ARM,
   REGISTERS_ARM64,
   REGISTERS_MIPS,
   REGISTERS_PPC,
@@ -20,7 +21,7 @@ function getRegisterMap(deviceArch: string) {
   }
 
   if (deviceArch.startsWith('arm')) {
-    return REGISTERS_ARM64;
+    return REGISTERS_ARM;
   }
 
   if (deviceArch.startsWith('mips')) {


### PR DESCRIPTION
ARM64 and ARM (32 bit) have different registers. Attempting to sort the ARM32 registers using the ARM64 register map will result in the registers appearing in lexicographic order.