### PR TITLE
feat(anomaly detection): Feedback Button

### DIFF
--- a/static/app/views/alerts/rules/metric/details/sidebar.tsx
+++ b/static/app/views/alerts/rules/metric/details/sidebar.tsx
@@ -4,12 +4,13 @@ import styled from '@emotion/styled';
 import {OnDemandWarningIcon} from 'sentry/components/alerts/onDemandMetricAlert';
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
 import AlertBadge from 'sentry/components/badge/alertBadge';
+import {Button} from 'sentry/components/button';
 import {SectionHeading} from 'sentry/components/charts/styles';
 import {DateTime} from 'sentry/components/dateTime';
 import Duration from 'sentry/components/duration';
 import {KeyValueTable, KeyValueTableRow} from 'sentry/components/keyValueTable';
 import TimeSince from 'sentry/components/timeSince';
-import {IconDiamond} from 'sentry/icons';
+import {IconDiamond, IconMegaphone} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {ActivationConditionType, MonitorType} from 'sentry/types/alerts';
@@ -17,6 +18,7 @@ import type {Actor} from 'sentry/types/core';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {getSearchFilters, isOnDemandSearchKey} from 'sentry/utils/onDemandMetrics/index';
 import {capitalize} from 'sentry/utils/string/capitalize';
+import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {COMPARISON_DELTA_OPTIONS} from 'sentry/views/alerts/rules/metric/constants';
 import type {Action, MetricRule} from 'sentry/views/alerts/rules/metric/types';
 import {
@@ -160,6 +162,27 @@ export function MetricDetailsSidebar({
       break;
   }
 
+  const openForm = useFeedbackForm();
+
+  const feedbackButton = openForm ? (
+    <Button
+      onClick={() => {
+        openForm({
+          formTitle: 'Anomaly Threshold Feedback',
+          messagePlaceholder: t('How can we make anomalous thresholds more useful?'),
+          tags: {
+            ['feedback.source']: 'dynamic_thresholding',
+            ['feedback.owner']: 'ml-ai',
+          },
+        });
+      }}
+      size="xs"
+      icon={<IconMegaphone />}
+    >
+      Give Feedback for Anomaly Thresholds
+    </Button>
+  ) : null;
+
   return (
     <Fragment>
       <StatusContainer>
@@ -289,6 +312,7 @@ export function MetricDetailsSidebar({
           )}
         </KeyValueTable>
       </SidebarGroup>
+      {rule.detectionType === AlertRuleComparisonType.PERCENT && feedbackButton}
     </Fragment>
   );
 }

--- a/static/app/views/alerts/rules/metric/details/sidebar.tsx
+++ b/static/app/views/alerts/rules/metric/details/sidebar.tsx
@@ -312,7 +312,7 @@ export function MetricDetailsSidebar({
           )}
         </KeyValueTable>
       </SidebarGroup>
-      {rule.detectionType === AlertRuleComparisonType.PERCENT && feedbackButton}
+      {rule.detectionType === AlertRuleComparisonType.DYNAMIC && feedbackButton}
     </Fragment>
   );
 }

