### PR TITLE
fix(issues): Remove margin-right from grouping help

### DIFF
--- a/static/app/data/forms/projectIssueGrouping.tsx
+++ b/static/app/data/forms/projectIssueGrouping.tsx
@@ -102,10 +102,8 @@ stack.function:mylibrary_* +app`}
 const RuleDescription = styled('div')`
   margin-bottom: ${space(1)};
   margin-top: -${space(1)};
-  margin-right: 36px;
 `;
 
 const RuleExample = styled('pre')`
   margin-bottom: ${space(1)};
-  margin-right: 36px;
 `;


### PR DESCRIPTION
I assume this was unintentional.

Before
![Screenshot 2024-10-02 at 2 10 59 PM](https://github.com/user-attachments/assets/31d0beed-5e2d-4752-b81a-33c14b4997e2)

After
![Screenshot 2024-10-02 at 2 10 38 PM](https://github.com/user-attachments/assets/c384259f-16b5-47ac-8423-0cd171fa55de)
