### PR TITLE
Skip the 4 anomaly detection tests, should investigate separately

### DIFF
--- a/tests/sentry/seer/anomaly_detection/test_store_data.py
+++ b/tests/sentry/seer/anomaly_detection/test_store_data.py
@@ -84,6 +84,9 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase, Performa
         )
         assert result == expected_return_value
 
+    @pytest.mark.skip(
+        reason="This test is flaking, skipping for now - this feature isn't released."
+    )
     def test_anomaly_detection_fetch_historical_data(self):
         alert_rule = self.create_alert_rule(organization=self.organization, projects=[self.project])
         snuba_query = SnubaQuery.objects.get(id=alert_rule.snuba_query_id)

--- a/tests/sentry/seer/anomaly_detection/test_store_data.py
+++ b/tests/sentry/seer/anomaly_detection/test_store_data.py
@@ -116,6 +116,9 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase, Performa
         assert {"time": int(self.time_1_ts), "count": 1} in result.data.get("data")
         assert {"time": int(self.time_2_ts), "count": 1} in result.data.get("data")
 
+    @pytest.mark.skip(
+        reason="This test is flaking, skipping for now - this feature isn't released."
+    )
     def test_anomaly_detection_fetch_historical_data_is_unresolved_query(self):
         alert_rule = self.create_alert_rule(organization=self.organization, projects=[self.project])
         snuba_query = SnubaQuery.objects.get(id=alert_rule.snuba_query_id)
@@ -150,6 +153,9 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase, Performa
         assert {"time": int(self.time_1_ts), "count": 1} in result.data.get("data")
         assert {"time": int(self.time_2_ts), "count": 1} in result.data.get("data")
 
+    @pytest.mark.skip(
+        reason="This test is flaking, skipping for now - this feature isn't released."
+    )
     def test_anomaly_detection_fetch_historical_data_performance_alert(self):
         alert_rule = self.create_alert_rule(
             organization=self.organization, projects=[self.project], dataset=Dataset.Transactions
@@ -188,6 +194,9 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase, Performa
         result = format_historical_data(data, ["count()"], metrics_performance, self.organization)
         assert result == expected_return_value
 
+    @pytest.mark.skip(
+        reason="This test is flaking, skipping for now - this feature isn't released."
+    )
     def test_anomaly_detection_fetch_historical_data_crash_rate_alert(self):
         self.store_session(
             self.build_session(


### PR DESCRIPTION
## Description
Looks like there are some flakey tests in anomaly detection. skipping them for now since the feature isn't rolled out yet.

@ceorourke let's investigate these tests and see why they're flakey. something tells me it's freeze time / timestamp related though 😅 