### PR TITLE
fix(auth): better audit log events for fly sso  + test disable

### DIFF
--- a/src/sentry/auth/providers/fly/provider.py
+++ b/src/sentry/auth/providers/fly/provider.py
@@ -94,5 +94,10 @@ class FlyOAuth2Provider(OAuth2Provider):
 
 
 class NonPartnerFlyOAuth2Provider(FlyOAuth2Provider):
+    """
+    When a customer is no longer on a Fly.io sponsored plan, we change their provider
+    to the "non-partner" version of Fly SSO so that it can be disabled.
+    """
+
     name = SPONSOR_OAUTH_NAME[ChannelName.FLY_NON_PARTNER]
     is_partner = False

--- a/src/sentry/auth/services/auth/model.py
+++ b/src/sentry/auth/services/auth/model.py
@@ -200,7 +200,13 @@ class RpcAuthProvider(RpcModel):
         return hash((self.id, self.organization_id, self.provider))
 
     def get_audit_log_data(self) -> dict[str, Any]:
-        return {"provider": self.provider, "config": self.config}
+        provider = self.provider
+        # NOTE(isabella): for both standard fly SSO and fly-non-partner SSO, we should record the
+        # provider as "fly" in the audit log entry data; the only difference between the two is
+        # that the latter can be disabled by customers
+        if "fly" in self.provider:
+            provider = "fly"
+        return {"provider": provider, "config": self.config}
 
     def get_provider(self) -> "Provider":
         from sentry.auth import manager

--- a/src/sentry/models/authprovider.py
+++ b/src/sentry/models/authprovider.py
@@ -212,7 +212,13 @@ class AuthProvider(ReplicatedControlModel):
             self.flags.scim_enabled = False
 
     def get_audit_log_data(self):
-        return {"provider": self.provider, "config": self.config}
+        provider = self.provider
+        # NOTE(isabella): for both standard fly SSO and fly-non-partner SSO, we should record the
+        # provider as "fly" in the audit log entry data; the only difference between the two is
+        # that the latter can be disabled by customers
+        if "fly" in self.provider:
+            provider = "fly"
+        return {"provider": provider, "config": self.config}
 
     def outboxes_for_mark_invalid_sso(self, user_id: int) -> list[ControlOutbox]:
         return [

--- a/tests/sentry/auth/providers/fly/test_provider.py
+++ b/tests/sentry/auth/providers/fly/test_provider.py
@@ -31,6 +31,7 @@ class FlyOAuth2ProviderTest(TestCase):
         resource = {"id": "nathans-org", "role": "member"}
         result = provider.build_config(resource=resource)
         assert result == {"org": {"id": "nathans-org"}}
+        assert provider.is_partner == (self.auth_provider.provider == ChannelName.FLY_IO.value)
 
     def test_build_identity(self):
         provider = self.auth_provider.get_provider()
@@ -70,6 +71,11 @@ class FlyOAuth2ProviderTest(TestCase):
             "data": provider.get_oauth_data(data),
             "email_verified": False,
         }
+
+    def test_audit_log_data(self):
+        audit_log_data = self.auth_provider.get_audit_log_data()
+        assert audit_log_data["provider"] == "fly"
+        assert audit_log_data["config"] == {}
 
 
 @control_silo_test


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/75167, we made it possible to disable Fly SSO by introducing a new provider class that was identical to the original, but designated as "non-partner." As such, it needed a unique key, "fly-non-partner," but we shouldn't use this name in the audit log. 

This PR changes the `get_audit_log_data` method to always use "fly" as the provider name if the AuthProvider provider is either of the Fly SSO classes. This PR also clarifies the difference between the two classes, and adds a missing test for disabling Fly SSO.

for context, this is what the disable audit log entry looks like before this change:
![sso disable ss](https://github.com/user-attachments/assets/765c5d11-f3ac-4202-a8a8-46988bef259a)
