### PR TITLE
feat(replays): enhance error details in SimpleStorageBlob.get

### DIFF
--- a/src/sentry/replays/lib/storage.py
+++ b/src/sentry/replays/lib/storage.py
@@ -197,7 +197,7 @@ class SimpleStorageBlob:
             result = blob.read()
             blob.close()
         except Exception:
-            logger.warning("Storage GET error.")
+            logger.warning("Storage GET error: %s", repr(e))
             return None
         else:
             return result


### PR DESCRIPTION
This pull request enhances the error logging in the SimpleStorageBlob.get method by including detailed exception information. Previously, the method only logged a generic message when an error occurred. Now, it logs the exception details using repr(e).

**Changes Made**:
Updated the get method in SimpleStorageBlob to log the exception details using logger.warning("Storage GET error: %s", repr(e)).

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
