### PR TITLE
fix(pageFilters): Update min widths

### DIFF
--- a/static/app/components/organizations/pageFilterBar.tsx
+++ b/static/app/components/organizations/pageFilterBar.tsx
@@ -70,7 +70,7 @@ const PageFilterBar = styled('div')<{condensed?: boolean}>`
 
     /* Prevent date filter from shrinking below 6.5rem */
     &:last-child {
-      min-width: 6.5rem;
+      min-width: 4.5rem;
     }
   }
 

--- a/static/app/components/organizations/pageFilterBar.tsx
+++ b/static/app/components/organizations/pageFilterBar.tsx
@@ -70,7 +70,7 @@ const PageFilterBar = styled('div')<{condensed?: boolean}>`
 
     /* Prevent date filter from shrinking below 6.5rem */
     &:last-child {
-      min-width: 4.5rem;
+      min-width: 4rem;
     }
   }
 

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -49,17 +49,6 @@ const StyledPageFilterBar = styled(PageFilterBar)`
   > div > button {
     width: 100%;
   }
-
-  & > * {
-    /* Prevent date filter from shrinking below 6.5rem */
-    &:nth-last-child(2) {
-      min-width: 6.5rem;
-    }
-
-    &:last-child {
-      min-width: 0;
-    }
-  }
 `;
 
 export default IssueListFilters;


### PR DESCRIPTION
After https://github.com/getsentry/sentry/pull/77867, we  can set lower min width for page filters.

**Before —**
<img width="311" alt="Screenshot 2024-09-23 at 12 38 04 PM" src="https://github.com/user-attachments/assets/28876dbf-c17e-4baa-be84-8697a990125a">


**After —**
<img width="275" alt="Screenshot 2024-09-23 at 12 37 49 PM" src="https://github.com/user-attachments/assets/b3965201-c721-4bc4-8744-9e37b96e4ccd">
