### PR TITLE
fix(uptime): Mark uptime header fix as is_post_deployment

### DIFF
--- a/src/sentry/uptime/migrations/0016_translate_uptime_object_headers_to_lists.py
+++ b/src/sentry/uptime/migrations/0016_translate_uptime_object_headers_to_lists.py
@@ -30,7 +30,7 @@ class Migration(CheckedMigration):
     #   is a schema change, it's completely safe to run the operation after the code has deployed.
     # Once deployed, run these manually via: https://develop.sentry.dev/database-migrations/#migration-deployment
 
-    is_post_deployment = False
+    is_post_deployment = True
 
     dependencies = [
         ("uptime", "0015_headers_deafult_empty_list"),


### PR DESCRIPTION
This backfill is bugged. Marking it as `is_post_deployment` so that it won't run, then we can fix it later and run.
