### PR TITLE
fix(settings): team admin is allowed to edit CSP settings

### DIFF
--- a/static/app/views/settings/projectSecurityHeaders/csp.tsx
+++ b/static/app/views/settings/projectSecurityHeaders/csp.tsx
@@ -102,7 +102,7 @@ export default function ProjectCspReports() {
         initialData={project.options}
         apiEndpoint={`/projects/${organization.slug}/${projectId}/`}
       >
-        <Access access={['project:write']}>
+        <Access access={['project:write']} project={project}>
           {({hasAccess}) => <JsonForm disabled={!hasAccess} forms={formGroups} />}
         </Access>
       </Form>


### PR DESCRIPTION
ProjectDetailsEndpoint is a project endpoint:
https://github.com/getsentry/sentry/blob/a4c01fe7377ad241aef1da49ad0a516320a9661a/src/sentry/api/endpoints/project_details.py#L443-L449
with the RelaxedProjectAndStaffPermission which includes RelaxedProjectPermission:
https://github.com/getsentry/sentry/blob/a4c01fe7377ad241aef1da49ad0a516320a9661a/src/sentry/api/endpoints/project_details.py#L427-L433

Team Admins have the `project:write` scope for certain projects, and can do PUT on their settings. Here we adjust the frontend part to reflect what's already possible on backend.