### PR TITLE
feat(dashboards): Implement previous period data for `BigNumberWidget`

### DIFF
--- a/static/app/components/percentChange.spec.tsx
+++ b/static/app/components/percentChange.spec.tsx
@@ -26,4 +26,10 @@ describe('PercentChange', function () {
 
     expect(screen.getByText('+5.52%')).toHaveAttribute('data-rating', 'good');
   });
+
+  it('respects lack of polarity preference', () => {
+    render(<PercentChange value={0.0552} preferredPolarity="" />);
+
+    expect(screen.getByText('+5.52%')).toHaveAttribute('data-rating', 'neutral');
+  });
 });

--- a/static/app/components/percentChange.tsx
+++ b/static/app/components/percentChange.tsx
@@ -50,6 +50,10 @@ export function getPolarityRating(
   polarity: Polarity,
   preferredPolarity: Polarity
 ): Rating {
+  if (preferredPolarity === '') {
+    return 'neutral';
+  }
+
   if (polarity === preferredPolarity) {
     return 'good';
   }

--- a/static/app/components/percentChange.tsx
+++ b/static/app/components/percentChange.tsx
@@ -34,7 +34,7 @@ export function PercentChange({
   );
 }
 
-function getPolarity(value: number): Polarity {
+export function getPolarity(value: number): Polarity {
   if (value > 0) {
     return '+';
   }
@@ -46,7 +46,10 @@ function getPolarity(value: number): Polarity {
   return '';
 }
 
-function getPolarityRating(polarity: Polarity, preferredPolarity: Polarity): Rating {
+export function getPolarityRating(
+  polarity: Polarity,
+  preferredPolarity: Polarity
+): Rating {
   if (polarity === preferredPolarity) {
     return 'good';
   }
@@ -58,7 +61,7 @@ function getPolarityRating(polarity: Polarity, preferredPolarity: Polarity): Rat
   return 'neutral';
 }
 
-const ColorizedRating = styled('div')<{
+export const ColorizedRating = styled('div')<{
   rating: Rating;
 }>`
   color: ${p =>

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.spec.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.spec.tsx
@@ -92,4 +92,35 @@ describe('BigNumberWidget', () => {
       expect(screen.getByText('Error: Uh oh')).toBeInTheDocument();
     });
   });
+
+  describe('Previous Period Data', () => {
+    it('Shows the difference between the current and previous data', () => {
+      render(
+        <BigNumberWidget
+          title="http_response_code_rate(500)"
+          data={[
+            {
+              'http_response_code_rate(500)': 0.14227123,
+            },
+          ]}
+          previousPeriodData={[
+            {
+              'http_response_code_rate(500)': 0.1728139,
+            },
+          ]}
+          meta={{
+            fields: {
+              'http_response_code_rate(500)': 'percentage',
+            },
+            units: {
+              'http_response_code_rate(500)': null,
+            },
+          }}
+        />
+      );
+
+      expect(screen.getByText('14.23%')).toBeInTheDocument();
+      expect(screen.getByText('3.05%')).toBeInTheDocument();
+    });
+  });
 });

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
@@ -114,9 +114,76 @@ export default storyBook(BigNumberWidget, story => {
       </Fragment>
     );
   });
+
+  story('Previous Period Data', () => {
+    return (
+      <Fragment>
+        <p>
+          <JSXNode name="BigNumberWidget" /> shows the difference of the current data and
+          the previous period data as the difference between the two values, in small text
+          next to the main value.
+        </p>
+
+        <SideBySide>
+          <NormalWidget>
+            <BigNumberWidget
+              title="eps()"
+              data={[
+                {
+                  'eps()': 17.1087819860850493,
+                },
+              ]}
+              previousPeriodData={[
+                {
+                  'eps()': 15.0088607819850493,
+                },
+              ]}
+              meta={{
+                fields: {
+                  'eps()': 'rate',
+                },
+                units: {
+                  'eps()': '1/second',
+                },
+              }}
+            />
+          </NormalWidget>
+
+          <NormalWidget>
+            <BigNumberWidget
+              title="http_response_code_rate(500)"
+              data={[
+                {
+                  'http_response_code_rate(500)': 0.14227123,
+                },
+              ]}
+              previousPeriodData={[
+                {
+                  'http_response_code_rate(500)': 0.1728139,
+                },
+              ]}
+              meta={{
+                fields: {
+                  'http_response_code_rate(500)': 'percentage',
+                },
+                units: {
+                  'http_response_code_rate(500)': null,
+                },
+              }}
+            />
+          </NormalWidget>
+        </SideBySide>
+      </Fragment>
+    );
+  });
 });
 
 const SmallSizingWindow = styled(SizingWindow)`
   width: auto;
   height: 200px;
+`;
+
+const NormalWidget = styled('div')`
+  width: 250px;
+  height: 100px;
 `;

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
@@ -151,23 +151,48 @@ export default storyBook(BigNumberWidget, story => {
 
           <NormalWidget>
             <BigNumberWidget
-              title="http_response_code_rate(500)"
+              title="http_rate(500)"
               data={[
                 {
-                  'http_response_code_rate(500)': 0.14227123,
+                  'http_rate(500)': 0.14227123,
                 },
               ]}
               previousPeriodData={[
                 {
-                  'http_response_code_rate(500)': 0.1728139,
+                  'http_rate(500)': 0.1728139,
                 },
               ]}
+              preferredPolarity="-"
               meta={{
                 fields: {
-                  'http_response_code_rate(500)': 'percentage',
+                  'http_rate(500)': 'percentage',
                 },
                 units: {
-                  'http_response_code_rate(500)': null,
+                  'http_rate(500)': null,
+                },
+              }}
+            />
+          </NormalWidget>
+          <NormalWidget>
+            <BigNumberWidget
+              title="http_rate(200)"
+              data={[
+                {
+                  'http_rate(200)': 0.14227123,
+                },
+              ]}
+              previousPeriodData={[
+                {
+                  'http_rate(200)': 0.1728139,
+                },
+              ]}
+              preferredPolarity="+"
+              meta={{
+                fields: {
+                  'http_rate(200)': 'percentage',
+                },
+                units: {
+                  'http_rate(200)': null,
                 },
               }}
             />

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
@@ -21,6 +21,7 @@ export function BigNumberWidget(props: Props) {
         <BigNumberWidgetVisualization
           data={props.data}
           previousPeriodData={props.previousPeriodData}
+          preferredPolarity={props.preferredPolarity}
           meta={props.meta}
           isLoading={props.isLoading}
           error={props.error}

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
@@ -20,6 +20,7 @@ export function BigNumberWidget(props: Props) {
       <BigNumberResizeWrapper>
         <BigNumberWidgetVisualization
           data={props.data}
+          previousPeriodData={props.previousPeriodData}
           meta={props.meta}
           isLoading={props.isLoading}
           error={props.error}
@@ -30,8 +31,7 @@ export function BigNumberWidget(props: Props) {
 }
 
 const BigNumberResizeWrapper = styled('div')`
-  flex-grow: 1;
-  overflow: hidden;
   position: relative;
-  margin: ${space(1)} ${space(3)} ${space(3)} ${space(3)};
+  flex-grow: 1;
+  margin-top: ${space(1)};
 `;

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
@@ -7,6 +7,7 @@ import {getFieldFormatter} from 'sentry/utils/discover/fieldRenderers';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {AutoSizedText} from 'sentry/views/dashboards/widgetCard/autoSizedText';
+import {DifferenceToPreviousPeriodData} from 'sentry/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodData';
 import {NO_DATA_PLACEHOLDER} from 'sentry/views/dashboards/widgets/bigNumberWidget/settings';
 import {ErrorPanel} from 'sentry/views/dashboards/widgets/common/errorPanel';
 import type {
@@ -18,10 +19,11 @@ import type {
 export interface Props extends StateProps {
   data?: TableData;
   meta?: Meta;
+  previousPeriodData?: TableData;
 }
 
 export function BigNumberWidgetVisualization(props: Props) {
-  const {data, meta, isLoading, error} = props;
+  const {data, previousPeriodData, meta, isLoading, error} = props;
 
   const location = useLocation();
   const organization = useOrganization();
@@ -34,7 +36,7 @@ export function BigNumberWidgetVisualization(props: Props) {
   const datum = data?.[0];
   // TODO: Instrument getting more than one data key back as an error
 
-  if (isLoading || !defined(datum) || Object.keys(datum).length === 0) {
+  if (isLoading || !defined(data) || !defined(datum) || Object.keys(datum).length === 0) {
     return (
       <AutoResizeParent>
         <AutoSizedText>
@@ -53,20 +55,35 @@ export function BigNumberWidgetVisualization(props: Props) {
     : value => value.toString();
 
   const unit = meta?.units?.[field];
-  const rendered = fieldFormatter(datum, {
+  const baggage = {
     location,
     organization,
     unit: unit ?? undefined, // TODO: Field formatters think units can't be null but they can
-  });
+  };
+
+  const rendered = fieldFormatter(datum, baggage);
 
   return (
     <AutoResizeParent>
       <AutoSizedText>
-        <NumberContainerOverride>
-          <Tooltip title={datum[field]} isHoverable delay={0}>
-            {rendered}
-          </Tooltip>
-        </NumberContainerOverride>
+        <NumberContainer>
+          <NumberContainerOverride>
+            <Tooltip title={datum[field]} isHoverable delay={0}>
+              {rendered}
+            </Tooltip>
+          </NumberContainerOverride>
+
+          {previousPeriodData && (
+            <DifferenceToPreviousPeriodData
+              data={data}
+              previousPeriodData={previousPeriodData}
+              formatter={(previousDatum: TableData[number]) =>
+                fieldFormatter(previousDatum, baggage)
+              }
+              field={field}
+            />
+          )}
+        </NumberContainer>
       </AutoSizedText>
     </AutoResizeParent>
   );
@@ -74,8 +91,12 @@ export function BigNumberWidgetVisualization(props: Props) {
 
 const AutoResizeParent = styled('div')`
   position: absolute;
-  color: ${p => p.theme.headingColor};
   inset: 0;
+
+  color: ${p => p.theme.headingColor};
+
+  container-type: size;
+  container-name: auto-resize-parent;
 
   * {
     line-height: 1;
@@ -83,8 +104,14 @@ const AutoResizeParent = styled('div')`
   }
 `;
 
+const NumberContainer = styled('div')`
+  display: flex;
+  align-items: flex-end;
+  gap: min(8px, 3cqw);
+`;
+
 const NumberContainerOverride = styled('div')`
-  display: inline-block;
+  display: inline-flex;
 
   * {
     text-overflow: clip !important;

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import type {Polarity} from 'sentry/components/percentChange';
 import {Tooltip} from 'sentry/components/tooltip';
 import {defined} from 'sentry/utils';
 import type {MetaType} from 'sentry/utils/discover/eventView';
@@ -19,11 +20,12 @@ import type {
 export interface Props extends StateProps {
   data?: TableData;
   meta?: Meta;
+  preferredPolarity?: Polarity;
   previousPeriodData?: TableData;
 }
 
 export function BigNumberWidgetVisualization(props: Props) {
-  const {data, previousPeriodData, meta, isLoading, error} = props;
+  const {data, previousPeriodData, preferredPolarity, meta, isLoading, error} = props;
 
   const location = useLocation();
   const organization = useOrganization();
@@ -77,6 +79,7 @@ export function BigNumberWidgetVisualization(props: Props) {
             <DifferenceToPreviousPeriodData
               data={data}
               previousPeriodData={previousPeriodData}
+              preferredPolarity={preferredPolarity}
               formatter={(previousDatum: TableData[number]) =>
                 fieldFormatter(previousDatum, baggage)
               }

--- a/static/app/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodData.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodData.tsx
@@ -1,0 +1,87 @@
+import styled from '@emotion/styled';
+import isNumber from 'lodash/isNumber';
+
+import {
+  ColorizedRating,
+  getPolarity,
+  getPolarityRating,
+  type Polarity,
+} from 'sentry/components/percentChange';
+import {IconArrow} from 'sentry/icons';
+import {space} from 'sentry/styles/space';
+import {NO_DATA_PLACEHOLDER} from 'sentry/views/dashboards/widgets/bigNumberWidget/settings';
+import type {TableData} from 'sentry/views/dashboards/widgets/common/types';
+
+interface Props {
+  data: TableData;
+  field: string;
+  formatter: (datum: TableData[number]) => React.ReactNode;
+  previousPeriodData: TableData;
+  preferredPolarity?: Polarity;
+}
+
+export function DifferenceToPreviousPeriodData({
+  data,
+  previousPeriodData,
+  preferredPolarity = '',
+  field,
+  formatter,
+}: Props) {
+  const currentValue = data[0][field];
+  const previousValue = previousPeriodData[0][field];
+
+  if (!isNumber(currentValue) || !isNumber(previousValue)) {
+    return <Deemphasize>{NO_DATA_PLACEHOLDER}</Deemphasize>;
+  }
+
+  const difference = currentValue - previousValue;
+  const polarity = getPolarity(difference);
+  const rating = getPolarityRating(polarity, preferredPolarity);
+
+  const directionMarker = getDifferenceDirectionMarker(difference);
+
+  // Create a fake data row so we can pass it to field renderers. Omit the +/- sign since the direction marker will indicate it
+  const differenceAsDatum = {
+    [field]: Math.abs(difference),
+  };
+
+  return (
+    <Difference rating={rating}>
+      <Indicator>{directionMarker}</Indicator>
+      <Number>{formatter(differenceAsDatum)}</Number>
+    </Difference>
+  );
+}
+
+const Difference = styled(ColorizedRating)`
+  display: flex;
+  gap: ${space(0.5)};
+
+  @container (min-height: 50px) {
+    padding-bottom: 5cqh;
+  }
+`;
+
+const Number = styled('div')`
+  font-size: clamp(14px, calc(10px + 4cqi), 30cqh);
+`;
+
+const Indicator = styled('div')`
+  font-size: clamp(14px, calc(10px + 4cqi), 30cqh);
+`;
+
+const Deemphasize = styled('span')`
+  color: ${p => p.theme.gray300};
+`;
+
+function getDifferenceDirectionMarker(difference: number) {
+  if (difference > 0) {
+    return <IconArrow direction="up" size="xs" />;
+  }
+
+  if (difference < 0) {
+    return <IconArrow direction="down" size="xs" />;
+  }
+
+  return null;
+}

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -47,6 +47,8 @@ const Frame = styled('div')`
   height: 100%;
   width: 100%;
 
+  padding: ${space(2)};
+
   border-radius: ${p => p.theme.panelBorderRadius};
   border: ${p => p.theme.border};
   border: 1px ${p => 'solid ' + p.theme.border};
@@ -58,10 +60,7 @@ const Header = styled('div')`
   display: flex;
   flex-direction: column;
 
-  width: 100%;
   min-height: 36px;
-
-  padding: ${space(2)} ${space(1)} 0 ${space(3)};
 `;
 
 const Title = styled('div')`


### PR DESCRIPTION
See [specification for details](https://www.notion.so/sentry/Widget-Components-Spec-c8aec2bc216a446b9616e31085204ce0?pvs=4#059656f8739f4ef5988dcfa345ec0c22). The layout is a little rough around the edges, but I'll know more once I see it live somewhere during integration.

**e.g.,**

<img width="554" alt="Screenshot 2024-09-25 at 1 44 45 PM" src="https://github.com/user-attachments/assets/8f8fa7de-e93d-4b78-94e6-80b99abeb10f">
