### PR TITLE
feat(taskworker) Improve prototype measurement harness for taskworkers

### DIFF
--- a/bin/taskworker-test
+++ b/bin/taskworker-test
@@ -1,7 +1,11 @@
 #!/usr/bin/env python
+import csv
+import math
 import os
+import random
 import sys
 import time
+from collections import defaultdict
 from subprocess import list2cmdline
 
 import click
@@ -16,16 +20,21 @@ configure()
 @click.command("taskworker-test")
 @click.option("--number", "-n", help="Number of messages to append", default=10_000)
 @click.option("--verbose", "-v", help="Enable verbose output", default=False, is_flag=True)
-def main(number: int, verbose: bool):
-    from sentry.taskdemo import say_hello
+@click.option("--seed", "-s", help="pseudo random number generator seed", default=None)
+@click.option("--workers", help="Number of worker processes", default=1)
+def main(number: int, verbose: bool, workers: int, seed: float | None):
+    from sentry.taskdemo import variable_time
 
     if verbose:
         click.echo(f"Adding {number} task messages")
+    if not seed:
+        seed = random.random()
 
     # Fill the topic up with a number of tasks
     start = time.monotonic()
     for i in range(number):
-        say_hello.delay(i)
+        variable_time.delay(wait=random.random(), taskno=i)
+
     end = time.monotonic()
     click.echo(f"Appending {number} tasks took {(end-start)}s")
 
@@ -52,17 +61,90 @@ def main(number: int, verbose: bool):
                 "warning",
             ],
         },
-        {
-            "name": "worker",
-            "cmd": ["sentry", "run", "taskworker", "--namespace", "demos"],
-        },
     ]
+    tasks_per_worker = math.ceil(number / workers)
+    for i in range(workers):
+        processes.append(
+            {
+                "name": f"worker-{i}",
+                "cmd": [
+                    "sentry",
+                    "run",
+                    "taskworker",
+                    "--namespace",
+                    "demos",
+                    "--max-task-count",
+                    str(tasks_per_worker),
+                ],
+            },
+        )
+
     for process in processes:
         manager.add_process(process["name"], list2cmdline(process["cmd"]), cwd=cwd)
 
     # Lets go!
     manager.loop()
+
+    print_results("./taskworker.log", workers)
+
     sys.exit(manager.returncode)
+
+
+def print_results(log_file: str, worker_count: int) -> None:
+    click.echo("")
+    click.echo("== Test run complete ==")
+    click.echo("")
+
+    fieldnames = ["event", "worker_id", "task_add_time", "execution_time", "latency"]
+    latency_times = []
+    with open(log_file) as logs:
+        results = csv.DictReader(logs, fieldnames=fieldnames)
+        for row in results:
+            latency_times.append(float(row["latency"]))
+
+    # We append tasks and then start applications. The first
+    # message always has long latency as application startup
+    # and kafka take some time to get going.
+    startup_latency = latency_times[0]
+
+    min_latency = min(latency_times)
+    max_latency = max(latency_times)
+    avg_latency = sum(latency_times) / len(latency_times)
+
+    # Remove the startup overhead to get relative latency.
+    adj_min_latency = min_latency - startup_latency
+    adj_max_latency = max_latency - startup_latency
+    adj_avg_latency = avg_latency - startup_latency
+
+    # Bucket latency into 50ms buckets and tally up buckets
+    bucket_count = 10
+    bucket_width = (adj_max_latency - adj_min_latency) / bucket_count
+    buckets = defaultdict(int)
+    for value in latency_times:
+        adjusted = value - startup_latency
+        bucket = int(adjusted % bucket_width)
+        buckets[bucket] += 1
+
+    click.echo("")
+    click.echo("## Task latency")
+    click.echo("")
+    click.echo(f"Startup Latency: {startup_latency}")
+    click.echo(f"Raw Min / Max / Avg latency: {min_latency} / {max_latency} / {avg_latency}")
+    click.echo(
+        f"Adjusted Min / Max / Avg latency: {adj_min_latency} / {adj_max_latency} / {adj_avg_latency}"
+    )
+
+    click.echo("")
+    click.echo("## Latency histogram")
+    click.echo("")
+    bars = []
+    for key, count in buckets.items():
+        bucket_upper = key * 0.05
+        bar = "█" * count
+        bars.append((bucket_upper, bar))
+
+    for (bucket_upper, bar) in sorted(bars, key=lambda x: x[0]):
+        click.echo(f"{bucket_upper:.4f} {bar}")
 
 
 if __name__ == "__main__":

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -255,17 +255,23 @@ def worker(ignore_unknown_queues: bool, **options: Any) -> None:
     ),
 )
 @click.option("--autoreload", is_flag=True, default=False, help="Enable autoreloading.")
-@click.option("--max-tasks-per-child", default=10000)
+@click.option(
+    "--max-task-count", help="Number of tasks this worker should run before exiting", default=10000
+)
 @log_options()
 @configuration
 def taskworker(**options: Any) -> None:
