### PR TITLE
chore(dashboards): Remove Big Number Autosize flag usage

### DIFF
--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -106,16 +106,8 @@ type WidgetCardChartProps = Pick<
   windowWidth?: number;
 };
 
-type State = {
-  // For tracking height of the container wrapping BigNumber widgets
-  // so we can dynamically scale font-size
-  containerHeight: number;
-};
-
-class WidgetCardChart extends Component<WidgetCardChartProps, State> {
-  state = {containerHeight: 0};
-
-  shouldComponentUpdate(nextProps: WidgetCardChartProps, nextState: State): boolean {
+class WidgetCardChart extends Component<WidgetCardChartProps> {
+  shouldComponentUpdate(nextProps: WidgetCardChartProps): boolean {
     if (
       this.props.widget.displayType === DisplayType.BIG_NUMBER &&
       nextProps.widget.displayType === DisplayType.BIG_NUMBER &&
@@ -142,7 +134,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps, State> {
       },
     };
 
-    return !isEqual(currentProps, nextProps) || !isEqual(this.state, nextState);
+    return !isEqual(currentProps, nextProps);
   }
 
   tableResultComponent({
@@ -299,7 +291,6 @@ class WidgetCardChart extends Component<WidgetCardChartProps, State> {
       widget,
       onZoom,
       legendOptions,
-      expandNumbers,
       showSlider,
       noPadding,
       chartZoomOptions,
@@ -323,16 +314,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps, State> {
       return (
         <TransitionChart loading={loading} reloading={loading}>
           <LoadingScreen loading={loading} />
-          <BigNumberResizeWrapper
-            ref={el => {
-              if (el !== null && !expandNumbers) {
-                const {height} = el.getBoundingClientRect();
-                if (height !== this.state.containerHeight) {
-                  this.setState({containerHeight: height});
-                }
-              }
-            }}
-          >
+          <BigNumberResizeWrapper>
             {this.bigNumberComponent({tableResults, loading, errorMessage})}
           </BigNumberResizeWrapper>
         </TransitionChart>

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -208,7 +208,6 @@ class WidgetCardChart extends Component<WidgetCardChartProps, State> {
       return <BigNumber>{'\u2014'}</BigNumber>;
     }
 
-    const {containerHeight} = this.state;
     const {location, organization, widget, isMobile, expandNumbers} = this.props;
 
     return tableResults.map(result => {
@@ -241,24 +240,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps, State> {
         return <BigNumber key={`big_number:${result.title}`}>{rendered}</BigNumber>;
       }
 
-      // The font size is the container height, minus the top and bottom padding
-      const fontSize = !expandNumbers
-        ? containerHeight - parseInt(space(1), 10) - parseInt(space(3), 10)
-        : `max(min(8vw, 90px), ${space(4)})`;
-
-      return !organization.features.includes('auto-size-big-number-widget') ? (
-        <BigNumber
-          key={`big_number:${result.title}`}
-          style={{
-            fontSize,
-            ...(expandNumbers ? {padding: `${space(1)} ${space(3)} 0 ${space(3)}`} : {}),
-          }}
-        >
-          <Tooltip title={rendered} showOnlyOnOverflow>
-            {rendered}
-          </Tooltip>
-        </BigNumber>
-      ) : expandNumbers ? (
+      return expandNumbers ? (
         <BigText>{rendered}</BigText>
       ) : (
         <AutoResizeParent key={`big_number:${result.title}`}>


### PR DESCRIPTION
- **Remove usage of flag**
- **Remove unused state**

Post-GA cleanup. It's also possible to simplify somewhat and remove usage of `BigText` component but we'll tackle that separately.
