### PR TITLE
ref(alerts): Allow for 5 minute time window for dynamic alerts

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -268,6 +268,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
 
     if (this.props.comparisonType === AlertRuleComparisonType.DYNAMIC) {
       options = pick(TIME_WINDOW_MAP, [
+        TimeWindow.FIVE_MINUTES,
         TimeWindow.FIFTEEN_MINUTES,
         TimeWindow.THIRTY_MINUTES,
         TimeWindow.ONE_HOUR,


### PR DESCRIPTION

<img width="1029" alt="Screenshot 2024-09-16 at 1 38 57 PM" src="https://github.com/user-attachments/assets/74e81c0a-1309-4449-bfd2-e643f5fec1c2">


Seer now supports a 5 minute time window for dynamic alerts, so we can add that as an option.

Backend counterpart: https://github.com/getsentry/sentry/pull/77593

Closes https://getsentry.atlassian.net/browse/ALRT-276