### PR TITLE
fix(issue-views): Fixes bug where persistent viewIds are being attached to multiple tabs

### DIFF
--- a/static/app/views/issueList/customViewsHeader.tsx
+++ b/static/app/views/issueList/customViewsHeader.tsx
@@ -300,13 +300,14 @@ function CustomViewsIssueListHeaderTabsContent({
 
   // Update local tabs when new views are received from mutation request
   useEffectAfterFirstRender(() => {
-    const assignedIds = new Set();
     const newlyCreatedViews = views.filter(
       view => !draggableTabs.find(tab => tab.id === view.id)
     );
     const currentView = draggableTabs.find(tab => tab.id === viewId);
-    setDraggableTabs(
-      draggableTabs.map(tab => {
+
+    setDraggableTabs(oldDraggableTabs => {
+      const assignedIds = new Set();
+      return oldDraggableTabs.map(tab => {
         // Temp viewIds are prefixed with '_'
         if (tab.id && tab.id[0] === '_') {
           const matchingView = newlyCreatedViews.find(
@@ -326,8 +327,8 @@ function CustomViewsIssueListHeaderTabsContent({
           }
         }
         return tab;
-      })
-    );
+      });
+    });
 
     if (viewId.startsWith('_') && currentView) {
       const matchingView = newlyCreatedViews.find(


### PR DESCRIPTION
Fixes a bug where a single viewId was being attached to multiple views, which caused a strange bug where trying to navigate to a tab would force the user back into a previous tab, demonstrated below: 

https://github.com/user-attachments/assets/5bea85b7-4622-461c-8c56-0aac156fabc2

This would be triggered under the following conditions:

1. The user created multiple new views via the `+ Add View` button 
2. The user did **not** update the query in these views, and left them in the new view page 
3. The user did an action that triggered the frontend to make a request to the backend to save the views (such as reordering their tabs) 

This triggered the behavior because the frontend would send _all_ tabs to the backend to save, including the newly created (but not committed) views. The backend would then create viewIds for all of them, and send them back to the frontend. The frontend would then attempt to dynamically update the viewIds of each of the newly created views. However, since all the new views were virtually identical (name = "New View", query = "", sort = "date"),  it assigned all of those new views the same, first id that it got back. 

The solution that I implemented works as follows: 

1. When the frontend receives new backend views  - first filter the backend views down to those whose id's are not currently in frontend views (called `newlyCreatedViews`). `newlyCreatedViews` views are the newly created Frontend views that were sent to the backend to be saved. 
2. Then for view in `newlyCreatedViews`, find a matching frontend view, and dynamically update it with the id from the backend view.
3. **Pop the matched view from newlyCreatedViews.** This prevents the same viewId from being attached to multiple tabs. 

Now, the behavior works as expected: 

https://github.com/user-attachments/assets/8a7324b0-66c2-412b-8c14-ca738e9341a3

_Notice how you can click on each new view, unlike in the first video_ 

**Note:** This does not solve a different issue where newly created, but not "committed" views shouldn't be sent to the backend in the first place. These are related, but fundamentally different bugs and thus should warrant different PRs. 