### PR TITLE
feat(spans): Adjust confidence calculations

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1848,7 +1848,7 @@ register(
 )
 # Used for the z-score when calculating the margin of error in performance
 register(
-    "performance.confidence.z-score",
+    "performance.extrapolation.confidence.z-score",
     type=Float,
     default=1.96,
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1846,6 +1846,13 @@ register(
     default=[],
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Used for the z-score when calculating the margin of error in performance
+register(
+    "performance.confidence.z-score",
+    type=Float,
+    default=1.96,
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
 # Used for enabling flags in ST. Should be removed once Flagpole works in all STs.
 register("performance.use_metrics.enabled", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -878,24 +878,29 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
             "proportion_by_sample",
         )
         return Function(
-            "multiply",
+            "round",
             [
                 Function(
-                    "arrayMax",
+                    "multiply",
                     [
-                        [
-                            0,
-                            Function(
-                                "minus",
+                        Function(
+                            "arrayMax",
+                            [
                                 [
-                                    proportion_by_sample,
-                                    self._resolve_margin_of_error(args, "margin_of_error"),
-                                ],
-                            ),
-                        ]
+                                    0,
+                                    Function(
+                                        "minus",
+                                        [
+                                            proportion_by_sample,
+                                            self._resolve_margin_of_error(args, "margin_of_error"),
+                                        ],
+                                    ),
+                                ]
+                            ],
+                        ),
+                        total_proportion,
                     ],
-                ),
-                total_proportion,
+                )
             ],
             alias,
         )
@@ -918,16 +923,21 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
             "proportion_by_sample",
         )
         return Function(
-            "multiply",
+            "round",
             [
                 Function(
-                    "plus",
+                    "multiply",
                     [
-                        proportion_by_sample,
-                        self._resolve_margin_of_error(args, "margin_of_error"),
+                        Function(
+                            "plus",
+                            [
+                                proportion_by_sample,
+                                self._resolve_margin_of_error(args, "margin_of_error"),
+                            ],
+                        ),
+                        total_proportion,
                     ],
-                ),
-                total_proportion,
+                )
             ],
             alias,
         )

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -872,6 +872,6 @@ class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsSpanIndexedEndpoin
         assert margin_of_error == pytest.approx(0.306, rel=1e-1)
         # How to read this; these results mean that the extrapolated count is
         # 500k, with a lower estimated bound of ~200k, and an upper bound of 800k
-        assert lower_limit == pytest.approx(193_612, abs=5000)
+        assert lower_limit == pytest.approx(190_000, abs=5000)
         assert extrapolated == pytest.approx(500_000)
-        assert upper_limit == pytest.approx(806_388, abs=5000)
+        assert upper_limit == pytest.approx(810_000, abs=5000)


### PR DESCRIPTION
- Shuffles the variables around for the bounds calculations to match a discussion I had with @shellmayr
    - The resulting values didn't change significantly, I think part of the problem for timeseries is i'm still using the overall count instead of the count of the bucket, going to update that in a follow up
- Adds an option to change zscore
- Adds a function param to disable FPC