### PR TITLE
fix(releases): increase lock to 10 minutes on set_commits

### DIFF
--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -16,6 +16,7 @@ from sentry.models.commitauthor import CommitAuthor
 from sentry.models.commitfilechange import CommitFileChange
 from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
 from sentry.models.groupinbox import GroupInbox, GroupInboxRemoveAction, remove_group_from_inbox
+from sentry.models.release import Release
 from sentry.models.releases.exceptions import ReleaseCommitError
 from sentry.signals import issue_resolved
 from sentry.users.services.user import RpcUser
@@ -50,8 +51,9 @@ def set_commits(release, commit_list):
     commit_list = [
         c for c in commit_list if not RepositoryProvider.should_ignore_commit(c.get("message", ""))
     ]
-    lock_key = type(release).get_lock_key(release.organization_id, release.id)
-    lock = locks.get(lock_key, duration=10, name="release_set_commits")
+    lock_key = Release.get_lock_key(release.organization_id, release.id)
+    # Acquire the lock for a maximum of 10 minutes
+    lock = locks.get(lock_key, duration=10 * 60, name="release_set_commits")
     if lock.locked():
         # Signal failure to the consumer rapidly. This aims to prevent the number
         # of timeouts and prevent web worker exhaustion when customers create


### PR DESCRIPTION
we observed SENTRY-3F2A during the rollout of https://github.com/getsentry/sentry/pull/77453.

This didn't make sense until i realized our redis lock is only 10 seconds right now, and this function can take longer than that. We increase the max timeout to 10 minutes, which should be plenty for 99.99+% of `set_commits` calls. 