### PR TITLE
fix(insights): Queries module page filters did not include `span.system`

### DIFF
--- a/static/app/views/insights/common/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/actionSelector.tsx
@@ -21,16 +21,23 @@ const {SPAN_ACTION} = SpanMetricsField;
 
 type Props = {
   moduleName: ModuleName;
+  filters?: Record<string, string>;
   spanCategory?: string;
   value?: string;
 };
 
-export function ActionSelector({value = '', moduleName, spanCategory}: Props) {
+export function ActionSelector({value = '', moduleName, spanCategory, filters}: Props) {
   // TODO: This only returns the top 25 actions. It should either load them all, or paginate, or allow searching
   //
   const location = useLocation();
   const organization = useOrganization();
   const eventView = getEventView(location, moduleName, spanCategory);
+
+  if (filters) {
+    Object.keys(filters).forEach(key =>
+      eventView.additionalConditions.addFilterValue(key, filters[key])
+    );
+  }
 
   const useHTTPActions = moduleName === ModuleName.HTTP;
 

--- a/static/app/views/insights/common/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/actionSelector.tsx
@@ -34,8 +34,8 @@ export function ActionSelector({value = '', moduleName, spanCategory, filters}: 
   const eventView = getEventView(location, moduleName, spanCategory);
 
   if (filters) {
-    Object.keys(filters).forEach(key =>
-      eventView.additionalConditions.addFilterValue(key, filters[key])
+    Object.entries(filters).forEach(([key, val]) =>
+      eventView.additionalConditions.addFilterValue(key, val)
     );
   }
 

--- a/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
@@ -104,7 +104,13 @@ export function DomainSelector({
 
   useEffect(() => {
     clearDomainOptionsCache();
-  }, [pageFilters.selection.projects, clearDomainOptionsCache, additionalQuery]);
+  }, [pageFilters.selection.projects, clearDomainOptionsCache]);
+
+  useEffect(() => {
+    if (additionalQuery.length > 0) {
+      clearDomainOptionsCache();
+    }
+  }, [additionalQuery, clearDomainOptionsCache]);
 
   const emptyOption = {
     value: EMPTY_OPTION_VALUE,

--- a/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
@@ -104,7 +104,7 @@ export function DomainSelector({
 
   useEffect(() => {
     clearDomainOptionsCache();
-  }, [pageFilters.selection.projects, clearDomainOptionsCache]);
+  }, [pageFilters.selection.projects, clearDomainOptionsCache, additionalQuery]);
 
   const emptyOption = {
     value: EMPTY_OPTION_VALUE,

--- a/static/app/views/insights/database/components/databasePageFilters.tsx
+++ b/static/app/views/insights/database/components/databasePageFilters.tsx
@@ -1,3 +1,4 @@
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
@@ -22,6 +23,8 @@ export function DatabasePageFilters(props: Props) {
 
   const {system, databaseCommand, table} = props;
 
+  const additionalQuery = useMemo(() => [`span.system:${system}`], [system]);
+
   return (
     <PageFilterWrapper>
       <ModulePageFilterBar moduleName={ModuleName.DB} />
@@ -40,7 +43,7 @@ export function DatabasePageFilters(props: Props) {
           domainAlias={
             system === SupportedDatabaseSystems.MONGODB ? t('Collection') : t('Table')
           }
-          additionalQuery={[`span.system:${system}`]}
+          additionalQuery={additionalQuery}
         />
       </PageFilterBar>
     </PageFilterWrapper>

--- a/static/app/views/insights/database/components/databasePageFilters.tsx
+++ b/static/app/views/insights/database/components/databasePageFilters.tsx
@@ -29,13 +29,18 @@ export function DatabasePageFilters(props: Props) {
         {organization.features.includes('performance-queries-mongodb-extraction') && (
           <DatabaseSystemSelector />
         )}
-        <ActionSelector moduleName={ModuleName.DB} value={databaseCommand ?? ''} />
+        <ActionSelector
+          moduleName={ModuleName.DB}
+          value={databaseCommand ?? ''}
+          filters={{'span.system': system}}
+        />
         <DomainSelector
           moduleName={ModuleName.DB}
           value={table ?? ''}
           domainAlias={
             system === SupportedDatabaseSystems.MONGODB ? t('Collection') : t('Table')
           }
+          additionalQuery={[`span.system:${system}`]}
         />
       </PageFilterBar>
     </PageFilterWrapper>

--- a/static/app/views/insights/database/components/databaseSystemSelector.tsx
+++ b/static/app/views/insights/database/components/databaseSystemSelector.tsx
@@ -6,7 +6,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useSystemSelectorOptions} from 'sentry/views/insights/database/components/useSystemSelectorOptions';
 import {SpanMetricsField} from 'sentry/views/insights/types';
 
-const {SPAN_SYSTEM} = SpanMetricsField;
+const {SPAN_SYSTEM, SPAN_DOMAIN, SPAN_ACTION} = SpanMetricsField;
 
 export function DatabaseSystemSelector() {
   const location = useLocation();
@@ -21,7 +21,16 @@ export function DatabaseSystemSelector() {
     <CompactSelect
       onChange={option => {
         setSelectedSystem(option.value);
-        navigate({...location, query: {...location.query, [SPAN_SYSTEM]: option.value}});
+        navigate({
+          ...location,
+          query: {
+            ...location.query,
+            [SPAN_SYSTEM]: option.value,
+            // Reset the table and command since they won't be valid if the DB system changes
+            [SPAN_DOMAIN]: null,
+            [SPAN_ACTION]: null,
+          },
+        });
       }}
       options={options}
       triggerProps={{prefix: t('DB System')}}

--- a/static/app/views/insights/database/components/databaseSystemSelector.tsx
+++ b/static/app/views/insights/database/components/databaseSystemSelector.tsx
@@ -27,8 +27,8 @@ export function DatabaseSystemSelector() {
             ...location.query,
             [SPAN_SYSTEM]: option.value,
             // Reset the table and command since they won't be valid if the DB system changes
-            [SPAN_DOMAIN]: null,
-            [SPAN_ACTION]: null,
+            [SPAN_DOMAIN]: undefined,
+            [SPAN_ACTION]: undefined,
           },
         });
       }}


### PR DESCRIPTION
Fixes an issue where the action (command) and domain (table) selectors in the DB module were not including the currently selected database system. With this change, the options for these page filters will only show DB commands and tables that are valid for the currently selected database system.