### PR TITLE
ref(grouping): Attach variants to event object during ingest

### DIFF
--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -364,8 +364,10 @@ class BaseEvent(metaclass=abc.ABCMeta):
         # Get each variant's hash value, filtering out Nones
         hashes = list({variant.get_hash() for _, variant in sorted_variants} - {None})
 
-        # Write to event before returning
+        # Write data to event - `hashes` goes in `self.data` so that it's included in the stored
+        # event, and `variants` goes straight on `self`, so that it isn't stored
         self.data["hashes"] = hashes
+        self.variants = variants
         return hashes
 
     def normalize_stacktraces_for_grouping(self, grouping_config: StrategyConfiguration) -> None:

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -97,7 +97,7 @@ def _has_customized_fingerprint(event: Event) -> bool:
             return True
 
     # Fully customized fingerprint (from either us or the user)
-    variants = event.get_grouping_variants()
+    variants = event.variants
     fingerprint_variant = variants.get("custom-fingerprint") or variants.get("built-in-fingerprint")
 
     if fingerprint_variant:
@@ -186,9 +186,7 @@ def get_seer_similar_issues(
     should go in (if any), or None if no neighbor was near enough.
     """
     event_hash = event.get_primary_hash()
-    stacktrace_string = get_stacktrace_string(
-        get_grouping_info_from_variants(event.get_grouping_variants())
-    )
+    stacktrace_string = get_stacktrace_string(get_grouping_info_from_variants(event.variants))
     exception_type = get_path(event.data, "exception", "values", -1, "type")
 
     request_data: SimilarIssuesEmbeddingsRequest = {


### PR DESCRIPTION
In order to avoid running the grouping calculation more than once during ingest, this attaches the list of variants to the event object after they're calculated. Because the variants are attached at the object's top level (and not in its `data`), we can add them without worrying about them getting stored in in the database- the data passed to `store` comes [from the event manager](https://github.com/getsentry/sentry/blob/6d5f99039ff28fdb33d785ee27a0ab372d41848e/src/sentry/tasks/store.py#L554-L566), which in turn takes its data from `event.data.data` [in `save_error_events`](https://github.com/getsentry/sentry/blob/6d5f99039ff28fdb33d785ee27a0ab372d41848e/src/sentry/event_manager.py#L655). In other words, nothing at the top level is preserved.