### PR TITLE
feat(explore): Supporting multi chart top N events

### DIFF
--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -8,7 +8,11 @@ import moment from 'moment-timezone';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import type {PageFilters} from 'sentry/types/core';
 import type {ReactEchartsRef, Series} from 'sentry/types/echarts';
-import type {EventsStats, MultiSeriesEventsStats} from 'sentry/types/organization';
+import type {
+  EventsStats,
+  GroupedMultiSeriesEventsStats,
+  MultiSeriesEventsStats,
+} from 'sentry/types/organization';
 import {defined, escape} from 'sentry/utils';
 import {getFormattedDate} from 'sentry/utils/dates';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
@@ -216,7 +220,7 @@ export function getSeriesSelection(
 }
 
 function isSingleSeriesStats(
-  data: MultiSeriesEventsStats | EventsStats
+  data: MultiSeriesEventsStats | EventsStats | GroupedMultiSeriesEventsStats
 ): data is EventsStats {
   return (
     (defined(data.data) || defined(data.totals)) &&
@@ -226,7 +230,12 @@ function isSingleSeriesStats(
 }
 
 export function isMultiSeriesStats(
-  data: MultiSeriesEventsStats | EventsStats | null | undefined,
+  data:
+    | MultiSeriesEventsStats
+    | EventsStats
+    | GroupedMultiSeriesEventsStats
+    | null
+    | undefined,
   isTopN?: boolean
 ): data is MultiSeriesEventsStats {
   return (

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -311,6 +311,10 @@ export type MultiSeriesEventsStats = {
   [seriesName: string]: EventsStats;
 };
 
+export type GroupedMultiSeriesEventsStats = {
+  [seriesName: string]: MultiSeriesEventsStats;
+};
+
 export type EventsStatsSeries<F extends string> = {
   data: {
     axis: F;

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -312,7 +312,7 @@ export type MultiSeriesEventsStats = {
 };
 
 export type GroupedMultiSeriesEventsStats = {
-  [seriesName: string]: MultiSeriesEventsStats;
+  [seriesName: string]: MultiSeriesEventsStats & {order: number};
 };
 
 export type EventsStatsSeries<F extends string> = {

--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -108,13 +108,12 @@ export function ExploreCharts({query}: ExploreChartsProps) {
 
   const getSeries = useCallback(
     (dedupedYAxes: string[]) => {
-      if (topEvents !== undefined) {
-        return topNSeriesResult.data;
-      }
-
-      return dedupedYAxes.map(yAxis => singleSeriesResult.data[yAxis]);
+      return dedupedYAxes.flatMap(yAxis => {
+        const series = topNSeriesResult.data[yAxis];
+        return series !== undefined ? series : [];
+      });
     },
-    [singleSeriesResult, topNSeriesResult, topEvents]
+    [topNSeriesResult]
   );
 
   const handleChartTypeChange = useCallback(

--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -16,8 +16,7 @@ import {useDataset} from 'sentry/views/explore/hooks/useDataset';
 import {useVisualizes} from 'sentry/views/explore/hooks/useVisualizes';
 import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
 import ChartPanel from 'sentry/views/insights/common/components/chartPanel';
-import {useSpanIndexedSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
-import {useSortedTopNSeries} from 'sentry/views/insights/common/queries/useSortedTopNSeries';
+import {useSortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
 import {CHART_HEIGHT} from 'sentry/views/insights/database/settings';
 
 import {useGroupBys} from '../hooks/useGroupBys';
@@ -81,23 +80,12 @@ export function ExploreCharts({query}: ExploreChartsProps) {
     return deduped;
   }, [visualizes]);
 
-  const singleSeriesResult = useSpanIndexedSeries(
+  const timeSeriesResult = useSortedTimeSeries(
     {
       search: new MutableSearch(query ?? ''),
       yAxis: yAxes,
       interval: interval ?? getInterval(pageFilters.selection.datetime, 'metrics'),
-      enabled: topEvents === undefined,
-    },
-    'api.explorer.stats',
-    dataset
-  );
-
-  const topNSeriesResult = useSortedTopNSeries(
-    {
-      search: new MutableSearch(query ?? ''),
-      yAxis: yAxes,
-      interval: interval ?? getInterval(pageFilters.selection.datetime, 'metrics'),
-      enabled: topEvents !== undefined,
+      enabled: true,
       fields,
       orderby,
       topEvents,
@@ -109,11 +97,11 @@ export function ExploreCharts({query}: ExploreChartsProps) {
   const getSeries = useCallback(
     (dedupedYAxes: string[]) => {
       return dedupedYAxes.flatMap(yAxis => {
-        const series = topNSeriesResult.data[yAxis];
+        const series = timeSeriesResult.data[yAxis];
         return series !== undefined ? series : [];
       });
     },
-    [topNSeriesResult]
+    [timeSeriesResult]
   );
 
   const handleChartTypeChange = useCallback(
@@ -124,11 +112,6 @@ export function ExploreCharts({query}: ExploreChartsProps) {
     },
     [visualizes, setVisualizes]
   );
-
-  const error =
-    topEvents === undefined ? singleSeriesResult.error : topNSeriesResult.error;
-  const loading =
-    topEvents === undefined ? singleSeriesResult.isPending : topNSeriesResult.isPending;
 
   return (
     <Fragment>
@@ -169,8 +152,8 @@ export function ExploreCharts({query}: ExploreChartsProps) {
                 }}
                 legendFormatter={value => formatVersion(value)}
                 data={getSeries(dedupedYAxes)}
-                error={error}
-                loading={loading}
+                error={timeSeriesResult.error}
+                loading={timeSeriesResult.isPending}
                 // TODO Abdullah: Make chart colors dynamic, with changing topN events count and overlay count.
                 chartColors={CHART_PALETTE[TOP_EVENTS_LIMIT - 1]}
                 type={chartType}

--- a/static/app/views/explore/hooks/useTopEvents.tsx
+++ b/static/app/views/explore/hooks/useTopEvents.tsx
@@ -20,8 +20,8 @@ export function useTopEvents(): number | undefined {
       return undefined;
     }
 
-    // We only support top events for a single chart with no overlaps in aggregate mode and
-    // the data must be grouped by at least one field
+    // We only support top events for when there are no multiple y-axes chart
+    // and there is at least one group by.
     return hasChartWithMultipleYaxes || (groupBys.length === 1 && groupBys[0] === '')
       ? undefined
       : TOP_EVENTS_LIMIT;

--- a/static/app/views/explore/hooks/useTopEvents.tsx
+++ b/static/app/views/explore/hooks/useTopEvents.tsx
@@ -1,7 +1,5 @@
 import {useMemo} from 'react';
 
-import {dedupeArray} from 'sentry/utils/dedupeArray';
-
 import {useGroupBys} from './useGroupBys';
 import {useResultMode} from './useResultsMode';
 import {useVisualizes} from './useVisualizes';
@@ -13,10 +11,8 @@ export function useTopEvents(): number | undefined {
   const [groupBys] = useGroupBys();
   const [resultMode] = useResultMode();
 
-  const yAxes = useMemo(() => {
-    const deduped = dedupeArray(visualizes.flatMap(visualize => visualize.yAxes));
-    deduped.sort();
-    return deduped;
+  const hasChartWithMultipleYaxes = useMemo(() => {
+    return visualizes.some(visualize => visualize.yAxes.length > 1);
   }, [visualizes]);
 
   const topEvents: number | undefined = useMemo(() => {
@@ -26,10 +22,10 @@ export function useTopEvents(): number | undefined {
 
     // We only support top events for a single chart with no overlaps in aggregate mode and
     // the data must be grouped by at least one field
-    return yAxes.length > 1 || (groupBys.length === 1 && groupBys[0] === '')
+    return hasChartWithMultipleYaxes || (groupBys.length === 1 && groupBys[0] === '')
       ? undefined
       : TOP_EVENTS_LIMIT;
-  }, [yAxes, groupBys, resultMode]);
+  }, [hasChartWithMultipleYaxes, groupBys, resultMode]);
 
   return topEvents;
 }


### PR DESCRIPTION
Did some data massaging to handle Single series, multiple series and grouped multiple series from the same `events-stats` query response

Dev-ui testing: [link](https://sentry.dev.getsentry.net:7999/traces/?field=project&field=id&field=span.op&field=span.description&field=span.duration&field=timestamp&field=plan.tier&groupBy=plan.tier&mode=aggregate&project=-1&statsPeriod=1h&utc=true&visualize=%7B%22yAxes%22%3A%5B%22count%28span.duration%29%22%5D%2C%22chartType%22%3A1%7D&visualize=%7B%22yAxes%22%3A%5B%22p50%28span.duration%29%22%5D%2C%22chartType%22%3A1%7D)

![Screenshot 2024-09-24 at 3 32 28 PM](https://github.com/user-attachments/assets/28f99070-30b2-42c4-b245-87ed4b76fd4f)
