### PR TITLE
feat(discover): Remove known incompatible columns dataset switch

### DIFF
--- a/static/app/views/discover/homepage.spec.tsx
+++ b/static/app/views/discover/homepage.spec.tsx
@@ -665,7 +665,8 @@ describe('Discover > Homepage', () => {
           dataset: 'transactions',
           name: 'homepage query',
           project: undefined,
-          query: 'event.type:error',
+          query: '',
+          field: 'environment',
           queryDataset: 'transaction-like',
         }),
       })

--- a/static/app/views/discover/savedQuery/datasetSelectorTabs.spec.tsx
+++ b/static/app/views/discover/savedQuery/datasetSelectorTabs.spec.tsx
@@ -59,7 +59,7 @@ describe('Discover DatasetSelector', function () {
       query: '(error.type:bar AND project:foo)',
       start: undefined,
       team: [],
-      sorts: [],
+      sorts: [{field: 'error.mechanism', kind: 'asc'}],
       statsPeriod: undefined,
       topEvents: undefined,
       id: undefined,
@@ -83,6 +83,7 @@ describe('Discover DatasetSelector', function () {
           field: ['transaction', 'project'],
           query: 'project:foo',
           queryDataset: 'transaction-like',
+          sort: '-transaction',
           incompatible: true,
         }),
       })

--- a/static/app/views/discover/savedQuery/datasetSelectorTabs.spec.tsx
+++ b/static/app/views/discover/savedQuery/datasetSelectorTabs.spec.tsx
@@ -43,8 +43,28 @@ describe('Discover DatasetSelector', function () {
     expect(screen.getByRole('tab', {name: 'Transactions'})).toBeInTheDocument();
   });
 
-  it('pushes new default event view if not a saved query', async function () {
-    const eventView = new EventView(EVENT_VIEW_CONSTRUCTOR_PROPS);
+  it('pushes compatible query', async function () {
+    const eventView = new EventView({
+      createdBy: undefined,
+      end: undefined,
+      environment: [],
+      fields: [
+        {field: 'transaction'},
+        {field: 'project'},
+        {field: 'count_unique(error.handled)'},
+        {field: 'error.mechanism'},
+      ],
+      name: 'Test',
+      project: [],
+      query: '(error.type:bar AND project:foo)',
+      start: undefined,
+      team: [],
+      sorts: [],
+      statsPeriod: undefined,
+      topEvents: undefined,
+      id: undefined,
+      display: undefined,
+    });
     render(
       <DatasetSelectorTabs
         isHomepage={false}
@@ -61,8 +81,9 @@ describe('Discover DatasetSelector', function () {
         query: expect.objectContaining({
           project: undefined,
           field: ['transaction', 'project'],
-          query: 'foo:bar',
+          query: 'project:foo',
           queryDataset: 'transaction-like',
+          incompatible: true,
         }),
       })
     );


### PR DESCRIPTION
Remove known incompatible query fields from columns, filters, sorts and y axis
when switching discover datasets.