### PR TITLE
feat(releases): Allow filtering by latest release on Releases page

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -42,6 +42,7 @@ from sentry.search.events.constants import (
     SEMVER_PACKAGE_ALIAS,
 )
 from sentry.search.events.filter import handle_operator_negation, parse_semver
+from sentry.search.utils import get_latest_release
 from sentry.signals import release_created
 from sentry.snuba.sessions import STATS_PERIODS
 from sentry.types.activity import ActivityType
@@ -101,6 +102,13 @@ def _filter_releases_by_query(queryset, organization, query, filter_params):
                 query_q = ~Q(version__in=raw_value)
             elif search_filter.operator == "IN":
                 query_q = Q(version__in=raw_value)
+            elif raw_value == "latest":
+                latest_releases = get_latest_release(
+                    projects=filter_params["project_id"],
+                    environments=filter_params.get("environment"),
+                    organization_id=organization.id,
+                )
+                query_q = Q(version__in=latest_releases)
             else:
                 query_q = Q(version=search_filter.value.value)
 

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -372,6 +372,29 @@ class OrganizationReleaseListTest(APITestCase, BaseMetricsTestCase):
         )
         self.assert_expected_versions(response, [])
 
+    def test_latest_release_filter(self):
+        self.login_as(user=self.user)
+
+        project1 = self.create_project(teams=[self.team], organization=self.organization)
+        project2 = self.create_project(teams=[self.team], organization=self.organization)
+
+        self.create_release(version="test@2.2", project=project1)
+        self.create_release(version="test@2.2-alpha", project=project1)
+        project1_latest_release = self.create_release(version="test@2.2+122", project=project1)
+        self.create_release(version="test@20.2.8", project=project2)
+        project2_latest_release = self.create_release(version="test@21.0.0", project=project2)
+
+        response = self.get_success_response(
+            self.organization.slug, query=f"{RELEASE_ALIAS}:latest"
+        )
+        self.assert_expected_versions(
+            response,
+            [
+                project2_latest_release,
+                project1_latest_release,
+            ],
+        )
+
     def test_query_filter_suffix(self):
         user = self.create_user(is_staff=False, is_superuser=False)
         org = self.organization


### PR DESCRIPTION
This is a somewhat mysterious change. I noticed that the Releases page seems to be the only spot where the `"release:latest"` filter doesn't work. This feels like an oversight, since it's pretty useful to show the latest releases for a bunch of projects at once. Maybe I'm missing something?

PR adds handling for special `"release:latest"` filter. If passed, fetch latest releases for the projects in question, and filter just to those releases.

**e.g.,**

![Screenshot 2024-09-24 at 1 36 20 PM](https://github.com/user-attachments/assets/9f2f8d57-fa3f-433b-bf77-2b2b13faf93a)
