### PR TITLE
fix(discover): Catch invalid query error on run query

### DIFF
--- a/src/sentry/discover/dashboard_widget_split.py
+++ b/src/sentry/discover/dashboard_widget_split.py
@@ -175,6 +175,7 @@ def _get_and_save_split_decision_for_dashboard_widget(
             IncompatibleMetricsQuery,
             snuba.QueryIllegalTypeOfArgument,
             snuba.UnqualifiedQueryError,
+            InvalidQueryError,
         ):
             pass
 
@@ -186,7 +187,7 @@ def _get_and_save_split_decision_for_dashboard_widget(
             )
         )
         has_errors = len(error_results["data"]) > 0
-    except (snuba.QueryIllegalTypeOfArgument, snuba.UnqualifiedQueryError):
+    except (snuba.QueryIllegalTypeOfArgument, snuba.UnqualifiedQueryError, InvalidQueryError):
         pass
 
     if has_errors:
@@ -212,7 +213,7 @@ def _get_and_save_split_decision_for_dashboard_widget(
             )
         )
         has_transactions = len(transaction_results["data"]) > 0
-    except (snuba.QueryIllegalTypeOfArgument, snuba.UnqualifiedQueryError):
+    except (snuba.QueryIllegalTypeOfArgument, snuba.UnqualifiedQueryError, InvalidQueryError):
         pass
 
     if has_transactions:

--- a/src/sentry/discover/dataset_split.py
+++ b/src/sentry/discover/dataset_split.py
@@ -422,7 +422,7 @@ def _get_and_save_split_decision_for_query(
             )
         )
         has_errors = len(error_results["data"]) > 0
-    except (snuba.QueryIllegalTypeOfArgument, snuba.UnqualifiedQueryError):
+    except (snuba.QueryIllegalTypeOfArgument, snuba.UnqualifiedQueryError, InvalidQueryError):
         pass
 
     if has_errors:
@@ -448,7 +448,7 @@ def _get_and_save_split_decision_for_query(
             )
         )
         has_transactions = len(transaction_results["data"]) > 0
-    except (snuba.QueryIllegalTypeOfArgument, snuba.UnqualifiedQueryError):
+    except (snuba.QueryIllegalTypeOfArgument, snuba.UnqualifiedQueryError, InvalidQueryError):
         pass
 
     if has_transactions:


### PR DESCRIPTION
If it's an invalid query, just continue running the script