### PR TITLE
feat(billing): Add quotas.backend.should_emit_profile_duration_outcome

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -187,7 +187,10 @@ def process_profile_task(
             if not project.flags.has_profiles:
                 first_profile_received.send_robust(project=project, sender=Project)
             try:
-                _track_duration_outcome(profile=profile, project=project)
+                if quotas.backend.should_emit_profile_duration_outcome(
+                    organization=organization, profile=profile
+                ):
+                    _track_duration_outcome(profile=profile, project=project)
             except Exception as e:
                 sentry_sdk.capture_exception(e)
             if profile.get("version") != "2":

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -15,9 +15,11 @@ from sentry.utils.json import prune_empty_keys
 from sentry.utils.services import Service
 
 if TYPE_CHECKING:
+    from sentry.models.organization import Organization
     from sentry.models.project import Project
     from sentry.models.projectkey import ProjectKey
     from sentry.monitors.models import Monitor
+    from sentry.profiles.task import Profile
 
 
 @unique
@@ -653,3 +655,11 @@ class Quota(Service):
         """
         Updates a monitor seat assignment's slug.
         """
+
+    def should_emit_profile_duration_outcome(
+        self, organization: Organization, profile: Profile
+    ) -> bool:
+        """
+        Determines if the profile duration outcome should be emitted.
+        """
+        return True


### PR DESCRIPTION
We want to be able to support continuous profiling (profiles v2) on pre-AM3 plans. 

In order to do so, we need to prevent the emission of `DataCategory.PROFILE_DURATION` for transactions based profiling (profiles v1) for pre-AM3 plans. This prevents doubling billing on profiles v1 for AM2 customers. 

We will be able to do this by introducing `quotas.backend.should_emit_profile_duration_outcome` method.

In getsentry, we will override this method, and appropriately check if we need to emit `DataCategory.PROFILE_DURATION` based on the organization's plan.