### PR TITLE
build(ui): Enable SDK debug statements

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -827,7 +827,8 @@ appConfig.plugins?.push(
       enabled: true,
     },
     bundleSizeOptimizations: {
-      excludeDebugStatements: IS_PRODUCTION,
+      // This is enabled so that our SDKs send exceptions to Sentry
+      excludeDebugStatements: false,
     },
   })
 );

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -829,6 +829,8 @@ appConfig.plugins?.push(
     bundleSizeOptimizations: {
       // This is enabled so that our SDKs send exceptions to Sentry
       excludeDebugStatements: false,
+      excludeReplayIframe: true,
+      excludeReplayShadowDom: true,
     },
   })
 );


### PR DESCRIPTION
Allow debug statements in our SDK, this also allows replay SDK to send exceptions up to Sentry.
