### PR TITLE
fix(insights): fix link from web vitals to page overview broken without slash

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.spec.tsx
@@ -147,7 +147,7 @@ describe('PagePerformanceTable', function () {
     expect(screen.getByRole('cell', {name: '/insights/browser/'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: '/insights/browser/'})).toHaveAttribute(
       'href',
-      '/mock-pathname/overview/?project=11276&transaction=%2Finsights%2Fbrowser%2F'
+      '/organizations/org-slug/insights/browser/pageloads/overview/?project=11276&transaction=%2Finsights%2Fbrowser%2F'
     );
 
     expect(screen.getByRole('cell', {name: 'frontend'})).toBeInTheDocument();

--- a/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.tsx
@@ -31,6 +31,7 @@ import type {RowWithScoreAndOpportunity} from 'sentry/views/insights/browser/web
 import {SORTABLE_FIELDS} from 'sentry/views/insights/browser/webVitals/types';
 import decodeBrowserTypes from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {useWebVitalsSort} from 'sentry/views/insights/browser/webVitals/utils/useWebVitalsSort';
+import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
 import {
   ModuleName,
   SpanIndexedField,
@@ -66,6 +67,7 @@ const DEFAULT_SORT: Sort = {
 export function PagePerformanceTable() {
   const location = useLocation();
   const organization = useOrganization();
+  const moduleUrl = useModuleURL(ModuleName.VITAL);
 
   const columnOrder = COLUMN_ORDER;
 
@@ -210,7 +212,7 @@ export function PagePerformanceTable() {
           <Link
             to={{
               ...location,
-              pathname: `${location.pathname}overview/`,
+              pathname: `${moduleUrl}/overview/`,
               query: {
                 ...location.query,
                 transaction: row.transaction,


### PR DESCRIPTION
fixes JAVASCRIPT-2VZK

There's some instances where the user may end up in the webvitals page without a `/` at the end of the url. 
This results in the links to the overview page being broken linking you to `/pageloadsoverview` instead of `/pageloads/overview/`
(Although ideally the user can't end up at that route without the slash, I didn't do the digging on how this happened, but instead made the web vitals page more robust so it doesn't matter)

This PR ensures the link from web vitals to the overview page never brakes by using a absolute path (via useModuleUrl) which ensures the slash will always be there. This similiar how we do most of the url linking between pages within modules.