### PR TITLE
fix(insights): Fixes Alerts from Queries module charts not always having accurate filters

### DIFF
--- a/static/app/components/metrics/metricSearchBar.tsx
+++ b/static/app/components/metrics/metricSearchBar.tsx
@@ -49,6 +49,12 @@ const INSIGHTS_ADDITIONAL_TAG_FILTERS: MetricTag[] = [
   {
     key: SpanMetricsField.FILE_EXTENSION,
   },
+  {
+    key: SpanMetricsField.SPAN_SYSTEM,
+  },
+  {
+    key: SpanMetricsField.SPAN_GROUP,
+  },
 ];
 
 export function MetricSearchBar({

--- a/static/app/views/insights/database/components/charts/durationChart.tsx
+++ b/static/app/views/insights/database/components/charts/durationChart.tsx
@@ -1,23 +1,23 @@
 import type {Series} from 'sentry/types/echarts';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {AVG_COLOR} from 'sentry/views/insights/colors';
 import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
 import ChartPanel from 'sentry/views/insights/common/components/chartPanel';
 import {getDurationChartTitle} from 'sentry/views/insights/common/views/spans/types';
 import {ALERTS} from 'sentry/views/insights/database/alerts';
 import {CHART_HEIGHT} from 'sentry/views/insights/database/settings';
+import type {SpanMetricsQueryFilters} from 'sentry/views/insights/types';
 
 interface Props {
   isLoading: boolean;
   series: Series[];
   error?: Error | null;
-  groupId?: string;
+  filters?: SpanMetricsQueryFilters;
 }
 
-export function DurationChart({series, isLoading, error, groupId}: Props) {
-  let alertConfig = ALERTS.duration;
-  if (groupId) {
-    alertConfig = {...alertConfig, query: `${alertConfig.query} span.group:${groupId}`};
-  }
+export function DurationChart({series, isLoading, error, filters}: Props) {
+  const filterString = filters && MutableSearch.fromQueryObject(filters).formatString();
+  const alertConfig = {...ALERTS.duration, query: filterString ?? ALERTS.duration.query};
   return (
     <ChartPanel title={getDurationChartTitle('db')} alertConfigs={[alertConfig]}>
       <Chart

--- a/static/app/views/insights/database/components/charts/throughputChart.tsx
+++ b/static/app/views/insights/database/components/charts/throughputChart.tsx
@@ -1,25 +1,25 @@
 import type {Series} from 'sentry/types/echarts';
 import {RateUnit} from 'sentry/utils/discover/fields';
 import {formatRate} from 'sentry/utils/formatters';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {THROUGHPUT_COLOR} from 'sentry/views/insights/colors';
 import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
 import ChartPanel from 'sentry/views/insights/common/components/chartPanel';
 import {getThroughputChartTitle} from 'sentry/views/insights/common/views/spans/types';
 import {ALERTS} from 'sentry/views/insights/database/alerts';
 import {CHART_HEIGHT} from 'sentry/views/insights/database/settings';
+import type {SpanMetricsQueryFilters} from 'sentry/views/insights/types';
 
 interface Props {
   isLoading: boolean;
   series: Series;
   error?: Error | null;
-  groupId?: string;
+  filters?: SpanMetricsQueryFilters;
 }
 
-export function ThroughputChart({series, isLoading, groupId}: Props) {
-  let alertConfig = ALERTS.spm;
-  if (groupId) {
-    alertConfig = {...alertConfig, query: `${alertConfig.query} span.group:${groupId}`};
-  }
+export function ThroughputChart({series, isLoading, filters}: Props) {
+  const filterString = filters && MutableSearch.fromQueryObject(filters).formatString();
+  const alertConfig = {...ALERTS.spm, query: filterString ?? ALERTS.spm.query};
   return (
     <ChartPanel title={getThroughputChartTitle('db')} alertConfigs={[alertConfig]}>
       <Chart

--- a/static/app/views/insights/database/views/databaseLandingPage.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.tsx
@@ -201,6 +201,7 @@ export function DatabaseLandingPage() {
                   series={throughputData['spm()']}
                   isLoading={isThroughputDataLoading}
                   error={throughputError}
+                  filters={chartFilters}
                 />
               </ModuleLayout.Half>
 
@@ -209,6 +210,7 @@ export function DatabaseLandingPage() {
                   series={[durationData[`${selectedAggregate}(span.self_time)`]]}
                   isLoading={isDurationDataLoading}
                   error={durationError}
+                  filters={chartFilters}
                 />
               </ModuleLayout.Half>
 

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
@@ -272,7 +272,7 @@ export function DatabaseSpanSummaryPage({params}: Props) {
                   series={throughputData['spm()']}
                   isLoading={isThroughputDataLoading}
                   error={throughputError}
-                  groupId={groupId}
+                  filters={filters}
                 />
 
                 <DurationChart
@@ -283,7 +283,7 @@ export function DatabaseSpanSummaryPage({params}: Props) {
                   ]}
                   isLoading={isDurationDataLoading}
                   error={durationError}
-                  groupId={groupId}
+                  filters={filters}
                 />
               </ChartContainer>
             </ModuleLayout.Full>


### PR DESCRIPTION
Fixes an issue where Alerts created from Queries module charts don't always have the same exact filters.
Also adds `span.system` and `span.group` as valid tag keys for Insights alerts.