### PR TITLE
ref(alerts): Remove unused fake anomaly detection flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -56,8 +56,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:alerts-migration-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable anomaly detection alerts
     manager.add("organizations:anomaly-detection-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable anomaly detection alerts
-    manager.add("organizations:fake-anomaly-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable anomaly detection charts
     manager.add("organizations:anomaly-detection-alerts-charts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable anr frame analysis

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -533,9 +533,6 @@ class SubscriptionProcessor:
         self.has_anomaly_detection = features.has(
             "organizations:anomaly-detection-alerts", self.subscription.project.organization
         )
-        has_fake_anomalies = features.has(
-            "organizations:fake-anomaly-detection", self.subscription.project.organization
-        )
 
         potential_anomalies = None
         if (
@@ -586,7 +583,7 @@ class SubscriptionProcessor:
                                 continue
 
                         if self.has_anomaly(
-                            potential_anomaly, trigger.label, has_fake_anomalies
+                            potential_anomaly, trigger.label
                         ) and not self.check_trigger_matches_status(trigger, TriggerStatus.ACTIVE):
                             metrics.incr(
                                 "incidents.alert_rules.threshold.alert",
@@ -601,9 +598,7 @@ class SubscriptionProcessor:
                             self.trigger_alert_counts[trigger.id] = 0
 
                         if (
-                            not self.has_anomaly(
-                                potential_anomaly, trigger.label, has_fake_anomalies
-                            )
+                            not self.has_anomaly(potential_anomaly, trigger.label)
                             and self.active_incident
                             and self.check_trigger_matches_status(trigger, TriggerStatus.ACTIVE)
                         ):
@@ -670,14 +665,11 @@ class SubscriptionProcessor:
         # before the next one then we might alert twice.
         self.update_alert_rule_stats()
 
-    def has_anomaly(self, anomaly: TimeSeriesPoint, label: str, has_fake_anomalies: bool) -> bool:
+    def has_anomaly(self, anomaly: TimeSeriesPoint, label: str) -> bool:
         """
         Helper function to determine whether we care about an anomaly based on the
         anomaly type and trigger type.
         """
-        if has_fake_anomalies:
-            return True
-
         anomaly_type = anomaly.get("anomaly", {}).get("anomaly_type")
 
         if anomaly_type == AnomalyType.HIGH_CONFIDENCE.value or (

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -725,23 +725,12 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         label = self.trigger.label
 
         processor = SubscriptionProcessor(self.sub)
-        assert processor.has_anomaly(anomaly1, label, False)
-        assert processor.has_anomaly(anomaly1, warning_label, False)
-        assert not processor.has_anomaly(anomaly2, label, False)
-        assert processor.has_anomaly(anomaly2, warning_label, False)
-        assert not processor.has_anomaly(not_anomaly, label, False)
-        assert not processor.has_anomaly(not_anomaly, warning_label, False)
-
-    def test_fake_anomaly(self):
-        anomaly: TimeSeriesPoint = {
-            "anomaly": {"anomaly_score": 0.2, "anomaly_type": AnomalyType.NONE.value},
-            "timestamp": 1,
-            "value": 10,
-        }
-        label = self.trigger.label
-        processor = SubscriptionProcessor(self.sub)
-
-        assert processor.has_anomaly(anomaly, label, True)
+        assert processor.has_anomaly(anomaly1, label)
+        assert processor.has_anomaly(anomaly1, warning_label)
+        assert not processor.has_anomaly(anomaly2, label)
+        assert processor.has_anomaly(anomaly2, warning_label)
+        assert not processor.has_anomaly(not_anomaly, label)
+        assert not processor.has_anomaly(not_anomaly, warning_label)
 
     @with_feature("organizations:anomaly-detection-alerts")
     @mock.patch(


### PR DESCRIPTION
We're not using this flag anymore, removed in options automator in https://github.com/getsentry/sentry-options-automator/pull/2407