### PR TITLE
feat(rr6): Drop react-router-6 flag usage

### DIFF
--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -216,8 +216,6 @@ class _ClientConfig:
 
     @property
     def enabled_features(self) -> Iterable[str]:
-        if self.last_org and features.has("organizations:react-router-6", self.last_org):
-            yield "organizations:react-router-6"
         if features.has("organizations:create", actor=self.user):
             yield "organizations:create"
         if auth.has_user_registration():


### PR DESCRIPTION
We are no longer checking this in the frontend.