### PR TITLE
fix(issues): Adjust viewers text color, duplicate info

### DIFF
--- a/static/app/components/group/streamlinedParticipantList.spec.tsx
+++ b/static/app/components/group/streamlinedParticipantList.spec.tsx
@@ -19,20 +19,20 @@ describe('ParticipantList', () => {
   it('expands and collapses the list when clicked', async () => {
     render(<ParticipantList teams={teams} users={users} />);
     expect(screen.queryByText('#team-1')).not.toBeInTheDocument();
-    await userEvent.click(screen.getByText('JD'));
+    await userEvent.click(screen.getByText('JD'), {skipHover: true});
     expect(await screen.findByText('#team-1')).toBeInTheDocument();
     expect(await screen.findByText('Bob Alice')).toBeInTheDocument();
 
     expect(screen.getByText('Teams (2)')).toBeInTheDocument();
     expect(screen.getByText('Individuals (2)')).toBeInTheDocument();
 
-    await userEvent.click(screen.getAllByText('JD')[0]);
+    await userEvent.click(screen.getAllByText('JD')[0], {skipHover: true});
     expect(screen.queryByText('Bob Alice')).not.toBeInTheDocument();
   });
 
   it('does not display section headers when there is only users or teams', async () => {
     render(<ParticipantList users={users} />);
-    await userEvent.click(screen.getByText('JD'));
+    await userEvent.click(screen.getByText('JD'), {skipHover: true});
     expect(await screen.findByText('Bob Alice')).toBeInTheDocument();
 
     expect(screen.queryByText('Teams')).not.toBeInTheDocument();
@@ -43,7 +43,7 @@ describe('ParticipantList', () => {
       UserFixture({id: '1', name: 'john.doe@example.com', email: 'john.doe@example.com'}),
     ];
     render(<ParticipantList users={duplicateInfoUsers} />);
-    await userEvent.click(screen.getByText('J'));
+    await userEvent.click(screen.getByText('J'), {skipHover: true});
     // Would find two elements if it was duplicated
     expect(await screen.findByText('john.doe@example.com')).toBeInTheDocument();
   });

--- a/static/app/components/group/streamlinedParticipantList.spec.tsx
+++ b/static/app/components/group/streamlinedParticipantList.spec.tsx
@@ -37,4 +37,14 @@ describe('ParticipantList', () => {
 
     expect(screen.queryByText('Teams')).not.toBeInTheDocument();
   });
+
+  it('skips duplicate information between name and email', async () => {
+    const duplicateInfoUsers = [
+      UserFixture({id: '1', name: 'john.doe@example.com', email: 'john.doe@example.com'}),
+    ];
+    render(<ParticipantList users={duplicateInfoUsers} />);
+    await userEvent.click(screen.getByText('J'));
+    // Would find two elements if it was duplicated
+    expect(await screen.findByText('john.doe@example.com')).toBeInTheDocument();
+  });
 });

--- a/static/app/components/group/streamlinedParticipantList.tsx
+++ b/static/app/components/group/streamlinedParticipantList.tsx
@@ -49,7 +49,9 @@ export default function ParticipantList({users, teams}: DropdownListProps) {
                   <TeamAvatar team={team} size={20} />
                   <div>
                     {`#${team.slug}`}
-                    <SubText>{tn('%s member', '%s members', team.memberCount)}</SubText>
+                    <SmallText>
+                      {tn('%s member', '%s members', team.memberCount)}
+                    </SmallText>
                   </div>
                 </UserRow>
               ))}
@@ -59,10 +61,12 @@ export default function ParticipantList({users, teams}: DropdownListProps) {
               {users.map(user => (
                 <UserRow key={user.id}>
                   <Avatar user={user} size={20} />
-                  <div>
-                    {user.name}
-                    <SubText>{user.email}</SubText>
-                  </div>
+                  <NameWrapper>
+                    <div>{user.name}</div>
+                    {user.email !== user.name ? (
+                      <SmallText>{user.email}</SmallText>
+                    ) : null}
+                  </NameWrapper>
                 </UserRow>
               ))}
             </ParticipantListWrapper>
@@ -82,6 +86,7 @@ const ParticipantListWrapper = styled('div')`
   max-height: 325px;
   overflow-y: auto;
   border-radius: ${p => p.theme.borderRadius};
+  color: ${p => p.theme.textColor};
 
   & > div:not(:last-child) {
     border-bottom: 1px solid ${p => p.theme.border};
@@ -106,10 +111,16 @@ const UserRow = styled('div')`
   gap: ${space(1)};
   line-height: 1.2;
   font-size: ${p => p.theme.fontSizeSmall};
+  min-height: 45px;
 `;
 
-const SubText = styled('div')`
-  color: ${p => p.theme.subText};
+const NameWrapper = styled('div')`
+  & > div:only-child {
+    margin-top: ${space(0.25)};
+  }
+`;
+
+const SmallText = styled('div')`
   font-size: ${p => p.theme.fontSizeExtraSmall};
 `;
 


### PR DESCRIPTION
Removes duplicate email information and changes font color

before
![image](https://github.com/user-attachments/assets/4b547a1a-296e-4a79-aff1-10e3a5da3e52)

after
![image](https://github.com/user-attachments/assets/82939568-37da-4c59-b777-6c045c591333)

fixes https://www.notion.so/sentry/Viewers-very-light-font-color-10c8b10e4b5d80d3a2c0d4d7035644d7