### PR TITLE
ref(rr6): Add legacy-organization-redirects hook

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1918,6 +1918,7 @@ function buildRoutes() {
       <Redirect from="/organizations/:orgId/teams/new/" to="/settings/:orgId/teams/" />
       <Route path="/organizations/:orgId/">
         {hook('routes:organization')}
+        {hook('routes:legacy-organization-redirects')}
         <IndexRedirect to="issues/" />
         <Redirect from="teams/" to="/settings/:orgId/teams/" />
         <Redirect from="teams/your-teams/" to="/settings/:orgId/teams/" />

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -62,6 +62,7 @@ export type HookName = keyof Hooks;
  * Route hooks.
  */
 export type RouteHooks = {
+  'routes:legacy-organization-redirects': RoutesHook;
   'routes:organization': RoutesHook;
   'routes:root': RoutesHook;
   'routes:settings': RoutesHook;


### PR DESCRIPTION
Like GH-77291, replaces the routes:organization hook with a more
specific one