### PR TITLE
ref(buffer): Update `Buffer.incr`-related docstrings

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -104,10 +104,24 @@ class Buffer(Service):
     ) -> None:
         """
         >>> incr(Group, columns={'times_seen': 1}, filters={'pk': group.pk})
-        signal_only - added to indicate that `process` should only call the complete
-        signal handler with the updated model and skip creates/updates in the database. this
-        is useful in cases where we need to do additional processing before writing to the
-        database and opt to do it in a `buffer_incr_complete` receiver.
+
+        model - The model whose records will be updated
+
+        columns - Columns whose values should be incremented, in the form
+        { column_name: increment_amount }
+
+        filters - kwargs to pass to `<model_class>.objects.get` to select the records which will be
+        updated
+
+        extra - Other columns whose values should be changed, in the form
+        { column_name: new_value }. This is separate from `columns` because existing values in those
+        columns are incremented, whereas existing values in these columns are fully overwritten with
+        the new values.
+
+        signal_only - Added to indicate that `process` should only call the `buffer_incr_complete`
+        signal handler with the updated model and skip creates/updates in the database. This is useful
+        in cases where we need to do additional processing before writing to the database and opt to do
+        it in a `buffer_incr_complete` receiver.
         """
         process_incr.apply_async(
             kwargs={

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2209,9 +2209,9 @@ def _process_existing_aggregate(
         "title": _get_updated_group_title(existing_metadata, incoming_metadata),
     }
 
-    update_kwargs = {"times_seen": 1}
-
-    buffer_incr(Group, update_kwargs, {"id": group.id}, updated_group_values)
+    # We pass `times_seen` separately from all of the other columns so that `buffer_inr` knows to
+    # increment rather than overwrite the existing value
+    buffer_incr(Group, {"times_seen": 1}, {"id": group.id}, updated_group_values)
 
     return bool(is_regression)
 

--- a/src/sentry/tasks/process_buffer.py
+++ b/src/sentry/tasks/process_buffer.py
@@ -67,9 +67,10 @@ def process_incr(**kwargs):
 
 def buffer_incr(model, *args, **kwargs):
     """
-    Call `buffer.incr` task, resolving the model name first.
+    Call `buffer.incr` as a task on the given model, either directly or via celery depending on
+    `settings.SENTRY_BUFFER_INCR_AS_CELERY_TASK`.
 
-    `model_name` must be in form `app_label.model_name` e.g. `sentry.group`.
+    See `Buffer.incr` for an explanation of the args and kwargs to pass here.
     """
     (buffer_incr_task.delay if settings.SENTRY_BUFFER_INCR_AS_CELERY_TASK else buffer_incr_task)(
         app_label=model._meta.app_label, model_name=model._meta.model_name, args=args, kwargs=kwargs
@@ -83,6 +84,8 @@ def buffer_incr(model, *args, **kwargs):
 def buffer_incr_task(app_label, model_name, args, kwargs):
     """
     Call `buffer.incr`, resolving the model first.
+
+    `model_name` must be in form `app_label.model_name` e.g. `sentry.group`.
     """
     from sentry import buffer
 


### PR DESCRIPTION
This updates the docstrings for a few functions related to the `Buffer.incr` method. It also cleans up and adds a comment to the particular use of `buffer_incr` which prompted me to figure out how `Buffer.incr` works in the first place.