### PR TITLE
ref(hybrid-cloud): Removes-cross-db-tombstone-option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1878,7 +1878,6 @@ register(
 register(
     "hybrid_cloud.disable_relative_upload_urls", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE
 )
-register("hybrid_cloud.allow_cross_db_tombstones", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("hybrid_cloud.disable_tombstone_cleanup", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Flagpole Configuration (used in getsentry)

--- a/src/sentry/tasks/deletion/hybrid_cloud.py
+++ b/src/sentry/tasks/deletion/hybrid_cloud.py
@@ -375,9 +375,6 @@ def _get_model_ids_for_tombstone_cascade(
 
             return to_delete_ids, oldest_seen
 
-    if not options.get("hybrid_cloud.allow_cross_db_tombstones"):
-        raise Exception("Cannot process tombstones due to model living in separate database.")
-
     # Because tombstones can span multiple databases, we can't always rely on
     # the join code above. Instead, we have to manually query IDs from the
     # watermark target table, querying the intersection of IDs manually.

--- a/tests/sentry/api/endpoints/test_project_index.py
+++ b/tests/sentry/api/endpoints/test_project_index.py
@@ -15,7 +15,6 @@ from sentry.tasks.deletion.hybrid_cloud import (
     schedule_hybrid_cloud_foreign_key_jobs_control,
 )
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 
@@ -250,7 +249,6 @@ class ProjectsListTest(APITestCase):
         assert self.project.name.encode("utf-8") in response.content
 
     @responses.activate
-    @override_options({"hybrid_cloud.allow_cross_db_tombstones": True})
     def test_deleted_token_with_public_integration(self):
         token = self.get_installed_unpublished_sentry_app_access_token()
 

--- a/tests/sentry/deletions/test_apiapplication.py
+++ b/tests/sentry/deletions/test_apiapplication.py
@@ -7,7 +7,6 @@ from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.tasks.deletion.scheduled import run_scheduled_deletions_control
 from sentry.testutils.cases import TransactionTestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
@@ -15,7 +14,6 @@ from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 @control_silo_test
 class DeleteApiApplicationTest(TransactionTestCase, HybridCloudTestMixin):
-    @override_options({"hybrid_cloud.allow_cross_db_tombstones": True})
     def test_simple(self):
         app = ApiApplication.objects.create(
             owner=self.user, status=ApiApplicationStatus.pending_deletion

--- a/tests/sentry/deletions/test_release.py
+++ b/tests/sentry/deletions/test_release.py
@@ -9,7 +9,6 @@ from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key
 from sentry.tasks.deletion.scheduled import run_scheduled_deletions
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.helpers import TaskRunner
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
@@ -37,7 +36,6 @@ class DeleteReleaseTest(TransactionTestCase, HybridCloudTestMixin):
         assert Environment.objects.filter(id=env.id).exists()
         assert Project.objects.filter(id=project.id).exists()
 
-    @override_options({"hybrid_cloud.allow_cross_db_tombstones": True})
     def test_cascade_from_user(self):
         org = self.create_organization()
         project = self.create_project(organization=org)

--- a/tests/sentry/deletions/test_sentry_app_installations.py
+++ b/tests/sentry/deletions/test_sentry_app_installations.py
@@ -15,7 +15,6 @@ from sentry.silo.base import SiloMode
 from sentry.silo.safety import unguarded_write
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
@@ -70,7 +69,6 @@ class TestSentryAppInstallationDeletionTask(TestCase):
 
         assert not SentryAppInstallationForProvider.objects.filter()
 
-    @override_options({"hybrid_cloud.allow_cross_db_tombstones": True})
     def test_deletes_service_hooks(self):
         hook = self.create_service_hook(
             application=self.sentry_app.application,

--- a/tests/sentry/monitors/endpoints/test_base_monitor_checkin_attachment.py
+++ b/tests/sentry/monitors/endpoints/test_base_monitor_checkin_attachment.py
@@ -4,7 +4,6 @@ from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.models.files import File
 from sentry.monitors.models import CheckInStatus, MonitorCheckIn
 from sentry.testutils.cases import MonitorTestCase
-from sentry.testutils.helpers.options import override_options
 
 
 class BaseMonitorCheckInAttachmentEndpointTest(MonitorTestCase):
@@ -49,7 +48,6 @@ class BaseMonitorCheckInAttachmentEndpointTest(MonitorTestCase):
         )
         assert resp.data["detail"] == "Check-in has no attachment"
 
-    @override_options({"hybrid_cloud.allow_cross_db_tombstones": True})
     def test_delete_cascade(self):
         file = self.create_file(name="log.txt", type="checkin.attachment")
         file.putfile(ContentFile(b"some data!"))

--- a/tests/sentry/tasks/test_groupowner.py
+++ b/tests/sentry/tasks/test_groupowner.py
@@ -11,7 +11,6 @@ from sentry.tasks.groupowner import PREFERRED_GROUP_OWNER_AGE, process_suspect_c
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import TaskRunner
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
@@ -101,7 +100,6 @@ class TestGroupOwners(TestCase):
             type=GroupOwnerType.SUSPECT_COMMIT.value,
         )
 
-    @override_options({"hybrid_cloud.allow_cross_db_tombstones": True})
     def test_user_deletion_cascade(self):
         other_user = self.create_user()
         group = self.create_group()

--- a/tests/sentry/users/models/test_user.py
+++ b/tests/sentry/users/models/test_user.py
@@ -32,7 +32,6 @@ from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.backups import BackupTestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of, control_silo_test
@@ -73,7 +72,6 @@ class UserHybridCloudDeletionTest(TestCase):
     def get_user_saved_search_count(self) -> int:
         return SavedSearch.objects.filter(owner_id=self.user_id).count()
 
-    @override_options({"hybrid_cloud.allow_cross_db_tombstones": True})
     def test_simple(self):
         assert not self.user_tombstone_exists(user_id=self.user_id)
         with outbox_runner():
@@ -90,7 +88,6 @@ class UserHybridCloudDeletionTest(TestCase):
         # Ensure they are all now gone.
         assert self.get_user_saved_search_count() == 0
 
-    @override_options({"hybrid_cloud.allow_cross_db_tombstones": True})
     def test_unrelated_saved_search_is_not_deleted(self):
         another_user = self.create_user()
         self.create_member(user=another_user, organization=self.organization)
@@ -106,7 +103,6 @@ class UserHybridCloudDeletionTest(TestCase):
         with assume_test_silo_mode(SiloMode.REGION):
             assert SavedSearch.objects.filter(owner_id=another_user.id).exists()
 
-    @override_options({"hybrid_cloud.allow_cross_db_tombstones": True})
     def test_cascades_to_multiple_regions(self):
         eu_org = self.create_organization(region=_TEST_REGIONS[1])
         self.create_member(user=self.user, organization=eu_org)
@@ -120,7 +116,6 @@ class UserHybridCloudDeletionTest(TestCase):
             schedule_hybrid_cloud_foreign_key_jobs()
         assert self.get_user_saved_search_count() == 0
 
-    @override_options({"hybrid_cloud.allow_cross_db_tombstones": True})
     def test_deletions_create_tombstones_in_regions_for_user_with_no_orgs(self):
         # Create a user with no org memberships
         user_to_delete = self.create_user("foo@example.com")
@@ -130,7 +125,6 @@ class UserHybridCloudDeletionTest(TestCase):
 
         assert self.user_tombstone_exists(user_id=user_id)
 
-    @override_options({"hybrid_cloud.allow_cross_db_tombstones": True})
     def test_cascades_to_regions_even_if_user_ownership_revoked(self):
         eu_org = self.create_organization(region=_TEST_REGIONS[1])
         self.create_member(user=self.user, organization=eu_org)


### PR DESCRIPTION
Removes cross-db tombstone option now that the option has been set to default to True
