### PR TITLE
feat(issue-views): Add character limits on tab titles

### DIFF
--- a/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 
 import {GrowingInput} from 'sentry/components/growingInput';
 import {TabsContext} from 'sentry/components/tabs';
+import {Tooltip} from 'sentry/components/tooltip';
 
 interface EditableTabTitleProps {
   isEditing: boolean;
@@ -84,30 +85,44 @@ function EditableTabTitle({
     setInputValue(e.target.value);
   };
 
-  return isSelected ? (
-    <StyledGrowingInput
-      value={inputValue}
-      onChange={handleOnChange}
-      onKeyDown={handleOnKeyDown}
-      onDoubleClick={() => isSelected && setIsEditing(true)}
-      onBlur={handleOnBlur}
-      ref={inputRef}
-      style={memoizedStyles}
-      isEditing={isEditing}
-      onFocus={e => e.target.select()}
-      onPointerDown={e => {
-        e.stopPropagation();
-      }}
-      onMouseDown={e => {
-        e.stopPropagation();
-      }}
-    />
-  ) : (
-    <div style={{height: '20px'}}>{label}</div>
+  return (
+    <Tooltip title={label} showOnlyOnOverflow>
+      {isSelected ? (
+        <StyledGrowingInput
+          value={inputValue}
+          onChange={handleOnChange}
+          onKeyDown={handleOnKeyDown}
+          onDoubleClick={() => isSelected && setIsEditing(true)}
+          onBlur={handleOnBlur}
+          ref={inputRef}
+          style={memoizedStyles}
+          isEditing={isEditing}
+          onFocus={e => e.target.select()}
+          onPointerDown={e => {
+            e.stopPropagation();
+          }}
+          onMouseDown={e => {
+            e.stopPropagation();
+          }}
+          maxLength={128}
+        />
+      ) : (
+        <UnselectedTabTitle>{label}</UnselectedTabTitle>
+      )}
+    </Tooltip>
   );
 }
 
 export default EditableTabTitle;
+
+const UnselectedTabTitle = styled('div')`
+  height: 20px;
+  /* The max width is slightly smaller than the GrowingInput since the text in the growing input is bolded */
+  max-width: 310px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
 
 const StyledGrowingInput = styled(GrowingInput)<{
   isEditing: boolean;
@@ -119,7 +134,10 @@ const StyledGrowingInput = styled(GrowingInput)<{
   min-height: 0px;
   height: 20px;
   border-radius: 0px;
+  text-overflow: ellipsis;
   cursor: ${p => (p.isEditing ? 'text' : 'pointer')};
+
+  ${p => !p.isEditing && `max-width: 325px;`}
 
   &,
   &:focus,


### PR DESCRIPTION
Adds "soft" and hard limits to the number of characters in the tab titles to prevent any weird behavior. The hard limit is 128 characters since this is the max character length enforced by the database schema. The soft character limit is approximately 50 characters, and a tooltip showing the full title will appear on hover if the tab title exceeds the maximum width.


https://github.com/user-attachments/assets/72f47938-5ecf-4ed3-820b-9302a4260cec

