### PR TITLE
fix(substatus): Unset substatus when merging groups

### DIFF
--- a/src/sentry/issues/merge.py
+++ b/src/sentry/issues/merge.py
@@ -42,7 +42,9 @@ def handle_merge(
         primary_group.project_id, group_ids_to_merge, primary_group.id
     )
 
-    Group.objects.filter(id__in=group_ids_to_merge).update(status=GroupStatus.PENDING_MERGE)
+    Group.objects.filter(id__in=group_ids_to_merge).update(
+        status=GroupStatus.PENDING_MERGE, substatus=None
+    )
 
     transaction_id = uuid4().hex
     merge_groups.delay(

--- a/tests/sentry/issues/test_merge.py
+++ b/tests/sentry/issues/test_merge.py
@@ -12,6 +12,7 @@ from sentry.models.groupinbox import GroupInboxReason, add_group_to_inbox
 from sentry.testutils.cases import TestCase
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
+from sentry.types.group import GroupSubStatus
 
 pytestmark = [requires_snuba]
 
@@ -21,7 +22,9 @@ class HandleIssueMergeTest(TestCase):
         self.groups = []
         self.project_lookup = {self.project.id: self.project}
         for _ in range(5):
-            group = self.create_group()
+            group = self.create_group(
+                status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.ONGOING
+            )
             add_group_to_inbox(group, GroupInboxReason.NEW)
             self.groups.append(group)
 
@@ -30,18 +33,18 @@ class HandleIssueMergeTest(TestCase):
         Activity.objects.all().delete()
         merge = handle_merge(self.groups, self.project_lookup, self.user)
 
-        statuses = list(
-            Group.objects.filter(id__in=[g.id for g in self.groups]).values_list(
-                "status", flat=True
-            )
-        )
-        assert statuses.count(GroupStatus.PENDING_MERGE) == 4
+        groups = Group.objects.filter(id__in=[g.id for g in self.groups])
+
+        assert len(groups.filter(status=GroupStatus.PENDING_MERGE)) == 4
+        assert len(groups.filter(substatus__isnull=True)) == 4
         assert merge_groups.called
 
         primary_group = self.groups[-1]
         assert Activity.objects.filter(type=ActivityType.MERGE.value, group=primary_group)
         assert merge["parent"] == str(primary_group.id)
         assert len(merge["children"]) == 4
+        assert primary_group.status == GroupStatus.UNRESOLVED
+        assert primary_group.substatus == GroupSubStatus.ONGOING
 
     def test_handle_merge_performance_issues(self) -> None:
         group = Group.objects.create(


### PR DESCRIPTION
The merged groups have the status set to pending_merge, but retain the old substatus which is inconsistent. This field should be unset, and the groups will take the status/substatus of the primary group once the merge is completed. 