### PR TITLE
fix(ui): Inmprove spacing on code snippet header

### DIFF
--- a/static/app/components/codeSnippet.tsx
+++ b/static/app/components/codeSnippet.tsx
@@ -240,7 +240,7 @@ const Header = styled('div')<{isSolid: boolean}>`
     `}
 `;
 
-const FileName = styled('p')`
+const FileName = styled('span')`
   ${p => p.theme.overflowEllipsis}
   padding: ${space(0.5)} ${space(0.5)};
   margin: 0;


### PR DESCRIPTION
Before
<img alt="clipboard.png" width="1085" src="https://i.imgur.com/8TmGqVt.png" />

After
<img alt="clipboard.png" width="1074" src="https://i.imgur.com/H4LOaeX.png" />