### PR TITLE
ref(ts): Remove the unused routes:organization hook

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -682,7 +682,6 @@ function buildRoutes() {
       )}
     >
       {hook('routes:settings')}
-      {hook('routes:organization')}
       {!USING_CUSTOMER_DOMAIN && (
         <IndexRoute
           name={t('General')}
@@ -1917,7 +1916,6 @@ function buildRoutes() {
     <Route component={errorHandler(OrganizationRoot)}>
       <Redirect from="/organizations/:orgId/teams/new/" to="/settings/:orgId/teams/" />
       <Route path="/organizations/:orgId/">
-        {hook('routes:organization')}
         {hook('routes:legacy-organization-redirects')}
         <IndexRedirect to="issues/" />
         <Redirect from="teams/" to="/settings/:orgId/teams/" />

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -63,7 +63,6 @@ export type HookName = keyof Hooks;
  */
 export type RouteHooks = {
   'routes:legacy-organization-redirects': RoutesHook;
-  'routes:organization': RoutesHook;
   'routes:root': RoutesHook;
   'routes:settings': RoutesHook;
 };


### PR DESCRIPTION
After https://github.com/getsentry/getsentry/pull/15089 we'll no longer
need this.