### PR TITLE
feat(autofix): Reproduction in root cause description

### DIFF
--- a/static/app/components/events/autofix/autofixRootCause.spec.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.spec.tsx
@@ -135,4 +135,34 @@ describe('AutofixRootCause', function () {
 
     expect(screen.queryByRole('link', {name: 'GitHub'})).not.toBeInTheDocument();
   });
+
+  it('shows reproduction steps when applicable', function () {
+    render(
+      <AutofixRootCause
+        {...{
+          ...defaultProps,
+          causes: [AutofixRootCauseData()],
+        }}
+      />
+    );
+
+    expect(
+      screen.getByText('This is the reproduction of a root cause.')
+    ).toBeInTheDocument();
+  });
+
+  it('does not show reproduction steps when not applicable', function () {
+    render(
+      <AutofixRootCause
+        {...{
+          ...defaultProps,
+          causes: [AutofixRootCauseData({reproduction: undefined})],
+        }}
+      />
+    );
+
+    expect(
+      screen.queryByText('This is the reproduction of a root cause.')
+    ).not.toBeInTheDocument();
+  });
 });

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -1,4 +1,4 @@
-import {type ReactNode, useState} from 'react';
+import {Fragment, type ReactNode, useState} from 'react';
 import {css, keyframes} from '@emotion/react';
 import styled from '@emotion/styled';
 import {AnimatePresence, type AnimationProps, motion} from 'framer-motion';
@@ -153,6 +153,30 @@ function getLinesToHighlight(suggestedFix: AutofixRootCauseCodeContext): number[
   return lineNumbersToHighlight;
 }
 
+function RootCauseDescription({cause}: {cause: AutofixRootCauseData}) {
+  return (
+    <Fragment>
+      <CauseDescription
+        dangerouslySetInnerHTML={{
+          __html: marked(cause.description),
+        }}
+      />
+      {cause.reproduction && (
+        <Fragment>
+          <CauseReproductionHeader>
+            {t('How to reproduce this root cause')}
+          </CauseReproductionHeader>
+          <CauseDescription
+            dangerouslySetInnerHTML={{
+              __html: marked(cause.reproduction),
+            }}
+          />
+        </Fragment>
+      )}
+    </Fragment>
+  );
+}
+
 function RootCauseContent({
   selected,
   children,
@@ -265,11 +289,7 @@ function CauseOption({
         </RootCauseOptionsRow>
       </RootCauseOptionHeader>
       <RootCauseContent selected={selected}>
-        <CauseDescription
-          dangerouslySetInnerHTML={{
-            __html: marked(cause.description),
-          }}
-        />
+        <RootCauseDescription cause={cause} />
         <AutofixRootCauseCodeContexts codeContext={cause.code_context} repos={repos} />
       </RootCauseContent>
     </RootCauseOption>
@@ -559,6 +579,11 @@ const Title = styled('div')`
 
 const CauseDescription = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
+  margin-top: ${space(1)};
+`;
+
+const CauseReproductionHeader = styled('div')`
+  font-weight: ${p => p.theme.fontWeightBold};
   margin-top: ${space(1)};
 `;
 

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -150,6 +150,7 @@ export type AutofixRootCauseData = {
   id: string;
   likelihood: number;
   title: string;
+  reproduction?: string;
 };
 
 export type EventMetadataWithAutofix = EventMetadata & {

--- a/tests/js/fixtures/autofixRootCauseData.ts
+++ b/tests/js/fixtures/autofixRootCauseData.ts
@@ -9,6 +9,7 @@ export function AutofixRootCauseData(
     id: '100',
     title: 'This is the title of a root cause.',
     description: 'This is the description of a root cause.',
+    reproduction: 'This is the reproduction of a root cause.',
     actionability: 0.8,
     likelihood: 0.9,
     code_context: [AutofixRootCauseCodeContext()],


### PR DESCRIPTION
Adds reproduction steps if available to each root cause description.

![Screenshot 2024-09-10 at 10 45 47 AM](https://github.com/user-attachments/assets/77ae4f5b-189e-4c80-b390-89c9ff20809e)

This can be merged w/o the seer changes as the field is optional.
