### PR TITLE
feat(dashboards): Update widget actions to hide/display on hover/focus

### DIFF
--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -163,6 +163,7 @@ describe('Dashboards > WidgetCard', function () {
       />
     );
 
+    await userEvent.hover(await screen.findByLabelText('Widget description'));
     expect(await screen.findByText('Valid widget description')).toBeInTheDocument();
   });
 

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -189,6 +189,7 @@ class WidgetCard extends Component<Props, State> {
           tableData={tableData}
           pageLinks={pageLinks}
           totalIssuesCount={totalIssuesCount}
+          description={widget.description}
         />
       </StyledWidgetCardContextMenuContainer>
     );
@@ -336,16 +337,6 @@ class WidgetCard extends Component<Props, State> {
                       <DisplayOnDemandWarnings widget={widget} />
                       <DiscoverSplitAlert widget={widget} />
                     </WidgetTitleRow>
-                    {widget.description && (
-                      <Tooltip
-                        title={widget.description}
-                        containerDisplayMode="grid"
-                        showOnlyOnOverflow
-                        isHoverable
-                      >
-                        <WidgetDescription>{widget.description}</WidgetDescription>
-                      </Tooltip>
-                    )}
                   </WidgetHeaderDescription>
                   {this.renderContextMenu()}
                 </WidgetHeaderWrapper>

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -190,6 +190,7 @@ class WidgetCard extends Component<Props, State> {
           pageLinks={pageLinks}
           totalIssuesCount={totalIssuesCount}
           description={widget.description}
+          title={widget.title}
         />
       </StyledWidgetCardContextMenuContainer>
     );

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -170,25 +170,27 @@ class WidgetCard extends Component<Props, State> {
     }
 
     return (
-      <WidgetCardContextMenu
-        organization={organization}
-        widget={widget}
-        selection={selection}
-        showContextMenu={showContextMenu}
-        isPreview={isPreview}
-        widgetLimitReached={widgetLimitReached}
-        onDuplicate={onDuplicate}
-        onEdit={onEdit}
-        onDelete={onDelete}
-        router={router}
-        location={location}
-        index={index}
-        seriesData={seriesData}
-        seriesResultsType={seriesResultsType}
-        tableData={tableData}
-        pageLinks={pageLinks}
-        totalIssuesCount={totalIssuesCount}
-      />
+      <StyledWidgetCardContextMenuContainer>
+        <WidgetCardContextMenu
+          organization={organization}
+          widget={widget}
+          selection={selection}
+          showContextMenu={showContextMenu}
+          isPreview={isPreview}
+          widgetLimitReached={widgetLimitReached}
+          onDuplicate={onDuplicate}
+          onEdit={onEdit}
+          onDelete={onDelete}
+          router={router}
+          location={location}
+          index={index}
+          seriesData={seriesData}
+          seriesResultsType={seriesResultsType}
+          tableData={tableData}
+          pageLinks={pageLinks}
+          totalIssuesCount={totalIssuesCount}
+        />
+      </StyledWidgetCardContextMenuContainer>
     );
   }
 
@@ -499,6 +501,13 @@ const ErrorCard = styled(Placeholder)`
   margin-bottom: ${space(2)};
 `;
 
