### PR TITLE
fix(issue-views): Fix query being overwritten on default tab

### DIFF
--- a/static/app/views/issueList/customViewsHeader.tsx
+++ b/static/app/views/issueList/customViewsHeader.tsx
@@ -156,6 +156,9 @@ function CustomViewsIssueListHeaderTabsContent({
 
   const getInitialTabKey = () => {
     if (draggableTabs[0].key.startsWith('default')) {
+      if (query) {
+        return TEMPORARY_TAB_KEY;
+      }
       return draggableTabs[0].key;
     }
     if (!query && !sort && !viewId) {


### PR DESCRIPTION
Fixes a bug where users were unable to load a query directly in the url query params if they were on a default view. 