### PR TITLE
chore(deletions) Swap deletion task names

### DIFF
--- a/src/sentry/deletions/tasks/groups.py
+++ b/src/sentry/deletions/tasks/groups.py
@@ -18,7 +18,7 @@ from sentry.tasks.base import instrumented_task, retry, track_group_async_operat
 )
 @retry(exclude=(DeleteAborted,))
 @track_group_async_operation
-def delete_groups_new(
+def delete_groups(
     object_ids: Sequence[int],
     transaction_id: str | None = None,
     eventstream_state: Mapping[str, Any] | None = None,
@@ -69,10 +69,10 @@ def delete_groups_new(
 )
 @retry(exclude=(DeleteAborted,))
 @track_group_async_operation
-def delete_groups(
+def delete_groups_old(
     object_ids: Sequence[int],
     transaction_id: str | None = None,
     eventstream_state: Mapping[str, Any] | None = None,
     **kwargs: Any,
 ) -> None:
-    delete_groups_new(object_ids, transaction_id, eventstream_state, **kwargs)
+    delete_groups(object_ids, transaction_id, eventstream_state, **kwargs)

--- a/src/sentry/deletions/tasks/hybrid_cloud.py
+++ b/src/sentry/deletions/tasks/hybrid_cloud.py
@@ -116,7 +116,7 @@ def _chunk_watermark_batch(
     acks_late=True,
     silo_mode=SiloMode.CONTROL,
 )
-def schedule_hybrid_cloud_foreign_key_jobs_control_new():
+def schedule_hybrid_cloud_foreign_key_jobs_control():
     if options.get("hybrid_cloud.disable_tombstone_cleanup"):
         return
 
@@ -131,9 +131,9 @@ def schedule_hybrid_cloud_foreign_key_jobs_control_new():
     acks_late=True,
     silo_mode=SiloMode.CONTROL,
 )
-def schedule_hybrid_cloud_foreign_key_jobs_control():
+def schedule_hybrid_cloud_foreign_key_jobs_control_old():
     # Deprecated deploy boundary shim
-    schedule_hybrid_cloud_foreign_key_jobs_control_new()
+    schedule_hybrid_cloud_foreign_key_jobs_control()
 
 
 @instrumented_task(
@@ -142,7 +142,7 @@ def schedule_hybrid_cloud_foreign_key_jobs_control():
     acks_late=True,
     silo_mode=SiloMode.REGION,
 )
-def schedule_hybrid_cloud_foreign_key_jobs_new():
+def schedule_hybrid_cloud_foreign_key_jobs():
     if options.get("hybrid_cloud.disable_tombstone_cleanup"):
         return
 
@@ -157,9 +157,9 @@ def schedule_hybrid_cloud_foreign_key_jobs_new():
     acks_late=True,
     silo_mode=SiloMode.REGION,
 )
-def schedule_hybrid_cloud_foreign_key_jobs():
+def schedule_hybrid_cloud_foreign_key_jobs_old():
     # Deprecated deploy boundary shim
-    schedule_hybrid_cloud_foreign_key_jobs_new()
+    schedule_hybrid_cloud_foreign_key_jobs()
 
 
 def _schedule_hybrid_cloud_foreign_key(silo_mode: SiloMode, cascade_task: Task) -> None:
@@ -190,7 +190,7 @@ def _schedule_hybrid_cloud_foreign_key(silo_mode: SiloMode, cascade_task: Task) 
     acks_late=True,
     silo_mode=SiloMode.CONTROL,
 )
