### PR TITLE
feat(spans): Add margin of error

### DIFF
--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -7,6 +7,7 @@ from snuba_sdk import Column, Direction, Function, OrderBy
 from sentry.api.event_search import SearchFilter
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.events import constants
+from sentry.search.events.builder import spans_indexed
 from sentry.search.events.builder.base import BaseQueryBuilder
 from sentry.search.events.datasets import field_aliases, filter_aliases, function_aliases
 from sentry.search.events.datasets.base import DatasetConfig
@@ -24,6 +25,7 @@ from sentry.search.events.fields import (
 )
 from sentry.search.events.types import SelectType, WhereType
 from sentry.search.utils import DEVICE_CLASS
+from sentry.snuba.referrer import Referrer
 
 
 class SpansIndexedDatasetConfig(DatasetConfig):
@@ -534,6 +536,8 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
     """Eventually should just write the eap dataset from scratch, but inheriting for now to move fast"""
 
     sampling_weight = Column("sampling_weight")
+    _cached_count = None
+    _cached_count_weighted = None
 
     def _resolve_span_duration(self, alias: str) -> SelectType:
         # In ClickHouse, duration is an UInt32 whereas self time is a Float64.
@@ -567,11 +571,7 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
                 SnQLFunction(
                     "count_weighted",
                     optional_args=[NullColumn("column")],
-                    snql_aggregate=lambda _, alias: Function(
-                        "sum",
-                        [Function("multiply", [Column("sign"), self.sampling_weight])],
-                        alias,
-                    ),
+                    snql_aggregate=self._resolve_count_weighted,
                     default_result_type="integer",
                 ),
                 SnQLFunction(
@@ -698,6 +698,21 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
                     default_result_type="duration",
                     redundant_grouping=True,
                 ),
+                SnQLFunction(
+                    "margin_of_error",
+                    snql_aggregate=self._resolve_margin_of_error,
+                    default_result_type="number",
+                ),
+                SnQLFunction(
+                    "lower_count_limit",
+                    snql_aggregate=self._resolve_lower_limit,
+                    default_result_type="number",
+                ),
+                SnQLFunction(
+                    "upper_count_limit",
+                    snql_aggregate=self._resolve_upper_limit,
+                    default_result_type="number",
+                ),
             ]
         }
 
@@ -723,6 +738,17 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
             alias,
         )
 
+    def _resolve_count_weighted(
+        self,
+        args: Mapping[str, str | Column | SelectType | int | float],
+        alias: str | None = None,
+    ) -> SelectType:
+        return Function(
+            "sum",
+            [Function("multiply", [Column("sign"), self.sampling_weight])],
+            alias,
+        )
+
     def _resolve_percentile_weighted(
         self,
         args: Mapping[str, str | Column | SelectType | int | float],
@@ -733,5 +759,156 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
             f'quantileTDigestWeighted({fixed_percentile if fixed_percentile is not None else args["percentile"]})',
             # Only convert to UInt64 when we have to since we lose rounding accuracy
             [args["column"], Function("toUInt64", [self.sampling_weight])],
+            alias,
+        )
+
+    def _query_total_counts(self) -> tuple[float | int, float | int]:
+        if self._cached_count is None:
+            total_query = spans_indexed.SpansEAPQueryBuilder(
+                dataset=self.builder.dataset,
+                params={},
+                snuba_params=self.builder.params,
+                selected_columns=["count()", "count_weighted()"],
+            )
+            total_results = total_query.run_query(Referrer.API_SPANS_TOTAL_COUNT_FIELD.value)
+            results = total_query.process_results(total_results)
+            if len(results["data"]) != 1:
+                raise Exception("Could not query population size")
+            self._cached_count = results["data"][0]["count"]
+            self._cached_count_weighted = results["data"][0]["count_weighted"]
+        return self._cached_count, self._cached_count_weighted
+
+    def _resolve_margin_of_error(
+        self,
+        args: Mapping[str, str | Column | SelectType | int | float],
+        alias: str | None = None,
+    ) -> SelectType:
+        """Calculates the Margin of error for a given value, but unfortunately basis the total count based on
+        extrapolated data"""
+        # both of these need to be aggregated without a query
+        total_samples, population_size = self._query_total_counts()
+        sampled_group = Function("count", [])
+        return Function(
+            "multiply",
+            [
+                # Based on a z score for a confidence level of 95%
+                1.96,
+                Function(
+                    "multiply",
+                    [
+                        # Unadjusted Margin of Error
+                        self._resolve_unadjusted_margin(sampled_group, total_samples),
+                        # Finite Population Correction
+                        self._resolve_finite_population_correction(total_samples, population_size),
+                    ],
+                ),
+            ],
+            alias,
+        )
+
+    def _resolve_unadjusted_margin(
+        self, sampled_group: SelectType, total_samples: SelectType
+    ) -> SelectType:
+        # Naming this p to match the formula
+        p = Function("divide", [sampled_group, total_samples])
+        return Function(
+            "sqrt",
+            [
+                Function(
+                    "divide", [Function("multiply", [p, Function("minus", [1, p])]), total_samples]
+                )
+            ],
+        )
+
+    def _resolve_finite_population_correction(
+        self,
+        total_samples: SelectType,
+        population_size: int | float,
+    ) -> SelectType:
+        return Function(
+            "sqrt",
+            [
+                Function(
+                    "divide",
+                    [
+                        Function("minus", [population_size, total_samples]),
+                        Function("minus", [population_size, 1]),
+                    ],
+                )
+            ],
+        )
+
+    def _resolve_lower_limit(
+        self,
+        args: Mapping[str, str | Column | SelectType | int | float],
+        alias: str,
+    ) -> SelectType:
+        total_samples, _ = self._query_total_counts()
+        sampled_group = Function("count", [])
+        proportion_by_sample = Function("divide", [sampled_group, total_samples])
+        return Function(
+            "divide",
+            [
+                Function(
+                    "multiply",
+                    [
+                        Function(
+                            "arrayMax",
+                            [
+                                [
+                                    0,
+                                    Function(
+                                        "minus",
+                                        [
+                                            proportion_by_sample,
+                                            self._resolve_margin_of_error(args, "margin_of_error"),
+                                        ],
+                                    ),
+                                ]
+                            ],
+                        ),
+                        total_samples,
+                    ],
+                ),
+                # Math assumes a single sampling_weight
+                Function("avg", [Column("sampling_factor")]),
+            ],
+            alias,
+        )
+
+    def _resolve_upper_limit(
+        self,
+        args: Mapping[str, str | Column | SelectType | int | float],
+        alias: str,
+    ) -> SelectType:
+        total_samples, _ = self._query_total_counts()
+        sampled_group = Function("count", [])
+        proportion_by_sample = Function("divide", [sampled_group, total_samples])
+        return Function(
+            "divide",
+            [
+                Function(
+                    "multiply",
+                    [
+                        Function(
+                            "arrayMin",
+                            [
+                                [
+                                    1,
+                                    Function(
+                                        "plus",
+                                        [
+                                            proportion_by_sample,
+                                            self._resolve_margin_of_error(args, "margin_of_error"),
+                                        ],
+                                    ),
+                                ]
+                            ],
+                        ),
+                        total_samples,
+                    ],
+                ),
+                Function("avg", [Column("sampling_factor")]),
+            ],
             alias,
         )

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -72,6 +72,7 @@ class Referrer(Enum):
     API_DASHBOARDS_WIDGET_LINE_CHART = "api.dashboards.widget.line-chart"
 
     API_DISCOVER_TOTAL_COUNT_FIELD = "api.discover.total-events-field"
