### PR TITLE
feat(onboarding): Avoid `new URL` for onboarding app routing

### DIFF
--- a/static/app/actionCreators/navigation.spec.tsx
+++ b/static/app/actionCreators/navigation.spec.tsx
@@ -34,19 +34,17 @@ describe('navigation ActionCreator', () => {
 
   it('should get project from query parameters', () => {
     router.location.query.project = '2';
-    expect(navigateTo('/settings/:projectId/alert', router)).toBe(undefined);
+    navigateTo('/settings/:projectId/alert', router);
     expect(openModal).not.toHaveBeenCalled();
     expect(router.push).toHaveBeenCalledWith('/settings/project-slug/alert');
   });
 
   it('should get project id from query parameters', () => {
     router.location.query.project = '2';
-    expect(
-      navigateTo(
-        '/organizations/albertos-apples/performance/?project=:project#performance-sidequest',
-        router
-      )
-    ).toBe(undefined);
+    navigateTo(
+      '/organizations/albertos-apples/performance/?project=:project#performance-sidequest',
+      router
+    );
     expect(openModal).not.toHaveBeenCalled();
     expect(router.push).toHaveBeenCalledWith(
       '/organizations/albertos-apples/performance/?project=2#performance-sidequest'
@@ -55,12 +53,10 @@ describe('navigation ActionCreator', () => {
 
   it('should get project and project id from query parameters', () => {
     router.location.query.project = '2';
-    expect(
-      navigateTo(
-        '/settings/:projectId/alert?project=:project#performance-sidequest',
-        router
-      )
-    ).toBe(undefined);
+    navigateTo(
+      '/settings/:projectId/alert?project=:project#performance-sidequest',
+      router
+    );
     expect(openModal).not.toHaveBeenCalled();
     expect(router.push).toHaveBeenCalledWith(
       '/settings/project-slug/alert?project=2#performance-sidequest'
@@ -69,39 +65,37 @@ describe('navigation ActionCreator', () => {
 
   it('should open modal if the store is somehow missing selected projectId', () => {
     router.location.query.project = '911';
-    expect(navigateTo('/settings/:projectId/alert', router)).toBe(undefined);
+    navigateTo('/settings/:projectId/alert', router);
     expect(openModal).toHaveBeenCalled();
   });
 
   it('should open modal when no project is selected', () => {
-    expect(navigateTo('/settings/:projectId/alert', router)).toBe(undefined);
+    navigateTo('/settings/:projectId/alert', router);
     expect(openModal).toHaveBeenCalled();
   });
 
   it('should open modal when no project id is selected', () => {
-    expect(
-      navigateTo(
-        '/organizations/albertos-apples/performance/?project=:project#performance-sidequest',
-        router
-      )
-    ).toBe(undefined);
+    navigateTo(
+      '/organizations/albertos-apples/performance/?project=:project#performance-sidequest',
+      router
+    );
     expect(openModal).toHaveBeenCalled();
   });
 
   it('should open modal if more than one project is selected', () => {
     router.location.query.project = ['1', '2', '3'];
-    expect(navigateTo('/settings/:projectId/alert', router)).toBe(undefined);
+    navigateTo('/settings/:projectId/alert', router);
     expect(openModal).toHaveBeenCalled();
   });
 
   it('should not open modal if url does not require project id', () => {
-    expect(navigateTo('/settings/alert', router)).toBe(undefined);
+    navigateTo('/settings/alert', router);
     expect(openModal).not.toHaveBeenCalled();
     expect(router.push).toHaveBeenCalledWith('/settings/alert');
   });
 
   it('should open modal for orgId', () => {
-    expect(navigateTo('/settings/:orgId', router)).toBe(undefined);
+    navigateTo('/settings/:orgId', router);
     expect(openModal).toHaveBeenCalled();
   });
 
@@ -123,15 +117,13 @@ describe('navigation ActionCreator', () => {
 
   it('preserves query parameters in path object', function () {
     router.location.query.project = '2';
-    expect(
-      navigateTo(
-        {
-          pathname: '/settings/:projectId/alert?project=:project#performance-sidequest',
-          query: {referrer: 'onboarding_task'},
-        },
-        router
-      )
-    ).toBe(undefined);
+    navigateTo(
+      {
+        pathname: '/settings/:projectId/alert?project=:project#performance-sidequest',
+        query: {referrer: 'onboarding_task'},
+      },
+      router
+    );
     expect(openModal).not.toHaveBeenCalled();
     expect(router.push).toHaveBeenCalledWith({
       pathname: '/settings/project-slug/alert?project=2#performance-sidequest',

--- a/static/app/actionCreators/navigation.spec.tsx
+++ b/static/app/actionCreators/navigation.spec.tsx
@@ -120,4 +120,22 @@ describe('navigation ActionCreator', () => {
     expect(openModal).not.toHaveBeenCalled();
     expect(router.push).toHaveBeenCalledWith('/settings/projects/project-slug/alerts/');
   });
+
+  it('preserves query parameters in path object', function () {
+    router.location.query.project = '2';
+    expect(
+      navigateTo(
+        {
+          pathname: '/settings/:projectId/alert?project=:project#performance-sidequest',
+          query: {referrer: 'onboarding_task'},
+        },
+        router
+      )
+    ).toBe(undefined);
+    expect(openModal).not.toHaveBeenCalled();
+    expect(router.push).toHaveBeenCalledWith({
+      pathname: '/settings/project-slug/alert?project=2#performance-sidequest',
+      query: {referrer: 'onboarding_task'},
+    });
+  });
 });

--- a/static/app/actionCreators/navigation.tsx
+++ b/static/app/actionCreators/navigation.tsx
@@ -1,4 +1,4 @@
-import type {Location} from 'history';
+import type {Location, Query} from 'history';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import ContextPickerModal from 'sentry/components/contextPickerModal';
@@ -9,13 +9,19 @@ import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 
 // TODO(ts): figure out better typing for react-router here
 export function navigateTo(
-  to: string,
+  to: string | {pathname: string; query?: Query},
   router: InjectedRouter & {location?: Location},
   configUrl?: string
 ) {
+  let pathname: string;
+  if (typeof to === 'string') {
+    pathname = to;
+  } else {
+    pathname = to.pathname;
+  }
   // Check for placeholder params
-  const needOrg = to.includes(':orgId');
-  const needProject = to.includes(':projectId') || to.includes(':project');
+  const needOrg = pathname.includes(':orgId');
+  const needProject = pathname.includes(':projectId') || pathname.includes(':project');
   const comingFromProjectId = router?.location?.query?.project;
   const needProjectId = !comingFromProjectId || Array.isArray(comingFromProjectId);
 
@@ -40,11 +46,12 @@ export function navigateTo(
     );
   } else {
     if (projectById) {
-      to = replaceRouterParams(to, {
+      pathname = replaceRouterParams(pathname, {
         projectId: projectById.slug,
         project: projectById.id,
       });
     }
-    router.push(normalizeUrl(to));
+    // Preserve query string
+    router.push(normalizeUrl(typeof to === 'string' ? pathname : {...to, pathname}));
   }
 }

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -2,6 +2,7 @@ import {Component, Fragment} from 'react';
 import {findDOMNode} from 'react-dom';
 import {components} from 'react-select';
 import styled from '@emotion/styled';
+import type {Query} from 'history';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent';
@@ -41,12 +42,13 @@ type Props = ModalRenderProps & {
   /**
    * The destination route
    */
-  nextPath: string;
+  nextPath: string | {pathname: string; query?: Query};
 
   /**
    * Finish callback
+   * @param path type will match nextPath's type {@link Props.nextPath}
    */
-  onFinish: (path: string) => number | void;
+  onFinish: (path: string | {pathname: string; query?: Query}) => number | void;
   /**
    * Callback for when organization is selected
    */
@@ -143,14 +145,18 @@ class ContextPickerModal extends Component<Props> {
     }
 
     window.clearTimeout(this.onFinishTimeout);
+    const pathname = typeof nextPath === 'string' ? nextPath : nextPath.pathname;
 
     // If there is only one org and we don't need a project slug, then call finish callback
     if (!needProject) {
+      const newPathname = replaceRouterParams(pathname, {
+        orgId: organizations[0].slug,
+      });
       this.onFinishTimeout =
         onFinish(
-          replaceRouterParams(nextPath, {
-            orgId: organizations[0].slug,
-          })
+          typeof nextPath === 'string'
+            ? newPathname
+            : {...nextPath, pathname: newPathname}
         ) ?? undefined;
       return;
     }
@@ -161,13 +167,14 @@ class ContextPickerModal extends Component<Props> {
       org = organizations[0].slug;
     }
 
+    const newPathname = replaceRouterParams(pathname, {
+      orgId: org,
+      projectId: projects[0].slug,
+      project: this.props.projects.find(p => p.slug === projects[0].slug)?.id,
+    });
     this.onFinishTimeout =
       onFinish(
-        replaceRouterParams(nextPath, {
-          orgId: org,
-          projectId: projects[0].slug,
-          project: this.props.projects.find(p => p.slug === projects[0].slug)?.id,
-        })
+        typeof nextPath === 'string' ? newPathname : {...nextPath, pathname: newPathname}
       ) ?? undefined;
   };
 
@@ -212,8 +219,14 @@ class ContextPickerModal extends Component<Props> {
     if (!value) {
       return;
     }
-
-    onFinish(`${nextPath}${value}/`);
+    const newPath =
+      typeof nextPath === 'string'
+        ? `${nextPath}${value}/`
+        : {
+            ...nextPath,
+            pathname: `${nextPath.pathname}${value}/`,
+          };
+    onFinish(newPath);
     return;
   };
 

--- a/static/app/components/onboardingWizard/task.tsx
+++ b/static/app/components/onboardingWizard/task.tsx
@@ -83,9 +83,13 @@ function Task(props: Props) {
     }
 
     if (task.actionType === 'app') {
-      const url = new URL(task.location, window.location.origin);
-      url.searchParams.append('referrer', 'onboarding_task');
-      navigateTo(url.toString(), router);
+      // Convert all paths to a location object
+      let to =
+        typeof task.location === 'string' ? {pathname: task.location} : task.location;
+      // Add referrer to all links
+      to = {...to, query: {...to.query, referrer: 'onboarding_task'}};
+
+      navigateTo(to, router);
     }
     hidePanel();
   };

--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -101,7 +101,12 @@ function getMetricAlertUrl({projects, organization}: Options) {
     project => !!project.firstTransactionEvent
   );
   const project = firstProjectWithEvents ?? projects[0];
-  return `/organizations/${organization.slug}/alerts/${project.slug}/wizard/?alert_option=trans_duration`;
+  return {
+    pathname: `/organizations/${organization.slug}/alerts/${project.slug}/wizard/`,
+    query: {
+      alert_option: 'trans_duration',
+    },
+  };
 }
 
 export function getOnboardingTasks({

--- a/static/app/components/pickProjectToContinue.tsx
+++ b/static/app/components/pickProjectToContinue.tsx
@@ -60,9 +60,9 @@ function PickProjectToContinue({
         needOrg={false}
         needProject
         nextPath={`${path}:project`}
-        onFinish={pathname => {
+        onFinish={to => {
           navigating = true;
-          router.replace(pathname);
+          router.replace(to);
         }}
         projectSlugs={projects.map(p => p.slug)}
         allowAllProjectsSelection={allowAllProjectsSelection}

--- a/static/app/types/onboarding.tsx
+++ b/static/app/types/onboarding.tsx
@@ -1,3 +1,5 @@
+import type {Query} from 'history';
+
 import type {OnboardingContextProps} from 'sentry/components/onboarding/onboardingContext';
 import type {Category} from 'sentry/components/platformPicker';
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
@@ -89,13 +91,19 @@ interface OnboardingTypeDescriptorWithAction extends OnboardingTaskDescriptorBas
 }
 
 interface OnboardingTypeDescriptorWithExternal extends OnboardingTaskDescriptorBase {
-  actionType: 'app' | 'external';
+  actionType: 'external';
   location: string;
+}
+
+interface OnboardingTypeDescriptorWithAppLink extends OnboardingTaskDescriptorBase {
+  actionType: 'app';
+  location: string | {pathname: string; query?: Query};
 }
 
 export type OnboardingTaskDescriptor =
   | OnboardingTypeDescriptorWithAction
-  | OnboardingTypeDescriptorWithExternal;
+  | OnboardingTypeDescriptorWithExternal
+  | OnboardingTypeDescriptorWithAppLink;
 
 export interface OnboardingTaskStatus {
   status: 'skipped' | 'pending' | 'complete';
@@ -126,7 +134,16 @@ interface OnboardingTaskWithExternal
   requisiteTasks: OnboardingTaskDescriptor[];
 }
 
-export type OnboardingTask = OnboardingTaskWithAction | OnboardingTaskWithExternal;
+interface OnboardingTaskWithAppLink
+  extends OnboardingTaskStatus,
+    OnboardingTypeDescriptorWithAppLink {
+  requisiteTasks: OnboardingTaskDescriptor[];
+}
+
+export type OnboardingTask =
+  | OnboardingTaskWithAction
+  | OnboardingTaskWithExternal
+  | OnboardingTaskWithAppLink;
 
 export enum OnboardingProjectStatus {
   WAITING = 'waiting',

--- a/static/app/views/settings/organizationIntegrations/pluginDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/pluginDetailedView.tsx
@@ -118,9 +118,9 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
           nextPath={`/settings/${organization.slug}/projects/:projectId/plugins/${plugin.id}/`}
           needProject
           needOrg={false}
-          onFinish={path => {
+          onFinish={to => {
             modalProps.closeModal();
-            router.push(normalizeUrl(path));
+            router.push(normalizeUrl(to));
           }}
         />
       ),


### PR DESCRIPTION
using `new URL` adds the host to the path which isn't router friendly since the router expects `/org/example/` and not `https://sentry.io/org/example/`

Adds the ability for navigateTo to accept path as an object
