### PR TITLE
chore: Remove spans used to debug ratelimit overhead

### DIFF
--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -51,49 +51,46 @@ class RatelimitMiddleware:
 
         with metrics.timer("middleware.ratelimit.process_view", sample_rate=0.01):
             try:
-                with sentry_sdk.start_span(op="ratelimit.early_return"):
-                    # TODO: put these fields into their own object
-                    request.will_be_rate_limited = False
-                    if settings.SENTRY_SELF_HOSTED:
-                        return None
-                    request.rate_limit_category = None
-                    request.rate_limit_uid = uuid.uuid4().hex
-                    view_class = getattr(view_func, "view_class", None)
-                    if not view_class:
-                        return None
+                # TODO: put these fields into their own object
+                request.will_be_rate_limited = False
+                if settings.SENTRY_SELF_HOSTED:
+                    return None
+                request.rate_limit_category = None
+                request.rate_limit_uid = uuid.uuid4().hex
+                view_class = getattr(view_func, "view_class", None)
+                if not view_class:
+                    return None
 
-                    enforce_rate_limit = getattr(view_class, "enforce_rate_limit", False)
-                    if enforce_rate_limit is False:
-                        return None
+                enforce_rate_limit = getattr(view_class, "enforce_rate_limit", False)
+                if enforce_rate_limit is False:
+                    return None
 
-                with sentry_sdk.start_span(op="ratelimit.determine_limit_config"):
-                    rate_limit_config = get_rate_limit_config(
-                        view_class, view_args, {**view_kwargs, "request": request}
-                    )
-                    rate_limit_group = (
-                        rate_limit_config.group if rate_limit_config else RateLimitConfig().group
-                    )
-                    request.rate_limit_key = get_rate_limit_key(
-                        view_func, request, rate_limit_group, rate_limit_config
-                    )
-                    if request.rate_limit_key is None:
-                        return None
+                rate_limit_config = get_rate_limit_config(
+                    view_class, view_args, {**view_kwargs, "request": request}
+                )
+                rate_limit_group = (
+                    rate_limit_config.group if rate_limit_config else RateLimitConfig().group
+                )
+                request.rate_limit_key = get_rate_limit_key(
+                    view_func, request, rate_limit_group, rate_limit_config
+                )
+                if request.rate_limit_key is None:
+                    return None
 
-                    category_str = request.rate_limit_key.split(":", 1)[0]
-                    request.rate_limit_category = category_str
+                category_str = request.rate_limit_key.split(":", 1)[0]
+                request.rate_limit_category = category_str
 
-                    rate_limit = get_rate_limit_value(
-                        http_method=request.method,
-                        category=RateLimitCategory(category_str),
-                        rate_limit_config=rate_limit_config,
-                    )
-                    if rate_limit is None:
-                        return None
+                rate_limit = get_rate_limit_value(
+                    http_method=request.method,
+                    category=RateLimitCategory(category_str),
+                    rate_limit_config=rate_limit_config,
+                )
+                if rate_limit is None:
+                    return None
 
-                with sentry_sdk.start_span(op="ratelimit.above_rate_limit_check"):
-                    request.rate_limit_metadata = above_rate_limit_check(
-                        request.rate_limit_key, rate_limit, request.rate_limit_uid, rate_limit_group
-                    )
+                request.rate_limit_metadata = above_rate_limit_check(
+                    request.rate_limit_key, rate_limit, request.rate_limit_uid, rate_limit_group
+                )
 
                 # TODO: also limit by concurrent window once we have the data
                 rate_limit_cond = (


### PR DESCRIPTION
With the source of overhead in ratelimit middleware tracked down (it was metrics initialization locks) we don't need these spans anymore.

