### PR TITLE
fix(issue-views): Fix uncommitted new views being saved 

### DIFF
--- a/static/app/views/issueList/customViewsHeader.tsx
+++ b/static/app/views/issueList/customViewsHeader.tsx
@@ -144,6 +144,7 @@ function CustomViewsIssueListHeaderTabsContent({
         label: name,
         query: viewQuery,
         querySort: viewQuerySort,
+        isCommitted: true,
       };
     }
   );
@@ -177,6 +178,7 @@ function CustomViewsIssueListHeaderTabsContent({
           label: t('Unsaved'),
           query: query,
           querySort: sort ?? IssueSortOptions.DATE,
+          isCommitted: true,
         }
       : undefined
   );
@@ -189,14 +191,18 @@ function CustomViewsIssueListHeaderTabsContent({
         if (newTabs) {
           updateViews({
             orgSlug: organization.slug,
-            groupSearchViews: newTabs.map(tab => ({
-              // Do not send over an ID if it's a temporary or default tab so that
-              // the backend will save these and generate permanent Ids for them
-              ...(tab.id[0] !== '_' && !tab.id.startsWith('default') ? {id: tab.id} : {}),
-              name: tab.label,
-              query: tab.query,
-              querySort: tab.querySort,
-            })),
+            groupSearchViews: newTabs
+              .filter(tab => tab.isCommitted)
+              .map(tab => ({
+                // Do not send over an ID if it's a temporary or default tab so that
+                // the backend will save these and generate permanent Ids for them
+                ...(tab.id[0] !== '_' && !tab.id.startsWith('default')
+                  ? {id: tab.id}
+                  : {}),
+                name: tab.label,
+                query: tab.query,
+                querySort: tab.querySort,
+              })),
           });
         }
       }, 500),
@@ -329,7 +335,7 @@ function CustomViewsIssueListHeaderTabsContent({
 
   useEffect(() => {
     if (viewId?.startsWith('_')) {
-      if (draggableTabs.find(tab => tab.id === viewId)?.label.endsWith('(Copy)')) {
+      if (draggableTabs.find(tab => tab.id === viewId)?.isCommitted) {
         return;
       }
       // If the user types in query manually while the new view flow is showing,

--- a/static/app/views/issueList/customViewsHeader.tsx
+++ b/static/app/views/issueList/customViewsHeader.tsx
@@ -348,6 +348,7 @@ function CustomViewsIssueListHeaderTabsContent({
             ? {
                 ...tab,
                 unsavedChanges: [query, sort ?? IssueSortOptions.DATE],
+                isCommitted: true,
               }
             : tab
         );

--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.spec.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.spec.tsx
@@ -33,6 +33,7 @@ describe.skip('DraggableTabBar', () => {
       query: 'priority:high',
       querySort: IssueSortOptions.DATE,
       unsavedChanges: ['priority:low', IssueSortOptions.DATE],
+      isCommitted: true,
     },
     {
       id: '2',
@@ -40,6 +41,7 @@ describe.skip('DraggableTabBar', () => {
       label: 'For Review',
       query: 'is:unassigned',
       querySort: IssueSortOptions.DATE,
+      isCommitted: true,
     },
     {
       id: '3',
@@ -47,6 +49,7 @@ describe.skip('DraggableTabBar', () => {
       label: 'Regressed',
       query: 'is:regressed',
       querySort: IssueSortOptions.DATE,
+      isCommitted: true,
     },
   ];
 


### PR DESCRIPTION
Fixes a bug where views that were newly created, but were not progressed past the new view flow, were being saved to the backend. 

https://github.com/user-attachments/assets/dde66230-7af9-41e6-8c2b-40ccde7b4fa2


_Notice how even after triggering an action that saves the views to the backend (renaming the first tab), the newly created view still has the new view flow, indicating it has not been saved._

Achieves this by adding an `isCommitted` property to each tab. The frontend only send views where `isCommitted=false` to be saved. 

**Logic details:**

* All views are initially marked with `isCommitted=true`
* Only views created via the `+ Add View` button will have is `isCommitted=false` 
	* Views created via duplcating, or by saving a temp view have `isCommitted=false`  
* `isCommitted` for a view can be switched from `false` to `true`...
	* If the view is renamed
	* If a recommended search or saved search is clicked 
	* If the query is changed manually 

There are some interesting questions to be considered regarding the last bullet point:

* Should we toggle `isCommitted` to true if the query is changed manually or if a recommended/saved search is chosen from a new view? Maybe this would give the user a chance to look at the results first before hitting `Save Changes`, which would then toggle `isCommitted` to true.
* Should we toggle `isCommitted` to true if the view is renamed? This cause the new view flow to disappear after renaming, which probably isn't ideal. On the other hand, it would be strange if I renamed a tab, forgot to add a query, then came back and found the tab to be gone. 