### PR TITLE
ref: fix process consumer test

### DIFF
--- a/tests/sentry/spans/consumers/process/test_factory.py
+++ b/tests/sentry/spans/consumers/process/test_factory.py
@@ -91,6 +91,7 @@ def process_spans_strategy():
     )
 
 
+@django_db_all
 @override_options(
     {
         "standalone-spans.process-spans-consumer.enable": True,


### PR DESCRIPTION
this test always fails when run by itself (due to positive pollution from other tests in the file populating the global cache):

```console
$ pytest -q tests/sentry/spans/consumers/process/test_factory.py -k test_consumer_pushes_to_redis
F                                                                            [100%]
===================================== FAILURES =====================================
__________________________ test_consumer_pushes_to_redis ___________________________
tests/sentry/spans/consumers/process/test_factory.py:122: in test_consumer_pushes_to_redis
    assert redis_client.lrange("segment:a49b42af9fb69da0:1:process-segment", 0, -1) == [
E   assert [] == [b'{"descript...c7d4e3ee2a"}']
E     
E     Right contains 2 more items, first extra item: b'{"description":"OrganizationNPlusOne","duration_ms":107,"event_id":"61ccae71d70f45bb9b1f2ccb7f7a49ec","exclusive_tim...imestamp_precise"
E     
E     ...Full output truncated (2 lines hidden), use '-vv' to show
============================= short test summary info ==============================
FAILED tests/sentry/spans/consumers/process/test_factory.py::test_consumer_pushes_to_redis - assert [] == [b'{"descript...c7d4e3ee2a"}']
1 failed, 8 deselected in 0.25s
```

<!-- Describe your PR here. -->