### PR TITLE
test(ui): Increase flamegraph test timeout

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraph.spec.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.spec.tsx
@@ -165,7 +165,9 @@ describe('Flamegraph', function () {
       {organization: initializeOrg().organization}
     );
 
-    const frames = await findAllByTestId(document.body, 'flamegraph-frame');
+    const frames = await findAllByTestId(document.body, 'flamegraph-frame', undefined, {
+      timeout: 5000,
+    });
 
     // 1 for main view and 1 for minimap
     expect(frames.length).toBe(2);


### PR DESCRIPTION
seems to flake sometimes i think the default only waits 1 second

https://github.com/getsentry/sentry/actions/runs/11074188518/job/30772445372#step:6:4631
