### PR TITLE
feat(query-builder): Add navigation shortcuts with cmd/option/ctrl + arrow keys

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -935,6 +935,29 @@ describe('SearchQueryBuilder', function () {
       ).toHaveFocus();
     });
 
+    it('skips over tokens when navigating with ctrl+arrow keys', async function () {
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          initialQuery="browser.name:firefox assigned:me"
+        />
+      );
+
+      await userEvent.click(getLastInput());
+
+      expect(getLastInput()).toHaveFocus();
+
+      // Ctrl+ArrowLeft should skip to the input to the left of assigned:me
+      await userEvent.keyboard('{Control>}{ArrowLeft}{/Control}');
+      expect(
+        screen.getAllByRole('combobox', {name: 'Add a search term'}).at(-2)
+      ).toHaveFocus();
+
+      // Ctrl+ArrowRight should go back to the last input
+      await userEvent.keyboard('{Control>}{ArrowRight}{/Control}');
+      expect(getLastInput()).toHaveFocus();
+    });
+
     it('when focus is in a filter segment, backspace first focuses the filter then deletes it', async function () {
       render(
         <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />

--- a/static/app/components/searchQueryBuilder/selectionKeyHandler.tsx
+++ b/static/app/components/searchQueryBuilder/selectionKeyHandler.tsx
@@ -1,10 +1,10 @@
 import {type ForwardedRef, forwardRef, useCallback} from 'react';
 import {VisuallyHidden} from '@react-aria/visually-hidden';
 import type {ListState} from '@react-stately/list';
-import type {Key} from '@react-types/shared';
 
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
-import {type ParseResultToken, Token} from 'sentry/components/searchSyntax/parser';
+import {findNearestFreeTextKey} from 'sentry/components/searchQueryBuilder/utils';
+import type {ParseResultToken} from 'sentry/components/searchSyntax/parser';
 import {defined} from 'sentry/utils';
 import {isCtrlKeyPressed} from 'sentry/utils/isCtrlKeyPressed';
 
@@ -12,32 +12,6 @@ type SelectionKeyHandlerProps = {
   state: ListState<ParseResultToken>;
   undo: () => void;
 };
-
-function findNearestFreeTextKey(
-  state: ListState<ParseResultToken>,
-  startKey: Key | null,
-  direction: 'right' | 'left'
-): Key | null {
-  let key: Key | null = startKey;
-  while (key) {
-    const item = state.collection.getItem(key);
-    if (!item) {
-      break;
-    }
-    if (item.value?.type === Token.FREE_TEXT) {
-      return key;
-    }
-    key = (direction === 'right' ? item.nextKey : item.prevKey) ?? null;
-  }
-
-  if (key) {
-    return key;
-  }
-
-  return direction === 'right'
-    ? state.collection.getLastKey()
-    : state.collection.getFirstKey();
-}
 
 /**
  * SelectionKeyHandler is used to handle keyboard events when a selection is

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -1,3 +1,6 @@
+import type {ListState} from '@react-stately/list';
+import type {Key} from '@react-types/shared';
+
 import type {FieldDefinitionGetter} from 'sentry/components/searchQueryBuilder/types';
 import {
   BooleanOperator,
@@ -196,4 +199,30 @@ export function recentSearchTypeToLabel(type: SavedSearchType | undefined) {
     default:
       return 'none';
   }
+}
+
+export function findNearestFreeTextKey(
+  state: ListState<ParseResultToken>,
+  startKey: Key | null,
+  direction: 'right' | 'left'
+): Key | null {
+  let key: Key | null = startKey;
+  while (key) {
+    const item = state.collection.getItem(key);
+    if (!item) {
+      break;
+    }
+    if (item.value?.type === Token.FREE_TEXT) {
+      return key;
+    }
+    key = (direction === 'right' ? item.nextKey : item.prevKey) ?? null;
+  }
+
+  if (key) {
+    return key;
+  }
+
+  return direction === 'right'
+    ? state.collection.getLastKey()
+    : state.collection.getFirstKey();
 }


### PR DESCRIPTION
Adds support for cmd+left/right to skip to start/end end and ctrl/option+left/right to skip over tokens.

https://github.com/user-attachments/assets/109658e5-7a4a-4314-a8ec-2f176906a703


