### PR TITLE
fix(custom-views): Change cursor for tab to pointer everywhere

### DIFF
--- a/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
@@ -99,8 +99,7 @@ const StyledGrowingInput = styled(GrowingInput)<{isSelected: boolean}>`
   min-height: 0px;
   height: 20px;
   border-radius: 0px;
-
-  cursor: ${p => (p.isSelected ? 'auto' : 'pointer')};
+  cursor: pointer;
 
   &,
   &:focus,


### PR DESCRIPTION
Changes the cursor for the tab to be `pointer` everywhere. Previously the cursor was `text` on the title, and pointer around it. 