### PR TITLE
fix(uptime): Default method to `GET`

### DIFF
--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -153,7 +153,7 @@ export function UptimeAlertForm({project, handleDelete, rule}: Props) {
             <SelectField
               name="method"
               label={t('Method')}
-              placeholder={'GET'}
+              defaultValue="GET"
               options={HTTP_METHOD_OPTIONS.map(option => ({
                 value: option,
                 label: option,


### PR DESCRIPTION
Prior to this it had a placeholder that looked like a default