### PR TITLE
ref(ui): Remove `qs` imports, not a dependency

### DIFF
--- a/static/app/views/insights/queues/components/tables/queuesTable.tsx
+++ b/static/app/views/insights/queues/components/tables/queuesTable.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
-import qs from 'qs';
+import * as qs from 'query-string';
 
 import GridEditable, {
   COL_WIDTH_UNDEFINED,

--- a/static/app/views/insights/queues/components/tables/transactionsTable.tsx
+++ b/static/app/views/insights/queues/components/tables/transactionsTable.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
-import qs from 'qs';
+import * as qs from 'query-string';
 
 import GridEditable, {
   COL_WIDTH_UNDEFINED,

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/http.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/http.tsx
@@ -1,4 +1,4 @@
-import qs from 'qs';
+import * as qs from 'query-string';
 
 import type {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
 import {t} from 'sentry/locale';

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -1,7 +1,7 @@
 import type {Theme} from '@emotion/react';
 import * as Sentry from '@sentry/react';
 import type {Location} from 'history';
-import qs from 'qs';
+import * as qs from 'query-string';
 
 import type {Client} from 'sentry/api';
 import type {RawSpanType} from 'sentry/components/events/interfaces/spans/types';


### PR DESCRIPTION
We do not have `qs` as a direct dependency. It works anyway because we have it as a sub dependency, but we shouldn't import things that aren't dependencies. This could be a eslint rule we enable.

```sh
yarn why qs

=> Found "qs@6.11.0"
info Reasons this module exists
   - "webpack-dev-server#express" depends on it
   - Hoisted from "webpack-dev-server#express#qs"
   - Hoisted from "@rsdoctor#webpack-plugin#@rsdoctor#sdk#body-parser#qs"
```
