### PR TITLE
feat(alerts): updates alerts serializers and validations allow mri checks to pass on orgs with insights alerts enabled

### DIFF
--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -248,6 +248,10 @@ def build_metric_alert_chart(
         "organizations:custom-metrics",
         organization,
         actor=user,
+    ) or features.has(
+        "organizations:insights-alerts",
+        organization,
+        actor=user,
     )
     aggregate = translate_aggregate_field(snuba_query.aggregate, reverse=True, allow_mri=allow_mri)
     # If we allow alerts to be across multiple orgs this will break

--- a/src/sentry/incidents/endpoints/serializers/alert_rule.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule.py
@@ -279,6 +279,10 @@ class AlertRuleSerializer(Serializer):
             "organizations:custom-metrics",
             obj.organization,
             actor=user,
+        ) or features.has(
+            "organizations:insights-alerts",
+            obj.organization,
+            actor=user,
         )
         # Temporary: Translate aggregate back here from `tags[sentry:user]` to `user` for the frontend.
         aggregate = translate_aggregate_field(

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -159,6 +159,10 @@ class AlertRuleSerializer(CamelSnakeModelSerializer[AlertRule]):
             "organizations:custom-metrics",
             self.context["organization"],
             actor=self.context.get("user", None),
+        ) or features.has(
+            "organizations:insights-alerts",
+            self.context["organization"],
+            actor=self.context.get("user", None),
         )
 
         try:
@@ -291,6 +295,10 @@ class AlertRuleSerializer(CamelSnakeModelSerializer[AlertRule]):
 
         if features.has(
             "organizations:custom-metrics",
+            self.context["organization"],
+            actor=self.context.get("user", None),
+        ) or features.has(
+            "organizations:insights-alerts",
             self.context["organization"],
             actor=self.context.get("user", None),
         ):


### PR DESCRIPTION
Insights Alerts rely on constructing aggregates using MRIs. Updates `allow_mri` checks to pass when users have `insights-alerts` enabled but not `custom-metrics`.