### PR TITLE
feat(rr6): Add routes:settings hook

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -682,6 +682,7 @@ function buildRoutes() {
         () => import('sentry/views/settings/organization/organizationSettingsLayout')
       )}
     >
+      {hook('routes:settings')}
       {hook('routes:organization')}
       {!USING_CUSTOMER_DOMAIN && (
         <IndexRoute

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -65,6 +65,7 @@ export type RouteHooks = {
   'routes:api': RoutesHook;
   'routes:organization': RoutesHook;
   'routes:root': RoutesHook;
+  'routes:settings': RoutesHook;
 };
 
 /**


### PR DESCRIPTION
Prior to this we were rendering `routes:organization` inside the
settings route tree, which doesn't make sense since there could be non
settings routes in there (though right now there aren't really)