### PR TITLE
fix(issues): Allow the parent to align annotated text

### DIFF
--- a/static/app/components/events/meta/annotatedText/redaction.tsx
+++ b/static/app/components/events/meta/annotatedText/redaction.tsx
@@ -2,6 +2,5 @@ import styled from '@emotion/styled';
 
 export const Redaction = styled('span')<{withoutBackground?: boolean}>`
   cursor: default;
-  vertical-align: middle;
   ${p => !p.withoutBackground && `background: rgba(255, 0, 0, 0.05);`}
 `;


### PR DESCRIPTION
before
<img width="287" alt="image" src="https://github.com/user-attachments/assets/76f81894-fbb2-4200-b511-853044e531f0">

after
<img width="304" alt="image" src="https://github.com/user-attachments/assets/f159a0cc-c373-4b65-b89e-f45a492904c4">

fixes https://www.notion.so/sentry/Context-scrubbed-data-alignment-0599b4631a4342c6a5cb5e8ba5a1209b