### PR TITLE
ref(dx): Detect bad test runs

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -15,7 +15,14 @@ const {
   GITHUB_PR_REF,
   GITHUB_RUN_ID,
   GITHUB_RUN_ATTEMPT,
+  USING_YARN_TEST,
 } = process.env;
+
+if (USING_YARN_TEST === undefined) {
+  // eslint-disable-next-line no-console
+  console.error('Do not run `jest` directly, use `yarn test` instead!');
+  process.exit();
+}
 
 const IS_MASTER_BRANCH = GITHUB_PR_REF === 'refs/heads/master';
 

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -6,6 +6,9 @@ process.env.NODE_ENV = 'test';
 process.env.PUBLIC_URL = '';
 process.env.TZ = 'America/New_York';
 
+// Marker to indicate that we've correctly ran with `yarn test`.
+process.env.USING_YARN_TEST = true;
+
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
 // terminate the Node.js process with a non-zero exit code.


### PR DESCRIPTION
To avoid confusion detect when people try to run jest directly and hint
for them to use `yarn test` instead of jest directly.