### PR TITLE
fix(insights): Fixes alerts serializer failing for some insights functions with special arguments

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1821,6 +1821,17 @@ TRANSLATABLE_COLUMNS = {
     "dist": "tags[sentry:dist]",
     "release": "tags[sentry:release]",
 }
+INSIGHTS_FUNCTION_VALID_ARGS_MAP = {
+    "http_response_rate": ["3", "4", "5"],
+    "performance_score": [
+        "measurements.score.lcp",
+        "measurements.score.fcp",
+        "measurements.score.inp",
+        "measurements.score.cls",
+        "measurements.score.ttfb",
+        "measurements.score.total",
+    ],
+}
 
 
 def get_column_from_aggregate(aggregate: str, allow_mri: bool) -> str | None:
@@ -1868,12 +1879,15 @@ def _get_column_from_aggregate_with_mri(aggregate: str) -> str | None:
 def check_aggregate_column_support(aggregate: str, allow_mri: bool = False) -> bool:
     # TODO(ddm): remove `allow_mri` once the experimental feature flag is removed.
     column = get_column_from_aggregate(aggregate, allow_mri)
+    match = is_function(aggregate)
+    function = match.group("function") if match else None
     return (
         column is None
         or is_measurement(column)
         or column in SUPPORTED_COLUMNS
         or column in TRANSLATABLE_COLUMNS
         or (is_mri(column) and allow_mri)
+        or (column in INSIGHTS_FUNCTION_VALID_ARGS_MAP.get(function, []))
     )
 
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1887,7 +1887,10 @@ def check_aggregate_column_support(aggregate: str, allow_mri: bool = False) -> b
         or column in SUPPORTED_COLUMNS
         or column in TRANSLATABLE_COLUMNS
         or (is_mri(column) and allow_mri)
-        or (column in INSIGHTS_FUNCTION_VALID_ARGS_MAP.get(function, []))
+        or (
+            isinstance(function, str)
+            and column in INSIGHTS_FUNCTION_VALID_ARGS_MAP.get(function, [])
+        )
     )
 
 


### PR DESCRIPTION
Some Insights functions have use special arguments that do not pass the existing column argument validation. For example `http_response_rate(3)` fails because `3` is not a valid measurement, supported column, or mri, etc.

This change adds a mapping of Insights functions and their arguments for the alerts serializer to check against, so that these Insights functions no longer fail when valid.