### PR TITLE
feat(autofix): Optional unit test in root cause

### DIFF
--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -70,9 +70,13 @@ function AutofixBreadcrumbSnippet({breadcrumb}: AutofixBreadcrumbSnippetProps) {
 export function ExpandableInsightContext({
   children,
   title,
+  icon,
+  rounded,
 }: {
   children: React.ReactNode;
   title: string;
+  icon?: React.ReactNode;
+  rounded?: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
 
@@ -81,10 +85,18 @@ export function ExpandableInsightContext({
   };
 
   return (
-    <ExpandableContext>
-      <ContextHeader onClick={toggleExpand} name={title}>
+    <ExpandableContext isRounded={rounded}>
+      <ContextHeader
+        onClick={toggleExpand}
+        name={title}
+        isRounded={rounded}
+        isExpanded={expanded}
+      >
         <ContextHeaderWrapper>
-          <ContextHeaderText>{title}</ContextHeaderText>
+          <ContextHeaderLeftAlign>
+            {icon}
+            <ContextHeaderText>{title}</ContextHeaderText>
+          </ContextHeaderLeftAlign>
           <IconChevron size="xs" direction={expanded ? 'down' : 'right'} />
         </ContextHeaderWrapper>
       </ContextHeader>
@@ -384,19 +396,34 @@ const MiniHeader = styled('p')`
   padding-left: ${space(2)};
 `;
 
-const ExpandableContext = styled('div')`
+const ExpandableContext = styled('div')<{isRounded?: boolean}>`
   width: 100%;
   background: ${p => p.theme.alert.info.backgroundLight};
+  border-radius: ${p => (p.isRounded ? p.theme.borderRadius : 0)};
 `;
 
-const ContextHeader = styled(Button)`
+const ContextHeader = styled(Button)<{isExpanded?: boolean; isRounded?: boolean}>`
   width: 100%;
   box-shadow: none;
   margin: 0;
   border: none;
   font-weight: normal;
   background: ${p => p.theme.backgroundSecondary};
-  border-radius: 0px;
+  border-radius: ${p => {
+    if (!p.isRounded) {
+      return 0;
+    }
+    if (p.isExpanded) {
+      return `${p.theme.borderRadius} ${p.theme.borderRadius} 0 0`;
+    }
+    return p.theme.borderRadius;
+  }};
+`;
+
+const ContextHeaderLeftAlign = styled('div')`
+  display: flex;
+  gap: ${space(1)};
+  align-items: center;
 `;
 
 const ContextHeaderWrapper = styled('div')`

--- a/static/app/components/events/autofix/autofixRootCause.spec.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.spec.tsx
@@ -133,7 +133,7 @@ describe('AutofixRootCause', function () {
     ).not.toBeInTheDocument();
   });
 
-  it('shows unit test when available', async function () {
+  it('shows unit test inside reproduction card when available', async function () {
     render(
       <AutofixRootCause
         {...{
@@ -151,10 +151,10 @@ describe('AutofixRootCause', function () {
       />
     );
 
-    expect(screen.getByText('Unit test')).toBeInTheDocument();
+    expect(screen.getByText('How to reproduce')).toBeInTheDocument();
     await userEvent.click(
       screen.getByRole('button', {
-        name: 'Unit test',
+        name: 'How to reproduce',
       })
     );
     expect(
@@ -163,16 +163,16 @@ describe('AutofixRootCause', function () {
     expect(screen.getByText('Test case for root cause')).toBeInTheDocument();
   });
 
-  it('does not show unit test when not available', function () {
+  it('does not show reproduction or unit test when not available', function () {
     render(
       <AutofixRootCause
         {...{
           ...defaultProps,
-          causes: [AutofixRootCauseData({unit_test: undefined})],
+          causes: [AutofixRootCauseData({unit_test: undefined, reproduction: undefined})],
         }}
       />
     );
 
-    expect(screen.queryByText('Unit Test')).not.toBeInTheDocument();
+    expect(screen.queryByText('How to reproduce')).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/events/autofix/autofixRootCause.spec.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.spec.tsx
@@ -132,4 +132,47 @@ describe('AutofixRootCause', function () {
       screen.queryByText('This is the reproduction of a root cause.')
     ).not.toBeInTheDocument();
   });
+
+  it('shows unit test when available', async function () {
+    render(
+      <AutofixRootCause
+        {...{
+          ...defaultProps,
+          causes: [
+            AutofixRootCauseData({
+              unit_test: {
+                snippet: 'Test case for root cause',
+                description: 'This is the description of a unit test.',
+                file_path: 'src/file.py',
+              },
+            }),
+          ],
+        }}
+      />
+    );
+
+    expect(screen.getByText('Unit test')).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: 'Unit test',
+      })
+    );
+    expect(
+      screen.getByText('This is the description of a unit test.')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Test case for root cause')).toBeInTheDocument();
+  });
+
+  it('does not show unit test when not available', function () {
+    render(
+      <AutofixRootCause
+        {...{
+          ...defaultProps,
+          causes: [AutofixRootCauseData({unit_test: undefined})],
+        }}
+      />
+    );
+
+    expect(screen.queryByText('Unit Test')).not.toBeInTheDocument();
+  });
 });

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -25,6 +25,7 @@ import {
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {Tooltip} from 'sentry/components/tooltip';
+import {IconCode, IconLab, IconLaptop} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {getFileExtension} from 'sentry/utils/fileExtension';
@@ -165,15 +166,37 @@ export function replaceHeadersWithBold(markdown: string) {
 
 function RootCauseDescription({cause}: {cause: AutofixRootCauseData}) {
   return (
-    <Fragment>
-      <CauseDescription
-        dangerouslySetInnerHTML={{
-          __html: marked(replaceHeadersWithBold(cause.description)),
-        }}
-      />
+    <CauseDescription
+      dangerouslySetInnerHTML={{
+        __html: marked(replaceHeadersWithBold(cause.description)),
+      }}
+    />
+  );
+}
+
+function RootCauseContext({
+  cause,
+  repos,
+}: {
+  cause: AutofixRootCauseData;
+  repos: AutofixRepository[];
+}) {
+  const unitTestFileExtension = cause.unit_test?.file_path
+    ? getFileExtension(cause.unit_test.file_path)
+    : undefined;
+  const unitTestLanguage = unitTestFileExtension
+    ? getPrismLanguage(unitTestFileExtension)
+    : undefined;
+
+  return (
+    <RootCauseContextContainer>
       {cause.reproduction && (
         <Fragment>
-          <ExpandableInsightContext title={'How to reproduce'}>
+          <ExpandableInsightContext
+            icon={<IconLaptop size="sm" color="subText" />}
+            title={'How to reproduce'}
+            rounded
+          >
             <CauseDescription
               dangerouslySetInnerHTML={{
                 __html: marked(replaceHeadersWithBold(cause.reproduction)),
@@ -182,7 +205,35 @@ function RootCauseDescription({cause}: {cause: AutofixRootCauseData}) {
           </ExpandableInsightContext>
         </Fragment>
       )}
-    </Fragment>
+      {cause.unit_test && (
+        <Fragment>
+          <ExpandableInsightContext
+            icon={<IconLab size="sm" color="subText" />}
+            title={'Unit test'}
+            rounded
+          >
+            <CauseDescription
+              dangerouslySetInnerHTML={{
+                __html: marked(replaceHeadersWithBold(cause.unit_test.description)),
+              }}
+            />
+            <StyledCodeSnippet
+              filename={cause.unit_test.file_path}
+              language={unitTestLanguage}
+            >
+              {cause.unit_test.snippet}
+            </StyledCodeSnippet>
+          </ExpandableInsightContext>
+        </Fragment>
+      )}
+      <ExpandableInsightContext
+        icon={<IconCode size="sm" color="subText" />}
+        title={'Relevant code'}
+        rounded
+      >
+        <AutofixRootCauseCodeContexts codeContext={cause.code_context} repos={repos} />
+      </ExpandableInsightContext>
+    </RootCauseContextContainer>
   );
 }
 
@@ -282,9 +333,7 @@ function CauseOption({
       </RootCauseOptionHeader>
       <RootCauseContent selected={selected}>
         <RootCauseDescription cause={cause} />
-        <ExpandableInsightContext title={'Relevant code'}>
-          <AutofixRootCauseCodeContexts codeContext={cause.code_context} repos={repos} />
-        </ExpandableInsightContext>
+        <RootCauseContext cause={cause} repos={repos} />
       </RootCauseContent>
     </RootCauseOption>
   );
@@ -292,7 +341,6 @@ function CauseOption({
 
 function SelectedRootCauseOption({
   selectedCause,
-  codeContext,
   repos,
 }: {
   codeContext: AutofixRootCauseCodeContext[];
@@ -307,9 +355,7 @@ function SelectedRootCauseOption({
         }}
       />
       <RootCauseDescription cause={selectedCause} />
-      <ExpandableInsightContext title={'Relevant code'}>
-        <AutofixRootCauseCodeContexts codeContext={codeContext} repos={repos} />
-      </ExpandableInsightContext>
+      <RootCauseContext cause={selectedCause} repos={repos} />
     </RootCauseOption>
   );
 }
@@ -373,18 +419,8 @@ function AutofixRootCauseDisplay({
                       {t('Fix This Instead')}
                     </Button>
                   </RootCauseOptionHeader>
-
-                  <CauseDescription
-                    dangerouslySetInnerHTML={{
-                      __html: marked(cause.description),
-                    }}
-                  />
-                  <ExpandableInsightContext title={'Relevant Code'}>
-                    <AutofixRootCauseCodeContexts
-                      codeContext={cause.code_context}
-                      repos={repos}
-                    />
-                  </ExpandableInsightContext>
+                  <RootCauseDescription cause={cause} />
+                  <RootCauseContext cause={cause} repos={repos} />
                 </RootCauseOption>
               ))}
             </AutofixShowMore>
@@ -501,6 +537,12 @@ const RootCauseOption = styled('div')<{selected: boolean}>`
   padding-top: ${space(1)};
   padding-left: ${space(2)};
   padding-right: ${space(2)};
+`;
+
+const RootCauseContextContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(0.5)};
 `;
 
 const RootCauseOptionHeader = styled('div')`

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -25,7 +25,7 @@ import {
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {Tooltip} from 'sentry/components/tooltip';
-import {IconCode, IconLab, IconLaptop} from 'sentry/icons';
+import {IconCode, IconInfo} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {getFileExtension} from 'sentry/utils/fileExtension';
@@ -190,41 +190,36 @@ function RootCauseContext({
 
   return (
     <RootCauseContextContainer>
-      {cause.reproduction && (
-        <Fragment>
-          <ExpandableInsightContext
-            icon={<IconLaptop size="sm" color="subText" />}
-            title={'How to reproduce'}
-            rounded
-          >
+      {(cause.reproduction || cause.unit_test) && (
+        <ExpandableInsightContext
+          icon={<IconInfo size="sm" color="subText" />}
+          title={'How to reproduce'}
+          rounded
+        >
+          {cause.reproduction && (
             <CauseDescription
               dangerouslySetInnerHTML={{
                 __html: marked(replaceHeadersWithBold(cause.reproduction)),
               }}
             />
-          </ExpandableInsightContext>
-        </Fragment>
-      )}
-      {cause.unit_test && (
-        <Fragment>
-          <ExpandableInsightContext
-            icon={<IconLab size="sm" color="subText" />}
-            title={'Unit test'}
-            rounded
-          >
-            <CauseDescription
-              dangerouslySetInnerHTML={{
-                __html: marked(replaceHeadersWithBold(cause.unit_test.description)),
-              }}
-            />
-            <StyledCodeSnippet
-              filename={cause.unit_test.file_path}
-              language={unitTestLanguage}
-            >
-              {cause.unit_test.snippet}
-            </StyledCodeSnippet>
-          </ExpandableInsightContext>
-        </Fragment>
+          )}
+          {cause.unit_test && (
+            <Fragment>
+              <strong>{t('Unit test that reproduces this root cause:')}</strong>
+              <CauseDescription
+                dangerouslySetInnerHTML={{
+                  __html: marked(replaceHeadersWithBold(cause.unit_test.description)),
+                }}
+              />
+              <StyledCodeSnippet
+                filename={cause.unit_test.file_path}
+                language={unitTestLanguage}
+              >
+                {cause.unit_test.snippet}
+              </StyledCodeSnippet>
+            </Fragment>
+          )}
+        </ExpandableInsightContext>
       )}
       <ExpandableInsightContext
         icon={<IconCode size="sm" color="subText" />}

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -166,12 +166,19 @@ export type AutofixRootCauseCodeContext = {
   snippet?: CodeSnippetContext;
 };
 
+export type AutofixRootCauseUnitTest = {
+  description: string;
+  file_path: string;
+  snippet: string;
+};
+
 export type AutofixRootCauseData = {
   code_context: AutofixRootCauseCodeContext[];
   description: string;
   id: string;
   title: string;
   reproduction?: string;
+  unit_test?: AutofixRootCauseUnitTest;
 };
 
 export type EventMetadataWithAutofix = EventMetadata & {


### PR DESCRIPTION
Renders the unit test to reproduce a given root cause. As this unit test is optional, this can be merged without the seer PR.

1. Adds a unit test dropdown w/ description
2. Adds icons and spacing to the root cause context area to make it feel less cluttered and more welcoming.

![CleanShot 2024-10-01 at 14 59 26@2x](https://github.com/user-attachments/assets/bd6793b4-f8c3-4b28-a20c-757991ff478c)
