### PR TITLE
ref(feedback): check ingest FF for all shims and refactor shim metrics+logs

### DIFF
--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -7,6 +7,7 @@ from typing import Any, TypedDict
 from uuid import uuid4
 
 import jsonschema
+from django.contrib.auth.models import AnonymousUser
 
 from sentry import features
 from sentry.constants import DataCategory
@@ -347,7 +348,7 @@ def shim_to_feedback(
     project: Project,
     source: FeedbackCreationSource,
     sentry_referrer: str | None = None,
-    actor: User | None = None,
+    actor: User | AnonymousUser | None = None,
 ) -> None:
     """
     takes user reports from the legacy user report form/endpoint and

--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -115,11 +115,9 @@ def save_userreport(
         )
 
         if has_feedback_ingest and event:
-            logger.info(
-                "ingest.user_report.shim_to_feedback",
-                extra={"project_id": project.id, "event_id": report["event_id"]},
+            shim_to_feedback(
+                report, event, project, source, sentry_referrer="ingest.save_userreport"
             )
-            shim_to_feedback(report, event, project, source)
 
         return report_instance
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1404,8 +1404,8 @@ def link_event_to_user_report(job: PostProcessJob) -> None:
                 event,
                 project,
                 FeedbackCreationSource.USER_REPORT_ENVELOPE,
+                sentry_referrer="event_manager.save.link_event_to_user_report",
             )
-            metrics.incr("event_manager.save._update_user_reports_with_event_link.shim_to_feedback")
 
         user_reports_updated = user_reports_without_group.update(
             group_id=group.id, environment_id=event.get_environment().id

--- a/src/sentry/tasks/update_user_reports.py
+++ b/src/sentry/tasks/update_user_reports.py
@@ -5,7 +5,7 @@ from typing import Any
 import sentry_sdk
 from django.utils import timezone
 
-from sentry import eventstore, features
+from sentry import eventstore
 from sentry.feedback.usecases.create_feedback import FeedbackCreationSource, shim_to_feedback
 from sentry.models.project import Project
 from sentry.models.userreport import UserReport
@@ -77,26 +77,19 @@ def update_user_reports(**kwargs: Any) -> None:
         for event in events:
             report = report_by_event.get(event.event_id)
             if report:
-                if features.has(
-                    "organizations:user-feedback-ingest", project.organization, actor=None
-                ):
-                    logger.info(
-                        "update_user_reports.shim_to_feedback",
-                        extra={"report_id": report.id, "event_id": event.event_id},
-                    )
-                    shim_to_feedback(
-                        {
-                            "name": report.name,
-                            "email": report.email,
-                            "comments": report.comments,
-                            "event_id": report.event_id,
-                            "level": "error",
-                        },
-                        event,
-                        project,
-                        FeedbackCreationSource.UPDATE_USER_REPORTS_TASK,
-                        sentry_referrer="tasks.update_user_reports",
-                    )
+                shim_to_feedback(
+                    {
+                        "name": report.name,
+                        "email": report.email,
+                        "comments": report.comments,
+                        "event_id": report.event_id,
+                        "level": "error",
+                    },
+                    event,
+                    project,
+                    FeedbackCreationSource.UPDATE_USER_REPORTS_TASK,
+                    sentry_referrer="tasks.update_user_reports",
+                )
                 report.update(group_id=event.group_id, environment_id=event.get_environment().id)
                 updated_reports += 1
 

--- a/src/sentry/tasks/update_user_reports.py
+++ b/src/sentry/tasks/update_user_reports.py
@@ -84,7 +84,6 @@ def update_user_reports(**kwargs: Any) -> None:
                         "update_user_reports.shim_to_feedback",
                         extra={"report_id": report.id, "event_id": event.event_id},
                     )
-                    metrics.incr("tasks.update_user_reports.shim_to_feedback")
                     shim_to_feedback(
                         {
                             "name": report.name,
@@ -96,6 +95,7 @@ def update_user_reports(**kwargs: Any) -> None:
                         event,
                         project,
                         FeedbackCreationSource.UPDATE_USER_REPORTS_TASK,
+                        sentry_referrer="tasks.update_user_reports",
                     )
                 report.update(group_id=event.group_id, environment_id=event.get_environment().id)
                 updated_reports += 1

--- a/src/sentry/web/frontend/error_page_embed.py
+++ b/src/sentry/web/frontend/error_page_embed.py
@@ -11,7 +11,7 @@ from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 
-from sentry import eventstore, features
+from sentry import eventstore
 from sentry.feedback.usecases.create_feedback import FeedbackCreationSource, shim_to_feedback
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.project import Project
@@ -194,12 +194,7 @@ class ErrorPageEmbedView(View):
             )
 
             project = Project.objects.get(id=report.project_id)
-            if (
-                features.has(
-                    "organizations:user-feedback-ingest", project.organization, actor=request.user
-                )
-                and event is not None
-            ):
+            if event is not None:
                 shim_to_feedback(
                     {
                         "name": report.name,
@@ -211,6 +206,8 @@ class ErrorPageEmbedView(View):
                     event,
                     project,
                     FeedbackCreationSource.CRASH_REPORT_EMBED_FORM,
+                    sentry_referrer="error_page_embed_view.post",
+                    actor=request.user,
                 )
 
             return self._smart_response(request)


### PR DESCRIPTION
The blocklist we use for feedback was not being applied in post process. This change ensures the user-feedback-ingest flag is always checked before shimming.

- Moved shim metric to inside the fx, rather than at the callsite
- Rm some logs we were using for debugging