### PR TITLE
feat(issue_platform): Enable UI for Issue Platform deletion

### DIFF
--- a/static/app/views/issueDetails/actions/index.spec.tsx
+++ b/static/app/views/issueDetails/actions/index.spec.tsx
@@ -34,6 +34,12 @@ const group = GroupFixture({
   project,
 });
 
+const issuePlatformGroup = GroupFixture({
+  id: '1338',
+  issueCategory: IssueCategory.PERFORMANCE,
+  project,
+});
+
 const organization = OrganizationFixture({
   id: '4660',
   slug: 'org',
@@ -177,34 +183,6 @@ describe('GroupActions', function () {
     });
   });
 
-  it('delete for issue platform is enabled', async () => {
-    const org = OrganizationFixture({
-      ...organization,
-      access: [...organization.access, 'event:admin'],
-      features: [...organization.features, 'issue-platform-deletions-ui'],
-    });
-    render(
-      <Fragment>
-        <GlobalModal />
-        <GroupActions
-          group={group}
-          project={project}
-          organization={org}
-          disabled={false}
-        />
-      </Fragment>,
-      {organization: org}
-    );
-
-    await userEvent.click(screen.getByLabelText('More Actions'));
-    expect(
-      await screen.findByRole('menuitemradio', {name: 'Delete'})
-    ).not.toHaveAttribute('aria-disabled');
-    expect(
-      await screen.findByRole('menuitemradio', {name: 'Delete and discard future events'})
-    ).toHaveAttribute('aria-disabled');
-  });
-
   it('opens share modal from more actions dropdown', async () => {
     const org = {
       ...organization,
@@ -237,48 +215,99 @@ describe('GroupActions', function () {
     expect(updateMock).toHaveBeenCalled();
   });
 
-  it('opens delete confirm modal from more actions dropdown', async () => {
-    const org = OrganizationFixture({
-      ...organization,
-      access: [...organization.access, 'event:admin'],
+  describe('delete', function () {
+    it('opens delete confirm modal from more actions dropdown', async () => {
+      const org = OrganizationFixture({
+        ...organization,
+        access: [...organization.access, 'event:admin'],
+      });
+      MockApiClient.addMockResponse({
+        url: `/projects/${org.slug}/${project.slug}/issues/`,
+        method: 'PUT',
+        body: {},
+      });
+      const deleteMock = MockApiClient.addMockResponse({
+        url: `/projects/${org.slug}/${project.slug}/issues/`,
+        method: 'DELETE',
+        body: {},
+      });
+      render(
+        <Fragment>
+          <GlobalModal />
+          <GroupActions
+            group={group}
+            project={project}
+            organization={org}
+            disabled={false}
+          />
+        </Fragment>,
+        {organization: org}
+      );
+
+      await userEvent.click(screen.getByLabelText('More Actions'));
+      await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Delete'}));
+
+      const modal = screen.getByRole('dialog');
+      expect(
+        within(modal).getByText(/Deleting this issue is permanent/)
+      ).toBeInTheDocument();
+
+      await userEvent.click(within(modal).getByRole('button', {name: 'Delete'}));
+
+      expect(deleteMock).toHaveBeenCalled();
+      expect(browserHistory.push).toHaveBeenCalledWith({
+        pathname: `/organizations/${org.slug}/issues/`,
+        query: {project: project.id},
+      });
     });
-    MockApiClient.addMockResponse({
-      url: `/projects/${org.slug}/${project.slug}/issues/`,
-      method: 'PUT',
-      body: {},
-    });
-    const deleteMock = MockApiClient.addMockResponse({
-      url: `/projects/${org.slug}/${project.slug}/issues/`,
-      method: 'DELETE',
-      body: {},
-    });
-    render(
-      <Fragment>
-        <GlobalModal />
+
+    it('delete for issue platform', async () => {
+      const org = OrganizationFixture({
+        access: ['event:admin'], // Delete is only shown if this is present
+      });
+      render(
         <GroupActions
-          group={group}
+          group={issuePlatformGroup}
           project={project}
           organization={org}
           disabled={false}
-        />
-      </Fragment>,
-      {organization: org}
-    );
+        />,
+        {organization: org}
+      );
 
-    await userEvent.click(screen.getByLabelText('More Actions'));
-    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Delete'}));
+      await userEvent.click(screen.getByLabelText('More Actions'));
+      expect(await screen.findByTestId('delete-issue')).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
+      expect(await screen.findByTestId('delete-and-discard')).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
+    });
+    it('delete for issue platform is enabled with feature flag', async () => {
+      const org = OrganizationFixture({
+        access: ['event:admin'],
+        features: ['issue-platform-deletion-ui'],
+      });
+      render(
+        <GroupActions
+          group={issuePlatformGroup}
+          project={project}
+          organization={org}
+          disabled={false}
+        />,
+        {organization: org}
+      );
 
-    const modal = screen.getByRole('dialog');
-    expect(
-      within(modal).getByText(/Deleting this issue is permanent/)
-    ).toBeInTheDocument();
-
-    await userEvent.click(within(modal).getByRole('button', {name: 'Delete'}));
-
-    expect(deleteMock).toHaveBeenCalled();
-    expect(browserHistory.push).toHaveBeenCalledWith({
-      pathname: `/organizations/${org.slug}/issues/`,
-      query: {project: project.id},
+      await userEvent.click(screen.getByLabelText('More Actions'));
+      expect(await screen.findByTestId('delete-issue')).not.toHaveAttribute(
+        'aria-disabled'
+      );
+      expect(await screen.findByTestId('delete-and-discard')).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
     });
   });
 

--- a/static/app/views/issueDetails/actions/index.spec.tsx
+++ b/static/app/views/issueDetails/actions/index.spec.tsx
@@ -177,6 +177,34 @@ describe('GroupActions', function () {
     });
   });
 
+  it('delete for issue platform is enabled', async () => {
+    const org = OrganizationFixture({
+      ...organization,
+      access: [...organization.access, 'event:admin'],
+      features: [...organization.features, 'issue-platform-deletions-ui'],
+    });
+    render(
+      <Fragment>
+        <GlobalModal />
+        <GroupActions
+          group={group}
+          project={project}
+          organization={org}
+          disabled={false}
+        />
+      </Fragment>,
+      {organization: org}
+    );
+
+    await userEvent.click(screen.getByLabelText('More Actions'));
+    expect(
+      await screen.findByRole('menuitemradio', {name: 'Delete'})
+    ).not.toHaveAttribute('aria-disabled');
+    expect(
+      await screen.findByRole('menuitemradio', {name: 'Delete and discard future events'})
+    ).toHaveAttribute('aria-disabled');
+  });
+
   it('opens share modal from more actions dropdown', async () => {
     const org = {
       ...organization,


### PR DESCRIPTION
This enables the UI for Issue Platform deletion.

This depends on #77794 being merged first.

<img width="321" alt="image" src="https://github.com/user-attachments/assets/2fd25b40-70ba-4ccf-8c50-d8c3c79d02a8">

