### PR TITLE
chore(grouping): Remove all uses of non-optimized-grouping-related code

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -53,11 +53,7 @@ from sentry.grouping.api import (
     GroupingConfig,
     get_grouping_config_dict_for_project,
 )
-from sentry.grouping.ingest.config import (
-    is_in_transition,
-    project_uses_optimized_grouping,
-    update_grouping_config_if_needed,
-)
+from sentry.grouping.ingest.config import is_in_transition, update_grouping_config_if_needed
 from sentry.grouping.ingest.hashing import (
     find_existing_grouphash,
     get_hash_values,
@@ -517,12 +513,10 @@ class EventManager:
             return jobs[0]["event"]
         else:
             project = job["event"].project
-            job["optimized_grouping"] = project_uses_optimized_grouping(project)
             job["in_grouping_transition"] = is_in_transition(project)
             metric_tags = {
                 "platform": job["event"].platform or "unknown",
                 "sdk": normalized_sdk_tag_from_event(job["event"].data),
-                "using_transition_optimization": job["optimized_grouping"],
                 "in_transition": job["in_grouping_transition"],
             }
             # This metric allows differentiating from all calls to the `event_manager.save` metric

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1323,20 +1323,11 @@ def get_culprit(data: Mapping[str, Any]) -> str:
 
 @sentry_sdk.tracing.trace
 def assign_event_to_group(event: Event, job: Job, metric_tags: MutableTags) -> GroupInfo | None:
-    if job["optimized_grouping"]:
-        group_info = _save_aggregate_new(
-            event=event,
-            job=job,
-            metric_tags=metric_tags,
-        )
-    else:
-        group_info = _save_aggregate(
-            event=event,
-            job=job,
-            release=job["release"],
-            received_timestamp=job["received_timestamp"],
-            metric_tags=metric_tags,
-        )
+    group_info = _save_aggregate_new(
+        event=event,
+        job=job,
+        metric_tags=metric_tags,
+    )
 
     if group_info:
         event.group = group_info.group

--- a/src/sentry/grouping/ingest/metrics.py
+++ b/src/sentry/grouping/ingest/metrics.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from sentry import options
 from sentry.grouping.api import GroupingConfig
-from sentry.grouping.ingest.config import is_in_transition, project_uses_optimized_grouping
+from sentry.grouping.ingest.config import is_in_transition
 from sentry.models.project import Project
 from sentry.utils import metrics
 from sentry.utils.tag_normalization import normalized_sdk_tag_from_event
@@ -65,7 +65,6 @@ def record_calculation_metric_with_result(
     # count to get an average number of calculations per event
     tags = {
         "in_transition": str(is_in_transition(project)),
-        "using_transition_optimization": str(project_uses_optimized_grouping(project)),
         "result": result,
     }
     metrics.incr(


### PR DESCRIPTION
As a first step towards removing the now-unused code paths related to non-optimized grouping, this removes all references to them, both in production code and in tests. Spedifically:

- Remove the branch in `assign_event_to_group` which calls `_save_aggregate`.
- Stop tagging both `job` and metrics with whether or not optimization is being used.
- In tests where we test both optimized and non-optimized grouping, remove the non-optimized cases.
- Remove the test of which path is taken.

The code itself will be removed in a follow-up PR.