### PR TITLE
feat(flags): attach flag evaluations in sentry's frontend to events

### DIFF
--- a/static/app/actionCreators/organization.tsx
+++ b/static/app/actionCreators/organization.tsx
@@ -42,7 +42,7 @@ async function fetchOrg(
   }
 
   FeatureFlagOverrides.singleton().loadOrg(org);
-  FeatureObserver.singleton().observeFlags(org);
+  FeatureObserver.singleton().observeFlags({organization: org, bufferSize: 10});
 
   OrganizationStore.onUpdate(org, {replace: true});
   setActiveOrganization(org);

--- a/static/app/actionCreators/organization.tsx
+++ b/static/app/actionCreators/organization.tsx
@@ -15,6 +15,7 @@ import TeamStore from 'sentry/stores/teamStore';
 import type {Organization, Team} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import FeatureFlagOverrides from 'sentry/utils/featureFlagOverrides';
+import FeatureObserver from 'sentry/utils/featureObserver';
 import {getPreloadedDataPromise} from 'sentry/utils/getPreloadedData';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 
@@ -41,6 +42,7 @@ async function fetchOrg(
   }
 
   FeatureFlagOverrides.singleton().loadOrg(org);
+  FeatureObserver.singleton().observeFlags(org);
 
   OrganizationStore.onUpdate(org, {replace: true});
   setActiveOrganization(org);

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -16,6 +16,7 @@ import {
   useNavigationType,
 } from 'react-router-dom';
 import {useEffect} from 'react';
+import FeatureFlagOverrides from 'sentry/utils/featureFlagOverrides';
 
 const SPA_MODE_ALLOW_URLS = [
   'localhost',
@@ -194,6 +195,12 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
       addEndpointTagToRequestError(event);
 
       lastEventId = event.event_id || hint.event_id;
+
+      // attach feature flags to the event context
+      if (event.contexts) {
+        const flags = FeatureFlagOverrides.singleton().getFeatureFlags();
+        event.contexts.flags = flags;
+      }
 
       return event;
     },

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -16,7 +16,7 @@ import {
   useNavigationType,
 } from 'react-router-dom';
 import {useEffect} from 'react';
