### PR TITLE
fix(jira): Ensures metrics/logs are captured for all issue creation exceptions

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2697,7 +2697,7 @@ register(
 )
 
 register(
-    "ecosystem:enable_integration_form_error_raise", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE
+    "ecosystem:enable_integration_form_error_raise", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE
 )
 
 # Controls the rate of using the sentry api shared secret for communicating to sentry.

--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -12,7 +12,6 @@ from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.services.integration.service import integration_service
 from sentry.models.grouplink import GroupLink
-from sentry.shared_integrations.exceptions import IntegrationFormError
 from sentry.silo.base import region_silo_function
 from sentry.types.rules import RuleFuture
 from sentry.utils import metrics
@@ -135,11 +134,7 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
                 },
             )
 
-            # Only raise IntegrationFormErrors, as these are exceptions we can handle
-            if isinstance(e, IntegrationFormError):
-                raise
-            else:
-                return
+            raise
 
         if not event.get_tag("sample_event") == "yes":
             create_link(integration, installation, event, response)


### PR DESCRIPTION
Currently, we only capture exceptions for `IntegrationFormErrors` which likely covers the vast majority of exception types; however, including all exceptions in our logging and metrics will give us a better basis for setting ticketing SLOs. This also removes the feature flag usage for conditionally raising.