### PR TITLE
chore(deletions) Move RuleFireHistory to model deletions

### DIFF
--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -98,6 +98,7 @@ def load_defaults():
         RepositoryProjectPathConfig,
     )
     from sentry.models.commitfilechange import CommitFileChange
+    from sentry.models.rulefirehistory import RuleFireHistory
     from sentry.monitors import models as monitor_models
     from sentry.snuba import models as snuba_models
 
@@ -176,7 +177,7 @@ def load_defaults():
     default_manager.register(models.UserReport, BulkModelDeletionTask)
     default_manager.register(models.ArtifactBundle, ArtifactBundleDeletionTask)
     default_manager.register(models.Rule, defaults.RuleDeletionTask)
-    default_manager.register(models.RuleFireHistory, defaults.RuleFireHistoryDeletionTask)
+    default_manager.register(RuleFireHistory, defaults.RuleFireHistoryDeletionTask)
 
 
 load_defaults()

--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -176,6 +176,7 @@ def load_defaults():
     default_manager.register(models.UserReport, BulkModelDeletionTask)
     default_manager.register(models.ArtifactBundle, ArtifactBundleDeletionTask)
     default_manager.register(models.Rule, defaults.RuleDeletionTask)
+    default_manager.register(models.RuleFireHistory, defaults.RuleFireHistoryDeletionTask)
 
 
 load_defaults()

--- a/src/sentry/deletions/defaults/__init__.py
+++ b/src/sentry/deletions/defaults/__init__.py
@@ -21,6 +21,7 @@ from .release import *  # noqa: F401,F403
 from .repository import *  # noqa: F401,F403
 from .repositoryprojectpathconfig import *  # noqa: F401,F403
 from .rule import *  # noqa: F401,F403
+from .rulefirehistory import *  # noqa: F401,F403
 from .sentry_app import *  # noqa: F401,F403
 from .sentry_app_installation import *  # noqa: F401,F403
 from .sentry_app_installation_token import *  # noqa: F401,F403

--- a/src/sentry/deletions/defaults/rulefirehistory.py
+++ b/src/sentry/deletions/defaults/rulefirehistory.py
@@ -1,0 +1,10 @@
+from sentry.deletions.base import ModelDeletionTask, ModelRelation
+
+
+class RuleFireHistoryDeletionTask(ModelDeletionTask):
+    def get_child_relations(self, instance):
+        from sentry.models.notificationmessage import NotificationMessage
+
+        return [
+            ModelRelation(NotificationMessage, {"rule_fire_history_id": instance.id}),
+        ]

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -171,7 +171,6 @@ def cleanup(
         from sentry.constants import ObjectStatus
         from sentry.data_export.models import ExportedData
         from sentry.db.deletion import BulkDeleteQuery
-        from sentry.models.notificationmessage import NotificationMessage
         from sentry.models.rulefirehistory import RuleFireHistory
         from sentry.monitors import models as monitor_models
         from sentry.replays import models as replay_models
@@ -211,8 +210,6 @@ def cleanup(
         BULK_QUERY_DELETES = [
             (models.UserReport, "date_added", None),
             (models.GroupEmailThread, "date", None),
-            (NotificationMessage, "date_added", "-id"),
-            (RuleFireHistory, "date_added", None),
         ] + additional_bulk_query_deletes
 
         # Deletions that use the `deletions` code path (which handles their child relations)
@@ -223,6 +220,7 @@ def cleanup(
             (models.ArtifactBundle, "date_added", "date_added"),
             (monitor_models.MonitorCheckIn, "date_added", "date_added"),
             (models.GroupRuleStatus, "date_added", "date_added"),
+            (RuleFireHistory, "date_added", "date_added"),
         ]
         # Deletions that we run per project. In some cases we can't use an index on just the date
         # column, so as an alternative we use `(project_id, <date_col>)` instead

--- a/tests/sentry/deletions/test_rulefirehistory.py
+++ b/tests/sentry/deletions/test_rulefirehistory.py
@@ -1,0 +1,45 @@
+from sentry.models.notificationmessage import NotificationMessage
+from sentry.models.rule import Rule
+from sentry.models.rulefirehistory import RuleFireHistory
+from sentry.tasks.deletion.scheduled import run_scheduled_deletions
+from sentry.testutils.cases import TestCase
+from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
+
+
+class DeleteRuleFireHistoryTest(TestCase, HybridCloudTestMixin):
+    def test_simple(self):
+        project = self.create_project()
+        rule = self.create_project_rule(project)
+        rule_fire_history = RuleFireHistory.objects.create(
+            project=rule.project,
+            rule=rule,
+            group=self.group,
+        )
+        second_fire = RuleFireHistory.objects.create(
+            project=rule.project,
+            rule=rule,
+            group=self.group,
+        )
+        parent_message = NotificationMessage.objects.create(
+            message_identifier="abc123",
+            parent_notification_message=None,
+            rule_fire_history=rule_fire_history,
+            rule_action_uuid="abc123",
+        )
+        message = NotificationMessage.objects.create(
+            message_identifier="def456",
+            parent_notification_message=parent_message,
+            rule_fire_history=second_fire,
+            rule_action_uuid="def456",
+        )
+
+        self.ScheduledDeletion.schedule(instance=rule_fire_history, days=0)
+
+        with self.tasks():
+            run_scheduled_deletions()
+
+        assert Rule.objects.filter(id=rule.id).exists()
+        assert not RuleFireHistory.objects.filter(id=rule_fire_history.id).exists()
+        assert RuleFireHistory.objects.filter(id=second_fire.id).exists()
+        assert not NotificationMessage.objects.filter(id=parent_message.id).exists()
+        assert not NotificationMessage.objects.filter(id=message.id).exists()


### PR DESCRIPTION
Ordering NotificationMessage by id when doing a bulk delete doesn't work because a message could be past retention, but also be a 'parent' for a message that is within retention.

Similarily rulefirehistory records cannot be deleted by date alone as there are foreign keys in notification message. By moving rulefirehistory deletion to model deletes, we'll be able to traverse relations and remove all notification messages related to a rulefirehistory at once.

This does create the opportunity for the parent message to be removed before the thread is 'complete'. Based on my interpretation of rule fire history a new parent message will be created on the next trigger.

Refs SENTRY-3BW5
Refs SENTRY-3E5X