### PR TITLE
fix(uptime): Match max interval_seconds with the uptime checker

### DIFF
--- a/src/sentry/uptime/endpoints/validators.py
+++ b/src/sentry/uptime/endpoints/validators.py
@@ -70,7 +70,7 @@ class UptimeMonitorValidator(CamelSnakeSerializer):
     )
     url = URLField(required=True, max_length=255)
     interval_seconds = serializers.IntegerField(
-        required=True, min_value=60, max_value=int(timedelta(days=1).total_seconds())
+        required=True, min_value=60, max_value=int(timedelta(hours=1).total_seconds())
     )
     mode = serializers.IntegerField(required=False)
     method = serializers.ChoiceField(


### PR DESCRIPTION
The uptime checker has a 1 hour maximum window for it's check pattern.

https://github.com/getsentry/uptime-checker/blob/bed2b29e104309dddcba6c04cd8a109e94d16c5b/src/types/check_config.rs#L27-L28