### PR TITLE
fix(routes): ignore route not found route

### DIFF
--- a/static/app/views/lastKnownRouteContextProvider.tsx
+++ b/static/app/views/lastKnownRouteContextProvider.tsx
@@ -1,11 +1,25 @@
-import {createContext, useContext} from 'react';
+import {createContext, useContext, useEffect, useRef} from 'react';
 
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
-import usePrevious from 'sentry/utils/usePrevious';
 import {useRoutes} from 'sentry/utils/useRoutes';
 
 interface Props {
   children: React.ReactNode;
+}
+
+/**
+ * Rewrite usePrevious for our use case, to ignore the not found route.
+ * The previous route can be '/*', which isn't useful for issue grouping.
+ */
+function usePrevious<T>(value: T): T {
+  const ref = useRef<T>(value);
+  useEffect(() => {
+    // only store the new value if it's not the "not found" route
+    if (value !== '/*') {
+      ref.current = value;
+    }
+  }, [value]);
+  return ref.current;
 }
 
 export const LastKnownRouteContext = createContext<string>('<unknown>');


### PR DESCRIPTION

follow up to https://github.com/getsentry/sentry/pull/77835

sometimes our last known route can be `/*`, which is the not found route. this isn't helpful for grouping, so we want to track routes distinct from that.