### PR TITLE
feat(insights): reorder columns and add back user misery into frontend view

### DIFF
--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -39,14 +39,15 @@ import {
 } from 'sentry/views/performance/utils';
 
 export const FRONTEND_COLUMN_TITLES = [
-  'route',
-  'project',
+  'transaction',
   'operation',
+  'project',
   'tpm',
   'p50()',
   'p75()',
   'p95()',
   'users',
+  'user misery',
 ];
 
 function FrontendOverviewPage() {
@@ -68,12 +69,15 @@ function FrontendOverviewPage() {
   eventView.fields = [
     {field: 'team_key_transaction'},
     {field: 'transaction'},
-    {field: 'project'},
     {field: 'transaction.op'},
+    {field: 'project'},
     {field: 'tpm()'},
     {field: 'p50(transaction.duration)'},
     {field: 'p75(transaction.duration)'},
     {field: 'p95(transaction.duration)'},
+    {field: 'count_unique(user)'},
+    {field: 'count_miserable(user)'},
+    {field: 'user_misery()'},
   ].map(field => ({...field, width: COL_WIDTH_UNDEFINED}));
 
   const showOnboarding = onboardingProject !== undefined;


### PR DESCRIPTION
Work for https://github.com/getsentry/sentry/issues/77572

After some feedback, we decided to keep the columns the same between the existing frontend view and the new frontend overview page. This PR adds any missing columns.
Additionally, we swapped the column orders so that operation always follows transaction (instead of project being between the two).