### PR TITLE
ref(replay): try 5s rage/dead click timeout for sentry orgs

### DIFF
--- a/src/sentry/replays/usecases/ingest/dom_index.py
+++ b/src/sentry/replays/usecases/ingest/dom_index.py
@@ -421,7 +421,6 @@ def _handle_breadcrumb(
         timeout = payload["data"].get("timeAfterClickMs", 0) or payload["data"].get(
             "timeafterclickms", 0
         )
-
         if is_timeout_reason and is_target_tagname and timeout >= dead_click_timeout:
             is_rage = (
                 payload["data"].get("clickCount", 0) or payload["data"].get("clickcount", 0)


### PR DESCRIPTION
See slack thread https://sentry.slack.com/archives/C03USURCFBJ/p1725645076151569. This flag is only enabled for internal orgs

Ref https://github.com/getsentry/sentry/pull/77284 and https://github.com/getsentry/sentry-options-automator/pull/2279