### PR TITLE
typing(search): Add parent class for ErrorsQueryBuilder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -319,7 +319,6 @@ module = [
     "sentry.scim.endpoints.members",
     "sentry.scim.endpoints.teams",
     "sentry.scim.endpoints.utils",
-    "sentry.search.events.builder.errors",
     "sentry.search.events.builder.metrics",
     "sentry.search.events.datasets.discover",
     "sentry.search.events.datasets.filter_aliases",

--- a/src/sentry/search/events/builder/errors.py
+++ b/src/sentry/search/events/builder/errors.py
@@ -18,6 +18,7 @@ from snuba_sdk import (
 )
 
 from sentry.api.issue_search import convert_query_values, convert_status_value
+from sentry.search.events.builder.base import BaseQueryBuilder
 from sentry.search.events.builder.discover import (
     DiscoverQueryBuilder,
     TimeseriesQueryBuilder,
@@ -30,7 +31,7 @@ from sentry.snuba.entity_subscription import ENTITY_TIME_COLUMNS, get_entity_key
 value_converters = {"status": convert_status_value}
 
 
-class ErrorsQueryBuilderMixin:
+class ErrorsQueryBuilderMixin(BaseQueryBuilder):
     def __init__(self, *args, **kwargs):
         self.match = None
         self.entities = set()


### PR DESCRIPTION
Fixes these issues:
```
mypy src/sentry/search/events/builder/errors.py
src/sentry/search/events/builder/errors.py:40: error: "parse_query" undefined in superclass  [misc]
src/sentry/search/events/builder/errors.py:43: error: "ErrorsQueryBuilderMixin" has no attribute "params"  [attr-defined]
src/sentry/search/events/builder/errors.py:44: error: "ErrorsQueryBuilderMixin" has no attribute "params"  [attr-defined]
src/sentry/search/events/builder/errors.py:45: error: "ErrorsQueryBuilderMixin" has no attribute "params"  [attr-defined]
src/sentry/search/events/builder/errors.py:52: error: "ErrorsQueryBuilderMixin" has no attribute "dataset"  [attr-defined]
src/sentry/search/events/builder/errors.py:52: error: "ErrorsQueryBuilderMixin" has no attribute "sample_rate"  [attr-defined]
src/sentry/search/events/builder/errors.py:62: error: "resolve_params" undefined in superclass  [misc]
src/sentry/search/events/builder/errors.py:68: error: "ErrorsQueryBuilderMixin" has no attribute "params"  [attr-defined]
src/sentry/search/events/builder/errors.py:81: error: "resolve_query" undefined in superclass  [misc]
src/sentry/search/events/builder/errors.py:85: error: "aliased_column" undefined in superclass  [misc]
src/sentry/search/events/builder/errors.py:100: error: "ErrorsQueryBuilderMixin" has no attribute "resolve_column_name"  [attr-defined]
src/sentry/search/events/builder/errors.py:108: error: "ErrorsQueryBuilderMixin" has no attribute "dataset"  [attr-defined]
Found 12 errors in 1 file (checked 1 source file)
```