### PR TITLE
ref(various): Small fixes and refactors

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1319,7 +1319,8 @@ def _save_aggregate_new(
     if primary.existing_grouphash:
         group_info = handle_existing_grouphash(job, primary.existing_grouphash, primary.grouphashes)
         result = "found_primary"
-    # If we haven't, try again using the secondary config
+    # If we haven't, try again using the secondary config. (If there is no secondary config, or
+    # we're out of the transition period, we'll get back the empty `NULL_GROUPHASH_INFO`.)
     else:
         secondary = get_hashes_and_grouphashes(job, maybe_run_secondary_grouping, metric_tags)
         all_grouphashes = primary.grouphashes + secondary.grouphashes

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -65,8 +65,8 @@ from sentry.grouping.ingest.metrics import record_hash_calculation_metrics, reco
 from sentry.grouping.ingest.seer import maybe_check_seer_for_matching_grouphash
 from sentry.grouping.ingest.utils import (
     add_group_id_to_grouphashes,
-    check_for_category_mismatch,
     check_for_group_creation_load_shed,
+    is_non_error_type_group,
 )
 from sentry.ingest.inbound_filters import FilterStatKeys
 from sentry.integrations.tasks.kick_off_status_syncs import kick_off_status_syncs
@@ -1422,7 +1422,7 @@ def handle_existing_grouphash(
     # well as GH-5085.
     group = Group.objects.get(id=existing_grouphash.group_id)
 
-    if check_for_category_mismatch(group):
+    if is_non_error_type_group(group):
         return None
 
     # There may still be hashes that we did not use to find an existing

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -55,7 +55,7 @@ from sentry.grouping.api import (
 )
 from sentry.grouping.ingest.config import is_in_transition, update_grouping_config_if_needed
 from sentry.grouping.ingest.hashing import (
-    find_existing_grouphash,
+    find_grouphash_with_group,
     get_or_create_grouphashes,
     maybe_run_background_grouping,
     maybe_run_secondary_grouping,
@@ -1384,7 +1384,7 @@ def get_hashes_and_grouphashes(
     if hashes:
         grouphashes = get_or_create_grouphashes(project, hashes)
 
-        existing_grouphash = find_existing_grouphash(grouphashes)
+        existing_grouphash = find_grouphash_with_group(grouphashes)
 
         return GroupHashInfo(grouping_config, hashes, grouphashes, existing_grouphash)
     else:
@@ -1487,7 +1487,7 @@ def create_group_with_grouphashes(job: Job, grouphashes: list[GroupHash]) -> Gro
         # condition scenario above, we'll have been blocked long enough for the other event to
         # have created the group and updated our grouphashes with a group id, which means this
         # time, we'll find something.
-        existing_grouphash = find_existing_grouphash(grouphashes)
+        existing_grouphash = find_grouphash_with_group(grouphashes)
 
         # If we still haven't found a matching grouphash, we're now safe to go ahead and create
         # the group.

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1297,6 +1297,9 @@ def assign_event_to_group(event: Event, job: Job, metric_tags: MutableTags) -> G
         metric_tags=metric_tags,
     )
 
+    # The only way there won't be group info is we matched to a performance, cron, replay, or
+    # other-non-error-type group because of a hash collision - exceedingly unlikely, and not
+    # something we've ever observed, but theoretically possible.
     if group_info:
         event.group = group_info.group
     job["groups"] = [group_info]
@@ -1422,6 +1425,10 @@ def handle_existing_grouphash(
     # well as GH-5085.
     group = Group.objects.get(id=existing_grouphash.group_id)
 
+    # As far as we know this has never happened, but in theory at least, the error event hashing
+    # algorithm and other event hashing algorithms could come up with the same hash value in the
+    # same project and our hash could have matched to a non-error group. Just to be safe, we make
+    # sure that's not the case before proceeding.
     if is_non_error_type_group(group):
         return None
 

--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -53,8 +53,8 @@ def update_grouping_config_if_needed(project: Project, source: str) -> None:
         from sentry import audit_log
         from sentry.utils.audit import create_system_audit_entry
 
-        # This is when we will stop calculating both old hashes (which we do in an effort to
-        # preserve group continuity).
+        # This is when we will stop calculating the old hash in cases where we don't find the new
+        # hash (which we do in an effort to preserve group continuity).
         expiry = int(time.time()) + settings.SENTRY_GROUPING_UPDATE_MIGRATION_PHASE
 
         changes: dict[str, str | int] = {"sentry:grouping_config": new_config}

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -194,6 +194,10 @@ def _calculate_primary_hashes(
 def find_grouphash_with_group(
     grouphashes: Sequence[GroupHash],
 ) -> GroupHash | None:
+    """
+    Search in the list of given `GroupHash` records for one which has a group assigned to it, and
+    return the first one found. (Assumes grouphashes have already been sorted in priority order.)
+    """
     for group_hash in grouphashes:
         if group_hash.group_id is not None:
             return group_hash

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -191,7 +191,7 @@ def _calculate_primary_hashes(
     return _calculate_event_grouping(project, job["event"], grouping_config)
 
 
-def find_existing_grouphash(
+def find_grouphash_with_group(
     grouphashes: Sequence[GroupHash],
 ) -> GroupHash | None:
     for group_hash in grouphashes:

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -40,8 +40,8 @@ def _calculate_event_grouping(
     project: Project, event: Event, grouping_config: GroupingConfig
 ) -> list[str]:
     """
-    Main entrypoint for modifying/enhancing and grouping an event, writes
-    hashes back into event payload.
+    Calculate hashes for the event using the given grouping config, and add them into the event
+    data.
     """
     metric_tags: MutableTags = {
         "grouping_config": grouping_config["id"],
@@ -147,7 +147,7 @@ def _calculate_secondary_hashes(
             description="event_manager.save.secondary_calculate_event_grouping",
         ):
             # create a copy since `_calculate_event_grouping` modifies the event to add all sorts
-            # of grouping info and we don't want the backup grouping data in there
+            # of grouping info and we don't want the secondary grouping data in there
             event_copy = copy.deepcopy(job["event"])
             secondary_hashes = _calculate_event_grouping(
                 project, event_copy, secondary_grouping_config

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -243,13 +243,12 @@ def maybe_check_seer_for_matching_grouphash(
             sample_rate=options.get("seer.similarity.metrics_sample_rate"),
             tags={"call_made": True, "blocker": "none"},
         )
+
         try:
             # If no matching group is found in Seer, we'll still get back result
             # metadata, but `seer_matched_grouphash` will be None
             seer_response_data, seer_matched_grouphash = get_seer_similar_issues(event)
-
-        # Insurance - in theory we shouldn't ever land here
-        except Exception as e:
+        except Exception as e:  # Insurance - in theory we shouldn't ever land here
             sentry_sdk.capture_exception(
                 e, tags={"event": event.event_id, "project": event.project.id}
             )

--- a/src/sentry/grouping/ingest/utils.py
+++ b/src/sentry/grouping/ingest/utils.py
@@ -48,7 +48,7 @@ def check_for_group_creation_load_shed(project: Project, event: Event) -> None:
         raise HashDiscarded("Load shedding group creation", reason="load_shed")
 
 
-def check_for_category_mismatch(group: Group) -> bool:
+def is_non_error_type_group(group: Group) -> bool:
     """
     Make sure an error event hasn't hashed to a value assigned to a non-error-type group
     """

--- a/src/sentry/projectoptions/manager.py
+++ b/src/sentry/projectoptions/manager.py
@@ -15,8 +15,11 @@ class WellKnownProjectOption:
                     epoch = 1
                 else:
                     epoch = project.get_option("sentry:option-epoch") or 1
+            # Find where in the ordered epoch list the project's epoch would go
             idx = bisect.bisect(self._epoch_default_list, epoch)
             if idx > 0:
+                # Return the value corresponding to the highest epoch which doesn't exceed the
+                # project epoch
                 return self.epoch_defaults[self._epoch_default_list[idx - 1]]
         return self.default
 

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -193,7 +193,7 @@ def get_stacktrace_string(data: dict[str, Any]) -> str:
                         if frame_dict["filename"].startswith(base64_prefix):
                             metrics.incr(
                                 "seer.grouping.base64_encoded_filename",
-                                sample_rate=1.0,
+                                sample_rate=options.get("seer.similarity.metrics_sample_rate"),
                             )
                             base64_encoded = True
                             break

--- a/tests/sentry/event_manager/grouping/test_assign_to_group.py
+++ b/tests/sentry/event_manager/grouping/test_assign_to_group.py
@@ -235,6 +235,17 @@ def get_results_from_saving_event(
         }
 
 
+# The overall idea of these tests is to prove that
+#
+#   a) We only run the secondary calculation when the project is in transtiion
+#   b) In transition, we only run the secondary calculation if the primary calculation
+#      doesn't find an existing group
+#   c) If the primary (or secondary, if it's calculated) hash finds a group, the event is
+#      assigned there
+#   d) If neither finds a group, a new group is created and both the primary (and secondary,
+#      if it's calculated) hashes are stored
+
+
 @django_db_all
 @pytest.mark.parametrize(
     "in_transition", (True, False), ids=(" in_transition: True ", " in_transition: False ")

--- a/tests/sentry/event_manager/grouping/test_assign_to_group.py
+++ b/tests/sentry/event_manager/grouping/test_assign_to_group.py
@@ -368,24 +368,18 @@ def test_existing_group_new_hash_exists(
         existing_event = save_event_with_grouping_config(
             event_data, project, DEFAULT_GROUPING_CONFIG, LEGACY_GROUPING_CONFIG, True
         )
-        assert existing_event.group_id is not None
-        assert (
-            GroupHash.objects.filter(
-                project_id=project.id, group_id=existing_event.group_id
-            ).count()
-            == 2
-        )
+        group_id = existing_event.group_id
+
+        assert group_id is not None
+        assert GroupHash.objects.filter(project_id=project.id, group_id=group_id).count() == 2
     else:
         existing_event = save_event_with_grouping_config(
             event_data, project, DEFAULT_GROUPING_CONFIG
         )
-        assert existing_event.group_id is not None
-        assert (
-            GroupHash.objects.filter(
-                project_id=project.id, group_id=existing_event.group_id
-            ).count()
-            == 1
-        )
+        group_id = existing_event.group_id
+
+        assert group_id is not None
+        assert GroupHash.objects.filter(project_id=project.id, group_id=group_id).count() == 1
 
     # Now save a new, identical, event
     results = get_results_from_saving_event(
@@ -394,7 +388,7 @@ def test_existing_group_new_hash_exists(
         primary_config=DEFAULT_GROUPING_CONFIG,
         secondary_config=LEGACY_GROUPING_CONFIG,
         in_transition=in_transition,
-        existing_group_id=existing_event.group_id,
+        existing_group_id=group_id,
     )
 
     assert results == {

--- a/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/event_manager/grouping/test_grouphash_metadata.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from sentry.models.grouphash import GroupHash
+from sentry.models.grouphashmetadata import GroupHashMetadata
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import Feature
+from sentry.testutils.helpers.eventprocessing import save_new_event
+from sentry.testutils.helpers.options import override_options
+from sentry.testutils.skips import requires_snuba
+
+pytestmark = [requires_snuba]
+
+
+class GroupHashMetadataTest(TestCase):
+    def test_creates_grouphash_metadata_when_appropriate(self):
+        # The killswitch is obeyed
+        with override_options({"grouping.grouphash_metadata.ingestion_writes_enabled": False}):
+            event1 = save_new_event({"message": "Dogs are great!"}, self.project)
+            grouphash = GroupHash.objects.filter(
+                project=self.project, hash=event1.get_primary_hash()
+            ).first()
+            assert grouphash and grouphash.metadata is None
+
+        # The feature flag is obeyed
+        with Feature({"organizations:grouphash-metadata-creation": False}):
+            event2 = save_new_event({"message": "Sit! Good dog!"}, self.project)
+            grouphash = GroupHash.objects.filter(
+                project=self.project, hash=event2.get_primary_hash()
+            ).first()
+            assert grouphash and grouphash.metadata is None
+
+        with Feature({"organizations:grouphash-metadata-creation": True}):
+            # New hashes get metadata
+            event3 = save_new_event({"message": "Adopt, don't shop"}, self.project)
+            grouphash = GroupHash.objects.filter(
+                project=self.project, hash=event3.get_primary_hash()
+            ).first()
+            assert grouphash and isinstance(grouphash.metadata, GroupHashMetadata)
+
+            # For now, existing hashes aren't backfiled when new events are assigned to them
+            event4 = save_new_event({"message": "Dogs are great!"}, self.project)
+            assert event4.get_primary_hash() == event1.get_primary_hash()
+            grouphash = GroupHash.objects.filter(
+                project=self.project, hash=event4.get_primary_hash()
+            ).first()
+            assert grouphash and grouphash.metadata is None

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -13,14 +13,10 @@ from sentry.event_manager import _get_updated_group_title
 from sentry.eventtypes.base import DefaultEvent
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.group import Group
-from sentry.models.grouphash import GroupHash
-from sentry.models.grouphashmetadata import GroupHashMetadata
 from sentry.models.project import Project
 from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG, LEGACY_GROUPING_CONFIG
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.eventprocessing import save_new_event
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.testutils.skips import requires_snuba
@@ -171,40 +167,6 @@ class EventManagerGroupingTest(TestCase):
             int(audit_log_entry.datetime.timestamp()) + SENTRY_GROUPING_UPDATE_MIGRATION_PHASE
         )
         assert actual_expiry == expected_expiry or actual_expiry == expected_expiry - 1
-
-    def test_creates_grouphash_metadata_when_appropriate(self):
-
-        # The killswitch is obeyed
-        with override_options({"grouping.grouphash_metadata.ingestion_writes_enabled": False}):
-            event1 = save_new_event({"message": "Dogs are great!"}, self.project)
-            grouphash = GroupHash.objects.filter(
-                project=self.project, hash=event1.get_primary_hash()
-            ).first()
-            assert grouphash and grouphash.metadata is None
-
-        # The feature flag is obeyed
-        with Feature({"organizations:grouphash-metadata-creation": False}):
-            event2 = save_new_event({"message": "Sit! Good dog!"}, self.project)
-            grouphash = GroupHash.objects.filter(
-                project=self.project, hash=event2.get_primary_hash()
-            ).first()
-            assert grouphash and grouphash.metadata is None
-
-        with Feature({"organizations:grouphash-metadata-creation": True}):
-            # New hashes get metadata
-            event3 = save_new_event({"message": "Adopt, don't shop"}, self.project)
-            grouphash = GroupHash.objects.filter(
-                project=self.project, hash=event3.get_primary_hash()
-            ).first()
-            assert grouphash and isinstance(grouphash.metadata, GroupHashMetadata)
-
-            # For now, existing hashes aren't backfiled when new events are assigned to them
-            event4 = save_new_event({"message": "Dogs are great!"}, self.project)
-            assert event4.get_primary_hash() == event1.get_primary_hash()
-            grouphash = GroupHash.objects.filter(
-                project=self.project, hash=event4.get_primary_hash()
-            ).first()
-            assert grouphash and grouphash.metadata is None
 
 
 class PlaceholderTitleTest(TestCase):


### PR DESCRIPTION
This is my latest collection of small tweaks and refactors pulled out of other PRs to avoid polluting them with off-topic stuff. No behavior changes.

Included changes:

- Rename `find_existing_grouphash` to `find_grouphash_with_group` and `check_for_category_mismatch` to `is_non_error_type_group`, since those names more accurately describe what those functions are doing.

- Use the seer metrics sample rate for a metric which was missed when that change was made.

- Do some small clean up work in the `test_existing_group_new_hash_exists` test in `test_assign_to_group.py`.

- Move the one existing grouphash metadata test into its own file, in anticipation of there being many more tests in the future.

- Update/add some comments and docstrings.