### PR TITLE
feat(insights): move geo selector to beta

### DIFF
--- a/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
@@ -38,7 +38,6 @@ import decodeBrowserTypes from 'sentry/views/insights/browser/webVitals/utils/qu
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {useModuleBreadcrumbs} from 'sentry/views/insights/common/utils/useModuleBreadcrumbs';
 import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
-import SubregionSelector from 'sentry/views/insights/common/views/spans/selectors/subregionSelector';
 import {SpanIndexedField, type SubregionCode} from 'sentry/views/insights/types';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
@@ -197,7 +196,6 @@ export function PageOverview() {
                   <DatePageFilter />
                 </PageFilterBar>
                 <BrowserTypeSelector />
-                <SubregionSelector />
               </TopMenuContainer>
               <Flex>
                 <PerformanceScoreBreakdownChart

--- a/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
+++ b/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
@@ -35,7 +35,6 @@ import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modul
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModulesOnboarding} from 'sentry/views/insights/common/components/modulesOnboarding';
 import {useModuleBreadcrumbs} from 'sentry/views/insights/common/utils/useModuleBreadcrumbs';
-import SubregionSelector from 'sentry/views/insights/common/views/spans/selectors/subregionSelector';
 import {
   type InsightLandingProps,
   ModuleName,
@@ -102,7 +101,6 @@ export function WebVitalsLandingPage({disableHeader}: InsightLandingProps) {
               extraFilters={
                 <Fragment>
                   <BrowserTypeSelector />
-                  <SubregionSelector />
                 </Fragment>
               }
             />

--- a/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
@@ -66,7 +66,7 @@ export default function SubregionSelector({size}: Props) {
       triggerProps={{
         prefix: (
           <Fragment>
-            <StyledFeatureBadge type="experimental" />
+            <StyledFeatureBadge type="beta" />
             {t('Geo region')}
           </Fragment>
         ),


### PR DESCRIPTION
1. move geo selector to beta to prepare for EA release
2. remove geo selector from web vitals as it is not fully supported. This is temporary until we fix the INP metric that isn't tagged with geo data. I might re-add it under a seperate flag.