### PR TITLE
feat(autofix): Add controllable insight cards

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -267,7 +267,7 @@ const ChangesContainer = styled('div')`
   border: 1px solid ${p => p.theme.innerBorder};
   border-radius: ${p => p.theme.borderRadius};
   overflow: hidden;
-  box-shadow: ${p => p.theme.dropShadowHeavy};
+  box-shadow: ${p => p.theme.dropShadowMedium};
   padding-left: ${space(2)};
   padding-right: ${space(2)};
   padding-top: ${space(1)};

--- a/static/app/components/events/autofix/autofixInsightCards.spec.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.spec.tsx
@@ -1,11 +1,14 @@
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import AutofixInsightCards from 'sentry/components/events/autofix/autofixInsightCards';
 import type {AutofixInsight} from 'sentry/components/events/autofix/types';
 
 jest.mock('sentry/utils/marked', () => ({
   singleLineRenderer: jest.fn(text => text),
 }));
+
+jest.mock('sentry/actionCreators/indicator');
 
 const sampleInsights: AutofixInsight[] = [
   {
@@ -59,6 +62,12 @@ const sampleRepos = [
     url: 'github.com/org/sample-repo',
   },
 ];
+
+beforeEach(() => {
+  (addSuccessMessage as jest.Mock).mockClear();
+  (addErrorMessage as jest.Mock).mockClear();
+  MockApiClient.clearMockResponses();
+});
 
 describe('AutofixInsightCards', () => {
   const renderComponent = (props = {}) => {
@@ -146,5 +155,112 @@ describe('AutofixInsightCards', () => {
     expect(screen.getByText('Sample insight 1')).toBeInTheDocument();
     expect(screen.getByText('User message')).toBeInTheDocument();
     expect(screen.getByText('Another insight')).toBeInTheDocument();
+  });
+
+  it('renders "Rethink from here" buttons', () => {
+    renderComponent();
+    const rethinkButtons = screen.getAllByText('Rethink from here');
+    expect(rethinkButtons.length).toBeGreaterThan(0);
+  });
+
+  it('shows rethink input overlay when "Rethink from here" is clicked', async () => {
+    renderComponent();
+    const rethinkButton = screen.getAllByText('Rethink from here')[0];
+    await userEvent.click(rethinkButton);
+    expect(screen.getByPlaceholderText('Say something...')).toBeInTheDocument();
+  });
+
+  it('hides rethink input overlay when clicked outside', async () => {
+    renderComponent();
+    const rethinkButton = screen.getAllByText('Rethink from here')[0];
+    await userEvent.click(rethinkButton);
+    expect(screen.getByPlaceholderText('Say something...')).toBeInTheDocument();
+
+    await userEvent.click(document.body);
+    expect(screen.queryByPlaceholderText('Say something...')).not.toBeInTheDocument();
+  });
+
+  it('submits rethink request when form is submitted', async () => {
+    const mockApi = MockApiClient.addMockResponse({
+      url: '/issues/1/autofix/update/',
+      method: 'POST',
+    });
+
+    renderComponent();
+    const rethinkButton = screen.getAllByText('Rethink from here')[0];
+    await userEvent.click(rethinkButton);
+
+    const input = screen.getByPlaceholderText('Say something...');
+    await userEvent.type(input, 'Rethink this part');
+
+    const submitButton = screen.getByLabelText(
+      'Restart analysis from this point in the chain'
+    );
+    await userEvent.click(submitButton);
+
+    expect(mockApi).toHaveBeenCalledWith(
+      '/issues/1/autofix/update/',
+      expect.objectContaining({
+        method: 'POST',
+        data: expect.objectContaining({
+          run_id: '1',
+          payload: expect.objectContaining({
+            type: 'restart_from_point_with_feedback',
+            message: 'Rethink this part',
+            step_index: 0,
+            retain_insight_card_index: null,
+          }),
+        }),
+      })
+    );
+  });
+
+  it('shows success message after successful rethink submission', async () => {
+    MockApiClient.addMockResponse({
+      url: '/issues/1/autofix/update/',
+      method: 'POST',
+    });
+
+    renderComponent();
+    const rethinkButton = screen.getAllByText('Rethink from here')[0];
+    await userEvent.click(rethinkButton);
+
+    const input = screen.getByPlaceholderText('Say something...');
+    await userEvent.type(input, 'Rethink this part');
+
+    const submitButton = screen.getByLabelText(
+      'Restart analysis from this point in the chain'
+    );
+    await userEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(addSuccessMessage).toHaveBeenCalledWith("Thanks, I'll rethink this...");
+    });
+  });
+
+  it('shows error message after failed rethink submission', async () => {
+    MockApiClient.addMockResponse({
+      url: '/issues/1/autofix/update/',
+      method: 'POST',
+      statusCode: 500,
+    });
+
+    renderComponent();
+    const rethinkButton = screen.getAllByText('Rethink from here')[0];
+    await userEvent.click(rethinkButton);
+
+    const input = screen.getByPlaceholderText('Say something...');
+    await userEvent.type(input, 'Rethink this part');
+
+    const submitButton = screen.getByLabelText(
+      'Restart analysis from this point in the chain'
+    );
+    await userEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(addErrorMessage).toHaveBeenCalledWith(
+        'Something went wrong when sending Autofix your message.'
+      );
+    });
   });
 });

--- a/static/app/components/events/autofix/autofixInsightCards.spec.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.spec.tsx
@@ -68,6 +68,9 @@ describe('AutofixInsightCards', () => {
         repos={sampleRepos}
         hasStepAbove={false}
         hasStepBelow={false}
+        groupId="1"
+        runId="1"
+        stepIndex={0}
         {...props}
       />
     );

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -1,9 +1,10 @@
-import {useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {AnimatePresence, type AnimationProps, motion} from 'framer-motion';
 
 import bannerImage from 'sentry-images/insights/module-upsells/insights-module-upsell.svg';
 
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {Button} from 'sentry/components/button';
 import {
   replaceHeadersWithBold,
@@ -21,13 +22,24 @@ import {
   getBreadcrumbColorConfig,
   getBreadcrumbTitle,
 } from 'sentry/components/events/breadcrumbs/utils';
+import Input from 'sentry/components/input';
 import StructuredEventData from 'sentry/components/structuredEventData';
 import Timeline from 'sentry/components/timeline';
-import {IconArrow, IconChevron, IconCode, IconFire, IconUser} from 'sentry/icons';
+import {
+  IconArrow,
+  IconChevron,
+  IconCode,
+  IconFire,
+  IconRefresh,
+  IconUser,
+} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {BreadcrumbLevelType, BreadcrumbType} from 'sentry/types/breadcrumbs';
 import {singleLineRenderer} from 'sentry/utils/marked';
+import {useMutation} from 'sentry/utils/queryClient';
 import testableTransition from 'sentry/utils/testableTransition';
+import useApi from 'sentry/utils/useApi';
 
 interface AutofixBreadcrumbSnippetProps {
   breadcrumb: BreadcrumbContext;
@@ -101,10 +113,14 @@ const animationProps: AnimationProps = {
 };
 
 interface AutofixInsightCardProps {
+  groupId: string;
   hasCardAbove: boolean;
   hasCardBelow: boolean;
+  index: number;
   insight: AutofixInsight;
   repos: AutofixRepository[];
+  runId: string;
+  stepIndex: number;
 }
 
 function AutofixInsightCard({
@@ -112,6 +128,10 @@ function AutofixInsightCard({
   hasCardBelow,
   hasCardAbove,
   repos,
+  index,
+  stepIndex,
+  groupId,
+  runId,
 }: AutofixInsightCardProps) {
   const isUserMessage = insight.justification === 'USER';
 
@@ -120,9 +140,12 @@ function AutofixInsightCard({
       <AnimatePresence initial>
         <AnimationWrapper key="content" {...animationProps}>
           {hasCardAbove && (
-            <IconContainer>
-              <IconArrow direction={'down'} />
-            </IconContainer>
+            <ChainLink
+              insightCardAboveIndex={index - 1}
+              stepIndex={stepIndex}
+              groupId={groupId}
+              runId={runId}
+            />
           )}
           {!isUserMessage && (
             <InsightContainer>
@@ -233,9 +256,12 @@ function AutofixInsightCard({
             </UserMessageContainer>
           )}
           {hasCardBelow && (
-            <IconContainer>
-              <IconArrow direction={'down'} />
-            </IconContainer>
+            <ChainLink
+              insightCardAboveIndex={index}
+              stepIndex={stepIndex}
+              groupId={groupId}
+              runId={runId}
+            />
           )}
         </AnimationWrapper>
       </AnimatePresence>
@@ -244,10 +270,13 @@ function AutofixInsightCard({
 }
 
 interface AutofixInsightCardsProps {
+  groupId: string;
   hasStepAbove: boolean;
   hasStepBelow: boolean;
   insights: AutofixInsight[];
   repos: AutofixRepository[];
+  runId: string;
+  stepIndex: number;
 }
 
 function AutofixInsightCards({
@@ -255,15 +284,21 @@ function AutofixInsightCards({
   repos,
   hasStepBelow,
   hasStepAbove,
+  stepIndex,
+  groupId,
+  runId,
 }: AutofixInsightCardsProps) {
   return (
     <InsightsContainer>
       {!hasStepAbove && (
         <div>
           <TitleText>Insights</TitleText>
-          <IconContainer>
-            <IconArrow direction={'down'} />
-          </IconContainer>
+          <ChainLink
+            insightCardAboveIndex={null}
+            stepIndex={stepIndex}
+            groupId={groupId}
+            runId={runId}
+          />
         </div>
       )}
       {insights.length > 0 ? (
@@ -275,6 +310,10 @@ function AutofixInsightCards({
               hasCardBelow={index < insights.length - 1 || hasStepBelow}
               hasCardAbove={hasStepAbove && index === 0}
               repos={repos}
+              index={index}
+              stepIndex={stepIndex}
+              groupId={groupId}
+              runId={runId}
             />
           )
         )
@@ -290,6 +329,118 @@ function AutofixInsightCards({
         </NoInsightsYet>
       ) : null}
     </InsightsContainer>
+  );
+}
+
+function useUpdateInsightCard({groupId, runId}: {groupId: string; runId: string}) {
+  const api = useApi({persistInFlight: true});
+
+  return useMutation({
+    mutationFn: (params: {
+      message: string;
+      retain_insight_card_index: number | null;
+      step_index: number;
+    }) => {
+      return api.requestPromise(`/issues/${groupId}/autofix/update/`, {
+        method: 'POST',
+        data: {
+          run_id: runId,
+          payload: {
+            type: 'restart_from_point_with_feedback',
+            message: params.message,
+            step_index: params.step_index,
+            retain_insight_card_index: params.retain_insight_card_index,
+          },
+        },
+      });
+    },
+    onSuccess: _ => {
+      addSuccessMessage(t("Thanks, I'll rethink this..."));
+    },
+    onError: () => {
+      addErrorMessage(t('Something went wrong when sending Autofix your message.'));
+    },
+  });
+}
+
+function ChainLink({
+  groupId,
+  runId,
+  stepIndex,
+  insightCardAboveIndex,
+}: {
+  groupId: string;
+  insightCardAboveIndex: number | null;
+  runId: string;
+  stepIndex: number;
+}) {
+  const [showOverlay, setShowOverlay] = useState(false);
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const [comment, setComment] = useState('');
+  const {mutate: send} = useUpdateInsightCard({groupId, runId});
+
+  const handleClickOutside = event => {
+    if (overlayRef.current && !overlayRef.current.contains(event.target)) {
+      setShowOverlay(false);
+    }
+  };
+
+  useEffect(() => {
+    if (showOverlay) {
+      document.addEventListener('mousedown', handleClickOutside);
+    } else {
+      document.removeEventListener('mousedown', handleClickOutside);
+    }
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [showOverlay]);
+
+  return (
+    <ArrowContainer>
+      <IconArrow direction={'down'} className="arrow-icon" />
+      <RethinkButton
+        icon={<IconRefresh />}
+        size="zero"
+        className="hover-button"
+        onClick={() => setShowOverlay(true)}
+      >
+        Rethink from here
+      </RethinkButton>
+
+      {showOverlay && (
+        <RethinkInput ref={overlayRef}>
+          <form
+            onSubmit={e => {
+              e.preventDefault();
+              setShowOverlay(false);
+              send({
+                message: comment,
+                step_index: stepIndex,
+                retain_insight_card_index: insightCardAboveIndex,
+              });
+              setComment('');
+            }}
+            className="row-form"
+          >
+            <Input
+              type="text"
+              placeholder="Say something..."
+              value={comment}
+              onChange={e => setComment(e.target.value)}
+              autoFocus
+            />
+            <Button
+              type="submit"
+              icon={<IconRefresh />}
+              title="Restart analysis from this point in the chain"
+              aria-label="Restart analysis from this point in the chain"
+              priority="primary"
+            />
+          </form>
+        </RethinkInput>
+      )}
+    </ArrowContainer>
   );
 }
 
@@ -338,11 +489,52 @@ const InsightContainer = styled(motion.div)`
   box-shadow: ${p => p.theme.dropShadowMedium};
 `;
 
-const IconContainer = styled('div')`
-  padding: ${space(1)};
-  display: flex;
-  justify-content: center;
+const ArrowContainer = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   color: ${p => p.theme.subText};
+  align-items: center;
+  position: relative;
+
+  .arrow-icon {
+    margin-top: ${space(1)};
+    grid-column: 2 / 3;
+    justify-self: center;
+  }
+
+  .hover-button {
+    opacity: 0;
+    grid-column: 3 / 4;
+    justify-self: end;
+    transition: opacity 0.1s ease-in-out;
+  }
+
+  &:hover .hover-button {
+    opacity: 1;
+  }
+`;
+
+const RethinkButton = styled(Button)`
+  font-weight: normal;
+  font-size: small;
+  border: none;
+  color: ${p => p.theme.subText};
+  margin-top: ${space(1)};
+`;
+
+const RethinkInput = styled('div')`
+  position: absolute;
+  box-shadow: ${p => p.theme.dropShadowHeavy};
+  width: 95%;
+  background: ${p => p.theme.backgroundElevated};
+  padding: ${space(1)};
+  border-radius: ${p => p.theme.borderRadius};
+  margin: 0 ${space(2)} 0 ${space(2)};
+
+  .row-form {
+    display: flex;
+    gap: ${space(1)};
+  }
 `;
 
 const BreadcrumbItem = styled(Timeline.Item)`

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -414,12 +414,12 @@ function ChainLink({
             onSubmit={e => {
               e.preventDefault();
               setShowOverlay(false);
+              setComment('');
               send({
                 message: comment,
                 step_index: stepIndex,
                 retain_insight_card_index: insightCardAboveIndex,
               });
-              setComment('');
             }}
             className="row-form"
           >
@@ -428,6 +428,7 @@ function ChainLink({
               placeholder="Say something..."
               value={comment}
               onChange={e => setComment(e.target.value)}
+              size="md"
               autoFocus
             />
             <Button
@@ -436,6 +437,7 @@ function ChainLink({
               title="Restart analysis from this point in the chain"
               aria-label="Restart analysis from this point in the chain"
               priority="primary"
+              size="md"
             />
           </form>
         </RethinkInput>
@@ -495,6 +497,7 @@ const ArrowContainer = styled('div')`
   color: ${p => p.theme.subText};
   align-items: center;
   position: relative;
+  z-index: 0;
 
   .arrow-icon {
     margin-top: ${space(1)};
@@ -525,9 +528,10 @@ const RethinkButton = styled(Button)`
 const RethinkInput = styled('div')`
   position: absolute;
   box-shadow: ${p => p.theme.dropShadowHeavy};
+  border: 1px solid ${p => p.theme.border};
   width: 95%;
   background: ${p => p.theme.backgroundElevated};
-  padding: ${space(1)};
+  padding: ${space(0.5)};
   border-radius: ${p => p.theme.borderRadius};
   margin: 0 ${space(2)} 0 ${space(2)};
 

--- a/static/app/components/events/autofix/autofixMessageBox.tsx
+++ b/static/app/components/events/autofix/autofixMessageBox.tsx
@@ -114,6 +114,11 @@ function AutofixMessageBox({
   const [message, setMessage] = useState('');
   const {mutate: send} = useSendMessage({groupId, runId});
 
+  isDisabled =
+    isDisabled ||
+    step?.status === 'ERROR' ||
+    (step?.type === AutofixStepType.ROOT_CAUSE_ANALYSIS && step.causes?.length === 0);
+
   const handleSend = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (message.trim() !== '' || allowEmptyMessage) {

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -482,7 +482,7 @@ const CausesContainer = styled('div')`
   border: 1px solid ${p => p.theme.innerBorder};
   border-radius: ${p => p.theme.borderRadius};
   overflow: hidden;
-  box-shadow: ${p => p.theme.dropShadowHeavy};
+  box-shadow: ${p => p.theme.dropShadowMedium};
 `;
 
 const PotentialCausesContainer = styled(CausesContainer)`

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -80,6 +80,9 @@ export function Step({
                   repos={repos}
                   hasStepBelow={hasStepBelow}
                   hasStepAbove={hasStepAbove}
+                  stepIndex={step.index}
+                  groupId={groupId}
+                  runId={runId}
                 />
               )}
               {step.type === AutofixStepType.ROOT_CAUSE_ANALYSIS && (

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -178,12 +178,6 @@ export function AutofixSteps({data, groupId, runId, onRetry}: AutofixStepsProps)
     lastStep.type === AutofixStepType.CHANGES && lastStep.status === 'COMPLETED';
   const disabled = areCodeChangesShowing ? true : false;
 
-  const previousStep = steps.length > 2 ? steps[steps.length - 2] : null;
-  const previousStepErrored =
-    previousStep !== null &&
-    previousStep?.type === lastStep.type &&
-    previousStep.status === 'ERROR';
-
   const scrollToMatchingStep = () => {
     const matchingStepIndex = steps.findIndex(step => step.type === lastStep.type);
     if (matchingStepIndex !== -1 && stepsRef.current[matchingStepIndex]) {
@@ -194,20 +188,27 @@ export function AutofixSteps({data, groupId, runId, onRetry}: AutofixStepsProps)
   return (
     <div>
       <StepsContainer>
-        {steps.map((step, index) => (
-          <div ref={el => (stepsRef.current[index] = el)} key={step.id}>
-            <Step
-              step={step}
-              hasStepBelow={index + 1 < steps.length}
-              hasStepAbove={index > 0}
-              groupId={groupId}
-              runId={runId}
-              onRetry={onRetry}
-              repos={repos}
-              hasErroredStepBefore={previousStepErrored}
-            />
-          </div>
-        ))}
+        {steps.map((step, index) => {
+          const previousStep = index > 0 ? steps[index - 1] : null;
+          const previousStepErrored =
+            previousStep !== null &&
+            previousStep?.type === step.type &&
+            previousStep.status === 'ERROR';
+          return (
+            <div ref={el => (stepsRef.current[index] = el)} key={step.id}>
+              <Step
+                step={step}
+                hasStepBelow={index + 1 < steps.length}
+                hasStepAbove={index > 0}
+                groupId={groupId}
+                runId={runId}
+                onRetry={onRetry}
+                repos={repos}
+                hasErroredStepBefore={previousStepErrored}
+              />
+            </div>
+          );
+        })}
       </StepsContainer>
 
       <AutofixMessageBox

--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -66,10 +66,7 @@ const makeErrorAutofixData = (errorMessage: string): AutofixResponse => {
   return data;
 };
 
-const isPolling = (autofixData?: AutofixData | null) =>
-  autofixData?.status === 'PROCESSING' ||
-  autofixData?.status === 'PENDING' ||
-  autofixData?.status === 'NEED_MORE_INFORMATION';
+const isPolling = (autofixData?: AutofixData | null) => autofixData?.status !== 'PENDING';
 
 export const useAutofixData = ({groupId}: {groupId: string}) => {
   const {data} = useApiQuery<AutofixResponse>(makeAutofixQueryKey(groupId), {


### PR DESCRIPTION
Allow the user to re-think the reasoning from any point in the chain.

Also fixes bug in how errored steps are displayed.

<img width="551" alt="Screenshot 2024-10-01 at 11 09 52 AM" src="https://github.com/user-attachments/assets/98bc41bc-881a-4aae-982f-5a1f82e06d64">
<img width="565" alt="Screenshot 2024-10-01 at 11 09 56 AM" src="https://github.com/user-attachments/assets/b1c173ff-2b8f-4ff2-a5a1-706ee24a06a6">
