### PR TITLE
test(ui): Remove duplicate global test mocks

### DIFF
--- a/static/app/actionCreators/account.spec.tsx
+++ b/static/app/actionCreators/account.spec.tsx
@@ -2,8 +2,6 @@ import {waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {logout} from './account';
 
-jest.mock('react-router-dom');
-
 describe('logout', () => {
   it('has can logout', async function () {
     jest.spyOn(window.location, 'assign').mockImplementation(() => {});

--- a/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
@@ -5,8 +5,6 @@ import {renderHook} from 'sentry-test/reactTestingLibrary';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import useActiveReplayTab, {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 
-jest.mock('react-router');
-
 const mockPush = jest.mocked(browserHistory.push);
 
 function mockLocation(query: string = '') {

--- a/static/app/utils/useCleanQueryParamsOnRouteLeave.spec.tsx
+++ b/static/app/utils/useCleanQueryParamsOnRouteLeave.spec.tsx
@@ -10,7 +10,6 @@ import useCleanQueryParamsOnRouteLeave, {
 } from './useCleanQueryParamsOnRouteLeave';
 import {useLocation} from './useLocation';
 
-jest.mock('react-router');
 jest.mock('./useLocation');
 
 const MockBrowserHistoryListen = jest.mocked(browserHistory.listen);

--- a/static/app/utils/useUrlParams.spec.tsx
+++ b/static/app/utils/useUrlParams.spec.tsx
@@ -6,8 +6,6 @@ import {browserHistory} from 'sentry/utils/browserHistory';
 
 import useUrlParams from './useUrlParams';
 
-jest.mock('react-router');
-
 describe('useUrlParams', () => {
   beforeEach(() => {
     window.location.search = qs.stringify({

--- a/static/app/views/alerts/create.spec.tsx
+++ b/static/app/views/alerts/create.spec.tsx
@@ -26,7 +26,6 @@ jest.mock('sentry/actionCreators/members', () => ({
     return {};
   }),
 }));
-jest.mock('react-router');
 jest.mock('sentry/utils/analytics', () => ({
   metric: {
     startSpan: jest.fn(() => ({

--- a/static/app/views/projectsDashboard/index.spec.tsx
+++ b/static/app/views/projectsDashboard/index.spec.tsx
@@ -17,8 +17,6 @@ import ProjectsStatsStore from 'sentry/stores/projectsStatsStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {Dashboard} from 'sentry/views/projectsDashboard';
 
-jest.mock('sentry/api');
-
 jest.unmock('lodash/debounce');
 jest.mock('lodash/debounce', () => {
   const debounceMap = new Map();

--- a/static/app/views/replays/detail/console/useConsoleFilters.spec.tsx
+++ b/static/app/views/replays/detail/console/useConsoleFilters.spec.tsx
@@ -11,7 +11,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import type {FilterFields} from 'sentry/views/replays/detail/console/useConsoleFilters';
 import useConsoleFilters from 'sentry/views/replays/detail/console/useConsoleFilters';
 
-jest.mock('react-router');
 jest.mock('sentry/utils/useLocation');
 
 const mockUseLocation = jest.mocked(useLocation);

--- a/static/app/views/replays/detail/errorList/useErrorFilters.spec.tsx
+++ b/static/app/views/replays/detail/errorList/useErrorFilters.spec.tsx
@@ -13,7 +13,6 @@ import type {
 } from 'sentry/views/replays/detail/errorList/useErrorFilters';
 import useErrorFilters from 'sentry/views/replays/detail/errorList/useErrorFilters';
 
-jest.mock('react-router');
 jest.mock('sentry/utils/useLocation');
 
 const mockUseLocation = jest.mocked(useLocation);

--- a/static/app/views/replays/detail/errorList/useSortErrors.spec.tsx
+++ b/static/app/views/replays/detail/errorList/useSortErrors.spec.tsx
@@ -6,7 +6,6 @@ import {act, renderHook} from 'sentry-test/reactTestingLibrary';
 import hydrateErrors from 'sentry/utils/replays/hydrateErrors';
 import useSortErrors from 'sentry/views/replays/detail/errorList/useSortErrors';
 
-jest.mock('react-router');
 jest.mock('sentry/utils/useUrlParams', () => {
   const map = new Map();
   return (name, dflt) => {

--- a/static/app/views/replays/detail/network/useNetworkFilters.spec.tsx
+++ b/static/app/views/replays/detail/network/useNetworkFilters.spec.tsx
@@ -16,7 +16,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import type {FilterFields, NetworkSelectOption} from './useNetworkFilters';
 import useNetworkFilters from './useNetworkFilters';
 
-jest.mock('react-router');
 jest.mock('sentry/utils/useLocation');
 
 const mockUseLocation = jest.mocked(useLocation);

--- a/static/app/views/replays/detail/network/useSortNetwork.spec.tsx
+++ b/static/app/views/replays/detail/network/useSortNetwork.spec.tsx
@@ -12,7 +12,6 @@ import hydrateSpans from 'sentry/utils/replays/hydrateSpans';
 
 import useSortNetwork from './useSortNetwork';
 
-jest.mock('react-router');
 jest.mock('sentry/utils/useUrlParams', () => {
   const map = new Map();
   return (name, dflt) => {

--- a/static/app/views/replays/detail/tagPanel/useTagFilters.spec.tsx
+++ b/static/app/views/replays/detail/tagPanel/useTagFilters.spec.tsx
@@ -8,7 +8,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import type {FilterFields} from 'sentry/views/replays/detail/tagPanel/useTagFilters';
 import useTagFilters from 'sentry/views/replays/detail/tagPanel/useTagFilters';
 
-jest.mock('react-router');
 jest.mock('sentry/utils/useLocation');
 
 const mockUseLocation = jest.mocked(useLocation);

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -24,8 +24,6 @@ import {browserHistory} from 'sentry/utils/browserHistory';
 import OrganizationMembersList from 'sentry/views/settings/organizationMembers/organizationMembersList';
 
 jest.mock('sentry/utils/analytics');
-
-jest.mock('sentry/api');
 jest.mock('sentry/actionCreators/indicator');
 
 const roles = [


### PR DESCRIPTION
All of these are mocked at the global level `tests/js/setup.ts` and don't currently do anything.
