### PR TITLE
fix(growinginput): Account for cursor width in Safari

### DIFF
--- a/static/app/components/growingInput.tsx
+++ b/static/app/components/growingInput.tsx
@@ -33,7 +33,8 @@ function resize(input: HTMLInputElement) {
     // parseInt is save here as the computed styles are always in px
     parseInt(computedStyles.paddingLeft, 10) +
     parseInt(computedStyles.paddingRight, 10) +
-    parseInt(computedStyles.borderWidth, 10) * 2;
+    parseInt(computedStyles.borderWidth, 10) * 2 +
+    1; // Add 1px to account for cursor width in Safari
 
   document.body.removeChild(sizingDiv);
 


### PR DESCRIPTION
A small difference, but it was causing text to get cut off in the search bar for Safari. It looks like Safari uses a wider cursor than other browsers which takes up some width.

Before:

https://github.com/user-attachments/assets/0d380e82-bd29-406d-9352-7d909a2e2bc4

After:

https://github.com/user-attachments/assets/f021cc28-9379-40b6-b178-48b9bc773045

