### PR TITLE
fix(ecosystem): Breaks issue sync cycles

### DIFF
--- a/src/sentry/integrations/services/assignment_source.py
+++ b/src/sentry/integrations/services/assignment_source.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING
 
 from django.utils import timezone
+
+from sentry.utils import json
 
 if TYPE_CHECKING:
     from sentry.integrations.models import Integration
@@ -30,3 +32,13 @@ class AssignmentSource:
             source_name=integration.name,
             integration_id=integration.id,
         )
+
+    def json(self) -> str:
+        return json.dumps(asdict(self))
+
+    @classmethod
+    def from_json(cls, json_data: str) -> AssignmentSource | None:
+        try:
+            return cls(**json.loads(json_data))
+        except ValueError:
+            return None

--- a/src/sentry/integrations/services/assignment_source.py
+++ b/src/sentry/integrations/services/assignment_source.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from django.utils import timezone
+
+if TYPE_CHECKING:
+    from sentry.integrations.models import Integration
+    from sentry.integrations.services.integration import RpcIntegration
+
+
+class AssignmentSourceType(str, Enum):
+    integration = "integration"
+
+
+@dataclass(frozen=True)
+class AssignmentSource:
+    source_type: AssignmentSourceType
+    source_name: str
+    integration_id: int
+    queued: datetime = timezone.now()
+
+    @classmethod
+    def from_integration(cls, integration: Integration | RpcIntegration) -> AssignmentSource:
+        return AssignmentSource(
+            source_type=AssignmentSourceType.integration,
+            source_name=integration.name,
+            integration_id=integration.id,
+        )

--- a/src/sentry/integrations/services/assignment_source.py
+++ b/src/sentry/integrations/services/assignment_source.py
@@ -2,11 +2,9 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from django.utils import timezone
-
-from sentry.utils import json
 
 if TYPE_CHECKING:
     from sentry.integrations.models import Integration
@@ -26,12 +24,12 @@ class AssignmentSource:
             integration_id=integration.id,
         )
 
-    def json(self) -> str:
-        return json.dumps(asdict(self))
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
 
     @classmethod
-    def from_json(cls, json_data: str) -> AssignmentSource | None:
+    def from_dict(cls, input_dict: dict[str, Any]) -> AssignmentSource | None:
         try:
-            return cls(**json.loads(json_data))
-        except ValueError:
+            return cls(**input_dict)
+        except (ValueError, TypeError):
             return None

--- a/src/sentry/integrations/services/assignment_source.py
+++ b/src/sentry/integrations/services/assignment_source.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 from datetime import datetime
-from enum import Enum
 from typing import TYPE_CHECKING
 
 from django.utils import timezone
@@ -14,13 +13,8 @@ if TYPE_CHECKING:
     from sentry.integrations.services.integration import RpcIntegration
 
 
-class AssignmentSourceType(str, Enum):
-    integration = "integration"
-
-
 @dataclass(frozen=True)
 class AssignmentSource:
-    source_type: AssignmentSourceType
     source_name: str
     integration_id: int
     queued: datetime = timezone.now()
@@ -28,7 +22,6 @@ class AssignmentSource:
     @classmethod
     def from_integration(cls, integration: Integration | RpcIntegration) -> AssignmentSource:
         return AssignmentSource(
-            source_type=AssignmentSourceType.integration,
             source_name=integration.name,
             integration_id=integration.id,
         )

--- a/src/sentry/integrations/tasks/sync_assignee_outbound.py
+++ b/src/sentry/integrations/tasks/sync_assignee_outbound.py
@@ -31,7 +31,7 @@ def sync_assignee_outbound(
     external_issue_id: int,
     user_id: int | None,
     assign: bool,
-    assignment_source_dict: dict[str, Any] = None,
+    assignment_source_dict: dict[str, Any] | None = None,
 ) -> None:
     # Sync Sentry assignee to an external issue.
     external_issue = ExternalIssue.objects.get(id=external_issue_id)

