### PR TITLE
fix(custom-views): Fix custom views renaming functionality

### DIFF
--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -182,16 +182,14 @@ function Tabs({
               onHoverStart={() => setHoveringKey(item.key)}
               onHoverEnd={() => setHoveringKey(null)}
             >
-              <div key={item.key}>
-                <Tab
-                  key={item.key}
-                  item={item}
-                  state={state}
-                  orientation={orientation}
-                  overflowing={overflowingTabs.some(tab => tab.key === item.key)}
-                  variant={tabVariant}
-                />
-              </div>
+              <Tab
+                key={item.key}
+                item={item}
+                state={state}
+                orientation={orientation}
+                overflowing={overflowingTabs.some(tab => tab.key === item.key)}
+                variant={tabVariant}
+              />
             </TabItemWrap>
             <TabDivider
               isVisible={

--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
@@ -350,6 +350,7 @@ export function DraggableTabBar({
             },
             pathname: `/organizations/${orgSlug}/issues/`,
           })}
+          disabled={tab.key === editingTabKey}
         >
           <TabContentWrap>
             <EditableTabTitle
@@ -357,7 +358,7 @@ export function DraggableTabBar({
               isEditing={editingTabKey === tab.key}
               setIsEditing={isEditing => setEditingTabKey(isEditing ? tab.key : null)}
               onChange={newLabel => handleOnTabRenamed(newLabel.trim(), tab.key)}
-              isSelected={tabListState?.selectedKey === tab.key}
+              tabKey={tab.key}
             />
             {tabListState?.selectedKey === tab.key && (
               <DraggableTabMenuButton


### PR DESCRIPTION
This PR makes several changes and fixes to the rename function for custom views:

1. **Bug fix:** You can now click within the tab's title while renaming 
2. **Regression fix:** You can now hit enter to save your changes 
3. **Improvement:** When the tab is in editing mode, the cursor will switch from `pointer` to `text` to signal that it is editable. 
4. **Improvement:** Entering editing mode automatically selects all the text by default 