### PR TITLE
feat(invite-members): backend for Resend Invites

### DIFF
--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -235,7 +235,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
             if not enable_member_invite:
                 return Response({"detail": ERR_INSUFFICIENT_SCOPE}, status=400)
             if not reinvite_request_only:
-                raise ValidationError({"detail": ERR_MEMBER_REINVITE})
+                return Response({"detail": ERR_MEMBER_REINVITE}, status=400)
             if not is_invite_from_user:
                 return Response({"detail": ERR_MEMBER_INVITE}, status=400)
 

--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -44,7 +44,8 @@ from . import get_allowed_org_roles, save_team_assignments
 ERR_NO_AUTH = "You cannot remove this member with an unauthenticated API request."
 ERR_INSUFFICIENT_ROLE = "You cannot remove a member who has more access than you."
 ERR_INSUFFICIENT_SCOPE = "You are missing the member:admin scope."
-ERR_MEMBER_INVITE = "Your role cannot remove an invitation that was sent by someone else."
+ERR_MEMBER_INVITE = "Your cannot modify invitations sent by someone else."
+ERR_MEMBER_REINVITE = "You can only reinvite members; you cannot modify other member details."
 ERR_ONLY_OWNER = "You cannot remove the only remaining owner of the organization."
 ERR_UNINVITABLE = "You cannot send an invitation to a user who is already a full member."
 ERR_EXPIRED = "You cannot resend an expired invitation without regenerating the token."
@@ -75,7 +76,7 @@ class RelaxedMemberPermission(OrganizationPermission):
     scope_map = {
         "GET": ["member:read", "member:write", "member:admin"],
         "POST": ["member:write", "member:admin"],
-        "PUT": ["member:write", "member:admin"],
+        "PUT": ["member:write", "member:admin", "member:invite"],
         # DELETE checks for role comparison as you can either remove a member
         # with a lower access role, or yourself, without having the req. scope
         "DELETE": ["member:read", "member:write", "member:admin"],
@@ -217,6 +218,26 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
                 },
                 status=403,
             )
+
+        is_member = not (
+            request.access.has_scope("member:invite") and request.access.has_scope("member:admin")
+        )
+        enable_member_invite = (
+            features.has("organizations:members-invite-teammates", organization)
+            and not organization.flags.disable_member_invite
+        )
+        # Members can only resend invites
+        reinvite_request_only = set(result.keys()).issubset({"reinvite", "regenerate"})
+        # Members can only resend invites that they sent
+        is_invite_from_user = member.inviter_id == request.user.id
+
+        if is_member:
+            if not enable_member_invite:
+                return Response({"detail": ERR_INSUFFICIENT_SCOPE}, status=400)
+            if not reinvite_request_only:
+                raise ValidationError({"detail": ERR_MEMBER_REINVITE})
+            if not is_invite_from_user:
+                return Response({"detail": ERR_MEMBER_INVITE}, status=400)
 
         # XXX(dcramer): if/when this expands beyond reinvite we need to check
         # access level
@@ -372,7 +393,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
         acting_member: OrganizationMember,
     ) -> Response:
         # Members can only delete invitations
-        if not member.inviter_id:
+        if not member.is_pending:
             return Response({"detail": ERR_INSUFFICIENT_SCOPE}, status=400)
         # Members can only delete invitations that they sent
         if member.inviter_id != acting_member.user_id:

--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -233,11 +233,11 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
 
         if is_member:
             if not enable_member_invite:
-                return Response({"detail": ERR_INSUFFICIENT_SCOPE}, status=400)
+                return Response({"detail": ERR_INSUFFICIENT_SCOPE}, status=403)
             if not reinvite_request_only:
-                return Response({"detail": ERR_MEMBER_REINVITE}, status=400)
+                return Response({"detail": ERR_MEMBER_REINVITE}, status=403)
             if not is_invite_from_user:
-                return Response({"detail": ERR_MEMBER_INVITE}, status=400)
+                return Response({"detail": ERR_MEMBER_INVITE}, status=403)
 
         # XXX(dcramer): if/when this expands beyond reinvite we need to check
         # access level


### PR DESCRIPTION
update API to allow members to resend invites that they sent

we error if the request contains additional body params other than `reinvite` or `regenerate`