### PR TITLE
fix(insights): JSON fails to parse some span descriptions

### DIFF
--- a/static/app/views/insights/database/utils/isValidJson.tsx
+++ b/static/app/views/insights/database/utils/isValidJson.tsx
@@ -1,0 +1,8 @@
+export const isValidJson = (str: string) => {
+  try {
+    JSON.parse(str);
+  } catch (e) {
+    return false;
+  }
+  return true;
+};


### PR DESCRIPTION
Sometimes a MongoDB span description can be truncated, or simply be invalid when attempting to parse. However, we can access the full description via `sentry_tags`. This PR adds an exhaustive check to find the most representative string for displaying the MongoDB query in the full span description, and prevents crashes.