+const StyledWidgetCardContextMenuContainer = styled('div')`
+  opacity: 0;
+  transform: scale(0);
+  transition: opacity 0.1s;
+  z-index: 1;
+`;
+
 export const WidgetCardPanel = styled(Panel, {
   shouldForwardProp: prop => prop !== 'isDragging',
 })<{
@@ -511,6 +520,14 @@ export const WidgetCardPanel = styled(Panel, {
   min-height: 96px;
   display: flex;
   flex-direction: column;
+
+  :hover
+    ${StyledWidgetCardContextMenuContainer},
+    :focus-within
+    ${StyledWidgetCardContextMenuContainer} {
+    opacity: 1;
+    transform: scale(1);
+  }
 `;
 
 const StoredDataAlert = styled(Alert)`

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -502,6 +502,7 @@ const ErrorCard = styled(Placeholder)`
 `;
 
 const StyledWidgetCardContextMenuContainer = styled('div')`
+  width: 0;
   opacity: 0;
   transform: scale(0);
   transition: opacity 0.1s;
@@ -525,6 +526,7 @@ export const WidgetCardPanel = styled(Panel, {
     ${StyledWidgetCardContextMenuContainer},
     :focus-within
     ${StyledWidgetCardContextMenuContainer} {
+    width: auto;
     opacity: 1;
     transform: scale(1);
   }

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -315,7 +315,7 @@ class WidgetCard extends Component<Props, State> {
               }
               disabled={Number(this.props.index) !== 0}
             >
-              <WidgetCardPanel isDragging={false}>
+              <WidgetCardPanel isDragging={false} aria-label={t('Widget panel')}>
                 <WidgetHeaderWrapper>
                   <WidgetHeaderDescription>
                     <WidgetTitleRow>
@@ -493,11 +493,8 @@ const ErrorCard = styled(Placeholder)`
 `;
 
 const StyledWidgetCardContextMenuContainer = styled('div')`
-  width: 0;
-  opacity: 0;
-  transform: scale(0);
+  opacity: 1;
   transition: opacity 0.1s;
-  z-index: 1;
 `;
 
 export const WidgetCardPanel = styled(Panel, {
@@ -513,13 +510,17 @@ export const WidgetCardPanel = styled(Panel, {
   display: flex;
   flex-direction: column;
 
-  :hover
-    ${StyledWidgetCardContextMenuContainer},
-    :focus-within
+  &:not(:hover):not(:focus-within) {
     ${StyledWidgetCardContextMenuContainer} {
-    width: auto;
-    opacity: 1;
-    transform: scale(1);
+      opacity: 0;
+      clip: rect(0 0 0 0);
+      clip-path: inset(50%);
+      height: 1px;
+      overflow: hidden;
+      position: absolute;
+      white-space: nowrap;
+      width: 1px;
+    }
   }
 `;
 

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -8,7 +8,8 @@ import {openConfirmModal} from 'sentry/components/confirm';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {isWidgetViewerPath} from 'sentry/components/modals/widgetViewerModal/utils';
-import {IconEllipsis, IconExpand} from 'sentry/icons';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconEllipsis, IconExpand, IconInfo} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types/core';
@@ -42,6 +43,7 @@ type Props = {
   selection: PageFilters;
   widget: Widget;
   widgetLimitReached: boolean;
+  description?: string;
   index?: string;
   isPreview?: boolean;
   onDelete?: () => void;
@@ -73,6 +75,7 @@ function WidgetCardContextMenu({
   pageLinks,
   totalIssuesCount,
   seriesResultsType,
+  description,
 }: Props) {
   const {isMetricsData} = useDashboardsMEPContext();
 
@@ -276,6 +279,16 @@ function WidgetCardContextMenu({
                     {t('Indexed')}
                   </SampledTag>
                 )}
+              {description && (
+                <Tooltip title={description} containerDisplayMode="grid" isHoverable>
+                  <Button
+                    aria-label={t('Widget description')}
+                    borderless
+                    size="xs"
+                    icon={<IconInfo />}
+                  />
+                </Tooltip>
+              )}
               <StyledDropdownMenuControl
                 items={menuOptions}
                 triggerProps={{

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -41,6 +41,7 @@ type Props = {
   organization: Organization;
   router: InjectedRouter;
   selection: PageFilters;
+  title: string;
   widget: Widget;
   widgetLimitReached: boolean;
   description?: string;
@@ -76,6 +77,7 @@ function WidgetCardContextMenu({
   totalIssuesCount,
   seriesResultsType,
   description,
+  title,
 }: Props) {
   const {isMetricsData} = useDashboardsMEPContext();
 
@@ -279,16 +281,25 @@ function WidgetCardContextMenu({
                     {t('Indexed')}
                   </SampledTag>
                 )}
-              {description && (
-                <Tooltip title={description} containerDisplayMode="grid" isHoverable>
-                  <Button
-                    aria-label={t('Widget description')}
-                    borderless
-                    size="xs"
-                    icon={<IconInfo />}
-                  />
-                </Tooltip>
-              )}
+              <Tooltip
+                title={
+                  <span>
+                    <WidgetTooltipTitle>{title}</WidgetTooltipTitle>
+                    {description && (
+                      <WidgetTooltipDescription>{description}</WidgetTooltipDescription>
+                    )}
+                  </span>
+                }
+                containerDisplayMode="grid"
+                isHoverable
+              >
+                <WidgetTooltipButton
+                  aria-label={t('Widget description')}
+                  borderless
+                  size="xs"
+                  icon={<IconInfo />}
+                />
+              </Tooltip>
               <StyledDropdownMenuControl
                 items={menuOptions}
                 triggerProps={{
@@ -344,4 +355,21 @@ const StyledDropdownMenuControl = styled(DropdownMenu)`
 
 const SampledTag = styled(Tag)`
   margin-right: ${space(0.5)};
+`;
+
+const WidgetTooltipTitle = styled('div')`
+  font-weight: bold;
+  font-size: ${p => p.theme.fontSizeMedium};
+  text-align: left;
+`;
+
+const WidgetTooltipDescription = styled('div')`
+  margin-top: ${space(0.5)};
+  font-size: ${p => p.theme.fontSizeSmall};
+  text-align: left;
+`;
+
+// We're using a button here to preserve tab accessibility
+const WidgetTooltipButton = styled(Button)`
+  pointer-events: none;
 `;

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -41,7 +41,6 @@ type Props = {
   organization: Organization;
   router: InjectedRouter;
   selection: PageFilters;
-  title: string;
   widget: Widget;
   widgetLimitReached: boolean;
   description?: string;
@@ -55,6 +54,7 @@ type Props = {
   seriesResultsType?: Record<string, AggregationOutputType>;
   showContextMenu?: boolean;
   tableData?: TableDataWithTitle[];
+  title?: string;
   totalIssuesCount?: string;
 };
 
@@ -281,25 +281,27 @@ function WidgetCardContextMenu({
                     {t('Indexed')}
                   </SampledTag>
                 )}
-              <Tooltip
-                title={
-                  <span>
-                    <WidgetTooltipTitle>{title}</WidgetTooltipTitle>
-                    {description && (
-                      <WidgetTooltipDescription>{description}</WidgetTooltipDescription>
-                    )}
-                  </span>
-                }
-                containerDisplayMode="grid"
-                isHoverable
-              >
-                <WidgetTooltipButton
-                  aria-label={t('Widget description')}
-                  borderless
-                  size="xs"
-                  icon={<IconInfo />}
-                />
-              </Tooltip>
+              {title && (
+                <Tooltip
+                  title={
+                    <span>
+                      <WidgetTooltipTitle>{title}</WidgetTooltipTitle>
+                      {description && (
+                        <WidgetTooltipDescription>{description}</WidgetTooltipDescription>
+                      )}
+                    </span>
+                  }
+                  containerDisplayMode="grid"
+                  isHoverable
+                >
+                  <WidgetTooltipButton
+                    aria-label={t('Widget description')}
+                    borderless
+                    size="xs"
+                    icon={<IconInfo />}
+                  />
+                </Tooltip>
+              )}
               <StyledDropdownMenuControl
                 items={menuOptions}
                 triggerProps={{

--- a/tests/acceptance/test_organization_dashboards.py
+++ b/tests/acceptance/test_organization_dashboards.py
@@ -413,6 +413,9 @@ class OrganizationDashboardsAcceptanceTest(AcceptanceTestCase):
         with self.feature(FEATURE_NAMES + EDIT_FEATURE):
             self.page.visit_dashboard_detail()
 
+            # Hover over the widget to show widget actions
+            self.browser.move_to('[aria-label="Widget panel"]')
+
             self.browser.element('[aria-label="Widget actions"]').click()
             self.browser.element('[data-test-id="delete-widget"]').click()
             self.browser.element('[data-test-id="confirm-button"]').click()

--- a/tests/acceptance/test_organization_dashboards.py
+++ b/tests/acceptance/test_organization_dashboards.py
@@ -377,6 +377,9 @@ class OrganizationDashboardsAcceptanceTest(AcceptanceTestCase):
         with self.feature(FEATURE_NAMES + EDIT_FEATURE):
             self.page.visit_dashboard_detail()
 
+            # Hover over the widget to show widget actions
+            self.browser.move_to('[aria-label="Widget panel"]')
+
             self.browser.element('[aria-label="Widget actions"]').click()
             self.browser.element('[data-test-id="duplicate-widget"]').click()
             self.page.wait_until_loaded()
@@ -512,6 +515,9 @@ class OrganizationDashboardsAcceptanceTest(AcceptanceTestCase):
         with self.feature(FEATURE_NAMES + EDIT_FEATURE):
             self.page.visit_dashboard_detail()
 
+            # Hover over the widget to show widget actions
+            self.browser.move_to('[aria-label="Widget panel"]')
+
             dropdown_trigger = self.browser.element('[aria-label="Widget actions"]')
             dropdown_trigger.click()
 
@@ -562,6 +568,9 @@ class OrganizationDashboardsAcceptanceTest(AcceptanceTestCase):
         )
         with self.feature(FEATURE_NAMES + EDIT_FEATURE):
             self.page.visit_dashboard_detail()
+
+            # Hover over the widget to show widget actions
+            self.browser.move_to('[aria-label="Widget panel"]')
 
             # Open edit modal for first widget
             dropdown_trigger = self.browser.element('[aria-label="Widget actions"]')


### PR DESCRIPTION
Updates widget actions behind hover/focus on the widget card to save title space. Also moves the widget description to a info tooltip in the widget menu.

https://github.com/user-attachments/assets/5be78120-fdd7-48f1-b64c-f40303caa6a3

https://github.com/getsentry/sentry/issues/77898
