### PR TITLE
fix(issues): Remove old trace view header zindex when embedded

### DIFF
--- a/static/app/components/events/interfaces/spans/header.tsx
+++ b/static/app/components/events/interfaces/spans/header.tsx
@@ -50,6 +50,7 @@ type PropType = {
   dragProps: DragManagerChildrenProps;
   event: EventTransaction | AggregateEventTransaction;
   generateBounds: (bounds: SpanBoundsType) => SpanGeneratedBoundsType;
+  isEmbedded: boolean;
   minimapInteractiveRef: React.RefObject<HTMLDivElement>;
   operationNameFilters: ActiveOperationFilter;
   organization: Organization;
@@ -475,6 +476,7 @@ class TraceViewHeader extends Component<PropType, State> {
             <HeaderContainer
               ref={this.props.traceViewHeaderRef}
               hasProfileMeasurementsChart={hasProfileMeasurementsChart}
+              isEmbedded={this.props.isEmbedded}
             >
               <DividerHandlerManager.Consumer>
                 {dividerHandlerChildrenProps => {
@@ -801,12 +803,15 @@ const DurationGuideBox = styled('div')<{alignLeft: boolean}>`
   }};
 `;
 
-export const HeaderContainer = styled('div')<{hasProfileMeasurementsChart: boolean}>`
+export const HeaderContainer = styled('div')<{
+  hasProfileMeasurementsChart: boolean;
+  isEmbedded: boolean;
+}>`
   width: 100%;
   position: sticky;
   left: 0;
   top: ${p => (ConfigStore.get('demoMode') ? p.theme.demo.headerSize : 0)};
-  z-index: ${p => p.theme.zIndex.traceView.minimapContainer};
+  z-index: ${p => (p.isEmbedded ? 'initial' : p.theme.zIndex.traceView.minimapContainer)};
   background-color: ${p => p.theme.background};
   border-bottom: 1px solid ${p => p.theme.border};
   height: ${p =>

--- a/static/app/components/events/interfaces/spans/traceView.tsx
+++ b/static/app/components/events/interfaces/spans/traceView.tsx
@@ -67,6 +67,7 @@ function TraceView(props: Props) {
               viewStart: 0,
               viewEnd: 1,
             })}
+            isEmbedded={!!props.isEmbedded}
           />
         );
       }}


### PR DESCRIPTION
The 999 zindex overlaps with our new sticky header, also it doesn't need it on issue details page.

[example](https://sentry.sentry.io/issues/4945181039/?project=1)
![image](https://github.com/user-attachments/assets/1ff0f43b-3638-4fdc-ad2e-8fecb2cb9d75)


Would the replay page still want the zindex when embedded?
