### PR TITLE
fix(deploys): Fix permissions for deploy endpoint projects

### DIFF
--- a/src/sentry/api/endpoints/release_deploys.py
+++ b/src/sentry/api/endpoints/release_deploys.py
@@ -72,7 +72,7 @@ class DeploySerializer(serializers.Serializer):
         help_text="An optional date that indicates when the deploy ended. If not provided, the current time is used.",
     )
     projects = serializers.ListField(
-        child=ProjectField(scope="project:read", id_allowed=True),
+        child=ProjectField(scope=("project:read", "project:releases"), id_allowed=True),
         required=False,
         allow_empty=False,
         help_text="The optional list of project slugs to create a deploy within. If not provided, deploys are created for all of the release's projects.",

--- a/src/sentry/api/serializers/rest_framework/project.py
+++ b/src/sentry/api/serializers/rest_framework/project.py
@@ -1,3 +1,5 @@
+from collections.abc import Collection
+
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
@@ -9,7 +11,14 @@ ValidationError = serializers.ValidationError
 
 @extend_schema_field(field=OpenApiTypes.STR)
 class ProjectField(serializers.Field):
-    def __init__(self, scope="project:write", id_allowed=False, **kwags):
+    def __init__(
+        self, scope: str | Collection[str] = "project:write", id_allowed: bool = False, **kwags
+    ):
+        """
+        The scope parameter specifies which permissions are required to access the project field.
+        If multiple scopes are provided, the project can be accessed when the user is authenticated with
+        any of the scopes.
+        """
         self.scope = scope
         self.id_allowed = id_allowed
         super().__init__(**kwags)
@@ -27,6 +36,8 @@ class ProjectField(serializers.Field):
                 project = Project.objects.get(organization=self.context["organization"], slug=data)
         except Project.DoesNotExist:
             raise ValidationError("Invalid project")
-        if not self.context["access"].has_project_scope(project, self.scope):
+
+        scopes = (self.scope,) if isinstance(self.scope, str) else self.scope
+        if not self.context["access"].has_any_project_scope(project, scopes):
             raise ValidationError("Insufficient access to project")
         return project


### PR DESCRIPTION
Currently, in order to link specific projects to a deploy, e.g. via the `sentry-cli deploys new` command, users must provide a token with the `project:read` scope. This is inconsistent with the `sentry-cli releases new` command, which allows users to create a new release associated with only some projects by using the `org:read` and `project:release` scopes.

This PR proposes allowing specifying projects for a deploy using a token with `project:releases` scope.

Fixes #78025