### PR TITLE
chore(apidocs): Fix inconsistencies in replay docs

### DIFF
--- a/src/sentry/replays/endpoints/organization_replay_count.py
+++ b/src/sentry/replays/endpoints/organization_replay_count.py
@@ -56,7 +56,7 @@ class OrganizationReplayCountEndpoint(OrganizationEventsV2EndpointBase):
 
     @extend_schema(
         examples=ReplayExamples.GET_REPLAY_COUNTS,
-        operation_id="Return a Count of Replays",
+        operation_id="Retrieve a Count of Replays",
         parameters=[
             GlobalParams.END,
             GlobalParams.ENVIRONMENT,
@@ -73,7 +73,7 @@ class OrganizationReplayCountEndpoint(OrganizationEventsV2EndpointBase):
         },
     )
     def get(self, request: Request, organization: Organization) -> Response:
-        """Return a count of replays for the given issue or transaction id."""
+        """Return a count of replays for the given issue or transaction ID."""
         if not features.has("organizations:session-replay", organization, actor=request.user):
             return Response(status=404)
 

--- a/src/sentry/replays/endpoints/organization_replay_count.py
+++ b/src/sentry/replays/endpoints/organization_replay_count.py
@@ -58,10 +58,10 @@ class OrganizationReplayCountEndpoint(OrganizationEventsV2EndpointBase):
         examples=ReplayExamples.GET_REPLAY_COUNTS,
         operation_id="Retrieve a Count of Replays",
         parameters=[
-            GlobalParams.END,
             GlobalParams.ENVIRONMENT,
             GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.START,
+            GlobalParams.END,
             GlobalParams.STATS_PERIOD,
             OrganizationParams.PROJECT,
             VisibilityParams.QUERY,

--- a/src/sentry/replays/endpoints/project_replay_details.py
+++ b/src/sentry/replays/endpoints/project_replay_details.py
@@ -85,7 +85,7 @@ class ProjectReplayDetailsEndpoint(ProjectEndpoint):
     )
     def delete(self, request: Request, project: Project, replay_id: str) -> Response:
         """
-        Delete a replay
+        Delete a replay.
         """
 
         if not features.has(

--- a/src/sentry/replays/endpoints/project_replay_recording_segment_details.py
+++ b/src/sentry/replays/endpoints/project_replay_recording_segment_details.py
@@ -32,7 +32,7 @@ class ProjectReplayRecordingSegmentDetailsEndpoint(ProjectEndpoint):
     }
 
     @extend_schema(
-        operation_id="Fetch Recording Segment",
+        operation_id="Retrieve a Recording Segment",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,

--- a/src/sentry/replays/endpoints/project_replay_viewed_by.py
+++ b/src/sentry/replays/endpoints/project_replay_viewed_by.py
@@ -39,7 +39,7 @@ class ProjectReplayViewedByEndpoint(ProjectEndpoint):
     permission_classes = (ProjectEventPermission,)
 
     @extend_schema(
-        operation_id="Get list of user who have viewed a replay",
+        operation_id="List Users Who Have Viewed a Replay",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,

--- a/src/sentry/replays/validators.py
+++ b/src/sentry/replays/validators.py
@@ -106,6 +106,8 @@ class ReplaySelectorValidator(serializers.Serializer):
         required=False,
     )
     project = serializers.ListField(
-        required=False, help_text="The ID of the projects to filter by."
+        required=False,
+        help_text="The ID of the projects to filter by.",
+        child=serializers.IntegerField(),
     )
     sort = serializers.CharField(help_text="The field to sort the output by.", required=False)


### PR DESCRIPTION
A couple small nits to make these docs a little more consistent with the rest:
- Return/Fetch -> Retrieve
- "Get list..." -> "List ..."
- Capitalization, punctuation
- Missing field type