### PR TITLE
chore(uptime): Make sure all tests use the `UptimeTestCase` base class

### DIFF
--- a/tests/sentry/uptime/detectors/test_detector.py
+++ b/tests/sentry/uptime/detectors/test_detector.py
@@ -1,11 +1,11 @@
 from sentry.models.organization import Organization
-from sentry.testutils.cases import TestCase
+from sentry.testutils.cases import UptimeTestCase
 from sentry.testutils.helpers import with_feature
 from sentry.uptime.detectors.detector import detect_base_url_for_project
 from sentry.uptime.detectors.ranking import _get_cluster, get_organization_bucket_key
 
 
-class DetectBaseUrlForProjectTest(TestCase):
+class DetectBaseUrlForProjectTest(UptimeTestCase):
     def assert_organization_key(self, organization: Organization, exists: bool) -> None:
         key = get_organization_bucket_key(organization)
         cluster = _get_cluster()

--- a/tests/sentry/uptime/detectors/test_ranking.py
+++ b/tests/sentry/uptime/detectors/test_ranking.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.testutils.cases import TestCase
+from sentry.testutils.cases import UptimeTestCase
 from sentry.uptime.detectors.ranking import (
     _get_cluster,
     add_base_url_to_rank,
@@ -19,7 +19,7 @@ from sentry.uptime.detectors.ranking import (
 )
 
 
-class AddBaseUrlToRankTest(TestCase):
+class AddBaseUrlToRankTest(UptimeTestCase):
     def assert_project_count(
         self, project: Project, count: int | None, expiry: int | None
     ) -> int | None:
@@ -106,7 +106,7 @@ class AddBaseUrlToRankTest(TestCase):
             assert cluster.zrange(key, 0, -1) == [url_2, url_1]
 
 
-class GetCandidateProjectsForOrgTest(TestCase):
+class GetCandidateProjectsForOrgTest(UptimeTestCase):
     def test(self):
         assert get_candidate_projects_for_org(self.organization) == []
         url_1 = "https://sentry.io"
@@ -122,7 +122,7 @@ class GetCandidateProjectsForOrgTest(TestCase):
         ]
 
 
-class GetCandidateUrlsForProjectTest(TestCase):
+class GetCandidateUrlsForProjectTest(UptimeTestCase):
     def test(self):
         assert get_candidate_urls_for_project(self.project) == []
         url_1 = "https://sentry.io"
@@ -134,7 +134,7 @@ class GetCandidateUrlsForProjectTest(TestCase):
         assert get_candidate_urls_for_project(self.project) == [(url_2, 2), (url_1, 1)]
 
 
-class DeleteCandidateUrlsForProjectTest(TestCase):
+class DeleteCandidateUrlsForProjectTest(UptimeTestCase):
     def test(self):
         delete_candidate_urls_for_project(self.project)
         url_1 = "https://sentry.io"
@@ -144,7 +144,7 @@ class DeleteCandidateUrlsForProjectTest(TestCase):
         assert get_candidate_urls_for_project(self.project) == []
 
 
-class GetOrganizationBucketTest(TestCase):
+class GetOrganizationBucketTest(UptimeTestCase):
     def test(self):
         bucket = datetime(2024, 7, 18, 0, 47)
         assert get_organization_bucket(bucket) == set()
@@ -155,7 +155,7 @@ class GetOrganizationBucketTest(TestCase):
         assert get_organization_bucket(bucket) == {self.project.organization_id}
 
 
-class DeleteOrganizationBucketTest(TestCase):
+class DeleteOrganizationBucketTest(UptimeTestCase):
     def test(self):
         bucket = datetime(2024, 7, 18, 0, 47)
         delete_organization_bucket(bucket)
@@ -168,7 +168,7 @@ class DeleteOrganizationBucketTest(TestCase):
         assert get_organization_bucket(bucket) == set()
 
 
-class ShouldDetectForProjectTest(TestCase):
+class ShouldDetectForProjectTest(UptimeTestCase):
     def test(self):
         assert should_detect_for_project(self.project)
         self.project.update_option("sentry:uptime_autodetection", False)
@@ -177,7 +177,7 @@ class ShouldDetectForProjectTest(TestCase):
         assert should_detect_for_project(self.project)
 
 
-class ShouldDetectForOrgTest(TestCase):
+class ShouldDetectForOrgTest(UptimeTestCase):
     def test(self):
         assert should_detect_for_organization(self.organization)
         self.organization.update_option("sentry:uptime_autodetection", False)

