### PR TITLE
chore(deletions) Remove import shims in deletions

### DIFF
--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -200,13 +200,6 @@ def get_manager() -> DeletionTaskManager:
     return _default_manager
 
 
-def __getattr__(name: str) -> Any:
-    # Shim for getsentry
-    if name == "default_manager":
-        return get_manager()
-    raise AttributeError(f"module {__name__} has no attribute {name}")
-
-
 def get(
     task: type[BaseDeletionTask[Any]] | None = None,
     **kwargs: Any,

--- a/src/sentry/models/__init__.py
+++ b/src/sentry/models/__init__.py
@@ -104,7 +104,6 @@ from .rule import *  # NOQA
 from .rulefirehistory import RuleFireHistory  # NOQA
 from .rulesnooze import RuleSnooze  # NOQA
 from .savedsearch import *  # NOQA
-from .scheduledeletion import *  # NOQA
 from .search_common import *  # NOQA
 from .sentryshot import *  # NOQA
 from .sourcemapprocessingissue import *  # NOQA

--- a/src/sentry/models/scheduledeletion.py
+++ b/src/sentry/models/scheduledeletion.py
@@ -1,6 +1,0 @@
-# TODO(mark) Remove getsentry import shim
-from __future__ import annotations
-
-from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
-
-__all__ = ("RegionScheduledDeletion",)


### PR DESCRIPTION
With getsentry updated, these import shims can be removed.

Part of #77479