### PR TITLE
fix(insights): fix broken issue link

### DIFF
--- a/static/app/views/insights/common/components/issues.tsx
+++ b/static/app/views/insights/common/components/issues.tsx
@@ -32,7 +32,7 @@ function Issue({data}: {data: Group}) {
   return (
     <StyledPanelItem as="tr">
       <IssueSummaryWrapper>
-        <IssueSummary data={data} organization={organization} event_id={'0'} />
+        <IssueSummary data={data} organization={organization} />
         <EventOrGroupExtraDetails data={data} />
       </IssueSummaryWrapper>
       <ChartWrapper>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issueSummary.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issueSummary.tsx
@@ -16,8 +16,8 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 interface EventOrGroupHeaderProps {
   data: Group;
-  event_id: string;
   organization: Organization;
+  event_id?: string;
 }
 
 /**
@@ -51,7 +51,7 @@ function IssueTitleChildren(props: IssueTitleChildrenProps) {
 
 interface IssueTitleProps {
   data: Group;
-  event_id: string;
+  event_id?: string;
 }
 function IssueTitle(props: IssueTitleProps) {
   const organization = useOrganization();
@@ -71,7 +71,9 @@ function IssueTitle(props: IssueTitleProps) {
     <TitleWithLink
       {...commonEleProps}
       to={{
-        pathname: `/organizations/${organization.slug}/issues/${props.data.id}/events/${props.event_id}/`,
+        pathname: props.event_id
+          ? `/organizations/${organization.slug}/issues/${props.data.id}/events/${props.event_id}/`
+          : `/organizations/${organization.slug}/issues/${props.data.id}/`,
       }}
     >
       <IssueTitleChildren data={props.data} organization={organization} />


### PR DESCRIPTION
if no `event_id` is passed into the component, then don't render a specific event page.

before:

https://github.com/user-attachments/assets/341e17c3-de61-41b4-bc16-96c03bfacb31


after:



https://github.com/user-attachments/assets/ad3c46e8-6a39-45dd-aaee-ddf10fd9dad4

