### PR TITLE
feat(autofix): Polish interactive flow UI

### DIFF
--- a/static/app/components/events/autofix/autofixBanner.spec.tsx
+++ b/static/app/components/events/autofix/autofixBanner.spec.tsx
@@ -35,7 +35,7 @@ describe('AutofixBanner', () => {
     expect(screen.getByRole('button', {name: /Set up Autofix/i})).toBeInTheDocument();
   });
 
-  it('renders the banner with "Run Autofix" button when setup is done', () => {
+  it('renders the banner with "Open Autofix" button when setup is done', () => {
     render(
       <AutofixBanner
         group={mockGroup}
@@ -46,7 +46,7 @@ describe('AutofixBanner', () => {
     );
 
     expect(screen.getByText(/Try Autofix/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: /Run Autofix/i})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /Open Autofix/i})).toBeInTheDocument();
   });
 
   it('opens the AutofixSetupModal when "Set up Autofix" is clicked', async () => {

--- a/static/app/components/events/autofix/autofixBanner.tsx
+++ b/static/app/components/events/autofix/autofixBanner.tsx
@@ -55,7 +55,7 @@ function SuccessfulSetup({
 
   return (
     <Button onClick={() => openAutofix()} size="sm" ref={openButtonRef}>
-      {t('Run Autofix')}
+      {t('Open Autofix')}
     </Button>
   );
 }

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
+import {AnimatePresence, type AnimationProps, motion} from 'framer-motion';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {openModal} from 'sentry/actionCreators/modal';
@@ -22,6 +23,7 @@ import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {setApiQueryData, useMutation, useQueryClient} from 'sentry/utils/queryClient';
+import testableTransition from 'sentry/utils/testableTransition';
 import useApi from 'sentry/utils/useApi';
 
 type AutofixChangesProps = {
@@ -184,6 +186,13 @@ function AutofixRepoChange({
   );
 }
 
+const cardAnimationProps: AnimationProps = {
+  exit: {opacity: 0},
+  initial: {opacity: 0, y: 20},
+  animate: {opacity: 1, y: 0},
+  transition: testableTransition({duration: 0.3}),
+};
+
 export function AutofixChanges({step, onRetry, groupId}: AutofixChangesProps) {
   const data = useAutofixData({groupId});
 
@@ -225,17 +234,21 @@ export function AutofixChanges({step, onRetry, groupId}: AutofixChangesProps) {
   }
 
   return (
-    <ChangesContainer>
-      <ClippedBox clipHeight={408}>
-        <HeaderText>{t('Fixes')}</HeaderText>
-        {step.changes.map((change, i) => (
-          <Fragment key={change.repo_external_id}>
-            {i > 0 && <Separator />}
-            <AutofixRepoChange change={change} groupId={groupId} />
-          </Fragment>
-        ))}
-      </ClippedBox>
-    </ChangesContainer>
+    <AnimatePresence initial>
+      <AnimationWrapper key="card" {...cardAnimationProps}>
+        <ChangesContainer>
+          <ClippedBox clipHeight={408}>
+            <HeaderText>{t('Fixes')}</HeaderText>
+            {step.changes.map((change, i) => (
+              <Fragment key={change.repo_external_id}>
+                {i > 0 && <Separator />}
+                <AutofixRepoChange change={change} groupId={groupId} />
+              </Fragment>
+            ))}
+          </ClippedBox>
+        </ChangesContainer>
+      </AnimationWrapper>
+    </AnimatePresence>
   );
 }
 
@@ -246,6 +259,8 @@ const PreviewContent = styled('div')`
   margin-top: ${space(2)};
 `;
 
+const AnimationWrapper = styled(motion.div)``;
+
 const PrefixText = styled('span')``;
 
 const ChangesContainer = styled('div')`
@@ -253,7 +268,9 @@ const ChangesContainer = styled('div')`
   border-radius: ${p => p.theme.borderRadius};
   overflow: hidden;
   box-shadow: ${p => p.theme.dropShadowHeavy};
-  padding: ${space(2)};
+  padding-left: ${space(2)};
+  padding-right: ${space(2)};
+  padding-top: ${space(1)};
 `;
 
 const Content = styled('div')`

--- a/static/app/components/events/autofix/autofixDrawer.spec.tsx
+++ b/static/app/components/events/autofix/autofixDrawer.spec.tsx
@@ -34,7 +34,7 @@ describe('AutofixDrawer', () => {
 
     expect(screen.getByRole('heading', {name: 'Autofix'})).toBeInTheDocument();
 
-    expect(screen.getByText('Ready to begin analyzing the issue?')).toBeInTheDocument();
+    expect(screen.getByText('Ready to Start')).toBeInTheDocument();
 
     const startButton = screen.getByRole('button', {name: 'Start'});
     expect(startButton).toBeInTheDocument();
@@ -88,7 +88,7 @@ describe('AutofixDrawer', () => {
     await userEvent.click(startOverButton);
 
     await waitFor(() => {
-      expect(screen.getByText('Ready to begin analyzing the issue?')).toBeInTheDocument();
+      expect(screen.getByText('Ready to Start')).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Start'})).toBeInTheDocument();
     });
   });

--- a/static/app/components/events/autofix/autofixDrawer.spec.tsx
+++ b/static/app/components/events/autofix/autofixDrawer.spec.tsx
@@ -34,7 +34,7 @@ describe('AutofixDrawer', () => {
 
     expect(screen.getByRole('heading', {name: 'Autofix'})).toBeInTheDocument();
 
-    expect(screen.getByText('Ready to Start')).toBeInTheDocument();
+    expect(screen.getByText('Autofix is ready to start')).toBeInTheDocument();
 
     const startButton = screen.getByRole('button', {name: 'Start'});
     expect(startButton).toBeInTheDocument();
@@ -88,7 +88,7 @@ describe('AutofixDrawer', () => {
     await userEvent.click(startOverButton);
 
     await waitFor(() => {
-      expect(screen.getByText('Ready to Start')).toBeInTheDocument();
+      expect(screen.getByText('Autofix is ready to start')).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Start'})).toBeInTheDocument();
     });
   });

--- a/static/app/components/events/autofix/autofixDrawer.tsx
+++ b/static/app/components/events/autofix/autofixDrawer.tsx
@@ -1,15 +1,17 @@
 import {useState} from 'react';
 import styled from '@emotion/styled';
 
+import bannerImage from 'sentry-images/spot/ai-suggestion-banner.svg';
+
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import {Breadcrumbs as NavigationBreadcrumbs} from 'sentry/components/breadcrumbs';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import AutofixFeedback from 'sentry/components/events/autofix/autofixFeedback';
-import AutofixMessageBox from 'sentry/components/events/autofix/autofixMessageBox';
 import {AutofixSteps} from 'sentry/components/events/autofix/autofixSteps';
 import {useAiAutofix} from 'sentry/components/events/autofix/useAutofix';
 import {DrawerBody, DrawerHeader} from 'sentry/components/globalDrawer/components';
+import Input from 'sentry/components/input';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
@@ -18,6 +20,43 @@ import type {Project} from 'sentry/types/project';
 import {getShortEventId} from 'sentry/utils/events';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {MIN_NAV_HEIGHT} from 'sentry/views/issueDetails/streamline/eventNavigation';
+
+interface AutofixStartBoxProps {
+  onSend: (message: string) => void;
+}
+
+function AutofixStartBox({onSend}: AutofixStartBoxProps) {
+  const [message, setMessage] = useState('');
+
+  const send = () => {
+    onSend(message);
+  };
+
+  return (
+    <StartBox>
+      <Header>Autofix is ready to start</Header>
+      <br />
+      <p>
+        We'll begin by trying to figure out the root cause, analyzing the issue details
+        and the codebase. If you have any other helpful context on the issue before we
+        begin, you can share that below.
+      </p>
+      <Input
+        type="text"
+        value={message}
+        onChange={e => setMessage(e.target.value)}
+        placeholder={'Provide any extra context here...'}
+      />
+      <br />
+      <Button priority="primary" onClick={send}>
+        Start
+      </Button>
+      <IllustrationContainer>
+        <Illustration src={bannerImage} />
+      </IllustrationContainer>
+    </StartBox>
+  );
+}
 
 interface AutofixDrawerProps {
   event: Event;
@@ -72,22 +111,7 @@ export function AutofixDrawer({group, project, event}: AutofixDrawerProps) {
       </AutofixNavigator>
       <AutofixDrawerBody ref={setContainer}>
         {!autofixData ? (
-          <AutofixMessageBox
-            displayText={
-              "If you have any extra context on the issue before we begin, you can share it below. If not, press start when you're ready."
-            }
-            headerTextOverride={'Ready to Start'}
-            step={null}
-            primaryAction
-            inputPlaceholder={'Optionally provide any extra context here...'}
-            responseRequired={false}
-            onSend={triggerAutofix}
-            actionText={'Start'}
-            allowEmptyMessage
-            isDisabled={false}
-            runId={''}
-            groupId={group.id}
-          />
+          <AutofixStartBox onSend={triggerAutofix} />
         ) : (
           <AutofixSteps
             data={autofixData}
@@ -100,6 +124,23 @@ export function AutofixDrawer({group, project, event}: AutofixDrawerProps) {
     </AutofixDrawerContainer>
   );
 }
+
+const IllustrationContainer = styled('div')`
+  padding-top: ${space(4)};
+`;
+
+const Illustration = styled('img')`
+  height: 100%;
+`;
+
+const StartBox = styled('div')`
+  padding: ${space(2)};
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100%;
+  width: 100%;
+`;
 
 const AutofixDrawerContainer = styled('div')`
   height: 100%;

--- a/static/app/components/events/autofix/autofixDrawer.tsx
+++ b/static/app/components/events/autofix/autofixDrawer.tsx
@@ -73,9 +73,13 @@ export function AutofixDrawer({group, project, event}: AutofixDrawerProps) {
       <AutofixDrawerBody ref={setContainer}>
         {!autofixData ? (
           <AutofixMessageBox
-            displayText={'Ready to begin analyzing the issue?'}
+            displayText={
+              "If you have any extra context on the issue before we begin, you can share it below. If not, press start when you're ready."
+            }
+            headerTextOverride={'Ready to Start'}
             step={null}
-            inputPlaceholder={'Optionally provide any extra context before we start...'}
+            primaryAction
+            inputPlaceholder={'Optionally provide any extra context here...'}
             responseRequired={false}
             onSend={triggerAutofix}
             actionText={'Start'}

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -2,6 +2,8 @@ import {useState} from 'react';
 import styled from '@emotion/styled';
 import {AnimatePresence, type AnimationProps, motion} from 'framer-motion';
 
+import bannerImage from 'sentry-images/spot/ai-suggestion-banner.svg';
+
 import {Button} from 'sentry/components/button';
 import {
   replaceHeadersWithBold,
@@ -237,20 +239,66 @@ function AutofixInsightCards({
 }: AutofixInsightCardsProps) {
   return (
     <InsightsContainer>
-      {insights.map((insight, index) =>
-        !insight ? null : (
-          <AutofixInsightCard
-            key={index}
-            insight={insight}
-            hasCardBelow={index < insights.length - 1 || hasStepBelow}
-            hasCardAbove={hasStepAbove && index === 0}
-            repos={repos}
-          />
-        )
+      {!hasStepAbove && (
+        <div>
+          <TitleText>Insights</TitleText>
+          <IconContainer>
+            <IconArrow direction={'down'} />
+          </IconContainer>
+        </div>
       )}
+      {insights.length > 0 ? (
+        insights.map((insight, index) =>
+          !insight ? null : (
+            <AutofixInsightCard
+              key={index}
+              insight={insight}
+              hasCardBelow={index < insights.length - 1 || hasStepBelow}
+              hasCardAbove={hasStepAbove && index === 0}
+              repos={repos}
+            />
+          )
+        )
+      ) : !hasStepAbove && !hasStepBelow ? (
+        <NoInsightsYet>
+          <p>Nothing yet...</p>
+          <p>
+            Autofix will share important conclusions here as it discovers them, building a
+            line of reasoning up to the root cause.
+          </p>
+          <IllustrationContainer>
+            <Illustration src={bannerImage} />
+          </IllustrationContainer>
+        </NoInsightsYet>
+      ) : null}
     </InsightsContainer>
   );
 }
+
+const IllustrationContainer = styled('div')`
+  padding-top: ${space(4)};
+`;
+
+const Illustration = styled('img')`
+  height: 100%;
+`;
+
+const NoInsightsYet = styled('div')`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  padding-left: ${space(4)};
+  padding-right: ${space(4)};
+  text-align: center;
+`;
+
+const TitleText = styled('p')`
+  font-size: ${p => p.theme.fontSizeLarge};
+  font-weight: ${p => p.theme.fontWeightBold};
+  margin: 0;
+  display: flex;
+  justify-content: center;
+`;
 
 const InsightsContainer = styled('div')``;
 
@@ -295,6 +343,7 @@ const TextBreak = styled('span')`
 
 const BackgroundPanel = styled('div')`
   padding: ${space(1)};
+  margin-bottom: ${space(1)};
   background: ${p => p.theme.backgroundSecondary};
   border-radius: ${p => p.theme.borderRadius};
 `;
@@ -308,7 +357,6 @@ const MiniHeader = styled('p')`
 const ExpandableContext = styled('div')`
   width: 100%;
   background: ${p => p.theme.alert.info.backgroundLight};
-  border-radius: ${p => p.theme.borderRadius};
 `;
 
 const ContextHeader = styled(Button)`
@@ -318,6 +366,7 @@ const ContextHeader = styled(Button)`
   border: none;
   font-weight: normal;
   background: ${p => p.theme.backgroundSecondary};
+  border-radius: 0px;
 `;
 
 const ContextHeaderWrapper = styled('div')`

--- a/static/app/components/events/autofix/autofixMessageBox.tsx
+++ b/static/app/components/events/autofix/autofixMessageBox.tsx
@@ -8,6 +8,7 @@ import Input from 'sentry/components/input';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {
   IconCheckmark,
+  IconChevron,
   IconClose,
   IconCode,
   IconFatal,
@@ -56,9 +57,10 @@ interface AutofixMessageBoxProps {
   responseRequired: boolean;
   runId: string;
   step: AutofixStep | null;
-  children?: React.ReactNode;
-  headerTextOverride?: string | null;
+  emptyInfoText?: string;
+  notEmptyInfoText?: string;
   primaryAction?: boolean;
+  scrollIntoView?: (() => void) | null;
 }
 
 function StepIcon({step}: {step: AutofixStep}) {
@@ -93,7 +95,6 @@ function StepIcon({step}: {step: AutofixStep}) {
 
 function AutofixMessageBox({
   displayText = '',
-  headerTextOverride = null,
   step = null,
   inputPlaceholder = 'Say something...',
   primaryAction = false,
@@ -104,7 +105,9 @@ function AutofixMessageBox({
   isDisabled = false,
   groupId,
   runId,
-  children,
+  emptyInfoText = '',
+  notEmptyInfoText = '',
+  scrollIntoView = null,
 }: AutofixMessageBoxProps) {
   const [message, setMessage] = useState('');
   const {mutate: send} = useSendMessage({groupId, runId});
@@ -125,7 +128,7 @@ function AutofixMessageBox({
   return (
     <Container>
       <DisplayArea>
-        {step && !headerTextOverride && (
+        {step && (
           <StepHeader>
             <StepIconContainer>
               <StepIcon step={step} />
@@ -135,14 +138,14 @@ function AutofixMessageBox({
                 __html: singleLineRenderer(step.title),
               }}
             />
-          </StepHeader>
-        )}
-        {headerTextOverride && (
-          <StepHeader>
-            <StepIconContainer>
-              <IconQuestion size="sm" color="gray300" />
-            </StepIconContainer>
-            <StepTitle>{headerTextOverride}</StepTitle>
+            {scrollIntoView !== null && (
+              <Button
+                onClick={scrollIntoView}
+                priority="link"
+                icon={<IconChevron isCircled direction="down" />}
+                aria-label={t('Jump to content')}
+              />
+            )}
           </StepHeader>
         )}
         <Message
@@ -150,7 +153,9 @@ function AutofixMessageBox({
             __html: marked(displayText),
           }}
         />
-        <ActionBar>{children}</ActionBar>
+        <ActionBar>
+          <p>{message.length > 0 ? notEmptyInfoText : emptyInfoText}</p>
+        </ActionBar>
       </DisplayArea>
       <InputArea>
         {!responseRequired ? (
@@ -202,7 +207,7 @@ const Container = styled('div')`
 `;
 
 const DisplayArea = styled('div')`
-  height: 10em;
+  height: 8em;
   overflow-y: hidden;
   padding: 8px;
   border-radius: 4px;
@@ -271,7 +276,8 @@ const ProcessingStatusIndicator = styled(LoadingIndicator)`
 
 const ActionBar = styled('div')`
   position: absolute;
-  bottom: 4em;
+  bottom: 3em;
+  color: ${p => p.theme.subText};
 `;
 
 export default AutofixMessageBox;

--- a/static/app/components/events/autofix/autofixMessageBox.tsx
+++ b/static/app/components/events/autofix/autofixMessageBox.tsx
@@ -57,6 +57,8 @@ interface AutofixMessageBoxProps {
   runId: string;
   step: AutofixStep | null;
   children?: React.ReactNode;
+  headerTextOverride?: string | null;
+  primaryAction?: boolean;
 }
 
 function StepIcon({step}: {step: AutofixStep}) {
@@ -91,8 +93,10 @@ function StepIcon({step}: {step: AutofixStep}) {
 
 function AutofixMessageBox({
   displayText = '',
+  headerTextOverride = null,
   step = null,
   inputPlaceholder = 'Say something...',
+  primaryAction = false,
   responseRequired = false,
   onSend,
   actionText = 'Send',
@@ -121,7 +125,7 @@ function AutofixMessageBox({
   return (
     <Container>
       <DisplayArea>
-        {step && (
+        {step && !headerTextOverride && (
           <StepHeader>
             <StepIconContainer>
               <StepIcon step={step} />
@@ -131,6 +135,14 @@ function AutofixMessageBox({
                 __html: singleLineRenderer(step.title),
               }}
             />
+          </StepHeader>
+        )}
+        {headerTextOverride && (
+          <StepHeader>
+            <StepIconContainer>
+              <IconQuestion size="sm" color="gray300" />
+            </StepIconContainer>
+            <StepTitle>{headerTextOverride}</StepTitle>
           </StepHeader>
         )}
         <Message
@@ -150,7 +162,11 @@ function AutofixMessageBox({
               placeholder={inputPlaceholder}
               disabled={isDisabled}
             />
-            <Button onClick={handleSend} disabled={isDisabled}>
+            <Button
+              onClick={handleSend}
+              disabled={isDisabled}
+              priority={primaryAction ? 'primary' : 'default'}
+            >
               {actionText}
             </Button>
           </Fragment>
@@ -163,7 +179,7 @@ function AutofixMessageBox({
               placeholder={'Please answer to continue...'}
               disabled={isDisabled}
             />
-            <Button onClick={handleSend} disabled={isDisabled}>
+            <Button onClick={handleSend} disabled={isDisabled} priority={'primary'}>
               {actionText}
             </Button>
           </Fragment>

--- a/static/app/components/events/autofix/autofixRootCause.spec.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.spec.tsx
@@ -17,7 +17,9 @@ describe('AutofixRootCause', function () {
     render(<AutofixRootCause {...defaultProps} />);
 
     // Displays all root cause and code context info
-    expect(screen.getByText('This is the title of a root cause.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Potential Root Cause: This is the title of a root cause.')
+    ).toBeInTheDocument();
     expect(
       screen.getByText('This is the description of a root cause.')
     ).toBeInTheDocument();

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -43,7 +43,7 @@ type AutofixRootCauseProps = {
   runId: string;
 };
 
-const animationProps: AnimationProps = {
+const contentAnimationProps: AnimationProps = {
   exit: {opacity: 0},
   initial: {opacity: 0},
   animate: {opacity: 1},
@@ -196,7 +196,7 @@ function RootCauseContent({
     <ContentWrapper selected={selected}>
       <AnimatePresence initial={false}>
         {selected && (
-          <AnimationWrapper key="content" {...animationProps}>
+          <AnimationWrapper key="content" {...contentAnimationProps}>
             {children}
           </AnimationWrapper>
         )}
@@ -271,7 +271,7 @@ function CauseOption({
       <RootCauseOptionHeader>
         <Title
           dangerouslySetInnerHTML={{
-            __html: singleLineRenderer(cause.title),
+            __html: singleLineRenderer(`Potential Root Cause: ${cause.title}`),
           }}
         />
       </RootCauseOptionHeader>
@@ -393,7 +393,6 @@ function AutofixRootCauseDisplay({
     <PotentialCausesContainer>
       <ClippedBox clipHeight={408}>
         <OptionsPadding>
-          <HeaderText>{t('Potential Root Cause')}</HeaderText>
           {causes.map(cause => (
             <CauseOption
               key={cause.id}
@@ -411,6 +410,13 @@ function AutofixRootCauseDisplay({
   );
 }
 
+const cardAnimationProps: AnimationProps = {
+  exit: {opacity: 0},
+  initial: {opacity: 0, y: 20},
+  animate: {opacity: 1, y: 0},
+  transition: testableTransition({duration: 0.3}),
+};
+
 export function AutofixRootCause(props: AutofixRootCauseProps) {
   if (props.causes.length === 0) {
     return (
@@ -422,7 +428,13 @@ export function AutofixRootCause(props: AutofixRootCauseProps) {
     );
   }
 
-  return <AutofixRootCauseDisplay {...props} />;
+  return (
+    <AnimatePresence initial>
+      <AnimationWrapper key="card" {...cardAnimationProps}>
+        <AutofixRootCauseDisplay {...props} />
+      </AnimationWrapper>
+    </AnimatePresence>
+  );
 }
 
 export function AutofixRootCauseCodeContexts({
@@ -473,13 +485,17 @@ const PotentialCausesContainer = styled(CausesContainer)`
 `;
 
 const OptionsPadding = styled('div')`
-  padding: ${space(2)};
+  padding-left: ${space(1)};
+  padding-right: ${space(1)};
+  padding-top: ${space(1)};
 `;
 
 const RootCauseOption = styled('div')<{selected: boolean}>`
-  position: relative;
   background: ${p => (p.selected ? p.theme.background : p.theme.backgroundElevated)};
   cursor: ${p => (p.selected ? 'default' : 'pointer')};
+  padding-top: ${space(1)};
+  padding-left: ${space(2)};
+  padding-right: ${space(2)};
 `;
 
 const RootCauseOptionHeader = styled('div')`
@@ -491,6 +507,7 @@ const RootCauseOptionHeader = styled('div')`
 
 const Title = styled('div')`
   font-weight: ${p => p.theme.fontWeightBold};
+  font-size: ${p => p.theme.fontSizeLarge};
 `;
 
 const CauseDescription = styled('div')`

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -105,14 +105,14 @@ function useInView(ref: HTMLElement | null) {
   const [inView, setInView] = useState(false);
 
   useEffect(() => {
+    const observer = new IntersectionObserver(([entry]) => {
+      setInView(entry.isIntersecting);
+    });
+
     if (!ref)
       return () => {
         observer.disconnect();
       };
-
-    const observer = new IntersectionObserver(([entry]) => {
-      setInView(entry.isIntersecting);
-    });
 
     observer.observe(ref);
     return () => {

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -1,8 +1,7 @@
-import {Fragment} from 'react';
+import {Fragment, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {AnimatePresence, type AnimationProps, motion} from 'framer-motion';
 
-import {Button} from 'sentry/components/button';
 import {AutofixChanges} from 'sentry/components/events/autofix/autofixChanges';
 import AutofixInsightCards from 'sentry/components/events/autofix/autofixInsightCards';
 import AutofixMessageBox from 'sentry/components/events/autofix/autofixMessageBox';
@@ -17,7 +16,6 @@ import {
   type AutofixStep,
   AutofixStepType,
 } from 'sentry/components/events/autofix/types';
-import {space} from 'sentry/styles/space';
 import testableTransition from 'sentry/utils/testableTransition';
 
 const animationProps: AnimationProps = {
@@ -28,12 +26,12 @@ const animationProps: AnimationProps = {
 };
 interface StepProps {
   groupId: string;
+  hasStepAbove: boolean;
+  hasStepBelow: boolean;
   onRetry: () => void;
   repos: AutofixRepository[];
   runId: string;
   step: AutofixStep;
-  totalSteps: number;
-  stepNumber?: number;
 }
 
 interface AutofixStepsProps {
@@ -64,8 +62,8 @@ export function Step({
   runId,
   onRetry,
   repos,
-  stepNumber,
-  totalSteps,
+  hasStepBelow,
+  hasStepAbove,
 }: StepProps) {
   const isActive = step.status !== 'PENDING' && step.status !== 'CANCELLED';
 
@@ -75,15 +73,12 @@ export function Step({
         <AnimatePresence initial={false}>
           <AnimationWrapper key="content" {...animationProps}>
             <Fragment>
-              {step.completedMessage && <StepBody>{step.completedMessage}</StepBody>}
               {step.type === AutofixStepType.DEFAULT && (
                 <AutofixInsightCards
                   insights={step.insights}
                   repos={repos}
-                  hasStepBelow={
-                    stepNumber !== undefined ? stepNumber < totalSteps : false
-                  }
-                  hasStepAbove={stepNumber !== undefined ? stepNumber > 1 : false}
+                  hasStepBelow={hasStepBelow}
+                  hasStepAbove={hasStepAbove}
                 />
               )}
               {step.type === AutofixStepType.ROOT_CAUSE_ANALYSIS && (
@@ -106,22 +101,50 @@ export function Step({
   );
 }
 
+function useInView(ref: HTMLElement | null) {
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    if (!ref)
+      return () => {
+        observer.disconnect();
+      };
+
+    const observer = new IntersectionObserver(([entry]) => {
+      setInView(entry.isIntersecting);
+    });
+
+    observer.observe(ref);
+    return () => {
+      observer.disconnect();
+    };
+  }, [ref]);
+  return inView;
+}
+
 export function AutofixSteps({data, groupId, runId, onRetry}: AutofixStepsProps) {
   const steps = data.steps;
   const repos = data.repositories;
 
+  const stepsRef = useRef<(HTMLDivElement | null)[]>([]);
+
   const {mutate: handleSelectFix} = useSelectCause({groupId, runId});
-  const provideCustomRootCause = (text: string) => {
-    handleSelectFix({customRootCause: text});
+  const selectRootCause = (text: string) => {
+    if (text.length > 0) {
+      handleSelectFix({customRootCause: text});
+    } else {
+      if (!steps) return;
+      const step = steps[steps.length - 1];
+      if (step.type !== AutofixStepType.ROOT_CAUSE_ANALYSIS) return;
+      const cause = step.causes[0];
+      const id = cause.id;
+      handleSelectFix({causeId: id});
+    }
   };
-  const useSuggestedRootCause = () => {
-    if (!steps) return;
-    const step = steps[steps.length - 1];
-    if (step.type !== AutofixStepType.ROOT_CAUSE_ANALYSIS) return;
-    const cause = step.causes[0];
-    const id = cause.id;
-    handleSelectFix({causeId: id});
-  };
+
+  const lastStepVisible = useInView(
+    stepsRef.current.length ? stepsRef.current[stepsRef.current.length - 1] : null
+  );
 
   if (!steps) {
     return null;
@@ -139,20 +162,28 @@ export function AutofixSteps({data, groupId, runId, onRetry}: AutofixStepsProps)
     lastStep.type === AutofixStepType.CHANGES && lastStep.status === 'COMPLETED';
   const disabled = areCodeChangesShowing ? true : false;
 
+  const scrollToMatchingStep = () => {
+    const matchingStepIndex = steps.findIndex(step => step.type === lastStep.type);
+    if (matchingStepIndex !== -1 && stepsRef.current[matchingStepIndex]) {
+      stepsRef.current[matchingStepIndex]?.scrollIntoView({behavior: 'smooth'});
+    }
+  };
+
   return (
     <div>
       <StepsContainer>
         {steps.map((step, index) => (
-          <Step
-            step={step}
-            key={step.id}
-            stepNumber={index + 1}
-            totalSteps={steps.length}
-            groupId={groupId}
-            runId={runId}
-            onRetry={onRetry}
-            repos={repos}
-          />
+          <div ref={el => (stepsRef.current[index] = el)} key={step.id}>
+            <Step
+              step={step}
+              hasStepBelow={index + 1 < steps.length}
+              hasStepAbove={index > 0}
+              groupId={groupId}
+              runId={runId}
+              onRetry={onRetry}
+              repos={repos}
+            />
+          </div>
         ))}
       </StepsContainer>
 
@@ -162,29 +193,36 @@ export function AutofixSteps({data, groupId, runId, onRetry}: AutofixStepsProps)
         inputPlaceholder={
           !isRootCauseSelectionStep
             ? 'Say something...'
-            : 'Propose your own root cause...'
+            : 'Or propose your own root cause instead...'
         }
         responseRequired={false}
-        onSend={!isRootCauseSelectionStep ? null : provideCustomRootCause}
-        actionText={'Send'}
-        allowEmptyMessage={false}
+        onSend={!isRootCauseSelectionStep ? null : selectRootCause}
+        actionText={!isRootCauseSelectionStep ? 'Send' : 'Find a Fix'}
+        allowEmptyMessage={!isRootCauseSelectionStep ? false : true}
         isDisabled={disabled}
         groupId={groupId}
         runId={runId}
-      >
-        {isRootCauseSelectionStep && (
-          <ActionBar>
-            <Button onClick={useSuggestedRootCause}>Fix the root cause above</Button>
-            <ActionBarText>OR</ActionBarText>
-          </ActionBar>
-        )}
-      </AutofixMessageBox>
+        primaryAction={isRootCauseSelectionStep}
+        emptyInfoText={
+          !isRootCauseSelectionStep ? '' : 'Selected: suggested root cause above'
+        }
+        notEmptyInfoText={
+          !isRootCauseSelectionStep ? '' : 'Selected: your custom root cause below'
+        }
+        scrollIntoView={
+          !lastStepVisible &&
+          (lastStep.type === AutofixStepType.ROOT_CAUSE_ANALYSIS ||
+            lastStep.type === AutofixStepType.CHANGES)
+            ? scrollToMatchingStep
+            : null
+        }
+      />
     </div>
   );
 }
 
 const StepsContainer = styled('div')`
-  margin-bottom: 15em;
+  margin-bottom: 13em;
 `;
 
 const StepCard = styled('div')<{active?: boolean}>`
@@ -194,11 +232,6 @@ const StepCard = styled('div')<{active?: boolean}>`
   :last-child {
     margin-bottom: 0;
   }
-`;
-
-const StepBody = styled('p')`
-  padding: 0 ${space(2)} ${space(2)} ${space(2)};
-  margin: -${space(1)} 0 0 0;
 `;
 
 const ContentWrapper = styled(motion.div)`
@@ -212,16 +245,6 @@ const ContentWrapper = styled(motion.div)`
     padding: 0 1px;
     overflow: hidden;
   }
-`;
-
-const ActionBar = styled('div')`
-  flex-direction: row;
-  display: flex;
-`;
-const ActionBarText = styled('p')`
-  padding-left: ${space(1)};
-  padding-bottom: 0;
-  margin-top: ${space(1)};
 `;
 
 const AnimationWrapper = styled(motion.div)``;

--- a/static/app/components/events/autofix/index.spec.tsx
+++ b/static/app/components/events/autofix/index.spec.tsx
@@ -77,6 +77,6 @@ describe('Autofix', () => {
 
     render(<Autofix event={event} group={group} />);
 
-    expect(await screen.findByRole('button', {name: 'Run Autofix'})).toBeInTheDocument();
+    expect(await screen.findByRole('button', {name: 'Open Autofix'})).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Polish Autofix new interactive flow UI in various ways.
- jump links
- fixed padding and styling
- labeling insights
- updated root cause selection flow
- placeholder art
- other minor tweaks
<img width="672" alt="Screenshot 2024-09-20 at 7 28 03 AM" src="https://github.com/user-attachments/assets/eeec6534-c52b-413c-9c0a-c6cd2d9078b5">
<img width="615" alt="Screenshot 2024-09-20 at 7 25 15 AM" src="https://github.com/user-attachments/assets/d5abf600-45e4-4ad7-90ee-c669659d0a7b">
<img width="609" alt="Screenshot 2024-09-19 at 3 57 24 PM" src="https://github.com/user-attachments/assets/7695aa5b-d2ad-4678-a7d2-14d9300272e9">
