### PR TITLE
chore(metrics): clean up of the custom alert filtering

### DIFF
--- a/src/sentry/incidents/models/alert_rule.py
+++ b/src/sentry/incidents/models/alert_rule.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Protocol, Self
 from django.conf import settings
 from django.core.cache import cache
 from django.db import models
-from django.db.models import Q, QuerySet
+from django.db.models import QuerySet
 from django.db.models.signals import post_delete, post_save
 from django.utils import timezone
 from django.utils.translation import gettext_lazy
@@ -223,20 +223,6 @@ class AlertRuleManager(BaseManager["AlertRule"]):
                 },
             )
         return []
-
-    def get_for_metrics(
-        self, organization: Organization, metric_mris: list[str]
-    ) -> BaseQuerySet[AlertRule]:
-        """
-        Fetches AlertRules associated with the metric MRIs
-        """
-
-        alert_query = Q()
-        for metric_mri in metric_mris:
-            alert_query |= Q(snuba_query__aggregate__contains=metric_mri)
-
-        queryset = self.filter(organization=organization).filter(alert_query)
-        return queryset
 
 
 @region_silo_model

--- a/tests/sentry/incidents/models/test_alert_rule.py
+++ b/tests/sentry/incidents/models/test_alert_rule.py
@@ -212,35 +212,6 @@ class AlertRuleTest(TestCase):
             assert current_activation.query_subscription == sub
             assert current_activation.is_complete() is False
 
-    def test_get_for_metrics(self):
-        self.create_alert_rule(organization=self.organization, aggregate="count(c:foo/1)")
-        self.create_alert_rule(organization=self.organization, aggregate="count(c:bar/2)")
-        self.create_alert_rule(organization=self.organization, aggregate="count(c:baz/2)")
-        new_org = self.create_organization()
-        self.create_alert_rule(organization=new_org, aggregate="count(c:foo/1)")
-
-        assert (
-            AlertRule.objects.get_for_metrics(self.organization, ["c:foo/1", "c:bar/2"]).count()
-            == 2
-        )
-        assert set(
-            AlertRule.objects.get_for_metrics(
-                self.organization, ["c:foo/1", "c:bar/2"]
-            ).values_list("snuba_query__aggregate", flat=True)
-        ) == {"count(c:foo/1)", "count(c:bar/2)"}
-
-        # Test that it works with a new organization
-        assert set(
-            AlertRule.objects.get_for_metrics(new_org, ["c:foo/1", "c:bar/2"]).values_list(
-                "snuba_query__aggregate", flat=True
-            )
-        ) == {"count(c:foo/1)"}
-        assert set(
-            AlertRule.objects.get_for_metrics(new_org, ["c:foo/1", "c:bar/2"]).values_list(
-                "organization_id", flat=True
-            )
-        ) == {new_org.id}
-
 
 class AlertRuleFetchForOrganizationTest(TestCase):
     def test_empty(self):


### PR DESCRIPTION
Clean up of custom filtering logic needed for span based attribute metrics.

Now it is no longer needed, since this logic isn't used anywhere
