### PR TITLE
fix(query-builder): Fix pasting with selection

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -287,6 +287,17 @@ function SearchQueryBuilderInputInternal({
 
   const onPaste = useCallback(
     (e: React.ClipboardEvent<HTMLInputElement>) => {
+      const {selectionStart, selectionEnd} = inputRef.current ?? {};
+      const currentText = inputRef.current?.value ?? '';
+
+      const allTextSelected = selectionStart === 0 && selectionEnd === currentText.length;
+
+      // If there is text and there is a custom selection, use default paste behavior
+      if (currentText.trim() && !allTextSelected) {
+        return;
+      }
+
+      // Otherwise, we want to parse the clipboard text and replace the current token with it
       e.preventDefault();
       e.stopPropagation();
 
@@ -294,12 +305,11 @@ function SearchQueryBuilderInputInternal({
         .getData('text/plain')
         .replace('\n', '')
         .trim();
-      const currentText = inputRef.current?.value ?? '';
 
       dispatch({
         type: 'REPLACE_TOKENS_WITH_TEXT',
         tokens: [token],
-        text: currentText + clipboardText,
+        text: clipboardText,
       });
       resetInputValue();
     },


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/77671

This simplifies pasting a bit. It uses the default behavior if there we are pasting into existing text. But if not, we parse the text and do a full replacement.