### PR TITLE
ref(trace): split helpers from trace tree model

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -346,18 +346,18 @@ export function TraceViewWaterfall(props: TraceViewWaterfallProps) {
       );
 
       // Root frame + 2 nodes
-      // const promises: Promise<void>[] = [];
-      // if (trace.list.length <= 3) {
-      //   for (const c of trace.list) {
-      //     if (c.canFetch) {
-      //       promises.push(trace.zoomIn(c, true, {api, organization}).then(rerender));
-      //     }
-      //   }
-      // }
+      const promises: Promise<void>[] = [];
+      if (trace.list.length <= 3) {
+        for (const c of trace.list) {
+          if (c.canFetch) {
+            promises.push(trace.zoomIn(c, true, {api, organization}).then(rerender));
+          }
+        }
+      }
 
-      // Promise.allSettled(promises).finally(() => {
-      setTree(trace);
-      // });
+      Promise.allSettled(promises).finally(() => {
+        setTree(trace);
+      });
     }
   }, [
     props.traceSlug,

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -570,7 +570,7 @@ function RenderTraceRow(props: {
       ? TRACE_RIGHT_COLUMN_ODD_CLASSNAME
       : TRACE_RIGHT_COLUMN_EVEN_CLASSNAME;
 
-  const listColumnClassName = node.isOrphaned
+  const listColumnClassName = isTraceNode(node)
     ? TRACE_CHILDREN_COUNT_WRAPPER_ORPHANED_CLASSNAME
     : TRACE_CHILDREN_COUNT_WRAPPER_CLASSNAME;
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/error.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/error.tsx
@@ -15,8 +15,9 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 
 import type {TraceTreeNodeDetailsProps} from '../../traceDrawer/tabs/traceTreeNodeDetails';
 import {TraceIcons} from '../../traceIcons';
-import {makeTraceNodeBarColor, TraceTree} from '../../traceModels/traceTree';
+import {TraceTree} from '../../traceModels/traceTree';
 import type {TraceTreeNode} from '../../traceModels/traceTreeNode';
+import {makeTraceNodeBarColor} from '../../traceModels/traceTreeNodeUtils';
 import {getTraceTabTitle} from '../../traceState/traceTabs';
 
 import {IssueList} from './issues/issues';

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/missingInstrumentation.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/missingInstrumentation.tsx
@@ -11,7 +11,8 @@ import {ProfileContext, ProfilesProvider} from 'sentry/views/profiling/profilesP
 import {ProfilePreview} from '../../traceDrawer/details/profiling/profilePreview';
 import type {TraceTreeNodeDetailsProps} from '../../traceDrawer/tabs/traceTreeNodeDetails';
 import type {MissingInstrumentationNode} from '../../traceModels/missingInstrumentationNode';
-import {makeTraceNodeBarColor, TraceTree} from '../../traceModels/traceTree';
+import {TraceTree} from '../../traceModels/traceTree';
+import {makeTraceNodeBarColor} from '../../traceModels/traceTreeNodeUtils';
 import {getTraceTabTitle} from '../../traceState/traceTabs';
 
 import {type SectionCardKeyValueList, TraceDrawerComponents} from './styles';

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/parentAutogroup.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/parentAutogroup.tsx
@@ -6,7 +6,8 @@ import {t} from 'sentry/locale';
 
 import type {TraceTreeNodeDetailsProps} from '../../traceDrawer/tabs/traceTreeNodeDetails';
 import type {ParentAutogroupNode} from '../../traceModels/parentAutogroupNode';
-import {makeTraceNodeBarColor, TraceTree} from '../../traceModels/traceTree';
+import {TraceTree} from '../../traceModels/traceTree';
+import {makeTraceNodeBarColor} from '../../traceModels/traceTreeNodeUtils';
 import {getTraceTabTitle} from '../../traceState/traceTabs';
 
 import {IssueList} from './issues/issues';

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/siblingAutogroup.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/siblingAutogroup.tsx
@@ -6,7 +6,8 @@ import {t, tct} from 'sentry/locale';
 
 import type {TraceTreeNodeDetailsProps} from '../../traceDrawer/tabs/traceTreeNodeDetails';
 import type {SiblingAutogroupNode} from '../../traceModels/siblingAutogroupNode';
-import {makeTraceNodeBarColor, TraceTree} from '../../traceModels/traceTree';
+import {TraceTree} from '../../traceModels/traceTree';
+import {makeTraceNodeBarColor} from '../../traceModels/traceTreeNodeUtils';
 import {getTraceTabTitle} from '../../traceState/traceTabs';
 
 import {IssueList} from './issues/issues';

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
@@ -36,12 +36,9 @@ import {
   usePassiveResizableDrawer,
   type UsePassiveResizableDrawerOptions,
 } from '../traceDrawer/usePassiveResizeableDrawer';
-import {
-  makeTraceNodeBarColor,
-  type TraceShape,
-  type TraceTree,
-} from '../traceModels/traceTree';
+import type {TraceShape, TraceTree} from '../traceModels/traceTree';
 import type {TraceTreeNode} from '../traceModels/traceTreeNode';
+import {makeTraceNodeBarColor} from '../traceModels/traceTreeNodeUtils';
 import type {TraceScheduler} from '../traceRenderers/traceScheduler';
 import type {VirtualizedViewManager} from '../traceRenderers/virtualizedViewManager';
 import type {TraceReducerAction, TraceReducerState} from '../traceState';

--- a/static/app/views/performance/newTraceDetails/traceGuards.tsx
+++ b/static/app/views/performance/newTraceDetails/traceGuards.tsx
@@ -120,3 +120,18 @@ export function isBrowserRequestSpan(value: TraceTree.Span): boolean {
     (value.op === 'browser' && value.description === 'request')
   );
 }
+
+export function getPageloadTransactionChildCount(
+  node: TraceTreeNode<TraceTree.NodeValue>
+): number {
+  if (!isTransactionNode(node)) {
+    return 0;
+  }
+  let count = 0;
+  for (const txn of node.value.children) {
+    if (txn && txn['transaction.op'] === 'pageload') {
+      count++;
+    }
+  }
+  return count;
+}

--- a/static/app/views/performance/newTraceDetails/traceModels/missingInstrumentationNode.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/missingInstrumentationNode.spec.tsx
@@ -1,0 +1,76 @@
+import {
+  makeNodeMetadata,
+  makeSpan,
+  makeTransaction,
+} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
+
+import {TraceTreeNode} from '../traceModels/traceTreeNode';
+
+import {
+  MissingInstrumentationNode,
+  shouldInsertMissingInstrumentationSpan,
+} from './missingInstrumentationNode';
+
+describe('MissingInstrumentationNode', () => {
+  it('stores references to previous and next spans', () => {
+    const previous = new TraceTreeNode(null, makeSpan(), makeNodeMetadata());
+    const current = new TraceTreeNode(null, makeSpan(), makeNodeMetadata());
+
+    const node = new MissingInstrumentationNode(
+      new TraceTreeNode(null, makeSpan(), makeNodeMetadata()),
+      {
+        type: 'missing_instrumentation',
+        start_timestamp: previous.value.timestamp,
+        timestamp: current.value.start_timestamp,
+      },
+      makeNodeMetadata(),
+      previous,
+      current
+    );
+
+    expect(node.previous).toBe(previous);
+    expect(node.next).toBe(current);
+  });
+
+  describe('shouldInsertMissingInstrumentationSpan', () => {
+    it('false if previous is not a span', () => {
+      const previous = new TraceTreeNode(null, makeTransaction(), makeNodeMetadata());
+      const current = new TraceTreeNode(null, makeSpan(), makeNodeMetadata());
+
+      expect(shouldInsertMissingInstrumentationSpan(previous, current)).toBe(false);
+    });
+    it('false if next is not a span', () => {
+      const previous = new TraceTreeNode(null, makeSpan(), makeNodeMetadata());
+      const current = new TraceTreeNode(null, makeTransaction(), makeNodeMetadata());
+
+      expect(shouldInsertMissingInstrumentationSpan(previous, current)).toBe(false);
+    });
+    it('false if gap is too small', () => {
+      const previous = new TraceTreeNode(
+        null,
+        makeSpan({start_timestamp: 0, timestamp: 1}),
+        makeNodeMetadata()
+      );
+      const current = new TraceTreeNode(
+        null,
+        makeSpan({start_timestamp: 1.01, timestamp: 2}),
+        makeNodeMetadata()
+      );
+
+      expect(shouldInsertMissingInstrumentationSpan(previous, current)).toBe(false);
+    });
+    it('true if gap is sufficiently large', () => {
+      const previous = new TraceTreeNode(
+        null,
+        makeSpan({start_timestamp: 0, timestamp: 1}),
+        makeNodeMetadata()
+      );
+      const current = new TraceTreeNode(
+        null,
+        makeSpan({start_timestamp: 1.2, timestamp: 2}),
+        makeNodeMetadata()
+      );
+      expect(shouldInsertMissingInstrumentationSpan(previous, current)).toBe(true);
+    });
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceModels/parentAutogroupNode.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/parentAutogroupNode.spec.tsx
@@ -1,0 +1,21 @@
+import {
+  makeNodeMetadata,
+  makeParentAutogroup,
+  makeSpan,
+} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
+
+import {ParentAutogroupNode} from './parentAutogroupNode';
+import {TraceTreeNode} from './traceTreeNode';
+
+describe('ParentAutogroupNode', () => {
+  it('not expanded by default', () => {
+    const node = new ParentAutogroupNode(
+      null,
+      makeParentAutogroup({autogrouped_by: {op: 'op'}}),
+      makeNodeMetadata(),
+      new TraceTreeNode(null, makeSpan(), makeNodeMetadata()),
+      new TraceTreeNode(null, makeSpan(), makeNodeMetadata())
+    );
+    expect(node.expanded).toBe(false);
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceModels/parentAutogroupNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/parentAutogroupNode.tsx
@@ -1,5 +1,6 @@
-import {computeAutogroupedBarSegments, type TraceTree} from './traceTree';
+import type {TraceTree} from './traceTree';
 import {TraceTreeNode} from './traceTreeNode';
+import {computeAutogroupedBarSegments} from './traceTreeNodeUtils';
 
 export class ParentAutogroupNode extends TraceTreeNode<TraceTree.ChildrenAutogroup> {
   head: TraceTreeNode<TraceTree.Span>;
@@ -28,10 +29,6 @@ export class ParentAutogroupNode extends TraceTreeNode<TraceTree.ChildrenAutogro
       return [this.head];
     }
     return this.tail.children;
-  }
-
-  get has_errors(): boolean {
-    return this.errors.size > 0 || this.performance_issues.size > 0;
   }
 
   get autogroupedSegments(): [number, number][] {

--- a/static/app/views/performance/newTraceDetails/traceModels/siblingAutogroupNode.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/siblingAutogroupNode.spec.tsx
@@ -1,0 +1,17 @@
+import {
+  makeNodeMetadata,
+  makeSiblingAutogroup,
+} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
+
+import {SiblingAutogroupNode} from './siblingAutogroupNode';
+
+describe('SiblingAutogroupNode', () => {
+  it('not expanded by default', () => {
+    const node = new SiblingAutogroupNode(
+      null,
+      makeSiblingAutogroup({autogrouped_by: {op: 'op', description: 'description'}}),
+      makeNodeMetadata()
+    );
+    expect(node.expanded).toBe(false);
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceModels/siblingAutogroupNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/siblingAutogroupNode.tsx
@@ -1,5 +1,6 @@
-import {computeAutogroupedBarSegments, type TraceTree} from './traceTree';
+import type {TraceTree} from './traceTree';
 import {TraceTreeNode} from './traceTreeNode';
+import {computeAutogroupedBarSegments} from './traceTreeNodeUtils';
 
 export class SiblingAutogroupNode extends TraceTreeNode<TraceTree.SiblingAutogroup> {
   groupCount: number = 0;
@@ -14,10 +15,6 @@ export class SiblingAutogroupNode extends TraceTreeNode<TraceTree.SiblingAutogro
   ) {
     super(parent, node, metadata);
     this.expanded = false;
-  }
-
-  get has_errors(): boolean {
-    return this.errors.size > 0 || this.performance_issues.size > 0;
   }
 
   get autogroupedSegments(): [number, number][] {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
@@ -1307,8 +1307,8 @@ describe('TraceTree', () => {
       expect(tree.list[1].connectors.length).toBe(1);
       expect(tree.list[1].connectors[0]).toBe(-1);
 
-      expect(tree.list[2].connectors[0]).toBe(-1);
-      expect(tree.list[2].connectors[1]).toBe(2);
+      expect(tree.list[2].connectors[0]).toBe(2);
+      expect(tree.list[2].connectors[1]).toBe(-1);
       expect(tree.list[2].connectors.length).toBe(2);
 
       expect(tree.list[3].connectors[0]).toBe(-1);

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeEventDispatcher.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeEventDispatcher.spec.tsx
@@ -1,0 +1,21 @@
+import {TraceTreeEventDispatcher} from './traceTreeEventDispatcher';
+
+describe('TraceEventDispatcher', () => {
+  it('dispatch events', () => {
+    const dispatcher = new TraceTreeEventDispatcher();
+    const mockCallback = jest.fn();
+    dispatcher.on('trace timeline change', mockCallback);
+    dispatcher.dispatch('trace timeline change', [0, 1]);
+    expect(mockCallback).toHaveBeenCalledWith([0, 1]);
+  });
+
+  it('off events', () => {
+    const dispatcher = new TraceTreeEventDispatcher();
+    const mockCallback = jest.fn();
+
+    dispatcher.on('trace timeline change', mockCallback);
+    dispatcher.off('trace timeline change', mockCallback);
+    dispatcher.dispatch('trace timeline change', [0, 1]);
+    expect(mockCallback).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeEventDispatcher.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeEventDispatcher.tsx
@@ -1,11 +1,11 @@
 import type {TraceTree} from './traceTree';
 
 type ArgumentTypes<F> = F extends (...args: infer A) => any ? A : never;
-
-export class TraceEventDispatcher {
-  listeners: TraceTree.EventStore = {
-    'trace timeline change': new Set(),
-  };
+export class TraceTreeEventDispatcher {
+  listeners: {[K in keyof TraceTree.TraceTreeEvents]: Set<TraceTree.TraceTreeEvents[K]>} =
+    {
+      'trace timeline change': new Set(),
+    };
 
   on<K extends keyof TraceTree.TraceTreeEvents>(
     event: K,

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode.spec.tsx
@@ -1,0 +1,131 @@
+import {
+  makeSpan,
+  makeTraceError,
+  makeTracePerformanceIssue,
+  makeTransaction,
+} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
+
+import type {TraceTree} from '../traceModels/traceTree';
+
+import {TraceTreeNode} from './traceTreeNode';
+
+const metadata: TraceTree.Metadata = {
+  event_id: '1',
+  project_slug: 'node',
+};
+
+describe('TraceTreeNode', () => {
+  it('infers space from timestamp and start_timestamp', () => {
+    const node = new TraceTreeNode(null, makeTraceError({timestamp: 1}), metadata);
+    expect(node.space).toEqual([1 * node.multiplier, 0]);
+  });
+
+  it('infers start_timestamp and timestamp when not provided', () => {
+    const node = new TraceTreeNode(
+      null,
+      makeSpan({start_timestamp: 1, timestamp: 3}),
+      metadata
+    );
+    expect(node.space).toEqual([1 * node.multiplier, 2 * node.multiplier]);
+  });
+
+  it('stores performance issue on node', () => {
+    const issue = makeTracePerformanceIssue({issue_short_id: 'issue1'});
+    const node = new TraceTreeNode(
+      null,
+      makeTransaction({
+        start_timestamp: 1,
+        timestamp: 3,
+        performance_issues: [issue],
+      }),
+      metadata
+    );
+    expect(node.performance_issues.has(issue)).toBe(true);
+  });
+
+  it('stores error on node', () => {
+    const issue = makeTraceError();
+
+    const node = new TraceTreeNode(
+      null,
+      makeTransaction({
+        start_timestamp: 1,
+        timestamp: 3,
+        errors: [issue],
+      }),
+      metadata
+    );
+
+    expect(node.errors.has(issue)).toBe(true);
+  });
+
+  it('a trace error is stored on node', () => {
+    const node = new TraceTreeNode(null, makeTraceError(), metadata);
+    expect(node.errors.size).toBe(1);
+  });
+
+  it('stores profile on node', () => {
+    const node = new TraceTreeNode(
+      null,
+      makeTransaction({
+        start_timestamp: 1,
+        timestamp: 3,
+        profile_id: 'profile',
+      }),
+      metadata
+    );
+
+    expect(node.profiles[0].profile_id).toBe('profile');
+  });
+
+  describe('isLastChild', () => {
+    it('true', () => {
+      const parent = new TraceTreeNode(null, makeTransaction(), metadata);
+      const child = new TraceTreeNode(parent, makeTransaction(), metadata);
+      parent.children.push(child);
+      expect(parent.children.length).toBe(1);
+      expect(child.isLastChild).toBe(true);
+    });
+
+    it('false', () => {
+      const parent = new TraceTreeNode(null, makeTransaction(), metadata);
+      const other = new TraceTreeNode(parent, makeTransaction(), metadata);
+      const child = new TraceTreeNode(parent, makeTransaction(), metadata);
+      parent.children.push(other);
+      parent.children.push(child);
+      expect(parent.children.length).toBe(2);
+      expect(other.isLastChild).toBe(false);
+    });
+  });
+
+  describe('maxSeverity', () => {
+    it('fatal > info', () => {
+      const node = new TraceTreeNode(
+        null,
+        makeTransaction({
+          errors: [makeTraceError({level: 'fatal'})],
+          performance_issues: [makeTracePerformanceIssue({level: 'info'})],
+        }),
+        metadata
+      );
+      expect(node.maxIssueSeverity).toBe('fatal');
+    });
+  });
+
+  describe('expanding and collapsing', () => {
+    it('default is expanded', () => {
+      const node = new TraceTreeNode(null, makeTransaction(), metadata);
+      expect(node.expanded).toBe(true);
+    });
+
+    it('android tcp connections are not expanded by default', () => {
+      const node = new TraceTreeNode(
+        null,
+        makeSpan({op: 'http.client', origin: 'auto.http.okhttp'}),
+        metadata
+      );
+
+      expect(node.expanded).toBe(false);
+    });
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode.tsx
@@ -25,7 +25,7 @@ function isTraceAutogroup(
   return !!(value && 'autogrouped_by' in value);
 }
 
-function isTraceRoot(value: TraceTree.NodeValue | undefined): value is TraceTree.Trace {
+function isTrace(value: TraceTree.NodeValue | undefined): value is TraceTree.Trace {
   return !!(value && 'orphan_errors' in value);
 }
 
@@ -171,24 +171,27 @@ export class TraceTreeNode<T extends TraceTree.NodeValue = TraceTree.NodeValue> 
    */
   get connectors(): number[] {
     if (this._connectors !== undefined) {
-      return this._connectors!;
+      return this._connectors;
     }
 
     this._connectors = [];
 
-    let node: TraceTreeNode<T> | TraceTreeNode<TraceTree.NodeValue> | null = this.parent;
+    let node: TraceTreeNode<T> | TraceTreeNode<TraceTree.NodeValue> | null = this;
 
     while (node) {
-      if (node.value === null) {
-        break;
+      if (!node.value) {
+        return this._connectors;
       }
-
       if (node.isLastChild) {
         node = node.parent;
         continue;
       }
 
-      this._connectors.push(isTraceRoot(node.parent?.value) ? -node.depth : node.depth);
+      if (isTrace(node.value)) {
+        this._connectors.push(-node.depth);
+        return this._connectors;
+      }
+      this._connectors.push(isTrace(node?.parent?.value) ? -node.depth : node.depth);
       node = node.parent;
     }
 

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode.tsx
@@ -25,12 +25,8 @@ function isTraceAutogroup(
   return !!(value && 'autogrouped_by' in value);
 }
 
-function isRoot(value: TraceTree.NodeValue): value is null {
-  return value === null;
-}
-
-function isTraceRoot(value: TraceTree.NodeValue): value is TraceTree.Trace {
-  return !!(value && ('orphan_errors' in value || 'transactions' in value));
+function isTraceRoot(value: TraceTree.NodeValue | undefined): value is TraceTree.Trace {
+  return !!(value && 'orphan_errors' in value);
 }
 
 function shouldCollapseNodeByDefault(node: TraceTreeNode<TraceTree.NodeValue>) {
@@ -180,21 +176,6 @@ export class TraceTreeNode<T extends TraceTree.NodeValue = TraceTree.NodeValue> 
 
     this._connectors = [];
 
-    if (!this.parent) {
-      return this._connectors;
-    }
-
-    if (this.parent?.connectors !== undefined) {
-      this._connectors = [...this.parent.connectors];
-
-      if (this.isLastChild || isRoot(this.value)) {
-        return this._connectors;
-      }
-
-      this.connectors.push(isTraceRoot(this.value) ? -this.depth : this.depth);
-      return this._connectors;
-    }
-
     let node: TraceTreeNode<T> | TraceTreeNode<TraceTree.NodeValue> | null = this.parent;
 
     while (node) {
@@ -207,7 +188,7 @@ export class TraceTreeNode<T extends TraceTree.NodeValue = TraceTree.NodeValue> 
         continue;
       }
 
-      this._connectors.push(this.value ? -node.depth : node.depth);
+      this._connectors.push(isTraceRoot(node.parent?.value) ? -node.depth : node.depth);
       node = node.parent;
     }
 

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNodeUtils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNodeUtils.tsx
@@ -1,12 +1,22 @@
+import type {Theme} from '@emotion/react';
+
+import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
+
+import {getStylingSliceName} from '../../../traces/utils';
 import {
+  isAutogroupedNode,
   isMissingInstrumentationNode,
   isParentAutogroupedNode,
   isSiblingAutogroupedNode,
+  isSpanNode,
+  isTraceErrorNode,
+  isTransactionNode,
 } from '../traceGuards';
 
 import {MissingInstrumentationNode} from './missingInstrumentationNode';
 import {ParentAutogroupNode} from './parentAutogroupNode';
 import {SiblingAutogroupNode} from './siblingAutogroupNode';
+import type {TraceTree} from './traceTree';
 import {TraceTreeNode} from './traceTreeNode';
 
 export function cloneTraceTreeNode(
@@ -93,4 +103,96 @@ export function cloneTraceTreeNode(
 
   node.cloneReference = cloned;
   return cloned;
+}
+
+// Returns a list of segments from a grouping sequence that can be used to render a span bar chart
+// It looks for gaps between spans and creates a segment for each gap. If there are no gaps, it
+// merges the n and n+1 segments.
+export function computeAutogroupedBarSegments(
+  nodes: TraceTreeNode<TraceTree.NodeValue>[]
+): [number, number][] {
+  if (nodes.length === 0) {
+    return [];
+  }
+
+  if (nodes.length === 1) {
+    const space = nodes[0].space;
+    if (!space) {
+      throw new Error(
+        'Autogrouped node child has no defined space. This should not happen.'
+      );
+    }
+    return [space];
+  }
+
+  const first = nodes[0];
+  const multiplier = first.multiplier;
+
+  if (!isSpanNode(first)) {
+    throw new Error('Autogrouped node must have span children');
+  }
+
+  const segments: [number, number][] = [];
+
+  let start = first.value.start_timestamp;
+  let end = first.value.timestamp;
+  let i = 1;
+
+  while (i < nodes.length) {
+    const next = nodes[i];
+
+    if (!isSpanNode(next)) {
+      throw new Error('Autogrouped node must have span children');
+    }
+
+    if (next.value.start_timestamp > end) {
+      segments.push([start * multiplier, (end - start) * multiplier]);
+      start = next.value.start_timestamp;
+      end = next.value.timestamp;
+      i++;
+    } else {
+      end = next.value.timestamp;
+      i++;
+    }
+  }
+
+  segments.push([start * multiplier, (end - start) * multiplier]);
+
+  return segments;
+}
+
+export function makeTraceNodeBarColor(
+  theme: Theme,
+  node: TraceTreeNode<TraceTree.NodeValue>
+): string {
+  if (isTransactionNode(node)) {
+    return pickBarColor(
+      getStylingSliceName(node.value.project_slug, node.value.sdk_name) ??
+        node.value['transaction.op']
+    );
+  }
+  if (isSpanNode(node)) {
+    return pickBarColor(node.value.op);
+  }
+  if (isAutogroupedNode(node)) {
+    if (node.errors.size > 0) {
+      return theme.red300;
+    }
+    return theme.blue300;
+  }
+  if (isMissingInstrumentationNode(node)) {
+    return theme.gray300;
+  }
+
+  if (isTraceErrorNode(node)) {
+    // Theme defines this as orange, yet everywhere in our product we show red for errors
+    if (node.value.level === 'error' || node.value.level === 'fatal') {
+      return theme.red300;
+    }
+    if (node.value.level) {
+      return theme.level[node.value.level] ?? theme.red300;
+    }
+    return theme.red300;
+  }
+  return pickBarColor('default');
 }

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeTestUtils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeTestUtils.tsx
@@ -1,0 +1,195 @@
+import {EntryType, type Event, type EventTransaction} from 'sentry/types/event';
+import type {
+  TracePerformanceIssue,
+  TraceSplitResults,
+} from 'sentry/utils/performance/quickTrace/types';
+
+import {
+  isAutogroupedNode,
+  isMissingInstrumentationNode,
+  isSpanNode,
+  isTraceErrorNode,
+  isTraceNode,
+  isTransactionNode,
+} from '../traceGuards';
+import type {TraceTree} from '../traceModels/traceTree';
+
+import {ParentAutogroupNode} from './parentAutogroupNode';
+import {SiblingAutogroupNode} from './siblingAutogroupNode';
+import type {TraceTreeNode} from './traceTreeNode';
+
+export function makeTrace(
+  overrides: Partial<TraceSplitResults<TraceTree.Transaction>>
+): TraceSplitResults<TraceTree.Transaction> {
+  return {
+    transactions: [],
+    orphan_errors: [],
+    ...overrides,
+  } as TraceSplitResults<TraceTree.Transaction>;
+}
+
+export function makeTransaction(
+  overrides: Partial<TraceTree.Transaction> = {}
+): TraceTree.Transaction {
+  return {
+    children: [],
+    sdk_name: '',
+    start_timestamp: 0,
+    timestamp: 1,
+    transaction: 'transaction',
+    'transaction.op': '',
+    'transaction.status': '',
+    performance_issues: [],
+    errors: [],
+    ...overrides,
+  } as TraceTree.Transaction;
+}
+
+export function makeSpan(overrides: Partial<TraceTree.RawSpan> = {}): TraceTree.Span {
+  return {
+    span_id: '',
+    op: '',
+    description: '',
+    start_timestamp: 0,
+    timestamp: 10,
+    data: {},
+    trace_id: '',
+    childTransactions: [],
+    event: makeEvent() as EventTransaction,
+    ...overrides,
+  };
+}
+
+export function makeTraceError(
+  overrides: Partial<TraceTree.TraceError> = {}
+): TraceTree.TraceError {
+  return {
+    title: 'MaybeEncodingError: Error sending result',
+    level: 'error',
+    event_type: 'error',
+    data: {},
+    ...overrides,
+  } as TraceTree.TraceError;
+}
+
+export function makeTracePerformanceIssue(
+  overrides: Partial<TracePerformanceIssue> = {}
+): TracePerformanceIssue {
+  return {
+    culprit: 'code',
+    end: new Date().toISOString(),
+    span: [],
+    start: new Date().toISOString(),
+    suspect_spans: ['sus span'],
+    type: 0,
+    issue_short_id: 'issue short id',
+    ...overrides,
+  } as TracePerformanceIssue;
+}
+
+export function makeEvent(
+  overrides: Partial<Event> = {},
+  spans: TraceTree.RawSpan[] = []
+): Event {
+  return {
+    entries: [{type: EntryType.SPANS, data: spans}],
+    ...overrides,
+  } as Event;
+}
+
+export function makeParentAutogroup(
+  overrides: Partial<TraceTree.ChildrenAutogroup> = {}
+): TraceTree.ChildrenAutogroup {
+  return {
+    autogrouped_by: {
+      op: overrides.op ?? 'op',
+    },
+    ...overrides,
+  } as TraceTree.ChildrenAutogroup;
+}
+
+export function makeSiblingAutogroup(
+  overrides: Partial<TraceTree.SiblingAutogroup> = {}
+): TraceTree.SiblingAutogroup {
+  return {
+    autogrouped_by: {
+      op: overrides.op ?? 'op',
+      description: overrides.description ?? 'description',
+    },
+    ...overrides,
+  } as TraceTree.SiblingAutogroup;
+}
+
+export function assertSpanNode(
+  node: TraceTreeNode<TraceTree.NodeValue>
+): asserts node is TraceTreeNode<TraceTree.Span> {
+  if (!isSpanNode(node)) {
+    throw new Error('node is not a span');
+  }
+}
+
+export function assertTraceNode(
+  node: TraceTreeNode<TraceTree.NodeValue>
+): asserts node is TraceTreeNode<TraceTree.Trace> {
+  if (!isTraceNode(node)) {
+    throw new Error('node is not a trace');
+  }
+}
+
+export function assertTransactionNode(
+  node: TraceTreeNode<TraceTree.NodeValue> | null
+): asserts node is TraceTreeNode<TraceTree.Transaction> {
+  if (!node || !isTransactionNode(node)) {
+    throw new Error('node is not a transaction');
+  }
+}
+
+export function assertMissingInstrumentationNode(
+  node: TraceTreeNode<TraceTree.NodeValue>
+): asserts node is TraceTreeNode<TraceTree.MissingInstrumentationSpan> {
+  if (!isMissingInstrumentationNode(node)) {
+    throw new Error('node is not a missing instrumentation node');
+  }
+}
+
+export function assertTraceErrorNode(
+  node: TraceTreeNode<TraceTree.NodeValue>
+): asserts node is TraceTreeNode<TraceTree.TraceError> {
+  if (!isTraceErrorNode(node)) {
+    throw new Error('node is not a trace error node');
+  }
+}
+
+export function assertAutogroupedNode(
+  node: TraceTreeNode<TraceTree.NodeValue>
+): asserts node is ParentAutogroupNode | SiblingAutogroupNode {
+  if (!isAutogroupedNode(node)) {
+    throw new Error('node is not a autogrouped node');
+  }
+}
+
+export function assertParentAutogroupedNode(
+  node: TraceTreeNode<TraceTree.NodeValue>
+): asserts node is ParentAutogroupNode {
+  if (!(node instanceof ParentAutogroupNode)) {
+    throw new Error('node is not a parent autogrouped node');
+  }
+}
+
+export function assertSiblingAutogroupedNode(
+  node: TraceTreeNode<TraceTree.NodeValue>
+): asserts node is ParentAutogroupNode {
+  if (!(node instanceof SiblingAutogroupNode)) {
+    throw new Error('node is not a parent node');
+  }
+}
+
+export function makeNodeMetadata(
+  overrides: Partial<TraceTree.Metadata> = {}
+): TraceTree.Metadata {
+  return {
+    event_id: undefined,
+    project_slug: undefined,
+    ...overrides,
+  };
+}

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeUtils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeUtils.tsx
@@ -1,0 +1,52 @@
+// Returns a list of errors related to the txn with ids matching the span id
+
+import {isTransactionNode} from '../traceGuards';
+
+import type {TraceTree} from './traceTree';
+import type {TraceTreeNode} from './traceTreeNode';
+
+export function getRelatedSpanErrorsFromTransaction(
+  span: TraceTree.RawSpan,
+  node: TraceTreeNode<TraceTree.NodeValue>
+): TraceTree.TraceError[] {
+  if (!isTransactionNode(node) || !node.value?.errors?.length) {
+    return [];
+  }
+
+  const errors: TraceTree.TraceError[] = [];
+  for (const error of node.value.errors) {
+    if (error.span === span.span_id) {
+      errors.push(error);
+    }
+  }
+
+  return errors;
+}
+
+// Returns a list of performance errors related to the txn with ids matching the span id
+export function getRelatedPerformanceIssuesFromTransaction(
+  span: TraceTree.RawSpan,
+  node: TraceTreeNode<TraceTree.NodeValue>
+): TraceTree.TracePerformanceIssue[] {
+  if (!isTransactionNode(node) || !node.value?.performance_issues?.length) {
+    return [];
+  }
+
+  const performanceIssues: TraceTree.TracePerformanceIssue[] = [];
+
+  for (const perfIssue of node.value.performance_issues) {
+    for (const s of perfIssue.span) {
+      if (s === span.span_id) {
+        performanceIssues.push(perfIssue);
+      }
+    }
+
+    for (const suspect of perfIssue.suspect_spans) {
+      if (suspect === span.span_id) {
+        performanceIssues.push(perfIssue);
+      }
+    }
+  }
+
+  return performanceIssues;
+}

--- a/static/app/views/performance/newTraceDetails/traceRow/traceAutogroupedRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceAutogroupedRow.tsx
@@ -3,7 +3,7 @@ import {t} from 'sentry/locale';
 import {TraceIcons} from '../traceIcons';
 import type {ParentAutogroupNode} from '../traceModels/parentAutogroupNode';
 import type {SiblingAutogroupNode} from '../traceModels/siblingAutogroupNode';
-import {makeTraceNodeBarColor} from '../traceModels/traceTree';
+import {makeTraceNodeBarColor} from '../traceModels/traceTreeNodeUtils';
 import {AutogroupedTraceBar} from '../traceRow/traceBar';
 import {
   maybeFocusTraceRow,
@@ -25,7 +25,7 @@ export function TraceAutogroupedRow(
           : null
       }
       tabIndex={props.tabIndex}
-      className={`Autogrouped TraceRow ${props.rowSearchClassName} ${props.node.has_errors ? props.node.max_severity : ''}`}
+      className={`Autogrouped TraceRow ${props.rowSearchClassName} ${props.node.hasErrors ? props.node.maxIssueSeverity : ''}`}
       onClick={props.onRowClick}
       onKeyDown={props.onRowKeyDown}
       style={props.style}

--- a/static/app/views/performance/newTraceDetails/traceRow/traceErrorRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceErrorRow.tsx
@@ -36,7 +36,7 @@ export function TraceErrorRow(props: TraceRowProps<TraceTreeNode<TraceTree.Trace
           : null
       }
       tabIndex={props.tabIndex}
-      className={`TraceRow ${props.rowSearchClassName} ${props.node.max_severity}`}
+      className={`TraceRow ${props.rowSearchClassName} ${props.node.maxIssueSeverity}`}
       onClick={props.onRowClick}
       onKeyDown={props.onRowKeyDown}
       style={props.style}

--- a/static/app/views/performance/newTraceDetails/traceRow/traceMissingInstrumentationRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceMissingInstrumentationRow.tsx
@@ -1,8 +1,9 @@
 import {t} from 'sentry/locale';
 
 import {TraceIcons} from '../traceIcons';
-import {makeTraceNodeBarColor, type TraceTree} from '../traceModels/traceTree';
+import type {TraceTree} from '../traceModels/traceTree';
 import type {TraceTreeNode} from '../traceModels/traceTreeNode';
+import {makeTraceNodeBarColor} from '../traceModels/traceTreeNodeUtils';
 import {MissingInstrumentationTraceBar} from '../traceRow/traceBar';
 import {
   maybeFocusTraceRow,

--- a/static/app/views/performance/newTraceDetails/traceRow/traceRootNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceRootNode.tsx
@@ -4,8 +4,9 @@ import {t} from 'sentry/locale';
 
 import {isTraceNode} from '../traceGuards';
 import {TraceIcons} from '../traceIcons';
-import {makeTraceNodeBarColor, type TraceTree} from '../traceModels/traceTree';
+import type {TraceTree} from '../traceModels/traceTree';
 import type {TraceTreeNode} from '../traceModels/traceTreeNode';
+import {makeTraceNodeBarColor} from '../traceModels/traceTreeNodeUtils';
 import {TraceBar} from '../traceRow/traceBar';
 import {
   maybeFocusTraceRow,
@@ -33,7 +34,7 @@ export function TraceRootRow(props: TraceRowProps<TraceTreeNode<TraceTree.Trace>
           : null
       }
       tabIndex={props.tabIndex}
-      className={`TraceRow ${props.rowSearchClassName} ${props.node.has_errors ? props.node.max_severity : ''}`}
+      className={`TraceRow ${props.rowSearchClassName} ${props.node.hasErrors ? props.node.maxIssueSeverity : ''}`}
       onClick={props.onRowClick}
       onKeyDown={props.onRowKeyDown}
       style={props.style}

--- a/static/app/views/performance/newTraceDetails/traceRow/traceRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceRow.tsx
@@ -4,8 +4,6 @@ import type {Theme} from '@emotion/react';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import type {PlatformKey} from 'sentry/types/project';
 
-import {isParentAutogroupedNode} from '../traceGuards';
-import {ParentAutogroupNode} from '../traceModels/parentAutogroupNode';
 import type {TraceTree} from '../traceModels/traceTree';
 import type {TraceTreeNode} from '../traceModels/traceTreeNode';
 import type {VirtualizedViewManager} from '../traceRenderers/virtualizedViewManager';
@@ -71,20 +69,7 @@ export function TraceRowConnectors(props: {
   manager: VirtualizedViewManager;
   node: TraceTreeNode<TraceTree.NodeValue>;
 }) {
-  const hasChildren =
-    (props.node.expanded || props.node.zoomedIn) && props.node.children.length > 0;
-  const showVerticalConnector =
-    hasChildren || (props.node.value && isParentAutogroupedNode(props.node));
-
-  // If the tail node of the collapsed node has no children,
-  // we don't want to render the vertical connector as no children
-  // are being rendered as the chain is entirely collapsed
-  const hideVerticalConnector =
-    showVerticalConnector &&
-    props.node.value &&
-    props.node instanceof ParentAutogroupNode &&
-    (!props.node.tail.children.length ||
-      (!props.node.tail.expanded && !props.node.expanded));
+  const hasChildren = props.node.children.length > 0;
 
   return (
     <Fragment>
@@ -97,18 +82,14 @@ export function TraceRowConnectors(props: {
                 Math.abs(Math.abs(c) - props.node.depth) * props.manager.row_depth_padding
               ),
             }}
-            className={`TraceVerticalConnector ${c < 0 ? 'Orphaned' : ''}`}
+            className={`TraceVerticalConnector ${c <= 0 ? 'Orphaned' : ''}`}
           />
         );
       })}
-      {showVerticalConnector && !hideVerticalConnector ? (
-        <span className="TraceExpandedVerticalConnector" />
-      ) : null}
+      {hasChildren ? <span className="TraceExpandedVerticalConnector" /> : null}
       {props.node.isLastChild ? (
         <span className="TraceVerticalLastChildConnector" />
-      ) : (
-        <span className="TraceVerticalConnector" />
-      )}
+      ) : null}
     </Fragment>
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
@@ -1,6 +1,7 @@
 import {TraceIcons} from '../traceIcons';
-import {makeTraceNodeBarColor, type TraceTree} from '../traceModels/traceTree';
+import type {TraceTree} from '../traceModels/traceTree';
 import type {TraceTreeNode} from '../traceModels/traceTreeNode';
+import {makeTraceNodeBarColor} from '../traceModels/traceTreeNodeUtils';
 import {TraceBar} from '../traceRow/traceBar';
 import {
   maybeFocusTraceRow,
@@ -22,7 +23,7 @@ export function TraceSpanRow(props: TraceRowProps<TraceTreeNode<TraceTree.Span>>
           : null
       }
       tabIndex={props.tabIndex}
-      className={`TraceRow ${props.rowSearchClassName} ${props.node.has_errors ? props.node.max_severity : ''}`}
+      className={`TraceRow ${props.rowSearchClassName} ${props.node.hasErrors ? props.node.maxIssueSeverity : ''}`}
       onClick={props.onRowClick}
       onKeyDown={props.onRowKeyDown}
       style={props.style}

--- a/static/app/views/performance/newTraceDetails/traceRow/traceTransactionRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceTransactionRow.tsx
@@ -1,8 +1,9 @@
 import {PlatformIcon} from 'platformicons';
 
 import {TraceIcons} from '../traceIcons';
-import {makeTraceNodeBarColor, type TraceTree} from '../traceModels/traceTree';
+import type {TraceTree} from '../traceModels/traceTree';
 import type {TraceTreeNode} from '../traceModels/traceTreeNode';
+import {makeTraceNodeBarColor} from '../traceModels/traceTreeNodeUtils';
 import {TraceBar} from '../traceRow/traceBar';
 import {
   maybeFocusTraceRow,
@@ -24,7 +25,7 @@ export function TraceTransactionRow(
           : null
       }
       tabIndex={props.tabIndex}
-      className={`TraceRow ${props.rowSearchClassName} ${props.node.has_errors ? props.node.max_severity : ''}`}
+      className={`TraceRow ${props.rowSearchClassName} ${props.node.hasErrors ? props.node.maxIssueSeverity : ''}`}
       onKeyDown={props.onRowKeyDown}
       onClick={props.onRowClick}
       style={props.style}


### PR DESCRIPTION
Splits helpers away from the trace tree model and move the logic so that it is logically grouped. I've removed some helpers that didnt make sense and I'll simplify the trace generating logic with better snapshotting as I dont like how convoluted it's become over time