### PR TITLE
feat(onboarding): Remove unused next steps

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -170,7 +170,7 @@ export function OnboardingLayout({
         {nextSteps.length > 0 && (
           <Fragment>
             <Divider />
-            <h4>{t('Next Steps')}</h4>
+            <h4>{t('Additional Information')}</h4>
             <List symbol="bullet">
               {nextSteps
                 .filter((step): step is Exclude<typeof step, null> => step !== null)

--- a/static/app/gettingStartedDocs/apple/ios.tsx
+++ b/static/app/gettingStartedDocs/apple/ios.tsx
@@ -521,14 +521,6 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       description: t('Learn about our first class integration with SwiftUI.'),
       link: 'https://docs.sentry.io/platforms/apple/tracing/instrumentation/swiftui-instrumentation/',
     },
-    {
-      id: 'profiling',
-      name: t('Profiling'),
-      description: t(
-        'Collect and analyze performance profiles from real user devices in production.'
-      ),
-      link: 'https://docs.sentry.io/platforms/apple/profiling/',
-    },
   ],
 };
 

--- a/static/app/gettingStartedDocs/apple/macos.tsx
+++ b/static/app/gettingStartedDocs/apple/macos.tsx
@@ -215,14 +215,6 @@ const onboarding: OnboardingConfig = {
       description: t('Learn about our first class integration with SwiftUI.'),
       link: 'https://docs.sentry.io/platforms/apple/tracing/instrumentation/swiftui-instrumentation/',
     },
-    {
-      id: 'profiling',
-      name: t('Profiling'),
-      description: t(
-        'Collect and analyze performance profiles from real user devices in production.'
-      ),
-      link: 'https://docs.sentry.io/platforms/apple/profiling/',
-    },
   ],
 };
 

--- a/static/app/gettingStartedDocs/bun/bun.spec.tsx
+++ b/static/app/gettingStartedDocs/bun/bun.spec.tsx
@@ -28,8 +28,5 @@ describe('bun onboarding docs', function () {
     expect(
       screen.queryByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0,/))
     ).not.toBeInTheDocument();
-
-    // Renders next steps
-    expect(screen.getByRole('link', {name: 'Tracing'})).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/bun/bun.tsx
+++ b/static/app/gettingStartedDocs/bun/bun.tsx
@@ -92,19 +92,7 @@ const onboarding: OnboardingConfig = {
       ],
     },
   ],
-  nextSteps: params =>
-    params.isPerformanceSelected
-      ? []
-      : [
-          {
-            id: 'performance-monitoring',
-            name: t('Tracing'),
-            description: t(
-              'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
-            ),
-            link: 'https://docs.sentry.io/platforms/javascript/guides/bun/tracing/',
-          },
-        ],
+  nextSteps: () => [],
 };
 
 const customMetricsOnboarding: OnboardingConfig = {

--- a/static/app/gettingStartedDocs/capacitor/capacitor.tsx
+++ b/static/app/gettingStartedDocs/capacitor/capacitor.tsx
@@ -251,26 +251,6 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       ),
       link: 'https://docs.sentry.io/platforms/javascript/guides/capacitor/?#capacitor-2---android-specifics',
     },
-    params.isPerformanceSelected
-      ? null
-      : {
-          id: 'performance-monitoring',
-          name: t('Tracing'),
-          description: t(
-            'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
-          ),
-          link: 'https://docs.sentry.io/platforms/javascript/guides/capacitor/tracing/',
-        },
-    params.isReplaySelected
-      ? null
-      : {
-          id: 'session-replay',
-          name: t('Session Replay'),
-          description: t(
-            'Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.'
-          ),
-          link: 'https://docs.sentry.io/platforms/javascript/guides/capacitor/session-replay/',
-        },
   ],
 };
 

--- a/static/app/gettingStartedDocs/capacitor/capacitor.tsx
+++ b/static/app/gettingStartedDocs/capacitor/capacitor.tsx
@@ -242,7 +242,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       ],
     },
   ],
