### PR TITLE
ref(uptime): Improve rdap data entity usage

### DIFF
--- a/tests/sentry/uptime/detectors/test_rdap.py
+++ b/tests/sentry/uptime/detectors/test_rdap.py
@@ -116,5 +116,5 @@ def test_resolve_rdap_network_details(mock_resolve_hostname):
     details = resolve_rdap_network_details("abc.com")
 
     mock_resolve_hostname.assert_called_with("abc.com")
-    assert details["name"] == "RRNY"
+    assert details["handle"] == "CC-3517"
     assert details["owner_name"] == "Charter Communications Inc"


### PR DESCRIPTION
- Use the handle as the network name. The "Network Name" attribute of
   the network may not always exist.

 - Handle cases where there is no vCard array present in the first
   entity.