### PR TITLE
fix(similarity): Return failure reason from multithread seer call

### DIFF
--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -499,6 +499,7 @@ def send_group_and_stacktrace_to_seer_multithreaded(
         for seer_response in seer_responses:
             if not seer_response["success"]:
                 aggregated_response["success"] = False
+                aggregated_response.update({"reason": seer_response["reason"]})
                 return aggregated_response
 
             aggregated_response["groups_with_neighbor"].update(


### PR DESCRIPTION
Return failure reason from multithread seer call in the backfill
This allows the reason to be logged and the logic to skip projects with gateway timeouts [here](https://github.com/getsentry/sentry/blob/ff9a79b8945522173459675164ecbcd7e055405c/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py#L248-L279)