### PR TITLE
feat(search): support IN operator for release package

### DIFF
--- a/src/sentry/models/releases/util.py
+++ b/src/sentry/models/releases/util.py
@@ -34,7 +34,7 @@ class SemverVersion(
 class SemverFilter:
     operator: str
     version_parts: Sequence[int | str]
-    package: str | None = None
+    package: str | Sequence[str] | None = None
     negated: bool = False
 
 
@@ -112,7 +112,10 @@ class ReleaseQuerySet(BaseQuerySet["Release"]):
         query_func = "exclude" if semver_filter.negated else "filter"
 
         if semver_filter.package:
-            qs = getattr(qs, query_func)(package=semver_filter.package)
+            if isinstance(semver_filter.package, str):
+                qs = getattr(qs, query_func)(package=semver_filter.package)
+            else:
+                qs = getattr(qs, query_func)(package__in=semver_filter.package)
         if project_ids:
             qs = qs.filter(
                 id__in=ReleaseProject.objects.filter(project_id__in=project_ids).values_list(

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -447,8 +447,7 @@ def _semver_package_filter_converter(
 
     organization_id: int = params["organization_id"]
     project_ids: list[int] | None = params.get("project_id")
-    package: str = search_filter.value.raw_value
-
+    package: str | list[str] = search_filter.value.raw_value
     versions = list(
         Release.objects.filter_by_semver(
             organization_id,

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -758,6 +758,8 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         project = self.project
         release1 = Release.objects.create(organization=project.organization, version="foo@1.0.0.0")
         release2 = Release.objects.create(organization=project.organization, version="bar@1.2.0.0")
+        release3 = Release.objects.create(organization=project.organization, version="cat@1.2.0.0")
+
         release1.add_project(project)
         release2.add_project(project)
 
@@ -774,6 +776,14 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
                 "release": release2.version,
                 "timestamp": iso_format(before_now(seconds=2)),
                 "fingerprint": ["2"],
+            },
+            project_id=project.id,
+        )
+        self.store_event(
+            data={
+                "release": release3.version,
+                "timestamp": iso_format(before_now(seconds=2)),
+                "fingerprint": ["3"],
             },
             project_id=project.id,
         )

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -753,6 +753,38 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert len(issues) == 1
         assert int(issues[0]["id"]) == event.group.id
 
+    def test_release_package_in(self, _: MagicMock) -> None:
+        self.login_as(self.user)
+        project = self.project
+        release1 = Release.objects.create(organization=project.organization, version="foo@1.0.0.0")
+        release2 = Release.objects.create(organization=project.organization, version="bar@1.2.0.0")
+        release1.add_project(project)
+        release2.add_project(project)
+
+        event1 = self.store_event(
+            data={
+                "release": release1.version,
+                "timestamp": iso_format(before_now(seconds=3)),
+                "fingerprint": ["1"],
+            },
+            project_id=project.id,
+        )
+        event2 = self.store_event(
+            data={
+                "release": release2.version,
+                "timestamp": iso_format(before_now(seconds=2)),
+                "fingerprint": ["2"],
+            },
+            project_id=project.id,
+        )
+
+        with self.feature("organizations:global-views"):
+            response = self.get_success_response(**{"query": 'release.package:["foo", "bar"]'})
+        issues = json.loads(response.content)
+        assert len(issues) == 2
+        assert int(issues[0]["id"]) == event2.group.id
+        assert int(issues[1]["id"]) == event1.group.id
+
     def test_lookup_by_release_wildcard(self, _: MagicMock) -> None:
         self.login_as(self.user)
         project = self.project

--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -421,6 +421,15 @@ class SemverPackageFilterConverterTest(BaseSemverConverterTest):
             project_id=[self.project.id, project_2.id],
         )
 
+    def test_in(self):
+        release_1 = self.create_release(version="foo@1.0.0.0")
+        release_2 = self.create_release(version="bar@1.2.0.0")
+        self.run_test("IN", ["foo"], "IN", [release_1.version])
+        self.run_test("IN", ["foo", "bar"], "IN", [release_1.version, release_2.version])
+        self.run_test(
+            "IN", ["foo", "bar", "notathing"], "IN", [release_1.version, release_2.version]
+        )
+
 
 class SemverBuildFilterConverterTest(BaseSemverConverterTest):
     key = SEMVER_BUILD_ALIAS


### PR DESCRIPTION
support `in` for for release package for issues search. 

related (but this one is much easier): https://github.com/getsentry/sentry/pull/76313