### PR TITLE
deps: Symbolic 12.8.0 -> 12.10.0

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -77,7 +77,7 @@ simplejson>=3.17.6
 sqlparse>=0.4.4
 statsd>=3.3
 structlog>=22
-symbolic==12.8.0
+symbolic==12.10.0
 tiktoken>=0.6.0
 tldextract>=5.1.2
 toronado>=0.1.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -200,7 +200,7 @@ sqlparse==0.5.0
 statsd==3.3.0
 stripe==3.1.0
 structlog==22.1.0
-symbolic==12.8.0
+symbolic==12.10.0
 tiktoken==0.6.0
 time-machine==2.13.0
 tldextract==5.1.2

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -140,7 +140,7 @@ sqlparse==0.5.0
 statsd==3.3.0
 stripe==3.1.0
 structlog==22.1.0
-symbolic==12.8.0
+symbolic==12.10.0
 tiktoken==0.6.0
 tldextract==5.1.2
 toronado==0.1.0


### PR DESCRIPTION
In particular, this pulls in https://github.com/getsentry/symbolic/pull/853.

Fixes https://github.com/getsentry/sentry/issues/76857.
