### PR TITLE
fix(migrations): Fix generate migration step to work in new Django apps.

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -68,7 +68,7 @@ jobs:
         id: file
         run: |
           echo 'added<<EOF' >> "$GITHUB_OUTPUT"
-          git diff --diff-filter=A --name-only origin/master HEAD -- 'src/sentry/*/migrations/*' 'src/sentry/migrations/*' >> "$GITHUB_OUTPUT"
+          git diff --diff-filter=A --name-only origin/master HEAD -- 'src/sentry/*/migrations/*' 'src/sentry/migrations/*' | grep -v "__init__.py" >> "$GITHUB_OUTPUT"
           echo 'EOF' >> "$GITHUB_OUTPUT"
 
       - name: Generate SQL for migration


### PR DESCRIPTION
This fixes the generate sql command to work correctly in new Django apps. It works by performing a diff of any new files in the migration folders compared to master. In a new app, this ends up including `__init__.py`, which causes the command to fail. Just excluding that file.

<!-- Describe your PR here. -->