### PR TITLE
feat(seer grouping): Store seer metadata on grouphash during ingest

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1527,16 +1527,6 @@ def _create_group(
     first_release: Release | None = None,
     **group_creation_kwargs: Any,
 ) -> Group:
-    # Temporary log to debug events seeming to disappear after being sent to Seer
-    if event.data.get("seer_similarity"):
-        logger.info(
-            "seer.similarity.pre_create_group",
-            extra={
-                "event_id": event.event_id,
-                "hash": event.get_primary_hash(),
-                "project": project.id,
-            },
-        )
 
     short_id = _get_next_short_id(project)
 
@@ -1611,18 +1601,6 @@ def _create_group(
             # Maybe the stuck counter was hiding some other error
             logger.exception("Error after unsticking project counter")
             raise
-
-    # Temporary log to debug events seeming to disappear after being sent to Seer
-    if event.data.get("seer_similarity"):
-        logger.info(
-            "seer.similarity.post_create_group",
-            extra={
-                "event_id": event.event_id,
-                "hash": event.get_primary_hash(),
-                "project": project.id,
-                "group_id": group.id,
-            },
-        )
 
     return group
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1335,7 +1335,7 @@ def _save_aggregate_new(
             result = "found_secondary"
         # If we still haven't found a group, ask Seer for a match (if enabled for the project)
         else:
-            seer_matched_grouphash = maybe_check_seer_for_matching_grouphash(event)
+            seer_matched_grouphash = maybe_check_seer_for_matching_grouphash(event, all_grouphashes)
 
             if seer_matched_grouphash:
                 group_info = handle_existing_grouphash(job, seer_matched_grouphash, all_grouphashes)

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -232,7 +232,9 @@ def get_seer_similar_issues(
     return (similar_issues_metadata, parent_grouphash)
 
 
-def maybe_check_seer_for_matching_grouphash(event: Event) -> GroupHash | None:
+def maybe_check_seer_for_matching_grouphash(
+    event: Event, all_grouphashes: list[GroupHash]
+) -> GroupHash | None:
     seer_matched_grouphash = None
 
     if should_call_seer_for_grouping(event):

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -245,7 +245,6 @@ def maybe_check_seer_for_matching_grouphash(event: Event) -> GroupHash | None:
             # If no matching group is found in Seer, we'll still get back result
             # metadata, but `seer_matched_grouphash` will be None
             seer_response_data, seer_matched_grouphash = get_seer_similar_issues(event)
-            event.data["seer_similarity"] = seer_response_data
 
         # Insurance - in theory we shouldn't ever land here
         except Exception as e:


### PR DESCRIPTION
This is a follow up to https://github.com/getsentry/sentry/pull/78106, which added seer-relevant fields to the `GroupHashMetadata` table, actually using those fields to store data about Seer calls during ingest. The following data is stored:

- When the grouphash was sent to Seer
- Which event's stacktrace was sent (stored as an event id)
- The Seer model version used to analyze the stacktrace
- The matched hash returned by Seer, if any (stored as a reference to that hash's `GroupHash` record)
- The similarity distance returned by Seer, if any

Notes:

- As a result of this change, we're no longer storing Seer results in event data. This is better - before, to see the Seer results you had to find the first event to generate a given hash (which is the first event in a group in cases where Seer doesn't find a match, but is some random event among a group's full event list in cases where Seer does match to an existing group). Now, you can find Seer resuls from any event in a group, via the group's `GroupHash` records. (It did mean I had to pull out some temporary logs I had added to group creation, but it's unclear if they're still necessary. If the issue which prompted them comes up again, I'll add them back in a different way.)

- As agreed offline, I'm updating the `GroupHashMetadata` records which are created elsewhere (rather than waiting to create them until the Seer results are available, or until we decide not to call Seer) because it's easier to reason about and because the cardinality here is low, given that more than 99% of events match to an existing group and therefore never hit this code. If, after the `GroupHashMetadata` MVP is done, we decide we need to optimize this, we can do so before GA.

- Not done here: Updating the backfill code to store Seer results in grouphash metadata rather than on the group. This should be done before the next time we run a backfill, but given that the current backfill is already half-completed, having them in one place for new groups and a different (single) place for backfilled groups - while not ideal - seemed better than having them in one place for new groups and sometimes the same place but sometimes a different place for backfilled groups.