### PR TITLE
fix(new-trace): Fixing hook rendering mismatch caused by drawer cards

### DIFF
--- a/static/app/components/keyValueData/index.tsx
+++ b/static/app/components/keyValueData/index.tsx
@@ -1,4 +1,4 @@
-import {Children, isValidElement, type ReactNode, useRef, useState} from 'react';
+import {Children, type ReactNode, useRef, useState} from 'react';
 import React from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -159,36 +159,21 @@ export function Card({
   );
 }
 
-type ReactFCWithProps = React.FC<KeyValueDataCardProps>;
-
-const isReactComponent = (type): type is ReactFCWithProps => {
-  return (
-    typeof type === 'function' ||
-    (typeof type === 'object' && type !== null && 'render' in type)
-  );
-};
-
-// Returns an array of children where null/undefined children and children returning null are filtered out.
+// Returns an array of children where null/undefined children are filtered out.
 // For example:
 // <Component1/> --> returns a <Card/>
 // {null}
-// <Component2/> --> returns null
-// Gives us back [<Component1/>]
+// <Component2/> --> returns a <Card/>
+// Gives us back [<Component1/>, <Component2/>]
 const filterChildren = (children: ReactNode): ReactNode[] => {
-  return Children.toArray(children).filter((child: React.ReactNode) => {
-    if (isValidElement(child) && isReactComponent(child.type)) {
-      // Render the child and check if it returns null
-      const renderedChild = child.type(child.props);
-      return renderedChild !== null;
-    }
-
-    return child != null;
-  });
+  return Children.toArray(children).filter(
+    (child: ReactNode) => child !== null && child !== undefined
+  );
 };
 
