### PR TITLE
chore(issue-details): Fix sidebar padding

### DIFF
--- a/static/app/components/group/externalIssuesList/streamlinedExternalIssueList.tsx
+++ b/static/app/components/group/externalIssuesList/streamlinedExternalIssueList.tsx
@@ -36,17 +36,17 @@ export function StreamlinedExternalIssueList({
 
   if (isLoading) {
     return (
-      <SidebarSection.Wrap data-test-id="linked-issues">
+      <div data-test-id="linked-issues">
         <StyledSectionTitle>{t('Issue Tracking')}</StyledSectionTitle>
         <SidebarSection.Content>
           <Placeholder height="25px" />
         </SidebarSection.Content>
-      </SidebarSection.Wrap>
+      </div>
     );
   }
 
   return (
-    <SidebarSection.Wrap data-test-id="linked-issues">
+    <div data-test-id="linked-issues">
       <StyledSectionTitle>{t('Issue Tracking')}</StyledSectionTitle>
       <SidebarSection.Content>
         {integrations.length || linkedIssues.length ? (
@@ -130,7 +130,7 @@ export function StreamlinedExternalIssueList({
           </AlertLink>
         )}
       </SidebarSection.Content>
-    </SidebarSection.Wrap>
+    </div>
   );
 }
 


### PR DESCRIPTION
this pr updates the padding in the streamlined sidebar

before: 
<img width="324" alt="Screenshot 2024-09-25 at 10 15 30 AM" src="https://github.com/user-attachments/assets/971c511e-b33b-44c1-93e8-9b8904219dad">

after: 
<img width="333" alt="Screenshot 2024-09-25 at 10 16 49 AM" src="https://github.com/user-attachments/assets/e0eaca59-b18e-43a2-ab41-00fea7f19b88">
