### PR TITLE
ref(quickContext) use complete user mock

### DIFF
--- a/static/app/views/discover/table/quickContext/testUtils.tsx
+++ b/static/app/views/discover/table/quickContext/testUtils.tsx
@@ -1,3 +1,5 @@
+import {UserFixture} from 'sentry-fixture/user';
+
 import type {Commit, Repository} from 'sentry/types/integrations';
 import type {User} from 'sentry/types/user';
 import type {EventData} from 'sentry/utils/discover/eventView';
@@ -31,18 +33,18 @@ export const mockedCommit: Commit = {
   releases: [],
 };
 
-export const mockedUser1 = {
+export const mockedUser1 = UserFixture({
   id: '2',
   username: 'author456',
   ip_address: '192.168.1.1',
   email: 'author1@commit.com',
   name: 'Key Name',
-} as User;
+});
 
-export const mockedUser2 = {
+export const mockedUser2 = UserFixture({
   id: '3',
   username: 'author123',
   ip_address: '192.168.1.3',
   email: 'author2@commit.com',
   name: 'Value Name',
-} as User;
+});


### PR DESCRIPTION
Use complete user mocks and remove type casts - this was masking a runtime error in a different PR where accessing  options.theme resulted in a runtime err
 