### PR TITLE
feat(uptime): Fetch rdap after subscription creation

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3303,7 +3303,7 @@ class MonitorIngestTestCase(MonitorTestCase):
         self.token = self.create_internal_integration_token(install=app, user=self.user)
 
 
-class UptimeTestCase(TestCase):
+class UptimeTestCaseMixin:
     def setUp(self):
         super().setUp()
         self.mock_resolve_hostname_ctx = mock.patch(
@@ -3324,6 +3324,8 @@ class UptimeTestCase(TestCase):
         self.mock_resolve_rdap_provider_ctx.__exit__(None, None, None)
         self.mock_requests_get_ctx.__exit__(None, None, None)
 
+
+class UptimeTestCase(UptimeTestCaseMixin, TestCase):
     def create_uptime_result(
         self,
         subscription_id: str | None = None,

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3304,6 +3304,26 @@ class MonitorIngestTestCase(MonitorTestCase):
 
 
 class UptimeTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.mock_resolve_hostname_ctx = mock.patch(
+            "sentry.uptime.rdap.query.resolve_hostname", return_value="192.168.0.1"
+        )
+        self.mock_resolve_rdap_provider_ctx = mock.patch(
+            "sentry.uptime.rdap.query.resolve_rdap_provider", return_value="https://fake.com/"
+        )
+        self.mock_requests_get_ctx = mock.patch("sentry.uptime.rdap.query.requests.get")
+        self.mock_resolve_hostname = self.mock_resolve_hostname_ctx.__enter__()
+        self.mock_resolve_rdap_provider = self.mock_resolve_rdap_provider_ctx.__enter__()
+        self.mock_requests_get = self.mock_requests_get_ctx.__enter__()
+        self.mock_requests_get.return_value.json.return_value = {"entities": [{"handle": "hi"}]}
+
+    def tearDown(self):
+        super().tearDown()
+        self.mock_resolve_hostname_ctx.__exit__(None, None, None)
+        self.mock_resolve_rdap_provider_ctx.__exit__(None, None, None)
+        self.mock_requests_get_ctx.__exit__(None, None, None)
+
     def create_uptime_result(
         self,
         subscription_id: str | None = None,

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -9,6 +9,7 @@ from sentry.uptime.models import (
     ProjectUptimeSubscriptionMode,
     UptimeSubscription,
 )
+from sentry.uptime.rdap.tasks import fetch_subscription_rdap_info
 from sentry.uptime.subscriptions.tasks import (
     create_remote_uptime_subscription,
     delete_remote_uptime_subscription,
@@ -53,6 +54,7 @@ def create_uptime_subscription(
 
     if created:
         create_remote_uptime_subscription.delay(subscription.id)
+        fetch_subscription_rdap_info.delay(subscription.id)
     return subscription
 
 

--- a/tests/sentry/uptime/endpoints/__init__.py
+++ b/tests/sentry/uptime/endpoints/__init__.py
@@ -1,0 +1,7 @@
+from sentry.testutils.cases import APITestCase, UptimeTestCaseMixin
+
+
+class UptimeAlertBaseEndpointTest(UptimeTestCaseMixin, APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_details.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_details.py
@@ -2,16 +2,12 @@ import pytest
 from rest_framework.exceptions import ErrorDetail
 
 from sentry.api.serializers import serialize
-from sentry.testutils.cases import APITestCase
 from sentry.uptime.models import ProjectUptimeSubscription
+from tests.sentry.uptime.endpoints import UptimeAlertBaseEndpointTest
 
 
-class ProjectUptimeAlertDetailsBaseEndpointTest(APITestCase):
+class ProjectUptimeAlertDetailsBaseEndpointTest(UptimeAlertBaseEndpointTest):
     endpoint = "sentry-api-0-project-uptime-alert-details"
-
-    def setUp(self):
-        super().setUp()
-        self.login_as(user=self.user)
 
 
 class ProjectUptimeAlertDetailsGetEndpointTest(ProjectUptimeAlertDetailsBaseEndpointTest):

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_index.py
@@ -1,17 +1,13 @@
 from rest_framework.exceptions import ErrorDetail
 
-from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import with_feature
 from sentry.uptime.models import ProjectUptimeSubscription, ProjectUptimeSubscriptionMode
 from sentry.uptime.subscriptions.subscriptions import DEFAULT_SUBSCRIPTION_TIMEOUT_MS
+from tests.sentry.uptime.endpoints import UptimeAlertBaseEndpointTest
 
 
-class ProjectUptimeAlertIndexBaseEndpointTest(APITestCase):
+class ProjectUptimeAlertIndexBaseEndpointTest(UptimeAlertBaseEndpointTest):
     endpoint = "sentry-api-0-project-uptime-alert-index"
-
-    def setUp(self):
-        super().setUp()
-        self.login_as(user=self.user)
 
 
 class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpointTest):


### PR DESCRIPTION
Depends on GH-77518.

We're going to want to keep an eye on what errors this task might produce. Right now it will retry on errors, but we'll have to see what that actually looks like.