### PR TITLE
ref(alerts): Update Snuba queries to match events-stats more closely

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -43,11 +43,12 @@ from sentry.utils.snuba import MAX_FIELDS, SnubaTSResult
 
 
 def get_query_columns(columns, rollup):
-    # Backwards compatibility for incidents which uses the old
-    # column aliases as it straddles both versions of events/discover.
-    # We will need these aliases until discover2 flags are enabled for all
-    # users.
-    # We need these rollup columns to generate correct events-stats results
+    """
+    Backwards compatibility for incidents which uses the old
+    column aliases as it straddles both versions of events/discover.
+    We will need these aliases until discover2 flags are enabled for all users.
+    We need these rollup columns to generate correct events-stats results
+    """
     column_map = {
         "user_count": "count_unique(user)",
         "event_count": "count()",

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -42,6 +42,26 @@ from sentry.utils.http import absolute_uri
 from sentry.utils.snuba import MAX_FIELDS, SnubaTSResult
 
 
+def get_query_columns(columns, rollup):
+    # Backwards compatibility for incidents which uses the old
+    # column aliases as it straddles both versions of events/discover.
+    # We will need these aliases until discover2 flags are enabled for all
+    # users.
+    # We need these rollup columns to generate correct events-stats results
+    column_map = {
+        "user_count": "count_unique(user)",
+        "event_count": "count()",
+        "epm()": "epm(%d)" % rollup,
+        "eps()": "eps(%d)" % rollup,
+        "tpm()": "tpm(%d)" % rollup,
+        "tps()": "tps(%d)" % rollup,
+        "sps()": "sps(%d)" % rollup,
+        "spm()": "spm(%d)" % rollup,
+    }
+
+    return [column_map.get(column, column) for column in columns]
+
+
 def resolve_axis_column(column: str, index: int = 0) -> str:
     return get_function_alias(column) if not is_equation(column) else f"equation[{index}]"
 
@@ -438,30 +458,13 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                     date_range = snuba_params.date_range
                     stats_period = parse_stats_period(get_interval_from_range(date_range, False))
                     rollup = int(stats_period.total_seconds()) if stats_period is not None else 3600
-
                 if comparison_delta is not None:
                     retention = quotas.get_event_retention(organization=organization)
                     comparison_start = snuba_params.start_date - comparison_delta
                     if retention and comparison_start < timezone.now() - timedelta(days=retention):
                         raise ValidationError("Comparison period is outside your retention window")
 
-                # Backwards compatibility for incidents which uses the old
-                # column aliases as it straddles both versions of events/discover.
-                # We will need these aliases until discover2 flags are enabled for all
-                # users.
-                # We need these rollup columns to generate correct events-stats results
-                column_map = {
-                    "user_count": "count_unique(user)",
-                    "event_count": "count()",
-                    "epm()": "epm(%d)" % rollup,
-                    "eps()": "eps(%d)" % rollup,
-                    "tpm()": "tpm(%d)" % rollup,
-                    "tps()": "tps(%d)" % rollup,
-                    "sps()": "sps(%d)" % rollup,
-                    "spm()": "spm(%d)" % rollup,
-                }
-
-                query_columns = [column_map.get(column, column) for column in columns]
+                query_columns = get_query_columns(columns, rollup)
             with sentry_sdk.start_span(op="discover.endpoint", description="base.stats_query"):
                 result = get_event_stats(
                     query_columns, query, snuba_params, rollup, zerofill_results, comparison_delta

--- a/src/sentry/incidents/endpoints/organization_alert_rule_anomalies.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_anomalies.py
@@ -66,7 +66,9 @@ class OrganizationAlertRuleAnomaliesEndpoint(OrganizationAlertRuleEndpoint):
                 status=400,
             )
 
-        anomalies = get_historical_anomaly_data_from_seer(alert_rule, project, start, end)
+        anomalies = get_historical_anomaly_data_from_seer(
+            alert_rule=alert_rule, project=project, start_string=start, end_string=end
+        )
         # NOTE: returns None if there's a problem with the Seer response
         if anomalies is None:
             return Response("Unable to get historical anomaly data", status=400)

--- a/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
+++ b/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
@@ -82,7 +82,10 @@ def get_historical_anomaly_data_from_seer(
         )
         return None
     formatted_data = format_historical_data(
-        historical_data, query_columns, dataset, project.organization
+        data=historical_data,
+        query_columns=query_columns,
+        dataset=dataset,
+        organization=project.organization,
     )
     if (
         not alert_rule.sensitivity

--- a/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
+++ b/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from django.conf import settings
 from urllib3.exceptions import MaxRetryError, TimeoutError
 
+from sentry.api.bases.organization_events import get_query_columns
 from sentry.conf.server import SEER_ANOMALY_DETECTION_ENDPOINT_URL
 from sentry.incidents.models.alert_rule import AlertRule, AlertRuleStatus
 from sentry.models.project import Project
@@ -58,8 +59,14 @@ def get_historical_anomaly_data_from_seer(
     window_min = int(snuba_query.time_window / 60)
     start = datetime.fromisoformat(start_string)
     end = datetime.fromisoformat(end_string)
+    query_columns = get_query_columns([snuba_query.aggregate], snuba_query.time_window)
     historical_data = fetch_historical_data(
-        alert_rule=alert_rule, snuba_query=snuba_query, project=project, start=start, end=end
+        alert_rule=alert_rule,
+        snuba_query=snuba_query,
+        query_columns=query_columns,
+        project=project,
+        start=start,
+        end=end,
     )
 
     if not historical_data:
@@ -74,7 +81,7 @@ def get_historical_anomaly_data_from_seer(
             },
         )
         return None
-    formatted_data = format_historical_data(historical_data, dataset)
+    formatted_data = format_historical_data(historical_data, query_columns, dataset)
     if (
         not alert_rule.sensitivity
         or not alert_rule.seasonality

--- a/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
+++ b/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
@@ -81,7 +81,9 @@ def get_historical_anomaly_data_from_seer(
             },
         )
         return None
-    formatted_data = format_historical_data(historical_data, query_columns, dataset)
+    formatted_data = format_historical_data(
+        historical_data, query_columns, dataset, project.organization
+    )
     if (
         not alert_rule.sensitivity
         or not alert_rule.seasonality

--- a/src/sentry/seer/anomaly_detection/store_data.py
+++ b/src/sentry/seer/anomaly_detection/store_data.py
@@ -65,13 +65,18 @@ def send_historical_data_to_seer(alert_rule: AlertRule, project: Project) -> Ale
     window_min = int(snuba_query.time_window / 60)
     dataset = get_dataset(snuba_query.dataset)
     query_columns = get_query_columns([snuba_query.aggregate], snuba_query.time_window)
-    historical_data = fetch_historical_data(alert_rule, snuba_query, query_columns, project)
+    historical_data = fetch_historical_data(
+        alert_rule=alert_rule, snuba_query=snuba_query, query_columns=query_columns, project=project
+    )
 
     if not historical_data:
         raise ValidationError("No historical data available.")
 
     formatted_data = format_historical_data(
-        historical_data, query_columns, dataset, project.organization
+        data=historical_data,
+        query_column=query_columns,
+        dataset=dataset,
+        organization=project.organization,
     )
     if not formatted_data:
         raise ValidationError("Unable to get historical data for this alert.")

--- a/src/sentry/seer/anomaly_detection/store_data.py
+++ b/src/sentry/seer/anomaly_detection/store_data.py
@@ -74,7 +74,7 @@ def send_historical_data_to_seer(alert_rule: AlertRule, project: Project) -> Ale
 
     formatted_data = format_historical_data(
         data=historical_data,
-        query_column=query_columns,
+        query_columns=query_columns,
         dataset=dataset,
         organization=project.organization,
     )

--- a/src/sentry/seer/anomaly_detection/store_data.py
+++ b/src/sentry/seer/anomaly_detection/store_data.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ValidationError
 from parsimonious.exceptions import ParseError
 from urllib3.exceptions import MaxRetryError, TimeoutError
 
+from sentry.api.bases.organization_events import get_query_columns
 from sentry.conf.server import SEER_ANOMALY_DETECTION_STORE_DATA_URL
 from sentry.incidents.models.alert_rule import AlertRule, AlertRuleStatus
 from sentry.models.project import Project
@@ -63,12 +64,15 @@ def send_historical_data_to_seer(alert_rule: AlertRule, project: Project) -> Ale
     snuba_query = SnubaQuery.objects.get(id=alert_rule.snuba_query_id)
     window_min = int(snuba_query.time_window / 60)
     dataset = get_dataset(snuba_query.dataset)
-    historical_data = fetch_historical_data(alert_rule, snuba_query, project)
+    query_columns = get_query_columns([snuba_query.aggregate], snuba_query.time_window)
+    historical_data = fetch_historical_data(alert_rule, snuba_query, query_columns, project)
 
     if not historical_data:
         raise ValidationError("No historical data available.")
 
-    formatted_data = format_historical_data(historical_data, dataset)
+    formatted_data = format_historical_data(
+        historical_data, query_columns, dataset, project.organization
+    )
     if not formatted_data:
         raise ValidationError("Unable to get historical data for this alert.")
 

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -108,9 +108,12 @@ def format_historical_data(
 
     for data in serialized_result.get("data"):
         if len(data) > 1:
-            ts = data[0]
-            count = data[1]
-            ts_point = TimeSeriesPoint(timestamp=ts, value=count[0].get("count", 0))
+            count_data = data[1]
+            if not len(count_data):
+                count = 0
+            else:
+                count = count[0].get("count", 0)
+            ts_point = TimeSeriesPoint(timestamp=data[0], value=count)
             formatted_data.append(ts_point)
 
     return formatted_data

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -177,11 +177,8 @@ def fetch_historical_data(
     if dataset_label == "events":
         # DATASET_OPTIONS expects the name 'errors'
         dataset_label = "errors"
-    elif dataset_label == "generic_metrics":
-        # XXX: performance alerts in prod
-        dataset_label = "transactions"
-    elif dataset_label == "transactions":
-        # XXX: performance alerts locally
+    elif dataset_label in ["generic_metrics", "transactions"]:
+        # XXX: performance alerts dataset differs locally vs in prod
         dataset_label = "discover"
     dataset = get_dataset(dataset_label)
 

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -151,6 +151,10 @@ def fetch_historical_data(
     if not project or not dataset or not alert_rule.organization:
         return None
 
+    environments = []
+    if snuba_query.environment:
+        environments = [snuba_query.environment]
+
     if dataset == metrics_performance:
         return get_crash_free_historical_data(
             start, end, project, alert_rule.organization, granularity
@@ -165,7 +169,7 @@ def fetch_historical_data(
                 start=start,
                 end=end,
                 stats_period=None,
-                environments=[snuba_query.environment],
+                environments=environments,
             ),
             rollup=granularity,
             referrer=(

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -59,12 +59,7 @@ def get_snuba_query_string(snuba_query: SnubaQuery) -> str:
         # e.g. (is:unresolved) AND (event.type:error)
         snuba_query_event_type_string = SNUBA_QUERY_EVENT_TYPE_TO_STRING[snuba_query.event_types[0]]
         event_types_string = f"(event.type:{snuba_query_event_type_string})"
-    # this is hacky as heck but if the query is just like level:error (non is: query), only put that and skip the event types
-    # this won't even work if there's a sneaky is: query in the middle of several queries
-    # try to find how this is handled in events-stats
-    if snuba_query.query and not snuba_query.query.startswith("is:"):
-        snuba_query_string = snuba_query.query
-    elif snuba_query.query:
+    if snuba_query.query:
         snuba_query_string = f"({snuba_query.query}) AND {event_types_string}"
     else:
         snuba_query_string = event_types_string

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -59,8 +59,12 @@ def get_snuba_query_string(snuba_query: SnubaQuery) -> str:
         # e.g. (is:unresolved) AND (event.type:error)
         snuba_query_event_type_string = SNUBA_QUERY_EVENT_TYPE_TO_STRING[snuba_query.event_types[0]]
         event_types_string = f"(event.type:{snuba_query_event_type_string})"
-
-    if snuba_query.query:
+    # this is hacky as heck but if the query is just like level:error (non is: query), only put that and skip the event types
+    # this won't even work if there's a sneaky is: query in the middle of several queries
+    # try to find how this is handled in events-stats
+    if snuba_query.query and not snuba_query.query.startswith("is:"):
+        snuba_query_string = snuba_query.query
+    elif snuba_query.query:
         snuba_query_string = f"({snuba_query.query}) AND {event_types_string}"
     else:
         snuba_query_string = event_types_string

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -89,7 +89,7 @@ def format_historical_data(
         data,
         resolve_axis_column(query_columns[0]),
         allow_partial_buckets=False,
-        zerofill_results=True,
+        zerofill_results=False,
         extra_columns=None,
     )
     formatted_data: list[TimeSeriesPoint] = []
@@ -151,7 +151,6 @@ def fetch_historical_data(
         return get_crash_free_historical_data(
             start, end, project, alert_rule.organization, granularity
         )
-
     else:
         historical_data = dataset.timeseries_query(
             selected_columns=query_columns,

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -109,10 +109,9 @@ def format_historical_data(
     for data in serialized_result.get("data"):
         if len(data) > 1:
             count_data = data[1]
-            if not len(count_data):
-                count = 0
-            else:
-                count = count[0].get("count", 0)
+            count = 0
+            if len(count_data):
+                count = count_data[0].get("count", 0)
             ts_point = TimeSeriesPoint(timestamp=data[0], value=count)
             formatted_data.append(ts_point)
 

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -107,9 +107,11 @@ def format_historical_data(
     #         formatted_data.append(ts_point)
 
     for data in serialized_result.get("data"):
-        ts, count = data
-        ts_point = TimeSeriesPoint(timestamp=ts, value=count[0].get("count", 0))
-        formatted_data.append(ts_point)
+        if len(data) > 1:
+            ts = data[0]
+            count = data[1]
+            ts_point = TimeSeriesPoint(timestamp=ts, value=count[0].get("count", 0))
+            formatted_data.append(ts_point)
 
     return formatted_data
 

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -965,9 +965,6 @@ class Factories:
         normalized_data = manager.get_data()
         event = None
 
-        if event_type == EventType.ERROR and normalized_data.get("type") == "default":
-            normalized_data["type"] = "error"
-
         # When fingerprint is present on transaction, inject performance problems
         if (
             normalized_data.get("type") == "transaction"

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -965,6 +965,9 @@ class Factories:
         normalized_data = manager.get_data()
         event = None
 
+        if event_type == EventType.ERROR and normalized_data.get("type") == "default":
+            normalized_data["type"] = "error"
+
         # When fingerprint is present on transaction, inject performance problems
         if (
             normalized_data.get("type") == "transaction"

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_anomalies.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_anomalies.py
@@ -14,7 +14,6 @@ from sentry.incidents.models.alert_rule import (
 )
 from sentry.seer.anomaly_detection.types import AnomalyType, StoreDataResponse
 from sentry.testutils.cases import SnubaTestCase
-from sentry.testutils.factories import EventType
 from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.outbox import outbox_runner
@@ -49,8 +48,8 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
                     "timestamp": iso_format(two_weeks_ago + timedelta(minutes=1)),
                     "fingerprint": ["group1"],
                     "tags": {"sentry:user": self.user.email},
+                    "exception": [{"value": "BadError"}],
                 },
-                event_type=EventType.ERROR,
                 project_id=self.project.id,
             )
             self.store_event(
@@ -60,8 +59,8 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
                     "timestamp": iso_format(two_weeks_ago + timedelta(days=10)),
                     "fingerprint": ["group2"],
                     "tags": {"sentry:user": self.user.email},
+                    "exception": [{"value": "BadError"}],
                 },
-                event_type=EventType.ERROR,
                 project_id=self.project.id,
             )
         seer_store_data_return_value: StoreDataResponse = {"success": True}
@@ -76,7 +75,6 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
             detection_type=AlertRuleDetectionType.DYNAMIC,
         )
         self.login_as(self.user)
-
         seer_return_value = {
             "success": True,
             "timeseries": [
@@ -170,8 +168,8 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
                     "timestamp": iso_format(two_weeks_ago + timedelta(minutes=1)),
                     "fingerprint": ["group1"],
                     "tags": {"sentry:user": self.user.email},
+                    "exception": [{"value": "BadError"}],
                 },
-                event_type=EventType.ERROR,
                 project_id=self.project.id,
             )
             self.store_event(
@@ -181,8 +179,8 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
                     "timestamp": iso_format(two_weeks_ago + timedelta(days=10)),
                     "fingerprint": ["group2"],
                     "tags": {"sentry:user": self.user.email},
+                    "exception": [{"value": "BadError"}],
                 },
-                event_type=EventType.ERROR,
                 project_id=self.project.id,
             )
 
@@ -242,8 +240,8 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
                     "timestamp": iso_format(two_weeks_ago + timedelta(minutes=1)),
                     "fingerprint": ["group1"],
                     "tags": {"sentry:user": self.user.email},
+                    "exception": [{"value": "BadError"}],
                 },
-                event_type=EventType.ERROR,
                 project_id=self.project.id,
             )
             self.store_event(
@@ -253,8 +251,8 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
                     "timestamp": iso_format(two_weeks_ago + timedelta(days=10)),
                     "fingerprint": ["group2"],
                     "tags": {"sentry:user": self.user.email},
+                    "exception": [{"value": "BadError"}],
                 },
-                event_type=EventType.ERROR,
                 project_id=self.project.id,
             )
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_anomalies.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_anomalies.py
@@ -75,7 +75,6 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
             seasonality=AlertRuleSeasonality.AUTO,
             detection_type=AlertRuleDetectionType.DYNAMIC,
         )
-
         self.login_as(self.user)
 
         seer_return_value = {

--- a/tests/sentry/seer/anomaly_detection/test_store_data.py
+++ b/tests/sentry/seer/anomaly_detection/test_store_data.py
@@ -10,7 +10,6 @@ from sentry.snuba import errors, metrics_performance
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import SnubaQuery
 from sentry.testutils.cases import BaseMetricsTestCase, PerformanceIssueTestCase
-from sentry.testutils.factories import EventType
 from sentry.testutils.helpers.datetime import iso_format
 from sentry.testutils.performance_issues.event_generators import get_event
 from sentry.utils.snuba import SnubaTSResult
@@ -97,8 +96,8 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase, Performa
                     "timestamp": iso_format(self.time_1_dt),
                     "fingerprint": ["group1"],
                     "tags": {"sentry:user": self.user.email},
+                    "exception": [{"value": "BadError"}],
                 },
-                event_type=EventType.ERROR,
                 project_id=self.project.id,
             )
             self.store_event(
@@ -108,8 +107,8 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase, Performa
                     "timestamp": iso_format(self.time_2_dt),
                     "fingerprint": ["group2"],
                     "tags": {"sentry:user": self.user.email},
+                    "exception": [{"value": "BadError"}],
                 },
-                event_type=EventType.ERROR,
                 project_id=self.project.id,
             )
         result = fetch_historical_data(alert_rule, snuba_query, ["count()"], self.project)
@@ -131,8 +130,8 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase, Performa
                     "timestamp": iso_format(self.time_1_dt),
                     "fingerprint": ["group1"],
                     "tags": {"sentry:user": self.user.email},
+                    "exception": [{"value": "BadError"}],
                 },
-                event_type=EventType.ERROR,
                 project_id=self.project.id,
             )
             self.store_event(
@@ -142,8 +141,8 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase, Performa
                     "timestamp": iso_format(self.time_2_dt),
                     "fingerprint": ["group2"],
                     "tags": {"sentry:user": self.user.email},
+                    "exception": [{"value": "BadError"}],
                 },
-                event_type=EventType.ERROR,
                 project_id=self.project.id,
             )
         result = fetch_historical_data(alert_rule, snuba_query, ["count()"], self.project)

