### PR TITLE
ref: fix the remaining `has-type` mypy errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -423,7 +423,6 @@ disable_error_code = [
     "call-arg",
     "call-overload",
     "dict-item",
-    "has-type",
     "index",
     "misc",
     "operator",

--- a/src/sentry/net/http.py
+++ b/src/sentry/net/http.py
@@ -105,7 +105,9 @@ class SafeHTTPSConnection(SafeConnectionMixin, HTTPSConnection):
     pass
 
 
-class InjectIPAddressMixin:
+class SafeHTTPConnectionPool(HTTPConnectionPool):
+    ConnectionCls = SafeHTTPConnection
+
     def __init__(self, *args, is_ipaddress_permitted: IsIpAddressPermitted = None, **kwargs):
         super().__init__(*args, **kwargs)
         self.ConnectionCls = partial(
@@ -113,12 +115,14 @@ class InjectIPAddressMixin:
         )
 
 
-class SafeHTTPConnectionPool(InjectIPAddressMixin, HTTPConnectionPool):
-    ConnectionCls = SafeHTTPConnection
-
-
-class SafeHTTPSConnectionPool(InjectIPAddressMixin, HTTPSConnectionPool):
+class SafeHTTPSConnectionPool(HTTPSConnectionPool):
     ConnectionCls = SafeHTTPSConnection
+
+    def __init__(self, *args, is_ipaddress_permitted: IsIpAddressPermitted = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ConnectionCls = partial(
+            self.ConnectionCls, is_ipaddress_permitted=is_ipaddress_permitted
+        )
 
 
 class SafePoolManager(PoolManager):


### PR DESCRIPTION
basically inlining the mixin here (since (1) it's not typesafe (2) it's not possible to annotation `ConnectionCls` as written)

<!-- Describe your PR here. -->