### PR TITLE
fix(invite-members): enable member role in dropdown

### DIFF
--- a/static/app/components/roleSelectControl.tsx
+++ b/static/app/components/roleSelectControl.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import type {ControlProps} from 'sentry/components/forms/controls/selectControl';
 import SelectControl from 'sentry/components/forms/controls/selectControl';
 import type {BaseRole} from 'sentry/types/organization';
+import useOrganization from 'sentry/utils/useOrganization';
 
 type OptionType = {
   details: React.ReactNode;
@@ -22,6 +23,12 @@ type Props = Omit<ControlProps<OptionType>, 'onChange' | 'value'> & {
 };
 
 function RoleSelectControl({roles, disableUnallowed, ...props}: Props) {
+  const organization = useOrganization();
+  const isMemberInvite =
+    organization.features.includes('members-invite-teammates') &&
+    organization.allowMemberInvite &&
+    organization.access?.includes('member:invite');
+
   return (
     <SelectControl
       options={roles
@@ -31,7 +38,10 @@ function RoleSelectControl({roles, disableUnallowed, ...props}: Props) {
             ({
               value: r.id,
               label: r.name,
-              disabled: disableUnallowed && !r.isAllowed,
+              disabled:
+                disableUnallowed &&
+                !r.isAllowed &&
+                !(isMemberInvite && r.id === 'member'),
               details: <Details>{r.desc}</Details>,
             }) as OptionType
         )}


### PR DESCRIPTION
fix for the "Member" role being disabled for members sending invites

<img width="886" alt="Screenshot 2024-09-20 at 1 43 16 PM" src="https://github.com/user-attachments/assets/c6735fd4-9e06-4c1d-9321-e4ae1b041f80">

chose to fix this on the frontend rather than modifying the GET request for this specific page so that the backend continues to returns the same result for all pages