### PR TITLE
feat(eap): Use RPC to fetch tag keys

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -67,7 +67,7 @@ rfc3986-validator>=0.1.1
 sentry-arroyo>=2.16.5
 sentry-kafka-schemas>=0.1.106
 sentry-ophio==0.2.7
-sentry-protos>=0.1.19
+sentry-protos>=0.1.21
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.9.1
 sentry-sdk>=2.12.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -184,7 +184,7 @@ sentry-forked-django-stubs==5.0.4.post2
 sentry-forked-djangorestframework-stubs==3.15.1.post1
 sentry-kafka-schemas==0.1.106
 sentry-ophio==0.2.7
-sentry-protos==0.1.19
+sentry-protos==0.1.21
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.1
 sentry-sdk==2.12.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -125,7 +125,7 @@ s3transfer==0.10.0
 sentry-arroyo==2.16.5
 sentry-kafka-schemas==0.1.106
 sentry-ophio==0.2.7
-sentry-protos==0.1.19
+sentry-protos==0.1.21
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.1
 sentry-sdk==2.12.0

--- a/src/sentry/api/endpoints/organization_spans_fields.py
+++ b/src/sentry/api/endpoints/organization_spans_fields.py
@@ -94,7 +94,7 @@ class OrganizationSpansFieldsEndpoint(OrganizationSpansFieldsEndpointBase):
                 meta=RequestMeta(
                     organization_id=organization.id,
                     cogs_category="performance",
-                    referrer=Referrer.API_SPANS_TAG_KEYS.value,
+                    referrer=Referrer.API_SPANS_TAG_KEYS_RPC.value,
                     project_ids=snuba_params.project_ids,
                     start_timestamp=start_timestamp,
                     end_timestamp=end_timestamp,

--- a/src/sentry/api/endpoints/organization_spans_fields.py
+++ b/src/sentry/api/endpoints/organization_spans_fields.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 import sentry_sdk
 from google.protobuf.timestamp_pb2 import Timestamp
 from rest_framework.request import Request
@@ -66,6 +68,7 @@ class OrganizationSpansFieldsEndpoint(OrganizationSpansFieldsEndpointBase):
             end_timestamp = Timestamp()
             end_timestamp.FromDatetime(
                 snuba_params.end_date.replace(hour=0, minute=0, second=0, microsecond=0)
+                + timedelta(days=1)
             )
 
             rpc_request = TraceItemAttributesRequest(

--- a/src/sentry/sentry_metrics/querying/eap/mql_eap_bridge.py
+++ b/src/sentry/sentry_metrics/querying/eap/mql_eap_bridge.py
@@ -8,11 +8,7 @@ from sentry_protos.snuba.v1alpha.endpoint_aggregate_bucket_pb2 import (
     AggregateBucketResponse,
 )
 from sentry_protos.snuba.v1alpha.request_common_pb2 import RequestMeta
-from sentry_protos.snuba.v1alpha.trace_item_attribute_pb2 import (
-    AttributeKey,
-    AttributeKeyTransformContext,
-    AttributeValue,
-)
+from sentry_protos.snuba.v1alpha.trace_item_attribute_pb2 import AttributeKey, AttributeValue
 from sentry_protos.snuba.v1alpha.trace_item_filter_pb2 import (
     AndFilter,
     ComparisonFilter,
@@ -96,9 +92,6 @@ def make_eap_request(
         granularity_secs=interval,
         key=AttributeKey(
             name=ts.metric.mri.split("/")[1].split("@")[0], type=AttributeKey.TYPE_FLOAT
-        ),
-        attribute_key_transform_context=AttributeKeyTransformContext(
-            project_ids_to_names={project.id: project.slug for project in projects}
         ),
     )
     aggregate_resp = snuba.rpc(aggregate_req, AggregateBucketResponse)

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -472,6 +472,7 @@ class Referrer(Enum):
     API_TRACE_EXPLORER_TRACES_OCCURRENCES = "api.trace-explorer.traces-occurrences"
     API_TRACE_EXPLORER_TRACE_SPANS_LIST = "api.trace-explorer.trace-spans-list"
     API_SPANS_TAG_KEYS = "api.spans.tags-keys"
+    API_SPANS_TAG_KEYS_RPC = "api.spans.tags-keys.rpc"
     API_SPANS_TRACE_VIEW = "api.spans.trace-view"
 
     # Performance Mobile UI Module

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1525,6 +1525,8 @@ class BaseSpansTestCase(SnubaTestCase):
         sdk_name: str | None = None,
         op: str | None = None,
         status: str | None = None,
+        organization_id: int = 1,
+        is_eap: bool = False,
     ):
         if span_id is None:
             span_id = self._random_span_id()
@@ -1533,7 +1535,7 @@ class BaseSpansTestCase(SnubaTestCase):
 
         payload = {
             "project_id": project_id,
-            "organization_id": 1,
+            "organization_id": organization_id,
             "span_id": span_id,
             "trace_id": trace_id,
             "duration_ms": int(duration),
@@ -1568,7 +1570,7 @@ class BaseSpansTestCase(SnubaTestCase):
         if status is not None:
             payload["sentry_tags"]["status"] = status
 
-        self.store_span(payload)
+        self.store_span(payload, is_eap=is_eap)
 
         if "_metrics_summary" in payload:
             self.store_metrics_summary(payload)

--- a/tests/sentry/api/endpoints/test_organization_spans_fields.py
+++ b/tests/sentry/api/endpoints/test_organization_spans_fields.py
@@ -76,6 +76,7 @@ class OrganizationEAPSpansTagsEndpointTest(OrganizationSpansTagsEndpointTest):
         if query is None:
             query = {}
         query["dataset"] = "spans"
+        query["type"] = "string"
 
         with self.feature(features):
             return self.client.get(

--- a/tests/sentry/api/endpoints/test_organization_spans_fields.py
+++ b/tests/sentry/api/endpoints/test_organization_spans_fields.py
@@ -7,6 +7,7 @@ from sentry.testutils.helpers.datetime import before_now
 
 
 class OrganizationSpansTagsEndpointTest(BaseSpansTestCase, APITestCase):
+    is_eap = False
     view = "sentry-api-0-organization-spans-fields"
 
     def setUp(self):
@@ -33,20 +34,23 @@ class OrganizationSpansTagsEndpointTest(BaseSpansTestCase, APITestCase):
         assert response.status_code == 200, response.data
         assert response.data == []
 
-    def test_tags(self):
+    def test_tags_list(self):
         for tag in ["foo", "bar", "baz"]:
             self.store_segment(
                 self.project.id,
                 uuid4().hex,
                 uuid4().hex,
                 span_id=uuid4().hex[:15],
+                organization_id=self.organization.id,
                 parent_span_id=None,
                 timestamp=before_now(days=0, minutes=10).replace(microsecond=0),
                 transaction="foo",
                 duration=100,
                 exclusive_time=100,
                 tags={tag: tag},
+                is_eap=self.is_eap,
             )
+
         for features in [
             None,  # use the default features
             ["organizations:performance-trace-explorer"],
@@ -58,6 +62,28 @@ class OrganizationSpansTagsEndpointTest(BaseSpansTestCase, APITestCase):
                 {"key": "baz", "name": "Baz"},
                 {"key": "foo", "name": "Foo"},
             ]
+
+
+class OrganizationEAPSpansTagsEndpointTest(OrganizationSpansTagsEndpointTest):
+    is_eap = True
+
+    def do_request(self, query=None, features=None, **kwargs):
+        if features is None:
+            features = ["organizations:performance-trace-explorer"]
+
+        features.append("organizations:visibility-explore-dataset")
+
+        if query is None:
+            query = {}
+        query["dataset"] = "spans"
+
+        with self.feature(features):
+            return self.client.get(
+                reverse(self.view, kwargs={"organization_id_or_slug": self.organization.slug}),
+                query,
+                format="json",
+                **kwargs,
+            )
 
 
 class OrganizationSpansTagKeyValuesEndpointTest(BaseSpansTestCase, APITestCase):


### PR DESCRIPTION
This uses RPC calls to fetch tag keys from eap spans.

Depends on getsentry/snuba#6301