### PR TITLE
feat(explore): replacing chart select with icons

### DIFF
--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -3,7 +3,10 @@ import styled from '@emotion/styled';
 
 import {getInterval} from 'sentry/components/charts/utils';
 import {CompactSelect} from 'sentry/components/compactSelect';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {CHART_PALETTE} from 'sentry/constants/chartPalette';
+import {IconClock} from 'sentry/icons';
+import {IconGraphLine} from 'sentry/icons/iconGraphLine';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {dedupeArray} from 'sentry/utils/dedupeArray';
@@ -135,15 +138,34 @@ export function ExploreCharts({query}: ExploreChartsProps) {
               <ChartHeader>
                 <ChartTitle>{dedupedYAxes.join(',')}</ChartTitle>
                 <ChartSettingsContainer>
+                  <DropdownMenu
+                    position="bottom-end"
+                    triggerProps={{
+                      icon: <IconGraphLine />,
+                      size: 'zero',
+                      showChevron: false,
+                      borderless: true,
+                      'aria-label': t('Chart Type'),
+                    }}
+                    items={[]}
+                  />
+                  <DropdownMenu
+                    position="bottom-end"
+                    triggerProps={{
+                      icon: <IconClock />,
+                      showChevron: false,
+                      borderless: true,
+                      'aria-label': t('Interval'),
+                    }}
+                    items={[]}
+                  />
                   <CompactSelect
-                    size="xs"
                     triggerProps={{prefix: t('Type')}}
                     value={chartType}
                     options={exploreChartTypeOptions}
                     onChange={option => handleChartTypeChange(option.value, index)}
                   />
                   <CompactSelect
-                    size="xs"
                     value={interval}
                     onChange={({value}) => setInterval(value)}
                     triggerProps={{

--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 
 import {getInterval} from 'sentry/components/charts/utils';
 import {CompactSelect} from 'sentry/components/compactSelect';
-import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 import {IconClock} from 'sentry/icons';
 import {IconGraphLine} from 'sentry/icons/iconGraphLine';
@@ -138,38 +137,25 @@ export function ExploreCharts({query}: ExploreChartsProps) {
               <ChartHeader>
                 <ChartTitle>{dedupedYAxes.join(',')}</ChartTitle>
                 <ChartSettingsContainer>
-                  <DropdownMenu
-                    position="bottom-end"
+                  <CompactSelect
+                    triggerLabel=""
                     triggerProps={{
                       icon: <IconGraphLine />,
-                      size: 'zero',
-                      showChevron: false,
                       borderless: true,
-                      'aria-label': t('Chart Type'),
-                    }}
-                    items={[]}
-                  />
-                  <DropdownMenu
-                    position="bottom-end"
-                    triggerProps={{
-                      icon: <IconClock />,
                       showChevron: false,
-                      borderless: true,
-                      'aria-label': t('Interval'),
                     }}
-                    items={[]}
-                  />
-                  <CompactSelect
-                    triggerProps={{prefix: t('Type')}}
                     value={chartType}
                     options={exploreChartTypeOptions}
                     onChange={option => handleChartTypeChange(option.value, index)}
                   />
                   <CompactSelect
+                    triggerLabel=""
                     value={interval}
                     onChange={({value}) => setInterval(value)}
                     triggerProps={{
-                      prefix: t('Interval'),
+                      icon: <IconClock />,
+                      borderless: true,
+                      showChevron: false,
                     }}
                     options={intervalOptions}
                   />

--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -130,7 +130,12 @@ export function ExploreCharts({query}: ExploreChartsProps) {
       {visualizes.map((visualize, index) => {
         const dedupedYAxes = dedupeArray(visualize.yAxes);
         const {chartType} = visualize;
-        const chartIcon = chartType === 1 ? 'line' : chartType === 2 ? 'area' : 'bar';
+        const chartIcon =
+          chartType === ChartType.LINE
+            ? 'line'
+            : chartType === ChartType.AREA
+              ? 'area'
+              : 'bar';
 
         return (
           <ChartContainer key={index}>

--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -4,8 +4,7 @@ import styled from '@emotion/styled';
 import {getInterval} from 'sentry/components/charts/utils';
 import {CompactSelect} from 'sentry/components/compactSelect';
 import {CHART_PALETTE} from 'sentry/constants/chartPalette';
-import {IconClock} from 'sentry/icons';
-import {IconGraphLine} from 'sentry/icons/iconGraphLine';
+import {IconClock, IconGraph} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {dedupeArray} from 'sentry/utils/dedupeArray';
@@ -131,6 +130,8 @@ export function ExploreCharts({query}: ExploreChartsProps) {
       {visualizes.map((visualize, index) => {
         const dedupedYAxes = dedupeArray(visualize.yAxes);
         const {chartType} = visualize;
+        const chartIcon = chartType === 1 ? 'line' : chartType === 2 ? 'area' : 'bar';
+
         return (
           <ChartContainer key={index}>
             <ChartPanel>
@@ -140,11 +141,13 @@ export function ExploreCharts({query}: ExploreChartsProps) {
                   <CompactSelect
                     triggerLabel=""
                     triggerProps={{
-                      icon: <IconGraphLine />,
+                      icon: <IconGraph type={chartIcon} />,
                       borderless: true,
                       showChevron: false,
+                      size: 'sm',
                     }}
                     value={chartType}
+                    menuTitle="Type"
                     options={exploreChartTypeOptions}
                     onChange={option => handleChartTypeChange(option.value, index)}
                   />
@@ -156,7 +159,9 @@ export function ExploreCharts({query}: ExploreChartsProps) {
                       icon: <IconClock />,
                       borderless: true,
                       showChevron: false,
+                      size: 'sm',
                     }}
+                    menuTitle="Interval"
                     options={intervalOptions}
                   />
                 </ChartSettingsContainer>
@@ -179,7 +184,6 @@ export function ExploreCharts({query}: ExploreChartsProps) {
                 type={chartType}
                 // for now, use the first y axis unit
                 aggregateOutputFormat={aggregateOutputType(dedupedYAxes[0])}
-                showLegend
               />
             </ChartPanel>
           </ChartContainer>
@@ -200,7 +204,6 @@ const ChartHeader = styled('div')`
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  margin-bottom: ${space(1)};
 `;
 
 const ChartTitle = styled('div')`
@@ -209,6 +212,4 @@ const ChartTitle = styled('div')`
 
 const ChartSettingsContainer = styled('div')`
   display: flex;
-  align-items: center;
-  gap: ${space(0.5)};
 `;

--- a/static/app/views/explore/content.tsx
+++ b/static/app/views/explore/content.tsx
@@ -69,7 +69,7 @@ function ExploreContentImpl({}: ExploreContentProps) {
             </Layout.HeaderContent>
             <Layout.HeaderActions>
               <ButtonBar gap={1}>
-                <Button onClick={switchToOldTraceExplorer}>
+                <Button onClick={switchToOldTraceExplorer} size="sm">
                   {t('Switch to Old Trace Explore')}
                 </Button>
                 <FeedbackWidgetButton />


### PR DESCRIPTION
**Before:**
![Screenshot 2024-10-03 at 2 49 53 PM](https://github.com/user-attachments/assets/25471636-f09e-49ca-81d7-07d082e092a2)

**After:**
![Screenshot 2024-10-03 at 3 04 39 PM](https://github.com/user-attachments/assets/f0a71e36-829b-409d-99f9-ab550c1183f0)
![Screenshot 2024-10-03 at 3 09 58 PM](https://github.com/user-attachments/assets/5929a77d-3a00-497f-ac3b-73f14df590c7)
![Screenshot 2024-10-03 at 3 10 06 PM](https://github.com/user-attachments/assets/13e732b1-020c-47f8-91cf-34a6f5c9c7db)

Note: The Explore table will be the legend for multiple lines. Otherwise, a single line is already corresponds with the title (i.e. count is in the header so it doesn't need to be a legend item) 