### PR TITLE
feat(metric-issue): Add new group type definition for detector issues

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -30,6 +30,7 @@ class GroupCategory(Enum):
     REPLAY = 5
     FEEDBACK = 6
     UPTIME = 7
+    METRIC = 8
 
 
 GROUP_CATEGORIES_CUSTOM_EMAIL = (

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -30,7 +30,7 @@ class GroupCategory(Enum):
     REPLAY = 5
     FEEDBACK = 6
     UPTIME = 7
-    METRIC = 8
+    DETECTOR = 8
 
 
 GROUP_CATEGORIES_CUSTOM_EMAIL = (
@@ -596,6 +596,18 @@ class UptimeDomainCheckFailure(GroupType):
     default_priority = PriorityLevel.HIGH
     enable_auto_resolve = False
     enable_escalation_detection = False
+
+
+@dataclass(frozen=True)
+class DetectorControlledIssueType(GroupType):
+    type_id = 8001
+    slug = "detector_based_issue"
+    description = "issue created from detectors"
+    category = GroupCategory.DETECTOR
+
+    enable_auto_resolve = False
+    enable_escalation_detection = False
+    released = False
 
 
 def should_create_group(

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -603,7 +603,7 @@ class DetectorControlledIssueType(GroupType):
     type_id = 8001
     slug = "detector_based_issue"
     description = "issue created from detectors"
-    category = GroupCategory.DETECTOR
+    category = GroupCategory.DETECTOR.value
 
     enable_auto_resolve = False
     enable_escalation_detection = False


### PR DESCRIPTION
Adding new GroupType and GroupCategory definitions to support metric issues, and more broadly, detector-controlled issues. 

The new GroupType disallows escalation detection and auto-resolve since these would be controlled by the detector.

Fixes https://github.com/getsentry/sentry/issues/78883