### PR TITLE
chore(similarity): Skip service unavailable projects

### DIFF
--- a/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
+++ b/src/sentry/tasks/embeddings_grouping/backfill_seer_grouping_records_for_project.py
@@ -26,7 +26,7 @@ from sentry.tasks.embeddings_grouping.utils import (
 
 BACKFILL_NAME = "backfill_grouping_records"
 BULK_DELETE_METADATA_CHUNK_SIZE = 100
-SEER_ACCEPTABLE_FAILURE_REASONS = ["Gateway Timeout"]
+SEER_ACCEPTABLE_FAILURE_REASONS = ["Gateway Timeout", "Service Unavailable"]
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -411,8 +411,8 @@ def _make_seer_call(
     seer_response = _retry_operation(
         post_bulk_grouping_records,
         create_grouping_records_request,
-        retries=15,
-        delay=10,
+        retries=20,
+        delay=15,
         exceptions=Exception,
     )
 


### PR DESCRIPTION
Skip projects where seer responses with Service Unavailable in the backfill
Increase seer retries and delay