### PR TITLE
fix(replay): Allow replay player instances to optionally be interactable/scrollable

### DIFF
--- a/static/app/components/replays/player/replayPlayer.tsx
+++ b/static/app/components/replays/player/replayPlayer.tsx
@@ -79,6 +79,7 @@ function useReplayerInstance() {
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
   css?: Interpolation<Theme>;
+  ['data-inspectable']?: boolean;
   offsetMs?: undefined | number;
 }
 

--- a/static/app/components/replays/player/replayPlayer.tsx
+++ b/static/app/components/replays/player/replayPlayer.tsx
@@ -79,7 +79,7 @@ function useReplayerInstance() {
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
   css?: Interpolation<Theme>;
-  ['data-inspectable']?: boolean;
+  inspectable?: boolean;
   offsetMs?: undefined | number;
 }
 

--- a/static/app/components/replays/player/styles.tsx
+++ b/static/app/components/replays/player/styles.tsx
@@ -18,7 +18,9 @@ export const baseReplayerCss = css`
   .replayer-wrapper > iframe {
     border: none;
     background: white;
+  }
 
+  &[data-inspectable='true'] .replayer-wrapper > iframe {
     /* Set pointer-events to make it easier to right-click & inspect */
     pointer-events: initial !important;
   }

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -33,7 +33,7 @@ interface Props {
    * diffs, people interact with the
    *
    */
-  ['data-inspectable']?: boolean;
+  inspectable?: boolean;
   /**
    * Use when the player is shown in an embedded preview context.
    */
@@ -83,7 +83,7 @@ function BasePlayerRoot({
   className,
   overlayContent,
   isPreview = false,
-  'data-inspectable': dataInspectable,
+  inspectable,
 }: Props) {
   const {
     dimensions: videoDimensions,
@@ -173,7 +173,7 @@ function BasePlayerRoot({
         </Overlay>
       )}
       <StyledNegativeSpaceContainer ref={windowEl} className="sentry-block">
-        <div ref={viewEl} className={className} data-inspectable={dataInspectable} />
+        <div ref={viewEl} className={className} data-inspectable={inspectable} />
         {fastForwardSpeed ? <PositionedFastForward speed={fastForwardSpeed} /> : null}
         {isBuffering || isVideoBuffering ? <PositionedBuffering /> : null}
         {isPreview || isVideoReplay || isFetching ? null : <PlayerDOMAlert />}

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -21,6 +21,20 @@ type Dimensions = ReturnType<typeof useReplayContext>['dimensions'];
 interface Props {
   className?: string;
   /**
+   * When the player is "inspectable" it'll capture the mouse and things like
+   * css :hover properties will be applied.
+   * This makes it easier to Right-Click > Inspect Dom Element
+   * But it also makes it harder to have sliders or mouse interactions that overlay
+   * on top of the player.
+   *
+   * Therefore, in cases where the replay is in a debugging/video context it
+   * should be interactable.
+   * But when the player is used for things like static rendering or hydration
+   * diffs, people interact with the
+   *
+   */
+  ['data-inspectable']?: boolean;
+  /**
    * Use when the player is shown in an embedded preview context.
    */
   isPreview?: boolean;
@@ -65,7 +79,12 @@ function useVideoSizeLogger({
   }, [organization, windowDimensions, videoDimensions, didLog, analyticsContext]);
 }
 
-function BasePlayerRoot({className, overlayContent, isPreview = false}: Props) {
+function BasePlayerRoot({
+  className,
+  overlayContent,
+  isPreview = false,
+  'data-inspectable': dataInspectable,
+}: Props) {
   const {
     dimensions: videoDimensions,
     fastForwardSpeed,
@@ -154,7 +173,7 @@ function BasePlayerRoot({className, overlayContent, isPreview = false}: Props) {
         </Overlay>
       )}
       <StyledNegativeSpaceContainer ref={windowEl} className="sentry-block">
-        <div ref={viewEl} className={className} />
+        <div ref={viewEl} className={className} data-inspectable={dataInspectable} />
         {fastForwardSpeed ? <PositionedFastForward speed={fastForwardSpeed} /> : null}
         {isBuffering || isVideoBuffering ? <PositionedBuffering /> : null}
         {isPreview || isVideoReplay || isFetching ? null : <PlayerDOMAlert />}

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -56,7 +56,7 @@ function ReplayView({toggleFullscreen, isLoading}: Props) {
             <FluidHeight>
               <CanvasSupportNotice />
               <Panel>
-                <ReplayPlayer />
+                <ReplayPlayer data-inspectable />
               </Panel>
             </FluidHeight>
           )}

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -56,7 +56,7 @@ function ReplayView({toggleFullscreen, isLoading}: Props) {
             <FluidHeight>
               <CanvasSupportNotice />
               <Panel>
-                <ReplayPlayer data-inspectable />
+                <ReplayPlayer inspectable />
               </Panel>
             </FluidHeight>
           )}


### PR DESCRIPTION
This is a followup of https://github.com/getsentry/sentry/pull/77647

What we really want is for the main player instance (and maybe other players around the app, but none are set so far) to allow interaction and be cool like that. Instances inside the diff tools (for example) should not capture mouse/pointer events because it conflicts with the diff-slider tool.