### PR TITLE
fix(frontend): team admin is allowed to edit project tags

### DIFF
--- a/static/app/views/settings/projectTags/index.tsx
+++ b/static/app/views/settings/projectTags/index.tsx
@@ -46,7 +46,7 @@ function ProjectTags(props: Props) {
   const {projects} = useProjects();
   const {projectId} = props.params;
 
-  const project = projects.find(p => p.id === projectId);
+  const project = projects.find(p => p.slug === projectId);
 
   const api = useApi();
   const queryClient = useQueryClient();


### PR DESCRIPTION
Before this fix, `const project` was undefined for organization-level Members who were Team Admins for certain projects because the match was attempted between `p.id` which is a numerical ID, and `projectId` which is actually a project slug.

ProjectTagKeyDetailsEndpoint is a project endpoint:
https://github.com/getsentry/sentry/blob/a4c01fe7377ad241aef1da49ad0a516320a9661a/src/sentry/api/endpoints/project_tagkey_details.py#L17
Hence, it uses ProjectPermission which requires `project:admin` scope for DELETE operations:
https://github.com/getsentry/sentry/blob/a4c01fe7377ad241aef1da49ad0a516320a9661a/src/sentry/api/bases/project.py#L28-L33
Team Admins have this scope for certain projects, so here we adjust the frontend part to reflect what's already possible on backend.