--- a/tests/sentry/seer/anomaly_detection/test_store_data.py
+++ b/tests/sentry/seer/anomaly_detection/test_store_data.py
@@ -153,9 +153,7 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase, Performa
             "intervals": [self.time_1, self.time_2],
         }
         data = SnubaTSResult({"data": snuba_raw_data}, self.time_1, self.time_2, 3600)
-        result = format_historical_data(
-            data, ["count()"], metrics_performance, format_historical_data
-        )
+        result = format_historical_data(data, ["count()"], metrics_performance, self.organization)
         assert result == expected_return_value
 
     def test_anomaly_detection_fetch_historical_data_crash_rate_alert(self):

--- a/tests/sentry/seer/anomaly_detection/test_store_data.py
+++ b/tests/sentry/seer/anomaly_detection/test_store_data.py
@@ -88,6 +88,11 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase, Performa
     def test_anomaly_detection_fetch_historical_data(self):
         alert_rule = self.create_alert_rule(organization=self.organization, projects=[self.project])
         snuba_query = SnubaQuery.objects.get(id=alert_rule.snuba_query_id)
+        # CEO: despite passing event_type to store_event, the event type is default
+        # so we'll just update the type it's looking for to default
+        snuba_query_event_type = SnubaQueryEventType.objects.get(snuba_query=snuba_query)
+        snuba_query_event_type.type = SnubaQueryEventType.EventType.DEFAULT.value
+        snuba_query_event_type.save()
 
         with self.options({"issues.group_attributes.send_kafka": True}):
             self.store_event(

--- a/tests/sentry/seer/anomaly_detection/test_store_data.py
+++ b/tests/sentry/seer/anomaly_detection/test_store_data.py
@@ -8,7 +8,7 @@ from sentry.incidents.models.alert_rule import AlertRuleThresholdType
 from sentry.seer.anomaly_detection.utils import fetch_historical_data, format_historical_data
 from sentry.snuba import errors, metrics_performance
 from sentry.snuba.dataset import Dataset
-from sentry.snuba.models import SnubaQuery, SnubaQueryEventType
+from sentry.snuba.models import SnubaQuery
 from sentry.testutils.cases import BaseMetricsTestCase, PerformanceIssueTestCase
 from sentry.testutils.factories import EventType
 from sentry.testutils.helpers.datetime import iso_format
@@ -88,11 +88,6 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase, Performa
     def test_anomaly_detection_fetch_historical_data(self):
         alert_rule = self.create_alert_rule(organization=self.organization, projects=[self.project])
         snuba_query = SnubaQuery.objects.get(id=alert_rule.snuba_query_id)
-        # CEO: despite passing event_type to store_event, the event type is default
-        # so we'll just update the type it's looking for to default
-        snuba_query_event_type = SnubaQueryEventType.objects.get(snuba_query=snuba_query)
-        snuba_query_event_type.type = SnubaQueryEventType.EventType.DEFAULT.value
-        snuba_query_event_type.save()
 
         with self.options({"issues.group_attributes.send_kafka": True}):
             self.store_event(
@@ -126,12 +121,7 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase, Performa
         alert_rule = self.create_alert_rule(organization=self.organization, projects=[self.project])
         snuba_query = SnubaQuery.objects.get(id=alert_rule.snuba_query_id)
         snuba_query.query = "is:unresolved"
-        # CEO: despite passing event_type to store_event, the event type is default
-        # so we'll just update the type it's looking for to default
-        snuba_query_event_type = SnubaQueryEventType.objects.get(snuba_query=snuba_query)
-        snuba_query_event_type.type = SnubaQueryEventType.EventType.DEFAULT.value
         snuba_query.save()
-        snuba_query_event_type.save()
 
         with self.options({"issues.group_attributes.send_kafka": True}):
             self.store_event(

--- a/tests/sentry/seer/anomaly_detection/test_store_data.py
+++ b/tests/sentry/seer/anomaly_detection/test_store_data.py
@@ -178,7 +178,6 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase, Performa
         assert {"time": int(event1.datetime.timestamp()), "count": 1} in result.data.get("data")
         assert {"time": int(event2.datetime.timestamp()), "count": 1} in result.data.get("data")
 
-    @pytest.mark.skip(reason="changed everything else and need to revisit this")
     def test_anomaly_detection_format_historical_data_crash_rate_alert(self):
         expected_return_value = [
             {"timestamp": self.time_1_ts, "value": 0},
@@ -200,7 +199,6 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase, Performa
         result = format_historical_data(data, ["count()"], metrics_performance, self.organization)
         assert result == expected_return_value
 
-    @pytest.mark.skip(reason="changed everything else and need to revisit this")
     def test_anomaly_detection_fetch_historical_data_crash_rate_alert(self):
         self.store_session(
             self.build_session(


### PR DESCRIPTION
When a user creates an anomaly detection alert we need to query snuba for 28 days worth of historical data to send to Seer to calculate the anomalies.  Originally (https://github.com/getsentry/sentry/pull/74614) I'd tried to pull out the relevant parts of the `events-stats` endpoint to mimic the data we see populated in metric alert preview charts (but for a larger time period, and it's happening after the rule is saved so I can't use any of the `request` object stuff) but I think I missed some things, so this PR aims to make that data be the same. 

Closes https://getsentry.atlassian.net/browse/ALRT-288 (hopefully)