--- a/static/app/views/alerts/rules/metric/details/sidebar.tsx
+++ b/static/app/views/alerts/rules/metric/details/sidebar.tsx
@@ -168,8 +168,10 @@ export function MetricDetailsSidebar({
     <Button
       onClick={() => {
         openForm({
-          formTitle: 'Anomaly Threshold Feedback',
-          messagePlaceholder: t('How can we make anomalous thresholds more useful?'),
+          formTitle: 'Anomaly Detection Feedback',
+          messagePlaceholder: t(
+            'How can we make alerts using anomaly detection more useful?'
+          ),
           tags: {
             ['feedback.source']: 'dynamic_thresholding',
             ['feedback.owner']: 'ml-ai',
@@ -179,7 +181,7 @@ export function MetricDetailsSidebar({
       size="xs"
       icon={<IconMegaphone />}
     >
-      Give Feedback for Anomaly Thresholds
+      Give Feedback
     </Button>
   ) : null;
 

--- a/static/app/views/alerts/rules/metric/triggers/dynamicAlertsFeedbackButton.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/dynamicAlertsFeedbackButton.tsx
@@ -17,8 +17,10 @@ export default function DynamicAlertsFeedbackButton({}) {
       <Button
         onClick={() => {
           openForm({
-            formTitle: 'Anomaly Threshold Feedback',
-            messagePlaceholder: t('How can we make anomalous thresholds more useful?'),
+            formTitle: 'Anomaly Detection Feedback',
+            messagePlaceholder: t(
+              'How can we make alerts using anomaly detection more useful?'
+            ),
             tags: {
               ['feedback.source']: 'dynamic_thresholding',
               ['feedback.owner']: 'ml-ai',
@@ -28,7 +30,7 @@ export default function DynamicAlertsFeedbackButton({}) {
         size="xs"
         icon={<IconMegaphone />}
       >
-        Give Feedback for Anomaly Thresholds
+        Give Feedback
       </Button>
     </ButtonContainer>
   );

--- a/static/app/views/alerts/rules/metric/triggers/dynamicAlertsFeedbackButton.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/dynamicAlertsFeedbackButton.tsx
@@ -1,0 +1,39 @@
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/button';
+import {IconMegaphone} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
+
+export default function DynamicAlertsFeedbackButton({}) {
+  const openForm = useFeedbackForm();
+
+  if (!openForm) {
+    return null;
+  }
+
+  return (
+    <ButtonContainer>
+      <Button
+        onClick={() => {
+          openForm({
+            formTitle: 'Anomaly Threshold Feedback',
+            messagePlaceholder: t('How can we make anomalous thresholds more useful?'),
+            tags: {
+              ['feedback.source']: 'dynamic_thresholding',
+              ['feedback.owner']: 'ml-ai',
+            },
+          });
+        }}
+        size="xs"
+        icon={<IconMegaphone />}
+      >
+        Give Feedback for Anomaly Thresholds
+      </Button>
+    </ButtonContainer>
+  );
+}
+
+const ButtonContainer = styled('div')`
+  padding: 8px 0px;
+`;

--- a/static/app/views/alerts/rules/metric/triggers/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/index.tsx
@@ -8,6 +8,7 @@ import removeAtArrayIndex from 'sentry/utils/array/removeAtArrayIndex';
 import replaceAtArrayIndex from 'sentry/utils/array/replaceAtArrayIndex';
 import ActionsPanel from 'sentry/views/alerts/rules/metric/triggers/actionsPanel';
 import AnomalyDetectionFormField from 'sentry/views/alerts/rules/metric/triggers/anomalyAlertsForm';
+import DynamicAlertsFeedbackButton from 'sentry/views/alerts/rules/metric/triggers/dynamicAlertsFeedbackButton';
 import TriggerForm from 'sentry/views/alerts/rules/metric/triggers/form';
 
 import {
@@ -151,6 +152,10 @@ class Triggers extends Component<Props> {
             )}
           </PanelBody>
         </Panel>
+
+        {comparisonType === AlertRuleComparisonType.DYNAMIC && (
+          <DynamicAlertsFeedbackButton />
+        )}
 
         {isMigration ? null : (
           <ActionsPanel


### PR DESCRIPTION
Add feedback buttons for anomaly thresholds on alerts dashboard and rule settings page
- Button on alert dashboard is only visible if anomaly threshold is set as the current rule

![Screenshot 2024-10-02 at 5 33 47 PM](https://github.com/user-attachments/assets/0c9be35c-eaf7-4f5c-8c3f-1e9c3fc545fd)

![Screenshot 2024-10-02 at 5 21 02 PM](https://github.com/user-attachments/assets/57caebdc-652b-4bbe-a8b9-2171c134b078)


