### PR TITLE
fix(spans): Convert sampling weight to uint64

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -558,11 +558,6 @@ class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsSpanIndexedEndpoin
         ]
         assert meta["dataset"] == self.dataset
 
-    # 2024-09-12 / shellmayr: Marked as failing because test fails in CI
-    # https://github.com/getsentry/sentry/actions/runs/10826394743/job/30037275706?pr=77376
-    @pytest.mark.xfail(
-        reason="percentile_weighted(span.duration, 0.23) causes: Invalid query. Argument to function is wrong type"
-    )
     def test_extrapolation_smoke(self):
         """This is a hack, we just want to make sure nothing errors from using the weighted functions"""
         for function in [


### PR DESCRIPTION
- Convert the sampling_weight column back to a uint64 so we can use it in the quantileTDigestWeighted function, all the other functions don't care haha, sampling_weight2 is already uint64, but we aren't currently writing data to it, and it won't have data for 90d