### PR TITLE
chore: Don't send no-op RPC calls from serializers

### DIFF
--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -17,9 +17,11 @@ class ActivitySerializer(Serializer):
     def get_attrs(self, item_list, user, **kwargs):
         # TODO(dcramer); assert on relations
         user_ids = [i.user_id for i in item_list if i.user_id]
-        user_list = user_service.serialize_many(
-            filter={"user_ids": user_ids}, as_user=serialize_generic_user(user)
-        )
+        user_list = []
+        if user_ids:
+            user_list = user_service.serialize_many(
+                filter={"user_ids": user_ids}, as_user=serialize_generic_user(user)
+            )
         users = {u["id"]: u for u in user_list}
 
         commit_ids = {

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -183,9 +183,12 @@ class GroupSerializerBase(Serializer, ABC):
         for team in Team.objects.filter(id__in=all_team_ids.keys()):
             for group_id in all_team_ids[team.id]:
                 result[group_id] = team
-        for user in user_service.get_many_by_id(ids=list(all_user_ids.keys())):
-            for group_id in all_user_ids[user.id]:
-                result[group_id] = user
+
+        user_ids = list(all_user_ids.keys())
+        if user_ids:
+            for user in user_service.get_many_by_id(ids=user_ids):
+                for group_id in all_user_ids[user.id]:
+                    result[group_id] = user
 
         return result
 

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -458,13 +458,16 @@ class ReleaseSerializer(Serializer):
                 issue_counts_by_release,
             ) = self.__get_release_data_with_environments(release_project_envs)
 
-        owners = {
-            d["id"]: d
-            for d in user_service.serialize_many(
-                filter={"user_ids": [i.owner_id for i in item_list if i.owner_id]},
-                as_user=serialize_generic_user(user),
-            )
-        }
+        owners = {}
+        owner_ids = [i.owner_id for i in item_list if i.owner_id]
+        if owner_ids:
+            owners = {
+                d["id"]: d
+                for d in user_service.serialize_many(
+                    filter={"user_ids": owner_ids},
+                    as_user=serialize_generic_user(user),
+                )
+            }
 
         authors_metadata_attrs = _get_authors_metadata(item_list, user)
         release_metadata_attrs = _get_last_commit_metadata(item_list, user)


### PR DESCRIPTION
When we have empty parameter lists there is no point in making an RPC call as we'll get nothing back. This should help reduce the number of RPC call failures that customers can experience and the overall volume as well.