### PR TITLE
fix(priority): Remove reference to default view in priority copy if custom views enabled

### DIFF
--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -179,9 +179,13 @@ function GroupPriorityLearnMore() {
         <strong>{t('Time to prioritize!')}</strong>
       </p>
       <p>
-        {t(
-          'Use priority to make your issue stream more actionable. Sentry will automatically assign a priority score to new issues and filter low priority issues from the default view.'
-        )}
+        {organization.features.includes('issue-stream-custom-views')
+          ? t(
+              'Use priority to make your issue stream more actionable. Sentry will automatically assign a priority score to new issues.'
+            )
+          : t(
+              'Use priority to make your issue stream more actionable. Sentry will automatically assign a priority score to new issues and filter low priority issues from the default view.'
+            )}
       </p>
       <LinkButton
         href="https://docs.sentry.io/product/issues/issue-priority/"


### PR DESCRIPTION
New, with feature flag:

> Use priority to make your issue stream more actionable. Sentry will automatically assign a priority score to new issues.


Old, without feature flag: 

> Use priority to make your issue stream more actionable. Sentry will automatically assign a priority score to new issues **and filter low priority issues from the default view.**


![Screenshot 2024-09-18 at 2 43 04 PM](https://github.com/user-attachments/assets/51675ac2-776b-48a9-853f-cc76ca5be63a)
