### PR TITLE
fix(ui): Remove team slug from settings search

### DIFF
--- a/static/app/data/forms/teamSettingsFields.tsx
+++ b/static/app/data/forms/teamSettingsFields.tsx
@@ -3,7 +3,8 @@ import {t} from 'sentry/locale';
 import slugify from 'sentry/utils/slugify';
 
 // Export route to make these forms searchable by label/help
-export const route = '/settings/:orgId/teams/:teamId/settings/';
+// TODO: :teamId is not a valid route parameter
+// export const route = '/settings/:orgId/teams/:teamId/settings/';
 
 const formGroups: JsonFormObject[] = [
   {


### PR DESCRIPTION
Team slug is attempting to use :teamId which is not supported as navigate path parameter. Disable for now.

![image](https://github.com/user-attachments/assets/0d10a989-3be5-4a83-b915-206875edae58)

fixes #77478
