### PR TITLE
chore(insights): Change copy for query not found message in MongoDB queries

### DIFF
--- a/static/app/views/insights/common/components/spanDescription.tsx
+++ b/static/app/views/insights/common/components/spanDescription.tsx
@@ -100,7 +100,7 @@ export function DatabaseSpanDescription({
               }}
             />
           ) : (
-            <MissingFrame />
+            <MissingFrame system={system} />
           )}
         </Fragment>
       )}

--- a/static/app/views/insights/database/components/stackTraceMiniFrame.tsx
+++ b/static/app/views/insights/database/components/stackTraceMiniFrame.tsx
@@ -55,17 +55,27 @@ export function StackTraceMiniFrame({frame, eventId, projectId}: Props) {
   );
 }
 
-export function MissingFrame() {
+type MissingFrameProps = {
+  system?: string;
+};
+
+export function MissingFrame({system}: MissingFrameProps) {
+  const documentation = <ExternalLink href={`${MODULE_DOC_LINK}#query-sources`} />;
+
+  const errorMessage =
+    system === 'mongodb'
+      ? tct(
+          'Query sources are not currently supported for MongoDB queries. Learn more in our [documentation:documentation].',
+          {documentation}
+        )
+      : tct(
+          'Could not find query source in the selected date range. Learn more in our [documentation:documentation].',
+          {documentation}
+        );
+
   return (
     <FrameContainer>
-      <Deemphasize>
-        {tct(
-          'Could not find query source in the selected date range. Learn more in our [documentation:documentation].',
-          {
-            documentation: <ExternalLink href={`${MODULE_DOC_LINK}#query-sources`} />,
-          }
-        )}
-      </Deemphasize>
+      <Deemphasize>{errorMessage}</Deemphasize>
     </FrameContainer>
   );
 }


### PR DESCRIPTION
The SDKs currently do not capture a query source for MongoDB queries, this PR updates the message informing the user that the query source was not found, since it can be misleading.

![image](https://github.com/user-attachments/assets/9756b4f9-f2c8-4ce4-a579-33aa71cb58e7)
