### PR TITLE
fix(dashboards): Prevent Big Number rendering error if a description is present

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/visualizationStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/visualizationStep.tsx
@@ -154,6 +154,7 @@ const VisualizationWrapper = styled('div')<{displayType: DisplayType}>`
   padding-right: ${space(2)};
   ${WidgetCardPanel} {
     height: initial;
+    min-height: 120px;
   }
   ${p =>
     p.displayType === DisplayType.TABLE &&


### PR DESCRIPTION
Another small edge case. During widget preview, the Big Number widget has a min-height of 96px. If there's a widget description, this isn't enough space to render the actual value, so the Big Number rendering essentially fails.

I'm increasing its height to 120px, which is the minimum actual height of the widget, as defined in the grid definition.

**Before:**
<img width="674" alt="Screenshot 2024-09-11 at 11 11 39 AM" src="https://github.com/user-attachments/assets/d8f671c1-a863-4594-b22d-8e6595d889dd">

**After:**
<img width="715" alt="Screenshot 2024-09-11 at 11 17 13 AM" src="https://github.com/user-attachments/assets/e87fd04f-6ea3-42d1-bc2e-e8066a91646b">
