### PR TITLE
fix(tooltip) Fixes tooltip's overflow calculation on Safari

### DIFF
--- a/static/app/utils/useHoverOverlay.tsx
+++ b/static/app/utils/useHoverOverlay.tsx
@@ -122,7 +122,16 @@ interface UseHoverOverlayProps {
 }
 
 function isOverflown(el: Element): boolean {
-  return el.scrollWidth > el.clientWidth || Array.from(el.children).some(isOverflown);
+  // Safari seems to calculate scrollWidth incorrectly, causing isOverflown to always return true in some cases.
+  // Adding a 2 pixel tolerance seems to account for this discrepancy.
+  const tolerance =
+    navigator.userAgent.includes('Safari') && !navigator.userAgent.includes('Chrome')
+      ? 2
+      : 0;
+  return (
+    el.scrollWidth - el.clientWidth > tolerance ||
+    Array.from(el.children).some(isOverflown)
+  );
 }
 
 function maybeClearRefTimeout(ref: React.MutableRefObject<number | undefined>) {

--- a/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
@@ -88,7 +88,7 @@ function EditableTabTitle({
   };
 
   return (
-    <Tooltip title={label} showOnlyOnOverflow skipWrapper>
+    <Tooltip title={label} disabled={isEditing} showOnlyOnOverflow skipWrapper>
       <motion.div layout="position" transition={{duration: 0.25}}>
         {isSelected ? (
           <StyledGrowingInput


### PR DESCRIPTION
Fixes a bug where with the `showOnlyOnOverflow` prop on tooltips where it would detect false positives on Safari. This was due to Safari apparently incorrectly calculating the scroll width to always be slightly greater than the client width, thus causing the tooltip to always think the content was overflowing. We can solve this simply by adding a tolerance if the user is  on Safari. 