### PR TITLE
ref(grouping): Simplify code getting hashes

### DIFF
--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -356,12 +356,7 @@ class BaseEvent(metaclass=abc.ABCMeta):
         from sentry.grouping.api import sort_grouping_variants
 
         variants = self.get_grouping_variants(force_config)
-        hashes = [
-            hash_
-            for _, hash_ in self._hashes_from_sorted_grouping_variants(
-                sort_grouping_variants(variants)
-            )
-        ]
+        hashes = self._hashes_from_sorted_grouping_variants(sort_grouping_variants(variants))
 
         # Write to event before returning
         self.data["hashes"] = hashes
@@ -370,18 +365,18 @@ class BaseEvent(metaclass=abc.ABCMeta):
     @staticmethod
     def _hashes_from_sorted_grouping_variants(
         variants: KeyedVariants,
-    ) -> list[tuple[str, str]]:
+    ) -> list[str]:
         """Create hashes from variants and filter out duplicates and None values"""
 
         filtered_hashes = []
         seen_hashes = set()
-        for name, variant in variants:
+        for _, variant in variants:
             hash_ = variant.get_hash()
             if hash_ is None or hash_ in seen_hashes:
                 continue
 
             seen_hashes.add(hash_)
-            filtered_hashes.append((name, hash_))
+            filtered_hashes.append(hash_)
 
         return filtered_hashes
 

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -356,7 +356,9 @@ class BaseEvent(metaclass=abc.ABCMeta):
         from sentry.grouping.api import sort_grouping_variants
 
         variants = self.get_grouping_variants(force_config)
-        hashes = self._hashes_from_sorted_grouping_variants(sort_grouping_variants(variants))
+        # Sort the variants so that the system variant (if any) is always last
+        sorted_variants = sort_grouping_variants(variants)
+        hashes = self._hashes_from_sorted_grouping_variants(sorted_variants)
 
         # Write to event before returning
         self.data["hashes"] = hashes

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -368,10 +368,8 @@ class BaseEvent(metaclass=abc.ABCMeta):
     ) -> list[str]:
         """Create hashes from variants and filter out duplicates and None values"""
 
-        filtered_hashes = {variant.get_hash() for _, variant in variants}
-
         # If any of the hashes came out as None, filter those out before returning
-        return list(filtered_hashes - {None})
+        return list({variant.get_hash() for _, variant in variants} - {None})
 
     def normalize_stacktraces_for_grouping(self, grouping_config: StrategyConfiguration) -> None:
         """Normalize stacktraces and clear memoized interfaces

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -368,9 +368,7 @@ class BaseEvent(metaclass=abc.ABCMeta):
     ) -> list[str]:
         """Create hashes from variants and filter out duplicates and None values"""
 
-        filtered_hashes = set()
-        for _, variant in variants:
-            filtered_hashes.add(variant.get_hash())
+        filtered_hashes = {variant.get_hash() for _, variant in variants}
 
         # If any of the hashes came out as None, filter those out before returning
         return list(filtered_hashes - {None})

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -370,9 +370,7 @@ class BaseEvent(metaclass=abc.ABCMeta):
 
         filtered_hashes = set()
         for _, variant in variants:
-            hash_ = variant.get_hash()
-
-            filtered_hashes.add(hash_)
+            filtered_hashes.add(variant.get_hash())
 
         # If any of the hashes came out as None, filter those out before returning
         return list(filtered_hashes - {None})

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -368,17 +368,15 @@ class BaseEvent(metaclass=abc.ABCMeta):
     ) -> list[str]:
         """Create hashes from variants and filter out duplicates and None values"""
 
-        filtered_hashes = []
-        seen_hashes = set()
+        filtered_hashes = set()
         for _, variant in variants:
             hash_ = variant.get_hash()
-            if hash_ is None or hash_ in seen_hashes:
+            if hash_ is None:
                 continue
 
-            seen_hashes.add(hash_)
-            filtered_hashes.append(hash_)
+            filtered_hashes.add(hash_)
 
-        return filtered_hashes
+        return list(filtered_hashes)
 
     def normalize_stacktraces_for_grouping(self, grouping_config: StrategyConfiguration) -> None:
         """Normalize stacktraces and clear memoized interfaces

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -371,12 +371,11 @@ class BaseEvent(metaclass=abc.ABCMeta):
         filtered_hashes = set()
         for _, variant in variants:
             hash_ = variant.get_hash()
