### PR TITLE
feat(uptime): Add UptimeHeaderField component

### DIFF
--- a/static/app/components/forms/model.tsx
+++ b/static/app/components/forms/model.tsx
@@ -21,7 +21,7 @@ export type FieldValue =
   | Set<string>
   | number
   | boolean
-| object
+  | object
   | Choice
   | undefined; // is undefined valid here?
 

--- a/static/app/components/forms/model.tsx
+++ b/static/app/components/forms/model.tsx
@@ -21,6 +21,7 @@ export type FieldValue =
   | Set<string>
   | number
   | boolean
+| object
   | Choice
   | undefined; // is undefined valid here?
 

--- a/static/app/views/alerts/rules/uptime/uptimeHeadersField.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeHeadersField.spec.tsx
@@ -1,0 +1,128 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import Form from 'sentry/components/forms/form';
+import FormModel from 'sentry/components/forms/model';
+
+import {UptimeHeadersField} from './uptimeHeadersField';
+
+describe('UptimeHeaderField', function () {
+  function input(name: string) {
+    return screen.getByRole('textbox', {name});
+  }
+
+  it('can be manipulated', async function () {
+    const model = new FormModel();
+    render(
+      <Form model={model}>
+        <UptimeHeadersField name="headers" />
+      </Form>
+    );
+
+    // Starts with one empty header row
+    expect(input('Name of header 1')).toBeInTheDocument();
+    expect(input('Value of header 1')).toBeInTheDocument();
+
+    // Change the name of the first item
+    await userEvent.type(input('Name of header 1'), 'My-Header');
+    expect(model.getValue('headers')).toEqual([['My-Header', '']]);
+
+    // Change the value of the first item
+    await userEvent.type(input('Value of My-Header'), 'example');
+    expect(model.getValue('headers')).toEqual([['My-Header', 'example']]);
+
+    // Add a new header
+    await userEvent.click(screen.getByRole('button', {name: 'Add Header'}));
+
+    // New item has been added
+    expect(input('Name of header 2')).toBeInTheDocument();
+    expect(input('Value of header 2')).toBeInTheDocument();
+
+    // Old items still exist
+    expect(input('Name of header 1')).toBeInTheDocument();
+    expect(input('Name of header 1')).toHaveValue('My-Header');
+    expect(model.getValue('headers')).toEqual([['My-Header', 'example']]);
+
+    // Setting the value of header item 2 does persist the value without a name
+    await userEvent.type(input('Value of header 2'), 'whatever');
+    expect(input('Value of header 2')).toHaveValue('whatever');
+    expect(model.getValue('headers')).toEqual([['My-Header', 'example']]);
+
+    // Giving header item 2 a name will persist it's value
+    await userEvent.type(input('Name of header 2'), 'X-Second-Header');
+    expect(model.getValue('headers')).toEqual([
+      ['My-Header', 'example'],
+      ['X-Second-Header', 'whatever'],
+    ]);
+
+    // Remove the first header
+    await userEvent.click(screen.getByRole('button', {name: 'Remove My-Header'}));
+    expect(model.getValue('headers')).toEqual([['X-Second-Header', 'whatever']]);
+    expect(
+      screen.queryByRole('textbox', {name: 'Vaalue of My-Header'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('disambiguates headers with the same name', async function () {
+    const model = new FormModel();
+    render(
+      <Form model={model}>
+        <UptimeHeadersField name="headers" />
+      </Form>
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Add Header'}));
+
+    await userEvent.type(input('Name of header 1'), 'test');
+    await userEvent.type(input('Name of header 2'), 'test');
+
+    expect(input('Value of test')).toBeInTheDocument();
+    expect(input('Value of test (2)')).toBeInTheDocument();
+  });
+
+  it('does not persist empty header names', async function () {
+    const model = new FormModel();
+    render(
+      <Form model={model}>
+        <UptimeHeadersField name="headers" />
+      </Form>
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Add Header'}));
+
+    await userEvent.type(input('Name of header 1'), 'test');
+    await userEvent.type(input('Value of test'), 'test value');
+
+    // The second value is dropped
+    expect(model.getValue('headers')).toEqual([['test', 'test value']]);
+  });
+
+  it('populates with initial values', function () {
+    const model = new FormModel({
+      initialData: {headers: {one: 'test one', two: 'test two'}},
+    });
+
+    render(
+      <Form model={model}>
+        <UptimeHeadersField name="headers" />
+      </Form>
+    );
+
+    expect(input('Name of header 1')).toHaveValue('one');
+    expect(input('Name of header 2')).toHaveValue('two');
+    expect(input('Value of one')).toHaveValue('test one');
+    expect(input('Value of two')).toHaveValue('test two');
+  });
+
+  it('remove special characters from header names', async function () {
+    const model = new FormModel();
+    render(
+      <Form model={model}>
+        <UptimeHeadersField name="headers" />
+      </Form>
+    );
+
+    // Spaces and special characters are stripped
+    await userEvent.type(input('Name of header 1'), 'My Awesome Header!');
+    expect(model.getValue('headers')).toEqual([['MyAwesomeHeader', '']]);
+  });
+});

--- a/static/app/views/alerts/rules/uptime/uptimeHeadersField.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeHeadersField.tsx
@@ -1,0 +1,167 @@
+import {useEffect, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/button';
+import type {FormFieldProps} from 'sentry/components/forms/formField';
+import FormField from 'sentry/components/forms/formField';
+import FormFieldControlState from 'sentry/components/forms/formField/controlState';
+import Input from 'sentry/components/input';
+import {IconAdd, IconDelete} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {uniqueId} from 'sentry/utils/guid';
+
+/**
+ * Matches characters that are not valid in a header name.
+ */
+const INVALID_NAME_HEADER_REGEX = new RegExp(/[^a-zA-Z0-9_-]+/g);
+
+type HeaderEntry = [id: string, name: string, value: string];
+
+// XXX(epurkhiser): The types of the FormField render props are absolutely
+// abysmal, so we're leaving this untyped for now.
+
+function UptimHeadersControl(props) {
+  const {onChange, onBlur, disabled, model, name, value} = props;
+
+  // Store itmes in local state so we can add empty values without persisting
+  // those into the form model.
+  const [items, setItems] = useState<HeaderEntry[]>(
+    Object.keys(value).length > 0
+      ? Object.entries(value).map(v => [uniqueId(), ...v] as HeaderEntry)
+      : [[uniqueId(), '', '']]
+  );
+
+  // Persist the field value back to the form model on changes to the items
+  // list. Empty items are discarded and not persisted.
+  useEffect(() => {
+    const newValue = items.filter(item => item[1] !== '').map(item => [item[1], item[2]]);
+
+    onChange(newValue, {});
+    onBlur(newValue, {});
+  }, [items, onChange, onBlur]);
+
+  function addItem() {
+    setItems(currentItems => [...currentItems, [uniqueId(), '', '']]);
+  }
+
+  function removeItem(index: number) {
+    setItems(currentItems => currentItems.toSpliced(index, 1));
+  }
+
+  function handleNameChange(index: number, newName: string) {
+    setItems(currentItems =>
+      currentItems.toSpliced(index, 1, [
+        items[index][0],
+        newName.replaceAll(INVALID_NAME_HEADER_REGEX, ''),
+        items[index][2],
+      ])
+    );
+  }
+
+  function handleValueChange(index: number, newHeaderValue: string) {
+    setItems(currentItems =>
+      currentItems.toSpliced(index, 1, [items[index][0], items[index][1], newHeaderValue])
+    );
+  }
+
+  /**
+   * Disambiguates headers that are named the same by adding a `(x)` number to
+   * the end of the name in the order they were added.
+   */
+  function disambiguateHeaderName(index: number) {
+    const headerName = items[index][1];
+    const matchingIndexes = items
+      .map((item, idx) => [idx, item[1]])
+      .filter(([_, itemName]) => itemName === headerName)
+      .map(([idx]) => idx);
+
+    const duplicateIndex = matchingIndexes.indexOf(index) + 1;
+
+    return duplicateIndex === 1 ? headerName : `${headerName} (${duplicateIndex})`;
+  }
+
+  return (
+    <HeadersContainer>
+      {items.length > 0 && (
+        <HeaderItems>
+          {items.map(([id, headerName, headerValue], index) => (
+            <HeaderRow key={id}>
+              <Input
+                monospace
+                disabled={disabled}
+                value={headerName ?? ''}
+                placeholder="X-Header-Value"
+                onChange={e => handleNameChange(index, e.target.value)}
+                aria-label={t('Name of header %s', index + 1)}
+              />
+              <Input
+                monospace
+                disabled={disabled}
+                value={headerValue ?? ''}
+                placeholder={t('Header Value')}
+                onChange={e => handleValueChange(index, e.target.value)}
+                aria-label={
+                  headerName
+                    ? t('Value of %s', disambiguateHeaderName(index))
+                    : t('Value of header %s', index + 1)
+                }
+              />
+              <Button
+                disabled={disabled}
+                icon={<IconDelete />}
+                size="sm"
+                borderless
+                aria-label={
+                  headerName
+                    ? t('Remove %s', disambiguateHeaderName(index))
+                    : t('Remove header %s', index + 1)
+                }
+                onClick={() => removeItem(index)}
+              />
+            </HeaderRow>
+          ))}
+        </HeaderItems>
+      )}
+      <HeaderActions>
+        <Button disabled={disabled} icon={<IconAdd />} size="sm" onClick={addItem}>
+          {t('Add Header')}
+        </Button>
+        <FormFieldControlState model={model} name={name} />
+      </HeaderActions>
+    </HeadersContainer>
+  );
+}
+
+export function UptimeHeadersField(props: Omit<FormFieldProps, 'children'>) {
+  return (
+    <FormField defaultValue={[]} {...props} hideControlState flexibleControlStateSize>
+      {({ref: _ref, ...fieldProps}) => <UptimHeadersControl {...fieldProps} />}
+    </FormField>
+  );
+}
+
+const HeadersContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
+`;
+
+const HeaderActions = styled('div')`
+  display: flex;
+  gap: ${space(1.5)};
+`;
+
+const HeaderItems = styled('fieldset')`
+  display: grid;
+  grid-template-columns: minmax(200px, 1fr) 2fr max-content;
+  gap: ${space(1)};
+  width: 100%;
+`;
+
+const HeaderRow = styled('div')`
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
+  align-items: center;
+`;


### PR DESCRIPTION
This component is responsible for managing the headers for a uptime
monitor alert. Each item has a name and value. More may be added and
individual headers may be deleted.

It looks like this
![sentry dev getsentry net_7999_alerts_new_uptime__project=cheezyp referrer=alert_stream](https://github.com/user-attachments/assets/44e11816-cf2f-4b14-95a2-333adf344227)

