### PR TITLE
ci: Ensure Sentry SDK is always bumped by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,6 @@ updates:
       babel-dependencies:
         patterns:
           - '@babel/*'
-      sentry-dependencies:
-        patterns:
-          - '@sentry/*'
       spectrum-dependencies:
         patterns:
           - '@react-stately/*'
@@ -63,6 +60,27 @@ updates:
       - dependency-name: 'reflux'
       - dependency-name: 'sprintf-js'
       - dependency-name: 'u2f-api'
+  # For Sentry SDK updates, we do not want to limit the open PRs
+  - package-ecosystem: npm
+    open-pull-requests-limit: 0
+    directory: '/'
+    schedule:
+      # Going to start with a high interval, and then tone it back
+      interval: daily
+      timezone: America/Los_Angeles
+      time: '15:30'
+    reviewers:
+      - '@getsentry/owners-js-deps'
+    labels: []
+    # Group dependency updates together in one PR
+    # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
+    groups:
+      # The name of the group, it will be used in PR titles and branch
+      sentry-dependencies:
+        patterns:
+          - '@sentry/*'
+        update-types:
+          - 'minor'
   - package-ecosystem: 'docker'
     directory: 'self-hosted/'
     schedule:


### PR DESCRIPTION
I was wondering why the SDK is not automatically kept up-to-date by dependabot. After looking into it, I guess the problem is that the limit is set to 10 open PRs that are generally there (some have been open for months), so there is no capacity to open new ones.

As we'd love to have the SDK be up to date generally, this PR splits the SDK updates out to not have a limit. Hopefully that should ensure that we generally have this at latest.