### PR TITLE
fix(onboarding): Open replay panel in quick start action

### DIFF
--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -7,8 +7,10 @@ import type {OnboardingContextProps} from 'sentry/components/onboarding/onboardi
 import {filterSupportedTasks} from 'sentry/components/onboardingWizard/filterSupportedTasks';
 import {taskIsDone} from 'sentry/components/onboardingWizard/utils';
 import {filterProjects} from 'sentry/components/performanceOnboarding/utils';
+import {SidebarPanelKey} from 'sentry/components/sidebar/types';
 import {sourceMaps} from 'sentry/data/platformCategories';
 import {t} from 'sentry/locale';
+import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
 import pulsingIndicatorStyles from 'sentry/styles/pulsingIndicator';
 import {space} from 'sentry/styles/space';
 import type {
@@ -320,10 +322,20 @@ export function getOnboardingTasks({
       ),
       skippable: true,
       requisites: [OnboardingTaskKey.FIRST_PROJECT, OnboardingTaskKey.FIRST_EVENT],
-      actionType: 'app',
-      location: normalizeUrl(
-        `/organizations/${organization.slug}/replays/#replay-sidequest`
-      ),
+      actionType: 'action',
+      action: router => {
+        router.push(
+          normalizeUrl({
+            pathname: `/organizations/${organization.slug}/replays/`,
+            query: {referrer: 'onboarding_task'},
+          })
+        );
+        // Since the quick start panel is already open and closes on route change
+        // Wait for the next tick to open the replay onboarding panel
+        setTimeout(() => {
+          SidebarPanelStore.activatePanel(SidebarPanelKey.REPLAYS_ONBOARDING);
+        }, 0);
+      },
       display: organization.features?.includes('session-replay'),
       SupplementComponent: withApi(
         ({api, task, onCompleteTask}: FirstEventWaiterProps) =>


### PR DESCRIPTION
The replay sidequest don't seem to open 100% of the time. the current version attempts to navigate to replays with `#replay-sidequest` but this sometimes doesn't work since the panel attempts to close at the same time

the area we close the panel on navigation

https://github.com/getsentry/sentry/blob/f72a7fc875fcfaf3ce2f28404e4d321ddfbbaff3/static/app/components/sidebar/index.tsx#L160


the performance-sidequest seems to work better but it also provides a project id? Maybe related to global selection setting a project id on page load

https://github.com/getsentry/sentry/blob/f72a7fc875fcfaf3ce2f28404e4d321ddfbbaff3/static/app/components/onboardingWizard/taskConfig.tsx#L271-L282
