### PR TITLE
fix(query-builder): Accept relative date shorthand

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -2139,6 +2139,17 @@ describe('SearchQueryBuilder', function () {
         expect(await screen.findByRole('row', {name: 'age:+24h'})).toBeInTheDocument();
       });
 
+      it('can type relative date shorthand (7d)', async function () {
+        render(<SearchQueryBuilder {...defaultProps} initialQuery="age:-24h" />);
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: age'})
+        );
+
+        await userEvent.keyboard('7d{Enter}');
+
+        expect(await screen.findByRole('row', {name: 'age:-7d'})).toBeInTheDocument();
+      });
+
       it('switches to an absolute date when choosing operator with equality', async function () {
         render(<SearchQueryBuilder {...defaultProps} initialQuery="age:-24h" />);
         await userEvent.click(

--- a/static/app/components/searchQueryBuilder/tokens/filter/parsers/date/grammar.pegjs
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parsers/date/grammar.pegjs
@@ -19,6 +19,6 @@ iso_8601_date_format
     }
 
 rel_date_format
-  = sign:[+-] value:[0-9]+ unit:[wdhm] {
+  = sign:[+-]? value:[0-9]+ unit:[wdhm] {
       return tc.tokenValueRelativeDate(value.join(''), sign, unit);
     }

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -95,7 +95,7 @@ function prepareInputValueForSaving(valueType: FieldValueType, inputValue: strin
   const values = uniq(
     inputValue
       .split(',')
-      .map(v => cleanFilterValue(valueType, v.trim()))
+      .map(v => cleanFilterValue({valueType, value: v.trim()}))
       .filter(v => v && v.length > 0)
   );
 
@@ -536,10 +536,11 @@ export function SearchQueryBuilderValueCombobox({
 
   const updateFilterValue = useCallback(
     (value: string) => {
-      const cleanedValue = cleanFilterValue(
-        getFilterValueType(token, fieldDefinition),
-        value
-      );
+      const cleanedValue = cleanFilterValue({
+        valueType: getFilterValueType(token, fieldDefinition),
+        value,
+        token,
+      });
 
       // TODO(malwilley): Add visual feedback for invalid values
       if (cleanedValue === null) {


### PR DESCRIPTION
Allows the user to type something like `7d` in a date filter and press enter. Previously it required the `-` or `+` (or for you to select it from one of the options). 