### PR TITLE
fix(ui): Restrict imports from 'moment' for 'moment-timezone'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -93,6 +93,10 @@ module.exports = {
             name: 'qs',
             message: 'Please use query-string instead of qs',
           },
+          {
+            name: 'moment',
+            message: 'Please import moment-timezone instead of moment',
+          },
         ],
       },
     ],

--- a/static/app/utils/getDaysSinceDate.spec.tsx
+++ b/static/app/utils/getDaysSinceDate.spec.tsx
@@ -1,7 +1,7 @@
 import getDaysSinceDate from 'sentry/utils/getDaysSinceDate';
 
 jest.mock('moment-timezone', () => {
-  const moment = jest.requireActual('moment');
+  const moment = jest.requireActual('moment-timezone');
   // Jun 06 2022
   moment.now = jest.fn().mockReturnValue(1654492173000);
   return moment;

--- a/static/app/views/organizationStats/mapSeriesToChart.ts
+++ b/static/app/views/organizationStats/mapSeriesToChart.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/react';
 import startCase from 'lodash/startCase';
-import moment from 'moment';
+import moment from 'moment-timezone';
 
 import type {TooltipSubLabel} from 'sentry/components/charts/components/tooltip';
 import type {DataCategoryInfo, IntervalPeriod} from 'sentry/types/core';

--- a/static/app/views/performance/trends/index.spec.tsx
+++ b/static/app/views/performance/trends/index.spec.tsx
@@ -32,7 +32,7 @@ const trendsViewQuery = {
 };
 
 jest.mock('moment-timezone', () => {
-  const moment = jest.requireActual('moment');
+  const moment = jest.requireActual('moment-timezone');
   moment.now = jest.fn().mockReturnValue(1601251200000);
   return moment;
 });


### PR DESCRIPTION
Removes existing imports and adds lint rule
