### PR TITLE
fix(alerts): Fix KeyError on AlertRuleThresholdType

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -548,9 +548,12 @@ class SubscriptionProcessor:
             return
 
         # OVER/UNDER value trigger
-        alert_operator, resolve_operator = self.THRESHOLD_TYPE_OPERATORS[
-            AlertRuleThresholdType(self.alert_rule.threshold_type)
-        ]
+        alert_operator = None
+        resolve_operator = None
+        if not potential_anomalies:
+            alert_operator, resolve_operator = self.THRESHOLD_TYPE_OPERATORS[
+                AlertRuleThresholdType(self.alert_rule.threshold_type)
+            ]
         fired_incident_triggers = []
         with transaction.atomic(router.db_for_write(AlertRule)):
             # Triggers is the threshold - NOT an instance of a trigger

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -306,6 +306,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             detection_type=AlertRuleDetectionType.DYNAMIC,
             sensitivity=AlertRuleSensitivity.HIGH,
             seasonality=AlertRuleSeasonality.AUTO,
+            threshold_type=AlertRuleThresholdType.ABOVE_AND_BELOW.value,
         )
         # dynamic alert rules have a threshold of 0.0
         self.trigger.update(alert_threshold=0)


### PR DESCRIPTION
We only read the `alert_operator` and `resolve_operator` for non-anomaly detection alerts (and only anomaly detection alerts would have above and below), so only set these if there are no `potential_anomalies`.

Fixes https://getsentry.atlassian.net/browse/ALRT-266
Closes SENTRY-3DSY