### PR TITLE
feat(insights): add tooltip to explain geo selector

### DIFF
--- a/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
@@ -7,8 +7,7 @@ import {
   type SelectOption,
   type SelectProps,
 } from 'sentry/components/compactSelect';
-import {Tooltip} from 'sentry/components/tooltip';
-import {IconInfo} from 'sentry/icons';
+import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -78,12 +77,10 @@ export default function SubregionSelector({size}: Props) {
       value={value}
       triggerLabel={value.length === 0 ? t('All') : undefined}
       menuTitle={
-        <Fragment>
+        <MenuTitleContainer>
           {t('Filter region')}
-          <Tooltip title={tooltip}>
-            <StyledInfoIcon size="xs" />
-          </Tooltip>
-        </Fragment>
+          <QuestionTooltip title={tooltip} size="xs" />
+        </MenuTitleContainer>
       }
       options={options}
       onChange={(selectedOptions: SelectOption<string>[]) => {
@@ -110,6 +107,8 @@ const StyledFeatureBadge = styled(FeatureBadge)`
   margin-right: ${space(1)};
 `;
 
-const StyledInfoIcon = styled(IconInfo)`
-  margin-left: ${space(0.5)};
+const MenuTitleContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
 `;

--- a/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
@@ -7,6 +7,8 @@ import {
   type SelectOption,
   type SelectProps,
 } from 'sentry/components/compactSelect';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconInfo} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -56,6 +58,8 @@ export default function SubregionSelector({size}: Props) {
     return <Fragment />;
   }
 
+  const tooltip = t('These correspond to the subregions of the UN M49 standard.');
+
   return (
     <CompactSelect
       size={size}
@@ -73,7 +77,14 @@ export default function SubregionSelector({size}: Props) {
       clearable
       value={value}
       triggerLabel={value.length === 0 ? t('All') : undefined}
-      menuTitle={t('Filter region')}
+      menuTitle={
+        <Fragment>
+          {t('Filter region')}
+          <Tooltip title={tooltip}>
+            <StyledInfoIcon size="xs" />
+          </Tooltip>
+        </Fragment>
+      }
       options={options}
       onChange={(selectedOptions: SelectOption<string>[]) => {
         trackAnalytics('insight.vital.select_browser_value', {
@@ -97,4 +108,8 @@ export default function SubregionSelector({size}: Props) {
 
 const StyledFeatureBadge = styled(FeatureBadge)`
   margin-right: ${space(1)};
+`;
+
+const StyledInfoIcon = styled(IconInfo)`
+  margin-left: ${space(0.5)};
 `;


### PR DESCRIPTION
Work towards https://github.com/getsentry/sentry/issues/75230

Small tooltip to explain what the subregions are.
<img width="323" alt="image" src="https://github.com/user-attachments/assets/30a80338-a660-4470-b18b-dc7a836c3c8c">

