### PR TITLE
fix(explore): Allow deleting last selected group by

### DIFF
--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -250,7 +250,13 @@ describe('ExploreToolbar', function () {
     await userEvent.click(within(section).getAllByLabelText('Remove')[0]);
     expect(groupBys).toEqual(['span.description']);
 
-    // only one left so cant be deleted
+    // only 1 left but it's not empty
+    expect(within(section).getByLabelText('Remove')).toBeEnabled();
+
+    await userEvent.click(within(section).getByLabelText('Remove'));
+    expect(groupBys).toEqual(['']);
+
+    // last one and it's empty
     expect(within(section).getByLabelText('Remove')).toBeDisabled();
   });
 });

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -89,7 +89,7 @@ export function ToolbarGroupBy({disabled}: ToolbarGroupByProps) {
               borderless
               icon={<IconDelete />}
               size="zero"
-              disabled={disabled || groupBys.length <= 1}
+              disabled={disabled || (groupBys.length <= 1 && groupBy === '')}
               onClick={() => deleteGroupBy(index)}
               aria-label={t('Remove')}
             />


### PR DESCRIPTION
When there's 1 group by left, the delete button just sets it to none instead of actually deleting the last dropdown item.