### PR TITLE
chore(relocation) Move trap for stuck outbox

### DIFF
--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -165,10 +165,11 @@ def process_relocation_reply_with_export(payload: Mapping[str, Any], **kwds):
     try:
         encrypted_bytes = relocation_storage.open(path)
     except Exception:
-        # TODO(mark) remove this after the stuck outbox is cleared
-        if slug == "test-reloc-ct":
-            return
         raise FileNotFoundError("Could not open SaaS -> SaaS export in proxy relocation bucket.")
+
+    # TODO(mark) remove this after the stuck outbox is cleared
+    if slug == "test-reloc-ct":
+        return
 
     with encrypted_bytes:
         region_relocation_export_service.reply_with_export(


### PR DESCRIPTION
I misread the stacktrace and the escape needs to be when reading the file, not opening it. Bailing early feels like the simplest solution, and will be easy to remove later today.

Fixes SENTRY-3CS1