### PR TITLE
ref(onboarding): Add analytics to take me to error button

### DIFF
--- a/static/app/utils/analytics/growthAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/growthAnalyticsEvents.tsx
@@ -101,7 +101,9 @@ export type GrowthEventParameters = {
   'growth.onboarding_start_onboarding': {
     source?: string;
   };
-  'growth.onboarding_take_to_error': {};
+  'growth.onboarding_take_to_error': {
+    platform?: string;
+  };
   'growth.onboarding_view_full_docs': {};
   'growth.onboarding_view_sample_event': SampleEventParam;
   'growth.platformpicker_category': PlatformCategory;

--- a/static/app/views/onboarding/components/firstEventFooter.tsx
+++ b/static/app/views/onboarding/components/firstEventFooter.tsx
@@ -57,6 +57,12 @@ export default function FirstEventFooter({
     }
     return (
       <LinkButton
+        onClick={() =>
+          trackAnalytics('growth.onboarding_take_to_error', {
+            organization: project.organization,
+            platform: project.platform,
+          })
+        }
         to={`/organizations/${organization.slug}/issues/${
           project?.firstIssue && 'id' in project.firstIssue
             ? `${project.firstIssue.id}/`

--- a/static/app/views/onboarding/components/firstEventIndicator.tsx
+++ b/static/app/views/onboarding/components/firstEventIndicator.tsx
@@ -37,6 +37,7 @@ function FirstEventIndicator({children, ...props}: FirstEventIndicatorProps) {
               onClick={() =>
                 trackAnalytics('growth.onboarding_take_to_error', {
                   organization: props.organization,
+                  platform: props.project.platform,
                 })
               }
               to={`/organizations/${props.organization.slug}/issues/${


### PR DESCRIPTION
Add analytics to "Take me to error" button, same as [here](https://github.com/getsentry/sentry/blob/0c4545761738a44b69c59d26ed5860c0c553c9bc/static/app/views/onboarding/components/firstEventIndicator.tsx#L38).

Also added additional info about event - platform

Part of https://github.com/getsentry/sentry/issues/77391