### PR TITLE
ref(replay): remove explicit tags[] bracket from tag panel links

### DIFF
--- a/static/app/views/replays/detail/tagPanel/index.spec.tsx
+++ b/static/app/views/replays/detail/tagPanel/index.spec.tsx
@@ -14,7 +14,7 @@ const mockReplay = ReplayReader.factory({
     },
     tags: {
       foo: ['bar', 'baz'],
-      'my custom tag': ['a wordy value'],
+      my_custom_tag: ['a wordy value'],
     },
   }),
   errors: [],
@@ -55,25 +55,25 @@ describe('TagPanel', () => {
     expect(screen.getByText('baz')).toBeInTheDocument();
   });
 
-  it('should link known tags to their proper field names', () => {
+  it('should link known tags to their proper field names and a valid search query', () => {
     renderComponent(mockReplay);
 
     expect(screen.getByText('bar').closest('a')).toHaveAttribute(
       'href',
-      '/organizations/org-slug/replays/?query=tags%5B%22foo%22%5D%3A%22bar%22'
+      '/organizations/org-slug/replays/?query=foo%3A%22bar%22'
     );
     expect(screen.getByText('baz').closest('a')).toHaveAttribute(
       'href',
-      '/organizations/org-slug/replays/?query=tags%5B%22foo%22%5D%3A%22baz%22'
+      '/organizations/org-slug/replays/?query=foo%3A%22baz%22'
     );
   });
 
-  it('should link user-submitted tags with the tags[] syntax', () => {
+  it('should link user-submitted tags to a valid search query', () => {
     renderComponent(mockReplay);
 
     expect(screen.getByText('a wordy value').closest('a')).toHaveAttribute(
       'href',
-      '/organizations/org-slug/replays/?query=tags%5B%22my%20custom%20tag%22%5D%3A%22a%20wordy%20value%22'
+      '/organizations/org-slug/replays/?query=my_custom_tag%3A%22a%20wordy%20value%22'
     );
   });
 

--- a/static/app/views/replays/detail/tagPanel/index.spec.tsx
+++ b/static/app/views/replays/detail/tagPanel/index.spec.tsx
@@ -14,7 +14,7 @@ const mockReplay = ReplayReader.factory({
     },
     tags: {
       foo: ['bar', 'baz'],
-      my_custom_tag: ['a wordy value'],
+      'my custom tag': ['a wordy value'],
     },
   }),
   errors: [],
@@ -60,11 +60,11 @@ describe('TagPanel', () => {
 
     expect(screen.getByText('bar').closest('a')).toHaveAttribute(
       'href',
-      '/organizations/org-slug/replays/?query=foo%3A%22bar%22'
+      '/organizations/org-slug/replays/?query=%22foo%22%3A%22bar%22'
     );
     expect(screen.getByText('baz').closest('a')).toHaveAttribute(
       'href',
-      '/organizations/org-slug/replays/?query=foo%3A%22baz%22'
+      '/organizations/org-slug/replays/?query=%22foo%22%3A%22baz%22'
     );
   });
 
@@ -73,7 +73,7 @@ describe('TagPanel', () => {
 
     expect(screen.getByText('a wordy value').closest('a')).toHaveAttribute(
       'href',
-      '/organizations/org-slug/replays/?query=my_custom_tag%3A%22a%20wordy%20value%22'
+      '/organizations/org-slug/replays/?query=%22my%20custom%20tag%22%3A%22a%20wordy%20value%22'
     );
   });
 

--- a/static/app/views/replays/detail/tagPanel/index.spec.tsx
+++ b/static/app/views/replays/detail/tagPanel/index.spec.tsx
@@ -14,7 +14,7 @@ const mockReplay = ReplayReader.factory({
     },
     tags: {
       foo: ['bar', 'baz'],
-      'my custom tag': ['a wordy value'],
+      my_custom_tag: ['a wordy value'],
     },
   }),
   errors: [],
@@ -60,11 +60,11 @@ describe('TagPanel', () => {
 
     expect(screen.getByText('bar').closest('a')).toHaveAttribute(
       'href',
-      '/organizations/org-slug/replays/?query=%22foo%22%3A%22bar%22'
+      '/organizations/org-slug/replays/?query=foo%3A%22bar%22'
     );
     expect(screen.getByText('baz').closest('a')).toHaveAttribute(
       'href',
-      '/organizations/org-slug/replays/?query=%22foo%22%3A%22baz%22'
+      '/organizations/org-slug/replays/?query=foo%3A%22baz%22'
     );
   });
 
@@ -73,7 +73,7 @@ describe('TagPanel', () => {
 
     expect(screen.getByText('a wordy value').closest('a')).toHaveAttribute(
       'href',
-      '/organizations/org-slug/replays/?query=%22my%20custom%20tag%22%3A%22a%20wordy%20value%22'
+      '/organizations/org-slug/replays/?query=my_custom_tag%3A%22a%20wordy%20value%22'
     );
   });
 

--- a/static/app/views/replays/detail/tagPanel/index.tsx
+++ b/static/app/views/replays/detail/tagPanel/index.tsx
@@ -17,27 +17,6 @@ import TabItemContainer from 'sentry/views/replays/detail/tabItemContainer';
 import TagFilters from 'sentry/views/replays/detail/tagPanel/tagFilters';
 import useTagFilters from 'sentry/views/replays/detail/tagPanel/useTagFilters';
 
-const notTags = [
-  'browser.name',
-  'browser.version',
-  'device.brand',
-  'device.family',
-  'device.model_id',
-  'device.name',
-  'platform',
-  'releases',
-  'replayType',
-  'os.name',
-  'os.version',
-  'sdk.name',
-  'sdk.version',
-  'user.email',
-  'user.username',
-  // TODO(replay): Remove this when backend changes `name` -> `username`
-  'user.name',
-  'user.id',
-  'user.ip',
-];
 const notSearchable = [
   'sdk.blockAllMedia',
   'sdk.errorSampleRate ',
@@ -86,9 +65,7 @@ function TagPanel() {
     (name: string, value: ReactNode): LocationDescriptor => ({
       pathname: normalizeUrl(`/organizations/${organization.slug}/replays/`),
       query: {
-        query: notTags.includes(name)
-          ? `${name}:"${value}"`
-          : `tags["${name}"]:"${value}"`,
+        query: `${name}:"${value}"`, // The replay index endpoint treats unknown filters as tags, by default.
       },
     }),
     [organization.slug]

--- a/static/app/views/replays/detail/tagPanel/index.tsx
+++ b/static/app/views/replays/detail/tagPanel/index.tsx
@@ -66,7 +66,7 @@ function TagPanel() {
       pathname: normalizeUrl(`/organizations/${organization.slug}/replays/`),
       query: {
         // The replay index endpoint treats unknown filters as tags, by default. Therefore we don't need the tags[] syntax, whether `name` is a tag or not.
-        query: `${name}:"${value}"`,
+        query: `"${name}":"${value}"`,
       },
     }),
     [organization.slug]

--- a/static/app/views/replays/detail/tagPanel/index.tsx
+++ b/static/app/views/replays/detail/tagPanel/index.tsx
@@ -65,7 +65,7 @@ function TagPanel() {
     (name: string, value: ReactNode): LocationDescriptor => ({
       pathname: normalizeUrl(`/organizations/${organization.slug}/replays/`),
       query: {
-        query: `${name}:"${value}"`, // The replay index endpoint treats unknown filters as tags, by default.
+        query: `${name}:"${value}"`, // The replay index endpoint treats unknown filters as tags, by default. Therefore we don't need the tags[] syntax.
       },
     }),
     [organization.slug]

--- a/static/app/views/replays/detail/tagPanel/index.tsx
+++ b/static/app/views/replays/detail/tagPanel/index.tsx
@@ -65,7 +65,8 @@ function TagPanel() {
     (name: string, value: ReactNode): LocationDescriptor => ({
       pathname: normalizeUrl(`/organizations/${organization.slug}/replays/`),
       query: {
-        query: `${name}:"${value}"`, // The replay index endpoint treats unknown filters as tags, by default. Therefore we don't need the tags[] syntax.
+        // The replay index endpoint treats unknown filters as tags, by default. Therefore we don't need the tags[] syntax, whether `name` is a tag or not.
+        query: `${name}:"${value}"`,
       },
     }),
     [organization.slug]

--- a/static/app/views/replays/detail/tagPanel/index.tsx
+++ b/static/app/views/replays/detail/tagPanel/index.tsx
@@ -66,7 +66,7 @@ function TagPanel() {
       pathname: normalizeUrl(`/organizations/${organization.slug}/replays/`),
       query: {
         // The replay index endpoint treats unknown filters as tags, by default. Therefore we don't need the tags[] syntax, whether `name` is a tag or not.
-        query: `"${name}":"${value}"`,
+        query: `${name}:"${value}"`,
       },
     }),
     [organization.slug]

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -509,7 +509,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
             assert "data" in response_data
             assert len(response_data["data"]) == 0
 
-    def test_get_replays_user_filters_a(self):
+    def test_get_replays_user_filters(self):
         """Test replays conform to the interchange format."""
         project = self.create_project(teams=[self.team])
 
@@ -537,12 +537,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                 device_brand="Apple",
                 device_family="Macintosh",
                 device_model="10",
-                tags={
-                    "a": "m",
-                    "b": "q",
-                    "c": "test",
-                    "quote": "quoted value",
-                },
+                tags={"a": "m", "b": "q", "c": "test"},
                 urls=["example.com"],
                 segment_id=0,
             )
@@ -657,14 +652,6 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                 "a:m",
                 "c:*st",
                 "!c:*zz",
-                # '"quoted key":abcd',  # fails, parses as ("quoted key", ":abcd")
-                'quote:"quoted value"',
-                # '"quoted key2":"quoted value"', # fails, parses as ("quoted key2", ":"quoted value"")
-                # Untested:
-                # '"my tag":"trailing space "',
-                # '" leading space":"I like whitespace"',
-                # '"trailing space ":"my value"',  # fails, parses as ("quoted key", ":abcd")
-                # '"my tag2":" leading space"',  # fails, parses as ("quoted key", ":abcd")
                 "urls:example.com",
                 "url:example.com",
                 "activity:8",

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -509,7 +509,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
             assert "data" in response_data
             assert len(response_data["data"]) == 0
 
-    def test_get_replays_user_filters(self):
+    def test_get_replays_user_filters_a(self):
         """Test replays conform to the interchange format."""
         project = self.create_project(teams=[self.team])
 
@@ -537,7 +537,12 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                 device_brand="Apple",
                 device_family="Macintosh",
                 device_model="10",
-                tags={"a": "m", "b": "q", "c": "test"},
+                tags={
+                    "a": "m",
+                    "b": "q",
+                    "c": "test",
+                    "quote": "quoted value",
+                },
                 urls=["example.com"],
                 segment_id=0,
             )
@@ -652,6 +657,14 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                 "a:m",
                 "c:*st",
                 "!c:*zz",
+                # '"quoted key":abcd',  # fails, parses as ("quoted key", ":abcd")
+                'quote:"quoted value"',
+                # '"quoted key2":"quoted value"', # fails, parses as ("quoted key2", ":"quoted value"")
+                # Untested:
+                # '"my tag":"trailing space "',
+                # '" leading space":"I like whitespace"',
+                # '"trailing space ":"my value"',  # fails, parses as ("quoted key", ":abcd")
+                # '"my tag2":" leading space"',  # fails, parses as ("quoted key", ":abcd")
                 "urls:example.com",
                 "url:example.com",
                 "activity:8",


### PR DESCRIPTION
`tags[""]` is a ~older~ search filter syntax, used to explicitly indicate the filter is a custom tag. It might be used in other products' search bars, but we don't need it for replays. The backend interprets unknown filters as tags by default, in the code snippet [here](https://github.com/getsentry/sentry/blob/c2a503aa39c8d26d2f841138051e49d9a73e668e/src/sentry/replays/usecases/query/__init__.py#L165-L167). If we wrap with `tags[""]` it is stripped [here](https://github.com/getsentry/sentry/blob/c2a503aa39c8d26d2f841138051e49d9a73e668e/src/sentry/replays/usecases/query/fields.py#L108-L109).

Right now:
1. list page > click search bar > select a tag suggestion: doesn't use `tags[""]`.
2. details > "Tags" tab > click on a blue link to make a search: uses `tags[""]`. Example: https://sentry.sentry.io/feedback/?feedbackSlug=javascript%3A5900621324&project=11276

To reduce confusion let's not use this syntax for 2.