### PR TITLE
ref(quick-start): Update 'project to set up' logic to default to the first project

### DIFF
--- a/static/app/components/onboardingWizard/onboardingProjectsCard.tsx
+++ b/static/app/components/onboardingWizard/onboardingProjectsCard.tsx
@@ -26,14 +26,12 @@ export default function OnboardingProjectsCard({
     });
   };
 
-  // TODO(Priscila): Reflect on this logic
   const selectedProjectSlug = onboardingContext.data.selectedSDK?.key;
 
   const project = selectedProjectSlug
     ? allProjects.find(p => p.slug === selectedProjectSlug)
-    : undefined;
+    : allProjects[0];
 
-  // Project selected during onboarding but not received first event
   const projectHasFirstEvent = !project?.firstEvent;
 
   if (!project || !projectHasFirstEvent) {


### PR DESCRIPTION
**Problem**  
In the quick start component, we only display "The Basics" if the user created a project during onboarding. However, users can skip onboarding and create a project afterward. In this case, the "New" UI card is not displayed.

**Solution**  
This PR updates the logic to default to the first created project.

**Note**  
While a user can create multiple projects, if the first project already has an event, they have likely completed this learning step. Therefore, defaulting to the first project is fine.

**Preview**
<img width="427" alt="image" src="https://github.com/user-attachments/assets/7de15590-ec39-43c1-8931-1eb7ddf04d9f">