-  nextSteps: params => [
+  nextSteps: () => [
     {
       id: 'capacitor-android-setup',
       name: t('Capacitor 2 Setup'),

--- a/static/app/gettingStartedDocs/deno/deno.spec.tsx
+++ b/static/app/gettingStartedDocs/deno/deno.spec.tsx
@@ -28,8 +28,5 @@ describe('deno onboarding docs', function () {
     expect(
       screen.queryByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0,/))
     ).not.toBeInTheDocument();
-
-    // Renders next steps
-    expect(screen.getByRole('link', {name: 'Tracing'})).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/deno/deno.tsx
+++ b/static/app/gettingStartedDocs/deno/deno.tsx
@@ -101,19 +101,7 @@ const onboarding: OnboardingConfig = {
       ],
     },
   ],
-  nextSteps: params =>
-    params.isPerformanceSelected
-      ? []
-      : [
-          {
-            id: 'performance-monitoring',
-            name: t('Tracing'),
-            description: t(
-              'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
-            ),
-            link: 'https://docs.sentry.io/platforms/javascript/guides/bun/tracing/',
-          },
-        ],
+  nextSteps: () => [],
 };
 
 const customMetricsOnboarding: OnboardingConfig = {

--- a/static/app/gettingStartedDocs/java/java.tsx
+++ b/static/app/gettingStartedDocs/java/java.tsx
@@ -286,14 +286,6 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       description: t('Check out our sample applications.'),
       link: 'https://github.com/getsentry/sentry-java/tree/main/sentry-samples',
     },
-    {
-      id: 'performance-monitoring',
-      name: t('Tracing'),
-      description: t(
-        'Stay ahead of latency issues and trace every slow transaction to a poor-performing API call or database query.'
-      ),
-      link: 'https://docs.sentry.io/platforms/java/tracing/',
-    },
   ],
 };
 

--- a/static/app/gettingStartedDocs/java/spring-boot.tsx
+++ b/static/app/gettingStartedDocs/java/spring-boot.tsx
@@ -288,14 +288,6 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       description: t('Check out our sample applications.'),
       link: 'https://github.com/getsentry/sentry-java/tree/main/sentry-samples',
     },
-    {
-      id: 'performance-monitoring',
-      name: t('Tracing'),
-      description: t(
-        'Stay ahead of latency issues and trace every slow transaction to a poor-performing API call or database query.'
-      ),
-      link: 'https://docs.sentry.io/platforms/java/guides/spring-boot/tracing/',
-    },
   ],
 };
 

--- a/static/app/gettingStartedDocs/java/spring.tsx
+++ b/static/app/gettingStartedDocs/java/spring.tsx
@@ -361,14 +361,6 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       description: t('Check out our sample applications.'),
       link: 'https://github.com/getsentry/sentry-java/tree/main/sentry-samples',
     },
-    {
-      id: 'performance-monitoring',
-      name: t('Tracing'),
-      description: t(
-        'Stay ahead of latency issues and trace every slow transaction to a poor-performing API call or database query.'
-      ),
-      link: 'https://docs.sentry.io/platforms/java/guides/spring/tracing/',
-    },
   ],
 };
 

--- a/static/app/gettingStartedDocs/javascript/angular.tsx
+++ b/static/app/gettingStartedDocs/javascript/angular.tsx
@@ -31,7 +31,6 @@ import {
   getReplayConfigureDescription,
   getReplayVerifyStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
-import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 import {t, tct} from 'sentry/locale';
 
 export enum AngularConfigType {
@@ -248,30 +247,6 @@ function getVerifyConfiguration(): Configuration {
   };
 }
 
-const getNextStep = (
-  params: Params
-): {
-  description: string;
-  id: string;
-  link: string;
-  name: string;
-}[] => {
-  let nextStepDocs = [...nextSteps];
-
-  if (params.isPerformanceSelected) {
-    nextStepDocs = nextStepDocs.filter(
-      step => step.id !== ProductSolution.PERFORMANCE_MONITORING
-    );
-  }
-
-  if (params.isReplaySelected) {
-    nextStepDocs = nextStepDocs.filter(
-      step => step.id !== ProductSolution.SESSION_REPLAY
-    );
-  }
-  return nextStepDocs;
-};
-
 const getInstallConfig = () => [
   {
     language: 'bash',
@@ -374,33 +349,17 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       ],
     },
   ],
