### PR TITLE
fix(ui): Improve border of code snippet header

### DIFF
--- a/static/app/components/codeSnippet.tsx
+++ b/static/app/components/codeSnippet.tsx
@@ -225,8 +225,8 @@ const Header = styled('div')<{isSolid: boolean}>`
   ${p =>
     p.isSolid
       ? `
-      margin: 0 ${space(0.5)};
-      border-bottom: solid 1px var(--prism-highlight-accent);
+      padding: 0 ${space(0.5)};
+      border-bottom: solid 1px ${p.theme.innerBorder};
     `
       : `
       justify-content: flex-end;


### PR DESCRIPTION
Makes it a bit more subtle

Before
<img alt="clipboard.png" width="579" src="https://i.imgur.com/smHjU1X.png" />

After
<img alt="clipboard.png" width="574" src="https://i.imgur.com/87IYjjJ.png" />