### PR TITLE
chore(anomaly detection): remove metrics from valid anomaly detection types

### DIFF
--- a/static/app/views/alerts/rules/metric/thresholdTypeForm.tsx
+++ b/static/app/views/alerts/rules/metric/thresholdTypeForm.tsx
@@ -47,8 +47,6 @@ function ThresholdTypeForm({
     'fid',
     'cls',
     'custom_transactions',
-    'custom_metrics',
-    'insights_metrics',
   ]);
 
   const hasAnomalyDetection = organization.features.includes('anomaly-detection-alerts');


### PR DESCRIPTION
Metrics are being killed in October, so we shouldn't enable anomaly detection alerts for them.