### PR TITLE
ref(codeowners): Add entry for uptime alerts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -170,6 +170,7 @@ yarn.lock                                                @getsentry/owners-js-de
 ## Alerts & Notifications
 /static/app/views/settings/projectAlerts/                 @getsentry/alerts-notifications
 /static/app/views/alerts/                                 @getsentry/alerts-notifications
+/static/app/views/alerts/rules/uptime                     @getsentry/crons
 /static/app/views/releases/                               @getsentry/alerts-notifications
 /src/sentry/rules/processing/delayed_processing.py        @getsentry/alerts-notifications
 


### PR DESCRIPTION
Uptime alert frontend changes should be routed to the crons/uptime team

Also tried to follow precedence for last matching rule wins, so I placed the rule inside of the `Alerts & Notifications` section, even though the owner is the `crons` team