+    API_SPANS_TOTAL_COUNT_FIELD = "api.spans.total-events-field"
     API_DISCOVER_TOTAL_SUM_TRANSACTION_DURATION_FIELD = (
         "api.discover.total-sum-transaction-duration-field"
     )

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -790,3 +790,61 @@ class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsSpanIndexedEndpoin
         assert data[1]["description"] == "bar"
         assert data[2]["tags[foo,number]"] == 71
         assert data[2]["description"] == "baz"
+
+    def test_margin_of_error(self):
+        total_samples = 10
+        in_group = 5
+        spans = []
+        for _ in range(in_group):
+            spans.append(
+                self.create_span(
+                    {
+                        "description": "foo",
+                        "sentry_tags": {"status": "success"},
+                        "measurements": {"client_sample_rate": {"value": 0.00001}},
+                    },
+                    start_ts=self.ten_mins_ago,
+                )
+            )
+        for _ in range(total_samples - in_group):
+            spans.append(
+                self.create_span(
+                    {
+                        "description": "bar",
+                        "sentry_tags": {"status": "success"},
+                        "measurements": {"client_sample_rate": {"value": 0.00001}},
+                    },
+                )
+            )
+
+        self.store_spans(
+            spans,
+            is_eap=self.is_eap,
+        )
+
+        response = self.do_request(
+            {
+                "field": [
+                    "margin_of_error()",
+                    "lower_count_limit()",
+                    "upper_count_limit()",
+                    "count_weighted()",
+                ],
+                "query": "description:foo",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 1
+        data = response.data["data"][0]
+        margin_of_error = data["margin_of_error()"]
+        lower_limit = data["lower_count_limit()"]
+        upper_limit = data["upper_count_limit()"]
+        extrapolated = data["count_weighted()"]
+        assert margin_of_error == pytest.approx(0.306, rel=1e-1)
+        # How to read this; these results mean that the extrapolated count is
+        # 500k, with a lower estimated bound of ~200k, and an upper bound of 800k
+        assert lower_limit == pytest.approx(193_612, abs=5000)
+        assert extrapolated == pytest.approx(500_000)
+        assert upper_limit == pytest.approx(806_388, abs=5000)


### PR DESCRIPTION
- This implements the margin of error and confidence interval functions as defined in this notion document; https://www.notion.so/sentry/2024-09-05-Finite-Population-Confidence-Intervals-aedc3668d84a481bbbb725b7a9dbe70d
- This implementation makes two major assumptions that mean these are only best treated as estimates
  1. It assumes the extrapolated count is a good replacement to knowing the total population size
  2. It assumes the average of the sampling rate can be used without any issue, it cannot, which means this is only reliable when the sampling rate is consistent for the entire query
- These assumptions are fine since these functions are only for internal testing currently