### PR TITLE
ref(flags): add sort by newest and oldest

### DIFF
--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -55,7 +55,7 @@ export function EventFeatureFlagList({
     </Button>
   ) : null;
 
-  const [sortMethod, setSortMethod] = useState<FlagSort>(FlagSort.EVAL);
+  const [sortMethod, setSortMethod] = useState<FlagSort>(FlagSort.NEWEST);
   const {closeDrawer, isDrawerOpen, openDrawer} = useDrawer();
   const viewAllButtonRef = useRef<HTMLButtonElement>(null);
   const organization = useOrganization();
@@ -72,9 +72,9 @@ export function EventFeatureFlagList({
     });
   };
 
-  // Remove duplicates
+  // Reverse the flags to show newest at the top by default
   const hydratedFlags = useMemo(
-    () => hydrateFlags(event.contexts?.flags?.values),
+    () => hydrateFlags(event.contexts?.flags?.values.reverse()),
     [event]
   );
 
@@ -85,7 +85,11 @@ export function EventFeatureFlagList({
   };
 
   const sortedFlags =
-    sortMethod === FlagSort.ALPHA ? handleSortAlphabetical(hydratedFlags) : hydratedFlags;
+    sortMethod === FlagSort.ALPHA
+      ? handleSortAlphabetical(hydratedFlags)
+      : sortMethod === FlagSort.OLDEST
+        ? [...hydratedFlags].reverse()
+        : hydratedFlags;
 
   const onViewAllFlags = useCallback(() => {
     trackAnalytics('flags.view-all-clicked', {

--- a/static/app/components/events/featureFlags/featureFlagDrawer.tsx
+++ b/static/app/components/events/featureFlags/featureFlagDrawer.tsx
@@ -31,18 +31,31 @@ import {getShortEventId} from 'sentry/utils/events';
 import useOrganization from 'sentry/utils/useOrganization';
 
 export enum FlagSort {
-  EVAL = 'eval',
+  NEWEST = 'newest',
+  OLDEST = 'oldest',
   ALPHA = 'alphabetical',
 }
 
 export const getLabel = (sort: string) => {
-  return sort === FlagSort.EVAL ? t('Evaluation Order') : t('Alphabetical');
+  switch (sort) {
+    case FlagSort.OLDEST:
+      return t('Oldest First');
+    case FlagSort.ALPHA:
+      return t('Alphabetical');
+    case FlagSort.NEWEST:
+    default:
+      return t('Newest First');
+  }
 };
 
 export const FLAG_SORT_OPTIONS = [
   {
-    label: getLabel(FlagSort.EVAL),
-    value: FlagSort.EVAL,
+    label: getLabel(FlagSort.NEWEST),
+    value: FlagSort.NEWEST,
+  },
+  {
+    label: getLabel(FlagSort.OLDEST),
+    value: FlagSort.OLDEST,
   },
   {
     label: getLabel(FlagSort.ALPHA),
@@ -81,7 +94,11 @@ export function FeatureFlagDrawer({
   };
 
   const sortedFlags =
-    sortMethod === FlagSort.ALPHA ? handleSortAlphabetical(hydratedFlags) : hydratedFlags;
+    sortMethod === FlagSort.ALPHA
+      ? handleSortAlphabetical(hydratedFlags)
+      : sortMethod === FlagSort.OLDEST
+        ? [...hydratedFlags].reverse()
+        : hydratedFlags;
   const searchResults = sortedFlags.filter(f => f.item.key.includes(search));
 
   const actions = (


### PR DESCRIPTION
Flags are sorted by "newest first" by default.

https://github.com/user-attachments/assets/ce4cdccc-b8bc-4cc9-9b96-5e2d1fc2fb3b

