### PR TITLE
ref(spans): Lift tag loading out of SpanSearchQueryBuilder

### DIFF
--- a/static/app/views/explore/attributes/index.tsx
+++ b/static/app/views/explore/attributes/index.tsx
@@ -1,0 +1,63 @@
+import {createContext, useContext, useMemo} from 'react';
+
+import {
+  useSpanBuiltinNumericTags,
+  useSpanBuiltinStringTags,
+  useSpanCustomNumericTags,
+  useSpanCustomStringTags,
+  useSpanFunctionTags,
+} from 'sentry/components/performance/spanSearchQueryBuilder';
+import type {PageFilters} from 'sentry/types/core';
+import type {TagCollection} from 'sentry/types/group';
+import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
+
+type SpanAttributes = {
+  builtinNumerics: TagCollection;
+  builtinStrings: TagCollection;
+  customNumerics: TagCollection;
+  customStrings: TagCollection;
+  functions: TagCollection;
+};
+
+const ExploreAttributesProviderContext = createContext<SpanAttributes>({
+  builtinNumerics: {},
+  builtinStrings: {},
+  customNumerics: {},
+  customStrings: {},
+  functions: {},
+});
+
+interface ExploreAttributesProviderProps {
+  children: React.ReactNode;
+  pageFilters: Readonly<PageFilters>;
+}
+
+export function ExploreAttributesProvider(props: ExploreAttributesProviderProps) {
+  const builtinNumerics = useSpanBuiltinNumericTags();
+  const builtinStrings = useSpanBuiltinStringTags({});
+  const customNumerics = useSpanCustomNumericTags({});
+  const customStrings = useSpanCustomStringTags({});
+  const functions = useSpanFunctionTags({
+    functions: ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
+  });
+
+  const attributes: SpanAttributes = useMemo(() => {
+    return {
+      builtinNumerics,
+      builtinStrings,
+      customNumerics,
+      customStrings,
+      functions,
+    };
+  }, [builtinNumerics, builtinStrings, customNumerics, customStrings, functions]);
+
+  return (
+    <ExploreAttributesProviderContext.Provider value={attributes}>
+      {props.children}
+    </ExploreAttributesProviderContext.Provider>
+  );
+}
+
+export function useExploreAttributes() {
+  return useContext(ExploreAttributesProviderContext);
+}

--- a/static/app/views/explore/content.tsx
+++ b/static/app/views/explore/content.tsx
@@ -1,6 +1,5 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback} from 'react';
 import styled from '@emotion/styled';
-import type {Location} from 'history';
 
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
@@ -15,32 +14,33 @@ import {SpanSearchQueryBuilder} from 'sentry/components/performance/spanSearchQu
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
-import {useResultMode} from './hooks/useResultsMode';
 import {useUserQuery} from './hooks/useUserQuery';
+import {ExploreAttributesProvider, useExploreAttributes} from './attributes';
 import {ExploreCharts} from './charts';
 import {ExploreTables} from './tables';
 import {ExploreToolbar} from './toolbar';
 
