### PR TITLE
feat(query-builder): Increase area between trigger and overlay

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -460,7 +460,7 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
     type: 'listbox',
     isOpen,
     position: 'bottom-start',
-    offset: [-12, 8],
+    offset: [-12, 12],
     isKeyboardDismissDisabled: true,
     shouldCloseOnBlur: true,
     shouldCloseOnInteractOutside: el => {

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyOperator.tsx
@@ -57,7 +57,7 @@ interface OperatorProps {
   middle?: boolean;
 }
 
-const MENU_OFFSET = [0, 12] as [number, number];
+const MENU_OFFSET: [number, number] = [0, 12];
 
 const OP_LABELS = {
   [TermOperator.DEFAULT]: 'is',

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyOperator.tsx
@@ -57,6 +57,8 @@ interface OperatorProps {
   middle?: boolean;
 }
 
+const MENU_OFFSET = [0, 12] as [number, number];
+
 const OP_LABELS = {
   [TermOperator.DEFAULT]: 'is',
   [TermOperator.GREATER_THAN]: '>',
@@ -319,6 +321,7 @@ function OperatorSelect({
           op: option.value,
         });
       }}
+      offset={MENU_OFFSET}
     />
   );
 }


### PR DESCRIPTION
Tiny change to give the menu a few pixels of separation from the search box:

![CleanShot 2024-09-11 at 17 56 59@2x](https://github.com/user-attachments/assets/c0543d83-a3a8-4c88-b252-f30d6a918e12)
