### PR TITLE
drop(grouping): Use new ophio parser

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -66,7 +66,7 @@ rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo>=2.16.5
 sentry-kafka-schemas>=0.1.109
-sentry-ophio==0.2.7
+sentry-ophio==0.2.8
 sentry-protos>=0.1.21
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.9.1

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -66,7 +66,7 @@ rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo>=2.16.5
 sentry-kafka-schemas>=0.1.109
-sentry-ophio==0.2.8
+sentry-ophio==0.2.9
 sentry-protos>=0.1.21
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.9.1

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -66,7 +66,7 @@ rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo>=2.16.5
 sentry-kafka-schemas>=0.1.109
-sentry-ophio==0.2.9
+sentry-ophio==1.0.0
 sentry-protos>=0.1.21
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.9.1

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -183,7 +183,7 @@ sentry-devenv==1.10.0
 sentry-forked-django-stubs==5.0.4.post2
 sentry-forked-djangorestframework-stubs==3.15.1.post1
 sentry-kafka-schemas==0.1.109
-sentry-ophio==0.2.7
+sentry-ophio==1.0.0
 sentry-protos==0.1.21
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.1

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -124,7 +124,7 @@ rsa==4.8
 s3transfer==0.10.0
 sentry-arroyo==2.16.5
 sentry-kafka-schemas==0.1.109
-sentry-ophio==0.2.7
+sentry-ophio==1.0.0
 sentry-protos==0.1.21
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.1

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -138,15 +138,7 @@ class Enhancements:
         """
         match_frames = [create_match_frame(frame, platform) for frame in frames]
 
-        # TODO: Update the Rust component to not take the two values
-        rust_components = [
-            RustComponent(
-                is_prefix_frame=False,
-                is_sentinel_frame=False,
-                contributes=c.contributes,
-            )
-            for c in components
-        ]
+        rust_components = [RustComponent(contributes=c.contributes) for c in components]
 
         rust_results = self.rust_enhancements.assemble_stacktrace_component(
             match_frames, make_rust_exception_data(exception_data), rust_components


### PR DESCRIPTION
It drops requiring `is_prefix` and `is_sentinel` which has already been deprecated.

See changes here: https://github.com/getsentry/ophio/pull/63