### PR TITLE
feat(insights): allow querying for user.geo.subregion in metrics

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -320,6 +320,7 @@ DEFAULT_METRIC_TAGS = {
     "device.class",
     "environment",
     "geo.country_code",
+    "user.geo.subregion",
     "has_profile",
     "histogram_outlier",
     "http.method",


### PR DESCRIPTION
TL:DR - this should allow us to query for user.geo.subregion in discover, when dataset=metrics


When querying for `user.geo.subregion` from the metrics dataset, i kept getting 
"user.geo.subregion is not a tag in the metrics dataset". This error only corresponds to this line, and it 
https://github.com/getsentry/sentry/blob/a9601b540fc155fc41142a9d106d555a62647c60/src/sentry/search/events/builder/metrics.py#L775
For this exception to not be raised, we can simply add this to the default_tags.