### PR TITLE
ref(onboarding-analytics): Add platform info when project is created

### DIFF
--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -145,6 +145,7 @@ export type TeamInsightsEventParameters = {
   'issue_stream.updated_empty_state_viewed': {platform: string};
   'project_creation_page.created': {
     issue_alert: 'Default' | 'Custom' | 'No Rule';
+    platform: string;
     project_id: string;
     rule_id: string;
   };

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -146,6 +146,7 @@ function CreateProject() {
               ? 'Custom'
               : 'No Rule',
           project_id: projectData.id,
+          platform: selectedPlatform.key,
           rule_id: ruleId || '',
         });
 


### PR DESCRIPTION
Added info about platform (or framework - if it is selected) to the analytical event that is fired when project is created.

Part of https://github.com/getsentry/sentry/issues/77391
