### PR TITLE
update incident activity string for dynamic alerts

### DIFF
--- a/static/app/views/alerts/rules/metric/details/metricActivity.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricActivity.tsx
@@ -116,21 +116,25 @@ function MetricAlertActivity({organization, incident}: MetricAlertActivityProps)
         </Link>
       </Cell>
       <Cell>
-        {incident.alertRule.comparisonDelta ? (
-          <Fragment>
-            {alertName} {curentTrigger?.alertThreshold}%
-            {t(
-              ' %s in %s compared to the ',
-              incident.alertRule.thresholdType === AlertRuleThresholdType.ABOVE
-                ? t('higher')
-                : t('lower'),
-              timeWindow
-            )}
-            {COMPARISON_DELTA_OPTIONS.find(
-              ({value}) => value === incident.alertRule.comparisonDelta
-            )?.label ?? COMPARISON_DELTA_OPTIONS[0].label}
-          </Fragment>
-        ) : (
+        {/* If an alert rule is a % detection type */}
+        {incident.alertRule.detectionType === 'percent' &&
+          incident.alertRule.comparisonDelta && (
+            <Fragment>
+              {alertName} {curentTrigger?.alertThreshold}%
+              {t(
+                ' %s in %s compared to the ',
+                incident.alertRule.thresholdType === AlertRuleThresholdType.ABOVE
+                  ? t('higher')
+                  : t('lower'),
+                timeWindow
+              )}
+              {COMPARISON_DELTA_OPTIONS.find(
+                ({value}) => value === incident.alertRule.comparisonDelta
+              )?.label ?? COMPARISON_DELTA_OPTIONS[0].label}
+            </Fragment>
+          )}
+        {/* If an alert rule is a static detection type */}
+        {incident.alertRule.detectionType === 'static' && (
           <Fragment>
             {alertName}{' '}
             {incident.alertRule.thresholdType === AlertRuleThresholdType.ABOVE
@@ -138,6 +142,13 @@ function MetricAlertActivity({organization, incident}: MetricAlertActivityProps)
               : t('below')}{' '}
             {curentTrigger?.alertThreshold || '_'} {t('within')} {timeWindow}
             {activationBlock}
+          </Fragment>
+        )}
+        {/* If an alert rule is a dynamic detection type */}
+        {incident.alertRule.detectionType === 'dynamic' && (
+          <Fragment>
+            {t('Detected an anomaly in the query for ')}
+            {alertName}
           </Fragment>
         )}
       </Cell>

--- a/static/app/views/alerts/rules/metric/details/metricActivity.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricActivity.tsx
@@ -116,8 +116,8 @@ function MetricAlertActivity({organization, incident}: MetricAlertActivityProps)
         </Link>
       </Cell>
       <Cell>
-        {/* If an alert rule is a % detection type */}
-        {incident.alertRule.detectionType === 'percent' &&
+        {/* If an alert rule is a % comparison based detection type */}
+        {incident.alertRule.detectionType !== 'dynamic' &&
           incident.alertRule.comparisonDelta && (
             <Fragment>
               {alertName} {curentTrigger?.alertThreshold}%
@@ -134,16 +134,17 @@ function MetricAlertActivity({organization, incident}: MetricAlertActivityProps)
             </Fragment>
           )}
         {/* If an alert rule is a static detection type */}
-        {incident.alertRule.detectionType === 'static' && (
-          <Fragment>
-            {alertName}{' '}
-            {incident.alertRule.thresholdType === AlertRuleThresholdType.ABOVE
-              ? t('above')
-              : t('below')}{' '}
-            {curentTrigger?.alertThreshold || '_'} {t('within')} {timeWindow}
-            {activationBlock}
-          </Fragment>
-        )}
+        {incident.alertRule.detectionType !== 'dynamic' &&
+          incident.alertRule.detectionType === 'static' && (
+            <Fragment>
+              {alertName}{' '}
+              {incident.alertRule.thresholdType === AlertRuleThresholdType.ABOVE
+                ? t('above')
+                : t('below')}{' '}
+              {curentTrigger?.alertThreshold || '_'} {t('within')} {timeWindow}
+              {activationBlock}
+            </Fragment>
+          )}
         {/* If an alert rule is a dynamic detection type */}
         {incident.alertRule.detectionType === 'dynamic' && (
           <Fragment>

--- a/static/app/views/alerts/rules/metric/details/metricActivity.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricActivity.tsx
@@ -135,7 +135,7 @@ function MetricAlertActivity({organization, incident}: MetricAlertActivityProps)
           )}
         {/* If an alert rule is a static detection type */}
         {incident.alertRule.detectionType !== 'dynamic' &&
-          incident.alertRule.detectionType === 'static' && (
+          !incident.alertRule.comparisonDelta && (
             <Fragment>
               {alertName}{' '}
               {incident.alertRule.thresholdType === AlertRuleThresholdType.ABOVE


### PR DESCRIPTION
NOTE:

Comparison detection types are labeled "percent" currently
Crash Free rates are 'percent' (or may become 'percent' soon) because the values they are comparing are _percents_ - however we are _not_ comparing a _percent change_. instead Crash free rates are comparing static values that happen to be "percent values"

so for now - we check whether there's a comparison delta and whether the type is dynamic or not

![Screenshot 2024-09-12 at 4 22 28 PM](https://github.com/user-attachments/assets/13d0b928-fc62-4795-8398-2b3562148a87)
