### PR TITLE
feat(discover): Add more tags for error reason

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -378,7 +378,10 @@ def handle_query_errors() -> Generator[None]:
                 QueryExecutionTimeMaximum,
                 QueryTooManySimultaneous,
             ),
-        ) or isinstance(
+        ):
+            sentry_sdk.set_tag("query.error_reason", type(error).__name__)
+            raise ParseError(detail=TIMEOUT_ERROR_MESSAGE)
+        elif isinstance(
             arg,
             ReadTimeoutError,
         ):


### PR DESCRIPTION
A lot of other errors are being eaten up as timeouts (e.g. rate limiting). Add the class name as a tag so we have better insight into what broke.

Note: I also think `ParseError` is the wrong exception to be throwing here, but the existing behaviour is to throw that. It might make more sense to break these out further and e.g. throw a 429 for a rate limit issue.