### PR TITLE
feat(issues): Consolidate group tags hooks

### DIFF
--- a/static/app/actionCreators/group.tsx
+++ b/static/app/actionCreators/group.tsx
@@ -1,6 +1,5 @@
 import * as Sentry from '@sentry/react';
 
-import type {Tag} from 'sentry/actionCreators/events';
 import type {RequestCallbacks, RequestOptions} from 'sentry/api';
 import {Client} from 'sentry/api';
 import GroupStore from 'sentry/stores/groupStore';
@@ -8,7 +7,7 @@ import type {Actor} from 'sentry/types/core';
 import type {Group, Note, Tag as GroupTag, TagValue} from 'sentry/types/group';
 import type {Member} from 'sentry/types/organization';
 import type {User} from 'sentry/types/user';
-import {buildTeamId, buildUserId, defined} from 'sentry/utils';
+import {buildTeamId, buildUserId} from 'sentry/utils';
 import {uniqueId} from 'sentry/utils/guid';
 import type {ApiQueryKey, UseApiQueryOptions} from 'sentry/utils/queryClient';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -413,46 +412,6 @@ export type GroupTagResponseItem = {
 };
 
 export type GroupTagsResponse = GroupTagResponseItem[];
-
-type FetchIssueTagsParameters = {
-  environment: string[];
-  orgSlug: string;
-  groupId?: string;
-  isStatisticalDetector?: boolean;
-  limit?: number;
-  readable?: boolean;
-  statisticalDetectorParameters?: {
-    durationBaseline: number;
-    end: string;
-    start: string;
-    transaction: string;
-  };
-};
-
-export const makeFetchIssueTagsQueryKey = ({
-  groupId,
-  orgSlug,
-  environment,
-  readable,
-  limit,
-}: FetchIssueTagsParameters): ApiQueryKey => [
-  `/organizations/${orgSlug}/issues/${groupId}/tags/`,
-  {query: {environment, readable, limit}},
-];
-
-export const useFetchIssueTags = (
-  parameters: FetchIssueTagsParameters,
-  {
-    enabled = true,
-    ...options
-  }: Partial<UseApiQueryOptions<GroupTagsResponse | Tag[]>> = {}
-) => {
-  return useApiQuery<GroupTagsResponse | Tag[]>(makeFetchIssueTagsQueryKey(parameters), {
-    staleTime: 30000,
-    enabled: defined(parameters.groupId) && enabled,
-    ...options,
-  });
-};
 
 type FetchIssueTagValuesParameters = {
   groupId: string;

--- a/static/app/components/group/tagFacets/index.tsx
+++ b/static/app/components/group/tagFacets/index.tsx
@@ -13,15 +13,13 @@ import QuestionTooltip from 'sentry/components/questionTooltip';
 import * as SidebarSection from 'sentry/components/sidebarSection';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Event} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import {defined} from 'sentry/utils';
 import {appendTagCondition} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
-import {useFetchIssueTagsForDetailsPage} from 'sentry/views/issueDetails/utils';
+import {useGroupTagsReadable} from 'sentry/views/issueDetails/groupTags/useGroupTagsQuery';
 
 import TagFacetsDistributionMeter from './tagFacetsDistributionMeter';
 
@@ -96,32 +94,11 @@ export function sumTagFacetsForTopValues(tag: Tag) {
   };
 }
 
