### PR TITLE
fix(billing): When deleting a monitor, disable monitor seat so that it can be re-allocated

### DIFF
--- a/src/sentry/monitors/endpoints/base_monitor_details.py
+++ b/src/sentry/monitors/endpoints/base_monitor_details.py
@@ -234,9 +234,9 @@ class MonitorDetailsMixin(BaseEndpointMixin):
                 # randomize slug on monitor deletion to prevent re-creation side effects
                 if isinstance(monitor_object, Monitor):
                     new_slug = get_random_string(length=24)
-                    quotas.backend.update_monitor_slug(monitor.slug, new_slug, monitor.project_id)
                     # we disable the monitor seat so that it can be re-used for another monitor
                     quotas.backend.disable_monitor_seat(monitor=monitor)
+                    quotas.backend.update_monitor_slug(monitor.slug, new_slug, monitor.project_id)
                     monitor_object.update(slug=new_slug)
 
         with transaction.atomic(router.db_for_write(Rule)):

--- a/src/sentry/monitors/endpoints/base_monitor_details.py
+++ b/src/sentry/monitors/endpoints/base_monitor_details.py
@@ -235,6 +235,8 @@ class MonitorDetailsMixin(BaseEndpointMixin):
                 if isinstance(monitor_object, Monitor):
                     new_slug = get_random_string(length=24)
                     quotas.backend.update_monitor_slug(monitor.slug, new_slug, monitor.project_id)
+                    # we disable the monitor seat so that it can be re-used for another monitor
+                    quotas.backend.disable_monitor_seat(monitor=monitor)
                     monitor_object.update(slug=new_slug)
 
         with transaction.atomic(router.db_for_write(Rule)):

--- a/tests/sentry/monitors/endpoints/test_base_monitor_details.py
+++ b/tests/sentry/monitors/endpoints/test_base_monitor_details.py
@@ -890,8 +890,9 @@ class BaseDeleteMonitorTest(MonitorTestCase):
         self.login_as(user=self.user)
         super().setUp()
 
+    @patch("sentry.quotas.backend.disable_monitor_seat")
     @patch("sentry.quotas.backend.update_monitor_slug")
-    def test_simple(self, update_monitor_slug):
+    def test_simple(self, mock_update_monitor_slug, mock_disable_monitor_seat):
         monitor = self._create_monitor()
         old_slug = monitor.slug
 
@@ -906,7 +907,8 @@ class BaseDeleteMonitorTest(MonitorTestCase):
         assert RegionScheduledDeletion.objects.filter(
             object_id=monitor.id, model_name="Monitor"
         ).exists()
-        update_monitor_slug.assert_called_once()
+        mock_update_monitor_slug.assert_called_once()
+        mock_disable_monitor_seat.assert_called_once_with(monitor=monitor)
 
     def test_mismatched_org_slugs(self):
         monitor = self._create_monitor()


### PR DESCRIPTION
Deleting a monitor is a scheduled region deletion, which means the user will need to wait for the monitor to be fully deleted before its monitor seat can be re-allocated to another monitor.

Here, we disable its monitor seat after scrambling the monitor slug.