### PR TITLE
feat(workflow_engine): Add way to hook logic into `Detector`

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+
+from sentry.incidents.utils.types import QuerySubscriptionUpdate
+from sentry.issues.grouptype import GroupType, GroupCategory
+from sentry.ratelimits.sliding_windows import Quota
+from sentry.types.group import PriorityLevel
+from sentry.workflow_engine.processors.detector import DetectorHandler
+
+
+# TODO: This will be a stateful detector when we build that abstraction
+class MetricAlertDetectorHandler(DetectorHandler[QuerySubscriptionUpdate]):
+    def evaluate(self, data_packet: QuerySubscriptionUpdate):
+        pass
+
+
+# Example GroupType and detector handler for metric alerts. We don't create these issues yet, but we'll use something
+# like these when we're sending issues as alerts
+@dataclass(frozen=True)
+class MetricAlertFire(GroupType):
+    type_id = 8001
+    slug = "metric_alert_fire"
+    description = "Metric alert fired"
+    category = GroupCategory.METRIC_ALERT.value
+    creation_quota = Quota(3600, 60, 100)
+    default_priority = PriorityLevel.HIGH
+    enable_auto_resolve = False
+    enable_escalation_detection = False
+    detector_handler = MetricAlertDetectorHandler

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -4,12 +4,15 @@ from sentry.incidents.utils.types import QuerySubscriptionUpdate
 from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
+from sentry.workflow_engine.models import DataPacket
 from sentry.workflow_engine.models.detector import DetectorEvaluationResult, DetectorHandler
 
 
 # TODO: This will be a stateful detector when we build that abstraction
 class MetricAlertDetectorHandler(DetectorHandler[QuerySubscriptionUpdate]):
-    def evaluate(self, data_packet: QuerySubscriptionUpdate) -> list[DetectorEvaluationResult]:
+    def evaluate(
+        self, data_packet: DataPacket[QuerySubscriptionUpdate]
+    ) -> list[DetectorEvaluationResult]:
         # TODO: Implement
         return []
 

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -4,7 +4,7 @@ from sentry.incidents.utils.types import QuerySubscriptionUpdate
 from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
-from sentry.workflow_engine.processors.detector import DetectorEvaluationResult, DetectorHandler
+from sentry.workflow_engine.models.detector import DetectorEvaluationResult, DetectorHandler
 
 
 # TODO: This will be a stateful detector when we build that abstraction

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -1,16 +1,17 @@
 from dataclasses import dataclass
 
 from sentry.incidents.utils.types import QuerySubscriptionUpdate
-from sentry.issues.grouptype import GroupType, GroupCategory
+from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
-from sentry.workflow_engine.processors.detector import DetectorHandler
+from sentry.workflow_engine.processors.detector import DetectorEvaluationResult, DetectorHandler
 
 
 # TODO: This will be a stateful detector when we build that abstraction
 class MetricAlertDetectorHandler(DetectorHandler[QuerySubscriptionUpdate]):
-    def evaluate(self, data_packet: QuerySubscriptionUpdate):
-        pass
+    def evaluate(self, data_packet: QuerySubscriptionUpdate) -> list[DetectorEvaluationResult]:
+        # TODO: Implement
+        return []
 
 
 # Example GroupType and detector handler for metric alerts. We don't create these issues yet, but we'll use something

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -157,7 +157,7 @@ class GroupType:
     # Quota around many of these issue types can be created per project in a given time window
     creation_quota: Quota = Quota(3600, 60, 5)  # default 5 per hour, sliding window of 60 seconds
     notification_config: NotificationConfig = NotificationConfig()
