### PR TITLE
fix(visibility) Improve `ReleaseSeries` memoization

### DIFF
--- a/static/app/components/charts/releaseSeries.tsx
+++ b/static/app/components/charts/releaseSeries.tsx
@@ -64,6 +64,15 @@ function getOrganizationReleases(
   }) as Promise<[ReleaseMetaBasic[], any, ResponseMeta]>;
 }
 
+const getOrganizationReleasesMemoized = memoize(
+  (api: Client, organization: Organization, conditions: ReleaseConditions) =>
+    getOrganizationReleases(api, organization, conditions),
+  (_, __, conditions) =>
+    Object.values(conditions)
+      .map(val => JSON.stringify(val))
+      .join('-')
+);
+
 export interface ReleaseSeriesProps extends WithRouterProps {
   api: Client;
   children: (s: State) => React.ReactNode;
@@ -130,15 +139,6 @@ class ReleaseSeries extends Component<ReleaseSeriesProps, State> {
 
   _isMounted: boolean = false;
 
-  getOrganizationReleasesMemoized = memoize(
-    (api: Client, organization: Organization, conditions: ReleaseConditions) =>
-      getOrganizationReleases(api, organization, conditions),
-    (_, __, conditions) =>
-      Object.values(conditions)
-        .map(val => JSON.stringify(val))
-        .join('-')
-  );
-
   async fetchData() {
     const {
       api,
@@ -164,7 +164,7 @@ class ReleaseSeries extends Component<ReleaseSeriesProps, State> {
     while (hasMore) {
       try {
         const getReleases = memoized
-          ? this.getOrganizationReleasesMemoized
+          ? getOrganizationReleasesMemoized
           : getOrganizationReleases;
         const [newReleases, , resp] = await getReleases(api, organization, conditions);
         releases.push(...newReleases);

--- a/static/app/components/charts/releaseSeries.tsx
+++ b/static/app/components/charts/releaseSeries.tsx
@@ -65,8 +65,7 @@ function getOrganizationReleases(
 }
 
 const getOrganizationReleasesMemoized = memoize(
-  (api: Client, organization: Organization, conditions: ReleaseConditions) =>
-    getOrganizationReleases(api, organization, conditions),
+  getOrganizationReleases,
   (_, __, conditions) =>
     Object.values(conditions)
       .map(val => JSON.stringify(val))


### PR DESCRIPTION
Allow `ReleaseSeries` to share data _across component instances_ rather than just multiple renders of the same component.
