### PR TITLE
chore(apidocs): Make UserRole related endpoints private

### DIFF
--- a/src/sentry/users/api/endpoints/user_role_details.py
+++ b/src/sentry/users/api/endpoints/user_role_details.py
@@ -20,9 +20,9 @@ audit_logger = logging.getLogger("sentry.audit.user")
 @control_silo_endpoint
 class UserUserRoleDetailsEndpoint(UserEndpoint):
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
-        "POST": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (SuperuserPermission,)
 

--- a/src/sentry/users/api/endpoints/user_roles.py
+++ b/src/sentry/users/api/endpoints/user_roles.py
@@ -14,7 +14,7 @@ from sentry.users.models.userrole import UserRole
 @control_silo_endpoint
 class UserUserRolesEndpoint(UserEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (SuperuserPermission,)
 

--- a/src/sentry/users/api/endpoints/userroles_details.py
+++ b/src/sentry/users/api/endpoints/userroles_details.py
@@ -19,9 +19,9 @@ audit_logger = logging.getLogger("sentry.audit.user")
 @control_silo_endpoint
 class UserRoleDetailsEndpoint(Endpoint):
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
-        "PUT": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (SuperuserPermission,)
 


### PR DESCRIPTION
`UserRolesEndpoint` was made private in https://github.com/getsentry/sentry/pull/75544, so we'll do the same for `UserRoleDetailsEndpoint`, `UserUserRolesEndpoint`, and `UserUserRoleDetailsEndpoint`.