### PR TITLE
fix(anomaly detection): set resolution == time_window

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -902,7 +902,9 @@ def update_alert_rule(
             updated_fields["seasonality"] = None
         elif detection_type == AlertRuleDetectionType.DYNAMIC:
             # NOTE: we set seasonality for EA
-            updated_query_fields["resolution"] = timedelta(minutes=time_window)
+            updated_query_fields["resolution"] = timedelta(
+                minutes=time_window if time_window is not None else snuba_query.time_window
+            )
             updated_fields["seasonality"] = AlertRuleSeasonality.AUTO
             updated_fields["comparison_delta"] = None
             if (

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -566,8 +566,10 @@ def create_alert_rule(
     """
     if monitor_type == AlertRuleMonitorTypeInt.ACTIVATED and not activation_condition:
         raise ValidationError("Activation condition required for activated alert rule")
-
-    resolution = get_alert_resolution(time_window, organization)
+    if detection_type == AlertRuleDetectionType.DYNAMIC:
+        resolution = time_window
+    else:
+        resolution = get_alert_resolution(time_window, organization)
 
     if detection_type == AlertRuleDetectionType.DYNAMIC:
         # NOTE: we hardcode seasonality for EA
@@ -900,6 +902,7 @@ def update_alert_rule(
             updated_fields["seasonality"] = None
         elif detection_type == AlertRuleDetectionType.DYNAMIC:
             # NOTE: we set seasonality for EA
+            updated_query_fields["resolution"] = timedelta(minutes=time_window)
             updated_fields["seasonality"] = AlertRuleSeasonality.AUTO
             updated_fields["comparison_delta"] = None
             if (

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -873,7 +873,10 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
             alert_rule.snuba_query.time_window
             == self.dynamic_metric_alert_settings["time_window"] * 60
         )
-        assert alert_rule.snuba_query.resolution == 120
+        assert (
+            alert_rule.snuba_query.resolution
+            == self.dynamic_metric_alert_settings["time_window"] * 60
+        )
         assert set(alert_rule.snuba_query.event_types) == set(
             self.dynamic_metric_alert_settings["event_types"]
         )


### PR DESCRIPTION
Set update frequency to be the same as time window for anomaly detection alerts, as requested by the Seer team.