### PR TITLE
chore(registry): Formalize registry pattern in the codebase

### DIFF
--- a/src/sentry/utils/registry.py
+++ b/src/sentry/utils/registry.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Generic, TypeVar
+
+
+class AlreadyRegisteredError(ValueError):
+    pass
+
+
+class NoRegistrationExistsError(ValueError):
+    pass
+
+
+T = TypeVar("T")
+
+
+class Registry(Generic[T]):
+    def __init__(self):
+        self.registrations: dict[str, T] = {}
+
+    def register(self, key: str):
+        def inner(item: T) -> T:
+            if key in self.registrations:
+                raise AlreadyRegisteredError(
+                    f"A registration already exists for {key}: {self.registrations[key]}"
+                )
+            self.registrations[key] = item
+            return item
+
+        return inner
+
+    def get_registration(self, key: str) -> T:
+        if key not in self.registrations:
+            raise NoRegistrationExistsError(f"No registration exists for {key}")
+        return self.registrations[key]

--- a/src/sentry/utils/registry.py
+++ b/src/sentry/utils/registry.py
@@ -29,7 +29,7 @@ class Registry(Generic[T]):
 
         return inner
 
-    def get_registration(self, key: str) -> T:
+    def get(self, key: str) -> T:
         if key not in self.registrations:
             raise NoRegistrationExistsError(f"No registration exists for {key}")
         return self.registrations[key]

--- a/tests/sentry/utils/test_registry.py
+++ b/tests/sentry/utils/test_registry.py
@@ -17,12 +17,12 @@ class RegistryTest(TestCase):
         def unregistered_func():
             pass
 
-        assert test_registry.get_registration("something") == registered_func
+        assert test_registry.get("something") == registered_func
         with pytest.raises(NoRegistrationExistsError):
-            test_registry.get_registration("something else")
+            test_registry.get("something else")
 
         with pytest.raises(AlreadyRegisteredError):
             test_registry.register("something")(unregistered_func)
 
         test_registry.register("something else")(unregistered_func)
-        assert test_registry.get_registration("something else") == unregistered_func
+        assert test_registry.get("something else") == unregistered_func

--- a/tests/sentry/utils/test_registry.py
+++ b/tests/sentry/utils/test_registry.py
@@ -1,0 +1,28 @@
+from collections.abc import Callable
+
+import pytest
+
+from sentry.testutils.cases import TestCase
+from sentry.utils.registry import AlreadyRegisteredError, NoRegistrationExistsError, Registry
+
+
+class RegistryTest(TestCase):
+    def test(self):
+        test_registry = Registry[Callable]()
+
+        @test_registry.register("something")
+        def registered_func():
+            pass
+
+        def unregistered_func():
+            pass
+
+        assert test_registry.get_registration("something") == registered_func
+        with pytest.raises(NoRegistrationExistsError):
+            test_registry.get_registration("something else")
+
+        with pytest.raises(AlreadyRegisteredError):
+            test_registry.register("something")(unregistered_func)
+
+        test_registry.register("something else")(unregistered_func)
+        assert test_registry.get_registration("something else") == unregistered_func


### PR DESCRIPTION
We use registries everywhere, but there's no standard way to implement them, and so usually they're just copy/pasted. This pr implements a standard registry class that allows a string to be mapped to a generic object.

Usually this will be a Callable, but can be any type that you want to register. One nice advantage of making the registry formal, is that you can declare your registry with a unique name, and then it's much more clear what things are registered to, and also to search for them.

As an example, we define our registry like this somewhere:
```
workflow_engine_registry = Registry[DetectorHandler]()
```
Then decorate like:
```
@workflow_engine_registry.register("metric")
class MetricDetectorHandler(DetectorHandler):
    pass
```

<!-- Describe your PR here. -->