### PR TITLE
fix(dashboards): `BigNumberWidget` improvement grab-bag I

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -990,7 +990,7 @@ export function getFieldRenderer(
   }
 
   const fieldName = isAlias ? getAggregateAlias(field) : field;
-  const fieldType = meta[fieldName] || meta.fields[fieldName];
+  const fieldType = meta[fieldName] || meta.fields?.[fieldName];
 
   for (const alias in SPECIAL_FUNCTIONS) {
     if (fieldName.startsWith(alias)) {
@@ -1024,7 +1024,7 @@ export function getFieldFormatter(
   isAlias: boolean = true
 ): FieldTypeFormatterRenderFunctionPartial {
   const fieldName = isAlias ? getAggregateAlias(field) : field;
-  const fieldType = meta[fieldName] || meta.fields[fieldName];
+  const fieldType = meta[fieldName] || meta.fields?.[fieldName];
 
   if (FIELD_FORMATTERS.hasOwnProperty(fieldType)) {
     return partial(FIELD_FORMATTERS[fieldType].renderFunc, fieldName);

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -990,7 +990,7 @@ export function getFieldRenderer(
   }
 
   const fieldName = isAlias ? getAggregateAlias(field) : field;
-  const fieldType = meta[fieldName];
+  const fieldType = meta[fieldName] || meta.fields[fieldName];
 
   for (const alias in SPECIAL_FUNCTIONS) {
     if (fieldName.startsWith(alias)) {

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
@@ -172,9 +172,6 @@ export default storyBook(BigNumberWidget, story => {
                 fields: {
                   'http_rate(500)': 'percentage',
                 },
-                units: {
-                  'http_rate(500)': null,
-                },
               }}
             />
           </NormalWidget>
@@ -195,9 +192,6 @@ export default storyBook(BigNumberWidget, story => {
               meta={{
                 fields: {
                   'http_rate(200)': 'percentage',
-                },
-                units: {
-                  'http_rate(200)': null,
                 },
               }}
             />

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
@@ -40,6 +40,11 @@ export default storyBook(BigNumberWidget, story => {
                   'eps()': 0.01087819860850493,
                 },
               ]}
+              previousPeriodData={[
+                {
+                  'eps()': 0.01087819860850493,
+                },
+              ]}
               meta={{
                 fields: {
                   'eps()': 'rate',
@@ -210,5 +215,4 @@ const SmallSizingWindow = styled(SizingWindow)`
 
 const NormalWidget = styled('div')`
   width: 250px;
-  height: 100px;
 `;

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
@@ -68,7 +68,7 @@ export function BigNumberWidgetVisualization(props: Props) {
   return (
     <AutoResizeParent>
       <AutoSizedText>
-        <NumberContainer>
+        <NumberAndDifferenceContainer>
           <NumberContainerOverride>
             <Tooltip title={datum[field]} isHoverable delay={0}>
               {rendered}
@@ -86,7 +86,7 @@ export function BigNumberWidgetVisualization(props: Props) {
               field={field}
             />
           )}
-        </NumberContainer>
+        </NumberAndDifferenceContainer>
       </AutoSizedText>
     </AutoResizeParent>
   );
@@ -107,7 +107,7 @@ const AutoResizeParent = styled('div')`
   }
 `;
 
-const NumberContainer = styled('div')`
+const NumberAndDifferenceContainer = styled('div')`
   display: flex;
   align-items: flex-end;
   gap: min(8px, 3cqw);

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
@@ -4,7 +4,7 @@ import type {Polarity} from 'sentry/components/percentChange';
 import {Tooltip} from 'sentry/components/tooltip';
 import {defined} from 'sentry/utils';
 import type {MetaType} from 'sentry/utils/discover/eventView';
-import {getFieldFormatter} from 'sentry/utils/discover/fieldRenderers';
+import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {AutoSizedText} from 'sentry/views/dashboards/widgetCard/autoSizedText';
@@ -52,8 +52,8 @@ export function BigNumberWidgetVisualization(props: Props) {
   const field = fields[0];
 
   // TODO: meta as MetaType is a white lie. `MetaType` doesn't know that types can be null, but they can!
-  const fieldFormatter = meta
-    ? getFieldFormatter(field, meta as MetaType, false)
+  const fieldRenderer = meta
+    ? getFieldRenderer(field, meta as MetaType, false)
     : value => value.toString();
 
   const unit = meta?.units?.[field];
@@ -63,7 +63,7 @@ export function BigNumberWidgetVisualization(props: Props) {
     unit: unit ?? undefined, // TODO: Field formatters think units can't be null but they can
   };
 
-  const rendered = fieldFormatter(datum, baggage);
+  const rendered = fieldRenderer(datum, baggage);
 
   return (
     <AutoResizeParent>
@@ -81,7 +81,7 @@ export function BigNumberWidgetVisualization(props: Props) {
               previousPeriodData={previousPeriodData}
               preferredPolarity={preferredPolarity}
               formatter={(previousDatum: TableData[number]) =>
-                fieldFormatter(previousDatum, baggage)
+                fieldRenderer(previousDatum, baggage)
               }
               field={field}
             />

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
@@ -83,7 +83,7 @@ export function BigNumberWidgetVisualization(props: Props) {
               data={data}
               previousPeriodData={previousPeriodData}
               preferredPolarity={preferredPolarity}
-              formatter={(previousDatum: TableData[number]) =>
+              renderer={(previousDatum: TableData[number]) =>
                 fieldRenderer(previousDatum, baggage)
               }
               field={field}

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
@@ -9,7 +9,10 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {AutoSizedText} from 'sentry/views/dashboards/widgetCard/autoSizedText';
 import {DifferenceToPreviousPeriodData} from 'sentry/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodData';
-import {NO_DATA_PLACEHOLDER} from 'sentry/views/dashboards/widgets/bigNumberWidget/settings';
+import {
+  DEEMPHASIS_COLOR_NAME,
+  NO_DATA_PLACEHOLDER,
+} from 'sentry/views/dashboards/widgets/bigNumberWidget/settings';
 import {ErrorPanel} from 'sentry/views/dashboards/widgets/common/errorPanel';
 import type {
   Meta,
@@ -124,5 +127,5 @@ const NumberContainerOverride = styled('div')`
 `;
 
 const Deemphasize = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme[DEEMPHASIS_COLOR_NAME]};
 `;

--- a/static/app/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodData.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodData.tsx
@@ -57,17 +57,25 @@ const Difference = styled(ColorizedRating)`
   display: flex;
   gap: ${space(0.5)};
 
-  @container (min-height: 50px) {
+  @container (min-height: 70px) {
     padding-bottom: 5cqh;
   }
 `;
 
 const Number = styled('div')`
-  font-size: clamp(14px, calc(10px + 4cqi), 30cqh);
+  font-size: 14px;
+
+  @container (min-height: 70px) {
+    font-size: clamp(14px, calc(10px + 4cqi), 30cqh);
+  }
 `;
 
 const Indicator = styled('div')`
-  font-size: clamp(14px, calc(10px + 4cqi), 30cqh);
+  font-size: 14px;
+
+  @container (min-height: 70px) {
+    font-size: clamp(14px, calc(10px + 4cqi), 30cqh);
+  }
 `;
 
 const Deemphasize = styled('span')`

--- a/static/app/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodData.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodData.tsx
@@ -9,7 +9,10 @@ import {
 } from 'sentry/components/percentChange';
 import {IconArrow} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
-import {NO_DATA_PLACEHOLDER} from 'sentry/views/dashboards/widgets/bigNumberWidget/settings';
+import {
+  DEEMPHASIS_COLOR_NAME,
+  NO_DATA_PLACEHOLDER,
+} from 'sentry/views/dashboards/widgets/bigNumberWidget/settings';
 import type {TableData} from 'sentry/views/dashboards/widgets/common/types';
 
 interface Props {
@@ -72,7 +75,7 @@ const Text = styled('div')`
 `;
 
 const Deemphasize = styled('span')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme[DEEMPHASIS_COLOR_NAME]};
 `;
 
 function getDifferenceDirectionMarker(difference: number) {

--- a/static/app/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodData.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodData.tsx
@@ -55,7 +55,7 @@ export function DifferenceToPreviousPeriodData({
 
 const Difference = styled(ColorizedRating)`
   display: flex;
-  gap: ${space(0.5)};
+  gap: ${space(0.25)};
 
   @container (min-height: 70px) {
     padding-bottom: 5cqh;

--- a/static/app/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodData.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodData.tsx
@@ -18,8 +18,8 @@ import type {TableData} from 'sentry/views/dashboards/widgets/common/types';
 interface Props {
   data: TableData;
   field: string;
-  formatter: (datum: TableData[number]) => React.ReactNode;
   previousPeriodData: TableData;
+  renderer: (datum: TableData[number]) => React.ReactNode;
   preferredPolarity?: Polarity;
 }
 
@@ -28,7 +28,7 @@ export function DifferenceToPreviousPeriodData({
   previousPeriodData,
   preferredPolarity = '',
   field,
-  formatter,
+  renderer,
 }: Props) {
   const currentValue = data[0][field];
   const previousValue = previousPeriodData[0][field];
@@ -51,7 +51,7 @@ export function DifferenceToPreviousPeriodData({
   return (
     <Difference rating={rating}>
       <Text>{directionMarker}</Text>
-      <Text>{formatter(differenceAsDatum)}</Text>
+      <Text>{renderer(differenceAsDatum)}</Text>
     </Difference>
   );
 }

--- a/static/app/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodData.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodData.tsx
@@ -47,8 +47,8 @@ export function DifferenceToPreviousPeriodData({
 
   return (
     <Difference rating={rating}>
-      <Indicator>{directionMarker}</Indicator>
-      <Number>{formatter(differenceAsDatum)}</Number>
+      <Text>{directionMarker}</Text>
+      <Text>{formatter(differenceAsDatum)}</Text>
     </Difference>
   );
 }
@@ -56,24 +56,17 @@ export function DifferenceToPreviousPeriodData({
 const Difference = styled(ColorizedRating)`
   display: flex;
   gap: ${space(0.25)};
+  margin-bottom: 6cqh;
 
-  @container (min-height: 70px) {
-    padding-bottom: 5cqh;
+  @container (min-height: 50px) {
+    margin-bottom: 10cqh;
   }
 `;
 
-const Number = styled('div')`
+const Text = styled('div')`
   font-size: 14px;
 
-  @container (min-height: 70px) {
-    font-size: clamp(14px, calc(10px + 4cqi), 30cqh);
-  }
-`;
-
-const Indicator = styled('div')`
-  font-size: 14px;
-
-  @container (min-height: 70px) {
+  @container (min-height: 50px) {
     font-size: clamp(14px, calc(10px + 4cqi), 30cqh);
   }
 `;

--- a/static/app/views/dashboards/widgets/bigNumberWidget/settings.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/settings.tsx
@@ -1,1 +1,2 @@
 export const NO_DATA_PLACEHOLDER = '\u2014';
+export const DEEMPHASIS_COLOR_NAME = 'gray300';

--- a/static/app/views/dashboards/widgets/common/errorPanel.tsx
+++ b/static/app/views/dashboards/widgets/common/errorPanel.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 
 import {IconWarning} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
+import {DEEMPHASIS_COLOR_NAME} from 'sentry/views/dashboards/widgets/bigNumberWidget/settings';
 import type {StateProps} from 'sentry/views/dashboards/widgets/common/types';
 
 interface Props {
@@ -11,7 +12,7 @@ interface Props {
 export function ErrorPanel({error}: Props) {
   return (
     <Panel>
-      <IconWarning color="gray500" size="lg" />
+      <IconWarning color={DEEMPHASIS_COLOR_NAME} size="lg" />
       <span>{error?.toString()}</span>
     </Panel>
   );
@@ -29,6 +30,6 @@ const Panel = styled('div')<{height?: string}>`
 
   overflow: hidden;
 
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme[DEEMPHASIS_COLOR_NAME]};
   font-size: ${p => p.theme.fontSizeExtraLarge};
 `;

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -1,6 +1,6 @@
 export type Meta = {
   fields: Record<string, string>;
-  units: Record<string, string | null>;
+  units?: Record<string, string | null>;
 };
 
 export type TableData = Record<string, number | string | undefined>[];

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -53,6 +53,7 @@ const Frame = styled('div')`
   height: 100%;
   min-height: 96px;
   width: 100%;
+  min-width: 120px;
 
   padding: ${space(2)};
 

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -24,7 +24,9 @@ export function WidgetFrame(props: Props) {
           </Tooltip>
 
           {description && showDescriptionInTooltip && (
-            <QuestionTooltip size="sm" title={description} />
+            <TooltipAligner>
+              <QuestionTooltip size="sm" title={description} />
+            </TooltipAligner>
           )}
         </Title>
 
@@ -86,6 +88,12 @@ const Description = styled('small')`
 const TitleText = styled(HeaderTitle)`
   ${p => p.theme.overflowEllipsis};
   font-weight: ${p => p.theme.fontWeightBold};
+`;
+
+const TooltipAligner = styled('div')`
+  font-size: 0;
+  line-height: 1;
+  margin-bottom: 2px;
 `;
 
 const VisualizationWrapper = styled('div')`

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -51,6 +51,7 @@ const Frame = styled('div')`
   flex-direction: column;
 
   height: 100%;
+  min-height: 96px;
   width: 100%;
 
   padding: ${space(2)};


### PR DESCRIPTION
A variety of small changes to `BigNumberWidget` to make it nicer to render, easier to use, and fit more closely to how it's currently used in the app.

- **Pull field meta off `meta['fields']`**
- **Tweak font sizes**
- **Use field renderers instead of formatters**
- **Reduce spacing**
- **Enforce minimum height**
- **Enforce minimum width**
- **Rename component**
- **More CSS tweaks**
- **Sync deemphasis colours**
- **Improve alignment of description tooltip**
- **Rename confusing prop**
- **Make meta units optional**
