### PR TITLE
fix(whats-new): move createdBy to AdminBroadcastSerializer

### DIFF
--- a/src/sentry/api/serializers/models/broadcast.py
+++ b/src/sentry/api/serializers/models/broadcast.py
@@ -53,5 +53,4 @@ class AdminBroadcastSerializer(BroadcastSerializer):
         context = super().serialize(obj, attrs, user)
         context["userCount"] = attrs["user_count"]
         context["createdBy"] = (obj.created_by_id.id if obj.created_by_id else None,)
-
         return context

--- a/src/sentry/api/serializers/models/broadcast.py
+++ b/src/sentry/api/serializers/models/broadcast.py
@@ -52,5 +52,5 @@ class AdminBroadcastSerializer(BroadcastSerializer):
     def serialize(self, obj, attrs, user, **kwargs):
         context = super().serialize(obj, attrs, user)
         context["userCount"] = attrs["user_count"]
-        context["createdBy"] = (obj.created_by_id.id if obj.created_by_id else None,)
+        context["createdBy"] = obj.created_by_id.id if obj.created_by_id else None
         return context

--- a/src/sentry/api/serializers/models/broadcast.py
+++ b/src/sentry/api/serializers/models/broadcast.py
@@ -31,7 +31,6 @@ class BroadcastSerializer(Serializer):
             "dateExpires": obj.date_expires,
             "hasSeen": attrs["seen"],
             "category": obj.category,
-            "createdBy": obj.created_by_id.id if obj.created_by_id else None,
         }
 
 
@@ -53,4 +52,6 @@ class AdminBroadcastSerializer(BroadcastSerializer):
     def serialize(self, obj, attrs, user, **kwargs):
         context = super().serialize(obj, attrs, user)
         context["userCount"] = attrs["user_count"]
+        context["createdBy"] = (obj.created_by_id.id if obj.created_by_id else None,)
+
         return context

--- a/tests/sentry/api/endpoints/test_broadcast_index.py
+++ b/tests/sentry/api/endpoints/test_broadcast_index.py
@@ -52,7 +52,7 @@ class BroadcastListTest(APITestCase):
 
     def test_basic_user_with_all(self):
         broadcast1 = Broadcast.objects.create(message="bar", is_active=True)
-        Broadcast.objects.create(message="foo", is_active=False)
+        Broadcast.objects.create(message="foo", is_active=False, created_by_id=self.user)
 
         self.add_user_permission(user=self.user, permission="broadcasts.admin")
         self.login_as(user=self.user, superuser=False)
@@ -61,6 +61,7 @@ class BroadcastListTest(APITestCase):
         assert response.status_code == 200
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(broadcast1.id)
+        assert "createdBy" not in response.data[0]
 
     def test_organization_filtering(self):
         broadcast1 = Broadcast.objects.create(message="foo", is_active=True)
@@ -122,6 +123,7 @@ class BroadcastCreateTest(APITestCase):
         assert broadcast.cta == "Read More"
         assert broadcast.media_url == "http://example.com/image.png"
         assert broadcast.category == "announcement"
+        assert broadcast.created_by_id == self.user
 
     def test_validation(self):
         self.add_user_permission(user=self.user, permission="broadcasts.admin")


### PR DESCRIPTION
Move the serialization of the createdBy field from BroadcastSerializer to AdminBroadcastSerializer to expose that information only when authorized. 