### PR TITLE
:sparkles: feat(azure): Add Support for new VSTS Identity Provider

### DIFF
--- a/src/sentry/identity/pipeline.py
+++ b/src/sentry/identity/pipeline.py
@@ -5,7 +5,7 @@ from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
-from sentry import features
+from sentry import features, options
 from sentry.models.organization import Organization
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.pipeline import Pipeline, PipelineProvider
@@ -46,6 +46,9 @@ class IdentityProviderPipeline(Pipeline):
             "organizations:migrate-azure-devops-integration", organization
         ):
             provider_key = "vsts_new"
+        # TODO(iamrajjoshi): Delete this after Azure DevOps migration is complete
+        if provider_key == "vsts_login" and options.get("vsts.social-auth-migration"):
+            provider_key = "vsts_login_new"
 
         return super().get_provider(provider_key)
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -581,6 +581,14 @@ register("vsts_new.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 register("vsts-limited.client-id", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
 register("vsts-limited.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 
+# Azure DevOps Integration Social Login Flow
+register(
+    "vsts.social-auth-migration",
+    default=False,
+    type=Bool,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # PagerDuty Integration
 register("pagerduty.app-id", default="", flags=FLAG_AUTOMATOR_MODIFIABLE)
 


### PR DESCRIPTION
we are introducing a new identity which uses the new Azure DevOps integration we created. this pr is a temporary shim that we use as we roll out the new integration, with this logic ultimately becoming the existing integration.