### PR TITLE
fix(csp-report): URL for Project Settings option in search

### DIFF
--- a/static/app/data/forms/cspReports.tsx
+++ b/static/app/data/forms/cspReports.tsx
@@ -2,7 +2,7 @@
 import type {JsonFormObject} from 'sentry/components/forms/types';
 import {t} from 'sentry/locale';
 
-export const route = '/settings/:orgId/projects/:projectId/csp/';
+export const route = '/settings/:orgId/projects/:projectId/security-headers/csp';
 
 const formGroups: JsonFormObject[] = [
   {

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -643,7 +643,10 @@ function buildRoutes() {
         name={t('Loader Script')}
         component={make(() => import('sentry/views/settings/project/loaderScript'))}
       />
-      <Redirect from="csp/" to="security-headers/" />
+      <Redirect
+        from="csp/"
+        to="/settings/:orgId/projects/:projectId/security-headers/csp/"
+      />
       <Route path="security-headers/" name={t('Security Headers')}>
         <IndexRoute
           component={make(() => import('sentry/views/settings/projectSecurityHeaders'))}


### PR DESCRIPTION
When searching for "Additional ignored sources" in the org settings, the redirect was going to the incorrect URL. Modify the URL to be the most up to date version now.

Technically, we do have a `<Redirect>` component in `routes.tsx` which is _supposed_ to handle this, but surprisingly, `<Redirect from="csp/" to="security-headers/" />` doesn't take a URL like `www.sentry.sentry.io/settings/sentry/projects/internal/csp` to `www.sentry.sentry.io/settings/sentry/projects/internal/security-headers`. Since it's using _relative_ paths, `security-headers/` simply gets appended on the end so our resulting URL is `www.sentry.sentry.io/settings/sentry/projects/internal/csp/security-headers`

The only way this works is if the `to` parameter is the full absolute path which is deeply nested. Since this behaviour is elsewhere in the app (e.g. go to `/settings/sentry/members/requests`), I decided to just fix the URL for this report for now, but I'll check if it can be fixed globally