### PR TITLE
fix(project): Undefined access for apdex triggering error

### DIFF
--- a/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
@@ -111,7 +111,7 @@ function ProjectApdexScoreCard(props: Props) {
 
   const apdex = Number(data?.data?.[0]?.['apdex()']) || undefined;
 
-  const previousApdex = Number(previousData?.data?.[0]['apdex()']) || undefined;
+  const previousApdex = Number(previousData?.data?.[0]?.['apdex()']) || undefined;
 
   const trend =
     defined(apdex) && defined(previousApdex)


### PR DESCRIPTION
All accesses of apdex on this page do a `?.` access, make it consistent to avoid attempting to access on undefined.