### PR TITLE
fix(query-builder): Stop component from crashing if filterKeys is cleared out

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -175,8 +175,10 @@ export function useSortedFilterKeyItems({
 
     const keyItems = searched
       .map(({item}) => item)
-      .filter(item => item.type === 'key')
-      .map(({item}) => createItem(filterKeys[item.key], getFieldDefinition(item.key)));
+      .filter(item => item.type === 'key' && filterKeys[item.item.key])
+      .map(({item}) => {
+        return createItem(filterKeys[item.key], getFieldDefinition(item.key));
+      });
 
     if (includeSuggestions) {
       const rawSearchSection: KeySectionItem = {


### PR DESCRIPTION
Fixes JAVASCRIPT-2VWT

There seems to be an edge case where if the filterKeys change (which can happen when you change the global selection) this part of the code will end up looking up a key that doesn't exist. Added a simple check to avoid this from blowing up.