### PR TITLE
fix(relocation) resolve stuck outbox

### DIFF
--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -165,6 +165,9 @@ def process_relocation_reply_with_export(payload: Mapping[str, Any], **kwds):
     try:
         encrypted_bytes = relocation_storage.open(path)
     except Exception:
+        # TODO(mark) remove this after the stuck outbox is cleared
+        if slug == "test-reloc-ct":
+            return
         raise FileNotFoundError("Could not open SaaS -> SaaS export in proxy relocation bucket.")
 
     with encrypted_bytes:


### PR DESCRIPTION
There is an outbox in production that has been stuck for a while as the file it needs cannot be found or has been removed/purged. This patch will ack the outbox and we'll need to manually recover the relocation attempt

Fixes SENTRY-3CS1