### PR TITLE
fix(alerts): Use the discover metrics dataset when the org has the insights-alerts feature

### DIFF
--- a/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
+++ b/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
@@ -5,6 +5,7 @@ import {hasCustomMetrics} from 'sentry/utils/metrics/features';
 import {hasOnDemandMetricAlertFeature} from 'sentry/utils/onDemandMetrics/features';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {getMEPAlertsDataset} from 'sentry/views/alerts/wizard/options';
+import {hasInsightsAlerts} from 'sentry/views/insights/common/utils/hasInsightsAlerts';
 
 import type {MetricRule} from '../types';
 
@@ -24,7 +25,8 @@ export function getMetricDatasetQueryExtras({
   const hasMetricDataset =
     hasOnDemandMetricAlertFeature(organization) ||
     hasCustomMetrics(organization) ||
-    organization.features.includes('mep-rollout-flag');
+    organization.features.includes('mep-rollout-flag') ||
+    hasInsightsAlerts(organization);
   const disableMetricDataset =
     decodeScalar(location?.query?.disableMetricDataset) === 'true';
 


### PR DESCRIPTION
Updates the `hasMetricDataset` check to `true` if the org has the `insights-alerts` feature flag. This fixes an issue with not being able to query events-stats for orgs that have `insights-alerts` enabled, but not custom metrics. This should be safe to do because any org with `insights-alerts` will have access to the discover `metrics` dataset.