-interface ExploreContentProps {
-  location: Location;
+export function ExploreContent() {
+  const {selection} = usePageFilters();
+
+  return (
+    <ExploreAttributesProvider pageFilters={selection}>
+      <ExploreContentInner />
+    </ExploreAttributesProvider>
+  );
 }
 
-export function ExploreContent({}: ExploreContentProps) {
+function ExploreContentInner() {
   const location = useLocation();
   const navigate = useNavigate();
   const organization = useOrganization();
   const {selection} = usePageFilters();
-  const [resultsMode] = useResultMode();
-
-  const supportedAggregates = useMemo(() => {
-    return resultsMode === 'aggregate' ? ALLOWED_EXPLORE_VISUALIZE_AGGREGATES : [];
-  }, [resultsMode]);
+  const attributes = useExploreAttributes();
 
   const [userQuery, setUserQuery] = useUserQuery();
 
@@ -83,11 +83,15 @@ export function ExploreContent({}: ExploreContentProps) {
                 <DatePageFilter />
               </PageFilterBar>
               <SpanSearchQueryBuilder
-                supportedAggregates={supportedAggregates}
                 projects={selection.projects}
                 initialQuery={userQuery}
                 onSearch={setUserQuery}
                 searchSource="explore"
+                builtinNumerics={attributes.builtinNumerics}
+                builtinStrings={attributes.builtinStrings}
+                customNumerics={attributes.customNumerics}
+                customStrings={attributes.customStrings}
+                functions={attributes.functions}
               />
             </FilterActions>
             <Side>

--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
@@ -8,7 +8,13 @@ import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import SearchBar from 'sentry/components/events/searchBar';
 import {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import Link from 'sentry/components/links/link';
-import {SpanSearchQueryBuilder} from 'sentry/components/performance/spanSearchQueryBuilder';
+import {
+  SpanSearchQueryBuilder,
+  useSpanBuiltinNumericTags,
+  useSpanBuiltinStringTags,
+  useSpanCustomNumericTags,
+  useSpanCustomStringTags,
+} from 'sentry/components/performance/spanSearchQueryBuilder';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -35,7 +41,6 @@ import {
   SpanMetricsField,
   type SubregionCode,
 } from 'sentry/views/insights/types';
-import {useSpanFieldSupportedTags} from 'sentry/views/performance/utils/useSpanFieldSupportedTags';
 
 const {HTTP_RESPONSE_CONTENT_LENGTH, SPAN_DESCRIPTION} = SpanMetricsField;
 
@@ -85,7 +90,19 @@ export function SampleList({
   const {projects} = useProjects();
 
   const spanSearchQuery = decodeScalar(location.query.spanSearchQuery);
-  const supportedTags = useSpanFieldSupportedTags();
+  const builtinNumerics = useSpanBuiltinNumericTags();
+  const builtinStrings = useSpanBuiltinStringTags({});
+  const customNumerics = useSpanCustomNumericTags({});
+  const customStrings = useSpanCustomStringTags({});
+
+  const supportedTags = useMemo(() => {
+    return {
+      ...builtinNumerics,
+      ...builtinStrings,
+      ...customNumerics,
+      ...customStrings,
+    };
+  }, [builtinNumerics, builtinStrings, customNumerics, customStrings]);
 
   const project = useMemo(
     () => projects.find(p => p.id === String(location.query.project)),
@@ -229,6 +246,10 @@ export function SampleList({
             <SpanSearchQueryBuilder
               projects={selection.projects}
               initialQuery={spanSearchQuery ?? ''}
+              builtinNumerics={builtinNumerics}
+              builtinStrings={builtinStrings}
+              customNumerics={customNumerics}
+              customStrings={customStrings}
               onSearch={handleSearch}
               placeholder={t('Search for span attributes')}
               searchSource={`${moduleName}-sample-panel`}

--- a/static/app/views/performance/utils/useSpanFieldSupportedTags.tsx
+++ b/static/app/views/performance/utils/useSpanFieldSupportedTags.tsx
@@ -14,7 +14,7 @@ const DATASET_TO_FIELDS = {
   [DiscoverDatasets.SPANS_METRICS]: SpanMetricsField,
 };
 
-const getSpanFieldSupportedTags = (
+export const getSpanFieldSupportedTags = (
   excludedTags,
   dataset: DiscoverDatasets.SPANS_INDEXED | DiscoverDatasets.SPANS_METRICS
 ) => {

--- a/static/app/views/traces/tracesSearchBar.tsx
+++ b/static/app/views/traces/tracesSearchBar.tsx
@@ -1,8 +1,15 @@
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
 import SearchBar from 'sentry/components/events/searchBar';
-import {SpanSearchQueryBuilder} from 'sentry/components/performance/spanSearchQueryBuilder';
+import {
+  SpanSearchQueryBuilder,
+  useSpanBuiltinNumericTags,
+  useSpanBuiltinStringTags,
+  useSpanCustomNumericTags,
+  useSpanCustomStringTags,
+} from 'sentry/components/performance/spanSearchQueryBuilder';
 import {IconAdd, IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -11,7 +18,6 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {useSpanFieldSupportedTags} from 'sentry/views/performance/utils/useSpanFieldSupportedTags';
 
 interface TracesSearchBarProps {
   handleClearSearch: (index: number) => boolean;
@@ -38,9 +44,19 @@ export function TracesSearchBar({
   const canAddMoreQueries = queries.length <= 2;
   const localQueries = queries.length ? queries : [''];
 
-  // Since trace explorer permits cross project searches,
-  // autocompletion should also be cross projects.
-  const supportedTags = useSpanFieldSupportedTags();
+  const builtinNumerics = useSpanBuiltinNumericTags();
+  const builtinStrings = useSpanBuiltinStringTags({});
+  const customNumerics = useSpanCustomNumericTags({});
+  const customStrings = useSpanCustomStringTags({});
+
+  const supportedTags = useMemo(() => {
+    return {
+      ...builtinNumerics,
+      ...builtinStrings,
+      ...customNumerics,
+      ...customStrings,
+    };
+  }, [builtinNumerics, builtinStrings, customNumerics, customStrings]);
 
   return (
     <TraceSearchBarsContainer>
@@ -51,6 +67,10 @@ export function TracesSearchBar({
             <SpanSearchQueryBuilder
               projects={selection.projects}
               initialQuery={query}
+              builtinNumerics={builtinNumerics}
+              builtinStrings={builtinStrings}
+              customNumerics={customNumerics}
+              customStrings={customStrings}
               onSearch={(queryString: string) => handleSearch(index, queryString)}
               searchSource="trace-explorer"
             />


### PR DESCRIPTION
This lifts the tag loading step out of the span search query builder so we can easily load spans from eap.