### PR TITLE
feat(integrations): Introduce common abstraction for messaging SLOs

### DIFF
--- a/src/sentry/integrations/discord/webhooks/command.py
+++ b/src/sentry/integrations/discord/webhooks/command.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from rest_framework.response import Response
 
 from sentry.integrations.discord.requests.base import DiscordRequest
+from sentry.integrations.discord.spec import DiscordMessagingSpec
 from sentry.integrations.discord.utils import logger
 from sentry.integrations.discord.views.link_identity import build_linking_url
 from sentry.integrations.discord.views.unlink_identity import build_unlinking_url
@@ -15,6 +16,7 @@ from sentry.integrations.messaging.commands import (
     MessagingIntegrationCommand,
     MessagingIntegrationCommandDispatcher,
 )
+from sentry.integrations.messaging.spec import MessagingIntegrationSpec
 
 LINK_USER_MESSAGE = "[Click here]({url}) to link your Discord account to your Sentry account."
 ALREADY_LINKED_MESSAGE = "You are already linked to the Sentry account with email: `{email}`."
@@ -58,6 +60,10 @@ class DiscordCommandHandler(DiscordInteractionHandler):
 @dataclass(frozen=True)
 class DiscordCommandDispatcher(MessagingIntegrationCommandDispatcher[str]):
     request: DiscordRequest
