### PR TITLE
ref: set relay fixture scope to module instead of session

### DIFF
--- a/src/sentry/testutils/pytest/relay.py
+++ b/src/sentry/testutils/pytest/relay.py
@@ -47,7 +47,7 @@ def _remove_container_if_exists(docker_client, container_name):
             pass  # could not remove the container nothing to do about it
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def relay_server_setup(live_server, tmpdir_factory):
     prefix = "test_relay_config_{}_".format(
         datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S_%f")


### PR DESCRIPTION
this should be a reasonable balance between the current state (relay lasting for the whole session and causing flakiness) and function (setting up and tearing down the container continually)

<!-- Describe your PR here. -->