### PR TITLE
feat(dashboards): Improve `apdex()` rendering

### DIFF
--- a/static/app/utils/discover/fieldRenderers.spec.tsx
+++ b/static/app/utils/discover/fieldRenderers.spec.tsx
@@ -132,30 +132,6 @@ describe('getFieldRenderer', function () {
     });
   });
 
-  describe('apdex()', function () {
-    it.each([
-      [0, '0'],
-      [0.2, '0.200'],
-      [0.61, '0.610'],
-      [0.781, '0.781'],
-      [0.771231, '0.771'],
-      [0.99999, '0.999'],
-      [1.0, '1'],
-    ])('format %s', (value, expected) => {
-      const renderer = getFieldRenderer('apdex()', {}, false);
-
-      render(
-        renderer(
-          {
-            'apdex()': value,
-          },
-          {location, organization}
-        ) as React.ReactElement<any, any>
-      );
-      expect(screen.getByText(expected)).toBeInTheDocument();
-    });
-  });
-
   describe('date', function () {
     beforeEach(function () {
       ConfigStore.loadInitialData(

--- a/static/app/utils/discover/fieldRenderers.spec.tsx
+++ b/static/app/utils/discover/fieldRenderers.spec.tsx
@@ -132,6 +132,30 @@ describe('getFieldRenderer', function () {
     });
   });
 
+  describe('apdex()', function () {
+    it.each([
+      [0, '0'],
+      [0.2, '0.200'],
+      [0.61, '0.610'],
+      [0.781, '0.781'],
+      [0.771231, '0.771'],
+      [0.99999, '0.999'],
+      [1.0, '1'],
+    ])('format %s', (value, expected) => {
+      const renderer = getFieldRenderer('apdex()', {}, false);
+
+      render(
+        renderer(
+          {
+            'apdex()': value,
+          },
+          {location, organization}
+        ) as React.ReactElement<any, any>
+      );
+      expect(screen.getByText(expected)).toBeInTheDocument();
+    });
+  });
+
   describe('date', function () {
     beforeEach(function () {
       ConfigStore.loadInitialData(

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -45,6 +45,7 @@ import {
 import {getShortEventId} from 'sentry/utils/events';
 import {formatRate} from 'sentry/utils/formatters';
 import getDynamicText from 'sentry/utils/getDynamicText';
+import {formatApdex} from 'sentry/utils/number/formatApdex';
 import {formatFloat} from 'sentry/utils/number/formatFloat';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import toPercent from 'sentry/utils/number/toPercent';
@@ -384,8 +385,7 @@ const SPECIAL_FIELDS: SpecialFields = {
 
       return (
         <NumberContainer>
-          {/* Always render Apdex with 3 decimal places */}
-          {typeof data[field] === 'number' ? formatFloat(data[field], 3) : emptyValue}
+          {typeof data[field] === 'number' ? formatApdex(data[field]) : emptyValue}
         </NumberContainer>
       );
     },

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -339,6 +339,7 @@ type SpecialField = {
 };
 
 type SpecialFields = {
+  'apdex()': SpecialField;
   attachments: SpecialField;
   'count_unique(user)': SpecialField;
   'error.handled': SpecialField;
@@ -376,6 +377,19 @@ const RightAlignedContainer = styled('span')`
 const SPECIAL_FIELDS: SpecialFields = {
   // This is a custom renderer for a field outside discover
   // TODO - refactor code and remove from this file or add ability to query for attachments in Discover
+  'apdex()': {
+    sortField: 'apdex()',
+    renderFunc: data => {
+      const field = 'apdex()';
+
+      return (
+        <NumberContainer>
+          {/* Always render Apdex with 3 decimal places */}
+          {typeof data[field] === 'number' ? formatFloat(data[field], 3) : emptyValue}
+        </NumberContainer>
+      );
+    },
+  },
   attachments: {
     sortField: null,
     renderFunc: (data, {organization, projectSlug}) => {

--- a/static/app/utils/number/formatApdex.spec.tsx
+++ b/static/app/utils/number/formatApdex.spec.tsx
@@ -1,0 +1,15 @@
+import {formatApdex} from 'sentry/utils/number/formatApdex';
+
+describe('formatApdex', function () {
+  it.each([
+    [0, '0'],
+    [0.2, '0.200'],
+    [0.61, '0.610'],
+    [0.781, '0.781'],
+    [0.771231, '0.771'],
+    [0.99999, '0.999'],
+    [1.0, '1'],
+  ])('%s', (value, expected) => {
+    expect(formatApdex(value)).toEqual(expected);
+  });
+});

--- a/static/app/utils/number/formatApdex.tsx
+++ b/static/app/utils/number/formatApdex.tsx
@@ -1,0 +1,15 @@
+export function formatApdex(value: number) {
+  if (value === 0) {
+    return '0';
+  }
+
+  if (value === 1) {
+    return '1';
+  }
+
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 3,
+    maximumFractionDigits: 3,
+    roundingMode: 'trunc',
+  });
+}


### PR DESCRIPTION
Ensures that Apdex is rendered the same is more places and more better!

1. Adds a custom renderer for `apdex()` so Discover-like properties (tables, and charts) that use the render pipeline make use of a custom renderer
2. Improves the custom renderer with a `formatApdex` helper that does something sensible

tl;dr always renders Apdex with 3 fraction digits. This makes it easier to compare the values in a table, by preventing "ragged edges". The exception is "1" and "0" which look less silly as single digits.

**Before:**
<img width="112" alt="Screenshot 2024-09-26 at 11 36 57 AM" src="https://github.com/user-attachments/assets/cdf4ffbe-781e-40d1-a9ba-06b6f637b367">

**After:**
<img width="63" alt="Screenshot 2024-09-26 at 11 59 51 AM" src="https://github.com/user-attachments/assets/e1e34edf-23d9-4b3a-b4c7-4c24947dd8a3">
