### PR TITLE
fix(flagpole-schema): Update created at schema pattern to accept UTC format

### DIFF
--- a/src/flagpole/flagpole-schema.json
+++ b/src/flagpole/flagpole-schema.json
@@ -32,7 +32,7 @@
       "title": "Created At",
       "description": "The datetime when this feature was created.",
       "type": "string",
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}(?:T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?)?$"
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}(?:T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:[-+]\\d{2}\\:?\\d{2})?Z?)?$"
     }
   },
   "required": ["name", "owner", "segments", "created_at"],


### PR DESCRIPTION
<!-- Describe your PR here. -->
This updates the sentry repo to adopt [this fix](https://github.com/getsentry/sentry-options-automator/pull/2313) from the options repo. It accepts the UTC datetime format in the `created_at` field in flagpole feature flags.
<!--

  Sentry employees and contractors can delete or ignore the following.

-->

