### PR TITLE
ref(grouping): Combine functions gathering metrics into one

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -61,11 +61,7 @@ from sentry.grouping.ingest.hashing import (
     maybe_run_secondary_grouping,
     run_primary_grouping,
 )
-from sentry.grouping.ingest.metrics import (
-    record_calculation_metric_with_result,
-    record_hash_calculation_metrics,
-    record_new_group_metrics,
-)
+from sentry.grouping.ingest.metrics import record_hash_calculation_metrics, record_new_group_metrics
 from sentry.grouping.ingest.seer import maybe_check_seer_for_matching_grouphash
 from sentry.grouping.ingest.utils import (
     add_group_id_to_grouphashes,
@@ -1352,14 +1348,7 @@ def _save_aggregate_new(
     maybe_run_background_grouping(project, job)
 
     record_hash_calculation_metrics(
-        primary.config, primary.hashes, secondary.config, secondary.hashes
-    )
-    # TODO: Once the legacy `_save_aggregate` goes away, the logic inside of
-    # `record_calculation_metric_with_result` can be pulled into `record_hash_calculation_metrics`
-    record_calculation_metric_with_result(
-        project=project,
-        has_secondary_hashes=len(secondary.hashes) > 0,
-        result=result,
+        project, primary.config, primary.hashes, secondary.config, secondary.hashes, result
     )
 
     # Now that we've used the current and possibly secondary grouping config(s) to calculate the

--- a/src/sentry/grouping/ingest/metrics.py
+++ b/src/sentry/grouping/ingest/metrics.py
@@ -20,15 +20,19 @@ Job = MutableMapping[str, Any]
 
 
 def record_hash_calculation_metrics(
+    project: Project,
     primary_config: GroupingConfig,
     primary_hashes: list[str],
     secondary_config: GroupingConfig,
     secondary_hashes: list[str],
+    existing_hash_search_result: str,
 ) -> None:
     has_secondary_hashes = len(secondary_hashes) > 0
 
+    # In cases where we've computed both primary and secondary hashes, track how often the config
+    # change has changed the resulting hashes
     if has_secondary_hashes:
-        tags = {
+        hash_comparison_tags = {
             "primary_config": primary_config["id"],
             "secondary_config": secondary_config["id"],
         }
@@ -37,46 +41,36 @@ def record_hash_calculation_metrics(
         hashes_match = current_values == secondary_values
 
         if hashes_match:
-            tags["result"] = "no change"
+            hash_comparison_tags["result"] = "no change"
         else:
             shared_hashes = set(current_values) & set(secondary_values)
             if len(shared_hashes) > 0:
-                tags["result"] = "partial change"
+                hash_comparison_tags["result"] = "partial change"
             else:
-                tags["result"] = "full change"
+                hash_comparison_tags["result"] = "full change"
 
         metrics.incr(
             "grouping.hash_comparison",
             sample_rate=options.get("grouping.config_transition.metrics_sample_rate"),
-            tags=tags,
+            tags=hash_comparison_tags,
         )
-
-
-# TODO: Once the legacy `_save_aggregate` goes away, this logic can be pulled into
-# `record_hash_calculation_metrics`. Right now it's split up because we don't know the value for
-# `result` at the time the legacy `_save_aggregate` (indirectly) calls `record_hash_calculation_metrics`
-def record_calculation_metric_with_result(
-    project: Project,
-    has_secondary_hashes: bool,
-    result: str,
-) -> None:
 
     # Track the total number of grouping calculations done overall, so we can divide by the
     # count to get an average number of calculations per event
-    tags = {
+    num_calculations_tags = {
         "in_transition": str(is_in_transition(project)),
-        "result": result,
+        "result": existing_hash_search_result,
     }
     metrics.incr(
         "grouping.event_hashes_calculated",
         sample_rate=options.get("grouping.config_transition.metrics_sample_rate"),
-        tags=tags,
+        tags=num_calculations_tags,
     )
     metrics.incr(
         "grouping.total_calculations",
         amount=2 if has_secondary_hashes else 1,
         sample_rate=options.get("grouping.config_transition.metrics_sample_rate"),
-        tags=tags,
+        tags=num_calculations_tags,
     )
 
 


### PR DESCRIPTION
When we had two versions of the grouping code (optimized and non-optimized), the differences in their logic meant that the helper recording metrics had to be split into two. (In the non-optimized path, we didn't have the information we needed for certain metrics early enough to record them in the main metrics-gathering function.) Now that we've switched to only using the optimized path (and have removed the old path), we can pull those straggler metics into the main metrics helper. 