### PR TITLE
fix(query-builder): Stop text from being overwritten when pasting

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -377,12 +377,16 @@ function SearchQueryBuilderInputInternal({
       e.preventDefault();
       e.stopPropagation();
 
-      const text = e.clipboardData.getData('text/plain').replace('\n', '').trim();
+      const clipboardText = e.clipboardData
+        .getData('text/plain')
+        .replace('\n', '')
+        .trim();
+      const currentText = inputRef.current?.value ?? '';
 
       dispatch({
         type: 'REPLACE_TOKENS_WITH_TEXT',
         tokens: [token],
-        text,
+        text: currentText + clipboardText,
       });
       resetInputValue();
     },


### PR DESCRIPTION
Small bug fix which appends the clipboard contents to the text that is already in the input. So if you start by typing "foo" and paste some "bar", we don't overwrite "foo".