### PR TITLE
chore(insights): Create beta label for MongoDB queries

### DIFF
--- a/static/app/views/insights/database/components/databaseSystemSelector.spec.tsx
+++ b/static/app/views/insights/database/components/databaseSystemSelector.spec.tsx
@@ -63,7 +63,7 @@ describe('DatabaseSystemSelector', function () {
     expect(mockSetState).not.toHaveBeenCalled();
     const dropdownButton = await screen.findByRole('button');
     expect(dropdownButton).toBeInTheDocument();
-    expect(dropdownButton).toHaveTextContent('DB SystemNone');
+    expect(dropdownButton).toHaveTextContent('SystemNone');
   });
 
   it('is disabled when only one database system is present and shows that system as selected', async function () {
@@ -208,7 +208,7 @@ describe('DatabaseSystemSelector', function () {
     render(<DatabaseSystemSelector />, {organization});
 
     const dropdownSelector = await screen.findByRole('button');
-    expect(dropdownSelector).toHaveTextContent('DB SystemMongoDB');
+    expect(dropdownSelector).toHaveTextContent('SystemMongoDB');
     expect(mockSetState).not.toHaveBeenCalledWith('mongodb');
 
     // Now that it has been confirmed that following a URL does not reset localStorage state, confirm that
@@ -219,7 +219,7 @@ describe('DatabaseSystemSelector', function () {
     expect(dropdownOptionLabels[1]).toHaveTextContent('MongoDB');
 
     await userEvent.click(dropdownOptionLabels[0]);
-    expect(dropdownSelector).toHaveTextContent('DB SystemPostgreSQL');
+    expect(dropdownSelector).toHaveTextContent('SystemPostgreSQL');
     expect(mockSetState).toHaveBeenCalledWith('postgresql');
     expect(mockNavigate).toHaveBeenCalledWith({
       action: 'POP',

--- a/static/app/views/insights/database/components/databaseSystemSelector.tsx
+++ b/static/app/views/insights/database/components/databaseSystemSelector.tsx
@@ -33,7 +33,7 @@ export function DatabaseSystemSelector() {
         });
       }}
       options={options}
-      triggerProps={{prefix: t('DB System')}}
+      triggerProps={{prefix: t('System')}}
       loading={isLoading}
       disabled={isError || isLoading || options.length <= 1}
       value={systemQueryParam ?? selectedSystem}

--- a/static/app/views/insights/database/components/useSystemSelectorOptions.tsx
+++ b/static/app/views/insights/database/components/useSystemSelectorOptions.tsx
@@ -1,8 +1,16 @@
+import type {ReactNode} from 'react';
+import styled from '@emotion/styled';
+
+import FeatureBadge from 'sentry/components/badge/featureBadge';
 import type {SelectOption} from 'sentry/components/compactSelect';
+import {space} from 'sentry/styles/space';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
-import {DATABASE_SYSTEM_TO_LABEL} from 'sentry/views/insights/database/utils/constants';
+import {
+  DATABASE_SYSTEM_TO_LABEL,
+  SupportedDatabaseSystem,
+} from 'sentry/views/insights/database/utils/constants';
 import {SpanMetricsField} from 'sentry/views/insights/types';
 
 export function useSystemSelectorOptions() {
@@ -25,10 +33,22 @@ export function useSystemSelectorOptions() {
   data.forEach(entry => {
     const system = entry['span.system'];
     if (system) {
-      const label: string =
+      let label: ReactNode = '';
+      const textValue =
         system in DATABASE_SYSTEM_TO_LABEL ? DATABASE_SYSTEM_TO_LABEL[system] : system;
 
-      options.push({value: system, label, textValue: label});
+      if (system === SupportedDatabaseSystem.MONGODB) {
+        label = (
+          <LabelContainer>
+            {textValue}
+            <StyledFeatureBadge type={'beta'} />
+          </LabelContainer>
+        );
+      } else {
+        label = textValue;
+      }
+
+      options.push({value: system, label, textValue});
     }
   });
 
@@ -44,3 +64,12 @@ export function useSystemSelectorOptions() {
 
   return {selectedSystem, setSelectedSystem, options, isLoading, isError};
 }
+
+const StyledFeatureBadge = styled(FeatureBadge)`
+  margin-left: ${space(1)};
+`;
+
+const LabelContainer = styled('div')`
+  display: flex;
+  align-items: center;
+`;


### PR DESCRIPTION
Also trims the fat on the the dropdown prefix text: `DB System` -> `System`

![image](https://github.com/user-attachments/assets/910150cc-0a35-4d7f-8384-59a8b10f4145)
