### PR TITLE
fix(issue-views): Load in default view by default if issue views enabled) 

### DIFF
--- a/static/app/utils/withSavedSearches.tsx
+++ b/static/app/utils/withSavedSearches.tsx
@@ -2,6 +2,7 @@ import type {SavedSearch} from 'sentry/types/group';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
+import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
 import {useFetchSavedSearchesForOrg} from 'sentry/views/issueList/queries/useFetchSavedSearchesForOrg';
 import {useSelectedSavedSearch} from 'sentry/views/issueList/utils/useSelectedSavedSearch';
 
@@ -15,6 +16,9 @@ type InjectedSavedSearchesProps = {
 /**
  * HOC to provide saved search data to class components.
  * When possible, use the hooks directly instead.
+ *
+ * Note: this HOC will be completely removed when issue views is GA'd, but until then
+ * we have to augment it to support both saved searches and issue views.
  */
 function withSavedSearches<P extends InjectedSavedSearchesProps>(
   WrappedComponent: React.ComponentType<P>
@@ -29,6 +33,12 @@ function withSavedSearches<P extends InjectedSavedSearchesProps>(
       },
       {enabled: !organization.features.includes('issue-stream-custom-views')}
     );
+    const {data: groupSearchViews, isPending: areViewsPending} = useFetchGroupSearchViews(
+      {
+        orgSlug: organization.slug,
+      },
+      {enabled: organization.features.includes('issue-stream-custom-views')}
+    );
 
     const params = useParams();
     const selectedSavedSearch = useSelectedSavedSearch();
@@ -38,10 +48,15 @@ function withSavedSearches<P extends InjectedSavedSearchesProps>(
         {...(props as P)}
         savedSearches={props.savedSearches ?? savedSearches}
         savedSearchLoading={
-          !organization.features.includes('issue-stream-custom-views') &&
-          (props.savedSearchLoading ?? isPending)
+          organization.features.includes('issue-stream-custom-views')
+            ? areViewsPending
+            : props.savedSearchLoading ?? isPending
         }
-        savedSearch={props.savedSearch ?? selectedSavedSearch}
+        savedSearch={
+          organization.features.includes('issue-stream-custom-views') && groupSearchViews
+            ? groupSearchViews[0]
+            : props.savedSearch ?? selectedSavedSearch
+        }
         selectedSearchId={params.searchId ?? null}
       />
     );

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -317,10 +317,7 @@ class IssueListOverview extends Component<Props, State> {
     savedSearch,
     location,
   }: Pick<Props, 'savedSearch' | 'location'>): string {
-    if (
-      !this.props.organization.features.includes('issue-stream-custom-views') &&
-      savedSearch
-    ) {
+    if (savedSearch) {
       return savedSearch.query;
     }
 


### PR DESCRIPTION
Fixes a bug where you'd see the default query flash in the search bar breifly when loading `/issues/ `, or when clicking the issues tab. Does this by hijacking the saved searches HOC, and returning the default issue view instead of the default search view if the organization has the feature enabled. 

This might also help the views load in faster, since the fetch request occurs earlier in the rendering cycle. 

I could not figure out how to stop the page filters from flashing some values, but I will continue to look into this: 

Before: 

https://github.com/user-attachments/assets/b37444e4-c6f2-4e6c-9ceb-1e81984a3c45

After

https://github.com/user-attachments/assets/00da134a-cfd9-49f3-b62c-e04cbc803dac

_notice how in the After video, the search query remains static even after clicking the issues tab_