### PR TITLE
ref(performance-onboarding): Remove old docs loading mechanism

### DIFF
--- a/static/app/components/performanceOnboarding/sidebar.spec.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.spec.tsx
@@ -17,8 +17,6 @@ import type {PlatformKey, Project} from 'sentry/types/project';
 import type {StatuspageIncident} from 'sentry/types/system';
 import * as incidentsHook from 'sentry/utils/useServiceIncidents';
 
-import {generateDocKeys} from './utils';
-
 jest.mock('sentry/utils/useServiceIncidents');
 
 describe('Sidebar > Performance Onboarding Checklist', function () {
@@ -228,18 +226,6 @@ describe('Sidebar > Performance Onboarding Checklist', function () {
       firstTransactionEvent: false,
     });
     ProjectsStore.loadInitialData([project]);
-
-    // TODO(aknaus): Remove old mocks when we remove the old onboarding
-    const docApiMocks: any = {};
-    const docKeys = generateDocKeys(project.platform!);
-
-    docKeys.forEach(docKey => {
-      docApiMocks[docKey] = MockApiClient.addMockResponse({
-        url: `/projects/${organization.slug}/${project.slug}/docs/${docKey}/`,
-        method: 'GET',
-        body: {html: `<h1>${docKey}</h1> content`},
-      });
-    });
 
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/`,


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/77539

Removes the (now unused) old docs loading mechanism from the performance sidebar.

Part of https://github.com/getsentry/sentry/issues/56553