### PR TITLE
feat(insights): Show detail panel when clicking on top-level cards

### DIFF
--- a/static/app/views/insights/mobile/screens/components/screensOverviewTable.tsx
+++ b/static/app/views/insights/mobile/screens/components/screensOverviewTable.tsx
@@ -87,12 +87,12 @@ function ScreensOverviewTable({data, eventView, isLoading, pageLinks}: Props) {
       pageLinks={pageLinks}
       columnOrder={[
         'transaction',
+        'avg(measurements.app_start_cold)',
+        'avg(measurements.app_start_warm)',
         `avg(mobile.slow_frames)`,
         `avg(mobile.frozen_frames)`,
         `avg(measurements.time_to_initial_display)`,
         `avg(measurements.time_to_full_display)`,
-        'avg(measurements.app_start_cold)',
-        'avg(measurements.app_start_warm)',
         `count()`,
       ]}
       defaultSort={[

--- a/static/app/views/insights/mobile/screens/components/vitalCard.tsx
+++ b/static/app/views/insights/mobile/screens/components/vitalCard.tsx
@@ -7,16 +7,24 @@ import {PERFORMANCE_SCORE_COLORS} from 'sentry/views/insights/browser/webVitals/
 
 type Props = {
   description: string;
-  formattedValue: React.ReactNode;
+  formattedValue: string | undefined;
   status: string | undefined;
   statusLabel: string | undefined;
   title: string;
+  onClick?: () => void;
 };
 
-function VitalCard({description, formattedValue, status, statusLabel, title}: Props) {
+function VitalCard({
+  description,
+  formattedValue,
+  status,
+  statusLabel,
+  title,
+  onClick,
+}: Props) {
   return (
     <Fragment>
-      <MeterBarContainer>
+      <MeterBarContainer clickable={onClick !== undefined} onClick={onClick}>
         <MeterBarBody>
           {description && (
             <StyledQuestionTooltip
@@ -84,7 +92,8 @@ function MeterBarFooter({
 const MeterBarFooterContainer = styled('div')<{status: string}>`
   color: ${p => p.theme[PERFORMANCE_SCORE_COLORS[p.status].normal]};
   border-radius: 0 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius};
-  background-color: ${p => p.theme[PERFORMANCE_SCORE_COLORS[p.status].light]};
+  background-color: ${p =>
+    p.status === 'none' ? 'none' : p.theme[PERFORMANCE_SCORE_COLORS[p.status].light]};
   border: solid 1px ${p => p.theme[PERFORMANCE_SCORE_COLORS[p.status].light]};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   padding: ${space(0.5)};

--- a/static/app/views/insights/mobile/screens/components/vitalDetailPanel.spec.tsx
+++ b/static/app/views/insights/mobile/screens/components/vitalDetailPanel.spec.tsx
@@ -1,0 +1,80 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
+import {
+  PerformanceScore,
+  type VitalItem,
+  type VitalStatus,
+} from 'sentry/views/insights/mobile/screens/utils';
+
+import {VitalDetailPanel} from './vitalDetailPanel';
+
+jest.mock('sentry/views/insights/mobile/common/queries/useCrossPlatformProject', () => ({
+  __esModule: true,
+  default: () => ({selectedPlatform: 'Android'}),
+}));
+
+const mockStatus: VitalStatus = {
+  formattedValue: '100ms',
+  score: PerformanceScore.GOOD,
+  description: 'Good performance',
+  value: {
+    type: 'duration',
+    unit: 'ms',
+    value: 100,
+  },
+};
+
+const mockVital: VitalItem = {
+  title: 'title',
+  description: 'description',
+  docs: 'docs',
+  setup: 'setup',
+  platformDocLinks: {
+    Android: 'https://example.com/platform-docs',
+  },
+  sdkDocLinks: {
+    Android: 'https://example.com/sdk-docs',
+  },
+  field: 'avg(measurements.app_start_cold)',
+  dataset: DiscoverDatasets.METRICS,
+  getStatus: () => mockStatus,
+};
+
+describe('VitalDetailPanel', () => {
+  test('renders correctly with given props', () => {
+    render(
+      <PageAlertProvider>
+        <VitalDetailPanel vital={mockVital} status={mockStatus} onClose={jest.fn()} />
+      </PageAlertProvider>
+    );
+
+    expect(screen.getByText('title')).toBeInTheDocument();
+    expect(screen.getByText('100ms')).toBeInTheDocument();
+    expect(screen.getByText('Good performance')).toBeInTheDocument();
+    expect(screen.getByText('docs')).toBeInTheDocument();
+    expect(screen.getByText('setup')).toBeInTheDocument();
+    expect(screen.getByText('Sentry SDK documentation')).toHaveAttribute(
+      'href',
+      'https://example.com/sdk-docs'
+    );
+    expect(screen.getByText('Platform documentation')).toHaveAttribute(
+      'href',
+      'https://example.com/platform-docs'
+    );
+  });
+
+  test('calls onClose when close action is triggered', async () => {
+    const onCloseMock = jest.fn();
+    render(
+      <PageAlertProvider>
+        <VitalDetailPanel vital={mockVital} status={mockStatus} onClose={onCloseMock} />
+      </PageAlertProvider>
+    );
+
+    const closeButton = screen.getByLabelText('Close Details');
+    await userEvent.click(closeButton);
+    expect(onCloseMock).toHaveBeenCalled();
+  });
+});

--- a/static/app/views/insights/mobile/screens/components/vitalDetailPanel.tsx
+++ b/static/app/views/insights/mobile/screens/components/vitalDetailPanel.tsx
@@ -30,10 +30,7 @@ export function VitalDetailPanel({
 
   return (
     <PageAlertProvider>
-      <DetailPanel
-        detailKey={vital !== undefined ? vital.field : undefined}
-        onClose={onClose}
-      >
+      <DetailPanel detailKey={vital?.field} onClose={onClose}>
         {vital && (
           <React.Fragment>
             <VitalDetailTitle>{vital.title}</VitalDetailTitle>

--- a/static/app/views/insights/mobile/screens/components/vitalDetailPanel.tsx
+++ b/static/app/views/insights/mobile/screens/components/vitalDetailPanel.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import ExternalLink from 'sentry/components/links/externalLink';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
+import {PERFORMANCE_SCORE_COLORS} from 'sentry/views/insights/browser/webVitals/utils/performanceScoreColors';
+import DetailPanel from 'sentry/views/insights/common/components/detailPanel';
+import useCrossPlatformProject from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
+import {
+  PerformanceScore,
+  type VitalItem,
+  type VitalStatus,
+} from 'sentry/views/insights/mobile/screens/utils';
+
+export function VitalDetailPanel({
+  vital,
+  status,
+  onClose,
+}: {
+  onClose: () => void;
+  status: VitalStatus | undefined;
+  vital: VitalItem | undefined;
+}) {
+  const {selectedPlatform} = useCrossPlatformProject();
+
+  const platformDocsLink = vital?.platformDocLinks[selectedPlatform];
+  const sdkDocsLink = vital?.sdkDocLinks[selectedPlatform];
+
+  return (
+    <PageAlertProvider>
+      <DetailPanel
+        detailKey={vital !== undefined ? vital.field : undefined}
+        onClose={onClose}
+      >
+        {vital && (
+          <React.Fragment>
+            <VitalDetailTitle>{vital.title}</VitalDetailTitle>
+            {status && (
+              <h2>
+                {status.formattedValue ?? '-'}{' '}
+                {status.score !== PerformanceScore.NONE && (
+                  <Badge status={status.score}>{status.description}</Badge>
+                )}
+              </h2>
+            )}
+            <p>{vital.docs}</p>
+            {vital.setup && <p>{vital.setup}</p>}
+            {(platformDocsLink || sdkDocsLink) && (
+              <React.Fragment>
+                <SubHeading>{t('Learn more')}</SubHeading>
+                <ul>
+                  {sdkDocsLink && (
+                    <li>
+                      <ExternalLink href={sdkDocsLink}>
+                        {t('Sentry SDK documentation')}
+                      </ExternalLink>
+                    </li>
+                  )}
+                  {platformDocsLink && (
+                    <li>
+                      <ExternalLink href={platformDocsLink}>
+                        {t('Platform documentation')}
+                      </ExternalLink>
+                    </li>
+                  )}
+                </ul>
+              </React.Fragment>
+            )}
+          </React.Fragment>
+        )}
+        <PageAlert />
+      </DetailPanel>
+    </PageAlertProvider>
+  );
+}
+
+const VitalDetailTitle = styled('h4')`
+  margin-bottom: ${space(1)};
+  margin-top: 40px;
+`;
+
+const Badge = styled('div')<{status: string}>`
+  white-space: nowrap;
+  border-radius: 12px;
+  color: ${p => p.theme[PERFORMANCE_SCORE_COLORS[p.status].normal]};
+  background-color: ${p => p.theme[PERFORMANCE_SCORE_COLORS[p.status].light]};
+  border: solid 1px ${p => p.theme[PERFORMANCE_SCORE_COLORS[p.status].light]};
+  font-size: ${p => p.theme.fontSizeSmall};
+  padding: 0 ${space(1)};
+  display: inline-block;
+  height: 17px;
+  vertical-align: middle;
+`;
+
+const SubHeading = styled('div')`
+  font-weight: ${p => p.theme.fontWeightBold};
+  margin-bottom: ${space(1)};
+`;

--- a/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
+++ b/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
@@ -1,13 +1,13 @@
-import {useCallback} from 'react';
+import {useCallback, useState} from 'react';
 import styled from '@emotion/styled';
 import omit from 'lodash/omit';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import ButtonBar from 'sentry/components/buttonBar';
-import Duration from 'sentry/components/duration';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
+import {TabbedCodeSnippet} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
@@ -19,9 +19,7 @@ import type {NewQuery} from 'sentry/types/organization';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
-import {DURATION_UNITS} from 'sentry/utils/discover/fieldRenderers';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {formatFloat} from 'sentry/utils/number/formatFloat';
 import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -31,8 +29,10 @@ import {ModulePageProviders} from 'sentry/views/insights/common/components/modul
 import {useModuleBreadcrumbs} from 'sentry/views/insights/common/utils/useModuleBreadcrumbs';
 import useCrossPlatformProject from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
 import {PlatformSelector} from 'sentry/views/insights/mobile/screenload/components/platformSelector';
+import {SETUP_CONTENT as TTFD_SETUP} from 'sentry/views/insights/mobile/screenload/data/setupContent';
 import {ScreensOverview} from 'sentry/views/insights/mobile/screens/components/screensOverview';
 import VitalCard from 'sentry/views/insights/mobile/screens/components/vitalCard';
+import {VitalDetailPanel} from 'sentry/views/insights/mobile/screens/components/vitalDetailPanel';
 import {Referrer} from 'sentry/views/insights/mobile/screens/referrers';
 import {
   MODULE_DESCRIPTION,
@@ -47,6 +47,7 @@ import {
   type MetricValue,
   STATUS_UNKNOWN,
   type VitalItem,
+  type VitalStatus,
 } from 'sentry/views/insights/mobile/screens/utils';
 import {type InsightLandingProps, ModuleName} from 'sentry/views/insights/types';
 
@@ -56,7 +57,6 @@ export function ScreensLandingPage({disableHeader}: InsightLandingProps) {
   const location = useLocation();
   const organization = useOrganization();
   const {isProjectCrossPlatform, selectedPlatform} = useCrossPlatformProject();
-  // const {primaryRelease, secondaryRelease} = useReleaseSelection();
 
   const handleProjectChange = useCallback(() => {
     browserHistory.replace({
@@ -72,6 +72,19 @@ export function ScreensLandingPage({disableHeader}: InsightLandingProps) {
     {
       title: t('Cold App Start'),
       description: t('Average Cold App Start duration'),
+      docs: t(
+        'The average cold app start duration. A cold start usually occurs when the app launched for the first time, after a reboot or an app update.'
+      ),
+      setup: undefined,
+      platformDocLinks: {
+        Android:
+          'https://developer.android.com/topic/performance/vitals/launch-time#cold',
+      },
+      sdkDocLinks: {
+        Android:
+          'https://docs.sentry.io/platforms/android/tracing/instrumentation/automatic-instrumentation/#app-start-instrumentation',
+        iOS: 'https://docs.sentry.io/platforms/apple/guides/ios/tracing/instrumentation/automatic-instrumentation/#app-start-tracing',
+      },
       field: 'avg(measurements.app_start_cold)',
       dataset: DiscoverDatasets.METRICS,
       getStatus: getColdAppStartPerformance,
@@ -79,13 +92,38 @@ export function ScreensLandingPage({disableHeader}: InsightLandingProps) {
     {
       title: t('Warm App Start'),
       description: t('Average Warm App Start duration'),
+      docs: t(
+        'The average warm app start duration. A warm start usually occurs occurs when the app was already launched previously or the process was created beforehand.'
+      ),
+      setup: undefined,
+      platformDocLinks: {
+        Android:
+          'https://developer.android.com/topic/performance/vitals/launch-time#warm',
+      },
+      sdkDocLinks: {
+        Android:
+          'https://docs.sentry.io/platforms/android/tracing/instrumentation/automatic-instrumentation/#app-start-instrumentation',
+        iOS: 'https://docs.sentry.io/platforms/apple/guides/ios/tracing/instrumentation/automatic-instrumentation/#app-start-tracing',
+      },
       field: 'avg(measurements.app_start_warm)',
       dataset: DiscoverDatasets.METRICS,
       getStatus: getWarmAppStartPerformance,
     },
     {
       title: t('Slow Frames'),
-      description: t('Average number of slow frames'),
+      description: t('Slow frames ratio'),
+      docs: t(
+        'The number of slow frames divided by the total number of frames rendered.'
+      ),
+      setup: undefined,
+      platformDocLinks: {
+        Android: 'https://developer.android.com/topic/performance/vitals/render',
+      },
+      sdkDocLinks: {
+        Android:
+          'https://docs.sentry.io/platforms/android/tracing/instrumentation/automatic-instrumentation/#slow-and-frozen-frames',
+        iOS: 'https://docs.sentry.io/platforms/apple/guides/ios/tracing/instrumentation/automatic-instrumentation/#slow-and-frozen-frames',
+      },
       field: `avg(mobile.slow_frames)`,
       dataset: DiscoverDatasets.SPANS_METRICS,
       getStatus: getDefaultMetricPerformance,
@@ -93,6 +131,18 @@ export function ScreensLandingPage({disableHeader}: InsightLandingProps) {
     {
       title: t('Frozen Frames'),
       description: t('Average number of frozen frames'),
+      docs: t(
+        'The number of frozen frames divided by the total number of frames rendered.'
+      ),
+      setup: undefined,
+      platformDocLinks: {
+        Android: 'https://developer.android.com/topic/performance/vitals/render',
+      },
+      sdkDocLinks: {
+        Android:
+          'https://docs.sentry.io/platforms/android/tracing/instrumentation/automatic-instrumentation/#slow-and-frozen-frames',
+        iOS: 'https://docs.sentry.io/platforms/apple/guides/ios/tracing/instrumentation/automatic-instrumentation/#slow-and-frozen-frames',
+      },
       field: `avg(mobile.frozen_frames)`,
       dataset: DiscoverDatasets.SPANS_METRICS,
       getStatus: getDefaultMetricPerformance,
@@ -100,6 +150,16 @@ export function ScreensLandingPage({disableHeader}: InsightLandingProps) {
     {
       title: t('Frame Delay'),
       description: t('Average frame delay'),
+      docs: t('The average delay divided by the total rendering time.'),
+      setup: undefined,
+      platformDocLinks: {
+        Android: 'https://developer.android.com/topic/performance/vitals/render',
+      },
+      sdkDocLinks: {
+        Android:
+          'https://docs.sentry.io/platforms/android/tracing/instrumentation/automatic-instrumentation/#slow-and-frozen-frames',
+        iOS: 'https://docs.sentry.io/platforms/apple/guides/ios/tracing/instrumentation/automatic-instrumentation/#slow-and-frozen-frames',
+      },
       field: `avg(mobile.frames_delay)`,
       dataset: DiscoverDatasets.SPANS_METRICS,
       getStatus: getDefaultMetricPerformance,
@@ -107,6 +167,17 @@ export function ScreensLandingPage({disableHeader}: InsightLandingProps) {
     {
       title: t('TTID'),
       description: t('Average time to intial display.'),
+      docs: t('The average time it takes until your app is drawing the first frame.'),
+      setup: undefined,
+      platformDocLinks: {
+        Android:
+          'https://developer.android.com/topic/performance/vitals/launch-time#time-initial',
+      },
+      sdkDocLinks: {
+        Android:
+          'https://docs.sentry.io/platforms/android/tracing/instrumentation/automatic-instrumentation/#time-to-initial-display',
+        iOS: 'https://docs.sentry.io/platforms/apple/features/experimental-features/',
+      },
       field: `avg(measurements.time_to_initial_display)`,
       dataset: DiscoverDatasets.METRICS,
       getStatus: getDefaultMetricPerformance,
@@ -114,6 +185,17 @@ export function ScreensLandingPage({disableHeader}: InsightLandingProps) {
     {
       title: t('TTFD'),
       description: t('Average time to full display.'),
+      docs: t('The average time it takes until your app is drawing the full content.'),
+      setup: <TabbedCodeSnippet tabs={TTFD_SETUP} />,
+      platformDocLinks: {
+        Android:
+          'https://developer.android.com/topic/performance/vitals/launch-time#time-full',
+      },
+      sdkDocLinks: {
+        Android:
+          'https://docs.sentry.io/platforms/android/tracing/instrumentation/automatic-instrumentation/#time-to-initial-display',
+        iOS: 'https://docs.sentry.io/platforms/apple/features/experimental-features/',
+      },
       field: `avg(measurements.time_to_full_display)`,
       dataset: DiscoverDatasets.METRICS,
       getStatus: getDefaultMetricPerformance,
@@ -122,6 +204,10 @@ export function ScreensLandingPage({disableHeader}: InsightLandingProps) {
 
   const metricsFields: string[] = new Array();
   const spanMetricsFields: string[] = new Array();
+  const [state, setState] = useState<{
+    status: VitalStatus | undefined;
+    vital: VitalItem | undefined;
+  }>({status: undefined, vital: undefined});
 
   vitalItems.forEach(element => {
     if (element.dataset === DiscoverDatasets.METRICS) {
@@ -201,26 +287,6 @@ export function ScreensLandingPage({disableHeader}: InsightLandingProps) {
     return undefined;
   };
 
-  const formattedMetricValueFor = (metric: MetricValue): React.ReactNode => {
-    if (typeof metric.value === 'number' && metric.type === 'duration' && metric.unit) {
-      return (
-        <Duration
-          seconds={
-            (metric.value * ((metric.unit && DURATION_UNITS[metric.unit]) ?? 1)) / 1000
-          }
-          fixedDigits={2}
-          abbreviation
-        />
-      );
-    }
-
-    if (typeof metric.value === 'number' && metric.type === 'number') {
-      return <span>{formatFloat(metric.value, 2)}</span>;
-    }
-
-    return <span>{metric.value}</span>;
-  };
-
   return (
     <ModulePageProviders moduleName="mobile-screens" features={[MODULE_FEATURE]}>
       <Layout.Page>
@@ -263,17 +329,21 @@ export function ScreensLandingPage({disableHeader}: InsightLandingProps) {
                       const metricValue = metricValueFor(item);
                       const status =
                         (metricValue && item.getStatus(metricValue)) ?? STATUS_UNKNOWN;
-                      const formattedValue: React.ReactNode =
-                        metricValue && formattedMetricValueFor(metricValue);
 
                       return (
                         <VitalCard
+                          onClick={() => {
+                            setState({
+                              vital: item,
+                              status: status,
+                            });
+                          }}
                           key={item.field}
                           title={item.title}
                           description={item.description}
                           statusLabel={status.description}
                           status={status.score}
-                          formattedValue={formattedValue}
+                          formattedValue={status.formattedValue}
                         />
                       );
                     })}
@@ -283,6 +353,13 @@ export function ScreensLandingPage({disableHeader}: InsightLandingProps) {
               </ErrorBoundary>
             </Layout.Main>
           </Layout.Body>
+          <VitalDetailPanel
+            vital={state.vital}
+            status={state.status}
+            onClose={() => {
+              setState({vital: undefined, status: undefined});
+            }}
+          />
         </PageAlertProvider>
       </Layout.Page>
     </ModulePageProviders>


### PR DESCRIPTION
Show a detail panel when clicking on a mobile screens metric. If a metric has no grading, no background color is applied to the card as well (previously it was greyed out).

<img width="1104" alt="image" src="https://github.com/user-attachments/assets/4e804a58-91eb-42da-9a74-9405569ab63a">
