### PR TITLE
fix(replay): Move timeline grid-column to style tag

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -39,7 +39,7 @@ export default function ReplayTimelineEvents({
   return (
     <Timeline.Columns className={className} totalColumns={totalColumns} remainder={0}>
       {Array.from(framesByCol.entries()).map(([column, colFrames]) => (
-        <EventColumn key={column} column={column}>
+        <EventColumn key={column} style={{gridColumn: Math.floor(column)}}>
           <Event
             frames={colFrames}
             markerWidth={markerWidth}
@@ -51,8 +51,7 @@ export default function ReplayTimelineEvents({
   );
 }
 
-const EventColumn = styled(Timeline.Col)<{column: number}>`
-  grid-column: ${p => Math.floor(p.column)};
+const EventColumn = styled(Timeline.Col)`
   place-items: stretch;
   display: grid;
   align-items: center;


### PR DESCRIPTION
Since each dot is in its own column, this change prevents inserting an emotion style for each dot. I saw this when i was creating the issues timeline and never got around to fixing it.
