### PR TITLE
fix(rr6): Ignore use{Router,Routes} throw tests

### DIFF
--- a/static/app/utils/useRouter.spec.tsx
+++ b/static/app/utils/useRouter.spec.tsx
@@ -31,6 +31,11 @@ describe('useRouter', () => {
   });
 
   it('throws error when called outside of routes provider', function () {
+    // XXX(epurkhiser): This test does nothing in react router 6 land
+    if (window.__SENTRY_USING_REACT_ROUTER_SIX) {
+      return;
+    }
+
     // Error is expected, do not fail when calling console.error
     jest.spyOn(console, 'error').mockImplementation();
 

--- a/static/app/utils/useRoutes.spec.tsx
+++ b/static/app/utils/useRoutes.spec.tsx
@@ -37,6 +37,11 @@ describe('useRoutes', () => {
   });
 
   it('throws error when called outside of routes provider', function () {
+    // XXX(epurkhiser): This test does nothing in react router 6 land
+    if (window.__SENTRY_USING_REACT_ROUTER_SIX) {
+      return;
+    }
+
     // Error is expected, do not fail when calling console.error
     jest.spyOn(console, 'error').mockImplementation();
 


### PR DESCRIPTION
These tests mean nothing in react router 6 since these hooks just become
shims around react router 6 hooks.