### PR TITLE
fix(spans): Support new attr format

### DIFF
--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -1309,7 +1309,7 @@ class BaseQueryBuilder:
         if search_filter.operator in ("=", "!=") and search_filter.value.value == "":
             if is_tag or is_attr or is_context or name in self.config.non_nullable_keys:
                 return Condition(lhs, Op(search_filter.operator), value)
-            else:
+            elif isinstance(lhs, Column):
                 # If not a tag, we can just check that the column is null.
                 return Condition(Function("isNull", [lhs]), Op(search_filter.operator), 1)
 

--- a/src/sentry/search/events/builder/spans_indexed.py
+++ b/src/sentry/search/events/builder/spans_indexed.py
@@ -108,7 +108,7 @@ class SpansEAPQueryBuilder(SpansIndexedQueryBuilderMixin, BaseQueryBuilder):
                 return Function(
                     "if",
                     [
-                        Function("notEquals", [unprefixed_field, ""]),
+                        Function("mapContains", [Column("attr_str"), key]),
                         unprefixed_field,
                         prefixed_field,
                     ],
@@ -142,7 +142,7 @@ class SpansEAPQueryBuilder(SpansIndexedQueryBuilderMixin, BaseQueryBuilder):
         col = Function(
             "if",
             [
-                Function("notEquals", [unprefixed_field, "" if attr_type == "attr_str" else 0]),
+                Function("mapContains", [Column(attr_type), field]),
                 unprefixed_field,
                 prefixed_field,
             ],

--- a/src/sentry/search/events/builder/spans_indexed.py
+++ b/src/sentry/search/events/builder/spans_indexed.py
@@ -89,7 +89,33 @@ class SpansEAPQueryBuilder(SpansIndexedQueryBuilderMixin, BaseQueryBuilder):
             # attr field is less permissive than tags, we can't have - in them
             or "-" in field
         ):
-            return super().resolve_field(raw_field, alias)
+            # Temporary until at least after 22 Dec 2024 when old data rotates out, otherwise we should just call super
+            # here and return default_field without any extra work
+            default_field = super().resolve_field(raw_field, alias)
+            if (
+                isinstance(default_field, Column)
+                and default_field.subscriptable == "attr_str"
+                or isinstance(default_field, AliasedExpression)
+                and default_field.exp.subscriptable == "attr_str"
+            ):
+                key = (
+                    default_field.key
+                    if isinstance(default_field, Column)
+                    else default_field.exp.key
+                )
+                unprefixed_field = Column(f"attr_str[{key}]")
+                prefixed_field = Column(f"attr_str[sentry.{key}]")
+                return Function(
+                    "if",
+                    [
+                        Function("notEquals", [unprefixed_field, ""]),
+                        unprefixed_field,
+                        prefixed_field,
+                    ],
+                    raw_field if alias else None,
+                )
+            else:
+                return default_field
 
         if field_type not in ["number", "string"]:
             raise InvalidSearchQuery(
@@ -97,17 +123,33 @@ class SpansEAPQueryBuilder(SpansIndexedQueryBuilderMixin, BaseQueryBuilder):
             )
 
         if field_type == "string":
-            col = Column(f"attr_str[{field}]")
+            attr_type = "attr_str"
+            field_col = Column(f"attr_str[{field}]")
         else:
-            col = Column(f"attr_num[{field}]")
+            attr_type = "attr_num"
+            field_col = Column(f"attr_num[{field}]")
 
         if alias:
             field_alias = f"tags_{field}@{field_type}"
             self.typed_tag_to_alias_map[raw_field] = field_alias
             self.alias_to_typed_tag_map[field_alias] = raw_field
-            return AliasedExpression(col, field_alias)
         else:
-            return col
+            field_alias = None
+
+        # Temporary until at least after 22 Dec 2024 when old data rotates out
+        unprefixed_field = field_col
+        prefixed_field = Column(f"{attr_type}[sentry.{field}]")
+        col = Function(
+            "if",
+            [
+                Function("notEquals", [unprefixed_field, "" if attr_type == "attr_str" else 0]),
+                unprefixed_field,
+                prefixed_field,
+            ],
+            field_alias,
+        )
+
+        return col
 
 
 class TimeseriesSpanIndexedQueryBuilder(SpansIndexedQueryBuilderMixin, TimeseriesQueryBuilder):

--- a/src/sentry/search/events/datasets/field_aliases.py
+++ b/src/sentry/search/events/datasets/field_aliases.py
@@ -93,11 +93,11 @@ def resolve_span_module(builder: BaseQueryBuilder, alias: str) -> SelectType:
     return Function(
         "if",
         [
-            Function("in", [builder.column("span.op"), list(OP_MAPPING.keys())]),
+            Function("in", [builder.resolve_field("span.op"), list(OP_MAPPING.keys())]),
             Function(
                 "transform",
                 [
-                    builder.column("span.op"),
+                    builder.resolve_field("span.op"),
                     list(OP_MAPPING.keys()),
                     list(OP_MAPPING.values()),
                     "other",
@@ -106,7 +106,7 @@ def resolve_span_module(builder: BaseQueryBuilder, alias: str) -> SelectType:
             Function(
                 "transform",
                 [
-                    builder.column("span.category"),
+                    builder.resolve_field("span.category"),
                     constants.SPAN_MODULE_CATEGORY_VALUES,
                     constants.SPAN_MODULE_CATEGORY_VALUES,
                     "other",

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -201,13 +201,19 @@ SPAN_EAP_COLUMN_MAP = {
     "trace": "trace_id",
     "transaction": "segment_name",
     "transaction.id": "segment_id",
+    "transaction.method": "attr_str[transaction.method]",
     "is_transaction": "is_segment",
     "segment.id": "segment_id",
     # We should be able to delete origin.transaction and just use transaction
     "origin.transaction": "segment_name",
+    # Copy paste, unsure if this is truth in production
+    "messaging.destination.name": "attr_str[messaging.destination.name]",
+    "messaging.message.id": "attr_str[messaging.message.id]",
     "span.status_code": "attr_str[status_code]",
     "replay.id": "attr_str[replay_id]",
     "span.ai.pipeline.group": "attr_str[ai_pipeline_group]",
+    "trace.status": "attr_str[trace.status]",
+    "browser.name": "attr_str[browser.name]",
     "ai.total_tokens.used": "attr_num[ai_total_tokens_used]",
     "ai.total_cost": "attr_num[ai_total_cost]",
 }

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -525,7 +525,9 @@ class OrganizationEventsSpanIndexedEndpointTest(OrganizationEventsEndpointTestBa
         assert response.data["data"] == [{"foo": "", "count()": 1}]
 
 
-@pytest.mark.xfail(reason="Snuba is prefixing keys, and Sentry wasn't updated first")
+@pytest.mark.xfail(
+    reason="Snuba is not stable for the EAP dataset, xfailing since its prone to failure"
+)
 class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsSpanIndexedEndpointTest):
     is_eap = True
 
@@ -649,7 +651,11 @@ class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsSpanIndexedEndpoin
         self.store_spans(
             [
                 self.create_span(
-                    {"description": "foo", "sentry_tags": {"status": "success", "foo": "five"}},
+                    {
+                        "description": "foo",
+                        "sentry_tags": {"status": "success"},
+                        "tags": {"foo": "five"},
+                    },
                     measurements={"foo": {"value": 5}},
                     start_ts=self.ten_mins_ago,
                 ),
@@ -678,7 +684,11 @@ class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsSpanIndexedEndpoin
         self.store_spans(
             [
                 self.create_span(
-                    {"description": "foo", "sentry_tags": {"status": "success", "foo": "five"}},
+                    {
+                        "description": "foo",
+                        "sentry_tags": {"status": "success"},
+                        "tags": {"foo": "five"},
+                    },
                     measurements={"foo": {"value": 5}},
                     start_ts=self.ten_mins_ago,
                 ),
@@ -707,7 +717,11 @@ class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsSpanIndexedEndpoin
         self.store_spans(
             [
                 self.create_span(
-                    {"description": "foo", "sentry_tags": {"status": "success", "foo": "five"}},
+                    {
+                        "description": "foo",
+                        "sentry_tags": {"status": "success"},
+                        "tags": {"foo": "five"},
+                    },
                     measurements={"foo": {"value": 5}},
                     start_ts=self.ten_mins_ago,
                 ),
@@ -754,17 +768,29 @@ class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsSpanIndexedEndpoin
         self.store_spans(
             [
                 self.create_span(
-                    {"description": "baz", "sentry_tags": {"status": "success", "foo": "five"}},
+                    {
+                        "description": "baz",
+                        "sentry_tags": {"status": "success"},
+                        "tags": {"foo": "five"},
+                    },
                     measurements={"foo": {"value": 71}},
                     start_ts=self.ten_mins_ago,
                 ),
                 self.create_span(
-                    {"description": "foo", "sentry_tags": {"status": "success", "foo": "five"}},
+                    {
+                        "description": "foo",
+                        "sentry_tags": {"status": "success"},
+                        "tags": {"foo": "five"},
+                    },
                     measurements={"foo": {"value": 5}},
                     start_ts=self.ten_mins_ago,
                 ),
                 self.create_span(
-                    {"description": "bar", "sentry_tags": {"status": "success", "foo": "five"}},
+                    {
+                        "description": "bar",
+                        "sentry_tags": {"status": "success"},
+                        "tags": {"foo": "five"},
+                    },
                     measurements={"foo": {"value": 8}},
                     start_ts=self.ten_mins_ago,
                 ),


### PR DESCRIPTION
- Attrs before sep 23rd have the format `attr_str[something]`, after sep 23rd if they're sentry attrs they become `attr_str[sentry.something]`
- This means until December 22nd we'll have to query both
- Can't just do `has(attr_str, "sentry.something")` to know what to query since `attr_str` isn't a real column in Clickhouse, instead its something like `attr_str_0`
- Instead settling on doing a pseudo coalesce by checking the column isn't empty if we query for it