### PR TITLE
ref: replace pytest-rerunfailures with flaky

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -78,7 +78,7 @@ runs:
 
         ### pytest configuration ###
         echo "PY_COLORS=1" >> "$GITHUB_ENV"
-        echo "PYTEST_ADDOPTS=--reruns=5 --durations=10 --fail-slow=60s" >> $GITHUB_ENV
+        echo "PYTEST_ADDOPTS=--force-flaky --max-runs=5 --no-flaky-report --durations=10 --fail-slow=60s" >> $GITHUB_ENV
         echo "COVERAGE_CORE=sysmon" >> "$GITHUB_ENV"
 
         ### pytest-sentry configuration ###

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -150,7 +150,7 @@ jobs:
 
       - name: run tests
         run: |
-          PYTEST_ADDOPTS="$PYTEST_ADDOPTS -m migrations --migrations --reruns 0" make test-python-ci
+          PYTEST_ADDOPTS="$PYTEST_ADDOPTS -m migrations --migrations --max-runs=1" make test-python-ci
 
       # Upload coverage data even if running the tests step fails since
       # it reduces large coverage fluctuations

--- a/fixtures/stubs-for-mypy/pytest_rerunfailures.pyi
+++ b/fixtures/stubs-for-mypy/pytest_rerunfailures.pyi
@@ -1,3 +1,0 @@
-import pytest
-
-def get_reruns_count(item: pytest.Item) -> int: ...

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -54,6 +54,7 @@ filelock==3.13.1
 flake8==7.0.0
 flake8-bugbear==22.10.27
 flake8-logging==1.5.0
+flaky==3.8.1
 google-api-core==2.19.1
 google-auth==2.29.0
 google-cloud-bigtable==2.26.0
@@ -149,7 +150,6 @@ pytest-django==4.9.0
 pytest-fail-slow==0.3.0
 pytest-json-report==1.5.0
 pytest-metadata==3.1.1
-pytest-rerunfailures==14.0
 pytest-sentry==0.3.0
 pytest-xdist==3.0.2
 python-dateutil==2.9.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ sentry-devenv>=1.10.2
 
 covdefaults>=2.3.0
 docker>=6
+flaky
 time-machine>=2.13.0
 honcho>=1.1.0
 openapi-core>=0.18.2
@@ -13,7 +14,6 @@ pytest-cov>=4.0.0
 pytest-django>=4.9.0
 pytest-fail-slow>=0.3.0
 pytest-json-report>=1.5.0
-pytest-rerunfailures>=14
 pytest-sentry>=0.3.0
 pytest-xdist>=3
 responses>=0.23.1


### PR DESCRIPTION
pytest-rerunfailures does not run class teardowns in pytest 8.2+

see pytest-dev/pytest#11833

<!-- Describe your PR here. -->