### PR TITLE
fix(rr6): Create routes after getsentry registerHooks

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -28,7 +28,6 @@ import RouteNotFound from 'sentry/views/routeNotFound';
 import SettingsWrapper from 'sentry/views/settings/components/settingsWrapper';
 
 import {IndexRoute, Route} from './components/route';
-import {buildReactRouter6Routes} from './utils/reactRouter6Compat/router';
 
 const hook = (name: HookName) => HookStore.get(name).map(cb => cb());
 
@@ -2281,10 +2280,6 @@ function buildRoutes() {
 // We load routes both when initializing the SDK (for routing integrations) and
 // when the app renders Main. Memoize to avoid rebuilding the route tree.
 export const routes = memoize(buildRoutes);
-
-// XXX(epurkhiser): Transforms the legacy react-router 3 routest tree into a
-// react-router 6 style routes tree.
-export const routes6 = buildReactRouter6Routes(buildRoutes());
 
 // Exported for use in tests.
 export {buildRoutes};


### PR DESCRIPTION
Before this change we were building the route tree at module load time for the routes.tsx file. This was **before** getsentry will have registered it's hooks, and thus the getsentry routes would never be registered.