### PR TITLE
fix(issues): Shrink stack trace platform icon

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/platformIcon.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/platformIcon.tsx
@@ -1,15 +1,18 @@
 import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
 
+import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
+
 type Props = {
   platform: string;
 };
 
 function StacktracePlatformIcon({platform}: Props) {
+  const hasStreamlineUi = useHasStreamlinedUI();
   return (
     <StyledPlatformIcon
       platform={platform}
-      size="20px"
+      size={hasStreamlineUi ? '16px' : '20px'}
       radius={null}
       data-test-id={`platform-icon-${platform}`}
     />
@@ -19,7 +22,7 @@ function StacktracePlatformIcon({platform}: Props) {
 const StyledPlatformIcon = styled(PlatformIcon)`
   position: absolute;
   top: 0;
-  left: -20px;
+  left: -${p => p.size};
   border-radius: 3px 0 0 3px;
 
   @media (max-width: ${p => p.theme.breakpoints.medium}) {


### PR DESCRIPTION
We reduced the padding on issue details page and 20px moves the icon outside the container.

before
![image](https://github.com/user-attachments/assets/04d881fb-cfcb-4d4c-9dde-925740a79677)


after
![image](https://github.com/user-attachments/assets/c5dc7bef-fd43-49bf-930e-b8641390c69f)

