### PR TITLE
fix(issue-views): No more jitter when switching tabs

### DIFF
--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -230,7 +230,6 @@ function Tabs({
               dragConstraints={dragConstraints} // dragConstraints are the bounds that the tab can be dragged within
               dragElastic={0} // Prevents the tab from being dragged outside of the dragConstraints (w/o this you can drag it outside but it'll spring back)
               dragTransition={{bounceStiffness: 400, bounceDamping: 40}} // Recovers spring behavior thats lost when using dragElastic=0
-              transition={{delay: -0.1}} // Skips the first few frames of the animation that make the tab appear to shrink before growing
               layout
               drag={item.key !== editingTabKey} // Disable dragging if the tab is being edited
               onDrag={() => setIsDragging(true)}

--- a/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
@@ -89,17 +89,17 @@ function EditableTabTitle({
 
   return (
     <Tooltip title={label} disabled={isEditing} showOnlyOnOverflow skipWrapper>
-      <motion.div layout="position" transition={{duration: 0.25}}>
-        {isSelected ? (
+      <motion.div layout="position" transition={{duration: 0.2}}>
+        {isSelected && isEditing ? (
           <StyledGrowingInput
             value={inputValue}
             onChange={handleOnChange}
             onKeyDown={handleOnKeyDown}
-            onDoubleClick={() => setIsEditing(true)}
             onBlur={handleOnBlur}
             ref={inputRef}
             style={memoizedStyles}
             isEditing={isEditing}
+            maxLength={128}
             onPointerDown={e => {
               e.stopPropagation();
               if (!isEditing) {
@@ -112,10 +112,26 @@ function EditableTabTitle({
                 e.preventDefault();
               }
             }}
-            maxLength={128}
           />
         ) : (
-          <UnselectedTabTitle>{label}</UnselectedTabTitle>
+          <UnselectedTabTitle
+            onDoubleClick={() => setIsEditing(true)}
+            onPointerDown={e => {
+              e.stopPropagation();
+              if (!isEditing) {
+                e.preventDefault();
+              }
+            }}
+            onMouseDown={e => {
+              e.stopPropagation();
+              if (!isEditing) {
+                e.preventDefault();
+              }
+            }}
+            isSelected={isSelected}
+          >
+            {label}
+          </UnselectedTabTitle>
         )}
       </motion.div>
     </Tooltip>
@@ -124,13 +140,15 @@ function EditableTabTitle({
 
 export default EditableTabTitle;
 
-const UnselectedTabTitle = styled('div')`
+const UnselectedTabTitle = styled('div')<{isSelected: boolean}>`
   height: 20px;
-  /* The max width is slightly smaller than the GrowingInput since the text in the growing input is bolded */
-  max-width: 310px;
+  max-width: ${p => (p.isSelected ? '325px' : '310px')};
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  padding-right: 1px;
+  cursor: pointer;
+  font-weight: ${p => (p.isSelected ? 'bold' : 'normal')};
 `;
 
 const StyledGrowingInput = styled(GrowingInput)<{
@@ -138,15 +156,15 @@ const StyledGrowingInput = styled(GrowingInput)<{
 }>`
   position: relative;
   border: none;
+  margin: 0;
   padding: 0;
   background: transparent;
   min-height: 0px;
   height: 20px;
   border-radius: 0px;
   text-overflow: ellipsis;
-  cursor: ${p => (p.isEditing ? 'text' : 'pointer')};
-
-  ${p => !p.isEditing && `max-width: 325px;`}
+  cursor: text;
+  max-width: 325px;
 
   &,
   &:focus,

--- a/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
@@ -117,14 +117,14 @@ function EditableTabTitle({
           <UnselectedTabTitle
             onDoubleClick={() => setIsEditing(true)}
             onPointerDown={e => {
-              e.stopPropagation();
-              if (!isEditing) {
+              if (isSelected) {
+                e.stopPropagation();
                 e.preventDefault();
               }
             }}
             onMouseDown={e => {
-              e.stopPropagation();
-              if (!isEditing) {
+              if (isSelected) {
+                e.stopPropagation();
                 e.preventDefault();
               }
             }}


### PR DESCRIPTION
Before: _notice the tab dividers jitter when the selected tab changes_

https://github.com/user-attachments/assets/17bcf2b2-fcee-45ac-9575-21e9074c0008

After


https://github.com/user-attachments/assets/dd7433ca-f861-433d-b83f-29270061af74

