### PR TITLE
[feat] Add API functionality to call Seer's test generation endpoint

### DIFF
--- a/src/sentry/api/endpoints/ai_unit_test_generation.py
+++ b/src/sentry/api/endpoints/ai_unit_test_generation.py
@@ -95,12 +95,16 @@ class AIUnitTestGenerationEndpoint(OrganizationEndpoint):
 
         return response.json().get("run_id")
 
-    def post(self, request: Request, *args, **kwargs) -> Response:
-        owner = kwargs.get("organization_id_or_slug")
+    def post(
+        self,
+        request: Request,
+        *args,
+        **kwargs,
+    ) -> Response:
+        owner = kwargs.get("organization").slug
         repo_name = kwargs.get("repo_name")
         pull_request_number = kwargs.get("pull_request_number")
         external_id = kwargs.get("external_id")
-
         created_at = datetime.now().isoformat()
 
         if pull_request_number is None:
@@ -131,5 +135,4 @@ class AIUnitTestGenerationEndpoint(OrganizationEndpoint):
                 "Test generation failed to start.",
                 500,
             )
-
         return Response(status=202)

--- a/src/sentry/api/endpoints/ai_unit_test_generation.py
+++ b/src/sentry/api/endpoints/ai_unit_test_generation.py
@@ -11,8 +11,7 @@ from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import region_silo_endpoint
-from sentry.api.bases.group import GroupEndpoint
+from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.seer.signed_seer_api import get_seer_salted_url, sign_with_seer_secret
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.users.models.user import User
@@ -25,7 +24,7 @@ TIMEOUT_SECONDS = 60 * 30  # 30 minutes
 
 
 @region_silo_endpoint
-class AIUnitTestGenerationEndpoint(GroupEndpoint):
+class AIUnitTestGenerationEndpoint(Endpoint):
     publish_status = {
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }
@@ -95,11 +94,11 @@ class AIUnitTestGenerationEndpoint(GroupEndpoint):
 
         return response.json().get("run_id")
 
-    def post(self, request: Request) -> Response:
-        owner = request.query_params.get("org_slug")
-        repo_name = request.query_params.get("repo_name")
-        pull_request_number = request.query_params.get("pull_request_number")
-        external_id = request.query_params.get("external_id")
+    def post(self, request: Request, *args, **kwargs) -> Response:
+        owner = kwargs.get("organization_id_or_slug")
+        repo_name = kwargs.get("repo_name")
+        pull_request_number = kwargs.get("pull_request_number")
+        external_id = kwargs.get("external_id")
 
         created_at = datetime.now().isoformat()
 
@@ -127,12 +126,9 @@ class AIUnitTestGenerationEndpoint(GroupEndpoint):
                     "exception": e,
                 },
             )
-
             return self._respond_with_error(
                 "Test generation failed to start.",
                 500,
             )
 
-        return Response(
-            status=202,
-        )
+        return Response(status=202)

--- a/src/sentry/api/endpoints/ai_unit_test_generation.py
+++ b/src/sentry/api/endpoints/ai_unit_test_generation.py
@@ -11,7 +11,8 @@ from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.seer.signed_seer_api import get_seer_salted_url, sign_with_seer_secret
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.users.models.user import User
@@ -24,7 +25,7 @@ TIMEOUT_SECONDS = 60 * 30  # 30 minutes
 
 
 @region_silo_endpoint
-class AIUnitTestGenerationEndpoint(Endpoint):
+class AIUnitTestGenerationEndpoint(OrganizationEndpoint):
     publish_status = {
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }

--- a/src/sentry/api/endpoints/ai_unit_test_generation.py
+++ b/src/sentry/api/endpoints/ai_unit_test_generation.py
@@ -101,7 +101,7 @@ class AIUnitTestGenerationEndpoint(OrganizationEndpoint):
         *args,
         **kwargs,
     ) -> Response:
-        owner = kwargs.get("organization").slug
+        owner = kwargs.get("github_org")
         repo_name = kwargs.get("repo_name")
         pull_request_number = kwargs.get("pull_request_number")
         external_id = kwargs.get("external_id")

