### PR TITLE
fix(issues): Hide placeholder when stacktrace link is pending

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -117,28 +117,24 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
   const hasGithubSourceLink = (frame.sourceLink || '').startsWith(
     'https://www.github.com/'
   );
-  const [isQueryEnabled, setIsQueryEnabled] = useState(
-    hasGithubSourceLink ? false : !frame.inApp
-  );
+  const [shouldStartQuery, setShouldStartQuery] = useState(false);
   const project = useMemo(
     () => projects.find(p => p.id === event.projectID),
     [projects, event]
   );
 
   useEffect(() => {
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    if (!validFilePath) {
-      return setIsQueryEnabled(false);
-    }
-    // Skip fetching if we already have the Source Link
-    if (!hasGithubSourceLink && frame.inApp) {
-      // Introduce a delay before enabling the query
-      timer = setTimeout(() => {
-        setIsQueryEnabled(true);
-      }, 100); // Delay of 100ms
-    }
+    // The stacktrace link is rendered on hover
+    // Delay the query until the mouse hovers the frame for more than 50ms
+    const timer = setTimeout(() => {
+      setShouldStartQuery(true);
+    }, 50); // Delay of 50ms
     return () => timer && clearTimeout(timer);
-  }, [validFilePath, hasGithubSourceLink, frame]);
+  }, []);
+
+  const isQueryEnabled = hasGithubSourceLink
+    ? false
+    : shouldStartQuery && validFilePath && frame.inApp && !hasGithubSourceLink;
 
   const {
     data: match,
@@ -246,7 +242,7 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
     );
   }
 
-  if (isPending || !match) {
+  if ((isPending && isQueryEnabled) || !match) {
     const placeholderWidth = coverageEnabled ? '40px' : '14px';
     return (
       <StacktraceLinkWrapper>

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -134,7 +134,7 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
 
   const isQueryEnabled = hasGithubSourceLink
     ? false
-    : shouldStartQuery && validFilePath && frame.inApp && !hasGithubSourceLink;
+    : shouldStartQuery && validFilePath && frame.inApp;
 
   const {
     data: match,


### PR DESCRIPTION
attempts to reduce flakes in stacktrace link tests by making the state simpler and hiding the placeholder when the query is pending.

example flakes
https://github.com/getsentry/sentry/actions/runs/11039848249/job/30666418878#step:6:4605 https://github.com/getsentry/sentry/actions/runs/11016413930/job/30591890881#step:6:4609
