### PR TITLE
test(ui): Remove useOrganization mocks

### DIFF
--- a/static/app/views/insights/mobile/screens/components/screensOverview.spec.tsx
+++ b/static/app/views/insights/mobile/screens/components/screensOverview.spec.tsx
@@ -5,12 +5,10 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useCrossPlatformProject from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
 import {ScreensOverview} from 'sentry/views/insights/mobile/screens/components/screensOverview';
 
-jest.mock('sentry/utils/useOrganization');
 jest.mock('sentry/views/insights/mobile/common/queries/useCrossPlatformProject');
 jest.mock('sentry/utils/usePageFilters');
 jest.mock('sentry/utils/useLocation');
@@ -55,8 +53,6 @@ describe('ScreensOverview', () => {
     isProjectCrossPlatform: true,
     selectedPlatform: 'Android',
   });
-
-  jest.mocked(useOrganization).mockReturnValue(organization);
 
   it('renders search bar and table', async () => {
     MockApiClient.addMockResponse({

--- a/static/app/views/insights/mobile/screens/components/screensOverviewTable.spec.tsx
+++ b/static/app/views/insights/mobile/screens/components/screensOverviewTable.spec.tsx
@@ -6,11 +6,9 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import EventView from 'sentry/utils/discover/eventView';
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import ScreensOverviewTable from 'sentry/views/insights/mobile/screens/components/screensOverviewTable';
 
-jest.mock('sentry/utils/useOrganization');
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/views/insights/common/utils/useModuleURL');
 jest.mock('sentry/utils/usePageFilters');
@@ -33,7 +31,6 @@ describe('ScreensOverviewTable', () => {
     state: undefined,
   } as Location;
 
-  jest.mocked(useOrganization).mockReturnValue(organization);
   jest.mocked(useLocation).mockReturnValue(location);
   jest.mocked(usePageFilters).mockReturnValue({
     isReady: true,
@@ -76,7 +73,10 @@ describe('ScreensOverviewTable', () => {
         eventView={mockEventView}
         isLoading={false}
         pageLinks=""
-      />
+      />,
+      {
+        organization,
+      }
     );
 
     // headers

--- a/static/app/views/insights/mobile/screens/views/screensLandingPage.spec.tsx
+++ b/static/app/views/insights/mobile/screens/views/screensLandingPage.spec.tsx
@@ -6,7 +6,6 @@ import {render, screen, waitFor, within} from 'sentry-test/reactTestingLibrary';
 
 import {t} from 'sentry/locale';
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useCrossPlatformProject from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
 import {MODULE_FEATURE} from 'sentry/views/insights/mobile/screens/settings';
@@ -15,7 +14,6 @@ import {ScreensLandingPage} from 'sentry/views/insights/mobile/screens/views/scr
 jest.mock('sentry/utils/usePageFilters');
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/views/insights/mobile/common/queries/useCrossPlatformProject');
-jest.mock('sentry/utils/useOrganization');
 
 describe('Screens Landing Page', function () {
   const organization = OrganizationFixture({
@@ -23,7 +21,6 @@ describe('Screens Landing Page', function () {
   });
   const project = ProjectFixture({platform: 'react-native'});
 
-  jest.mocked(useOrganization).mockReturnValue(organization);
   jest.mocked(useLocation).mockReturnValue({
     action: 'PUSH',
     hash: '',
@@ -200,7 +197,7 @@ describe('Screens Landing Page', function () {
 
     it('shows no content if permission is missing', async function () {
       organization.features = [];
-      render(<ScreensLandingPage />);
+      render(<ScreensLandingPage />, {organization});
       expect(
         await screen.findByText(t("You don't have access to this feature"))
       ).toBeInTheDocument();
@@ -208,7 +205,7 @@ describe('Screens Landing Page', function () {
 
     it('shows content if permission is there', async function () {
       organization.features = [MODULE_FEATURE];
-      render(<ScreensLandingPage />);
+      render(<ScreensLandingPage />, {organization});
       expect(await screen.findAllByText(t('Mobile Screens'))).toHaveLength(2);
     });
   });


### PR DESCRIPTION
use our built in test contexts https://develop.sentry.dev/frontend/using-rtl/#use-our-built-in-contexts