-  nextSteps: (params: Params) => getNextStep(params),
+  nextSteps: () => [
+    {
+      id: 'angular-features',
+      name: t('Angular Features'),
+      description: t(
+        'Learn about our first class integration with the Angular framework.'
+      ),
+      link: 'https://docs.sentry.io/platforms/javascript/guides/angular/features/',
+    },
+  ],
 };
-
-export const nextSteps = [
-  {
-    id: 'angular-features',
-    name: t('Angular Features'),
-    description: t('Learn about our first class integration with the Angular framework.'),
-    link: 'https://docs.sentry.io/platforms/javascript/guides/angular/features/',
-  },
-  {
-    id: 'performance-monitoring',
-    name: t('Tracing'),
-    description: t(
-      'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
-    ),
-    link: 'https://docs.sentry.io/platforms/javascript/guides/angular/tracing/',
-  },
-  {
-    id: 'session-replay',
-    name: t('Session Replay'),
-    description: t(
-      'Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.'
-    ),
-    link: 'https://docs.sentry.io/platforms/javascript/guides/angular/session-replay/',
-  },
-];
 
 const replayOnboarding: OnboardingConfig<PlatformOptions> = {
   install: () => [

--- a/static/app/gettingStartedDocs/javascript/astro.tsx
+++ b/static/app/gettingStartedDocs/javascript/astro.tsx
@@ -205,22 +205,6 @@ const onboarding: OnboardingConfig = {
       ),
       link: 'https://docs.sentry.io/platforms/javascript/guides/astro/manual-setup/',
     },
-    {
-      id: 'performance-monitoring',
-      name: t('Tracing'),
-      description: t(
-        'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/astro/tracing/',
-    },
-    {
-      id: 'session-replay',
-      name: t('Session Replay'),
-      description: t(
-        'Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/astro/session-replay/',
-    },
   ],
 };
 

--- a/static/app/gettingStartedDocs/javascript/ember.tsx
+++ b/static/app/gettingStartedDocs/javascript/ember.tsx
@@ -178,24 +178,7 @@ const onboarding: OnboardingConfig = {
       ],
     },
   ],
-  nextSteps: () => [
-    {
-      id: 'performance-monitoring',
-      name: t('Tracing'),
-      description: t(
-        'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/ember/tracing/',
-    },
-    {
-      id: 'session-replay',
-      name: t('Session Replay'),
-      description: t(
-        'Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/ember/session-replay/',
-    },
-  ],
+  nextSteps: () => [],
 };
 
 const replayOnboarding: OnboardingConfig = {

--- a/static/app/gettingStartedDocs/javascript/gatsby.tsx
+++ b/static/app/gettingStartedDocs/javascript/gatsby.tsx
@@ -208,24 +208,7 @@ const onboarding: OnboardingConfig = {
       ],
     },
   ],
