### PR TITLE
fix(django-onboarding): Add missing django extra

### DIFF
--- a/static/app/gettingStartedDocs/python/django.spec.tsx
+++ b/static/app/gettingStartedDocs/python/django.spec.tsx
@@ -15,7 +15,9 @@ describe('django onboarding docs', function () {
 
     // Renders install instructions
     expect(
-      screen.getByText(textWithMarkupMatcher('pip install --upgrade sentry-sdk'))
+      screen.getByText(
+        textWithMarkupMatcher("pip install --upgrade 'sentry-sdk[django]'")
+      )
     ).toBeInTheDocument();
   });
 

--- a/static/app/gettingStartedDocs/python/django.tsx
+++ b/static/app/gettingStartedDocs/python/django.tsx
@@ -13,7 +13,7 @@ import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
 
-const getInstallSnippet = () => `pip install --upgrade sentry-sdk`;
+const getInstallSnippet = () => `pip install --upgrade 'sentry-sdk[django]'`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk


### PR DESCRIPTION
The install snippet for the Django SDK was missing the `django` extra even though it is referenced in the text.