+    import time
+
     from sentry.taskworker.worker import Worker
 
     with managed_bgtasks(role="taskworker"):
         worker = Worker(
-            namespace=options.get("namespace"),
+            namespace=options.get("namespace"), max_task_count=options.get("max_task_count")
         )
         worker.start()
+        # Give consumer time to catch up
+        time.sleep(1)
         raise SystemExit(worker.exitcode)
 
 

--- a/src/sentry/taskdemo/__init__.py
+++ b/src/sentry/taskdemo/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +19,13 @@ demotasks = taskregistry.create_namespace(
 @demotasks.register(name="demos.say_hello")
 def say_hello(name):
     logger.info("hello %s", name)
+
+
+@demotasks.register(name="demos.variable_time")
+def variable_time(wait=None, taskno=None):
+    logger.info("running task %s with %s delay", taskno, wait)
+    if wait is not None:
+        time.sleep(wait)
 
 
 @demotasks.register(name="demos.broken", retry=Retry(times=5, on=(KeyError,)))

--- a/src/sentry/taskworker/config.py
+++ b/src/sentry/taskworker/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import time
 from collections.abc import Mapping
 from datetime import timedelta
@@ -17,6 +18,8 @@ from sentry.taskworker.models import InflightActivationModel
 from sentry.taskworker.retry import FALLBACK_RETRY, Retry
 from sentry.taskworker.task import Task
 from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
+
+logger = logging.getLogger(__name__)
 
 
 class TaskNamespace:

--- a/src/sentry/taskworker/pending_task_store.py
+++ b/src/sentry/taskworker/pending_task_store.py
@@ -15,7 +15,8 @@ class PendingTaskStore:
         from sentry.taskworker.models import InflightActivationModel
 
         InflightActivationModel.objects.bulk_create(
-            [InflightActivationModel.from_proto(task) for task in batch]
+            [InflightActivationModel.from_proto(task) for task in batch],
+            ignore_conflicts=True,
         )
 
     def get_pending_task(self) -> InflightActivation | None:

--- a/src/sentry/taskworker/worker.py
+++ b/src/sentry/taskworker/worker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import time
+from uuid import uuid4
 
 import grpc
 import orjson
@@ -18,12 +19,18 @@ logger = logging.getLogger("sentry.taskworker")
 result_logger = logging.getLogger("taskworker.results")
 
 
+class WorkerComplete(Exception):
+    ...
+
+
 class Worker:
     __namespace: TaskNamespace | None = None
 
     def __init__(self, **options):
         self.options = options
         self.exitcode = None
+        self.__execution_count = 0
+        self.__worker_id = uuid4().hex
 
     @property
     def namespace(self) -> TaskNamespace:
@@ -40,11 +47,19 @@ class Worker:
 
     def start(self) -> None:
         self.do_imports()
+        max_task_count = self.options.get("max_task_count", None)
         try:
             while True:
                 self.process_tasks(self.namespace)
+                if max_task_count is not None and max_task_count <= self.__execution_count:
+                    self.exitcode = 1
+                    raise WorkerComplete("Max task exeuction count reached")
+
         except KeyboardInterrupt:
             self.exitcode = 1
+        except WorkerComplete as err:
+            self.exitcode = 0
+            logger.warning(str(err))
         except Exception:
             logger.exception("Worker process crashed")
 
@@ -83,10 +98,14 @@ class Worker:
             if task_meta.should_retry(activation.retry_state, err):
                 logger.info("taskworker.task.retry", extra={"task": activation.taskname})
                 next_state = TASK_ACTIVATION_STATUS_RETRY
+
         task_latency = execution_time - task_added_time
+        self.__execution_count += 1
 
         # Dump results to a log file that is CSV shaped
-        result_logger.info(f"task.complete,{task_added_time},{execution_time},{task_latency}")
+        result_logger.info(
+            f"task.complete,{self.__worker_id},{task_added_time},{execution_time},{task_latency}"
+        )
 
         if next_state == TASK_ACTIVATION_STATUS_COMPLETE:
             logger.info(


### PR DESCRIPTION
By logging task processing latency to a file from the workers we can process those results and do analysis on the distribution of task execution. This gives us a bit more information on how our various alternatives will stack against each other.

I've also added a second worker and a seed to get consistent rng for task execution sleeps.

```
== Test run complete ==


## Task latency

Startup Latency: 12.797434091567993
Raw Min / Max / Avg latency: 11.108879804611206 / 163.42958307266235 / 21.947246882452895
Adjusted Min / Max / Avg latency: -1.688554286956787 / 150.63214898109436 / 9.149812790884901

## Latency histogram

0.0000 ███████████████████████
0.0500 █████
0.1000 ██
0.1500 █
0.2500 █
0.4500 ██
0.6500 ██████████
0.7000 ███████████████████
0.7500 ████
```

Is the output from a 10 task run I did locally.