### PR TITLE
devenv: bump to 1.10.2

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -179,7 +179,7 @@ s3transfer==0.10.0
 selenium==4.16.0
 sentry-arroyo==2.16.5
 sentry-cli==2.16.0
-sentry-devenv==1.10.1
+sentry-devenv==1.10.2
 sentry-forked-django-stubs==5.0.4.post2
 sentry-forked-djangorestframework-stubs==3.15.1.post1
 sentry-kafka-schemas==0.1.109

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -179,7 +179,7 @@ s3transfer==0.10.0
 selenium==4.16.0
 sentry-arroyo==2.16.5
 sentry-cli==2.16.0
-sentry-devenv==1.10.0
+sentry-devenv==1.10.1
 sentry-forked-django-stubs==5.0.4.post2
 sentry-forked-djangorestframework-stubs==3.15.1.post1
 sentry-kafka-schemas==0.1.109

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 
-sentry-devenv>=1.10.1
+sentry-devenv>=1.10.2
 
 covdefaults>=2.3.0
 docker>=6

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 
-sentry-devenv>=1.10.0
+sentry-devenv>=1.10.1
 
 covdefaults>=2.3.0
 docker>=6


### PR DESCRIPTION
actually probably gonna wait for https://github.com/getsentry/devenv/pull/144 and just bump to 1.10.2