### PR TITLE
feat(dashboards): Adds a background and shadow hover effect to dashboard widgets

### DIFF
--- a/static/app/views/dashboards/metrics/widgetCard.tsx
+++ b/static/app/views/dashboards/metrics/widgetCard.tsx
@@ -220,6 +220,7 @@ export function MetricWidgetCard({
                   location={location}
                   onDelete={onDelete}
                   onDuplicate={onDuplicate}
+                  title={widget.title || widgetMQL}
                 />
               </WidgetCardContextMenuContainer>
             )}

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -523,6 +523,14 @@ export const WidgetCardPanel = styled(Panel, {
       width: 1px;
     }
   }
+
+  :hover {
+    background-color: ${p => p.theme.surface200};
+    transition:
+      background-color 100ms linear,
+      box-shadow 100ms linear;
+    box-shadow: ${p => p.theme.dropShadowLight};
+  }
 `;
 
 const StoredDataAlert = styled(Alert)`

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -1,3 +1,4 @@
+import type React from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
@@ -54,7 +55,7 @@ type Props = {
   seriesResultsType?: Record<string, AggregationOutputType>;
   showContextMenu?: boolean;
   tableData?: TableDataWithTitle[];
-  title?: string;
+  title?: string | React.ReactNode;
   totalIssuesCount?: string;
 };
 
@@ -117,6 +118,29 @@ function WidgetCardContextMenu({
                       {t('Indexed')}
                     </SampledTag>
                   )}
+                {title && (
+                  <Tooltip
+                    title={
+                      <span>
+                        <WidgetTooltipTitle>{title}</WidgetTooltipTitle>
+                        {description && (
+                          <WidgetTooltipDescription>
+                            {description}
+                          </WidgetTooltipDescription>
+                        )}
+                      </span>
+                    }
+                    containerDisplayMode="grid"
+                    isHoverable
+                  >
+                    <WidgetTooltipButton
+                      aria-label={t('Widget description')}
+                      borderless
+                      size="xs"
+                      icon={<IconInfo />}
+                    />
+                  </Tooltip>
+                )}
                 <StyledDropdownMenuControl
                   items={[
                     {


### PR DESCRIPTION
Adds a background and shadow hover effect to dashboard widgets.
Also fixes tooltip not displaying for metric and preview widgets.
![image](https://github.com/user-attachments/assets/39a44376-14bc-4558-a8f9-60a5aa957934)
