### PR TITLE
fix(perf): Prevents settings route from marking "Performance" in sidebar as active

### DIFF
--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -335,7 +335,9 @@ export function isItemActive(
       location.pathname.includes('/alerts/') &&
       !location.pathname.startsWith('/settings/')) ||
     (item?.label === 'Releases' && location.pathname.includes('/release-thresholds/')) ||
-    (item?.label === 'Performance' && location.pathname.includes('/performance/'))
+    (item?.label === 'Performance' &&
+      location.pathname.includes('/performance/') &&
+      !location.pathname.startsWith('/settings/'))
   );
 }
 


### PR DESCRIPTION
There's a `/settings/projects/<project-slug>performance/` URL that activates the "Performance" sidebar item because it's using an inexact URL match. Omit Settings pages the same way other paths do this. Yucky but works for now!

**Before:**

<img width="858" alt="Screenshot 2024-09-23 at 10 28 15 AM" src="https://github.com/user-attachments/assets/9c55a218-b2cf-4d45-89a2-29194e736286">

You can see both "Performance" and "Settings" are active, gross.