--- a/src/sentry/api/endpoints/ai_unit_test_generation.py
+++ b/src/sentry/api/endpoints/ai_unit_test_generation.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+import orjson
+import requests
+from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.group import GroupEndpoint
+from sentry.seer.signed_seer_api import get_seer_salted_url, sign_with_seer_secret
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.users.models.user import User
+
+logger = logging.getLogger(__name__)
+
+from rest_framework.request import Request
+
+TIMEOUT_SECONDS = 60 * 30  # 30 minutes
+
+
+@region_silo_endpoint
+class AIUnitTestGenerationEndpoint(GroupEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ML_AI
+    # go away
+    private = True
+    enforce_rate_limit = True
+    rate_limits = {
+        "POST": {
+            RateLimitCategory.IP: RateLimit(limit=10, window=60),
+            RateLimitCategory.USER: RateLimit(limit=10, window=60),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=10, window=60),
+        }
+    }
+
+    def _respond_with_error(self, reason: str, status: int):
+        return Response(
+            {
+                "detail": reason,
+            },
+            status=status,
+        )
+
+    def _call_unit_test_generation(
+        self,
+        user: User | AnonymousUser,
+        owner: str,
+        name: str,
+        external_id: str,
+        pr_id: int,
+    ):
+        path = "/v1/automation/codegen/unit-tests"
+        body = orjson.dumps(
+            {
+                "repo": {
+                    "provider": "github",
+                    "owner": owner,
+                    "name": name,
+                    "external_id": external_id,
+                },
+                "pr_id": pr_id,
+                "invoking_user": (
+                    {
+                        "id": user.id,
+                        "display_name": user.get_display_name(),
+                    }
+                    if not isinstance(user, AnonymousUser)
+                    else None
+                ),
+            },
+            option=orjson.OPT_NON_STR_KEYS,
+        )
+
+        # not sure if proper URL
+        url, salt = get_seer_salted_url(f"{settings.SEER_AUTOFIX_URL}{path}")
+        response = requests.post(
+            url,
+            data=body,
+            headers={
+                "content-type": "application/json;charset=utf-8",
+                **sign_with_seer_secret(
+                    salt,
+                    body=body,
+                ),
+            },
+        )
+
+        response.raise_for_status()
+
+        return response.json().get("run_id")
+
+    def post(self, request: Request) -> Response:
+        owner = request.query_params.get("org_slug")
+        repo_name = request.query_params.get("repo_name")
+        pull_request_number = request.query_params.get("pull_request_number")
+        external_id = request.query_params.get("external_id")
+
+        created_at = datetime.now().isoformat()
+
+        try:
+            self._call_unit_test_generation(
+                request.user,
+                owner=owner,
+                name=repo_name,
+                external_id=external_id,
+                pr_id=pull_request_number,
+            )
+        except Exception as e:
+            logger.exception(
+                "Failed to send test generation request to seer",
+                extra={
+                    "created_at": created_at,
+                    "exception": e,
+                },
+            )
+
+            return self._respond_with_error(
+                "Test generation failed to start.",
+                500,
+            )
+
+        return Response(
+            status=202,
+        )

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -3317,7 +3317,7 @@ urlpatterns = [
         name="sentry-api-catchall",
     ),
     re_path(
-        r"^api/0/organizations/(?P<org_slug>[^/]+)/repo/(?P<repo_name>[^/]+)/pr/(?P<pull_request_number>\d+)/externalid/(?P<external_id>[^/]+)/generate-unit-tests/$",
+        r"^api/0/organizations/(?P<organization_id_or_slug>[^/]+)/repo/(?P<repo_name>[^/]+)/pr/(?P<pull_request_number>\d+)/externalid/(?P<external_id>[^/]+)/generate-unit-tests/$",
         AIUnitTestGenerationEndpoint.as_view(),
         name="generate_unit_tests",
     ),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2070,6 +2070,11 @@ ORGANIZATION_URLS = [
         name="sentry-api-0-organization-request-project-creation",
     ),
     re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/repo/(?P<repo_name>[^\/]+)/pr/(?P<pull_request_number>[^\/]+)/externalid/(?P<external_id>[^\/]+)/generate-unit-tests/$",
