### PR TITLE
ref(trace) split expanding from scroll position

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -735,7 +735,7 @@ export function TraceViewWaterfall(props: TraceViewWaterfallProps) {
         if (maybeNode) {
           previouslyFocusedNodeRef.current = null;
           const index = tree.list.findIndex(n => n === maybeNode);
-          if (index !== -1) {
+          if (index === -1) {
             Sentry.captureMessage('Trace tree node is not visible in tree');
             return;
           }
@@ -789,7 +789,7 @@ export function TraceViewWaterfall(props: TraceViewWaterfallProps) {
         if (maybeNode) {
           previouslyFocusedNodeRef.current = null;
           const index = tree.list.findIndex(n => n === maybeNode);
-          if (index !== -1) {
+          if (index === -1) {
             Sentry.captureMessage('Trace tree node is not visible in tree');
             return;
           }

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -734,28 +734,32 @@ export function TraceViewWaterfall(props: TraceViewWaterfallProps) {
       }).then(maybeNode => {
         if (maybeNode) {
           previouslyFocusedNodeRef.current = null;
-          scrollRowIntoView(maybeNode.node, maybeNode.index, 'center if outside', true);
+          const index = tree.list.findIndex(n => n === maybeNode);
+          if (index !== -1) {
+            Sentry.captureMessage('Trace tree node is not visible in tree');
+            return;
+          }
+          scrollRowIntoView(maybeNode, index, 'center if outside', true);
           traceDispatch({
             type: 'set roving index',
-            node: maybeNode.node,
-            index: maybeNode.index,
+            node: maybeNode,
+            index: index,
             action_source: 'click',
           });
           setRowAsFocused(
-            maybeNode.node,
+            maybeNode,
             null,
             traceStateRef.current.search.resultsLookup,
             null,
             0
           );
 
-          if (traceStateRef.current.search.resultsLookup.has(maybeNode.node)) {
+          if (traceStateRef.current.search.resultsLookup.has(maybeNode)) {
             traceDispatch({
               type: 'set search iterator index',
-              resultIndex: maybeNode.index,
-              resultIteratorIndex: traceStateRef.current.search.resultsLookup.get(
-                maybeNode.node
-              )!,
+              resultIndex: index,
+              resultIteratorIndex:
+                traceStateRef.current.search.resultsLookup.get(maybeNode)!,
             });
           } else if (traceStateRef.current.search.resultIteratorIndex !== null) {
             traceDispatch({type: 'clear search iterator index'});
@@ -784,21 +788,25 @@ export function TraceViewWaterfall(props: TraceViewWaterfallProps) {
       }).then(maybeNode => {
         if (maybeNode) {
           previouslyFocusedNodeRef.current = null;
-          scrollRowIntoView(maybeNode.node, maybeNode.index, 'center if outside', true);
+          const index = tree.list.findIndex(n => n === maybeNode);
+          if (index !== -1) {
+            Sentry.captureMessage('Trace tree node is not visible in tree');
+            return;
+          }
+          scrollRowIntoView(maybeNode, index, 'center if outside', true);
           traceDispatch({
             type: 'set roving index',
-            node: maybeNode.node,
-            index: maybeNode.index,
+            node: maybeNode,
+            index: index,
             action_source: 'click',
           });
 
-          if (traceStateRef.current.search.resultsLookup.has(maybeNode.node)) {
+          if (traceStateRef.current.search.resultsLookup.has(maybeNode)) {
             traceDispatch({
               type: 'set search iterator index',
-              resultIndex: maybeNode.index,
-              resultIteratorIndex: traceStateRef.current.search.resultsLookup.get(
-                maybeNode.node
-              )!,
+              resultIndex: index,
+              resultIteratorIndex:
+                traceStateRef.current.search.resultsLookup.get(maybeNode)!,
             });
           } else if (traceStateRef.current.search.resultIteratorIndex !== null) {
             traceDispatch({type: 'clear search iterator index'});

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -290,16 +290,10 @@ export function Trace({
         : Promise.resolve(null);
 
     promise
-      .then(async () => {
+      .then(async node => {
         if (!scrollQueueRef.current?.path && !scrollQueueRef.current?.eventId) {
           return;
         }
-
-        const node = scrollQueueRef.current?.eventId
-          ? trace.findByEventId(trace.root, scrollQueueRef.current?.eventId)
-          : scrollQueueRef.current?.path
-            ? trace.findByPath(trace.root, scrollQueueRef.current?.path)
-            : null;
 
         if (!node) {
           Sentry.captureMessage('Failed to find and scroll to node in tree');
@@ -316,7 +310,32 @@ export function Trace({
           });
         }
 
-        const index = trace.list.indexOf(node);
+        let index = trace.list.indexOf(node);
+        // We have found the node, yet it is somehow not in the visible tree.
+        // This means that the path we were given did not match the current tree.
+        // This sometimes happens when we receive external links like span-x, txn-y
+        // however the resulting tree looks like span-x, autogroup, txn-y. In this case,
+        // we should expand the autogroup node and try to find the node again.
+        if (node && index === -1) {
+          let parent_node = node.parent;
+          while (parent_node) {
+            // Transactions break autogrouping chains, so we can stop here
+            if (isTransactionNode(parent_node)) {
+              break;
+            }
+            if (isAutogroupedNode(parent_node)) {
+              trace.expand(parent_node, true);
+              // This is very wasteful as it performs O(n^2) search each time we expand a node...
+              // In most cases though, we should be operating on a tree with sub 10k elements and hopefully
+              // a low autogrouped node count.
+              index = node ? trace.list.findIndex(n => n === node) : -1;
+              if (index !== -1) {
+                break;
+              }
+            }
+            parent_node = parent_node.parent;
+          }
+        }
         onTraceLoad(trace, node, index === -1 ? null : index);
       })
       .finally(() => {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -1484,7 +1484,7 @@ export class TraceTree {
 
     if (segments.length === 1 && segments[0] === 'trace-root') {
       rerender();
-      return Promise.resolve(null);
+      return Promise.resolve(tree.root.children[0]);
     }
 
     // Keep parent reference as we traverse the tree so that we can only

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -835,6 +835,45 @@ export class TraceTree {
     }
   }
 
+  findByEventId(
+    start: TraceTreeNode<TraceTree.NodeValue>,
+    eventId: string
+  ): TraceTreeNode<TraceTree.NodeValue> | null {
+    return TraceTreeNode.Find(start, node => {
+      if (isTransactionNode(node)) {
+        return node.value.event_id === eventId;
+      }
+      if (isSpanNode(node)) {
+        return node.value.span_id === eventId;
+      }
+      if (isTraceErrorNode(node)) {
+        return node.value.event_id === eventId;
+      }
+      return hasEventWithEventId(node, eventId);
+    });
+  }
+
+  findByPath(
+    start: TraceTreeNode<TraceTree.NodeValue>,
+    path: TraceTree.NodePath[]
+  ): TraceTreeNode<TraceTree.NodeValue> | null {
+    const queue = [...path];
+    let segment = start;
+    let node: TraceTreeNode<TraceTree.NodeValue> | null = null;
+
+    while (queue.length > 0) {
+      const current = queue.pop()!;
+
+      node = findInTreeFromSegment(segment, current);
+      if (!node) {
+        return null;
+      }
+      segment = node;
+    }
+
+    return node;
+  }
+
   get shape(): TraceType {
     const trace = this.root.children[0];
     if (!trace) {
@@ -1421,28 +1460,13 @@ export class TraceTree {
     rerender: () => void,
     options: ViewManagerScrollToOptions
   ): Promise<{index: number; node: TraceTreeNode<TraceTree.NodeValue>} | null | null> {
-    const node = findInTreeByEventId(tree.root, eventId);
+    const node = tree.findByEventId(tree.root, eventId);
 
     if (!node) {
       return Promise.resolve(null);
     }
 
-    return TraceTree.ExpandToPath(tree, node.path, rerender, options).then(
-      async result => {
-        // When users are coming off an eventID link, we want to fetch the children
-        // of the node that the eventID points to. This is because the eventID link
-        // only points to the transaction, but we want to fetch the children of the
-        // transaction to show the user the list of spans in that transaction
-        if (result?.node?.canFetch) {
-          await tree.zoomIn(result.node, true, options).catch(_e => {
-            Sentry.captureMessage('Failed to fetch children of eventId on mount');
-          });
-          return result;
-        }
-
-        return result;
-      }
-    );
+    return TraceTree.ExpandToPath(tree, node.path, rerender, options);
   }
 
   static ExpandToPath(
@@ -1450,7 +1474,7 @@ export class TraceTree {
     scrollQueue: TraceTree.NodePath[],
     rerender: () => void,
     options: ViewManagerScrollToOptions
-  ): Promise<{index: number; node: TraceTreeNode<TraceTree.NodeValue>} | null | null> {
+  ): Promise<null> {
     const segments = [...scrollQueue];
     const list = tree.list;
 
@@ -1460,17 +1484,14 @@ export class TraceTree {
 
     if (segments.length === 1 && segments[0] === 'trace-root') {
       rerender();
-      return Promise.resolve({index: 0, node: tree.root.children[0]});
+      return Promise.resolve(null);
     }
 
     // Keep parent reference as we traverse the tree so that we can only
     // perform searching in the current level and not the entire tree
     let parent: TraceTreeNode<TraceTree.NodeValue> = tree.root;
 
-    const recurseToRow = async (): Promise<{
-      index: number;
-      node: TraceTreeNode<TraceTree.NodeValue>;
-    } | null | null> => {
+    const recurseToRow = async (): Promise<null> => {
       const path = segments.pop();
       let current = findInTreeFromSegment(parent, path!);
 
@@ -1559,7 +1580,7 @@ export class TraceTree {
       }
 
       rerender();
-      return {index, node: current};
+      return null;
     };
 
     return recurseToRow();
@@ -2594,21 +2615,6 @@ function hasEventWithEventId(
   }
 
   return false;
-}
-
-function findInTreeByEventId(start: TraceTreeNode<TraceTree.NodeValue>, eventId: string) {
-  return TraceTreeNode.Find(start, node => {
-    if (isTransactionNode(node)) {
-      return node.value.event_id === eventId;
-    }
-    if (isSpanNode(node)) {
-      return node.value.span_id === eventId;
-    }
-    if (isTraceErrorNode(node)) {
-      return node.value.event_id === eventId;
-    }
-    return hasEventWithEventId(node, eventId);
-  });
 }
 
 function findInTreeFromSegment(

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
@@ -329,7 +329,6 @@ describe('VirtualizedViewManger', () => {
       );
 
       manager.list = makeList();
-
       const result = await TraceTree.ExpandToPath(tree, tree.list[0].path, () => void 0, {
         api: api,
         organization,

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
@@ -335,7 +335,7 @@ describe('VirtualizedViewManger', () => {
         organization,
       });
 
-      expect(result?.node).toBe(tree.list[0]);
+      expect(result).toBe(tree.list[0]);
     });
 
     it('scrolls to transaction', async () => {
@@ -360,7 +360,7 @@ describe('VirtualizedViewManger', () => {
         organization,
       });
 
-      expect(result?.node).toBe(tree.list[2]);
+      expect(result).toBe(tree.list[2]);
     });
 
     it('scrolls to nested transaction', async () => {
@@ -404,7 +404,7 @@ describe('VirtualizedViewManger', () => {
         }
       );
 
-      expect(result?.node).toBe(tree.list[tree.list.length - 1]);
+      expect(result).toBe(tree.list[tree.list.length - 1]);
     });
 
     it('scrolls to spans of expanded transaction', async () => {
@@ -441,7 +441,7 @@ describe('VirtualizedViewManger', () => {
       );
 
       expect(tree.list[1].zoomedIn).toBe(true);
-      expect(result?.node).toBe(tree.list[2]);
+      expect(result).toBe(tree.list[2]);
     });
 
     it('scrolls to span -> transaction -> span -> transaction', async () => {
@@ -678,7 +678,7 @@ describe('VirtualizedViewManger', () => {
         organization,
       });
 
-      expect(result?.node).toBe(tree.list[2]);
+      expect(result).toBe(tree.list[2]);
     });
 
     describe('error handling', () => {


### PR DESCRIPTION
Split scroll from expanding - this is going to enable a change to autogrouping logic later on that we need in order to support enabling/disabling autogrouping