### PR TITLE
feat(issues): Add missing clojure prismjs extensions

### DIFF
--- a/static/app/utils/prism.tsx
+++ b/static/app/utils/prism.tsx
@@ -55,6 +55,12 @@ const EXTRA_LANGUAGE_ALIASES: Record<string, string> = {
   bundle: 'javascript',
   vue: 'javascript',
   svelte: 'javascript',
+  'js?': 'javascript',
+
+  // Clojure
+  clj: 'clojure',
+  cljc: 'clojure',
+  cljs: 'clojure',
 };
 
 export const getPrismLanguage = (lang: string) => {


### PR DESCRIPTION
Clojure appears to use more than just .clojure files which is the only file extension prism supports by default https://prismjs.com/#supported-languages

was using this query to find examples https://redash.getsentry.net/queries/7534/source

also adds confused js files