### PR TITLE
fix(dashboards): Prevent `AutoSizedText` from continuing iteration if it found a perfect fit

### DIFF
--- a/static/app/views/dashboards/widgetCard/autoSizedText.tsx
+++ b/static/app/views/dashboards/widgetCard/autoSizedText.tsx
@@ -69,7 +69,7 @@ export function AutoSizedText({children}: Props) {
           const widthDifference = parentDimensions.width - childDimensions.width;
           const heightDifference = parentDimensions.height - childDimensions.height;
 
-          const childFitsIntoParent = heightDifference > 0 && widthDifference > 0;
+          const childFitsIntoParent = heightDifference >= 0 && widthDifference >= 0;
           const childIsWithinWidthTolerance =
             Math.abs(widthDifference) <= MAXIMUM_DIFFERENCE;
           const childIsWithinHeightTolerance =


### PR DESCRIPTION
Right now, a child fits into the parent if it's smaller than it. We should also consider it a fit if it's _perfectly_ sized, i.e., the exact same dimensions.

This is a rare case, but it's legitimate and it happens. Otherwise the algorithm continues to iterate and hits the iteration limit despite finding a perfect fit.