-import FeatureFlagOverrides from 'sentry/utils/featureFlagOverrides';
+import FeatureObserver from 'sentry/utils/featureObserver';
 
 const SPA_MODE_ALLOW_URLS = [
   'localhost',
@@ -198,7 +198,7 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
 
       // attach feature flags to the event context
       if (event.contexts) {
-        const flags = FeatureFlagOverrides.singleton().getFeatureFlags();
+        const flags = FeatureObserver.singleton().getFeatureFlags();
         event.contexts.flags = flags;
       }
 

--- a/static/app/utils/featureFlagOverrides.ts
+++ b/static/app/utils/featureFlagOverrides.ts
@@ -138,7 +138,7 @@ export default class FeatureFlagOverrides {
         }
 
         // Check if the flag is already in the buffer
-        const index = FEATURE_FLAGS.values.findIndex(f => f.flag === flagName);
+        const index = FEATURE_FLAGS.values.findIndex(f => f.flag === flagName[0]);
 
         // The flag is already in the buffer
         if (index !== -1) {
@@ -147,7 +147,7 @@ export default class FeatureFlagOverrides {
 
         // Store the flag and its result in the buffer
         FEATURE_FLAGS.values.push({
-          flag: flagName,
+          flag: flagName[0],
           result: flagResult,
         });
 

--- a/static/app/utils/featureFlagOverrides.ts
+++ b/static/app/utils/featureFlagOverrides.ts
@@ -15,8 +15,7 @@ let __SINGLETON: FeatureFlagOverrides | null = null;
 const BUFFER_SIZE = 10;
 
 // do we need to initialize the array with empty objects?
-const FEATURE_FLAGS: Flags = {values: new Array(10)};
-let buffer_idx = 0;
+const FEATURE_FLAGS: Flags = {values: []};
 export default class FeatureFlagOverrides {
   /**
    * Return the same instance of FeatureFlagOverrides in each part of the app.
@@ -135,13 +134,15 @@ export default class FeatureFlagOverrides {
 
         // Check that the flag is not already in the buffer
         if (!FEATURE_FLAGS.values.some(f => f.flag === flagName)) {
+          // If at capacity, we need to remove the earliest flag
+          if (FEATURE_FLAGS.values.length === BUFFER_SIZE) {
+            FEATURE_FLAGS.values.shift();
+          }
           // Store the flag and its result in the buffer
-          FEATURE_FLAGS.values[buffer_idx] = {
+          FEATURE_FLAGS.values.push({
             flag: flagName,
             result: flagResult,
-          };
-          // Increment the buffer index for next time
-          buffer_idx = (buffer_idx + 1) % BUFFER_SIZE;
+          });
         }
         return flagResult;
       },

--- a/static/app/utils/featureFlagOverrides.ts
+++ b/static/app/utils/featureFlagOverrides.ts
@@ -132,18 +132,25 @@ export default class FeatureFlagOverrides {
         // Evaluate the result of .includes()
         const flagResult = target.apply(orgFeatures, flagName);
 
-        // Check that the flag is not already in the buffer
-        if (!FEATURE_FLAGS.values.some(f => f.flag === flagName)) {
-          // If at capacity, we need to remove the earliest flag
-          if (FEATURE_FLAGS.values.length === BUFFER_SIZE) {
-            FEATURE_FLAGS.values.shift();
-          }
-          // Store the flag and its result in the buffer
-          FEATURE_FLAGS.values.push({
-            flag: flagName,
-            result: flagResult,
-          });
+        // If at capacity, we need to remove the earliest flag
+        if (FEATURE_FLAGS.values.length === BUFFER_SIZE) {
+          FEATURE_FLAGS.values.shift();
         }
+
+        // Check if the flag is already in the buffer
+        const index = FEATURE_FLAGS.values.findIndex(f => f.flag === flagName);
+
+        // The flag is already in the buffer
+        if (index !== -1) {
+          FEATURE_FLAGS.values.splice(index, 1);
+        }
+
+        // Store the flag and its result in the buffer
+        FEATURE_FLAGS.values.push({
+          flag: flagName,
+          result: flagResult,
+        });
+
         return flagResult;
       },
     };

--- a/static/app/utils/featureObserver.spec.ts
+++ b/static/app/utils/featureObserver.spec.ts
@@ -76,5 +76,21 @@ describe('FeatureObserver', () => {
         {flag: 'spam-ingest', result: false},
       ]);
     });
+
+    it('should not change the functionality of `includes`', () => {
+      const inst = new FeatureObserver();
+      inst.observeFlags({organization, bufferSize: 3});
+      expect(inst.getFeatureFlags().values).toEqual([]);
+
+      organization.features.includes('enable-issues');
+      organization.features.includes('replay-mobile-ui');
+      expect(inst.getFeatureFlags().values).toEqual([
+        {flag: 'enable-issues', result: true},
+        {flag: 'replay-mobile-ui', result: false},
+      ]);
+
+      expect(organization.features.includes('enable-issues')).toBe(true);
+      expect(organization.features.includes('replay-mobile-ui')).toBe(false);
+    });
   });
 });

--- a/static/app/utils/featureObserver.spec.ts
+++ b/static/app/utils/featureObserver.spec.ts
@@ -1,0 +1,80 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import FeatureObserver from 'sentry/utils/featureObserver';
+
+describe('FeatureObserver', () => {
+  let organization;
+  beforeEach(() => {
+    organization = OrganizationFixture({
+      features: ['enable-issues', 'enable-profiling', 'enable-replay'],
+    });
+  });
+
+  describe('observeFlags', () => {
+    it('should add recently evaluated flags to the flag queue', () => {
+      const inst = new FeatureObserver();
+      expect(organization.features).toEqual([
+        'enable-issues',
+        'enable-profiling',
+        'enable-replay',
+      ]);
+
+      inst.observeFlags({organization, bufferSize: 3});
+      expect(inst.getFeatureFlags().values).toEqual([]);
+
+      organization.features.includes('enable-issues');
+      organization.features.includes('replay-mobile-ui');
+      expect(inst.getFeatureFlags().values).toEqual([
+        {flag: 'enable-issues', result: true},
+        {flag: 'replay-mobile-ui', result: false},
+      ]);
+
+      // do more evaluations to fill up and overflow the buffer
+      organization.features.includes('enable-replay');
+      organization.features.includes('autofix-ui');
+      organization.features.includes('new-issue-details');
+      expect(inst.getFeatureFlags().values).toEqual([
+        {flag: 'enable-replay', result: true},
+        {flag: 'autofix-ui', result: false},
+        {flag: 'new-issue-details', result: false},
+      ]);
+    });
+
+    it('should remove duplicate flags', () => {
+      const inst = new FeatureObserver();
+      inst.observeFlags({organization, bufferSize: 3});
+      expect(inst.getFeatureFlags().values).toEqual([]);
+
+      organization.features.includes('enable-issues');
+      organization.features.includes('replay-mobile-ui');
+      expect(inst.getFeatureFlags().values).toEqual([
+        {flag: 'enable-issues', result: true},
+        {flag: 'replay-mobile-ui', result: false},
+      ]);
+
+      // this is already in the queue; it should be removed and
+      // added back to the end of the queue
+      organization.features.includes('enable-issues');
+      expect(inst.getFeatureFlags().values).toEqual([
+        {flag: 'replay-mobile-ui', result: false},
+        {flag: 'enable-issues', result: true},
+      ]);
+
+      organization.features.includes('spam-ingest');
+      expect(inst.getFeatureFlags().values).toEqual([
+        {flag: 'replay-mobile-ui', result: false},
+        {flag: 'enable-issues', result: true},
+        {flag: 'spam-ingest', result: false},
+      ]);
+
+      // this is already in the queue but in the back
+      // the queue should not change
+      organization.features.includes('spam-ingest');
+      expect(inst.getFeatureFlags().values).toEqual([
+        {flag: 'replay-mobile-ui', result: false},
+        {flag: 'enable-issues', result: true},
+        {flag: 'spam-ingest', result: false},
+      ]);
+    });
+  });
+});

--- a/static/app/utils/featureObserver.ts
+++ b/static/app/utils/featureObserver.ts
@@ -34,10 +34,6 @@ export default class FeatureObserver {
   }) {
     const FLAGS = this.FEATURE_FLAGS;
 
-    if (!FLAGS) {
-      return;
-    }
-
     // Track names of features that are passed into the .includes() function.
     const handler = {
       apply: function (target, orgFeatures, flagName) {

--- a/static/app/utils/featureObserver.ts
+++ b/static/app/utils/featureObserver.ts
@@ -1,0 +1,66 @@
+import type {Flags} from 'sentry/types/event';
+import type {Organization} from 'sentry/types/organization';
+
+const BUFFER_SIZE = 10;
+let __SINGLETON: FeatureObserver | null = null;
+
+export default class FeatureObserver {
+  /**
+   * Return the same instance of FeatureObserver in each part of the app.
+   * Multiple instances of FeatureObserver are needed by tests only.
+   */
+  public static singleton() {
+    if (!__SINGLETON) {
+      __SINGLETON = new FeatureObserver();
+    }
+    return __SINGLETON;
+  }
+
+  private FEATURE_FLAGS: Flags = {values: []};
+
+  /**
+   * Return list of recently accessed feature flags.
+   */
+  public getFeatureFlags() {
+    return this.FEATURE_FLAGS;
+  }
+
+  public observeFlags(organization: Organization) {
+    const FLAGS = this.FEATURE_FLAGS;
+
+    if (!FLAGS) {
+      return;
+    }
+
+    // Track names of features that are passed into the .includes() function.
+    const handler = {
+      apply: function (target, orgFeatures, flagName) {
+        // Evaluate the result of .includes()
+        const flagResult = target.apply(orgFeatures, flagName);
+
+        // If at capacity, we need to remove the earliest flag
+        if (FLAGS.values.length === BUFFER_SIZE) {
+          FLAGS.values.shift();
+        }
+
+        // Check if the flag is already in the buffer
+        const index = FLAGS.values.findIndex(f => f.flag === flagName[0]);
+
+        // The flag is already in the buffer
+        if (index !== -1) {
+          FLAGS.values.splice(index, 1);
+        }
+
+        // Store the flag and its result in the buffer
+        FLAGS.values.push({
+          flag: flagName[0],
+          result: flagResult,
+        });
+
+        return flagResult;
+      },
+    };
+    const proxy = new Proxy(organization.features.includes, handler);
+    organization.features.includes = proxy;
+  }
+}


### PR DESCRIPTION
- set the `event.contexts.flags` value to be the list of recently evaluated feature flags on sentry JS frontend.
- default buffer size is 10; we can increase this at any time to match the python SDK
- data structure used is a FIFO queue -- when new flags are added, they are appended to the end of the queue, and the oldest one gets kicked out.
- we are removing duplicate flags automatically, so the queue is a unique set of flags.
- closes https://github.com/getsentry/sentry/issues/77446