### PR TITLE
chore(integrations): query active integrations for vsts, stacktrace linking, syncing, webhooks

### DIFF
--- a/src/sentry/api/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/api/endpoints/group_autofix_setup_check.py
@@ -17,6 +17,7 @@ from sentry.api.helpers.autofix import (
     get_project_codebase_indexing_status,
 )
 from sentry.autofix.utils import get_autofix_repos_from_project_code_mappings
+from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.utils.code_mapping import get_sorted_code_mapping_configs
 from sentry.models.group import Group
@@ -44,7 +45,7 @@ def get_autofix_integration_setup_problems(
 
     organization_integration = organization_integrations[0] if organization_integrations else None
     integration = organization_integration and integration_service.get_integration(
-        organization_integration_id=organization_integration.id
+        organization_integration_id=organization_integration.id, status=ObjectStatus.ACTIVE
     )
     installation = integration and integration.get_installation(organization_id=organization.id)
 

--- a/src/sentry/integrations/api/endpoints/organization_repository_details.py
+++ b/src/sentry/integrations/api/endpoints/organization_repository_details.py
@@ -74,7 +74,9 @@ class OrganizationRepositoryDetailsEndpoint(OrganizationEndpoint):
                 raise NotImplementedError
         if result.get("integrationId"):
             integration = integration_service.get_integration(
-                integration_id=result["integrationId"], organization_id=coerce_id_from(organization)
+                integration_id=result["integrationId"],
+                organization_id=coerce_id_from(organization),
+                status=ObjectStatus.ACTIVE,
             )
             if integration is None:
                 return Response({"detail": "Invalid integration id"}, status=400)

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -17,6 +17,7 @@ from django.views.decorators.csrf import csrf_exempt
 from sentry import options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.constants import ObjectStatus
 from sentry.integrations.github.webhook import (
     InstallationEventWebhook,
     PullRequestEventWebhook,
@@ -79,6 +80,7 @@ def get_installation_metadata(event, host):
     integration = integration_service.get_integration(
         external_id=external_id,
         provider="github_enterprise",
+        status=ObjectStatus.ACTIVE,
     )
     if integration is None:
         metrics.incr("integrations.github_enterprise.does_not_exist")

--- a/src/sentry/integrations/msteams/parsing.py
+++ b/src/sentry/integrations/msteams/parsing.py
@@ -2,6 +2,7 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
+from sentry.constants import ObjectStatus
 from sentry.integrations.msteams.spec import PROVIDER
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.integration.model import RpcIntegration
@@ -23,14 +24,18 @@ def get_integration_from_channel_data(data: Mapping[str, Any]) -> RpcIntegration
     team_id = _infer_team_id_from_channel_data(data=data)
     if team_id is None:
         return None
-    return integration_service.get_integration(provider=PROVIDER, external_id=team_id)
+    return integration_service.get_integration(
+        provider=PROVIDER, external_id=team_id, status=ObjectStatus.ACTIVE
+    )
 
 
 def get_integration_for_tenant(data: Mapping[str, Any]) -> RpcIntegration | None:
     try:
         channel_data = data["channelData"]
         tenant_id = channel_data["tenant"]["id"]
-        return integration_service.get_integration(provider=PROVIDER, external_id=tenant_id)
+        return integration_service.get_integration(
+            provider=PROVIDER, external_id=tenant_id, status=ObjectStatus.ACTIVE
+        )
     except Exception as err:
         logger.info("failed to get tenant id from request data", exc_info=err, extra={"data": data})
     return None
@@ -56,7 +61,9 @@ def get_integration_from_card_action(data: Mapping[str, Any]) -> RpcIntegration 
     integration_id = _infer_integration_id_from_card_action(data=data)
     if integration_id is None:
         return None
-    return integration_service.get_integration(integration_id=integration_id)
+    return integration_service.get_integration(
+        integration_id=integration_id, status=ObjectStatus.ACTIVE
+    )
 
 
 def can_infer_integration(data: Mapping[str, Any]) -> bool:

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -18,6 +18,7 @@ from sentry.api import client
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, all_silo_endpoint
+from sentry.constants import ObjectStatus
 from sentry.identity.services.identity import identity_service
 from sentry.identity.services.identity.model import RpcIdentity
 from sentry.integrations.msteams import parsing
@@ -506,7 +507,9 @@ class MsTeamsWebhookEndpoint(Endpoint):
 
         group = Group.objects.select_related("project__organization").filter(id=group_id).first()
         if group:
-            integration = integration_service.get_integration(integration_id=integration.id)
+            integration = integration_service.get_integration(
+                integration_id=integration.id, status=ObjectStatus.ACTIVE
+            )
             if integration is None:
                 group = None
 

--- a/src/sentry/integrations/opsgenie/integration.py
+++ b/src/sentry/integrations/opsgenie/integration.py
@@ -10,6 +10,7 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework.request import Request
 from rest_framework.serializers import ValidationError
 
+from sentry.constants import ObjectStatus
 from sentry.integrations.base import (
     FeatureDescription,
     IntegrationFeatures,
@@ -169,7 +170,7 @@ class OpsgenieIntegration(IntegrationInstallation):
         }
 
         integration = integration_service.get_integration(
-            organization_integration_id=self.org_integration.id
+            organization_integration_id=self.org_integration.id, status=ObjectStatus.ACTIVE
         )
         if not integration:
             raise IntegrationError("Integration does not exist")

--- a/src/sentry/integrations/slack/requests/base.py
+++ b/src/sentry/integrations/slack/requests/base.py
@@ -10,6 +10,7 @@ from rest_framework.request import Request
 from slack_sdk.signature import SignatureVerifier
 
 from sentry import options
+from sentry.constants import ObjectStatus
 from sentry.identity.services.identity import RpcIdentity, identity_service
 from sentry.identity.services.identity.model import RpcIdentityProvider
 from sentry.integrations.services.integration import RpcIntegration, integration_service
@@ -224,7 +225,7 @@ class SlackRequest:
     def validate_integration(self) -> None:
         if not self._integration:
             self._integration = integration_service.get_integration(
-                provider="slack", external_id=self.team_id
+                provider="slack", external_id=self.team_id, status=ObjectStatus.ACTIVE
             )
 
         if not self._integration:

--- a/src/sentry/integrations/tasks/sync_assignee_outbound.py
+++ b/src/sentry/integrations/tasks/sync_assignee_outbound.py
@@ -1,4 +1,5 @@
 from sentry import analytics, features
+from sentry.constants import ObjectStatus
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration import integration_service
@@ -32,7 +33,9 @@ def sync_assignee_outbound(external_issue_id: int, user_id: int | None, assign: 
     has_issue_sync = features.has("organizations:integrations-issue-sync", organization)
     if not has_issue_sync:
         return
-    integration = integration_service.get_integration(integration_id=external_issue.integration_id)
+    integration = integration_service.get_integration(
+        integration_id=external_issue.integration_id, status=ObjectStatus.ACTIVE
+    )
     if not integration:
         return
 

--- a/src/sentry/integrations/tasks/sync_status_inbound.py
+++ b/src/sentry/integrations/tasks/sync_status_inbound.py
@@ -7,6 +7,7 @@ from django.utils import timezone as django_timezone
 
 from sentry import analytics
 from sentry.api.helpers.group_index.update import get_current_release_version_of_group
+from sentry.constants import ObjectStatus
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration import integration_service
 from sentry.models.group import Group, GroupStatus
@@ -181,7 +182,9 @@ def sync_status_inbound(
 ) -> None:
     from sentry.integrations.mixins import ResolveSyncAction
 
-    integration = integration_service.get_integration(integration_id=integration_id)
+    integration = integration_service.get_integration(
+        integration_id=integration_id, status=ObjectStatus.ACTIVE
+    )
     if integration is None:
         raise Integration.DoesNotExist
 

--- a/src/sentry/integrations/tasks/sync_status_outbound.py
+++ b/src/sentry/integrations/tasks/sync_status_outbound.py
@@ -1,4 +1,5 @@
 from sentry import analytics, features
+from sentry.constants import ObjectStatus
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration import integration_service
@@ -34,7 +35,9 @@ def sync_status_outbound(group_id: int, external_issue_id: int) -> bool | None:
         # Issue link could have been deleted while sync job was in the queue.
         return None
 
-    integration = integration_service.get_integration(integration_id=external_issue.integration_id)
+    integration = integration_service.get_integration(
+        integration_id=external_issue.integration_id, status=ObjectStatus.ACTIVE
+    )
     if not integration:
         return None
     installation = integration.get_installation(organization_id=external_issue.organization_id)

--- a/src/sentry/integrations/utils/common.py
+++ b/src/sentry/integrations/utils/common.py
@@ -1,8 +1,8 @@
 import logging
 
+from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import RpcIntegration, integration_service
 from sentry.integrations.types import ExternalProviderEnum
-from sentry.models.organization import OrganizationStatus
 
 _default_logger = logging.getLogger(__name__)
 
@@ -13,7 +13,7 @@ def get_active_integration_for_organization(
     try:
         return integration_service.get_integration(
             organization_id=organization_id,
-            status=OrganizationStatus.ACTIVE,
+            status=ObjectStatus.ACTIVE,
             provider=provider.value,
         )
     except Exception as err:

--- a/src/sentry/integrations/utils/stacktrace_link.py
+++ b/src/sentry/integrations/utils/stacktrace_link.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, NotRequired, TypedDict
 
+from sentry.constants import ObjectStatus
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.source_code_management.repository import RepositoryIntegration
@@ -30,7 +31,7 @@ def get_link(
     result: RepositoryLinkOutcome = {}
 
     integration = integration_service.get_integration(
-        organization_integration_id=config.organization_integration_id
+        organization_integration_id=config.organization_integration_id, status=ObjectStatus.ACTIVE
     )
     if not integration:
         result["error"] = "integration_not_found"

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -8,6 +8,7 @@ from urllib.parse import quote
 from requests import PreparedRequest
 from rest_framework.response import Response
 
+from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidIdentity
 from sentry.integrations.base import IntegrationFeatureNotImplementedError
 from sentry.integrations.client import ApiClient
@@ -207,7 +208,7 @@ class VstsApiClient(IntegrationProxyClient, VstsApiMixin, RepositoryClient):
             from sentry.integrations.vsts.integration import VstsIntegrationProvider
 
             integration = integration_service.get_integration(
-                organization_integration_id=self.org_integration_id
+                organization_integration_id=self.org_integration_id, status=ObjectStatus.ACTIVE
             )
             # check if integration has migrated to new identity provider
             migration_version = integration.metadata.get("integration_migration_version", 0)

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -6,6 +6,7 @@ from django.utils.translation import gettext as _
 from mistune import markdown
 from rest_framework.response import Response
 
+from sentry.constants import ObjectStatus
 from sentry.integrations.mixins import ResolveSyncAction
 from sentry.integrations.mixins.issues import IssueSyncIntegration
 from sentry.integrations.services.integration import integration_service
@@ -361,7 +362,7 @@ class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration):
         client = self.get_client()
 
         integration = integration_service.get_integration(
-            integration_id=self.org_integration.integration_id
+            integration_id=self.org_integration.integration_id, status=ObjectStatus.ACTIVE
         )
         if not integration:
             raise IntegrationError("Azure DevOps integration not found")

--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -12,6 +12,7 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.constants import ObjectStatus
 from sentry.integrations.mixins.issues import IssueSyncIntegration
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.utils import sync_group_assignee_inbound
@@ -52,7 +53,7 @@ class WorkItemWebhook(Endpoint):
         # https://docs.microsoft.com/en-us/azure/devops/service-hooks/events?view=azure-devops#workitem.updated
         if event_type == "workitem.updated":
             integration = integration_service.get_integration(
-                provider=PROVIDER_KEY, external_id=external_id
+                provider=PROVIDER_KEY, external_id=external_id, status=ObjectStatus.ACTIVE
             )
             if integration is None:
                 logger.info(


### PR DESCRIPTION
Query for active integrations when:
- Doing an autofix setup check (non-active GH integrations will not make successful downstream calls)
- Editing a repository to be attached to a different integration
- Fetching installation metadata to process GH Enterprise webhook
- Fetching MSTeams integrations from various sources, used in MSTeams middleware
- Processing MSTeams webhooks
- Updating organization config for Opsgenie
- Validating Slack integration for incoming requests
- Syncing issues inbound and outbound
- Processing stacktrace links (we make an external API call to check if the file exists)
- Processing VSTS webhooks, client (for refresh token), and searching issues (calls `client.search_issues`)