### PR TITLE
fix(issues): Hide device context for non-mobile

### DIFF
--- a/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
@@ -18,6 +18,13 @@ describe('HighlightsIconSummary', function () {
     contexts: TEST_EVENT_CONTEXTS,
     tags: TEST_EVENT_TAGS,
   });
+  const iosDeviceContext = {
+    type: 'device',
+    name: 'device',
+    version: 'device version',
+    model: 'iPhone14,5',
+    arch: 'x86',
+  };
 
   it('hides user if there is no id, email, username, etc', function () {
     const eventWithoutUser = EventFixture({
@@ -57,25 +64,31 @@ describe('HighlightsIconSummary', function () {
     expect(screen.getAllByRole('img')).toHaveLength(2);
   });
 
-  it('hides device if client_os is present', function () {
-    const eventWithClientOs = EventFixture({
+  it('hides device for non mobile/native', function () {
+    const eventWithDevice = EventFixture({
       contexts: {
         ...TEST_EVENT_CONTEXTS,
-        device: {
-          type: 'device',
-          name: 'device',
-          version: 'device version',
-        },
-        client_os: {
-          type: 'client_os',
-          name: 'client_os',
-          version: 'client_os version',
-        },
+        device: iosDeviceContext,
       },
+      platform: 'javascript',
     });
 
-    render(<HighlightsIconSummary event={eventWithClientOs} />);
-    expect(screen.queryByText('device')).not.toBeInTheDocument();
-    expect(screen.getByText('client_os')).toBeInTheDocument();
+    render(<HighlightsIconSummary event={eventWithDevice} />);
+    expect(screen.queryByText('iPhone 13')).not.toBeInTheDocument();
+    expect(screen.queryByText('Arch: x86')).not.toBeInTheDocument();
+  });
+
+  it('displays device for mobile/native event platforms', function () {
+    const eventWithDevice = EventFixture({
+      contexts: {
+        ...TEST_EVENT_CONTEXTS,
+        device: iosDeviceContext,
+      },
+      platform: 'android',
+    });
+
+    render(<HighlightsIconSummary event={eventWithDevice} />);
+    expect(screen.getByText('iPhone 13')).toBeInTheDocument();
+    expect(screen.getByText('Arch: x86')).toBeInTheDocument();
   });
 });

--- a/static/app/utils/platform.tsx
+++ b/static/app/utils/platform.tsx
@@ -17,19 +17,19 @@ export function platformToCategory(platform: PlatformKey | undefined): PlatformC
   if (!platform) {
     return PlatformCategory.OTHER;
   }
-  if (([...frontend] as string[]).includes(platform)) {
+  if ((frontend as string[]).includes(platform)) {
     return PlatformCategory.FRONTEND;
   }
-  if (([...backend] as string[]).includes(platform)) {
+  if ((backend as string[]).includes(platform)) {
     return PlatformCategory.BACKEND;
   }
-  if (([...serverless] as string[]).includes(platform)) {
+  if ((serverless as string[]).includes(platform)) {
     return PlatformCategory.SERVERLESS;
   }
-  if (([...mobile] as string[]).includes(platform)) {
+  if ((mobile as string[]).includes(platform)) {
     return PlatformCategory.MOBILE;
   }
-  if (([...desktop] as string[]).includes(platform)) {
+  if ((desktop as string[]).includes(platform)) {
     return PlatformCategory.DESKTOP;
   }
   return PlatformCategory.OTHER;
@@ -54,5 +54,5 @@ export function isMobilePlatform(platform: string | undefined) {
     return false;
   }
 
-  return ([...mobile] as string[]).includes(platform);
+  return (mobile as string[]).includes(platform);
 }


### PR DESCRIPTION
Before we were hiding it if client_os was also present, but hiding it for everything except mobile seems more correct.


what mobile platforms will see [event](https://demo.sentry.io/issues/5399336660/events/fed6a98db5a94e64b3c4a9879b15a63a/?project=6249899&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=previous-event&sort=date&statsPeriod=14d&stream_index=0)

![image](https://github.com/user-attachments/assets/66d63764-b7ca-456e-b564-8f02a8cfc10b)

what non-mobile platforms will see [event](https://sentry.sentry.io/issues/5807045510/events/6bd97087bf574ee7b643c68356105521/?fov=0%2C0&project=11276)

![image](https://github.com/user-attachments/assets/09a48014-64f1-4f3d-a672-6f450e242dbe)

fixes https://www.notion.so/sentry/Duplicate-context-summary-info-8d962be50b484544a514a730fce8274a