### PR TITLE
fix(releases): use get_or_create instead of sub transaction

### DIFF
--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -7,7 +7,6 @@ from typing import TypedDict
 
 from django.db import IntegrityError, router
 
-from sentry import features
 from sentry.constants import ObjectStatus
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.locks import locks
@@ -58,19 +57,14 @@ def set_commits(release, commit_list):
         # the same release rapidly for different projects.
         raise ReleaseCommitError
 
-    if features.has("organizations:set-commits-updated", release.organization):
-        create_repositories(commit_list, release)
-        create_commit_authors(commit_list, release)
+    create_repositories(commit_list, release)
+    create_commit_authors(commit_list, release)
 
     with TimedRetryPolicy(10)(lock.acquire):
         with (
             atomic_transaction(using=router.db_for_write(type(release))),
             in_test_hide_transaction_boundary(),
         ):
-            if not features.has("organizations:set-commits-updated", release.organization):
-                create_repositories(commit_list, release)
-                create_commit_authors(commit_list, release)
-
             head_commit_by_repo, commit_author_by_commit = set_commits_on_release(
                 release, commit_list
             )
@@ -155,16 +149,12 @@ def set_commit(idx, data, release):
             batch_size=100,
         )
 
-    try:
-        with atomic_transaction(using=router.db_for_write(ReleaseCommit)):
-            ReleaseCommit.objects.create(
-                organization_id=release.organization_id,
-                release=release,
-                commit=commit,
-                order=idx,
-            )
-    except IntegrityError:
-        pass
+    ReleaseCommit.objects.get_or_create(
+        organization_id=release.organization_id,
+        release=release,
+        commit=commit,
+        order=idx,
+    )
 
     return commit
 

--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -57,10 +57,10 @@ def set_commits(release, commit_list):
         # the same release rapidly for different projects.
         raise ReleaseCommitError
 
-    create_repositories(commit_list, release)
-    create_commit_authors(commit_list, release)
-
     with TimedRetryPolicy(10)(lock.acquire):
+        create_repositories(commit_list, release)
+        create_commit_authors(commit_list, release)
+
         with (
             atomic_transaction(using=router.db_for_write(type(release))),
             in_test_hide_transaction_boundary(),


### PR DESCRIPTION
reduce the amount of sub transactions by using get_or_create instead of catching integrity errors. also removes the ff flag for now. will keep the ff flag defined incase i make any more radical changes