### PR TITLE
fix(tests): Fix act warnings in SearchQueryBuilder tests

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -805,6 +805,9 @@ describe('SearchQueryBuilder', function () {
 
       await userEvent.click(getLastInput());
 
+      // XXX(malwilley): SearchQueryBuilderInput updates state in the render
+      // function which causes an act warning despite using userEvent.click.
+      // Cannot find a way to avoid this warning.
       jest.spyOn(console, 'error').mockImplementation(jest.fn());
       await userEvent.type(screen.getByRole('combobox'), 'some free text brow');
       await userEvent.click(screen.getByRole('option', {name: 'browser.name'}));

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -2,6 +2,7 @@ import type {ComponentProps} from 'react';
 import {destroyAnnouncer} from '@react-aria/live-announcer';
 
 import {
+  act,
   render,
   screen,
   userEvent,
@@ -189,7 +190,7 @@ describe('SearchQueryBuilder', function () {
           onSearch={mockOnSearch}
         />
       );
-      userEvent.click(screen.getByRole('button', {name: 'Clear search query'}));
+      await userEvent.click(screen.getByRole('button', {name: 'Clear search query'}));
 
       await waitFor(() => {
         expect(mockOnChange).toHaveBeenCalledWith('', expect.anything());
@@ -203,7 +204,7 @@ describe('SearchQueryBuilder', function () {
       expect(screen.getByRole('combobox')).toHaveFocus();
     });
 
-    it('is hidden at small sizes', function () {
+    it('is hidden at small sizes', async function () {
       Object.defineProperty(Element.prototype, 'clientWidth', {value: 100});
       const mockOnChange = jest.fn();
       render(
@@ -213,6 +214,8 @@ describe('SearchQueryBuilder', function () {
           onChange={mockOnChange}
         />
       );
+      // Must await something to prevent act warnings
+      await act(tick);
 
       expect(
         screen.queryByRole('button', {name: 'Clear search query'})
@@ -221,7 +224,7 @@ describe('SearchQueryBuilder', function () {
   });
 
   describe('disabled', function () {
-    it('disables all interactable elements', function () {
+    it('disables all interactable elements', async function () {
       const mockOnChange = jest.fn();
       render(
         <SearchQueryBuilder
@@ -231,6 +234,8 @@ describe('SearchQueryBuilder', function () {
           disabled
         />
       );
+      // Must await something to prevent act warnings
+      await act(tick);
 
       expect(getLastInput()).toBeDisabled();
       expect(
@@ -800,9 +805,6 @@ describe('SearchQueryBuilder', function () {
 
       await userEvent.click(getLastInput());
 
-      // XXX(malwilley): SearchQueryBuilderInput updates state in the render
-      // function which causes an act warning despite using userEvent.click.
-      // Cannot find a way to avoid this warning.
       jest.spyOn(console, 'error').mockImplementation(jest.fn());
       await userEvent.type(screen.getByRole('combobox'), 'some free text brow');
       await userEvent.click(screen.getByRole('option', {name: 'browser.name'}));
@@ -1011,10 +1013,11 @@ describe('SearchQueryBuilder', function () {
         <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />
       );
 
-      // Focus into search (cursor be at end of the query)
-      screen
-        .getByRole('button', {name: 'Edit operator for filter: browser.name'})
-        .focus();
+      // Focus the filter operator dropdown
+      const opButton = await screen.findByRole('button', {
+        name: 'Edit operator for filter: browser.name',
+      });
+      await act(() => opButton.focus());
 
       // Pressing backspace once should focus the token
       await userEvent.keyboard('{backspace}');
@@ -1689,7 +1692,7 @@ describe('SearchQueryBuilder', function () {
         expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveFocus();
       });
 
-      it('collapses many selected options', function () {
+      it('collapses many selected options', async function () {
         render(
           <SearchQueryBuilder
             {...defaultProps}
@@ -1697,7 +1700,7 @@ describe('SearchQueryBuilder', function () {
           />
         );
 
-        const valueButton = screen.getByRole('button', {
+        const valueButton = await screen.findByRole('button', {
           name: 'Edit value for filter: browser.name',
         });
         expect(within(valueButton).getByText('one')).toBeInTheDocument();
@@ -2361,14 +2364,14 @@ describe('SearchQueryBuilder', function () {
         });
       });
 
-      it('displays absolute date value correctly (just date)', function () {
+      it('displays absolute date value correctly (just date)', async function () {
         render(<SearchQueryBuilder {...defaultProps} initialQuery="age:>=2017-10-17" />);
 
-        expect(screen.getByText('is on or after')).toBeInTheDocument();
+        expect(await screen.findByText('is on or after')).toBeInTheDocument();
         expect(screen.getByText('Oct 17')).toBeInTheDocument();
       });
 
-      it('displays absolute date value correctly (with local time)', function () {
+      it('displays absolute date value correctly (with local time)', async function () {
         render(
           <SearchQueryBuilder
             {...defaultProps}
@@ -2376,11 +2379,11 @@ describe('SearchQueryBuilder', function () {
           />
         );
 
-        expect(screen.getByText('is on or after')).toBeInTheDocument();
+        expect(await screen.findByText('is on or after')).toBeInTheDocument();
         expect(screen.getByText('Oct 17, 2:00 PM')).toBeInTheDocument();
       });
 
-      it('displays absolute date value correctly (with UTC time)', function () {
+      it('displays absolute date value correctly (with UTC time)', async function () {
         render(
           <SearchQueryBuilder
             {...defaultProps}
@@ -2388,7 +2391,7 @@ describe('SearchQueryBuilder', function () {
           />
         );
 
-        expect(screen.getByText('is on or after')).toBeInTheDocument();
+        expect(await screen.findByText('is on or after')).toBeInTheDocument();
         expect(screen.getByText('Oct 17, 2:00 PM UTC')).toBeInTheDocument();
       });
     });


### PR DESCRIPTION
Some tests did not await any act() functions which caused act warnings. These warnings were somehow covered up by a missing await early in the test suite (somehow).