### PR TITLE
ref: fix test pollution integrity errors due to cache leaks between tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from collections.abc import MutableMapping
 import psutil
 import pytest
 import responses
+from django.core.cache import cache
 from django.db import connections
 
 from sentry.silo.base import SiloMode
@@ -102,6 +103,12 @@ def audit_hybrid_cloud_writes_and_deletes(request):
             conn.force_debug_cursor = debug_cursor_state[conn.alias]
 
             validate_protected_queries(conn.queries)
+
+
+@pytest.fixture(autouse=True)
+def clear_caches():
+    yield
+    cache.clear()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
this results in about a 15% failure rate:

```pytest
$ pytest --count 10 tests/sentry/event_manager/test_event_manager_grouping.py -k test_records_hash_comparison_metric
...
```

failing with:

```
E   django.db.utils.IntegrityError: ForeignKeyViolation('insert or update on table "sentry_environmentproject" violates foreign key constraint "sentry_environmentpr_environment_id_f5d02227_fk_sentry_en"\nDETAIL:  Key (environment_id)=(18) is not present in table "sentry_environment".\n')
E   SQL: SET CONSTRAINTS ALL IMMEDIATE
```

I traced this down to a cache leaking from one test to another -- after applying this patch I had no failures in 100x runs of the tests

<!-- Describe your PR here. -->