-// Note: When rendered children have hooks, we need to ensure that there are no hook count mismatches between renders.
-// Instead of rendering rendering {condition ? <Component/> : null}, we should render
-// if(!condition) return null inside Component itself, where Component renders a Card.
+// Note: When conditionally rendering children, instead of returning
+// if(!condition) return null inside Component, we should render  {condition ? <Component/> : null}
+// where Component returns a <Card/>. {null} is ignored when distributing cards into columns.
 export function Container({children}: {children: React.ReactNode}) {
   const containerRef = useRef<HTMLDivElement>(null);
   const columnCount = useIssueDetailsColumnCount(containerRef);

--- a/static/app/components/metrics/customMetricsEventData.tsx
+++ b/static/app/components/metrics/customMetricsEventData.tsx
@@ -60,7 +60,11 @@ export function eventHasCustomMetrics(
   organization: Organization,
   metricsSummary: MetricsSummary | undefined
 ) {
-  return hasCustomMetrics(organization) && metricsSummary && flattenMetricsSummary(metricsSummary).length > 0;
+  return (
+    hasCustomMetrics(organization) &&
+    metricsSummary &&
+    flattenMetricsSummary(metricsSummary).length > 0
+  );
 }
 
 const HALF_HOUR_IN_MS = 30 * 60 * 1000;

--- a/static/app/components/metrics/customMetricsEventData.tsx
+++ b/static/app/components/metrics/customMetricsEventData.tsx
@@ -60,9 +60,7 @@ export function eventHasCustomMetrics(
   organization: Organization,
   metricsSummary: MetricsSummary | undefined
 ) {
-  return hasCustomMetrics(organization) && metricsSummary
-    ? flattenMetricsSummary(metricsSummary).length > 0
-    : false;
+  return hasCustomMetrics(organization) && metricsSummary && flattenMetricsSummary(metricsSummary).length > 0;
 }
 
 const HALF_HOUR_IN_MS = 30 * 60 * 1000;

--- a/static/app/components/metrics/customMetricsEventData.tsx
+++ b/static/app/components/metrics/customMetricsEventData.tsx
@@ -21,6 +21,7 @@ import type {
   MetricType,
   MRI,
 } from 'sentry/types/metrics';
+import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {getDefaultAggregation, getMetricsUrl} from 'sentry/utils/metrics';
 import {hasCustomMetrics} from 'sentry/utils/metrics/features';
@@ -53,6 +54,15 @@ function flattenMetricsSummary(
 
 function tagToQuery(tagKey: string, tagValue: string) {
   return `${tagKey}:"${tagValue}"`;
+}
+
+export function eventHasCustomMetrics(
+  organization: Organization,
+  metricsSummary: MetricsSummary | undefined
+) {
+  return hasCustomMetrics(organization) && metricsSummary
+    ? flattenMetricsSummary(metricsSummary).length > 0
+    : false;
 }
 
 const HALF_HOUR_IN_MS = 30 * 60 * 1000;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -4,7 +4,10 @@ import {EventContexts} from 'sentry/components/events/contexts';
 import {SpanProfileDetails} from 'sentry/components/events/interfaces/spans/spanProfileDetails';
 import {getSpanOperation} from 'sentry/components/events/interfaces/spans/utils';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
-import {CustomMetricsEventData} from 'sentry/components/metrics/customMetricsEventData';
+import {
+  CustomMetricsEventData,
+  eventHasCustomMetrics,
+} from 'sentry/components/metrics/customMetricsEventData';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
@@ -23,11 +26,11 @@ import {TraceDrawerComponents} from '.././styles';
 import {IssueList} from '../issues/issues';
 
 import Alerts from './sections/alerts';
-import {SpanDescription} from './sections/description';
+import {hasFormattedSpanDescription, SpanDescription} from './sections/description';
 import {GeneralInfo} from './sections/generalInfo';
-import {SpanHTTPInfo} from './sections/http';
-import {SpanKeys} from './sections/keys';
-import {Tags} from './sections/tags';
+import {hasSpanHTTPInfo, SpanHTTPInfo} from './sections/http';
+import {hasSpanKeys, SpanKeys} from './sections/keys';
+import {hasSpanTags, Tags} from './sections/tags';
 
 function SpanNodeDetailHeader({
   node,
@@ -109,25 +112,31 @@ export function SpanNodeDetails({
                   <IssueList organization={organization} issues={issues} node={node} />
                 ) : null}
                 <TraceDrawerComponents.SectionCardGroup>
-                  <SpanDescription
-                    node={node}
-                    organization={organization}
-                    location={location}
-                  />
+                  {hasFormattedSpanDescription(node) ? (
+                    <SpanDescription
+                      node={node}
+                      organization={organization}
+                      location={location}
+                    />
+                  ) : null}
                   <GeneralInfo
                     node={node}
                     organization={organization}
                     location={location}
                     onParentClick={onParentClick}
                   />
-                  <SpanHTTPInfo span={node.value} />
-                  <Tags span={node.value} />
-                  <SpanKeys node={node} />
-                  <CustomMetricsEventData
-                    projectId={project?.id || ''}
-                    metricsSummary={node.value._metrics_summary}
-                    startTimestamp={node.value.start_timestamp}
-                  />
+                  {hasSpanHTTPInfo(node.value) ? (
+                    <SpanHTTPInfo span={node.value} />
+                  ) : null}
+                  {hasSpanTags(node.value) ? <Tags span={node.value} /> : null}
+                  {hasSpanKeys(node) ? <SpanKeys node={node} /> : null}
+                  {eventHasCustomMetrics(organization, node.value._metrics_summary) ? (
+                    <CustomMetricsEventData
+                      projectId={project?.id || ''}
+                      metricsSummary={node.value._metrics_summary}
+                      startTimestamp={node.value.start_timestamp}
+                    />
+                  ) : null}
                 </TraceDrawerComponents.SectionCardGroup>
                 <EventContexts event={node.value.event} />
                 {organization.features.includes('profiling') ? (

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
@@ -26,6 +26,24 @@ import {TraceDrawerComponents} from '../../styles';
 
 const formatter = new SQLishFormatter();
 
+export function hasFormattedSpanDescription(node: TraceTreeNode<TraceTree.Span>) {
+  const span = node.value;
+  const resolvedModule: ModuleName = resolveSpanModule(
+    span.sentry_tags?.op,
+    span.sentry_tags?.category
+  );
+
+  const formattedDescription =
+    resolvedModule !== ModuleName.DB
+      ? span.description ?? ''
+      : formatter.toString(span.description ?? '');
+
+  return (
+    !!formattedDescription &&
+    [ModuleName.DB, ModuleName.RESOURCE].includes(resolvedModule)
+  );
+}
+
 export function SpanDescription({
   node,
   organization,
@@ -50,10 +68,7 @@ export function SpanDescription({
     return formatter.toString(span.description ?? '');
   }, [span.description, resolvedModule]);
 
-  if (
-    !formattedDescription ||
-    ![ModuleName.DB, ModuleName.RESOURCE].includes(resolvedModule)
-  ) {
+  if (!hasFormattedSpanDescription(node)) {
     return null;
   }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/http.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/http.tsx
@@ -6,6 +6,17 @@ import {safeURL} from 'sentry/utils/url/safeURL';
 
 import {type SectionCardKeyValueList, TraceDrawerComponents} from '../../styles';
 
+export function hasSpanHTTPInfo(span: RawSpanType) {
+  if (span.op !== 'http.client' || !span.description) {
+    return false;
+  }
+
+  const [_, url] = span.description.split(' ');
+  const parsedURL = safeURL(url);
+
+  return !!parsedURL;
+}
+
 export function SpanHTTPInfo({span}: {span: RawSpanType}) {
   if (span.op === 'http.client' && span.description) {
     const [method, url] = span.description.split(' ');

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/tags.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/tags.tsx
@@ -3,6 +3,10 @@ import {t} from 'sentry/locale';
 
 import {type SectionCardKeyValueList, TraceDrawerComponents} from '../../styles';
 
+export function hasSpanTags(span: RawSpanType) {
+  return !!span.tags && Object.keys(span.tags).length > 0;
+}
+
 export function Tags({span}: {span: RawSpanType}) {
   const tags: {[tag_name: string]: string} | undefined = span?.tags;
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/additionalData.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/additionalData.tsx
@@ -45,6 +45,10 @@ function getEventExtraDataKnownDataDetails({
   }
 }
 
+export function hasAdditionalData(event: EventTransaction) {
+  return !!event.context && !isEmptyObject(event.context);
+}
+
 export function AdditionalData({event}: {event: EventTransaction}) {
   const [raw, setRaw] = useState(false);
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/measurements.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/measurements.tsx
@@ -47,6 +47,16 @@ function generateLinkWithQuery(
   });
 }
 
+export function hasMeasurements(event: EventTransaction) {
+  const measurementNames = Object.keys(event.measurements ?? {})
+    .filter(name => isCustomMeasurement(`measurements.${name}`))
+    .filter(isNotMarkMeasurement)
+    .filter(isNotPerformanceScoreMeasurement)
+    .sort();
+
+  return measurementNames.length > 0;
+}
+
 export function Measurements({event, location, organization}: MeasurementsProps) {
   const measurementNames = Object.keys(event.measurements ?? {})
     .filter(name => isCustomMeasurement(`measurements.${name}`))

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/sdk.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/sdk.tsx
@@ -5,6 +5,10 @@ import {isEmptyObject} from 'sentry/utils/object/isEmptyObject';
 
 import {type SectionCardKeyValueList, TraceDrawerComponents} from '../../styles';
 
+export function hasSDKContext(event: EventTransaction) {
+  return !!event.sdk && !isEmptyObject(event.sdk);
+}
+
 export function Sdk({event}: {event: EventTransaction}) {
   if (!event.sdk || isEmptyObject(event.sdk)) {
     return null;


### PR DESCRIPTION
Previously we tried to filter out components that returned null from within:
```
//<Component1/> --> returns a <Card/>
// {null}
// <Component2/> --> returns null
// Gives us back [<Component1/>]
```
This leads to `Rendered more hooks than during the previous render` error as we try to conditionally render the children (with hooks) to see if they return null: [example](https://sentry.sentry.io/issues/5800979093/?project=11276&query=rendered%20more%20hooks&referrer=issue-stream&sort=date&statsPeriod=7d&stream_index=6)

Now we moved the rendering logic to the parent of Component, and just filter out null values, without having to render the children:
```
//<Component1/> --> returns a <Card/>
// {null}
// { condition ? <Component2/> : null} where Component2 returns a Card
// Gives us back [<Component1/>]
```