### PR TITLE
fix(alerts): properly expose validation errors

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -842,7 +842,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
             : Object.values(err?.responseJSON)
           : [];
         let apiErrors = '';
-        if (typeof errors[0] === 'object') {
+        if (typeof errors[0] === 'object' && !Array.isArray(errors[0])) {
           // NOTE: this occurs if we get a TimeoutError when attempting to hit the Seer API
           apiErrors = ': ' + errors[0].message;
         } else {


### PR DESCRIPTION
The logic as it was was leading to some validation errors being exposed as undefined. Open to better solutions to check for timeout errors (which are something like `[{"message": "timeout occurred", "status": 408}]`.