### PR TITLE
fix(visibility): Look for field meta on `data['meta']['fields']`

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -1024,7 +1024,7 @@ export function getFieldFormatter(
   isAlias: boolean = true
 ): FieldTypeFormatterRenderFunctionPartial {
   const fieldName = isAlias ? getAggregateAlias(field) : field;
-  const fieldType = meta[fieldName];
+  const fieldType = meta[fieldName] || meta.fields[fieldName];
 
   if (FIELD_FORMATTERS.hasOwnProperty(fieldType)) {
     return partial(FIELD_FORMATTERS[fieldType].renderFunc, fieldName);


### PR DESCRIPTION
Discover responses look like this:

```js
{
  data: [
    {
      'eps()': 0.01087819860850493,
    },
  ],
  meta: {
    fields: {
      'eps()': 'rate',
    },
    units: {
      'eps()': '1/second',
    },
  }
}
```

You can see that field _types_ are on the `meta.fields` object. However, the field renderers look for field types like this:

```jsx
const fieldType = meta[fieldName] || meta.fields[fieldName];
```

They're just looking for keys on `meta` itself! This is because Discover data fetchers do this:

```jsx
const {fields, ...otherMeta} = data.meta ?? {};
return {
  ...data,
  meta: {...fields, ...otherMeta},
};
```

I don't know why! I'm curious to know why. However, regardless of why, field renderers should _attempt_ to find field definitions on the `data.meta.fields` object, if it exists. This makes it easier to use field renderes on Discover responses regardless of context (e.g., in the new data visualization widget components)