### PR TITLE
chore(snuba-search): Add log to see snuba pre-filtering

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1162,6 +1162,8 @@ class InvalidQueryForExecutor(Exception):
 
 
 class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
+    logger = logging.getLogger("sentry.search.groupattributessnuba")
+
     def get_times_seen_filter(
         self, search_filter: SearchFilter, joined_entity: Entity
     ) -> Condition:
@@ -1715,6 +1717,14 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
                         : max_candidates + 1
                     ]
                 )
+                self.logger.info(
+                    "GroupAttributesExecutor: found snuba candidates",
+                    extra={
+                        "count": len(group_ids_to_pass_to_snuba),
+                        "max_candidates": max_candidates,
+                        "projects": [p.id for p in projects],
+                    },
+                )
                 span.set_data("Max Candidates", max_candidates)
                 span.set_data("Result Size", len(group_ids_to_pass_to_snuba))
 
@@ -1722,6 +1732,7 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
                     metrics.incr(
                         "snuba.search.group_attributes.too_many_candidates", skip_internal=False
                     )
+                    self.logger.info("GroupAttributesExecutor: too many candidates")
                     group_ids_to_pass_to_snuba = None
 
         # remove the search filters that are only for postgres
@@ -1765,6 +1776,10 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
 
                 # limit groups and events to the group ids
                 for entity_with_group_id in [attr_entity, joined_entity]:
+                    self.logger.info(
+                        "GroupAttributesExecutor: adding group_id filter to entity",
+                        extra={"entity": entity_with_group_id},
+                    )
                     where_conditions.append(
                         Condition(
                             Column("group_id", entity_with_group_id),

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1778,7 +1778,7 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
                 for entity_with_group_id in [attr_entity, joined_entity]:
                     self.logger.info(
                         "GroupAttributesExecutor: adding group_id filter to entity",
-                        extra={"entity": entity_with_group_id},
+                        extra={"entity": entity_with_group_id.name},
                     )
                     where_conditions.append(
                         Condition(


### PR DESCRIPTION
This feature is only enabled for the sentry org. Adding logs to debug why the `is:unlinked` query succeeds on some projects but not others.