### PR TITLE
fix(toolbar): set CSP for auth endpoints

### DIFF
--- a/src/sentry/middleware/subdomain.py
+++ b/src/sentry/middleware/subdomain.py
@@ -30,6 +30,7 @@ class SubdomainMiddleware:
         self.get_response = get_response
 
     def __call__(self, request: HttpRequest) -> HttpResponseBase:
+        print("MIDDLEWARE!!")
         request.subdomain = None
 
         if not self.base_hostname:

--- a/src/sentry/middleware/subdomain.py
+++ b/src/sentry/middleware/subdomain.py
@@ -30,7 +30,6 @@ class SubdomainMiddleware:
         self.get_response = get_response
 
     def __call__(self, request: HttpRequest) -> HttpResponseBase:
-        print("MIDDLEWARE!!")
         request.subdomain = None
 
         if not self.base_hostname:

--- a/src/sentry/templates/sentry/toolbar/iframe-invalid.html
+++ b/src/sentry/templates/sentry/toolbar/iframe-invalid.html
@@ -13,6 +13,7 @@ Required context variables:
     <link rel="icon" type="image/png" href="{% absolute_asset_url "sentry" "images/favicon.png" %}" style="color:red">
   </head>
   <body>
+    {% script %}
     <script>
       const referrer = "{{ referrer|escapejs }}";
 
@@ -33,5 +34,6 @@ Required context variables:
 
       {% endif %}
     </script>
+    {% endscript %}
   </body>
 </html>

--- a/src/sentry/templates/sentry/toolbar/iframe.html
+++ b/src/sentry/templates/sentry/toolbar/iframe.html
@@ -12,6 +12,7 @@ Required context variables:
     <link rel="icon" type="image/png" href="{% absolute_asset_url "sentry" "images/favicon.png" %}">
   </head>
   <body>
+    {% script %}
     <script>
       const referrer = "{{ referrer|escapejs }}";
 
@@ -63,5 +64,6 @@ Required context variables:
       }, referrer, [port2]);
       log('Sent', {message: 'port-connect', referrer})
     </script>
+    {% endscript %}
   </body>
 </html>

--- a/src/sentry/templates/sentry/toolbar/login-success.html
+++ b/src/sentry/templates/sentry/toolbar/login-success.html
@@ -13,6 +13,7 @@
       <button type="button" id="close-popup">Close Popup</button>
     </div>
 
+    {% script %}
     <script>
       (function() {
         function notifyOpener() {
@@ -37,5 +38,6 @@
         });
       })();
     </script>
+    {% endscript %}
   </body>
 </html>

--- a/src/sentry/toolbar/utils/testutils.py
+++ b/src/sentry/toolbar/utils/testutils.py
@@ -1,0 +1,9 @@
+def csp_has_directive(csp: str, key: str, include_values: list[str], exclude_values: list[str]):
+    for directive in csp.split(";"):
+        directive = directive.strip()
+        if directive.startswith(key):
+            values = directive.split()[1:]
+            return all(v in values for v in include_values) and all(
+                v not in values for v in exclude_values
+            )
+    return False

--- a/src/sentry/toolbar/views/iframe_view.py
+++ b/src/sentry/toolbar/views/iframe_view.py
@@ -16,10 +16,10 @@ INVALID_TEMPLATE = "sentry/toolbar/iframe-invalid.html"
 class IframeView(OrganizationView):
     def respond(self, template: str, context: dict[str, Any] | None = None, status: int = 200):
         response = super().respond(template, context=context, status=status)
-        # These HTTP headers allows response to be embedded in an iframe.
+        # These HTTP headers allow response to be embedded in an iframe.
         response["X-Frame-Options"] = "ALLOWALL"
         response._csp_replace = {  # type: ignore[attr-defined]
-            # This is an alternative to @csp_replace - we need this pattern to access the referrer.
+            # This is an alternative to @csp_replace - we need to use this pattern to access the referrer.
             "frame-ancestors": [self.request.META.get(REFERRER_HEADER, "'none'")]
         }
         return response
@@ -50,6 +50,7 @@ class IframeView(OrganizationView):
     def get(
         self, request: HttpRequest, organization: Organization, project: Project, *args, **kwargs
     ):
