### PR TITLE
ref(issues): rename _process_batch

### DIFF
--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -378,7 +378,9 @@ def _process_message(
 
 @sentry_sdk.tracing.trace
 @metrics.wraps("occurrence_consumer.process_batch")
-def _process_batch(worker: ThreadPoolExecutor, message: Message[ValuesBatch[KafkaPayload]]) -> None:
+def process_occurrence_batch(
+    worker: ThreadPoolExecutor, message: Message[ValuesBatch[KafkaPayload]]
+) -> None:
     """
     Receives batches of occurrences. This function will take the batch
     and group them together by fingerprint (ensuring order is preserved) and

--- a/src/sentry/issues/run.py
+++ b/src/sentry/issues/run.py
@@ -103,9 +103,9 @@ def process_message(message: Message[KafkaPayload]) -> None:
 
 
 def process_batch(worker: ThreadPoolExecutor, messages: Message[ValuesBatch[KafkaPayload]]) -> None:
-    from sentry.issues.occurrence_consumer import _process_batch
+    from sentry.issues.occurrence_consumer import process_occurrence_batch
 
     try:
-        _process_batch(worker, messages)
+        process_occurrence_batch(worker, messages)
     except Exception:
         logger.exception("failed to process batch payload")


### PR DESCRIPTION
methods starting with underscore should be considered private from the module perspective, but this method is not. let's rename to clear up confusion.