### PR TITLE
style(onboarding): Fix overflow for SplitContainer

### DIFF
--- a/static/app/views/insights/common/components/modulesOnboarding.tsx
+++ b/static/app/views/insights/common/components/modulesOnboarding.tsx
@@ -178,6 +178,7 @@ const Header = styled('h3')`
 const SplitContainer = styled(Panel)`
   display: flex;
   justify-content: center;
+  overflow: hidden;
 `;
 
 const ModuleInfo = styled('div')`


### PR DESCRIPTION
Before:
<img width="884" alt="overflow" src="https://github.com/user-attachments/assets/f519c444-5b7c-4e0d-abdd-ee74eeb3e130">
After: <img width="884" alt="image" src="https://github.com/user-attachments/assets/45c93cdc-f11c-4c48-81ae-6841710bdb19">
