### PR TITLE
ref(access): simplify access component

### DIFF
--- a/static/app/components/acl/access.spec.tsx
+++ b/static/app/components/acl/access.spec.tsx
@@ -134,7 +134,7 @@ describe('Access', function () {
         })
       );
 
-      render(<Access>{childrenMock}</Access>, {organization});
+      render(<Access access={[]}>{childrenMock}</Access>, {organization});
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasAccess: true,
@@ -149,9 +149,14 @@ describe('Access', function () {
         })
       );
 
-      render(<Access isSuperuser>{childrenMock}</Access>, {
-        organization,
-      });
+      render(
+        <Access access={[]} isSuperuser>
+          {childrenMock}
+        </Access>,
+        {
+          organization,
+        }
+      );
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasAccess: true,
@@ -166,9 +171,14 @@ describe('Access', function () {
         })
       );
 
-      render(<Access isSuperuser>{childrenMock}</Access>, {
-        organization,
-      });
+      render(
+        <Access access={[]} isSuperuser>
+          {childrenMock}
+        </Access>,
+        {
+          organization,
+        }
+      );
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasAccess: true,
@@ -208,7 +218,7 @@ describe('Access', function () {
       );
 
       render(
-        <Access isSuperuser>
+        <Access access={[]} isSuperuser>
           <p>The Child</p>
         </Access>,
         {organization}
@@ -225,7 +235,7 @@ describe('Access', function () {
       );
 
       render(
-        <Access isSuperuser>
+        <Access access={[]} isSuperuser>
           <p>The Child</p>
         </Access>,
         {organization}

--- a/static/app/components/acl/access.tsx
+++ b/static/app/components/acl/access.tsx
@@ -18,7 +18,7 @@ type Props = {
   /**
    * List of required access levels
    */
-  access?: Scope[];
+  access: Scope[];
   /**
    * Children can be a node or a function as child.
    */
@@ -40,7 +40,7 @@ type Props = {
    * An "org-member" does not have project:write but if they are "team-admin" for
    * of a parent team, they will have appropriate scopes.
    */
-  project?: Project | null | undefined;
+  project?: Project;
   /**
    * Optional: To be used when you need to check for access to the Team
    *
@@ -48,13 +48,13 @@ type Props = {
    * An "org-member" does not have team:write but if they are "team-admin" for
    * the team, they will have appropriate scopes.
    */
-  team?: Team | null | undefined;
+  team?: Team;
 };
 
 /**
  * Component to handle access restrictions.
  */
-function Access({children, isSuperuser = false, access = [], team, project}: Props) {
+function Access({children, isSuperuser, access, team, project}: Props) {
   const user = useUser();
   const organization = useOrganization();
 

--- a/static/app/components/acl/access.tsx
+++ b/static/app/components/acl/access.tsx
@@ -91,13 +91,18 @@ export function hasEveryAccess(
     project?: Project | null;
     team?: Team | null;
   }
-) {
-  return (
-    !access.length ||
-    access.every(acc => entities.organization?.access?.includes(acc)) ||
-    access.every(acc => entities.team?.access?.includes(acc)) ||
-    access.every(acc => entities.project?.access?.includes(acc))
-  );
+): boolean {
+  const hasOrganizationAccess = entities.organization
+    ? access.every(acc => entities.organization?.access?.includes(acc))
+    : false;
+  const hasTeamAccess = entities.team
+    ? access.every(acc => entities.team?.access?.includes(acc))
+    : false;
+  const hasProjectAccess = entities.project
+    ? access.every(acc => entities.project?.access?.includes(acc))
+    : false;
+
+  return !access.length || hasOrganizationAccess || hasTeamAccess || hasProjectAccess;
 }
 
 export default Access;

--- a/static/app/components/acl/access.tsx
+++ b/static/app/components/acl/access.tsx
@@ -54,9 +54,17 @@ type Props = {
 /**
  * Component to handle access restrictions.
  */
-function Access({children, isSuperuser, access, team, project}: Props) {
+function Access({
+  children,
+  organization: overrideOrganization,
+  isSuperuser,
+  access,
+  team,
+  project,
+}: Props) {
   const user = useUser();
-  const organization = useOrganization();
+  const implicitOrganization = useOrganization();
+  const organization = overrideOrganization || implicitOrganization;
 
   const hasSuperuser = Boolean(user?.isSuperuser);
   const hasAccess = hasEveryAccess(access, {

--- a/static/app/components/acl/access.tsx
+++ b/static/app/components/acl/access.tsx
@@ -22,7 +22,7 @@ type Props = {
   /**
    * Children can be a node or a function as child.
    */
-  children?: React.ReactNode | ChildFunction;
+  children: React.ReactNode | ChildFunction;
   /**
    * Requires superuser
    */

--- a/static/app/components/search/sources/commandSource.tsx
+++ b/static/app/components/search/sources/commandSource.tsx
@@ -167,7 +167,7 @@ class CommandSource extends Component<Props, State> {
 
 function CommandSourceWithFeature(props: Omit<Props, 'isSuperuser'>) {
   return (
-    <Access isSuperuser>
+    <Access access={[]} isSuperuser>
       {({hasSuperuser}) => <CommandSource {...props} isSuperuser={hasSuperuser} />}
     </Access>
   );

--- a/static/app/views/settings/project/permissionAlert.tsx
+++ b/static/app/views/settings/project/permissionAlert.tsx
@@ -7,8 +7,8 @@ import type {Project} from 'sentry/types/project';
 
 interface Props extends React.ComponentPropsWithoutRef<typeof Alert> {
   access?: Scope[];
-  project?: Project | null | undefined;
-  team?: Team | null | undefined;
+  project?: Project;
+  team?: Team;
 }
 
 export const permissionAlertText = t(


### PR DESCRIPTION
Simplify types and enforce passing of access type (even though) empty as it is better to explicitly require empty set of access level permissions for such components.