### PR TITLE
ref(alerts): Move anomaly detection code out of subscription processor

### DIFF
--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -1,0 +1,127 @@
+import logging
+
+from django.conf import settings
+from urllib3.exceptions import MaxRetryError, TimeoutError
+
+from sentry.conf.server import SEER_ANOMALY_DETECTION_ENDPOINT_URL
+from sentry.incidents.models.alert_rule import AlertRule
+from sentry.net.http import connection_from_url
+from sentry.seer.anomaly_detection.types import (
+    AlertInSeer,
+    AnomalyDetectionConfig,
+    DetectAnomaliesRequest,
+    DetectAnomaliesResponse,
+    TimeSeriesPoint,
+)
+from sentry.seer.anomaly_detection.utils import translate_direction
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
+from sentry.snuba.models import QuerySubscription
+from sentry.utils import json
+from sentry.utils.json import JSONDecodeError
+
+logger = logging.getLogger(__name__)
+
+SEER_ANOMALY_DETECTION_CONNECTION_POOL = connection_from_url(
+    settings.SEER_ANOMALY_DETECTION_URL,
+    timeout=settings.SEER_ANOMALY_DETECTION_TIMEOUT,
+)
+
+
+def get_anomaly_data_from_seer(
+    alert_rule: AlertRule,
+    subscription: QuerySubscription,
+    last_update: float,
+    aggregation_value: float | None,
+) -> list[TimeSeriesPoint] | None:
+    anomaly_detection_config = AnomalyDetectionConfig(
+        time_period=int(alert_rule.snuba_query.time_window / 60),
+        sensitivity=alert_rule.sensitivity,
+        direction=translate_direction(alert_rule.threshold_type),
+        expected_seasonality=alert_rule.seasonality,
+    )
+    context = AlertInSeer(
+        id=alert_rule.id,
+        cur_window=TimeSeriesPoint(timestamp=last_update, value=aggregation_value),
+    )
+    detect_anomalies_request = DetectAnomaliesRequest(
+        organization_id=subscription.project.organization.id,
+        project_id=subscription.project_id,
+        config=anomaly_detection_config,
+        context=context,
+    )
+    extra_data = {
+        "subscription_id": subscription.id,
+        "dataset": subscription.snuba_query.dataset,
+        "organization_id": subscription.project.organization.id,
+        "project_id": subscription.project_id,
+        "alert_rule_id": alert_rule.id,
+    }
+    try:
+        response = make_signed_seer_api_request(
+            SEER_ANOMALY_DETECTION_CONNECTION_POOL,
+            SEER_ANOMALY_DETECTION_ENDPOINT_URL,
+            json.dumps(detect_anomalies_request).encode("utf-8"),
+        )
+    except (TimeoutError, MaxRetryError):
+        logger.warning("Timeout error when hitting anomaly detection endpoint", extra=extra_data)
+        return None
+
+    if response.status > 400:
+        logger.error(
+            "Error when hitting Seer detect anomalies endpoint",
+            extra={
+                "response_data": response.data,
+                **extra_data,
+            },
+        )
+        return None
+    try:
+        decoded_data = response.data.decode("utf-8")
+    except AttributeError:
+        logger.exception(
+            "Failed to parse Seer anomaly detection response",
+            extra={
+                "ad_config": anomaly_detection_config,
+                "context": context,
+                "response_data": response.data,
+                "response_code": response.status,
+            },
+        )
+        return None
+
+    try:
+        results: DetectAnomaliesResponse = json.loads(decoded_data)
+    except JSONDecodeError:
+        logger.exception(
+            "Failed to parse Seer anomaly detection response",
+            extra={
+                "ad_config": anomaly_detection_config,
+                "context": context,
+                "response_data": decoded_data,
+                "response_code": response.status,
+            },
+        )
+        return None
+
+    if not results.get("success"):
+        logger.error(
+            "Error when hitting Seer detect anomalies endpoint",
+            extra={
+                "error_message": results.get("message", ""),
+                **extra_data,
+            },
+        )
+        return None
+
+    ts = results.get("timeseries")
+    if not ts:
+        logger.warning(
+            "Seer anomaly detection response returned no potential anomalies",
+            extra={
+                "ad_config": anomaly_detection_config,
+                "context": context,
+                "response_data": results.get("message"),
+            },
+        )
+        return None
+    return ts

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 from typing import Any
 
-from django.conf import settings
 from django.utils import timezone
 from django.utils.datastructures import MultiValueDict
 from rest_framework.exceptions import ParseError
@@ -12,7 +11,6 @@ from sentry.api.serializers.snuba import SnubaTSResultSerializer
 from sentry.incidents.models.alert_rule import AlertRule, AlertRuleThresholdType
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.net.http import connection_from_url
 from sentry.search.events.types import SnubaParams
 from sentry.seer.anomaly_detection.types import AnomalyType, TimeSeriesPoint
 from sentry.snuba import metrics_performance
