### PR TITLE
ref(issue-details): Move Issues tabs to data sections

### DIFF
--- a/static/app/views/issueDetails/groupMerged/index.spec.tsx
+++ b/static/app/views/issueDetails/groupMerged/index.spec.tsx
@@ -54,10 +54,6 @@ describe('Issues -> Merged View', function () {
         project={project}
         params={{orgId: 'orgId', groupId: 'groupId'}}
         location={router.location}
-        routeParams={{}}
-        route={{}}
-        routes={router.routes}
-        router={router}
       />,
       {router}
     );
@@ -81,10 +77,6 @@ describe('Issues -> Merged View', function () {
         project={project}
         params={{orgId: 'orgId', groupId: 'groupId'}}
         location={router.location}
-        routeParams={{}}
-        route={{}}
-        routes={router.routes}
-        router={router}
       />,
       {router}
     );

--- a/static/app/views/issueDetails/groupMerged/index.tsx
+++ b/static/app/views/issueDetails/groupMerged/index.tsx
@@ -19,9 +19,9 @@ import withOrganization from 'sentry/utils/withOrganization';
 
 import MergedList from './mergedList';
 
-type Props = RouteComponentProps<
-  {groupId: Group['id']; orgId: Organization['slug']},
-  {}
+type Props = Pick<
+  RouteComponentProps<{groupId: Group['id']; orgId: Organization['slug']}, {}>,
+  'params' | 'location'
 > & {
   organization: Organization;
   project: Project;

--- a/static/app/views/issueDetails/groupMerged/mergedIssuesDataSection.tsx
+++ b/static/app/views/issueDetails/groupMerged/mergedIssuesDataSection.tsx
@@ -1,0 +1,32 @@
+import {t} from 'sentry/locale';
+import type {Group} from 'sentry/types/group';
+import type {Project} from 'sentry/types/project';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import GroupMergedView from 'sentry/views/issueDetails/groupMerged';
+import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
+import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
+
+interface MergedIssuesDataSectionProps {
+  group: Group;
+  project: Project;
+}
+
+export function MergedIssuesDataSection({project, group}: MergedIssuesDataSectionProps) {
+  const organization = useOrganization();
+  const location = useLocation();
+
+  return (
+    <FoldSection sectionKey={SectionKey.MERGED_ISSUES} title={t('Merged Issues')}>
+      <GroupMergedView
+        project={project}
+        params={{
+          groupId: group.id,
+          orgId: organization.id,
+        }}
+        organization={organization}
+        location={location}
+      />
+    </FoldSection>
+  );
+}

--- a/static/app/views/issueDetails/groupMerged/mergedIssuesDataSection.tsx
+++ b/static/app/views/issueDetails/groupMerged/mergedIssuesDataSection.tsx
@@ -17,7 +17,11 @@ export function MergedIssuesDataSection({project, group}: MergedIssuesDataSectio
   const location = useLocation();
 
   return (
-    <FoldSection sectionKey={SectionKey.MERGED_ISSUES} title={t('Merged Issues')}>
+    <FoldSection
+      sectionKey={SectionKey.MERGED_ISSUES}
+      title={t('Merged Issues')}
+      initialCollapse
+    >
       <GroupMergedView
         project={project}
         params={{

--- a/static/app/views/issueDetails/groupRelatedIssues/index.spec.tsx
+++ b/static/app/views/issueDetails/groupRelatedIssues/index.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -9,7 +8,6 @@ describe('Related Issues View', function () {
   let sameRootIssuesMock: jest.Mock;
   let traceIssuesMock: jest.Mock;
   let issuesMock: jest.Mock;
-  const router = RouterFixture();
 
   const organization = OrganizationFixture();
   const orgSlug = organization.slug;
@@ -85,16 +83,7 @@ describe('Related Issues View', function () {
       body: issuesData,
     });
 
-    render(
-      <GroupRelatedIssues
-        params={params}
-        location={router.location}
-        router={router}
-        routeParams={router.params}
-        routes={router.routes}
-        route={{}}
-      />
-    );
+    render(<GroupRelatedIssues params={params} />);
 
     // Wait for the issues showing up on the table
     expect(await screen.findByText(`EARTH-${group1}`)).toBeInTheDocument();
@@ -123,16 +112,7 @@ describe('Related Issues View', function () {
       url: orgIssuesEndpoint,
       body: issuesData,
     });
-    render(
-      <GroupRelatedIssues
-        params={params}
-        location={router.location}
-        router={router}
-        routeParams={router.params}
-        routes={router.routes}
-        route={{}}
-      />
-    );
+    render(<GroupRelatedIssues params={params} />);
 
     // Wait for the issues showing up on the table
     expect(await screen.findByText(`EARTH-${group1}`)).toBeInTheDocument();

--- a/static/app/views/issueDetails/groupRelatedIssues/index.tsx
+++ b/static/app/views/issueDetails/groupRelatedIssues/index.tsx
@@ -16,7 +16,7 @@ type RouteParams = {
   groupId: string;
 };
 
-type Props = RouteComponentProps<RouteParams, {}>;
+type Props = Pick<RouteComponentProps<RouteParams, {}>, 'params'>;
 
 type RelatedIssuesResponse = {
   data: number[];

--- a/static/app/views/issueDetails/groupSimilarIssues/index.spec.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/index.spec.tsx
@@ -69,10 +69,6 @@ describe('Issues Similar View', function () {
         project={project}
         params={{orgId: 'org-slug', groupId: 'group-id'}}
         location={router.location}
-        router={router}
-        routeParams={router.params}
-        routes={router.routes}
-        route={{}}
       />,
       {router}
     );
@@ -98,10 +94,6 @@ describe('Issues Similar View', function () {
         project={project}
         params={{orgId: 'org-slug', groupId: 'group-id'}}
         location={router.location}
-        router={router}
-        routeParams={router.params}
-        routes={router.routes}
-        route={{}}
       />,
       {router}
     );
@@ -131,10 +123,6 @@ describe('Issues Similar View', function () {
         project={project}
         params={{orgId: 'org-slug', groupId: 'group-id'}}
         location={router.location}
-        router={router}
-        routeParams={router.params}
-        routes={router.routes}
-        route={{}}
       />,
       {router}
     );
@@ -162,10 +150,6 @@ describe('Issues Similar View', function () {
         project={project}
         params={{orgId: 'org-slug', groupId: 'group-id'}}
         location={router.location}
-        router={router}
-        routeParams={router.params}
-        routes={router.routes}
-        route={{}}
       />,
       {router}
     );
@@ -239,10 +223,6 @@ describe('Issues Similar Embeddings View', function () {
         project={project}
         params={{orgId: 'org-slug', groupId: 'group-id'}}
         location={router.location}
-        router={router}
-        routeParams={router.params}
-        routes={router.routes}
-        route={{}}
       />,
       {router}
     );
@@ -269,10 +249,6 @@ describe('Issues Similar Embeddings View', function () {
         project={project}
         params={{orgId: 'org-slug', groupId: 'group-id'}}
         location={router.location}
-        router={router}
-        routeParams={router.params}
-        routes={router.routes}
-        route={{}}
       />,
       {router}
     );
@@ -302,10 +278,6 @@ describe('Issues Similar Embeddings View', function () {
         project={project}
         params={{orgId: 'org-slug', groupId: 'group-id'}}
         location={router.location}
-        router={router}
-        routeParams={router.params}
-        routes={router.routes}
-        route={{}}
       />,
       {router}
     );
@@ -325,10 +297,6 @@ describe('Issues Similar Embeddings View', function () {
         project={project}
         params={{orgId: 'org-slug', groupId: 'group-id'}}
         location={router.location}
-        router={router}
-        routeParams={router.params}
-        routes={router.routes}
-        route={{}}
       />,
       {router}
     );
@@ -362,10 +330,6 @@ describe('Issues Similar Embeddings View', function () {
         project={project}
         params={{orgId: 'org-slug', groupId: 'group-id'}}
         location={router.location}
-        router={router}
-        routeParams={router.params}
-        routes={router.routes}
-        route={{}}
       />,
       {router}
     );

--- a/static/app/views/issueDetails/groupSimilarIssues/similarIssuesDataSection.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarIssuesDataSection.tsx
@@ -1,0 +1,34 @@
+import {t} from 'sentry/locale';
+import type {Group} from 'sentry/types/group';
+import type {Project} from 'sentry/types/project';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import GroupSimilarIssues from 'sentry/views/issueDetails/groupSimilarIssues';
+import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
+import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
+
+interface SimilarIssuesDataSectionProps {
+  group: Group;
+  project: Project;
+}
+
+export function SimilarIssuesDataSection({
+  project,
+  group,
+}: SimilarIssuesDataSectionProps) {
+  const organization = useOrganization();
+  const location = useLocation();
+
+  return (
+    <FoldSection sectionKey={SectionKey.SIMILAR_ISSUES} title={t('Similar Issues')}>
+      <GroupSimilarIssues
+        location={location}
+        params={{
+          groupId: group.id,
+          orgId: organization.id,
+        }}
+        project={project}
+      />
+    </FoldSection>
+  );
+}

--- a/static/app/views/issueDetails/groupSimilarIssues/similarIssuesDataSection.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarIssuesDataSection.tsx
@@ -20,7 +20,11 @@ export function SimilarIssuesDataSection({
   const location = useLocation();
 
   return (
-    <FoldSection sectionKey={SectionKey.SIMILAR_ISSUES} title={t('Similar Issues')}>
+    <FoldSection
+      sectionKey={SectionKey.SIMILAR_ISSUES}
+      title={t('Similar Issues')}
+      initialCollapse
+    >
       <GroupSimilarIssues
         location={location}
         params={{

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
@@ -25,7 +25,7 @@ type RouteParams = {
   orgId: string;
 };
 
-type Props = RouteComponentProps<RouteParams, {}> & {
+type Props = Pick<RouteComponentProps<RouteParams, {}>, 'params' | 'location'> & {
   location: Location;
   project: Project;
 };

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -38,7 +38,7 @@ import {useIssueDetailsHeader} from 'sentry/views/issueDetails/useIssueDetailsHe
 
 import GroupActions from './actions';
 import {Tab} from './types';
-import type {ReprocessingStatus} from './utils';
+import {type ReprocessingStatus, useHasStreamlinedUI} from './utils';
 
 type Props = {
   baseUrl: string;
@@ -63,6 +63,7 @@ export function GroupHeaderTabs({
 }: GroupHeaderTabsProps) {
   const organization = useOrganization();
   const location = useLocation();
+  const hasStreamlinedUI = useHasStreamlinedUI();
 
   const {getReplayCountForIssue} = useReplayCountForIssues({
     statsPeriod: '90d',
@@ -94,7 +95,73 @@ export function GroupHeaderTabs({
     }
   }, [group.issueType, organization]);
 
-  return (
+  return hasStreamlinedUI ? (
+    <StyledTabList hideBorder>
+      <TabList.Item
+        key={Tab.DETAILS}
+        disabled={disabledTabs.includes(Tab.DETAILS)}
+        to={`${baseUrl}${location.search}`}
+      >
+        {t('Details')}
+      </TabList.Item>
+      <TabList.Item
+        key={Tab.ACTIVITY}
+        textValue={t('Activity')}
+        disabled={disabledTabs.includes(Tab.ACTIVITY)}
+        to={{pathname: `${baseUrl}activity/`, query: queryParams}}
+      >
+        {t('Activity')}
+        <IconBadge>
+          {group.numComments}
+          <IconChat size="xs" />
+        </IconBadge>
+      </TabList.Item>
+      <TabList.Item
+        key={Tab.USER_FEEDBACK}
+        textValue={t('User Feedback')}
+        hidden={!issueTypeConfig.userFeedback.enabled}
+        disabled={disabledTabs.includes(Tab.USER_FEEDBACK)}
+        to={{pathname: `${baseUrl}feedback/`, query: queryParams}}
+      >
+        {t('User Feedback')} <Badge text={group.userReportCount} />
+      </TabList.Item>
+      <TabList.Item
+        key={Tab.ATTACHMENTS}
+        hidden={!hasEventAttachments || !issueTypeConfig.attachments.enabled}
+        disabled={disabledTabs.includes(Tab.ATTACHMENTS)}
+        to={{pathname: `${baseUrl}attachments/`, query: queryParams}}
+      >
+        {t('Attachments')}
+      </TabList.Item>
+      <TabList.Item
+        key={Tab.TAGS}
+        hidden={!issueTypeConfig.tags.enabled}
+        disabled={disabledTabs.includes(Tab.TAGS)}
+        to={{pathname: `${baseUrl}tags/`, query: queryParams}}
+      >
+        {t('Tags')}
+      </TabList.Item>
+      <TabList.Item
+        key={Tab.EVENTS}
+        hidden={!issueTypeConfig.events.enabled}
+        disabled={disabledTabs.includes(Tab.EVENTS)}
+        to={eventRoute}
+      >
+        {group.issueCategory === IssueCategory.ERROR
+          ? t('All Events')
+          : t('Sampled Events')}
+      </TabList.Item>
+      <TabList.Item
+        key={Tab.REPLAYS}
+        textValue={t('Replays')}
+        hidden={!hasReplaySupport || !issueTypeConfig.replays.enabled}
+        to={{pathname: `${baseUrl}replays/`, query: queryParams}}
+      >
+        {t('Replays')}
+        <ReplayCountBadge count={replaysCount} />
+      </TabList.Item>
+    </StyledTabList>
+  ) : (
     <StyledTabList hideBorder>
       <TabList.Item
         key={Tab.DETAILS}

--- a/static/app/views/issueDetails/streamline/context.tsx
+++ b/static/app/views/issueDetails/streamline/context.tsx
@@ -55,6 +55,9 @@ export const enum SectionKey {
   PROCESSING_ERROR = 'processing-error',
   RRWEB = 'rrweb', // Legacy integration prior to replays
 
+  MERGED_ISSUES = 'merged',
+  SIMILAR_ISSUES = 'similar',
+
   REGRESSION_SUMMARY = 'regression-summary',
   REGRESSION_BREAKPOINT_CHART = 'regression-breakpoint-chart',
   REGRESSION_FLAMEGRAPH = 'regression-flamegraph',

--- a/static/app/views/issueDetails/streamline/eventDetails.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetails.spec.tsx
@@ -13,6 +13,7 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import {EventDetails} from 'sentry/views/issueDetails/streamline/eventDetails';
 
 jest.mock('sentry/views/issueDetails/groupEventDetails/groupEventDetailsContent');
+jest.mock('sentry/views/issueDetails/streamline/issueContent');
 jest.mock('screenfull', () => ({
   enabled: true,
   isFullscreen: false,

--- a/static/app/views/issueDetails/streamline/eventDetails.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetails.tsx
@@ -28,8 +28,8 @@ import {
   EventSearch,
   useEventQuery,
 } from 'sentry/views/issueDetails/streamline/eventSearch';
-import {useFetchEventStats} from 'sentry/views/issueDetails/streamline/useFetchEventStats';
 import {IssueContent} from 'sentry/views/issueDetails/streamline/issueContent';
+import {useFetchEventStats} from 'sentry/views/issueDetails/streamline/useFetchEventStats';
 
 export function EventDetails({
   group,

--- a/static/app/views/issueDetails/streamline/eventDetails.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetails.tsx
@@ -29,6 +29,7 @@ import {
   useEventQuery,
 } from 'sentry/views/issueDetails/streamline/eventSearch';
 import {useFetchEventStats} from 'sentry/views/issueDetails/streamline/useFetchEventStats';
+import {IssueContent} from 'sentry/views/issueDetails/streamline/issueContent';
 
 export function EventDetails({
   group,
@@ -119,10 +120,15 @@ export function EventDetails({
           ref={setNav}
           query={searchQuery}
         />
-        <GroupContentPadding>
+        <ContentPadding>
           <EventDetailsContent group={group} event={event} project={project} />
-        </GroupContentPadding>
+        </ContentPadding>
       </GroupContent>
+      <ExtraContent>
+        <ContentPadding>
+          <IssueContent group={group} project={project} />
+        </ContentPadding>
+      </ExtraContent>
     </EventDetailsContext.Provider>
   );
 }
@@ -153,14 +159,16 @@ const GraphAlert = styled(Alert)`
   border: 1px solid ${p => p.theme.translucentBorder};
 `;
 
-const GroupContent = styled('div')<{navHeight?: number}>`
+const ExtraContent = styled('div')`
   border: 1px solid ${p => p.theme.translucentBorder};
   background: ${p => p.theme.background};
   border-radius: ${p => p.theme.borderRadius};
-  position: relative;
 `;
 
-const GroupContentPadding = styled('div')`
+const GroupContent = styled(ExtraContent)<{navHeight?: number}>`
+  position: relative;
+`;
+const ContentPadding = styled('div')`
   padding: ${space(1)} ${space(1.5)};
 `;
 

--- a/static/app/views/issueDetails/streamline/eventDetails.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetails.tsx
@@ -113,7 +113,7 @@ export function EventDetails({
       ) : (
         graphComponent
       )}
-      <GroupContent navHeight={nav?.offsetHeight}>
+      <GroupContent>
         <FloatingEventNavigation
           event={event}
           group={group}
@@ -165,9 +165,10 @@ const ExtraContent = styled('div')`
   border-radius: ${p => p.theme.borderRadius};
 `;
 
-const GroupContent = styled(ExtraContent)<{navHeight?: number}>`
+const GroupContent = styled(ExtraContent)`
   position: relative;
 `;
+
 const ContentPadding = styled('div')`
   padding: ${space(1)} ${space(1.5)};
 `;

--- a/static/app/views/issueDetails/streamline/eventGraph.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.spec.tsx
@@ -16,6 +16,7 @@ import {EventDetails} from 'sentry/views/issueDetails/streamline/eventDetails';
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/components/events/suspectCommits');
 jest.mock('sentry/views/issueDetails/groupEventDetails/groupEventDetailsContent');
+jest.mock('sentry/views/issueDetails/streamline/issueContent');
 jest.mock('screenfull', () => ({
   enabled: true,
   isFullscreen: false,

--- a/static/app/views/issueDetails/streamline/issueContent.spec.tsx
+++ b/static/app/views/issueDetails/streamline/issueContent.spec.tsx
@@ -1,0 +1,48 @@
+import {EventFixture} from 'sentry-fixture/event';
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {IssueContent} from 'sentry/views/issueDetails/streamline/issueContent';
+
+describe('IssueContent', () => {
+  const organization = OrganizationFixture();
+  const project = ProjectFixture({features: ['similarity-view']});
+  const group = GroupFixture();
+  const event = EventFixture();
+
+  let mockMergedIssues;
+  let mockSimilarIssues;
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    mockMergedIssues = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/hashes/?limit=50&query=`,
+      body: [
+        {
+          latestEvent: event,
+          state: 'unlocked',
+          id: '2c4887696f708c476a81ce4e834c4b02',
+        },
+      ],
+      method: 'GET',
+    });
+    mockSimilarIssues = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.id}/issues/${group.id}/similar/?limit=50`,
+      body: [[group, {'exception:stacktrace:pairs': 0.375}]],
+      method: 'GET',
+    });
+  });
+
+  it('displays the extra data sections', async function () {
+    render(<IssueContent group={group} project={project} />, {organization});
+    expect(await screen.findByText('Merged Issues')).toBeInTheDocument();
+    expect(screen.getByText('Fingerprints included in this issue')).toBeInTheDocument();
+    expect(mockMergedIssues).toHaveBeenCalled();
+    expect(await screen.findByText('Similar Issues')).toBeInTheDocument();
+    expect(screen.getByText('Issues with a similar stack trace')).toBeInTheDocument();
+    expect(mockSimilarIssues).toHaveBeenCalled();
+  });
+});

--- a/static/app/views/issueDetails/streamline/issueContent.spec.tsx
+++ b/static/app/views/issueDetails/streamline/issueContent.spec.tsx
@@ -3,7 +3,7 @@ import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {IssueContent} from 'sentry/views/issueDetails/streamline/issueContent';
 
@@ -36,12 +36,24 @@ describe('IssueContent', () => {
     });
   });
 
-  it('displays the extra data sections', async function () {
+  it('displays the extra data sections as closed by default', async function () {
     render(<IssueContent group={group} project={project} />, {organization});
-    expect(await screen.findByText('Merged Issues')).toBeInTheDocument();
+
+    const mergedIssues = await screen.findByText('Merged Issues');
+    expect(mergedIssues).toBeInTheDocument();
+    expect(
+      screen.queryByText('Fingerprints included in this issue')
+    ).not.toBeInTheDocument();
+    await userEvent.click(mergedIssues);
     expect(screen.getByText('Fingerprints included in this issue')).toBeInTheDocument();
     expect(mockMergedIssues).toHaveBeenCalled();
-    expect(await screen.findByText('Similar Issues')).toBeInTheDocument();
+
+    const similarIssues = await screen.findByText('Similar Issues');
+    expect(similarIssues).toBeInTheDocument();
+    expect(
+      screen.queryByText('Issues with a similar stack trace')
+    ).not.toBeInTheDocument();
+    await userEvent.click(similarIssues);
     expect(screen.getByText('Issues with a similar stack trace')).toBeInTheDocument();
     expect(mockSimilarIssues).toHaveBeenCalled();
   });

--- a/static/app/views/issueDetails/streamline/issueContent.tsx
+++ b/static/app/views/issueDetails/streamline/issueContent.tsx
@@ -1,0 +1,20 @@
+import {Fragment} from 'react';
+
+import type {Group} from 'sentry/types/group';
+import type {Project} from 'sentry/types/project';
+import {MergedIssuesDataSection} from 'sentry/views/issueDetails/groupMerged/mergedIssuesDataSection';
+import {SimilarIssuesDataSection} from 'sentry/views/issueDetails/groupSimilarIssues/similarIssuesDataSection';
+
+export interface IssueContentProps {
+  group: Group;
+  project: Project;
+}
+
+export function IssueContent({group, project}: IssueContentProps) {
+  return (
+    <Fragment>
+      <MergedIssuesDataSection group={group} project={project} />
+      <SimilarIssuesDataSection group={group} project={project} />
+    </Fragment>
+  );
+}


### PR DESCRIPTION
Converts the tabs to folding data sections. They are rendered as is, and we can introduce new designs if we have more time later on, but for now, styling and text sizes are the same.


![image](https://github.com/user-attachments/assets/2581519f-214d-4b30-bf07-9d1cbe2412da)

![image](https://github.com/user-attachments/assets/8e5f68ae-21b4-4641-ac15-eab026b310c7)

![image](https://github.com/user-attachments/assets/195e1241-67e2-4432-a456-a653901c6c86)

**todo**
- [x] Add tests for their new location
- [ ] Figure out subrouting so directly linking to `/merged` and `/similar` does something expected