### PR TITLE
feat(insights): update mobile domain view columns/charts

### DIFF
--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -43,23 +43,25 @@ import {
 
 const MOBILE_COLUMN_TITLES = [
   'transaction',
-  'project',
   'operation',
+  'project',
   'tpm',
   'slow frame %',
   'frozen frame %',
   'users',
+  'user misery',
 ];
 
 const REACT_NATIVE_COLUMN_TITLES = [
   'transaction',
-  'project',
   'operation',
+  'project',
   'tpm',
   'slow frame %',
   'frozen frame %',
   'stall %',
   'users',
+  'user misery',
 ];
 
 function MobileOverviewPage() {
@@ -80,10 +82,6 @@ function MobileOverviewPage() {
     organization
   );
 
-  eventView.fields = eventView.fields.filter(
-    field => !['user_misery()', 'count_miserable(user)'].includes(field.field)
-  );
-
   let columnTitles = checkIsReactNative(eventView)
     ? REACT_NATIVE_COLUMN_TITLES
     : MOBILE_COLUMN_TITLES;
@@ -102,10 +100,6 @@ function MobileOverviewPage() {
     PerformanceWidgetSetting.P95_DURATION_AREA,
     PerformanceWidgetSetting.P99_DURATION_AREA,
     PerformanceWidgetSetting.FAILURE_RATE_AREA,
-    PerformanceWidgetSetting.COLD_STARTUP_AREA,
-    PerformanceWidgetSetting.WARM_STARTUP_AREA,
-    PerformanceWidgetSetting.SLOW_FRAMES_AREA,
-    PerformanceWidgetSetting.FROZEN_FRAMES_AREA,
   ];
 
   if (organization.features.includes('mobile-vitals')) {


### PR DESCRIPTION
Work for https://github.com/getsentry/sentry/issues/77572

Same as https://github.com/getsentry/sentry/pull/78511 but for mobile.

Removes some charts from the "triple chart row" as they are already covered by the "double chart row" as per product feedback