### PR TITLE
feat(insights): Better styling for Queries landing page filters

### DIFF
--- a/static/app/views/insights/database/components/databasePageFilters.tsx
+++ b/static/app/views/insights/database/components/databasePageFilters.tsx
@@ -1,0 +1,54 @@
+import styled from '@emotion/styled';
+
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
+import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
+import {ActionSelector} from 'sentry/views/insights/common/views/spans/selectors/actionSelector';
+import {DomainSelector} from 'sentry/views/insights/common/views/spans/selectors/domainSelector';
+import {DatabaseSystemSelector} from 'sentry/views/insights/database/components/databaseSystemSelector';
+import {SupportedDatabaseSystems} from 'sentry/views/insights/database/utils/constants';
+import {ModuleName} from 'sentry/views/insights/types';
+
+type Props = {
+  system: string;
+  databaseCommand?: string;
+  table?: string;
+};
+
+export function DatabasePageFilters(props: Props) {
+  const organization = useOrganization();
+
+  const {system, databaseCommand, table} = props;
+
+  return (
+    <PageFilterWrapper>
+      <ModulePageFilterBar moduleName={ModuleName.DB} />
+      <DbFilterWrapper>
+        {organization.features.includes('performance-queries-mongodb-extraction') && (
+          <DatabaseSystemSelector />
+        )}
+        <ActionSelector moduleName={ModuleName.DB} value={databaseCommand ?? ''} />
+        <DomainSelector
+          moduleName={ModuleName.DB}
+          value={table ?? ''}
+          domainAlias={
+            system === SupportedDatabaseSystems.MONGODB ? t('Collection') : t('Table')
+          }
+        />
+      </DbFilterWrapper>
+    </PageFilterWrapper>
+  );
+}
+
+const PageFilterWrapper = styled('div')`
+  display: flex;
+  gap: ${space(3)};
+  flex-wrap: wrap;
+`;
+
+const DbFilterWrapper = styled('div')`
+  display: flex;
+  gap: ${space(3)};
+  flex-wrap: wrap;
+`;

--- a/static/app/views/insights/database/components/databasePageFilters.tsx
+++ b/static/app/views/insights/database/components/databasePageFilters.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -24,7 +25,7 @@ export function DatabasePageFilters(props: Props) {
   return (
     <PageFilterWrapper>
       <ModulePageFilterBar moduleName={ModuleName.DB} />
-      <DbFilterWrapper>
+      <PageFilterBar condensed>
         {organization.features.includes('performance-queries-mongodb-extraction') && (
           <DatabaseSystemSelector />
         )}
@@ -36,18 +37,12 @@ export function DatabasePageFilters(props: Props) {
             system === SupportedDatabaseSystems.MONGODB ? t('Collection') : t('Table')
           }
         />
-      </DbFilterWrapper>
+      </PageFilterBar>
     </PageFilterWrapper>
   );
 }
 
 const PageFilterWrapper = styled('div')`
-  display: flex;
-  gap: ${space(3)};
-  flex-wrap: wrap;
-`;
-
-const DbFilterWrapper = styled('div')`
   display: flex;
   gap: ${space(3)};
   flex-wrap: wrap;

--- a/static/app/views/insights/database/views/databaseLandingPage.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
@@ -9,7 +8,6 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import SearchBar from 'sentry/components/searchBar';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
@@ -18,7 +16,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useSynchronizeCharts} from 'sentry/views/insights/common/components/chart';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
-import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModulesOnboarding} from 'sentry/views/insights/common/components/modulesOnboarding';
 import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
@@ -27,11 +24,9 @@ import {useHasFirstSpan} from 'sentry/views/insights/common/queries/useHasFirstS
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {useModuleBreadcrumbs} from 'sentry/views/insights/common/utils/useModuleBreadcrumbs';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
-import {ActionSelector} from 'sentry/views/insights/common/views/spans/selectors/actionSelector';
-import {DomainSelector} from 'sentry/views/insights/common/views/spans/selectors/domainSelector';
 import {DurationChart} from 'sentry/views/insights/database/components/charts/durationChart';
 import {ThroughputChart} from 'sentry/views/insights/database/components/charts/throughputChart';
-import {DatabaseSystemSelector} from 'sentry/views/insights/database/components/databaseSystemSelector';
+import {DatabasePageFilters} from 'sentry/views/insights/database/components/databasePageFilters';
 import {NoDataMessage} from 'sentry/views/insights/database/components/noDataMessage';
 import {
   isAValidSort,
@@ -45,7 +40,6 @@ import {
   MODULE_DOC_LINK,
   MODULE_TITLE,
 } from 'sentry/views/insights/database/settings';
-import {SupportedDatabaseSystems} from 'sentry/views/insights/database/utils/constants';
 import {ModuleName, SpanMetricsField} from 'sentry/views/insights/types';
 
 export function DatabaseLandingPage() {
@@ -195,24 +189,11 @@ export function DatabaseLandingPage() {
             )}
 
             <ModuleLayout.Full>
-              <PageFilterWrapper>
-                <ModulePageFilterBar moduleName={ModuleName.DB} />
-                <DbFilterWrapper>
-                  {organization.features.includes(
-                    'performance-queries-mongodb-extraction'
-                  ) && <DatabaseSystemSelector />}
-                  <ActionSelector moduleName={moduleName} value={spanAction ?? ''} />
-                  <DomainSelector
-                    moduleName={moduleName}
-                    value={spanDomain ?? ''}
-                    domainAlias={
-                      system === SupportedDatabaseSystems.MONGODB
-                        ? t('Collection')
-                        : t('Table')
-                    }
-                  />
-                </DbFilterWrapper>
-              </PageFilterWrapper>
+              <DatabasePageFilters
+                system={system}
+                databaseCommand={spanAction}
+                table={spanDomain}
+              />
             </ModuleLayout.Full>
             <ModulesOnboarding moduleName={ModuleName.DB}>
               <ModuleLayout.Half>
@@ -276,17 +257,5 @@ function PageWithProviders() {
     </ModulePageProviders>
   );
 }
-
-const PageFilterWrapper = styled('div')`
-  display: flex;
-  gap: ${space(3)};
-  flex-wrap: wrap;
-`;
-
-const DbFilterWrapper = styled('div')`
-  display: flex;
-  gap: ${space(3)};
-  flex-wrap: wrap;
-`;
 
 export default PageWithProviders;


### PR DESCRIPTION
Condenses the additional page filters for the queries module into a single bar

### Before
![image](https://github.com/user-attachments/assets/54e373d6-c2e7-4a34-b33d-2cb326016161)

### After
![image](https://github.com/user-attachments/assets/c61c76d2-b836-4452-bb7d-c33bf45f20cf)
