### PR TITLE
fix(integrations): Don't raise exceptions from EventLifecycle

### DIFF
--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -84,10 +84,6 @@ class EventLifecycleMetric(ABC):
         return EventLifecycle(self, assume_success)
 
 
-class EventLifecycleStateError(Exception):
-    pass
-
-
 class EventLifecycle:
     """Context object that measures an event that may succeed or fail.
 
@@ -132,13 +128,17 @@ class EventLifecycle:
         if outcome == EventLifecycleOutcome.FAILURE:
             logger.error(key, extra=self._extra, exc_info=exc)
 
+    @staticmethod
+    def _report_flow_error(message) -> None:
+        logger.error("EventLifecycle flow error: %s", message)
+
     def _terminate(
         self, new_state: EventLifecycleOutcome, exc: BaseException | None = None
     ) -> None:
         if self._state is None:
-            raise EventLifecycleStateError("The lifecycle has not yet been entered")
+            self._report_flow_error("The lifecycle has not yet been entered")
         if self._state != EventLifecycleOutcome.STARTED:
-            raise EventLifecycleStateError("The lifecycle has already been exited")
+            self._report_flow_error("The lifecycle has already been exited")
         self._state = new_state
         self.record_event(new_state, exc)
 
@@ -169,7 +169,7 @@ class EventLifecycle:
 
     def __enter__(self) -> Self:
         if self._state is not None:
-            raise EventLifecycleStateError("The lifecycle has already been entered")
+            self._report_flow_error("The lifecycle has already been entered")
         self._state = EventLifecycleOutcome.STARTED
         self.record_event(EventLifecycleOutcome.STARTED)
         return self


### PR DESCRIPTION
The checks are valid, but raising the exception is likely to cause more trouble than it saves, especially if we are already midway through handling another exception. (Thanks @GabeVillalobos for pointing this out.) So just log the error instead.