### PR TITLE
chore(integrations): get active integrations for discord, slack, codemappings

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1613,7 +1613,9 @@ def _get_alert_rule_trigger_action_slack_channel_id(
         except StopIteration:
             integration = None
     else:
-        integration = integration_service.get_integration(integration_id=integration_id)
+        integration = integration_service.get_integration(
+            integration_id=integration_id, status=ObjectStatus.ACTIVE
+        )
     if integration is None:
         raise InvalidTriggerActionError("Slack workspace is a required field.")
 
@@ -1644,7 +1646,9 @@ def _get_alert_rule_trigger_action_slack_channel_id(
 def _get_alert_rule_trigger_action_discord_channel_id(name: str, integration_id: int) -> str | None:
     from sentry.integrations.discord.utils.channel import validate_channel_id
 
-    integration = integration_service.get_integration(integration_id=integration_id)
+    integration = integration_service.get_integration(
+        integration_id=integration_id, status=ObjectStatus.ACTIVE
+    )
     if integration is None:
         raise InvalidTriggerActionError("Discord integration not found.")
     try:

--- a/src/sentry/integrations/api/endpoints/organization_code_mapping_codeowners.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mapping_codeowners.py
@@ -8,6 +8,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationIntegrationsPermission
+from sentry.constants import ObjectStatus
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.source_code_management.repository import RepositoryIntegration
@@ -18,7 +19,9 @@ def get_codeowner_contents(config):
     if not config.organization_integration_id:
         raise NotFound(detail="No associated integration")
 
-    integration = integration_service.get_integration(integration_id=config.integration_id)
+    integration = integration_service.get_integration(
+        integration_id=config.integration_id, status=ObjectStatus.ACTIVE
+    )
     if not integration:
         return None
     install = integration.get_installation(organization_id=config.project.organization_id)

--- a/src/sentry/integrations/discord/actions/issue_alert/form.py
+++ b/src/sentry/integrations/discord/actions/issue_alert/form.py
@@ -6,6 +6,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.forms.fields import ChoiceField
 
+from sentry.constants import ObjectStatus
 from sentry.integrations.discord.utils.channel import validate_channel_id
 from sentry.integrations.discord.utils.channel_from_url import get_channel_id_from_url
 from sentry.integrations.services.integration import integration_service
@@ -36,7 +37,9 @@ class DiscordNotifyServiceForm(forms.Form):
         cleaned_data: dict[str, object] = super().clean() or {}
         channel_id = cleaned_data.get("channel_id")
         server = cleaned_data.get("server")
-        integration = integration_service.get_integration(integration_id=server)
+        integration = integration_service.get_integration(
+            integration_id=server, status=ObjectStatus.ACTIVE
+        )
 
         if not server or not integration:
             raise forms.ValidationError(

--- a/src/sentry/integrations/discord/requests/base.py
+++ b/src/sentry/integrations/discord/requests/base.py
@@ -9,6 +9,7 @@ from rest_framework import status
 from rest_framework.request import Request
 
 from sentry import options
+from sentry.constants import ObjectStatus
 from sentry.identity.services.identity import RpcIdentityProvider
 from sentry.identity.services.identity.model import RpcIdentity
 from sentry.identity.services.identity.service import identity_service
@@ -224,7 +225,7 @@ class DiscordRequest:
     def validate_integration(self) -> None:
         if not self._integration:
             self._integration = integration_service.get_integration(
-                provider="discord", external_id=self.guild_id
+                provider="discord", external_id=self.guild_id, status=ObjectStatus.ACTIVE
             )
         self._info("discord.validate.integration")
 

--- a/src/sentry/integrations/messaging/linkage.py
+++ b/src/sentry/integrations/messaging/linkage.py
@@ -14,6 +14,7 @@ from rest_framework.request import Request
 
 from sentry import analytics, features
 from sentry.api.helpers.teams import is_team_admin
+from sentry.constants import ObjectStatus
 from sentry.identity.services.identity import identity_service
 from sentry.integrations.messaging.spec import MessagingIntegrationSpec
 from sentry.integrations.models.external_actor import ExternalActor
@@ -360,7 +361,9 @@ class TeamLinkageView(LinkageView, ABC):
         slack_id: str = params["slack_id"]
         organization_id: str | None = params.get("organization_id")
 
-        integration = integration_service.get_integration(integration_id=integration_id)
+        integration = integration_service.get_integration(
+            integration_id=integration_id, status=ObjectStatus.ACTIVE
+        )
         if integration is None:
             logger.info(
                 "integration.not_found",

--- a/src/sentry/integrations/models/external_actor.py
+++ b/src/sentry/integrations/models/external_actor.py
@@ -6,6 +6,7 @@ from django.db.models.signals import post_delete, post_save
 from django.utils import timezone
 
 from sentry.backup.scopes import RelocationScope
+from sentry.constants import ObjectStatus
 from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, region_silo_model
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.hybridcloud.outbox.base import ReplicatedRegionModel
@@ -68,7 +69,9 @@ class ExternalActor(ReplicatedRegionModel):
 
         # TODO: Extract this out of the delete method into the endpoint / controller instead.
         if self.team is not None:
-            integration = integration_service.get_integration(integration_id=self.integration_id)
+            integration = integration_service.get_integration(
+                integration_id=self.integration_id, status=ObjectStatus.ACTIVE
+            )
             if integration:
                 install = integration.get_installation(organization_id=self.organization.id)
                 team = self.team

--- a/src/sentry/integrations/models/external_issue.py
+++ b/src/sentry/integrations/models/external_issue.py
@@ -7,6 +7,7 @@ from django.db.models import QuerySet
 from django.utils import timezone
 
 from sentry.backup.scopes import RelocationScope
+from sentry.constants import ObjectStatus
 from sentry.db.models import FlexibleForeignKey, JSONField, Model, region_silo_model, sane_repr
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.db.models.manager.base import BaseManager
@@ -89,7 +90,9 @@ class ExternalIssue(Model):
     def get_installation(self) -> Any:
         from sentry.integrations.services.integration import integration_service
 
-        integration = integration_service.get_integration(integration_id=self.integration_id)
+        integration = integration_service.get_integration(
+            integration_id=self.integration_id, status=ObjectStatus.ACTIVE
+        )
 
         assert integration, "Integration is required to get an installation"
         return integration.get_installation(organization_id=self.organization_id)

--- a/src/sentry/integrations/slack/tasks/link_slack_user_identities.py
+++ b/src/sentry/integrations/slack/tasks/link_slack_user_identities.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 
 from django.utils import timezone
 
+from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.slack.utils.users import SlackUserData, get_slack_data_by_user
 from sentry.integrations.utils import get_identities_by_user
@@ -28,13 +29,20 @@ def link_slack_user_identities(
     integration_id: int,
     organization_id: int,
 ) -> None:
-    integration = integration_service.get_integration(integration_id=integration_id)
+    integration = integration_service.get_integration(
+        integration_id=integration_id, status=ObjectStatus.ACTIVE
+    )
     organization_context = organization_service.get_organization_by_id(id=organization_id)
     organization = organization_context.organization if organization_context else None
     if organization is None or integration is None:
         logger.error(
             "slack.post_install.link_identities.invalid_params",
-            extra={"organization": organization_id, "integration": integration_id},
+            extra={
+                "organization_id": organization_id,
+                "integration_id": integration_id,
+                "integration": bool(integration),
+                "organization": bool(organization),
+            },
         )
         return None
 


### PR DESCRIPTION
We should filter for active integrations when:
- Fetching target identifier display for Slack and Discord for alert rules (we make external API call, we should do this with active integrations only)
- Fetching codeowner contents (we make a subsequent external API call that goes through integration proxy)
- Validating Discord issue alert form and incoming requests
- Fetching integration in linking teams for messaging integrations (if the integration is inactive, subsequent messages won't send so we shouldn't link the team)
- Deleting an `ExternalActor`, which calls `install.notify_remove_external_team(external_team=self, team=team)` and makes an external API call 
- Getting installation from an `ExternalIssue`, if we call functions on the installation that make external API requests, they should only be for active integrations
- Linking Slack user identities, we already error when initializing `SlackSdkClient` with an inactive integration but can early return when fetching the integration