### PR TITLE
feat(issue_platform): Auto import grouptype.py in all Django apps if present

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import timedelta
@@ -7,6 +8,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 import sentry_sdk
+from django.apps import apps
 from redis.client import StrictRedis
 from rediscluster import RedisCluster
 
@@ -20,6 +22,9 @@ if TYPE_CHECKING:
     from sentry.models.organization import Organization
     from sentry.models.project import Project
     from sentry.users.models.user import User
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class GroupCategory(Enum):
@@ -627,3 +632,19 @@ def should_create_group(
     else:
         client.expire(key, noise_config.expiry_seconds)
         return False
+
+
+def import_grouptypes():
+    """
+    Ensures that grouptype.py is imported in any apps that implement it. We do this to make sure that all implemented
+    grouptypes are loaded and registered.
+    """
+    for app_config in apps.get_app_configs():
+        grouptype_module = f"{app_config.name}.grouptype"
+        try:
+            # Try to import the module
+            importlib.import_module(grouptype_module)
+            logger.debug("Imported module", extra={"module_name": grouptype_module})
+        except ModuleNotFoundError:
+            # If the module is not found, continue without any issues
+            logger.debug("No grouptypes found for app", extra={"app": app_config.name})

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -634,7 +634,7 @@ def should_create_group(
         return False
 
 
-def import_grouptypes():
+def import_grouptype():
     """
     Ensures that grouptype.py is imported in any apps that implement it. We do this to make sure that all implemented
     grouptypes are loaded and registered.

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -389,6 +389,8 @@ def initialize_app(config: dict[str, Any], skip_service_validation: bool = False
 
     setup_services(validate=not skip_service_validation)
 
+    import_grouptypes()
+
     from django.utils import timezone
 
     from sentry.app import env
@@ -711,3 +713,9 @@ def validate_outbox_config() -> None:
 
     for outbox_name in settings.SENTRY_OUTBOX_MODELS["REGION"]:
         RegionOutboxBase.from_outbox_name(outbox_name)
+
+
+def import_grouptypes() -> None:
+    from sentry.issues.grouptype import import_grouptypes
+
+    import_grouptypes()

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -389,7 +389,7 @@ def initialize_app(config: dict[str, Any], skip_service_validation: bool = False
 
     setup_services(validate=not skip_service_validation)
 
-    import_grouptypes()
+    import_grouptype()
 
     from django.utils import timezone
 
@@ -715,7 +715,7 @@ def validate_outbox_config() -> None:
         RegionOutboxBase.from_outbox_name(outbox_name)
 
 
-def import_grouptypes() -> None:
-    from sentry.issues.grouptype import import_grouptypes
+def import_grouptype() -> None:
+    from sentry.issues.grouptype import import_grouptype
 
-    import_grouptypes()
+    import_grouptype()


### PR DESCRIPTION
This pr ensures that if a `grouptype.py` is implemented in any Django app that we use that it will be imported. This allows us to define `GroupType` entries outside of `issues/` without worrying that they might not be imported.

This allows us to move logic that is specific to given issue types outside of `issues/`. In retrospect, it was probably not the right move to store the actual definitions here since the platform is meant to be generic and not be aware of the details of any specific issue type.

As well as this, as part of alerts are issues we're planning on hooking in information about detectors into the issue types, which would mean that we'd need to import from `uptime`/`incidents`/etc. This would likely result in import loops.

<!-- Describe your PR here. -->