### PR TITLE
fix(replay): Check custom breadcrumb for category

### DIFF
--- a/static/app/utils/replays/getFrameDetails.tsx
+++ b/static/app/utils/replays/getFrameDetails.tsx
@@ -446,7 +446,7 @@ export default function getFrameDetails(frame: ReplayFrame): Details {
   }
 }
 
-function defaultTitle(frame: ReplayFrame) {
+export function defaultTitle(frame: ReplayFrame) {
   // Override title for User Feedback frames
   if ('message' in frame && frame.message === 'User Feedback') {
     return t('User Feedback');

--- a/static/app/utils/replays/getFrameDetails.tsx
+++ b/static/app/utils/replays/getFrameDetails.tsx
@@ -40,6 +40,7 @@ import type {
   MultiClickFrame,
   MutationFrame,
   NavFrame,
+  RawBreadcrumbFrame,
   ReplayFrame,
   SlowClickFrame,
   TapFrame,
@@ -446,19 +447,19 @@ export default function getFrameDetails(frame: ReplayFrame): Details {
   }
 }
 
-export function defaultTitle(frame: ReplayFrame) {
+export function defaultTitle(frame: ReplayFrame | RawBreadcrumbFrame) {
   // Override title for User Feedback frames
   if ('message' in frame && frame.message === 'User Feedback') {
     return t('User Feedback');
   }
-  if ('category' in frame) {
+  if ('category' in frame && frame.category) {
     const [type, action] = frame.category.split('.');
     return `${type} ${action || ''}`.trim();
   }
-  if ('message' in frame) {
+  if ('message' in frame && frame.message) {
     return frame.message as string; // TODO(replay): Included for backwards compat
   }
-  return frame.description ?? '';
+  return 'description' in frame ? frame.description ?? '' : '';
 }
 
 function stringifyNodeAttributes(node: SlowClickFrame['data']['node']) {

--- a/static/app/utils/replays/hydrateBreadcrumbs.tsx
+++ b/static/app/utils/replays/hydrateBreadcrumbs.tsx
@@ -3,6 +3,7 @@ import invariant from 'invariant';
 import {t} from 'sentry/locale';
 import {BreadcrumbType} from 'sentry/types/breadcrumbs';
 import isValidDate from 'sentry/utils/date/isValidDate';
+import {defaultTitle} from 'sentry/utils/replays/getFrameDetails';
 import type {BreadcrumbFrame, RawBreadcrumbFrame} from 'sentry/utils/replays/types';
 import {isBreadcrumbFrame} from 'sentry/utils/replays/types';
 import type {ReplayRecord} from 'sentry/views/replays/types';
@@ -26,6 +27,8 @@ export default function hydrateBreadcrumbs(
         }
         return {
           ...frame,
+          // custom frames might not have a defined category, so we need to set one
+          category: frame.category || defaultTitle(frame) || 'custom',
           offsetMs: Math.abs(time.getTime() - startTimestampMs),
           timestamp: time,
           timestampMs: time.getTime(),

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -8,6 +8,7 @@ import domId from 'sentry/utils/domId';
 import localStorageWrapper from 'sentry/utils/localStorage';
 import clamp from 'sentry/utils/number/clamp';
 import extractHtmlandSelector from 'sentry/utils/replays/extractHtml';
+import {defaultTitle} from 'sentry/utils/replays/getFrameDetails';
 import hydrateBreadcrumbs, {
   replayInitBreadcrumb,
 } from 'sentry/utils/replays/hydrateBreadcrumbs';
@@ -587,9 +588,13 @@ export default class ReplayReader {
   );
 
   getCustomFrames = memoize(() =>
-    this._sortedBreadcrumbFrames.filter(
-      frame => frame.category && !BreadcrumbCategories.includes(frame.category)
-    )
+    this._sortedBreadcrumbFrames
+      .filter(frame => !BreadcrumbCategories.includes(frame.category))
+      // custom frames might not have a defined category, so we need to set one
+      .map(frame => ({
+        ...frame,
+        category: frame.category || defaultTitle(frame) || 'custom',
+      }))
   );
 
   getChapterFrames = memoize(() =>

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -8,7 +8,6 @@ import domId from 'sentry/utils/domId';
 import localStorageWrapper from 'sentry/utils/localStorage';
 import clamp from 'sentry/utils/number/clamp';
 import extractHtmlandSelector from 'sentry/utils/replays/extractHtml';
-import {defaultTitle} from 'sentry/utils/replays/getFrameDetails';
 import hydrateBreadcrumbs, {
   replayInitBreadcrumb,
 } from 'sentry/utils/replays/hydrateBreadcrumbs';
@@ -588,13 +587,9 @@ export default class ReplayReader {
   );
 
   getCustomFrames = memoize(() =>
-    this._sortedBreadcrumbFrames
-      .filter(frame => !BreadcrumbCategories.includes(frame.category))
-      // custom frames might not have a defined category, so we need to set one
-      .map(frame => ({
-        ...frame,
-        category: frame.category || defaultTitle(frame) || 'custom',
-      }))
+    this._sortedBreadcrumbFrames.filter(
+      frame => !BreadcrumbCategories.includes(frame.category)
+    )
   );
 
   getChapterFrames = memoize(() =>

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -588,7 +588,7 @@ export default class ReplayReader {
 
   getCustomFrames = memoize(() =>
     this._sortedBreadcrumbFrames.filter(
-      frame => !BreadcrumbCategories.includes(frame.category)
+      frame => frame.category && !BreadcrumbCategories.includes(frame.category)
     )
   );
 


### PR DESCRIPTION
Custom breadcrumbs might not have a defined category, which causes an error when we try to get the frame's op or category. Since we want to show all custom breadcrumbs in the breadcrumb list, if the custom breadcrumb doesn't have a category, we set it to the title, else 'custom'.

Fixes JAVASCRIPT-2VYZ 
Fixes JAVASCRIPT-2VZ1