--- a/src/sentry/integrations/tasks/sync_assignee_outbound.py
+++ b/src/sentry/integrations/tasks/sync_assignee_outbound.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from sentry import analytics, features
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration import Integration
@@ -29,7 +31,7 @@ def sync_assignee_outbound(
     external_issue_id: int,
     user_id: int | None,
     assign: bool,
-    assignment_source_json: str | None = None,
+    assignment_source_dict: dict[str, Any] = None,
 ) -> None:
     # Sync Sentry assignee to an external issue.
     external_issue = ExternalIssue.objects.get(id=external_issue_id)
@@ -49,7 +51,7 @@ def sync_assignee_outbound(
         return
 
     parsed_assignment_source = (
-        AssignmentSource.from_json(assignment_source_json) if assignment_source_json else None
+        AssignmentSource.from_dict(assignment_source_dict) if assignment_source_dict else None
     )
     if installation.should_sync("outbound_assignee", parsed_assignment_source):
         # Assume unassign if None.

--- a/src/sentry/integrations/utils/sync.py
+++ b/src/sentry/integrations/utils/sync.py
@@ -138,6 +138,6 @@ def sync_group_assignee_outbound(
                 "external_issue_id": external_issue_id,
                 "user_id": user_id,
                 "assign": assign,
-                "assignment_source": assignment_source,
+                "assignment_source_json": assignment_source.json() if assignment_source else None,
             }
         )

--- a/src/sentry/integrations/utils/sync.py
+++ b/src/sentry/integrations/utils/sync.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING
 
 from sentry import features
+from sentry.integrations.services.assignment_source import AssignmentSource
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.tasks.sync_assignee_outbound import sync_assignee_outbound
 from sentry.models.group import Group
