### PR TITLE
ref(replay): add extra loading indicator on replay index to avoid blank screen

### DIFF
--- a/static/app/views/replays/list/listContent.tsx
+++ b/static/app/views/replays/list/listContent.tsx
@@ -2,6 +2,7 @@ import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import ReplayRageClickSdkVersionBanner from 'sentry/components/replays/replayRageClickSdkVersionBanner';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -43,7 +44,7 @@ export default function ListContent() {
   });
 
   if (hasSentReplays.fetching || rageClicksSdkVersion.isFetching) {
-    return null;
+    return <LoadingIndicator />;
   }
 
   if (!hasSessionReplay || !hasSentReplays.hasSentOneReplay) {

--- a/static/app/views/replays/list/listContent.tsx
+++ b/static/app/views/replays/list/listContent.tsx
@@ -44,7 +44,15 @@ export default function ListContent() {
   });
 
   if (hasSentReplays.fetching || rageClicksSdkVersion.isFetching) {
-    return <LoadingIndicator />;
+    return (
+      <Fragment>
+        <FiltersContainer>
+          <ReplaysFilters />
+          <ReplaysSearch />
+        </FiltersContainer>
+        <LoadingIndicator />
+      </Fragment>
+    );
   }
 
   if (!hasSessionReplay || !hasSentReplays.hasSentOneReplay) {


### PR DESCRIPTION
when the replay index is first loading, while it waits for things to fetch, it returns `null`. this leads the screen to be blank for a while. to avoid this and let users know things are loading, add a `LoadingIndicator` while we wait for things to fetch.

before:

https://github.com/user-attachments/assets/5968a9f4-56d6-4427-841e-69128ab31afa

after:

https://github.com/user-attachments/assets/08a47ced-e8ec-4748-ae62-f950ec533cde


fixes https://github.com/getsentry/sentry/issues/69781