### PR TITLE
fix(insights): fix view all button to link from perf landing to insights

### DIFF
--- a/static/app/views/insights/pages/useFilters.tsx
+++ b/static/app/views/insights/pages/useFilters.tsx
@@ -3,16 +3,23 @@ import type {ModuleName} from 'webpack-cli';
 
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
-import type {AI_LANDING_SUB_PATH} from 'sentry/views/insights/pages/aiLandingPage';
-import type {BACKEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/backendLandingPage';
-import type {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
-import type {MOBILE_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mobileLandingPage';
+import {AI_LANDING_SUB_PATH} from 'sentry/views/insights/pages/aiLandingPage';
+import {BACKEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/backendLandingPage';
+import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
+import {MOBILE_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mobileLandingPage';
 
 export type DomainView =
   | typeof FRONTEND_LANDING_SUB_PATH
   | typeof BACKEND_LANDING_SUB_PATH
   | typeof AI_LANDING_SUB_PATH
   | typeof MOBILE_LANDING_SUB_PATH;
+
+const domainViews = [
+  FRONTEND_LANDING_SUB_PATH,
+  BACKEND_LANDING_SUB_PATH,
+  AI_LANDING_SUB_PATH,
+  MOBILE_LANDING_SUB_PATH,
+];
 
 export type DomainViewFilters = {
   isInDomainView?: boolean;
@@ -30,6 +37,9 @@ export const useDomainViewFilters = () => {
   const isInDomainView = indexOfPerformance !== -1;
 
   const view = pathSegments[indexOfPerformance + 1] as DomainViewFilters['view'];
+  if (!domainViews.includes(view || '')) {
+    return {isInDomainView: false};
+  }
 
   if (isInDomainView) {
     return {


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry/issues/78219

performance domain views are only under `/performance/<viewname>`, so we can be more explicit here to prevent bugs.