### PR TITLE
feat(issue-views): Style add view button's hover state like tab

### DIFF
--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -508,10 +508,10 @@ const AddViewButton = styled(Button)`
   display: flex;
   color: ${p => p.theme.gray300};
   font-weight: normal;
-  padding: ${space(0.5)} ${space(1)};
-  margin-bottom: 1px;
-  border: none;
-  bottom: -1px;
+  border-radius: 4px 4px 0 0;
+  padding: ${space(1)} ${space(1)};
+  height: 31px;
+  line-height: 1.4;
 `;
 
 const StyledIconAdd = styled(IconAdd)`

--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -508,7 +508,7 @@ const AddViewButton = styled(Button)`
   display: flex;
   color: ${p => p.theme.gray300};
   font-weight: normal;
-  border-radius: 4px 4px 0 0;
+  border-radius: ${p => `${p.theme.borderRadius} ${p.theme.borderRadius} 0 0`};
   padding: ${space(1)} ${space(1)};
   height: 31px;
   line-height: 1.4;


### PR DESCRIPTION
Makes the hover background of the add view button the same as the tabs 

https://github.com/user-attachments/assets/9a1fe232-5632-4b5e-8411-f1242dcbfd79