-    detector_handler: DetectorHandler | None = None
+    detector_handler: type[DetectorHandler] | None = None
 
     def __init_subclass__(cls: type[GroupType], **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from sentry.models.organization import Organization
     from sentry.models.project import Project
     from sentry.users.models.user import User
+    from sentry.workflow_engine.processors.detector import DetectorHandler
 import logging
 
 logger = logging.getLogger(__name__)
@@ -35,6 +36,7 @@ class GroupCategory(Enum):
     REPLAY = 5
     FEEDBACK = 6
     UPTIME = 7
+    METRIC_ALERT = 8
 
 
 GROUP_CATEGORIES_CUSTOM_EMAIL = (
@@ -152,8 +154,10 @@ class GroupType:
     enable_auto_resolve: bool = True
     # Allow escalation forecasts and detection
     enable_escalation_detection: bool = True
+    # Quota around many of these issue types can be created per project in a given time window
     creation_quota: Quota = Quota(3600, 60, 5)  # default 5 per hour, sliding window of 60 seconds
     notification_config: NotificationConfig = NotificationConfig()
+    detector_handler: DetectorHandler | None = None
 
     def __init_subclass__(cls: type[GroupType], **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from sentry.models.organization import Organization
     from sentry.models.project import Project
     from sentry.users.models.user import User
-    from sentry.workflow_engine.processors.detector import DetectorHandler
+    from sentry.workflow_engine.models.detector import DetectorHandler
 import logging
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -2138,7 +2138,11 @@ class Factories:
         if name is None:
             name = petname.generate(2, " ", letters=10).title()
         return Detector.objects.create(
-            organization=organization, name=name, owner_user_id=owner_user_id, owner_team=owner_team
+            organization=organization,
+            name=name,
+            owner_user_id=owner_user_id,
+            owner_team=owner_team,
+            **kwargs,
         )
 
     @staticmethod

--- a/src/sentry/workflow_engine/models/data_source.py
+++ b/src/sentry/workflow_engine/models/data_source.py
@@ -1,4 +1,5 @@
-from typing import Protocol
+import dataclasses
+from typing import Generic, TypeVar
 
 from django.db import models
 
@@ -11,9 +12,13 @@ from sentry.db.models import (
 )
 from sentry.workflow_engine.models.data_source_detector import DataSourceDetector
 
+T = TypeVar("T")
 
-class DataPacket(Protocol):
-    query_id: int
+
+@dataclasses.dataclass
+class DataPacket(Generic[T]):
+    query_id: str
+    packet: T
 
 
 @region_silo_model

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -1,10 +1,16 @@
+import logging
+
 from django.db import models
 from django.db.models import UniqueConstraint
 
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import DefaultFieldsModel, FlexibleForeignKey, region_silo_model
 from sentry.models.owner_base import OwnerModel
+from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.models.data_source_detector import DataSourceDetector
+from sentry.issues import grouptype
+
+logger = logging.getLogger(__name__)
 
 
 @region_silo_model
@@ -35,3 +41,20 @@ class Detector(DefaultFieldsModel, OwnerModel):
                 name="workflow_engine_detector_org_name",
             )
         ]
+
+    def evaluate(self, data_packet: DataPacket):
+        group_type = grouptype.registry.get_by_slug(self.type)
+        if not group_type:
+            logger.error(
+                "No registered grouptype for detector",
+                extra={"group_type": group_type, "detector_id": self.id},
+            )
+            return
+
+        if not group_type.detector_handler:
+            logger.error(
+                "Registered grouptype for detector has no detector_handler",
+                extra={"group_type": group_type, "detector_id": self.id},
+            )
+            return
+        return group_type.detector_handler.evaluate(data_packet)

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -13,6 +13,7 @@ from sentry.db.models import DefaultFieldsModel, FlexibleForeignKey, region_silo
 from sentry.issues import grouptype
 from sentry.models.owner_base import OwnerModel
 from sentry.types.group import PriorityLevel
+from sentry.workflow_engine.models import DataPacket
 
 if TYPE_CHECKING:
     from sentry.workflow_engine.models.detector_state import DetectorStatus
@@ -57,14 +58,22 @@ class Detector(DefaultFieldsModel, OwnerModel):
         if not group_type:
             logger.error(
                 "No registered grouptype for detector",
-                extra={"group_type": group_type, "detector_id": self.id},
+                extra={
+                    "group_type": str(group_type),
+                    "detector_id": self.id,
+                    "detector_type": self.type,
+                },
             )
             return None
 
         if not group_type.detector_handler:
             logger.error(
                 "Registered grouptype for detector has no detector_handler",
-                extra={"group_type": group_type, "detector_id": self.id},
+                extra={
+                    "group_type": str(group_type),
+                    "detector_id": self.id,
+                    "detector_type": self.type,
+                },
             )
             return None
         return group_type.detector_handler(self)
@@ -100,5 +109,5 @@ class DetectorHandler(abc.ABC, Generic[T]):
         self.detector = detector
 
     @abc.abstractmethod
-    def evaluate(self, data_packet: T) -> list[DetectorEvaluationResult]:
+    def evaluate(self, data_packet: DataPacket[T]) -> list[DetectorEvaluationResult]:
         pass

--- a/src/sentry/workflow_engine/models/detector_state.py
+++ b/src/sentry/workflow_engine/models/detector_state.py
@@ -5,8 +5,6 @@ from django.db import models
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import DefaultFieldsModel, FlexibleForeignKey, region_silo_model
 
-from .detector import Detector
-
 
 class DetectorStatus(StrEnum):
     OK = "ok"
@@ -16,7 +14,7 @@ class DetectorStatus(StrEnum):
 class DetectorState(DefaultFieldsModel):
     __relocation_scope__ = RelocationScope.Organization
 
-    detector = FlexibleForeignKey(Detector)
+    detector = FlexibleForeignKey("workflow_engine.Detector")
 
     # This key is used when a detector is using group-by
     # allows us to link to a specific group from a single detector

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -1,47 +1,10 @@
-import abc
-import dataclasses
 import logging
-from typing import Any, Generic, TypeVar
 
-from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models import Detector
 from sentry.workflow_engine.models.data_source import DataPacket
-from sentry.workflow_engine.models.detector_state import DetectorStatus
-
-T = TypeVar("T")
+from sentry.workflow_engine.models.detector import DetectorEvaluationResult
 
 logger = logging.getLogger(__name__)
-
-
-@dataclasses.dataclass(frozen=True)
-class DetectorStateData:
-    group_key: str | None
-    active: bool
-    status: DetectorStatus
-    # Stateful detectors always process data packets in order. Once we confirm that a data packet has been fully
-    # processed and all workflows have been done, this value will be used by the stateful detector to prevent
-    # reprocessing
-    dedupe_value: int
-    # Stateful detectors allow various counts to be tracked. We need to update these after we process workflows, so
-    # include the updates in the state
-    counter_updates: dict[str, int]
-
-
-@dataclasses.dataclass(frozen=True)
-class DetectorEvaluationResult:
-    is_active: bool
-    priority: PriorityLevel
-    data: Any
-    state_update_data: DetectorStateData | None = None
-
-
-class DetectorHandler(abc.ABC, Generic[T]):
-    def __init__(self, detector: Detector):
-        self.detector = detector
-
-    @abc.abstractmethod
-    def evaluate(self, data_packet: T) -> list[DetectorEvaluationResult]:
-        pass
 
 
 def process_detectors(

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -1,0 +1,28 @@
+import abc
+import dataclasses
+from typing import TypeVar, Generic
+
+from sentry.workflow_engine.models import Detector
+from sentry.workflow_engine.models.data_source import DataPacket
+
+T = TypeVar("T")
+
+
+class DetectorHandler(abc.ABC, Generic[T]):
+    def __init__(self, detector: Detector):
+        self.detector = detector
+
+    @abc.abstractmethod
+    def evaluate(self, data_packet: T):
+        pass
+
+
+def process_detectors(data_packet: DataPacket, detectors: list[Detector]):
+    for detector in detectors:
+        detector.evaluate(data_packet)
+
+
+
+@dataclasses.dataclass(frozen=True)
+class DetectorEvaluationResult:
+    pass

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -1,6 +1,6 @@
 import abc
 import dataclasses
-from typing import TypeVar, Generic
+from typing import Generic, TypeVar
 
 from sentry.workflow_engine.models import Detector
 from sentry.workflow_engine.models.data_source import DataPacket
@@ -20,7 +20,6 @@ class DetectorHandler(abc.ABC, Generic[T]):
 def process_detectors(data_packet: DataPacket, detectors: list[Detector]):
     for detector in detectors:
         detector.evaluate(data_packet)
-
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -1,11 +1,38 @@
 import abc
 import dataclasses
-from typing import Generic, TypeVar
+import logging
+from typing import Any, Generic, TypeVar
 
+from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models import Detector
 from sentry.workflow_engine.models.data_source import DataPacket
+from sentry.workflow_engine.models.detector_state import DetectorStatus
 
 T = TypeVar("T")
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class DetectorStateData:
+    group_key: str | None
+    active: bool
+    status: DetectorStatus
+    # Stateful detectors always process data packets in order. Once we confirm that a data packet has been fully
+    # processed and all workflows have been done, this value will be used by the stateful detector to prevent
+    # reprocessing
+    dedupe_value: int
+    # Stateful detectors allow various counts to be tracked. We need to update these after we process workflows, so
+    # include the updates in the state
+    counter_updates: dict[str, int]
+
+
+@dataclasses.dataclass(frozen=True)
+class DetectorEvaluationResult:
+    is_active: bool
+    priority: PriorityLevel
+    data: Any
+    state_update_data: DetectorStateData | None = None
 
 
 class DetectorHandler(abc.ABC, Generic[T]):
@@ -13,15 +40,34 @@ class DetectorHandler(abc.ABC, Generic[T]):
         self.detector = detector
 
     @abc.abstractmethod
-    def evaluate(self, data_packet: T):
+    def evaluate(self, data_packet: T) -> list[DetectorEvaluationResult]:
         pass
 
 
-def process_detectors(data_packet: DataPacket, detectors: list[Detector]):
+def process_detectors(
+    data_packet: DataPacket, detectors: list[Detector]
+) -> list[tuple[Detector, list[DetectorEvaluationResult]]]:
+    results = []
     for detector in detectors:
-        detector.evaluate(data_packet)
+        handler = detector.detector_handler
+        if not handler:
+            continue
+        detector_results = handler.evaluate(data_packet)
+        detector_group_keys = set()
+        for result in detector_results:
+            if result.state_update_data:
+                if result.state_update_data.group_key in detector_group_keys:
+                    # This shouldn't happen - log an error and continue on, but we should investigate this.
+                    logger.error(
+                        "Duplicate detector state group keys found",
+                        extra={
+                            "detector_id": detector.id,
+                            "group_key": result.state_update_data.group_key,
+                        },
+                    )
+                detector_group_keys.add(result.state_update_data.group_key)
 
+        if detector_results:
+            results.append((detector, detector_results))
 
-@dataclasses.dataclass(frozen=True)
-class DetectorEvaluationResult:
-    pass
+    return results

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -1,0 +1,155 @@
+from unittest import mock
+
+from sentry.issues.grouptype import GroupCategory, GroupType
+from sentry.types.group import PriorityLevel
+from sentry.workflow_engine.models import DataPacket
+from sentry.workflow_engine.models.detector import (
+    DetectorEvaluationResult,
+    DetectorHandler,
+    DetectorStateData,
+)
+from sentry.workflow_engine.models.detector_state import DetectorStatus
+from sentry.workflow_engine.processors.detector import process_detectors
+from tests.sentry.issues.test_grouptype import BaseGroupTypeTest
+
+
+class TestProcessDetectors(BaseGroupTypeTest):
+    def setUp(self):
+        super().setUp()
+
+        class NoHandlerGroupType(GroupType):
+            type_id = 1
+            slug = "no_handler"
+            description = "no handler"
+            category = GroupCategory.METRIC_ALERT.value
+
+        class MockDetectorHandler(DetectorHandler[dict]):
+            def evaluate(self, data_packet: DataPacket[dict]) -> list[DetectorEvaluationResult]:
+                return [DetectorEvaluationResult(True, PriorityLevel.HIGH, data_packet)]
+
+        class HandlerGroupType(GroupType):
+            type_id = 2
+            slug = "handler"
+            description = "handler"
+            category = GroupCategory.METRIC_ALERT.value
+            detector_handler = MockDetectorHandler
+
+        class MockDetectorStateHandler(DetectorHandler[dict]):
+            def evaluate(self, data_packet: DataPacket[dict]) -> list[DetectorEvaluationResult]:
+                group_keys = data_packet.packet.get("group_keys", [None])
+                return [
+                    DetectorEvaluationResult(
+                        True,
+                        PriorityLevel.HIGH,
+                        data_packet,
+                        DetectorStateData(
+                            group_key,
+                            True,
+                            DetectorStatus.OK,
+                            100,
+                            {},
+                        ),
+                    )
+                    for group_key in group_keys
+                ]
+
+        class HandlerStateGroupType(GroupType):
+            type_id = 3
+            slug = "handler_with_state"
+            description = "handler with state"
+            category = GroupCategory.METRIC_ALERT.value
+            detector_handler = MockDetectorStateHandler
+
+        self.no_handler_type = NoHandlerGroupType
+        self.handler_type = HandlerGroupType
+        self.handler_state_type = HandlerStateGroupType
+
+    def build_data_packet(self, **kwargs):
+        query_id = "1234"
+        return DataPacket[dict](query_id, {"query_id": query_id, "some": "data", **kwargs})
+
+    def test(self):
+        detector = self.create_detector(type=self.handler_type.slug)
+        data_packet = self.build_data_packet()
+        results = process_detectors(data_packet, [detector])
+        assert results == [
+            (detector, [DetectorEvaluationResult(True, PriorityLevel.HIGH, data_packet)])
+        ]
+
+    def test_state_results(self):
+        detector = self.create_detector(type=self.handler_state_type.slug)
+        data_packet = self.build_data_packet()
+        results = process_detectors(data_packet, [detector])
+        result = DetectorEvaluationResult(
+            True,
+            PriorityLevel.HIGH,
+            data_packet,
+            DetectorStateData(None, True, DetectorStatus.OK, 100, {}),
+        )
+        assert results == [
+            (
+                detector,
+                [result],
+            )
+        ]
+
+    def test_state_results_multi_group(self):
+        detector = self.create_detector(type=self.handler_state_type.slug)
+        data_packet = self.build_data_packet(group_keys=["group_1", "group_2"])
+        results = process_detectors(data_packet, [detector])
+        result_1 = DetectorEvaluationResult(
+            True,
+            PriorityLevel.HIGH,
+            data_packet,
+            DetectorStateData("group_1", True, DetectorStatus.OK, 100, {}),
+        )
+        result_2 = DetectorEvaluationResult(
+            True,
+            PriorityLevel.HIGH,
+            data_packet,
+            DetectorStateData("group_2", True, DetectorStatus.OK, 100, {}),
+        )
+        assert results == [
+            (
+                detector,
+                [result_1, result_2],
+            )
+        ]
+
+    def test_state_results_multi_group_dupe(self):
+        detector = self.create_detector(type=self.handler_state_type.slug)
+        data_packet = self.build_data_packet(group_keys=["dupe", "dupe"])
+        with mock.patch("sentry.workflow_engine.processors.detector.logger") as mock_logger:
+            results = process_detectors(data_packet, [detector])
+            assert mock_logger.error.call_args[0][0] == "Duplicate detector state group keys found"
+        result = DetectorEvaluationResult(
+            True,
+            PriorityLevel.HIGH,
+            data_packet,
+            DetectorStateData("dupe", True, DetectorStatus.OK, 100, {}),
+        )
+        assert results == [
+            (
+                detector,
+                [result, result],
+            )
+        ]
+
+    def test_no_issue_type(self):
+        detector = self.create_detector(type="invalid slug")
+        data_packet = self.build_data_packet()
+        with mock.patch("sentry.workflow_engine.models.detector.logger") as mock_logger:
+            results = process_detectors(data_packet, [detector])
+            assert mock_logger.error.call_args[0][0] == "No registered grouptype for detector"
+        assert results == []
+
+    def test_no_handler(self):
+        detector = self.create_detector(type=self.no_handler_type.slug)
+        data_packet = self.build_data_packet()
+        with mock.patch("sentry.workflow_engine.models.detector.logger") as mock_logger:
+            results = process_detectors(data_packet, [detector])
+            assert (
+                mock_logger.error.call_args[0][0]
+                == "Registered grouptype for detector has no detector_handler"
+            )
+        assert results == []


### PR DESCRIPTION
This adds some ways that we can hook custom logic into the detector. Looking at the options, it feels like splitting this logic into different handlers makes sense. Doesn't have to be a function - we can implement classes so that we can share logic.

<!-- Describe your PR here. -->