### PR TITLE
feat(issue-views): Tab title char limits (dupe) 

### DIFF
--- a/static/app/views/issueList/customViewsHeader.tsx
+++ b/static/app/views/issueList/customViewsHeader.tsx
@@ -326,6 +326,9 @@ function CustomViewsIssueListHeaderTabsContent({
 
   useEffect(() => {
     if (viewId?.startsWith('_')) {
+      if (draggableTabs.find(tab => tab.id === viewId)?.label.endsWith('(Copy)')) {
+        return;
+      }
       // If the user types in query manually while the new view flow is showing,
       // then replace the add view flow with the issue stream with the query loaded,
       // and persist the query

--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
@@ -388,15 +388,13 @@ export function DraggableTabBar({
           disabled={tab.key === editingTabKey}
         >
           <TabContentWrap>
-            <motion.div layout="position" transition={{duration: 0.25}}>
-              <EditableTabTitle
-                label={tab.label}
-                isEditing={editingTabKey === tab.key}
-                setIsEditing={isEditing => setEditingTabKey(isEditing ? tab.key : null)}
-                onChange={newLabel => handleOnTabRenamed(newLabel.trim(), tab.key)}
-                tabKey={tab.key}
-              />
-            </motion.div>
+            <EditableTabTitle
+              label={tab.label}
+              isEditing={editingTabKey === tab.key}
+              setIsEditing={isEditing => setEditingTabKey(isEditing ? tab.key : null)}
+              onChange={newLabel => handleOnTabRenamed(newLabel.trim(), tab.key)}
+              tabKey={tab.key}
+            />
             {/* If tablistState isn't initialized, we want to load the elipsis menu
                 for the initial tab, that way it won't load in a second later
                 and cause the tabs to shift and animate on load.

--- a/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 
 import {GrowingInput} from 'sentry/components/growingInput';
 import {TabsContext} from 'sentry/components/tabs';
+import {Tooltip} from 'sentry/components/tooltip';
 
 interface EditableTabTitleProps {
   isEditing: boolean;
@@ -84,30 +85,44 @@ function EditableTabTitle({
     setInputValue(e.target.value);
   };
 
-  return isSelected ? (
-    <StyledGrowingInput
-      value={inputValue}
-      onChange={handleOnChange}
-      onKeyDown={handleOnKeyDown}
-      onDoubleClick={() => isSelected && setIsEditing(true)}
-      onBlur={handleOnBlur}
-      ref={inputRef}
-      style={memoizedStyles}
-      isEditing={isEditing}
-      onFocus={e => e.target.select()}
-      onPointerDown={e => {
-        e.stopPropagation();
-      }}
-      onMouseDown={e => {
-        e.stopPropagation();
-      }}
-    />
-  ) : (
-    <div style={{height: '20px'}}>{label}</div>
+  return (
+    <Tooltip title={label} showOnlyOnOverflow>
+      {isSelected ? (
+        <StyledGrowingInput
+          value={inputValue}
+          onChange={handleOnChange}
+          onKeyDown={handleOnKeyDown}
+          onDoubleClick={() => isSelected && setIsEditing(true)}
+          onBlur={handleOnBlur}
+          ref={inputRef}
+          style={memoizedStyles}
+          isEditing={isEditing}
+          onFocus={e => e.target.select()}
+          onPointerDown={e => {
+            e.stopPropagation();
+          }}
+          onMouseDown={e => {
+            e.stopPropagation();
+          }}
+          maxLength={128}
+        />
+      ) : (
+        <UnselectedTabTitle>{label}</UnselectedTabTitle>
+      )}
+    </Tooltip>
   );
 }
 
 export default EditableTabTitle;
+
+const UnselectedTabTitle = styled('div')`
+  height: 20px;
+  /* The max width is slightly smaller than the GrowingInput since the text in the growing input is bolded */
+  max-width: 310px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
 
 const StyledGrowingInput = styled(GrowingInput)<{
   isEditing: boolean;
@@ -119,7 +134,10 @@ const StyledGrowingInput = styled(GrowingInput)<{
   min-height: 0px;
   height: 20px;
   border-radius: 0px;
+  text-overflow: ellipsis;
   cursor: ${p => (p.isEditing ? 'text' : 'pointer')};
+
+  ${p => !p.isEditing && `max-width: 325px;`}
 
   &,
   &:focus,

--- a/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
@@ -1,6 +1,7 @@
 import {useContext, useEffect, useMemo, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
+import {motion} from 'framer-motion';
 
 import {GrowingInput} from 'sentry/components/growingInput';
 import {TabsContext} from 'sentry/components/tabs';
@@ -86,29 +87,31 @@ function EditableTabTitle({
   };
 
   return (
-    <Tooltip title={label} showOnlyOnOverflow>
-      {isSelected ? (
-        <StyledGrowingInput
-          value={inputValue}
-          onChange={handleOnChange}
-          onKeyDown={handleOnKeyDown}
-          onDoubleClick={() => isSelected && setIsEditing(true)}
-          onBlur={handleOnBlur}
-          ref={inputRef}
-          style={memoizedStyles}
-          isEditing={isEditing}
-          onFocus={e => e.target.select()}
-          onPointerDown={e => {
-            e.stopPropagation();
-          }}
-          onMouseDown={e => {
-            e.stopPropagation();
-          }}
-          maxLength={128}
-        />
-      ) : (
-        <UnselectedTabTitle>{label}</UnselectedTabTitle>
-      )}
+    <Tooltip title={label} showOnlyOnOverflow skipWrapper>
+      <motion.div layout="position" transition={{duration: 0.25}}>
+        {isSelected ? (
+          <StyledGrowingInput
+            value={inputValue}
+            onChange={handleOnChange}
+            onKeyDown={handleOnKeyDown}
+            onDoubleClick={() => isSelected && setIsEditing(true)}
+            onBlur={handleOnBlur}
+            ref={inputRef}
+            style={memoizedStyles}
+            isEditing={isEditing}
+            onFocus={e => e.target.select()}
+            onPointerDown={e => {
+              e.stopPropagation();
+            }}
+            onMouseDown={e => {
+              e.stopPropagation();
+            }}
+            maxLength={128}
+          />
+        ) : (
+          <UnselectedTabTitle>{label}</UnselectedTabTitle>
+        )}
+      </motion.div>
     </Tooltip>
   );
 }


### PR DESCRIPTION
This PR is nearly identical to [this previous PR](https://github.com/getsentry/sentry/pull/77883) that I reverted because of an unexpected visual bug that occurred because of a conflict with another PR. (specifically [this one](https://github.com/getsentry/sentry/pull/77890) that added animation wrappers over the tab title) 

The behavior is identical to the previous PR, see that one for a visual demo. 


This PR also fixes an unrelated bug with the duplicate functionality. Previously, clicking on the "Duplicate" action for a tab would flash the Add View page before going back to the issue stream. This happened because the add view page is automatically triggered when the search's viewId begins with a "_", indicating a tab that has not been persisted on our backend yet. 