### PR TITLE
fix(uptime): Use ProjectAlertRulePermission for index

### DIFF
--- a/src/sentry/uptime/endpoints/project_uptime_alert_index.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_index.py
@@ -7,6 +7,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import ProjectEndpoint
+from sentry.api.bases.project import ProjectAlertRulePermission
 from sentry.api.serializers import serialize
 from sentry.apidocs.constants import (
     RESPONSE_BAD_REQUEST,
@@ -27,6 +28,7 @@ class ProjectUptimeAlertIndexEndpoint(ProjectEndpoint):
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.CRONS
+    permission_classes = (ProjectAlertRulePermission,)
 
     @extend_schema(
         operation_id="Create an Uptime Monitor",


### PR DESCRIPTION
Without this we're unable to create uptime alerts without higher level permissions