### PR TITLE
ref(grouping): Combine `_assign_event_to_group` and `_save_aggregate_new`

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1420,7 +1420,7 @@ def handle_existing_grouphash(
     #    (otherwise the update would not change anything)
     #
     # We think this is a very unlikely situation. A previous version of
-    # _save_aggregate had races around group creation which made this race
+    # this function had races around group creation which made this race
     # more user visible. For more context, see 84c6f75a and d0e22787, as
     # well as GH-5085.
     group = Group.objects.get(id=existing_grouphash.group_id)

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1290,24 +1290,7 @@ def get_culprit(data: Mapping[str, Any]) -> str:
 
 
 @sentry_sdk.tracing.trace
-def assign_event_to_group(event: Event, job: Job, metric_tags: MutableTags) -> GroupInfo | None:
-    group_info = _save_aggregate_new(
-        event=event,
-        job=job,
-        metric_tags=metric_tags,
-    )
-
-    # The only way there won't be group info is we matched to a performance, cron, replay, or
-    # other-non-error-type group because of a hash collision - exceedingly unlikely, and not
-    # something we've ever observed, but theoretically possible.
-    if group_info:
-        event.group = group_info.group
-    job["groups"] = [group_info]
-
-    return group_info
-
-
-def _save_aggregate_new(
+def assign_event_to_group(
     event: Event,
     job: Job,
     metric_tags: MutableTags,
@@ -1360,6 +1343,13 @@ def _save_aggregate_new(
     # config, but will also be grandfathered into the current config for a week, so as not to
     # erroneously create new groups.
     update_grouping_config_if_needed(project, "ingest")
+
+    # The only way there won't be group info is we matched to a performance, cron, replay, or
+    # other-non-error-type group because of a hash collision - exceedingly unlikely, and not
+    # something we've ever observed, but theoretically possible.
+    if group_info:
+        event.group = group_info.group
+    job["groups"] = [group_info]
 
     return group_info
 

--- a/tests/sentry/event_manager/grouping/test_group_creation_lock.py
+++ b/tests/sentry/event_manager/grouping/test_group_creation_lock.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from sentry.event_manager import GroupInfo, _save_aggregate_new
+from sentry.event_manager import GroupInfo, assign_event_to_group
 from sentry.eventstore.models import Event
 from sentry.testutils.pytest.fixtures import django_db_all
 
@@ -26,7 +26,7 @@ def save_event(project_id: int, return_values: list[GroupInfo]) -> None:
         data={"timestamp": time.time()},
     )
 
-    group_info = _save_aggregate_new(
+    group_info = assign_event_to_group(
         event=event,
         job={"event_metadata": {}, "release": "dogpark", "event": event, "data": {}},
         metric_tags={},


### PR DESCRIPTION
Now that the optimized grouping config transition logic is enabled for everyone and we've gotten rid of the old code path (specifically `_save_aggregate`), we can do some refactoring to clean things up. Before the removal, `assign_event_to_group` conditionaly either called `_save_aggregate` or `_save_aggregate_new`. Now that the former is gone, `assign_event_to_group` is just a wrapper around `_save_aggregate_new` and there's no longer a need for them to be separate functions.