### PR TITLE
fix(member): inc-866

### DIFF
--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -510,8 +510,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
         with transaction.atomic(router.db_for_write(OrganizationMember)):
             # Delete any invite requests and pending invites by the deleted member
             existing_invites = OrganizationMember.objects.filter(
-                Q(invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value)
-                | Q(token__isnull=False),
+                Q(invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value),
                 inviter_id=member.user_id,
                 organization=organization,
             )

--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -508,14 +508,16 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
             )
 
         with transaction.atomic(router.db_for_write(OrganizationMember)):
-            # Delete any invite requests and pending invites by the deleted member
-            existing_invites = OrganizationMember.objects.filter(
-                Q(invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value),
-                inviter_id=member.user_id,
-                organization=organization,
-            )
-            for om in existing_invites:
-                om.delete()
+            if member.user_id:
+                # Delete any invite requests and pending invites by the deleted member
+                existing_invites = OrganizationMember.objects.filter(
+                    Q(invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value)
+                    | Q(token__isnull=False),
+                    inviter_id=member.user_id,
+                    organization=organization,
+                )
+                for om in existing_invites:
+                    om.delete()
 
         self.create_audit_entry(
             request=request,


### PR DESCRIPTION
We cascade delete all the pending invites from a member that is being deleted. But we made a mistake here because apparently sometimes the member themselves can be a pending invite. This means we cascade delete all the pending invite from no one 🤦‍♀️  which in practice means we delete all the members who for some reason still have invite token on them although they might already be approved members.