### PR TITLE
test(issues): Remove flaky stacktrace link test

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
@@ -41,17 +41,6 @@ describe('StacktraceLink', function () {
     HookStore.init?.();
   });
 
-  it('renders nothing when missing integrations', async function () {
-    MockApiClient.addMockResponse({
-      url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
-      body: {config: null, sourceUrl: null, integrations: []},
-    });
-    const {container} = render(<StacktraceLink frame={frame} event={event} line="" />);
-    await waitFor(() => {
-      expect(container).toBeEmptyDOMElement();
-    });
-  });
-
   it('renders setup CTA with integration but no configs', async function () {
     MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,


### PR DESCRIPTION
This test just checks that we look at the array of integrations. Its not that interesting and flaking a bunch.

this component has a timeout which is probably messing things up here.