### PR TITLE
feat(uptime): Send request configuration to uptime checker

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -65,7 +65,7 @@ rfc3339-validator>=0.1.2
 rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo>=2.16.5
-sentry-kafka-schemas>=0.1.109
+sentry-kafka-schemas>=0.1.111
 sentry-ophio==1.0.0
 sentry-protos>=0.1.21
 sentry-redis-tools>=0.1.7

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -182,7 +182,7 @@ sentry-cli==2.16.0
 sentry-devenv==1.10.2
 sentry-forked-django-stubs==5.0.4.post2
 sentry-forked-djangorestframework-stubs==3.15.1.post1
-sentry-kafka-schemas==0.1.109
+sentry-kafka-schemas==0.1.111
 sentry-ophio==1.0.0
 sentry-protos==0.1.21
 sentry-redis-tools==0.1.7

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -123,7 +123,7 @@ rpds-py==0.15.2
 rsa==4.8
 s3transfer==0.10.0
 sentry-arroyo==2.16.5
-sentry-kafka-schemas==0.1.109
+sentry-kafka-schemas==0.1.111
 sentry-ophio==1.0.0
 sentry-protos==0.1.21
 sentry-redis-tools==0.1.7

--- a/src/sentry/uptime/subscriptions/tasks.py
+++ b/src/sentry/uptime/subscriptions/tasks.py
@@ -83,12 +83,22 @@ def send_uptime_subscription_config(subscription: UptimeSubscription) -> str:
 def uptime_subscription_to_check_config(
     subscription: UptimeSubscription, subscription_id: str
 ) -> CheckConfig:
-    return {
+    headers = subscription.headers
+    # XXX: Temporary translation code. We want to support headers with the same keys, so convert to a list
+    if isinstance(headers, dict):
+        headers = [[key, val] for key, val in headers.items()]
+
+    config: CheckConfig = {
         "subscription_id": subscription_id,
         "url": subscription.url,
         "interval_seconds": subscription.interval_seconds,  # type: ignore[typeddict-item]
         "timeout_ms": subscription.timeout_ms,
+        "request_method": subscription.method,  # type: ignore[typeddict-item]
+        "request_headers": headers,
     }
+    if subscription.body is not None:
+        config["request_body"] = subscription.body
+    return config
 
 
 def send_uptime_config_deletion(subscription_id: str) -> None:

--- a/tests/sentry/uptime/subscriptions/test_tasks.py
+++ b/tests/sentry/uptime/subscriptions/test_tasks.py
@@ -153,6 +153,39 @@ class UptimeSubscriptionToCheckConfigTest(UptimeTestCase):
             "url": sub.url,
             "interval_seconds": sub.interval_seconds,
             "timeout_ms": sub.timeout_ms,
+            "request_method": "GET",
+            "request_headers": [],
+        }
+
+    def test_request_fields(self):
+        headers = [["hi", "bye"]]
+        body = "some request body"
+        method = "POST"
+        sub = self.create_uptime_subscription(method=method, headers=headers, body=body)
+        sub.refresh_from_db()
+        subscription_id = uuid4().hex
+        assert uptime_subscription_to_check_config(sub, subscription_id) == {
+            "subscription_id": subscription_id,
+            "url": sub.url,
+            "interval_seconds": sub.interval_seconds,
+            "timeout_ms": sub.timeout_ms,
+            "request_method": method,
+            "request_headers": headers,
+            "request_body": body,
+        }
+
+    def test_header_translation(self):
+        headers = {"hi": "bye"}
+        sub = self.create_uptime_subscription(headers=headers)
+        sub.refresh_from_db()
+        subscription_id = uuid4().hex
+        assert uptime_subscription_to_check_config(sub, subscription_id) == {
+            "subscription_id": subscription_id,
+            "url": sub.url,
+            "interval_seconds": sub.interval_seconds,
+            "timeout_ms": sub.timeout_ms,
+            "request_method": "GET",
+            "request_headers": [["hi", "bye"]],
         }
 
 


### PR DESCRIPTION
This starts sending the request_* field to the uptime checker. Also adds in a temporary translation layer to convert the headers dict to a list of lists.

<!-- Describe your PR here. -->