### PR TITLE
fix(alerts): Add logging to store data endpoint

### DIFF
--- a/src/sentry/seer/anomaly_detection/store_data.py
+++ b/src/sentry/seer/anomaly_detection/store_data.py
@@ -95,6 +95,16 @@ def send_historical_data_to_seer(alert_rule: AlertRule, project: Project) -> Ale
         config=anomaly_detection_config,
         timeseries=formatted_data,
     )
+    logger.info(
+        "Sending data to Seer's store data endpoint",
+        extra={
+            "ad_config": anomaly_detection_config,
+            "alert": alert_rule.id,
+            "dataset": snuba_query.dataset,
+            "aggregate": snuba_query.aggregate,
+            "meta": json.dumps(historical_data.data.get("meta", {}).get("fields", {})),
+        },
+    )
     try:
         response = make_signed_seer_api_request(
             connection_pool=seer_anomaly_detection_connection_pool,
@@ -145,6 +155,8 @@ def send_historical_data_to_seer(alert_rule: AlertRule, project: Project) -> Ale
                 "alert": alert_rule.id,
                 "response_data": response.data,
                 "reponse_code": response.status,
+                "dataset": snuba_query.dataset,
+                "meta": json.dumps(historical_data.data.get("meta", {}).get("fields", {})),
             },
         )
         raise ParseError(parse_error_string)

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -78,11 +78,11 @@ def get_crash_free_historical_data(
 def format_historical_data(data: SnubaTSResult, dataset: Any) -> list[TimeSeriesPoint]:
     """
     Format Snuba data into the format the Seer API expects.
-    For errors data:
+    For errors/transactions data:
         If there are no results, it's just the timestamp
         {'time': 1719012000}, {'time': 1719018000}, {'time': 1719024000}
 
-        If there are results, the count is added
+        If there are results, the aggregate is added
         {'time': 1721300400, 'count': 2}
 
     For metrics_performance dataset/sessions data:
@@ -97,7 +97,7 @@ def format_historical_data(data: SnubaTSResult, dataset: Any) -> list[TimeSeries
             return formatted_data
         series = groups[0].get("series")
 
-        for time, count in zip(nested_data.get("intervals"), series.get("sum(session)")):
+        for time, count in zip(nested_data.get("intervals"), series.get("sum(session)", 0)):
             date = datetime.strptime(time, "%Y-%m-%dT%H:%M:%SZ")
             ts_point = TimeSeriesPoint(timestamp=date.timestamp(), value=count)
             formatted_data.append(ts_point)


### PR DESCRIPTION
I'm trying to debug https://sentry.sentry.io/issues/5860348416/ where we're sending some `TimeSeriesPoint` values as `None`. The `dataset` is listed as `None` in the Sentry issue which means it should have gone into the else block in `format_historical_data` and in that case, there is no way we'd pass a `None` value. I added logging to try to figure out what's going on because I don't know how to store various performance data locally to be able to query snuba on it, and if there are no values the query only has timestamps, no other keys even with a None value. The `SnubaTSResult` has a `meta` key in it with usually something like "time" and then the snuba query aggregate name which would be used to populate the data if there were any, but unfortunately we can't use that directly because in the errors data for example, the snuba query aggregate is `count()` but the key in `SnubaTSResult` is `count`.