### PR TITLE
fix(dashboards): Awalys give test widget a layout

### DIFF
--- a/tests/acceptance/test_organization_dashboards.py
+++ b/tests/acceptance/test_organization_dashboards.py
@@ -259,6 +259,7 @@ class OrganizationDashboardsAcceptanceTest(AcceptanceTestCase):
             display_type=DashboardWidgetDisplayTypes.LINE_CHART,
             widget_type=DashboardWidgetTypes.DISCOVER,
             interval="1d",
+            detail={"layout": {"x": 0, "y": 0, "w": 2, "h": 2, "minH": 2}},
         )
         DashboardWidgetQuery.objects.create(
             widget=existing_widget, fields=["count()"], columns=[], aggregates=["count()"], order=0


### PR DESCRIPTION
This fixes a case where the layout is empty and on render it assigns a
layout, but as a side effect it causes the dashboard to be in an edited
state.