### PR TITLE
ref(rr6): Restrict import from react-router

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -40,7 +40,9 @@
         "noRestrictedImports": {
           "level": "warn",
           "options": {
-            "paths": {}
+            "paths": {
+              "react-router": "Do not import from react-router. While we transition to 6 there are shims to import from"
+            }
           }
         }
       },

--- a/static/app/components/links/link.tsx
+++ b/static/app/components/links/link.tsx
@@ -1,4 +1,5 @@
 import {forwardRef} from 'react';
+// biome-ignore lint/nursery/noRestrictedImports: Will be removed with react router 6
 import {Link as RouterLink} from 'react-router';
 import {Link as Router6Link} from 'react-router-dom';
 import styled from '@emotion/styled';

--- a/static/app/components/links/listLink.tsx
+++ b/static/app/components/links/listLink.tsx
@@ -1,3 +1,4 @@
+// biome-ignore lint/nursery/noRestrictedImports: Will be removed with react router 6
 import {Link as RouterLink} from 'react-router';
 import {NavLink} from 'react-router-dom';
 import styled from '@emotion/styled';

--- a/static/app/components/onboarding/gettingStartedDoc/utils/useCurrentProjectState.spec.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/useCurrentProjectState.spec.tsx
@@ -1,3 +1,4 @@
+// biome-ignore lint/nursery/noRestrictedImports: Will be removed with react router 6
 import {createMemoryHistory, Route, Router, RouterContext} from 'react-router';
 import {ProjectFixture} from 'sentry-fixture/project';
 

--- a/static/app/components/route.tsx
+++ b/static/app/components/route.tsx
@@ -1,4 +1,6 @@
+// biome-ignore lint/nursery/noRestrictedImports: Will be removed with react router 6
 import type {IndexRouteProps, PlainRoute, RouteProps} from 'react-router';
+// biome-ignore lint/nursery/noRestrictedImports: Will be removed with react router 6
 import {IndexRoute as BaseIndexRoute, Route as BaseRoute} from 'react-router';
 
 import {USING_CUSTOMER_DOMAIN} from 'sentry/constants';

--- a/static/app/main.tsx
+++ b/static/app/main.tsx
@@ -1,4 +1,5 @@
 import {useState} from 'react';
+// biome-ignore lint/nursery/noRestrictedImports: Will be removed with react router 6
 import {Router, RouterContext} from 'react-router';
 import {createBrowserRouter, RouterProvider} from 'react-router-dom';
 import {wrapCreateBrowserRouter} from '@sentry/react';

--- a/static/app/routes.spec.tsx
+++ b/static/app/routes.spec.tsx
@@ -1,3 +1,4 @@
+// biome-ignore lint/nursery/noRestrictedImports: Will be removed with react router 6
 import {createRoutes} from 'react-router';
 
 import * as constants from 'sentry/constants';

--- a/static/app/utils/browserHistory.tsx
+++ b/static/app/utils/browserHistory.tsx
@@ -1,3 +1,4 @@
+// biome-ignore lint/nursery/noRestrictedImports: Will be removed with react router 6
 import {browserHistory as react3BrowserHistory} from 'react-router';
 import type {Router} from '@remix-run/router/dist/router';
 import type {History} from 'history';

--- a/static/app/utils/withDomainRedirect.tsx
+++ b/static/app/utils/withDomainRedirect.tsx
@@ -1,3 +1,4 @@
+// biome-ignore lint/nursery/noRestrictedImports: Will be removed with react router 6
 import {formatPattern} from 'react-router';
 import trimEnd from 'lodash/trimEnd';
 import trimStart from 'lodash/trimStart';

--- a/static/app/views/explore/hooks/useChartInterval.spec.tsx
+++ b/static/app/views/explore/hooks/useChartInterval.spec.tsx
@@ -1,3 +1,4 @@
+// biome-ignore lint/nursery/noRestrictedImports: Will be removed with react router 6
 import {createMemoryHistory, Route, Router, RouterContext} from 'react-router';
 
 import {act, render} from 'sentry-test/reactTestingLibrary';

