### PR TITLE
fix(ui): Prevent LinkButton from using `to` and `external`

### DIFF
--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -148,6 +148,7 @@ interface ToLinkButtonProps extends BaseLinkButtonProps {
    * Similar to `href`, but for internal links within the app.
    */
   to: string | object;
+  external?: never;
 }
 
 interface HrefLinkButtonProps extends BaseLinkButtonProps {

--- a/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
@@ -1,8 +1,7 @@
-import type {ComponentProps} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert} from 'sentry/components/alert';
-import type {LinkButton} from 'sentry/components/button';
+import type {LinkButtonProps} from 'sentry/components/button';
 import {Flex} from 'sentry/components/container/flex';
 import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceContainer';
 import {
@@ -31,7 +30,7 @@ interface ReplayClipPreviewPlayerProps {
   orgSlug: string;
   replayReaderResult: ReturnType<typeof useReplayReader>;
   focusTab?: TabKey;
-  fullReplayButtonProps?: Partial<ComponentProps<typeof LinkButton>>;
+  fullReplayButtonProps?: Partial<Omit<LinkButtonProps, 'external'>>;
   handleBackClick?: () => void;
   handleForwardClick?: () => void;
   isLarge?: boolean;

--- a/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
@@ -2,7 +2,7 @@ import type {ComponentProps} from 'react';
 import {useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
-import {Button, LinkButton} from 'sentry/components/button';
+import {Button, LinkButton, type LinkButtonProps} from 'sentry/components/button';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import Panel from 'sentry/components/panels/panel';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
@@ -44,7 +44,7 @@ function ReplayPreviewPlayer({
 }: {
   replayId: string;
   replayRecord: ReplayRecord;
-  fullReplayButtonProps?: Partial<ComponentProps<typeof LinkButton>>;
+  fullReplayButtonProps?: Partial<Omit<LinkButtonProps, 'external'>>;
   handleBackClick?: () => void;
   handleForwardClick?: () => void;
   overlayContent?: React.ReactNode;

--- a/static/app/components/events/eventReplay/staticReplayPreview.tsx
+++ b/static/app/components/events/eventReplay/staticReplayPreview.tsx
@@ -1,7 +1,7 @@
-import {type ComponentProps, Fragment, useMemo} from 'react';
+import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
-import {LinkButton} from 'sentry/components/button';
+import {LinkButton, type LinkButtonProps} from 'sentry/components/button';
 import {REPLAY_LOADING_HEIGHT} from 'sentry/components/events/eventReplay/constants';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
@@ -23,7 +23,7 @@ type StaticReplayPreviewProps = {
   replay: ReplayReader | null;
   replayId: string;
   focusTab?: TabKey;
-  fullReplayButtonProps?: Partial<ComponentProps<typeof LinkButton>>;
+  fullReplayButtonProps?: Partial<Omit<LinkButtonProps, 'external'>>;
 };
 
 export function StaticReplayPreview({

--- a/static/app/components/onboardingWizard/skipConfirm.tsx
+++ b/static/app/components/onboardingWizard/skipConfirm.tsx
@@ -53,7 +53,7 @@ export default SkipConfirm;
 const SkipHelp = HookOrDefault({
   hookName: 'onboarding-wizard:skip-help',
   defaultComponent: () => (
-    <LinkButton priority="primary" size="xs" to="https://forum.sentry.io/" external>
+    <LinkButton priority="primary" size="xs" href="https://forum.sentry.io/" external>
       {t('Community Forum')}
     </LinkButton>
   ),

--- a/static/app/components/profiling/exportProfileButton.tsx
+++ b/static/app/components/profiling/exportProfileButton.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import type {ButtonProps} from 'sentry/components/button';
+import type {LinkButtonProps} from 'sentry/components/button';
 import {LinkButton} from 'sentry/components/button';
 import {IconDownload} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -9,7 +9,8 @@ import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 
-interface ExportProfileButtonProps extends Omit<ButtonProps, 'onClick' | 'children'> {
+interface ExportProfileButtonProps
+  extends Omit<LinkButtonProps, 'onClick' | 'children' | 'external'> {
   eventId: string | undefined;
   orgId: string;
   projectId: string | undefined;

--- a/static/app/views/monitors/components/newMonitorButton.tsx
+++ b/static/app/views/monitors/components/newMonitorButton.tsx
@@ -1,9 +1,9 @@
-import type {ButtonProps} from 'sentry/components/button';
+import type {LinkButtonProps} from 'sentry/components/button';
 import {LinkButton} from 'sentry/components/button';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
-export function NewMonitorButton(props: ButtonProps) {
+export function NewMonitorButton(props: Omit<LinkButtonProps, 'to' | 'external'>) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
 

--- a/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
@@ -161,7 +161,7 @@ function TeamAlertsTriggered({
             <LinkButton
               size="sm"
               external
-              to="https://docs.sentry.io/product/alerts/create-alerts/"
+              href="https://docs.sentry.io/product/alerts/create-alerts/"
             >
               {t('Learn more')}
             </LinkButton>

--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -1,8 +1,8 @@
-import type {ComponentProps, ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import {useState} from 'react';
 import styled from '@emotion/styled';
 
-import {LinkButton} from 'sentry/components/button';
+import {LinkButton, type LinkButtonProps} from 'sentry/components/button';
 import {Flex} from 'sentry/components/container/flex';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import Placeholder from 'sentry/components/placeholder';
@@ -215,7 +215,7 @@ function SearchButton({
   label: ReactNode;
   path: string;
   sort: string;
-} & Omit<ComponentProps<typeof LinkButton>, 'size' | 'to'>) {
+} & Omit<LinkButtonProps, 'size' | 'to' | 'external'>) {
   const location = useLocation();
   const organization = useOrganization();
 


### PR DESCRIPTION
Fixes a link that used to + external and landed on a route not found.

All links using `to` should never be external. Fixes some prop type to omit external.

Typescript attempts to save you from merging two objects with no overlap in the union.
