### PR TITLE
feat(uptime): Add accept environment in APIs

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -1984,6 +1984,7 @@ class Factories:
     @staticmethod
     def create_project_uptime_subscription(
         project: Project,
+        env: Environment | None,
         uptime_subscription: UptimeSubscription,
         mode: ProjectUptimeSubscriptionMode,
         name: str,
@@ -2001,6 +2002,7 @@ class Factories:
         return ProjectUptimeSubscription.objects.create(
             uptime_subscription=uptime_subscription,
             project=project,
+            environment=env,
             mode=mode,
             name=name,
             owner_team_id=owner_team_id,

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -14,6 +14,7 @@ from sentry.incidents.models.incident import IncidentActivityType
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.models.activity import Activity
+from sentry.models.environment import Environment
 from sentry.models.grouprelease import GroupRelease
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
@@ -708,6 +709,7 @@ class Fixtures:
     def create_project_uptime_subscription(
         self,
         project: Project | None = None,
+        env: Environment | None = None,
         uptime_subscription: UptimeSubscription | None = None,
         mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
         name="Test Name",
@@ -721,6 +723,7 @@ class Fixtures:
             uptime_subscription = self.create_uptime_subscription()
         return Factories.create_project_uptime_subscription(
             project,
+            env,
             uptime_subscription,
             mode,
             name,

--- a/src/sentry/uptime/detectors/tasks.py
+++ b/src/sentry/uptime/detectors/tasks.py
@@ -244,6 +244,9 @@ def monitor_url_for_project(project: Project, url: str):
         )
     get_or_create_project_uptime_subscription(
         project,
+        # TODO(epurkhiser): This is where we would put the environment object
+        # from autodetection if we decide to do that.
+        environment=None,
         url=url,
         interval_seconds=ONBOARDING_SUBSCRIPTION_INTERVAL_SECONDS,
         mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING,

--- a/src/sentry/uptime/endpoints/project_uptime_alert_details.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_details.py
@@ -92,6 +92,7 @@ class ProjectUptimeAlertDetailsEndpoint(ProjectUptimeAlertEndpoint):
             instance=uptime_subscription,
             context={
                 "organization": project.organization,
+                "project": project,
                 "access": request.access,
                 "request": request,
             },

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -7,6 +7,7 @@ from django.db.models import TextField
 from django.db.models.expressions import Value
 from django.db.models.functions import MD5, Coalesce
 
+from sentry.models.environment import Environment
 from sentry.models.project import Project
 from sentry.types.actor import Actor
 from sentry.uptime.detectors.url_extraction import extract_domain_parts
@@ -142,6 +143,7 @@ def delete_uptime_subscription(uptime_subscription: UptimeSubscription):
 
 def get_or_create_project_uptime_subscription(
     project: Project,
+    environment: Environment | None,
     url: str,
     interval_seconds: int,
     timeout_ms: int = DEFAULT_SUBSCRIPTION_TIMEOUT_MS,
@@ -174,6 +176,7 @@ def get_or_create_project_uptime_subscription(
             owner_team_id = owner.id
     return ProjectUptimeSubscription.objects.get_or_create(
         project=project,
+        environment=environment,
         uptime_subscription=uptime_subscription,
         mode=mode.value,
         name=name,
@@ -184,6 +187,7 @@ def get_or_create_project_uptime_subscription(
 
 def update_project_uptime_subscription(
     uptime_monitor: ProjectUptimeSubscription,
+    environment: Environment | None,
     url: str,
     interval_seconds: int,
     method: str,
@@ -217,6 +221,7 @@ def update_project_uptime_subscription(
             owner_user_id = None
 
     uptime_monitor.update(
+        environment=environment,
         uptime_subscription=new_uptime_subscription,
         name=name,
         mode=mode,

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -133,6 +133,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
     def test(self):
         created = get_or_create_project_uptime_subscription(
             self.project,
+            self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
@@ -150,6 +151,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
     def test_already_exists(self):
         assert get_or_create_project_uptime_subscription(
             self.project,
+            self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
@@ -157,6 +159,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
         )[1]
         assert not get_or_create_project_uptime_subscription(
             self.project,
+            self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
@@ -177,6 +180,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
     def test_different_modes(self):
         assert get_or_create_project_uptime_subscription(
             self.project,
+            self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
@@ -184,6 +188,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
         )[1]
         assert get_or_create_project_uptime_subscription(
             self.project,
+            self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
@@ -206,6 +211,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
         ):
             assert get_or_create_project_uptime_subscription(
                 self.project,
+                self.environment,
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
@@ -214,6 +220,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
             with pytest.raises(MaxManualUptimeSubscriptionsReached):
                 assert get_or_create_project_uptime_subscription(
                     self.project,
+                    self.environment,
                     url="https://santry.io",
                     interval_seconds=3600,
                     timeout_ms=1000,
@@ -226,6 +233,7 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
         with self.tasks():
             proj_sub = get_or_create_project_uptime_subscription(
                 self.project,
+                self.environment,
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
@@ -234,6 +242,7 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
             prev_uptime_subscription = proj_sub.uptime_subscription
             update_project_uptime_subscription(
                 proj_sub,
+                environment=self.environment,
                 url="https://santry.io",
                 interval_seconds=60,
                 method="POST",
@@ -265,6 +274,7 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
         with self.tasks():
             proj_sub = get_or_create_project_uptime_subscription(
                 self.project,
+                self.environment,
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
@@ -273,6 +283,7 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
             prev_uptime_subscription = proj_sub.uptime_subscription
             update_project_uptime_subscription(
                 proj_sub,
+                environment=self.environment,
                 url="https://santry.io",
                 interval_seconds=proj_sub.uptime_subscription.interval_seconds,
                 method=proj_sub.uptime_subscription.method,
@@ -298,6 +309,7 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
         with self.tasks():
             proj_sub = get_or_create_project_uptime_subscription(
                 self.project,
+                self.environment,
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
@@ -305,6 +317,7 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
             )[0]
             other_proj_sub = get_or_create_project_uptime_subscription(
                 self.project,
+                self.environment,
                 url="https://santry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
@@ -313,6 +326,7 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
 
             update_project_uptime_subscription(
                 proj_sub,
+                environment=self.environment,
                 url=proj_sub.uptime_subscription.url,
                 interval_seconds=other_proj_sub.uptime_subscription.interval_seconds,
                 method=other_proj_sub.uptime_subscription.method,
@@ -339,6 +353,7 @@ class DeleteUptimeSubscriptionsForProjectTest(UptimeTestCase):
         other_project = self.create_project()
         proj_sub = get_or_create_project_uptime_subscription(
             self.project,
+            self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
@@ -346,6 +361,7 @@ class DeleteUptimeSubscriptionsForProjectTest(UptimeTestCase):
         )[0]
         get_or_create_project_uptime_subscription(
             other_project,
+            self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
@@ -367,6 +383,7 @@ class DeleteUptimeSubscriptionsForProjectTest(UptimeTestCase):
     def test_single_subscriptions(self):
         proj_sub = get_or_create_project_uptime_subscription(
             self.project,
+            self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
@@ -400,6 +417,7 @@ class DeleteUptimeSubscriptionsForProjectTest(UptimeTestCase):
         other_project = self.create_project()
         other_proj_sub = get_or_create_project_uptime_subscription(
             other_project,
+            self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
@@ -418,6 +436,7 @@ class DeleteUptimeSubscriptionsForProjectTest(UptimeTestCase):
     def test_delete_other_modes(self):
         proj_active_sub = get_or_create_project_uptime_subscription(
             self.project,
+            self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
@@ -425,6 +444,7 @@ class DeleteUptimeSubscriptionsForProjectTest(UptimeTestCase):
         )[0]
         proj_manual_sub = get_or_create_project_uptime_subscription(
             self.project,
+            self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
@@ -463,6 +483,7 @@ class DeleteProjectUptimeSubscriptionTest(UptimeTestCase):
         other_project = self.create_project()
         proj_sub = get_or_create_project_uptime_subscription(
             self.project,
+            self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
@@ -471,6 +492,7 @@ class DeleteProjectUptimeSubscriptionTest(UptimeTestCase):
 
         other_sub = get_or_create_project_uptime_subscription(
             other_project,
+            self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
@@ -490,6 +512,7 @@ class DeleteProjectUptimeSubscriptionTest(UptimeTestCase):
     def test_single_subscriptions(self):
         proj_sub = get_or_create_project_uptime_subscription(
             self.project,
+            self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
@@ -517,6 +540,7 @@ class RemoveUptimeSubscriptionIfUnusedTest(UptimeTestCase):
     def test_keep(self):
         proj_sub = get_or_create_project_uptime_subscription(
             self.project,
+            self.environment,
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,


### PR DESCRIPTION
Allows creation / assignment of environment names when creating uptime alerts