### PR TITLE
fix(issues): Tag drawer links should not append /events/

### DIFF
--- a/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
+++ b/static/app/views/issueDetails/groupTags/groupTagsDrawer.tsx
@@ -36,6 +36,8 @@ import {useParams} from 'sentry/utils/useParams';
 import useProjects from 'sentry/utils/useProjects';
 import {TagDetailsDrawerContent} from 'sentry/views/issueDetails/groupTags/tagDetailsDrawerContent';
 import {useGroupTags} from 'sentry/views/issueDetails/groupTags/useGroupTags';
+import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
+import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
 
 type GroupTagsDrawerProps = {
   groupId: string;
@@ -49,6 +51,7 @@ export function GroupTagsDrawer({projectSlug, groupId}: GroupTagsDrawerProps) {
   const drawerRef = useRef<HTMLDivElement>(null);
   const {projects} = useProjects();
   const project = projects.find(p => p.slug === projectSlug)!;
+  const {baseUrl} = useGroupDetailsRoute();
 
   const {
     data = [],
@@ -92,7 +95,7 @@ export function GroupTagsDrawer({projectSlug, groupId}: GroupTagsDrawerProps) {
               label: t('All Tags'),
               to: tagKey
                 ? {
-                    pathname: `/organizations/${organization.slug}/issues/${groupId}/tags/`,
+                    pathname: `${baseUrl}${TabPaths[Tab.TAGS]}`,
                     query: location.query,
                   }
                 : undefined,
@@ -166,8 +169,9 @@ export function GroupTagsDrawer({projectSlug, groupId}: GroupTagsDrawerProps) {
                             <TagProgressBarLink
                               // All events with the tag as the query
                               to={{
-                                pathname: `${location.pathname}events/`,
+                                pathname: `${baseUrl}${TabPaths[Tab.EVENTS]}`,
                                 query: {
+                                  ...location.query,
                                   query:
                                     tagValue.query || `${tag.key}:"${tagValue.value}"`,
                                 },

--- a/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.spec.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.spec.tsx
@@ -138,7 +138,7 @@ describe('TagDetailsDrawerContent', () => {
     );
 
     expect(router.push).toHaveBeenCalledWith({
-      pathname: '/organizations/org-slug/issues/',
+      pathname: '/organizations/org-slug/issues/1/',
       query: {query: 'user.username:david'},
     });
   });

--- a/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import {useFetchIssueTag, useFetchIssueTagValues} from 'sentry/actionCreators/group';
 import {DeviceName} from 'sentry/components/deviceName';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
-import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
 import UserBadge from 'sentry/components/idBadge/userBadge';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
@@ -27,7 +26,9 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
+import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
 import {useGroup} from 'sentry/views/issueDetails/useGroup';
+import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
 import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 
 type GroupTagsDrawerProps = {
@@ -56,6 +57,7 @@ export function TagDetailsDrawerContent({
   const organization = useOrganization();
   const {tagKey} = useParams<{tagKey: string}>();
   const environments = useEnvironmentsFromUrl();
+  const {baseUrl} = useGroupDetailsRoute();
 
   const title = tagKey === 'user' ? t('Affected Users') : tagKey;
   const sort: TagSort =
@@ -159,15 +161,17 @@ export function TagDetailsDrawerContent({
             version: 2 as SavedQueryVersions,
             range: '90d',
           });
-          const issuesPath = `/organizations/${organization.slug}/issues/`;
           return (
             <Fragment key={tagValueIdx}>
               <NameColumn>
                 <NameWrapper data-test-id="group-tag-value">
-                  <GlobalSelectionLink
+                  <Link
                     to={{
-                      pathname: `${location.pathname}events/`,
-                      query: {query: issuesQuery},
+                      pathname: `${baseUrl}${TabPaths[Tab.EVENTS]}`,
+                      query: {
+                        ...globalSelectionParams,
+                        query: issuesQuery,
+                      },
                     }}
                   >
                     {key === 'user' ? (
@@ -179,7 +183,7 @@ export function TagDetailsDrawerContent({
                     ) : (
                       <DeviceName value={tagValue.name} />
                     )}
-                  </GlobalSelectionLink>
+                  </Link>
                 </NameWrapper>
 
                 {tagValue.email && (
@@ -230,7 +234,7 @@ export function TagDetailsDrawerContent({
                       key: 'search-issues',
                       label: t('Search All Issues with Tag Value'),
                       to: {
-                        pathname: issuesPath,
+                        pathname: baseUrl,
                         query: {
                           ...globalSelectionParams, // preserve page filter selections
                           query: issuesQuery,


### PR DESCRIPTION
we don't want them to go from /tags/ to /tags/events/ since that route doesn't exist. we can use `useGroupDetailsRoute` to go to the correct path since it can be either

`/issues/:issueId/events/?query`  
`/issues/:issueId/events/:eventId/events/?query`  

