### PR TITLE
chore(issues): Begin migrating ownership rules limits to flagpole

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -239,6 +239,10 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:onboarding", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enable the SDK selection feature in the onboarding
     manager.add("organizations:onboarding-sdk-selection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable large ownership rule file size limit
+    manager.add("organizations:ownership-size-limit-large", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable xlarge ownership rule file size limit
+    manager.add("organizations:ownership-size-limit-xlarge", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable views for anomaly detection
     manager.add("organizations:performance-anomaly-detection-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable mobile performance score calculation for transactions in relay

--- a/tests/sentry/api/endpoints/test_project_ownership.py
+++ b/tests/sentry/api/endpoints/test_project_ownership.py
@@ -372,7 +372,7 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
 
     def test_max_raw_length(self):
         new_raw = f"*.py admin@localhost #{self.team.slug}"
-        with mock.patch("sentry.api.endpoints.project_ownership.LARGE_RAW_LENGTH", 10):
+        with mock.patch("sentry.api.endpoints.project_ownership.DEFAULT_MAX_RAW_LENGTH", 10):
             resp = self.get_error_response(
                 self.organization.slug,
                 self.project.slug,

--- a/tests/sentry/api/endpoints/test_project_ownership.py
+++ b/tests/sentry/api/endpoints/test_project_ownership.py
@@ -372,7 +372,7 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
 
     def test_max_raw_length(self):
         new_raw = f"*.py admin@localhost #{self.team.slug}"
-        with mock.patch("sentry.api.endpoints.project_ownership.MAX_RAW_LENGTH", 10):
+        with mock.patch("sentry.api.endpoints.project_ownership.LARGE_RAW_LENGTH", 10):
             resp = self.get_error_response(
                 self.organization.slug,
                 self.project.slug,


### PR DESCRIPTION
XLARGE is not used yet and won't be enabled without additional research/testing (and possibly changing the actual value).

Old check will get removed once the values are migrated over to flagpole.