### PR TITLE
feat(uptime): Add rdap query utilities

### DIFF
--- a/src/sentry/uptime/detectors/rdap.py
+++ b/src/sentry/uptime/detectors/rdap.py
@@ -1,0 +1,166 @@
+import ipaddress
+import logging
+from collections.abc import Mapping, MutableMapping, Sequence
+from socket import gethostbyname
+from typing import Any, TypedDict
+
+import requests
+from django.core.cache import cache
+
+RDAP_BOOTSTRAP_REGSITRY = "https://data.iana.org/rdap/ipv4.json"
+"""
+JSON service registry maintained by the IANA containing a mapping of ipv4 CIDRs
+to RDAP service urls.
+"""
+
+CIDRList = Sequence[str]
+"""
+List of CIDR addresses that a Regional Internet Registry is responsible for.
+"""
+
+RDAPServiceURLList = Sequence[str]
+"""
+List of Regional Internet Registry RDAP Service URLs for a CIDR set.
+"""
+
+ServiceArray = Sequence[tuple[CIDRList, RDAPServiceURLList]]
+
+logger = logging.getLogger(__name__)
+
+# Cache the RDAP boostrap file for a day
+RDAP_BOOTSTRAP_JSON_CACHE_TIMEOUT = 60 * 60 * 24
+
+
+class DomainAddressDetails(TypedDict):
+    """
+    This dictionary encapsulates the details of a rdap request that we care about
+    """
+
+    name: str
+    """
+    A string representing an identifier assigned to the network registration by
+    the registration holder.
+    """
+
+    owner_name: str
+    """
+    The human readible name of the owner of the network registration.
+    """
+
+
+def resolve_rdap_network_details(hostname: str):
+    addr = resolve_hostname(hostname)
+    rdap_provider_url = resolve_rdap_provider(addr)
+
+    resp = requests.get(f"{rdap_provider_url}ip/{addr}")
+    result: Mapping[str, Any] = resp.json()
+
+    # We only extract the jCard from the FIRST entity, there may be more with
+    # other information about the network registration, but for now we're just
+    # going to look at the first and assume it's the most relevant
+    entity = parse_jcard_to_dict(result["entities"][0]["vcardArray"][1])
+
+    details: DomainAddressDetails = {
+        "name": result["name"],
+        "owner_name": entity["fn"],
+    }
+
+    logger.info(
+        "uptime.resolve_rdap_network_details",
+        extra={
+            "hostname": hostname,
+            "resolved_addr": addr,
+            "rdap_provider_url": rdap_provider_url,
+            **details,
+        },
+    )
+
+    return details
+
+
+class RDAPBootstrapConfig(TypedDict):
+    """
+    Resulting structure of the RDAP_BOOTSTRAP_REGSITRY json file.
+    """
+
+    description: str
+    publication: str
+    services: ServiceArray
+    version: str
+
+
+def resolve_rdap_bootstrap_registry() -> ServiceArray:
+    """
+    Resolves the RDAP Bootstrap Registry JSON file. Caches the result for
+    future calls.
+    """
+    cache_key = "uptime.rdap_bootstrap_registry_json"
+    services: ServiceArray = cache.get(cache_key)
+
+    if not services:
+        # TODO(epurkhiser): Error handling for failing to get this bootstrap file
+        config: RDAPBootstrapConfig = requests.get(RDAP_BOOTSTRAP_REGSITRY).json()
+        services = config["services"]
+        cache.set(cache_key, services, timeout=RDAP_BOOTSTRAP_JSON_CACHE_TIMEOUT)
+
+    return services
+
+
+def resolve_hostname(hostname: str) -> str:
+    """
+    Resolves a hostname to a ipv4 address.
+    """
+    return gethostbyname(hostname)
+
+
+def resolve_rdap_provider(addr: str) -> str | None:
+    """
+    Given an ipv4 address, resolve the RDAP service API url for that address
+    using the ICAN bootstrap file.
+    """
+    services = resolve_rdap_bootstrap_registry()
+    ip_addr = ipaddress.ip_address(addr)
+
+    service = next(
+        (s for s in services if any(ip_addr in ipaddress.ip_network(cidr) for cidr in s[0])),
+        None,
+    )
+
+    # IP Address could not be resolved to a RDAP service
+    if service is None:
+        logger.warning("uptime.no_rdap_provider_match", extra={"addr": addr})
+        return None
+
+    rdap_service_url = service[1][0]
+    return rdap_service_url
+
+
+def parse_jcard_to_dict(vcard: Sequence[tuple[str, Any, str, Any]]) -> Mapping[str, str]:
+    """
+    Converts a JSON jCard array into a dictionary.
+
+    This currently ONLY translates `text` type fields into the dictionary
+    mapping. See more about this format in the RFC [0].
+
+    [0]: https://datatracker.ietf.org/doc/html/rfc7095
+    """
+    mapping: MutableMapping[str, str] = {}
+
+    for items in vcard:
+        name, property_type, values = items[0], items[2], items[3:]
+
+        # Currently ignore anything that isn't `text`
+        if property_type != "text":
+            continue
+
+        # Ignore text properties that have text values as lists. See Section
+        # 3.3.1.3 [0] of the RFC for examples where this is the case.
+        #
+        # [0]: https://datatracker.ietf.org/doc/html/rfc7095#section-3.3.1.3
+        if isinstance(values[0], list):
+            continue
+
+        # Join the values in case they are a list. See the RFC for more details
+        mapping[name] = str(", ".join(values))
+
+    return mapping

