### PR TITLE
fix: Remove logging and sampling related to INC-893

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -28,7 +28,6 @@ from sentry.utils import metrics
 from sentry.utils.db import DjangoAtomicIntegration
 from sentry.utils.flag import get_flags_serialized
 from sentry.utils.rust import RustInfoIntegration
-from sentry.utils.safe import get_path
 
 # Can't import models in utils because utils should be the bottom of the food chain
 if TYPE_CHECKING:
@@ -194,14 +193,6 @@ def traces_sampler(sampling_context):
 
     if "celery_job" in sampling_context:
         task_name = sampling_context["celery_job"].get("task")
-
-        # Temporarily sample the `assemble_dif` task at 100% for the
-        # sentry-test/rust project for debugging purposes
-        if (
-            task_name == "sentry.tasks.assemble.assemble_dif"
-            and get_path(sampling_context, "celery_job", "kwargs", "project_id") == 1041156
-        ):
-            return 1.0
 
         if task_name in SAMPLED_TASKS:
             return SAMPLED_TASKS[task_name]


### PR DESCRIPTION
In commits 7c9844a09165538579c877bad0d7091797e2c613, 6bc52ff8ca17b9628fb70d57f4de1b7d34371855, and 8203c4e938b5194b30f5a9069a6ce4c682ed36c5 I added some logging and sampling in an effort to diagnose INC-893. Since that incident is now resolved, we can remove it again.