### PR TITLE
fix(alerts): Checks the alert rule to ensure it is not an insights alert before displaying the metrics beta end banner

### DIFF
--- a/static/app/views/alerts/rules/metric/details/body.tsx
+++ b/static/app/views/alerts/rules/metric/details/body.tsx
@@ -27,6 +27,7 @@ import MetricHistory from 'sentry/views/alerts/rules/metric/details/metricHistor
 import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
 import {Dataset, TimePeriod} from 'sentry/views/alerts/rules/metric/types';
 import {extractEventTypeFilterFromRule} from 'sentry/views/alerts/rules/metric/utils/getEventTypeFilter';
+import {isInsightsMetricAlert} from 'sentry/views/alerts/rules/metric/utils/isInsightsMetricAlert';
 import {isOnDemandMetricAlert} from 'sentry/views/alerts/rules/metric/utils/onDemandMetricAlert';
 import {getAlertRuleActionCategory} from 'sentry/views/alerts/rules/utils';
 import type {Anomaly, Incident} from 'sentry/views/alerts/types';
@@ -170,9 +171,10 @@ export default function MetricDetailsBody({
   return (
     <Fragment>
       <StyledLayoutBody>
-        {isCustomMetricAlert(rule.aggregate) && (
-          <MetricsBetaEndAlert style={{marginBottom: 0}} />
-        )}
+        {isCustomMetricAlert(rule.aggregate) &&
+          !isInsightsMetricAlert(rule.aggregate) && (
+            <MetricsBetaEndAlert style={{marginBottom: 0}} />
+          )}
       </StyledLayoutBody>
       {selectedIncident?.alertRule.status === AlertRuleStatus.SNAPSHOT && (
         <StyledLayoutBody>


### PR DESCRIPTION
Updates the Alert Rule detail page to check that the alert is not an Insights Alert before displaying the Metrics Beta end banner