### PR TITLE
ref(dashboards): Replace Project Details score cards with `BigNumberWidget`

### DIFF
--- a/static/app/views/dashboards/widgets/common/settings.tsx
+++ b/static/app/views/dashboards/widgets/common/settings.tsx
@@ -1,7 +1,7 @@
 import {t} from 'sentry/locale';
 
 export const MIN_WIDTH = 200;
-export const MIN_HEIGHT = 120;
+export const MIN_HEIGHT = 96;
 
 export const DEFAULT_FIELD = 'unknown'; // Numeric data might, in theory, have a missing field. In this case we need a fallback to provide to the field rendering pipeline. `'unknown'` will results in rendering as a string
 

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -106,6 +106,7 @@ const Frame = styled('div')`
 const Header = styled('div')`
   display: flex;
   flex-direction: column;
+  min-height: 20px;
 `;
 
 const Title = styled('div')`

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {Button} from 'sentry/components/button';
+import {Button, LinkButton} from 'sentry/components/button';
 import {HeaderTitle} from 'sentry/components/charts/styles';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import QuestionTooltip from 'sentry/components/questionTooltip';
@@ -54,9 +54,15 @@ export function WidgetFrame(props: Props) {
           {actions && actions.length > 0 && (
             <TitleActions>
               {actions.length === 1 ? (
-                <Button size="xs" onClick={actions[0].onAction}>
-                  {actions[0].label}
-                </Button>
+                actions[0].to ? (
+                  <LinkButton size="xs" onClick={actions[0].onAction} to={actions[0].to}>
+                    {actions[0].label}
+                  </LinkButton>
+                ) : (
+                  <Button size="xs" onClick={actions[0].onAction}>
+                    {actions[0].label}
+                  </Button>
+                )
               ) : null}
 
               {actions.length > 1 ? (

--- a/static/app/views/projectDetail/projectScoreCards/projectAnrScoreCard.spec.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectAnrScoreCard.spec.tsx
@@ -108,8 +108,8 @@ describe('ProjectDetail > ProjectAnr', function () {
       })
     );
 
-    await waitFor(() => expect(screen.getByText('11.562%')).toBeInTheDocument());
-    await waitFor(() => expect(screen.getByText('0.03%')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('11.56%')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('3%')).toBeInTheDocument());
   });
 
   it('renders open in issues CTA', async function () {
@@ -127,7 +127,7 @@ describe('ProjectDetail > ProjectAnr', function () {
       }
     );
 
-    await waitFor(() => expect(screen.getByText('11.562%')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('11.56%')).toBeInTheDocument());
 
     expect(screen.getByRole('button', {name: 'View Issues'})).toHaveAttribute(
       'href',

--- a/static/app/views/projectDetail/projectScoreCards/projectAnrScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectAnrScoreCard.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import type {Location} from 'history';
 import pick from 'lodash/pick';
 
@@ -139,39 +139,37 @@ export function ProjectAnrScoreCard({
   };
 
   return (
-    <Fragment>
-      <BigNumberWidget
-        title={t('ANR Rate')}
-        description={getSessionTermDescription(SessionTerm.ANR_RATE, null)}
-        data={[
-          {
-            'anr_rate()': value ?? undefined,
+    <BigNumberWidget
+      title={t('ANR Rate')}
+      description={getSessionTermDescription(SessionTerm.ANR_RATE, null)}
+      data={[
+        {
+          'anr_rate()': value ?? undefined,
+        },
+      ]}
+      previousPeriodData={[
+        {
+          'anr_rate()': previousValue ?? undefined,
+        },
+      ]}
+      preferredPolarity="-"
+      meta={{
+        fields: {
+          'anr_rate()': 'percentage',
+        },
+      }}
+      actions={[
+        {
+          key: 'issue-search',
+          label: t('View Issues'),
+          to: issueSearch,
+          onAction: () => {
+            trackAnalytics('project_detail.open_anr_issues', {
+              organization,
+            });
           },
-        ]}
-        previousPeriodData={[
-          {
-            'anr_rate()': previousValue ?? undefined,
-          },
-        ]}
-        preferredPolarity="-"
-        meta={{
-          fields: {
-            'anr_rate()': 'percentage',
-          },
-        }}
-        actions={[
-          {
-            key: 'issue-search',
-            label: t('View Issues'),
-            to: issueSearch,
-            onAction: () => {
-              trackAnalytics('project_detail.open_anr_issues', {
-                organization,
-              });
-            },
-          },
-        ]}
-      />
-    </Fragment>
+        },
+      ]}
+    />
   );
 }

--- a/static/app/views/projectDetail/projectScoreCards/projectAnrScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectAnrScoreCard.tsx
@@ -1,24 +1,19 @@
 import {Fragment, useEffect, useState} from 'react';
 import type {Location} from 'history';
 import pick from 'lodash/pick';
-import round from 'lodash/round';
 
 import {doSessionsRequest} from 'sentry/actionCreators/sessions';
-import {LinkButton} from 'sentry/components/button';
 import {shouldFetchPreviousPeriod} from 'sentry/components/charts/utils';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
-import ScoreCard from 'sentry/components/scoreCard';
 import {parseStatsPeriod} from 'sentry/components/timeRangeSelector/utils';
 import {URL_PARAM} from 'sentry/constants/pageFilters';
-import {IconArrow} from 'sentry/icons/iconArrow';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization, SessionApiResponse} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getPeriod} from 'sentry/utils/duration/getPeriod';
-import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
-import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import useApi from 'sentry/utils/useApi';
+import {BigNumberWidget} from 'sentry/views/dashboards/widgets/bigNumberWidget/bigNumberWidget';
 import {
   getSessionTermDescription,
   SessionTerm,
@@ -122,28 +117,10 @@ export function ProjectAnrScoreCard({
   }, [start, end, period, api, organization.slug, environments, projects, query]);
 
   const value = sessionsData?.groups?.[0]?.totals['anr_rate()'] ?? null;
-
   const previousValue = previousSessionData?.groups?.[0]?.totals['anr_rate()'] ?? null;
-
-  const hasCurrentAndPrevious = previousValue && value;
-  const trend = hasCurrentAndPrevious ? round(value - previousValue, 4) : null;
-  const trendStatus = !trend ? undefined : trend < 0 ? 'good' : 'bad';
 
   if (!isProjectStabilized) {
     return null;
-  }
-
-  function renderTrend() {
-    return trend ? (
-      <Fragment>
-        {trend >= 0 ? (
-          <IconArrow direction="up" size="xs" />
-        ) : (
-          <IconArrow direction="down" size="xs" />
-        )}
-        {`${formatAbbreviatedNumber(Math.abs(trend))}\u0025`}
-      </Fragment>
-    ) : null;
   }
 
   const endpointPath = `/organizations/${organization.slug}/issues/`;
@@ -161,31 +138,40 @@ export function ProjectAnrScoreCard({
     query: queryParams,
   };
 
-  function renderButton() {
-    return (
-      <LinkButton
-        data-test-id="issues-open"
-        size="xs"
-        to={issueSearch}
-        onClick={() => {
-          trackAnalytics('project_detail.open_anr_issues', {
-            organization,
-          });
-        }}
-      >
-        {t('View Issues')}
-      </LinkButton>
-    );
-  }
-
   return (
-    <ScoreCard
-      title={t('ANR Rate')}
-      help={getSessionTermDescription(SessionTerm.ANR_RATE, null)}
-      score={value ? formatPercentage(value, 3) : '\u2014'}
-      trend={renderTrend()}
-      trendStatus={trendStatus}
-      renderOpenButton={renderButton}
-    />
+    <Fragment>
+      <BigNumberWidget
+        title={t('ANR Rate')}
+        description={getSessionTermDescription(SessionTerm.ANR_RATE, null)}
+        data={[
+          {
+            'anr_rate()': value ?? undefined,
+          },
+        ]}
+        previousPeriodData={[
+          {
+            'anr_rate()': previousValue ?? undefined,
+          },
+        ]}
+        preferredPolarity="-"
+        meta={{
+          fields: {
+            'anr_rate()': 'percentage',
+          },
+        }}
+        actions={[
+          {
+            key: 'issue-search',
+            label: t('View Issues'),
+            to: issueSearch,
+            onAction: () => {
+              trackAnalytics('project_detail.open_anr_issues', {
+                organization,
+              });
+            },
+          },
+        ]}
+      />
+    </Fragment>
   );
 }

--- a/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.spec.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.spec.tsx
@@ -61,7 +61,7 @@ describe('ProjectDetail > ProjectApdex', function () {
 
     expect(await screen.findByText('Apdex')).toBeInTheDocument();
     expect(await screen.findByText('0.781')).toBeInTheDocument();
-    expect(await screen.findByText('0.103')).toBeInTheDocument();
+    expect(await screen.findByText('0.102')).toBeInTheDocument();
 
     expect(currentDataEndpointMock).toHaveBeenNthCalledWith(
       1,

--- a/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
@@ -1,12 +1,9 @@
-import round from 'lodash/round';
-
 import {shouldFetchPreviousPeriod} from 'sentry/components/charts/utils';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {parseStatsPeriod} from 'sentry/components/timeRangeSelector/utils';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
-import {defined} from 'sentry/utils';
 import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import {getPeriod} from 'sentry/utils/duration/getPeriod';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -110,18 +107,9 @@ function ProjectApdexScoreCard(props: Props) {
 
   const previousApdex = Number(previousData?.data?.[0]?.['apdex()']) || undefined;
 
-  const trend =
-    defined(apdex) && defined(previousApdex)
-      ? round(apdex - previousApdex, 3)
-      : undefined;
-
   const cardTitle = t('Apdex');
 
-  let cardHelp = getTermHelp(organization, PerformanceTerm.APDEX);
-
-  if (trend) {
-    cardHelp += t(' This shows how it has changed since the last period.');
-  }
+  const cardHelp = getTermHelp(organization, PerformanceTerm.APDEX);
 
   if (!hasTransactions || !organization.features.includes('performance-view')) {
     return (

--- a/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
@@ -1,13 +1,8 @@
-import {Fragment} from 'react';
 import round from 'lodash/round';
 
 import {shouldFetchPreviousPeriod} from 'sentry/components/charts/utils';
-import Count from 'sentry/components/count';
-import LoadingError from 'sentry/components/loadingError';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
-import ScoreCard from 'sentry/components/scoreCard';
 import {parseStatsPeriod} from 'sentry/components/timeRangeSelector/utils';
-import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
@@ -15,6 +10,8 @@ import {defined} from 'sentry/utils';
 import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import {getPeriod} from 'sentry/utils/duration/getPeriod';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {BigNumberWidget} from 'sentry/views/dashboards/widgets/bigNumberWidget/bigNumberWidget';
+import {WidgetFrame} from 'sentry/views/dashboards/widgets/common/widgetFrame';
 import {getTermHelp, PerformanceTerm} from 'sentry/views/performance/data';
 
 import MissingPerformanceButtons from '../missingFeatureButtons/missingPerformanceButtons';
@@ -118,8 +115,6 @@ function ProjectApdexScoreCard(props: Props) {
       ? round(apdex - previousApdex, 3)
       : undefined;
 
-  const shouldRenderTrend = !isLoading && defined(apdex) && defined(trend);
-
   const cardTitle = t('Apdex');
 
   let cardHelp = getTermHelp(organization, PerformanceTerm.APDEX);
@@ -130,44 +125,35 @@ function ProjectApdexScoreCard(props: Props) {
 
   if (!hasTransactions || !organization.features.includes('performance-view')) {
     return (
-      <ScoreCard
-        title={cardTitle}
-        help={cardHelp}
-        score={<MissingPerformanceButtons organization={organization} />}
-      />
-    );
-  }
-
-  if (error) {
-    return (
-      <LoadingError
-        message={
-          (error.responseJSON?.detail as React.ReactNode) ||
-          t('There was an error loading data.')
-        }
-        onRetry={refetch}
-      />
+      <WidgetFrame title={cardTitle} description={cardHelp}>
+        <MissingPerformanceButtons organization={organization} />
+      </WidgetFrame>
     );
   }
 
   return (
-    <ScoreCard
+    <BigNumberWidget
       title={cardTitle}
-      help={cardHelp}
-      score={isLoading || !defined(apdex) ? '\u2014' : <Count value={apdex} />}
-      trend={
-        shouldRenderTrend ? (
-          <Fragment>
-            {trend >= 0 ? (
-              <IconArrow direction="up" size="xs" />
-            ) : (
-              <IconArrow direction="down" size="xs" />
-            )}
-            <Count value={Math.abs(trend)} />
-          </Fragment>
-        ) : null
-      }
-      trendStatus={!trend ? undefined : trend > 0 ? 'good' : 'bad'}
+      description={cardHelp}
+      data={[
+        {
+          'apdex()': apdex,
+        },
+      ]}
+      previousPeriodData={[
+        {
+          'apdex()': previousApdex,
+        },
+      ]}
+      meta={{
+        fields: {
+          'apdex()': 'number',
+        },
+      }}
+      preferredPolarity="+"
+      isLoading={isLoading}
+      error={error ?? undefined}
+      onRetry={refetch}
     />
   );
 }

--- a/static/app/views/projectDetail/projectScoreCards/projectScoreCards.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectScoreCards.tsx
@@ -83,6 +83,11 @@ function ProjectScoreCards({
 }
 
 const CardWrapper = styled('div')`
+  display: grid;
+  gap: ${space(2)};
+  grid-template-columns: 1fr;
+  margin-bottom: ${space(2)};
+
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
     display: grid;
     grid-column-gap: ${space(2)};

--- a/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
@@ -1,25 +1,21 @@
-import round from 'lodash/round';
+import {Fragment} from 'react';
 
 import {
   getDiffInMinutes,
   shouldFetchPreviousPeriod,
 } from 'sentry/components/charts/utils';
-import LoadingError from 'sentry/components/loadingError';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
-import ScoreCard from 'sentry/components/scoreCard';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
-import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import type {SessionApiResponse} from 'sentry/types/organization';
 import {SessionFieldWithOperation} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import {defined} from 'sentry/utils';
 import {getPeriod} from 'sentry/utils/duration/getPeriod';
-import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
-import {displayCrashFreePercent} from 'sentry/views/releases/utils';
+import {BigNumberWidget} from 'sentry/views/dashboards/widgets/bigNumberWidget/bigNumberWidget';
+import {WidgetFrame} from 'sentry/views/dashboards/widgets/common/widgetFrame';
 import {
   getSessionTermDescription,
   SessionTerm,
@@ -111,8 +107,6 @@ const useCrashFreeRate = (props: Props) => {
   };
 };
 
-// shouldRenderBadRequests = true;
-
 function ProjectStabilityScoreCard(props: Props) {
   const {hasSessions} = props;
   const organization = useOrganization();
@@ -140,60 +134,44 @@ function ProjectStabilityScoreCard(props: Props) {
     ? undefined
     : previousCrashFreeRate?.groups[0]?.totals[props.field] * 100;
 
-  const trend =
-    defined(score) && defined(previousScore)
-      ? round(score - previousScore, 3)
-      : undefined;
-
-  const shouldRenderTrend = !isLoading && defined(score) && defined(trend);
-
   if (hasSessions === false) {
     return (
-      <ScoreCard
-        title={cardTitle}
-        help={cardHelp}
-        score={
-          <MissingReleasesButtons
-            organization={organization}
-            health
-            platform={props.project?.platform}
-          />
-        }
-      />
-    );
-  }
-
-  if (error) {
-    return (
-      <LoadingError
-        message={
-          (error.responseJSON?.detail as React.ReactNode) ||
-          t('There was an error loading data.')
-        }
-        onRetry={refetch}
-      />
+      <WidgetFrame title={cardTitle} description={cardHelp}>
+        <MissingReleasesButtons
+          organization={organization}
+          health
+          platform={props.project?.platform}
+        />
+      </WidgetFrame>
     );
   }
 
   return (
-    <ScoreCard
-      title={cardTitle}
-      help={cardHelp}
-      score={isLoading || !defined(score) ? '\u2014' : displayCrashFreePercent(score)}
-      trend={
-        shouldRenderTrend ? (
-          <div>
-            {trend >= 0 ? (
-              <IconArrow direction="up" size="xs" />
-            ) : (
-              <IconArrow direction="down" size="xs" />
-            )}
-            {`${formatAbbreviatedNumber(Math.abs(trend))}\u0025`}
-          </div>
-        ) : null
-      }
-      trendStatus={!trend ? undefined : trend > 0 ? 'good' : 'bad'}
-    />
+    <Fragment>
+      <BigNumberWidget
+        title={cardTitle}
+        description={cardHelp}
+        data={[
+          {
+            [`${props.field}()`]: score ? score / 100 : undefined,
+          },
+        ]}
+        previousPeriodData={[
+          {
+            [`${props.field}()`]: previousScore ? previousScore / 100 : undefined,
+          },
+        ]}
+        meta={{
+          fields: {
+            [`${props.field}()`]: 'percentage',
+          },
+        }}
+        preferredPolarity="+"
+        isLoading={isLoading}
+        error={error ?? undefined}
+        onRetry={refetch}
+      />
+    </Fragment>
   );
 }
 

--- a/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
@@ -1,5 +1,3 @@
-import {Fragment} from 'react';
-
 import {
   getDiffInMinutes,
   shouldFetchPreviousPeriod,
@@ -147,31 +145,29 @@ function ProjectStabilityScoreCard(props: Props) {
   }
 
   return (
-    <Fragment>
-      <BigNumberWidget
-        title={cardTitle}
-        description={cardHelp}
-        data={[
-          {
-            [`${props.field}()`]: score ? score / 100 : undefined,
-          },
-        ]}
-        previousPeriodData={[
-          {
-            [`${props.field}()`]: previousScore ? previousScore / 100 : undefined,
-          },
-        ]}
-        meta={{
-          fields: {
-            [`${props.field}()`]: 'percentage',
-          },
-        }}
-        preferredPolarity="+"
-        isLoading={isLoading}
-        error={error ?? undefined}
-        onRetry={refetch}
-      />
-    </Fragment>
+    <BigNumberWidget
+      title={cardTitle}
+      description={cardHelp}
+      data={[
+        {
+          [`${props.field}()`]: score ? score / 100 : undefined,
+        },
+      ]}
+      previousPeriodData={[
+        {
+          [`${props.field}()`]: previousScore ? previousScore / 100 : undefined,
+        },
+      ]}
+      meta={{
+        fields: {
+          [`${props.field}()`]: 'percentage',
+        },
+      }}
+      preferredPolarity="+"
+      isLoading={isLoading}
+      error={error ?? undefined}
+      onRetry={refetch}
+    />
   );
 }
 

--- a/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.spec.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.spec.tsx
@@ -48,7 +48,7 @@ describe('ProjectDetail > ProjectVelocity', function () {
       />
     );
 
-    expect(await screen.findByText('Number of Releases')).toBeInTheDocument();
+    expect(await screen.findByText(/Number of Releases/)).toBeInTheDocument();
     expect(await screen.findByText('202')).toBeInTheDocument();
     expect(await screen.findByText('104')).toBeInTheDocument();
 

--- a/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.spec.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.spec.tsx
@@ -48,7 +48,7 @@ describe('ProjectDetail > ProjectVelocity', function () {
       />
     );
 
-    expect(await screen.findByText(/Number of Releases/)).toBeInTheDocument();
+    expect(await screen.findByText('Number of Releases')).toBeInTheDocument();
     expect(await screen.findByText('202')).toBeInTheDocument();
     expect(await screen.findByText('104')).toBeInTheDocument();
 

--- a/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.tsx
@@ -4,7 +4,6 @@ import {parseStatsPeriod} from 'sentry/components/timeRangeSelector/utils';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
-import {defined} from 'sentry/utils';
 import {getPeriod} from 'sentry/utils/duration/getPeriod';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {BigNumberWidget} from 'sentry/views/dashboards/widgets/bigNumberWidget/bigNumberWidget';
@@ -137,27 +136,13 @@ function ProjectVelocityScoreCard(props: Props) {
     refetch,
   } = useReleaseCount(props);
 
-  const trend =
-    defined(currentReleases) &&
-    defined(previousReleases) &&
-    currentReleases?.length !== API_LIMIT
-      ? currentReleases.length - previousReleases.length
-      : undefined;
-
-  const shouldRenderTrend =
-    !isLoading && defined(currentReleases) && defined(previousReleases) && defined(trend);
-
   const noReleaseEver =
     [...(allTimeReleases ?? []), ...(previousReleases ?? []), ...(allTimeReleases ?? [])]
       .length === 0;
 
   const cardTitle = t('Number of Releases');
 
-  const cardHelp = shouldRenderTrend
-    ? t(
-        'The number of releases for this project and how it has changed since the last period.'
-      )
-    : t('The number of releases for this project.');
+  const cardHelp = t('The number of releases for this project.');
 
   if (!isLoading && noReleaseEver) {
     return (
@@ -181,6 +166,7 @@ function ProjectVelocityScoreCard(props: Props) {
           'count()': previousReleases?.length,
         },
       ]}
+      maximumValue={API_LIMIT}
       meta={{
         fields: {
           'count()': 'number',


### PR DESCRIPTION
Replaces usage of `ProjectCard` in project details pages with [`BigNumberWidget`](https://sentry.sentry.io/stories/?name=app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx). A small refactor, to clean stuff up and try that component out. A few immediate wins:

- consistent rounding and truncation
- a little less code duplication
- uncovered at least one bug
- nicer loading and error states
- full value on hover

**Before:**
![Screenshot 2024-10-03 at 3 00 50 PM](https://github.com/user-attachments/assets/0354f906-1e89-4726-8e00-6d460148295a)

**After:**
![Screenshot 2024-10-03 at 3 02 03 PM](https://github.com/user-attachments/assets/0e06484f-6db9-4e06-871b-332565e417c1)
![Screenshot 2024-10-03 at 3 07 07 PM](https://github.com/user-attachments/assets/1e231c4d-f943-44a9-a42f-80ff3b0ebed4)

Closes https://github.com/getsentry/sentry/issues/77780