### PR TITLE
ref(js): Remove broken onRouteLeave from dashboard details

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1,5 +1,4 @@
 import {cloneElement, Component, Fragment, isValidElement} from 'react';
-import type {Location} from 'react-router-dom';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
 import isEqualWith from 'lodash/isEqualWith';
@@ -38,7 +37,6 @@ import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metr
 import {MetricsResultsMetaProvider} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {OnDemandControlProvider} from 'sentry/utils/performance/contexts/onDemandControl';
-import {OnRouteLeave} from 'sentry/utils/reactRouter6Compat/onRouteLeave';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -336,27 +334,6 @@ class DashboardDetail extends Component<Props, State> {
       dashboardState: DashboardState.EDIT,
       modifiedDashboard: cloneDashboard(dashboard),
     });
-  };
-
-  onLegacyRouteLeave = () => {
-    if (
-      ![
-        DashboardState.VIEW,
-        DashboardState.PENDING_DELETE,
-        DashboardState.PREVIEW,
-      ].includes(this.state.dashboardState) &&
-      !isEqual(this.state.modifiedDashboard, this.props.dashboard)
-    ) {
-      return UNSAVED_MESSAGE;
-    }
-    return undefined;
-  };
-
-  onRouteLeave = (state: {currentLocation: Location; nextLocation: Location}) => {
-    return (
-      state.currentLocation.pathname !== state.nextLocation.pathname &&
-      !!this.onLegacyRouteLeave()
-    );
   };
 
   onDelete = (dashboard: State['modifiedDashboard']) => () => {
@@ -706,13 +683,6 @@ class DashboardDetail extends Component<Props, State> {
 
     return (
       <Fragment>
-        <OnRouteLeave
-          router={this.props.router}
-          route={this.props.route}
-          message={UNSAVED_MESSAGE}
-          legacyWhen={this.onLegacyRouteLeave}
-          when={this.onRouteLeave}
-        />
         {isValidElement(children)
           ? cloneElement<any>(children, {
               dashboard: modifiedDashboard ?? dashboard,
@@ -755,13 +725,6 @@ class DashboardDetail extends Component<Props, State> {
           },
         }}
       >
-        <OnRouteLeave
-          router={this.props.router}
-          route={this.props.route}
-          message={UNSAVED_MESSAGE}
-          legacyWhen={this.onLegacyRouteLeave}
-          when={this.onRouteLeave}
-        />
         <Layout.Page withPadding>
           <OnDemandControlProvider location={location}>
             <MetricsResultsMetaProvider>
@@ -889,13 +852,6 @@ class DashboardDetail extends Component<Props, State> {
             },
           }}
         >
-          <OnRouteLeave
-            router={this.props.router}
-            route={this.props.route}
-            message={UNSAVED_MESSAGE}
-            legacyWhen={this.onLegacyRouteLeave}
-            when={this.onRouteLeave}
-          />
           <Layout.Page>
             <OnDemandControlProvider location={location}>
               <MetricsResultsMetaProvider>


### PR DESCRIPTION
As far as I can tell, this does not work at all in react-router 3 land, and in react-router 6 land it is incorrectly prompting the user to confirm leaving the page when clicking the add widget button in edit mode.

You can reprodce this by:

 - Enter edit mode
 - Add a new widget using the blank widget add button.
 - Try to add another widget and observe that you are prompted to confirm leaving the page with unsaved changes (incorrect)

In react router 3 mode, you can do this same thing and you will not be prompted. However if you completely leave the dashboards page by for example clicking an item in the sidenav, you are also not prompted.

I think for now we should remove this feature since it seems to be broken in both cases and I think the value add for the customer is pretty minimal. It was also not tested whatsoever.

Removing this also "fixes" the acceptance tests for react-router 6for dashboard details, since it had the incorrect behavior of prompting the user to confirm navigation when adding a new widget in edit mode, which is not accounted for in the acceptance tests.