### PR TITLE
ref(broadcasts): Improve img rendering

### DIFF
--- a/static/app/components/sidebar/broadcastPanelItem.tsx
+++ b/static/app/components/sidebar/broadcastPanelItem.tsx
@@ -1,4 +1,5 @@
 import {useCallback} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import Tag from 'sentry/components/badge/tag';
@@ -7,6 +8,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Broadcast} from 'sentry/types/system';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
 
 export const BROADCAST_CATEGORIES: Record<NonNullable<Broadcast['category']>, string> = {
@@ -32,6 +34,8 @@ export function BroadcastPanelItem({
   category,
 }: BroadcastPanelItemProps) {
   const organization = useOrganization();
+  const theme = useTheme();
+  const isScreenExtraLarge = useMedia(`(min-width: ${theme.breakpoints.xxlarge})`);
 
   const handlePanelClicked = useCallback(() => {
     trackAnalytics('whats_new.link_clicked', {organization, title, category});
@@ -46,7 +50,9 @@ export function BroadcastPanelItem({
         </Title>
         <Message>{message}</Message>
       </TextBlock>
-      {mediaUrl && <Media src={mediaUrl} alt={title} />}
+      {mediaUrl && (
+        <Media src={mediaUrl} alt={title} isScreenExtraLarge={isScreenExtraLarge} />
+      )}
     </SidebarPanelItemRoot>
   );
 }
@@ -79,10 +85,11 @@ const TextBlock = styled('div')`
   align-items: flex-start;
 `;
 
-const Media = styled('img')`
+const Media = styled('img')<{isScreenExtraLarge: boolean}>`
   border-radius: ${p => p.theme.borderRadius};
   border: 1px solid ${p => p.theme.translucentGray200};
   max-width: 100%;
+  image-rendering: ${p => (p.isScreenExtraLarge ? 'pixelated' : 'auto')};
 `;
 
 const CategoryTag = styled(Tag)`


### PR DESCRIPTION
**Problem**

In the "what's new" sidebar, the images look blurry on large screens as the browser scales it down to fit the container. 


**Solution** (still not happy with this solution but it improves the blurry. Open to feedback)

Detect if the screen is large and if yes, we use the [img-rendering](https://developer.mozilla.org/en-US/docs/Web/CSS/image-rendering) CSS property with the value `pixelated`. This helps to improve the blurry effect but the image is still not decent. 

Before
![image](https://github.com/user-attachments/assets/b6ec7771-0a6a-4a7e-81ac-175bbccc5c47)



After

![image](https://github.com/user-attachments/assets/dd107a90-d83a-4681-a305-2ab7b77bdbf2)


Maybe the blurry is even better 🤔
