### PR TITLE
fix(onboarding): Fix sentry configure SDK pyhton code snippet

### DIFF
--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -136,7 +136,7 @@ export const performanceOnboarding: OnboardingConfig = {
 import sentry-sdk
 
 sentry_sdk.init(
-  dsn: "${params.dsn.public}",
+  dsn="${params.dsn.public}",
   enable_tracing=True,
 )`,
           additionalInfo: tct(


### PR DESCRIPTION
Non python syntax was used for passing function parameter.
