### PR TITLE
feat(query-builder): Add wildcard matching text to value menu footer

### DIFF
--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -11,6 +11,7 @@ import type {FieldDefinition} from 'sentry/utils/fields';
 
 export interface SearchQueryBuilderContextData {
   disabled: boolean;
+  disallowWildcard: boolean;
   dispatch: Dispatch<QueryBuilderActions>;
   filterKeyMenuWidth: number;
   filterKeySections: FilterKeySection[];
@@ -47,4 +48,5 @@ export const SearchQueryBuilderContext = createContext<SearchQueryBuilderContext
   searchSource: '',
   size: 'normal',
   disabled: false,
+  disallowWildcard: false,
 });

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -213,6 +213,7 @@ export function SearchQueryBuilder({
     return {
       ...state,
       disabled,
+      disallowWildcard: Boolean(disallowWildcard),
       parsedQuery,
       filterKeySections: filterKeySections ?? [],
       filterKeyMenuWidth,
@@ -230,6 +231,7 @@ export function SearchQueryBuilder({
   }, [
     state,
     disabled,
+    disallowWildcard,
     parsedQuery,
     filterKeySections,
     filterKeyMenuWidth,

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -224,6 +224,14 @@ function tokenSupportsMultipleValues(
   }
 }
 
+// Filters support wildcards if they are string filters and it is not explicity disallowed
+function keySupportsWildcard(fieldDefinition: FieldDefinition | null) {
+  const isStringFilter =
+    !fieldDefinition || fieldDefinition?.valueType === FieldValueType.STRING;
+
+  return isStringFilter && fieldDefinition?.allowWildcard !== false;
+}
+
 function useSelectionIndex({
   inputRef,
   inputValue,
@@ -450,6 +458,7 @@ export function SearchQueryBuilderValueCombobox({
     dispatch,
     searchSource,
     recentSearches,
+    disallowWildcard,
     wrapperRef: topLevelWrapperRef,
   } = useSearchQueryBuilder();
   const keyName = getKeyName(token.key);
@@ -459,6 +468,7 @@ export function SearchQueryBuilderValueCombobox({
     filterKeys,
     fieldDefinition
   );
+  const canUseWildard = disallowWildcard ? false : keySupportsWildcard(fieldDefinition);
   const [inputValue, setInputValue] = useState(() =>
     getInitialInputValue(token, canSelectMultipleValues)
   );
@@ -721,6 +731,7 @@ export function SearchQueryBuilderValueCombobox({
               {...props}
               isMultiSelect={canSelectMultipleValues}
               items={items}
+              canUseWildcard={canUseWildard}
             />
           );
         };
@@ -759,6 +770,7 @@ export function SearchQueryBuilderValueCombobox({
       showDatePicker,
       canSelectMultipleValues,
       items,
+      canUseWildard,
       inputValue,
       token,
       analyticsData,

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
@@ -10,8 +10,30 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 interface ValueListBoxProps<T> extends CustomComboboxMenuProps<T> {
+  canUseWildcard: boolean;
   isMultiSelect: boolean;
   items: T[];
+}
+
+function Footer({
+  isMultiSelect,
+  canUseWildcard,
+}: {
+  canUseWildcard: boolean;
+  isMultiSelect: boolean;
+}) {
+  if (!isMultiSelect && !canUseWildcard) {
+    return null;
+  }
+
+  return (
+    <FooterContainer>
+      {isMultiSelect ? (
+        <Label>{t('Hold %s to select multiple', isMac() ? '⌘' : 'Ctrl')}</Label>
+      ) : null}
+      {canUseWildcard ? <Label>{t('Wildcard (*) matching allowed')}</Label> : null}
+    </FooterContainer>
+  );
 }
 
 export function ValueListBox<T extends SelectOptionOrSectionWithKey<string>>({
@@ -25,6 +47,7 @@ export function ValueListBox<T extends SelectOptionOrSectionWithKey<string>>({
   filterValue,
   isMultiSelect,
   items,
+  canUseWildcard,
 }: ValueListBoxProps<T>) {
   const totalOptions = items.reduce(
     (acc, item) => acc + (itemIsSection(item) ? item.options.length : 1),
@@ -51,9 +74,7 @@ export function ValueListBox<T extends SelectOptionOrSectionWithKey<string>>({
           size="sm"
           style={{maxWidth: overlayProps.style.maxWidth}}
         />
-        {isMultiSelect ? (
-          <Label>{t('Hold %s to select multiple', isMac() ? '⌘' : 'Ctrl')}</Label>
-        ) : null}
+        <Footer isMultiSelect={isMultiSelect} canUseWildcard={canUseWildcard} />
       </SectionedOverlay>
     </StyledPositionWrapper>
   );
@@ -63,7 +84,7 @@ const SectionedOverlay = styled(Overlay)`
   display: grid;
   grid-template-rows: 1fr auto;
   overflow: hidden;
-  max-height: 300px;
+  max-height: 340px;
   width: min-content;
 `;
 
@@ -77,9 +98,14 @@ const StyledPositionWrapper = styled('div')<{visible?: boolean}>`
   z-index: ${p => p.theme.zIndex.tooltip};
 `;
 
-const Label = styled('div')`
+const FooterContainer = styled('div')`
   padding: ${space(1)} ${space(2)};
   color: ${p => p.theme.subText};
   border-top: 1px solid ${p => p.theme.innerBorder};
   font-size: ${p => p.theme.fontSizeSmall};
+  display: flex;
+  flex-direction: column;
+  gap: ${space(0.5)};
 `;
+
+const Label = styled('div')``;

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -283,6 +283,12 @@ export interface FieldDefinition {
    */
   allowComparisonOperators?: boolean;
   /**
+   * Allow wildcard (*) matching for this field.
+   * This is only valid for string fields and will default to true.
+   * Note that the `disallowWilcard` setting will override this.
+   */
+  allowWildcard?: boolean;
+  /**
    * Default value for the field
    */
   defaultValue?: string;
@@ -1100,11 +1106,13 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
     desc: t('Assignee of the issue as a user ID'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
+    allowWildcard: false,
   },
   [FieldKey.ASSIGNED_OR_SUGGESTED]: {
     desc: t('Assignee or suggestee of the issue as a user ID'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
+    allowWildcard: false,
   },
   [FieldKey.CULPRIT]: {
     deprecated: true,
@@ -1115,6 +1123,7 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
     desc: t('The issues bookmarked by a user ID'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
+    allowWildcard: false,
   },
   [FieldKey.BROWSER_NAME]: {
     desc: t('Name of the browser'),
@@ -1314,28 +1323,33 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
     valueType: FieldValueType.STRING,
     keywords: ['ignored', 'assigned', 'for_review', 'unassigned', 'linked', 'unlinked'],
     defaultValue: 'unresolved',
+    allowWildcard: false,
   },
   [FieldKey.ISSUE]: {
     desc: t('The issue identification short code'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
+    allowWildcard: false,
   },
   [FieldKey.ISSUE_CATEGORY]: {
     desc: t('Category of issue (error or performance)'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
     keywords: ['error', 'performance'],
+    allowWildcard: false,
   },
   [FieldKey.ISSUE_PRIORITY]: {
     desc: t('The priority of the issue'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
     keywords: ['high', 'medium', 'low'],
+    allowWildcard: false,
   },
   [FieldKey.ISSUE_TYPE]: {
     desc: t('Type of problem the issue represents (i.e. N+1 Query)'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
+    allowWildcard: false,
   },
   [FieldKey.LAST_SEEN]: {
     desc: t('Issues last seen at a given time'),
@@ -1405,6 +1419,7 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
     desc: t('Determines if a tag or field exists in an event'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
+    allowWildcard: false,
   },
   [FieldKey.OS_NAME]: {
     desc: t('Name of the Operating System'),


### PR DESCRIPTION
Will show this helper text for any string filter that is not explicitly disallowed. Added an option to the field definition to do this, and went ahead and disallowed for all the filters I tested that did not allow wildcards (most of the issue filters).

![CleanShot 2024-09-11 at 15 56 28](https://github.com/user-attachments/assets/7ac2bf50-9b71-45c6-8717-e966ec206c8c)
