### PR TITLE
feat(query-builder): Value-based filter suggestions

### DIFF
--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -11,6 +11,7 @@ import type {FieldDefinition} from 'sentry/utils/fields';
 
 export interface SearchQueryBuilderContextData {
   disabled: boolean;
+  disallowFreeText: boolean;
   disallowWildcard: boolean;
   dispatch: Dispatch<QueryBuilderActions>;
   filterKeyMenuWidth: number;
@@ -48,5 +49,6 @@ export const SearchQueryBuilderContext = createContext<SearchQueryBuilderContext
   searchSource: '',
   size: 'normal',
   disabled: false,
+  disallowFreeText: false,
   disallowWildcard: false,
 });

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -249,6 +249,7 @@ export function SearchQueryBuilder({
     return {
       ...state,
       disabled,
+      disallowFreeText: Boolean(disallowFreeText),
       disallowWildcard: Boolean(disallowWildcard),
       parsedQuery,
       filterKeySections: filterKeySections ?? [],
@@ -267,6 +268,7 @@ export function SearchQueryBuilder({
   }, [
     state,
     disabled,
+    disallowFreeText,
     disallowWildcard,
     parsedQuery,
     filterKeySections,

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -298,7 +298,6 @@ function OverlayContent<T extends SelectOptionOrSectionWithKey<string>>({
           hiddenOptions={hiddenOptions}
           keyDownHandler={() => true}
           overlayIsOpen={isOpen}
-          showSectionHeaders={!filterValue}
           size="sm"
         />
       </ListBoxOverlay>

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
@@ -6,7 +6,7 @@ import type {Node} from '@react-types/shared';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import {SearchQueryBuilderCombobox} from 'sentry/components/searchQueryBuilder/tokens/combobox';
 import {getFilterValueType} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
-import type {KeyItem} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/types';
+import type {SearchKeyItem} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/types';
 import {useSortedFilterKeyItems} from 'sentry/components/searchQueryBuilder/tokens/useSortedFilterKeyItems';
 import {getInitialFilterText} from 'sentry/components/searchQueryBuilder/tokens/utils';
 import type {
@@ -28,7 +28,11 @@ type KeyComboboxProps = {
 export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [inputValue, setInputValue] = useState('');
-  const sortedFilterKeys = useSortedFilterKeyItems({filterValue: inputValue});
+  const sortedFilterKeys = useSortedFilterKeyItems({
+    filterValue: inputValue,
+    inputValue,
+    includeSuggestions: false,
+  });
   const {dispatch, getFieldDefinition} = useSearchQueryBuilder();
 
   const currentFilterValueType = getFilterValueType(
@@ -78,7 +82,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
   );
 
   const onOptionSelected = useCallback(
-    (option: KeyItem) => {
+    (option: SearchKeyItem) => {
       handleSelectKey(option.value);
     },
     [handleSelectKey]

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
@@ -16,8 +16,18 @@ export interface KeyItem extends SelectOptionWithKey<string> {
 }
 
 export interface KeySectionItem extends SelectSectionWithKey<string> {
-  options: KeyItem[];
+  options: SearchKeyItem[];
   type: 'section';
+  value: string;
+}
+
+export interface RawSearchItem extends SelectOptionWithKey<string> {
+  type: 'raw-search';
+  value: string;
+}
+
+export interface FilterValueItem extends SelectOptionWithKey<string> {
+  type: 'filter-value';
   value: string;
 }
 
@@ -32,7 +42,15 @@ export interface RecentQueryItem extends SelectOptionWithKey<string> {
   value: string;
 }
 
-export type FilterKeyItem = KeyItem | RecentFilterItem | KeySectionItem | RecentQueryItem;
+export type SearchKeyItem = KeySectionItem | KeyItem | RawSearchItem | FilterValueItem;
+
+export type FilterKeyItem =
+  | KeyItem
+  | RecentFilterItem
+  | KeySectionItem
+  | RecentQueryItem
+  | RawSearchItem
+  | FilterValueItem;
 
 export type Section = {
   label: ReactNode;

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -1,9 +1,13 @@
+import styled from '@emotion/styled';
+
 import {getEscapedKey} from 'sentry/components/compactSelect/utils';
 import {FormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
 import {KeyDescription} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/keyDescription';
 import type {
+  FilterValueItem,
   KeyItem,
   KeySectionItem,
+  RawSearchItem,
   RecentQueryItem,
 } from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/types';
 import type {
@@ -13,6 +17,7 @@ import type {
 import {t} from 'sentry/locale';
 import type {RecentSearch, Tag, TagCollection} from 'sentry/types/group';
 import {type FieldDefinition, FieldKind} from 'sentry/utils/fields';
+import {escapeFilterValue} from 'sentry/utils/tokenizeSearch';
 
 export const ALL_CATEGORY_VALUE = '__all' as const;
 export const RECENT_SEARCH_CATEGORY_VALUE = '__recent_searches' as const;
@@ -25,6 +30,10 @@ export const RECENT_SEARCH_CATEGORY = {
 
 const RECENT_FILTER_KEY_PREFIX = '__recent_filter_key__';
 const RECENT_QUERY_KEY_PREFIX = '__recent_search__';
+
+function trimQuotes(value) {
+  return value.replace(/^"+|"+$/g, '');
+}
 
 export function createRecentFilterOptionKey(filter: string) {
   return getEscapedKey(`${RECENT_FILTER_KEY_PREFIX}${filter}`);
@@ -90,6 +99,37 @@ export function createItem(
   };
 }
 
+export function createRawSearchItem(value: string): RawSearchItem {
+  const quoted = `"${trimQuotes(value)}"`;
+
+  return {
+    key: getEscapedKey(quoted),
+    label: quoted,
+    value: quoted,
+    textValue: quoted,
+    hideCheck: true,
+    showDetailsInOverlay: true,
+    details: null,
+    type: 'raw-search',
+    trailingItems: <SearchItemLabel>{t('Raw Search')}</SearchItemLabel>,
+  };
+}
+
+export function createFilterValueItem(key: string, value: string): FilterValueItem {
+  const filter = `${key}:${escapeFilterValue(value)}`;
+
+  return {
+    key: getEscapedKey(`${key}:${value}`),
+    label: <FormattedQuery query={filter} />,
+    value: filter,
+    textValue: filter,
+    hideCheck: true,
+    showDetailsInOverlay: true,
+    details: null,
+    type: 'filter-value',
+  };
+}
+
 export function createRecentFilterItem({filter}: {filter: string}) {
   return {
     key: createRecentFilterOptionKey(filter),
@@ -124,3 +164,8 @@ export function createRecentQueryItem({
     hideCheck: true,
   };
 }
+
+const SearchItemLabel = styled('div')`
+  color: ${p => p.theme.subText};
+  white-space: nowrap;
+`;

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -64,6 +64,27 @@ function getWordAtCursorPosition(value: string, cursorPosition: number) {
 }
 
 /**
+ * Replaces the focused word (at cursorPosition) with the given text.
+ */
+function replaceFocusedWord(value: string, cursorPosition: number, replacement: string) {
+  const words = value.split(' ');
+
+  let characterCount = 0;
+  for (const word of words) {
+    characterCount += word.length + 1;
+    if (characterCount >= cursorPosition) {
+      return (
+        value.slice(0, characterCount - word.length - 1).trim() +
+        ` ${replacement} ` +
+        value.slice(characterCount).trim()
+      ).trim();
+    }
+  }
+
+  return value;
+}
+
+/**
  * Replaces the focused word (at cursorPosition) with the selected filter key.
  *
  * Example:
@@ -75,21 +96,11 @@ function replaceFocusedWordWithFilter(
   key: string,
   getFieldDefinition: FieldDefinitionGetter
 ) {
-  const words = value.split(' ');
-
-  let characterCount = 0;
-  for (const word of words) {
-    characterCount += word.length + 1;
-    if (characterCount >= cursorPosition) {
-      return (
-        value.slice(0, characterCount - word.length - 1).trim() +
-        ` ${getInitialFilterText(key, getFieldDefinition(key))} ` +
-        value.slice(characterCount).trim()
-      ).trim();
-    }
-  }
-
-  return value;
+  return replaceFocusedWord(
+    value,
+    cursorPosition,
+    getInitialFilterText(key, getFieldDefinition(key))
+  );
 }
 
 function countPreviousItemsOfType({
@@ -119,7 +130,7 @@ function calculateNextFocusForFilter(state: ListState<ParseResultToken>): FocusO
   };
 }
 
-function calculateNextFocusForParen(item: Node<ParseResultToken>): FocusOverride {
+function calculateNextFocusForInsertedToken(item: Node<ParseResultToken>): FocusOverride {
   const [, tokenTypeIndexStr] = item.key.toString().split(':');
 
   const tokenTypeIndex = parseInt(tokenTypeIndexStr, 10);
@@ -223,7 +234,11 @@ function SearchQueryBuilderInputInternal({
   const {customMenu, sectionItems, maxOptions, onKeyDownCapture} = useFilterKeyListBox({
     filterValue,
   });
-  const sortedFilteredItems = useSortedFilterKeyItems({filterValue});
+  const sortedFilteredItems = useSortedFilterKeyItems({
+    filterValue,
+    inputValue,
+    includeSuggestions: true,
+  });
 
   const items = customMenu ? sectionItems : sortedFilteredItems;
 
@@ -335,6 +350,27 @@ function SearchQueryBuilderInputInternal({
             return;
           }
 
+          if (option.type === 'raw-search') {
+            dispatch({type: 'UPDATE_FREE_TEXT', tokens: [token], text: option.value});
+            resetInputValue();
+
+            // Because the query does not change until a subsequent render,
+            // we need to do the replacement that is does in the reducer here
+            handleSearch(replaceTokensWithPadding(query, [token], option.value));
+            return;
+          }
+
+          if (option.type === 'filter-value' && option.textValue) {
+            dispatch({
+              type: 'UPDATE_FREE_TEXT',
+              tokens: [token],
+              text: replaceFocusedWord(inputValue, selectionIndex, option.textValue),
+              focusOverride: calculateNextFocusForInsertedToken(item),
+            });
+            resetInputValue();
+            return;
+          }
+
           const value = option.value;
 
           dispatch({
@@ -398,7 +434,7 @@ function SearchQueryBuilderInputInternal({
               type: 'UPDATE_FREE_TEXT',
               tokens: [token],
               text: e.target.value,
-              focusOverride: calculateNextFocusForParen(item),
+              focusOverride: calculateNextFocusForInsertedToken(item),
             });
             resetInputValue();
             return;

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -2,41 +2,222 @@ import {useMemo} from 'react';
 import type Fuse from 'fuse.js';
 
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
-import type {KeyItem} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/types';
-import {createItem} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/utils';
+import type {
+  FilterValueItem,
+  KeySectionItem,
+  SearchKeyItem,
+} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/types';
+import {
+  createFilterValueItem,
+  createItem,
+  createRawSearchItem,
+} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/utils';
+import type {FieldDefinitionGetter} from 'sentry/components/searchQueryBuilder/types';
+import type {Tag} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import {useFuzzySearch} from 'sentry/utils/fuzzySearch';
 
-const FUZZY_SEARCH_OPTIONS: Fuse.IFuseOptions<KeyItem> = {
-  keys: ['label', 'description'],
+type FilterKeySearchItem = {
+  description: string;
+  item: Tag;
+  keywords: string[];
+  type: 'value' | 'key';
+  key?: string;
+  value?: string;
+};
+
+const FUZZY_SEARCH_OPTIONS: Fuse.IFuseOptions<FilterKeySearchItem> = {
+  keys: [
+    {name: 'key', weight: 10},
+    {name: 'value', weight: 5},
+    {name: 'keywords', weight: 2},
+    {name: 'description', weight: 1},
+  ],
   threshold: 0.2,
   includeMatches: false,
   minMatchCharLength: 1,
+  includeScore: true,
 };
 
-export function useSortedFilterKeyItems({filterValue}: {filterValue: string}): KeyItem[] {
-  const {filterKeys, getFieldDefinition, filterKeySections} = useSearchQueryBuilder();
-  const flatItems = useMemo<KeyItem[]>(
-    () =>
-      Object.values(filterKeys).map(filterKey =>
-        createItem(filterKey, getFieldDefinition(filterKey.key))
-      ),
-    [filterKeys, getFieldDefinition]
-  );
-  const search = useFuzzySearch(flatItems, FUZZY_SEARCH_OPTIONS);
+function isQuoted(inputValue: string) {
+  return inputValue.startsWith('"') && inputValue.endsWith('"');
+}
+
+// Adds static filter values to the searchable items so that they can be
+// suggested if they appear high in the search results.
+function getFilterSearchValues(
+  keys: Tag[],
+  {getFieldDefinition}: {getFieldDefinition: FieldDefinitionGetter}
+): FilterKeySearchItem[] {
+  return keys.reduce<FilterKeySearchItem[]>((acc, key) => {
+    const fieldDef = getFieldDefinition(key.key);
+    const values = key.values ?? fieldDef?.values ?? [];
+
+    const addItem = (value: string) => {
+      acc.push({
+        value,
+        description: '',
+        keywords: [],
+        type: 'value',
+        item: key,
+      });
+    };
+
+    for (const value of values) {
+      if (typeof value === 'string') {
+        addItem(value);
+      } else {
+        if (value.children.length) {
+          for (const child of value.children) {
+            if (child.value) {
+              addItem(child.value);
+            }
+          }
+        } else {
+          if (value.value) {
+            addItem(value.value);
+          }
+        }
+      }
+    }
+
+    return acc;
+  }, []);
+}
+
+// Returns a section of suggested filter values.
+// This will suggest a maximum of 3 options, and only if they
+// are more relevant than any of the key suggestions.
+function getValueSuggestionsFromSearchResult(
+  results: Fuse.FuseResult<FilterKeySearchItem>[]
+) {
+  const suggestions: FilterValueItem[] = [];
+
+  for (const result of results) {
+    if (result.item.type === 'key' || suggestions.length >= 3) {
+      break;
+    }
+
+    suggestions.push(
+      createFilterValueItem(result.item.item.key, result.item.value ?? '')
+    );
+  }
+
+  const suggestedFiltersSection: KeySectionItem = {
+    key: 'suggested-filters',
+    value: 'suggested-filters',
+    label: '',
+    options: suggestions,
+    type: 'section',
+  };
+
+  return suggestions.length ? [suggestedFiltersSection] : [];
+}
+
+export function useSortedFilterKeyItems({
+  inputValue,
+  filterValue,
+  includeSuggestions,
+}: {
+  filterValue: string;
+  includeSuggestions: boolean;
+  inputValue: string;
+}): SearchKeyItem[] {
+  const {filterKeys, getFieldDefinition, filterKeySections, disallowFreeText} =
+    useSearchQueryBuilder();
+
+  const flatKeys = useMemo(() => Object.values(filterKeys), [filterKeys]);
+
+  const searchableItems = useMemo<FilterKeySearchItem[]>(() => {
+    const searchKeyItems: FilterKeySearchItem[] = flatKeys.map(key => {
+      const fieldDef = getFieldDefinition(key.key);
+
+      return {
+        key: key.key,
+        description: fieldDef?.desc ?? '',
+        keywords: fieldDef?.keywords ?? [],
+        item: key,
+        type: 'key',
+      };
+    });
+
+    if (includeSuggestions) {
+      return [
+        ...searchKeyItems,
+        ...getFilterSearchValues(flatKeys, {getFieldDefinition}),
+      ];
+    }
+
+    return searchKeyItems;
+  }, [flatKeys, getFieldDefinition, includeSuggestions]);
+
+  const search = useFuzzySearch(searchableItems, FUZZY_SEARCH_OPTIONS);
 
   return useMemo(() => {
     if (!filterValue || !search) {
       if (!filterKeySections.length) {
-        return flatItems.sort((a, b) => a.textValue.localeCompare(b.textValue));
+        return flatKeys
+          .map(key => createItem(key, getFieldDefinition(key.key)))
+          .sort((a, b) => a.textValue.localeCompare(b.textValue));
       }
 
-      return filterKeySections
-        .flatMap(section => section.children)
-        .map(key => flatItems.find(item => item.key === key))
-        .filter(defined);
+      const filterSectionKeys = [
+        ...new Set(filterKeySections.flatMap(section => section.children)),
+      ].slice(0, 50);
+
+      return filterSectionKeys
+        .map(key => filterKeys[key])
+        .filter(defined)
+        .map(key => createItem(key, getFieldDefinition(key.key)));
     }
 
-    return search.search(filterValue).map(({item}) => item);
-  }, [filterKeySections, filterValue, flatItems, search]);
+    const searched = search.search(filterValue);
+
+    const keyItems = searched
+      .map(({item}) => item)
+      .filter(item => item.type === 'key')
+      .map(({item}) => createItem(filterKeys[item.key], getFieldDefinition(item.key)));
+
+    if (includeSuggestions) {
+      const rawSearchSection: KeySectionItem = {
+        key: 'raw-search',
+        value: 'raw-search',
+        label: '',
+        options: [createRawSearchItem(inputValue)],
+        type: 'section',
+      };
+
+      const shouldIncludeRawSearch =
+        !disallowFreeText &&
+        inputValue &&
+        !isQuoted(inputValue) &&
+        (!keyItems.length || inputValue.trim().includes(' '));
+
+      const keyItemsSection: KeySectionItem = {
+        key: 'key-items',
+        value: 'key-items',
+        label: '',
+        options: keyItems,
+        type: 'section',
+      };
+
+      return [
+        ...getValueSuggestionsFromSearchResult(searched),
+        ...(shouldIncludeRawSearch ? [rawSearchSection] : []),
+        keyItemsSection,
+      ];
+    }
+
+    return keyItems;
+  }, [
+    disallowFreeText,
+    filterKeySections,
+    filterKeys,
+    filterValue,
+    flatKeys,
+    getFieldDefinition,
+    includeSuggestions,
+    inputValue,
+    search,
+  ]);
 }

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1321,7 +1321,6 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
     desc: t('The properties of an issue (i.e. Resolved, unresolved)'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
-    keywords: ['ignored', 'assigned', 'for_review', 'unassigned', 'linked', 'unlinked'],
     defaultValue: 'unresolved',
     allowWildcard: false,
   },
@@ -1335,14 +1334,12 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
     desc: t('Category of issue (error or performance)'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
-    keywords: ['error', 'performance'],
     allowWildcard: false,
   },
   [FieldKey.ISSUE_PRIORITY]: {
     desc: t('The priority of the issue'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
-    keywords: ['high', 'medium', 'low'],
     allowWildcard: false,
   },
   [FieldKey.ISSUE_TYPE]: {


### PR DESCRIPTION
Adds smarter filter key suggestions. Will now suggest:

- Filter values. Searches through static filter values (like `is`, `issue.category`, etc) and will suggest the full key/value filter if it is a strong enough match.
- Raw search. If the string has a space in it, or no filter keys match, will suggest the quoted value as a raw search.

https://github.com/user-attachments/assets/8533996c-7a8f-4e59-871b-c27f74048190

