### PR TITLE
ref(tests): Update store_event for error and default events

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -952,7 +952,7 @@ class Factories:
         data,
         project_id: int,
         assert_no_errors: bool = True,
-        event_type: EventType | None = None,
+        default_event_type: EventType | None = None,
         sent_at: datetime | None = None,
     ) -> Event:
         """
@@ -961,11 +961,11 @@ class Factories:
         """
 
         # this creates a basic message event
-        if event_type == EventType.DEFAULT:
+        if default_event_type == EventType.DEFAULT:
             data.update({"stacktrace": copy.deepcopy(DEFAULT_EVENT_DATA["stacktrace"])})
 
         # this creates an error event
-        elif event_type == EventType.ERROR:
+        elif default_event_type == EventType.ERROR:
             data.update({"exception": [{"value": "BadError"}]})
 
         manager = EventManager(data, sent_at=sent_at)

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -952,15 +952,21 @@ class Factories:
         data,
         project_id: int,
         assert_no_errors: bool = True,
-        event_type: EventType = EventType.DEFAULT,
+        event_type: EventType | None = None,
         sent_at: datetime | None = None,
     ) -> Event:
         """
         Like `create_event`, but closer to how events are actually
         ingested. Prefer to use this method over `create_event`
         """
-        if event_type == EventType.ERROR:
+
+        # this creates a basic message event
+        if event_type == EventType.DEFAULT:
             data.update({"stacktrace": copy.deepcopy(DEFAULT_EVENT_DATA["stacktrace"])})
+
+        # this creates an error event
+        elif event_type == EventType.ERROR:
+            data.update({"exception": [{"value": "BadError"}]})
 
         manager = EventManager(data, sent_at=sent_at)
         manager.normalize()

--- a/tests/sentry/api/endpoints/test_event_committers.py
+++ b/tests/sentry/api/endpoints/test_event_committers.py
@@ -28,7 +28,7 @@ class EventCommittersTest(APITestCase):
                 "release": release.version,
             },
             project_id=project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
 
         url = reverse(
@@ -159,7 +159,6 @@ class EventCommittersTest(APITestCase):
                 "timestamp": iso_format(before_now(minutes=1)),
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
         )
         assert event.group is not None
 
@@ -220,7 +219,6 @@ class EventCommittersTest(APITestCase):
                 "timestamp": iso_format(before_now(minutes=1)),
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
         )
         assert event.group is not None
 

--- a/tests/sentry/api/endpoints/test_event_committers.py
+++ b/tests/sentry/api/endpoints/test_event_committers.py
@@ -28,7 +28,7 @@ class EventCommittersTest(APITestCase):
                 "release": release.version,
             },
             project_id=project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
 
         url = reverse(

--- a/tests/sentry/api/endpoints/test_group_integration_details.py
+++ b/tests/sentry/api/endpoints/test_group_integration_details.py
@@ -27,7 +27,7 @@ class GroupIntegrationDetailsTest(APITestCase):
                 "message": "message",
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         self.group = self.event.group
 

--- a/tests/sentry/api/endpoints/test_group_integration_details.py
+++ b/tests/sentry/api/endpoints/test_group_integration_details.py
@@ -27,7 +27,7 @@ class GroupIntegrationDetailsTest(APITestCase):
                 "message": "message",
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         self.group = self.event.group
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -316,7 +316,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
                     "fingerprint": ["group1"],
                     "tags": {"sentry:user": self.user.email},
                 },
-                event_type=EventType.ERROR,
+                default_event_type=EventType.ERROR,
                 project_id=self.project.id,
             )
             self.store_event(
@@ -327,7 +327,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
                     "fingerprint": ["group2"],
                     "tags": {"sentry:user": self.user.email},
                 },
-                event_type=EventType.ERROR,
+                default_event_type=EventType.ERROR,
                 project_id=self.project.id,
             )
 

