### PR TITLE
fix(custom-views): Align hover state of overflow menu with add view button

### DIFF
--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -434,6 +434,10 @@ const MotionWrapper = styled(motion.div)`
 `;
 
 const OverflowMenuTrigger = styled(DropdownButton)`
-  padding-left: ${space(1)};
-  padding-right: ${space(1)};
+  padding: ${space(0.5)} ${space(0.75)};
+  border: none;
+
+  & > span {
+    height: 26px;
+  }
 `;


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/7904cd07-b5d5-4de2-8f42-a1946422b52b


After:

https://github.com/user-attachments/assets/068d2076-8355-4be2-822d-fc97d77289ed

