### PR TITLE
feat(insights): Tracks user clicks on create alerts buttons in insights

### DIFF
--- a/static/app/utils/analytics/insightAnalyticEvents.tsx
+++ b/static/app/utils/analytics/insightAnalyticEvents.tsx
@@ -8,6 +8,11 @@ export type InsightEventParameters = {
   'insight.asset.filter_by_page': {};
   'insight.asset.filter_by_type': {filter: string};
   'insight.general.chart_zoom': {chart_name: string; source: string};
+  'insight.general.create_alert': {
+    alert_name: string;
+    chart_name?: string;
+    source?: string;
+  };
   'insight.general.search': {query: string; source: string};
   'insight.general.select_action_value': {source: string; value: string};
   // Don't specify domain because domains are arbitrary values
@@ -77,4 +82,5 @@ export const insightEventMap: Record<InsightEventKey, string | null> = {
   'insight.vital.overview.toggle_data_type':
     'Insights: Web Vitals Overview - toggle data type',
   'insight.vital.select_browser_value': 'Insights: Web Vitals - filter by browser type',
+  'insight.general.create_alert': 'Insights: Create Alert clicked',
 };

--- a/static/app/views/insights/common/components/chartPanel.tsx
+++ b/static/app/views/insights/common/components/chartPanel.tsx
@@ -8,11 +8,13 @@ import Panel from 'sentry/components/panels/panel';
 import {IconEllipsis, IconExpand} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 import {hasInsightsAlerts} from 'sentry/views/insights/common/utils/hasInsightsAlerts';
+import {useModuleNameFromUrl} from 'sentry/views/insights/common/utils/useModuleNameFromUrl';
 import {Subtitle} from 'sentry/views/performance/landing/widgets/widgets/singleFieldAreaWidget';
 
 export type AlertConfig = {
@@ -46,6 +48,7 @@ export default function ChartPanel({
         : undefined,
     [projects, selection.projects]
   );
+  const moduleName = useModuleNameFromUrl();
   const alertsUrls =
     alertConfigs?.map(alertConfig => {
       // Alerts only support single project selection
@@ -66,6 +69,14 @@ export default function ChartPanel({
               'Alerts are only available for single project selection. Update your project filter to create an alert.'
             )
           : undefined,
+        onClick: () => {
+          trackAnalytics('insight.general.create_alert', {
+            organization,
+            chart_name: typeof title === 'string' ? title : undefined,
+            alert_name: name,
+            source: moduleName ?? undefined,
+          });
+        },
       };
     }) ?? [];
 

--- a/static/app/views/insights/common/utils/useModuleNameFromUrl.tsx
+++ b/static/app/views/insights/common/utils/useModuleNameFromUrl.tsx
@@ -1,0 +1,23 @@
+import {useLocation} from 'sentry/utils/useLocation';
+import {MODULE_BASE_URLS} from 'sentry/views/insights/common/utils/useModuleURL';
+import {INSIGHTS_BASE_URL} from 'sentry/views/insights/settings';
+import type {ModuleName} from 'sentry/views/insights/types';
+
+export function useModuleNameFromUrl(): ModuleName | null {
+  const {pathname} = useLocation();
+  // Reverse MODULE_BASE_URLS
+  const urlToModuleNameMap: Record<string, ModuleName> = Object.fromEntries(
+    Object.entries(MODULE_BASE_URLS)
+      .map(([key, value]) => [value, key])
+      .filter(([key]) => Boolean(key))
+  );
+  const moduleKey = Object.keys(urlToModuleNameMap).find(key => {
+    return pathname.startsWith(`/${INSIGHTS_BASE_URL}/${key}`);
+  });
+
+  if (moduleKey) {
+    return urlToModuleNameMap[moduleKey];
+  }
+
+  return null;
+}


### PR DESCRIPTION
Tracks analytics on insights create alert clicks. Adds a `useModuleNameFromUrl` that gets the module name of the current page.