### PR TITLE
fix(dashboards): Use custom cell renderer in `DiscoverTable`

### DIFF
--- a/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
+++ b/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
@@ -34,6 +34,7 @@ import {
   generateEventSlug,
 } from 'sentry/utils/discover/urls';
 import {formatMRIField, parseField} from 'sentry/utils/metrics/mri';
+import {getCustomEventsFieldRenderer} from 'sentry/views/dashboards/datasetConfig/errorsAndTransactions';
 import type {Widget} from 'sentry/views/dashboards/types';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import {eventViewFromWidget} from 'sentry/views/dashboards/utils';
@@ -202,18 +203,17 @@ export const renderGridBodyCell = ({
         )(dataRow, {organization, location});
         break;
       case WidgetType.DISCOVER:
+      case WidgetType.TRANSACTIONS:
+      case WidgetType.ERRORS:
       default:
         if (!tableData || !tableData.meta) {
           return dataRow[column.key];
         }
         const unit = tableData.meta.units?.[column.key];
-        cell = getFieldRenderer(
-          columnKey,
-          tableData.meta,
-          false
-        )(dataRow, {
+        cell = getCustomEventsFieldRenderer(columnKey, tableData.meta)(dataRow, {
           organization,
           location,
+          eventView,
           unit,
         });
 


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/76731. The issue is caused by using different renderer strategies. The renderer for the _small_ table (the widget's normal view) is using `SimpleTableChart` which correctly delegates the rendering of special fields to the relevant dataset's `getCustomFieldRenderer` configuration. The full-screen modal uses the `DiscoverTable` component, which sets up the custom renderers differently. There, the custom renderers do _not_ use the linkifying logic from the table.

This PR ensures that Discover and Discover-ish datasets import and use the same field renderers. Longer-term the solution would be to move this logic to the _default_ field renderers or otherwise unify the renderers used in Dashboards but for now this fixes the issue.
