### PR TITLE
fix(issue-views): Fix redirect broken on save temp view

### DIFF
--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
@@ -250,15 +250,18 @@ export function DraggableTabBar({
         querySort: tempTab.querySort,
       };
       const newTabs = [...tabs, newTab];
-      navigate({
-        ...location,
-        query: {
-          ...queryParams,
-          query: tempTab.query,
-          querySort: tempTab.querySort,
-          viewId: tempId,
+      navigate(
+        {
+          ...location,
+          query: {
+            ...queryParams,
+            query: tempTab.query,
+            querySort: tempTab.querySort,
+            viewId: tempId,
+          },
         },
-      });
+        {replace: true}
+      );
       setTabs(newTabs);
       setTempTab(undefined);
       tabListState?.setSelectedKey(tempId);

--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
@@ -250,6 +250,15 @@ export function DraggableTabBar({
         querySort: tempTab.querySort,
       };
       const newTabs = [...tabs, newTab];
+      navigate({
+        ...location,
+        query: {
+          ...queryParams,
+          query: tempTab.query,
+          querySort: tempTab.querySort,
+          viewId: tempId,
+        },
+      });
       setTabs(newTabs);
       setTempTab(undefined);
       tabListState?.setSelectedKey(tempId);


### PR DESCRIPTION
fixes a minor bug where saving a temp view would incorrectly redirect to the first view, rather than the view that was just saved. 