### PR TITLE
feat(insights): Adds insights alerts for http module

### DIFF
--- a/static/app/components/metrics/metricSearchBar.tsx
+++ b/static/app/components/metrics/metricSearchBar.tsx
@@ -46,6 +46,9 @@ const INSIGHTS_ADDITIONAL_TAG_FILTERS: MetricTag[] = [
   {
     key: SpanMetricsField.SPAN_MODULE,
   },
+  {
+    key: SpanMetricsField.FILE_EXTENSION,
+  },
 ];
 
 export function MetricSearchBar({

--- a/static/app/utils/metrics/mri.tsx
+++ b/static/app/utils/metrics/mri.tsx
@@ -7,6 +7,7 @@ import type {
   UseCase,
 } from 'sentry/types/metrics';
 import {parseFunction} from 'sentry/utils/discover/fields';
+import {INSIGHTS_METRICS_OPERATIONS} from 'sentry/views/alerts/rules/metric/utils/isInsightsMetricAlert';
 
 export const DEFAULT_MRI: MRI = 'c:custom/sentry_metric@none';
 export const DEFAULT_SPAN_MRI: MRI = 'c:custom/span_attribute_0@none';
@@ -117,7 +118,11 @@ export function isMRIField(field: string): boolean {
 // convenience function to get the MRI from a field, returns defaut MRI if it fails
 export function getMRI(field: string): MRI {
   // spm() doesn't take an argument and it always operates on the spans exclusive time mri
-  if (['spm()', 'cache_miss_rate()'].includes(field)) {
+  if (
+    INSIGHTS_METRICS_OPERATIONS.map(({value}) => {
+      return `${value}()`;
+    }).includes(field)
+  ) {
     return 'd:spans/exclusive_time@millisecond';
   }
   const parsed = parseField(field);

--- a/static/app/utils/metrics/mri.tsx
+++ b/static/app/utils/metrics/mri.tsx
@@ -7,6 +7,7 @@ import type {
   UseCase,
 } from 'sentry/types/metrics';
 import {parseFunction} from 'sentry/utils/discover/fields';
+import {SPAN_DURATION_MRI} from 'sentry/utils/metrics/constants';
 import {INSIGHTS_METRICS_OPERATIONS} from 'sentry/views/alerts/rules/metric/utils/isInsightsMetricAlert';
 
 export const DEFAULT_MRI: MRI = 'c:custom/sentry_metric@none';
@@ -117,15 +118,20 @@ export function isMRIField(field: string): boolean {
 
 // convenience function to get the MRI from a field, returns defaut MRI if it fails
 export function getMRI(field: string): MRI {
-  // spm() doesn't take an argument and it always operates on the spans exclusive time mri
-  if (
-    INSIGHTS_METRICS_OPERATIONS.map(({value}) => {
-      return `${value}()`;
-    }).includes(field)
-  ) {
-    return 'd:spans/exclusive_time@millisecond';
-  }
   const parsed = parseField(field);
+  // Insights functions don't always take an MRI as an argument.
+  // In these cases, we need to default to a specific MRI.
+  if (parsed?.aggregation) {
+    const operation = INSIGHTS_METRICS_OPERATIONS.find(({value}) => {
+      return value === parsed?.aggregation;
+    });
+    if (operation) {
+      if (operation.mri) {
+        return operation.mri as MRI;
+      }
+      return SPAN_DURATION_MRI;
+    }
+  }
   return parsed?.mri ?? DEFAULT_MRI;
 }
 

--- a/static/app/views/alerts/rules/metric/insightsMetricField.spec.tsx
+++ b/static/app/views/alerts/rules/metric/insightsMetricField.spec.tsx
@@ -89,4 +89,21 @@ describe('InsightsMetricField', () => {
     userEvent.click(await screen.findByText('spm'));
     await waitFor(() => expect(onChange).toHaveBeenCalledWith('spm()', {}));
   });
+
+  it('should call onChange using the http_response_rate function defaulting with argument 3 when switching to http_response_rate', async () => {
+    const {project} = initializeOrg();
+    const onChange = jest.fn();
+    render(
+      <InsightsMetricField
+        aggregate={'avg(d:spans/exclusive_time@millisecond)'}
+        onChange={onChange}
+        project={project}
+      />
+    );
+    userEvent.click(screen.getByText('avg'));
+    userEvent.click(await screen.findByText('http_response_rate'));
+    await waitFor(() =>
+      expect(onChange).toHaveBeenCalledWith('http_response_rate(3)', {})
+    );
+  });
 });

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -57,6 +57,7 @@ import TriggersChart from 'sentry/views/alerts/rules/metric/triggers/chart';
 import {getEventTypeFilter} from 'sentry/views/alerts/rules/metric/utils/getEventTypeFilter';
 import hasThresholdValue from 'sentry/views/alerts/rules/metric/utils/hasThresholdValue';
 import {isCustomMetricAlert} from 'sentry/views/alerts/rules/metric/utils/isCustomMetricAlert';
+import {isInsightsMetricAlert} from 'sentry/views/alerts/rules/metric/utils/isInsightsMetricAlert';
 import {isOnDemandMetricAlert} from 'sentry/views/alerts/rules/metric/utils/onDemandMetricAlert';
 import {AlertRuleType} from 'sentry/views/alerts/types';
 import {ruleNeedsErrorMigration} from 'sentry/views/alerts/utils/migrationUi';
@@ -1197,7 +1198,8 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
     return (
       <Main fullWidth>
         <PermissionAlert access={['alerts:write']} project={project} />
-        {isCustomMetricAlert(rule.aggregate) && <MetricsBetaEndAlert />}
+        {isCustomMetricAlert(rule.aggregate) &&
+          !isInsightsMetricAlert(rule.aggregate) && <MetricsBetaEndAlert />}
 
         {eventView && <IncompatibleAlertQuery eventView={eventView} />}
         <Form

--- a/static/app/views/alerts/rules/metric/utils/isInsightsMetricAlert.tsx
+++ b/static/app/views/alerts/rules/metric/utils/isInsightsMetricAlert.tsx
@@ -1,6 +1,6 @@
 import {parseField} from 'sentry/utils/metrics/mri';
 
-export const INSIGHTS_METRICS_OPERATIONS = [
+export const INSIGHTS_METRICS_OPERATIONS_WITHOUT_ARGS = [
   {
     label: 'spm',
     value: 'spm',
@@ -9,6 +9,36 @@ export const INSIGHTS_METRICS_OPERATIONS = [
     label: 'cache_miss_rate',
     value: 'cache_miss_rate',
   },
+];
+
+export const INSIGHTS_METRICS_OPERATIONS_WITH_CUSTOM_ARGS = [
+  {
+    label: 'http_response_rate',
+    value: 'http_response_rate',
+    options: [
+      {label: '3', value: '3'},
+      {label: '4', value: '4'},
+      {label: '5', value: '5'},
+    ],
+    mri: 'd:spans/exclusive_time@millisecond',
+  },
+  {
+    label: 'performance_score',
+    value: 'performance_score',
+    options: [
+      {label: 'measurements.score.lcp', value: 'measurements.score.lcp'},
+      {label: 'measurements.score.fcp', value: 'measurements.score.fcp'},
+      {label: 'measurements.score.inp', value: 'measurements.score.inp'},
+      {label: 'measurements.score.cls', value: 'measurements.score.cls'},
+      {label: 'measurements.score.ttfb', value: 'measurements.score.ttfb'},
+      {label: 'measurements.score.total', value: 'measurements.score.total'},
+    ],
+  },
+];
+
+export const INSIGHTS_METRICS_OPERATIONS = [
+  ...INSIGHTS_METRICS_OPERATIONS_WITH_CUSTOM_ARGS,
+  ...INSIGHTS_METRICS_OPERATIONS_WITHOUT_ARGS,
 ];
 
 export const INSIGHTS_METRICS = [

--- a/static/app/views/alerts/rules/metric/utils/isInsightsMetricAlert.tsx
+++ b/static/app/views/alerts/rules/metric/utils/isInsightsMetricAlert.tsx
@@ -4,10 +4,12 @@ export const INSIGHTS_METRICS_OPERATIONS_WITHOUT_ARGS = [
   {
     label: 'spm',
     value: 'spm',
+    mri: 'd:spans/duration@millisecond',
   },
   {
     label: 'cache_miss_rate',
     value: 'cache_miss_rate',
+    mri: 'd:spans/duration@millisecond',
   },
 ];
 
@@ -20,7 +22,7 @@ export const INSIGHTS_METRICS_OPERATIONS_WITH_CUSTOM_ARGS = [
       {label: '4', value: '4'},
       {label: '5', value: '5'},
     ],
-    mri: 'd:spans/exclusive_time@millisecond',
+    mri: 'd:spans/duration@millisecond',
   },
   {
     label: 'performance_score',
@@ -33,6 +35,7 @@ export const INSIGHTS_METRICS_OPERATIONS_WITH_CUSTOM_ARGS = [
       {label: 'measurements.score.ttfb', value: 'measurements.score.ttfb'},
       {label: 'measurements.score.total', value: 'measurements.score.total'},
     ],
+    mri: 'd:transactions/measurements.score.total@ratio',
   },
 ];
 

--- a/static/app/views/insights/http/alerts.ts
+++ b/static/app/views/insights/http/alerts.ts
@@ -1,0 +1,27 @@
+import type {AlertConfig} from 'sentry/views/insights/common/components/chartPanel';
+
+export const ALERTS: Record<string, AlertConfig> = {
+  spm: {
+    aggregate: 'spm()',
+    query: 'span.module:http span.op:http.client',
+  },
+  duration: {
+    aggregate: 'avg(d:spans/duration@millisecond)',
+    query: 'span.module:http span.op:http.client',
+  },
+  threeHundreds: {
+    aggregate: 'http_response_rate(3)',
+    query: 'span.module:http span.op:http.client',
+    name: 'Create 3XX Response Rate Alert',
+  },
+  fourHundreds: {
+    aggregate: 'http_response_rate(4)',
+    query: 'span.module:http span.op:http.client',
+    name: 'Create 4XX Response Rate Alert',
+  },
+  fiveHundreds: {
+    aggregate: 'http_response_rate(5)',
+    query: 'span.module:http span.op:http.client',
+    name: 'Create 5XX Response Rate Alert',
+  },
+};

--- a/static/app/views/insights/http/alerts.ts
+++ b/static/app/views/insights/http/alerts.ts
@@ -1,27 +1,29 @@
 import type {AlertConfig} from 'sentry/views/insights/common/components/chartPanel';
 
+const QUERY = 'span.module:http span.op:http.client';
+
 export const ALERTS: Record<string, AlertConfig> = {
   spm: {
     aggregate: 'spm()',
-    query: 'span.module:http span.op:http.client',
+    query: QUERY,
   },
   duration: {
     aggregate: 'avg(d:spans/duration@millisecond)',
-    query: 'span.module:http span.op:http.client',
+    query: QUERY,
   },
   threeHundreds: {
     aggregate: 'http_response_rate(3)',
-    query: 'span.module:http span.op:http.client',
+    query: QUERY,
     name: 'Create 3XX Response Rate Alert',
   },
   fourHundreds: {
     aggregate: 'http_response_rate(4)',
-    query: 'span.module:http span.op:http.client',
+    query: QUERY,
     name: 'Create 4XX Response Rate Alert',
   },
   fiveHundreds: {
     aggregate: 'http_response_rate(5)',
-    query: 'span.module:http span.op:http.client',
+    query: QUERY,
     name: 'Create 5XX Response Rate Alert',
   },
 };

--- a/static/app/views/insights/http/components/charts/durationChart.tsx
+++ b/static/app/views/insights/http/components/charts/durationChart.tsx
@@ -1,16 +1,20 @@
 import type {ComponentProps} from 'react';
 
 import type {EChartHighlightHandler, Series} from 'sentry/types/echarts';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {AVG_COLOR} from 'sentry/views/insights/colors';
 import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
 import ChartPanel from 'sentry/views/insights/common/components/chartPanel';
 import {getDurationChartTitle} from 'sentry/views/insights/common/views/spans/types';
+import {ALERTS} from 'sentry/views/insights/http/alerts';
 import {CHART_HEIGHT} from 'sentry/views/insights/http/settings';
+import type {SpanMetricsQueryFilters} from 'sentry/views/insights/types';
 
 interface Props {
   isLoading: boolean;
   series: Series[];
   error?: Error | null;
+  filters?: SpanMetricsQueryFilters;
   onHighlight?: (highlights: Highlight[], event: Event) => void; // TODO: Correctly type this
   scatterPlot?: ComponentProps<typeof Chart>['scatterPlot'];
 }
@@ -26,6 +30,7 @@ export function DurationChart({
   isLoading,
   error,
   onHighlight,
+  filters,
 }: Props) {
   // TODO: This is duplicated from `DurationChart` in `SampleList`. Resolve the duplication
   const handleChartHighlight: EChartHighlightHandler = function (event) {
@@ -50,8 +55,14 @@ export function DurationChart({
     onHighlight?.(highlightedDataPoints, event);
   };
 
+  const filterString = filters && MutableSearch.fromQueryObject(filters).formatString();
+  const alertConfig = {
+    ...ALERTS.duration,
+    query: filterString ?? ALERTS.duration.query,
+  };
+
   return (
-    <ChartPanel title={getDurationChartTitle('http')}>
+    <ChartPanel title={getDurationChartTitle('http')} alertConfigs={[alertConfig]}>
       <Chart
         height={CHART_HEIGHT}
         grid={{

--- a/static/app/views/insights/http/components/charts/responseRateChart.tsx
+++ b/static/app/views/insights/http/components/charts/responseRateChart.tsx
@@ -1,5 +1,6 @@
 import type {Series} from 'sentry/types/echarts';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {
   HTTP_RESPONSE_3XX_COLOR,
   HTTP_RESPONSE_4XX_COLOR,
@@ -8,17 +9,26 @@ import {
 import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
 import ChartPanel from 'sentry/views/insights/common/components/chartPanel';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
+import {ALERTS} from 'sentry/views/insights/http/alerts';
 import {CHART_HEIGHT} from 'sentry/views/insights/http/settings';
+import type {SpanMetricsQueryFilters} from 'sentry/views/insights/types';
 
 interface Props {
   isLoading: boolean;
   series: [Series, Series, Series];
   error?: Error | null;
+  filters?: SpanMetricsQueryFilters;
 }
 
-export function ResponseRateChart({series, isLoading, error}: Props) {
+export function ResponseRateChart({series, isLoading, error, filters}: Props) {
+  const filterString = filters && MutableSearch.fromQueryObject(filters).formatString();
+  const alertConfig = [
+    {...ALERTS.threeHundreds, query: filterString ?? ALERTS.threeHundreds.query},
+    {...ALERTS.fourHundreds, query: filterString ?? ALERTS.fourHundreds.query},
+    {...ALERTS.fiveHundreds, query: filterString ?? ALERTS.fiveHundreds.query},
+  ];
   return (
-    <ChartPanel title={DataTitles.unsuccessfulHTTPCodes}>
+    <ChartPanel title={DataTitles.unsuccessfulHTTPCodes} alertConfigs={alertConfig}>
       <Chart
         showLegend
         height={CHART_HEIGHT}

--- a/static/app/views/insights/http/components/charts/throughputChart.tsx
+++ b/static/app/views/insights/http/components/charts/throughputChart.tsx
@@ -1,21 +1,27 @@
 import type {Series} from 'sentry/types/echarts';
 import {RateUnit} from 'sentry/utils/discover/fields';
 import {formatRate} from 'sentry/utils/formatters';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {THROUGHPUT_COLOR} from 'sentry/views/insights/colors';
 import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
 import ChartPanel from 'sentry/views/insights/common/components/chartPanel';
 import {getThroughputChartTitle} from 'sentry/views/insights/common/views/spans/types';
+import {ALERTS} from 'sentry/views/insights/http/alerts';
 import {CHART_HEIGHT} from 'sentry/views/insights/http/settings';
+import type {SpanMetricsQueryFilters} from 'sentry/views/insights/types';
 
 interface Props {
   isLoading: boolean;
   series: Series;
   error?: Error | null;
+  filters?: SpanMetricsQueryFilters;
 }
 
-export function ThroughputChart({series, isLoading, error}: Props) {
+export function ThroughputChart({series, isLoading, error, filters}: Props) {
+  const filterString = filters && MutableSearch.fromQueryObject(filters).formatString();
+  const alertConfig = {...ALERTS.spm, query: filterString ?? ALERTS.spm.query};
   return (
-    <ChartPanel title={getThroughputChartTitle('http')}>
+    <ChartPanel title={getThroughputChartTitle('http')} alertConfigs={[alertConfig]}>
       <Chart
         height={CHART_HEIGHT}
         grid={{

--- a/static/app/views/insights/http/components/httpSamplesPanel.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.tsx
@@ -462,6 +462,7 @@ export function HTTPSamplesPanel() {
                   }}
                   isLoading={isDurationDataFetching}
                   error={durationError}
+                  filters={filters}
                 />
               </ModuleLayout.Full>
             </Fragment>

--- a/static/app/views/insights/http/views/httpDomainSummaryPage.tsx
+++ b/static/app/views/insights/http/views/httpDomainSummaryPage.tsx
@@ -284,6 +284,7 @@ export function HTTPDomainSummaryPage() {
                 series={throughputData['spm()']}
                 isLoading={isThroughputDataLoading}
                 error={throughputError}
+                filters={filters}
               />
             </ModuleLayout.Third>
 
@@ -292,6 +293,7 @@ export function HTTPDomainSummaryPage() {
                 series={[durationData[`avg(${SpanMetricsField.SPAN_SELF_TIME})`]]}
                 isLoading={isDurationDataLoading}
                 error={durationError}
+                filters={filters}
               />
             </ModuleLayout.Third>
 
@@ -313,6 +315,7 @@ export function HTTPDomainSummaryPage() {
                 ]}
                 isLoading={isResponseCodeDataLoading}
                 error={responseCodeError}
+                filters={filters}
               />
             </ModuleLayout.Third>
 

--- a/static/app/views/insights/http/views/httpLandingPage.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.tsx
@@ -194,6 +194,7 @@ export function HTTPLandingPage() {
                   series={throughputData['spm()']}
                   isLoading={isThroughputDataLoading}
                   error={throughputError}
+                  filters={chartFilters}
                 />
               </ModuleLayout.Third>
 
@@ -202,6 +203,7 @@ export function HTTPLandingPage() {
                   series={[durationData[`avg(span.self_time)`]]}
                   isLoading={isDurationDataLoading}
                   error={durationError}
+                  filters={chartFilters}
                 />
               </ModuleLayout.Third>
 
@@ -223,6 +225,7 @@ export function HTTPLandingPage() {
                   ]}
                   isLoading={isResponseCodeDataLoading}
                   error={responseCodeError}
+                  filters={chartFilters}
                 />
               </ModuleLayout.Third>
 

--- a/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
+++ b/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
@@ -358,6 +358,10 @@ export function MessageSpanSamplesPanel() {
               }}
               isLoading={isDurationDataFetching}
               error={durationError}
+              filters={timeseriesFilters.getFilterKeys().reduce((acc, key) => {
+                acc[key] = timeseriesFilters.getFilterValues(key)[0];
+                return acc;
+              }, {})}
             />
           </ModuleLayout.Full>
 


### PR DESCRIPTION
Adds create alert buttons to http module charts.
Includes changes to `insightsMetricField` to support functions with non MRI args.
Also organizes some constants better.