### PR TITLE
:bug: fix(slack): Update Discover Chart Interval Validation

### DIFF
--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -199,7 +199,7 @@ def unfurl_discover(
             y_axis = params.getlist("yAxis")[0]
             if display_mode != "dailytop5":
                 display_mode = get_top5_display_mode(y_axis)
-            top_events = params.getlist("topEvents")[0]
+            top_events = int(params.getlist("topEvents")[0])
         else:
             # topEvents param persists in the URL in some cases, we want to discard
             # it if it's not a top n display type.


### PR DESCRIPTION
Fixes [SENTRY-3A0Z](https://sentry.sentry.io/issues/5444045247/)

`validate_interval` expects an int for `top_events`, but the value in param is stringified, so just converting it here.