### PR TITLE
fix(datadog): make disable_buffering a param instead of setting it on statsd object

### DIFF
--- a/src/sentry/metrics/dogstatsd.py
+++ b/src/sentry/metrics/dogstatsd.py
@@ -24,7 +24,7 @@ class DogStatsdMetricsBackend(MetricsBackend):
     def __init__(self, prefix: str | None = None, **kwargs: Any) -> None:
         # TODO(dcramer): it'd be nice if the initialize call wasn't a global
         self.tags = kwargs.pop("tags", None)
-        kwargs["disable_buffering"] = False
+        kwargs["statsd_disable_buffering"] = False
 
         initialize(**kwargs)
         statsd.disable_telemetry()

--- a/src/sentry/metrics/dogstatsd.py
+++ b/src/sentry/metrics/dogstatsd.py
@@ -24,9 +24,10 @@ class DogStatsdMetricsBackend(MetricsBackend):
     def __init__(self, prefix: str | None = None, **kwargs: Any) -> None:
         # TODO(dcramer): it'd be nice if the initialize call wasn't a global
         self.tags = kwargs.pop("tags", None)
+        kwargs["disable_buffering"] = False
+
         initialize(**kwargs)
         statsd.disable_telemetry()
-        statsd.disable_buffering = False
 
         # When enabled, a background thread will be used to send metric payloads to the Agent.
         statsd.enable_background_sender(


### PR DESCRIPTION
set `disable_buffering` as a kwarg that we pass to `initialize`. this makes it so it only gets set once (right now it gets set in `initialize` and afterward here.

we're seeing slow profiles of this codepath in control silo. want to see if this helps.

slow profile example: https://sentry.sentry.io/profiling/profile/sentry/ad932d5ba6f244c4bb7abfc29667da09/flamegraph/?colorCoding=by%20system%20vs%20application%20frame&fov=0%2C87%2C7048375808%2C14&query=&sorting=call%20order&tid=135938038548160&view=top%20down

docs: https://datadogpy.readthedocs.io/en/stable/#datadog.initialize