-def process_hybrid_cloud_foreign_key_cascade_batch_control_new(
+def process_hybrid_cloud_foreign_key_cascade_batch_control(
     app_name: str, model_name: str, field_name: str, **kwargs: Any
 ) -> None:
     if options.get("hybrid_cloud.disable_tombstone_cleanup"):
@@ -211,11 +211,11 @@ def process_hybrid_cloud_foreign_key_cascade_batch_control_new(
     acks_late=True,
     silo_mode=SiloMode.CONTROL,
 )
-def process_hybrid_cloud_foreign_key_cascade_batch_control(
+def process_hybrid_cloud_foreign_key_cascade_batch_control_old(
     app_name: str, model_name: str, field_name: str, **kwargs: Any
 ) -> None:
     # Deprecated deploy boundary shim
-    process_hybrid_cloud_foreign_key_cascade_batch_control_new(
+    process_hybrid_cloud_foreign_key_cascade_batch_control(
         app_name, model_name, field_name, **kwargs
     )
 
@@ -226,7 +226,7 @@ def process_hybrid_cloud_foreign_key_cascade_batch_control(
     acks_late=True,
     silo_mode=SiloMode.REGION,
 )
-def process_hybrid_cloud_foreign_key_cascade_batch_new(
+def process_hybrid_cloud_foreign_key_cascade_batch(
     app_name: str, model_name: str, field_name: str, **kwargs: Any
 ) -> None:
     if options.get("hybrid_cloud.disable_tombstone_cleanup"):
@@ -247,11 +247,11 @@ def process_hybrid_cloud_foreign_key_cascade_batch_new(
     acks_late=True,
     silo_mode=SiloMode.REGION,
 )
-def process_hybrid_cloud_foreign_key_cascade_batch(
+def process_hybrid_cloud_foreign_key_cascade_batch_old(
     app_name: str, model_name: str, field_name: str, **kwargs: Any
 ) -> None:
     # Deprecated deploy boundary shim
-    process_hybrid_cloud_foreign_key_cascade_batch_new(app_name, model_name, field_name)
+    process_hybrid_cloud_foreign_key_cascade_batch(app_name, model_name, field_name)
 
 
 def _process_hybrid_cloud_foreign_key_cascade(

--- a/src/sentry/deletions/tasks/scheduled.py
+++ b/src/sentry/deletions/tasks/scheduled.py
@@ -31,7 +31,7 @@ MAX_RETRIES = 5
     acks_late=True,
     silo_mode=SiloMode.CONTROL,
 )
-def reattempt_deletions_control_new():
+def reattempt_deletions_control():
     _reattempt_deletions(ScheduledDeletion)
 
 
@@ -41,9 +41,9 @@ def reattempt_deletions_control_new():
     acks_late=True,
     silo_mode=SiloMode.CONTROL,
 )
-def reattempt_deletions_control():
+def reattempt_deletions_control_old():
     # Deprecated deploy boundary shim
-    reattempt_deletions_control_new()
+    reattempt_deletions_control()
 
 
 @instrumented_task(
@@ -52,7 +52,7 @@ def reattempt_deletions_control():
     acks_late=True,
     silo_mode=SiloMode.REGION,
 )
-def reattempt_deletions_new():
+def reattempt_deletions():
     _reattempt_deletions(RegionScheduledDeletion)
 
 
@@ -62,9 +62,9 @@ def reattempt_deletions_new():
     acks_late=True,
     silo_mode=SiloMode.REGION,
 )
-def reattempt_deletions():
+def reattempt_deletions_old():
     # Deprecated deploy boundary shim
-    reattempt_deletions_new()
+    reattempt_deletions()
 
 
 def _reattempt_deletions(model_class: type[BaseScheduledDeletion]) -> None:
@@ -83,7 +83,7 @@ def _reattempt_deletions(model_class: type[BaseScheduledDeletion]) -> None:
     queue="cleanup.control",
     acks_late=True,
 )
-def run_scheduled_deletions_control_new() -> None:
+def run_scheduled_deletions_control() -> None:
     _run_scheduled_deletions(
         model_class=ScheduledDeletion,
         process_task=run_deletion_control,
@@ -95,15 +95,15 @@ def run_scheduled_deletions_control_new() -> None:
     queue="cleanup.control",
     acks_late=True,
 )
-def run_scheduled_deletions_control() -> None:
+def run_scheduled_deletions_control_old() -> None:
     # Deprecated deploy boundary shim
-    run_scheduled_deletions_control_new()
+    run_scheduled_deletions_control()
 
 
 @instrumented_task(
     name="sentry.deletions.tasks.run_scheduled_deletions", queue="cleanup", acks_late=True
 )
-def run_scheduled_deletions_new() -> None:
+def run_scheduled_deletions() -> None:
     _run_scheduled_deletions(
         model_class=RegionScheduledDeletion,
         process_task=run_deletion,
@@ -113,9 +113,9 @@ def run_scheduled_deletions_new() -> None:
 @instrumented_task(
     name="sentry.tasks.deletion.run_scheduled_deletions", queue="cleanup", acks_late=True
 )
-def run_scheduled_deletions() -> None:
+def run_scheduled_deletions_old() -> None:
     # Deprecated deploy boundary shim
-    run_scheduled_deletions_new()
+    run_scheduled_deletions()
 
 
 def _run_scheduled_deletions(model_class: type[BaseScheduledDeletion], process_task: Task) -> None:
@@ -141,7 +141,7 @@ def _run_scheduled_deletions(model_class: type[BaseScheduledDeletion], process_t
     silo_mode=SiloMode.CONTROL,
 )
 @retry(exclude=(DeleteAborted,))
-def run_deletion_control_new(deletion_id, first_pass=True, **kwargs: Any):
+def run_deletion_control(deletion_id, first_pass=True, **kwargs: Any):
     _run_deletion(
         deletion_id=deletion_id,
         first_pass=first_pass,
@@ -159,9 +159,9 @@ def run_deletion_control_new(deletion_id, first_pass=True, **kwargs: Any):
     silo_mode=SiloMode.CONTROL,
 )
 @retry(exclude=(DeleteAborted,))
-def run_deletion_control(deletion_id, first_pass=True, **kwargs: Any):
+def run_deletion_control_old(deletion_id, first_pass=True, **kwargs: Any):
     # Deprecated deploy boundary shim
-    run_deletion_control_new(deletion_id, first_pass, **kwargs)
+    run_deletion_control(deletion_id, first_pass, **kwargs)
 
 
 @instrumented_task(
@@ -173,7 +173,7 @@ def run_deletion_control(deletion_id, first_pass=True, **kwargs: Any):
     silo_mode=SiloMode.REGION,
 )
 @retry(exclude=(DeleteAborted,))
-def run_deletion_new(deletion_id, first_pass=True, **kwargs: Any):
+def run_deletion(deletion_id, first_pass=True, **kwargs: Any):
     _run_deletion(
         deletion_id=deletion_id,
         first_pass=first_pass,
@@ -191,9 +191,9 @@ def run_deletion_new(deletion_id, first_pass=True, **kwargs: Any):
     silo_mode=SiloMode.REGION,
 )
 @retry(exclude=(DeleteAborted,))
-def run_deletion(deletion_id, first_pass=True, **kwargs: Any):
+def run_deletion_old(deletion_id, first_pass=True, **kwargs: Any):
     # Deprecated deploy boundary shim
-    run_deletion_new(deletion_id, first_pass, **kwargs)
+    run_deletion(deletion_id, first_pass, **kwargs)
 
 
 def _run_deletion(


### PR DESCRIPTION
Make the tasks that the rest of the application imports be the new task names. I've kept the old tasks around to handle deployment boundaries.

Refs #77479