### PR TITLE
fix(issues): Apply client sample rate to issue occurrence consumer

### DIFF
--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -351,7 +351,6 @@ def _process_message(
     with sentry_sdk.start_transaction(
         op="_process_message",
         name="issues.occurrence_consumer",
-        sampled=True,
     ) as txn:
         try:
             # Messages without payload_type default to an OCCURRENCE payload


### PR DESCRIPTION
The issue occurrence consumer creates high a high volume of spans and
transactions that were previously sampled on the server. It is now one of the
main contributors for reaching rate limits, so this removes the forced sample
decision.

