### PR TITLE
ref(ownership): remove premunge option

### DIFF
--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -361,9 +361,8 @@ class ProjectOwnership(Model):
     ) -> Sequence[Rule]:
         rules = []
         if ownership.schema is not None:
-            munged_data = None
-            if options.get("ownership.munge_data_for_performance"):
-                munged_data = Matcher.munge_if_needed(data)
+            munged_data = Matcher.munge_if_needed(data)
+
             for rule in load_schema(ownership.schema):
                 if rule.test(data, munged_data):
                     rules.append(rule)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2706,10 +2706,3 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-
-register(
-    "ownership.munge_data_for_performance",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -141,8 +141,8 @@ class Matcher(namedtuple("Matcher", "type pattern")):
         self, data: PathSearchable, munged_data: tuple[Sequence[Mapping[str, Any]], Sequence[str]]
     ) -> bool:
         """
-        Temporary function to test pre-munging data performance in production. will remove
-        and combine with test if prod deployment goes well.
+        A function for optimized performance which can take in the pre-munged data.
+        functionalty equivalent to test() but faster when used repeatedly.
         """
         if self.type == URL:
             return self.test_url(data)


### PR DESCRIPTION
our test of improved ownership evaluation with only munging data once was a success https://app.datadoghq.com/metric/explorer?fromUser=false&start=1726079473808&end=1726080373808&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKHsTIWiIFWAB0DhoITvLaONkaGnWMGCJQaHBOOGAiOk4YnRwi6jV1FcAAVDx1bWhoePIAFBUAlCA8ALpUru54mKHhJ6pnGDGl8ftHIE1YAzIg8hgDCAg5STgwJyZc4aCCZRJoUSDOSKZTpSFQCFQpz0JjKERuDxofb8CD2TBYJwwv6Q0aPHh8Z7ySEIADCUmEMBQIjOaB4QA

this PR removes the option and uses it by default.