### PR TITLE
fix(insights): move pagination for web vitals

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.tsx
@@ -305,11 +305,6 @@ export function PagePerformanceTable() {
           onSearch={handleSearch}
           defaultQuery={query}
         />
-        <StyledPagination
-          pageLinks={pageLinks}
-          disabled={isTransactionWebVitalsQueryLoading}
-          size="md"
-        />
         {/* The Pagination component disappears if pageLinks is not defined,
         which happens any time the table data is loading. So we render a
         disabled button bar if pageLinks is not defined to minimize ui shifting */}
@@ -342,6 +337,7 @@ export function PagePerformanceTable() {
             renderBodyCell,
           }}
         />
+        <Pagination pageLinks={pageLinks} disabled={isTransactionWebVitalsQueryLoading} />
       </GridContainer>
     </span>
   );
@@ -367,9 +363,7 @@ const AlignCenter = styled('span')`
 `;
 
 const SearchBarContainer = styled('div')`
-  display: flex;
-  margin-bottom: ${space(1)};
-  gap: ${space(1)};
+  margin-bottom: ${space(2)};
 `;
 
 const GridContainer = styled('div')`
@@ -382,10 +376,6 @@ const TooltipHeader = styled('span')`
 
 const StyledSearchBar = styled(SearchBar)`
   flex-grow: 1;
-`;
-
-const StyledPagination = styled(Pagination)`
-  margin: 0;
 `;
 
 const Wrapper = styled('div')`

--- a/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.tsx
@@ -305,6 +305,20 @@ export function PagePerformanceTable() {
           onSearch={handleSearch}
           defaultQuery={query}
         />
+      </SearchBarContainer>
+      <GridContainer>
+        <GridEditable
+          aria-label={t('Pages')}
+          isLoading={isTransactionWebVitalsQueryLoading}
+          columnOrder={columnOrder}
+          columnSortBy={[]}
+          data={tableData}
+          grid={{
+            renderHeadCell,
+            renderBodyCell,
+          }}
+        />
+        <Pagination pageLinks={pageLinks} disabled={isTransactionWebVitalsQueryLoading} />
         {/* The Pagination component disappears if pageLinks is not defined,
         which happens any time the table data is loading. So we render a
         disabled button bar if pageLinks is not defined to minimize ui shifting */}
@@ -324,20 +338,6 @@ export function PagePerformanceTable() {
             </ButtonBar>
           </Wrapper>
         )}
-      </SearchBarContainer>
-      <GridContainer>
-        <GridEditable
-          aria-label={t('Pages')}
-          isLoading={isTransactionWebVitalsQueryLoading}
-          columnOrder={columnOrder}
-          columnSortBy={[]}
-          data={tableData}
-          grid={{
-            renderHeadCell,
-            renderBodyCell,
-          }}
-        />
-        <Pagination pageLinks={pageLinks} disabled={isTransactionWebVitalsQueryLoading} />
       </GridContainer>
     </span>
   );

--- a/static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx
@@ -558,7 +558,9 @@ const NoValue = styled('span')`
 `;
 
 const SearchBarContainer = styled('div')`
+  display: flex;
   margin-bottom: ${space(2)};
+  gap: ${space(1)};
 `;
 
 const StyledSearchBar = styled('div')`

--- a/static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx
@@ -474,35 +474,6 @@ export function PageSamplePerformanceTable({transaction, search, limit = 9}: Pro
             />
           )}
         </StyledSearchBar>
-
-        <StyledPagination
-          pageLinks={
-            datatype === Datatype.INTERACTIONS ? interactionsPageLinks : pageLinks
-          }
-          disabled={
-            datatype === Datatype.INTERACTIONS ? isInteractionsLoading : isLoading
-          }
-          size="md"
-        />
-        {/* The Pagination component disappears if pageLinks is not defined,
-        which happens any time the table data is loading. So we render a
-        disabled button bar if pageLinks is not defined to minimize ui shifting */}
-        {!(datatype === Datatype.INTERACTIONS ? interactionsPageLinks : pageLinks) && (
-          <Wrapper>
-            <ButtonBar merged>
-              <Button
-                icon={<IconChevron direction="left" />}
-                disabled
-                aria-label={t('Previous')}
-              />
-              <Button
-                icon={<IconChevron direction="right" />}
-                disabled
-                aria-label={t('Next')}
-              />
-            </ButtonBar>
-          </Wrapper>
-        )}
       </SearchBarContainer>
       {datatype === Datatype.PAGELOADS && (
         <GridEditable
@@ -529,6 +500,29 @@ export function PageSamplePerformanceTable({transaction, search, limit = 9}: Pro
           }}
           minimumColWidth={70}
         />
+      )}
+      <StyledPagination
+        pageLinks={datatype === Datatype.INTERACTIONS ? interactionsPageLinks : pageLinks}
+        disabled={datatype === Datatype.INTERACTIONS ? isInteractionsLoading : isLoading}
+      />
+      {/* The Pagination component disappears if pageLinks is not defined,
+        which happens any time the table data is loading. So we render a
+        disabled button bar if pageLinks is not defined to minimize ui shifting */}
+      {!(datatype === Datatype.INTERACTIONS ? interactionsPageLinks : pageLinks) && (
+        <Wrapper>
+          <ButtonBar merged>
+            <Button
+              icon={<IconChevron direction="left" />}
+              disabled
+              aria-label={t('Previous')}
+            />
+            <Button
+              icon={<IconChevron direction="right" />}
+              disabled
+              aria-label={t('Next')}
+            />
+          </ButtonBar>
+        </Wrapper>
       )}
     </span>
   );
@@ -564,10 +558,7 @@ const NoValue = styled('span')`
 `;
 
 const SearchBarContainer = styled('div')`
-  display: flex;
-  margin-top: ${space(2)};
-  margin-bottom: ${space(1)};
-  gap: ${space(1)};
+  margin-bottom: ${space(2)};
 `;
 
 const StyledSearchBar = styled('div')`

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
@@ -280,5 +280,5 @@ const PageSamplePerformanceTableContainer = styled('div')`
 `;
 
 const WebVitalMetersContainer = styled('div')`
-  margin: ${space(2)} 0 ${space(4)} 0;
+  margin: ${space(2)} 0;
 `;

--- a/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
+++ b/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
@@ -196,7 +196,7 @@ const MainContentContainer = styled('div')`
 `;
 
 const WebVitalMetersContainer = styled('div')`
-  margin-bottom: ${space(4)};
+  margin-bottom: ${space(2)};
 `;
 
 export const AlertContent = styled('div')`


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/76065

1. Move pagination to bottom of page within in web vitals module, this is consistent with every other table in insights (and perhaps sentry as a whole)
2. Also makes the spacing above/below the search bar, consistent with queries and requests module.

Before
<img width="1286" alt="image" src="https://github.com/user-attachments/assets/f6fa09e9-c7f9-4723-b3b4-1956ac20c94b">

After
<img width="1289" alt="image" src="https://github.com/user-attachments/assets/cdf0a8de-27cb-48f9-b2b4-b9350fe62c7d">
