### PR TITLE
fix(insights): Incorrect URL in view full query button

### DIFF
--- a/static/app/views/insights/common/components/fullSpanDescription.tsx
+++ b/static/app/views/insights/common/components/fullSpanDescription.tsx
@@ -134,7 +134,7 @@ function QueryClippedBox({group, children}: TruncatedQueryClipBoxProps) {
         icon: <IconOpen />,
         onClick: () =>
           navigate({
-            pathname: `${databaseURL}/spans/span/${group}`, // `insights/database/spans/span/${group}/`,
+            pathname: `${databaseURL}/spans/span/${group}`,
           }),
       }}
     >

--- a/static/app/views/insights/common/components/fullSpanDescription.tsx
+++ b/static/app/views/insights/common/components/fullSpanDescription.tsx
@@ -9,7 +9,6 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {SQLishFormatter} from 'sentry/utils/sqlish/SQLishFormatter';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useSpansIndexed} from 'sentry/views/insights/common/queries/useDiscover';
 import {useFullSpanFromTrace} from 'sentry/views/insights/common/queries/useFullSpanFromTrace';
@@ -123,7 +122,6 @@ type TruncatedQueryClipBoxProps = {
 };
 
 function QueryClippedBox({group, children}: TruncatedQueryClipBoxProps) {
-  const location = useLocation();
   const navigate = useNavigate();
 
   return (
@@ -134,7 +132,7 @@ function QueryClippedBox({group, children}: TruncatedQueryClipBoxProps) {
         icon: <IconOpen />,
         onClick: () =>
           navigate({
-            pathname: `${location.pathname}spans/span/${group}/`,
+            pathname: `insights/database/spans/span/${group}/`,
           }),
       }}
     >

--- a/static/app/views/insights/common/components/fullSpanDescription.tsx
+++ b/static/app/views/insights/common/components/fullSpanDescription.tsx
@@ -12,6 +12,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useSpansIndexed} from 'sentry/views/insights/common/queries/useDiscover';
 import {useFullSpanFromTrace} from 'sentry/views/insights/common/queries/useFullSpanFromTrace';
+import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
 import {prettyPrintJsonString} from 'sentry/views/insights/database/utils/jsonUtils';
 import {ModuleName, SpanIndexedField} from 'sentry/views/insights/types';
 
@@ -123,6 +124,7 @@ type TruncatedQueryClipBoxProps = {
 
 function QueryClippedBox({group, children}: TruncatedQueryClipBoxProps) {
   const navigate = useNavigate();
+  const databaseURL = useModuleURL(ModuleName.DB);
 
   return (
     <StyledClippedBox
@@ -132,7 +134,7 @@ function QueryClippedBox({group, children}: TruncatedQueryClipBoxProps) {
         icon: <IconOpen />,
         onClick: () =>
           navigate({
-            pathname: `insights/database/spans/span/${group}/`,
+            pathname: `${databaseURL}/spans/span/${group}`, // `insights/database/spans/span/${group}/`,
           }),
       }}
     >


### PR DESCRIPTION
When clicking on the "View full query" button in the slow queries widget on the performance landing page, it would link to an incorrect URL because it was using a relative path. This fixes the URL so it uses the correct path, and clicking the button will work regardless of the location where it is clicked from

![image](https://github.com/user-attachments/assets/8f1cebb1-fef6-47f1-a697-edc921c9cccc)

Fixes JAVASCRIPT-2VZR