### PR TITLE
feat(queryClient): Add support for select function

### DIFF
--- a/static/app/utils/queryClient.spec.tsx
+++ b/static/app/utils/queryClient.spec.tsx
@@ -102,5 +102,39 @@ describe('queryClient', function () {
 
       expect(await screen.findByText('something bad happened')).toBeInTheDocument();
     });
+
+    it('can pass select function to return a subset of data', async function () {
+      type TestResponseData = {
+        other: string;
+        value: number;
+      };
+      MockApiClient.addMockResponse({
+        url: '/some/test/path/',
+        body: {value: 5, other: 'data'},
+      });
+
+      function TestComponent() {
+        const {isPending, data} = useApiQuery<
+          TestResponseData,
+          Error,
+          TestResponseData['other']
+        >(['/some/test/path/'], {
+          staleTime: 0,
+          select: response => {
+            return response[0].other;
+          },
+        });
+
+        if (isPending) {
+          return null;
+        }
+
+        return <div>{data}</div>;
+      }
+
+      render(<TestComponent />);
+
+      expect(await screen.findByText('data')).toBeInTheDocument();
+    });
   });
 });

--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -124,12 +124,11 @@ export function useApiQuery<TResponseData, TError = RequestError, TData = TRespo
   const {data, ...rest} = useQuery({
     queryKey,
     queryFn,
+    select: response => response[0] as any as TData,
     ...options,
   });
 
   const queryResult = {
-    // If select is provided, return the selected data, otherwise return the first element of ApiResult tuple
-    data: options.select ? data : data?.[0],
     getResponseHeader: data?.[2]?.getResponseHeader,
     ...rest,
   };


### PR DESCRIPTION
Allows the use of react query's [select function](https://tanstack.com/query/latest/docs/framework/react/guides/render-optimizations#select) that can watch just part of a query.

> You can use the select option to select a subset of the data that your component should subscribe to. This is useful for highly optimized data transformations or to avoid unnecessary re-renders.

