### PR TITLE
fix(issue-details): Correct graphs on streamlined view

### DIFF
--- a/static/app/views/issueDetails/streamline/eventGraph.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.spec.tsx
@@ -39,6 +39,7 @@ describe('EventGraph', () => {
   });
   const group = GroupFixture();
   const event = EventFixture({id: 'event-id'});
+  const persistantQuery = ` issue:${group.shortId}`;
   const defaultProps = {project, group, event};
 
   let mockEventStats;
@@ -113,7 +114,7 @@ describe('EventGraph', () => {
           environment: [],
           interval: '12h',
           project: '2',
-          query: '',
+          query: persistantQuery,
           referrer: 'issue_details.streamline',
           statsPeriod: '14d',
           yAxis: ['count()', 'count_unique(user)'],
@@ -185,7 +186,7 @@ describe('EventGraph', () => {
       '/organizations/org-slug/events-stats/',
       expect.objectContaining({
         query: expect.objectContaining({
-          query: locationQuery.query.query,
+          query: locationQuery.query.query + persistantQuery,
         }),
       })
     );

--- a/static/app/views/issueDetails/streamline/useFetchEvents.tsx
+++ b/static/app/views/issueDetails/streamline/useFetchEvents.tsx
@@ -50,7 +50,7 @@ export function useFetchEventStats({
       ? DiscoverDatasets.ISSUE_PLATFORM
       : DiscoverDatasets.ERRORS,
     project: group.project.id,
-    query: query,
+    query: `${query} issue:${group.shortId}`,
   };
   const queryKey = makeFetchEventStatsQueryKey({
     organizationSlug: organization.slug,


### PR DESCRIPTION
The graphs on the streamlined issue details view omitted the only thing they needed to be somewhat accurate. That's on me lol. this should fix things up:

Before:

<img width="1499" alt="image" src="https://github.com/user-attachments/assets/620c1e74-7a54-4b67-9e91-6ee280715c1e">

After: 

<img width="1497" alt="image" src="https://github.com/user-attachments/assets/0ba7c314-01ef-4519-8178-42c677d3f01c">
