### PR TITLE
fix(onboarding-analytics): Do not fire modal closed event on configure or skip click

### DIFF
--- a/static/app/components/onboarding/frameworkSuggestionModal.spec.tsx
+++ b/static/app/components/onboarding/frameworkSuggestionModal.spec.tsx
@@ -1,5 +1,5 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {
   makeClosableHeader,
@@ -73,8 +73,5 @@ describe('Framework suggestion modal', function () {
     expect(screen.getByRole('button', {name: 'Configure SDK'})).toBeEnabled();
 
     await userEvent.click(screen.getByRole('button', {name: 'Skip'}));
-    await waitFor(() => {
-      expect(closeModal).toHaveBeenCalled();
-    });
   });
 });

--- a/static/app/components/onboarding/frameworkSuggestionModal.tsx
+++ b/static/app/components/onboarding/frameworkSuggestionModal.tsx
@@ -209,15 +209,7 @@ export function FrameworkSuggestionModal({
     );
 
     onConfigure(selectedFramework);
-    closeModal();
-  }, [
-    selectedPlatform,
-    selectedFramework,
-    organization,
-    onConfigure,
-    closeModal,
-    newOrg,
-  ]);
+  }, [selectedPlatform, selectedFramework, organization, onConfigure, newOrg]);
 
   const handleSkip = useCallback(() => {
     trackAnalytics(
@@ -230,8 +222,7 @@ export function FrameworkSuggestionModal({
       }
     );
     onSkip();
-    closeModal();
-  }, [selectedPlatform, organization, closeModal, onSkip, newOrg]);
+  }, [selectedPlatform, organization, onSkip, newOrg]);
 
   const listEntries = [...topFrameworksOrdered, ...otherFrameworksSortedAlphabetically];
 

--- a/static/app/components/onboarding/frameworkSuggestionModal.tsx
+++ b/static/app/components/onboarding/frameworkSuggestionModal.tsx
@@ -233,12 +233,20 @@ export function FrameworkSuggestionModal({
     closeModal();
   }, [selectedPlatform, organization, closeModal, onSkip, newOrg]);
 
+  const handleClose = useCallback(() => {
+    trackAnalytics('project_creation.select_framework_modal_close_button_clicked', {
+      platform: selectedPlatform.key,
+      organization,
+    });
+    closeModal();
+  }, [selectedPlatform, organization, closeModal]);
+
   const listEntries = [...topFrameworksOrdered, ...otherFrameworksSortedAlphabetically];
 
   return (
     <Fragment>
       <Header>
-        <CloseButton onClick={closeModal} />
+        <CloseButton onClick={handleClose} />
       </Header>
       <Body>
         <TopFrameworksImage frameworks={listEntries} />

--- a/static/app/components/onboarding/frameworkSuggestionModal.tsx
+++ b/static/app/components/onboarding/frameworkSuggestionModal.tsx
@@ -233,20 +233,12 @@ export function FrameworkSuggestionModal({
     closeModal();
   }, [selectedPlatform, organization, closeModal, onSkip, newOrg]);
 
-  const handleClose = useCallback(() => {
-    trackAnalytics('project_creation.select_framework_modal_close_button_clicked', {
-      platform: selectedPlatform.key,
-      organization,
-    });
-    closeModal();
-  }, [selectedPlatform, organization, closeModal]);
-
   const listEntries = [...topFrameworksOrdered, ...otherFrameworksSortedAlphabetically];
 
   return (
     <Fragment>
       <Header>
-        <CloseButton onClick={handleClose} />
+        <CloseButton onClick={closeModal} />
       </Header>
       <Body>
         <TopFrameworksImage frameworks={listEntries} />

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -230,6 +230,12 @@ function CreateProject() {
       ),
       {
         modalCss,
+        onClose: () => {
+          trackAnalytics('project_creation.select_framework_modal_close_button_clicked', {
+            platform: selectedPlatform.key,
+            organization,
+          });
+        },
       }
     );
   }, [platform, createProject, organization]);

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -230,12 +230,6 @@ function CreateProject() {
       ),
       {
         modalCss,
-        onClose: () => {
-          trackAnalytics('project_creation.select_framework_modal_close_button_clicked', {
-            platform: selectedPlatform.key,
-            organization,
-          });
-        },
       }
     );
   }, [platform, createProject, organization]);


### PR DESCRIPTION
With previous implementation, `onClose` function was called on every modal closing event, including clicking on "Skip" or "Configure SDK" button. Since those 2 events are already tracked by analytics, we wanted to fire `project_creation.select_framework_modal_close_button_clicked` only when close button was clicked, so the `closeModal` callback call was removed from the functions that handle "configure sdk" and "Skip" button clicks

Part of https://github.com/getsentry/sentry/issues/77391
