### PR TITLE
copy(activity): Improve copy for linked Azure Devops issue

### DIFF
--- a/static/app/views/issueDetails/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/groupActivityItem.tsx
@@ -474,6 +474,15 @@ function GroupActivityItem({
       }
       case GroupActivityType.CREATE_ISSUE: {
         const {data} = activity;
+
+        if (data.provider === 'Azure DevOps') {
+          return tct('[author] linked this issue to [provider] issue titled [title]', {
+            author,
+            provider: data.provider,
+            title: <ExternalLink href={data.location}>{data.title}</ExternalLink>,
+          });
+        }
+
         return tct('[author] created an issue on [provider] titled [title]', {
           author,
           provider: data.provider,


### PR DESCRIPTION
resolves #77410

Changes the copy of the activity log entry when a sentry issue is linked to an Azure DevOps ticket to be more clear that the two issues are linked. 

Before: 

> \<author> created an issue on Azure Devops titled <devops_issue_title>

After:

>  \<author> **linked this** issue **to** Azure Devops **issue** titled <devops_issue_title>