### PR TITLE
chore(grouping): Remove orphan todo re: adding Seer to `_save_aggregate_new`

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1585,8 +1585,6 @@ def _save_aggregate(
     return GroupInfo(group, is_new, is_regression)
 
 
-# TODO: None of the seer logic has been added to this version yet, so you can't simultaneously use
-# optimized transitions and seer
 def _save_aggregate_new(
     event: Event,
     job: Job,


### PR DESCRIPTION
This removes a `TODO` which became obsolete as of https://github.com/getsentry/sentry/pull/75266 (and therefore should have been removed then) but which was missed at the time.