### PR TITLE
feat(js): Use replaceRouterParams over generatePath

### DIFF
--- a/static/app/utils/reactRouter6Compat/router.tsx
+++ b/static/app/utils/reactRouter6Compat/router.tsx
@@ -1,6 +1,5 @@
 import {Children, isValidElement} from 'react';
 import {
-  generatePath,
   Navigate,
   type NavigateProps,
   Outlet,
@@ -9,6 +8,7 @@ import {
 } from 'react-router-dom';
 
 import {USING_CUSTOMER_DOMAIN} from 'sentry/constants';
+import replaceRouterParams from 'sentry/utils/replaceRouterParams';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';
 import useRouter from 'sentry/utils/useRouter';
@@ -76,7 +76,7 @@ interface RedirectProps extends Omit<NavigateProps, 'to'> {
 function Redirect({to, ...rest}: RedirectProps) {
   const params = useParams();
 
-  return <Navigate to={generatePath(to, params)} {...rest} />;
+  return <Navigate to={replaceRouterParams(to, params)} {...rest} />;
 }
 Redirect.displayName = 'Redirect';
 


### PR DESCRIPTION
React router 6's [generatePath][0] function is a bit too complex for our
needs and is losing the trailing slash on routes.

In the future we can consider going back to generatePath, but for now
let's use ours.

[0]: https://github.com/remix-run/react-router/blob/9c32cfa3529071373ff306d7711c34f7052dfc78/packages/router/utils.ts#L857-L913