-            if hash_ is None:
-                continue
 
             filtered_hashes.add(hash_)
 
-        return list(filtered_hashes)
+        # If any of the hashes came out as None, filter those out before returning
+        return list(filtered_hashes - {None})
 
     def normalize_stacktraces_for_grouping(self, grouping_config: StrategyConfiguration) -> None:
         """Normalize stacktraces and clear memoized interfaces

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -353,11 +353,14 @@ class BaseEvent(metaclass=abc.ABCMeta):
                 return hashes
 
         # Create fresh hashes
-        from sentry.grouping.api import sort_grouping_variants
 
         variants = self.get_grouping_variants(force_config)
-        # Sort the variants so that the system variant (if any) is always last
-        sorted_variants = sort_grouping_variants(variants)
+        # Sort the variants so that the system variant (if any) is always last, in order to resolve
+        # ambiguities when choosing primary_hash for Snuba
+        sorted_variants = sorted(
+            variants.items(),
+            key=lambda name_and_variant: 1 if name_and_variant[0] == "system" else 0,
+        )
         # Get each variant's hash value, filtering out Nones
         hashes = list({variant.get_hash() for _, variant in sorted_variants} - {None})
 

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -26,7 +26,6 @@ from sentry.grouping.variants import (
     ComponentVariant,
     CustomFingerprintVariant,
     FallbackVariant,
-    KeyedVariants,
     SaltedComponentVariant,
 )
 from sentry.models.grouphash import GroupHash
@@ -370,13 +369,3 @@ def get_grouping_variants_for_event(
         rv["fallback"] = FallbackVariant()
 
     return rv
-
-
-def sort_grouping_variants(variants: dict[str, BaseVariant]) -> KeyedVariants:
-    """Sort a sequence of variants into flat variants"""
-
-    # Sort system variant to the back of the list to resolve ambiguities when
-    # choosing primary_hash for Snuba
-    return sorted(
-        variants.items(), key=lambda name_and_variant: 1 if name_and_variant[0] == "system" else 0
-    )

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -375,10 +375,7 @@ def get_grouping_variants_for_event(
 def sort_grouping_variants(variants: dict[str, BaseVariant]) -> KeyedVariants:
     """Sort a sequence of variants into flat variants"""
 
-    flat_variants = []
-
-    for name, variant in variants.items():
-        flat_variants.append((name, variant))
+    flat_variants = list(variants.items())
 
     # Sort system variant to the back of the list to resolve ambiguities when
     # choosing primary_hash for Snuba

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -375,10 +375,8 @@ def get_grouping_variants_for_event(
 def sort_grouping_variants(variants: dict[str, BaseVariant]) -> KeyedVariants:
     """Sort a sequence of variants into flat variants"""
 
-    flat_variants = list(variants.items())
-
     # Sort system variant to the back of the list to resolve ambiguities when
     # choosing primary_hash for Snuba
-    flat_variants.sort(key=lambda name_and_variant: 1 if name_and_variant[0] == "system" else 0)
-
-    return flat_variants
+    return sorted(
+        variants.items(), key=lambda name_and_variant: 1 if name_and_variant[0] == "system" else 0
+    )


### PR DESCRIPTION
Now that the hierarchical grouping code is gone, a number of our grouping helper functions do little enough that there's no longer a real reason to keep them separate. This refactors both `_hashes_from_sorted_grouping_variants` and `sort_grouping_variants` into one-liners and then pulls them into `get_hashes`.

Note: `_hashes_from_sorted_grouping_variants` has been returning the variant name along with each variant, but `get_hashes` is the only place we were calling it, and we were ignoring that part of the return value, so I eliminated it. Other than that, the refactors are all simplification, with no behavior changes.