### PR TITLE
feat(insights): Occlude very large queries in the hover tooltip

### DIFF
--- a/static/app/views/insights/common/components/fullSpanDescription.tsx
+++ b/static/app/views/insights/common/components/fullSpanDescription.tsx
@@ -1,17 +1,18 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import ClippedBox from 'sentry/components/clippedBox';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {IconOpen} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {SQLishFormatter} from 'sentry/utils/sqlish/SQLishFormatter';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {useFullSpanFromTrace} from 'sentry/views/insights/common/queries/useFullSpanFromTrace';
 import {prettyPrintJsonString} from 'sentry/views/insights/database/utils/jsonUtils';
 import {ModuleName} from 'sentry/views/insights/types';
-import Alert from 'sentry/components/alert';
-import {t} from 'sentry/locale';
-import ClippedBox, {ClipFade} from 'sentry/components/clippedBox';
-import {IconOpen} from 'sentry/icons';
 
 const formatter = new SQLishFormatter();
 
@@ -38,6 +39,9 @@ export function FullSpanDescription({
     isLoading,
     isFetching,
   } = useFullSpanFromTrace(group, [INDEXED_SPAN_SORT], Boolean(group), filters);
+
+  const navigate = useNavigate();
+  const location = useLocation();
 
   const description = fullSpan?.description ?? shortDescription;
   const system = fullSpan?.data?.['db.system'];
@@ -80,9 +84,14 @@ export function FullSpanDescription({
       if (shouldDisplayTruncatedWarning) {
         return (
           <StyledClippedBox
-            onReveal={console.log}
             btnText={t('View full query')}
-            buttonProps={{icon: <IconOpen />}}
+            buttonProps={{
+              icon: <IconOpen />,
+              onClick: () =>
+                navigate({
+                  pathname: `${location.pathname}spans/span/${group}/`,
+                }),
+            }}
           >
             <CodeSnippet language="json">{stringifiedQuery}</CodeSnippet>
           </StyledClippedBox>

--- a/static/app/views/insights/common/components/fullSpanDescription.tsx
+++ b/static/app/views/insights/common/components/fullSpanDescription.tsx
@@ -91,8 +91,7 @@ export function FullSpanDescription({
       }
 
       if (result) {
-        const {prettifiedQuery} = result;
-        stringifiedQuery = prettifiedQuery;
+        stringifiedQuery = result.prettifiedQuery;
       }
 
       return (

--- a/static/app/views/insights/common/components/fullSpanDescription.tsx
+++ b/static/app/views/insights/common/components/fullSpanDescription.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, type ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import ClippedBox from 'sentry/components/clippedBox';
@@ -40,9 +40,6 @@ export function FullSpanDescription({
     isFetching,
   } = useFullSpanFromTrace(group, [INDEXED_SPAN_SORT], Boolean(group), filters);
 
-  const navigate = useNavigate();
-  const location = useLocation();
-
   const description = fullSpan?.description ?? shortDescription;
   const system = fullSpan?.data?.['db.system'];
 
@@ -83,24 +80,18 @@ export function FullSpanDescription({
 
       if (shouldDisplayTruncatedWarning) {
         return (
-          <StyledClippedBox
-            btnText={t('View full query')}
-            clipHeight={320}
-            buttonProps={{
-              icon: <IconOpen />,
-              onClick: () =>
-                navigate({
-                  pathname: `${location.pathname}spans/span/${group}/`,
-                }),
-            }}
-          >
+          <TruncatedQueryClipBox group={group}>
             <CodeSnippet language="json">{stringifiedQuery}</CodeSnippet>
-          </StyledClippedBox>
+          </TruncatedQueryClipBox>
         );
       }
 
       return <CodeSnippet language="json">{stringifiedQuery}</CodeSnippet>;
     }
+
+    <CodeSnippet language="sql">
+      {formatter.toString(description, {maxLineLength: LINE_LENGTH})}
+    </CodeSnippet>;
 
     return (
       <CodeSnippet language="sql">
@@ -114,6 +105,32 @@ export function FullSpanDescription({
   }
 
   return <Fragment>{description}</Fragment>;
+}
+
+type TruncatedQueryClipBoxProps = {
+  children: ReactNode;
+  group: string | undefined;
+};
+
+function TruncatedQueryClipBox({group, children}: TruncatedQueryClipBoxProps) {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  return (
+    <StyledClippedBox
+      btnText={t('View full query')}
+      clipHeight={320}
+      buttonProps={{
+        icon: <IconOpen />,
+        onClick: () =>
+          navigate({
+            pathname: `${location.pathname}spans/span/${group}/`,
+          }),
+      }}
+    >
+      {children}
+    </StyledClippedBox>
+  );
 }
 
 const LINE_LENGTH = 60;

--- a/static/app/views/insights/common/components/fullSpanDescription.tsx
+++ b/static/app/views/insights/common/components/fullSpanDescription.tsx
@@ -85,6 +85,7 @@ export function FullSpanDescription({
         return (
           <StyledClippedBox
             btnText={t('View full query')}
+            clipHeight={320}
             buttonProps={{
               icon: <IconOpen />,
               onClick: () =>

--- a/static/app/views/insights/common/components/fullSpanDescription.tsx
+++ b/static/app/views/insights/common/components/fullSpanDescription.tsx
@@ -76,7 +76,6 @@ export function FullSpanDescription({
   if (moduleName === ModuleName.DB) {
     if (system === 'mongodb') {
       let stringifiedQuery = '';
-      let shouldDisplayTruncatedWarning = false;
       let result: ReturnType<typeof prettyPrintJsonString> | undefined = undefined;
 
       if (indexedSpan?.['span.description']) {
@@ -89,34 +88,26 @@ export function FullSpanDescription({
         result = prettyPrintJsonString(fullSpan?.sentry_tags?.description);
       } else {
         stringifiedQuery = description || fullSpan?.sentry_tags?.description || 'N/A';
-        shouldDisplayTruncatedWarning = false;
       }
 
       if (result) {
-        const {prettifiedQuery, isTruncated} = result;
+        const {prettifiedQuery} = result;
         stringifiedQuery = prettifiedQuery;
-        shouldDisplayTruncatedWarning = isTruncated;
       }
 
-      if (shouldDisplayTruncatedWarning) {
-        return (
-          <TruncatedQueryClipBox group={group}>
-            <CodeSnippet language="json">{stringifiedQuery}</CodeSnippet>
-          </TruncatedQueryClipBox>
-        );
-      }
-
-      return <CodeSnippet language="json">{stringifiedQuery}</CodeSnippet>;
+      return (
+        <QueryClippedBox group={group}>
+          <CodeSnippet language="json">{stringifiedQuery}</CodeSnippet>
+        </QueryClippedBox>
+      );
     }
 
-    <CodeSnippet language="sql">
-      {formatter.toString(description, {maxLineLength: LINE_LENGTH})}
-    </CodeSnippet>;
-
     return (
-      <CodeSnippet language="sql">
-        {formatter.toString(description, {maxLineLength: LINE_LENGTH})}
-      </CodeSnippet>
+      <QueryClippedBox group={group}>
+        <CodeSnippet language="sql">
+          {formatter.toString(description, {maxLineLength: LINE_LENGTH})}
+        </CodeSnippet>
+      </QueryClippedBox>
     );
   }
 
@@ -132,14 +123,14 @@ type TruncatedQueryClipBoxProps = {
   group: string | undefined;
 };
 
-function TruncatedQueryClipBox({group, children}: TruncatedQueryClipBoxProps) {
+function QueryClippedBox({group, children}: TruncatedQueryClipBoxProps) {
   const location = useLocation();
   const navigate = useNavigate();
 
   return (
     <StyledClippedBox
       btnText={t('View full query')}
-      clipHeight={320}
+      clipHeight={500}
       buttonProps={{
         icon: <IconOpen />,
         onClick: () =>

--- a/static/app/views/insights/common/components/spanDescription.tsx
+++ b/static/app/views/insights/common/components/spanDescription.tsx
@@ -90,7 +90,7 @@ export function DatabaseSpanDescription({
         return rawDescription ?? 'N/A';
       }
 
-      return prettyPrintJsonString(bestDescription);
+      return prettyPrintJsonString(bestDescription).prettifiedQuery;
     }
 
     return formatter.toString(rawDescription ?? '');

--- a/static/app/views/insights/database/utils/jsonUtils.tsx
+++ b/static/app/views/insights/database/utils/jsonUtils.tsx
@@ -10,9 +10,9 @@ export const isValidJson = (str: string) => {
 };
 
 export function prettyPrintJsonString(json: string): {
-  prettifiedQuery: string;
-  isTruncated: boolean;
   failed: boolean;
+  isTruncated: boolean;
+  prettifiedQuery: string;
 } {
   try {
     return {

--- a/static/app/views/insights/database/utils/jsonUtils.tsx
+++ b/static/app/views/insights/database/utils/jsonUtils.tsx
@@ -9,16 +9,28 @@ export const isValidJson = (str: string) => {
   return true;
 };
 
-export function prettyPrintJsonString(json: string) {
+export function prettyPrintJsonString(json: string): {
+  prettifiedQuery: string;
+  isTruncated: boolean;
+  failed: boolean;
+} {
   try {
-    return JSON.stringify(JSON.parse(json), null, 4);
+    return {
+      prettifiedQuery: JSON.stringify(JSON.parse(json), null, 4),
+      isTruncated: false,
+      failed: false,
+    };
   } catch {
     // Attempt to repair the JSON
     try {
       const repairedJson = jsonrepair(json);
-      return JSON.stringify(JSON.parse(repairedJson), null, 4);
+      return {
+        prettifiedQuery: JSON.stringify(JSON.parse(repairedJson), null, 4),
+        isTruncated: true,
+        failed: false,
+      };
     } catch {
-      return json;
+      return {prettifiedQuery: json, isTruncated: false, failed: true};
     }
   }
 }


### PR DESCRIPTION
Extremely long queries can be overwhelming and ugly when they appear in the tooltip preview after hovering over a query description. This PR uses the `ClippedBox` component to add a max height to queries, and provides a "View full query" button to encourage the user to inspect the query in its entirety. Clicking on this button will just jump to the summary page for that query

Applies to both SQL and MongoDB queries.


![image](https://github.com/user-attachments/assets/3cad00b1-21e5-4999-8ddd-f690e82136a4)

