### PR TITLE
fix(issues): Adjust next event padding

### DIFF
--- a/static/app/views/issueDetails/streamline/eventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.tsx
@@ -198,7 +198,7 @@ export const EventNavigation = forwardRef<HTMLDivElement, EventNavigationProps>(
           </Tabs>
           <NavigationWrapper>
             <Navigation>
-              <Tooltip title={t('Previous Event')}>
+              <Tooltip title={t('Previous Event')} skipWrapper>
                 <LinkButton
                   aria-label={t('Previous Event')}
                   borderless
@@ -212,7 +212,7 @@ export const EventNavigation = forwardRef<HTMLDivElement, EventNavigationProps>(
                   css={grayText}
                 />
               </Tooltip>
-              <Tooltip title={t('Next Event')}>
+              <Tooltip title={t('Next Event')} skipWrapper>
                 <LinkButton
                   aria-label={t('Next Event')}
                   borderless
@@ -387,6 +387,7 @@ const NavigationWrapper = styled('div')`
 
 const Navigation = styled('div')`
   display: flex;
+  padding-right: ${space(0.25)};
   border-right: 1px solid ${p => p.theme.gray100};
 `;
 


### PR DESCRIPTION
Border right puts the border right up against the button on hover. Adds padding.

![image](https://github.com/user-attachments/assets/76c84614-e981-44fe-8b47-16b73bc2fafb)

fixes https://www.notion.so/sentry/Slight-margin-misalignment-10c8b10e4b5d80ee8b90f732c0076c33