### PR TITLE
feat(explore): Go to eap spans for timeseries

### DIFF
--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -12,6 +12,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
 import {useChartType} from 'sentry/views/explore/hooks/useChartType';
+import {useDataset} from 'sentry/views/explore/hooks/useDataset';
 import {useVisualizes} from 'sentry/views/explore/hooks/useVisualizes';
 import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
 import ChartPanel from 'sentry/views/insights/common/components/chartPanel';
@@ -40,6 +41,8 @@ const exploreChartTypeOptions = [
 // TODO: Update to support aggregate mode and multiple queries / visualizations
 export function ExploreCharts({query}: ExploreChartsProps) {
   const pageFilters = usePageFilters();
+
+  const [dataset] = useDataset();
   const [visualizes] = useVisualizes();
   const [chartType, setChartType] = useChartType();
   const [interval, setInterval, intervalOptions] = useChartInterval();
@@ -57,7 +60,8 @@ export function ExploreCharts({query}: ExploreChartsProps) {
       interval: interval ?? getInterval(pageFilters.selection.datetime, 'metrics'),
       enabled: true,
     },
-    'api.explorer.stats'
+    'api.explorer.stats',
+    dataset
   );
 
   return (

--- a/static/app/views/explore/hooks/useDataset.tsx
+++ b/static/app/views/explore/hooks/useDataset.tsx
@@ -25,10 +25,10 @@ function useDatasetImpl({
 }: Options): [DiscoverDatasets, (dataset: DiscoverDatasets) => void] {
   const dataset: DiscoverDatasets = useMemo(() => {
     const rawDataset = decodeScalar(location.query.dataset);
-    if (rawDataset === 'spans') {
-      return DiscoverDatasets.SPANS_EAP;
+    if (rawDataset === 'spansIndexed') {
+      return DiscoverDatasets.SPANS_INDEXED;
     }
-    return DiscoverDatasets.SPANS_INDEXED;
+    return DiscoverDatasets.SPANS_EAP;
   }, [location.query.dataset]);
 
   const setDataset = useCallback(

--- a/static/app/views/explore/toolbar/toolbarDataset.tsx
+++ b/static/app/views/explore/toolbar/toolbarDataset.tsx
@@ -21,11 +21,11 @@ export function ToolbarDataset({dataset, setDataset}: ToolbarDatasetProps) {
         value={dataset}
         onChange={setDataset}
       >
-        <SegmentedControl.Item key={DiscoverDatasets.SPANS_INDEXED}>
-          {t('Indexed Spans')}
-        </SegmentedControl.Item>
         <SegmentedControl.Item key={DiscoverDatasets.SPANS_EAP}>
           {t('EAP Spans')}
+        </SegmentedControl.Item>
+        <SegmentedControl.Item key={DiscoverDatasets.SPANS_INDEXED}>
+          {t('Indexed Spans')}
         </SegmentedControl.Item>
       </SegmentedControl>
     </ToolbarSection>

--- a/static/app/views/insights/common/queries/useDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.ts
@@ -48,9 +48,14 @@ export const useSpanIndexedSeries = <
   Fields extends SpanIndexedField[] | SpanFunctions[] | string[],
 >(
   options: UseMetricsSeriesOptions<Fields> = {},
-  referrer: string
+  referrer: string,
+  dataset?: DiscoverDatasets
 ) => {
-  return useDiscoverSeries<Fields>(options, DiscoverDatasets.SPANS_INDEXED, referrer);
+  return useDiscoverSeries<Fields>(
+    options,
+    dataset ?? DiscoverDatasets.SPANS_INDEXED,
+    referrer
+  );
 };
 
 const useDiscoverSeries = <T extends string[]>(


### PR DESCRIPTION
This switches the explore charts to use eap spans for timeseries.