### PR TITLE
fix(jira): Adds skips for empty string data

### DIFF
--- a/src/sentry/integrations/jira/utils/create_issue_schema_transformers.py
+++ b/src/sentry/integrations/jira/utils/create_issue_schema_transformers.py
@@ -103,10 +103,8 @@ def transform_fields(
     for field in jira_fields:
         field_data = data.get(field.key)
 
-        # We don't have a mapping for this field, so it's probably extraneous.
-        # TODO(Gabe): Explore raising a sentry issue for unmapped fields in
-        #  order for us to properly filter them out.
-        if field_data is None:
+        # Skip any empty data, as we have some templated
+        if field_data is None or field_data == "":
             continue
 
         field_transformer = get_transformer_for_field(
@@ -137,7 +135,7 @@ def transform_fields(
         except JiraSchemaParseError as e:
             raise IntegrationFormError(field_errors={field.name: str(e)}) from e
 
-        if transformed_value:
+        if transformed_value is not None:
             transformed_data[field.key] = transformed_value
 
     return transformed_data

--- a/src/sentry/integrations/jira/utils/create_issue_schema_transformers.py
+++ b/src/sentry/integrations/jira/utils/create_issue_schema_transformers.py
@@ -103,7 +103,9 @@ def transform_fields(
     for field in jira_fields:
         field_data = data.get(field.key)
 
-        # Skip any empty data, as we have some templated
+        # Skip any values that indicate no value should be provided.
+        # We have some older alert templates with "" values, which will raise
+        # if we don't skip them.
         if field_data is None or field_data == "":
             continue
 

--- a/tests/sentry/integrations/jira/utils/test_create_issue_schema_transformers.py
+++ b/tests/sentry/integrations/jira/utils/test_create_issue_schema_transformers.py
@@ -158,3 +158,39 @@ class TestDataTransformer(TestCase):
         )
 
         assert transformed_data == {"sprint": 2}
+
+    def test_version_custom_field(self):
+        version_field = JiraField(
+            schema=JiraSchema(
+                schema_type=JiraSchemaTypes.version,
+            ),
+            name="fixVersion",
+            key="fixVersion",
+            required=False,
+            has_default_value=False,
+            operations=[],
+        )
+
+        transformed_data = transform_fields(
+            self.client.user_id_field(),
+            jira_fields=[version_field],
+            **{"fixVersion": 2},
+        )
+
+        assert transformed_data == {"fixVersion": {"id": 2}}
+
+        transformed_data = transform_fields(
+            self.client.user_id_field(),
+            jira_fields=[version_field],
+            **{"fixVersion": ""},
+        )
+
+        assert transformed_data == {}
+
+        transformed_data = transform_fields(
+            self.client.user_id_field(),
+            jira_fields=[version_field],
+            **{"fixVersion": 0},
+        )
+
+        assert transformed_data == {"fixVersion": {"id": 0}}


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes an issue where older issue templates created with `''` for fields values requiring data in the `{"id": <value>}` format will fail to create an issue via Jira'as API. This was covered by a Falsey check in the older transform code, but has bene made more strict to avoid omitting valid falsey values, such as `0` or `[]`.
<!--

  Sentry employees and contractors can delete or ignore the following.

-->
