### PR TITLE
feat(issue-views): Add a Save All button for saved searches

### DIFF
--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -221,6 +221,7 @@ export type IssueEventParameters = {
     search_source: string;
     search_type: string;
   };
+  'issue_views.add_view.all_saved_searches_saved': {};
   'issue_views.add_view.clicked': {};
   'issue_views.add_view.custom_query_saved': {
     query: string;
@@ -385,6 +386,8 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issue_views.add_view.custom_query_saved':
     'Issue Views: Custom Query Saved From Add View',
   'issue_views.add_view.saved_search_saved': 'Issue Views: Saved Search Saved',
+  'issue_views.add_view.all_saved_searches_saved':
+    'Issue Views: All Saved Searches Saved',
   'issue_views.add_view.recommended_view_saved': 'Issue Views: Recommended View Saved',
   'issue_views.shared_view_opened': 'Issue Views: Shared View Opened',
   'issue_views.temp_view_discarded': 'Issue Views: Temporary View Discarded',

--- a/static/app/views/issueList/addViewPage.tsx
+++ b/static/app/views/issueList/addViewPage.tsx
@@ -97,18 +97,44 @@ function SearchSuggestionList({
   searchSuggestions,
   type,
 }: SearchSuggestionListProps) {
-  const {onNewViewSaved} = useContext(NewTabContext);
+  const {onNewViewsSaved} = useContext(NewTabContext);
   const organization = useOrganization();
 
   return (
     <Suggestions>
-      <TitleWrapper>{title}</TitleWrapper>
+      <TitleWrapper>
+        {title}
+        {type === 'saved_searches' && (
+          <StyledButton
+            size="zero"
+            onClick={e => {
+              e.stopPropagation();
+              onNewViewsSaved?.(
+                searchSuggestions.map(suggestion => ({
+                  ...suggestion,
+                  saveQueryToView: true,
+                }))
+              );
+            }}
+            analyticsEventKey="issue_views.add_view.all_saved_searches_saved"
+            analyticsEventName="Issue Views: All Saved Searches Saved"
+            borderless
+          >
+            {t('Save all')}
+          </StyledButton>
+        )}
+      </TitleWrapper>
       <SuggestionList>
         {searchSuggestions.map((suggestion, index) => (
           <Suggestion
             key={index}
             onClick={() => {
-              onNewViewSaved?.(suggestion.label, suggestion.query, false);
+              onNewViewsSaved?.([
+                {
+                  ...suggestion,
+                  saveQueryToView: false,
+                },
+              ]);
               const analyticsKey =
                 type === 'recommended'
                   ? 'issue_views.add_view.recommended_view_saved'
@@ -135,7 +161,12 @@ function SearchSuggestionList({
                   size="zero"
                   onClick={e => {
                     e.stopPropagation();
-                    onNewViewSaved?.(suggestion.label, suggestion.query, true);
+                    onNewViewsSaved?.([
+                      {
+                        ...suggestion,
+                        saveQueryToView: true,
+                      },
+                    ]);
                     const analyticsKey =
                       type === 'recommended'
                         ? 'issue_views.add_view.recommended_view_saved'
@@ -210,6 +241,8 @@ const StyledOverflowEllipsisTextContainer = styled(OverflowEllipsisTextContainer
 `;
 
 const TitleWrapper = styled('div')`
+  display: flex;
+  justify-content: space-between;
   color: ${p => p.theme.subText};
   font-weight: 550;
   font-size: ${p => p.theme.fontSizeMedium};
@@ -253,6 +286,10 @@ const SuggestionList = styled('ul')`
   }
 
   li:hover {
+    border-bottom: 1px solid transparent;
+  }
+
+  li:last-child {
     border-bottom: 1px solid transparent;
   }
 `;

--- a/static/app/views/issueList/addViewPage.tsx
+++ b/static/app/views/issueList/addViewPage.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import bannerStar from 'sentry-images/spot/banner-star.svg';
 
 import {Button} from 'sentry/components/button';
+import {openConfirmModal} from 'sentry/components/confirm';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {FormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
@@ -44,11 +45,11 @@ const RECOMMENDED_SEARCHES: SearchSuggestion[] = [
 function AddViewPage({savedSearches}: {savedSearches: SavedSearch[]}) {
   const savedSearchTitle = (
     <SavedSearchesTitle>
-      {t('Saved Searches (will be deprecated)')}
+      {t('Saved Searches (will be removed)')}
       <QuestionTooltip
         icon="info"
         title={t(
-          'Saved searches will be deprecated soon. For any you wish to return to, please save them as views.'
+          'Saved searches will be removed soon. For any you wish to return to, please save them as views.'
         )}
         size="sm"
         position="top"
@@ -109,12 +110,23 @@ function SearchSuggestionList({
             size="zero"
             onClick={e => {
               e.stopPropagation();
-              onNewViewsSaved?.(
-                searchSuggestions.map(suggestion => ({
-                  ...suggestion,
-                  saveQueryToView: true,
-                }))
-              );
+              openConfirmModal({
+                message: (
+                  <b style={{display: 'flex', justifyContent: 'center'}}>
+                    {t('Save ') +
+                      searchSuggestions.length +
+                      t(' saved searches as views?')}
+                  </b>
+                ),
+                onConfirm: () => {
+                  onNewViewsSaved?.(
+                    searchSuggestions.map(suggestion => ({
+                      ...suggestion,
+                      saveQueryToView: true,
+                    }))
+                  );
+                },
+              });
             }}
             analyticsEventKey="issue_views.add_view.all_saved_searches_saved"
             analyticsEventName="Issue Views: All Saved Searches Saved"

--- a/static/app/views/issueList/addViewPage.tsx
+++ b/static/app/views/issueList/addViewPage.tsx
@@ -9,7 +9,7 @@ import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {FormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
 import {IconMegaphone} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {SavedSearch} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -112,11 +112,13 @@ function SearchSuggestionList({
               e.stopPropagation();
               openConfirmModal({
                 message: (
-                  <b style={{display: 'flex', justifyContent: 'center'}}>
-                    {t('Save ') +
-                      searchSuggestions.length +
-                      t(' saved searches as views?')}
-                  </b>
+                  <ConfirmModalMessage>
+                    {tn(
+                      'Save %s saved search as a view?',
+                      'Save %s saved searches as views?',
+                      searchSuggestions.length
+                    )}
+                  </ConfirmModalMessage>
                 ),
                 onConfirm: () => {
                   onNewViewsSaved?.(
@@ -390,4 +392,10 @@ const BannerStar3 = styled('img')`
   @media (max-width: ${p => p.theme.breakpoints.large}) {
     display: none;
   }
+`;
+
+const ConfirmModalMessage = styled('div')`
+  display: flex;
+  justify-content: center;
+  font-weight: ${p => p.theme.fontWeightBold};
 `;

--- a/static/app/views/issueList/customViewsHeader.tsx
+++ b/static/app/views/issueList/customViewsHeader.tsx
@@ -293,6 +293,7 @@ function CustomViewsIssueListHeaderTabsContent({
 
   // Update local tabs when new views are received from mutation request
   useEffect(() => {
+    const currentViewId = viewId;
     setDraggableTabs(
       draggableTabs.map(tab => {
         if (tab.id && tab.id[0] === '_') {
@@ -304,19 +305,21 @@ function CustomViewsIssueListHeaderTabsContent({
               tab.querySort === view.querySort &&
               tab.label === view.name
             ) {
+              if (tab.id === currentViewId) {
+                navigate(
+                  normalizeUrl({
+                    ...location,
+                    query: {
+                      ...queryParamsWithPageFilters,
+                      viewId: view.id,
+                    },
+                  }),
+                  {replace: true}
+                );
+              }
               tab.id = view.id;
             }
           });
-          navigate(
-            normalizeUrl({
-              ...location,
-              query: {
-                ...queryParamsWithPageFilters,
-                viewId: tab.id,
-              },
-            }),
-            {replace: true}
-          );
         }
         return tab;
       })

--- a/static/app/views/issueList/utils/newTabContext.tsx
+++ b/static/app/views/issueList/utils/newTabContext.tsx
@@ -1,34 +1,38 @@
 import {createContext, useState} from 'react';
 
+export type NewView = {
+  label: string;
+  query: string;
+  saveQueryToView: boolean;
+};
+
 export interface NewTabContext {
   newViewActive: boolean;
-  onNewViewSaved: (label: string, query: string, saveQueryToView: boolean) => void;
+  onNewViewsSaved: (newViews: NewView[]) => void;
   setNewViewActive: (isActive: boolean) => void;
-  setOnNewViewSaved: (
-    onNewViewSaved: (label: string, query: string, saveQueryToView: boolean) => void
-  ) => void;
+  setOnNewViewsSaved: (onNewViewSaved: (newViews: NewView[]) => void) => void;
 }
 
 export const NewTabContext = createContext<NewTabContext>({
   newViewActive: false,
   setNewViewActive: () => {},
-  onNewViewSaved: () => {},
-  setOnNewViewSaved: () => {},
+  onNewViewsSaved: () => {},
+  setOnNewViewsSaved: () => {},
 });
 
 export function NewTabContextProvider({children}: {children: React.ReactNode}) {
   const [newViewActive, setNewViewActive] = useState<boolean>(false);
-  const [onNewViewSaved, setOnNewViewSaved] = useState<NewTabContext['onNewViewSaved']>(
-    () => () => {}
-  );
+  const [onNewViewsSaved, setOnNewViewsSaved] = useState<
+    NewTabContext['onNewViewsSaved']
+  >(() => () => {});
 
   return (
     <NewTabContext.Provider
       value={{
         newViewActive,
         setNewViewActive,
-        onNewViewSaved,
-        setOnNewViewSaved,
+        onNewViewsSaved,
+        setOnNewViewsSaved,
       }}
     >
       {children}

--- a/static/app/views/issueList/utils/newTabContext.tsx
+++ b/static/app/views/issueList/utils/newTabContext.tsx
@@ -3,6 +3,10 @@ import {createContext, useState} from 'react';
 export type NewView = {
   label: string;
   query: string;
+  /**
+   * If true, the query will be saved to the view.
+   * Otherwise, the query will act as an unsaved change.
+   */
   saveQueryToView: boolean;
 };
 


### PR DESCRIPTION
Adds a "Save All" button for the saved searches section, which adds and saves all saved searches as views. 

<img width="1159" alt="Screenshot 2024-09-24 at 12 01 53 PM" src="https://github.com/user-attachments/assets/bc5daa1a-9d48-4ff0-97e6-59f096c3d613">