--- a/tests/sentry/integrations/bitbucket/test_issues.py
+++ b/tests/sentry/integrations/bitbucket/test_issues.py
@@ -41,7 +41,7 @@ class BitbucketIssueTest(APITestCase):
                 "timestamp": min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         self.group = event.group
         self.repo_choices = [

--- a/tests/sentry/integrations/bitbucket/test_issues.py
+++ b/tests/sentry/integrations/bitbucket/test_issues.py
@@ -41,7 +41,7 @@ class BitbucketIssueTest(APITestCase):
                 "timestamp": min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         self.group = event.group
         self.repo_choices = [

--- a/tests/sentry/integrations/gitlab/test_issues.py
+++ b/tests/sentry/integrations/gitlab/test_issues.py
@@ -24,7 +24,7 @@ class GitlabIssuesTest(GitLabTestCase):
                 "timestamp": min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         self.group = event.group
 

--- a/tests/sentry/integrations/gitlab/test_issues.py
+++ b/tests/sentry/integrations/gitlab/test_issues.py
@@ -24,7 +24,7 @@ class GitlabIssuesTest(GitLabTestCase):
                 "timestamp": min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         self.group = event.group
 

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -95,7 +95,7 @@ class RegionJiraIntegrationTest(APITestCase):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         group = event.group
         assert group is not None
@@ -215,7 +215,7 @@ class RegionJiraIntegrationTest(APITestCase):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         group = event.group
 
@@ -235,7 +235,7 @@ class RegionJiraIntegrationTest(APITestCase):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         group = event.group
         installation = self.integration.get_installation(self.organization.id)
@@ -290,7 +290,7 @@ class RegionJiraIntegrationTest(APITestCase):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         group = event.group
         installation = self.integration.get_installation(self.organization.id)
@@ -344,7 +344,7 @@ class RegionJiraIntegrationTest(APITestCase):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         group = event.group
         assert group is not None
@@ -379,7 +379,7 @@ class RegionJiraIntegrationTest(APITestCase):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         group = event.group
         assert group is not None
@@ -415,7 +415,7 @@ class RegionJiraIntegrationTest(APITestCase):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         group = event.group
         assert group is not None
@@ -461,7 +461,7 @@ class RegionJiraIntegrationTest(APITestCase):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         group = event.group
         assert group is not None

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -95,7 +95,7 @@ class RegionJiraIntegrationTest(APITestCase):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         group = event.group
         assert group is not None
@@ -215,7 +215,7 @@ class RegionJiraIntegrationTest(APITestCase):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         group = event.group
 
@@ -235,7 +235,7 @@ class RegionJiraIntegrationTest(APITestCase):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         group = event.group
         installation = self.integration.get_installation(self.organization.id)
@@ -290,7 +290,7 @@ class RegionJiraIntegrationTest(APITestCase):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         group = event.group
         installation = self.integration.get_installation(self.organization.id)
@@ -344,7 +344,7 @@ class RegionJiraIntegrationTest(APITestCase):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         group = event.group
         assert group is not None
@@ -379,7 +379,7 @@ class RegionJiraIntegrationTest(APITestCase):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         group = event.group
         assert group is not None
@@ -415,7 +415,7 @@ class RegionJiraIntegrationTest(APITestCase):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         group = event.group
         assert group is not None
@@ -461,7 +461,7 @@ class RegionJiraIntegrationTest(APITestCase):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         group = event.group
         assert group is not None

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -91,7 +91,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         group = event.group
         assert group is not None
@@ -271,7 +271,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         group = event.group
 
@@ -324,7 +324,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         group = event.group
 
@@ -386,7 +386,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         group = event.group
         assert group is not None
@@ -420,7 +420,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         group = event.group
         assert group is not None
@@ -490,7 +490,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         group = event.group
         assert group is not None
@@ -533,7 +533,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         group = event.group
         assert group is not None

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -91,7 +91,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         group = event.group
         assert group is not None
@@ -271,7 +271,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         group = event.group
 
@@ -324,7 +324,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         group = event.group
 
@@ -386,7 +386,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         group = event.group
         assert group is not None
@@ -420,7 +420,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         group = event.group
         assert group is not None
@@ -490,7 +490,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         group = event.group
         assert group is not None
@@ -533,7 +533,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         group = event.group
         assert group is not None

--- a/tests/sentry/integrations/pagerduty/test_client.py
+++ b/tests/sentry/integrations/pagerduty/test_client.py
@@ -62,7 +62,7 @@ class PagerDutyClientTest(APITestCase):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
 
         self.integration_key = self.service["integration_key"]

--- a/tests/sentry/integrations/pagerduty/test_client.py
+++ b/tests/sentry/integrations/pagerduty/test_client.py
@@ -62,7 +62,7 @@ class PagerDutyClientTest(APITestCase):
                 "timestamp": self.min_ago,
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
 
         self.integration_key = self.service["integration_key"]

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -500,7 +500,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             },
             project_id=self.project.id,
             assert_no_errors=False,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         assert event.group
         group = event.group
@@ -565,7 +565,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             },
             project_id=self.project.id,
             assert_no_errors=False,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         assert event.group
         group = event.group

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -500,7 +500,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             },
             project_id=self.project.id,
             assert_no_errors=False,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         assert event.group
         group = event.group

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -565,7 +565,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             },
             project_id=self.project.id,
             assert_no_errors=False,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         assert event.group
         group = event.group

