### PR TITLE
fix(metric alerts): add http.url to default tags

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -326,6 +326,7 @@ DEFAULT_METRIC_TAGS = {
     "histogram_outlier",
     "http.method",
     "http.status_code",
+    "http.url",
     "measurement_rating",
     "os.name",
     "query_hash",


### PR DESCRIPTION
`http.url` was missing from default tags, which was causing some issues for users flagged in to default tags.