### PR TITLE
fix(onboarding-analytics) Do not fire `project_creation.data_removal_modal_dismissed` on modal confirm 

### DIFF
--- a/static/app/views/projectInstall/platformDocHeader.tsx
+++ b/static/app/views/projectInstall/platformDocHeader.tsx
@@ -104,7 +104,7 @@ export function PlatformDocHeader({platform, projectSlug, title}: Props) {
           priority="danger"
           confirmText={t("Yes I'm sure")}
           onConfirm={handleGoBack}
-          onClose={() => {
+          onCancel={() => {
             if (!recentCreatedProject) {
               return;
             }


### PR DESCRIPTION
`onClose` is being called whenever a modal is closed - even on modal confirm.

There is a callback `onCancel` which can be used to track `project_creation.data_removal_modal_dismissed` events. `onCancel` is called only when the modal is dismissed.

Part of https://github.com/getsentry/sentry/issues/77391
