### PR TITLE
feat(alerts): require trigger actions to save metric alerts

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -105,12 +105,6 @@ class AlertRuleIndexMixin(Endpoint):
         if project:
             data["projects"] = [project.slug]
 
-        for trigger in data["triggers"]:
-            if not trigger.get("actions", []):
-                raise ValidationError(
-                    "Each trigger must have an associated action for this alert to fire."
-                )
-
         serializer = DrfAlertRuleSerializer(
             context={
                 "organization": organization,
@@ -126,6 +120,13 @@ class AlertRuleIndexMixin(Endpoint):
 
         if not serializer.is_valid():
             raise ValidationError(serializer.errors)
+
+        # if there are no triggers, then the serializer will raise an error
+        for trigger in data["triggers"]:
+            if not trigger.get("actions", []):
+                raise ValidationError(
+                    "Each trigger must have an associated action for this alert to fire."
+                )
 
         trigger_sentry_app_action_creators_for_incidents(serializer.validated_data)
         if get_slack_actions_with_async_lookups(organization, request.user, request.data):

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -105,6 +105,12 @@ class AlertRuleIndexMixin(Endpoint):
         if project:
             data["projects"] = [project.slug]
 
+        for trigger in data["triggers"]:
+            if not trigger.get("actions", []):
+                raise ValidationError(
+                    "Each trigger must have an associated action for this alert to fire."
+                )
+
         serializer = DrfAlertRuleSerializer(
             context={
                 "organization": organization,

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -916,12 +916,15 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         }
 
         with self.feature("organizations:incidents"):
-            resp = self.get_success_response(
-                self.organization.slug, status_code=201, **rule_one_trigger_only_critical_no_action
+            resp = self.get_error_response(
+                self.organization.slug, status_code=400, **rule_one_trigger_only_critical_no_action
             )
-        assert "id" in resp.data
-        alert_rule = AlertRule.objects.get(id=resp.data["id"])
-        assert resp.data == serialize(alert_rule, self.user)
+        assert resp.data == [
+            ErrorDetail(
+                string="Each trigger must have an associated action for this alert to fire.",
+                code="invalid",
+            )
+        ]
 
     def test_invalid_projects(self):
         with self.feature("organizations:incidents"):
@@ -1004,7 +1007,15 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             "name": "JustATestRule",
             "resolveThreshold": 100,
             "thresholdType": 1,
-            "triggers": [{"label": "critical", "alertThreshold": 75}],
+            "triggers": [
+                {
+                    "label": "critical",
+                    "alertThreshold": 75,
+                    "actions": [
+                        {"type": "email", "targetType": "team", "targetIdentifier": self.team.id}
+                    ],
+                }
+            ],
         }
 
         with self.feature("organizations:incidents"):


### PR DESCRIPTION
Prevent saving metric alerts if each trigger doesn't have an associated action