### PR TITLE
Create wrapper for `makemigrations`

### DIFF
--- a/bin/make-migration
+++ b/bin/make-migration
@@ -3,6 +3,7 @@
 import os
 import subprocess
 import sys
+import textwrap
 
 
 def run_command(command):
@@ -14,24 +15,40 @@ def run_command(command):
         sys.exit(1)
 
 
+def print_help():
+    help_message = textwrap.dedent(
+        """
+    Usage: ./bin/make-migration.py [options]
+
+    This script runs three commands in sequence:
+    1. sentry django makemigrations (with any provided arguments)
+    2. ./bin/generate-model-dependency-fixtures
+    3. SENTRY_SNAPSHOTS_WRITEBACK=1 pytest (specific test files)
+
+    Options:
+        -h, --help    Show this help message and exit
+
+    Any other options provided will be passed directly to the 'sentry django makemigrations' command.
+    """
+    )
+
+    sys.stdout.write(help_message)
+
+
 def main():
     if "-h" in sys.argv or "--help" in sys.argv:
-        sys.stdout.write("This script runs the following commands:\n")
-        sys.stdout.write("1. sentry django makemigrations\n")
-        sys.stdout.write("2. ./bin/generate-model-dependency-fixtures\n")
-        sys.stdout.write("3. SENTRY_SNAPSHOTS_WRITEBACK=1 pytest ...\n")
-        sys.stdout.write("\n")
-        sys.stdout.write(
-            "Ensure all tests/sentry/backup files have been updated before running this script.\n"
-        )
+        print_help()
         sys.exit(0)
+
+    current_dir = os.path.dirname(os.path.realpath(__file__))
 
     # Command 1: sentry django makemigrations (with potential additional args)
     makemigrations_cmd = ["sentry", "django", "makemigrations"] + sys.argv[1:]
     run_command(makemigrations_cmd)
 
     # Command 2: ./bin/generate-model-dependency-fixtures
-    run_command(["./bin/generate-model-dependency-fixtures"])
+    generate_fixtures_cmd = [os.path.join(current_dir, "bin", "generate-model-dependency-fixtures")]
+    run_command(generate_fixtures_cmd)
 
     # Command 3: SENTRY_SNAPSHOTS_WRITEBACK=1 pytest ...
     pytest_cmd = [

--- a/bin/make-migration
+++ b/bin/make-migration
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+import sys
+
+
+def run_command(command):
+    try:
+        return subprocess.run(command, check=True)
+    except subprocess.CalledProcessError as e:
+        sys.stderr.write(f"Error executing command: {' '.join(command)}\n")
+        sys.stderr.write(f"Error details: {e}\n")
+        sys.exit(1)
+
+
+def main():
+    if "-h" in sys.argv or "--help" in sys.argv:
+        sys.stdout.write("This script runs the following commands:\n")
+        sys.stdout.write("1. sentry django makemigrations\n")
+        sys.stdout.write("2. ./bin/generate-model-dependency-fixtures\n")
+        sys.stdout.write("3. SENTRY_SNAPSHOTS_WRITEBACK=1 pytest ...\n")
+        sys.stdout.write("\n")
+        sys.stdout.write(
+            "Ensure all tests/sentry/backup files have been updated before running this script.\n"
+        )
+        sys.exit(0)
+
+    # Command 1: sentry django makemigrations (with potential additional args)
+    makemigrations_cmd = ["sentry", "django", "makemigrations"] + sys.argv[1:]
+    run_command(makemigrations_cmd)
+
+    # Command 2: ./bin/generate-model-dependency-fixtures
+    run_command(["./bin/generate-model-dependency-fixtures"])
+
+    # Command 3: SENTRY_SNAPSHOTS_WRITEBACK=1 pytest ...
+    pytest_cmd = [
+        "pytest",
+        "tests/sentry/backup/test_comparators.py",
+        "tests/sentry/backup/test_releases.py",
+        "tests/sentry/backup/test_sanitize.py",
+        "tests/sentry/tasks/test_relocation.py",
+    ]
+    env = os.environ.copy()
+    env["SENTRY_SNAPSHOTS_WRITEBACK"] = "1"
+    subprocess.run(pytest_cmd, check=True, env=env)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/make-migration
+++ b/bin/make-migration
@@ -36,6 +36,14 @@ def print_help():
 
 
 def main():
+    """
+    If there are test failures after this command has run make sure to:
+        - check the relocation scope information
+        - check to see if there are additional snapshots to update for the 3rd command
+        - check that test/utils/helpers/backups.py is setup correctly
+        - check that the test fixtures have been updated correctly
+    """
+
     if "-h" in sys.argv or "--help" in sys.argv:
         print_help()
         sys.exit(0)

--- a/src/sentry/management/commands/makemigrations.py
+++ b/src/sentry/management/commands/makemigrations.py
@@ -48,7 +48,7 @@ class Command(makemigrations.Command):
                 "Please name your migrations using `-n <migration_name>`. "
                 "For example, `-n backfill_my_new_table`"
             )
-            return
+            sys.exit(1)
         super().handle(*app_labels, **options)
         loader = MigrationLoader(None, ignore_no_migrations=True)
 


### PR DESCRIPTION
# Description
I've been creating a number of new data models recently, but it's been fairly tricky to understand all the places and commands to run.

As a quick fix to the issue, proposing this bin script file that wraps all the automation that needs to run.

I've confirmed this script works as expected:
- when there isn't a migration file
- if `-h` or `--help` is passed in
- and if a migration is successfully configured.

I also was able to reproduce some of the failure scenarios i've seen on CI, locally with the 3rd command (things missing from backups.py, related to the relocation scope).