### PR TITLE
ref(alerts): Move dynamic rule code into their own functions for create/update alert

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -15,12 +15,9 @@ from django.db.models import QuerySet
 from django.db.models.signals import post_save
 from django.forms import ValidationError
 from django.utils import timezone as django_timezone
-from parsimonious.exceptions import ParseError
 from snuba_sdk import Column, Condition, Limit, Op
-from urllib3.exceptions import MaxRetryError, TimeoutError
 
-from sentry import analytics, audit_log, features, quotas
-from sentry.api.exceptions import ResourceDoesNotExist
+from sentry import analytics, audit_log, quotas
 from sentry.auth.access import SystemAccess
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS, ObjectStatus
 from sentry.db.models import Model
@@ -71,7 +68,7 @@ from sentry.search.events.constants import (
 )
 from sentry.search.events.fields import is_function, resolve_field
 from sentry.seer.anomaly_detection.delete_rule import delete_rule_in_seer
-from sentry.seer.anomaly_detection.store_data import send_historical_data_to_seer
+from sentry.seer.anomaly_detection.store_data import send_new_rule_data, update_rule_data
 from sentry.sentry_apps.services.app import RpcSentryAppInstallation, app_service
 from sentry.shared_integrations.exceptions import (
     ApiTimeoutError,
@@ -568,12 +565,9 @@ def create_alert_rule(
     """
     if monitor_type == AlertRuleMonitorTypeInt.ACTIVATED and not activation_condition:
         raise ValidationError("Activation condition required for activated alert rule")
-    if detection_type == AlertRuleDetectionType.DYNAMIC:
-        resolution = time_window
-    else:
-        resolution = get_alert_resolution(time_window, organization)
 
     if detection_type == AlertRuleDetectionType.DYNAMIC:
+        resolution = time_window
         # NOTE: we hardcode seasonality for EA
         seasonality = AlertRuleSeasonality.AUTO
         if not (sensitivity):
@@ -581,7 +575,7 @@ def create_alert_rule(
         if time_window not in DYNAMIC_TIME_WINDOWS:
             raise ValidationError(INVALID_TIME_WINDOW)
     else:
-        # NOTE: we hardcode seasonality for EA
+        resolution = get_alert_resolution(time_window, organization)
         seasonality = None
         if sensitivity:
             raise ValidationError("Sensitivity is not a valid field for this alert type")
@@ -652,31 +646,8 @@ def create_alert_rule(
             AlertRuleExcludedProjects.objects.bulk_create(exclusions)
 
         if alert_rule.detection_type == AlertRuleDetectionType.DYNAMIC.value:
-            if not features.has("organizations:anomaly-detection-alerts", organization):
-                alert_rule.delete()
-                raise ResourceDoesNotExist(
-                    "Your organization does not have access to this feature."
-                )
-
-            try:
-                # NOTE: if adding a new metric alert type, take care to check that it's handled here
-                rule_status = send_historical_data_to_seer(
-                    alert_rule=alert_rule, project=projects[0]
-                )
-                if rule_status == AlertRuleStatus.NOT_ENOUGH_DATA:
-                    # if we don't have at least seven days worth of data, then the dynamic alert won't fire
-                    alert_rule.update(status=AlertRuleStatus.NOT_ENOUGH_DATA.value)
-            except (TimeoutError, MaxRetryError):
-                alert_rule.delete()
-                raise TimeoutError("Failed to send data to Seer - cannot create alert rule.")
-            except ParseError:
-                alert_rule.delete()
-                raise ParseError("Failed to parse Seer store data response")
-            except (ValidationError, Exception):
-                alert_rule.delete()
-                raise
-            else:
-                metrics.incr("anomaly_detection_alert.created")
+            # NOTE: if adding a new metric alert type, take care to check that it's handled here
+            send_new_rule_data(organization, alert_rule, projects[0])
 
         if user:
             create_audit_entry_from_user(
@@ -932,35 +903,11 @@ def update_alert_rule(
             updated_fields["team_id"] = alert_rule.team_id
 
         if detection_type == AlertRuleDetectionType.DYNAMIC:
-            if not features.has("organizations:anomaly-detection-alerts", organization):
-                raise ResourceDoesNotExist(
-                    "Your organization does not have access to this feature."
-                )
-
-            if updated_fields.get("detection_type") == AlertRuleDetectionType.DYNAMIC and (
-                alert_rule.detection_type != AlertRuleDetectionType.DYNAMIC or query or aggregate
-            ):
-                for k, v in updated_fields.items():
-                    setattr(alert_rule, k, v)
-
-                try:
-                    # NOTE: if adding a new metric alert type, take care to check that it's handled here
-                    rule_status = send_historical_data_to_seer(
-                        alert_rule=alert_rule,
-                        project=projects[0] if projects else alert_rule.projects.get(),
-                    )
-                    if rule_status == AlertRuleStatus.NOT_ENOUGH_DATA:
-                        # if we don't have at least seven days worth of data, then the dynamic alert won't fire
-                        alert_rule.update(status=AlertRuleStatus.NOT_ENOUGH_DATA.value)
-                except (TimeoutError, MaxRetryError):
-                    raise TimeoutError("Failed to send data to Seer - cannot update alert rule.")
-                except ParseError:
-                    raise ParseError(
-                        "Failed to parse Seer store data response - cannot update alert rule."
-                    )
-                except (ValidationError, Exception):
-                    # If there's no historical data available—something went wrong when querying snuba
-                    raise ValidationError("Failed to send data to Seer - cannot update alert rule.")
+            # NOTE: if adding a new metric alert type, take care to check that it's handled here
+            project = projects[0] if projects else alert_rule.projects.get()
+            update_rule_data(
+                organization, alert_rule, project, updated_fields, updated_query_fields
+            )
         else:
             # if this was a dynamic rule, delete the data in Seer
             if alert_rule.detection_type == AlertRuleDetectionType.DYNAMIC:

--- a/src/sentry/seer/anomaly_detection/store_data.py
+++ b/src/sentry/seer/anomaly_detection/store_data.py
@@ -7,12 +7,9 @@ from django.core.exceptions import ValidationError
 from parsimonious.exceptions import ParseError
 from urllib3.exceptions import MaxRetryError, TimeoutError
 
-from sentry import features
 from sentry.api.bases.organization_events import get_query_columns
-from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.conf.server import SEER_ANOMALY_DETECTION_STORE_DATA_URL
 from sentry.incidents.models.alert_rule import AlertRule, AlertRuleDetectionType, AlertRuleStatus
-from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.net.http import connection_from_url
 from sentry.seer.anomaly_detection.types import (
@@ -78,10 +75,7 @@ def handle_send_historical_data_to_seer(alert_rule: AlertRule, project: Project,
         raise ValidationError(f"Failed to send data to Seer - cannot {method} alert rule.")
 
 
-def send_new_rule_data(organization: Organization, alert_rule: AlertRule, project: Project) -> None:
-    if not features.has("organizations:anomaly-detection-alerts", organization):
-        alert_rule.delete()
-        raise ResourceDoesNotExist("Your organization does not have access to this feature.")
+def send_new_rule_data(alert_rule: AlertRule, project: Project) -> None:
     try:
         handle_send_historical_data_to_seer(alert_rule, project, "create")
     except (TimeoutError, MaxRetryError, ParseError, ValidationError):
@@ -92,14 +86,11 @@ def send_new_rule_data(organization: Organization, alert_rule: AlertRule, projec
 
 
 def update_rule_data(
-    organization: Organization,
     alert_rule: AlertRule,
     project: Project,
     updated_fields: dict[str, Any],
     updated_query_fields: dict[str, Any],
 ) -> None:
-    if not features.has("organizations:anomaly-detection-alerts", organization):
-        raise ResourceDoesNotExist("Your organization does not have access to this feature.")
     # if the rule previously wasn't a dynamic type but it is now, we need to send Seer data for the first time
     # OR it's dynamic but the query or aggregate is changing so we need to update the data Seer has
     if updated_fields.get("detection_type") == AlertRuleDetectionType.DYNAMIC and (

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -10,6 +10,7 @@ from django.db import router, transaction
 from django.test.utils import override_settings
 from httpx import HTTPError
 from rest_framework import status
+from rest_framework.exceptions import ErrorDetail
 from urllib3.exceptions import MaxRetryError, TimeoutError
 from urllib3.response import HTTPResponse
 
@@ -400,7 +401,10 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
                 **data,
             )
         assert not AlertRule.objects.filter(detection_type=AlertRuleDetectionType.DYNAMIC).exists()
-        assert resp.data["detail"]["message"] == "Invalid request"
+        assert resp.data[0] == ErrorDetail(
+            string="Failed to send data to Seer - cannot create alert rule.", code="invalid"
+        )
+
         assert mock_seer_request.call_count == 1
 
     @with_feature("organizations:anomaly-detection-alerts")


### PR DESCRIPTION
`create_alert_rule` and `update_alert_rule` are long functions already, so this PR moves the dynamic rule specific code out of it. 

Closes https://getsentry.atlassian.net/browse/ALRT-306