### PR TITLE
ref(releases): dont send back release stats on update

### DIFF
--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -526,7 +526,7 @@ class OrganizationReleaseDetailsEndpoint(
                     datetime=release.date_released,
                 )
 
-        return Response(serialize(release, request.user))
+        return Response(serialize(release, request.user, no_snuba_for_release_creation=True))
 
     @extend_schema(
         operation_id="Delete an Organization's Release",

--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -5,7 +5,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import ListField
 
-from sentry import release_health
+from sentry import options, release_health
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import ReleaseAnalyticsMixin, region_silo_endpoint
@@ -526,7 +526,12 @@ class OrganizationReleaseDetailsEndpoint(
                     datetime=release.date_released,
                 )
 
-        return Response(serialize(release, request.user, no_snuba_for_release_creation=True))
+        no_snuba_for_release_creation = options.get("releases.no_snuba_for_release_creation")
+        return Response(
+            serialize(
+                release, request.user, no_snuba_for_release_creation=no_snuba_for_release_creation
+            )
+        )
 
     @extend_schema(
         operation_id="Delete an Organization's Release",

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -588,7 +588,9 @@ class OrganizationReleasesEndpoint(
                 update_org_auth_token_last_used(request.auth, [project.id for project in projects])
 
             scope.set_tag("success_status", status)
-            return Response(serialize(release, request.user), status=status)
+            return Response(
+                serialize(release, request.user, no_snuba_for_release_creation=True), status=status
+            )
         scope.set_tag("failure_reason", "serializer_error")
         return Response(serializer.errors, status=400)
 

--- a/src/sentry/api/endpoints/project_release_details.py
+++ b/src/sentry/api/endpoints/project_release_details.py
@@ -145,7 +145,7 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
                 datetime=release.date_released,
             )
 
-        return Response(serialize(release, request.user))
+        return Response(serialize(release, request.user, no_snuba_for_release_creation=True))
 
     def delete(self, request: Request, project, version) -> Response:
         """

--- a/src/sentry/api/endpoints/project_release_details.py
+++ b/src/sentry/api/endpoints/project_release_details.py
@@ -2,6 +2,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import options
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import ReleaseAnalyticsMixin, region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
@@ -144,8 +145,12 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
                 data={"version": release.version},
                 datetime=release.date_released,
             )
-
-        return Response(serialize(release, request.user, no_snuba_for_release_creation=True))
+        no_snuba_for_release_creation = options.get("releases.no_snuba_for_release_creation")
+        return Response(
+            serialize(
+                release, request.user, no_snuba_for_release_creation=no_snuba_for_release_creation
+            )
+        )
 
     def delete(self, request: Request, project, version) -> Response:
         """

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2729,3 +2729,10 @@ register(
     default=[],
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+register(
+    "releases.no_snuba_for_release_creation",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)


### PR DESCRIPTION
I can't think of a reason why release stats are super necessary on updates to a release. This causes extra load on snuba, and can also result in release update failures when snuba is being rate limited or 429ing.

If this is too aggressive, we could consider catching 429's in the release serializer and making them empty instead.


releasing under an option so we can rollback if any problems are observed.