### PR TITLE
fix(custom-views): Stop tabs from animating on load

### DIFF
--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -155,7 +155,13 @@ function Tabs({
 
   return (
     <TabListWrap {...tabListProps} className={className} ref={tabListRef}>
-      <ReorderGroup axis="x" values={values} onReorder={onReorder} as="div">
+      <ReorderGroup
+        axis="x"
+        values={values}
+        onReorder={onReorder}
+        as="div"
+        initial={false}
+      >
         {tabs.map((item, i) => (
           <Fragment key={item.key}>
             <TabItemWrap
@@ -183,6 +189,7 @@ function Tabs({
               onDragEnd={() => setIsDragging(false)}
               onHoverStart={() => setHoveringKey(item.key)}
               onHoverEnd={() => setHoveringKey(null)}
+              initial={false}
             >
               <div key={item.key}>
                 <Tab
@@ -203,6 +210,7 @@ function Tabs({
                 hoveringKey !== item.key &&
                 state.collection.getKeyAfter(item.key) !== hoveringKey
               }
+              initial={false}
             />
           </Fragment>
         ))}

--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
@@ -363,7 +363,12 @@ export function DraggableTabBar({
               onChange={newLabel => handleOnTabRenamed(newLabel.trim(), tab.key)}
               isSelected={tabListState?.selectedKey === tab.key}
             />
-            {tabListState?.selectedKey === tab.key && (
+            {/* If tablistState isn't initialized, we want to load the elipsis menu
+                for the initial tab, that way it won't load in a second later
+                and cause the tabs to shift and animate on load.
+            */}
+            {((tabListState && tabListState?.selectedKey === tab.key) ||
+              (!tabListState && tab.key === initialTabKey)) && (
               <DraggableTabMenuButton
                 hasUnsavedChanges={!!tab.unsavedChanges}
                 menuOptions={makeMenuOptions(tab)}


### PR DESCRIPTION
Stop tabs from animating on load: 

Before:

https://github.com/user-attachments/assets/ffcc6ed6-4289-4758-938c-cad90ff6ef94


After: 

https://github.com/user-attachments/assets/532e68e1-f7de-460c-a554-0dbce15d1886

