### PR TITLE
ref(whats-new): Move the logic to update internal seen state

### DIFF
--- a/static/app/components/sidebar/broadcasts.tsx
+++ b/static/app/components/sidebar/broadcasts.tsx
@@ -47,9 +47,11 @@ function BroadcastSidebarContent({
 } & Pick<CommonSidebarProps, 'orientation' | 'collapsed' | 'hidePanel'>) {
   useEffect(() => {
     return () => {
-      onResetCounter();
+      if (whatIsNewRevampFeature) {
+        onResetCounter();
+      }
     };
-  }, [onResetCounter]);
+  }, [onResetCounter, whatIsNewRevampFeature]);
 
   return (
     <SidebarPanel
@@ -156,6 +158,10 @@ class Broadcasts extends Component<Props, State> {
     this.props.onShowPanel();
   };
 
+  get hasWhatsNewRevampFeature() {
+    return this.props.organization.features.includes('what-is-new-revamp');
+  }
+
   markSeen = async () => {
     const unseenBroadcastIds = this.unseenIds;
     if (unseenBroadcastIds.length === 0) {
@@ -163,6 +169,12 @@ class Broadcasts extends Component<Props, State> {
     }
 
     await markBroadcastsAsSeen(this.props.api, unseenBroadcastIds);
+
+    if (!this.hasWhatsNewRevampFeature) {
+      this.setState(state => ({
+        broadcasts: state.broadcasts.map(item => ({...item, hasSeen: true})),
+      }));
+    }
   };
 
   get unseenIds() {
@@ -178,11 +190,10 @@ class Broadcasts extends Component<Props, State> {
   };
 
   render() {
-    const {orientation, collapsed, currentPanel, hidePanel, organization} = this.props;
+    const {orientation, collapsed, currentPanel, hidePanel} = this.props;
     const {broadcasts, loading} = this.state;
 
     const unseenPosts = this.unseenIds;
-    const whatIsNewRevampFeature = organization.features.includes('what-is-new-revamp');
 
     return (
       <DemoModeGate>
@@ -206,7 +217,7 @@ class Broadcasts extends Component<Props, State> {
               broadcasts={broadcasts}
               collapsed={collapsed}
               orientation={orientation}
-              whatIsNewRevampFeature={whatIsNewRevampFeature}
+              whatIsNewRevampFeature={this.hasWhatsNewRevampFeature}
               onResetCounter={this.handleResetCounter}
             />
           )}

--- a/static/app/components/sidebar/broadcasts.tsx
+++ b/static/app/components/sidebar/broadcasts.tsx
@@ -171,9 +171,7 @@ class Broadcasts extends Component<Props, State> {
     await markBroadcastsAsSeen(this.props.api, unseenBroadcastIds);
 
     if (!this.hasWhatsNewRevampFeature) {
-      this.setState(state => ({
-        broadcasts: state.broadcasts.map(item => ({...item, hasSeen: true})),
-      }));
+      this.handleResetCounter();
     }
   };
 

--- a/static/app/components/sidebar/broadcasts.tsx
+++ b/static/app/components/sidebar/broadcasts.tsx
@@ -28,7 +28,6 @@ type Props = CommonSidebarProps & {
 
 type State = {
   broadcasts: Broadcast[];
-  error: boolean;
   loading: boolean;
 };
 
@@ -36,7 +35,6 @@ class Broadcasts extends Component<Props, State> {
   state: State = {
     broadcasts: [],
     loading: true,
-    error: false,
   };
 
   componentDidMount() {
@@ -75,7 +73,7 @@ class Broadcasts extends Component<Props, State> {
       const data = await getAllBroadcasts(this.props.api, this.props.organization.slug);
       this.setState({loading: false, broadcasts: data || []});
     } catch {
-      this.setState({loading: false, error: true});
+      this.setState({loading: false});
     }
 
     this.startPolling();
@@ -103,10 +101,6 @@ class Broadcasts extends Component<Props, State> {
     }
 
     await markBroadcastsAsSeen(this.props.api, unseenBroadcastIds);
-
-    this.setState(state => ({
-      broadcasts: state.broadcasts.map(item => ({...item, hasSeen: true})),
-    }));
   };
 
   get unseenIds() {


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/77462


Preview of the new behavior as a video/image can tell more than 1.000 words:


https://github.com/user-attachments/assets/6df5ee62-4ec3-4f53-9704-b5683ee9233a