--- a/tests/sentry/uptime/detectors/test_tasks.py
+++ b/tests/sentry/uptime/detectors/test_tasks.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 from sentry.locks import locks
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.testutils.cases import TestCase
+from sentry.testutils.cases import UptimeTestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.uptime.detectors.ranking import (
@@ -41,7 +41,7 @@ from sentry.uptime.subscriptions.subscriptions import (
 
 
 @freeze_time()
-class ScheduleDetectionsTest(TestCase):
+class ScheduleDetectionsTest(UptimeTestCase):
     def test_no_last_processed(self):
         # The first time this runs we don't expect much to happen,
         # just that it'll update the last processed date in redis
@@ -90,7 +90,7 @@ class ScheduleDetectionsTest(TestCase):
 
 
 @freeze_time()
-class ProcessDetectionBucketTest(TestCase):
+class ProcessDetectionBucketTest(UptimeTestCase):
     def test_empty_bucket(self):
         with mock.patch(
             "sentry.uptime.detectors.tasks.process_organization_url_ranking"
@@ -123,7 +123,7 @@ class ProcessDetectionBucketTest(TestCase):
 
 
 @freeze_time()
-class ProcessOrganizationUrlRankingTest(TestCase):
+class ProcessOrganizationUrlRankingTest(UptimeTestCase):
     def test(self):
         # TODO: Better testing for this function when we implement things that happen on success
         url_1 = "https://sentry.io"
@@ -179,7 +179,7 @@ class ProcessOrganizationUrlRankingTest(TestCase):
 
 
 @freeze_time()
-class ProcessProjectUrlRankingTest(TestCase):
+class ProcessProjectUrlRankingTest(UptimeTestCase):
     def test(self):
         # TODO: Better testing for this function when we implement things that happen on success
         url_1 = "https://sentry.io"
@@ -209,7 +209,7 @@ class ProcessProjectUrlRankingTest(TestCase):
 
 
 @freeze_time()
-class ProcessCandidateUrlTest(TestCase):
+class ProcessCandidateUrlTest(UptimeTestCase):
     @with_feature("organizations:uptime-automatic-subscription-creation")
     def test_succeeds_new(self):
         url = "https://sentry.io"
@@ -321,7 +321,7 @@ class ProcessCandidateUrlTest(TestCase):
             assert process_candidate_url(self.project, 100, url, 50)
 
 
-class TestFailedUrl(TestCase):
+class TestFailedUrl(UptimeTestCase):
     def test(self):
         url = "https://sentry.io"
         assert not is_failed_url(url)
@@ -330,7 +330,7 @@ class TestFailedUrl(TestCase):
         assert not is_failed_url("https://sentry.sentry.io")
 
 
-class TestMonitorUrlForProject(TestCase):
+class TestMonitorUrlForProject(UptimeTestCase):
     def test(self):
         url = "http://sentry.io"
         assert not is_url_auto_monitored_for_project(self.project, url)

--- a/tests/sentry/uptime/detectors/test_url_extraction.py
+++ b/tests/sentry/uptime/detectors/test_url_extraction.py
@@ -1,8 +1,8 @@
-from sentry.testutils.cases import TestCase
+from sentry.testutils.cases import UptimeTestCase
 from sentry.uptime.detectors.url_extraction import extract_base_url
 
 
-class ExtractBaseUrlTest(TestCase):
+class ExtractBaseUrlTest(UptimeTestCase):
     def run_test(self, url: str, expected_url: str | None):
         assert extract_base_url(url) == expected_url
 

--- a/tests/sentry/uptime/endpoints/test_serializers.py
+++ b/tests/sentry/uptime/endpoints/test_serializers.py
@@ -1,8 +1,8 @@
 from sentry.api.serializers import serialize
-from sentry.testutils.cases import TestCase
+from sentry.testutils.cases import UptimeTestCase
 
 
-class ProjectUptimeSubscriptionSerializerTest(TestCase):
+class ProjectUptimeSubscriptionSerializerTest(UptimeTestCase):
     def test(self):
         uptime_monitor = self.create_project_uptime_subscription()
         result = serialize(uptime_monitor)

--- a/tests/sentry/uptime/rdap/test_tasks.py
+++ b/tests/sentry/uptime/rdap/test_tasks.py
@@ -1,11 +1,11 @@
 from unittest import mock
 
-from sentry.testutils.cases import TestCase
+from sentry.testutils.cases import UptimeTestCase
 from sentry.uptime.rdap.query import DomainAddressDetails
 from sentry.uptime.rdap.tasks import fetch_subscription_rdap_info
 
 
-class RDAPTasksTest(TestCase):
+class RDAPTasksTest(UptimeTestCase):
     @mock.patch(
         "sentry.uptime.rdap.tasks.resolve_rdap_network_details",
     )

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sentry.testutils.cases import TestCase
+from sentry.testutils.cases import UptimeTestCase
 from sentry.testutils.skips import requires_kafka
 from sentry.uptime.models import (
     ProjectUptimeSubscription,
@@ -22,7 +22,7 @@ from sentry.uptime.subscriptions.subscriptions import (
 pytestmark = [requires_kafka]
 
 
-class CreateUptimeSubscriptionTest(TestCase):
+class CreateUptimeSubscriptionTest(UptimeTestCase):
     def test(self):
         url = "https://sentry.io"
         interval_seconds = 300
@@ -105,7 +105,7 @@ class CreateUptimeSubscriptionTest(TestCase):
         assert uptime_sub.timeout_ms == timeout_ms
 
 
-class DeleteUptimeSubscriptionTest(TestCase):
+class DeleteUptimeSubscriptionTest(UptimeTestCase):
     def test_with_task(self):
         with self.tasks():
             uptime_sub = create_uptime_subscription("https://sentry.io", 3600, 1000)
@@ -124,7 +124,7 @@ class DeleteUptimeSubscriptionTest(TestCase):
         assert uptime_sub.status == UptimeSubscription.Status.DELETING.value
 
 
-class CreateProjectUptimeSubscriptionTest(TestCase):
+class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
     def test(self):
         uptime_sub = create_uptime_subscription("https://sentry.io", 3600, 1000)
         create_project_uptime_subscription(
@@ -167,7 +167,7 @@ class CreateProjectUptimeSubscriptionTest(TestCase):
         )
 
 
-class DeleteUptimeSubscriptionsForProjectTest(TestCase):
+class DeleteUptimeSubscriptionsForProjectTest(UptimeTestCase):
     def test_other_subscriptions(self):
         other_project = self.create_project()
         uptime_sub = create_uptime_subscription("https://sentry.io", 3600, 1000)
@@ -269,7 +269,7 @@ class DeleteUptimeSubscriptionsForProjectTest(TestCase):
             uptime_sub.refresh_from_db()
 
 
-class DeleteProjectUptimeSubscriptionTest(TestCase):
+class DeleteProjectUptimeSubscriptionTest(UptimeTestCase):
     def test_other_subscriptions(self):
         other_project = self.create_project()
         uptime_sub = create_uptime_subscription("https://sentry.io", 3600, 1000)
@@ -302,7 +302,7 @@ class DeleteProjectUptimeSubscriptionTest(TestCase):
             uptime_sub.refresh_from_db()
 
 
-class RemoveUptimeSubscriptionIfUnusedTest(TestCase):
+class RemoveUptimeSubscriptionIfUnusedTest(UptimeTestCase):
     def test_remove(self):
         uptime_sub = create_uptime_subscription("https://sentry.io", 3600, 1000)
         with self.tasks():
@@ -324,7 +324,7 @@ class RemoveUptimeSubscriptionIfUnusedTest(TestCase):
         assert UptimeSubscription.objects.filter(id=uptime_sub.id).exists()
 
 
-class IsUrlMonitoredForProjectTest(TestCase):
+class IsUrlMonitoredForProjectTest(UptimeTestCase):
     def test_not_monitored(self):
         assert not is_url_auto_monitored_for_project(self.project, "https://sentry.io")
         subscription = self.create_project_uptime_subscription(
@@ -355,7 +355,7 @@ class IsUrlMonitoredForProjectTest(TestCase):
         )
 
 
-class GetAutoMonitoredSubscriptionsForProjectTest(TestCase):
+class GetAutoMonitoredSubscriptionsForProjectTest(UptimeTestCase):
     def test_empty(self):
         assert get_auto_monitored_subscriptions_for_project(self.project) == []
 

--- a/tests/sentry/uptime/subscriptions/test_tasks.py
+++ b/tests/sentry/uptime/subscriptions/test_tasks.py
@@ -8,7 +8,7 @@ import pytest
 from django.utils import timezone
 
 from sentry.testutils.abstract import Abstract
-from sentry.testutils.cases import TestCase
+from sentry.testutils.cases import UptimeTestCase
 from sentry.testutils.skips import requires_kafka
 from sentry.uptime.config_producer import UPTIME_CONFIGS_CODEC
 from sentry.uptime.models import UptimeSubscription
@@ -24,7 +24,7 @@ from sentry.uptime.subscriptions.tasks import (
 pytestmark = [requires_kafka]
 
 
-class ProducerTestMixin(TestCase):
+class ProducerTestMixin(UptimeTestCase):
     __test__ = Abstract(__module__, __qualname__)
 
     @pytest.fixture(autouse=True)
@@ -52,7 +52,7 @@ class ProducerTestMixin(TestCase):
         assert expected_payloads == passed_payloads
 
 
-class BaseUptimeSubscriptionTaskTest(ProducerTestMixin, TestCase, metaclass=abc.ABCMeta):
+class BaseUptimeSubscriptionTaskTest(ProducerTestMixin, UptimeTestCase, metaclass=abc.ABCMeta):
     __test__ = Abstract(__module__, __qualname__)
 
     status_translations = {
@@ -144,7 +144,7 @@ class DeleteUptimeSubscriptionTaskTest(BaseUptimeSubscriptionTaskTest):
         self.assert_producer_calls()
 
 
-class UptimeSubscriptionToCheckConfigTest(TestCase):
+class UptimeSubscriptionToCheckConfigTest(UptimeTestCase):
     def test(self):
         sub = self.create_uptime_subscription()
         subscription_id = uuid4().hex
@@ -163,7 +163,7 @@ class SendUptimeConfigDeletionTest(ProducerTestMixin):
         self.assert_producer_calls(subscription_id)
 
 
-class SubscriptionCheckerTest(TestCase):
+class SubscriptionCheckerTest(UptimeTestCase):
     def test_create_delete(self):
         for status in (
             UptimeSubscription.Status.CREATING,


### PR DESCRIPTION
We want to mock some expensive functions in all uptime tests, so making sure we share a base class
