### PR TITLE
ref(crons): Simplify MonitorBucketData type

### DIFF
--- a/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
+++ b/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
@@ -25,7 +25,7 @@ import {
   GridLineOverlay,
 } from 'sentry/views/monitors/components/timeline/gridLines';
 import type {
-  MonitorBucketData,
+  MonitorBucket,
   TimeWindow,
 } from 'sentry/views/monitors/components/timeline/types';
 import {getConfigFromTimeRange} from 'sentry/views/monitors/components/timeline/utils/getConfigFromTimeRange';
@@ -55,7 +55,7 @@ export function CronTimelineSection({event, organization, project}: Props) {
   const rollup = Math.floor((timeWindowConfig.elapsedMinutes * 60) / timelineWidth);
 
   const monitorStatsQueryKey = `/organizations/${organization.slug}/monitors-stats/`;
-  const {data: monitorStats, isPending} = useApiQuery<Record<string, MonitorBucketData>>(
+  const {data: monitorStats, isPending} = useApiQuery<Record<string, MonitorBucket[]>>(
     [
       monitorStatsQueryKey,
       {

--- a/static/app/views/monitors/components/timeline/checkInTimeline.tsx
+++ b/static/app/views/monitors/components/timeline/checkInTimeline.tsx
@@ -8,14 +8,14 @@ import {getTickStyle} from 'sentry/views/monitors/utils';
 import {getAggregateStatus} from './utils/getAggregateStatus';
 import {mergeBuckets} from './utils/mergeBuckets';
 import {CheckInTooltip} from './checkInTooltip';
-import type {MonitorBucketData, TimeWindowConfig} from './types';
+import type {MonitorBucket, TimeWindowConfig} from './types';
 
 interface TimelineProps {
   timeWindowConfig: TimeWindowConfig;
 }
 
 export interface CheckInTimelineProps extends TimelineProps {
-  bucketedData: MonitorBucketData;
+  bucketedData: MonitorBucket[];
   environment: string;
 }
 

--- a/static/app/views/monitors/components/timeline/hooks/useMonitorStats.tsx
+++ b/static/app/views/monitors/components/timeline/hooks/useMonitorStats.tsx
@@ -2,7 +2,7 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
 
-import type {MonitorBucketData, TimeWindowConfig} from '../types';
+import type {MonitorBucket, TimeWindowConfig} from '../types';
 
 interface Options {
   /**
@@ -35,7 +35,7 @@ export function useMonitorStats({monitors, timeWindowConfig}: Options) {
 
   const monitorStatsQueryKey = `/organizations/${organization.slug}/monitors-stats/`;
 
-  return useApiQuery<Record<string, MonitorBucketData>>(
+  return useApiQuery<Record<string, MonitorBucket[]>>(
     [
       monitorStatsQueryKey,
       {

--- a/static/app/views/monitors/components/timeline/types.tsx
+++ b/static/app/views/monitors/components/timeline/types.tsx
@@ -51,9 +51,6 @@ export interface TimeWindowConfig {
   timelineWidth: number;
 }
 
-// TODO(davidenwang): Remove this type as its a little too specific
-export type MonitorBucketData = MonitorBucket[];
-
 export type MonitorBucket = [timestamp: number, envData: MonitorBucketEnvMapping];
 
 export interface JobTickData {

--- a/static/app/views/monitors/components/timeline/utils/mergeBuckets.spec.tsx
+++ b/static/app/views/monitors/components/timeline/utils/mergeBuckets.spec.tsx
@@ -1,6 +1,6 @@
 import {CheckInStatus} from 'sentry/views/monitors/types';
 
-import type {MonitorBucketData} from '../types';
+import type {MonitorBucket} from '../types';
 
 import {mergeBuckets} from './mergeBuckets';
 
@@ -35,7 +35,7 @@ function generateJobRun(envName: string, jobStatus: CheckInStatus) {
 
 describe('mergeBuckets', function () {
   it('does not generate ticks less than 3px width', function () {
-    const bucketData: MonitorBucketData = [
+    const bucketData: MonitorBucket[] = [
       [1, generateJobRun('prod', CheckInStatus.OK)],
       [2, generateJobRun('prod', CheckInStatus.OK)],
       [3, generateJobRun('prod', CheckInStatus.OK)],
@@ -61,7 +61,7 @@ describe('mergeBuckets', function () {
   });
 
   it('generates adjacent ticks without border radius', function () {
-    const bucketData: MonitorBucketData = [
+    const bucketData: MonitorBucket[] = [
       [1, generateJobRun('prod', CheckInStatus.OK)],
       [2, generateJobRun('prod', CheckInStatus.OK)],
       [3, generateJobRun('prod', CheckInStatus.OK)],
@@ -95,7 +95,7 @@ describe('mergeBuckets', function () {
   });
 
   it('does not generate a separate tick if the next generated tick would be the same status', function () {
-    const bucketData: MonitorBucketData = [
+    const bucketData: MonitorBucket[] = [
       [1, generateJobRun('prod', CheckInStatus.TIMEOUT)],
       [2, generateJobRun('prod', CheckInStatus.TIMEOUT)],
       [3, generateJobRun('prod', CheckInStatus.TIMEOUT)],
@@ -121,7 +121,7 @@ describe('mergeBuckets', function () {
   });
 
   it('filters off environment', function () {
-    const bucketData: MonitorBucketData = [
+    const bucketData: MonitorBucket[] = [
       [
         1,
         {

--- a/static/app/views/monitors/components/timeline/utils/mergeBuckets.tsx
+++ b/static/app/views/monitors/components/timeline/utils/mergeBuckets.tsx
@@ -1,4 +1,4 @@
-import type {JobTickData, MonitorBucketData} from '../types';
+import type {JobTickData, MonitorBucket} from '../types';
 
 import {filterMonitorStatsBucketByEnv} from './filterMonitorStatsBucketByEnv';
 import {getAggregateStatus} from './getAggregateStatus';
@@ -7,7 +7,7 @@ import {isEnvMappingEmpty} from './isEnvMappingEmpty';
 import {mergeEnvMappings} from './mergeEnvMappings';
 
 function generateJobTickFromBucket(
-  bucket: MonitorBucketData[number],
+  bucket: MonitorBucket,
   options?: Partial<JobTickData>
 ) {
   const [timestamp, envMapping] = bucket;
@@ -22,7 +22,7 @@ function generateJobTickFromBucket(
   };
 }
 
-export function mergeBuckets(data: MonitorBucketData, environment: string) {
+export function mergeBuckets(data: MonitorBucket[], environment: string) {
   const minTickWidth = 4;
 
   const jobTicks: JobTickData[] = [];


### PR DESCRIPTION
Clearing out this old TODO from myself

Don't really need this `MonitorBucketData` type as its longer to input than `MonitorBucket[]` and adds a layer of opaqueness to what the type actually represents.