### PR TITLE
cleanup(priority-alerts): Remove priority-ga flag from the backend

### DIFF
--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -7,7 +7,6 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.constants import MIGRATED_CONDITIONS, SENTRY_APP_ACTIONS, TICKET_ACTIONS
-from sentry.receivers.rules import has_high_priority_issue_alerts
 from sentry.rules import rules
 
 
@@ -75,11 +74,6 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
                 continue
 
             if rule_type.startswith("condition/"):
-                if not has_high_priority_issue_alerts(project=project) and context["id"] in (
-                    "sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition",
-                    "sentry.rules.conditions.high_priority_issue.ExistingHighPriorityIssueCondition",
-                ):
-                    continue
                 condition_list.append(context)
             elif rule_type.startswith("filter/"):
                 if (

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -314,7 +314,7 @@ def register_temporary_features(manager: FeatureManager):
     # Enable showing INP web vital in default views
     manager.add("organizations:performance-vitals-inp", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable the GA features for priority alerts
-    manager.add("organizations:priority-ga-features", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:priority-ga-features", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=True, api_expose=True)
     # Enable profiling
     manager.add("organizations:profiling", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enabled for those orgs who participated in the profiling Beta program

--- a/src/sentry/receivers/rules.py
+++ b/src/sentry/receivers/rules.py
@@ -1,10 +1,9 @@
-from sentry import features
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.notifications.types import FallthroughChoiceType
 from sentry.signals import project_created
 
-DEFAULT_RULE_LABEL = "Send a notification for new issues"
+DEFAULT_RULE_LABEL = "Send a notification for high priority issues"
 DEFAULT_RULE_ACTIONS = [
     {
         "id": "sentry.mail.actions.NotifyEmailAction",
@@ -14,27 +13,12 @@ DEFAULT_RULE_ACTIONS = [
     }
 ]
 DEFAULT_RULE_DATA = {
-    "action_match": "all",
-    "conditions": [{"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}],
-    "actions": DEFAULT_RULE_ACTIONS,
-}
-
-DEFAULT_RULE_LABEL_NEW = "Send a notification for high priority issues"
-DEFAULT_RULE_ACTIONS_NEW = [
-    {
-        "id": "sentry.mail.actions.NotifyEmailAction",
-        "targetType": "IssueOwners",
-        "targetIdentifier": None,
-        "fallthroughType": FallthroughChoiceType.ACTIVE_MEMBERS.value,
-    }
-]
-DEFAULT_RULE_DATA_NEW = {
     "action_match": "any",
     "conditions": [
         {"id": "sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition"},
         {"id": "sentry.rules.conditions.high_priority_issue.ExistingHighPriorityIssueCondition"},
     ],
-    "actions": DEFAULT_RULE_ACTIONS_NEW,
+    "actions": DEFAULT_RULE_ACTIONS,
 }
 
 
@@ -42,22 +26,12 @@ DEFAULT_RULE_DATA_NEW = {
 PLATFORMS_WITH_PRIORITY_ALERTS = ["python", "javascript"]
 
 
-def has_high_priority_issue_alerts(project: Project) -> bool:
-    # Seer-based priority is enabled if the organization has the feature flag
-    return features.has("organizations:priority-ga-features", project.organization)
-
-
 def create_default_rules(project: Project, default_rules=True, RuleModel=Rule, **kwargs):
     if not default_rules:
         return
 
-    if has_high_priority_issue_alerts(project):
-        rule_data = DEFAULT_RULE_DATA_NEW
-        RuleModel.objects.create(project=project, label=DEFAULT_RULE_LABEL_NEW, data=rule_data)
-
-    else:
-        rule_data = DEFAULT_RULE_DATA
-        RuleModel.objects.create(project=project, label=DEFAULT_RULE_LABEL, data=rule_data)
+    rule_data = DEFAULT_RULE_DATA
+    RuleModel.objects.create(project=project, label=DEFAULT_RULE_LABEL, data=rule_data)
 
 
 project_created.connect(create_default_rules, dispatch_uid="create_default_rules", weak=False)

--- a/src/sentry/rules/conditions/existing_high_priority_issue.py
+++ b/src/sentry/rules/conditions/existing_high_priority_issue.py
@@ -5,7 +5,6 @@ from sentry.eventstore.models import GroupEvent
 from sentry.models.activity import Activity
 from sentry.rules import EventState
 from sentry.rules.conditions.base import EventCondition
-from sentry.rules.conditions.new_high_priority_issue import has_high_priority_issue_alerts
 from sentry.types.activity import ActivityType
 from sentry.types.condition_activity import ConditionActivity, ConditionActivityType
 from sentry.types.group import PriorityLevel
@@ -16,9 +15,6 @@ class ExistingHighPriorityIssueCondition(EventCondition):
     label = "Sentry marks an existing issue as high priority"
 
     def passes(self, event: GroupEvent, state: EventState) -> bool:
-        if not has_high_priority_issue_alerts(self.project):
-            return False
-
         if state.is_new:
             return False
 

--- a/src/sentry/rules/conditions/new_high_priority_issue.py
+++ b/src/sentry/rules/conditions/new_high_priority_issue.py
@@ -1,19 +1,12 @@
 from collections.abc import Sequence
 from datetime import datetime
 
-from sentry import features
 from sentry.eventstore.models import GroupEvent
 from sentry.models.group import Group
-from sentry.models.project import Project
 from sentry.rules import EventState
 from sentry.rules.conditions.base import EventCondition
 from sentry.types.condition_activity import ConditionActivity, ConditionActivityType
 from sentry.types.group import PriorityLevel
-
-
-def has_high_priority_issue_alerts(project: Project) -> bool:
-    # Seer-based priority is enabled if the organization has the feature flag
-    return features.has("organizations:priority-ga-features", project.organization)
 
 
 class NewHighPriorityIssueCondition(EventCondition):
@@ -27,9 +20,6 @@ class NewHighPriorityIssueCondition(EventCondition):
         return state.is_new_group_environment
 
     def passes(self, event: GroupEvent, state: EventState) -> bool:
-        if not has_high_priority_issue_alerts(self.project):
-            return False
-
         is_new = self.is_new(state)
         if not event.project.flags.has_high_priority_alerts:
             return is_new

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -1419,7 +1419,7 @@ class CopyProjectSettingsTest(APITestCase):
         # default rule
         rules = Rule.objects.filter(project_id=project.id)
         assert len(rules) == 1
-        assert rules[0].label == "Send a notification for new issues"
+        assert rules[0].label == "Send a notification for high priority issues"
 
     def test_simple(self):
         project = self.create_project()

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -33,7 +33,7 @@ class ProjectRuleConfigurationTest(APITestCase):
 
         response = self.get_success_response(self.organization.slug, project1.slug)
         assert len(response.data["actions"]) == 12
-        assert len(response.data["conditions"]) == 7
+        assert len(response.data["conditions"]) == 9
         assert len(response.data["filters"]) == 8
 
     @property
@@ -148,7 +148,7 @@ class ProjectRuleConfigurationTest(APITestCase):
                 "service": {"type": "choice", "choices": [[sentry_app.slug, sentry_app.name]]}
             },
         } in response.data["actions"]
-        assert len(response.data["conditions"]) == 7
+        assert len(response.data["conditions"]) == 9
         assert len(response.data["filters"]) == 8
 
     @patch("sentry.sentry_apps.components.SentryAppComponentPreparer.run")
@@ -179,28 +179,17 @@ class ProjectRuleConfigurationTest(APITestCase):
             "formFields": settings_schema["settings"],
             "sentryAppInstallationUuid": str(install.uuid),
         } in response.data["actions"]
-        assert len(response.data["conditions"]) == 7
+        assert len(response.data["conditions"]) == 9
         assert len(response.data["filters"]) == 8
 
     def test_issue_type_and_category_filter_feature(self):
         response = self.get_success_response(self.organization.slug, self.project.slug)
         assert len(response.data["actions"]) == 12
-        assert len(response.data["conditions"]) == 7
+        assert len(response.data["conditions"]) == 9
         assert len(response.data["filters"]) == 8
 
         filter_ids = {f["id"] for f in response.data["filters"]}
         assert IssueCategoryFilter.id in filter_ids
-
-    def test_high_priority_issue_condition(self):
-        with self.feature({"organizations:priority-ga-features": True}):
-            response = self.get_success_response(self.organization.slug, self.project.slug)
-            assert "sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition" in [
-                filter["id"] for filter in response.data["conditions"]
-            ]
-            assert (
-                "sentry.rules.conditions.high_priority_issue.ExistingHighPriorityIssueCondition"
-                in [filter["id"] for filter in response.data["conditions"]]
-            )
 
     def test_is_in_feature(self):
         response = self.get_success_response(self.organization.slug, self.project.slug)

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -85,6 +85,7 @@ class OrganizationSerializerTest(TestCase):
             "integrations-stacktrace-link",
             "integrations-ticket-rules",
             "performance-tracing-without-performance",
+            "priority-ga-features",
             "invite-members",
             "minute-resolution-sessions",
             "new-page-filter",

--- a/tests/sentry/integrations/slack/tasks/test_tasks.py
+++ b/tests/sentry/integrations/slack/tasks/test_tasks.py
@@ -16,7 +16,7 @@ from sentry.integrations.slack.tasks import (
 from sentry.integrations.slack.utils.channel import SlackChannelIdData
 from sentry.integrations.slack.utils.rule_status import RedisRuleStatus
 from sentry.models.rule import Rule
-from sentry.receivers.rules import DEFAULT_RULE_LABEL, DEFAULT_RULE_LABEL_NEW
+from sentry.receivers.rules import DEFAULT_RULE_LABEL
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import install_slack
 from sentry.testutils.skips import requires_snuba
@@ -100,9 +100,7 @@ class SlackTasksTest(TestCase):
         with self.tasks():
             find_channel_id_for_rule(**data)
 
-        rule = Rule.objects.exclude(label__in=[DEFAULT_RULE_LABEL, DEFAULT_RULE_LABEL_NEW]).get(
-            project_id=self.project.id
-        )
+        rule = Rule.objects.exclude(label__in=[DEFAULT_RULE_LABEL]).get(project_id=self.project.id)
         mock_set_value.assert_called_with("success", rule.id)
         assert rule.label == "New Rule"
         # check that the channel_id got added

--- a/tests/sentry/rules/conditions/test_existing_high_priority_issue.py
+++ b/tests/sentry/rules/conditions/test_existing_high_priority_issue.py
@@ -1,7 +1,6 @@
 from sentry.models.rule import Rule
 from sentry.rules.conditions.existing_high_priority_issue import ExistingHighPriorityIssueCondition
 from sentry.testutils.cases import RuleTestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
 from sentry.types.group import PriorityLevel
 
@@ -14,7 +13,6 @@ class ExistingHighPriorityIssueConditionTest(RuleTestCase):
     def setUp(self):
         self.rule = Rule(environment_id=1, project=self.project, label="label")
 
-    @with_feature("organizations:priority-ga-features")
     def test_applies_correctly(self):
         rule = self.get_rule(rule=self.rule)
 

--- a/tests/sentry/rules/conditions/test_new_high_priority_issue.py
+++ b/tests/sentry/rules/conditions/test_new_high_priority_issue.py
@@ -1,7 +1,6 @@
 from sentry.models.rule import Rule
 from sentry.rules.conditions.new_high_priority_issue import NewHighPriorityIssueCondition
 from sentry.testutils.cases import RuleTestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
 from sentry.types.group import PriorityLevel
 
@@ -14,7 +13,6 @@ class NewHighPriorityIssueConditionTest(RuleTestCase):
     def setUp(self):
         self.rule = Rule(environment_id=1, project=self.project, label="label")
 
-    @with_feature("organizations:priority-ga-features")
     def test_applies_correctly_with_high_priority_alerts(self):
         self.project.flags.has_high_priority_alerts = True
         self.project.save()
@@ -34,7 +32,6 @@ class NewHighPriorityIssueConditionTest(RuleTestCase):
         self.event.group.update(priority=PriorityLevel.LOW)
         self.assertDoesNotPass(rule, is_new_group_environment=True)
 
-    @with_feature("organizations:priority-ga-features")
     def test_applies_correctly_without_high_priority_alerts(self):
         self.project.flags.has_high_priority_alerts = False
         self.project.save()


### PR DESCRIPTION
The feature has been GA for a few weeks and alert migrations are complete. We can remove the flag now.