@@ -24,11 +22,6 @@ from sentry.snuba.utils import DATASET_OPTIONS, get_dataset
 from sentry.utils.snuba import SnubaTSResult
 
 NUM_DAYS = 28
-
-SEER_ANOMALY_DETECTION_CONNECTION_POOL = connection_from_url(
-    settings.SEER_ANOMALY_DETECTION_URL,
-    timeout=settings.SEER_ANOMALY_DETECTION_TIMEOUT,
-)
 
 SNUBA_QUERY_EVENT_TYPE_TO_STRING = {
     SnubaQueryEventType.EventType.ERROR: "error",

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -888,7 +888,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         seer_return_value: DetectAnomaliesResponse = {"success": True, "timeseries": []}
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
         result = get_anomaly_data_from_seer(
-            alert_rule=processor.alert_rule,
+            alert_rule=self.dynamic_rule,
             subscription=processor.subscription,
             last_update=processor.last_update.timestamp(),
             aggregation_value=10,
@@ -908,7 +908,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         processor = SubscriptionProcessor(self.sub)
         mock_seer_request.return_value = HTTPResponse(status=403)
         result = get_anomaly_data_from_seer(
-            alert_rule=processor.alert_rule,
+            alert_rule=self.dynamic_rule,
             subscription=processor.subscription,
             last_update=processor.last_update.timestamp(),
             aggregation_value=10,
@@ -936,7 +936,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         processor = SubscriptionProcessor(self.sub)
         mock_seer_request.return_value = HTTPResponse(None, status=200)  # type: ignore[arg-type]
         result = get_anomaly_data_from_seer(
-            alert_rule=processor.alert_rule,
+            alert_rule=self.dynamic_rule,
             subscription=processor.subscription,
             last_update=processor.last_update.timestamp(),
             aggregation_value=10,

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -52,12 +52,13 @@ from sentry.incidents.subscription_processor import (
 )
 from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.models.project import Project
+from sentry.seer.anomaly_detection.get_anomaly_data import get_anomaly_data_from_seer
 from sentry.seer.anomaly_detection.types import (
     AnomalyType,
     DetectAnomaliesResponse,
     TimeSeriesPoint,
 )
-from sentry.seer.anomaly_detection.utils import translate_direction
+from sentry.seer.anomaly_detection.utils import has_anomaly, translate_direction
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.indexer.postgres.models import MetricsKeyIndexer
 from sentry.sentry_metrics.utils import resolve_tag_key
@@ -474,7 +475,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         self.assert_action_handler_called_with_actions(None, [])
 
     @mock.patch(
-        "sentry.incidents.subscription_processor.SubscriptionProcessor.seer_anomaly_detection_connection_pool.urlopen"
+        "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"
     )
     @with_feature("organizations:incidents")
     @with_feature("organizations:anomaly-detection-alerts")
@@ -608,7 +609,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         )
 
     @mock.patch(
-        "sentry.incidents.subscription_processor.SubscriptionProcessor.seer_anomaly_detection_connection_pool.urlopen"
+        "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"
     )
     @with_feature("organizations:incidents")
     @with_feature("organizations:anomaly-detection-alerts")
@@ -726,27 +727,31 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
 
         label = self.trigger.label
 
-        processor = SubscriptionProcessor(self.sub)
-        assert processor.has_anomaly(anomaly1, label)
-        assert processor.has_anomaly(anomaly1, warning_label)
-        assert not processor.has_anomaly(anomaly2, label)
-        assert processor.has_anomaly(anomaly2, warning_label)
-        assert not processor.has_anomaly(not_anomaly, label)
-        assert not processor.has_anomaly(not_anomaly, warning_label)
+        assert has_anomaly(anomaly1, label)
+        assert has_anomaly(anomaly1, warning_label)
+        assert not has_anomaly(anomaly2, label)
+        assert has_anomaly(anomaly2, warning_label)
+        assert not has_anomaly(not_anomaly, label)
+        assert not has_anomaly(not_anomaly, warning_label)
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
     @mock.patch(
-        "sentry.incidents.subscription_processor.SubscriptionProcessor.seer_anomaly_detection_connection_pool.urlopen"
+        "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"
     )
-    @mock.patch("sentry.incidents.subscription_processor.logger")
+    @mock.patch("sentry.seer.anomaly_detection.get_anomaly_data.logger")
     def test_seer_call_timeout_error(self, mock_logger, mock_seer_request):
         rule = self.dynamic_rule
         processor = SubscriptionProcessor(self.sub)
         from urllib3.exceptions import TimeoutError
 
         mock_seer_request.side_effect = TimeoutError
-        result = processor.get_anomaly_data_from_seer(10)
+        result = get_anomaly_data_from_seer(
+            alert_rule=processor.alert_rule,
+            subscription=processor.subscription,
+            last_update=processor.last_update.timestamp(),
+            aggregation_value=10,
+        )
         timeout_extra = {
             "subscription_id": self.sub.id,
             "dataset": self.sub.snuba_query.dataset,
@@ -764,7 +769,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
     @mock.patch(
-        "sentry.incidents.subscription_processor.SubscriptionProcessor.seer_anomaly_detection_connection_pool.urlopen"
+        "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"
     )
     def test_dynamic_alert_rule_not_enough_data(self, mock_seer_request):
         rule = self.dynamic_rule
@@ -798,7 +803,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
     @mock.patch(
-        "sentry.incidents.subscription_processor.SubscriptionProcessor.seer_anomaly_detection_connection_pool.urlopen"
+        "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"
     )
     def test_enable_dynamic_alert_rule(self, mock_seer_request):
         rule = self.dynamic_rule
@@ -833,7 +838,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
     @mock.patch(
-        "sentry.incidents.subscription_processor.SubscriptionProcessor.seer_anomaly_detection_connection_pool.urlopen"
+        "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"
     )
     def test_enable_dynamic_alert_rule_and_fire(self, mock_seer_request):
         rule = self.dynamic_rule
@@ -875,14 +880,19 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
     @mock.patch(
-        "sentry.incidents.subscription_processor.SubscriptionProcessor.seer_anomaly_detection_connection_pool.urlopen"
+        "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"
     )
-    @mock.patch("sentry.incidents.subscription_processor.logger")
+    @mock.patch("sentry.seer.anomaly_detection.get_anomaly_data.logger")
     def test_seer_call_empty_list(self, mock_logger, mock_seer_request):
         processor = SubscriptionProcessor(self.sub)
         seer_return_value: DetectAnomaliesResponse = {"success": True, "timeseries": []}
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
-        result = processor.get_anomaly_data_from_seer(10)
+        result = get_anomaly_data_from_seer(
+            alert_rule=processor.alert_rule,
+            subscription=processor.subscription,
+            last_update=processor.last_update.timestamp(),
+            aggregation_value=10,
+        )
         assert mock_logger.warning.call_args[0] == (
             "Seer anomaly detection response returned no potential anomalies",
         )
@@ -891,13 +901,18 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
     @mock.patch(
-        "sentry.incidents.subscription_processor.SubscriptionProcessor.seer_anomaly_detection_connection_pool.urlopen"
+        "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"
     )
-    @mock.patch("sentry.incidents.subscription_processor.logger")
+    @mock.patch("sentry.seer.anomaly_detection.get_anomaly_data.logger")
     def test_seer_call_bad_status(self, mock_logger, mock_seer_request):
         processor = SubscriptionProcessor(self.sub)
         mock_seer_request.return_value = HTTPResponse(status=403)
-        result = processor.get_anomaly_data_from_seer(10)
+        result = get_anomaly_data_from_seer(
+            alert_rule=processor.alert_rule,
+            subscription=processor.subscription,
+            last_update=processor.last_update.timestamp(),
+            aggregation_value=10,
+        )
         mock_logger.error.assert_called_with(
             "Error when hitting Seer detect anomalies endpoint",
             extra={
@@ -914,13 +929,18 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
     @mock.patch(
-        "sentry.incidents.subscription_processor.SubscriptionProcessor.seer_anomaly_detection_connection_pool.urlopen"
+        "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"
     )
-    @mock.patch("sentry.incidents.subscription_processor.logger")
+    @mock.patch("sentry.seer.anomaly_detection.get_anomaly_data.logger")
     def test_seer_call_failed_parse(self, mock_logger, mock_seer_request):
         processor = SubscriptionProcessor(self.sub)
         mock_seer_request.return_value = HTTPResponse(None, status=200)  # type: ignore[arg-type]
-        result = processor.get_anomaly_data_from_seer(10)
+        result = get_anomaly_data_from_seer(
+            alert_rule=processor.alert_rule,
+            subscription=processor.subscription,
+            last_update=processor.last_update.timestamp(),
+            aggregation_value=10,
+        )
         mock_logger.exception.assert_called_with(
             "Failed to parse Seer anomaly detection response", extra=mock.ANY
         )
@@ -3002,7 +3022,7 @@ class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetrics
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
     @mock.patch(
-        "sentry.incidents.subscription_processor.SubscriptionProcessor.seer_anomaly_detection_connection_pool.urlopen"
+        "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"
     )
     def test_dynamic_crash_rate_alert_for_sessions_with_auto_resolve_critical(
         self, mock_seer_request


### PR DESCRIPTION
This PR moves anomaly detection specific functions out of the subscription processor, there are no logic changes.