### PR TITLE
Reintroduce fix(redis-lua): compatibility with dragonfly and lua 5.4

### DIFF
--- a/src/sentry/scripts/digests/digests.lua
+++ b/src/sentry/scripts/digests/digests.lua
@@ -354,7 +354,7 @@ local configuration_argument_parser = object_argument_parser({
     {"ttl", argument_parser(tonumber)},
     {"timestamp", argument_parser(tonumber)},
 }, function (configuration)
-    math.randomseed(configuration.timestamp)
+    math.randomseed(math.floor(configuration.timestamp))
 
     function configuration:get_schedule_waiting_key()
         return string.format('%s:s:w', self.namespace)

--- a/src/sentry/scripts/similarity/index.lua
+++ b/src/sentry/scripts/similarity/index.lua
@@ -27,7 +27,11 @@ This is modeled as two data structures:
 -- greater. This is wrapped in `pcall` so that we can continue to support older
 -- Redis versions while using this feature if it's available.
 if not pcall(redis.replicate_commands) then
-    redis.log(redis.LOG_DEBUG, 'Could not enable script effects replication.')
+    if redis.log == nil then
+        print('Could not enable script effects replication.')
+    else
+        redis.log(redis.LOG_DEBUG, 'Could not enable script effects replication.')
+    end
 end
 
 


### PR DESCRIPTION
This PR reintroduces https://github.com/getsentry/sentry/pull/65825 with no change because it was closed for inactivity when it's not supposed to. Would be happy to address any potential feedback on @aarnaud 's behalf.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