@@ -92,8 +93,12 @@ def sync_group_assignee_inbound(
 
     if not assign:
         for group in affected_groups:
-            GroupAssignee.objects.deassign(group)
-        return affected_groups
+            GroupAssignee.objects.deassign(
+                group,
+                assignment_source=AssignmentSource.from_integration(integration),
+            )
+
+        return list(affected_groups)
 
     users = user_service.get_many_by_email(emails=[email], is_verified=True)
     users_by_id = {user.id: user for user in users}
@@ -104,14 +109,23 @@ def sync_group_assignee_inbound(
         user_id = get_user_id(projects_by_user, group)
         user = users_by_id.get(user_id)
         if user:
-            GroupAssignee.objects.assign(group, user)
+            GroupAssignee.objects.assign(
+                group,
+                user,
+                assignment_source=AssignmentSource.from_integration(integration),
+            )
             groups_assigned.append(group)
         else:
             logger.info("assignee-not-found-inbound", extra=log_context)
     return groups_assigned
 
 
-def sync_group_assignee_outbound(group: Group, user_id: int | None, assign: bool = True) -> None:
+def sync_group_assignee_outbound(
+    group: Group,
+    user_id: int | None,
+    assign: bool = True,
+    assignment_source: AssignmentSource | None = None,
+) -> None:
     from sentry.models.grouplink import GroupLink
 
     external_issue_ids = GroupLink.objects.filter(
@@ -120,5 +134,10 @@ def sync_group_assignee_outbound(group: Group, user_id: int | None, assign: bool
 
     for external_issue_id in external_issue_ids:
         sync_assignee_outbound.apply_async(
-            kwargs={"external_issue_id": external_issue_id, "user_id": user_id, "assign": assign}
+            kwargs={
+                "external_issue_id": external_issue_id,
+                "user_id": user_id,
+                "assign": assign,
+                "assignment_source": assignment_source,
+            }
         )

--- a/src/sentry/integrations/utils/sync.py
+++ b/src/sentry/integrations/utils/sync.py
@@ -98,7 +98,7 @@ def sync_group_assignee_inbound(
                 assignment_source=AssignmentSource.from_integration(integration),
             )
 
-        return list(affected_groups)
+        return affected_groups
 
     users = user_service.get_many_by_email(emails=[email], is_verified=True)
     users_by_id = {user.id: user for user in users}

--- a/src/sentry/integrations/utils/sync.py
+++ b/src/sentry/integrations/utils/sync.py
@@ -138,6 +138,8 @@ def sync_group_assignee_outbound(
                 "external_issue_id": external_issue_id,
                 "user_id": user_id,
                 "assign": assign,
-                "assignment_source_json": assignment_source.json() if assignment_source else None,
+                "assignment_source_dict": assignment_source.to_dict()
+                if assignment_source
+                else None,
             }
         )

--- a/tests/sentry/integrations/services/test_assignment_source.py
+++ b/tests/sentry/integrations/services/test_assignment_source.py
@@ -1,0 +1,36 @@
+from sentry.integrations.services.assignment_source import AssignmentSource
+from sentry.testutils.cases import TestCase
+
+
+class TestAssignmentSource(TestCase):
+    def test_from_dict_empty_array(self):
+        data = {}
+        result = AssignmentSource.from_dict(data)
+        assert result is None
+
+    def test_from_dict_inalid_data(self):
+        data = {
+            "foo": "bar",
+        }
+
+        result = AssignmentSource.from_dict(data)
+        assert result is None
+
+    def test_from_dict_valid_data(self):
+        data = {"source_name": "foo-source", "integration_id": 123}
+
+        result = AssignmentSource.from_dict(data)
+        assert result is not None
+        assert result.source_name == "foo-source"
+        assert result.integration_id == 123
+
+    def test_to_dict(self):
+        source = AssignmentSource(
+            source_name="foo-source",
+            integration_id=123,
+        )
+
+        result = source.to_dict()
+        assert result.get("queued") is not None
+        assert result.get("source_name") == "foo-source"
+        assert result.get("integration_id") == 123

--- a/tests/sentry/integrations/services/test_assignment_source.py
+++ b/tests/sentry/integrations/services/test_assignment_source.py
@@ -1,10 +1,12 @@
+from typing import Any
+
 from sentry.integrations.services.assignment_source import AssignmentSource
 from sentry.testutils.cases import TestCase
 
 
 class TestAssignmentSource(TestCase):
     def test_from_dict_empty_array(self):
-        data = {}
+        data: dict[str, Any] = {}
         result = AssignmentSource.from_dict(data)
         assert result is None
 

--- a/tests/sentry/models/test_groupassignee.py
+++ b/tests/sentry/models/test_groupassignee.py
@@ -151,7 +151,10 @@ class GroupAssigneeTestCase(TestCase):
                 GroupAssignee.objects.assign(self.group, self.user)
 
                 mock_sync_assignee_outbound.assert_called_with(
-                    external_issue, user_service.get_user(self.user.id), assign=True
+                    external_issue,
+                    user_service.get_user(self.user.id),
+                    assign=True,
+                    assignment_source=None,
                 )
 
                 assert GroupAssignee.objects.filter(
@@ -205,7 +208,9 @@ class GroupAssigneeTestCase(TestCase):
         with self.feature({"organizations:integrations-issue-sync": True}):
             with self.tasks():
                 GroupAssignee.objects.deassign(self.group)
-                mock_sync_assignee_outbound.assert_called_with(external_issue, None, assign=False)
+                mock_sync_assignee_outbound.assert_called_with(
+                    external_issue, None, assign=False, assignment_source=None
+                )
 
                 assert not GroupAssignee.objects.filter(
                     project=self.group.project,


### PR DESCRIPTION
## The problem:
When a Jira issue's `assignee` field is quickly modified multiple times in a row, we end up assigning and resyncing the assignees to Jira, which causes a loop. This is because _all_ inbound integration webhooks that modify an issue assignment generate an outbound update for all issue sync integrations as well.

## Solution:
This PR adds a new `AssignmentSource` dataclass, which acts as a context carrier when an external webhook triggers an issue assignment change. This is then checked on the outbound sync logic, preventing the change from being propagated to the same integration that initially triggered the change.

