### PR TITLE
feat(autofix): Add clean error handling, keyboard support in message box

### DIFF
--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -261,7 +261,6 @@ function AutofixInsightCards({
         )
       ) : !hasStepAbove && !hasStepBelow ? (
         <NoInsightsYet>
-          <p>Nothing yet...</p>
           <p>
             Autofix will share important conclusions here as it discovers them, building a
             line of reasoning up to the root cause.

--- a/static/app/components/events/autofix/autofixMessageBox.tsx
+++ b/static/app/components/events/autofix/autofixMessageBox.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useState} from 'react';
+import {type FormEvent, Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -112,7 +112,8 @@ function AutofixMessageBox({
   const [message, setMessage] = useState('');
   const {mutate: send} = useSendMessage({groupId, runId});
 
-  const handleSend = () => {
+  const handleSend = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
     if (message.trim() !== '' || allowEmptyMessage) {
       if (onSend != null) {
         onSend(message);
@@ -157,39 +158,41 @@ function AutofixMessageBox({
           <p>{message.length > 0 ? notEmptyInfoText : emptyInfoText}</p>
         </ActionBar>
       </DisplayArea>
-      <InputArea>
-        {!responseRequired ? (
-          <Fragment>
-            <NormalInput
-              type="text"
-              value={message}
-              onChange={e => setMessage(e.target.value)}
-              placeholder={inputPlaceholder}
-              disabled={isDisabled}
-            />
-            <Button
-              onClick={handleSend}
-              disabled={isDisabled}
-              priority={primaryAction ? 'primary' : 'default'}
-            >
-              {actionText}
-            </Button>
-          </Fragment>
-        ) : (
-          <Fragment>
-            <RequiredInput
-              type="text"
-              value={message}
-              onChange={e => setMessage(e.target.value)}
-              placeholder={'Please answer to continue...'}
-              disabled={isDisabled}
-            />
-            <Button onClick={handleSend} disabled={isDisabled} priority={'primary'}>
-              {actionText}
-            </Button>
-          </Fragment>
-        )}
-      </InputArea>
+      <form onSubmit={handleSend}>
+        <InputArea>
+          {!responseRequired ? (
+            <Fragment>
+              <NormalInput
+                type="text"
+                value={message}
+                onChange={e => setMessage(e.target.value)}
+                placeholder={inputPlaceholder}
+                disabled={isDisabled}
+              />
+              <Button
+                type="submit"
+                priority={primaryAction ? 'primary' : 'default'}
+                disabled={isDisabled}
+              >
+                {actionText}
+              </Button>
+            </Fragment>
+          ) : (
+            <Fragment>
+              <RequiredInput
+                type="text"
+                value={message}
+                disabled={isDisabled}
+                onChange={e => setMessage(e.target.value)}
+                placeholder={'Please answer to continue...'}
+              />
+              <Button type="submit" priority={'primary'} disabled={isDisabled}>
+                {actionText}
+              </Button>
+            </Fragment>
+          )}
+        </InputArea>
+      </form>
     </Container>
   );
 }


### PR DESCRIPTION
- You can use the return key in the message box to send the message now
- Cleanly displays errors and step retries
- Small copy change
<img width="621" alt="Screenshot 2024-09-20 at 1 47 37 PM" src="https://github.com/user-attachments/assets/1d523394-c721-4756-8241-76f061bcd635">