### PR TITLE
fix(issues): Handle native frame jump to images loaded

### DIFF
--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -1,7 +1,6 @@
 import {Component, Fragment} from 'react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
-import scrollToElement from 'scroll-to-element';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import Tag from 'sentry/components/badge/tag';
@@ -30,6 +29,7 @@ import type {PlatformKey} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import withOrganization from 'sentry/utils/withOrganization';
 import withSentryAppComponents from 'sentry/utils/withSentryAppComponents';
+import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 
 import type DebugImage from '../debugMeta/debugImage';
 import {combineStatus} from '../debugMeta/utils';
@@ -204,12 +204,17 @@ export class DeprecatedLine extends Component<Props, State> {
         makeFilter(instructionAddr, addrMode, this.props.image)
       );
     }
-    scrollToElement('#images-loaded');
+
+    document
+      .getElementById(SectionKey.DEBUGMETA)
+      ?.scrollIntoView({block: 'start', behavior: 'smooth'});
   };
 
   scrollToSuspectRootCause = event => {
     event.stopPropagation(); // to prevent collapsing if collapsible
-    scrollToElement('#suspect-root-cause');
+    document
+      .getElementById(SectionKey.SUSPECT_ROOT_CAUSE)
+      ?.scrollIntoView({block: 'start', behavior: 'smooth'});
   };
 
   preventCollapse = evt => {

--- a/static/app/components/events/interfaces/frame/line/native.tsx
+++ b/static/app/components/events/interfaces/frame/line/native.tsx
@@ -1,12 +1,12 @@
 import {useContext} from 'react';
 import styled from '@emotion/styled';
-import scrollToElement from 'scroll-to-element';
 
 import {TraceEventDataSectionContext} from 'sentry/components/events/traceEventDataSection';
 import {t} from 'sentry/locale';
 import DebugMetaStore from 'sentry/stores/debugMetaStore';
 import {space} from 'sentry/styles/space';
 import type {Frame} from 'sentry/types/event';
+import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 
 import type DebugImage from '../../debugMeta/debugImage';
 import {combineStatus} from '../../debugMeta/utils';
@@ -92,7 +92,10 @@ export function Native({
     if (instructionAddr) {
       DebugMetaStore.updateFilter(makeFilter(instructionAddr));
     }
-    scrollToElement('#images-loaded');
+
+    document
+      .getElementById(SectionKey.DEBUGMETA)
+      ?.scrollIntoView({block: 'start', behavior: 'smooth'});
   }
 
   const shouldShowLinkToImage =

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -1,7 +1,6 @@
 import type {MouseEvent} from 'react';
 import {Fragment, useContext, useState} from 'react';
 import styled from '@emotion/styled';
-import scrollToElement from 'scroll-to-element';
 
 import Tag from 'sentry/components/badge/tag';
 import {Button} from 'sentry/components/button';
@@ -38,7 +37,11 @@ import type {
 } from 'sentry/types/integrations';
 import type {PlatformKey} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
+import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
 import withSentryAppComponents from 'sentry/utils/withSentryAppComponents';
+import {SectionKey, useEventDetails} from 'sentry/views/issueDetails/streamline/context';
+import {getFoldSectionKey} from 'sentry/views/issueDetails/streamline/foldSection';
+import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 import type DebugImage from './debugMeta/debugImage';
 import {combineStatus} from './debugMeta/utils';
@@ -101,6 +104,14 @@ function NativeFrame({
 }: Props) {
   const traceEventDataSectionContext = useContext(TraceEventDataSectionContext);
 
+  const {sectionData} = useEventDetails();
+  const debugSectionConfig = sectionData[SectionKey.DEBUGMETA];
+  const [_isCollapsed, setIsCollapsed] = useSyncedLocalStorageState(
+    getFoldSectionKey(SectionKey.DEBUGMETA),
+    debugSectionConfig?.initialCollapse ?? false
+  );
+  const hasStreamlinedUI = useHasStreamlinedUI();
+
   const absolute = traceEventDataSectionContext?.display.includes('absolute-addresses');
 
   const fullStackTrace = traceEventDataSectionContext?.fullStackTrace;
@@ -118,7 +129,9 @@ function NativeFrame({
   const packageClickable =
     !!frame.symbolicatorStatus &&
     frame.symbolicatorStatus !== SymbolicatorStatus.UNKNOWN_IMAGE &&
-    !isHoverPreviewed;
+    !isHoverPreviewed &&
+    // We know the debug section is rendered (only once streamline ui is enabled)
+    (hasStreamlinedUI ? !!debugSectionConfig : true);
 
   const leadsToApp = !frame.inApp && (nextFrame?.inApp || !nextFrame);
   const expandable =
@@ -229,6 +242,7 @@ function NativeFrame({
     }
   }
 
+  // This isn't possible when the page doesn't have the images loaded section
   function handleGoToImagesLoaded(e: MouseEvent) {
     e.stopPropagation(); // to prevent collapsing if collapsible
 
@@ -241,7 +255,15 @@ function NativeFrame({
       DebugMetaStore.updateFilter(searchTerm);
     }
 
-    scrollToElement('#images-loaded');
+    if (hasStreamlinedUI) {
+      // Expand the section
+      setIsCollapsed(false);
+    }
+
+    // Scroll to the section
+    document
+      .getElementById(SectionKey.DEBUGMETA)
+      ?.scrollIntoView({block: 'start', behavior: 'smooth'});
   }
 
   function handleToggleContext(e: MouseEvent) {


### PR DESCRIPTION
we changed the id to `debugmeta` so it no longer scrolled to the correct section. we can also fix a longstanding bug once streamline issue details is GA by detecting when images loaded aren't available. For example: the shared issue page

example of links appearing on the shared issue page that don't do anything
![image](https://github.com/user-attachments/assets/5da47659-4da1-4c27-a0f2-4a20a566d2d2)
