### PR TITLE
fix(alerts): Fix dataset label for performance metric alerts

### DIFF
--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -131,8 +131,10 @@ def fetch_historical_data(
 
     dataset_label = snuba_query.dataset
     if dataset_label == "events":
-        # DATSET_OPTIONS expects the name 'errors'
+        # DATASET_OPTIONS expects the name 'errors'
         dataset_label = "errors"
+    elif dataset_label == "generic_metrics":
+        dataset_label = "transactions"
     dataset = get_dataset(dataset_label)
 
     if not project or not dataset or not alert_rule.organization:


### PR DESCRIPTION
Locally the dataset for performance metric alerts is `transactions` but in production it's being set as `generic_metrics` which isn't a key in the dictionary, so we have to rename it. 

Fixes https://getsentry.atlassian.net/browse/ALRT-265