### PR TITLE
fix(explore): Updating groupBy options by supported span tags.

### DIFF
--- a/static/app/views/explore/content.tsx
+++ b/static/app/views/explore/content.tsx
@@ -21,6 +21,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
+import {SpanTagsProvider} from './contexts/spanTagsContext';
 import {useResultMode} from './hooks/useResultsMode';
 import {useUserQuery} from './hooks/useUserQuery';
 import {ExploreCharts} from './charts';
@@ -31,7 +32,7 @@ interface ExploreContentProps {
   location: Location;
 }
 
-export function ExploreContent({}: ExploreContentProps) {
+function ExploreContentImpl({}: ExploreContentProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const organization = useOrganization();
@@ -101,6 +102,14 @@ export function ExploreContent({}: ExploreContentProps) {
         </Layout.Page>
       </PageFiltersContainer>
     </SentryDocumentTitle>
+  );
+}
+
+export function ExploreContent(props: ExploreContentProps) {
+  return (
+    <SpanTagsProvider>
+      <ExploreContentImpl {...props} />
+    </SpanTagsProvider>
   );
 }
 

--- a/static/app/views/explore/contexts/spanTagsContext.tsx
+++ b/static/app/views/explore/contexts/spanTagsContext.tsx
@@ -1,0 +1,23 @@
+import type React from 'react';
+import {createContext, useContext} from 'react';
+
+import type {TagCollection} from 'sentry/types/group';
+import {useSpanFieldSupportedTags} from 'sentry/views/performance/utils/useSpanFieldSupportedTags';
+
+const SpanTagsContext = createContext<TagCollection | undefined>(undefined);
+
+export function SpanTagsProvider({children}: {children: React.ReactNode}) {
+  const tags = useSpanFieldSupportedTags();
+
+  return <SpanTagsContext.Provider value={tags}>{children}</SpanTagsContext.Provider>;
+}
+
+export const useSpanTags = (): TagCollection => {
+  const context = useContext(SpanTagsContext);
+
+  if (context === undefined) {
+    throw new Error('useSpanTags must be used within a SpanTagsProvider');
+  }
+
+  return context;
+};

--- a/static/app/views/explore/hooks/useGroupBys.spec.tsx
+++ b/static/app/views/explore/hooks/useGroupBys.spec.tsx
@@ -1,13 +1,33 @@
 // biome-ignore lint/nursery/noRestrictedImports: Will be removed with react router 6
 import {createMemoryHistory, Route, Router, RouterContext} from 'react-router';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {act, render} from 'sentry-test/reactTestingLibrary';
+import {act, render, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {useGroupBys} from 'sentry/views/explore/hooks/useGroupBys';
 import {RouteContext} from 'sentry/views/routeContext';
 
+import {SpanTagsProvider} from '../contexts/spanTagsContext';
+
 describe('useGroupBys', function () {
-  it('allows changing group bys', function () {
+  it('allows changing group bys', async function () {
+    const organization = OrganizationFixture();
+
+    const mockSpanTagsApiCall = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/spans/fields/`,
+      method: 'GET',
+      body: [
+        {
+          key: 'foo',
+          name: 'Foo',
+        },
+        {
+          key: 'bar',
+          name: 'Bar',
+        },
+      ],
+    });
+
     let groupBys, setGroupBys;
 
     function TestPage() {
@@ -18,20 +38,23 @@ describe('useGroupBys', function () {
     const memoryHistory = createMemoryHistory();
 
     render(
-      <Router
-        history={memoryHistory}
-        render={props => {
-          return (
-            <RouteContext.Provider value={props}>
-              <RouterContext {...props} />
-            </RouteContext.Provider>
-          );
-        }}
-      >
-        <Route path="/" component={TestPage} />
-      </Router>
+      <SpanTagsProvider>
+        <Router
+          history={memoryHistory}
+          render={props => {
+            return (
+              <RouteContext.Provider value={props}>
+                <RouterContext {...props} />
+              </RouteContext.Provider>
+            );
+          }}
+        >
+          <Route path="/" component={TestPage} />
+        </Router>
+      </SpanTagsProvider>
     );
 
+    await waitFor(() => expect(mockSpanTagsApiCall).toHaveBeenCalledTimes(1));
     expect(groupBys).toEqual(['']); // default
 
     act(() => setGroupBys(['foo', 'bar']));

--- a/static/app/views/explore/hooks/useGroupBys.tsx
+++ b/static/app/views/explore/hooks/useGroupBys.tsx
@@ -33,7 +33,9 @@ function useGroupBysImpl({
     const rawGroupBys = decodeList(location.query.groupBy);
 
     // Filter out groupBys that are not in span field supported tags
-    const validGroupBys = rawGroupBys.filter(groupBy => tags.hasOwnProperty(groupBy));
+    const validGroupBys = rawGroupBys.filter(
+      groupBy => groupBy === '' || tags.hasOwnProperty(groupBy)
+    );
 
     if (validGroupBys.length) {
       return validGroupBys;

--- a/static/app/views/explore/hooks/useGroupBys.tsx
+++ b/static/app/views/explore/hooks/useGroupBys.tsx
@@ -1,20 +1,25 @@
 import {useCallback, useMemo} from 'react';
 import type {Location} from 'history';
 
+import type {TagCollection} from 'sentry/types/group';
 import {decodeList} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import type {Field} from 'sentry/views/explore/hooks/useSampleFields';
 
+import {useSpanTags} from '../contexts/spanTagsContext';
+
 interface Options {
   location: Location;
   navigate: ReturnType<typeof useNavigate>;
+  tags: TagCollection;
 }
 
 export function useGroupBys(): [Field[], (fields: Field[]) => void] {
   const location = useLocation();
   const navigate = useNavigate();
-  const options = {location, navigate};
+  const tags = useSpanTags();
+  const options = {location, navigate, tags};
 
   return useGroupBysImpl(options);
 }
@@ -22,16 +27,20 @@ export function useGroupBys(): [Field[], (fields: Field[]) => void] {
 function useGroupBysImpl({
   location,
   navigate,
+  tags,
 }: Options): [Field[], (fields: Field[]) => void] {
   const groupBys = useMemo(() => {
     const rawGroupBys = decodeList(location.query.groupBy);
 
-    if (rawGroupBys.length) {
-      return rawGroupBys;
+    // Filter out groupBys that are not in span field supported tags
+    const validGroupBys = rawGroupBys.filter(groupBy => tags.hasOwnProperty(groupBy));
+
+    if (validGroupBys.length) {
+      return validGroupBys;
     }
 
     return [''];
-  }, [location.query.groupBy]);
+  }, [location.query.groupBy, tags]);
 
   const setGroupBys = useCallback(
     (newGroupBys: Field[]) => {

--- a/static/app/views/explore/hooks/useResultsMode.spec.tsx
+++ b/static/app/views/explore/hooks/useResultsMode.spec.tsx
@@ -1,5 +1,6 @@
 // biome-ignore lint/nursery/noRestrictedImports: Will be removed with react router 6
 import {createMemoryHistory, Route, Router, RouterContext} from 'react-router';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {act, render} from 'sentry-test/reactTestingLibrary';
 
@@ -8,11 +9,21 @@ import {useResultMode} from 'sentry/views/explore/hooks/useResultsMode';
 import {useSampleFields} from 'sentry/views/explore/hooks/useSampleFields';
 import {RouteContext} from 'sentry/views/routeContext';
 
+import {SpanTagsProvider} from '../contexts/spanTagsContext';
+
 describe('useResultMode', function () {
   it('allows changing results mode', function () {
     let resultMode, setResultMode;
     let sampleFields;
     let setGroupBys;
+
+    const organization = OrganizationFixture();
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/spans/fields/`,
+      method: 'GET',
+      body: [],
+    });
 
     function TestPage() {
       [sampleFields] = useSampleFields();
@@ -24,18 +35,20 @@ describe('useResultMode', function () {
     const memoryHistory = createMemoryHistory();
 
     render(
-      <Router
-        history={memoryHistory}
-        render={props => {
-          return (
-            <RouteContext.Provider value={props}>
-              <RouterContext {...props} />
-            </RouteContext.Provider>
-          );
-        }}
-      >
-        <Route path="/" component={TestPage} />
-      </Router>
+      <SpanTagsProvider>
+        <Router
+          history={memoryHistory}
+          render={props => {
+            return (
+              <RouteContext.Provider value={props}>
+                <RouterContext {...props} />
+              </RouteContext.Provider>
+            );
+          }}
+        >
+          <Route path="/" component={TestPage} />
+        </Router>
+      </SpanTagsProvider>
     );
 
     expect(resultMode).toEqual('samples'); // default

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -9,7 +9,8 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {useResultMode} from 'sentry/views/explore/hooks/useResultsMode';
 import {useSampleFields} from 'sentry/views/explore/hooks/useSampleFields';
-import {useSpanFieldSupportedTags} from 'sentry/views/performance/utils/useSpanFieldSupportedTags';
+
+import {useSpanTags} from '../contexts/spanTagsContext';
 
 import {TracesTable} from './tracesTable/index';
 import {AggregatesTable} from './aggregatesTable';
@@ -40,10 +41,8 @@ function ExploreAggregatesTable() {
 
 function ExploreSamplesTable() {
   const [tab, setTab] = useState(Tab.SPAN);
-
   const [fields, setFields] = useSampleFields();
-  // TODO: This should be loaded from context to avoid loading tags twice.
-  const tags = useSpanFieldSupportedTags();
+  const tags = useSpanTags();
 
   const openColumnEditor = useCallback(() => {
     openModal(

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -1,5 +1,6 @@
 // biome-ignore lint/nursery/noRestrictedImports: Will be removed with react router 6
 import {createMemoryHistory, Route, Router, RouterContext} from 'react-router';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
@@ -12,29 +13,41 @@ import {ExploreToolbar} from 'sentry/views/explore/toolbar';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {RouteContext} from 'sentry/views/routeContext';
 
+import {SpanTagsProvider} from '../contexts/spanTagsContext';
+
 function renderWithRouter(component) {
   const memoryHistory = createMemoryHistory();
 
   render(
-    <Router
-      history={memoryHistory}
-      render={props => {
-        return (
-          <RouteContext.Provider value={props}>
-            <RouterContext {...props} />
-          </RouteContext.Provider>
-        );
-      }}
-    >
-      <Route path="/" component={component} />
-    </Router>
+    <SpanTagsProvider>
+      <Router
+        history={memoryHistory}
+        render={props => {
+          return (
+            <RouteContext.Provider value={props}>
+              <RouterContext {...props} />
+            </RouteContext.Provider>
+          );
+        }}
+      >
+        <Route path="/" component={component} />
+      </Router>
+    </SpanTagsProvider>
   );
 }
 
 describe('ExploreToolbar', function () {
+  const organization = OrganizationFixture();
+
   beforeEach(function () {
     // without this the `CompactSelect` component errors with a bunch of async updates
     jest.spyOn(console, 'error').mockImplementation();
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/spans/fields/`,
+      method: 'GET',
+      body: [],
+    });
   });
 
   it('allows changing results mode', async function () {

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -7,7 +7,8 @@ import {IconDelete} from 'sentry/icons/iconDelete';
 import {t} from 'sentry/locale';
 import {useGroupBys} from 'sentry/views/explore/hooks/useGroupBys';
 import type {Field} from 'sentry/views/explore/hooks/useSampleFields';
-import {useSpanFieldSupportedTags} from 'sentry/views/performance/utils/useSpanFieldSupportedTags';
+
+import {useSpanTags} from '../contexts/spanTagsContext';
 
 import {
   ToolbarHeader,
@@ -22,8 +23,7 @@ interface ToolbarGroupByProps {
 }
 
 export function ToolbarGroupBy({disabled}: ToolbarGroupByProps) {
-  // TODO: This should be loaded from context to avoid loading tags twice.
-  const tags = useSpanFieldSupportedTags();
+  const tags = useSpanTags();
 
   const [groupBys, setGroupBys] = useGroupBys();
 


### PR DESCRIPTION
As we switched between projects, we passed unsupported span field tags to the table and chart queries. This caused the page to break for the topN events scenario in aggregate mode. 

To test, try switching to `project: seer` for this [query](https://sentry.sentry.io/traces/?field=project&field=id&field=span.op&field=span.description&field=span.duration&field=timestamp&groupBy=organization_slug&mode=aggregate&project=1&statsPeriod=1h).


