### PR TITLE
feat(insights): ensure all links within domain views, stay within domain views

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -264,7 +264,7 @@ function Sidebar() {
     </Feature>
   );
 
-  const moduleURLBuilder = useModuleURLBuilder(true);
+  const moduleURLBuilder = useModuleURLBuilder(true, false);
 
   const queries = hasOrganization && (
     <Feature key="db" features="insights-entry-points" organization={organization}>

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1642,19 +1642,19 @@ function buildRoutes() {
         component={make(() => import('sentry/views/performance/trends'))}
       />
       <Route
-        path={`${FRONTEND_LANDING_SUB_PATH}/`}
+        path={`${FRONTEND_LANDING_SUB_PATH}/*`}
         component={make(() => import('sentry/views/insights/pages/frontendLandingPage'))}
       />
       <Route
-        path={`${BACKEND_LANDING_SUB_PATH}/`}
+        path={`${BACKEND_LANDING_SUB_PATH}/*`}
         component={make(() => import('sentry/views/insights/pages/backendLandingPage'))}
       />
       <Route
-        path={`${MOBILE_LANDING_SUB_PATH}/`}
+        path={`${MOBILE_LANDING_SUB_PATH}/*`}
         component={make(() => import('sentry/views/insights/pages/mobileLandingPage'))}
       />
       <Route
-        path={`${AI_LANDING_SUB_PATH}/`}
+        path={`${AI_LANDING_SUB_PATH}/*`}
         component={make(() => import('sentry/views/insights/pages/aiLandingPage'))}
       />
       <Route path="summary/">

--- a/static/app/views/insights/browser/resources/views/resourceSummaryPage.tsx
+++ b/static/app/views/insights/browser/resources/views/resourceSummaryPage.tsx
@@ -31,6 +31,7 @@ import {useModuleBreadcrumbs} from 'sentry/views/insights/common/utils/useModule
 import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
 import SubregionSelector from 'sentry/views/insights/common/views/spans/selectors/subregionSelector';
 import {SampleList} from 'sentry/views/insights/common/views/spanSummaryPage/sampleList';
+import {useFilters} from 'sentry/views/insights/pages/useFilters';
 import {ModuleName, SpanMetricsField} from 'sentry/views/insights/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceMetadataHeader';
 
@@ -46,7 +47,13 @@ const {
 
 function ResourceSummary() {
   const webVitalsModuleURL = useModuleURL('vital');
-  const {groupId} = useParams();
+  const location = useLocation();
+  const {isInDomainView} = useFilters();
+  let {groupId} = useParams();
+  if (isInDomainView) {
+    groupId = location.pathname.split('/').filter(Boolean).pop() || '';
+  }
+
   const filters = useResourceModuleFilters();
   const selectedSpanOp = filters[SPAN_OP];
   const {

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
@@ -66,7 +66,7 @@ function getCurrentTabSelection(selectedTab) {
 }
 
 export function PageOverview() {
-  const moduleURL = useModuleURL('vital', undefined, true);
+  const moduleURL = useModuleURL('vital');
   const organization = useOrganization();
   const location = useLocation();
   const {projects} = useProjects();

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
@@ -66,7 +66,7 @@ function getCurrentTabSelection(selectedTab) {
 }
 
 export function PageOverview() {
-  const moduleURL = useModuleURL('vital');
+  const moduleURL = useModuleURL('vital', undefined, true);
   const organization = useOrganization();
   const location = useLocation();
   const {projects} = useProjects();

--- a/static/app/views/insights/http/components/tables/domainsTable.tsx
+++ b/static/app/views/insights/http/components/tables/domainsTable.tsx
@@ -115,6 +115,7 @@ interface Props {
     pageLinks?: string;
   };
   sort: ValidSort;
+  disableHeader?: boolean;
 }
 
 export function DomainsTable({response, sort}: Props) {

--- a/static/app/views/insights/http/views/httpLandingPage.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.tsx
@@ -244,7 +244,11 @@ export function HTTPLandingPage({disableHeader}: InsightLandingProps) {
               </ModuleLayout.Full>
 
               <ModuleLayout.Full>
-                <DomainsTable response={domainsListResponse} sort={sort} />
+                <DomainsTable
+                  response={domainsListResponse}
+                  sort={sort}
+                  disableHeader={disableHeader}
+                />
               </ModuleLayout.Full>
             </ModulesOnboarding>
           </ModuleLayout.Layout>

--- a/static/app/views/insights/pages/aiLandingPage.tsx
+++ b/static/app/views/insights/pages/aiLandingPage.tsx
@@ -4,10 +4,10 @@ import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
 import ButtonBar from 'sentry/components/buttonBar';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {TabList, TabPanels, Tabs} from 'sentry/components/tabs';
+import {TabList, Tabs} from 'sentry/components/tabs';
 import {t} from 'sentry/locale';
 import {PageAlert} from 'sentry/utils/performance/contexts/pageAlert';
-import LLMLandingPage from 'sentry/views/insights/llmMonitoring/views/llmMonitoringLandingPage';
+import {ModuleRenderer} from 'sentry/views/insights/pages/moduleRenderer';
 import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
 import {
   type Filters,
@@ -15,13 +15,11 @@ import {
   useUpdateFilters,
 } from 'sentry/views/insights/pages/useFilters';
 import {MODULE_TITLES} from 'sentry/views/insights/settings';
-import {type InsightLandingProps, ModuleName} from 'sentry/views/insights/types';
+import {ModuleName} from 'sentry/views/insights/types';
 
 function AiLandingPage() {
   const filters = useFilters();
   const updateFilters = useUpdateFilters();
-
-  const landingPageProps: InsightLandingProps = {disableHeader: true};
 
   const crumbs: Crumb[] = [
     {
@@ -78,12 +76,8 @@ function AiLandingPage() {
         </Layout.Header>
         <Layout.Main fullWidth>
           <PageAlert />
-          <TabPanels>
-            <TabPanels.Item key={OVERVIEW_PAGE_TITLE}>{'overview page'}</TabPanels.Item>
-            <TabPanels.Item key={ModuleName.AI}>
-              <LLMLandingPage {...landingPageProps} />
-            </TabPanels.Item>
-          </TabPanels>
+          {!filters.module && 'overview page'}
+          {filters.module && <ModuleRenderer />}
         </Layout.Main>
       </Tabs>
     </Fragment>

--- a/static/app/views/insights/pages/backendLandingPage.tsx
+++ b/static/app/views/insights/pages/backendLandingPage.tsx
@@ -4,27 +4,22 @@ import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
 import ButtonBar from 'sentry/components/buttonBar';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {TabList, TabPanels, Tabs} from 'sentry/components/tabs';
+import {TabList, Tabs} from 'sentry/components/tabs';
 import {t} from 'sentry/locale';
 import {PageAlert} from 'sentry/utils/performance/contexts/pageAlert';
-import CachesLandingPage from 'sentry/views/insights/cache/views/cacheLandingPage';
-import DatabaseLandingPage from 'sentry/views/insights/database/views//databaseLandingPage';
-import HTTPLandingPage from 'sentry/views/insights/http/views/httpLandingPage';
+import {ModuleRenderer} from 'sentry/views/insights/pages/moduleRenderer';
 import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
 import {
   type Filters,
   useFilters,
   useUpdateFilters,
 } from 'sentry/views/insights/pages/useFilters';
-import QueuesLandingPage from 'sentry/views/insights/queues/views/queuesLandingPage';
 import {MODULE_TITLES} from 'sentry/views/insights/settings';
-import {type InsightLandingProps, ModuleName} from 'sentry/views/insights/types';
+import type {ModuleName} from 'sentry/views/insights/types';
 
 function BackendLandingPage() {
   const filters = useFilters();
   const updateFilters = useUpdateFilters();
-
-  const landingPageProps: InsightLandingProps = {disableHeader: true};
 
   const crumbs: Crumb[] = [
     {
@@ -90,21 +85,8 @@ function BackendLandingPage() {
         </Layout.Header>
         <Layout.Main fullWidth>
           <PageAlert />
-          <TabPanels>
-            <TabPanels.Item key={OVERVIEW_PAGE_TITLE}>{'overview page'}</TabPanels.Item>
-            <TabPanels.Item key={ModuleName.DB}>
-              <DatabaseLandingPage {...landingPageProps} />
-            </TabPanels.Item>
-            <TabPanels.Item key={ModuleName.HTTP}>
-              <HTTPLandingPage {...landingPageProps} />
-            </TabPanels.Item>
-            <TabPanels.Item key={ModuleName.CACHE}>
-              <CachesLandingPage {...landingPageProps} />
-            </TabPanels.Item>
-            <TabPanels.Item key={ModuleName.QUEUE}>
-              <QueuesLandingPage {...landingPageProps} />
-            </TabPanels.Item>
-          </TabPanels>
+          {!filters.module && 'overview page'}
+          {filters.module && <ModuleRenderer />}
         </Layout.Main>
       </Tabs>
     </Fragment>

--- a/static/app/views/insights/pages/frontendLandingPage.tsx
+++ b/static/app/views/insights/pages/frontendLandingPage.tsx
@@ -4,12 +4,10 @@ import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
 import ButtonBar from 'sentry/components/buttonBar';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {TabList, TabPanels, Tabs} from 'sentry/components/tabs';
+import {TabList, Tabs} from 'sentry/components/tabs';
 import {t} from 'sentry/locale';
 import {PageAlert} from 'sentry/utils/performance/contexts/pageAlert';
-import ResourcesLandingPage from 'sentry/views/insights/browser/resources/views/resourcesLandingPage';
-import WebVitalsLandingPage from 'sentry/views/insights/browser/webVitals/views/webVitalsLandingPage';
-import HTTPLandingPage from 'sentry/views/insights/http/views/httpLandingPage';
+import {ModuleRenderer} from 'sentry/views/insights/pages/moduleRenderer';
 import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
 import {
   type Filters,
@@ -17,13 +15,11 @@ import {
   useUpdateFilters,
 } from 'sentry/views/insights/pages/useFilters';
 import {MODULE_TITLES} from 'sentry/views/insights/settings';
-import {type InsightLandingProps, ModuleName} from 'sentry/views/insights/types';
+import {ModuleName} from 'sentry/views/insights/types';
 
 function FrontendLandingPage() {
   const filters = useFilters();
   const updateFilters = useUpdateFilters();
-
-  const landingPageProps: InsightLandingProps = {disableHeader: true};
 
   const crumbs: Crumb[] = [
     {
@@ -72,7 +68,7 @@ function FrontendLandingPage() {
             </ButtonBar>
           </Layout.HeaderActions>
           <TabList>
-            <TabList.Item key={OVERVIEW_PAGE_TITLE}>{'Overview'}</TabList.Item>
+            <TabList.Item key={OVERVIEW_PAGE_TITLE}>{OVERVIEW_PAGE_TITLE}</TabList.Item>
             <TabList.Item key={ModuleName.VITAL}>
               {MODULE_TITLES[ModuleName.VITAL]}
             </TabList.Item>
@@ -86,18 +82,8 @@ function FrontendLandingPage() {
         </Layout.Header>
         <Layout.Main fullWidth>
           <PageAlert />
-          <TabPanels>
-            <TabPanels.Item key={OVERVIEW_PAGE_TITLE}>{'overview page'}</TabPanels.Item>
-            <TabPanels.Item key={ModuleName.HTTP}>
-              <HTTPLandingPage {...landingPageProps} />
-            </TabPanels.Item>
-            <TabPanels.Item key={ModuleName.RESOURCE}>
-              <ResourcesLandingPage {...landingPageProps} />
-            </TabPanels.Item>
-            <TabPanels.Item key={ModuleName.VITAL}>
-              <WebVitalsLandingPage {...landingPageProps} />
-            </TabPanels.Item>
-          </TabPanels>
+          {!filters.module && 'overview page'}
+          {filters.module && <ModuleRenderer />}
         </Layout.Main>
       </Tabs>
     </Fragment>

--- a/static/app/views/insights/pages/mobileLandingPage.tsx
+++ b/static/app/views/insights/pages/mobileLandingPage.tsx
@@ -4,10 +4,10 @@ import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
 import ButtonBar from 'sentry/components/buttonBar';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {TabList, TabPanels, Tabs} from 'sentry/components/tabs';
+import {TabList, Tabs} from 'sentry/components/tabs';
 import {t} from 'sentry/locale';
 import {PageAlert} from 'sentry/utils/performance/contexts/pageAlert';
-import ScreensLandingPage from 'sentry/views/insights/mobile/screens/views/screensLandingPage';
+import {ModuleRenderer} from 'sentry/views/insights/pages/moduleRenderer';
 import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
 import {
   type Filters,
@@ -15,13 +15,11 @@ import {
   useUpdateFilters,
 } from 'sentry/views/insights/pages/useFilters';
 import {MODULE_TITLES} from 'sentry/views/insights/settings';
-import {type InsightLandingProps, ModuleName} from 'sentry/views/insights/types';
+import {ModuleName} from 'sentry/views/insights/types';
 
 function MobileLandingPage() {
   const filters = useFilters();
   const updateFilters = useUpdateFilters();
-
-  const landingPageProps: InsightLandingProps = {disableHeader: true};
 
   const crumbs: Crumb[] = [
     {
@@ -78,12 +76,8 @@ function MobileLandingPage() {
         </Layout.Header>
         <Layout.Main fullWidth>
           <PageAlert />
-          <TabPanels>
-            <TabPanels.Item key={OVERVIEW_PAGE_TITLE}>{'overview page'}</TabPanels.Item>
-            <TabPanels.Item key={ModuleName.MOBILE_SCREENS}>
-              <ScreensLandingPage {...landingPageProps} />
-            </TabPanels.Item>
-          </TabPanels>
+          {!filters.module && 'overview page'}
+          {filters.module && <ModuleRenderer />}
         </Layout.Main>
       </Tabs>
     </Fragment>

--- a/static/app/views/insights/pages/moduleRenderer.tsx
+++ b/static/app/views/insights/pages/moduleRenderer.tsx
@@ -1,0 +1,55 @@
+import ResourcesLandingPage from 'sentry/views/insights/browser/resources/views/resourcesLandingPage';
+import ResourceSummaryPage from 'sentry/views/insights/browser/resources/views/resourceSummaryPage';
+import PageOverview from 'sentry/views/insights/browser/webVitals/views/pageOverview';
+import WebVitalsLandingPage from 'sentry/views/insights/browser/webVitals/views/webVitalsLandingPage';
+import CachesLandingPage from 'sentry/views/insights/cache/views/cacheLandingPage';
+import DatabaseLandingPage from 'sentry/views/insights/database/views//databaseLandingPage';
+import HTTPDomainSummaryPage from 'sentry/views/insights/http/views/httpDomainSummaryPage';
+import HTTPLandingPage from 'sentry/views/insights/http/views/httpLandingPage';
+import LLMLandingPage from 'sentry/views/insights/llmMonitoring/views/llmMonitoringLandingPage';
+import AppStartsLandingPage from 'sentry/views/insights/mobile/appStarts/views/appStartsLandingPage';
+import ScreenLoadLandingPage from 'sentry/views/insights/mobile/screenload/views/screenloadLandingPage';
+import ScreensLandingPage from 'sentry/views/insights/mobile/screens/views/screensLandingPage';
+import MobileUiLandingPage from 'sentry/views/insights/mobile/ui/views/uiLandingPage';
+import {useFilters} from 'sentry/views/insights/pages/useFilters';
+import QueuesLandingPage from 'sentry/views/insights/queues/views/queuesLandingPage';
+import {type InsightLandingProps, ModuleName} from 'sentry/views/insights/types';
+
+export function ModuleRenderer() {
+  const {module, hasSubpage} = useFilters();
+
+  const landingProps: InsightLandingProps = {disableHeader: true};
+
+  const ModuleSubPage = hasSubpage && ModuleSubpages[module || ''];
+  const ModuleLandingPage = ModuleNameToComponent[module || ''];
+
+  if (ModuleSubPage) {
+    return <ModuleSubPage {...landingProps} />;
+  }
+
+  if (ModuleLandingPage) {
+    return <ModuleLandingPage {...landingProps} />;
+  }
+  return null;
+}
+
+const ModuleNameToComponent: Record<ModuleName, React.ComponentType> = {
+  [ModuleName.DB]: DatabaseLandingPage,
+  [ModuleName.HTTP]: HTTPLandingPage,
+  [ModuleName.CACHE]: CachesLandingPage,
+  [ModuleName.QUEUE]: QueuesLandingPage,
+  [ModuleName.AI]: LLMLandingPage,
+  [ModuleName.RESOURCE]: ResourcesLandingPage,
+  [ModuleName.VITAL]: WebVitalsLandingPage,
+  [ModuleName.MOBILE_UI]: MobileUiLandingPage,
+  [ModuleName.SCREEN_LOAD]: ScreenLoadLandingPage,
+  [ModuleName.MOBILE_SCREENS]: ScreensLandingPage,
+  [ModuleName.APP_START]: AppStartsLandingPage,
+  [ModuleName.OTHER]: () => null,
+};
+
+const ModuleSubpages: Partial<Record<ModuleName, React.ComponentType>> = {
+  [ModuleName.RESOURCE]: ResourceSummaryPage,
+  [ModuleName.HTTP]: HTTPDomainSummaryPage,
+  [ModuleName.VITAL]: PageOverview,
+};

--- a/static/app/views/insights/pages/useFilters.tsx
+++ b/static/app/views/insights/pages/useFilters.tsx
@@ -1,32 +1,56 @@
-import pick from 'lodash/pick';
 import type {ModuleName} from 'webpack-cli';
 
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+import type {AI_LANDING_SUB_PATH} from 'sentry/views/insights/pages/aiLandingPage';
+import type {BACKEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/backendLandingPage';
+import type {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontendLandingPage';
+import type {MOBILE_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mobileLandingPage';
 
 export type Filters = {
+  hasSubpage?: boolean;
+  isInDomainView?: boolean;
   module?: ModuleName;
+  view?:
+    | typeof FRONTEND_LANDING_SUB_PATH
+    | typeof BACKEND_LANDING_SUB_PATH
+    | typeof AI_LANDING_SUB_PATH
+    | typeof MOBILE_LANDING_SUB_PATH;
 };
 
-export const useFilters = () => {
-  const location = useLocation<Filters>();
+export const useFilters = (): Filters => {
+  const location = useLocation();
+  const pathSegements = location.pathname.split('/').filter(Boolean);
+  const indexOfPerformance = pathSegements.indexOf('performance');
+  const isInDomainView = indexOfPerformance !== -1;
 
-  const filters = pick(location.query, ['module']);
+  const view = pathSegements[indexOfPerformance + 1] as Filters['view'];
+  const module = pathSegements[indexOfPerformance + 2] as ModuleName;
+  const hasSubpage = pathSegements.length > indexOfPerformance + 3;
 
-  return filters;
+  if (isInDomainView) {
+    return {
+      module,
+      hasSubpage,
+      view,
+      isInDomainView,
+    };
+  }
+  return {isInDomainView};
 };
 
 export const useUpdateFilters = () => {
-  const location = useLocation<Filters>();
+  const {slug} = useOrganization();
   const navigate = useNavigate();
+  const {view} = useFilters();
+  const baseUrl = normalizeUrl(`/organizations/${slug}/performance/${view}`);
 
   return (newFilters: Filters) => {
     navigate({
-      pathname: location.pathname,
-      query: {
-        ...location.query,
-        ...newFilters,
-      },
+      pathname: newFilters.module ? `${baseUrl}/${newFilters.module}/` : baseUrl,
+      query: {},
     });
   };
 };


### PR DESCRIPTION
Work for https://github.com/getsentry/sentry/issues/77572

This ensures any links within a module that is within a domain view, stays within that domain view.
(this means you can now go to the http domain summary, resource summary, etc)

This is only necessary to support existing insights, and domain view work, at the same time. Something to keep in mind, this is all likely to change at somepoint when we remove the flag and do the release, i was trying to be "non-intrusive" as possible with the existing stuff so it works well in two places

This was quite tricky to do, so to make it support both at the same time, i'm using the pathname rather then query params in order to keep track of what page to render. This is because all modules use subpaths to get to their respective summary pages. This all handled in a new component called `ModuleRenderer` which looks at the current url to render the appropriate module page/summary page.

There are other approaches to this problem, 
1. Create a wrapper component for each module, the wrapper would have all the domain view controls (overview, web vitals, http, assets). The issue I found with this approach, is that it seemed like a lot of duplication. And we'll to handle the case where a module fits under many domain views.