+        AIUnitTestGenerationEndpoint.as_view(),
+        name="sentry-api-0-generate-unit-tests",
+    ),
+    re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/scim/v2/",
         include(
             [
@@ -3315,11 +3320,6 @@ urlpatterns = [
         r"^",
         CatchallEndpoint.as_view(),
         name="sentry-api-catchall",
-    ),
-    re_path(
-        r"^organizations/(?P<organization_id_or_slug>[^/]+)/repo/(?P<repo_name>[^/]+)/pr/(?P<pull_request_number>[^/]+)/externalid/(?P<external_id>[^/]+)/generate-unit-tests/$",
-        AIUnitTestGenerationEndpoint.as_view(),
-        name="sentry-api-0-generate-unit-tests",
     ),
     # re_path(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
 ]

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -351,6 +351,7 @@ from sentry.users.api.endpoints.userroles_index import UserRolesEndpoint
 from .endpoints.accept_organization_invite import AcceptOrganizationInvite
 from .endpoints.accept_project_transfer import AcceptProjectTransferEndpoint
 from .endpoints.admin_project_configs import AdminRelayProjectConfigsEndpoint
+from .endpoints.ai_unit_test_generation import AIUnitTestGenerationEndpoint
 from .endpoints.api_application_details import ApiApplicationDetailsEndpoint
 from .endpoints.api_application_rotate_secret import ApiApplicationRotateSecretEndpoint
 from .endpoints.api_applications import ApiApplicationsEndpoint
@@ -3314,6 +3315,11 @@ urlpatterns = [
         r"^",
         CatchallEndpoint.as_view(),
         name="sentry-api-catchall",
+    ),
+    re_path(
+        r"^api/0/organizations/(?P<org_slug>[^/]+)/repo/(?P<repo_name>[^/]+)/pr/(?P<pull_request_number>\d+)/externalid/(?P<external_id>[^/]+)/generate-unit-tests/$",
+        AIUnitTestGenerationEndpoint.as_view(),
+        name="generate_unit_tests",
     ),
     # re_path(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
 ]

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2070,11 +2070,6 @@ ORGANIZATION_URLS = [
         name="sentry-api-0-organization-request-project-creation",
     ),
     re_path(
-        r"^(?P<organization_id_or_slug>[^\/]+)/repo/(?P<repo_name>[^\/]+)/pr/(?P<pull_request_number>[^\/]+)/externalid/(?P<external_id>[^\/]+)/generate-unit-tests/$",
-        AIUnitTestGenerationEndpoint.as_view(),
-        name="sentry-api-0-generate-unit-tests",
-    ),
-    re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/scim/v2/",
         include(
             [
@@ -3234,6 +3229,11 @@ urlpatterns = [
         r"^organizations/(?P<organization_id_or_slug>[^\/]+)/shared/(?:issues|groups)/(?P<share_id>[^\/]+)/$",
         SharedGroupDetailsEndpoint.as_view(),
         name="sentry-api-0-organization-shared-group-details",
+    ),
+    re_path(
+        r"organizations/(?P<organization_id_or_slug>[^\/]+)/repo/(?P<repo_name>[^\/]+)/pr/(?P<pull_request_number>[^\/]+)/externalid/(?P<external_id>[^\/]+)/generate-unit-tests/$",
+        AIUnitTestGenerationEndpoint.as_view(),
+        name="sentry-api-0-generate-unit-tests",
     ),
     re_path(
         r"^shared/(?:issues|groups)/(?P<share_id>[^\/]+)/$",

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -3317,9 +3317,9 @@ urlpatterns = [
         name="sentry-api-catchall",
     ),
     re_path(
-        r"^api/0/organizations/(?P<organization_id_or_slug>[^/]+)/repo/(?P<repo_name>[^/]+)/pr/(?P<pull_request_number>\d+)/externalid/(?P<external_id>[^/]+)/generate-unit-tests/$",
+        r"^organizations/(?P<organization_id_or_slug>[^/]+)/repo/(?P<repo_name>[^/]+)/pr/(?P<pull_request_number>\d+)/externalid/(?P<external_id>[^/]+)/generate-unit-tests/$",
         AIUnitTestGenerationEndpoint.as_view(),
-        name="sentry-api-generate-unit-tests",
+        name="sentry-api-0-generate-unit-tests",
     ),
     # re_path(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
 ]

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -3231,7 +3231,7 @@ urlpatterns = [
         name="sentry-api-0-organization-shared-group-details",
     ),
     re_path(
-        r"organizations/(?P<organization_id_or_slug>[^\/]+)/repo/(?P<repo_name>[^\/]+)/pr/(?P<pull_request_number>[^\/]+)/externalid/(?P<external_id>[^\/]+)/generate-unit-tests/$",
+        r"organizations/(?P<organization_id_or_slug>[^\/]+)/repo/(?P<repo_name>[^\/]+)/pr/(?P<pull_request_number>[^\/]+)/external-id/(?P<external_id>[^\/]+)/github-org/(?P<github_org>[^\/]+)/generate-unit-tests/$",
         AIUnitTestGenerationEndpoint.as_view(),
         name="sentry-api-0-generate-unit-tests",
     ),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -3317,7 +3317,7 @@ urlpatterns = [
         name="sentry-api-catchall",
     ),
     re_path(
-        r"^organizations/(?P<organization_id_or_slug>[^/]+)/repo/(?P<repo_name>[^/]+)/pr/(?P<pull_request_number>\d+)/externalid/(?P<external_id>[^/]+)/generate-unit-tests/$",
+        r"^organizations/(?P<organization_id_or_slug>[^/]+)/repo/(?P<repo_name>[^/]+)/pr/(?P<pull_request_number>[^/]+)/externalid/(?P<external_id>[^/]+)/generate-unit-tests/$",
         AIUnitTestGenerationEndpoint.as_view(),
         name="sentry-api-0-generate-unit-tests",
     ),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -3319,7 +3319,7 @@ urlpatterns = [
     re_path(
         r"^api/0/organizations/(?P<organization_id_or_slug>[^/]+)/repo/(?P<repo_name>[^/]+)/pr/(?P<pull_request_number>\d+)/externalid/(?P<external_id>[^/]+)/generate-unit-tests/$",
         AIUnitTestGenerationEndpoint.as_view(),
-        name="generate_unit_tests",
+        name="sentry-api-generate-unit-tests",
     ),
     # re_path(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
 ]

--- a/tests/sentry/api/endpoints/test_ai_unit_test_generation.py
+++ b/tests/sentry/api/endpoints/test_ai_unit_test_generation.py
@@ -21,11 +21,11 @@ class AIUnitTestGenerationEndpointTest(APITestCase):
         self.repo_name = "example-repo"
         self.pull_request_number = "123"
         self.external_id = "456"
-        # Construct the URL using the provided URL pattern
+
         self.url = reverse(
             "generate_unit_tests",
             kwargs={
-                "org_slug": self.org.slug,
+                "organization_id_or_slug": self.org.slug,
                 "repo_name": self.repo_name,
                 "pull_request_number": self.pull_request_number,
                 "external_id": self.external_id,
@@ -68,13 +68,12 @@ class AIUnitTestGenerationEndpointTest(APITestCase):
             )
 
     def test_post_invalid_pull_request_number(self):
-        # Test with an invalid pull request number
         invalid_url = reverse(
             "generate_unit_tests",
             kwargs={
-                "org_slug": self.org.slug,
+                "organization_id_or_slug": self.org.slug,
                 "repo_name": self.repo_name,
-                "pull_request_number": "invalid-pr-number",  # invalid string
+                "pull_request_number": "invalid-pr-number",
                 "external_id": self.external_id,
             },
         )

--- a/tests/sentry/api/endpoints/test_ai_unit_test_generation.py
+++ b/tests/sentry/api/endpoints/test_ai_unit_test_generation.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 from rest_framework.test import APIClient
 
 from sentry.api.endpoints.ai_unit_test_generation import AIUnitTestGenerationEndpoint
-from sentry.testutils import APITestCase
+from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import no_silo_test
 
 

--- a/tests/sentry/api/endpoints/test_ai_unit_test_generation.py
+++ b/tests/sentry/api/endpoints/test_ai_unit_test_generation.py
@@ -15,6 +15,7 @@ class AIUnitTestGenerationEndpointTest(APITestCase):
         self.repo_name = "example-repo"
         self.pull_request_number = "123"
         self.external_id = "456"
+        self.github_org = "example-org"
         self.user = self.create_user(email="example@example.com")
         self.login_as(user=self.user)
 
@@ -28,6 +29,7 @@ class AIUnitTestGenerationEndpointTest(APITestCase):
                 "repo_name": self.repo_name,
                 "pull_request_number": self.pull_request_number,
                 "external_id": self.external_id,
+                "github_org": self.github_org,
             },
         )
 
@@ -42,7 +44,7 @@ class AIUnitTestGenerationEndpointTest(APITestCase):
         assert response.status_code == 202
         mock_call_unit_test_generation.assert_called_once_with(
             ANY,
-            owner=self.project.organization.slug,
+            owner=self.github_org,
             name=self.repo_name,
             external_id=self.external_id,
             pr_id=int(self.pull_request_number),
@@ -59,7 +61,7 @@ class AIUnitTestGenerationEndpointTest(APITestCase):
         assert response.status_code == 500
         mock_call_unit_test_generation.assert_called_once_with(
             ANY,
-            owner=self.project.organization.slug,
+            owner=self.github_org,
             name=self.repo_name,
             external_id=self.external_id,
             pr_id=int(self.pull_request_number),

--- a/tests/sentry/api/endpoints/test_ai_unit_test_generation.py
+++ b/tests/sentry/api/endpoints/test_ai_unit_test_generation.py
@@ -15,7 +15,7 @@ class AIUnitTestGenerationEndpointTest(APITestCase):
         self.repo_name = "example-repo"
         self.pull_request_number = "123"
         self.external_id = "456"
-        self.url = f"/api/0/organizations/{self.organization.slug}/repo/{self.repo_name}/pr/{self.pull_request_number}/external/{self.external_id}/generate-unit-tests/"
+        self.url = f"/api/0/organizations/{self.organization.slug}/repo/{self.repo_name}/pr/{self.pull_request_number}/externalid/{self.external_id}/generate-unit-tests/"
 
     def test_post_success(self):
         with patch.object(
@@ -46,7 +46,7 @@ class AIUnitTestGenerationEndpointTest(APITestCase):
                 self.url,
             )
 
-            assert response.status_code == 404
+            assert response.status_code == 500
             assert response.data == {"detail": "Test generation failed to start."}
             mock_call_unit_test_generation.assert_called_once_with(
                 self.owner,

--- a/tests/sentry/api/endpoints/test_ai_unit_test_generation.py
+++ b/tests/sentry/api/endpoints/test_ai_unit_test_generation.py
@@ -20,7 +20,7 @@ class AIUnitTestGenerationEndpointTest(APITestCase):
         self.pull_request_number = "123"
         self.external_id = "456"
         self.path = reverse(
-            "sentry-api-generate-unit-tests",
+            "sentry-api-0-generate-unit-tests",
             kwargs={
                 "organization_id_or_slug": self.org.slug,
                 "repo_name": self.repo_name,
@@ -66,7 +66,7 @@ class AIUnitTestGenerationEndpointTest(APITestCase):
 
     def test_post_invalid_pull_request_number(self):
         invalid_path = reverse(
-            "sentry-api-generate-unit-tests",
+            "sentry-api-0-generate-unit-tests",
             kwargs={
                 "organization_id_or_slug": self.org.slug,
                 "repo_name": self.repo_name,

--- a/tests/sentry/api/endpoints/test_ai_unit_test_generation.py
+++ b/tests/sentry/api/endpoints/test_ai_unit_test_generation.py
@@ -67,11 +67,7 @@ class AIUnitTestGenerationEndpointTest(APITestCase):
             pr_id=self.pull_request_number,
         )
 
-    @patch(
-        "sentry.api.endpoints.ai_unit_test_generation.AIUnitTestGenerationEndpoint._call_unit_test_generation",
-        side_effect=Exception("Something went wrong"),
-    )
-    def test_post_validation_error(self, mock_call_unit_test_generation):
+    def test_post_validation_error(self):
         invalid_pr_url = reverse(
             self.endpoint,
             kwargs={

--- a/tests/sentry/api/endpoints/test_ai_unit_test_generation.py
+++ b/tests/sentry/api/endpoints/test_ai_unit_test_generation.py
@@ -1,0 +1,97 @@
+from unittest.mock import patch
+
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from sentry.api.endpoints.ai_unit_test_generation import AIUnitTestGenerationEndpoint
+from sentry.testutils import APITestCase
+from sentry.testutils.silo import no_silo_test
+
+
+@no_silo_test
+class AIUnitTestGenerationEndpointTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.owner = self.create_user(
+            email="example@example.com", is_superuser=False, is_staff=True, is_active=True
+        )
+        self.org = self.create_organization(owner=self.owner)
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.owner)
+        self.repo_name = "example-repo"
+        self.pull_request_number = "123"
+        self.external_id = "456"
+        # Construct the URL using the provided URL pattern
+        self.url = reverse(
+            "generate_unit_tests",
+            kwargs={
+                "org_slug": self.org.slug,
+                "repo_name": self.repo_name,
+                "pull_request_number": self.pull_request_number,
+                "external_id": self.external_id,
+            },
+        )
+
+    def test_post_success(self):
+        with patch.object(
+            AIUnitTestGenerationEndpoint, "_call_unit_test_generation"
+        ) as mock_call_unit_test_generation:
+            mock_call_unit_test_generation.return_value = "test-run-id"
+
+            response = self.client.post(self.url)
+
+            assert response.status_code == 202
+            mock_call_unit_test_generation.assert_called_once_with(
+                self.owner,
+                owner=self.org.slug,
+                name=self.repo_name,
+                external_id=self.external_id,
+                pr_id=self.pull_request_number,
+            )
+
+    def test_post_failure(self):
+        with patch.object(
+            AIUnitTestGenerationEndpoint, "_call_unit_test_generation"
+        ) as mock_call_unit_test_generation:
+            mock_call_unit_test_generation.side_effect = Exception("Test exception")
+
+            response = self.client.post(self.url)
+
+            assert response.status_code == 500
+            assert response.data == {"detail": "Test generation failed to start."}
+            mock_call_unit_test_generation.assert_called_once_with(
+                self.owner,
+                owner=self.org.slug,
+                name=self.repo_name,
+                external_id=self.external_id,
+                pr_id=self.pull_request_number,
+            )
+
+    def test_post_missing_parameters(self):
+        # Construct a URL missing the 'external_id' parameter
+        url = reverse(
+            "generate_unit_tests",
+            kwargs={
+                "org_slug": self.org.slug,
+                "repo_name": self.repo_name,
+                "pull_request_number": self.pull_request_number,
+                # 'external_id' is omitted
+            },
+        )
+
+        with patch.object(
+            AIUnitTestGenerationEndpoint, "_call_unit_test_generation"
+        ) as mock_call_unit_test_generation:
+            response = self.client.post(url)
+
+            response = self.client.post(self.url.replace(f"/{self.external_id}/", "//"))
+
+            assert response.status_code == 500
+            assert response.data == {"detail": "Test generation failed to start."}
+            mock_call_unit_test_generation.assert_called_once_with(
+                self.owner,
+                owner=self.org.slug,
+                name=self.repo_name,
+                external_id=None,
+                pr_id=self.pull_request_number,
+            )


### PR DESCRIPTION
<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