+        print("GET METHOD!!")
         referrer = request.META.get(REFERRER_HEADER)
         if not project:
             return self.respond(

--- a/src/sentry/toolbar/views/iframe_view.py
+++ b/src/sentry/toolbar/views/iframe_view.py
@@ -50,7 +50,6 @@ class IframeView(OrganizationView):
     def get(
         self, request: HttpRequest, organization: Organization, project: Project, *args, **kwargs
     ):
-        print("GET METHOD!!")
         referrer = request.META.get(REFERRER_HEADER)
         if not project:
             return self.respond(

--- a/src/sentry/toolbar/views/iframe_view.py
+++ b/src/sentry/toolbar/views/iframe_view.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-from csp.decorators import csp_update  # type: ignore[import-untyped]
 from django.http import HttpRequest, HttpResponse
 
 from sentry.models.organization import Organization
@@ -48,7 +47,6 @@ class IframeView(OrganizationView):
         kwargs["project"] = active_project
         return args, kwargs
 
-    @csp_update(SCRIPT_SRC=["'unsafe-inline'"])
     def get(
         self, request: HttpRequest, organization: Organization, project: Project, *args, **kwargs
     ):

--- a/src/sentry/toolbar/views/iframe_view.py
+++ b/src/sentry/toolbar/views/iframe_view.py
@@ -19,7 +19,8 @@ class IframeView(OrganizationView):
         response = super().respond(template, context=context, status=status)
         # These HTTP headers allows response to be embedded in an iframe.
         response["X-Frame-Options"] = "ALLOWALL"
-        response._csp_replace = {  # This is an alternative to @csp_replace decorator.
+        response._csp_replace = {  # type: ignore[attr-defined]
+            # This is an alternative to @csp_replace - we need this pattern to access the referrer.
             "frame-ancestors": [self.request.META.get(REFERRER_HEADER, "'none'")]
         }
         return response

--- a/src/sentry/toolbar/views/iframe_view.py
+++ b/src/sentry/toolbar/views/iframe_view.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from csp.decorators import csp_update
+from csp.decorators import csp_update  # type: ignore[import-untyped]
 from django.http import HttpRequest, HttpResponse
 
 from sentry.models.organization import Organization

--- a/src/sentry/toolbar/views/login_success_view.py
+++ b/src/sentry/toolbar/views/login_success_view.py
@@ -1,3 +1,4 @@
+from csp.decorators import csp_update
 from django.http import HttpRequest
 
 from sentry.web.frontend.base import OrganizationView, region_silo_view
@@ -5,5 +6,6 @@ from sentry.web.frontend.base import OrganizationView, region_silo_view
 
 @region_silo_view
 class LoginSuccessView(OrganizationView):
+    @csp_update(SCRIPT_SRC=["'unsafe-inline'"])
     def get(self, request: HttpRequest, organization, project_id_or_slug):
         return self.respond("sentry/toolbar/login-success.html", status=200)

--- a/src/sentry/toolbar/views/login_success_view.py
+++ b/src/sentry/toolbar/views/login_success_view.py
@@ -3,9 +3,11 @@ from django.http import HttpRequest
 
 from sentry.web.frontend.base import OrganizationView, region_silo_view
 
+SUCCESS_TEMPLATE = "sentry/toolbar/login-success.html"
+
 
 @region_silo_view
 class LoginSuccessView(OrganizationView):
     @csp_update(SCRIPT_SRC=["'unsafe-inline'"])
     def get(self, request: HttpRequest, organization, project_id_or_slug):
-        return self.respond("sentry/toolbar/login-success.html", status=200)
+        return self.respond(SUCCESS_TEMPLATE, status=200)

--- a/src/sentry/toolbar/views/login_success_view.py
+++ b/src/sentry/toolbar/views/login_success_view.py
@@ -1,4 +1,4 @@
-from csp.decorators import csp_update
+from csp.decorators import csp_update  # type: ignore[import-untyped]
 from django.http import HttpRequest
 
 from sentry.web.frontend.base import OrganizationView, region_silo_view

--- a/src/sentry/toolbar/views/login_success_view.py
+++ b/src/sentry/toolbar/views/login_success_view.py
@@ -1,4 +1,3 @@
-from csp.decorators import csp_update  # type: ignore[import-untyped]
 from django.http import HttpRequest
 
 from sentry.web.frontend.base import OrganizationView, region_silo_view
@@ -8,6 +7,5 @@ SUCCESS_TEMPLATE = "sentry/toolbar/login-success.html"
 
 @region_silo_view
 class LoginSuccessView(OrganizationView):
-    @csp_update(SCRIPT_SRC=["'unsafe-inline'"])
     def get(self, request: HttpRequest, organization, project_id_or_slug):
         return self.respond(SUCCESS_TEMPLATE, status=200)

--- a/tests/sentry/toolbar/views/test_iframe_view.py
+++ b/tests/sentry/toolbar/views/test_iframe_view.py
@@ -71,13 +71,6 @@ class IframeViewTest(APITestCase):
         # Check CSP frame-ancestors directive
         pass
 
-    @override_settings(CSP_INCLUDE_NONCE_IN=[])
-    def test_csp_script_src_unsafe_inline(self):
-        # TODO:
-        # Pass res through middleware
-        # Check
-        pass
-
     @override_settings(CSP_INCLUDE_NONCE_IN=["script-src"])
     def test_csp_script_src_nonce(self):
         # TODO:

--- a/tests/sentry/toolbar/views/test_iframe_view.py
+++ b/tests/sentry/toolbar/views/test_iframe_view.py
@@ -1,11 +1,9 @@
 from typing import Any
 from unittest.mock import Mock, patch
 
-from csp.middleware import CSPMiddleware
 from django.test import override_settings
 from django.urls import reverse
 
-from sentry.middleware.placeholder import placeholder_get_response
 from sentry.testutils.cases import APITestCase
 from sentry.toolbar.utils.testutils import csp_has_directive
 from sentry.toolbar.views.iframe_view import INVALID_TEMPLATE, SUCCESS_TEMPLATE
@@ -18,7 +16,6 @@ class IframeViewTest(APITestCase):
         super().setUp()
         self.login_as(user=self.user)
         self.url = reverse(self.view_name, args=(self.organization.slug, self.project.slug))
-        self.csp_middleware = CSPMiddleware(placeholder_get_response)
 
     def test_missing_project(self):
         url = reverse(self.view_name, args=(self.organization.slug, "abc123xyz"))

--- a/tests/sentry/toolbar/views/test_iframe_view.py
+++ b/tests/sentry/toolbar/views/test_iframe_view.py
@@ -1,6 +1,7 @@
 from typing import Any
 from unittest.mock import Mock, patch
 
+from django.test import override_settings
 from django.urls import reverse
 
 from sentry.testutils.cases import APITestCase
@@ -63,6 +64,26 @@ class IframeViewTest(APITestCase):
         self.project.update_option("sentry:toolbar_allowed_origins", ["https://sentry.io"])
         res = self.client.get(self.url, HTTP_REFERER="https://sentry.io")
         assert res.headers.get("X-Frame-Options") == "ALLOWALL"
+
+    def test_csp_frame_ancestors(self):
+        # TODO:
+        # Pass res through middleware
+        # Check CSP frame-ancestors directive
+        pass
+
+    @override_settings(CSP_INCLUDE_NONCE_IN=[])
+    def test_csp_script_src_unsafe_inline(self):
+        # TODO:
+        # Pass res through middleware
+        # Check
+        pass
+
+    @override_settings(CSP_INCLUDE_NONCE_IN=["script-src"])
+    def test_csp_script_src_nonce(self):
+        # TODO:
+        # Pass req and res through middleware
+        # Check res template content contains same nonce as req
+        pass
 
 
 def _has_expected_response(

--- a/tests/sentry/toolbar/views/test_login_success_view.py
+++ b/tests/sentry/toolbar/views/test_login_success_view.py
@@ -1,0 +1,43 @@
+from django.test import override_settings
+from django.urls import reverse
+
+from sentry.testutils.cases import APITestCase
+from sentry.toolbar.views.login_success_view import SUCCESS_TEMPLATE
+
+
+class LoginSuccessViewTest(APITestCase):
+    view_name = "sentry-toolbar-login-success"
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse(self.view_name, args=(self.organization.slug, self.project.slug))
+        # Note no login
+
+    def test_get_requires_auth(self):
+        """
+        Unauthenticated requests should redirect to /auth/login.
+        Similar to self.assertRequiresAuthentication, which is outdated.
+        """
+        res = self.client.get(self.url)
+        assert res.status_code == 302
+        assert reverse("sentry-login") in res["Location"]
+
+    def test_get(self):
+        self.login_as(self.user)
+        res = self.client.get(self.url)
+        assert res.status_code == 200
+        self.assertTemplateUsed(res, SUCCESS_TEMPLATE)
+
+    @override_settings(CSP_INCLUDE_NONCE_IN=[])
+    def test_csp_script_src_unsafe_inline(self):
+        # TODO:
+        # Pass res through middleware
+        # Check
+        pass
+
+    @override_settings(CSP_INCLUDE_NONCE_IN=["script-src"])
+    def test_csp_script_src_nonce(self):
+        # TODO:
+        # Pass req and res through middleware
+        # Check res template content contains same nonce as req
+        pass

--- a/tests/sentry/toolbar/views/test_login_success_view.py
+++ b/tests/sentry/toolbar/views/test_login_success_view.py
@@ -28,13 +28,6 @@ class LoginSuccessViewTest(APITestCase):
         assert res.status_code == 200
         self.assertTemplateUsed(res, SUCCESS_TEMPLATE)
 
-    @override_settings(CSP_INCLUDE_NONCE_IN=[])
-    def test_csp_script_src_unsafe_inline(self):
-        # TODO:
-        # Pass res through middleware
-        # Check
-        pass
-
     @override_settings(CSP_INCLUDE_NONCE_IN=["script-src"])
     def test_csp_script_src_nonce(self):
         # TODO:

--- a/tests/sentry/toolbar/views/test_login_success_view.py
+++ b/tests/sentry/toolbar/views/test_login_success_view.py
@@ -28,9 +28,9 @@ class LoginSuccessViewTest(APITestCase):
         assert res.status_code == 200
         self.assertTemplateUsed(res, SUCCESS_TEMPLATE)
 
-    @override_settings(CSP_INCLUDE_NONCE_IN=["script-src"])
+    @override_settings(CSP_REPORT_ONLY=False, CSP_INCLUDE_NONCE_IN=["script-src"])
     def test_csp_script_src_nonce(self):
-        # TODO:
-        # Pass req and res through middleware
-        # Check res template content contains same nonce as req
-        pass
+        nonce = ""  # TODO:
+        # TODO: mock CSPMiddleware.process_request to add mock nonce
+        res = self.client.get(self.url)
+        # TODO: assert response template has nonce

--- a/tests/sentry/toolbar/views/test_login_success_view.py
+++ b/tests/sentry/toolbar/views/test_login_success_view.py
@@ -1,7 +1,10 @@
+from unittest.mock import Mock, patch
+
 from django.test import override_settings
 from django.urls import reverse
 
 from sentry.testutils.cases import APITestCase
+from sentry.toolbar.utils.testutils import csp_has_directive
 from sentry.toolbar.views.login_success_view import SUCCESS_TEMPLATE
 
 
@@ -30,7 +33,23 @@ class LoginSuccessViewTest(APITestCase):
 
     @override_settings(CSP_REPORT_ONLY=False, CSP_INCLUDE_NONCE_IN=["script-src"])
     def test_csp_script_src_nonce(self):
-        nonce = ""  # TODO:
-        # TODO: mock CSPMiddleware.process_request to add mock nonce
-        res = self.client.get(self.url)
-        # TODO: assert response template has nonce
+        self.login_as(self.user)
+        mock_nonce = f"{'a' * 22}=="
+
+        def mock_process_request(request):
+            request._csp_nonce = mock_nonce
+            request.csp_nonce = mock_nonce
+            return None
+
+        with patch(
+            "csp.middleware.CSPMiddleware.process_request", Mock(side_effect=mock_process_request)
+        ):
+            res = self.client.get(self.url)
+
+        # Header
+        csp = res.headers.get("Content-Security-Policy", "")
+        assert csp_has_directive(csp, "script-src", [f"'nonce-{mock_nonce}'"], [])
+
+        # Content
+        script_tag = f'<script nonce="{mock_nonce}">'
+        assert script_tag in res.content.decode("utf-8")


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/78237 (motivation/context is in this ticket).

- `frame-ancestors` CSP is stronger than the X-frame-options we were using, so we need to ensure the list = the referring origin.

- For prod: inline scripts need to be enclosed with `{% script %}` to inject the CSP nonce . "'unsafe-inline'" is ignored when there's a nonce. The nonce is included by this setting: [server.py](https://github.com/getsentry/sentry/blob/94861995c291d23f294196fa6ff5f4658b567c5e/src/sentry/conf/server.py#L450-L452)

If CSP is enforced, we require the server to include a nonce in script-src directive, _for any environment or self-hosted_

- Includes 2 basic tests for the LoginSuccessView.