### PR TITLE
feat(flags): hide flags from context and add feedback button

### DIFF
--- a/static/app/components/events/contexts/index.tsx
+++ b/static/app/components/events/contexts/index.tsx
@@ -33,9 +33,9 @@ export function getOrderedContextItems(event: Event): ContextItem[] {
   const {user, contexts} = event;
   const {data: customUserData, ...userContext} = user ?? {};
 
-  // don't show `flags` in the contexts section
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const {feedback, response, flags, ...otherContexts} = contexts ?? {};
+  // hide `flags` in the contexts section since we display this
+  // info in the feature flag section below
+  const {feedback, response, flags: _, ...otherContexts} = contexts ?? {};
   const orderedContext: [ContextItem['alias'], ContextValue][] = [
     ['response', response],
     ['feedback', feedback],

--- a/static/app/components/events/contexts/index.tsx
+++ b/static/app/components/events/contexts/index.tsx
@@ -33,7 +33,9 @@ export function getOrderedContextItems(event: Event): ContextItem[] {
   const {user, contexts} = event;
   const {data: customUserData, ...userContext} = user ?? {};
 
-  const {feedback, response, ...otherContexts} = contexts ?? {};
+  // don't show `flags` in the contexts section
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const {feedback, response, flags, ...otherContexts} = contexts ?? {};
   const orderedContext: [ContextItem['alias'], ContextValue][] = [
     ['response', response],
     ['feedback', feedback],

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -16,11 +16,12 @@ import useDrawer from 'sentry/components/globalDrawer';
 import KeyValueData, {
   type KeyValueDataContentProps,
 } from 'sentry/components/keyValueData';
-import {IconSort} from 'sentry/icons';
+import {IconMegaphone, IconSort} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Event, FeatureFlag} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
+import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 
 export function EventFeatureFlagList({
@@ -32,6 +33,26 @@ export function EventFeatureFlagList({
   group: Group;
   project: Project;
 }) {
+  const openForm = useFeedbackForm();
+  const feedbackButton = openForm ? (
+    <Button
+      aria-label={t('Give feedback on this component')}
+      icon={<IconMegaphone />}
+      size={'xs'}
+      onClick={() =>
+        openForm({
+          messagePlaceholder: t('How can we make feature flags work better for you?'),
+          tags: {
+            ['feedback.source']: 'issue_details_feature_flags',
+            ['feedback.owner']: 'replay',
+          },
+        })
+      }
+    >
+      {t('Give Feedback')}
+    </Button>
+  ) : null;
+
   const [sortMethod, setSortMethod] = useState<FlagSort>(FlagSort.EVAL);
   const {closeDrawer, isDrawerOpen, openDrawer} = useDrawer();
   const viewAllButtonRef = useRef<HTMLButtonElement>(null);
@@ -96,6 +117,7 @@ export function EventFeatureFlagList({
 
   const actions = (
     <ButtonBar gap={1}>
+      {feedbackButton}
       <Button
         size="xs"
         aria-label={t('View All')}

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -36,7 +36,7 @@ export function EventFeatureFlagList({
   const openForm = useFeedbackForm();
   const feedbackButton = openForm ? (
     <Button
-      aria-label={t('Give feedback on this component')}
+      aria-label={t('Give feedback on the feature flag section')}
       icon={<IconMegaphone />}
       size={'xs'}
       onClick={() =>


### PR DESCRIPTION
## add give feedback button:
it wouldn't show up in the drawer for some reason so added it to the main component action bar:

https://github.com/user-attachments/assets/ef3b778e-daa2-4fc1-9cad-3b93d8ad4deb

## remove `flags` from the context display
<img width="996" alt="SCR-20240913-jueq" src="https://github.com/user-attachments/assets/80697333-062d-41ca-800d-41529ead0112">

closes https://github.com/getsentry/sentry/issues/77399
closes https://github.com/getsentry/sentry/issues/77160


