### PR TITLE
ref(chevron): Lighten stroke color

### DIFF
--- a/static/app/components/actions/archive.tsx
+++ b/static/app/components/actions/archive.tsx
@@ -159,7 +159,14 @@ function ArchiveActions({
             {...triggerProps}
             aria-label={t('Archive options')}
             size={size}
-            icon={<Chevron weight="medium" direction={isOpen ? 'up' : 'down'} />}
+            icon={
+              <Chevron
+                light
+                color="subText"
+                weight="medium"
+                direction={isOpen ? 'up' : 'down'}
+              />
+            }
             disabled={disabled}
           />
         )}

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -272,7 +272,14 @@ function ResolveActions({
             size={size}
             priority={priority}
             aria-label={t('More resolve options')}
-            icon={<Chevron weight="medium" direction={isOpen ? 'up' : 'down'} />}
+            icon={
+              <Chevron
+                light
+                color="subText"
+                weight="medium"
+                direction={isOpen ? 'up' : 'down'}
+              />
+            }
             disabled={isDisabled}
           />
         )}

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -64,7 +64,7 @@ export function AssigneeBadge({
             style={{color: theme.textColor}}
           >{`${actor.type === 'team' ? '#' : ''}${actor.name}`}</div>
         )}
-        <Chevron direction={chevronDirection} size="small" />
+        <Chevron light color="subText" direction={chevronDirection} size="small" />
       </Fragment>
     );
   };
@@ -73,7 +73,7 @@ export function AssigneeBadge({
     <Fragment>
       <StyledLoadingIndicator mini hideMessage relative size={AVATAR_SIZE} />
       {showLabel && 'Loading...'}
-      <Chevron direction={chevronDirection} size="small" />
+      <Chevron light color="subText" direction={chevronDirection} size="small" />
     </Fragment>
   );
 
@@ -86,7 +86,7 @@ export function AssigneeBadge({
         height={`${AVATAR_SIZE}px`}
       />
       {showLabel && <Fragment>Unassigned</Fragment>}
-      <Chevron direction={chevronDirection} size="small" />
+      <Chevron light color="subText" direction={chevronDirection} size="small" />
     </Fragment>
   );
 

--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -208,7 +208,7 @@ export function GroupPriorityDropdown({
           size="zero"
         >
           <GroupPriorityBadge priority={value}>
-            <Chevron direction={isOpen ? 'up' : 'down'} size="small" />
+            <Chevron light direction={isOpen ? 'up' : 'down'} size="small" />
           </GroupPriorityBadge>
         </DropdownButton>
       )}

--- a/static/app/components/chevron.tsx
+++ b/static/app/components/chevron.tsx
@@ -6,6 +6,11 @@ import theme from 'sentry/utils/theme';
 interface ChevronProps extends React.SVGAttributes<SVGSVGElement> {
   direction?: 'up' | 'right' | 'down' | 'left';
   /**
+   * Whether to lighten (by lowering the opacity) the chevron. Useful if the chevron is
+   * inside a dropdown trigger button.
+   */
+  light?: boolean;
+  /**
    * The size of the checkbox. Defaults to 'sm'.
    */
   size?: 'large' | 'medium' | 'small';
@@ -51,6 +56,7 @@ function Chevron({
   size = 'medium',
   weight = 'regular',
   direction = 'down',
+  light = false,
   ...props
 }: ChevronProps) {
   return (
@@ -58,6 +64,7 @@ function Chevron({
       viewBox="0 0 14 14"
       size={chevronSizeMap[size]}
       weightFactor={rubikWeightFactor[weight]}
+      strokeOpacity={light ? 0.6 : 1}
       {...props}
     >
       <motion.path

--- a/static/app/components/dropdownButton.tsx
+++ b/static/app/components/dropdownButton.tsx
@@ -51,6 +51,8 @@ function DropdownButton({
       {showChevron && (
         <ChevronWrap>
           <Chevron
+            light
+            color="subText"
             size={size === 'xs' ? 'small' : 'medium'}
             weight="medium"
             direction={isOpen ? 'up' : 'down'}
@@ -68,10 +70,6 @@ const ChevronWrap = styled('div')`
   margin-left: auto;
   padding-left: ${space(0.5)};
   flex-shrink: 0;
-
-  button:hover & {
-    opacity: 1;
-  }
 `;
 
 interface StyledButtonProps

--- a/static/app/components/forms/controls/selectControl.tsx
+++ b/static/app/components/forms/controls/selectControl.tsx
@@ -19,8 +19,9 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import omit from 'lodash/omit';
 
+import {Chevron} from 'sentry/components/chevron';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {IconChevron, IconClose} from 'sentry/icons';
+import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Choices, SelectValue} from 'sentry/types/core';
@@ -61,7 +62,7 @@ function DropdownIndicator(
 ) {
   return (
     <selectComponents.DropdownIndicator {...props}>
-      <IconChevron direction="down" size="sm" />
+      <Chevron light color="subText" direction="down" size="medium" />
     </selectComponents.DropdownIndicator>
   );
 }


### PR DESCRIPTION
Chevrons, when acting as a secondary visual indicator, e.g. to indicate that a button opens a dropdown menu, can be lightened to redirect focus to more important elements, e.g. button labels.

Before —
<img width="320" alt="Screenshot 2024-09-23 at 11 22 50 AM" src="https://github.com/user-attachments/assets/0c2eab13-bc47-4863-9c41-24b6b973e4e5">

After —
<img width="320" alt="Screenshot 2024-09-23 at 11 23 02 AM" src="https://github.com/user-attachments/assets/17af5e69-cf9b-4f6c-bfdb-46747ebb0863">
