### PR TITLE
fix(hybrid-cloud): Default cross_db_tombstones option to true

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1878,7 +1878,7 @@ register(
 register(
     "hybrid_cloud.disable_relative_upload_urls", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE
 )
-register("hybrid_cloud.allow_cross_db_tombstones", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("hybrid_cloud.allow_cross_db_tombstones", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("hybrid_cloud.disable_tombstone_cleanup", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Flagpole Configuration (used in getsentry)


### PR DESCRIPTION
Mostly a cleanup PR. This option has been live in prod for a few months already, but is locally disabled causing some models to raise exceptions when running the local devserver. Defaulting this option to True will allow us to remove the option from our option config and clean up the remaining references in another PR.
