### PR TITLE
feat(custom-views): Don't show tab dividers next to hovering tabs 

### DIFF
--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -1,6 +1,7 @@
 import {
   type Dispatch,
   Fragment,
+  type Key,
   type SetStateAction,
   useContext,
   useEffect,
@@ -144,6 +145,7 @@ function Tabs({
   const values = useMemo(() => [...state.collection], [state.collection]);
 
   const [isDragging, setIsDragging] = useState(false);
+  const [hoveringKey, setHoveringKey] = useState<Key | null>(null);
 
   // Only apply this while dragging, because it causes tabs to stay within the container
   // which we do not want (we hide tabs once they overflow
@@ -177,6 +179,8 @@ function Tabs({
               layout
               onDrag={() => setIsDragging(true)}
               onDragEnd={() => setIsDragging(false)}
+              onHoverStart={() => setHoveringKey(item.key)}
+              onHoverEnd={() => setHoveringKey(null)}
             >
               <div key={item.key}>
                 <Tab
@@ -191,9 +195,11 @@ function Tabs({
             </TabItemWrap>
             <TabDivider
               isVisible={
-                state.selectedKey === 'temporary-tab' ||
-                (state.selectedKey !== item.key &&
-                  state.collection.getKeyAfter(item.key) !== state.selectedKey)
+                (state.selectedKey === 'temporary-tab' ||
+                  (state.selectedKey !== item.key &&
+                    state.collection.getKeyAfter(item.key) !== state.selectedKey)) &&
+                hoveringKey !== item.key &&
+                state.collection.getKeyAfter(item.key) !== hoveringKey
               }
             />
           </Fragment>


### PR DESCRIPTION
Tab dividers around the hovering tab now disappear. This mimics the behavior of our dropdown menus. Unfortunately we do have to add extra state for this. 

https://github.com/user-attachments/assets/6d1cb50f-99e6-458a-9364-531d60640e63