+
+    @property
+    def integration_spec(self) -> MessagingIntegrationSpec:
+        return DiscordMessagingSpec()
 
     @property
     def command_handlers(

--- a/src/sentry/integrations/messaging/commands.py
+++ b/src/sentry/integrations/messaging/commands.py
@@ -4,6 +4,12 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import Generic, TypeVar
 
+from sentry.integrations.messaging.metrics import (
+    MessagingInteractionEvent,
+    MessagingInteractionType,
+)
+from sentry.integrations.messaging.spec import MessagingIntegrationSpec
+
 
 @dataclass(frozen=True, eq=True)
 class CommandInput:
@@ -45,11 +51,20 @@ class CommandSlug:
 
 
 class MessagingIntegrationCommand:
-    def __init__(self, name: str, command_text: str, aliases: Iterable[str] = ()) -> None:
+    def __init__(
+        self,
+        interaction_type: MessagingInteractionType,
+        command_text: str,
+        aliases: Iterable[str] = (),
+    ) -> None:
         super().__init__()
-        self.name = name
+        self.interaction_type = interaction_type
         self.command_slug = CommandSlug(command_text)
         self.aliases = frozenset(CommandSlug(alias) for alias in aliases)
+
+    @property
+    def name(self) -> str:
+        return self.interaction_type.value
 
     @staticmethod
     def _to_tokens(text: str) -> tuple[str, ...]:
@@ -61,11 +76,27 @@ class MessagingIntegrationCommand:
 
 
 MESSAGING_INTEGRATION_COMMANDS = (
-    HELP := MessagingIntegrationCommand("HELP", "help", aliases=("", "support", "docs")),
-    LINK_IDENTITY := MessagingIntegrationCommand("LINK_IDENTITY", "link"),
-    UNLINK_IDENTITY := MessagingIntegrationCommand("UNLINK_IDENTITY", "unlink"),
-    LINK_TEAM := MessagingIntegrationCommand("LINK_TEAM", "link team"),
-    UNLINK_TEAM := MessagingIntegrationCommand("UNLINK_TEAM", "unlink team"),
+    HELP := MessagingIntegrationCommand(
+        MessagingInteractionType.HELP,
+        "help",
+        aliases=("", "support", "docs"),
+    ),
+    LINK_IDENTITY := MessagingIntegrationCommand(
+        MessagingInteractionType.LINK_IDENTITY,
+        "link",
+    ),
+    UNLINK_IDENTITY := MessagingIntegrationCommand(
+        MessagingInteractionType.UNLINK_IDENTITY,
+        "unlink",
+    ),
+    LINK_TEAM := MessagingIntegrationCommand(
+        MessagingInteractionType.LINK_TEAM,
+        "link team",
+    ),
+    UNLINK_TEAM := MessagingIntegrationCommand(
+        MessagingInteractionType.UNLINK_TEAM,
+        "unlink team",
+    ),
 )
 
 R = TypeVar("R")  # response
@@ -76,28 +107,45 @@ class MessagingIntegrationCommandDispatcher(Generic[R], ABC):
 
     @property
     @abstractmethod
+    def integration_spec(self) -> MessagingIntegrationSpec:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
     def command_handlers(
         self,
     ) -> Iterable[tuple[MessagingIntegrationCommand, Callable[[CommandInput], R]]]:
         raise NotImplementedError
 
+    def get_event(self, command: MessagingIntegrationCommand) -> MessagingInteractionEvent:
+        return MessagingInteractionEvent(
+            interaction_type=command.interaction_type, spec=self.integration_spec
+        )
+
     def dispatch(self, cmd_input: CommandInput) -> R:
+        @dataclass(frozen=True)
+        class CandidateHandler:
+            command: MessagingIntegrationCommand
+            slug: CommandSlug
+            callback: Callable[[CommandInput], R]
+
+            def parsing_order(self) -> int:
+                # Sort by descending length of arg tokens. If one slug is a prefix of
+                # another (e.g., "link" and "link team"), we must check for the longer
+                # one first.
+                return -len(self.slug.tokens)
+
         candidate_handlers = [
-            (slug, callback)
+            CandidateHandler(command, slug, callback)
             for (command, callback) in self.command_handlers
             for slug in command.get_all_command_slugs()
         ]
+        candidate_handlers.sort(key=CandidateHandler.parsing_order)
 
-        def parsing_order(handler: tuple[CommandSlug, Callable[[CommandInput], R]]) -> int:
-            # Sort by descending length of arg tokens. If one slug is a prefix of
-            # another (e.g., "link" and "link team"), we must check for the longer
-            # one first.
-            slug, _ = handler
-            return -len(slug.tokens)
+        for handler in candidate_handlers:
+            if handler.slug.does_match(cmd_input):
+                arg_input = cmd_input.adjust(handler.slug)
+                with self.get_event(handler.command).capture(assume_success=False):
+                    return handler.callback(arg_input)
 
-        candidate_handlers.sort(key=parsing_order)
-        for (slug, callback) in candidate_handlers:
-            if slug.does_match(cmd_input):
-                arg_input = cmd_input.adjust(slug)
-                return callback(arg_input)
         raise CommandNotMatchedError(f"{cmd_input=!r}", cmd_input)

--- a/src/sentry/integrations/messaging/metrics.py
+++ b/src/sentry/integrations/messaging/metrics.py
@@ -59,8 +59,6 @@ class MessagingInteractionEvent(EventLifecycleMetric):
 
     def get_extras(self) -> Mapping[str, Any]:
         return {
-            "interaction_type": self.interaction_type.value,
-            "provider": self.spec.provider_slug,
             "user_id": (self.user.id if self.user else None),
             "organization_id": (self.organization.id if self.organization else None),
         }

--- a/src/sentry/integrations/messaging/metrics.py
+++ b/src/sentry/integrations/messaging/metrics.py
@@ -45,20 +45,17 @@ class MessagingInteractionEvent(EventLifecycleMetric):
     interaction_type: MessagingInteractionType
     spec: MessagingIntegrationSpec
 
-    # We can cram various optional attributes here if we want to capture them in logs
+    # Optional attributes to populate extras
     user: User | RpcUser | None = None
     organization: Organization | RpcOrganization | None = None
 
     def get_key(self, outcome: EventLifecycleOutcome) -> str:
-        # For now, creating a new namespace (with an "slo" token) to avoid clashing
-        # with existing keys. When we settle on an approach we like, this could
-        # replace or combine with existing metrics keys.
-        tag_tokens = ["sentry", "integrations", "messaging", "slo"]  # TODO: Change these?
-
-        tag_tokens += [
-            str(token) for token in [self.spec.provider_slug, self.interaction_type, outcome]
-        ]
-        return ".".join(tag_tokens)
+        return self.get_standard_key(
+            domain="messaging",
+            integration_name=self.spec.provider_slug,
+            interaction_type=str(self.interaction_type),
+            outcome=outcome,
+        )
 
     def get_extras(self) -> Mapping[str, Any]:
         return {

--- a/src/sentry/integrations/messaging/metrics.py
+++ b/src/sentry/integrations/messaging/metrics.py
@@ -1,0 +1,69 @@
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from sentry.integrations.messaging.spec import MessagingIntegrationSpec
+from sentry.integrations.utils.metrics import EventLifecycleMetric, EventLifecycleOutcome
+from sentry.models.organization import Organization
+from sentry.organizations.services.organization import RpcOrganization
+from sentry.users.models import User
+from sentry.users.services.user import RpcUser
+
+
+class MessagingInteractionType(Enum):
+    """A way in which a user can interact with Sentry through a messaging app."""
+
+    # General interactions
+    HELP = "HELP"
+    LINK_IDENTITY = "LINK_IDENTITY"
+    UNLINK_IDENTITY = "UNLINK_IDENTITY"
+    LINK_TEAM = "LINK_TEAM"
+    UNLINK_TEAM = "UNLINK_TEAM"
+
+    # Interactions on Issues
+    STATUS = "STATUS"
+    ARCHIVE_DIALOG = "ARCHIVE_DIALOG"
+    ARCHIVE = "ARCHIVE"
+    ASSIGN_DIALOG = "ASSIGN_DIALOG"
+    ASSIGN = "ASSIGN"
+    UNASSIGN = "ASSIGN"
+    RESOLVE_DIALOG = "RESOLVE_DIALOG"
+    RESOLVE = "RESOLVE"
+    UNRESOLVE = "UNRESOLVE"
+    IGNORE = "IGNORE"
+    MARK_ONGOING = "MARK_ONGOING"
+
+    def __str__(self) -> str:
+        return self.value.lower()
+
+
+@dataclass
+class MessagingInteractionEvent(EventLifecycleMetric):
+    """An instance to be recorded of a user interacting through a messaging app."""
+
+    interaction_type: MessagingInteractionType
+    spec: MessagingIntegrationSpec
+
+    # We can cram various optional attributes here if we want to capture them in logs
+    user: User | RpcUser | None = None
+    organization: Organization | RpcOrganization | None = None
+
+    def get_key(self, outcome: EventLifecycleOutcome) -> str:
+        # For now, creating a new namespace (with an "slo" token) to avoid clashing
+        # with existing keys. When we settle on an approach we like, this could
+        # replace or combine with existing metrics keys.
+        tag_tokens = ["sentry", "integrations", "messaging", "slo"]  # TODO: Change these?
+
+        tag_tokens += [
+            str(token) for token in [self.spec.provider_slug, self.interaction_type, outcome]
+        ]
+        return ".".join(tag_tokens)
+
+    def get_extras(self) -> Mapping[str, Any]:
+        return {
+            "interaction_type": self.interaction_type.value,
+            "provider": self.spec.provider_slug,
+            "user_id": (self.user.id if self.user else None),
+            "organization_id": (self.organization.id if self.organization else None),
+        }

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -28,8 +28,13 @@ from sentry.integrations.messaging.commands import (
     MessagingIntegrationCommand,
     MessagingIntegrationCommandDispatcher,
 )
+from sentry.integrations.messaging.metrics import (
+    MessagingInteractionEvent,
+    MessagingInteractionType,
+)
+from sentry.integrations.messaging.spec import MessagingIntegrationSpec
 from sentry.integrations.msteams import parsing
-from sentry.integrations.msteams.spec import PROVIDER
+from sentry.integrations.msteams.spec import PROVIDER, MsTeamsMessagingSpec
 from sentry.integrations.services.integration import integration_service
 from sentry.models.activity import ActivityIntegration
 from sentry.models.apikey import ApiKey
@@ -455,22 +460,21 @@ class MsTeamsWebhookEndpoint(Endpoint):
             action_data = {"assignedTo": ""}
         return action_data
 
+    _ACTION_TYPES = {
+        ACTION_TYPE.RESOLVE: ("resolve", MessagingInteractionType.RESOLVE),
+        ACTION_TYPE.IGNORE: ("ignore", MessagingInteractionType.IGNORE),
+        ACTION_TYPE.ASSIGN: ("assign", MessagingInteractionType.ASSIGN),
+        ACTION_TYPE.UNRESOLVE: ("unresolve", MessagingInteractionType.UNRESOLVE),
+        ACTION_TYPE.UNASSIGN: ("unassign", MessagingInteractionType.UNASSIGN),
+    }
+
     def _issue_state_change(self, group: Group, identity: RpcIdentity, data) -> Response:
         event_write_key = ApiKey(
             organization_id=group.project.organization_id, scope_list=["event:write"]
         )
 
-        # undoing the enum structure of ACTION_TYPE to
-        # get a more sensible analytics_event
-        action_types = {
-            ACTION_TYPE.RESOLVE: "resolve",
-            ACTION_TYPE.IGNORE: "ignore",
-            ACTION_TYPE.ASSIGN: "assign",
-            ACTION_TYPE.UNRESOLVE: "unresolve",
-            ACTION_TYPE.UNASSIGN: "unassign",
-        }
         action_data = self._make_action_data(data, identity.user_id)
-        status = action_types[data["payload"]["actionType"]]
+        status, interaction_type = self._ACTION_TYPES[data["payload"]["actionType"]]
         analytics_event = f"integrations.msteams.{status}"
         analytics.record(
             analytics_event,
@@ -478,13 +482,19 @@ class MsTeamsWebhookEndpoint(Endpoint):
             organization_id=group.project.organization.id,
         )
 
-        return client.put(
-            path=f"/projects/{group.project.organization.slug}/{group.project.slug}/issues/",
-            params={"id": group.id},
-            data=action_data,
-            user=user_service.get_user(user_id=identity.user_id),
-            auth=event_write_key,
-        )
+        with MessagingInteractionEvent(
+            interaction_type, MsTeamsMessagingSpec()
+        ).capture() as lifecycle:
+            response = client.put(
+                path=f"/projects/{group.project.organization.slug}/{group.project.slug}/issues/",
+                params={"id": group.id},
+                data=action_data,
+                user=user_service.get_user(user_id=identity.user_id),
+                auth=event_write_key,
+            )
+            if response.status_code >= 400:
+                lifecycle.record_failure()
+            return response
 
     def _handle_action_submitted(self, request: Request) -> Response:
         # pull out parameters
@@ -625,6 +635,10 @@ class MsTeamsWebhookEndpoint(Endpoint):
 @dataclass(frozen=True)
 class MsTeamsCommandDispatcher(MessagingIntegrationCommandDispatcher[AdaptiveCard]):
     data: dict[str, Any]
+
+    @property
+    def integration_spec(self) -> MessagingIntegrationSpec:
+        return MsTeamsMessagingSpec()
 
     @property
     def conversation_id(self) -> str:

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -25,6 +25,10 @@ from sentry.api.client import ApiClient
 from sentry.api.helpers.group_index import update_groups
 from sentry.auth.access import from_member
 from sentry.exceptions import UnableToAcceptMemberInvitationException
+from sentry.integrations.messaging.metrics import (
+    MessagingInteractionEvent,
+    MessagingInteractionType,
+)
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.slack.message_builder.issues import SlackIssuesMessageBuilder
 from sentry.integrations.slack.metrics import (
@@ -34,6 +38,7 @@ from sentry.integrations.slack.metrics import (
 from sentry.integrations.slack.requests.action import SlackActionRequest
 from sentry.integrations.slack.requests.base import SlackRequestError
 from sentry.integrations.slack.sdk_client import SlackSdkClient
+from sentry.integrations.slack.spec import SlackMessagingSpec
 from sentry.integrations.slack.utils.errors import MODAL_NOT_FOUND, unpack_slack_api_error
 from sentry.integrations.types import ExternalProviderEnum
 from sentry.integrations.utils.scope import bind_org_context_from_integration
@@ -44,6 +49,7 @@ from sentry.models.rule import Rule
 from sentry.notifications.services import notifications_service
 from sentry.notifications.utils.actions import BlockKitMessageAction, MessageAction
 from sentry.shared_integrations.exceptions import ApiError
+from sentry.users.models import User
 from sentry.users.services.user import RpcUser
 from sentry.utils import metrics
 
@@ -431,23 +437,33 @@ class SlackActionEndpoint(Endpoint):
         # response_url later to update it.
         defer_attachment_update = False
 
+        def record_event(interaction_type: MessagingInteractionType) -> MessagingInteractionEvent:
+            user = request.user
+            return MessagingInteractionEvent(
+                interaction_type,
+                SlackMessagingSpec(),
+                user=(user if isinstance(user, User) else None),
+                organization=(group.project.organization if group else None),
+            )
+
         # Handle interaction actions
         for action in action_list:
             try:
-                if action.name in (
-                    "status",
-                    "unresolved:ongoing",
-                ):
-                    self.on_status(request, identity_user, group, action)
+                if action.name in ("status", "unresolved:ongoing"):
+                    with record_event(MessagingInteractionType.STATUS).capture():
+                        self.on_status(request, identity_user, group, action)
                 elif (
                     action.name == "assign"
                 ):  # TODO: remove this as it is replaced by the options-load endpoint
-                    self.on_assign(request, identity_user, group, action)
+                    with record_event(MessagingInteractionType.ASSIGN).capture():
+                        self.on_assign(request, identity_user, group, action)
                 elif action.name == "resolve_dialog":
-                    _ResolveDialog().open_dialog(slack_request, group)
+                    with record_event(MessagingInteractionType.RESOLVE_DIALOG).capture():
+                        _ResolveDialog().open_dialog(slack_request, group)
                     defer_attachment_update = True
                 elif action.name == "archive_dialog":
-                    _ArchiveDialog().open_dialog(slack_request, group)
+                    with record_event(MessagingInteractionType.ARCHIVE_DIALOG).capture():
+                        _ArchiveDialog().open_dialog(slack_request, group)
                     defer_attachment_update = True
             except client.ApiError as error:
                 return self.api_error(slack_request, group, identity_user, error, action.name)

--- a/src/sentry/integrations/slack/webhooks/base.py
+++ b/src/sentry/integrations/slack/webhooks/base.py
@@ -16,12 +16,14 @@ from sentry.integrations.messaging.commands import (
     MessagingIntegrationCommand,
     MessagingIntegrationCommandDispatcher,
 )
+from sentry.integrations.messaging.spec import MessagingIntegrationSpec
 from sentry.integrations.slack.message_builder.help import SlackHelpMessageBuilder
 from sentry.integrations.slack.metrics import (
     SLACK_WEBHOOK_DM_ENDPOINT_FAILURE_DATADOG_METRIC,
     SLACK_WEBHOOK_DM_ENDPOINT_SUCCESS_DATADOG_METRIC,
 )
 from sentry.integrations.slack.requests.base import SlackDMRequest, SlackRequestError
+from sentry.integrations.slack.spec import SlackMessagingSpec
 from sentry.utils import metrics
 
 LINK_USER_MESSAGE = (
@@ -126,6 +128,10 @@ class SlackDMEndpoint(Endpoint, abc.ABC):
 class SlackCommandDispatcher(MessagingIntegrationCommandDispatcher[Response]):
     endpoint: SlackDMEndpoint
     request: SlackDMRequest
+
+    @property
+    def integration_spec(self) -> MessagingIntegrationSpec:
+        return SlackMessagingSpec()
 
     @property
     def command_handlers(

--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -91,13 +91,13 @@ class EventLifecycleStateError(Exception):
 class EventLifecycle:
     """Context object that measures an event that may succeed or fail.
 
-    The `assume_success` attribute can be set to False for events that may or may not
-    have a soft failure condition (that is, if investigating the event's exit
-    condition is still a to-do item). In this state, if the program exits the context
-    without `record_success` or `record_failure` being called first, it will log the
-    outcome "halt" in place of "success" or "failure". A "halt" outcome should be
-    understood to mean, "No exception was logged and the event presumably succeeded,
-    but there may have been a soft failure."
+    The `assume_success` attribute can be set to False for events where exiting the
+    context may or may not represent a failure condition. In this state,
+    if the program exits the context without `record_success` or `record_failure`
+    being called first, it will log the outcome "halted" in place of "success" or
+    "failure". "Halted" could mean that we received an ambiguous exception from a
+    remote service that may have been caused either by a bug or user error, or merely
+    that inserting `record_failure` calls is still a dev to-do item.
     """
 
     def __init__(self, payload: EventLifecycleMetric, assume_success: bool = True) -> None:

--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -105,7 +105,9 @@ class EventLifecycle:
         self.assume_success = assume_success
         self._state: EventLifecycleOutcome | None = None
 
-    def record_event(self, outcome: EventLifecycleOutcome, exc: BaseException | None) -> None:
+    def record_event(
+        self, outcome: EventLifecycleOutcome, exc: BaseException | None = None
+    ) -> None:
         """Record a starting or halting event.
 
         This method is public so that unit tests may mock it, but it should be called
@@ -155,7 +157,7 @@ class EventLifecycle:
         `record_failure` on the context object.
         """
 
-        self._terminate(EventLifecycleOutcome.FAILURE)
+        self._terminate(EventLifecycleOutcome.FAILURE, exc)
 
     def __enter__(self) -> Self:
         if self._state is not None:

--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -1,0 +1,147 @@
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from enum import Enum
+from types import TracebackType
+from typing import Any, Self
+
+from django.conf import settings
+
+from sentry.utils import metrics
+
+
+class EventLifecycleOutcome(Enum):
+    STARTED = "STARTED"
+    HALTED = "HALTED"
+    SUCCESS = "SUCCESS"
+    FAILURE = "FAILURE"
+
+    def __str__(self) -> str:
+        return self.value.lower()
+
+
+class EventLifecycleMetric(ABC):
+    """Information about an event to be measured.
+
+    This class is intended to be used across different integrations that share the
+    same business concern. Generally a subclass would represent one business concern
+    (such as MessagingInteractionEvent, which extends this class and is used in the
+    `slack`, `msteams`, and `discord` integration packages).
+    """
+
+    @abstractmethod
+    def get_key(self, outcome: EventLifecycleOutcome) -> str:
+        """Construct the metrics key that will represent this event."""
+        raise NotImplementedError
+
+    def get_extras(self) -> Mapping[str, Any]:
+        """Get extra data to log."""
+        return {}
+
+    def capture(self, assume_success: bool = True) -> "EventLifecycle":
+        """Open a context to measure the event."""
+        return EventLifecycle(self, assume_success)
+
+
+class EventLifecycleStateError(Exception):
+    pass
+
+
+class EventLifecycle:
+    """Context object that measures an event that may succeed or fail.
+
+    The `assume_success` attribute can be set to False for events that may or may not
+    have a soft failure condition (that is, if investigating the event's exit
+    condition is still a to-do item). In this state, if the program exits the context
+    without `record_success` or `record_failure` being called first, it will log the
+    outcome "halt" in place of "success" or "failure". A "halt" outcome should be
+    understood to mean, "No exception was logged and the event presumably succeeded,
+    but there may have been a soft failure."
+    """
+
+    def __init__(self, payload: EventLifecycleMetric, assume_success: bool = True) -> None:
+        self.payload = payload
+        self.assume_success = assume_success
+        self._state: EventLifecycleOutcome | None = None
+
+    def record_event(self, outcome: EventLifecycleOutcome) -> None:
+        """Record a starting or halting event.
+
+        This method is public so that unit tests may mock it, but it should be called
+        only by the other "record" methods.
+        """
+
+        key = self.payload.get_key(outcome)
+        sample_rate = (
+            1.0 if outcome == EventLifecycleOutcome.FAILURE else settings.SENTRY_METRICS_SAMPLE_RATE
+        )
+
+        # For now, assume that all cases want to increment metrics. Future cases may
+        # also want to write to a logger, which we may want to control from the
+        # EventLifecycleMetric object.
+        metrics.incr(key, sample_rate=sample_rate)
+
+    def _terminate(self, new_state: EventLifecycleOutcome) -> None:
+        if self._state is None:
+            raise EventLifecycleStateError("The lifecycle has not yet been entered")
+        if self._state != EventLifecycleOutcome.STARTED:
+            raise EventLifecycleStateError("The lifecycle has already been exited")
+        self._state = new_state
+        self.record_event(new_state)
+
+    def record_success(self) -> None:
+        """Record that the event halted successfully.
+
+        Exiting the context without raising an exception will call this method
+        automatically, unless the context was initialized with `assume_success` set
+        to False.
+        """
+
+        self._terminate(EventLifecycleOutcome.SUCCESS)
+
+    def record_failure(self, exc: BaseException | None = None) -> None:
+        """Record that the event halted in failure.
+
+        There is no need to call this method directly if an exception is raised from
+        inside the context. It will be called automatically when exiting the context
+        on an exception.
+
+        This method should be called if we return a soft failure from the event. For
+        example, if we receive an error status from a remote service and gracefully
+        display an error response to the user, it would be necessary to manually call
+        `record_failure` on the context object.
+        """
+
+        # TODO: Capture information from `exc`?
+
+        self._terminate(EventLifecycleOutcome.FAILURE)
+
+    def __enter__(self) -> Self:
+        if self._state is not None:
+            raise EventLifecycleStateError("The lifecycle has already been entered")
+        self._state = EventLifecycleOutcome.STARTED
+        self.record_event(EventLifecycleOutcome.STARTED)
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType,
+    ) -> None:
+        if self._state != EventLifecycleOutcome.STARTED:
+            # The context called record_success or record_failure being closing,
+            # so we can just exit quietly.
+            return
+
+        if exc_value is not None:
+            # We were forced to exit the context by a raised exception.
+            self.record_failure(exc_value)
+        else:
+            # We exited the context without record_success or record_failure being
+            # called. Assume success if we were told to do so. Else, log a halt
+            # indicating that there is no clear success or failure signal.
+            self._terminate(
+                EventLifecycleOutcome.SUCCESS
+                if self.assume_success
+                else EventLifecycleOutcome.HALTED
+            )

--- a/tests/sentry/integrations/discord/webhooks/test_command.py
+++ b/tests/sentry/integrations/discord/webhooks/test_command.py
@@ -272,5 +272,5 @@ class DiscordCommandInteractionTest(APITestCase):
 
         assert len(mock_record.mock_calls) == 2
         start, halt = mock_record.mock_calls
-        assert start.args == (EventLifecycleOutcome.STARTED,)
-        assert halt.args == (EventLifecycleOutcome.HALTED,)
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.HALTED

--- a/tests/sentry/integrations/discord/webhooks/test_command.py
+++ b/tests/sentry/integrations/discord/webhooks/test_command.py
@@ -4,6 +4,7 @@ from sentry.integrations.discord.message_builder.base.flags import EPHEMERAL_FLA
 from sentry.integrations.discord.requests.base import DiscordRequestTypes
 from sentry.integrations.discord.webhooks.command import HELP_MESSAGE, NOT_LINKED_MESSAGE
 from sentry.integrations.discord.webhooks.types import DiscordResponseTypes
+from sentry.integrations.utils.metrics import EventLifecycleOutcome
 from sentry.testutils.cases import APITestCase
 
 WEBHOOK_URL = "/extensions/discord/interactions/"
@@ -246,7 +247,8 @@ class DiscordCommandInteractionTest(APITestCase):
             assert data["data"]["flags"] == EPHEMERAL_FLAG
             assert response.status_code == 200
 
-    def test_help(self):
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_help(self, mock_record):
         with mock.patch(
             "sentry.integrations.discord.requests.base.verify_signature", return_value=True
         ):
@@ -267,3 +269,8 @@ class DiscordCommandInteractionTest(APITestCase):
             assert HELP_MESSAGE in data["data"]["content"]
             assert data["data"]["flags"] == EPHEMERAL_FLAG
             assert response.status_code == 200
+
+        assert len(mock_record.mock_calls) == 2
+        start, halt = mock_record.mock_calls
+        assert start.args == (EventLifecycleOutcome.STARTED,)
+        assert halt.args == (EventLifecycleOutcome.SUCCESS,)

--- a/tests/sentry/integrations/discord/webhooks/test_command.py
+++ b/tests/sentry/integrations/discord/webhooks/test_command.py
@@ -273,4 +273,4 @@ class DiscordCommandInteractionTest(APITestCase):
         assert len(mock_record.mock_calls) == 2
         start, halt = mock_record.mock_calls
         assert start.args == (EventLifecycleOutcome.STARTED,)
-        assert halt.args == (EventLifecycleOutcome.SUCCESS,)
+        assert halt.args == (EventLifecycleOutcome.HALTED,)

--- a/tests/sentry/integrations/discord/webhooks/test_message_component.py
+++ b/tests/sentry/integrations/discord/webhooks/test_message_component.py
@@ -178,8 +178,8 @@ class DiscordMessageComponentInteractionTest(APITestCase):
 
         assert len(mock_record.mock_calls) == 2
         start, halt = mock_record.mock_calls
-        assert start.args == (EventLifecycleOutcome.STARTED,)
-        assert halt.args == (EventLifecycleOutcome.SUCCESS,)
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.SUCCESS
 
     def test_resolve_dialog(self):
         response = self.send_interaction(

--- a/tests/sentry/integrations/discord/webhooks/test_message_component.py
+++ b/tests/sentry/integrations/discord/webhooks/test_message_component.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 from unittest import mock
+from unittest.mock import patch
 
 from sentry.integrations.discord.message_builder.base.component import (
     DiscordComponentCustomIds as CustomIds,
@@ -23,6 +24,7 @@ from sentry.integrations.discord.webhooks.message_component import (
     RESOLVED_IN_NEXT_RELEASE,
     UNRESOLVED,
 )
+from sentry.integrations.utils.metrics import EventLifecycleOutcome
 from sentry.models.release import Release
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
@@ -162,7 +164,8 @@ class DiscordMessageComponentInteractionTest(APITestCase):
         assert response.status_code == 200
         assert self.get_message_content(response) == INVALID_GROUP_ID
 
-    def test_assign(self):
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_assign(self, mock_record):
         response = self.send_interaction(
             {
                 "component_type": DiscordMessageComponentTypes.SELECT,
@@ -172,6 +175,11 @@ class DiscordMessageComponentInteractionTest(APITestCase):
         )
         assert response.status_code == 200
         assert self.get_message_content(response) == ASSIGNEE_UPDATED
+
+        assert len(mock_record.mock_calls) == 2
+        start, halt = mock_record.mock_calls
+        assert start.args == (EventLifecycleOutcome.STARTED,)
+        assert halt.args == (EventLifecycleOutcome.SUCCESS,)
 
     def test_resolve_dialog(self):
         response = self.send_interaction(

--- a/tests/sentry/integrations/msteams/test_action_state_change.py
+++ b/tests/sentry/integrations/msteams/test_action_state_change.py
@@ -11,6 +11,7 @@ from sentry.integrations.msteams.card_builder.identity import build_linking_card
 from sentry.integrations.msteams.constants import SALT
 from sentry.integrations.msteams.link_identity import build_linking_url
 from sentry.integrations.msteams.utils import ACTION_TYPE
+from sentry.integrations.utils.metrics import EventLifecycleOutcome
 from sentry.models.activity import Activity, ActivityIntegration
 from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider
@@ -227,8 +228,9 @@ class StatusActionTest(APITestCase):
         }
 
     @responses.activate
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.integrations.msteams.webhook.verify_signature", return_value=True)
-    def test_assign_to_me(self, verify):
+    def test_assign_to_me(self, verify, mock_record):
         resp = self.post_webhook(action_type=ACTION_TYPE.ASSIGN, assign_input="ME")
 
         assert resp.status_code == 200, resp.content
@@ -243,6 +245,11 @@ class StatusActionTest(APITestCase):
             "assigneeType": "user",
             "integration": ActivityIntegration.MSTEAMS.value,
         }
+
+        assert len(mock_record.mock_calls) == 2
+        start, halt = mock_record.mock_calls
+        assert start.args == (EventLifecycleOutcome.STARTED,)
+        assert halt.args == (EventLifecycleOutcome.SUCCESS,)
 
     @responses.activate
     @patch("sentry.integrations.msteams.webhook.verify_signature", return_value=True)

--- a/tests/sentry/integrations/msteams/test_action_state_change.py
+++ b/tests/sentry/integrations/msteams/test_action_state_change.py
@@ -248,8 +248,8 @@ class StatusActionTest(APITestCase):
 
         assert len(mock_record.mock_calls) == 2
         start, halt = mock_record.mock_calls
-        assert start.args == (EventLifecycleOutcome.STARTED,)
-        assert halt.args == (EventLifecycleOutcome.SUCCESS,)
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.SUCCESS
 
     @responses.activate
     @patch("sentry.integrations.msteams.webhook.verify_signature", return_value=True)

--- a/tests/sentry/integrations/msteams/test_webhook.py
+++ b/tests/sentry/integrations/msteams/test_webhook.py
@@ -10,6 +10,7 @@ from django.urls import reverse
 
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.msteams.utils import ACTION_TYPE
+from sentry.integrations.utils.metrics import EventLifecycleOutcome
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
@@ -396,9 +397,10 @@ class MsTeamsWebhookTest(APITestCase):
         assert "Bearer my_token" in responses.calls[3].request.headers["Authorization"]
 
     @responses.activate
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @mock.patch("sentry.utils.jwt.decode")
     @mock.patch("time.time")
-    def test_help_command(self, mock_time, mock_decode):
+    def test_help_command(self, mock_time, mock_decode, mock_record):
         other_command = deepcopy(EXAMPLE_UNLINK_COMMAND)
         other_command["text"] = "Help"
         access_json = {"expires_in": 86399, "access_token": "my_token"}
@@ -427,6 +429,11 @@ class MsTeamsWebhookTest(APITestCase):
             3
         ].request.body.decode("utf-8")
         assert "Bearer my_token" in responses.calls[3].request.headers["Authorization"]
+
+        assert len(mock_record.mock_calls) == 2
+        start, halt = mock_record.mock_calls
+        assert start.args == (EventLifecycleOutcome.STARTED,)
+        assert halt.args == (EventLifecycleOutcome.SUCCESS,)
 
     @responses.activate
     @mock.patch("sentry.utils.jwt.decode")

--- a/tests/sentry/integrations/msteams/test_webhook.py
+++ b/tests/sentry/integrations/msteams/test_webhook.py
@@ -433,7 +433,7 @@ class MsTeamsWebhookTest(APITestCase):
         assert len(mock_record.mock_calls) == 2
         start, halt = mock_record.mock_calls
         assert start.args == (EventLifecycleOutcome.STARTED,)
-        assert halt.args == (EventLifecycleOutcome.SUCCESS,)
+        assert halt.args == (EventLifecycleOutcome.HALTED,)
 
     @responses.activate
     @mock.patch("sentry.utils.jwt.decode")

--- a/tests/sentry/integrations/msteams/test_webhook.py
+++ b/tests/sentry/integrations/msteams/test_webhook.py
@@ -432,8 +432,8 @@ class MsTeamsWebhookTest(APITestCase):
 
         assert len(mock_record.mock_calls) == 2
         start, halt = mock_record.mock_calls
-        assert start.args == (EventLifecycleOutcome.STARTED,)
-        assert halt.args == (EventLifecycleOutcome.HALTED,)
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.HALTED
 
     @responses.activate
     @mock.patch("sentry.utils.jwt.decode")

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -14,6 +14,7 @@ from sentry.integrations.slack.webhooks.action import (
     LINK_IDENTITY_MESSAGE,
     UNLINK_IDENTITY_MESSAGE,
 )
+from sentry.integrations.utils.metrics import EventLifecycleOutcome
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType
 from sentry.models.activity import Activity, ActivityIntegration
 from sentry.models.authidentity import AuthIdentity
@@ -234,8 +235,9 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert resp.data["response_type"] == "ephemeral"
         assert resp.data["text"] == LINK_IDENTITY_MESSAGE.format(associate_url=associate_url)
 
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
-    def test_archive_issue_until_escalating(self, mock_tags):
+    def test_archive_issue_until_escalating(self, mock_tags, mock_record):
         original_message = self.get_original_message(self.group.id)
         self.archive_issue(original_message, "ignored:archived_until_escalating")
 
@@ -252,6 +254,11 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert blocks[2]["text"]["text"].endswith(expect_status)
         assert "via" not in blocks[4]["elements"][0]["text"]
         assert ":white_circle:" in blocks[0]["text"]["text"]
+
+        assert len(mock_record.mock_calls) == 2
+        start, halt = mock_record.mock_calls
+        assert start.args == (EventLifecycleOutcome.STARTED,)
+        assert halt.args == (EventLifecycleOutcome.SUCCESS,)
 
     @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
     def test_archive_issue_until_escalating_through_unfurl(self, mock_tags):

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -257,8 +257,8 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
 
         assert len(mock_record.mock_calls) == 2
         start, halt = mock_record.mock_calls
-        assert start.args == (EventLifecycleOutcome.STARTED,)
-        assert halt.args == (EventLifecycleOutcome.SUCCESS,)
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.SUCCESS
 
     @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
     def test_archive_issue_until_escalating_through_unfurl(self, mock_tags):

--- a/tests/sentry/integrations/slack/webhooks/commands/test_link_team.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/test_link_team.py
@@ -66,7 +66,7 @@ class SlackCommandsLinkTeamTest(SlackCommandsLinkTeamTestBase):
         assert len(mock_record.mock_calls) == 2
         start, halt = mock_record.mock_calls
         assert start.args == (EventLifecycleOutcome.STARTED,)
-        assert halt.args == (EventLifecycleOutcome.SUCCESS,)
+        assert halt.args == (EventLifecycleOutcome.HALTED,)
 
     @responses.activate
     def test_link_team_from_dm(self):

--- a/tests/sentry/integrations/slack/webhooks/commands/test_link_team.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/test_link_team.py
@@ -65,8 +65,8 @@ class SlackCommandsLinkTeamTest(SlackCommandsLinkTeamTestBase):
 
         assert len(mock_record.mock_calls) == 2
         start, halt = mock_record.mock_calls
-        assert start.args == (EventLifecycleOutcome.STARTED,)
-        assert halt.args == (EventLifecycleOutcome.HALTED,)
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.HALTED
 
     @responses.activate
     def test_link_team_from_dm(self):

--- a/tests/sentry/integrations/slack/webhooks/commands/test_link_team.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/test_link_team.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import orjson
 import responses
 from rest_framework import status
@@ -9,6 +11,7 @@ from sentry.integrations.slack.webhooks.command import (
     LINK_USER_FIRST_MESSAGE,
     TEAM_NOT_LINKED_MESSAGE,
 )
+from sentry.integrations.utils.metrics import EventLifecycleOutcome
 from sentry.silo.base import SiloMode
 from sentry.testutils.helpers import get_response_text, link_user
 from sentry.testutils.silo import assume_test_silo_mode
@@ -39,8 +42,9 @@ class SlackCommandsLinkTeamTestBase(SlackCommandsTest):
 
 
 class SlackCommandsLinkTeamTest(SlackCommandsLinkTeamTestBase):
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @responses.activate
-    def test_link_another_team_to_channel(self):
+    def test_link_another_team_to_channel(self, mock_record):
         """
         Test that we block a user who tries to link a second team to a
         channel that already has a team linked to it.
@@ -58,6 +62,11 @@ class SlackCommandsLinkTeamTest(SlackCommandsLinkTeamTestBase):
         )
         data = orjson.loads(response.content)
         assert CHANNEL_ALREADY_LINKED_MESSAGE in get_response_text(data)
+
+        assert len(mock_record.mock_calls) == 2
+        start, halt = mock_record.mock_calls
+        assert start.args == (EventLifecycleOutcome.STARTED,)
+        assert halt.args == (EventLifecycleOutcome.SUCCESS,)
 
     @responses.activate
     def test_link_team_from_dm(self):

--- a/tests/sentry/integrations/slack/webhooks/commands/test_link_user.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/test_link_user.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.slack.views.link_identity import SUCCESS_LINKED_MESSAGE, build_linking_url
 from sentry.integrations.slack.views.unlink_identity import (
@@ -5,6 +7,7 @@ from sentry.integrations.slack.views.unlink_identity import (
     build_unlinking_url,
 )
 from sentry.integrations.slack.webhooks.base import NOT_LINKED_MESSAGE
+from sentry.integrations.utils.metrics import EventLifecycleOutcome
 from sentry.testutils.helpers import get_response_text
 from sentry.testutils.silo import control_silo_test
 from sentry.users.models.identity import Identity
@@ -102,10 +105,16 @@ class SlackUnlinkIdentityViewTest(SlackCommandsTest):
 class SlackCommandsUnlinkUserTest(SlackCommandsTest):
     """Slash commands results are generated on Region Silo"""
 
-    def test_unlink_command(self):
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_unlink_command(self, mock_record):
         self.link_user()
         data = self.send_slack_message("unlink")
         assert "to unlink your identity" in get_response_text(data)
+
+        assert len(mock_record.mock_calls) == 2
+        start, halt = mock_record.mock_calls
+        assert start.args == (EventLifecycleOutcome.STARTED,)
+        assert halt.args == (EventLifecycleOutcome.SUCCESS,)
 
     def test_unlink_command_already_unlinked(self):
         data = self.send_slack_message("unlink")

--- a/tests/sentry/integrations/slack/webhooks/commands/test_link_user.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/test_link_user.py
@@ -113,8 +113,8 @@ class SlackCommandsUnlinkUserTest(SlackCommandsTest):
 
         assert len(mock_record.mock_calls) == 2
         start, halt = mock_record.mock_calls
-        assert start.args == (EventLifecycleOutcome.STARTED,)
-        assert halt.args == (EventLifecycleOutcome.HALTED,)
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.HALTED
 
     def test_unlink_command_already_unlinked(self):
         data = self.send_slack_message("unlink")

--- a/tests/sentry/integrations/slack/webhooks/commands/test_link_user.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/test_link_user.py
@@ -114,7 +114,7 @@ class SlackCommandsUnlinkUserTest(SlackCommandsTest):
         assert len(mock_record.mock_calls) == 2
         start, halt = mock_record.mock_calls
         assert start.args == (EventLifecycleOutcome.STARTED,)
-        assert halt.args == (EventLifecycleOutcome.SUCCESS,)
+        assert halt.args == (EventLifecycleOutcome.HALTED,)
 
     def test_unlink_command_already_unlinked(self):
         data = self.send_slack_message("unlink")

--- a/tests/sentry/integrations/slack/webhooks/events/test_message_im.py
+++ b/tests/sentry/integrations/slack/webhooks/events/test_message_im.py
@@ -110,7 +110,7 @@ class MessageIMEventTest(BaseEventTest, IntegratedApiTestCase):
         assert len(mock_record.mock_calls) == 2
         start, halt = mock_record.mock_calls
         assert start.args == (EventLifecycleOutcome.STARTED,)
-        assert halt.args == (EventLifecycleOutcome.SUCCESS,)
+        assert halt.args == (EventLifecycleOutcome.HALTED,)
 
     def test_user_message_already_linked_sdk(self):
         """

--- a/tests/sentry/integrations/slack/webhooks/events/test_message_im.py
+++ b/tests/sentry/integrations/slack/webhooks/events/test_message_im.py
@@ -4,6 +4,7 @@ import orjson
 import pytest
 from slack_sdk.web import SlackResponse
 
+from sentry.integrations.utils.metrics import EventLifecycleOutcome
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import IntegratedApiTestCase
 from sentry.testutils.helpers import get_response_text
@@ -92,7 +93,8 @@ class MessageIMEventTest(BaseEventTest, IntegratedApiTestCase):
             == "Here are the commands you can use. Commands not working? Re-install the app!"
         )
 
-    def test_user_message_link(self):
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_user_message_link(self, mock_record):
         """
         Test that when a user types in "link" to the DM we reply with the correct response.
         """
@@ -104,6 +106,11 @@ class MessageIMEventTest(BaseEventTest, IntegratedApiTestCase):
 
         data = self.mock_post.call_args[1]
         assert "Link your Slack identity" in get_response_text(data)
+
+        assert len(mock_record.mock_calls) == 2
+        start, halt = mock_record.mock_calls
+        assert start.args == (EventLifecycleOutcome.STARTED,)
+        assert halt.args == (EventLifecycleOutcome.SUCCESS,)
 
     def test_user_message_already_linked_sdk(self):
         """

--- a/tests/sentry/integrations/slack/webhooks/events/test_message_im.py
+++ b/tests/sentry/integrations/slack/webhooks/events/test_message_im.py
@@ -109,8 +109,8 @@ class MessageIMEventTest(BaseEventTest, IntegratedApiTestCase):
 
         assert len(mock_record.mock_calls) == 2
         start, halt = mock_record.mock_calls
-        assert start.args == (EventLifecycleOutcome.STARTED,)
-        assert halt.args == (EventLifecycleOutcome.HALTED,)
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.HALTED
 
     def test_user_message_already_linked_sdk(self):
         """


### PR DESCRIPTION
Introduce EventLifecycle and EventLifecycleMetric to capture success/failure metrics, with the purpose of enforcing a consistent key scheme across different integrations.

Introduce MessagingInteractionEvent as the first EventLifecycleMetric subclass, to unify messaging integrations. Represent distinct messaging features or behaviors with the MessagingInteractionType, whose values should eventually map one-to-one onto desired messaging SLOs.

In the various messaging integrations, capture an initial set of those events represented by MessagingInteractionType values.