### PR TITLE
fix(replay): Node highlight not being removed

### DIFF
--- a/static/app/utils/replays/highlightNode.tsx
+++ b/static/app/utils/replays/highlightNode.tsx
@@ -66,7 +66,7 @@ export function highlightNode(replayer: Replayer, props: AddHighlightParams) {
 
   const nodes =
     'nodeIds' in props
-      ? props.nodeIds.map(nodeId => mirror.getNode(nodeId))
+      ? new Set(props.nodeIds.map(nodeId => mirror.getNode(nodeId)))
       : [replayer.iframe.contentDocument?.body.querySelector(props.selector)];
 
   for (const node of nodes) {


### PR DESCRIPTION
The node highlight wasn't being removed when there are multiple of the same`nodeId`. When adding the highlight, we end up drawing multiple of the same canvases. To fix this, a set is used to return unique values, so we only highlight each node once.

Before:

https://github.com/user-attachments/assets/896e3889-31ab-41d5-909f-8b75f0e83444


After:

https://github.com/user-attachments/assets/7e84e27e-9179-4be9-b675-77d82f8f5d40

