### PR TITLE
:sparkles: feat(azure_devops): Update Azure DevOps Integration

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -727,7 +727,7 @@ class AuthHelper(Pipeline):
         self.organization: RpcOrganization = self.organization
         self.provider: Provider = self.provider
 
-    def get_provider(self, provider_key: str | None) -> PipelineProvider:
+    def get_provider(self, provider_key: str | None, **kwargs) -> PipelineProvider:
         if self.provider_model:
             return cast(PipelineProvider, self.provider_model.get_provider())
         elif provider_key:

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -191,7 +191,7 @@ def register_temporary_features(manager: FeatureManager):
     # Enables the search bar for metrics samples list
     manager.add("organizations:metrics-samples-list-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Migrate Orgs to new Azure DevOps Integration
-    manager.add("organizations:migrate-azure-devops-integration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
+    manager.add("organizations:migrate-azure-devops-integration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Session Stats down to a minute resolution
     manager.add("organizations:minute-resolution-sessions", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     # Display CPU and memory metrics in transactions with profiles

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -190,6 +190,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:metric-alert-threshold-period", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables the search bar for metrics samples list
     manager.add("organizations:metrics-samples-list-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Migrate Orgs to new Azure DevOps Integration
+    manager.add("organizations:migrate-azure-devops-integration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Session Stats down to a minute resolution
     manager.add("organizations:minute-resolution-sessions", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     # Display CPU and memory metrics in transactions with profiles

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -191,7 +191,7 @@ def register_temporary_features(manager: FeatureManager):
     # Enables the search bar for metrics samples list
     manager.add("organizations:metrics-samples-list-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Migrate Orgs to new Azure DevOps Integration
-    manager.add("organizations:migrate-azure-devops-integration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:migrate-azure-devops-integration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Session Stats down to a minute resolution
     manager.add("organizations:minute-resolution-sessions", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     # Display CPU and memory metrics in transactions with profiles

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -191,7 +191,7 @@ def register_temporary_features(manager: FeatureManager):
     # Enables the search bar for metrics samples list
     manager.add("organizations:metrics-samples-list-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Migrate Orgs to new Azure DevOps Integration
-    manager.add("organizations:migrate-azure-devops-integration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:migrate-azure-devops-integration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
     # Enable Session Stats down to a minute resolution
     manager.add("organizations:minute-resolution-sessions", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     # Display CPU and memory metrics in transactions with profiles

--- a/src/sentry/identity/__init__.py
+++ b/src/sentry/identity/__init__.py
@@ -9,7 +9,7 @@ from .manager import IdentityManager
 from .oauth2 import *  # NOQA
 from .slack import *  # NOQA
 from .vercel import *  # NOQA
-from .vsts import VSTSIdentityProvider
+from .vsts import VSTSIdentityProvider, VSTSNewIdentityProvider
 from .vsts_extension import *  # NOQA
 
 default_manager = IdentityManager()
@@ -25,6 +25,7 @@ is_login_provider = default_manager.is_login_provider
 register(SlackIdentityProvider)  # NOQA
 register(GitHubIdentityProvider)  # NOQA
 register(GitHubEnterpriseIdentityProvider)  # NOQA
+register(VSTSNewIdentityProvider)  # NOQA
 register(VSTSIdentityProvider)  # NOQA
 register(VstsExtensionIdentityProvider)  # NOQA
 register(VercelIdentityProvider)  # NOQA

--- a/src/sentry/identity/pipeline.py
+++ b/src/sentry/identity/pipeline.py
@@ -38,6 +38,7 @@ class IdentityProviderPipeline(Pipeline):
         # Use configured redirect_url if specified for the pipeline if available
         return self.config.get("redirect_url", associate_url)
 
+    # TODO(iamrajjoshi): Delete this after Azure DevOps migration is complete
     def get_provider(self, provider_key: str, **kwargs) -> PipelineProvider:
         if kwargs.get("organization"):
             organization: Organization | RpcOrganization = kwargs["organization"]

--- a/src/sentry/identity/pipeline.py
+++ b/src/sentry/identity/pipeline.py
@@ -41,9 +41,8 @@ class IdentityProviderPipeline(Pipeline):
     def get_provider(self, provider_key: str, **kwargs) -> PipelineProvider:
         if kwargs.get("organization"):
             organization: Organization | RpcOrganization = kwargs["organization"]
-        if (
-            features.has("organizations:migrate-azure-devops-integration", organization.id)
-            and provider_key == "vsts"
+        if provider_key == "vsts" and features.has(
+            "organizations:migrate-azure-devops-integration", organization
         ):
             provider_key = "vsts_new"
 

--- a/src/sentry/identity/pipeline.py
+++ b/src/sentry/identity/pipeline.py
@@ -5,7 +5,10 @@ from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
-from sentry.pipeline import Pipeline
+from sentry import features
+from sentry.models.organization import Organization
+from sentry.organizations.services.organization.model import RpcOrganization
+from sentry.pipeline import Pipeline, PipelineProvider
 from sentry.users.models.identity import Identity, IdentityProvider
 from sentry.utils import metrics
 
@@ -34,6 +37,17 @@ class IdentityProviderPipeline(Pipeline):
 
         # Use configured redirect_url if specified for the pipeline if available
         return self.config.get("redirect_url", associate_url)
+
+    def get_provider(self, provider_key: str, **kwargs) -> PipelineProvider:
+        if kwargs.get("organization"):
+            organization: Organization | RpcOrganization = kwargs["organization"]
+        if (
+            features.has("organizations:migrate-azure-devops-integration", organization.id)
+            and provider_key == "vsts"
+        ):
+            provider_key = "vsts_new"
+
+        return super().get_provider(provider_key)
 
     def finish_pipeline(self):
         # NOTE: only reached in the case of linking a new identity

--- a/src/sentry/identity/vsts/provider.py
+++ b/src/sentry/identity/vsts/provider.py
@@ -137,6 +137,10 @@ class VSTSOAuth2CallbackView(OAuth2CallbackView):
         return orjson.loads(body)
 
 
+# TODO(iamrajjoshi): Make this the default provider
+# We created this new flow in order to quickly update the DevOps integration to use
+# the new Azure AD OAuth2 flow.
+# This is a temporary solution until we can fully migrate to the new flow once customers are migrated
 class VSTSNewIdentityProvider(OAuth2Provider):
     key = "vsts_new"
     name = "Azure DevOps"
@@ -144,6 +148,7 @@ class VSTSNewIdentityProvider(OAuth2Provider):
     oauth_access_token_url = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
     oauth_authorize_url = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
 
+    # Using a new option
     def get_oauth_client_id(self):
         return options.get("vsts_new.client-id")
 
@@ -155,6 +160,7 @@ class VSTSNewIdentityProvider(OAuth2Provider):
 
     def get_pipeline_views(self):
         return [
+            # made a new view to override `get_authorize_params` for the new params needed for the oauth
             VSTSOAuth2LoginView(
                 authorize_url=self.oauth_authorize_url,
                 client_id=self.get_oauth_client_id(),

--- a/src/sentry/identity/vsts/provider.py
+++ b/src/sentry/identity/vsts/provider.py
@@ -135,3 +135,108 @@ class VSTSOAuth2CallbackView(OAuth2CallbackView):
         if req.headers["Content-Type"].startswith("application/x-www-form-urlencoded"):
             return dict(parse_qsl(body))
         return orjson.loads(body)
+
+
+class VSTSNewIdentityProvider(OAuth2Provider):
+    key = "vsts_new"
+    name = "Azure DevOps"
+
+    oauth_access_token_url = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+    oauth_authorize_url = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+
+    def get_oauth_client_id(self):
+        return options.get("vsts.client-id")
+
+    def get_oauth_client_secret(self):
+        return options.get("vsts.client-secret")
+
+    def get_refresh_token_url(self):
+        return self.oauth_access_token_url
+
+    def get_pipeline_views(self):
+        return [
+            VSTSOAuth2LoginView(
+                authorize_url=self.oauth_authorize_url,
+                client_id=self.get_oauth_client_id(),
+                scope=" ".join(self.get_oauth_scopes()),
+            ),
+            VSTSNewOAuth2CallbackView(
+                access_token_url=self.oauth_access_token_url,
+                client_id=self.get_oauth_client_id(),
+                client_secret=self.get_oauth_client_secret(),
+            ),
+        ]
+
+    def get_refresh_token_headers(self):
+        return {"Content-Type": "application/x-www-form-urlencoded", "Content-Length": "1654"}
+
+    def get_refresh_token_params(self, refresh_token, *args, **kwargs):
+        # Note: ignoring the below from the original provider
+        # # If "vso.code" is missing from the identity.scopes, we know that we installed
+        # using the "vsts-limited.client-secret" and therefore should use that to refresh
+        # the token.
+
+        oauth_redirect_url = kwargs.get("redirect_url")
+        if oauth_redirect_url is None:
+            raise ValueError("VSTS requires oauth redirect url when refreshing identity")
+
+        return {
+            "grant_type": "refresh_token",
+            "client_id": self.get_oauth_client_id(),
+            "client_secret": self.get_oauth_client_secret(),
+            "refresh_token": refresh_token,
+        }
+
+    def build_identity(self, data):
+        data = data["data"]
+        access_token = data.get("access_token")
+        if not access_token:
+            raise PermissionDenied()
+        user = get_user_info(access_token)
+
+        return {
+            "type": "vsts",
+            "id": user["id"],
+            "email": user["emailAddress"],
+            "email_verified": True,
+            "name": user["displayName"],
+            "scopes": sorted(self.oauth_scopes),
+            "data": self.get_oauth_data(data),
+        }
+
+
+class VSTSOAuth2LoginView(OAuth2LoginView):
+    def get_authorize_params(self, state, redirect_uri):
+        return {
+            "client_id": self.client_id,
+            "response_type": "code",
+            "redirect_uri": redirect_uri,
+            "response_mode": "query",
+            "scope": self.get_scope(),
+            "state": state,
+            "prompt": "consent",
+        }
+
+
+class VSTSNewOAuth2CallbackView(OAuth2CallbackView):
+    def exchange_token(self, request: Request, pipeline, code):
+        from urllib.parse import parse_qsl
+
+        from sentry.http import safe_urlopen, safe_urlread
+        from sentry.utils.http import absolute_uri
+
+        req = safe_urlopen(
+            url=self.access_token_url,
+            headers={"Content-Type": "application/x-www-form-urlencoded", "Content-Length": "1322"},
+            data={
+                "grant_type": "authorization_code",
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+                "code": code,
+                "redirect_uri": absolute_uri(pipeline.redirect_url()),
+            },
+        )
+        body = safe_urlread(req)
+        if req.headers["Content-Type"].startswith("application/x-www-form-urlencoded"):
+            return dict(parse_qsl(body))
+        return orjson.loads(body)

--- a/src/sentry/identity/vsts/provider.py
+++ b/src/sentry/identity/vsts/provider.py
@@ -145,10 +145,10 @@ class VSTSNewIdentityProvider(OAuth2Provider):
     oauth_authorize_url = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
 
     def get_oauth_client_id(self):
-        return options.get("vsts.client-id")
+        return options.get("vsts_new.client-id")
 
     def get_oauth_client_secret(self):
-        return options.get("vsts.client-secret")
+        return options.get("vsts_new.client-secret")
 
     def get_refresh_token_url(self):
         return self.oauth_access_token_url

--- a/src/sentry/identity/vsts/provider.py
+++ b/src/sentry/identity/vsts/provider.py
@@ -177,6 +177,7 @@ class VSTSNewIdentityProvider(OAuth2Provider):
         return {"Content-Type": "application/x-www-form-urlencoded", "Content-Length": "1654"}
 
     def get_refresh_token_params(self, refresh_token, *args, **kwargs):
+        # TODO(iamrajjoshi): Fix vsts-limited here
         # Note: ignoring the below from the original provider
         # # If "vso.code" is missing from the identity.scopes, we know that we installed
         # using the "vsts-limited.client-secret" and therefore should use that to refresh

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -423,7 +423,7 @@ class VstsIntegrationProvider(IntegrationProvider):
 
     def get_scopes(self) -> Sequence[str]:
         if features.has(
-            "organizations:migrate-azure-devops-integration", self.pipeline.organization.id
+            "organizations:migrate-azure-devops-integration", self.pipeline.organization
         ):
             # This is the new way we need to pass scopes to the OAuth flow
             # https://stackoverflow.com/questions/75729931/get-access-token-for-azure-devops-pat
@@ -479,7 +479,7 @@ class VstsIntegrationProvider(IntegrationProvider):
 
             if (
                 features.has(
-                    "organizations:migrate-azure-devops-integration", self.pipeline.organization.id
+                    "organizations:migrate-azure-devops-integration", self.pipeline.organization
                 )
                 and integration_migration_version < CURRENT_MIGRATION_VERSION
             ):

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -422,6 +422,7 @@ class VstsIntegrationProvider(IntegrationProvider):
             )
 
     def get_scopes(self) -> Sequence[str]:
+        # TODO(iamrajjoshi): Delete this after Azure DevOps migration is complete
         if features.has(
             "organizations:migrate-azure-devops-integration", self.pipeline.organization
         ):
@@ -465,6 +466,7 @@ class VstsIntegrationProvider(IntegrationProvider):
             },
         }
 
+        # TODO(iamrajjoshi): Clean this up this after Azure DevOps migration is complete
         try:
             CURRENT_MIGRATION_VERSION = 1
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -572,6 +572,11 @@ register(
 # VSTS Integration
 register("vsts.client-id", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
 register("vsts.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
+
+# New VSTS Integration
+register("vsts_new.client-id", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
+register("vsts_new.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
+
 # VSTS Integration - with limited scopes
 register("vsts-limited.client-id", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
 register("vsts-limited.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)

--- a/src/sentry/pipeline/base.py
+++ b/src/sentry/pipeline/base.py
@@ -95,7 +95,7 @@ class Pipeline(abc.ABC):
 
         return PipelineRequestState(state, provider_model, organization, provider_key)
 
-    def get_provider(self, provider_key: str) -> PipelineProvider:
+    def get_provider(self, provider_key: str, **kwargs) -> PipelineProvider:
         provider: PipelineProvider = self.provider_manager.get(provider_key)
         return provider
 
@@ -118,7 +118,7 @@ class Pipeline(abc.ABC):
         )
         self.state = self.session_store_cls(request, self.pipeline_name, ttl=PIPELINE_STATE_TTL)
         self.provider_model = provider_model
-        self.provider = self.get_provider(provider_key)
+        self.provider = self.get_provider(provider_key, organization=organization)
 
         self.config = config or {}
         self.provider.set_pipeline(self)

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -8,18 +8,103 @@ import pytest
 import responses
 
 from fixtures.vsts import CREATE_SUBSCRIPTION, VstsIntegrationTestCase
+from sentry.identity.vsts.provider import VSTSNewIdentityProvider
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.integration_external_project import IntegrationExternalProject
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.pipeline import ensure_integration
 from sentry.integrations.vsts import VstsIntegration, VstsIntegrationProvider
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import IntegrationError, IntegrationProviderError
 from sentry.silo.base import SiloMode
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.users.models.identity import Identity
 
 FULL_SCOPES = ["vso.code", "vso.graph", "vso.serviceendpoint_manage", "vso.work_write"]
 LIMITED_SCOPES = ["vso.graph", "vso.serviceendpoint_manage", "vso.work_write"]
+
+NEW_SCOPES = ["offline_access", "499b84ac-1321-427f-aa17-267ca6975798/.default"]
+
+
+@control_silo_test
+class VstsIntegrationMigrationTest(VstsIntegrationTestCase):
+
+    # Test regular install still works
+    @with_feature("organizations:migrate-azure-devops-integration")
+    @patch("sentry.integrations.vsts.VstsIntegrationProvider.get_scopes", return_value=NEW_SCOPES)
+    @patch(
+        "sentry.identity.pipeline.IdentityProviderPipeline.get_provider",
+        return_value=VSTSNewIdentityProvider(),
+    )
+    def test_original_installation_still_works(self, mock_get_scopes, mock_get_provider):
+        self.pipeline = Mock()
+        self.pipeline.organization = self.organization
+        self.assert_installation(new=True)
+        integration = Integration.objects.get(provider="vsts")
+        assert integration.external_id == self.vsts_account_id
+        assert integration.name == self.vsts_account_name
+
+        metadata = integration.metadata
+        assert set(metadata["scopes"]) == set(NEW_SCOPES)
+        assert metadata["subscription"]["id"] == CREATE_SUBSCRIPTION["id"]
+        assert metadata["domain_name"] == self.vsts_base_url
+
+    # Test that install second time doesn't have the metadata and updates the integration object
+    # Assert that the Integration object now has the migrated metadata
+    @with_feature("organizations:migrate-azure-devops-integration")
+    @patch("sentry.integrations.vsts.VstsIntegrationProvider.get_scopes", return_value=NEW_SCOPES)
+    def test_migration(self, mock_get_scopes):
+        state = {
+            "account": {"accountName": self.vsts_account_name, "accountId": self.vsts_account_id},
+            "base_url": self.vsts_base_url,
+            "identity": {
+                "data": {
+                    "access_token": self.access_token,
+                    "expires_in": "3600",
+                    "refresh_token": self.refresh_token,
+                    "token_type": "jwt-bearer",
+                }
+            },
+        }
+
+        external_id = self.vsts_account_id
+        # Create the integration with old integration metadata
+        old_integraton_obj = self.create_provider_integration(
+            metadata=state, provider="vsts", external_id=external_id
+        )
+        assert old_integraton_obj.metadata.get("subscription", None) is None
+
+        provider = VstsIntegrationProvider()
+        pipeline = Mock()
+        pipeline.organization = self.organization
+        provider.set_pipeline(pipeline)
+
+        data = provider.build_integration(
+            {
+                "account": {"accountName": self.vsts_account_name, "accountId": external_id},
+                "base_url": self.vsts_base_url,
+                "identity": {
+                    "data": {
+                        "access_token": "new_access_token",
+                        "expires_in": "3600",
+                        "refresh_token": "new_refresh_token",
+                        "token_type": "bearer",
+                    }
+                },
+            }
+        )
+        assert external_id == data["external_id"]
+        subscription = data["metadata"]["subscription"]
+        assert subscription["id"] is not None and subscription["secret"] is not None
+        assert set(data.get("metadata")["scopes"]) == set(NEW_SCOPES)
+        assert data.get("metadata")["integration_migration_version"] == 1
+
+        # Make sure the integration object is updated
+        # ensure_integration will be called in _finish_pipeline
+        new_integration_obj = ensure_integration("vsts", data)
+        assert new_integration_obj.metadata["integration_migration_version"] == 1
+        assert set(new_integration_obj.metadata["scopes"]) == set(NEW_SCOPES)
 
 
 @control_silo_test
@@ -125,7 +210,11 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
     def test_fix_subscription(self, mock_get_scopes):
         external_id = self.vsts_account_id
         self.create_provider_integration(metadata={}, provider="vsts", external_id=external_id)
-        data = VstsIntegrationProvider().build_integration(
+        provider = VstsIntegrationProvider()
+        pipeline = Mock()
+        pipeline.organization = self.organization
+        provider.set_pipeline(pipeline)
+        data = provider.build_integration(
             {
                 "account": {"accountName": self.vsts_account_name, "accountId": external_id},
                 "base_url": self.vsts_base_url,

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -97,8 +97,10 @@ class VstsIntegrationMigrationTest(VstsIntegrationTestCase):
         assert external_id == data["external_id"]
         subscription = data["metadata"]["subscription"]
         assert subscription["id"] is not None and subscription["secret"] is not None
-        assert set(data.get("metadata")["scopes"]) == set(NEW_SCOPES)
-        assert data.get("metadata")["integration_migration_version"] == 1
+        metadata = data.get("metadata")
+        assert metadata is not None
+        assert set(metadata["scopes"]) == set(NEW_SCOPES)
+        assert metadata["integration_migration_version"] == 1
 
         # Make sure the integration object is updated
         # ensure_integration will be called in _finish_pipeline


### PR DESCRIPTION
# Update:
i also updated the IdentityProvider logic so that it uses the new OAuth flow if the organization has the feature flag. the main difference between the existing provider and the new provider is i changed the `/authorize` and `/token` urls, the parameters we pass to each of these endpoints & updated the refresh token params.

---
Part of addressing: https://github.com/getsentry/sentry/issues/77570

In this pr, i add logic to migrate existing integrations to the new app. in the integration installation pipeline, we check for a `integration_migrated` key in metadata. If it doesn't exist, we create a new subscription and add it to the integration dict that `build_integration` returns. we will also set the `integration_migration` key to be True.

In `pipelin.py` - https://github.com/getsentry/sentry/blob/c1ebcc18b4c6a41311f45dee35482553feb0f922/src/sentry/integrations/pipeline.py#L88-L129

the data (the dict that we returned earlier) will then be passed to `ensure_integration`, which ends up saving the new user credentials as well as the migrated key:
https://github.com/getsentry/sentry/blob/c1ebcc18b4c6a41311f45dee35482553feb0f922/src/sentry/integrations/pipeline.py#L29-L41