### PR TITLE
ref(quick-start): Add 'quick_start' analytics

### DIFF
--- a/static/app/components/onboardingWizard/task.tsx
+++ b/static/app/components/onboardingWizard/task.tsx
@@ -30,7 +30,7 @@ const recordAnalytics = (
   organization: Organization,
   action: string
 ) =>
-  trackAnalytics('onboarding.wizard_clicked', {
+  trackAnalytics('quick_start.task_card_clicked', {
     organization,
     todo_id: task.task,
     todo_title: task.title,

--- a/static/app/utils/analytics.tsx
+++ b/static/app/utils/analytics.tsx
@@ -10,6 +10,10 @@ import {
   type FeatureFlagEventParameters,
 } from 'sentry/utils/analytics/featureFlagAnalyticsEvents';
 import {
+  quickStartEventMap,
+  type QuickStartEventParameters,
+} from 'sentry/utils/analytics/quickStartAnalyticsEvents';
+import {
   statsEventMap,
   type StatsEventParameters,
 } from 'sentry/utils/analytics/statsAnalyticsEvents';
@@ -92,6 +96,7 @@ interface EventParameters
     SignupAnalyticsParameters,
     TracingEventParameters,
     StatsEventParameters,
+    QuickStartEventParameters,
     Record<string, Record<string, any>> {}
 
 const allEventMap: Record<string, string | null> = {
@@ -123,6 +128,7 @@ const allEventMap: Record<string, string | null> = {
   ...starfishEventMap,
   ...signupEventMap,
   ...statsEventMap,
+  ...quickStartEventMap,
 };
 
 /**

--- a/static/app/utils/analytics/quickStartAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/quickStartAnalyticsEvents.tsx
@@ -1,0 +1,13 @@
+export type QuickStartEventParameters = {
+  'quick_start.opened': {};
+  'quick_start.task_card_clicked': {
+    action: string;
+    todo_id: string;
+    todo_title: string;
+  };
+};
+
+export const quickStartEventMap: Record<keyof QuickStartEventParameters, string> = {
+  'quick_start.opened': 'Quick Start: Opened',
+  'quick_start.task_card_clicked': 'Quick Start: Task Card Clicked',
+};


### PR DESCRIPTION
We would like to have better descriptive events for the quick start guide. This PR introduces a new file containing a list of 2x analytics events, which will expand as we continue to replace the existing ones.

So far, we have updated the following events:

"onboarding.wizard_clicked" -> "quick_start.task_card_clicked"
"onboarding.wizard_opened" -> "quick_start.opened" (Previously, this event was also triggered when the sidebar was closed. This PR updates the logic only to trigger when opened.)

closes https://github.com/getsentry/sentry/issues/78454