### PR TITLE
ref(broadcast): Make CTA not required

### DIFF
--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -179,7 +179,7 @@ class BroadcastIndexEndpoint(ControlSiloOrganizationEndpoint):
                 title=result["title"],
                 message=result["message"],
                 link=result["link"],
-                cta=result["cta"],
+                cta=result.get("cta"),
                 is_active=result.get("isActive") or False,
                 date_expires=result.get("dateExpires"),
                 media_url=result.get("mediaUrl"),

--- a/src/sentry/api/validators/broadcast.py
+++ b/src/sentry/api/validators/broadcast.py
@@ -13,6 +13,6 @@ class AdminBroadcastValidator(BroadcastValidator):
     link = serializers.URLField(required=True)
     isActive = serializers.BooleanField(required=False)
     dateExpires = serializers.DateTimeField(required=False, allow_null=True)
-    cta = serializers.CharField(max_length=256, required=True)
+    cta = serializers.CharField(max_length=256, required=False)
     mediaUrl = serializers.URLField(required=False)
     category = serializers.ChoiceField(choices=BROADCAST_CATEGORIES, required=False)

--- a/tests/sentry/api/endpoints/test_broadcast_index.py
+++ b/tests/sentry/api/endpoints/test_broadcast_index.py
@@ -181,6 +181,23 @@ class BroadcastCreateTest(APITestCase):
 
         assert response.status_code == 200, response.data
 
+    def test_not_required_cta(self):
+        self.add_user_permission(user=self.user, permission="broadcasts.admin")
+        self.login_as(user=self.user, superuser=True)
+
+        response = self.client.post(
+            "/api/0/broadcasts/",
+            {
+                "title": "bar",
+                "message": "foo",
+                "link": "http://example.com",
+                "mediaUrl": "http://example.com/image.png",
+                "category": "announcement",
+            },
+        )
+
+        assert response.status_code == 200, response.data
+
 
 @control_silo_test
 class BroadcastUpdateTest(APITestCase):


### PR DESCRIPTION
We are making the CTA in the broadcast not required for now and will remove it at the same point.

Contributes to https://github.com/getsentry/getsentry/pull/15130