### PR TITLE
feat(issue-views): Update banner and tooltip copy, make banner dismissable, feedback -> read docs

### DIFF
--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -222,6 +222,7 @@ export type IssueEventParameters = {
     search_type: string;
   };
   'issue_views.add_view.all_saved_searches_saved': {};
+  'issue_views.add_view.banner_dismissed': {};
   'issue_views.add_view.clicked': {};
   'issue_views.add_view.custom_query_saved': {
     query: string;
@@ -389,6 +390,7 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issue_views.add_view.all_saved_searches_saved':
     'Issue Views: All Saved Searches Saved',
   'issue_views.add_view.recommended_view_saved': 'Issue Views: Recommended View Saved',
+  'issue_views.add_view.banner_dismissed': 'Issue Views: Add View Banner Dismissed',
   'issue_views.shared_view_opened': 'Issue Views: Shared View Opened',
   'issue_views.temp_view_discarded': 'Issue Views: Temporary View Discarded',
   'issue_views.temp_view_saved': 'Issue Views: Temporary View Saved',

--- a/static/app/views/issueList/addViewPage.tsx
+++ b/static/app/views/issueList/addViewPage.tsx
@@ -137,8 +137,8 @@ function AddViewBanner({hasSavedSearches}: {hasSavedSearches: boolean}) {
           </li>
           {hasSavedSearches && (
             <li>
-              <b>Custom searches will be deprecated in the future. </b> You can save them
-              as views from the list below (only appears if you have custom searches)
+              <b>Saved searches will be deprecated in the future. </b> You can save them
+              as views from the list below (only appears if you have saved searches)
             </li>
           )}
         </AFewNotesList>

--- a/static/app/views/issueList/addViewPage.tsx
+++ b/static/app/views/issueList/addViewPage.tsx
@@ -128,17 +128,21 @@ function AddViewBanner({hasSavedSearches}: {hasSavedSearches: boolean}) {
         <div>{t('A few notes before you get started:')}</div>
         <AFewNotesList>
           <li>
-            <b>Views are for your eyes only.</b> No need to worry about messing up other
-            team members' views
+            <BannerNoteBold>{t('Views are for your eyes only. ')}</BannerNoteBold>
+            {t("No need to worry about messing up other team members' views")}
           </li>
           <li>
-            <b>Drag your views to reorder.</b> The leftmost view is your “default”
-            experience
+            <BannerNoteBold>{t('Drag your views to reorder. ')}</BannerNoteBold>{' '}
+            {t('The leftmost view is your “default” experience')}
           </li>
           {hasSavedSearches && (
             <li>
-              <b>Saved searches will be deprecated in the future. </b> You can save them
-              as views from the list below (only appears if you have saved searches)
+              <BannerNoteBold>
+                {t('Saved searches will be deprecated in the future. ')}
+              </BannerNoteBold>{' '}
+              {t(
+                'You can save them as views from the list below (only appears if you have saved searches)'
+              )}
             </li>
           )}
         </AFewNotesList>
@@ -408,6 +412,11 @@ const Banner = styled('div')`
 `;
 const Title = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
+  font-weight: ${p => p.theme.fontWeightBold};
+`;
+
+const BannerNoteBold = styled('div')`
+  display: inline;
   font-weight: ${p => p.theme.fontWeightBold};
 `;
 

--- a/static/app/views/issueList/addViewPage.tsx
+++ b/static/app/views/issueList/addViewPage.tsx
@@ -137,7 +137,7 @@ function AddViewBanner({hasSavedSearches}: {hasSavedSearches: boolean}) {
           </li>
           {hasSavedSearches && (
             <li>
-              <b>Custom searches will be deprecated in the future. </b> you can save them
+              <b>Custom searches will be deprecated in the future. </b> You can save them
               as views from the list below (only appears if you have custom searches)
             </li>
           )}

--- a/static/app/views/issueList/addViewPage.tsx
+++ b/static/app/views/issueList/addViewPage.tsx
@@ -3,12 +3,14 @@ import styled from '@emotion/styled';
 
 import bannerStar from 'sentry-images/spot/banner-star.svg';
 
-import {Button} from 'sentry/components/button';
+import {usePrompt} from 'sentry/actionCreators/prompts';
+import {Button, LinkButton} from 'sentry/components/button';
 import {openConfirmModal} from 'sentry/components/confirm';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
+import ExternalLink from 'sentry/components/links/externalLink';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {FormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
-import {IconMegaphone} from 'sentry/icons';
+import {IconClose, IconMegaphone} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {SavedSearch} from 'sentry/types/group';
@@ -43,35 +45,34 @@ const RECOMMENDED_SEARCHES: SearchSuggestion[] = [
 ];
 
 function AddViewPage({savedSearches}: {savedSearches: SavedSearch[]}) {
+  const toolTipContents = (
+    <Container>
+      {t(
+        'Saved searches will be deprecated soon. For any you wish to return to, please save them as views.'
+      )}
+      <ExternalLink href={'https://docs.sentry.io/product/issues/issue-views'}>
+        {t('Learn More')}
+      </ExternalLink>
+    </Container>
+  );
+
   const savedSearchTitle = (
     <SavedSearchesTitle>
       {t('Saved Searches (will be removed)')}
       <QuestionTooltip
         icon="info"
-        title={t(
-          'Saved searches will be removed soon. For any you wish to return to, please save them as views.'
-        )}
+        title={toolTipContents}
         size="sm"
         position="top"
         skipWrapper
+        isHoverable
       />
     </SavedSearchesTitle>
   );
 
   return (
     <AddViewWrapper>
-      <Banner>
-        <BannerStar1 src={bannerStar} />
-        <BannerStar2 src={bannerStar} />
-        <BannerStar3 src={bannerStar} />
-        <Title>{t('Find what you need, faster')}</Title>
-        <SubTitle>
-          {t(
-            "Save your issue searches for quick access. Views are for your eyes only – no need to worry about messing up other team members' views."
-          )}
-        </SubTitle>
-        <FeedbackButton />
-      </Banner>
+      <AddViewBanner hasSavedSearches={savedSearches && savedSearches.length !== 0} />
       <SearchSuggestionList
         title={'Recommended Searches'}
         searchSuggestions={RECOMMENDED_SEARCHES}
@@ -93,6 +94,67 @@ function AddViewPage({savedSearches}: {savedSearches: SavedSearch[]}) {
   );
 }
 
+function AddViewBanner({hasSavedSearches}: {hasSavedSearches: boolean}) {
+  const organization = useOrganization();
+
+  const {isPromptDismissed, dismissPrompt} = usePrompt({
+    feature: 'issue_views_add_view_banner',
+    organization,
+  });
+
+  return !isPromptDismissed ? (
+    <Banner>
+      <BannerStar1 src={bannerStar} />
+      <BannerStar2 src={bannerStar} />
+      <BannerStar3 src={bannerStar} />
+      <Title>
+        {t('Welcome to the new Issue Views experience (Early Adopter only)')}
+        <DismissButton
+          analyticsEventKey="issue_views.add_view.banner_dismissed"
+          analyticsEventName="'Issue Views: Add View Banner Dismissed"
+          size="zero"
+          borderless
+          icon={<IconClose size="xs" />}
+          aria-label={t('Dismiss')}
+          onClick={() => dismissPrompt()}
+        />
+      </Title>
+      <SubTitle>
+        <div>
+          {t(
+            'Issues just got a lot more personalized! Save your frequent issue searches for quick access.'
+          )}
+        </div>
+        <div>{t('A few notes before you get started:')}</div>
+        <AFewNotesList>
+          <li>
+            <b>Views are for your eyes only.</b> No need to worry about messing up other
+            team members' views
+          </li>
+          <li>
+            <b>Drag your views to reorder.</b> The leftmost view is your “default”
+            experience
+          </li>
+          {hasSavedSearches && (
+            <li>
+              <b>Custom searches will be deprecated in the future. </b> you can save them
+              as views from the list below (only appears if you have custom searches)
+            </li>
+          )}
+        </AFewNotesList>
+      </SubTitle>
+      <FittedLinkButton
+        size="sm"
+        href="https://docs.sentry.io/product/issues/issue-views"
+        external
+      >
+        {t('Read Docs')}
+      </FittedLinkButton>
+      <FeedbackButton />
+    </Banner>
+  ) : null;
+}
+
 function SearchSuggestionList({
   title,
   searchSuggestions,
@@ -100,6 +162,15 @@ function SearchSuggestionList({
 }: SearchSuggestionListProps) {
   const {onNewViewsSaved} = useContext(NewTabContext);
   const organization = useOrganization();
+
+  const analyticsKey =
+    type === 'recommended'
+      ? 'issue_views.add_view.recommended_view_saved'
+      : 'issue_views.add_view.saved_search_saved';
+  const analyticsEventName =
+    type === 'recommended'
+      ? 'Issue Views: Recommended View Saved'
+      : 'Issue Views: Saved Search Saved';
 
   return (
     <Suggestions>
@@ -149,10 +220,6 @@ function SearchSuggestionList({
                   saveQueryToView: false,
                 },
               ]);
-              const analyticsKey =
-                type === 'recommended'
-                  ? 'issue_views.add_view.recommended_view_saved'
-                  : 'issue_views.add_view.saved_search_saved';
               trackAnalytics(analyticsKey, {
                 organization,
                 persisted: false,
@@ -181,16 +248,13 @@ function SearchSuggestionList({
                         saveQueryToView: true,
                       },
                     ]);
-                    const analyticsKey =
-                      type === 'recommended'
-                        ? 'issue_views.add_view.recommended_view_saved'
-                        : 'issue_views.add_view.saved_search_saved';
-                    trackAnalytics(analyticsKey, {
-                      organization,
-                      persisted: true,
-                      label: suggestion.label,
-                      query: suggestion.query,
-                    });
+                  }}
+                  analyticsEventKey={analyticsKey}
+                  analyticsEventName={analyticsEventName}
+                  analyticsParams={{
+                    persisted: true,
+                    label: suggestion.label,
+                    query: suggestion.query,
                   }}
                   borderless
                 >
@@ -348,8 +412,11 @@ const Title = styled('div')`
 `;
 
 const SubTitle = styled('div')`
+  display: flex;
+  flex-direction: column;
   font-weight: ${p => p.theme.fontWeightNormal};
   font-size: ${p => p.theme.fontSizeMedium};
+  gap: ${space(0.5)};
 `;
 
 const AddViewWrapper = styled('div')`
@@ -398,4 +465,27 @@ const ConfirmModalMessage = styled('div')`
   display: flex;
   justify-content: center;
   font-weight: ${p => p.theme.fontWeightBold};
+`;
+
+const Container = styled('div')`
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  text-align: left;
+  gap: ${space(1)};
+`;
+
+const AFewNotesList = styled('ul')`
+  margin-bottom: ${space(0.5)};
+`;
+
+const FittedLinkButton = styled(LinkButton)`
+  width: fit-content;
+`;
+
+const DismissButton = styled(Button)`
+  position: absolute;
+  top: ${space(1)};
+  right: ${space(1)};
+  color: ${p => p.theme.subText};
 `;


### PR DESCRIPTION
Makes a couple changes to the add view page for EA readiness: 

1. Updates the banner copy to call out: views are user scoped, views are reorderable, and that custom searches are persisted temporarily (only appears if you actually have any custom searches)
2. Adds a dismiss button to the banner 
3. Switches the "Give Feedback" button for a "Read Docs" button 
4. Adds a "Learn More" link to docs within the saved searches tooltip 


**IMPORTANT**: Issue views docs have not been merged in yet, so the docs links are **broken**. I will not merge this until the docs links resolve. [Docs PR](https://github.com/getsentry/sentry-docs/pull/11390) if you're curious about it. 