### PR TITLE
feat(grouping): Deprecated configs are upgraded to the latest

### DIFF
--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -137,6 +137,13 @@ class EventManagerGroupingTest(TestCase):
         assert group.message == event2.message
         assert group.data["metadata"]["title"] == event2.title
 
+    def test_auto_updates_grouping_config_even_if_config_is_gone(self):
+        """This tests that setups with deprecated configs will auto-upgrade."""
+        self.project.update_option("sentry:grouping_config", "non_existing_config")
+        save_new_event({"message": "foo"}, self.project)
+        assert self.project.get_option("sentry:grouping_config") == DEFAULT_GROUPING_CONFIG
+        assert self.project.get_option("sentry:secondary_grouping_config") is None
+
     def test_auto_updates_grouping_config(self):
         self.project.update_option("sentry:grouping_config", LEGACY_GROUPING_CONFIG)
 


### PR DESCRIPTION
This will prevent any self-hosted deployments that may be using deprecated configs to auto-update to the latest valid config without a migration phase.