### PR TITLE
fix(slack): Remove Org from Logging Payload

### DIFF
--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -401,7 +401,6 @@ class SlackActionEndpoint(Endpoint):
                 _logger.exception(
                     "slack.action.update-modal-not-found",
                     extra={
-                        "organization_id": slack_request.organization.id,
                         "integration_id": slack_request.integration.id,
                         "trigger_id": slack_request.data["trigger_id"],
                         "dialog": "resolve",

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -398,10 +398,11 @@ class SlackActionEndpoint(Endpoint):
                     sample_rate=1.0,
                     tags={"type": "update_modal"},
                 )
+                logging_data = slack_request.get_logging_data()
                 _logger.exception(
                     "slack.action.update-modal-not-found",
                     extra={
-                        "integration_id": slack_request.integration.id,
+                        **logging_data,
                         "trigger_id": slack_request.data["trigger_id"],
                         "dialog": "resolve",
                     },


### PR DESCRIPTION
quick fix for [SENTRY-3EMV](https://sentry.sentry.io/issues/5827836858/), org doesn't exist in slack request