### PR TITLE
test(ui): Transaction tags browserHistory flakes

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionTags/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/index.spec.tsx
@@ -164,13 +164,15 @@ describe('Performance > Transaction Tags', function () {
     // It shows the tag chart
     expect(screen.getByText('Heat Map')).toBeInTheDocument();
 
-    expect(browserHistory.replace).toHaveBeenCalledWith({
-      query: {
-        project: '1',
-        statsPeriod: '14d',
-        tagKey: 'hardwareConcurrency',
-        transaction: 'Test Transaction',
-      },
+    await waitFor(() => {
+      expect(browserHistory.replace).toHaveBeenCalledWith({
+        query: {
+          project: '1',
+          statsPeriod: '14d',
+          tagKey: 'hardwareConcurrency',
+          transaction: 'Test Transaction',
+        },
+      });
     });
 
     expect(await screen.findByRole('radio', {name: 'hardwareConcurrency'})).toBeChecked();
@@ -189,13 +191,15 @@ describe('Performance > Transaction Tags', function () {
       expect(screen.getByRole('table')).toBeInTheDocument();
     });
 
-    expect(browserHistory.replace).toHaveBeenCalledWith({
-      query: {
-        project: '1',
-        statsPeriod: '14d',
-        tagKey: 'hardwareConcurrency',
-        transaction: 'Test Transaction',
-      },
+    await waitFor(() => {
+      expect(browserHistory.replace).toHaveBeenCalledWith({
+        query: {
+          project: '1',
+          statsPeriod: '14d',
+          tagKey: 'hardwareConcurrency',
+          transaction: 'Test Transaction',
+        },
+      });
     });
 
     await waitFor(() => expect(histogramMock).toHaveBeenCalledTimes(1));
@@ -226,13 +230,15 @@ describe('Performance > Transaction Tags', function () {
       expect(screen.getByRole('table')).toBeInTheDocument();
     });
 
-    expect(browserHistory.replace).toHaveBeenCalledWith({
-      query: {
-        project: '1',
-        statsPeriod: '14d',
-        tagKey: 'effectiveConnectionType',
-        transaction: 'Test Transaction',
-      },
+    await waitFor(() => {
+      expect(browserHistory.replace).toHaveBeenCalledWith({
+        query: {
+          project: '1',
+          statsPeriod: '14d',
+          tagKey: 'effectiveConnectionType',
+          transaction: 'Test Transaction',
+        },
+      });
     });
 
     await waitFor(() => expect(histogramMock).toHaveBeenCalledTimes(1));
@@ -286,13 +292,15 @@ describe('Performance > Transaction Tags', function () {
 
     expect(await screen.findByText('Suspect Tags')).toBeInTheDocument();
 
-    expect(browserHistory.replace).toHaveBeenCalledWith({
-      query: {
-        project: '1',
-        statsPeriod: '14d',
-        tagKey: 'hardwareConcurrency',
-        transaction: 'Test Transaction',
-      },
+    await waitFor(() => {
+      expect(browserHistory.replace).toHaveBeenCalledWith({
+        query: {
+          project: '1',
+          statsPeriod: '14d',
+          tagKey: 'hardwareConcurrency',
+          transaction: 'Test Transaction',
+        },
+      });
     });
 
     expect(await screen.findByRole('radio', {name: 'hardwareConcurrency'})).toBeChecked();
@@ -319,13 +327,15 @@ describe('Performance > Transaction Tags', function () {
     // Choose a different tag
     await userEvent.click(screen.getByRole('radio', {name: 'effectiveConnectionType'}));
 
-    expect(browserHistory.replace).toHaveBeenCalledWith({
-      query: {
-        project: '1',
-        statsPeriod: '14d',
-        tagKey: 'effectiveConnectionType',
-        transaction: 'Test Transaction',
-      },
+    await waitFor(() => {
+      expect(browserHistory.replace).toHaveBeenCalledWith({
+        query: {
+          project: '1',
+          statsPeriod: '14d',
+          tagKey: 'effectiveConnectionType',
+          transaction: 'Test Transaction',
+        },
+      });
     });
   });
 


### PR DESCRIPTION
attempt to fix flakes from browserHistory not being called.

[discover query](https://sentry.sentry.io/discover/homepage/?dataset=transactions&environment=ci%3Amaster&environment=ci%3Apull_request&field=title&field=count_unique%28branch%29&field=count_if%28branch%2Cequals%2Crefs%2Fheads%2Fmaster%29&name=All%20Events&project=4857230&query=event.type%3Atransaction%20transaction.status%3Ainternal_error%20title%3A%22%2ATransaction%20Tags%2A%22&queryDataset=transaction-like&sort=-count_if_branch_equals_refs_heads_master&statsPeriod=30d&yAxis=count%28%29)
