### PR TITLE
fix(issue-views): Fixes unsaved changes not detected on reload

### DIFF
--- a/static/app/views/issueList/customViewsHeader.tsx
+++ b/static/app/views/issueList/customViewsHeader.tsx
@@ -237,7 +237,7 @@ function CustomViewsIssueListHeaderTabsContent({
 
         setDraggableTabs(
           draggableTabs.map(tab =>
-            tab.key === selectedTab!.key
+            tab.key === selectedTab.key
               ? {
                   ...tab,
                   unsavedChanges,
@@ -289,7 +289,7 @@ function CustomViewsIssueListHeaderTabsContent({
       return;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [navigate, organization.slug, query, sort, viewId]);
+  }, [navigate, organization.slug, query, sort, viewId, tabListState]);
 
   // Update local tabs when new views are received from mutation request
   useEffect(() => {


### PR DESCRIPTION
Fixes a uncommon bug where reloading the page on a tab where the query is not the tab's persistent query would not retrigger the unsaved changes icon. 

<details open>
 <summary>Before (notice how after the page refresh, the unsaved changes indicator is gone)</summary>

  https://github.com/user-attachments/assets/2f6f471f-27b0-431a-8a1a-357df65c2881

</details>

<details>
 <summary>After </summary>


  https://github.com/user-attachments/assets/87c4b6a6-008e-4f65-b0b6-c6d891b54fb6
</details>



