### PR TITLE
fix(issues): Align streamlined event id

### DIFF
--- a/static/app/views/issueDetails/streamline/eventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.tsx
@@ -410,6 +410,7 @@ const EventInfo = styled('div')`
   gap: ${space(1)};
   flex-direction: row;
   align-items: center;
+  line-height: 1.2;
 `;
 
 const JumpTo = styled('div')`


### PR DESCRIPTION
was slightly off from the event id being a button

![image](https://github.com/user-attachments/assets/1a94b0ab-3420-43b5-ba92-2f5bfe22723b)


after

![image](https://github.com/user-attachments/assets/7511a056-1c58-411a-8bd7-3ad918fab905)
