### PR TITLE
fix(charts): Properly synchronize charts

### DIFF
--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -1,6 +1,5 @@
-import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
+import {Fragment, useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
-import * as echarts from 'echarts/core';
 
 import {getInterval} from 'sentry/components/charts/utils';
 import {CompactSelect} from 'sentry/components/compactSelect';
@@ -15,7 +14,10 @@ import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
 import {useDataset} from 'sentry/views/explore/hooks/useDataset';
 import {useVisualizes} from 'sentry/views/explore/hooks/useVisualizes';
-import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
+import Chart, {
+  ChartType,
+  useSynchronizeCharts,
+} from 'sentry/views/insights/common/components/chart';
 import ChartPanel from 'sentry/views/insights/common/components/chartPanel';
 import {useSortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
 import {CHART_HEIGHT} from 'sentry/views/insights/database/settings';
@@ -116,14 +118,11 @@ export function ExploreCharts({query}: ExploreChartsProps) {
     [visualizes, setVisualizes]
   );
 
-  // Synchronize chart cursors
-  const [_, setRenderTrigger] = useState(0);
-  useEffect(() => {
-    if (!timeSeriesResult.isPending) {
-      echarts?.connect(EXPLORE_CHART_GROUP);
-      setRenderTrigger(prev => (prev + 1) % Number.MAX_SAFE_INTEGER);
-    }
-  }, [visualizes, timeSeriesResult.isPending]);
+  useSynchronizeCharts(
+    visualizes.length,
+    !timeSeriesResult.isPending,
+    EXPLORE_CHART_GROUP
+  );
 
   return (
     <Fragment>

--- a/static/app/views/insights/common/components/chart.tsx
+++ b/static/app/views/insights/common/components/chart.tsx
@@ -1,5 +1,5 @@
 import type {RefObject} from 'react';
-import {createContext, useContext, useEffect, useMemo, useRef, useState} from 'react';
+import {createContext, useContext, useEffect, useMemo, useReducer, useRef} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {LineSeriesOption} from 'echarts';
@@ -611,14 +611,27 @@ export function computeAxisMax(data: Series[], stacked?: boolean) {
   return Math.ceil(Math.ceil(maxValue / step) * step);
 }
 
-export function useSynchronizeCharts(deps: boolean[] = []) {
-  const [synchronized, setSynchronized] = useState<boolean>(false);
+export function useSynchronizeCharts(
+  charts: number,
+  ready: boolean,
+  group: string = STARFISH_CHART_GROUP
+) {
+  // Tries to connect all the charts under the same group so the cursor is shared.
+  const [, forceUpdate] = useReducer(x => x + 1, 0);
+
   useEffect(() => {
-    if (deps.every(Boolean)) {
-      echarts?.connect?.(STARFISH_CHART_GROUP);
-      setSynchronized(true);
+    if (charts && ready) {
+      echarts.connect(group);
+
+      // need to force a re-render otherwise only the currently visible charts
+      // in the group will end up connected
+      forceUpdate();
     }
-  }, [deps, synchronized]);
+  }, [
+    charts, // this re-connects when new charts are added/removed
+    ready, // this waits until the chart data has loaded before attempting to connect
+    group,
+  ]);
 }
 
 const StyledTransparentLoadingMask = styled(props => (

--- a/static/app/views/insights/common/components/chart.tsx
+++ b/static/app/views/insights/common/components/chart.tsx
@@ -621,7 +621,7 @@ export function useSynchronizeCharts(
 
   useEffect(() => {
     if (charts && ready) {
-      echarts.connect(group);
+      echarts?.connect?.(group);
 
       // need to force a re-render otherwise only the currently visible charts
       // in the group will end up connected

--- a/static/app/views/insights/common/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/insights/common/views/spans/spanTimeCharts.tsx
@@ -81,7 +81,7 @@ export function SpanTimeCharts({
     referrer: 'api.starfish.span-time-charts',
   });
 
-  useSynchronizeCharts([!isPending]);
+  useSynchronizeCharts(1, !isPending);
 
   const moduleCharts: Record<
     ModuleName,

--- a/static/app/views/insights/database/views/databaseLandingPage.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.tsx
@@ -159,7 +159,7 @@ export function DatabaseLandingPage() {
     ) ||
     throughputData['spm()'].data?.some(({value}) => value > 0);
 
-  useSynchronizeCharts([!isThroughputDataLoading && !isDurationDataLoading]);
+  useSynchronizeCharts(2, !isThroughputDataLoading && !isDurationDataLoading);
 
   const crumbs = useModuleBreadcrumbs('db');
 

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
@@ -180,7 +180,7 @@ export function DatabaseSpanSummaryPage({params}: Props) {
     'api.starfish.span-summary-page-metrics-chart'
   );
 
-  useSynchronizeCharts([!isThroughputDataLoading && !isDurationDataLoading]);
+  useSynchronizeCharts(2, !isThroughputDataLoading && !isDurationDataLoading);
 
   const crumbs = useModuleBreadcrumbs('db');
 

--- a/static/app/views/insights/http/views/httpDomainSummaryPage.tsx
+++ b/static/app/views/insights/http/views/httpDomainSummaryPage.tsx
@@ -180,7 +180,10 @@ export function HTTPDomainSummaryPage() {
     Referrer.DOMAIN_SUMMARY_TRANSACTIONS_LIST
   );
 
-  useSynchronizeCharts([!isThroughputDataLoading && !isDurationDataLoading]);
+  useSynchronizeCharts(
+    3,
+    !isThroughputDataLoading && !isDurationDataLoading && !isResponseCodeDataLoading
+  );
 
   const crumbs = useModuleBreadcrumbs('http');
 

--- a/static/app/views/insights/http/views/httpLandingPage.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.tsx
@@ -157,7 +157,10 @@ export function HTTPLandingPage() {
     Referrer.LANDING_DOMAINS_LIST
   );
 
-  useSynchronizeCharts([!isThroughputDataLoading && !isDurationDataLoading]);
+  useSynchronizeCharts(
+    3,
+    !isThroughputDataLoading && !isDurationDataLoading && !isResponseCodeDataLoading
+  );
 
   const crumbs = useModuleBreadcrumbs('http');
 


### PR DESCRIPTION
The synchronize worked in explore but seems broken in insights. Generalizing it into the existing hook.