--- a/tests/sentry/issues/endpoints/test_group_hashes.py
+++ b/tests/sentry/issues/endpoints/test_group_hashes.py
@@ -4,7 +4,6 @@ from urllib.parse import urlencode
 from sentry.eventstream.snuba import SnubaEventStream
 from sentry.models.grouphash import GroupHash
 from sentry.testutils.cases import APITestCase, SnubaTestCase
-from sentry.testutils.factories import EventType
 from sentry.testutils.helpers.datetime import before_now, iso_format
 
 
@@ -24,7 +23,6 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
                 "fingerprint": ["group-1"],
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
         )
 
         new_event = self.store_event(
@@ -35,7 +33,6 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
                 "fingerprint": ["group-1"],
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
         )
 
         assert new_event.group_id == old_event.group_id
@@ -61,7 +58,6 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
                 "fingerprint": ["group-1"],
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
         )
 
         event2 = self.store_event(

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -133,7 +133,10 @@ class CreateEventTestCase(TestCase, BaseEventFrequencyPercentTest):
         return cast(
             GroupEvent,
             self.store_event(
-                data=data, project_id=project_id, assert_no_errors=False, event_type=EventType.ERROR
+                data=data,
+                project_id=project_id,
+                assert_no_errors=False,
+                default_event_type=EventType.ERROR,
             ),
         )
 

--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -73,7 +73,7 @@ class DailySummaryTest(
                     data=data,
                     project_id=project_id,
                     assert_no_errors=False,
-                    event_type=EventType.ERROR,
+                    event_type=EventType.DEFAULT,
                 )
             elif category == DataCategory.TRANSACTION:
                 event = self.create_performance_issue()
@@ -749,7 +749,7 @@ class DailySummaryTest(
                 data=data,
                 project_id=self.project.id,
                 assert_no_errors=False,
-                event_type=EventType.ERROR,
+                event_type=EventType.DEFAULT,
             )
             self.store_outcomes(
                 {
@@ -798,7 +798,7 @@ class DailySummaryTest(
                 data=data,
                 project_id=self.project.id,
                 assert_no_errors=False,
-                event_type=EventType.ERROR,
+                event_type=EventType.DEFAULT,
             )
             self.store_outcomes(
                 {
@@ -847,7 +847,7 @@ class DailySummaryTest(
                 data=data,
                 project_id=self.project.id,
                 assert_no_errors=False,
-                event_type=EventType.ERROR,
+                event_type=EventType.DEFAULT,
             )
             self.store_outcomes(
                 {

--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -73,7 +73,7 @@ class DailySummaryTest(
                     data=data,
                     project_id=project_id,
                     assert_no_errors=False,
-                    event_type=EventType.DEFAULT,
+                    default_event_type=EventType.DEFAULT,
                 )
             elif category == DataCategory.TRANSACTION:
                 event = self.create_performance_issue()
@@ -749,7 +749,7 @@ class DailySummaryTest(
                 data=data,
                 project_id=self.project.id,
                 assert_no_errors=False,
-                event_type=EventType.DEFAULT,
+                default_event_type=EventType.DEFAULT,
             )
             self.store_outcomes(
                 {
@@ -798,7 +798,7 @@ class DailySummaryTest(
                 data=data,
                 project_id=self.project.id,
                 assert_no_errors=False,
-                event_type=EventType.DEFAULT,
+                default_event_type=EventType.DEFAULT,
             )
             self.store_outcomes(
                 {
@@ -847,7 +847,7 @@ class DailySummaryTest(
                 data=data,
                 project_id=self.project.id,
                 assert_no_errors=False,
-                event_type=EventType.DEFAULT,
+                default_event_type=EventType.DEFAULT,
             )
             self.store_outcomes(
                 {

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -281,7 +281,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                 "fingerprint": ["group-1"],
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         event1.group.substatus = GroupSubStatus.ONGOING
         event1.group.save()
@@ -294,7 +294,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                 "fingerprint": ["group-2"],
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         event2.group.substatus = GroupSubStatus.NEW
         event2.group.save()
@@ -329,7 +329,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                     "fingerprint": ["group-1"],
                 },
                 project_id=self.project.id,
-                event_type=EventType.DEFAULT,
+                default_event_type=EventType.DEFAULT,
             )
             event2 = self.store_event(
                 data={
@@ -339,7 +339,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                     "fingerprint": ["group-2"],
                 },
                 project_id=self.project.id,
-                event_type=EventType.DEFAULT,
+                default_event_type=EventType.DEFAULT,
             )
             group2 = event2.group
             group2.status = GroupStatus.RESOLVED
@@ -367,7 +367,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                     "fingerprint": ["group-1"],
                 },
                 project_id=self.project.id,
-                event_type=EventType.DEFAULT,
+                default_event_type=EventType.DEFAULT,
             )
 
             event2 = self.store_event(
@@ -378,7 +378,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                     "fingerprint": ["group-2"],
                 },
                 project_id=self.project.id,
-                event_type=EventType.DEFAULT,
+                default_event_type=EventType.DEFAULT,
             )
             self.store_event_outcomes(
                 self.organization.id, self.project.id, self.three_days_ago, num_times=2
@@ -465,7 +465,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                     "fingerprint": ["group-1"],
                 },
                 project_id=self.project.id,
-                event_type=EventType.DEFAULT,
+                default_event_type=EventType.DEFAULT,
             )
 
             self.store_event(
@@ -476,7 +476,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                     "fingerprint": ["group-2"],
                 },
                 project_id=self.project.id,
-                event_type=EventType.DEFAULT,
+                default_event_type=EventType.DEFAULT,
             )
             self.store_event_outcomes(
                 self.organization.id, self.project.id, self.three_days_ago, num_times=2
@@ -544,7 +544,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                     "level": "info",
                 },
                 project_id=self.project.id,
-                event_type=EventType.DEFAULT,
+                default_event_type=EventType.DEFAULT,
             )
 
             self.store_event(
@@ -556,7 +556,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                     "level": "error",
                 },
                 project_id=self.project.id,
-                event_type=EventType.DEFAULT,
+                default_event_type=EventType.DEFAULT,
             )
             self.store_event_outcomes(
                 self.organization.id, self.project.id, self.three_days_ago, num_times=2
@@ -604,7 +604,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                     "fingerprint": ["group-1"],
                 },
                 project_id=self.project.id,
-                event_type=EventType.DEFAULT,
+                default_event_type=EventType.DEFAULT,
             )
 
             event2 = self.store_event(
@@ -615,7 +615,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                     "fingerprint": ["group-2"],
                 },
                 project_id=self.project.id,
-                event_type=EventType.DEFAULT,
+                default_event_type=EventType.DEFAULT,
             )
             self.store_event_outcomes(
                 self.organization.id, self.project.id, self.three_days_ago, num_times=2
@@ -714,7 +714,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                 "fingerprint": ["group-1"],
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         group1 = event1.group
         group1.substatus = GroupSubStatus.NEW
@@ -728,7 +728,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                 "fingerprint": ["group-2"],
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
         group2 = event2.group
         group2.substatus = GroupSubStatus.ONGOING
@@ -781,7 +781,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                 "fingerprint": ["group-1"],
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
 
         group1 = event1.group
@@ -828,7 +828,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                 "fingerprint": ["group-1"],
             },
             project_id=self.project.id,
-            event_type=EventType.DEFAULT,
+            default_event_type=EventType.DEFAULT,
         )
 
         prepare_organization_report(

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -281,7 +281,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                 "fingerprint": ["group-1"],
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         event1.group.substatus = GroupSubStatus.ONGOING
         event1.group.save()
@@ -294,7 +294,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                 "fingerprint": ["group-2"],
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         event2.group.substatus = GroupSubStatus.NEW
         event2.group.save()
@@ -329,7 +329,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                     "fingerprint": ["group-1"],
                 },
                 project_id=self.project.id,
-                event_type=EventType.ERROR,
+                event_type=EventType.DEFAULT,
             )
             event2 = self.store_event(
                 data={
@@ -339,7 +339,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                     "fingerprint": ["group-2"],
                 },
                 project_id=self.project.id,
-                event_type=EventType.ERROR,
+                event_type=EventType.DEFAULT,
             )
             group2 = event2.group
             group2.status = GroupStatus.RESOLVED
