### PR TITLE
ref(stats): Add analytics to main file

### DIFF
--- a/static/app/utils/analytics.tsx
+++ b/static/app/utils/analytics.tsx
@@ -9,6 +9,10 @@ import {
   featureFlagEventMap,
   type FeatureFlagEventParameters,
 } from 'sentry/utils/analytics/featureFlagAnalyticsEvents';
+import {
+  statsEventMap,
+  type StatsEventParameters,
+} from 'sentry/utils/analytics/statsAnalyticsEvents';
 
 import type {AiSuggestedSolutionEventParameters} from './analytics/aiSuggestedSolutionAnalyticsEvents';
 import {aiSuggestedSolutionEventMap} from './analytics/aiSuggestedSolutionAnalyticsEvents';
@@ -87,6 +91,7 @@ interface EventParameters
     ProjectCreationEventParameters,
     SignupAnalyticsParameters,
     TracingEventParameters,
+    StatsEventParameters,
     Record<string, Record<string, any>> {}
 
 const allEventMap: Record<string, string | null> = {
@@ -117,6 +122,7 @@ const allEventMap: Record<string, string | null> = {
   ...projectCreationEventMap,
   ...starfishEventMap,
   ...signupEventMap,
+  ...statsEventMap,
 };
 
 /**

--- a/static/app/utils/analytics/statsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/statsAnalyticsEvents.tsx
@@ -1,6 +1,6 @@
 export type StatsEventParameters = {
   'stats.docs_clicked': {
-    projects: string;
+    dataCategory: string;
     source:
       | 'card-accepted'
       | 'card-filtered'

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -319,10 +319,11 @@ class UsageStatsOrganization<
       | 'card-invalid'
       | 'chart-title'
   ) => {
-    const {organization} = this.props;
+    const {organization, dataCategory} = this.props;
     trackAnalytics('stats.docs_clicked', {
       organization,
       source,
+      dataCategory,
     });
   };
 


### PR DESCRIPTION
By using `DEBUG_ANALYTICS` I could see that the events were being fired but were not being recorded in Amplitude. This pull request addresses the issue.