### PR TITLE
feat(uptime): Enforce per-domain limits

### DIFF
--- a/src/sentry/uptime/detectors/url_extraction.py
+++ b/src/sentry/uptime/detectors/url_extraction.py
@@ -6,6 +6,7 @@ from urllib.parse import urlsplit
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator, validate_ipv46_address
 from tldextract import TLDExtract
+from tldextract.tldextract import ExtractResult
 
 if TYPE_CHECKING:
     pass
@@ -51,3 +52,9 @@ def extract_base_url(url: str | None) -> str | None:
     extracted_url = extractor.extract_urllib(split_url)
     fqdn = extracted_url.fqdn
     return f"{split_url.scheme}://{fqdn}" if fqdn else None
+
+
+def extract_domain_parts(url: str) -> ExtractResult:
+    # We enable private PSL domains so that hosting services that use
+    # subdomains are treated as suffixes for the purposes of monitoring.
+    return extractor.extract_str(url, include_psl_private_domains=True)

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from sentry.models.project import Project
 from sentry.types.actor import Actor
-from sentry.uptime.detectors.url_extraction import extractor
+from sentry.uptime.detectors.url_extraction import extract_domain_parts
 from sentry.uptime.models import (
     ProjectUptimeSubscription,
     ProjectUptimeSubscriptionMode,
@@ -32,9 +32,7 @@ def create_uptime_subscription(
     """
     # We extract the domain and suffix of the url here. This is used to prevent there being too many checks to a single
     # domain.
-    # We enable private PSL domains so that hosting services that use subdomains are treated as suffixes for the
-    # purposes of monitoring.
-    result = extractor.extract_str(url, include_psl_private_domains=True)
+    result = extract_domain_parts(url)
     subscription, created = UptimeSubscription.objects.get_or_create(
         url=url,
         interval_seconds=interval_seconds,


### PR DESCRIPTION
Need to fix the test, but this will make it so you can no longer create
more monitors once the per domain limit is reached