### PR TITLE
tests(issue_platform): Test that we can delete Issue Platform issues

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -512,6 +512,7 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /src/sentry/api/helpers/group_index/                        @getsentry/issues
 /src/sentry/api/helpers/source_map_helper.py                @getsentry/issues
 /src/sentry/api/issue_search.py                             @getsentry/issues
+/src/sentry/deletions/defaults/group.py                     @getsentry/issues
 /src/sentry/deletions/tasks/groups.py                       @getsentry/issues
 /src/sentry/event_manager.py                                @getsentry/issues
 /src/sentry/eventstore/models.py                            @getsentry/issues

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -512,6 +512,7 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /src/sentry/api/helpers/group_index/                        @getsentry/issues
 /src/sentry/api/helpers/source_map_helper.py                @getsentry/issues
 /src/sentry/api/issue_search.py                             @getsentry/issues
+/src/sentry/deletions/tasks/groups.py                       @getsentry/issues
 /src/sentry/event_manager.py                                @getsentry/issues
 /src/sentry/eventstore/models.py                            @getsentry/issues
 /src/sentry/grouping/                                       @getsentry/issues
@@ -550,6 +551,7 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /static/app/utils/analytics.tsx                             @getsentry/issues
 /static/app/utils/routeAnalytics/                           @getsentry/issues
 /tests/sentry/api/test_issue_search.py                      @getsentry/issues
+/tests/sentry/deletions/test_group.py                       @getsentry/issues
 /tests/sentry/event_manager/                                @getsentry/issues
 /tests/sentry/grouping/                                     @getsentry/issues
 /tests/sentry/search/                                       @getsentry/issues

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -17,6 +17,7 @@ from sentry.models.groupredirect import GroupRedirect
 from sentry.models.userreport import UserReport
 from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
 
 class DeleteGroupTest(TestCase, SnubaTestCase):
@@ -25,8 +26,6 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
         one_minute = iso_format(before_now(minutes=1))
         group1_data = {"timestamp": one_minute, "fingerprint": ["group1"]}
         group2_data = {"timestamp": one_minute, "fingerprint": ["group2"]}
-        group3_data = {"timestamp": one_minute, "fingerprint": ["group3"]}
-        self.project = self.create_project()
 
         # Group 1 events
         self.event = self.store_event(
@@ -42,13 +41,6 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
         self.keep_event = self.store_event(data=group2_data, project_id=self.project.id)
         self.event_id3 = self.keep_event.event_id
         self.node_id3 = Event.generate_node_id(self.project.id, self.event_id3)
-
-        # Group 3: issue platform event
-        self.issue_platform_event = self.store_event(
-            data=group3_data | {"type": "transaction", "start_timestamp": one_minute},
-            project_id=self.project.id,
-        )
-        self.node_id4 = Event.generate_node_id(self.project.id, self.issue_platform_event.event_id)
 
         UserReport.objects.create(
             group_id=group.id, project_id=self.event.project_id, name="With group id"
@@ -90,17 +82,6 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
         assert not nodestore.backend.get(self.node_id2)
         assert nodestore.backend.get(self.node_id3), "Does not remove from second group"
         assert Group.objects.filter(id=self.keep_event.group_id).exists()
-
-    def test_issue_platform(self):
-        EventDataDeletionTask.DEFAULT_CHUNK_SIZE = 1  # test chunking logic
-        group_id = self.issue_platform_event.group_id
-        assert nodestore.backend.get(self.node_id4)
-
-        # Issue platform issues cannot be deleted
-        with self.tasks():
-            delete_groups(object_ids=[group_id])
-        assert nodestore.backend.get(self.node_id4), "Does not remove issue platform event"
-        assert Group.objects.filter(id=group_id).exists()
 
     def test_simple_multiple_groups(self):
         other_event = self.store_event(
@@ -209,3 +190,16 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
         assert mock_delete_seer_grouping_records_by_hash_apply_async.call_args[1] == {
             "args": [group.project.id, hashes, 0]
         }
+
+
+class DeleteIssuePlatformTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
+    def test_issue_platform(self):
+        event = self.store_event(data={}, project_id=self.project.id)
+        node_id = Event.generate_node_id(event.project_id, event.event_id)
+        self.build_occurrence(event_id=event.event_id)
+
+        with self.tasks():
+            delete_groups(object_ids=[event.group_id])
+
+        assert not nodestore.backend.get(node_id)
+        assert not Group.objects.filter(id=event.group_id).exists()


### PR DESCRIPTION
The endpoint does not permit deleting Issue Platform issues, however, the task allows for it.

I will follow-up with a different PR to add the support for deleting the occurrence from Snuba.