### PR TITLE
chore(tests): Fix merge conflict headers in default comparator snapshot

### DIFF
--- a/tests/sentry/backup/snapshots/test_comparators/test_default_comparators.pysnap
+++ b/tests/sentry/backup/snapshots/test_comparators/test_default_comparators.pysnap
@@ -1,13 +1,5 @@
 ---
-<<<<<<< HEAD
-<<<<<<< HEAD
-created: '2024-09-17T12:19:51.014511+00:00'
-=======
-created: '2024-09-13T18:54:42.196428+00:00'
->>>>>>> 2b539135d0b (feat(auth): add org level api access)
-=======
-created: '2024-09-13T19:02:32.104869+00:00'
->>>>>>> 24aea8081e6 (removed api application changes)
+created: '2024-09-25T03:20:17.552524+00:00'
 creator: sentry
 source: tests/sentry/backup/test_comparators.py
 ---


### PR DESCRIPTION
This fixes a merge conflict which seems to have crept into master.