### PR TITLE
fix(rules): Fix serializer when rule snooze owner is None

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -258,7 +258,7 @@ class RuleSerializer(Serializer):
             created_by = None
             if user.id == snooze.get("owner_id"):
                 created_by = "You"
-            else:
+            elif snooze.get("owner_id"):
                 creator = user_service.get_user(snooze.get("owner_id"))
                 if creator:
                     created_by = creator.get_display_name()

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -258,8 +258,8 @@ class RuleSerializer(Serializer):
             created_by = None
             if user.id == snooze.get("owner_id"):
                 created_by = "You"
-            elif snooze.get("owner_id"):
-                creator = user_service.get_user(snooze.get("owner_id"))
+            elif owner_id := snooze.get("owner_id"):
+                creator = user_service.get_user(owner_id)
                 if creator:
                     created_by = creator.get_display_name()
 

--- a/src/sentry/incidents/endpoints/serializers/alert_rule.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule.py
@@ -397,8 +397,13 @@ class CombinedRuleSerializer(Serializer):
             user=user,
             serializer=RuleSerializer(expand=self.expand),
         )
+        # there are none results in the list of serialized issue rules
+        # something is wrong with the RuleSerializer
         serialized_issue_rule_map_by_id = {
-            serialized_rule["id"]: serialized_rule for serialized_rule in serialized_issue_rules
+            serialized_rule["id"]: serialized_rule
+            for serialized_rule in list(
+                filter(lambda item: item is not None, serialized_issue_rules)
+            )
         }
 
         serialized_uptime_monitors = serialize(

--- a/src/sentry/incidents/endpoints/serializers/alert_rule.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule.py
@@ -397,13 +397,8 @@ class CombinedRuleSerializer(Serializer):
             user=user,
             serializer=RuleSerializer(expand=self.expand),
         )
-        # there are none results in the list of serialized issue rules
-        # something is wrong with the RuleSerializer
         serialized_issue_rule_map_by_id = {
-            serialized_rule["id"]: serialized_rule
-            for serialized_rule in list(
-                filter(lambda item: item is not None, serialized_issue_rules)
-            )
+            serialized_rule["id"]: serialized_rule for serialized_rule in serialized_issue_rules
         }
 
         serialized_uptime_monitors = serialize(

--- a/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
+++ b/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
@@ -99,6 +99,69 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         )
         self.combined_rules_url = f"/api/0/organizations/{self.org.slug}/combined-rules/"
 
+    def test_simple(self):
+        self.setup_project_and_rules()
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            request_data = {"per_page": "10", "project": self.project_ids}
+            response = self.client.get(
+                path=self.combined_rules_url, data=request_data, content_type="application/json"
+            )
+        assert response.status_code == 200
+        result = json.loads(response.content)
+        assert len(result) == 4
+        self.assert_alert_rule_serialized(self.yet_another_alert_rule, result[0], skip_dates=True)
+        assert result[1]["id"] == str(self.issue_rule.id)
+        assert result[1]["type"] == "rule"
+        self.assert_alert_rule_serialized(self.other_alert_rule, result[2], skip_dates=True)
+        self.assert_alert_rule_serialized(self.alert_rule, result[3], skip_dates=True)
+
+    def test_snoozed_rules(self):
+        """
+        Test that we properly serialize snoozed rules with and without an owner
+        """
+        self.setup_project_and_rules()
+        issue_rule2 = self.create_issue_alert_rule(
+            data={
+                "project": self.project2,
+                "name": "Issue Rule Test",
+                "conditions": [],
+                "actions": [],
+                "actionMatch": "all",
+                "date_added": before_now(minutes=4),
+            }
+        )
+        self.snooze_rule(user_id=self.user.id, rule=self.issue_rule)
+        self.snooze_rule(user_id=self.user.id, rule=issue_rule2, owner_id=self.user.id)
+        self.snooze_rule(user_id=self.user.id, alert_rule=self.alert_rule)
+        self.snooze_rule(
+            user_id=self.user.id, alert_rule=self.yet_another_alert_rule, owner_id=self.user.id
+        )
+
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            request_data = {"per_page": "10", "project": self.project_ids}
+            response = self.client.get(
+                path=self.combined_rules_url, data=request_data, content_type="application/json"
+            )
+        assert response.status_code == 200
+        result = json.loads(response.content)
+        assert len(result) == 5
+        self.assert_alert_rule_serialized(self.yet_another_alert_rule, result[0], skip_dates=True)
+        assert result[0]["snooze"]
+
+        assert result[1]["id"] == str(issue_rule2.id)
+        assert result[1]["type"] == "rule"
+        assert result[1]["snooze"]
+
+        assert result[2]["id"] == str(self.issue_rule.id)
+        assert result[2]["type"] == "rule"
+        assert result[2]["snooze"]
+
+        self.assert_alert_rule_serialized(self.other_alert_rule, result[3], skip_dates=True)
+        assert not result[3].get("snooze")
+
+        self.assert_alert_rule_serialized(self.alert_rule, result[4], skip_dates=True)
+        assert result[4]["snooze"]
+
     def test_invalid_limit(self):
         self.setup_project_and_rules()
         with self.feature(["organizations:incidents", "organizations:performance-view"]):


### PR DESCRIPTION
If the `RuleSnooze` object `owner_id` is `None` we were hitting an error calling `user_service.get_user()` on it which caused serialization to fail and `None` entries were in the `serialized_issue_rules` in the combined rule serializer.

Closes https://getsentry.atlassian.net/browse/ALRT-285
Fixes SENTRY-3A73
Fixes SENTRY-3D67