### PR TITLE
chore(replay): ff to test reduced timeout for rage/dead clicks

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -399,6 +399,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:session-replay-new-event-counts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Rage Click Issue Creation In Recording Consumer
     manager.add("organizations:session-replay-rage-click-issue-creation", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
+    # Enable a reduced timeout when waiting for the DOM, before reporting Rage and Dead clicks
+    manager.add("organizations:session-replay-dead-click-reduced-timeout", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable data scrubbing of replay recording payloads in Relay.
     manager.add("organizations:session-replay-recording-scrubbing", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable core Session Replay SDK for recording on sentry.io

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -400,7 +400,7 @@ def register_temporary_features(manager: FeatureManager):
     # Enable Rage Click Issue Creation In Recording Consumer
     manager.add("organizations:session-replay-rage-click-issue-creation", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable a reduced timeout when waiting for the DOM, before reporting Rage and Dead clicks
-    manager.add("organizations:session-replay-dead-click-reduced-timeout", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:session-replay-dead-click-reduced-timeout", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=False)
     # Enable data scrubbing of replay recording payloads in Relay.
     manager.add("organizations:session-replay-recording-scrubbing", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable core Session Replay SDK for recording on sentry.io


### PR DESCRIPTION
This timeout is in [dom_index.py](https://github.com/getsentry/sentry/blob/d9a1829b381ab54efbad09bdc908ef6dfab408d7/src/sentry/replays/usecases/ingest/dom_index.py#L415) (7000ms) and is the time we wait for dom changes before reporting a rage or dead click. 

Trying out 5s instead of 7 for sentry orgs. Slack thread: https://sentry.slack.com/archives/C03USURCFBJ/p1725645076151569