### PR TITLE
:mag: nit(azure): add better error message

### DIFF
--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -582,8 +582,9 @@ class VstsIntegrationProvider(IntegrationProvider):
                 raise IntegrationProviderError(
                     "Sentry cannot communicate with this Azure DevOps organization.\n"
                     "Please ensure third-party app access via OAuth is enabled \n"
-                    "in the organization's security policy. \n"
-                    "The user installing the integration must have project administrator permissions."
+                    "in the organization's security policy \n"
+                    "The user installing the integration must have project administrator permissions. \n"
+                    "The user installing might also need admin permissions depending on the organization's security policy."
                 )
             raise
 

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -582,7 +582,8 @@ class VstsIntegrationProvider(IntegrationProvider):
                 raise IntegrationProviderError(
                     "Sentry cannot communicate with this Azure DevOps organization.\n"
                     "Please ensure third-party app access via OAuth is enabled \n"
-                    "in the organization's security policy."
+                    "in the organization's security policy. \n"
+                    "The user installing the integration must have project administrator permissions."
                 )
             raise
 

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -385,7 +385,7 @@ class VstsIntegrationProviderBuildIntegrationTest(VstsIntegrationTestCase):
         integration.set_pipeline(pipeline)
         with pytest.raises(IntegrationProviderError) as err:
             integration.build_integration(state)
-        assert "ensure third-party app access via OAuth is enabled" in str(err)
+        assert "Azure DevOps organization" in str(err) and "Please ensu" in str(err)
 
     @patch("sentry.integrations.vsts.VstsIntegrationProvider.get_scopes", return_value=FULL_SCOPES)
     def test_create_subscription_unauthorized(self, mock_get_scopes):
@@ -420,7 +420,7 @@ class VstsIntegrationProviderBuildIntegrationTest(VstsIntegrationTestCase):
         integration.set_pipeline(pipeline)
         with pytest.raises(IntegrationProviderError) as err:
             integration.build_integration(state)
-        assert "ensure third-party app access via OAuth is enabled" in str(err)
+        assert "Azure DevOps organization" in str(err) and "Please ensu" in str(err)
 
 
 @control_silo_test


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0c8b67c6-292a-4a79-a23a-93e12bd8d112)

during install flow, if a user sees this error, it could also be because the user doesn't have the right permissions. updating the error message temporarily for users before we GA the integration migration. 

long term solution should be to differentiate between the error codes.