### PR TITLE
fix(discover): Prevent overflow menu for dataset selector tabs

### DIFF
--- a/static/app/views/discover/resultsHeader.tsx
+++ b/static/app/views/discover/resultsHeader.tsx
@@ -230,12 +230,14 @@ class ResultsHeader extends Component<Props, State> {
         >
           {({hasFeature}) =>
             hasFeature && (
-              <DatasetSelectorTabs
-                eventView={eventView}
-                isHomepage={isHomepage}
-                savedQuery={savedQuery}
-                splitDecision={splitDecision}
-              />
+              <DatasetSelectorWrapper>
+                <DatasetSelectorTabs
+                  eventView={eventView}
+                  isHomepage={isHomepage}
+                  savedQuery={savedQuery}
+                  splitDecision={splitDecision}
+                />
+              </DatasetSelectorWrapper>
             )
           }
         </Feature>
@@ -252,6 +254,12 @@ const Subtitle = styled('h4')`
 `;
 
 const BannerWrapper = styled('div')`
+  grid-column: 1 / -1;
+`;
+
+// Force the dataset selector to have the entire width of the grid
+// so it doesn't go into the overflow menu state when the window is small
+const DatasetSelectorWrapper = styled('div')`
   grid-column: 1 / -1;
 `;
 


### PR DESCRIPTION
When the window is shrunk, the grid cell that was assigned to the dataset selector would cause it to overflow and render as an overflow menu. Wrap the tabs to enforce the whole width for the component so this overflow doesn't occur.

Before:
<img width="338" alt="Screenshot 2024-09-18 at 12 57 14 PM" src="https://github.com/user-attachments/assets/1d68d2a7-db22-44f3-82aa-7da535d54bd5">

After:
<img width="378" alt="Screenshot 2024-09-18 at 12 57 21 PM" src="https://github.com/user-attachments/assets/df29afe6-0bc7-41de-90cf-2a37cb020270">