-  nextSteps: () => [
-    {
-      id: 'performance-monitoring',
-      name: t('Tracing'),
-      description: t(
-        'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/gatsby/tracing/',
-    },
-    {
-      id: 'session-replay',
-      name: t('Session Replay'),
-      description: t(
-        'Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/gatsby/session-replay/',
-    },
-  ],
+  nextSteps: () => [],
 };
 
 const replayOnboarding: OnboardingConfig = {

--- a/static/app/gettingStartedDocs/javascript/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/javascript.tsx
@@ -253,34 +253,10 @@ const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
   verify: getVerifyConfig,
   nextSteps: () => [
     {
-      id: 'performance-monitoring',
-      name: t('Tracing'),
-      description: t(
-        'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/tracing/',
-    },
-    {
-      id: 'session-replay',
-      name: t('Session Replay'),
-      description: t(
-        'Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/session-replay/',
-    },
-    {
       id: 'source-maps',
       name: t('Source Maps'),
       description: t('Learn how to enable readable stack traces in your Sentry errors.'),
       link: 'https://docs.sentry.io/platforms/javascript/sourcemaps/',
-    },
-    {
-      id: 'sdk-configuration',
-      name: t('SDK Configuration'),
-      description: t(
-        'Learn about additional configuration options for the Javascript SDK.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/configuration/',
     },
   ],
   onPageLoad: params => {
@@ -367,24 +343,7 @@ const packageManagerOnboarding: OnboardingConfig<PlatformOptions> = {
     }),
   ],
   verify: getVerifyConfig,
-  nextSteps: () => [
-    {
-      id: 'performance-monitoring',
-      name: t('Tracing'),
-      description: t(
-        'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/tracing/',
-    },
-    {
-      id: 'session-replay',
-      name: t('Session Replay'),
-      description: t(
-        'Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/session-replay/',
-    },
-  ],
+  nextSteps: () => [],
   onPageLoad: params => {
     return () => {
       trackAnalytics('onboarding.js_loader_npm_docs_shown', {

--- a/static/app/gettingStartedDocs/javascript/react.tsx
+++ b/static/app/gettingStartedDocs/javascript/react.tsx
@@ -202,22 +202,6 @@ const onboarding: OnboardingConfig = {
       ),
       link: 'https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/',
     },
-    {
-      id: 'performance-monitoring',
-      name: t('Tracing'),
-      description: t(
-        'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/react/tracing/',
-    },
-    {
-      id: 'session-replay',
-      name: t('Session Replay'),
-      description: t(
-        'Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/react/session-replay/',
-    },
   ],
 };
 

--- a/static/app/gettingStartedDocs/javascript/solid.tsx
+++ b/static/app/gettingStartedDocs/javascript/solid.tsx
@@ -209,22 +209,6 @@ const onboarding: OnboardingConfig = {
       description: t('Learn about our first class integration with the Solid framework.'),
       link: 'https://docs.sentry.io/platforms/javascript/guides/solid/features/',
     },
-    {
-      id: 'performance-monitoring',
-      name: t('Tracing'),
-      description: t(
-        'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/solid/tracing/',
-    },
-    {
-      id: 'session-replay',
-      name: t('Session Replay'),
-      description: t(
-        'Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/solid/session-replay/',
-    },
   ],
 };
 

--- a/static/app/gettingStartedDocs/javascript/solidstart.tsx
+++ b/static/app/gettingStartedDocs/javascript/solidstart.tsx
@@ -388,22 +388,6 @@ const onboarding: OnboardingConfig = {
       description: t('Learn about our first class integration with the Solid framework.'),
       link: 'https://docs.sentry.io/platforms/javascript/guides/solid/features/',
     },
-    {
-      id: 'performance-monitoring',
-      name: t('Performance Monitoring'),
-      description: t(
-        'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/solid/tracing/',
-    },
-    {
-      id: 'session-replay',
-      name: t('Session Replay'),
-      description: t(
-        'Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/solid/session-replay/',
-    },
   ],
 };
 

--- a/static/app/gettingStartedDocs/javascript/svelte.tsx
+++ b/static/app/gettingStartedDocs/javascript/svelte.tsx
@@ -204,22 +204,6 @@ const onboarding: OnboardingConfig = {
       ),
       link: 'https://docs.sentry.io/platforms/javascript/guides/svelte/features/',
     },
-    {
-      id: 'performance-monitoring',
-      name: t('Tracing'),
-      description: t(
-        'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/svelte/tracing/',
-    },
-    {
-      id: 'session-replay',
-      name: t('Session Replay'),
-      description: t(
-        'Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.'
-      ),
-      link: 'https://docs.sentry.io/platforms/javascript/guides/svelte/session-replay/',
-    },
   ],
 };
 

--- a/static/app/gettingStartedDocs/javascript/vue.tsx
+++ b/static/app/gettingStartedDocs/javascript/vue.tsx
@@ -28,7 +28,6 @@ import {
   getReplayConfigureDescription,
   getReplayVerifyStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
-import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 import {t, tct} from 'sentry/locale';
 
 export enum VueVersion {

--- a/static/app/gettingStartedDocs/javascript/vue.tsx
+++ b/static/app/gettingStartedDocs/javascript/vue.tsx
@@ -122,30 +122,6 @@ const getInstallConfig = () => [
   },
 ];
 
-const getNextStep = (
-  params: Params
-): {
-  description: string;
-  id: string;
-  link: string;
-  name: string;
-}[] => {
-  let nextStepDocs = [...nextSteps];
-
-  if (params.isPerformanceSelected) {
-    nextStepDocs = nextStepDocs.filter(
-      step => step.id !== ProductSolution.PERFORMANCE_MONITORING
-    );
-  }
-
-  if (params.isReplaySelected) {
-    nextStepDocs = nextStepDocs.filter(
-      step => step.id !== ProductSolution.SESSION_REPLAY
-    );
-  }
-  return nextStepDocs;
-};
-
 const onboarding: OnboardingConfig<PlatformOptions> = {
   introduction: params => (
     <Fragment>
@@ -201,33 +177,15 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       ],
     },
   ],
-  nextSteps: params => getNextStep(params),
+  nextSteps: () => [
+    {
+      id: 'vue-features',
+      name: t('Vue Features'),
+      description: t('Learn about our first class integration with the Vue framework.'),
+      link: 'https://docs.sentry.io/platforms/javascript/guides/vue/features/',
+    },
+  ],
 };
-
-export const nextSteps = [
-  {
-    id: 'vue-features',
-    name: t('Vue Features'),
-    description: t('Learn about our first class integration with the Vue framework.'),
-    link: 'https://docs.sentry.io/platforms/javascript/guides/vue/features/',
-  },
-  {
-    id: 'performance-monitoring',
-    name: t('Tracing'),
-    description: t(
-      'Track down transactions to connect the dots between 10-second page loads and poor-performing API calls or slow database queries.'
-    ),
-    link: 'https://docs.sentry.io/platforms/javascript/guides/vue/tracing/',
-  },
-  {
-    id: 'session-replay',
-    name: t('Session Replay'),
-    description: t(
-      'Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay on your web application.'
-    ),
-    link: 'https://docs.sentry.io/platforms/javascript/guides/vue/session-replay/',
-  },
-];
 
 function getSiblingImportsSetupConfiguration(siblingOption: string): string {
   switch (siblingOption) {

--- a/static/app/gettingStartedDocs/kotlin/kotlin.tsx
+++ b/static/app/gettingStartedDocs/kotlin/kotlin.tsx
@@ -263,14 +263,6 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       description: t('Check out our sample applications.'),
       link: 'https://github.com/getsentry/sentry-java/tree/main/sentry-samples',
     },
-    {
-      id: 'performance-monitoring',
-      name: t('Tracing'),
-      description: t(
-        'Stay ahead of latency issues and trace every slow transaction to a poor-performing API call or database query.'
-      ),
-      link: 'https://docs.sentry.io/platforms/java/tracing/',
-    },
   ],
 };
 


### PR DESCRIPTION
These next steps had inconsistent conditional logic based on the product selection.
It was confusing and, at that point of onboarding, just a distraction.
We hooked up analytics, and the click rate was around 1%.
This PR removes the docs links for additional products and keeps relevant information there (like integration to React Router).
## Before
![CleanShot 2024-10-02 at 13 31 12](https://github.com/user-attachments/assets/99b18b09-f37f-4a2a-847c-4d773c55e9d0)

## After
![CleanShot 2024-10-02 at 13 31 39](https://github.com/user-attachments/assets/2bf9107e-8821-42d0-90bf-ad486bb14b1e)

Closes https://github.com/getsentry/sentry/issues/78322