### PR TITLE
ref(alerts): Update rule status on dynamic alert rule update

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1009,17 +1009,7 @@ def update_alert_rule(
                 "time_window", timedelta(seconds=snuba_query.time_window)
             )
             updated_query_fields.setdefault("event_types", None)
-            if detection_type and detection_type == AlertRuleDetectionType.DYNAMIC:
-                updated_query_fields.setdefault(
-                    "resolution",
-                    timedelta(
-                        seconds=time_window if time_window is not None else snuba_query.time_window
-                    ),
-                )
-            else:
-                updated_query_fields.setdefault(
-                    "resolution", timedelta(seconds=snuba_query.resolution)
-                )
+            updated_query_fields.setdefault("resolution", timedelta(seconds=snuba_query.resolution))
             update_snuba_query(snuba_query, environment=environment, **updated_query_fields)
 
         existing_subs: Iterable[QuerySubscription] = ()

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -936,7 +936,6 @@ def update_alert_rule(
                 raise ResourceDoesNotExist(
                     "Your organization does not have access to this feature."
                 )
-
             if updated_fields.get("detection_type") == AlertRuleDetectionType.DYNAMIC and (
                 alert_rule.detection_type != AlertRuleDetectionType.DYNAMIC or query or aggregate
             ):
@@ -952,6 +951,11 @@ def update_alert_rule(
                     if rule_status == AlertRuleStatus.NOT_ENOUGH_DATA:
                         # if we don't have at least seven days worth of data, then the dynamic alert won't fire
                         alert_rule.update(status=AlertRuleStatus.NOT_ENOUGH_DATA.value)
+                    elif (
+                        rule_status == AlertRuleStatus.PENDING
+                        and alert_rule.status != AlertRuleStatus.PENDING
+                    ):
+                        alert_rule.update(status=AlertRuleStatus.PENDING.value)
                 except (TimeoutError, MaxRetryError):
                     raise TimeoutError("Failed to send data to Seer - cannot update alert rule.")
                 except ParseError:

--- a/src/sentry/seer/anomaly_detection/store_data.py
+++ b/src/sentry/seer/anomaly_detection/store_data.py
@@ -35,7 +35,6 @@ seer_anomaly_detection_connection_pool = connection_from_url(
     settings.SEER_ANOMALY_DETECTION_URL,
     timeout=settings.SEER_ANOMALY_DETECTION_TIMEOUT,
 )
-NUM_DAYS = 28
 MIN_DAYS = 7
 
 

--- a/src/sentry/seer/anomaly_detection/store_data.py
+++ b/src/sentry/seer/anomaly_detection/store_data.py
@@ -62,7 +62,7 @@ def send_historical_data_to_seer(
     alert_rule: AlertRule,
     project: Project,
     snuba_query=None,
-    event_types: list[SnubaQueryEventType] | None = None,
+    event_types: list[SnubaQueryEventType.EventType] | None = None,
 ) -> AlertRuleStatus:
     """
     Get 28 days of historical data and pass it to Seer to be used for prediction anomalies on the alert.

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -23,6 +23,12 @@ from sentry.utils.snuba import SnubaTSResult
 
 NUM_DAYS = 28
 
+SNUBA_QUERY_EVENT_TYPE_TO_STRING = {
+    SnubaQueryEventType.EventType.ERROR: "error",
+    SnubaQueryEventType.EventType.DEFAULT: "default",
+    SnubaQueryEventType.EventType.TRANSACTION: "transaction",
+}
+
 
 def translate_direction(direction: int) -> str:
     """
@@ -42,16 +48,11 @@ def get_snuba_query_string(
     """
     Generate a query string that matches what the OrganizationEventsStatsEndpoint does
     """
-    SNUBA_QUERY_EVENT_TYPE_TO_STRING = {
-        SnubaQueryEventType.EventType.ERROR: "error",
-        SnubaQueryEventType.EventType.DEFAULT: "default",
-        SnubaQueryEventType.EventType.TRANSACTION: "transaction",
-    }
     if not event_types:
         event_types = snuba_query.event_types or []
 
     if len(event_types) > 1:
-        # e.g. (is:unresolved) AND (event.type:[error, default])
+        # e.g. '(is:unresolved) AND (event.type:[error, default])'
         event_types_list = [
             SNUBA_QUERY_EVENT_TYPE_TO_STRING[event_type] for event_type in event_types
         ]
@@ -59,7 +60,7 @@ def get_snuba_query_string(
         event_types_string += ", ".join(event_types_list)
         event_types_string += "])"
     else:
-        # e.g. (is:unresolved) AND (event.type:error)
+        # e.g. '(is:unresolved) AND (event.type:error)'
         snuba_query_event_type_string = SNUBA_QUERY_EVENT_TYPE_TO_STRING[event_types[0]]
         event_types_string = f"(event.type:{snuba_query_event_type_string})"
     if snuba_query.query:
@@ -175,6 +176,7 @@ def get_dataset_from_label(dataset_label: str):
     dataset = get_dataset(dataset_label)
     if dataset is None:
         raise ParseError(detail=f"dataset must be one of: {', '.join(DATASET_OPTIONS.keys())}")
+    return dataset
 
 
 def fetch_historical_data(

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from django.utils import timezone
 from django.utils.datastructures import MultiValueDict
+from rest_framework.exceptions import ParseError
 
 from sentry import release_health
 from sentry.api.bases.organization_events import resolve_axis_column
@@ -17,7 +18,7 @@ from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.snuba.models import SnubaQuery, SnubaQueryEventType
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.sessions_v2 import QueryDefinition
-from sentry.snuba.utils import get_dataset
+from sentry.snuba.utils import DATASET_OPTIONS, get_dataset
 from sentry.utils.snuba import SnubaTSResult
 
 NUM_DAYS = 28
@@ -171,7 +172,9 @@ def get_dataset_from_label(dataset_label: str):
     elif dataset_label in ["generic_metrics", "transactions"]:
         # XXX: performance alerts dataset differs locally vs in prod
         dataset_label = "discover"
-    return get_dataset(dataset_label)
+    dataset = get_dataset(dataset_label)
+    if dataset is None:
+        raise ParseError(detail=f"dataset must be one of: {', '.join(DATASET_OPTIONS.keys())}")
 
 
 def fetch_historical_data(

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -36,7 +36,7 @@ def translate_direction(direction: int) -> str:
 
 
 def get_snuba_query_string(
-    snuba_query: SnubaQuery, event_types: list[SnubaQueryEventType] | None = None
+    snuba_query: SnubaQuery, event_types: list[SnubaQueryEventType.EventType] | None = None
 ) -> str:
     """
     Generate a query string that matches what the OrganizationEventsStatsEndpoint does
@@ -47,9 +47,9 @@ def get_snuba_query_string(
         SnubaQueryEventType.EventType.TRANSACTION: "transaction",
     }
     if not event_types:
-        event_types = snuba_query.event_types
+        event_types = snuba_query.event_types or []
 
-    if len(snuba_query.event_types) > 1:
+    if len(event_types) > 1:
         # e.g. (is:unresolved) AND (event.type:[error, default])
         event_types_list = [
             SNUBA_QUERY_EVENT_TYPE_TO_STRING[event_type] for event_type in event_types
@@ -181,7 +181,7 @@ def fetch_historical_data(
     project: Project,
     start: datetime | None = None,
     end: datetime | None = None,
-    event_types: list[SnubaQueryEventType] | None = None,
+    event_types: list[SnubaQueryEventType.EventType] | None = None,
 ) -> SnubaTSResult | None:
     """
     Fetch 28 days of historical data from Snuba to pass to Seer to build the anomaly detection model

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -101,7 +101,7 @@ from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.testutils.cases import BaseIncidentsTest, BaseMetricsTestCase, TestCase
-from sentry.testutils.helpers.datetime import before_now, freeze_time
+from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of
@@ -1755,6 +1755,119 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
     @patch(
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
+    def test_update_dynamic_alert_not_enough_to_pending(self, mock_seer_request):
+        """
+        Update a dynamic rule's aggregate so the rule's status changes from not enough data to enough/pending
+        """
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
+
+        dynamic_rule = self.create_alert_rule(
+            sensitivity=AlertRuleSensitivity.HIGH,
+            seasonality=AlertRuleSeasonality.AUTO,
+            time_window=60,
+            detection_type=AlertRuleDetectionType.DYNAMIC,
+        )
+        assert mock_seer_request.call_count == 1
+        assert dynamic_rule.status == AlertRuleStatus.NOT_ENOUGH_DATA.value
+        mock_seer_request.reset_mock()
+
+        two_weeks_ago = before_now(days=14).replace(hour=10, minute=0, second=0, microsecond=0)
+        with self.options({"issues.group_attributes.send_kafka": True}):
+            self.store_event(
+                data={
+                    "event_id": "a" * 32,
+                    "message": "super bad",
+                    "timestamp": iso_format(two_weeks_ago + timedelta(minutes=1)),
+                    "tags": {"sentry:user": self.user.email},
+                    "exception": [{"value": "BadError"}],
+                },
+                project_id=self.project.id,
+            )
+            self.store_event(
+                data={
+                    "event_id": "a" * 32,
+                    "message": "super bad",
+                    "timestamp": iso_format(two_weeks_ago + timedelta(days=10)),  # 4 days ago
+                    "tags": {"sentry:user": self.user.email},
+                    "exception": [{"value": "BadError"}],
+                },
+                project_id=self.project.id,
+            )
+        # update aggregate
+        update_alert_rule(
+            dynamic_rule,
+            aggregate="count_unique(user)",
+            time_window=60,
+            detection_type=AlertRuleDetectionType.DYNAMIC,
+        )
+        assert mock_seer_request.call_count == 1
+        assert dynamic_rule.status == AlertRuleStatus.PENDING.value
+
+    @with_feature("organizations:anomaly-detection-alerts")
+    @patch(
+        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
+    )
+    def test_update_dynamic_alert_pending_to_not_enough(self, mock_seer_request):
+        """
+        Update a dynamic rule's aggregate so the rule's status changes from enough/pending to not enough data
+        """
+        seer_return_value: StoreDataResponse = {"success": True}
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
+
+        two_weeks_ago = before_now(days=14).replace(hour=10, minute=0, second=0, microsecond=0)
+        with self.options({"issues.group_attributes.send_kafka": True}):
+            self.store_event(
+                data={
+                    "event_id": "b" * 32,
+                    "message": "super bad",
+                    "timestamp": iso_format(two_weeks_ago + timedelta(minutes=1)),
+                    "fingerprint": ["group2"],
+                    "tags": {"sentry:user": self.user.email},
+                    "exception": [{"value": "BadError"}],
+                },
+                project_id=self.project.id,
+            )
+            self.store_event(
+                data={
+                    "event_id": "b" * 32,
+                    "message": "super bad",
+                    "timestamp": iso_format(two_weeks_ago + timedelta(days=10)),  # 4 days ago
+                    "fingerprint": ["group2"],
+                    "tags": {"sentry:user": self.user.email},
+                    "exception": [{"value": "BadError"}],
+                },
+                project_id=self.project.id,
+            )
+
+        dynamic_rule = self.create_alert_rule(
+            sensitivity=AlertRuleSensitivity.HIGH,
+            seasonality=AlertRuleSeasonality.AUTO,
+            time_window=60,
+            detection_type=AlertRuleDetectionType.DYNAMIC,
+        )
+        assert mock_seer_request.call_count == 1
+        assert dynamic_rule.status == AlertRuleStatus.PENDING.value
+
+        mock_seer_request.reset_mock()
+
+        # update aggregate
+        update_alert_rule(
+            dynamic_rule,
+            aggregate="p95(measurements.fid)",  # first input delay data we don't have stored
+            dataset=Dataset.Transactions,
+            event_types=[SnubaQueryEventType.EventType.TRANSACTION],
+            query="",
+            # time_window=60,
+            detection_type=AlertRuleDetectionType.DYNAMIC,
+        )
+        assert mock_seer_request.call_count == 1
+        assert dynamic_rule.status == AlertRuleStatus.NOT_ENOUGH_DATA.value
+
+    @with_feature("organizations:anomaly-detection-alerts")
+    @patch(
+        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
+    )
     def test_update_alert_rule_static_to_dynamic_not_enough_data(self, mock_seer_request):
         """
         Assert that the status is NOT_ENOUGH_DATA if we don't have 7 days of data.
@@ -1830,6 +1943,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
             seasonality=AlertRuleSeasonality.AUTO,
             time_window=60,
             detection_type=AlertRuleDetectionType.DYNAMIC,
+            name="my rule",
         )
         assert mock_seer_request.call_count == 1
         mock_seer_request.reset_mock()
@@ -1845,6 +1959,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
                 detection_type=AlertRuleDetectionType.DYNAMIC,
                 sensitivity=AlertRuleSensitivity.HIGH,
                 seasonality=AlertRuleSeasonality.AUTO,
+                name="your rule",
             )
 
         assert mock_logger.warning.call_count == 1
@@ -1865,10 +1980,16 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
                 detection_type=AlertRuleDetectionType.DYNAMIC,
                 sensitivity=AlertRuleSensitivity.HIGH,
                 seasonality=AlertRuleSeasonality.AUTO,
+                name="hellboy's rule",
             )
 
         assert mock_logger.warning.call_count == 1
         assert mock_seer_request.call_count == 1
+        # make sure the rule wasn't updated - need to refetch
+        fresh_dynamic_rule = AlertRule.objects.get(id=dynamic_rule.id)
+        assert fresh_dynamic_rule.name == "my rule"
+        assert fresh_dynamic_rule.snuba_query.time_window == 60 * 60
+        assert fresh_dynamic_rule.snuba_query.query == "level:error"
 
     @with_feature("organizations:anomaly-detection-alerts")
     @patch(

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1988,6 +1988,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         # make sure the rule wasn't updated - need to refetch
         fresh_dynamic_rule = AlertRule.objects.get(id=dynamic_rule.id)
         assert fresh_dynamic_rule.name == "my rule"
+        assert fresh_dynamic_rule.snuba_query
         assert fresh_dynamic_rule.snuba_query.time_window == 60 * 60
         assert fresh_dynamic_rule.snuba_query.query == "level:error"
 


### PR DESCRIPTION
A classic "various fixes" including:

If we’re updating the alert rule status from dynamic to dynamic, we also need to update the status to be PENDING if the updated alert rule has enough data.

This also fixes setting the resolution to be equal to the time window for dynamic alerts which was initially added in https://github.com/getsentry/sentry/pull/77364 but missed a spot further down in the code, and set the timedelta to minutes when it should be seconds.

I noticed that we weren't updating the snuba query data that we pass to Seer if the aggregate, dataset, or query changes when the rule is updated, so I fixed that as well.

Closes https://getsentry.atlassian.net/browse/ALRT-281