### PR TITLE
fix(integrations): get active integrations

### DIFF
--- a/src/sentry/integrations/github/repository.py
+++ b/src/sentry/integrations/github/repository.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping, MutableMapping, Sequence
 from typing import Any
 
+from sentry.constants import ObjectStatus
 from sentry.integrations.base import IntegrationInstallation
 from sentry.integrations.services.integration import integration_service
 from sentry.models.organization import Organization
@@ -75,9 +76,13 @@ class GitHubRepositoryProvider(IntegrationRepositoryProvider):
         integration_id = repo.integration_id
         if integration_id is None:
             raise NotImplementedError("GitHub apps requires an integration id to fetch commits")
-        integration = integration_service.get_integration(integration_id=integration_id)
+        integration = integration_service.get_integration(
+            integration_id=integration_id, status=ObjectStatus.ACTIVE
+        )
         if integration is None:
-            raise NotImplementedError("GitHub apps requires a valid integration to fetch commits")
+            raise NotImplementedError(
+                "GitHub apps requires a valid active integration to fetch commits"
+            )
 
         installation = integration.get_installation(organization_id=repo.organization_id)
         client = installation.get_client()

--- a/src/sentry/integrations/github/tasks/link_all_repos.py
+++ b/src/sentry/integrations/github/tasks/link_all_repos.py
@@ -1,5 +1,6 @@
 import logging
 
