### PR TITLE
feat(onboarding): remove 'take me to...' buttons

### DIFF
--- a/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
@@ -68,14 +68,6 @@ export type OnboardingEventParameters = {
     platform: string;
     project_id: string;
   };
-  'onboarding.take_me_to_performance_clicked': {
-    platform: string;
-    project_id: string;
-  };
-  'onboarding.take_me_to_session_replay_clicked': {
-    platform: string;
-    project_id: string;
-  };
 };
 
 export const onboardingEventMap: Record<keyof OnboardingEventParameters, string> = {
@@ -109,9 +101,5 @@ export const onboardingEventMap: Record<keyof OnboardingEventParameters, string>
   'onboarding.messaging_integration_steps_refreshed':
     'Onboarding: Messaging Integration Steps Refreshed',
   'onboarding.take_me_to_issues_clicked': 'Onboarding: Take Me to Issues Clicked',
-  'onboarding.take_me_to_performance_clicked':
-    'Onboarding: Take Me to Performance Clicked',
-  'onboarding.take_me_to_session_replay_clicked':
-    'Onboarding: Take Me to Session Replay Clicked',
   'onboarding.slack_setup_clicked': 'Onboarding: Slack Setup Clicked',
 };

--- a/static/app/views/projectInstall/platform.spec.tsx
+++ b/static/app/views/projectInstall/platform.spec.tsx
@@ -169,7 +169,5 @@ describe('ProjectInstallPlatform', function () {
     ).toBeInTheDocument();
 
     expect(screen.getByText('Take me to Issues')).toBeInTheDocument();
-    expect(() => screen.getByText('Take me to Performance')).toThrow();
-    expect(() => screen.getByText('Take me to Session Replay')).toThrow();
   });
 });

--- a/static/app/views/projectInstall/platform.tsx
+++ b/static/app/views/projectInstall/platform.tsx
@@ -13,10 +13,7 @@ import {SdkDocumentation} from 'sentry/components/onboarding/gettingStartedDoc/s
 import type {ProductSolution} from 'sentry/components/onboarding/productSelection';
 import {platformProductAvailability} from 'sentry/components/onboarding/productSelection';
 import {setPageFiltersStorage} from 'sentry/components/organizations/pageFilters/persistence';
-import {
-  performance as performancePlatforms,
-  replayPlatforms,
-} from 'sentry/data/platformCategories';
+import {performance as performancePlatforms} from 'sentry/data/platformCategories';
 import type {Platform} from 'sentry/data/platformPickerCategories';
 import platforms from 'sentry/data/platforms';
 import {t} from 'sentry/locale';
@@ -61,7 +58,6 @@ export function ProjectInstallPlatform({
   const gettingStartedWithProjectContext = useContext(GettingStartedWithProjectContext);
 
   const isSelfHosted = ConfigStore.get('isSelfHosted');
-  const isSelfHostedErrorsOnly = ConfigStore.get('isSelfHostedErrorsOnly');
   const showLoaderOnboarding = location.query.showLoader === 'true';
 
   const products = useMemo(
@@ -160,10 +156,7 @@ export function ProjectInstallPlatform({
   }
 
   const issueStreamLink = `/organizations/${organization.slug}/issues/`;
-  const performanceOverviewLink = `/organizations/${organization.slug}/performance/`;
-  const replayLink = `/organizations/${organization.slug}/replays/`;
   const showPerformancePrompt = performancePlatforms.includes(platform.id as PlatformKey);
-  const showReplayButton = replayPlatforms.includes(platform.id as PlatformKey);
   const isGettingStarted = window.location.href.indexOf('getting-started') > 0;
   const showDocsWithProductSelection =
     (platformProductAvailability[platform.key] ?? []).length > 0;
@@ -233,40 +226,6 @@ export function ProjectInstallPlatform({
           >
             {t('Take me to Issues')}
           </Button>
-          {!isSelfHostedErrorsOnly && (
-            <Button
-              busy={loading}
-              onClick={() => {
-                trackAnalytics('onboarding.take_me_to_performance_clicked', {
-                  organization,
-                  platform: platform.name ?? 'unknown',
-                  project_id: project.id,
-                });
-                redirectWithProjectSelection({
-                  pathname: performanceOverviewLink,
-                });
-              }}
-            >
-              {t('Take me to Performance')}
-            </Button>
-          )}
-          {!isSelfHostedErrorsOnly && showReplayButton && (
-            <Button
-              busy={loading}
-              onClick={() => {
-                trackAnalytics('onboarding.take_me_to_session_replay_clicked', {
-                  organization,
-                  platform: platform.name ?? 'unknown',
-                  project_id: project.id,
-                });
-                redirectWithProjectSelection({
-                  pathname: replayLink,
-                });
-              }}
-            >
-              {t('Take me to Session Replay')}
-            </Button>
-          )}
         </StyledButtonBar>
       </div>
     </Fragment>

--- a/static/app/views/projectInstall/platformOrIntegration.spec.tsx
+++ b/static/app/views/projectInstall/platformOrIntegration.spec.tsx
@@ -67,7 +67,5 @@ describe('ProjectInstallPlatform', function () {
     ).toBeInTheDocument();
 
     expect(screen.getByText('Take me to Issues')).toBeInTheDocument();
-    expect(screen.getByText('Take me to Performance')).toBeInTheDocument();
-    expect(screen.getByText('Take me to Session Replay')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
After instrumenting the final onboarding step in 
- https://github.com/getsentry/sentry/pull/76834
it turned out that the "Take me to Performance" and "Take me to session replay" buttons are no sufficiently used.


- closes #77138

Before: 
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/f9c1f333-85dc-4fea-91b6-7ae5edf72ee0">
After:
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/46497851-cc27-474d-bfbe-65a6f37dd46b">
