### PR TITLE
chore(grouping): Stop calling `_save_aggregate`

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1323,20 +1323,11 @@ def get_culprit(data: Mapping[str, Any]) -> str:
 
 @sentry_sdk.tracing.trace
 def assign_event_to_group(event: Event, job: Job, metric_tags: MutableTags) -> GroupInfo | None:
-    if job["optimized_grouping"]:
-        group_info = _save_aggregate_new(
-            event=event,
-            job=job,
-            metric_tags=metric_tags,
-        )
-    else:
-        group_info = _save_aggregate(
-            event=event,
-            job=job,
-            release=job["release"],
-            received_timestamp=job["received_timestamp"],
-            metric_tags=metric_tags,
-        )
+    group_info = _save_aggregate_new(
+        event=event,
+        job=job,
+        metric_tags=metric_tags,
+    )
 
     if group_info:
         event.group = group_info.group

--- a/tests/sentry/event_manager/grouping/test_assign_to_group.py
+++ b/tests/sentry/event_manager/grouping/test_assign_to_group.py
@@ -377,8 +377,8 @@ def test_existing_group_no_new_hash(
 )
 @pytest.mark.parametrize(
     "new_logic_enabled",
-    (True, False),
-    ids=(" new_logic_enabled: True ", " new_logic_enabled: False "),
+    (True,),
+    ids=(" new_logic_enabled: True ",),
 )
 @pytest.mark.parametrize(
     "secondary_hash_exists",
@@ -506,13 +506,4 @@ def test_uses_regular_or_optimized_grouping_as_appropriate(
             {"message": "Dogs are great!"}, project, DEFAULT_GROUPING_CONFIG
         )
 
-    if killswitch_enabled:
-        assert mock_save_aggregate.call_count == 1
-    elif flag_on:
-        assert mock_save_aggregate_new.call_count == 1
-    elif in_transition:
-        assert mock_save_aggregate_new.call_count == 1
-    elif id_qualifies:
-        assert mock_save_aggregate_new.call_count == 1
-    else:
-        assert mock_save_aggregate.call_count == 1
+    assert mock_save_aggregate_new.call_count == 1


### PR DESCRIPTION
As of https://github.com/getsentry/sentry/pull/77027, all projects are using the new grouping config transition flow, because `project_uses_optimized_grouping` now always returns `True`. We can therefore start removing the old code path. 

This takes the first step in that direction by removing the call to the old version of the `_save_aggregate` function. Though this isn't strictly necessary before removing the function (since now no one should be going through the branch which calls it), this makes it extra obvious that nothing can go wrong when that happens. 