### PR TITLE
fix(issue-views): Fix bug where unsaved changes not detected on empty query

### DIFF
--- a/static/app/views/issueList/customViewsHeader.tsx
+++ b/static/app/views/issueList/customViewsHeader.tsx
@@ -225,7 +225,7 @@ function CustomViewsIssueListHeaderTabsContent({
     // if a viewId is present, check if it exists in the existing views.
     if (viewId) {
       const selectedTab = draggableTabs.find(tab => tab.id === viewId);
-      if (selectedTab && query && sort) {
+      if (selectedTab && query !== undefined && sort) {
         const issueSortOption = Object.values(IssueSortOptions).includes(sort)
           ? sort
           : IssueSortOptions.DATE;


### PR DESCRIPTION
Fixes a minor bug where unsaved changes would not be detected if the query was empty 