### PR TITLE
fix(2fa): do not allow to enforce 2FA when having recovery codes only

### DIFF
--- a/src/sentry/users/services/user/model.py
+++ b/src/sentry/users/services/user/model.py
@@ -122,7 +122,7 @@ class RpcUser(RpcUserProfile):
         return "User"
 
     def has_2fa(self) -> bool:
-        return len(self.authenticators) > 0
+        return any(a.type != 0 for a in self.authenticators)
 
 
 class UserCreateResult(RpcModel):


### PR DESCRIPTION
Currently, when an owner has only recovery codes (backup interface), this still allows them to enforce 2FA for the organization what is wrong.

The requirement of having a proper 2FA method was implemented in https://github.com/getsentry/sentry/pull/6812 but it was broken during HC changes in https://github.com/getsentry/sentry/pull/44219.

The `has_2fa()` method has a different semantic in the regional silo:

https://github.com/getsentry/sentry/blob/e362bf517fe606490a727dde9736a2d2f21a92bd/src/sentry/users/services/user/model.py#L124-L125

vs control silo:
https://github.com/getsentry/sentry/blob/e362bf517fe606490a727dde9736a2d2f21a92bd/src/sentry/users/models/user.py#L239-L242