### PR TITLE
fix(integrations): restore `code` for sentryapp installation webhooks

### DIFF
--- a/src/sentry/api/serializers/models/sentry_app_installation.py
+++ b/src/sentry/api/serializers/models/sentry_app_installation.py
@@ -45,7 +45,9 @@ class SentryAppInstallationSerializer(Serializer):
             "status": SentryAppInstallationStatus.as_str(obj.status),
         }
 
-        if obj.api_grant and access and access.has_scope("org:integrations"):
+        is_webhook = "is_webhook" in kwargs and kwargs["is_webhook"]
+
+        if obj.api_grant and ((access and access.has_scope("org:integrations")) or is_webhook):
             data["code"] = obj.api_grant.code
 
         return data

--- a/src/sentry/mediators/sentry_app_installations/installation_notifier.py
+++ b/src/sentry/mediators/sentry_app_installations/installation_notifier.py
@@ -32,9 +32,11 @@ class InstallationNotifier(Mediator):
     @property
     def request(self) -> AppPlatformEvent:
         data = serialize(
-            [self.install], user=self.user, serializer=SentryAppInstallationSerializer()
+            [self.install],
+            user=self.user,
+            serializer=SentryAppInstallationSerializer(),
+            is_webhook=True,
         )[0]
-
         return AppPlatformEvent(
             resource="installation",
             action=self.action,

--- a/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
@@ -56,6 +56,7 @@ class TestInstallationNotifier(TestCase):
                     "app": {"uuid": self.sentry_app.uuid, "slug": self.sentry_app.slug},
                     "organization": {"slug": self.organization.slug},
                     "uuid": self.install.uuid,
+                    "code": self.install.api_grant.code,
                     "status": "installed",
                 }
             },
@@ -84,6 +85,7 @@ class TestInstallationNotifier(TestCase):
                     "app": {"uuid": self.sentry_app.uuid, "slug": self.sentry_app.slug},
                     "organization": {"slug": self.organization.slug},
                     "uuid": self.install.uuid,
+                    "code": self.install.api_grant.code,
                     "status": "installed",
                 }
             },


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/76903
The issue was introduced in https://github.com/getsentry/sentry/pull/71551