### PR TITLE
chore(dashboards): Reduce `AutoSizedText` iteration limit

### DIFF
--- a/static/app/views/dashboards/widgetCard/autoSizedText.tsx
+++ b/static/app/views/dashboards/widgetCard/autoSizedText.tsx
@@ -143,7 +143,7 @@ const SizedChild = styled('div')`
   display: inline-block;
 `;
 
-const ITERATION_LIMIT = 50;
+const ITERATION_LIMIT = 20;
 
 // The maximum difference strongly affects the number of iterations required.
 // A value of 10 means that matches are often found in fewer than 5 iterations.


### PR DESCRIPTION
Not very important, but 50 is a _hugely_ generous limit. In the wild, pretty much _every_ component converges in 6 iterations. 8 is rare. I'm setting 20, just to give it headroom. 50 is bonkers.

You can see for yourself: https://sentry.sentry.io/dashboard/106138/
