### PR TITLE
fix(ui): Set focus color for pre focus

### DIFF
--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -167,6 +167,10 @@ const styles = (theme: Theme, isDark: boolean) => css`
     background-color: ${theme.backgroundSecondary};
     white-space: pre-wrap;
     overflow-x: auto;
+
+    &:focus-visible {
+      outline: ${theme.focusBorder} auto 1px;
+    }
   }
 
   code {


### PR DESCRIPTION
This is for code snippets, it was using the webkit focus color.

Looks like this now

<img width="1014" alt="image" src="https://github.com/user-attachments/assets/bf9eaec5-7fbd-4bc8-902d-4d8d962b4693">