### PR TITLE
fix(toolbar): use targetOrigin * for iframe-invalid template

### DIFF
--- a/src/sentry/templates/sentry/toolbar/iframe-invalid.html
+++ b/src/sentry/templates/sentry/toolbar/iframe-invalid.html
@@ -22,14 +22,14 @@ Required context variables:
       window.parent.postMessage({
         source: 'sentry-toolbar',
         message: 'missing-project',
-      }, referrer);
+      }, "*");
 
       {% elif not allow_origin %}
       console.log('Invalid referring domain: %s', referrer);
       window.parent.postMessage({
         source: 'sentry-toolbar',
         message: 'invalid-domain',
-      }, referrer);
+      }, "*");
 
       {% endif %}
     </script>

--- a/src/sentry/templates/sentry/toolbar/iframe.html
+++ b/src/sentry/templates/sentry/toolbar/iframe.html
@@ -13,55 +13,61 @@ Required context variables:
   </head>
   <body>
     <script>
-      const referrer = "{{ referrer|escapejs }}";
+      (function() {
+        const referrer = "{{ referrer|escapejs }}";  // This should not be None and match your app's domain.
+        function log(...args) {
+          console.log('iframe:', ...args);
+        }
 
-      function log(...args) {
-        console.log('iframe:', ...args);
-      }
+        if (!referrer || referrer === "None") {
+          log('Invalid referrer', {referrer})
+          return;
+        }
 
-      log('Init', {referrer});
+        log('Init', {referrer});
 
-      const {port1, port2} = new MessageChannel();
+        const {port1, port2} = new MessageChannel();
 
-      const messageDispatch = {
-        'log': log,
-        'fetch': async (url, init) => {
-          const response =  await fetch(url, init);
-          return {
-            ok: response.ok,
-            status: response.status,
-            statusText: response.statusText,
-            url: response.url,
-            headers: Object.fromEntries(response.headers.entries()),
-            text: await response.text(),
+        const messageDispatch = {
+          'log': log,
+          'fetch': async (url, init) => {
+            const response =  await fetch(url, init);
+            return {
+              ok: response.ok,
+              status: response.status,
+              statusText: response.statusText,
+              url: response.url,
+              headers: Object.fromEntries(response.headers.entries()),
+              text: await response.text(),
+            }
+          },
+        };
+
+        port1.addEventListener('message', (postMessage) => {
+          log('port.onMessage', postMessage.data);
+
+          const {$id, message} = postMessage.data;
+          if (!$id) {
+            return; // MessageEvent is malformed, missing $id
           }
-        },
-      };
 
-      port1.addEventListener('message', (postMessage) => {
-        log('port.onMessage', postMessage.data);
+          if (!message.$function || !(message.$function in messageDispatch)) {
+            return; // No-op without a $function to call
+          }
 
-        const {$id, message} = postMessage.data;
-        if (!$id) {
-          return; // MessageEvent is malformed, missing $id
-        }
+          messageDispatch[message.$function]
+            .apply(undefined, message.$args || [])
+            .then($result => port1.postMessage({$id, $result}))
+            .catch((error) => port1.postMessage({$id, $error: error}));
+        });
+        port1.start();
 
-        if (!message.$function || !(message.$function in messageDispatch)) {
-          return; // No-op without a $function to call
-        }
-
-        messageDispatch[message.$function]
-          .apply(undefined, message.$args || [])
-          .then($result => port1.postMessage({$id, $result}))
-          .catch((error) => port1.postMessage({$id, $error: error}));
-      });
-      port1.start();
-
-      window.parent.postMessage({
-        source: 'sentry-toolbar',
-        message: 'port-connect',
-      }, referrer, [port2]);
-      log('Sent', {message: 'port-connect', referrer})
+        window.parent.postMessage({
+          source: 'sentry-toolbar',
+          message: 'port-connect',
+        }, referrer, [port2]);
+        log('Sent', {message: 'port-connect', referrer})
+      })();
     </script>
   </body>
 </html>


### PR DESCRIPTION
![Screenshot 2024-09-25 at 4 04 43 PM](https://github.com/user-attachments/assets/b0c7dfbc-146d-44f9-8180-316d8c668819)
Fixes the issue above. We're not guaranteed a valid referrer here so let's just log it, and postMessage to *.

Also handles this case in the iframe script by logging and quitting (shouldn't happen after allowed origin check).