--- a/static/app/views/explore/hooks/useGroupBys.spec.tsx
+++ b/static/app/views/explore/hooks/useGroupBys.spec.tsx
@@ -1,3 +1,4 @@
+// biome-ignore lint/nursery/noRestrictedImports: Will be removed with react router 6
 import {createMemoryHistory, Route, Router, RouterContext} from 'react-router';
 
 import {act, render} from 'sentry-test/reactTestingLibrary';

--- a/static/app/views/explore/hooks/useResultsMode.spec.tsx
+++ b/static/app/views/explore/hooks/useResultsMode.spec.tsx
@@ -1,3 +1,4 @@
+// biome-ignore lint/nursery/noRestrictedImports: Will be removed with react router 6
 import {createMemoryHistory, Route, Router, RouterContext} from 'react-router';
 
 import {act, render} from 'sentry-test/reactTestingLibrary';

--- a/static/app/views/explore/hooks/useSampleFields.spec.tsx
+++ b/static/app/views/explore/hooks/useSampleFields.spec.tsx
@@ -1,3 +1,4 @@
+// biome-ignore lint/nursery/noRestrictedImports: Will be removed with react router 6
 import {createMemoryHistory, Route, Router, RouterContext} from 'react-router';
 
 import {act, render} from 'sentry-test/reactTestingLibrary';

--- a/static/app/views/explore/hooks/useSorts.spec.tsx
+++ b/static/app/views/explore/hooks/useSorts.spec.tsx
@@ -1,3 +1,4 @@
+// biome-ignore lint/nursery/noRestrictedImports: Will be removed with react router 6
 import {createMemoryHistory, Route, Router, RouterContext} from 'react-router';
 
 import {act, render} from 'sentry-test/reactTestingLibrary';

--- a/static/app/views/explore/hooks/useUserQuery.spec.tsx
+++ b/static/app/views/explore/hooks/useUserQuery.spec.tsx
@@ -1,3 +1,4 @@
+// biome-ignore lint/nursery/noRestrictedImports: Will be removed with react router 6
 import {createMemoryHistory, Route, Router, RouterContext} from 'react-router';
 
 import {act, render} from 'sentry-test/reactTestingLibrary';

--- a/static/app/views/explore/hooks/useVisualizes.spec.tsx
+++ b/static/app/views/explore/hooks/useVisualizes.spec.tsx
@@ -1,3 +1,4 @@
+// biome-ignore lint/nursery/noRestrictedImports: Will be removed with react router 6
 import {createMemoryHistory, Route, Router, RouterContext} from 'react-router';
 
 import {act, render} from 'sentry-test/reactTestingLibrary';

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -1,3 +1,4 @@
+// biome-ignore lint/nursery/noRestrictedImports: Will be removed with react router 6
 import {createMemoryHistory, Route, Router, RouterContext} from 'react-router';
 
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';

--- a/static/app/views/integrationPipeline/pipelineView.tsx
+++ b/static/app/views/integrationPipeline/pipelineView.tsx
@@ -1,4 +1,5 @@
 import {useEffect} from 'react';
+// biome-ignore lint/nursery/noRestrictedImports: Will be removed with react router 6
 import {createMemoryHistory, Route, Router, RouterContext} from 'react-router';
 
 import Indicators from 'sentry/components/indicators';

--- a/static/app/views/settings/components/settingsNavItem.tsx
+++ b/static/app/views/settings/components/settingsNavItem.tsx
@@ -1,5 +1,6 @@
 import type {ReactElement} from 'react';
 import {Fragment} from 'react';
+// biome-ignore lint/nursery/noRestrictedImports: Will be removed with react router 6
 import {Link as RouterLink} from 'react-router';
 import {NavLink as Router6NavLink} from 'react-router-dom';
 import styled from '@emotion/styled';


### PR DESCRIPTION
A few people have imported browserHistory directly from react-router,
resulting in it not working in react router 6.