@@ -367,7 +367,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                     "fingerprint": ["group-1"],
                 },
                 project_id=self.project.id,
-                event_type=EventType.ERROR,
+                event_type=EventType.DEFAULT,
             )
 
             event2 = self.store_event(
@@ -378,7 +378,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                     "fingerprint": ["group-2"],
                 },
                 project_id=self.project.id,
-                event_type=EventType.ERROR,
+                event_type=EventType.DEFAULT,
             )
             self.store_event_outcomes(
                 self.organization.id, self.project.id, self.three_days_ago, num_times=2
@@ -465,7 +465,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                     "fingerprint": ["group-1"],
                 },
                 project_id=self.project.id,
-                event_type=EventType.ERROR,
+                event_type=EventType.DEFAULT,
             )
 
             self.store_event(
@@ -476,7 +476,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                     "fingerprint": ["group-2"],
                 },
                 project_id=self.project.id,
-                event_type=EventType.ERROR,
+                event_type=EventType.DEFAULT,
             )
             self.store_event_outcomes(
                 self.organization.id, self.project.id, self.three_days_ago, num_times=2
@@ -544,7 +544,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                     "level": "info",
                 },
                 project_id=self.project.id,
-                event_type=EventType.ERROR,
+                event_type=EventType.DEFAULT,
             )
 
             self.store_event(
@@ -556,7 +556,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                     "level": "error",
                 },
                 project_id=self.project.id,
