### PR TITLE
tests(spans): Disable spans fields test because its failing

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_spans_fields.py
+++ b/tests/sentry/api/endpoints/test_organization_spans_fields.py
@@ -1,5 +1,6 @@
 from uuid import uuid4
 
+import pytest
 from django.urls import reverse
 
 from sentry.testutils.cases import APITestCase, BaseSpansTestCase
@@ -86,6 +87,7 @@ class OrganizationEAPSpansTagsEndpointTest(OrganizationSpansTagsEndpointTest):
                 **kwargs,
             )
 
+    @pytest.mark.skip("rpc seems to have changed")
     def test_tags_list(self):
         for tag in ["foo", "bar", "baz"]:
             self.store_segment(


### PR DESCRIPTION
Failing likely because the rpc changes in snuba. Disable for now and will fix soon as this isn't used in production yet.