### PR TITLE
drop(grouping): Remove invert-stacktrace as a valid stack trace rule

### DIFF
--- a/src/sentry/grouping/enhancer/actions.py
+++ b/src/sentry/grouping/enhancer/actions.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from typing import Any
 
-from sentry.grouping.utils import get_rule_bool
 from sentry.utils.safe import get_path, set_path
 
 from .exceptions import InvalidEnhancerConfig
@@ -142,7 +141,6 @@ class VarAction(Action):
     _VALUE_PARSERS: dict[str, Callable[[Any], Any]] = {
         "max-frames": int,
         "min-frames": int,
-        "invert-stacktrace": get_rule_bool,
         "category": lambda x: x,
     }
 

--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
@@ -68,18 +68,6 @@ family:native function:"__*[[]Sentry*"                            -app -group
 # own grouping enhancers.
 family:native function:"?[[]Sentry*"                              -app -group
 
-# Android ANR: Exception stack is a snapshot of the UI/main thread. The
-# *outermost* in-app frame is most indicative of which user action has led to ANR,
-# and that's what we want to group by. (innermost=crashing frame)
-#
-# Note: Newer Android SDKs send the snapshot flag with ANRs, so this rule is
-# not strictly necessary.
-error.mechanism:ANR invert-stacktrace=1
-
-# NSError iOS: Stacktrace is a thread snapshot as well.
-# Note: Newer iOS SDK sends snapshot flag, so this is not strictly necessary.
-error.mechanism:NSError invert-stacktrace=1
-
 # Dart/Flutter stacktraces that are not in-app
 family:javascript stack.abs_path:org-dartlang-sdk:///** -app -group
 family:javascript module:**/packages/flutter/** -app

--- a/src/sentry/grouping/enhancer/parser.py
+++ b/src/sentry/grouping/enhancer/parser.py
@@ -29,7 +29,7 @@ callee_matcher   = _ "|" _ "[" _ frame_matcher _ "]"
 actions          = action+
 action           = flag_action / var_action
 var_action       = _ var_name _ "=" _ ident
-var_name         = "max-frames" / "min-frames" / "invert-stacktrace" / "category"
+var_name         = "max-frames" / "min-frames" / "category"
 flag_action      = _ range? flag flag_action_name
 flag_action_name = "group" / "app"
 flag             = "+" / "-"


### PR DESCRIPTION
The code to support this syntax was only used in the mobile grouping and the code was removed in #76994