### PR TITLE
chore(ui): Remove searchbar releases flag

### DIFF
--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -5,7 +5,6 @@ import {ReleaseFixture} from 'sentry-fixture/release';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   act,
-  fireEvent,
   render,
   screen,
   userEvent,
@@ -262,7 +261,9 @@ describe('ReleasesList', () => {
 
     // we want release header to be visible despite the error message
     expect(
-      screen.getByPlaceholderText('Search by version, build, package, or stage')
+      await screen.getByRole('combobox', {
+        name: 'Add a search term',
+      })
     ).toBeInTheDocument();
   });
 
@@ -614,16 +615,15 @@ describe('ReleasesList', () => {
       router,
       organization,
     });
-    const smartSearchBar = await screen.findByTestId('smart-search-input');
+    const smartSearchBar = await screen.findByRole('combobox', {
+      name: 'Add a search term',
+    });
+    await userEvent.click(smartSearchBar);
+    await userEvent.clear(smartSearchBar);
+    expect(await screen.findByRole('option', {name: 'release'})).toBeInTheDocument();
 
     await userEvent.clear(smartSearchBar);
-    fireEvent.change(smartSearchBar, {target: {value: 'release'}});
-
-    const autocompleteItems = await screen.findAllByTestId('search-autocomplete-item');
-    expect(autocompleteItems.at(0)).toHaveTextContent('release');
-
-    await userEvent.clear(smartSearchBar);
-    fireEvent.change(smartSearchBar, {target: {value: 'release.version:'}});
+    await userEvent.click(screen.getByRole('option', {name: 'release.version'}));
 
     expect(await screen.findByText('sentry@0.5.3')).toBeInTheDocument();
   });

--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -611,7 +611,7 @@ describe('ReleasesList', () => {
       url: '/organizations/org-slug/recent-searches/',
       method: 'POST',
     });
-    render(<ReleasesList {...props} />, {
+    render(<ReleasesList {...props} location={{...props.location, query: {}}} />, {
       router,
       organization,
     });

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -22,8 +22,6 @@ import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilt
 import Pagination from 'sentry/components/pagination';
 import Panel from 'sentry/components/panels/panel';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
-import SmartSearchBar from 'sentry/components/smartSearchBar';
-import {ItemType} from 'sentry/components/smartSearchBar/types';
 import {getRelativeSummary} from 'sentry/components/timeRangeSelector/utils';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
@@ -568,35 +566,15 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
 
               {this.shouldShowQuickstart ? null : (
                 <SortAndFilterWrapper>
-                  {organization.features.includes('search-query-builder-releases') ? (
-                    <StyledSearchQueryBuilder
-                      onSearch={this.handleSearch}
-                      initialQuery={this.getQuery() || ''}
-                      filterKeys={this.filterKeys}
-                      getTagValues={this.getTagValues}
-                      placeholder={t('Search by version, build, package, or stage')}
-                      searchSource="releases"
-                      showUnsubmittedIndicator
-                    />
-                  ) : (
-                    <StyledSmartSearchBar
-                      searchSource="releases"
-                      query={this.getQuery()}
-                      placeholder={t('Search by version, build, package, or stage')}
-                      hasRecentSearches={false}
-                      maxMenuHeight={500}
-                      supportedTagType={ItemType.PROPERTY}
-                      onSearch={this.handleSearch}
-                      onGetTagValues={this.getTagValues}
-                      supportedTags={{
-                        ...SEMVER_TAGS,
-                        release: {
-                          key: 'release',
-                          name: 'release',
-                        },
-                      }}
-                    />
-                  )}
+                  <StyledSearchQueryBuilder
+                    onSearch={this.handleSearch}
+                    initialQuery={this.getQuery() || ''}
+                    filterKeys={this.filterKeys}
+                    getTagValues={this.getTagValues}
+                    placeholder={t('Search by version, build, package, or stage')}
+                    searchSource="releases"
+                    showUnsubmittedIndicator
+                  />
                   <ReleasesStatusOptions
                     selected={activeStatus}
                     onSelect={this.handleStatus}
@@ -663,12 +641,6 @@ const SortAndFilterWrapper = styled('div')`
   }
   @media (max-width: ${p => p.theme.breakpoints.small}) {
     grid-template-columns: minmax(0, 1fr);
-  }
-`;
-
-const StyledSmartSearchBar = styled(SmartSearchBar)`
-  @media (max-width: ${p => p.theme.breakpoints.medium}) {
-    grid-column: 1 / -1;
   }
 `;
 


### PR DESCRIPTION
Removing the `search-query-builder-releases` from FE