### PR TITLE
feat(dashboards): Add warning with tooltip to show forced widgets

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -13,7 +13,6 @@ import {
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {openWidgetViewerModal} from 'sentry/actionCreators/modal';
 import type {Client} from 'sentry/api';
-import Feature from 'sentry/components/acl/feature';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -35,7 +34,6 @@ import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import EventView from 'sentry/utils/discover/eventView';
-import {DatasetSource} from 'sentry/utils/discover/types';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MetricsResultsMetaProvider} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
@@ -46,7 +44,6 @@ import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import withProjects from 'sentry/utils/withProjects';
-import {DiscoverSplitAlert} from 'sentry/views/dashboards/discoverSplitAlert';
 import {defaultMetricWidget} from 'sentry/views/dashboards/metrics/utils';
 import {
   cloneDashboard,
@@ -879,10 +876,6 @@ class DashboardDetail extends Component<Props, State> {
       isWidgetUsingTransactionName
     );
 
-    const hasForcedWidgets = (modifiedDashboard ?? dashboard).widgets.some(
-      widget => widget.datasetSource === DatasetSource.FORCED
-    );
-
     return (
       <SentryDocumentTitle title={dashboard.title} orgSlug={organization.slug}>
         <PageFiltersContainer
@@ -945,12 +938,6 @@ class DashboardDetail extends Component<Props, State> {
                   </Layout.Header>
                   <Layout.Body>
                     <Layout.Main fullWidth>
-                      <Feature features="performance-discover-dataset-selector">
-                        <DiscoverSplitAlert
-                          hasForcedWidgets={hasForcedWidgets}
-                          dashboardId={(modifiedDashboard ?? dashboard).id}
-                        />
-                      </Feature>
                       <MetricsCardinalityProvider
                         organization={organization}
                         location={location}

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -13,6 +13,7 @@ import {
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {openWidgetViewerModal} from 'sentry/actionCreators/modal';
 import type {Client} from 'sentry/api';
+import Feature from 'sentry/components/acl/feature';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -34,6 +35,7 @@ import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import EventView from 'sentry/utils/discover/eventView';
+import {DatasetSource} from 'sentry/utils/discover/types';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MetricsResultsMetaProvider} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
@@ -44,6 +46,7 @@ import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import withProjects from 'sentry/utils/withProjects';
+import {DiscoverSplitAlert} from 'sentry/views/dashboards/discoverSplitAlert';
 import {defaultMetricWidget} from 'sentry/views/dashboards/metrics/utils';
 import {
   cloneDashboard,
@@ -876,6 +879,10 @@ class DashboardDetail extends Component<Props, State> {
       isWidgetUsingTransactionName
     );
 
+    const hasForcedWidgets = (modifiedDashboard ?? dashboard).widgets.some(
+      widget => widget.datasetSource === DatasetSource.FORCED
+    );
+
     return (
       <SentryDocumentTitle title={dashboard.title} orgSlug={organization.slug}>
         <PageFiltersContainer
@@ -938,6 +945,12 @@ class DashboardDetail extends Component<Props, State> {
                   </Layout.Header>
                   <Layout.Body>
                     <Layout.Main fullWidth>
+                      <Feature features="performance-discover-dataset-selector">
+                        <DiscoverSplitAlert
+                          hasForcedWidgets={hasForcedWidgets}
+                          dashboardId={(modifiedDashboard ?? dashboard).id}
+                        />
+                      </Feature>
                       <MetricsCardinalityProvider
                         organization={organization}
                         location={location}

--- a/static/app/views/dashboards/discoverSplitAlert.spec.tsx
+++ b/static/app/views/dashboards/discoverSplitAlert.spec.tsx
@@ -1,5 +1,8 @@
+import {WidgetFixture} from 'sentry-fixture/widget';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
+import {DatasetSource} from 'sentry/utils/discover/types';
 import localStorage from 'sentry/utils/localStorage';
 import {DiscoverSplitAlert} from 'sentry/views/dashboards/discoverSplitAlert';
 
@@ -8,35 +11,23 @@ describe('DiscoverSplitAlert', () => {
     localStorage.clear();
   });
 
-  it('renders if there are forced widgets', async () => {
-    render(<DiscoverSplitAlert hasForcedWidgets dashboardId="1" />);
+  it('renders if the widget has a forced split decision', async () => {
+    render(
+      <DiscoverSplitAlert
+        widget={{...WidgetFixture(), datasetSource: DatasetSource.FORCED}}
+      />
+    );
+
+    await userEvent.hover(screen.getByLabelText('Dataset split warning'));
 
     expect(
-      screen.getByText(/We're splitting our Errors and Transactions dataset/)
+      await screen.findByText(/We're splitting our datasets up/)
     ).toBeInTheDocument();
-
-    await userEvent.click(screen.getByLabelText('Close'));
-
-    expect(
-      screen.queryByText(/We're splitting our Errors and Transactions dataset/)
-    ).not.toBeInTheDocument();
   });
 
-  it('does not render if there are no forced widgets', () => {
-    render(<DiscoverSplitAlert hasForcedWidgets={false} dashboardId="1" />);
+  it('does not render if there the widget has not been forced', () => {
+    render(<DiscoverSplitAlert widget={WidgetFixture()} />);
 
-    expect(
-      screen.queryByText(/We're splitting our Errors and Transactions dataset/)
-    ).not.toBeInTheDocument();
-  });
-
-  it('does not render if the alert has been dismissed', () => {
-    localStorage.setItem('dashboard-discover-split-alert-dismissed-1', '1');
-
-    render(<DiscoverSplitAlert hasForcedWidgets dashboardId="1" />);
-
-    expect(
-      screen.queryByText(/We're splitting our Errors and Transactions dataset/)
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/We're splitting our datasets up/)).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/dashboards/discoverSplitAlert.spec.tsx
+++ b/static/app/views/dashboards/discoverSplitAlert.spec.tsx
@@ -1,0 +1,42 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import localStorage from 'sentry/utils/localStorage';
+import {DiscoverSplitAlert} from 'sentry/views/dashboards/discoverSplitAlert';
+
+describe('DiscoverSplitAlert', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('renders if there are forced widgets', async () => {
+    render(<DiscoverSplitAlert hasForcedWidgets dashboardId="1" />);
+
+    expect(
+      screen.getByText(/We're splitting our Errors and Transactions dataset/)
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText('Close'));
+
+    expect(
+      screen.queryByText(/We're splitting our Errors and Transactions dataset/)
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render if there are no forced widgets', () => {
+    render(<DiscoverSplitAlert hasForcedWidgets={false} dashboardId="1" />);
+
+    expect(
+      screen.queryByText(/We're splitting our Errors and Transactions dataset/)
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render if the alert has been dismissed', () => {
+    localStorage.setItem('dashboard-discover-split-alert-dismissed-1', '1');
+
+    render(<DiscoverSplitAlert hasForcedWidgets dashboardId="1" />);
+
+    expect(
+      screen.queryByText(/We're splitting our Errors and Transactions dataset/)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/static/app/views/dashboards/discoverSplitAlert.tsx
+++ b/static/app/views/dashboards/discoverSplitAlert.tsx
@@ -1,0 +1,58 @@
+import styled from '@emotion/styled';
+
+import Alert from 'sentry/components/alert';
+import {Button} from 'sentry/components/button';
+import {IconClose} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import useDismissAlert from 'sentry/utils/useDismissAlert';
+
+const DASHBOARD_SPLIT_ALERT_DISMISSED_KEY = 'dashboard-discover-split-alert-dismissed';
+
+interface DiscoverSplitAlertProps {
+  dashboardId: string;
+  hasForcedWidgets: boolean;
+}
+
+export function DiscoverSplitAlert({
+  hasForcedWidgets,
+  dashboardId,
+}: DiscoverSplitAlertProps) {
+  const {isDismissed, dismiss} = useDismissAlert({
+    key: `${DASHBOARD_SPLIT_ALERT_DISMISSED_KEY}-${dashboardId}`,
+  });
+
+  if (!hasForcedWidgets || isDismissed) {
+    return null;
+  }
+
+  return (
+    <Alert
+      type="warning"
+      showIcon
+      trailingItems={
+        <StyledCloseButton
+          icon={<IconClose size="sm" />}
+          aria-label={t('Close')}
+          onClick={dismiss}
+          size="zero"
+          borderless
+        />
+      }
+    >
+      {t(
+        "We're splitting our Errors and Transactions dataset up to make it a bit easier to digest. Some of your widgets have been defaulted to the Errors dataset. If this is incorrect you can change the dataset by editing the widget."
+      )}
+    </Alert>
+  );
+}
+
+const StyledCloseButton = styled(Button)`
+  background-color: transparent;
+  transition: opacity 0.1s linear;
+
+  &:hover,
+  &:focus {
+    background-color: transparent;
+    opacity: 1;
+  }
+`;

--- a/static/app/views/dashboards/discoverSplitAlert.tsx
+++ b/static/app/views/dashboards/discoverSplitAlert.tsx
@@ -1,58 +1,26 @@
-import styled from '@emotion/styled';
-
-import Alert from 'sentry/components/alert';
-import {Button} from 'sentry/components/button';
-import {IconClose} from 'sentry/icons';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import useDismissAlert from 'sentry/utils/useDismissAlert';
-
-const DASHBOARD_SPLIT_ALERT_DISMISSED_KEY = 'dashboard-discover-split-alert-dismissed';
+import {DatasetSource} from 'sentry/utils/discover/types';
+import type {Widget} from 'sentry/views/dashboards/types';
 
 interface DiscoverSplitAlertProps {
-  dashboardId: string;
-  hasForcedWidgets: boolean;
+  widget: Widget;
 }
 
-export function DiscoverSplitAlert({
-  hasForcedWidgets,
-  dashboardId,
-}: DiscoverSplitAlertProps) {
-  const {isDismissed, dismiss} = useDismissAlert({
-    key: `${DASHBOARD_SPLIT_ALERT_DISMISSED_KEY}-${dashboardId}`,
-  });
-
-  if (!hasForcedWidgets || isDismissed) {
+export function DiscoverSplitAlert({widget}: DiscoverSplitAlertProps) {
+  if (widget?.datasetSource !== DatasetSource.FORCED) {
     return null;
   }
 
   return (
-    <Alert
-      type="warning"
-      showIcon
-      trailingItems={
-        <StyledCloseButton
-          icon={<IconClose size="sm" />}
-          aria-label={t('Close')}
-          onClick={dismiss}
-          size="zero"
-          borderless
-        />
-      }
-    >
-      {t(
-        "We're splitting our Errors and Transactions dataset up to make it a bit easier to digest. Some of your widgets have been defaulted to the Errors dataset. If this is incorrect you can change the dataset by editing the widget."
+    <Tooltip
+      containerDisplayMode="inline-flex"
+      title={t(
+        "We're splitting our datasets up to make it a bit easier to digest. We defaulted this widget to Errors. Edit as you see fit."
       )}
-    </Alert>
+    >
+      <IconWarning color="warningText" aria-label={t('Dataset split warning')} />
+    </Tooltip>
   );
 }
-
-const StyledCloseButton = styled(Button)`
-  background-color: transparent;
-  transition: opacity 0.1s linear;
-
-  &:hover,
-  &:focus {
-    background-color: transparent;
-    opacity: 1;
-  }
-`;

--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {WidgetFixture} from 'sentry-fixture/widget';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
@@ -12,6 +13,7 @@ import {
 import * as modal from 'sentry/actionCreators/modal';
 import * as LineChart from 'sentry/components/charts/lineChart';
 import SimpleTableChart from 'sentry/components/charts/simpleTableChart';
+import {DatasetSource} from 'sentry/utils/discover/types';
 import {MINUTE, SECOND} from 'sentry/utils/formatters';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import type {Widget} from 'sentry/views/dashboards/types';
@@ -788,5 +790,32 @@ describe('Dashboards > WidgetCard', function () {
     );
 
     expect(await screen.findByText('Indexed')).toBeInTheDocument();
+  });
+
+  it('displays the discover split warning icon when the dataset source is forced', async function () {
+    const testWidget = {...WidgetFixture(), datasetSource: DatasetSource.FORCED};
+
+    renderWithProviders(
+      <WidgetCard
+        api={api}
+        organization={organization}
+        widget={testWidget}
+        selection={selection}
+        isEditingDashboard={false}
+        onDelete={() => undefined}
+        onEdit={() => undefined}
+        onDuplicate={() => undefined}
+        renderErrorMessage={() => undefined}
+        showContextMenu
+        widgetLimitReached={false}
+        isPreview
+      />
+    );
+
+    await userEvent.hover(screen.getByLabelText('Dataset split warning'));
+
+    expect(
+      await screen.findByText(/We're splitting our datasets up/)
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -41,6 +41,7 @@ import withPageFilters from 'sentry/utils/withPageFilters';
 // eslint-disable-next-line no-restricted-imports
 import withSentryRouter from 'sentry/utils/withSentryRouter';
 import {DASHBOARD_CHART_GROUP} from 'sentry/views/dashboards/dashboard';
+import {DiscoverSplitAlert} from 'sentry/views/dashboards/discoverSplitAlert';
 import {MetricWidgetCard} from 'sentry/views/dashboards/metrics/widgetCard';
 import {Toolbar} from 'sentry/views/dashboards/widgetCard/toolbar';
 
@@ -331,6 +332,7 @@ class WidgetCard extends Component<Props, State> {
                         )}
                       <ExtractedMetricsTag queryKey={widget} />
                       <DisplayOnDemandWarnings widget={widget} />
+                      <DiscoverSplitAlert widget={widget} />
                     </WidgetTitleRow>
                     {widget.description && (
                       <Tooltip


### PR DESCRIPTION
Displays a warning icon on widgets that have been forced to the errors dataset. This makes it so users can easily figure out which widgets to update. Uses the same messaging as in the widget builder for consistency.

<img width="326" alt="Screenshot 2024-09-19 at 10 38 16 AM" src="https://github.com/user-attachments/assets/4cbfd9a1-8848-4229-a225-29b7f5ceb487">
