### PR TITLE
feat(uptime): Add api for editing uptime monitors

### DIFF
--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_details.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_details.py
@@ -29,6 +29,31 @@ class ProjectUptimeAlertDetailsGetEndpointTest(ProjectUptimeAlertDetailsBaseEndp
 class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndpointTest):
     method = "put"
 
+    def test_all(self):
+        proj_sub = self.create_project_uptime_subscription()
+        resp = self.get_success_response(
+            self.organization.slug,
+            proj_sub.project.slug,
+            proj_sub.id,
+            name="test",
+            owner=f"user:{self.user.id}",
+            url="https://santry.io",
+            interval_seconds=120,
+            headers={"hello": "world"},
+            body="something",
+        )
+        proj_sub.refresh_from_db()
+        assert resp.data == serialize(proj_sub, self.user)
+        assert proj_sub.name == "test"
+        assert proj_sub.owner_user_id == self.user.id
+        assert proj_sub.owner_team_id is None
+        uptime_sub = proj_sub.uptime_subscription
+        uptime_sub.refresh_from_db()
+        assert uptime_sub.url == "https://santry.io"
+        assert uptime_sub.interval_seconds == 120
+        assert uptime_sub.headers == {"hello": "world"}
+        assert uptime_sub.body == "something"
+
     def test_user(self):
         uptime_subscription = self.create_project_uptime_subscription()
 


### PR DESCRIPTION
This adds an api to fully edit uptime monitors. We're careful here to not edit the existing checker subscription row - instead we create a new row and associate it with the existing subscription. If the old checker is now orphaned, we also remove it.

<!-- Describe your PR here. -->