### PR TITLE
fix(alerts): Pass 0 instead of None

### DIFF
--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -142,9 +142,7 @@ def format_snuba_ts_data(
             count_data = data[1]
             count = 0
             if len(count_data):
-                count = count_data[0].get("count", 0)
-                if count is None:
-                    count = 0
+                count = count_data[0].get("count", 0) or 0
             ts_point = TimeSeriesPoint(timestamp=data[0], value=count)
             formatted_data.append(ts_point)
     return formatted_data

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -142,7 +142,7 @@ def format_snuba_ts_data(
             count_data = data[1]
             count = 0
             if len(count_data):
-                count = count_data[0].get("count", 0)
+                count = count_data[0].get("count", 0) or 0
             ts_point = TimeSeriesPoint(timestamp=data[0], value=count)
             formatted_data.append(ts_point)
     return formatted_data

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -142,6 +142,7 @@ def format_snuba_ts_data(
             count_data = data[1]
             count = 0
             if len(count_data):
+                # there are sometimes None values from snuba
                 count = count_data[0].get("count", 0) or 0
             ts_point = TimeSeriesPoint(timestamp=data[0], value=count)
             formatted_data.append(ts_point)

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -142,7 +142,9 @@ def format_snuba_ts_data(
             count_data = data[1]
             count = 0
             if len(count_data):
-                count = count_data[0].get("count", 0) or 0
+                count = count_data[0].get("count", 0)
+                if count is None:
+                    count = 0
             ts_point = TimeSeriesPoint(timestamp=data[0], value=count)
             formatted_data.append(ts_point)
     return formatted_data

--- a/tests/sentry/seer/anomaly_detection/test_store_data.py
+++ b/tests/sentry/seer/anomaly_detection/test_store_data.py
@@ -87,7 +87,6 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase, Performa
         )
         assert result == expected_return_value
 
-
     def test_anomaly_detection_format_historical_data_none_value(self):
         """
         Test that we don't end up with a None value, but rather 0.
@@ -195,10 +194,6 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase, Performa
         assert {"time": int(event1.datetime.timestamp()), "count": 1} in result.data.get("data")
         assert {"time": int(event2.datetime.timestamp()), "count": 1} in result.data.get("data")
 
-
-    @pytest.mark.skip(
-        reason="This test is flaking, skipping for now - this feature isn't released."
-    )
     def test_anomaly_detection_format_historical_data_crash_rate_alert(self):
         expected_return_value = [
             {"timestamp": self.time_1_ts, "value": 0},

--- a/tests/sentry/seer/anomaly_detection/test_store_data.py
+++ b/tests/sentry/seer/anomaly_detection/test_store_data.py
@@ -110,7 +110,6 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase, Performa
         )
         assert result == expected_return_value
 
-
     def test_anomaly_detection_fetch_historical_data(self):
         alert_rule = self.create_alert_rule(organization=self.organization, projects=[self.project])
         snuba_query = SnubaQuery.objects.get(id=alert_rule.snuba_query_id)


### PR DESCRIPTION
When attempting to create first input delay dynamic alerts we're trying to pass `None` to Seer's store data endpoint for some of the values rather than a 0, so we need to make sure to never do that. 

Fixes https://getsentry.atlassian.net/browse/ALRT-282