-// Statistical detector issues need to use a Discover query
-// which means we need to massage the values to fit the component API
-function transformTagFacetDataToGroupTagResponseItems(
-  tagFacetData: Record<string, Tag>
-): Record<string, GroupTagResponseItem> {
-  const keyedResponse = {};
-
-  // Statistical detectors are scoped to a single transaction so
-  // the filter out transaction since the tag is not helpful in the UI
-  Object.keys(tagFacetData)
-    .filter(tagKey => tagKey !== 'transaction')
-    .forEach(tagKey => {
-      const tagData = tagFacetData[tagKey];
-      keyedResponse[tagKey] = sumTagFacetsForTopValues(tagData);
-    });
-
-  return keyedResponse;
-}
-
 type Props = {
   environments: string[];
   groupId: string;
   project: Project;
   tagKeys: string[];
-  event?: Event;
-  isStatisticalDetector?: boolean;
   tagFormatter?: (
     tagsData: Record<string, GroupTagResponseItem>
   ) => Record<string, GroupTagResponseItem>;
@@ -133,28 +110,12 @@ export default function TagFacets({
   groupId,
   tagFormatter,
   project,
-  isStatisticalDetector,
-  event,
 }: Props) {
   const organization = useOrganization();
-  const now = useMemo(() => Date.now(), []);
 
-  const {transaction, aggregateRange2, breakpoint} =
-    event?.occurrence?.evidenceData ?? {};
-  const {isPending, isError, data, refetch} = useFetchIssueTagsForDetailsPage({
+  const {isPending, isError, data, refetch} = useGroupTagsReadable({
     groupId,
-    orgSlug: organization.slug,
     environment: environments,
-    isStatisticalDetector,
-    statisticalDetectorParameters:
-      isStatisticalDetector && defined(breakpoint)
-        ? {
-            transaction,
-            durationBaseline: aggregateRange2,
-            start: new Date(breakpoint * 1000).toISOString(),
-            end: new Date(now).toISOString(),
-          }
-        : undefined,
   });
 
   const tagsData = useMemo(() => {
@@ -162,16 +123,12 @@ export default function TagFacets({
       return {};
     }
 
-    let keyed = keyBy(data, 'key');
-    if (isStatisticalDetector) {
-      keyed = transformTagFacetDataToGroupTagResponseItems(keyed as Record<string, Tag>);
-    }
-
+    const keyed = keyBy(data, 'key');
     const formatted =
       tagFormatter?.(keyed as Record<string, GroupTagResponseItem>) ?? keyed;
 
     return formatted as Record<string, GroupTagResponseItem>;
-  }, [data, tagFormatter, isStatisticalDetector]);
+  }, [data, tagFormatter]);
 
   // filter out replayId since we no longer want to
   // display this on issue details

--- a/static/app/components/group/tagFacets/index.tsx
+++ b/static/app/components/group/tagFacets/index.tsx
@@ -19,7 +19,7 @@ import {appendTagCondition} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
-import {useGroupTagsReadable} from 'sentry/views/issueDetails/groupTags/useGroupTagsQuery';
+import {useGroupTagsReadable} from 'sentry/views/issueDetails/groupTags/useGroupTags';
 
 import TagFacetsDistributionMeter from './tagFacetsDistributionMeter';
 

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1808,7 +1808,9 @@ function buildRoutes() {
         />
         <Route
           path={TabPaths[Tab.TAGS]}
-          component={hoc(make(() => import('sentry/views/issueDetails/groupTags')))}
+          component={hoc(
+            make(() => import('sentry/views/issueDetails/groupTags/groupTags'))
+          )}
         />
         <Route
           path={`${TabPaths[Tab.TAGS]}:tagKey/`}

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1809,7 +1809,7 @@ function buildRoutes() {
         <Route
           path={TabPaths[Tab.TAGS]}
           component={hoc(
-            make(() => import('sentry/views/issueDetails/groupTags/groupTags'))
+            make(() => import('sentry/views/issueDetails/groupTags/groupTagsTab'))
           )}
         />
         <Route

--- a/static/app/views/issueDetails/groupSidebar.tsx
+++ b/static/app/views/issueDetails/groupSidebar.tsx
@@ -28,7 +28,6 @@ import IssueListCacheStore from 'sentry/stores/IssueListCacheStore';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group, TeamParticipant, UserParticipant} from 'sentry/types/group';
-import {IssueType} from 'sentry/types/group';
 import type {Organization, OrganizationSummary} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import type {CurrentRelease} from 'sentry/types/release';
@@ -299,13 +298,8 @@ export default function GroupSidebar({
                   ? BACKEND_TAGS
                   : DEFAULT_TAGS
           }
-          event={event}
           tagFormatter={TAGS_FORMATTER}
           project={project}
-          isStatisticalDetector={
-            group.issueType === IssueType.PERFORMANCE_DURATION_REGRESSION ||
-            group.issueType === IssueType.PERFORMANCE_ENDPOINT_REGRESSION
-          }
         />
       )}
       {issueTypeConfig.regression.enabled && event && (

--- a/static/app/views/issueDetails/groupTags/groupTagsTab.spec.tsx
+++ b/static/app/views/issueDetails/groupTags/groupTagsTab.spec.tsx
@@ -4,9 +4,9 @@ import {TagsFixture} from 'sentry-fixture/tags';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import GroupTags from 'sentry/views/issueDetails/groupTags';
+import GroupTagsTab from './groupTagsTab';
 
-describe('GroupTags', function () {
+describe('GroupTagsTab', function () {
   const {routerProps, router, organization} = initializeOrg();
   const group = GroupFixture();
   let tagsMock;
@@ -19,7 +19,7 @@ describe('GroupTags', function () {
 
   it('navigates to issue details events tab with correct query params', async function () {
     render(
-      <GroupTags
+      <GroupTagsTab
         {...routerProps}
         group={group}
         environments={['dev']}
@@ -60,7 +60,7 @@ describe('GroupTags', function () {
     });
 
     render(
-      <GroupTags
+      <GroupTagsTab
         {...routerProps}
         group={group}
         environments={['dev']}

--- a/static/app/views/issueDetails/groupTags/groupTagsTab.tsx
+++ b/static/app/views/issueDetails/groupTags/groupTagsTab.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 
-import {useFetchIssueTags} from 'sentry/actionCreators/group';
 import {Alert} from 'sentry/components/alert';
 import Count from 'sentry/components/count';
 import {DeviceName} from 'sentry/components/deviceName';
@@ -20,7 +19,7 @@ import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
 import {percent} from 'sentry/utils';
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
+import {useGroupTags} from 'sentry/views/issueDetails/groupTags/useGroupTags';
 
 type GroupTagsProps = {
   baseUrl: string;
@@ -39,8 +38,7 @@ type SimpleTag = {
   totalValues: number;
 };
 
-function GroupTags({group, baseUrl, environments}: GroupTagsProps) {
-  const organization = useOrganization();
+function GroupTagsTab({group, baseUrl, environments}: GroupTagsProps) {
   const location = useLocation();
 
   const {
@@ -48,8 +46,7 @@ function GroupTags({group, baseUrl, environments}: GroupTagsProps) {
     isPending,
     isError,
     refetch,
-  } = useFetchIssueTags({
-    orgSlug: organization.slug,
+  } = useGroupTags({
     groupId: group.id,
     environment: environments,
   });
@@ -209,4 +206,4 @@ const TagBarCount = styled('div')`
   font-variant-numeric: tabular-nums;
 `;
 
-export default GroupTags;
+export default GroupTagsTab;

--- a/static/app/views/issueDetails/groupTags/useGroupTags.tsx
+++ b/static/app/views/issueDetails/groupTags/useGroupTags.tsx
@@ -1,0 +1,72 @@
+import type {Tag} from 'sentry/actionCreators/events';
+import type {GroupTagsResponse} from 'sentry/actionCreators/group';
+import {defined} from 'sentry/utils';
+import {
+  type ApiQueryKey,
+  useApiQuery,
+  type UseApiQueryOptions,
+} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+
+type FetchIssueTagsParameters = {
+  environment: string[];
+  /**
+   * Request is disabled until groupId is defined
+   */
+  groupId: string | undefined;
+  orgSlug: string;
+  limit?: number;
+  /**
+   * Readable formats mobile device names
+   * TODO(scott): Can we do this in the frontend instead
+   */
+  readable?: boolean;
+};
+
+type GroupTagUseQueryOptions = Partial<UseApiQueryOptions<GroupTagsResponse | Tag[]>>;
+
+const makeGroupTagsQueryKey = ({
+  groupId,
+  orgSlug,
+  environment,
+  readable,
+  limit,
+}: FetchIssueTagsParameters): ApiQueryKey => [
+  `/organizations/${orgSlug}/issues/${groupId}/tags/`,
+  {query: {environment, readable, limit}},
+];
+
+export function useGroupTags(
+  parameters: Omit<FetchIssueTagsParameters, 'orgSlug'>,
+  {enabled = true, ...options}: GroupTagUseQueryOptions = {}
+) {
+  const organization = useOrganization();
+  return useApiQuery<GroupTagsResponse | Tag[]>(
+    makeGroupTagsQueryKey({
+      orgSlug: organization.slug,
+      ...parameters,
+    }),
+    {
+      staleTime: 30000,
+      enabled: defined(parameters.groupId) && enabled,
+      ...options,
+    }
+  );
+}
+
+/**
+ * Primarily used for tag facets
+ */
+export function useGroupTagsReadable(
+  parameters: Omit<FetchIssueTagsParameters, 'orgSlug' | 'limit' | 'readable'>,
+  options: GroupTagUseQueryOptions = {}
+) {
+  return useGroupTags(
+    {
+      readable: true,
+      limit: 4,
+      ...parameters,
+    },
+    options
+  );
+}

--- a/static/app/views/issueDetails/streamline/eventSearch.tsx
+++ b/static/app/views/issueDetails/streamline/eventSearch.tsx
@@ -22,7 +22,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {ALL_EVENTS_EXCLUDED_TAGS} from 'sentry/views/issueDetails/groupEvents';
-import {useGroupTags} from 'sentry/views/issueDetails/groupTags/useGroupTagsQuery';
+import {useGroupTags} from 'sentry/views/issueDetails/groupTags/useGroupTags';
 import {mergeAndSortTagValues} from 'sentry/views/issueDetails/utils';
 import {makeGetIssueTagValues} from 'sentry/views/issueList/utils/getIssueTagValues';
 

--- a/static/app/views/issueDetails/streamline/eventSearch.tsx
+++ b/static/app/views/issueDetails/streamline/eventSearch.tsx
@@ -1,7 +1,6 @@
 import {useCallback, useMemo} from 'react';
 import orderBy from 'lodash/orderBy';
 
-import {useFetchIssueTags} from 'sentry/actionCreators/group';
 import {fetchTagValues} from 'sentry/actionCreators/tags';
 import {
   SearchQueryBuilder,
@@ -23,6 +22,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {ALL_EVENTS_EXCLUDED_TAGS} from 'sentry/views/issueDetails/groupEvents';
+import {useGroupTags} from 'sentry/views/issueDetails/groupTags/useGroupTagsQuery';
 import {mergeAndSortTagValues} from 'sentry/views/issueDetails/utils';
 import {makeGetIssueTagValues} from 'sentry/views/issueList/utils/getIssueTagValues';
 
@@ -36,7 +36,6 @@ interface EventSearchProps {
 }
 
 export function useEventQuery({group}: {group: Group}): string {
-  const organization = useOrganization();
   const {selection} = usePageFilters();
   const location = useLocation();
   const environments = selection.environments;
@@ -49,8 +48,7 @@ export function useEventQuery({group}: {group: Group}): string {
     eventQuery = locationQuery;
   }
 
-  const {data = []} = useFetchIssueTags({
-    orgSlug: organization.slug,
+  const {data = []} = useGroupTags({
     groupId: group.id,
     environment: environments,
   });
@@ -138,8 +136,7 @@ export function EventSearch({
   const api = useApi();
   const organization = useOrganization();
 
-  const {data = []} = useFetchIssueTags({
-    orgSlug: organization.slug,
+  const {data = []} = useGroupTags({
     groupId: group.id,
     environment: environments,
   });

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -13,7 +13,7 @@ import {defined} from 'sentry/utils';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';
 import {useUser} from 'sentry/utils/useUser';
-import {useGroupTagsReadable} from 'sentry/views/issueDetails/groupTags/useGroupTagsQuery';
+import {useGroupTagsReadable} from 'sentry/views/issueDetails/groupTags/useGroupTags';
 
 export function markEventSeen(
   api: Client,

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -1,7 +1,7 @@
 import {useMemo} from 'react';
 import orderBy from 'lodash/orderBy';
 
-import {bulkUpdate, useFetchIssueTags} from 'sentry/actionCreators/group';
+import {bulkUpdate} from 'sentry/actionCreators/group';
 import {Client} from 'sentry/api';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
@@ -11,9 +11,9 @@ import type {Event} from 'sentry/types/event';
 import type {Group, GroupActivity, TagValue} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useUser} from 'sentry/utils/useUser';
+import {useGroupTagsReadable} from 'sentry/views/issueDetails/groupTags/useGroupTagsQuery';
 
 export function markEventSeen(
   api: Client,
@@ -190,41 +190,6 @@ export function getGroupReprocessingStatus(
   }
 }
 
-export const useFetchIssueTagsForDetailsPage = (
-  {
-    groupId,
-    orgSlug,
-    environment = [],
-    isStatisticalDetector = false,
-    statisticalDetectorParameters,
-  }: {
-    environment: string[];
-    orgSlug: string;
-    groupId?: string;
-    isStatisticalDetector?: boolean;
-    statisticalDetectorParameters?: {
-      durationBaseline: number;
-      end: string;
-      start: string;
-      transaction: string;
-    };
-  },
-  {enabled = true}: {enabled?: boolean} = {}
-) => {
-  return useFetchIssueTags(
-    {
-      groupId,
-      orgSlug,
-      environment,
-      readable: true,
-      limit: 4,
-      isStatisticalDetector,
-      statisticalDetectorParameters,
-    },
-    {enabled}
-  );
-};
-
 export function useEnvironmentsFromUrl(): string[] {
   const location = useLocation();
   const envs = location.query.environment;
@@ -284,18 +249,16 @@ export function useHasStreamlinedUI() {
 }
 
 export function useIsSampleEvent(): boolean {
-  const params = useParams();
-  const organization = useOrganization();
+  const params = useParams<{groupId: string}>();
   const environments = useEnvironmentsFromUrl();
 
   const groupId = params.groupId;
 
   const group = GroupStore.get(groupId);
 
-  const {data} = useFetchIssueTagsForDetailsPage(
+  const {data} = useGroupTagsReadable(
     {
       groupId: groupId,
-      orgSlug: organization.slug,
       environment: environments,
     },
     // Don't want this query to take precedence over the main requests


### PR DESCRIPTION
- move the 2 hooks into a single file instead of exporting from various components
- cleanup `isStatisticalDetector` as the backend doesn't support it anymore
- rename groupTags to groupTagsTab because i'm going to add a drawer and some other things