### PR TITLE
fix(alerts): Restrict threshold type above and below

### DIFF
--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -410,7 +410,12 @@ class AlertRuleSerializer(CamelSnakeModelSerializer[AlertRule]):
         if comparison_delta is None:
             return
 
-        translator = self.threshold_translators[threshold_type]
+        translator = self.threshold_translators.get(threshold_type)
+        if not translator:
+            raise serializers.ValidationError(
+                "Invalid threshold type: Allowed types for comparison alerts are above OR below"
+            )
+
         resolve_threshold = data.get("resolve_threshold")
         if resolve_threshold:
             data["resolve_threshold"] = translator(resolve_threshold)


### PR DESCRIPTION
`_translate_thresholds` is only used for comparison alerts but someone tried to use the "above and below" threshold whcih is only for dynamic alerts. This throws a validation error if that value is passed for an alert with a comparison delta.

Closes https://getsentry.atlassian.net/browse/ALRT-279

Fixes SENTRY-3EWQ