--- a/tests/sentry/uptime/detectors/test_rdap.py
+++ b/tests/sentry/uptime/detectors/test_rdap.py
@@ -1,0 +1,120 @@
+from unittest import mock
+
+import responses
+
+from sentry.uptime.detectors.rdap import (
+    RDAP_BOOTSTRAP_REGSITRY,
+    resolve_rdap_bootstrap_registry,
+    resolve_rdap_network_details,
+    resolve_rdap_provider,
+)
+
+SIMPLE_RDAP_BOOTSTRAP_RESPONSE = {
+    "description": "Example RDAP bootstrap file for IPv4 address allocations",
+    "publication": "2024-01-01T00:00:00Z",
+    "services": [
+        [
+            [
+                "1.0.0.0/8",
+                "4.0.0.0/8",
+            ],
+            ["https://rdap.example.net/rdap/", "http://rdap.extra-example.net/rdap/"],
+        ],
+        [
+            [
+                "2.0.0.0/8",
+                "5.0.0.0/8",
+            ],
+            ["https://rdap.other-example.net/"],
+        ],
+    ],
+    "version": "1.0",
+}
+
+SIMPLE_RDAP_RESPONSE = {
+    "handle": "NET-67-240-0-0-1",
+    "startAddress": "67.240.0.0",
+    "endAddress": "67.255.255.255",
+    "ipVersion": "v4",
+    "name": "RRNY",
+    "type": "DIRECT ALLOCATION",
+    "parentHandle": "NET-67-0-0-0-0",
+    "events": [
+        # Removed for brevity
+    ],
+    "links": [
+        # Removed for brevity
+    ],
+    "entities": [
+        {
+            "handle": "CC-3517",
+            "vcardArray": [
+                "vcard",
+                [
+                    ["version", {}, "text", "4.0"],
+                    ["fn", {}, "text", "Charter Communications Inc"],
+                    [
+                        "adr",
+                        {"label": "6175 S. Willow Dr\nGreenwood Village\nCO\n80111\nUnited States"},
+                        "text",
+                        ["", "", "", "", "", "", ""],
+                    ],
+                    ["kind", {}, "text", "org"],
+                ],
+            ],
+            "roles": ["registrant"],
+            "remarks": [],
+            "links": [
+                # Removed for brevity
+            ],
+            "events": [
+                # Removed for brevity
+            ],
+            "entities": [],
+            "port43": "whois.arin.net",
+            "objectClassName": "entity",
+        }
+    ],
+    "port43": "whois.arin.net",
+    "status": ["active"],
+    "objectClassName": "ip network",
+    "cidr0_cidrs": [{"v4prefix": "67.240.0.0", "length": 12}],
+    "arin_originas0_originautnums": [],
+}
+
+
+@responses.activate
+def test_resolve_rdap_bootstrap_registry():
+    mock_request = responses.add(
+        "GET",
+        RDAP_BOOTSTRAP_REGSITRY,
+        json=SIMPLE_RDAP_BOOTSTRAP_RESPONSE,
+    )
+
+    assert resolve_rdap_bootstrap_registry() == SIMPLE_RDAP_BOOTSTRAP_RESPONSE["services"]
+    assert mock_request.call_count == 1
+
+    # Second call is cached, call count does not increase
+    assert resolve_rdap_bootstrap_registry() == SIMPLE_RDAP_BOOTSTRAP_RESPONSE["services"]
+    assert mock_request.call_count == 1
+
+
+def test_resolve_rdap_provider():
+    assert resolve_rdap_provider("1.10.20.30") == "https://rdap.example.net/rdap/"
+    assert resolve_rdap_provider("2.10.20.30") == "https://rdap.other-example.net/"
+    assert resolve_rdap_provider("6.0.0.0") is None
+
+
+@responses.activate
+@mock.patch("sentry.uptime.detectors.rdap.resolve_hostname", return_value="1.0.0.0")
+def test_resolve_rdap_network_details(mock_resolve_hostname):
+    responses.add(
+        "GET",
+        "https://rdap.example.net/rdap/ip/1.0.0.0",
+        json=SIMPLE_RDAP_RESPONSE,
+    )
+    details = resolve_rdap_network_details("abc.com")
+
+    mock_resolve_hostname.assert_called_with("abc.com")
+    assert details["name"] == "RRNY"
+    assert details["owner_name"] == "Charter Communications Inc"


### PR DESCRIPTION
Adds a function `resolve_rdap_network_details` which given a domain name will resolve the IP Address and subsiquently lookup the network registration details for the address using [RDAP](https://www.icann.org/rdap).

This currently does not have much error handling since it's likely we'll want to start by just propegating errors up to Sentry.

Part of https://github.com/getsentry/sentry/issues/76874