### PR TITLE
drop(grouping): Remove sentinel and prefix from event types

### DIFF
--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -198,8 +198,6 @@ export type Frame = {
   trust: any | null;
   vars: Record<string, any> | null;
   addrMode?: string;
-  isPrefix?: boolean;
-  isSentinel?: boolean;
   lock?: Lock | null;
   // map exists if the frame has a source map
   map?: string | null;
@@ -211,8 +209,6 @@ export type Frame = {
 };
 
 export enum FrameBadge {
-  SENTINEL = 'sentinel',
-  PREFIX = 'prefix',
   GROUPING = 'grouping',
 }
 


### PR DESCRIPTION
This is part of deprecating hierarchical related code.

The main PR can be found in #77235.