### PR TITLE
fix: Use `force-cache` when fetching debug IDs

### DIFF
--- a/static/app/utils/getErrorDebugIds.ts
+++ b/static/app/utils/getErrorDebugIds.ts
@@ -33,7 +33,9 @@ export async function getErrorDebugIds(e: Error): Promise<{[filename: string]: s
     }
 
     try {
-      const text = await fetch(stackFrame.filename).then(res => res.text());
+      const text = await fetch(stackFrame.filename, {cache: 'force-cache'}).then(res =>
+        res.text()
+      );
       const debugIdMatch = text.match(/^\/\/# debugId=(\S+)/im);
 
       if (!debugIdMatch) {


### PR DESCRIPTION
When fetching JavaScript source files to get their debug IDs, we leave the cache setting as default which means:

- `default` — The browser looks for a matching request in its HTTP cache.
  - If there is a match and it is fresh, it will be returned from the cache.
  - If there is a match but it is stale, the browser will make a conditional request to the remote server. If the server indicates that the resource has not changed, it will be returned from the cache. Otherwise the resource will be downloaded from the server and the cache will be updated.
  - If there is no match, the browser will make a normal request, and will update the cache with the downloaded resource.

In the case of fetching debug IDs, we are not bothered about the cache match being fresh or stale. Regardless of the staleness, the source file in the cache is much more likely to be the code that is currently executing.

- `force-cache` — The browser looks for a matching request in its HTTP cache.
  - If there is a match, _fresh or stale_, it will be returned from the cache.
  - If there is no match, the browser will make a normal request, and will update the cache with the downloaded resource.

Using `force-cache` can result in less conditional requests checking if the source has changed.

Of course, Sentrys JavaScript assets might be so heavily cached that this makes little to no difference!