### PR TITLE
chore(sentry-apps): log timed out url

### DIFF
--- a/src/sentry/mediators/external_requests/util.py
+++ b/src/sentry/mediators/external_requests/util.py
@@ -73,6 +73,7 @@ def send_and_save_sentry_app_request(
                 "error_type": error_type,
                 "organization_id": org_id,
                 "integration_slug": sentry_app.slug,
+                "url": url,
             },
         )
         track_response_code(error_type, slug, event)

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -149,6 +149,7 @@ def send_and_save_webhook_request(
                 "error_type": error_type,
                 "organization_id": org_id,
                 "integration_slug": sentry_app.slug,
+                "url": url,
             },
         )
         track_response_code(error_type, slug, event)


### PR DESCRIPTION
Log the url that resulted in the `TimeoutError` or `ConnectionError`