### PR TITLE
feat(rr6): Always use react-router 6

### DIFF
--- a/static/app/index.tsx
+++ b/static/app/index.tsx
@@ -67,22 +67,8 @@
 //
 // [1]: https://sentry.io/careers/
 
-// TODO(__SENTRY_USING_REACT_ROUTER_SIX): Very early on check if we're running
-// using the react-router 6 faeture flag so we can enable ths beefore the app
-// boots.
-//
-try {
-  if (
-    process.env.NODE_ENV === 'development' ||
-    // @ts-expect-error features is an array at this point. It is unfortuantely
-    // typed incorrectly
-    window.__initialData?.features?.includes('organizations:react-router-6')
-  ) {
-    window.__SENTRY_USING_REACT_ROUTER_SIX = true;
-  }
-} catch {
-  // XXX: Just don't crash the app for any reason
-}
+// TODO(__SENTRY_USING_REACT_ROUTER_SIX): Always on until we full remove 3
+window.__SENTRY_USING_REACT_ROUTER_SIX = true;
 
 async function app() {
   // We won't need initalizeMainImport until we complete bootstrapping.


### PR DESCRIPTION
This removes the feature flag checking on the frontend and enforces `window.__SENTRY_USING_REACT_ROUTER_SIX` as true.

There is no going back after this.

getsentry: https://github.com/getsentry/getsentry/pull/15252