-                event_type=EventType.ERROR,
+                event_type=EventType.DEFAULT,
             )
             self.store_event_outcomes(
                 self.organization.id, self.project.id, self.three_days_ago, num_times=2
@@ -604,7 +604,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                     "fingerprint": ["group-1"],
                 },
                 project_id=self.project.id,
-                event_type=EventType.ERROR,
+                event_type=EventType.DEFAULT,
             )
 
             event2 = self.store_event(
@@ -615,7 +615,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                     "fingerprint": ["group-2"],
                 },
                 project_id=self.project.id,
-                event_type=EventType.ERROR,
+                event_type=EventType.DEFAULT,
             )
             self.store_event_outcomes(
                 self.organization.id, self.project.id, self.three_days_ago, num_times=2
@@ -714,7 +714,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                 "fingerprint": ["group-1"],
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         group1 = event1.group
         group1.substatus = GroupSubStatus.NEW
@@ -728,7 +728,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                 "fingerprint": ["group-2"],
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
         group2 = event2.group
         group2.substatus = GroupSubStatus.ONGOING
@@ -781,7 +781,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                 "fingerprint": ["group-1"],
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
 
         group1 = event1.group
@@ -828,7 +828,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                 "fingerprint": ["group-1"],
             },
             project_id=self.project.id,
-            event_type=EventType.ERROR,
+            event_type=EventType.DEFAULT,
         )
 
         prepare_organization_report(


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/71306/, tbh I'm not sure if I was incorrect back then or if something changed, but the "error" data I had before creates a "default" type event (like a capture message event) and you need to pass an exception to the data to create an "error" type of event.

Closes https://getsentry.atlassian.net/browse/ALRT-303