### PR TITLE
fix(dashboards): BigNumberWidget improvement grab-bag II

### DIFF
--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.spec.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.spec.tsx
@@ -10,7 +10,6 @@ describe('BigNumberWidget', () => {
         <BigNumberWidget
           title="EPS"
           description="Number of events per second"
-          showDescriptionInTooltip={false}
           data={[
             {
               'eps()': 0.01087819860850493,

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.spec.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.spec.tsx
@@ -46,6 +46,25 @@ describe('BigNumberWidget', () => {
       expect(screen.getByText('No Data')).toBeInTheDocument();
     });
 
+    it('Explains non-numeric data', () => {
+      render(
+        <BigNumberWidget
+          data={[
+            {
+              'count()': Infinity,
+            },
+          ]}
+          meta={{
+            fields: {
+              'count()': 'number',
+            },
+          }}
+        />
+      );
+
+      expect(screen.getByText('Value is not a finite number.')).toBeInTheDocument();
+    });
+
     it('Formats duration data', () => {
       render(
         <BigNumberWidget

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.spec.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.spec.tsx
@@ -1,4 +1,5 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {BigNumberWidget} from 'sentry/views/dashboards/widgets/bigNumberWidget/bigNumberWidget';
 
@@ -31,6 +32,21 @@ describe('BigNumberWidget', () => {
   });
 
   describe('Visualization', () => {
+    it('Explains missing data', () => {
+      render(
+        <BigNumberWidget
+          data={[{}]}
+          meta={{
+            fields: {
+              'p95(span.duration)': 'number',
+            },
+          }}
+        />
+      );
+
+      expect(screen.getByText('No Data')).toBeInTheDocument();
+    });
+
     it('Formats duration data', () => {
       render(
         <BigNumberWidget
@@ -75,6 +91,27 @@ describe('BigNumberWidget', () => {
       await userEvent.hover(screen.getByText('178m'));
 
       expect(screen.getByText('178451214')).toBeInTheDocument();
+    });
+
+    it('Respect maximum value', () => {
+      render(
+        <BigNumberWidget
+          title="Count"
+          data={[
+            {
+              'count()': 178451214,
+            },
+          ]}
+          maximumValue={100000000}
+          meta={{
+            fields: {
+              'count()': 'integer',
+            },
+          }}
+        />
+      );
+
+      expect(screen.getByText(textWithMarkupMatcher('>100m'))).toBeInTheDocument();
     });
   });
 

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import JSXNode from 'sentry/components/stories/jsxNode';
+import JSXProperty from 'sentry/components/stories/jsxProperty';
 import SideBySide from 'sentry/components/stories/sideBySide';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
 import storyBook from 'sentry/stories/storyBook';
@@ -36,11 +37,6 @@ export default storyBook(BigNumberWidget, story => {
               title="EPS"
               description="Number of events per second"
               data={[
-                {
-                  'eps()': 0.01087819860850493,
-                },
-              ]}
-              previousPeriodData={[
                 {
                   'eps()': 0.01087819860850493,
                 },
@@ -93,6 +89,32 @@ export default storyBook(BigNumberWidget, story => {
             />
           </SmallSizingWindow>
         </SideBySide>
+        <p>
+          The <code>maximumValue</code> prop allows setting the maximum displayable value.
+          e.g., imagine a widget that displays a count. A count of more than a million is
+          too expensive for the API to compute, so the API returns a maximum of 1,000,000.
+          If the API returns exactly 1,000,000, that means the actual number is unknown,
+          something higher than the max. Setting{' '}
+          <JSXProperty name="maximumValue" value={1000000} /> will show &gt;1m.
+        </p>
+        <SideBySide>
+          <NormalWidget>
+            <BigNumberWidget
+              title="Count"
+              data={[
+                {
+                  'count()': 1000000,
+                },
+              ]}
+              maximumValue={1000000}
+              meta={{
+                fields: {
+                  'count()': 'integer',
+                },
+              }}
+            />
+          </NormalWidget>
+        </SideBySide>
       </Fragment>
     );
   });
@@ -106,15 +128,24 @@ export default storyBook(BigNumberWidget, story => {
         </p>
 
         <SideBySide>
-          <SmallSizingWindow>
-            <BigNumberWidget title="Count" isLoading />
-          </SmallSizingWindow>
-          <SmallSizingWindow>
+          <NormalWidget>
+            <BigNumberWidget title="Loading Count" isLoading />
+          </NormalWidget>
+          <NormalWidget>
             <BigNumberWidget
-              title="Bad Count"
+              title="Text"
+              data={[{'max(user.email)': 'bufo@example.com'}]}
+            />
+          </NormalWidget>
+          <NormalWidget>
+            <BigNumberWidget title="Missing Count" data={[{}]} />
+          </NormalWidget>
+          <NormalWidget>
+            <BigNumberWidget
+              title="Count Error"
               error={new Error('Something went wrong!')}
             />
-          </SmallSizingWindow>
+          </NormalWidget>
         </SideBySide>
       </Fragment>
     );
@@ -127,6 +158,14 @@ export default storyBook(BigNumberWidget, story => {
           <JSXNode name="BigNumberWidget" /> shows the difference of the current data and
           the previous period data as the difference between the two values, in small text
           next to the main value.
+        </p>
+
+        <p>
+          The <code>preferredPolarity</code> prop controls the color of the comparison
+          string. Setting <JSXProperty name="preferredPolarity" value={'+'} /> mean that a
+          higher number is <i>better</i> and will paint increases in the value green. Vice
+          versa with negative polarity. Omitting a preferred polarity will prevent
+          colorization.
         </p>
 
         <SideBySide>

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
@@ -19,7 +19,6 @@ export function BigNumberWidget(props: Props) {
     <WidgetFrame
       title={props.title}
       description={props.description}
-      showDescriptionInTooltip={props.showDescriptionInTooltip}
       actions={props.actions}
     >
       <BigNumberResizeWrapper>

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
@@ -26,6 +26,7 @@ export function BigNumberWidget(props: Props) {
         <BigNumberWidgetVisualization
           data={props.data}
           previousPeriodData={props.previousPeriodData}
+          maximumValue={props.maximumValue}
           preferredPolarity={props.preferredPolarity}
           meta={props.meta}
           isLoading={props.isLoading}

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
@@ -34,7 +34,7 @@ export function BigNumberWidgetVisualization(props: Props) {
   const {
     data,
     previousPeriodData,
-    maximumValue,
+    maximumValue = Number.MAX_VALUE,
     preferredPolarity,
     meta,
     isLoading,
@@ -81,7 +81,7 @@ export function BigNumberWidgetVisualization(props: Props) {
     : renderableValue => renderableValue.toString();
 
   const doesValueHitMaximum = maximumValue ? parsedValue >= maximumValue : false;
-  const clampedValue = Math.min(parsedValue, maximumValue ?? Infinity);
+  const clampedValue = Math.min(parsedValue, maximumValue);
 
   const datum = {
     [field]: clampedValue,

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
-import isNumber from 'lodash/isNumber';
 
 import type {Polarity} from 'sentry/components/percentChange';
 import {Tooltip} from 'sentry/components/tooltip';
+import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import type {MetaType} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
@@ -69,21 +69,19 @@ export function BigNumberWidgetVisualization(props: Props) {
     );
   }
 
-  if (!isNumber(value)) {
-    return (
-      <Wrapper>
-        <Deemphasize>{value.toString()}</Deemphasize>
-      </Wrapper>
-    );
+  if (!Number.isFinite(value) || error) {
+    return <ErrorPanel error={t('Value is not a finite number.')} />;
   }
+
+  const parsedValue = Number(value);
 
   // TODO: meta as MetaType is a white lie. `MetaType` doesn't know that types can be null, but they can!
   const fieldRenderer = meta
     ? getFieldRenderer(field, meta as MetaType, false)
     : renderableValue => renderableValue.toString();
 
-  const doesValueHitMaximum = maximumValue ? value >= maximumValue : false;
-  const clampedValue = Math.min(value, maximumValue ?? Infinity);
+  const doesValueHitMaximum = maximumValue ? parsedValue >= maximumValue : false;
+  const clampedValue = Math.min(parsedValue, maximumValue ?? Infinity);
 
   const datum = {
     [field]: clampedValue,
@@ -104,7 +102,7 @@ export function BigNumberWidgetVisualization(props: Props) {
       <NumberAndDifferenceContainer>
         <NumberContainerOverride>
           <Tooltip
-            title={value}
+            title={parsedValue}
             isHoverable
             delay={0}
             disabled={doesValueHitMaximum}

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import isNumber from 'lodash/isNumber';
 
 import type {Polarity} from 'sentry/components/percentChange';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -11,6 +12,7 @@ import {AutoSizedText} from 'sentry/views/dashboards/widgetCard/autoSizedText';
 import {DifferenceToPreviousPeriodData} from 'sentry/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodData';
 import {
   DEEMPHASIS_COLOR_NAME,
+  LOADING_PLACEHOLDER,
   NO_DATA_PLACEHOLDER,
 } from 'sentry/views/dashboards/widgets/bigNumberWidget/settings';
 import {ErrorPanel} from 'sentry/views/dashboards/widgets/common/errorPanel';
@@ -22,13 +24,22 @@ import type {
 
 export interface Props extends StateProps {
   data?: TableData;
+  maximumValue?: number;
   meta?: Meta;
   preferredPolarity?: Polarity;
   previousPeriodData?: TableData;
 }
 
 export function BigNumberWidgetVisualization(props: Props) {
-  const {data, previousPeriodData, preferredPolarity, meta, isLoading, error} = props;
+  const {
+    data,
+    previousPeriodData,
+    maximumValue,
+    preferredPolarity,
+    meta,
+    isLoading,
+    error,
+  } = props;
 
   const location = useLocation();
   const organization = useOrganization();
@@ -37,29 +48,49 @@ export function BigNumberWidgetVisualization(props: Props) {
     return <ErrorPanel error={error} />;
   }
 
-  // Big Number widgets only show one number, so we only ever look at the first item in the Discover response
-  const datum = data?.[0];
   // TODO: Instrument getting more than one data key back as an error
+  // e.g., with data that looks like `[{'apdex()': 0.8}] this pulls out `"apdex()"` or `undefined`
+  const field = Object.keys(data?.[0] ?? {})[0];
+  const value = data?.[0]?.[field];
 
-  if (isLoading || !defined(data) || !defined(datum) || Object.keys(datum).length === 0) {
+  if (isLoading) {
     return (
-      <AutoResizeParent>
-        <AutoSizedText>
-          <Deemphasize>{NO_DATA_PLACEHOLDER}</Deemphasize>
-        </AutoSizedText>
-      </AutoResizeParent>
+      <Wrapper>
+        <Deemphasize>{LOADING_PLACEHOLDER}</Deemphasize>
+      </Wrapper>
     );
   }
 
-  const fields = Object.keys(datum);
-  const field = fields[0];
+  if (!defined(value)) {
+    return (
+      <Wrapper>
+        <Deemphasize>{NO_DATA_PLACEHOLDER}</Deemphasize>
+      </Wrapper>
+    );
+  }
+
+  if (!isNumber(value)) {
+    return (
+      <Wrapper>
+        <Deemphasize>{value.toString()}</Deemphasize>
+      </Wrapper>
+    );
+  }
 
   // TODO: meta as MetaType is a white lie. `MetaType` doesn't know that types can be null, but they can!
   const fieldRenderer = meta
     ? getFieldRenderer(field, meta as MetaType, false)
-    : value => value.toString();
+    : renderableValue => renderableValue.toString();
+
+  const doesValueHitMaximum = maximumValue ? value >= maximumValue : false;
+  const clampedValue = Math.min(value, maximumValue ?? Infinity);
+
+  const datum = {
+    [field]: clampedValue,
+  };
 
   const unit = meta?.units?.[field];
+
   const baggage = {
     location,
     organization,
@@ -69,28 +100,41 @@ export function BigNumberWidgetVisualization(props: Props) {
   const rendered = fieldRenderer(datum, baggage);
 
   return (
-    <AutoResizeParent>
-      <AutoSizedText>
-        <NumberAndDifferenceContainer>
-          <NumberContainerOverride>
-            <Tooltip title={datum[field]} isHoverable delay={0}>
-              {rendered}
-            </Tooltip>
-          </NumberContainerOverride>
+    <Wrapper>
+      <NumberAndDifferenceContainer>
+        <NumberContainerOverride>
+          <Tooltip
+            title={value}
+            isHoverable
+            delay={0}
+            disabled={doesValueHitMaximum}
+            containerDisplayMode="inline-flex"
+          >
+            {doesValueHitMaximum ? '>' : ''}
+            {rendered}
+          </Tooltip>
+        </NumberContainerOverride>
 
-          {previousPeriodData && (
-            <DifferenceToPreviousPeriodData
-              data={data}
-              previousPeriodData={previousPeriodData}
-              preferredPolarity={preferredPolarity}
-              renderer={(previousDatum: TableData[number]) =>
-                fieldRenderer(previousDatum, baggage)
-              }
-              field={field}
-            />
-          )}
-        </NumberAndDifferenceContainer>
-      </AutoSizedText>
+        {data && previousPeriodData && !doesValueHitMaximum && (
+          <DifferenceToPreviousPeriodData
+            data={data}
+            previousPeriodData={previousPeriodData}
+            preferredPolarity={preferredPolarity}
+            renderer={(previousDatum: TableData[number]) =>
+              fieldRenderer(previousDatum, baggage)
+            }
+            field={field}
+          />
+        )}
+      </NumberAndDifferenceContainer>
+    </Wrapper>
+  );
+}
+
+function Wrapper({children}) {
+  return (
+    <AutoResizeParent>
+      <AutoSizedText>{children}</AutoSizedText>
     </AutoResizeParent>
   );
 }

--- a/static/app/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodData.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodData.tsx
@@ -11,7 +11,7 @@ import {IconArrow} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
 import {
   DEEMPHASIS_COLOR_NAME,
-  NO_DATA_PLACEHOLDER,
+  LOADING_PLACEHOLDER,
 } from 'sentry/views/dashboards/widgets/bigNumberWidget/settings';
 import type {TableData} from 'sentry/views/dashboards/widgets/common/types';
 
@@ -34,7 +34,7 @@ export function DifferenceToPreviousPeriodData({
   const previousValue = previousPeriodData[0][field];
 
   if (!isNumber(currentValue) || !isNumber(previousValue)) {
-    return <Deemphasize>{NO_DATA_PLACEHOLDER}</Deemphasize>;
+    return <Deemphasize>{LOADING_PLACEHOLDER}</Deemphasize>;
   }
 
   const difference = currentValue - previousValue;

--- a/static/app/views/dashboards/widgets/bigNumberWidget/settings.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/settings.tsx
@@ -1,2 +1,5 @@
-export const NO_DATA_PLACEHOLDER = '\u2014';
+import {t} from 'sentry/locale';
+
+export const LOADING_PLACEHOLDER = '\u2014';
+export const NO_DATA_PLACEHOLDER = t('No Data');
 export const DEEMPHASIS_COLOR_NAME = 'gray300';

--- a/static/app/views/dashboards/widgets/common/widgetFrame.spec.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.spec.tsx
@@ -5,13 +5,7 @@ import {WidgetFrame} from 'sentry/views/dashboards/widgets/common/widgetFrame';
 describe('WidgetFrame', () => {
   describe('Layout', () => {
     it('Renders the title and description', () => {
-      render(
-        <WidgetFrame
-          title="EPS"
-          description="Number of events per second"
-          showDescriptionInTooltip={false}
-        />
-      );
+      render(<WidgetFrame title="EPS" description="Number of events per second" />);
 
       expect(screen.getByText('EPS')).toBeInTheDocument();
       expect(screen.getByText('Number of events per second')).toBeInTheDocument();
@@ -26,7 +20,6 @@ describe('WidgetFrame', () => {
         <WidgetFrame
           title="EPS"
           description="Number of events per second"
-          showDescriptionInTooltip={false}
           actions={[
             {
               key: 'hello',
@@ -52,7 +45,6 @@ describe('WidgetFrame', () => {
         <WidgetFrame
           title="EPS"
           description="Number of events per second"
-          showDescriptionInTooltip={false}
           actions={[
             {
               key: 'one',

--- a/static/app/views/dashboards/widgets/common/widgetFrame.spec.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.spec.tsx
@@ -4,11 +4,13 @@ import {WidgetFrame} from 'sentry/views/dashboards/widgets/common/widgetFrame';
 
 describe('WidgetFrame', () => {
   describe('Layout', () => {
-    it('Renders the title and description', () => {
+    it('Renders the title and description', async () => {
       render(<WidgetFrame title="EPS" description="Number of events per second" />);
 
       expect(screen.getByText('EPS')).toBeInTheDocument();
-      expect(screen.getByText('Number of events per second')).toBeInTheDocument();
+
+      await userEvent.hover(screen.getByTestId('more-information'));
+      expect(await screen.findByText('Number of events per second')).toBeInTheDocument();
     });
   });
 

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -13,22 +13,21 @@ export interface Props {
   actions?: MenuItemProps[];
   children?: React.ReactNode;
   description?: string;
-  showDescriptionInTooltip?: boolean;
   title?: string;
 }
 
 export function WidgetFrame(props: Props) {
-  const {title, description, showDescriptionInTooltip = true, actions, children} = props;
+  const {title, description, actions, children} = props;
 
   return (
     <Frame>
-      <Header showDescriptionInTooltip={showDescriptionInTooltip}>
+      <Header>
         <Title>
           <Tooltip title={title} containerDisplayMode="grid" showOnlyOnOverflow>
             <TitleText>{title}</TitleText>
           </Tooltip>
 
-          {description && showDescriptionInTooltip && (
+          {description && (
             <TooltipAligner>
               <QuestionTooltip size="sm" title={description} />
             </TooltipAligner>
@@ -58,17 +57,6 @@ export function WidgetFrame(props: Props) {
             </TitleActions>
           )}
         </Title>
-
-        {description && !showDescriptionInTooltip && (
-          <Tooltip
-            title={description}
-            containerDisplayMode="grid"
-            showOnlyOnOverflow
-            isHoverable
-          >
-            <Description>{description}</Description>
-          </Tooltip>
-        )}
       </Header>
 
       <VisualizationWrapper>{children}</VisualizationWrapper>
@@ -95,23 +83,15 @@ const Frame = styled('div')`
   background: ${p => p.theme.background};
 `;
 
-const Header = styled('div')<{showDescriptionInTooltip: boolean}>`
+const Header = styled('div')`
   display: flex;
   flex-direction: column;
-
-  min-height: ${p => (p.showDescriptionInTooltip ? '' : '36px')};
 `;
 
 const Title = styled('div')`
   display: inline-flex;
   align-items: center;
   gap: ${space(0.75)};
-`;
-
-const Description = styled('small')`
-  ${p => p.theme.overflowEllipsis}
-
-  color: ${p => p.theme.gray300};
 `;
 
 const TitleText = styled(HeaderTitle)`


### PR DESCRIPTION
A few more nice changes, to support using this widget in Project Details pages.

- `maximumValue` prop
- better stories
- better data handling
- remove description tooltip option
