### PR TITLE
chore(grouping): Remove non-optimized-grouping-related code

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -879,26 +879,6 @@ def _materialize_metadata_many(jobs: Sequence[Job]) -> None:
         job["culprit"] = data["culprit"]
 
 
-# TODO: This is only called in `_save_aggregate`, so when that goes, so can this (it's been
-# supplanted by `_get_group_processing_kwargs` below)
-def _get_group_creation_kwargs(job: Job | PerformanceJob) -> dict[str, Any]:
-    kwargs = {
-        "platform": job["platform"],
-        "message": job["event"].search_message,
-        "logger": job["logger_name"],
-        "level": LOG_LEVELS_MAP.get(job["level"]),
-        "last_seen": job["event"].datetime,
-        "first_seen": job["event"].datetime,
-        "active_at": job["event"].datetime,
-        "culprit": job["culprit"],
-    }
-
-    if job["release"]:
-        kwargs["first_release"] = job["release"]
-
-    return kwargs
-
-
 def _get_group_processing_kwargs(job: Job) -> dict[str, Any]:
     """
     Pull together all the metadata used when creating a group or updating a group's metadata based

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -56,7 +56,6 @@ from sentry.grouping.api import (
 from sentry.grouping.ingest.config import is_in_transition, update_grouping_config_if_needed
 from sentry.grouping.ingest.hashing import (
     find_existing_grouphash,
-    get_hash_values,
     get_or_create_grouphashes,
     maybe_run_background_grouping,
     maybe_run_secondary_grouping,
@@ -75,7 +74,7 @@ from sentry.grouping.ingest.utils import (
 )
 from sentry.ingest.inbound_filters import FilterStatKeys
 from sentry.integrations.tasks.kick_off_status_syncs import kick_off_status_syncs
-from sentry.issues.grouptype import ErrorGroupType, GroupCategory
+from sentry.issues.grouptype import ErrorGroupType
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.killswitches import killswitch_matches_context
@@ -135,7 +134,6 @@ from sentry.utils.performance_issues.performance_problem import PerformanceProbl
 from sentry.utils.safe import get_path, safe_execute, setdefault_path, trim
 from sentry.utils.sdk import set_measurement
 from sentry.utils.tag_normalization import normalized_sdk_tag_from_event
-from sentry.utils.types import NonNone
 
 if TYPE_CHECKING:
     from sentry.eventstore.models import BaseEvent, Event
@@ -1328,246 +1326,6 @@ def assign_event_to_group(event: Event, job: Job, metric_tags: MutableTags) -> G
     job["groups"] = [group_info]
 
     return group_info
-
-
-def _save_aggregate(
-    event: Event,
-    job: Job,
-    release: Release | None,
-    received_timestamp: int | float,
-    metric_tags: MutableTags,
-) -> GroupInfo | None:
-    project = event.project
-
-    primary_hashes, secondary_hashes = get_hash_values(project, job, metric_tags)
-    hashes = primary_hashes + secondary_hashes
-    has_secondary_hashes = len(secondary_hashes) > 0
-
-    # Now that we've used the current and possibly secondary grouping config(s) to calculate the
-    # hashes, we're free to perform a config update if permitted. Future events will use the new
-    # config, but will also be grandfathered into the current config for a month, so as not to
-    # erroneously create new groups.
-    update_grouping_config_if_needed(project, "ingest")
-
-    _materialize_metadata_many([job])
-    metadata = dict(job["event_metadata"])
-
-    group_creation_kwargs = _get_group_creation_kwargs(job)
-
-    grouphashes = get_or_create_grouphashes(project, hashes)
-
-    existing_grouphash = find_existing_grouphash(grouphashes)
-
-    # In principle the group gets the same metadata as the event, so common
-    # attributes can be defined in eventtypes.
-    #
-    # Additionally the `last_received` key is set for group metadata, later in
-    # _save_aggregate
-    group_creation_kwargs["data"] = materialize_metadata(
-        event.data,
-        get_event_type(event.data),
-        metadata,
-    )
-    group_creation_kwargs["data"]["last_received"] = received_timestamp
-
-    if existing_grouphash is None:
-        if killswitch_matches_context(
-            "store.load-shed-group-creation-projects",
-            {
-                "project_id": project.id,
-                "platform": event.platform,
-            },
-        ):
-            raise HashDiscarded("Load shedding group creation", reason="load_shed")
-
-        with (
-            sentry_sdk.start_span(op="event_manager.create_group_transaction") as span,
-            metrics.timer("event_manager.create_group_transaction") as metric_tags,
-            transaction.atomic(router.db_for_write(GroupHash)),
-        ):
-            # These values will get overridden with whatever happens inside the lock if we do manage
-            # to acquire it, so it should only end up with `wait-for-lock` if we don't
-            #
-            # TODO: If we're using this `outome` value for anything more than a count in DD (in
-            # other words, if we care about duration), we should probably update it so that when an
-            # event does have to wait, we record whether during its wait the event which got the
-            # lock first
-            #   a) created a new group without consulting Seer,
-            #   b) created a new group because Seer didn't find a close enough match, or
-            #   c) used an existing group found by Seer
-            # because which of those things happened will have an effect on how long the event had to wait.
-            span.set_tag("outcome", "wait_for_lock")
-            metric_tags["outcome"] = "wait_for_lock"
-
-            grouphash_ids = [h.id for h in grouphashes]
-
-            # If we're in this branch, we checked our grouphashes and didn't find one with a group
-            # attached. We thus want to either ask seer for a nearest neighbor group (and create a
-            # new group if one isn't found) or just create a new group without consulting seer, but
-            # either way we need to guard against another event with the same hash coming in before
-            # we're done here and also thinking it needs to talk to seer and/or create a new group.
-            # To prevent this, we're using double-checked locking
-            # (https://en.wikipedia.org/wiki/Double-checked_locking).
-
-            # First, try to lock the relevant rows in the `GroupHash` table. If another (identically
-            # hashed) event is already in the process of talking to seer and/or creating a group and
-            # has grabbed the lock before us, we'll block here until it's done. If not, we've now
-            # got the lock and other identically-hashed events will have to wait for us.
-            all_grouphashes = list(
-                GroupHash.objects.filter(id__in=grouphash_ids).select_for_update()
-            )
-
-            grouphashes = [gh for gh in all_grouphashes if gh.hash in hashes]
-
-            # Now check again to see if any of our grouphashes have a group. If we got the lock, the
-            # result won't have changed and we still won't find anything. If we didn't get it, we'll
-            # have blocked until whichever identically-hashed event *did* get the lock has either
-            # created a new group for our hashes or assigned them to a neighboring group suggessted
-            # by seer. If that happens, we'll skip this whole branch and jump down to the same one
-            # we would have landed in had we found a group to begin with.
-            existing_grouphash = find_existing_grouphash(grouphashes)
-
-            # If we still haven't found a matching grouphash, we're now safe to go ahead and talk to
-            # seer and/or create the group.
-            if existing_grouphash is None:
-                seer_matched_grouphash = maybe_check_seer_for_matching_grouphash(event)
-                seer_matched_group = (
-                    Group.objects.filter(id=seer_matched_grouphash.group_id).first()
-                    if seer_matched_grouphash
-                    else None
-                )
-
-                group = seer_matched_group or _create_group(project, event, **group_creation_kwargs)
-
-                new_hashes = list(grouphashes)
-
-                GroupHash.objects.filter(id__in=[h.id for h in new_hashes]).exclude(
-                    state=GroupHash.State.LOCKED_IN_MIGRATION
-                ).update(group=group)
-
-                is_new = not seer_matched_group
-                is_regression = (
-                    False
-                    if is_new
-                    else _process_existing_aggregate(
-                        # If `seer_matched_group` were `None`, `is_new` would be true and we
-                        # wouldn't be here
-                        group=NonNone(seer_matched_group),
-                        event=event,
-                        incoming_group_values=group_creation_kwargs,
-                        release=release,
-                    )
-                )
-
-                span.set_tag("outcome", "new_group" if is_new else "seer_match")
-                metric_tags["outcome"] = "new_group" if is_new else "seer_match"
-                record_calculation_metric_with_result(
-                    project=project,
-                    has_secondary_hashes=has_secondary_hashes,
-                    result="no_match",
-                )
-
-                if is_new:
-                    metrics.incr(
-                        "group.created",
-                        skip_internal=True,
-                        tags={
-                            "platform": event.platform or "unknown",
-                            "sdk": normalized_sdk_tag_from_event(event.data),
-                        },
-                    )
-
-                    # This only applies to events with stacktraces, and we only do this for new
-                    # groups, because we assume that if Seer puts an event in an existing group, it
-                    # and the existing group have the same frame mix
-                    frame_mix = event.get_event_metadata().get("in_app_frame_mix")
-                    if frame_mix:
-                        metrics.incr(
-                            "grouping.in_app_frame_mix",
-                            sample_rate=1.0,
-                            tags={
-                                "platform": event.platform or "unknown",
-                                "sdk": normalized_sdk_tag_from_event(event.data),
-                                "frame_mix": frame_mix,
-                            },
-                        )
-
-                return GroupInfo(group, is_new, is_regression)
-
-    # If we land here, it's because either:
-    #
-    # a) There's an existing group with one of our hashes and we found it the first time we looked.
-    #
-    # b) We didn't find a group the first time we looked, but another identically-hashed event beat
-    # us to the lock and while we were waiting either created a new group or assigned our hashes to
-    # a neighboring group suggested by seer - such that when we finally got the lock and looked
-    # again, this time there was a group to find.
-
-    group = Group.objects.get(id=existing_grouphash.group_id)
-    if group.issue_category != GroupCategory.ERROR:
-        logger.info(
-            "event_manager.category_mismatch",
-            extra={
-                "issue_category": group.issue_category,
-                "event_type": "error",
-            },
-        )
-        return None
-
-    is_new = False
-
-    new_hashes = [h for h in grouphashes if h.group_id is None]
-
-    primary_hash_values = set(primary_hashes)
-    new_hash_values = {gh.hash for gh in new_hashes}
-    all_primary_hashes_are_new = primary_hash_values.issubset(new_hash_values)
-    record_calculation_metric_with_result(
-        project=project,
-        has_secondary_hashes=has_secondary_hashes,
-        # If at least one primary hash value isn't new, then we'll definitely have found it, since
-        # we check all of the primary hashes before any secondary ones. If the primary hash values
-        # *are* all new, then we must have gotten here by finding a secondary hash (or we'd be in
-        # the group-creation/seer-consultation branch).
-        result="found_primary" if not all_primary_hashes_are_new else "found_secondary",
-    )
-
-    if new_hashes:
-        # There may still be secondary hashes that we did not use to find an
-        # existing group. A classic example is when grouping makes changes to
-        # the app-hash (changes to in_app logic), but the system hash stays
-        # stable and is used to find an existing group. Associate any new
-        # hashes with the group such that event saving continues to be
-        # resilient against grouping algorithm changes.
-        #
-        # There is a race condition here where two processes could "steal"
-        # hashes from each other. In practice this should not be user-visible
-        # as group creation is synchronized. Meaning the only way hashes could
-        # jump between groups is if there were two processes that:
-        #
-        # 1) have BOTH found an existing group
-        #    (otherwise at least one of them would be in the group creation
-        #    codepath which has transaction isolation/acquires row locks)
-        # 2) AND are looking at the same set, or an overlapping set of hashes
-        #    (otherwise they would not operate on the same rows)
-        # 3) yet somehow also sort their event into two different groups each
-        #    (otherwise the update would not change anything)
-        #
-        # We think this is a very unlikely situation. A previous version of
-        # _save_aggregate had races around group creation which made this race
-        # more user visible. For more context, see 84c6f75a and d0e22787, as
-        # well as GH-5085.
-        GroupHash.objects.filter(id__in=[h.id for h in new_hashes]).exclude(
-            state=GroupHash.State.LOCKED_IN_MIGRATION
-        ).update(group=group)
-
-    is_regression = _process_existing_aggregate(
-        group=group,
-        event=event,
-        incoming_group_values=group_creation_kwargs,
-        release=release,
-    )
-
-    return GroupInfo(group, is_new, is_regression)
 
 
 def _save_aggregate_new(

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -132,8 +132,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:feature-flag-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable disabling gitlab integrations when broken is detected
     manager.add("organizations:gitlab-disable-on-broken", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable only calculating a secondary hash when needed
-    manager.add("organizations:grouping-suppress-unnecessary-secondary-hash", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Allow creating `GroupHashMetadata` records
     manager.add("organizations:grouphash-metadata-creation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Allows an org to have a larger set of project ownership rules per project

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -22,7 +22,6 @@ from sentry.grouping.api import (
     load_grouping_config,
 )
 from sentry.grouping.ingest.config import is_in_transition
-from sentry.grouping.ingest.metrics import record_hash_calculation_metrics
 from sentry.models.grouphash import GroupHash
 from sentry.models.grouphashmetadata import GroupHashMetadata
 from sentry.models.project import Project
@@ -210,32 +209,6 @@ def find_existing_grouphash(
             )
 
     return None
-
-
-def get_hash_values(
-    project: Project,
-    job: Job,
-    metric_tags: MutableTags,
-) -> tuple[list[str], list[str]]:
-    # Background grouping is a way for us to get performance metrics for a new
-    # config without having it actually affect on how events are grouped. It runs
-    # either before or after the main grouping logic, depending on the option value.
-    maybe_run_background_grouping(project, job)
-
-    secondary_grouping_config, secondary_hashes = maybe_run_secondary_grouping(
-        project, job, metric_tags
-    )
-
-    primary_grouping_config, primary_hashes = run_primary_grouping(project, job, metric_tags)
-
-    record_hash_calculation_metrics(
-        primary_grouping_config,
-        primary_hashes,
-        secondary_grouping_config,
-        secondary_hashes,
-    )
-
-    return (primary_hashes, secondary_hashes)
 
 
 def get_or_create_grouphashes(project: Project, hashes: Sequence[str]) -> list[GroupHash]:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2395,12 +2395,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "grouping.config_transition.killswitch_enabled",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Sample rate for double writing to experimental dsn
 register(


### PR DESCRIPTION
This is a follow up to https://github.com/getsentry/sentry/pull/78260, which removed all references to code related to the non-unused non-optimized grouping logic, actually removing the code itself. Code which is removed includes:

- `_save_aggregate` (the main function controlling the legacy behavior) and its helpers `get_hash_values` and `_get_group_creation_kwargs`
- `project_uses_optimized_grouping`, which controls which code path to follow
- the `grouping-suppress-unnecessary-secondary-hash` feature flag and the `config_transition.killswitch_enabled` option

Once this code is removed there are a few places where we'll be able to clean up what remains, but for ease of review I'm going to do those separately in follow-up PRs.