### PR TITLE
fix(invite-members): enable Resend button + display correct disabled message for Remove button

### DIFF
--- a/static/app/views/settings/organizationMembers/organizationMemberRow.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.spec.tsx
@@ -13,6 +13,7 @@ describe('OrganizationMemberRow', function () {
     name: '',
     orgRole: 'member',
     roleName: 'Member',
+    inviterName: 'Current User',
     pending: false,
     flags: {
       'sso:linked': false,
@@ -32,6 +33,7 @@ describe('OrganizationMemberRow', function () {
   const currentUser = UserFixture({
     id: '2',
     email: 'currentUser@email.com',
+    name: 'Current User',
   });
 
   const defaultProps: React.ComponentProps<typeof OrganizationMemberRow> = {
@@ -109,11 +111,39 @@ describe('OrganizationMemberRow', function () {
       expect(resendButton()).toBeDisabled();
     });
 
-    it('has "Resend Invite" button only if `canAddMembers` is true', function () {
+    it('has "Resend Invite" button if `canAddMembers` is true', function () {
       render(<OrganizationMemberRow {...props} canAddMembers />);
 
       expect(screen.getByTestId('member-role')).toHaveTextContent('Invited Member');
       expect(resendButton()).toBeEnabled();
+    });
+
+    it('has "Resend Invite" button if invite was sent from curr user and feature is on', function () {
+      const org = OrganizationFixture({
+        features: ['members-invite-teammates'],
+        access: ['member:invite'],
+      });
+      render(<OrganizationMemberRow {...props} organization={org} />);
+
+      expect(screen.getByTestId('member-role')).toHaveTextContent('Invited Member');
+      expect(resendButton()).toBeEnabled();
+    });
+
+    it('does not have "Resend Invite" button if invite was sent from other user and feature is on', function () {
+      const org = OrganizationFixture({
+        features: ['members-invite-teammates'],
+        access: ['member:invite'],
+      });
+      render(
+        <OrganizationMemberRow
+          {...props}
+          organization={org}
+          member={{...member, pending: true, inviterName: 'Other User'}}
+        />
+      );
+
+      expect(screen.getByTestId('member-role')).toHaveTextContent('Invited Member');
+      expect(resendButton()).toBeDisabled();
     });
 
     it('has the right inviting states', function () {
@@ -287,6 +317,32 @@ describe('OrganizationMemberRow', function () {
       render(<OrganizationMemberRow {...props} canRemoveMembers />);
 
       expect(removeButton()).toBeEnabled();
+    });
+
+    it('has Remove button if invite was sent from curr user and feature is on', function () {
+      const org = OrganizationFixture({
+        features: ['members-invite-teammates'],
+        access: ['member:invite'],
+      });
+      render(<OrganizationMemberRow {...props} organization={org} />);
+
+      expect(removeButton()).toBeEnabled();
+    });
+
+    it('has disabled Remove button if invite was sent from other user and feature is on', function () {
+      const org = OrganizationFixture({
+        features: ['members-invite-teammates'],
+        access: ['member:invite'],
+      });
+      render(
+        <OrganizationMemberRow
+          {...props}
+          organization={org}
+          member={{...member, pending: true, inviterName: 'Other User'}}
+        />
+      );
+
+      expect(removeButton()).toBeDisabled();
     });
   });
 });

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.spec.tsx
@@ -172,6 +172,32 @@ describe('OrganizationMemberRow', function () {
       expect(resendButton()).not.toBeInTheDocument();
       expect(screen.getByTestId('member-status')).toHaveTextContent('Sent!');
     });
+
+    it('has Remove button if invite was sent from curr user and feature is on', function () {
+      const org = OrganizationFixture({
+        features: ['members-invite-teammates'],
+        access: ['member:invite'],
+      });
+      render(<OrganizationMemberRow {...props} organization={org} />);
+
+      expect(removeButton()).toBeEnabled();
+    });
+
+    it('has disabled Remove button if invite was sent from other user and feature is on', function () {
+      const org = OrganizationFixture({
+        features: ['members-invite-teammates'],
+        access: ['member:invite'],
+      });
+      render(
+        <OrganizationMemberRow
+          {...props}
+          organization={org}
+          member={{...member, pending: true, inviterName: 'Other User'}}
+        />
+      );
+
+      expect(removeButton()).toBeDisabled();
+    });
   });
 
   describe('Expired user', function () {
@@ -317,32 +343,6 @@ describe('OrganizationMemberRow', function () {
       render(<OrganizationMemberRow {...props} canRemoveMembers />);
 
       expect(removeButton()).toBeEnabled();
-    });
-
-    it('has Remove button if invite was sent from curr user and feature is on', function () {
-      const org = OrganizationFixture({
-        features: ['members-invite-teammates'],
-        access: ['member:invite'],
-      });
-      render(<OrganizationMemberRow {...props} organization={org} />);
-
-      expect(removeButton()).toBeEnabled();
-    });
-
-    it('has disabled Remove button if invite was sent from other user and feature is on', function () {
-      const org = OrganizationFixture({
-        features: ['members-invite-teammates'],
-        access: ['member:invite'],
-      });
-      render(
-        <OrganizationMemberRow
-          {...props}
-          organization={org}
-          member={{...member, pending: true, inviterName: 'Other User'}}
-        />
-      );
-
-      expect(removeButton()).toBeDisabled();
     });
   });
 });

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
@@ -114,9 +114,9 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
     const isCurrentUser = currentUser.email === email;
     const showRemoveButton = !isCurrentUser;
     const showLeaveButton = isCurrentUser;
-    // inviterName is null if this is not a pending invite
-    // i.e. invite has been accepted
-    const isInvite = inviterName !== null;
+    // member has a `user` property if they are registered with sentry
+    // i.e. has accepted an invite to join org
+    const isInvite = !user;
     const isInviteFromCurrentUser = inviterName === currentUser.name;
     const canRemoveInvites =
       organization.features?.includes('members-invite-teammates') &&
@@ -126,8 +126,6 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
       (canRemoveMembers && !isCurrentUser && !isIdpProvisioned && !isPartnershipUser) ||
       // members can remove invites they sent if allowMemberInvite is true
       (canRemoveInvites && isInviteFromCurrentUser);
-    // member has a `user` property if they are registered with sentry
-    // i.e. has accepted an invite to join org
     const has2fa = user?.has2fa;
     const detailsUrl = `/settings/${organization.slug}/members/${id}/`;
     const isInviteSuccessful = status === 'success';

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
@@ -115,14 +115,14 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
     const showRemoveButton = !isCurrentUser;
     const showLeaveButton = isCurrentUser;
     const isInviteFromCurrentUser = inviterName === currentUser.name;
-    const canRemoveInvites =
+    const canInvite =
       organization.features?.includes('members-invite-teammates') &&
       organization.allowMemberInvite &&
       access.includes('member:invite');
     const canRemoveMember =
       (canRemoveMembers && !isCurrentUser && !isIdpProvisioned && !isPartnershipUser) ||
       // members can remove invites they sent if allowMemberInvite is true
-      (canRemoveInvites && isInviteFromCurrentUser);
+      (canInvite && isInviteFromCurrentUser);
     // member has a `user` property if they are registered with sentry
     // i.e. has accepted an invite to join org
     const has2fa = user?.has2fa;
@@ -159,7 +159,7 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
               {isInviteSuccessful && <span>{t('Sent!')}</span>}
               {!isInviting && !isInviteSuccessful && (
                 <Button
-                  disabled={!canAddMembers || !isInviteFromCurrentUser}
+                  disabled={!canAddMembers && !(canInvite && isInviteFromCurrentUser)}
                   priority="primary"
                   size="sm"
                   onClick={this.handleSendInvite}
@@ -213,7 +213,7 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
                     : isPartnershipUser
                       ? t('You cannot make changes to this partner-provisioned user.')
                       : // only show this message if member can remove invites but invite was not sent by them
-                        pending && canRemoveInvites && !isInviteFromCurrentUser
+                        pending && canInvite && !isInviteFromCurrentUser
                         ? t('Your role cannot modify this invite.')
                         : t('You do not have access to remove members')
                 }

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
@@ -114,15 +114,16 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
     const isCurrentUser = currentUser.email === email;
     const showRemoveButton = !isCurrentUser;
     const showLeaveButton = isCurrentUser;
-    const isInviteFromCurrentUser = inviterName === currentUser.name;
+    const isInviteFromCurrentUser = pending && inviterName === currentUser.name;
     const canInvite =
       organization.features?.includes('members-invite-teammates') &&
       organization.allowMemberInvite &&
       access.includes('member:invite');
+    // members can remove invites they sent if allowMemberInvite is true
+    const canEditInvite = canInvite && isInviteFromCurrentUser;
     const canRemoveMember =
       (canRemoveMembers && !isCurrentUser && !isIdpProvisioned && !isPartnershipUser) ||
-      // members can remove invites they sent if allowMemberInvite is true
-      (canInvite && isInviteFromCurrentUser);
+      canEditInvite;
     // member has a `user` property if they are registered with sentry
     // i.e. has accepted an invite to join org
     const has2fa = user?.has2fa;
@@ -159,7 +160,7 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
               {isInviteSuccessful && <span>{t('Sent!')}</span>}
               {!isInviting && !isInviteSuccessful && (
                 <Button
-                  disabled={!canAddMembers && !(canInvite && isInviteFromCurrentUser)}
+                  disabled={!canAddMembers && !canEditInvite}
                   priority="primary"
                   size="sm"
                   onClick={this.handleSendInvite}
@@ -214,7 +215,7 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
                       ? t('You cannot make changes to this partner-provisioned user.')
                       : // only show this message if member can remove invites but invite was not sent by them
                         pending && canInvite && !isInviteFromCurrentUser
-                        ? t('Your role cannot modify this invite.')
+                        ? t('You cannot modify this invite.')
                         : t('You do not have access to remove members')
                 }
                 icon={<IconSubtract isCircled />}

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
@@ -114,9 +114,6 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
     const isCurrentUser = currentUser.email === email;
     const showRemoveButton = !isCurrentUser;
     const showLeaveButton = isCurrentUser;
-    // member has a `user` property if they are registered with sentry
-    // i.e. has accepted an invite to join org
-    const isInvite = !user;
     const isInviteFromCurrentUser = inviterName === currentUser.name;
     const canRemoveInvites =
       organization.features?.includes('members-invite-teammates') &&
@@ -126,6 +123,8 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
       (canRemoveMembers && !isCurrentUser && !isIdpProvisioned && !isPartnershipUser) ||
       // members can remove invites they sent if allowMemberInvite is true
       (canRemoveInvites && isInviteFromCurrentUser);
+    // member has a `user` property if they are registered with sentry
+    // i.e. has accepted an invite to join org
     const has2fa = user?.has2fa;
     const detailsUrl = `/settings/${organization.slug}/members/${id}/`;
     const isInviteSuccessful = status === 'success';
@@ -160,7 +159,7 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
               {isInviteSuccessful && <span>{t('Sent!')}</span>}
               {!isInviting && !isInviteSuccessful && (
                 <Button
-                  disabled={!canAddMembers}
+                  disabled={!canAddMembers || !isInviteFromCurrentUser}
                   priority="primary"
                   size="sm"
                   onClick={this.handleSendInvite}
@@ -214,7 +213,7 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
                     : isPartnershipUser
                       ? t('You cannot make changes to this partner-provisioned user.')
                       : // only show this message if member can remove invites but invite was not sent by them
-                        isInvite && canRemoveInvites && !isInviteFromCurrentUser
+                        pending && canRemoveInvites && !isInviteFromCurrentUser
                         ? t('Your role cannot modify this invite.')
                         : t('You do not have access to remove members')
                 }

--- a/static/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -277,11 +277,8 @@ class OrganizationMembersList extends DeprecatedAsyncView<Props, State> {
     const {membersPageLinks, members, member: currentMember, inviteRequests} = this.state;
     const {access} = organization;
 
-    const canAddMembers =
-      access.includes('member:write') ||
-      (organization.features?.includes('members-invite-teammates') &&
-        organization.allowMemberInvite &&
-        access.includes('member:invite'));
+    const canAddMembers = access.includes('member:write');
+
     const canRemove = access.includes('member:admin');
     const currentUser = ConfigStore.get('user');
 

--- a/static/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -278,7 +278,6 @@ class OrganizationMembersList extends DeprecatedAsyncView<Props, State> {
     const {access} = organization;
 
     const canAddMembers = access.includes('member:write');
-
     const canRemove = access.includes('member:admin');
     const currentUser = ConfigStore.get('user');
 

--- a/static/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -277,7 +277,11 @@ class OrganizationMembersList extends DeprecatedAsyncView<Props, State> {
     const {membersPageLinks, members, member: currentMember, inviteRequests} = this.state;
     const {access} = organization;
 
-    const canAddMembers = access.includes('member:write');
+    const canAddMembers =
+      access.includes('member:write') ||
+      (organization.features?.includes('members-invite-teammates') &&
+        organization.allowMemberInvite &&
+        access.includes('member:invite'));
     const canRemove = access.includes('member:admin');
     const currentUser = ConfigStore.get('user');
 


### PR DESCRIPTION
was displaying incorrect disabled message:
<img width="562" alt="Screenshot 2024-09-16 at 2 13 28 PM" src="https://github.com/user-attachments/assets/0ff2ed4a-8023-4256-a1a4-96a3e34a4cd8">

fixed by checking if the member has the `pending` property instead of checking for `inviterName`

also enabled Resend Invite button for invites sent by the current user
<img width="763" alt="Screenshot 2024-09-16 at 4 06 03 PM" src="https://github.com/user-attachments/assets/f30a18c8-8802-4879-9f8f-f1ea7349a0ad">