### PR TITLE
ref(alerts): Updates for new Seer response

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -54,7 +54,7 @@ def register_temporary_features(manager: FeatureManager):
     # Enables the migration of alerts (checked in a migration script).
     manager.add("organizations:alerts-migration-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable anomaly detection alerts
-    manager.add("organizations:anomaly-detection-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True, default=True)
+    manager.add("organizations:anomaly-detection-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable anomaly detection alerts
     manager.add("organizations:fake-anomaly-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable anomaly detection charts

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -54,7 +54,7 @@ def register_temporary_features(manager: FeatureManager):
     # Enables the migration of alerts (checked in a migration script).
     manager.add("organizations:alerts-migration-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable anomaly detection alerts
-    manager.add("organizations:anomaly-detection-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:anomaly-detection-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True, default=True)
     # Enable anomaly detection alerts
     manager.add("organizations:fake-anomaly-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable anomaly detection charts

--- a/src/sentry/incidents/endpoints/organization_alert_rule_anomalies.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_anomalies.py
@@ -1,5 +1,4 @@
 from drf_spectacular.utils import extend_schema
-from pydantic import BaseModel
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -25,11 +24,7 @@ from sentry.models.organization import Organization
 from sentry.seer.anomaly_detection.get_historical_anomalies import (
     get_historical_anomaly_data_from_seer,
 )
-from sentry.seer.anomaly_detection.types import TimeSeriesPoint
-
-
-class DetectAnomaliesResponse(BaseModel):
-    timeseries: list[TimeSeriesPoint]
+from sentry.seer.anomaly_detection.types import DetectAnomaliesResponse
 
 
 @region_silo_endpoint

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -6,6 +6,7 @@ from django import forms
 from django.conf import settings
 from django.db import router, transaction
 from django.utils import timezone
+from parsimonious.exceptions import ParseError
 from rest_framework import serializers
 from snuba_sdk import Column, Condition, Entity, Limit, Op
 from urllib3.exceptions import MaxRetryError, TimeoutError
@@ -514,6 +515,8 @@ class AlertRuleSerializer(CamelSnakeModelSerializer[AlertRule]):
                 )
             except (TimeoutError, MaxRetryError):
                 raise RequestTimeout
+            except ParseError:
+                raise serializers.ValidationError("Failed to parse Seer store data response")
             except forms.ValidationError as e:
                 # if we fail in create_metric_alert, then only one message is ever returned
                 raise serializers.ValidationError(e.error_list[0].message)
@@ -546,6 +549,8 @@ class AlertRuleSerializer(CamelSnakeModelSerializer[AlertRule]):
                 )
             except (TimeoutError, MaxRetryError):
                 raise RequestTimeout
+            except ParseError:
+                raise serializers.ValidationError("Failed to parse Seer store data response")
             except forms.ValidationError as e:
                 # if we fail in update_metric_alert, then only one message is ever returned
                 raise serializers.ValidationError(e.error_list[0].message)

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -725,7 +725,10 @@ class SubscriptionProcessor:
         if response.status > 400:
             logger.error(
                 "Error when hitting Seer detect anomalies endpoint",
-                extra=extra_data,
+                extra={
+                    "response_data": response.data,
+                    **extra_data,
+                },
             )
             return None
         try:

--- a/src/sentry/seer/anomaly_detection/store_data.py
+++ b/src/sentry/seer/anomaly_detection/store_data.py
@@ -14,8 +14,8 @@ from sentry.seer.anomaly_detection.types import (
     AlertInSeer,
     AnomalyDetectionConfig,
     StoreDataRequest,
-    TimeSeriesPoint,
     StoreDataResponse,
+    TimeSeriesPoint,
 )
 from sentry.seer.anomaly_detection.utils import (
     fetch_historical_data,
@@ -101,6 +101,7 @@ def send_historical_data_to_seer(alert_rule: AlertRule, project: Project) -> Ale
             path=SEER_ANOMALY_DETECTION_STORE_DATA_URL,
             body=json.dumps(body).encode("utf-8"),
         )
+    # See SEER_ANOMALY_DETECTION_TIMEOUT in sentry.conf.server.py
     except (TimeoutError, MaxRetryError):
         logger.warning(
             "Timeout error when hitting Seer store data endpoint",

--- a/src/sentry/seer/anomaly_detection/types.py
+++ b/src/sentry/seer/anomaly_detection/types.py
@@ -33,11 +33,22 @@ class StoreDataRequest(TypedDict):
     timeseries: list[TimeSeriesPoint]
 
 
+class StoreDataResponse(TypedDict):
+    success: bool
+    message: NotRequired[str]
+
+
 class DetectAnomaliesRequest(TypedDict):
     organization_id: int
     project_id: int
     config: AnomalyDetectionConfig
     context: AlertInSeer | list[TimeSeriesPoint]
+
+
+class DetectAnomaliesResponse(TypedDict):
+    success: bool
+    message: NotRequired[str]
+    timeseries: list[TimeSeriesPoint]
 
 
 class AnomalyType(Enum):

--- a/tests/sentry/incidents/action_handlers/test_email.py
+++ b/tests/sentry/incidents/action_handlers/test_email.py
@@ -1,6 +1,7 @@
 from functools import cached_property
 from unittest.mock import patch
 
+import orjson
 import pytest
 import responses
 from django.conf import settings
@@ -26,6 +27,7 @@ from sentry.incidents.models.alert_rule import (
 from sentry.incidents.models.incident import INCIDENT_STATUS, IncidentStatus, TriggerStatus
 from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.models.notificationsettingoption import NotificationSettingOption
+from sentry.seer.anomaly_detection.types import StoreDataResponse
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.dataset import Dataset
@@ -351,7 +353,9 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
     def test_dynamic_alert(self, mock_seer_request):
-        mock_seer_request.return_value = HTTPResponse(status=200)
+
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
         trigger_status = TriggerStatus.ACTIVE
         alert_rule = self.create_alert_rule(
             detection_type=AlertRuleDetectionType.DYNAMIC,

--- a/tests/sentry/incidents/action_handlers/test_msteams.py
+++ b/tests/sentry/incidents/action_handlers/test_msteams.py
@@ -2,6 +2,7 @@ import time
 from typing import cast
 from unittest.mock import patch
 
+import orjson
 import responses
 from urllib3.response import HTTPResponse
 
@@ -22,6 +23,7 @@ from sentry.integrations.msteams.card_builder.block import (
     TextBlock,
 )
 from sentry.integrations.msteams.spec import MsTeamsMessagingSpec
+from sentry.seer.anomaly_detection.types import StoreDataResponse
 from sentry.silo.base import SiloMode
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
@@ -135,7 +137,8 @@ class MsTeamsActionHandlerTest(FireTest):
             build_incident_attachment,
         )
 
-        mock_seer_request.return_value = HTTPResponse(status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
         alert_rule = self.create_alert_rule(
             detection_type=AlertRuleDetectionType.DYNAMIC,
             time_window=30,

--- a/tests/sentry/incidents/action_handlers/test_opsgenie.py
+++ b/tests/sentry/incidents/action_handlers/test_opsgenie.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import orjson
 import responses
 from urllib3.response import HTTPResponse
 
@@ -14,6 +15,7 @@ from sentry.incidents.models.alert_rule import (
 from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.seer.anomaly_detection.types import StoreDataResponse
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode_of
@@ -109,7 +111,8 @@ class OpsgenieActionHandlerTest(FireTest):
     def test_build_incident_attachment_dynamic_alert(self, mock_seer_request):
         from sentry.integrations.opsgenie.utils import build_incident_attachment
 
-        mock_seer_request.return_value = HTTPResponse(status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
         alert_rule = self.create_alert_rule(
             detection_type=AlertRuleDetectionType.DYNAMIC,
             time_window=30,

--- a/tests/sentry/incidents/action_handlers/test_pagerduty.py
+++ b/tests/sentry/incidents/action_handlers/test_pagerduty.py
@@ -1,6 +1,7 @@
 import uuid
 from unittest.mock import patch
 
+import orjson
 import pytest
 import responses
 from django.http import Http404
@@ -16,6 +17,7 @@ from sentry.incidents.models.alert_rule import (
 )
 from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod
 from sentry.integrations.pagerduty.utils import add_service
+from sentry.seer.anomaly_detection.types import StoreDataResponse
 from sentry.silo.base import SiloMode
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
@@ -106,7 +108,8 @@ class PagerDutyActionHandlerTest(FireTest):
     def test_build_incident_attachment_dynamic_alert(self, mock_seer_request):
         from sentry.integrations.pagerduty.utils import build_incident_attachment
 
-        mock_seer_request.return_value = HTTPResponse(status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
         alert_rule = self.create_alert_rule(
             detection_type=AlertRuleDetectionType.DYNAMIC,
             time_window=30,

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_anomalies.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_anomalies.py
@@ -75,6 +75,7 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
         self.login_as(self.user)
 
         seer_return_value = {
+            "success": True,
             "timeseries": [
                 {
                     "anomaly": {
@@ -92,7 +93,7 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
                     "timestamp": 2,
                     "value": 1,
                 },
-            ]
+            ],
         }
         mock_seer_store_request.return_value = HTTPResponse(status=200)
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
@@ -129,7 +130,7 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
         )
 
         self.login_as(self.user)
-        mock_seer_store_request.return_value = HTTPResponse(status=200)
+        mock_seer_store_request.return_value = HTTPResponse({"success": True}, status=200)
         with outbox_runner():
             resp = self.get_success_response(
                 self.organization.slug,
@@ -187,7 +188,7 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
         )
 
         self.login_as(self.user)
-        mock_seer_store_request.return_value = HTTPResponse(status=200)
+        mock_seer_store_request.return_value = HTTPResponse({"success": True}, status=200)
         mock_seer_request.side_effect = TimeoutError
         with outbox_runner():
             resp = self.get_error_response(
@@ -256,7 +257,7 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
         )
 
         self.login_as(self.user)
-        mock_seer_store_request.return_value = HTTPResponse(status=200)
+        mock_seer_store_request.return_value = HTTPResponse({"success": True}, status=200)
         mock_seer_request.return_value = HTTPResponse("Bad stuff", status=500)
         with outbox_runner():
             resp = self.get_error_response(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_anomalies.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_anomalies.py
@@ -64,6 +64,10 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
                 event_type=EventType.ERROR,
                 project_id=self.project.id,
             )
+        seer_store_data_return_value: StoreDataResponse = {"success": True}
+        mock_seer_store_request.return_value = HTTPResponse(
+            orjson.dumps(seer_store_data_return_value), status=200
+        )
 
         alert_rule = self.create_alert_rule(
             time_window=15,
@@ -95,7 +99,6 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
                 },
             ],
         }
-        mock_seer_store_request.return_value = HTTPResponse(status=200)
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
         with outbox_runner():
             resp = self.get_success_response(
@@ -122,6 +125,11 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
     def test_alert_not_enough_data(self, mock_seer_store_request):
         self.create_team(organization=self.organization, members=[self.user])
         two_weeks_ago = before_now(days=14).replace(hour=10, minute=0, second=0, microsecond=0)
+
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_store_request.return_value = HTTPResponse(
+            orjson.dumps(seer_return_value), status=200
+        )
         alert_rule = self.create_alert_rule(
             time_window=15,
             sensitivity=AlertRuleSensitivity.MEDIUM,
@@ -130,10 +138,6 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
         )
 
         self.login_as(self.user)
-        seer_return_value: StoreDataResponse = {"success": True}
-        mock_seer_store_request.return_value = HTTPResponse(
-            orjson.dumps(seer_return_value), status=200
-        )
         with outbox_runner():
             resp = self.get_success_response(
                 self.organization.slug,
@@ -183,6 +187,10 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
                 project_id=self.project.id,
             )
 
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_store_request.return_value = HTTPResponse(
+            orjson.dumps(seer_return_value), status=200
+        )
         alert_rule = self.create_alert_rule(
             time_window=15,
             sensitivity=AlertRuleSensitivity.MEDIUM,
@@ -191,10 +199,6 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
         )
 
         self.login_as(self.user)
-        seer_return_value: StoreDataResponse = {"success": True}
-        mock_seer_store_request.return_value = HTTPResponse(
-            orjson.dumps(seer_return_value), status=200
-        )
         mock_seer_request.side_effect = TimeoutError
         with outbox_runner():
             resp = self.get_error_response(
@@ -255,6 +259,10 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
                 project_id=self.project.id,
             )
 
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_store_request.return_value = HTTPResponse(
+            orjson.dumps(seer_return_value), status=200
+        )
         alert_rule = self.create_alert_rule(
             time_window=15,
             sensitivity=AlertRuleSensitivity.MEDIUM,
@@ -263,10 +271,6 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
         )
 
         self.login_as(self.user)
-        seer_return_value: StoreDataResponse = {"success": True}
-        mock_seer_store_request.return_value = HTTPResponse(
-            orjson.dumps(seer_return_value), status=200
-        )
         mock_seer_request.return_value = HTTPResponse("Bad stuff", status=500)
         with outbox_runner():
             resp = self.get_error_response(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_anomalies.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_anomalies.py
@@ -12,7 +12,7 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleSeasonality,
     AlertRuleSensitivity,
 )
-from sentry.seer.anomaly_detection.types import AnomalyType
+from sentry.seer.anomaly_detection.types import AnomalyType, StoreDataResponse
 from sentry.testutils.cases import SnubaTestCase
 from sentry.testutils.factories import EventType
 from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
@@ -130,7 +130,10 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
         )
 
         self.login_as(self.user)
-        mock_seer_store_request.return_value = HTTPResponse({"success": True}, status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_store_request.return_value = HTTPResponse(
+            orjson.dumps(seer_return_value), status=200
+        )
         with outbox_runner():
             resp = self.get_success_response(
                 self.organization.slug,
@@ -188,7 +191,10 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
         )
 
         self.login_as(self.user)
-        mock_seer_store_request.return_value = HTTPResponse({"success": True}, status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_store_request.return_value = HTTPResponse(
+            orjson.dumps(seer_return_value), status=200
+        )
         mock_seer_request.side_effect = TimeoutError
         with outbox_runner():
             resp = self.get_error_response(
@@ -257,7 +263,10 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
         )
 
         self.login_as(self.user)
-        mock_seer_store_request.return_value = HTTPResponse({"success": True}, status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_store_request.return_value = HTTPResponse(
+            orjson.dumps(seer_return_value), status=200
+        )
         mock_seer_request.return_value = HTTPResponse("Bad stuff", status=500)
         with outbox_runner():
             resp = self.get_error_response(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -6,6 +6,7 @@ from typing import Any
 from unittest import mock
 from unittest.mock import patch
 
+import orjson
 import pytest
 import responses
 from django.conf import settings
@@ -46,6 +47,7 @@ from sentry.integrations.slack.utils.channel import SlackChannelIdData
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.seer.anomaly_detection.store_data import seer_anomaly_detection_connection_pool
+from sentry.seer.anomaly_detection.types import StoreDataResponse
 from sentry.sentry_apps.services.app import app_service
 from sentry.silo.base import SiloMode
 from sentry.testutils.abstract import Abstract
@@ -301,7 +303,8 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
     def test_dynamic_detection_type(self, mock_seer_request):
-        mock_seer_request.return_value = HTTPResponse(status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
 
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -66,7 +66,11 @@ class AlertRuleDetailsBase(AlertRuleBase):
 
     endpoint = "sentry-api-0-organization-alert-rule-details"
 
-    def new_alert_rule(self, data=None):
+    @patch(
+        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
+    )
+    def new_alert_rule(self, mock_seer_request, data=None):
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps({"success": True}), status=200)
         if data is None:
             data = deepcopy(self.alert_rule_dict)
 
@@ -831,9 +835,9 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         self.login_as(self.user)
         alert_rule = self.dynamic_alert_rule
         # We need the IDs to force update instead of create, so we just get the rule using our own API. Like frontend would.
-        mock_seer_request.side_effect = TimeoutError
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps({"success": True}), status=200)
         data = self.get_serialized_alert_rule()
-
+        mock_seer_request.side_effect = TimeoutError
         resp = self.get_error_response(
             self.organization.slug,
             alert_rule.id,
@@ -841,7 +845,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
             **data,
         )
         assert resp.data["detail"]["message"] == "Proxied request timed out"
-        assert mock_seer_request.call_count == 2  # one for create, one for update
+        assert mock_seer_request.call_count == 1
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:incidents")
@@ -853,6 +857,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         self.login_as(self.user)
         alert_rule = self.dynamic_alert_rule
         # We need the IDs to force update instead of create, so we just get the rule using our own API. Like frontend would.
+
         mock_seer_request.side_effect = MaxRetryError(
             seer_anomaly_detection_connection_pool, SEER_ANOMALY_DETECTION_STORE_DATA_URL
         )
@@ -865,7 +870,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
             **data,
         )
         assert resp.data["detail"]["message"] == "Proxied request timed out"
-        assert mock_seer_request.call_count == 2
+        assert mock_seer_request.call_count == 1
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:incidents")
@@ -889,8 +894,10 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
             status_code=400,
             **data,
         )
-        assert resp.data["detail"]["message"] == "Invalid request"
-        assert mock_seer_request.call_count == 2
+        assert resp.data[0] == ErrorDetail(
+            string="Failed to send data to Seer - cannot update alert rule.", code="invalid"
+        )
+        assert mock_seer_request.call_count == 1
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:incidents")
@@ -916,7 +923,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
             == "Invalid time window for dynamic alert (valid windows are 60, 30, 15 minutes)"
         )
         # We don't call send_historical_data_to_seer if we encounter a validation error.
-        assert mock_seer_request.call_count == 1
+        assert mock_seer_request.call_count == 0
 
     def test_delete_action(self):
         self.create_member(

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -4,6 +4,7 @@ from functools import cached_property
 from typing import Any
 from unittest.mock import patch
 
+import orjson
 import pytest
 import responses
 from django.test import override_settings
@@ -42,6 +43,7 @@ from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.integration.serial import serialize_integration
 from sentry.integrations.slack.utils.channel import SlackChannelIdData
 from sentry.models.environment import Environment
+from sentry.seer.anomaly_detection.types import StoreDataResponse
 from sentry.sentry_apps.services.app import app_service
 from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
@@ -477,7 +479,8 @@ class TestAlertRuleSerializer(TestAlertRuleSerializerBase):
         """
         Anomaly detection alerts cannot have a nonzero alert rule threshold
         """
-        mock_seer_request.return_value = HTTPResponse(status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
 
         params = self.valid_params.copy()
         params["detection_type"] = AlertRuleDetectionType.DYNAMIC

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -95,6 +95,7 @@ from sentry.integrations.pagerduty.utils import add_service
 from sentry.integrations.services.integration.serial import serialize_integration
 from sentry.models.group import GroupStatus
 from sentry.seer.anomaly_detection.store_data import seer_anomaly_detection_connection_pool
+from sentry.seer.anomaly_detection.types import StoreDataResponse
 from sentry.shared_integrations.exceptions import ApiRateLimitedError, ApiTimeoutError
 from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
@@ -842,7 +843,8 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
     def test_create_alert_rule_anomaly_detection(self, mock_seer_request):
-        mock_seer_request.return_value = HTTPResponse(status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
 
         two_weeks_ago = before_now(days=14).replace(hour=10, minute=0, second=0, microsecond=0)
         self.create_event(two_weeks_ago + timedelta(minutes=1))
@@ -890,7 +892,8 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
     def test_create_alert_rule_anomaly_detection_not_enough_data(self, mock_seer_request):
-        mock_seer_request.return_value = HTTPResponse(status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
 
         two_days_ago = before_now(days=2).replace(hour=10, minute=0, second=0, microsecond=0)
         self.create_event(two_days_ago + timedelta(minutes=1))
@@ -911,7 +914,8 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
     def test_create_alert_rule_anomaly_detection_no_data(self, mock_seer_request):
-        mock_seer_request.return_value = HTTPResponse(status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
 
         # no events, so we expect _get_start_and_end to return -1, -1
         alert_rule = create_alert_rule(
@@ -1470,7 +1474,8 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
     def test_update_detection_type(self, mock_seer_request):
-        mock_seer_request.return_value = HTTPResponse(status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
         comparison_delta = 60
         # test percent to dynamic
         rule = self.create_alert_rule(
@@ -1579,7 +1584,8 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
     def test_update_infer_detection_type(self, mock_seer_request):
-        mock_seer_request.return_value = HTTPResponse(status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
         # static to static
         rule = self.create_alert_rule()
         updated_rule = update_alert_rule(rule, time_window=15)
@@ -1637,7 +1643,8 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
     def test_update_dynamic_alerts(self, mock_seer_request):
-        mock_seer_request.return_value = HTTPResponse(status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
 
         dynamic_rule = self.create_alert_rule(
             sensitivity=AlertRuleSensitivity.HIGH,
@@ -1678,7 +1685,8 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
     def test_update_dynamic_alert_static_to_dynamic(self, mock_seer_request):
-        mock_seer_request.return_value = HTTPResponse(status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
 
         static_rule = self.create_alert_rule(time_window=30)
         update_alert_rule(
@@ -1695,7 +1703,8 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
     def test_update_dynamic_alert_percent_to_dynamic(self, mock_seer_request):
-        mock_seer_request.return_value = HTTPResponse(status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
         percent_rule = self.create_alert_rule(
             comparison_delta=60, time_window=30, detection_type=AlertRuleDetectionType.PERCENT
         )
@@ -1716,7 +1725,8 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         """
         Assert that the status is PENDING if enough data exists.
         """
-        mock_seer_request.return_value = HTTPResponse(status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
 
         two_weeks_ago = before_now(days=14).replace(hour=10, minute=0, second=0, microsecond=0)
         self.create_event(two_weeks_ago + timedelta(minutes=1))
@@ -1743,7 +1753,8 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         """
         Assert that the status is NOT_ENOUGH_DATA if we don't have 7 days of data.
         """
-        mock_seer_request.return_value = HTTPResponse(status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
 
         two_days_ago = before_now(days=2).replace(hour=10, minute=0, second=0, microsecond=0)
         self.create_event(two_days_ago + timedelta(minutes=1))
@@ -1771,7 +1782,8 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         Assert that the alert rule status changes to PENDING if we switch from a dynamic alert to another type of alert.
         """
         # just setting up an alert
-        mock_seer_request.return_value = HTTPResponse(status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
 
         two_days_ago = before_now(days=2).replace(hour=10, minute=0, second=0, microsecond=0)
         self.create_event(two_days_ago + timedelta(minutes=1))
@@ -1805,7 +1817,8 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
     def test_update_alert_rule_anomaly_detection_seer_timeout_max_retry(
         self, mock_logger, mock_seer_request
     ):
-        mock_seer_request.return_value = HTTPResponse(status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
         dynamic_rule = self.create_alert_rule(
             sensitivity=AlertRuleSensitivity.HIGH,
             seasonality=AlertRuleSeasonality.AUTO,
@@ -1897,7 +1910,8 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
     def test_update_invalid_time_window(self, mock_seer_request):
-        mock_seer_request.return_value = HTTPResponse(status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
 
         rule = self.create_alert_rule(
             sensitivity=AlertRuleSensitivity.HIGH,
@@ -2043,7 +2057,8 @@ class CreateAlertRuleTriggerTest(TestCase):
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
     def test_invalid_threshold_dynamic_alert(self, mock_seer_request):
-        mock_seer_request.return_value = HTTPResponse(status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
 
         rule = self.create_alert_rule(
             time_window=15,
@@ -2114,7 +2129,8 @@ class UpdateAlertRuleTriggerTest(TestCase):
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
     def test_invalid_threshold_dynamic_alert(self, mock_seer_request):
-        mock_seer_request.return_value = HTTPResponse(status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
 
         rule = self.create_alert_rule(
             time_window=15,

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -52,7 +52,11 @@ from sentry.incidents.subscription_processor import (
 )
 from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.models.project import Project
-from sentry.seer.anomaly_detection.types import AnomalyType, TimeSeriesPoint
+from sentry.seer.anomaly_detection.types import (
+    AnomalyType,
+    DetectAnomaliesResponse,
+    TimeSeriesPoint,
+)
 from sentry.seer.anomaly_detection.utils import translate_direction
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.indexer.postgres.models import MetricsKeyIndexer
@@ -485,7 +489,8 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             AlertRuleTriggerAction.TargetType.USER,
             str(self.user.id),
         )
-        seer_return_value_1 = {
+        seer_return_value_1: DetectAnomaliesResponse = {
+            "success": True,
             "timeseries": [
                 {
                     "anomaly": {
@@ -495,7 +500,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
                     "timestamp": 1,
                     "value": 5,
                 }
-            ]
+            ],
         }
 
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value_1), status=200)
@@ -525,7 +530,8 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         )
 
         # trigger critical
-        seer_return_value_2 = {
+        seer_return_value_2: DetectAnomaliesResponse = {
+            "success": True,
             "timeseries": [
                 {
                     "anomaly": {
@@ -535,7 +541,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
                     "timestamp": 1,
                     "value": 10,
                 }
-            ]
+            ],
         }
 
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value_2), status=200)
@@ -565,14 +571,15 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         )
 
         # trigger a resolution
-        seer_return_value_3 = {
+        seer_return_value_3: DetectAnomaliesResponse = {
+            "success": True,
             "timeseries": [
                 {
                     "anomaly": {"anomaly_score": 0.5, "anomaly_type": AnomalyType.NONE.value},
                     "timestamp": 1,
                     "value": 1,
                 }
-            ]
+            ],
         }
 
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value_3), status=200)
@@ -609,7 +616,8 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         throughput_rule = self.dynamic_rule
         throughput_rule.snuba_query.update(time_window=15 * 60, dataset=Dataset.Transactions)
         # trigger critical
-        seer_return_value = {
+        seer_return_value: DetectAnomaliesResponse = {
+            "success": True,
             "timeseries": [
                 {
                     "anomaly": {
@@ -619,7 +627,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
                     "timestamp": 1,
                     "value": 10,
                 }
-            ]
+            ],
         }
 
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
@@ -652,14 +660,15 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         )
 
         # trigger a resolution
-        seer_return_value_2 = {
+        seer_return_value_2: DetectAnomaliesResponse = {
+            "success": True,
             "timeseries": [
                 {
                     "anomaly": {"anomaly_score": 0.5, "anomaly_type": AnomalyType.NONE.value},
                     "timestamp": 1,
                     "value": 1,
                 }
-            ]
+            ],
         }
 
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value_2), status=200)

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -923,7 +923,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
     @mock.patch("sentry.incidents.subscription_processor.logger")
     def test_seer_call_empty_list(self, mock_logger, mock_seer_request):
         processor = SubscriptionProcessor(self.sub)
-        seer_return_value: dict[str, list] = {"success": True, "timeseries": []}
+        seer_return_value: DetectAnomaliesResponse = {"success": True, "timeseries": []}
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
         result = processor.get_anomaly_data_from_seer(10)
         assert mock_logger.warning.call_args[0] == (
@@ -3096,7 +3096,7 @@ class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetrics
         self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.ACTIVE)
 
         # Close the metric alert
-        seer_return_value: DetectAnomaliesResponse = {
+        seer_return_value2: DetectAnomaliesResponse = {
             "success": True,
             "timeseries": [
                 {
@@ -3109,7 +3109,7 @@ class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetrics
                 }
             ],
         }
-        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value2), status=200)
         update_value = (1 - trigger.alert_threshold / 100) - 0.05
         self.send_crash_rate_alert_update(
             rule=rule,

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -948,6 +948,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
                 "organization_id": self.organization.id,
                 "project_id": self.project.id,
                 "alert_rule_id": self.rule.id,
+                "response_data": None,
             },
         )
         assert result is None

--- a/tests/sentry/integrations/discord/test_message_builder.py
+++ b/tests/sentry/integrations/discord/test_message_builder.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import orjson
 from django.urls import reverse
 from urllib3.response import HTTPResponse
 
@@ -17,6 +18,7 @@ from sentry.integrations.discord.message_builder.metric_alerts import (
     DiscordMetricAlertMessageBuilder,
     get_started_at,
 )
+from sentry.seer.anomaly_detection.types import StoreDataResponse
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.utils.http import absolute_uri
@@ -234,7 +236,8 @@ class BuildMetricAlertAttachmentTest(TestCase):
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
     def test_metric_alert_with_anomaly_detection(self, mock_seer_request):
-        mock_seer_request.return_value = HTTPResponse(status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
         alert_rule = self.create_alert_rule(
             detection_type=AlertRuleDetectionType.DYNAMIC,
             time_window=30,

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Any
 from unittest.mock import Mock, patch
 
+import orjson
 from django.urls import reverse
 from urllib3.response import HTTPResponse
 
@@ -47,6 +48,7 @@ from sentry.models.repository import Repository
 from sentry.models.team import Team
 from sentry.notifications.utils.actions import MessageAction
 from sentry.ownership.grammar import Matcher, Owner, Rule, dump_schema
+from sentry.seer.anomaly_detection.types import StoreDataResponse
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import PerformanceIssueTestCase, TestCase
 from sentry.testutils.factories import EventType
@@ -1124,7 +1126,8 @@ class BuildIncidentAttachmentTest(TestCase):
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
     def test_metric_alert_with_anomaly_detection(self, mock_seer_request):
-        mock_seer_request.return_value = HTTPResponse(status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
         alert_rule = self.create_alert_rule(
             detection_type=AlertRuleDetectionType.DYNAMIC,
             time_window=30,
@@ -1336,7 +1339,8 @@ class BuildMetricAlertAttachmentTest(TestCase):
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
     def test_metric_alert_with_anomaly_detection(self, mock_seer_request):
-        mock_seer_request.return_value = HTTPResponse(status=200)
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
         alert_rule = self.create_alert_rule(
             detection_type=AlertRuleDetectionType.DYNAMIC,
             time_window=30,


### PR DESCRIPTION
Update the places we call Seer to expect `success` as a bool and an optional `message` which gets added if `success` is false. 

Closes https://getsentry.atlassian.net/browse/ALRT-264