### PR TITLE
feat(dashboards): Big Number Widget error state improvements

### DIFF
--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.spec.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.spec.tsx
@@ -153,6 +153,37 @@ describe('BigNumberWidget', () => {
 
       expect(screen.getByText('Error: Uh oh')).toBeInTheDocument();
     });
+
+    it('Shows a retry button', async () => {
+      const onRetry = jest.fn();
+
+      render(<BigNumberWidget error={new Error('Oh no!')} onRetry={onRetry} />);
+
+      await userEvent.click(screen.getByRole('button', {name: 'Retry'}));
+      expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+
+    it('Hides other actions if there is an error and a retry handler', () => {
+      const onRetry = jest.fn();
+
+      render(
+        <BigNumberWidget
+          error={new Error('Oh no!')}
+          onRetry={onRetry}
+          actions={[
+            {
+              key: 'Open in Discover',
+              to: '/discover',
+            },
+          ]}
+        />
+      );
+
+      expect(screen.getByRole('button', {name: 'Retry'})).toBeInTheDocument();
+      expect(
+        screen.queryByRole('link', {name: 'Open in Discover'})
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe('Previous Period Data', () => {

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.spec.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.spec.tsx
@@ -140,6 +140,14 @@ describe('BigNumberWidget', () => {
       expect(screen.getByText('—')).toBeInTheDocument();
     });
 
+    it('Loading state takes precedence over error state', () => {
+      render(
+        <BigNumberWidget isLoading error={new Error('Parsing error of old value')} />
+      );
+
+      expect(screen.getByText('—')).toBeInTheDocument();
+    });
+
     it('Shows an error message', () => {
       render(<BigNumberWidget error={new Error('Uh oh')} />);
 

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
@@ -124,7 +124,8 @@ export default storyBook(BigNumberWidget, story => {
       <Fragment>
         <p>
           <JSXNode name="BigNumberWidget" /> supports the usual loading and error states.
-          The loading state shows a simple placeholder.
+          The loading state shows a simple placeholder. The error state also shows an
+          optional "Retry" button.
         </p>
 
         <SideBySide>
@@ -144,6 +145,13 @@ export default storyBook(BigNumberWidget, story => {
             <BigNumberWidget
               title="Count Error"
               error={new Error('Something went wrong!')}
+            />
+          </NormalWidget>
+          <NormalWidget>
+            <BigNumberWidget
+              title="Data Error"
+              error={new Error('Something went wrong!')}
+              onRetry={() => {}}
             />
           </NormalWidget>
         </SideBySide>

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import {space} from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
 import {
   BigNumberWidgetVisualization,
   type Props as BigNumberWidgetVisualizationProps,
@@ -10,11 +11,53 @@ import {
   WidgetFrame,
 } from 'sentry/views/dashboards/widgets/common/widgetFrame';
 
+import {ErrorPanel} from '../common/errorPanel';
+import {MISSING_DATA_MESSAGE, NON_FINITE_NUMBER_MESSAGE} from '../common/settings';
+import type {DataProps, StateProps} from '../common/types';
+
+import {DEEMPHASIS_COLOR_NAME, LOADING_PLACEHOLDER} from './settings';
+
 interface Props
-  extends Omit<WidgetFrameProps, 'children'>,
-    BigNumberWidgetVisualizationProps {}
+  extends DataProps,
+    StateProps,
+    Omit<WidgetFrameProps, 'children'>,
+    Omit<BigNumberWidgetVisualizationProps, 'value' | 'previousPeriodValue'> {}
 
 export function BigNumberWidget(props: Props) {
+  const {data, previousPeriodData} = props;
+
+  // TODO: Instrument getting more than one data key back as an error
+  // e.g., with data that looks like `[{'apdex()': 0.8}] this pulls out `"apdex()"` or `undefined`
+  const field = Object.keys(data?.[0] ?? {})[0];
+  const value = data?.[0]?.[field];
+  const previousPeriodValue = previousPeriodData?.[0]?.[field];
+
+  if (props.isLoading) {
+    return (
+      <WidgetFrame title={props.title} description={props.description}>
+        <LoadingPlaceholder>{LOADING_PLACEHOLDER}</LoadingPlaceholder>
+      </WidgetFrame>
+    );
+  }
+
+  let parsingError: string | undefined = undefined;
+
+  if (!defined(value)) {
+    parsingError = MISSING_DATA_MESSAGE;
+  } else if (!Number.isFinite(value) || Number.isNaN(value)) {
+    parsingError = NON_FINITE_NUMBER_MESSAGE;
+  }
+
+  const error = props.error ?? parsingError;
+
+  if (error) {
+    return (
+      <WidgetFrame title={props.title} description={props.description}>
+        <ErrorPanel error={error} />
+      </WidgetFrame>
+    );
+  }
+
   return (
     <WidgetFrame
       title={props.title}
@@ -23,13 +66,12 @@ export function BigNumberWidget(props: Props) {
     >
       <BigNumberResizeWrapper>
         <BigNumberWidgetVisualization
-          data={props.data}
-          previousPeriodData={props.previousPeriodData}
+          value={Number(value)}
+          previousPeriodValue={Number(previousPeriodValue)}
+          field={field}
           maximumValue={props.maximumValue}
           preferredPolarity={props.preferredPolarity}
           meta={props.meta}
-          isLoading={props.isLoading}
-          error={props.error}
         />
       </BigNumberResizeWrapper>
     </WidgetFrame>
@@ -40,4 +82,9 @@ const BigNumberResizeWrapper = styled('div')`
   position: relative;
   flex-grow: 1;
   margin-top: ${space(1)};
+`;
+
+const LoadingPlaceholder = styled('span')`
+  color: ${p => p.theme[DEEMPHASIS_COLOR_NAME]};
+  font-size: ${p => p.theme.fontSizeLarge};
 `;

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
@@ -11,7 +11,6 @@ import {
   WidgetFrame,
 } from 'sentry/views/dashboards/widgets/common/widgetFrame';
 
-import {ErrorPanel} from '../common/errorPanel';
 import {MISSING_DATA_MESSAGE, NON_FINITE_NUMBER_MESSAGE} from '../common/settings';
 import type {DataProps, StateProps} from '../common/types';
 
@@ -50,19 +49,13 @@ export function BigNumberWidget(props: Props) {
 
   const error = props.error ?? parsingError;
 
-  if (error) {
-    return (
-      <WidgetFrame title={props.title} description={props.description}>
-        <ErrorPanel error={error} />
-      </WidgetFrame>
-    );
-  }
-
   return (
     <WidgetFrame
       title={props.title}
       description={props.description}
       actions={props.actions}
+      error={error}
+      onRetry={props.onRetry}
     >
       <BigNumberResizeWrapper>
         <BigNumberWidgetVisualization

--- a/static/app/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodValue.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodValue.tsx
@@ -15,24 +15,23 @@ import {
 } from 'sentry/views/dashboards/widgets/bigNumberWidget/settings';
 import type {TableData} from 'sentry/views/dashboards/widgets/common/types';
 
+import {DEFAULT_FIELD} from '../common/settings';
+
 interface Props {
-  data: TableData;
-  field: string;
-  previousPeriodData: TableData;
+  previousPeriodValue: number;
   renderer: (datum: TableData[number]) => React.ReactNode;
+  value: number;
+  field?: string;
   preferredPolarity?: Polarity;
 }
 
-export function DifferenceToPreviousPeriodData({
-  data,
-  previousPeriodData,
+export function DifferenceToPreviousPeriodValue({
+  value: currentValue,
+  previousPeriodValue: previousValue,
   preferredPolarity = '',
-  field,
+  field = DEFAULT_FIELD,
   renderer,
 }: Props) {
-  const currentValue = data[0][field];
-  const previousValue = previousPeriodData[0][field];
-
   if (!isNumber(currentValue) || !isNumber(previousValue)) {
     return <Deemphasize>{LOADING_PLACEHOLDER}</Deemphasize>;
   }
@@ -45,7 +44,7 @@ export function DifferenceToPreviousPeriodData({
 
   // Create a fake data row so we can pass it to field renderers. Omit the +/- sign since the direction marker will indicate it
   const differenceAsDatum = {
-    [field]: Math.abs(difference),
+    [field ?? 'unknown']: Math.abs(difference),
   };
 
   return (

--- a/static/app/views/dashboards/widgets/common/errorPanel.tsx
+++ b/static/app/views/dashboards/widgets/common/errorPanel.tsx
@@ -12,24 +12,27 @@ interface Props {
 export function ErrorPanel({error}: Props) {
   return (
     <Panel>
-      <IconWarning color={DEEMPHASIS_COLOR_NAME} size="lg" />
+      <NonShrinkingWarningIcon color={DEEMPHASIS_COLOR_NAME} size="md" />
       <span>{error?.toString()}</span>
     </Panel>
   );
 }
 
+const NonShrinkingWarningIcon = styled(IconWarning)`
+  flex-shrink: 0;
+`;
+
 const Panel = styled('div')<{height?: string}>`
   position: absolute;
   inset: 0;
 
+  padding: ${space(0.5)} 0;
+
   display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  gap: ${space(0.5)};
+  gap: ${space(1)};
 
   overflow: hidden;
 
   color: ${p => p.theme[DEEMPHASIS_COLOR_NAME]};
-  font-size: ${p => p.theme.fontSizeExtraLarge};
+  font-size: ${p => p.theme.fontSizeLarge};
 `;

--- a/static/app/views/dashboards/widgets/common/settings.tsx
+++ b/static/app/views/dashboards/widgets/common/settings.tsx
@@ -1,0 +1,2 @@
+export const MIN_WIDTH = 200;
+export const MIN_HEIGHT = 120;

--- a/static/app/views/dashboards/widgets/common/settings.tsx
+++ b/static/app/views/dashboards/widgets/common/settings.tsx
@@ -1,2 +1,9 @@
+import {t} from 'sentry/locale';
+
 export const MIN_WIDTH = 200;
 export const MIN_HEIGHT = 120;
+
+export const DEFAULT_FIELD = 'unknown'; // Numeric data might, in theory, have a missing field. In this case we need a fallback to provide to the field rendering pipeline. `'unknown'` will results in rendering as a string
+
+export const MISSING_DATA_MESSAGE = t('No Data');
+export const NON_FINITE_NUMBER_MESSAGE = t('Value is not a finite number.');

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -3,7 +3,13 @@ export type Meta = {
   units?: Record<string, string | null>;
 };
 
-export type TableData = Record<string, number | string | undefined>[];
+type TableRow = Record<string, number | string | undefined>;
+export type TableData = TableRow[];
+
+export interface DataProps {
+  data?: TableData;
+  previousPeriodData?: TableData;
+}
 
 export interface StateProps {
   error?: Error | string;

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -11,7 +11,10 @@ export interface DataProps {
   previousPeriodData?: TableData;
 }
 
+export type ErrorProp = Error | string;
+
 export interface StateProps {
-  error?: Error | string;
+  error?: ErrorProp;
   isLoading?: boolean;
+  onRetry?: () => void;
 }

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -9,9 +9,11 @@ import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
+import {ErrorPanel} from './errorPanel';
 import {MIN_HEIGHT, MIN_WIDTH} from './settings';
+import type {StateProps} from './types';
 
-export interface Props {
+export interface Props extends StateProps {
   actions?: MenuItemProps[];
   children?: React.ReactNode;
   description?: string;
@@ -19,19 +21,33 @@ export interface Props {
 }
 
 export function WidgetFrame(props: Props) {
-  const {title, description, actions, children} = props;
+  const {error} = props;
+
+  // The error state has its own set of available actions
+  const actions =
+    (error
+      ? props.onRetry
+        ? [
+            {
+              key: 'retry',
+              label: t('Retry'),
+              onAction: props.onRetry,
+            },
+          ]
+        : []
+      : props.actions) ?? [];
 
   return (
     <Frame>
       <Header>
         <Title>
-          <Tooltip title={title} containerDisplayMode="grid" showOnlyOnOverflow>
-            <TitleText>{title}</TitleText>
+          <Tooltip title={props.title} containerDisplayMode="grid" showOnlyOnOverflow>
+            <TitleText>{props.title}</TitleText>
           </Tooltip>
 
-          {description && (
+          {props.description && (
             <TooltipAligner>
-              <QuestionTooltip size="sm" title={description} />
+              <QuestionTooltip size="sm" title={props.description} />
             </TooltipAligner>
           )}
 
@@ -61,7 +77,9 @@ export function WidgetFrame(props: Props) {
         </Title>
       </Header>
 
-      <VisualizationWrapper>{children}</VisualizationWrapper>
+      <VisualizationWrapper>
+        {props.error ? <ErrorPanel error={error} /> : props.children}
+      </VisualizationWrapper>
     </Frame>
   );
 }

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -9,6 +9,8 @@ import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
+import {MIN_HEIGHT, MIN_WIDTH} from './settings';
+
 export interface Props {
   actions?: MenuItemProps[];
   children?: React.ReactNode;
@@ -70,9 +72,9 @@ const Frame = styled('div')`
   flex-direction: column;
 
   height: 100%;
-  min-height: 96px;
+  min-height: ${MIN_HEIGHT}px;
   width: 100%;
-  min-width: 120px;
+  min-width: ${MIN_WIDTH}px;
 
   padding: ${space(2)};
 


### PR DESCRIPTION
This is a small feature and a refactor that enables it. In short, all the code that handled value errors, loading states, and error states is lifted out of `BigNumberWidgetVisualization` into `BigNumberWidget`. This is a lot simpler because this way we don't have lower components detect errors that might affect higher components. Now the visualization component just visualizes good data. Everything else is higher, and/or moved into `WidgetFrame` so it can be shared between different widgets.

Once that's done, I improved the layout of the error panel somewhat, and adds support for "Retry" buttons. There's also a bit of cleanup to go with this.

**e.g.,**
<img width="524" alt="Screenshot 2024-10-03 at 12 24 15 PM" src="https://github.com/user-attachments/assets/90ac2c52-a6d2-4299-9d97-c8e6240f9629">