+from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import integration_service
 from sentry.organizations.services.organization import organization_service
 from sentry.plugins.providers.integration_repository import (
@@ -34,7 +35,9 @@ def link_all_repos(
     integration_id: int,
     organization_id: int,
 ):
-    integration = integration_service.get_integration(integration_id=integration_id)
+    integration = integration_service.get_integration(
+        integration_id=integration_id, status=ObjectStatus.ACTIVE
+    )
     if not integration:
         logger.error(
             "%s.link_all_repos.integration_missing",

--- a/src/sentry/integrations/github/tasks/open_pr_comment.py
+++ b/src/sentry/integrations/github/tasks/open_pr_comment.py
@@ -21,7 +21,7 @@ from snuba_sdk import (
 )
 from snuba_sdk import Request as SnubaRequest
 
-from sentry.constants import EXTENSION_LANGUAGE_MAP
+from sentry.constants import EXTENSION_LANGUAGE_MAP, ObjectStatus
 from sentry.integrations.github.client import GitHubApiClient
 from sentry.integrations.github.constants import (
     ISSUE_LOCKED_ERROR_MESSAGE,
@@ -439,7 +439,9 @@ def open_pr_comment_workflow(pr_id: int) -> None:
         return
 
     # check integration exists to hit Github API with client
-    integration = integration_service.get_integration(integration_id=repo.integration_id)
+    integration = integration_service.get_integration(
+        integration_id=repo.integration_id, status=ObjectStatus.ACTIVE
+    )
     if not integration:
         logger.info("github.open_pr_comment.integration_missing", extra={"organization_id": org_id})
         metrics.incr(OPEN_PR_METRICS_BASE.format(key="error"), tags={"type": "missing_integration"})

--- a/src/sentry/integrations/notifications.py
+++ b/src/sentry/integrations/notifications.py
@@ -91,8 +91,10 @@ def _get_channel_and_integration_by_team(
     except ExternalActor.DoesNotExist:
         return {}
 
-    integration = integration_service.get_integration(integration_id=external_actor.integration_id)
-    if integration.status != ObjectStatus.ACTIVE:
+    integration = integration_service.get_integration(
+        integration_id=external_actor.integration_id, status=ObjectStatus.ACTIVE
+    )
+    if not integration:
         return {}
     return {external_actor.external_id: integration}
 

--- a/src/sentry/integrations/slack/sdk_client.py
+++ b/src/sentry/integrations/slack/sdk_client.py
@@ -6,6 +6,7 @@ from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web import SlackResponse
 
+from sentry.constants import ObjectStatus
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.integrations.base import disable_integration, is_response_error, is_response_success
 from sentry.integrations.models import Integration
@@ -119,9 +120,13 @@ class SlackSdkClient(WebClient, metaclass=MetaClass):
             # this is a read operation.
             """
             with in_test_hide_transaction_boundary():
-                integration = integration_service.get_integration(integration_id=integration_id)
+                integration = integration_service.get_integration(
+                    integration_id=integration_id, status=ObjectStatus.ACTIVE
+                )
         else:  # control or monolith (local)
-            integration = Integration.objects.filter(id=integration_id).first()
+            integration = Integration.objects.filter(
+                id=integration_id, status=ObjectStatus.ACTIVE
+            ).first()
 
         if integration is None:
             raise ValueError(f"Integration with id {integration_id} not found")

--- a/tests/sentry/integrations/github/tasks/test_open_pr_comment.py
+++ b/tests/sentry/integrations/github/tasks/test_open_pr_comment.py
@@ -5,6 +5,7 @@ import pytest
 import responses
 from django.utils import timezone
 
+from sentry.constants import ObjectStatus
 from sentry.integrations.github.constants import STACKFRAME_COUNT
 from sentry.integrations.github.tasks.language_parsers import PATCH_PARSERS
 from sentry.integrations.github.tasks.open_pr_comment import (
@@ -21,8 +22,10 @@ from sentry.integrations.github.tasks.utils import PullRequestFile, PullRequestI
 from sentry.models.group import Group, GroupStatus
 from sentry.models.pullrequest import CommentType, PullRequest, PullRequestComment
 from sentry.shared_integrations.exceptions import ApiError
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import IntegrationTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from tests.sentry.integrations.github.tasks.test_pr_comment import GithubCommentTestCase
 
@@ -1178,9 +1181,9 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
         mock_reverse_codemappings,
         mock_pr_filenames,
     ):
-        # invalid integration id
-        self.gh_repo.integration_id = 0
-        self.gh_repo.save()
+        # inactive integration
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration.update(status=ObjectStatus.DISABLED)
 
         open_pr_comment_workflow(self.pr.id)
 

--- a/tests/sentry/integrations/github/tasks/test_open_pr_comment.py
+++ b/tests/sentry/integrations/github/tasks/test_open_pr_comment.py
@@ -19,13 +19,13 @@ from sentry.integrations.github.tasks.open_pr_comment import (
     safe_for_comment,
 )
 from sentry.integrations.github.tasks.utils import PullRequestFile, PullRequestIssue
+from sentry.integrations.models.integration import Integration
 from sentry.models.group import Group, GroupStatus
 from sentry.models.pullrequest import CommentType, PullRequest, PullRequestComment
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.silo.base import SiloMode
 from sentry.testutils.cases import IntegrationTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.testutils.silo import assume_test_silo_mode
+from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.testutils.skips import requires_snuba
 from tests.sentry.integrations.github.tasks.test_pr_comment import GithubCommentTestCase
 
@@ -1182,7 +1182,7 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
         mock_pr_filenames,
     ):
         # inactive integration
-        with assume_test_silo_mode(SiloMode.CONTROL):
+        with assume_test_silo_mode_of(Integration):
             self.integration.update(status=ObjectStatus.DISABLED)
 
         open_pr_comment_workflow(self.pr.id)

--- a/tests/sentry/integrations/github/tasks/test_pr_comment.py
+++ b/tests/sentry/integrations/github/tasks/test_pr_comment.py
@@ -6,6 +6,7 @@ import pytest
 import responses
 from django.utils import timezone
 
+from sentry.constants import ObjectStatus
 from sentry.integrations.github.integration import GitHubIntegrationProvider
 from sentry.integrations.github.tasks.pr_comment import (
     format_comment,
@@ -29,9 +30,11 @@ from sentry.models.pullrequest import (
 )
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
+from sentry.silo.base import SiloMode
 from sentry.tasks.commit_context import DEBOUNCE_PR_COMMENT_CACHE_KEY
 from sentry.testutils.cases import IntegrationTestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from sentry.utils.cache import cache
 
@@ -622,9 +625,9 @@ class TestCommentWorkflow(GithubCommentTestCase):
         # missing integration should trigger the cache to release the key
         cache.set(self.cache_key, True, timedelta(minutes=5).total_seconds())
 
-        # invalid integration id
-        self.gh_repo.integration_id = 0
-        self.gh_repo.save()
+        # inactive integration
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration.update(status=ObjectStatus.DISABLED)
 
         mock_issues.return_value = [
             {"group_id": g.id, "event_count": 10} for g in Group.objects.all()

--- a/tests/sentry/integrations/github/tasks/test_pr_comment.py
+++ b/tests/sentry/integrations/github/tasks/test_pr_comment.py
@@ -17,6 +17,7 @@ from sentry.integrations.github.tasks.pr_comment import (
     pr_to_issue_query,
 )
 from sentry.integrations.github.tasks.utils import PullRequestIssue
+from sentry.integrations.models.integration import Integration
 from sentry.models.commit import Commit
 from sentry.models.group import Group
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
@@ -30,11 +31,10 @@ from sentry.models.pullrequest import (
 )
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.silo.base import SiloMode
 from sentry.tasks.commit_context import DEBOUNCE_PR_COMMENT_CACHE_KEY
 from sentry.testutils.cases import IntegrationTestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
-from sentry.testutils.silo import assume_test_silo_mode
+from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.testutils.skips import requires_snuba
 from sentry.utils.cache import cache
 
@@ -626,7 +626,7 @@ class TestCommentWorkflow(GithubCommentTestCase):
         cache.set(self.cache_key, True, timedelta(minutes=5).total_seconds())
 
         # inactive integration
-        with assume_test_silo_mode(SiloMode.CONTROL):
+        with assume_test_silo_mode_of(Integration):
             self.integration.update(status=ObjectStatus.DISABLED)
 
         mock_issues.return_value = [

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -10,13 +10,14 @@ from django.utils import timezone
 from fixtures.github import COMPARE_COMMITS_EXAMPLE, GET_COMMIT_EXAMPLE, GET_LAST_COMMITS_EXAMPLE
 from sentry.constants import ObjectStatus
 from sentry.integrations.github.repository import GitHubRepositoryProvider
+from sentry.integrations.models.integration import Integration
 from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.silo.base import SiloMode
 from sentry.testutils.asserts import assert_commit_shape
 from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of, control_silo_test
 
 
 @control_silo_test
@@ -103,7 +104,7 @@ class GitHubAppsProviderTest(TestCase):
             self.provider.compare_commits(self.repository, None, "abcdef")
 
     def test_compare_commits_inactive_integration(self):
-        with assume_test_silo_mode(SiloMode.CONTROL):
+        with assume_test_silo_mode_of(Integration):
             self.integration.update(status=ObjectStatus.DISABLED)
 
         with pytest.raises(NotImplementedError):

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -8,6 +8,7 @@ import responses
 from django.utils import timezone
 
 from fixtures.github import COMPARE_COMMITS_EXAMPLE, GET_COMMIT_EXAMPLE, GET_LAST_COMMITS_EXAMPLE
+from sentry.constants import ObjectStatus
 from sentry.integrations.github.repository import GitHubRepositoryProvider
 from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
@@ -100,6 +101,13 @@ class GitHubAppsProviderTest(TestCase):
         )
         with pytest.raises(IntegrationError):
             self.provider.compare_commits(self.repository, None, "abcdef")
+
+    def test_compare_commits_inactive_integration(self):
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration.update(status=ObjectStatus.DISABLED)
+
+        with pytest.raises(NotImplementedError):
+            self.provider.compare_commits(self.repository, "xyz123", "abcdef")
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate

--- a/tests/sentry/integrations/slack/test_sdk_client.py
+++ b/tests/sentry/integrations/slack/test_sdk_client.py
@@ -4,6 +4,7 @@ import orjson
 import pytest
 from slack_sdk.errors import SlackApiError
 
+from sentry.constants import ObjectStatus
 from sentry.integrations.slack.sdk_client import SLACK_DATADOG_METRIC, SlackSdkClient
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
@@ -24,6 +25,13 @@ class SlackClientTest(TestCase):
     def test_no_integration_found_error(self):
         with pytest.raises(ValueError):
             SlackSdkClient(integration_id=2)
+
+    def test_inactive_integration_error(self):
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration.update(status=ObjectStatus.DISABLED)
+
+        with pytest.raises(ValueError):
+            SlackSdkClient(self.integration.id)
 
     def test_no_access_token_error(self):
         with assume_test_silo_mode(SiloMode.CONTROL):

--- a/tests/sentry/integrations/slack/test_sdk_client.py
+++ b/tests/sentry/integrations/slack/test_sdk_client.py
@@ -5,10 +5,11 @@ import pytest
 from slack_sdk.errors import SlackApiError
 
 from sentry.constants import ObjectStatus
+from sentry.integrations.models.integration import Integration
 from sentry.integrations.slack.sdk_client import SLACK_DATADOG_METRIC, SlackSdkClient
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import assume_test_silo_mode
+from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of
 
 
 class SlackClientTest(TestCase):
@@ -27,7 +28,7 @@ class SlackClientTest(TestCase):
             SlackSdkClient(integration_id=2)
 
     def test_inactive_integration_error(self):
-        with assume_test_silo_mode(SiloMode.CONTROL):
+        with assume_test_silo_mode_of(Integration):
             self.integration.update(status=ObjectStatus.DISABLED)
 
         with pytest.raises(ValueError):


### PR DESCRIPTION
For any integration that makes a call to an external API which passes through the integration proxy, we need to make sure we're always fetching active integrations, otherwise the request will be rejected by the integration proxy. This PR addresses a few features for SCMs, namely the PR comments features, that are not currently doing this.

While Slack no longer uses the integration proxy, we should still check for active integrations as requests made by inactive integrations will still technically be rejected by the integration proxy -- applying a similar approach there.

This is NOT all the places that need to be fixed, but just some easy wins that I'm sure about.