### PR TITLE
fix(uptime): Allow null to be passed when creating/updating an uptime monitor

### DIFF
--- a/src/sentry/uptime/endpoints/validators.py
+++ b/src/sentry/uptime/endpoints/validators.py
@@ -47,13 +47,17 @@ HEADERS_LIST_SCHEMA = {
 }
 
 
-def compute_http_request_size(method: str, url: str, headers: Sequence[tuple[str, str]], body: str):
+def compute_http_request_size(
+    method: str, url: str, headers: Sequence[tuple[str, str]], body: str | None
+):
     request_line_size = len(f"{method} {url} HTTP/1.1\r\n")
     headers_size = sum(
         len(key) + len(value.encode("utf-8")) + len("\r\n") for key, value in headers
     )
-    body_size = len(body.encode("utf-8"))
-    return request_line_size + headers_size + len("\r\n") + body_size
+    body_size = 0
+    if body is not None:
+        body_size = len(body.encode("utf-8")) + len("\r\n")
+    return request_line_size + headers_size + body_size
 
 
 @extend_schema_serializer()
@@ -77,17 +81,17 @@ class UptimeMonitorValidator(CamelSnakeSerializer):
         required=False, choices=list(zip(SUPPORTED_HTTP_METHODS, SUPPORTED_HTTP_METHODS))
     )
     headers = serializers.JSONField(required=False)
-    body = serializers.CharField(required=False)
+    body = serializers.CharField(required=False, allow_null=True)
 
     def validate(self, attrs):
         headers = []
         method = "GET"
-        body = ""
+        body = None
         url = ""
         if self.instance:
             headers = self.instance.uptime_subscription.headers
             method = self.instance.uptime_subscription.method
-            body = self.instance.uptime_subscription.body or ""
+            body = self.instance.uptime_subscription.body
             url = self.instance.uptime_subscription.url
 
         request_size = compute_http_request_size(

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_details.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_details.py
@@ -54,6 +54,29 @@ class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndp
         assert uptime_sub.headers == [["hello", "world"]]
         assert uptime_sub.body == "something"
 
+        resp = self.get_success_response(
+            self.organization.slug,
+            proj_sub.project.slug,
+            proj_sub.id,
+            name="test",
+            owner=f"user:{self.user.id}",
+            url="https://santry.io",
+            interval_seconds=120,
+            headers=[["hello", "world"]],
+            body=None,
+        )
+        proj_sub.refresh_from_db()
+        assert resp.data == serialize(proj_sub, self.user)
+        assert proj_sub.name == "test"
+        assert proj_sub.owner_user_id == self.user.id
+        assert proj_sub.owner_team_id is None
+        uptime_sub = proj_sub.uptime_subscription
+        uptime_sub.refresh_from_db()
+        assert uptime_sub.url == "https://santry.io"
+        assert uptime_sub.interval_seconds == 120
+        assert uptime_sub.headers == [["hello", "world"]]
+        assert uptime_sub.body is None
+
     def test_user(self):
         uptime_subscription = self.create_project_uptime_subscription()
 

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_index.py
@@ -36,6 +36,7 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
             owner=f"user:{self.user.id}",
             url="http://sentry.io",
             interval_seconds=60,
+            body=None,
         )
         uptime_monitor = ProjectUptimeSubscription.objects.get(id=resp.data["id"])
         uptime_subscription = uptime_monitor.uptime_subscription
@@ -46,6 +47,7 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
         assert uptime_subscription.url == "http://sentry.io"
         assert uptime_subscription.interval_seconds == 60
         assert uptime_subscription.timeout_ms == DEFAULT_SUBSCRIPTION_TIMEOUT_MS
+        assert uptime_subscription.body is None
 
     @with_feature("organizations:uptime-api-create-update")
     def test_no_owner(self):

--- a/tests/sentry/uptime/endpoints/test_serializers.py
+++ b/tests/sentry/uptime/endpoints/test_serializers.py
@@ -1,6 +1,5 @@
 from sentry.api.serializers import serialize
 from sentry.testutils.cases import UptimeTestCase
-from sentry.uptime.endpoints.validators import compute_http_request_size
 
 
 class ProjectUptimeSubscriptionSerializerTest(UptimeTestCase):
@@ -81,26 +80,3 @@ class ProjectUptimeSubscriptionSerializerTest(UptimeTestCase):
         )
         result = serialize(uptime_monitor)
         assert result["headers"] == [["legacy", "format"]]
-
-
-class ComputeHttpRequestSizeTest(UptimeTestCase):
-    def test(self):
-        assert (
-            compute_http_request_size(
-                "GET",
-                "https://sentry.io",
-                [("auth", "1234"), ("utf_text", "我喜欢哨兵正常运行时间监视器")],
-                "some body stuff",
-            )
-            == 111
-        )
-        assert (
-            compute_http_request_size(
-                "GET",
-                "https://sentry.io",
-                # Test same number of characters but ascii instead
-                [("auth", "1234"), ("non_utf_text", "abcdefghijklmn")],
-                "some body stuff",
-            )
-            == 87
-        )

--- a/tests/sentry/uptime/endpoints/test_validators.py
+++ b/tests/sentry/uptime/endpoints/test_validators.py
@@ -1,0 +1,35 @@
+from sentry.testutils.cases import UptimeTestCase
+from sentry.uptime.endpoints.validators import compute_http_request_size
+
+
+class ComputeHttpRequestSizeTest(UptimeTestCase):
+    def test(self):
+        assert (
+            compute_http_request_size(
+                "GET",
+                "https://sentry.io",
+                [("auth", "1234"), ("utf_text", "我喜欢哨兵正常运行时间监视器")],
+                "some body stuff",
+            )
+            == 111
+        )
+        assert (
+            compute_http_request_size(
+                "GET",
+                "https://sentry.io",
+                # Test same number of characters but ascii instead
+                [("auth", "1234"), ("non_utf_text", "abcdefghijklmn")],
+                "some body stuff",
+            )
+            == 87
+        )
+        assert (
+            compute_http_request_size(
+                "GET",
+                "https://sentry.io",
+                # Test same number of characters but ascii instead
+                [("auth", "1234"), ("non_utf_text", "abcdefghijklmn")],
+                None,
+            )
+            == 70
+        )


### PR DESCRIPTION
We want to be able to explicitly pass `None` for the body instead of just not including it.

<!-- Describe your PR here. -->