### PR TITLE
feat(toolbar): setup backend for allowed_origins project option

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -829,6 +829,11 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                     "sentry:feedback_ai_spam_detection",
                     bool(options["sentry:feedback_ai_spam_detection"]),
                 )
+            if "sentry:toolbar_allowed_origins" in options:
+                project.update_option(
+                    "sentry:toolbar_allowed_origins",
+                    clean_newline_inputs(options["sentry:toolbar_allowed_origins"]),
+                )
             if "filters:react-hydration-errors" in options:
                 project.update_option(
                     "filters:react-hydration-errors",

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -1103,6 +1103,9 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             "sentry:replay_hydration_error_issues": self.get_value_with_default(
                 attrs, "sentry:replay_hydration_error_issues"
             ),
+            "sentry:toolbar_allowed_origins": "\n".join(
+                self.get_value_with_default(attrs, "sentry:toolbar_allowed_origins") or []
+            ),
             "quotas:spike-protection-disabled": options.get("quotas:spike-protection-disabled"),
         }
 

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -43,6 +43,7 @@ OPTION_KEYS = frozenset(
         "sentry:replay_rage_click_issues",
         "sentry:feedback_user_report_notifications",
         "sentry:feedback_ai_spam_detection",
+        "sentry:toolbar_allowed_origins",
         "sentry:token",
         "sentry:token_header",
         "sentry:verify_ssl",

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -149,7 +149,7 @@ register(
 
 register(
     key="sentry:toolbar_allowed_origins",
-    default=["*"],
+    default=[],
 )
 
 register(

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -148,6 +148,11 @@ register(
 )
 
 register(
+    key="sentry:toolbar_allowed_origins",
+    default=["*"],
+)
+
+register(
     key="sentry:feedback_user_report_notifications",
     epoch_defaults={12: True},
 )

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -619,6 +619,7 @@ class ProjectUpdateTest(APITestCase):
             "sentry:token_header": "*",
             "sentry:verify_ssl": False,
             "sentry:replay_hydration_error_issues": True,
+            "sentry:toolbar_allowed_origins": "*.sentry.io\nexample.net  \nnugettrends.com",
             "sentry:replay_rage_click_issues": True,
             "sentry:feedback_user_report_notifications": True,
             "sentry:feedback_ai_spam_detection": True,
@@ -736,6 +737,11 @@ class ProjectUpdateTest(APITestCase):
             ).exists()
         assert project.get_option("feedback:branding") == "0"
         assert project.get_option("sentry:replay_hydration_error_issues") is True
+        assert project.get_option("sentry:toolbar_allowed_origins") == [
+            "*.sentry.io",
+            "example.net",
+            "nugettrends.com",
+        ]
         assert project.get_option("sentry:replay_rage_click_issues") is True
         assert project.get_option("sentry:feedback_user_report_notifications") is True
         assert project.get_option("sentry:feedback_ai_spam_detection") is True

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -794,9 +794,9 @@ class DetailedProjectSerializerTest(TestCase):
 
     def test_toolbar_allowed_origins(self):
         # Does not allow trailing newline or extra whitespace.
-        # Default is wildcard:
+        # Default is empty:
         result = serialize(self.project, self.user, DetailedProjectSerializer())
-        assert result["options"]["sentry:toolbar_allowed_origins"] == "*"
+        assert result["options"]["sentry:toolbar_allowed_origins"] == ""
 
         origins = ["*.sentry.io", "example.net", "nugettrends.com"]
         self.project.update_option("sentry:toolbar_allowed_origins", origins)

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -792,6 +792,17 @@ class DetailedProjectSerializerTest(TestCase):
         result = serialize(self.project, self.user, DetailedProjectSerializer())
         assert result["options"]["sentry:replay_hydration_error_issues"] is False
 
+    def test_toolbar_allowed_origins(self):
+        # Does not allow trailing newline or extra whitespace.
+        # Default is wildcard:
+        result = serialize(self.project, self.user, DetailedProjectSerializer())
+        assert result["options"]["sentry:toolbar_allowed_origins"] == "*"
+
+        origins = ["*.sentry.io", "example.net", "nugettrends.com"]
+        self.project.update_option("sentry:toolbar_allowed_origins", origins)
+        result = serialize(self.project, self.user, DetailedProjectSerializer())
+        assert result["options"]["sentry:toolbar_allowed_origins"].split("\n") == origins
+
 
 class BulkFetchProjectLatestReleases(TestCase):
     @cached_property


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/77213

~~Is it ok to do validation on the frontend, before submitting?~~ Discussed on https://github.com/getsentry/sentry/pull/77675

All the endpoint expects ATM is a string-ified list of valid URLs, separated by newlines. Trailing/leading whitespace is handled (but not preferred).
