### PR TITLE
chore(api): Remove 'helpful' from allowed group event values

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -720,7 +720,7 @@ def create_group_urls(name_prefix: str) -> list[URLPattern | URLResolver]:
             name=f"{name_prefix}-group-events",
         ),
         re_path(
-            r"^(?P<issue_id>[^\/]+)/events/(?P<event_id>(?:latest|oldest|helpful|recommended|\d+|[A-Fa-f0-9-]{32,36}))/$",
+            r"^(?P<issue_id>[^\/]+)/events/(?P<event_id>(?:latest|oldest|recommended|\d+|[A-Fa-f0-9-]{32,36}))/$",
             GroupEventDetailsEndpoint.as_view(),
             name=f"{name_prefix}-group-event-details",
         ),

--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -115,10 +115,10 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
 
     def get(self, request: Request, group: Group, event_id: str) -> Response:
         """
-        Retrieve the latest(most recent), oldest, or most helpful Event for an Issue
+        Retrieve the latest(most recent), oldest, or recommended Event for an Issue
         ``````````````````````````````````````
 
-        Retrieves the details of the latest/oldest/most-helpful event for an issue.
+        Retrieves the details of the latest/oldest/recommended event for an issue.
 
         :pparam string group_id: the ID of the issue
         """
@@ -133,7 +133,7 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
         elif event_id == "oldest":
             with metrics.timer("api.endpoints.group_event_details.get", tags={"type": "oldest"}):
                 event = group.get_oldest_event_for_environments(environment_names)
-        elif event_id in ("helpful", "recommended"):
+        elif event_id == "recommended":
             query = request.GET.get("query")
             if query:
                 with metrics.timer(

--- a/tests/sentry/issues/endpoints/test_group_event_details.py
+++ b/tests/sentry/issues/endpoints/test_group_event_details.py
@@ -157,7 +157,7 @@ class GroupEventDetailsHelpfulEndpointTest(
             },
             project_id=self.project_1.id,
         )
-        url = f"/api/0/issues/{self.event_a.group.id}/events/helpful/"
+        url = f"/api/0/issues/{self.event_a.group.id}/events/recommended/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -193,7 +193,7 @@ class GroupEventDetailsHelpfulEndpointTest(
             },
             project_id=self.project_1.id,
         )
-        url = f"/api/0/issues/{self.event_a.group.id}/events/helpful/"
+        url = f"/api/0/issues/{self.event_a.group.id}/events/recommended/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -241,7 +241,7 @@ class GroupEventDetailsHelpfulEndpointTest(
             project_id=self.project_1.id,
         )
 
-        url = f"/api/0/issues/{self.event_d.group.id}/events/helpful/"
+        url = f"/api/0/issues/{self.event_d.group.id}/events/recommended/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -250,7 +250,7 @@ class GroupEventDetailsHelpfulEndpointTest(
         assert response.data["nextEventID"] == str(self.event_f.event_id)
 
     def test_with_empty_query(self):
-        url = f"/api/0/issues/{self.event_a.group.id}/events/helpful/"
+        url = f"/api/0/issues/{self.event_a.group.id}/events/recommended/"
         response = self.client.get(url, {"query": ""}, format="json")
 
         assert response.status_code == 200, response.content
@@ -259,7 +259,7 @@ class GroupEventDetailsHelpfulEndpointTest(
         assert response.data["nextEventID"] is None
 
     def test_issue_filter_query_ignored(self):
-        url = f"/api/0/issues/{self.event_a.group.id}/events/helpful/"
+        url = f"/api/0/issues/{self.event_a.group.id}/events/recommended/"
         response = self.client.get(url, {"query": "is:unresolved"}, format="json")
 
         assert response.status_code == 200, response.content
@@ -268,7 +268,7 @@ class GroupEventDetailsHelpfulEndpointTest(
         assert response.data["nextEventID"] is None
 
     def test_event_release_query(self):
-        url = f"/api/0/issues/{self.event_a.group.id}/events/helpful/"
+        url = f"/api/0/issues/{self.event_a.group.id}/events/recommended/"
         response = self.client.get(url, {"query": f"release:{self.release_version}"}, format="json")
 
         assert response.status_code == 200, response.content
@@ -292,7 +292,7 @@ class GroupEventDetailsHelpfulEndpointTest(
         assert release.version == "test@1.2.3"
         assert release.is_semver_release
 
-        url = f"/api/0/issues/{event_g.group.id}/events/helpful/"
+        url = f"/api/0/issues/{event_g.group.id}/events/recommended/"
         response = self.client.get(url, {"query": f"{SEMVER_ALIAS}:1.2.3"}, format="json")
 
         assert response.status_code == 200, response.content
@@ -301,7 +301,7 @@ class GroupEventDetailsHelpfulEndpointTest(
         assert response.data["nextEventID"] is None
 
     def test_has_environment(self):
-        url = f"/api/0/issues/{self.event_a.group.id}/events/helpful/"
+        url = f"/api/0/issues/{self.event_a.group.id}/events/recommended/"
         response = self.client.get(url, {"query": "has:environment"}, format="json")
 
         assert response.status_code == 200, response.content
@@ -344,7 +344,7 @@ class GroupEventDetailsHelpfulEndpointTest(
         group.substatus = None
         group.save(update_fields=["status", "substatus"])
 
-        url = f"/api/0/issues/{group.id}/events/helpful/"
+        url = f"/api/0/issues/{group.id}/events/recommended/"
         response = self.client.get(url, {"query": "is:unresolved has:environment"}, format="json")
 
         assert response.status_code == 200, response.content
@@ -365,7 +365,7 @@ class GroupEventDetailsHelpfulEndpointTest(
             project_id=self.project_1.id,
         )
 
-        url = f"/api/0/issues/{event_e.group.id}/events/helpful/"
+        url = f"/api/0/issues/{event_e.group.id}/events/recommended/"
         response = self.client.get(url, {"query": f'title:"{title}"'}, format="json")
 
         assert response.status_code == 200, response.content
@@ -382,7 +382,7 @@ class GroupEventDetailsHelpfulEndpointTest(
         )
 
         assert group_info is not None
-        url = f"/api/0/issues/{group_info.group.id}/events/helpful/"
+        url = f"/api/0/issues/{group_info.group.id}/events/recommended/"
         response = self.client.get(url, {"query": f'title:"{issue_title}"'}, format="json")
 
         assert response.status_code == 200, response.content


### PR DESCRIPTION
When developing recommended event, we changed the name from `helpful` to `recommended` and accepted both values. Now we are only using `recommended` on the frontend, so this removes `helpful` as it just adds confusion. 

We never documented "helpful" or "recommended", so I doubt this will affect anyone.