### PR TITLE
chore(endpoints): Undo incorrect typing lines

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -152,14 +152,6 @@ class EventsApiResponse(TypedDict):
     meta: EventsMeta
 
 
-# When calling make build-spectacular-docs we hit this issue
-# https://github.com/tfranzel/drf-spectacular/issues/1041
-# This is a work around
-EventsMeta.__annotations__["datasetReason"] = str
-EventsMeta.__annotations__["isMetricsData"] = bool
-EventsMeta.__annotations__["isMetricsExtractedData"] = bool
-
-
 def rate_limit_events(
     request: Request, organization_id_or_slug: str | None = None, *args, **kwargs
 ) -> dict[str, dict[RateLimitCategory, RateLimit]]:


### PR DESCRIPTION
In #60614, I introduced something I should not have which was suggested on Slack for debugging purposes. I lost track of it and this remediates that.