### PR TITLE
fix(insights): Incorrect comma placement in MongoDB queries

### DIFF
--- a/static/app/views/insights/database/utils/formatMongoDBQuery.spec.tsx
+++ b/static/app/views/insights/database/utils/formatMongoDBQuery.spec.tsx
@@ -101,4 +101,16 @@ describe('formatMongoDBQuery', function () {
     );
     expect(truncatedEntry).toBeInTheDocument();
   });
+
+  it('properly handles formatting MongoDB queries when the operation entry is the last entry', function () {
+    const query = `{"first_key":"first_value","second_key":"second_value","findOne":"my_collection"}`;
+    const tokenizedQuery = formatMongoDBQuery(query, 'findOne');
+    render(<Fragment>{tokenizedQuery}</Fragment>);
+
+    const boldedText = screen.getByText(/"findOne": "my_collection"/i);
+    expect(boldedText).toContainHTML('<b>"findOne": "my_collection"</b>');
+
+    const commaTokens = screen.getAllByText(',');
+    expect(commaTokens).toHaveLength(2);
+  });
 });

--- a/static/app/views/insights/database/utils/formatMongoDBQuery.tsx
+++ b/static/app/views/insights/database/utils/formatMongoDBQuery.tsx
@@ -39,30 +39,27 @@ export function formatMongoDBQuery(query: string, command: string) {
   const tempTokens: ReactElement[] = [];
 
   const queryEntries = Object.entries(queryObject);
-  queryEntries.forEach(([key, val], index) => {
-    // Push the bolded entry into tokens so it is the first entry displayed.
-    // The other tokens will be pushed into tempTokens, and then copied into tokens afterwards
+  queryEntries.forEach(([key, val]) => {
     const isBoldedEntry = key.toLowerCase() === command.toLowerCase();
 
-    if (index === queryEntries.length - 1) {
-      isBoldedEntry
-        ? tokens.push(jsonEntryToToken(key, val, true))
-        : tempTokens.push(jsonEntryToToken(key, val));
-
-      return;
-    }
-
-    if (isBoldedEntry) {
-      tokens.push(jsonEntryToToken(key, val, true));
-      tokens.push(stringToToken(', ', `${key}:${val},`));
-      return;
-    }
-
-    tempTokens.push(jsonEntryToToken(key, val));
-    tempTokens.push(stringToToken(', ', `${key}:${val},`));
+    // Push the bolded entry into tokens so it is the first entry displayed.
+    // The other tokens will be pushed into tempTokens, and then copied into tokens afterwards
+    isBoldedEntry
+      ? tokens.push(jsonEntryToToken(key, val, true))
+      : tempTokens.push(jsonEntryToToken(key, val));
   });
 
-  tempTokens.forEach(token => tokens.push(token));
+  if (tokens.length === 1 && tempTokens.length > 0) {
+    tokens.push(stringToToken(', ', `${tokens[0].key}:,`));
+  }
+
+  tempTokens.forEach((token, index) => {
+    tokens.push(token);
+
+    if (index !== tempTokens.length - 1) {
+      tokens.push(stringToToken(', ', `${token.key}:${index}`));
+    }
+  });
 
   sentrySpan.end();
 


### PR DESCRIPTION
Fixes a bug where a comma separator would not be added when formatting MongoDB queries, when the original query JSON has the operation entry as the very last entry in the object

### Before
```
"findOne": "my_collection""first_key": "first_value", "second_key": "second_value",
```

### After
```
"findOne": "my_collection", "first_key": "first_value", "second_key": "second_value"
```