### PR TITLE
Update Sentry Python SDK to version 2.15.0

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -70,7 +70,7 @@ sentry-ophio==1.0.0
 sentry-protos>=0.1.21
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.9.2
-sentry-sdk>=2.12.0
+sentry-sdk>=2.15.0
 slack-sdk>=3.27.2
 snuba-sdk>=3.0.40
 simplejson>=3.17.6

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -187,7 +187,7 @@ sentry-ophio==1.0.0
 sentry-protos==0.1.21
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.2
-sentry-sdk==2.12.0
+sentry-sdk==2.15.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -128,7 +128,7 @@ sentry-ophio==1.0.0
 sentry-protos==0.1.21
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.2
-sentry-sdk==2.12.0
+sentry-sdk==2.15.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -394,7 +394,7 @@ class Endpoint(APIView):
         Identical to rest framework's dispatch except we add the ability
         to convert arguments (for common URL params).
         """
-        with sentry_sdk.start_span(op="base.dispatch.setup", description=type(self).__name__):
+        with sentry_sdk.start_span(op="base.dispatch.setup", name=type(self).__name__):
             self.args = args
             self.kwargs = kwargs
             request = self.initialize_request(request, *args, **kwargs)
@@ -415,7 +415,7 @@ class Endpoint(APIView):
             origin = None
 
         try:
-            with sentry_sdk.start_span(op="base.dispatch.request", description=type(self).__name__):
+            with sentry_sdk.start_span(op="base.dispatch.request", name=type(self).__name__):
                 if origin:
                     if request.auth:
                         allowed_origins = request.auth.get_allowed_origins()
@@ -449,7 +449,7 @@ class Endpoint(APIView):
 
             with sentry_sdk.start_span(
                 op="base.dispatch.execute",
-                description=".".join(
+                name=".".join(
                     getattr(part, "__name__", None) or str(part) for part in (type(self), handler)
                 ),
             ) as span:
@@ -469,7 +469,7 @@ class Endpoint(APIView):
             if duration < (settings.SENTRY_API_RESPONSE_DELAY / 1000.0):
                 with sentry_sdk.start_span(
                     op="base.dispatch.sleep",
-                    description=type(self).__name__,
+                    name=type(self).__name__,
                 ) as span:
                     span.set_data("SENTRY_API_RESPONSE_DELAY", settings.SENTRY_API_RESPONSE_DELAY)
                     time.sleep(settings.SENTRY_API_RESPONSE_DELAY / 1000.0 - duration)
@@ -556,7 +556,7 @@ class Endpoint(APIView):
             cursor = self.get_cursor_from_request(request, cursor_cls)
             with sentry_sdk.start_span(
                 op="base.paginate.get_result",
-                description=type(self).__name__,
+                name=type(self).__name__,
             ) as span:
                 annotate_span_with_pagination_args(span, per_page)
                 paginator = get_paginator(paginator, paginator_cls, paginator_kwargs)
@@ -576,7 +576,7 @@ class Endpoint(APIView):
         if on_results:
             with sentry_sdk.start_span(
                 op="base.paginate.on_results",
-                description=type(self).__name__,
+                name=type(self).__name__,
             ):
                 results = on_results(cursor_result.results)
         else:

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -117,7 +117,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         quantize_date_params: bool = True,
     ) -> SnubaParams:
         """Returns params to make snuba queries with"""
-        with sentry_sdk.start_span(op="discover.endpoint", description="filter_params(dataclass)"):
+        with sentry_sdk.start_span(op="discover.endpoint", name="filter_params(dataclass)"):
             if (
                 len(self.get_field_list(organization, request))
                 + len(self.get_equation_list(organization, request))
@@ -317,7 +317,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         standard_meta: bool | None = False,
         dataset: Any | None = None,
     ) -> dict[str, Any]:
-        with sentry_sdk.start_span(op="discover.endpoint", description="base.handle_results"):
+        with sentry_sdk.start_span(op="discover.endpoint", name="base.handle_results"):
             data = self.handle_data(request, organization, project_ids, results.get("data"))
             meta = results.get("meta", {})
             fields_meta = meta.get("fields", {})
@@ -424,9 +424,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         dataset: Any | None = None,
     ) -> dict[str, Any]:
         with handle_query_errors():
-            with sentry_sdk.start_span(
-                op="discover.endpoint", description="base.stats_query_creation"
-            ):
+            with sentry_sdk.start_span(op="discover.endpoint", name="base.stats_query_creation"):
                 _columns = [query_column]
                 # temporary change to make topN query work for multi-axes requests
                 if additional_query_column is not None:
@@ -466,14 +464,14 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                         raise ValidationError("Comparison period is outside your retention window")
 
                 query_columns = get_query_columns(columns, rollup)
-            with sentry_sdk.start_span(op="discover.endpoint", description="base.stats_query"):
+            with sentry_sdk.start_span(op="discover.endpoint", name="base.stats_query"):
                 result = get_event_stats(
                     query_columns, query, snuba_params, rollup, zerofill_results, comparison_delta
                 )
 
         serializer = SnubaTSResultSerializer(organization, None, request.user)
 
-        with sentry_sdk.start_span(op="discover.endpoint", description="base.stats_serialization"):
+        with sentry_sdk.start_span(op="discover.endpoint", name="base.stats_serialization"):
             # When the request is for top_events, result can be a SnubaTSResult in the event that
             # there were no top events found. In this case, result contains a zerofilled series
             # that acts as a placeholder.

--- a/src/sentry/api/endpoints/organization_events_facets.py
+++ b/src/sentry/api/endpoints/organization_events_facets.py
@@ -32,7 +32,7 @@ class OrganizationEventsFacetsEndpoint(OrganizationEventsV2EndpointBase):
         update_snuba_params_with_timestamp(request, snuba_params, timestamp_key="traceTimestamp")
 
         def data_fn(offset, limit):
-            with sentry_sdk.start_span(op="discover.endpoint", description="discover_query"):
+            with sentry_sdk.start_span(op="discover.endpoint", name="discover_query"):
                 with handle_query_errors():
                     facets = discover.get_facets(
                         query=request.GET.get("query"),
@@ -42,9 +42,7 @@ class OrganizationEventsFacetsEndpoint(OrganizationEventsV2EndpointBase):
                         cursor=offset,
                     )
 
-            with sentry_sdk.start_span(
-                op="discover.endpoint", description="populate_results"
-            ) as span:
+            with sentry_sdk.start_span(op="discover.endpoint", name="populate_results") as span:
                 span.set_data("facet_count", len(facets or []))
                 resp = defaultdict(lambda: {"key": "", "topValues": []})
                 for row in facets:

--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -90,7 +90,7 @@ class OrganizationEventsFacetsPerformanceEndpoint(OrganizationEventsFacetsPerfor
             tag_key = TAG_ALIASES.get(tag_key)
 
         def data_fn(offset, limit):
-            with sentry_sdk.start_span(op="discover.endpoint", description="discover_query"):
+            with sentry_sdk.start_span(op="discover.endpoint", name="discover_query"):
                 referrer = "api.organization-events-facets-performance.top-tags"
                 tag_data = query_tag_data(
                     filter_query=filter_query,
@@ -178,7 +178,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpoint(
             tag_key = TAG_ALIASES.get(tag_key)
 
         def data_fn(offset, limit, raw_limit):
-            with sentry_sdk.start_span(op="discover.endpoint", description="discover_query"):
+            with sentry_sdk.start_span(op="discover.endpoint", name="discover_query"):
                 referrer = "api.organization-events-facets-performance-histogram"
                 top_tags = query_top_tags(
                     tag_key=tag_key,
@@ -269,9 +269,7 @@ def query_tag_data(
     :return: Returns the row with aggregate and count if the query was successful
              Returns None if query was not successful which causes the endpoint to return early
     """
-    with sentry_sdk.start_span(
-        op="discover.discover", description="facets.filter_transform"
-    ) as span:
+    with sentry_sdk.start_span(op="discover.discover", name="facets.filter_transform") as span:
         span.set_data("query", filter_query)
         tag_query = DiscoverQueryBuilder(
             dataset=Dataset.Discover,
@@ -289,7 +287,7 @@ def query_tag_data(
             Condition(tag_query.resolve_column(aggregate_column), Op.IS_NOT_NULL)
         )
 
-    with sentry_sdk.start_span(op="discover.discover", description="facets.frequent_tags"):
+    with sentry_sdk.start_span(op="discover.discover", name="facets.frequent_tags"):
         # Get the average and count to use to filter the next request to facets
         tag_data = tag_query.run_query(f"{referrer}.all_transactions")
 
@@ -324,7 +322,7 @@ def query_top_tags(
     """
     translated_aggregate_column = discover.resolve_discover_column(aggregate_column)
 
-    with sentry_sdk.start_span(op="discover.discover", description="facets.top_tags"):
+    with sentry_sdk.start_span(op="discover.discover", name="facets.top_tags"):
         if not orderby:
             orderby = ["-count"]
 
@@ -399,9 +397,7 @@ def query_facet_performance(
 
     tag_key_limit = limit if tag_key else 1
 
-    with sentry_sdk.start_span(
-        op="discover.discover", description="facets.filter_transform"
-    ) as span:
+    with sentry_sdk.start_span(op="discover.discover", name="facets.filter_transform") as span:
         span.set_data("query", filter_query)
         tag_query = DiscoverQueryBuilder(
             dataset=Dataset.Discover,
@@ -452,7 +448,7 @@ def query_facet_performance(
         ["trace", "trace.ctx", "trace.span", "project", "browser", "celery_task_id", "url"],
     )
 
-    with sentry_sdk.start_span(op="discover.discover", description="facets.aggregate_tags"):
+    with sentry_sdk.start_span(op="discover.discover", name="facets.aggregate_tags"):
         span.set_data("sample_rate", sample_rate)
         span.set_data("target_sample", target_sample)
         aggregate_comparison = transaction_aggregate * 1.005 if transaction_aggregate else 0

--- a/src/sentry/api/endpoints/organization_events_has_measurements.py
+++ b/src/sentry/api/endpoints/organization_events_has_measurements.py
@@ -58,7 +58,7 @@ class OrganizationEventsHasMeasurementsEndpoint(OrganizationEventsV2EndpointBase
         if not self.has_feature(organization, request):
             return Response(status=404)
 
-        with sentry_sdk.start_span(op="discover.endpoint", description="parse params"):
+        with sentry_sdk.start_span(op="discover.endpoint", name="parse params"):
             try:
                 # This endpoint only allows for a single project + transaction, so no need
                 # to check `global-views`.

--- a/src/sentry/api/endpoints/organization_events_histogram.py
+++ b/src/sentry/api/endpoints/organization_events_histogram.py
@@ -72,7 +72,7 @@ class OrganizationEventsHistogramEndpoint(OrganizationEventsV2EndpointBase):
 
         sentry_sdk.set_tag("performance.metrics_enhanced", metrics_enhanced)
 
-        with sentry_sdk.start_span(op="discover.endpoint", description="histogram"):
+        with sentry_sdk.start_span(op="discover.endpoint", name="histogram"):
             serializer = HistogramSerializer(data=request.GET)
             if serializer.is_valid():
                 data = serializer.validated_data

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -66,7 +66,7 @@ class OrganizationEventsRelatedIssuesEndpoint(OrganizationEventsEndpointBase, En
         except NoProjects:
             return Response([])
 
-        with sentry_sdk.start_span(op="discover.endpoint", description="find_lookup_keys") as span:
+        with sentry_sdk.start_span(op="discover.endpoint", name="find_lookup_keys") as span:
             possible_keys = ["transaction"]
             lookup_keys = {key: request.query_params.get(key) for key in possible_keys}
 
@@ -79,7 +79,7 @@ class OrganizationEventsRelatedIssuesEndpoint(OrganizationEventsEndpointBase, En
                 )
 
         with handle_query_errors():
-            with sentry_sdk.start_span(op="discover.endpoint", description="filter_creation"):
+            with sentry_sdk.start_span(op="discover.endpoint", name="filter_creation"):
                 projects = self.get_projects(request, organization)
                 query_kwargs = build_query_params_from_request(
                     request, organization, projects, snuba_params.environments
@@ -99,10 +99,10 @@ class OrganizationEventsRelatedIssuesEndpoint(OrganizationEventsEndpointBase, En
 
                 query_kwargs["actor"] = request.user
 
-            with sentry_sdk.start_span(op="discover.endpoint", description="issue_search"):
+            with sentry_sdk.start_span(op="discover.endpoint", name="issue_search"):
                 results_cursor = search.backend.query(**query_kwargs)
 
-        with sentry_sdk.start_span(op="discover.endpoint", description="serialize_results") as span:
+        with sentry_sdk.start_span(op="discover.endpoint", name="serialize_results") as span:
             results = list(results_cursor)
             span.set_data("result_length", len(results))
             context = serialize(

--- a/src/sentry/api/endpoints/organization_events_spans_histogram.py
+++ b/src/sentry/api/endpoints/organization_events_spans_histogram.py
@@ -55,7 +55,7 @@ class OrganizationEventsSpansHistogramEndpoint(OrganizationEventsV2EndpointBase)
         except NoProjects:
             return Response({})
 
-        with sentry_sdk.start_span(op="discover.endpoint", description="spans_histogram"):
+        with sentry_sdk.start_span(op="discover.endpoint", name="spans_histogram"):
             serializer = SpansHistogramSerializer(data=request.GET)
             if serializer.is_valid():
                 data = serializer.validated_data

--- a/src/sentry/api/endpoints/organization_events_spans_performance.py
+++ b/src/sentry/api/endpoints/organization_events_spans_performance.py
@@ -333,9 +333,7 @@ class OrganizationEventsSpansStatsEndpoint(OrganizationEventsSpansEndpointBase):
             zerofill_results: bool,
             comparison_delta: datetime | None = None,
         ) -> SnubaTSResult:
-            with sentry_sdk.start_span(
-                op="discover.discover", description="timeseries.filter_transform"
-            ):
+            with sentry_sdk.start_span(op="discover.discover", name="timeseries.filter_transform"):
                 builder = TimeseriesQueryBuilder(
                     Dataset.Discover,
                     {},
@@ -372,9 +370,7 @@ class OrganizationEventsSpansStatsEndpoint(OrganizationEventsSpansEndpointBase):
                     snql_query, "api.organization-events-spans-performance-stats"
                 )
 
-            with sentry_sdk.start_span(
-                op="discover.discover", description="timeseries.transform_results"
-            ):
+            with sentry_sdk.start_span(op="discover.discover", name="timeseries.transform_results"):
                 result = discover.zerofill(
                     results["data"],
                     snuba_params.start_date,

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -183,7 +183,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
 
     def get(self, request: Request, organization: Organization) -> Response:
         query_source = self.get_request_source(request)
-        with sentry_sdk.start_span(op="discover.endpoint", description="filter_params") as span:
+        with sentry_sdk.start_span(op="discover.endpoint", name="filter_params") as span:
             span.set_data("organization", organization)
 
             top_events = 0

--- a/src/sentry/api/endpoints/organization_events_trends.py
+++ b/src/sentry/api/endpoints/organization_events_trends.py
@@ -261,9 +261,11 @@ class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
                         if trend_type == IMPROVED
                         else aggregate_filter.operator
                     ),
-                    -1 * aggregate_filter.value.value
-                    if trend_type == IMPROVED
-                    else aggregate_filter.value.value,
+                    (
+                        -1 * aggregate_filter.value.value
+                        if trend_type == IMPROVED
+                        else aggregate_filter.value.value
+                    ),
                 ),
                 ["minus", "transaction.duration"],
                 trend_columns["trend_difference"],
@@ -276,9 +278,11 @@ class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
                         if trend_type == REGRESSION
                         else aggregate_filter.operator
                     ),
-                    -1 * aggregate_filter.value.value
-                    if trend_type == REGRESSION
-                    else aggregate_filter.value.value,
+                    (
+                        -1 * aggregate_filter.value.value
+                        if trend_type == REGRESSION
+                        else aggregate_filter.value.value
+                    ),
                 ),
                 None,
                 trend_columns["t_test"],
@@ -304,9 +308,11 @@ class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
             "trend_percentage()": Alias(
                 lambda aggregate_filter: [
                     "trend_percentage",
-                    CORRESPONDENCE_MAP[aggregate_filter.operator]
-                    if trend_type == IMPROVED
-                    else aggregate_filter.operator,
+                    (
+                        CORRESPONDENCE_MAP[aggregate_filter.operator]
+                        if trend_type == IMPROVED
+                        else aggregate_filter.operator
+                    ),
                     1 + (aggregate_filter.value.value * (-1 if trend_type == IMPROVED else 1)),
                 ],
                 ["percentage", "transaction.duration"],
@@ -315,12 +321,16 @@ class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
             "trend_difference()": Alias(
                 lambda aggregate_filter: [
                     "trend_difference",
-                    CORRESPONDENCE_MAP[aggregate_filter.operator]
-                    if trend_type == IMPROVED
-                    else aggregate_filter.operator,
-                    -1 * aggregate_filter.value.value
-                    if trend_type == IMPROVED
-                    else aggregate_filter.value.value,
+                    (
+                        CORRESPONDENCE_MAP[aggregate_filter.operator]
+                        if trend_type == IMPROVED
+                        else aggregate_filter.operator
+                    ),
+                    (
+                        -1 * aggregate_filter.value.value
+                        if trend_type == IMPROVED
+                        else aggregate_filter.value.value
+                    ),
                 ],
                 ["minus", "transaction.duration"],
                 None,
@@ -328,12 +338,16 @@ class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
             "confidence()": Alias(
                 lambda aggregate_filter: [
                     "t_test",
-                    CORRESPONDENCE_MAP[aggregate_filter.operator]
-                    if trend_type == REGRESSION
-                    else aggregate_filter.operator,
-                    -1 * aggregate_filter.value.value
-                    if trend_type == REGRESSION
-                    else aggregate_filter.value.value,
+                    (
+                        CORRESPONDENCE_MAP[aggregate_filter.operator]
+                        if trend_type == REGRESSION
+                        else aggregate_filter.operator
+                    ),
+                    (
+                        -1 * aggregate_filter.value.value
+                        if trend_type == REGRESSION
+                        else aggregate_filter.value.value
+                    ),
                 ],
                 None,
                 None,
@@ -431,7 +445,7 @@ class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
         except NoProjects:
             return Response([])
 
-        with sentry_sdk.start_span(op="discover.endpoint", description="trend_dates"):
+        with sentry_sdk.start_span(op="discover.endpoint", name="trend_dates"):
             middle_date = request.GET.get("middle")
             if middle_date:
                 try:

--- a/src/sentry/api/endpoints/organization_events_vitals.py
+++ b/src/sentry/api/endpoints/organization_events_vitals.py
@@ -31,7 +31,7 @@ class OrganizationEventsVitalsEndpoint(OrganizationEventsV2EndpointBase):
         if not self.has_feature(organization, request):
             return Response(status=404)
 
-        with sentry_sdk.start_span(op="discover.endpoint", description="parse params"):
+        with sentry_sdk.start_span(op="discover.endpoint", name="parse params"):
             try:
                 snuba_params = self.get_snuba_params(request, organization)
             except NoProjects:

--- a/src/sentry/api/endpoints/organization_measurements_meta.py
+++ b/src/sentry/api/endpoints/organization_measurements_meta.py
@@ -33,7 +33,7 @@ class OrganizationMeasurementsMeta(OrganizationEventsEndpointBase):
                 use_case_id=UseCaseID.TRANSACTIONS,
             )
 
-        with start_span(op="transform", description="metric meta"):
+        with start_span(op="transform", name="metric meta"):
             result = {
                 item["name"]: {
                     "functions": METRIC_FUNCTION_LIST_BY_TYPE[item["type"]],

--- a/src/sentry/api/endpoints/organization_on_demand_metrics_estimation_stats.py
+++ b/src/sentry/api/endpoints/organization_on_demand_metrics_estimation_stats.py
@@ -66,9 +66,7 @@ class OrganizationOnDemandMetricsEstimationStatsEndpoint(OrganizationEventsV2End
         if measurement is None:
             return Response({"detail": "missing required parameter yAxis"}, status=400)
 
-        with sentry_sdk.start_span(
-            op="discover.metrics.endpoint", description="get_full_metrics"
-        ) as span:
+        with sentry_sdk.start_span(op="discover.metrics.endpoint", name="get_full_metrics") as span:
             span.set_data("organization", organization)
 
             try:

--- a/src/sentry/api/endpoints/organization_sessions.py
+++ b/src/sentry/api/endpoints/organization_sessions.py
@@ -82,9 +82,7 @@ class OrganizationSessionsEndpoint(OrganizationEndpoint):
 
         def data_fn(offset: int, limit: int) -> SessionsQueryResult:
             with self.handle_query_errors():
-                with sentry_sdk.start_span(
-                    op="sessions.endpoint", description="build_sessions_query"
-                ):
+                with sentry_sdk.start_span(op="sessions.endpoint", name="build_sessions_query"):
                     request_limit = None
                     if request.GET.get("per_page") is not None:
                         request_limit = limit

--- a/src/sentry/api/endpoints/organization_spans_aggregation.py
+++ b/src/sentry/api/endpoints/organization_spans_aggregation.py
@@ -410,7 +410,7 @@ class OrganizationSpansAggregationEndpoint(OrganizationEventsEndpointBase):
                 )
 
             with sentry_sdk.start_span(
-                op="span.aggregation", description="AggregateIndexedSpans.build_aggregate_span_tree"
+                op="span.aggregation", name="AggregateIndexedSpans.build_aggregate_span_tree"
             ):
                 aggregated_tree = AggregateIndexedSpans().build_aggregate_span_tree(results)
 
@@ -442,7 +442,7 @@ class OrganizationSpansAggregationEndpoint(OrganizationEventsEndpointBase):
         )
 
         with sentry_sdk.start_span(
-            op="span.aggregation", description="AggregateNodestoreSpans.build_aggregate_span_tree"
+            op="span.aggregation", name="AggregateNodestoreSpans.build_aggregate_span_tree"
         ):
             aggregated_tree = AggregateNodestoreSpans().build_aggregate_span_tree(events)
 

--- a/src/sentry/api/endpoints/organization_stats_summary.py
+++ b/src/sentry/api/endpoints/organization_stats_summary.py
@@ -142,16 +142,14 @@ class OrganizationStatsSummaryEndpoint(OrganizationEndpoint):
         """
         with self.handle_query_errors():
             tenant_ids = {"organization_id": organization.id}
-            with sentry_sdk.start_span(op="outcomes.endpoint", description="build_outcomes_query"):
+            with sentry_sdk.start_span(op="outcomes.endpoint", name="build_outcomes_query"):
                 query = self.build_outcomes_query(
                     request,
                     organization,
                 )
-            with sentry_sdk.start_span(op="outcomes.endpoint", description="run_outcomes_query"):
+            with sentry_sdk.start_span(op="outcomes.endpoint", name="run_outcomes_query"):
                 result_totals = run_outcomes_query_totals(query, tenant_ids=tenant_ids)
-            with sentry_sdk.start_span(
-                op="outcomes.endpoint", description="massage_outcomes_result"
-            ):
+            with sentry_sdk.start_span(op="outcomes.endpoint", name="massage_outcomes_result"):
                 projects, result = massage_sessions_result_summary(
                     query, result_totals, request.GET.getlist("outcome")
                 )

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -166,21 +166,19 @@ class OrganizationStatsEndpointV2(OrganizationEndpoint):
         with self.handle_query_errors():
 
             tenant_ids = {"organization_id": organization.id}
-            with sentry_sdk.start_span(op="outcomes.endpoint", description="build_outcomes_query"):
+            with sentry_sdk.start_span(op="outcomes.endpoint", name="build_outcomes_query"):
                 query = self.build_outcomes_query(
                     request,
                     organization,
                 )
-            with sentry_sdk.start_span(op="outcomes.endpoint", description="run_outcomes_query"):
+            with sentry_sdk.start_span(op="outcomes.endpoint", name="run_outcomes_query"):
                 result_totals = run_outcomes_query_totals(query, tenant_ids=tenant_ids)
                 result_timeseries = (
                     None
                     if "project_id" in query.query_groupby
                     else run_outcomes_query_timeseries(query, tenant_ids=tenant_ids)
                 )
-            with sentry_sdk.start_span(
-                op="outcomes.endpoint", description="massage_outcomes_result"
-            ):
+            with sentry_sdk.start_span(op="outcomes.endpoint", name="massage_outcomes_result"):
                 result = massage_outcomes_result(query, result_totals, result_timeseries)
             return Response(result, status=200)
 

--- a/src/sentry/api/endpoints/organization_tags.py
+++ b/src/sentry/api/endpoints/organization_tags.py
@@ -37,7 +37,7 @@ class OrganizationTagsEndpoint(OrganizationEndpoint):
         else:
             dataset = Dataset.Discover
 
-        with sentry_sdk.start_span(op="tagstore", description="get_tag_keys_for_projects"):
+        with sentry_sdk.start_span(op="tagstore", name="get_tag_keys_for_projects"):
             with handle_query_errors():
                 results = tagstore.backend.get_tag_keys_for_projects(
                     filter_params["project_id"],

--- a/src/sentry/api/serializers/base.py
+++ b/src/sentry/api/serializers/base.py
@@ -61,10 +61,10 @@ def serialize(
                 pass
         else:
             return objects
-    with sentry_sdk.start_span(op="serialize", description=type(serializer).__name__) as span:
+    with sentry_sdk.start_span(op="serialize", name=type(serializer).__name__) as span:
         span.set_data("Object Count", len(objects))
 
-        with sentry_sdk.start_span(op="serialize.get_attrs", description=type(serializer).__name__):
+        with sentry_sdk.start_span(op="serialize.get_attrs", name=type(serializer).__name__):
             attrs = serializer.get_attrs(
                 # avoid passing NoneType's to the serializer as they're allowed and
                 # filtered out of serialize()
@@ -73,7 +73,7 @@ def serialize(
                 **kwargs,
             )
 
-        with sentry_sdk.start_span(op="serialize.iterate", description=type(serializer).__name__):
+        with sentry_sdk.start_span(op="serialize.iterate", name=type(serializer).__name__):
             return [serializer(o, attrs=attrs.get(o, {}), user=user, **kwargs) for o in objects]
 
 

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -426,7 +426,7 @@ class SqlFormatEventSerializer(EventSerializer):
     def serialize(self, obj, attrs, user, include_full_release_data=False):
         result = super().serialize(obj, attrs, user)
 
-        with sentry_sdk.start_span(op="serialize", description="Format SQL"):
+        with sentry_sdk.start_span(op="serialize", name="Format SQL"):
             result = self._format_breadcrumb_messages(result, obj, user)
             result = self._format_db_spans(result, obj, user)
             result["release"] = self._get_release_info(user, obj, include_full_release_data)

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -266,7 +266,7 @@ class OrganizationSerializer(Serializer):
         ]
         feature_set = set()
 
-        with sentry_sdk.start_span(op="features.check", description="check batch features"):
+        with sentry_sdk.start_span(op="features.check", name="check batch features"):
             # Check features in batch using the entity handler
             batch_features = features.batch_has(org_features, actor=user, organization=obj)
 
@@ -282,7 +282,7 @@ class OrganizationSerializer(Serializer):
                     # This feature_name was found via `batch_has`, don't check again using `has`
                     org_features.remove(feature_name)
 
-        with sentry_sdk.start_span(op="features.check", description="check individual features"):
+        with sentry_sdk.start_span(op="features.check", name="check individual features"):
             # Remaining features should not be checked via the entity handler
             for feature_name in org_features:
                 if features.has(feature_name, obj, actor=user, skip_entity=True):

--- a/src/sentry/charts/chartcuterie.py
+++ b/src/sentry/charts/chartcuterie.py
@@ -67,7 +67,7 @@ class Chartcuterie(ChartRenderer):
 
         with sentry_sdk.start_span(
             op="charts.chartcuterie.generate_chart",
-            description=type(self).__name__,
+            name=type(self).__name__,
         ):
 
             # Using sentry json formatter to handle datetime objects
@@ -90,7 +90,7 @@ class Chartcuterie(ChartRenderer):
 
         with sentry_sdk.start_span(
             op="charts.chartcuterie.upload",
-            description=type(self).__name__,
+            name=type(self).__name__,
         ):
             storage = get_storage(self.storage_options)
             storage.save(file_name, BytesIO(resp.content))

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -111,7 +111,7 @@ class RegisteredFeatureManager:
 
                 with sentry_sdk.start_span(
                     op="feature.has_for_batch.handler",
-                    description=f"{type(handler).__name__} ({name})",
+                    name=f"{type(handler).__name__} ({name})",
                 ) as span:
                     batch_size = len(remaining)
                     span.set_data("Batch Size", batch_size)

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -144,7 +144,7 @@ def _calculate_secondary_hashes(
     try:
         with sentry_sdk.start_span(
             op="event_manager",
-            description="event_manager.save.secondary_calculate_event_grouping",
+            name="event_manager.save.secondary_calculate_event_grouping",
         ):
             # create a copy since `_calculate_event_grouping` modifies the event to add all sorts
             # of grouping info and we don't want the secondary grouping data in there
@@ -171,7 +171,7 @@ def run_primary_grouping(
     with (
         sentry_sdk.start_span(
             op="event_manager",
-            description="event_manager.save.calculate_event_grouping",
+            name="event_manager.save.calculate_event_grouping",
         ),
         metrics.timer("event_manager.calculate_event_grouping", tags=metric_tags),
     ):

--- a/src/sentry/hybridcloud/rpc/pagination.py
+++ b/src/sentry/hybridcloud/rpc/pagination.py
@@ -46,7 +46,7 @@ class RpcPaginationArgs(RpcModel):
         cursor = get_cursor(self.encoded_cursor, cursor_cls)
         with sentry_sdk.start_span(
             op="hybrid_cloud.paginate.get_result",
-            description=description,
+            name=description,
         ) as span:
             annotate_span_with_pagination_args(span, self.per_page)
             paginator = get_paginator(

--- a/src/sentry/hybridcloud/rpc/service.py
+++ b/src/sentry/hybridcloud/rpc/service.py
@@ -586,7 +586,7 @@ class _RemoteSiloCall:
         timer = metrics.timer("hybrid_cloud.dispatch_rpc.duration", tags=self._metrics_tags())
         span = sentry_sdk.start_span(
             op="hybrid_cloud.dispatch_rpc",
-            description=f"rpc to {self.service_name}.{self.method_name}",
+            name=f"rpc to {self.service_name}.{self.method_name}",
         )
         with span, timer:
             yield

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -554,7 +554,7 @@ class GitHubBaseClient(GithubProxyClient, RepositoryClient, CommitContextClient)
 
         with sentry_sdk.start_span(
             op=f"{self.integration_type}.http.pagination",
-            description=f"{self.integration_type}.http_response.pagination.{self.name}",
+            name=f"{self.integration_type}.http_response.pagination.{self.name}",
         ):
             output = []
 

--- a/src/sentry/integrations/msteams/notifications.py
+++ b/src/sentry/integrations/msteams/notifications.py
@@ -82,9 +82,7 @@ def send_notification_as_msteams(
         )
         return
 
-    with sentry_sdk.start_span(
-        op="notification.send_msteams", description="gen_channel_integration_map"
-    ):
+    with sentry_sdk.start_span(op="notification.send_msteams", name="gen_channel_integration_map"):
         data = get_integrations_by_channel_by_recipient(
             organization=notification.organization,
             recipients=recipients,
@@ -92,13 +90,11 @@ def send_notification_as_msteams(
         )
 
         for recipient, integrations_by_channel in data.items():
-            with sentry_sdk.start_span(op="notification.send_msteams", description="send_one"):
+            with sentry_sdk.start_span(op="notification.send_msteams", name="send_one"):
                 extra_context = (extra_context_by_actor or {}).get(recipient, {})
                 context = get_context(notification, recipient, shared_context, extra_context)
 
-                with sentry_sdk.start_span(
-                    op="notification.send_msteams", description="gen_attachments"
-                ):
+                with sentry_sdk.start_span(op="notification.send_msteams", name="gen_attachments"):
                     card = get_notification_card(notification, context, recipient)
 
                 for channel, integration in integrations_by_channel.items():
@@ -107,7 +103,7 @@ def send_notification_as_msteams(
                     client = MsTeamsClient(integration)
                     try:
                         with sentry_sdk.start_span(
-                            op="notification.send_msteams", description="notify_recipient"
+                            op="notification.send_msteams", name="notify_recipient"
                         ):
                             client.send_card(conversation_id, card)
 

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -54,16 +54,14 @@ def send_notification_as_slack(
     Sending Slack notifications to a channel is in integrations/slack/actions/notification.py"""
 
     service = SlackService.default()
-    with sentry_sdk.start_span(
-        op="notification.send_slack", description="gen_channel_integration_map"
-    ):
+    with sentry_sdk.start_span(op="notification.send_slack", name="gen_channel_integration_map"):
         data = get_integrations_by_channel_by_recipient(
             notification.organization, recipients, ExternalProviders.SLACK
         )
 
     for recipient, integrations_by_channel in data.items():
-        with sentry_sdk.start_span(op="notification.send_slack", description="send_one"):
-            with sentry_sdk.start_span(op="notification.send_slack", description="gen_attachments"):
+        with sentry_sdk.start_span(op="notification.send_slack", name="send_one"):
+            with sentry_sdk.start_span(op="notification.send_slack", name="gen_attachments"):
                 attachments = service.get_attachments(
                     notification,
                     recipient,

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -335,7 +335,7 @@ class SlackService:
 
         """Send an "activity" or "alert rule" notification to a Slack user or team, but NOT to a channel directly.
         This is used in the send_notification_as_slack function."""
-        with sentry_sdk.start_span(op="notification.send_slack", description="notify_recipient"):
+        with sentry_sdk.start_span(op="notification.send_slack", name="notify_recipient"):
             # Make a local copy to which we can append.
             local_attachments = copy(attachments)
 

--- a/src/sentry/issues/ongoing.py
+++ b/src/sentry/issues/ongoing.py
@@ -20,7 +20,7 @@ def bulk_transition_group_to_ongoing(
     group_ids: list[int],
     activity_data: Mapping[str, Any] | None = None,
 ) -> None:
-    with sentry_sdk.start_span(description="groups_to_transistion") as span:
+    with sentry_sdk.start_span(name="groups_to_transistion") as span:
         # make sure we don't update the Group when its already updated by conditionally updating the Group
         groups_to_transistion = Group.objects.filter(
             id__in=group_ids, status=from_status, substatus=from_substatus
@@ -28,7 +28,7 @@ def bulk_transition_group_to_ongoing(
         span.set_tag("group_ids", group_ids)
         span.set_tag("groups_to_transistion count", len(groups_to_transistion))
 
-    with sentry_sdk.start_span(description="update_group_status"):
+    with sentry_sdk.start_span(name="update_group_status"):
         Group.objects.update_group_status(
             groups=groups_to_transistion,
             status=GroupStatus.UNRESOLVED,
@@ -51,10 +51,10 @@ def bulk_transition_group_to_ongoing(
                 sender=bulk_transition_group_to_ongoing,
             )
 
-    with sentry_sdk.start_span(description="bulk_remove_groups_from_inbox"):
+    with sentry_sdk.start_span(name="bulk_remove_groups_from_inbox"):
         bulk_remove_groups_from_inbox(groups_to_transistion)
 
-    with sentry_sdk.start_span(description="post_save_send_robust"):
+    with sentry_sdk.start_span(name="post_save_send_robust"):
         if not options.get("groups.enable-post-update-signal"):
             for group in groups_to_transistion:
                 post_save.send_robust(

--- a/src/sentry/mail/notifications.py
+++ b/src/sentry/mail/notifications.py
@@ -114,20 +114,20 @@ def send_notification_as_email(
 ) -> None:
     for recipient in recipients:
         recipient_actor = Actor.from_object(recipient)
-        with sentry_sdk.start_span(op="notification.send_email", description="one_recipient"):
+        with sentry_sdk.start_span(op="notification.send_email", name="one_recipient"):
             if recipient_actor.is_team:
                 # TODO(mgaeta): MessageBuilder only works with Users so filter out Teams for now.
                 continue
             _log_message(notification, recipient_actor)
 
-            with sentry_sdk.start_span(op="notification.send_email", description="build_message"):
+            with sentry_sdk.start_span(op="notification.send_email", name="build_message"):
                 msg = MessageBuilder(
                     **get_builder_args(
                         notification, recipient_actor, shared_context, extra_context_by_actor
                     )
                 )
 
-            with sentry_sdk.start_span(op="notification.send_email", description="send_message"):
+            with sentry_sdk.start_span(op="notification.send_email", name="send_message"):
                 # TODO: find better way of handling this
                 add_users_kwargs = {}
                 if isinstance(notification, ProjectNotification):

--- a/src/sentry/middleware/locale.py
+++ b/src/sentry/middleware/locale.py
@@ -8,7 +8,7 @@ from django.utils import translation
 
 class SentryLocaleMiddleware(LocaleMiddleware):
     def process_request(self, request: HttpRequest) -> None:
-        with sentry_sdk.start_span(op="middleware.locale", description="process_request"):
+        with sentry_sdk.start_span(op="middleware.locale", name="process_request"):
             # No locale for static media
             # This avoids touching user session, which means we avoid
             # setting `Vary: Cookie` as a response header which will

--- a/src/sentry/models/groupinbox.py
+++ b/src/sentry/models/groupinbox.py
@@ -111,7 +111,7 @@ def remove_group_from_inbox(group, action=None, user=None, referrer=None):
 
 
 def bulk_remove_groups_from_inbox(groups, action=None, user=None, referrer=None):
-    with sentry_sdk.start_span(description="bulk_remove_groups_from_inbox"):
+    with sentry_sdk.start_span(name="bulk_remove_groups_from_inbox"):
         try:
             group_inbox = GroupInbox.objects.filter(group__in=groups)
             group_inbox.delete()

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -171,7 +171,7 @@ class BaseNotification(abc.ABC):
         analytics.record(event_name, *args, **kwargs)
 
     def record_notification_sent(self, recipient: Actor, provider: ExternalProviders) -> None:
-        with sentry_sdk.start_span(op="notification.send", description="record_notification_sent"):
+        with sentry_sdk.start_span(op="notification.send", name="record_notification_sent"):
             # may want to explicitly pass in the parameters for this event
             self.record_analytics(
                 f"integrations.{provider.name}.notification_sent",
@@ -284,14 +284,14 @@ class BaseNotification(abc.ABC):
         """The default way to send notifications that respects Notification Settings."""
         from sentry.notifications.notify import notify
 
-        with sentry_sdk.start_span(op="notification.send", description="get_participants"):
+        with sentry_sdk.start_span(op="notification.send", name="get_participants"):
             participants_by_provider = self.get_participants()
             if not participants_by_provider:
                 return
 
         context = self.get_context()
         for provider, recipients in participants_by_provider.items():
-            with sentry_sdk.start_span(op="notification.send", description=f"send_for_{provider}"):
+            with sentry_sdk.start_span(op="notification.send", name=f"send_for_{provider}"):
                 safe_execute(notify, provider, self, recipients, context)
 
 

--- a/src/sentry/replays/endpoints/project_replay_recording_segment_details.py
+++ b/src/sentry/replays/endpoints/project_replay_recording_segment_details.py
@@ -81,7 +81,7 @@ class ProjectReplayRecordingSegmentDetailsEndpoint(ProjectEndpoint):
     def download(self, segment: RecordingSegmentStorageMeta) -> StreamingHttpResponse:
         with sentry_sdk.start_span(
             op="download_segment",
-            description="ProjectReplayRecordingSegmentDetailsEndpoint.download_segment",
+            name="ProjectReplayRecordingSegmentDetailsEndpoint.download_segment",
         ) as child_span:
             segment_bytes = download_segment(segment, span=child_span)
             segment_reader = BytesIO(segment_bytes)

--- a/src/sentry/replays/usecases/ingest/__init__.py
+++ b/src/sentry/replays/usecases/ingest/__init__.py
@@ -74,7 +74,7 @@ def ingest_recording(
     with sentry_sdk.scope.use_isolation_scope(isolation_scope):
         with transaction.start_child(
             op="replays.usecases.ingest.ingest_recording",
-            description="ingest_recording",
+            name="ingest_recording",
         ):
             message = RecordingIngestMessage(
                 replay_id=message_dict["replay_id"],
@@ -260,7 +260,7 @@ def recording_post_processor(
         # Emit DOM search metadata to Clickhouse.
         with transaction.start_child(
             op="replays.usecases.ingest.parse_and_emit_replay_actions",
-            description="parse_and_emit_replay_actions",
+            name="parse_and_emit_replay_actions",
         ):
             project = Project.objects.get_from_cache(id=message.project_id)
             parse_and_emit_replay_actions(

--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -321,20 +321,20 @@ class BaseQueryBuilder:
         equations: list[str] | None = None,
         orderby: list[str] | str | None = None,
     ) -> None:
-        with sentry_sdk.start_span(op="QueryBuilder", description="resolve_query"):
-            with sentry_sdk.start_span(op="QueryBuilder", description="resolve_time_conditions"):
+        with sentry_sdk.start_span(op="QueryBuilder", name="resolve_query"):
+            with sentry_sdk.start_span(op="QueryBuilder", name="resolve_time_conditions"):
                 # Has to be done early, since other conditions depend on start and end
                 self.resolve_time_conditions()
-            with sentry_sdk.start_span(op="QueryBuilder", description="resolve_conditions"):
+            with sentry_sdk.start_span(op="QueryBuilder", name="resolve_conditions"):
                 self.where, self.having = self.resolve_conditions(query)
-            with sentry_sdk.start_span(op="QueryBuilder", description="resolve_params"):
+            with sentry_sdk.start_span(op="QueryBuilder", name="resolve_params"):
                 # params depends on parse_query, and conditions being resolved first since there may be projects in conditions
                 self.where += self.resolve_params()
-            with sentry_sdk.start_span(op="QueryBuilder", description="resolve_columns"):
+            with sentry_sdk.start_span(op="QueryBuilder", name="resolve_columns"):
                 self.columns = self.resolve_select(selected_columns, equations)
-            with sentry_sdk.start_span(op="QueryBuilder", description="resolve_orderby"):
+            with sentry_sdk.start_span(op="QueryBuilder", name="resolve_orderby"):
                 self.orderby = self.resolve_orderby(orderby)
-            with sentry_sdk.start_span(op="QueryBuilder", description="resolve_groupby"):
+            with sentry_sdk.start_span(op="QueryBuilder", name="resolve_groupby"):
                 self.groupby = self.resolve_groupby(groupby_columns)
 
     def parse_config(self) -> None:
@@ -1535,7 +1535,7 @@ class BaseQueryBuilder:
         return raw_snql_query(self.get_snql_query(), referrer, use_cache, query_source)
 
     def process_results(self, results: Any) -> EventsResponse:
-        with sentry_sdk.start_span(op="QueryBuilder", description="process_results") as span:
+        with sentry_sdk.start_span(op="QueryBuilder", name="process_results") as span:
             span.set_data("result_count", len(results.get("data", [])))
             translated_columns = self.alias_to_typed_tag_map
             if self.builder_config.transform_alias_to_input_format:

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -340,7 +340,7 @@ def timeseries_query(
         Dataset.Transactions,
     ], "A dataset is required to query discover"
 
-    with sentry_sdk.start_span(op="discover.discover", description="timeseries.filter_transform"):
+    with sentry_sdk.start_span(op="discover.discover", name="timeseries.filter_transform"):
         equations, columns = categorize_columns(selected_columns)
         base_builder = TimeseriesQueryBuilder(
             dataset,
@@ -379,7 +379,7 @@ def timeseries_query(
             [query.get_snql_query() for query in query_list], referrer, query_source=query_source
         )
 
-    with sentry_sdk.start_span(op="discover.discover", description="timeseries.transform_results"):
+    with sentry_sdk.start_span(op="discover.discover", name="timeseries.transform_results"):
         results = []
         for snql_query, snuba_result in zip(query_list, query_results):
             results.append(
@@ -506,7 +506,7 @@ def top_events_timeseries(
     ], "A dataset is required to query discover"
 
     if top_events is None:
-        with sentry_sdk.start_span(op="discover.discover", description="top_events.fetch_events"):
+        with sentry_sdk.start_span(op="discover.discover", name="top_events.fetch_events"):
             top_events = query(
                 selected_columns,
                 query=user_query,
@@ -577,9 +577,7 @@ def top_events_timeseries(
             snuba_params.end_date,
             rollup,
         )
-    with sentry_sdk.start_span(
-        op="discover.discover", description="top_events.transform_results"
-    ) as span:
+    with sentry_sdk.start_span(op="discover.discover", name="top_events.transform_results") as span:
         span.set_data("result_count", len(result.get("data", [])))
         result = top_events_builder.process_results(result)
 
@@ -660,7 +658,7 @@ def get_facets(
     sample = len(snuba_params.project_ids) > 2
     fetch_projects = len(snuba_params.project_ids) > 1
 
-    with sentry_sdk.start_span(op="discover.discover", description="facets.frequent_tags"):
+    with sentry_sdk.start_span(op="discover.discover", name="facets.frequent_tags"):
         key_name_builder = DiscoverQueryBuilder(
             Dataset.Discover,
             params={},
@@ -706,7 +704,7 @@ def get_facets(
     project_results = []
     # Inject project data on the first page if multiple projects are selected
     if fetch_projects and cursor == 0:
-        with sentry_sdk.start_span(op="discover.discover", description="facets.projects"):
+        with sentry_sdk.start_span(op="discover.discover", name="facets.projects"):
             project_value_builder = DiscoverQueryBuilder(
                 Dataset.Discover,
                 params={},
@@ -740,9 +738,7 @@ def get_facets(
         else:
             individual_tags.append(tag)
 
-    with sentry_sdk.start_span(
-        op="discover.discover", description="facets.individual_tags"
-    ) as span:
+    with sentry_sdk.start_span(op="discover.discover", name="facets.individual_tags") as span:
         span.set_data("tag_count", len(individual_tags))
         for tag_name in individual_tags:
             tag = f"tags[{tag_name}]"
@@ -767,7 +763,7 @@ def get_facets(
             )
 
     if aggregate_tags:
-        with sentry_sdk.start_span(op="discover.discover", description="facets.aggregate_tags"):
+        with sentry_sdk.start_span(op="discover.discover", name="facets.aggregate_tags"):
             aggregate_value_builder = DiscoverQueryBuilder(
                 Dataset.Discover,
                 params={},

--- a/src/sentry/snuba/errors.py
+++ b/src/sentry/snuba/errors.py
@@ -106,7 +106,7 @@ def timeseries_query(
     query_source: QuerySource | None = None,
 ):
 
-    with sentry_sdk.start_span(op="errors", description="timeseries.filter_transform"):
+    with sentry_sdk.start_span(op="errors", name="timeseries.filter_transform"):
         equations, columns = categorize_columns(selected_columns)
         base_builder = ErrorsTimeseriesQueryBuilder(
             Dataset.Events,
@@ -145,7 +145,7 @@ def timeseries_query(
             [query.get_snql_query() for query in query_list], referrer, query_source=query_source
         )
 
-    with sentry_sdk.start_span(op="errors", description="timeseries.transform_results"):
+    with sentry_sdk.start_span(op="errors", name="timeseries.transform_results"):
         results = []
         for snql_query, result in zip(query_list, query_results):
             results.append(
@@ -238,7 +238,7 @@ def top_events_timeseries(
                     the top events earlier and want to save a query.
     """
     if top_events is None:
-        with sentry_sdk.start_span(op="discover.errors", description="top_events.fetch_events"):
+        with sentry_sdk.start_span(op="discover.errors", name="top_events.fetch_events"):
             top_events = query(
                 selected_columns,
                 query=user_query,
@@ -308,9 +308,7 @@ def top_events_timeseries(
             snuba_params.end_date,
             rollup,
         )
-    with sentry_sdk.start_span(
-        op="discover.errors", description="top_events.transform_results"
-    ) as span:
+    with sentry_sdk.start_span(op="discover.errors", name="top_events.transform_results") as span:
         span.set_data("result_count", len(result.get("data", [])))
         result = top_events_builder.process_results(result)
 

--- a/src/sentry/snuba/functions.py
+++ b/src/sentry/snuba/functions.py
@@ -156,7 +156,7 @@ def top_events_timeseries(
     assert not include_other, "Other is not supported"  # TODO: support other
 
     if top_events is None:
-        with sentry_sdk.start_span(op="discover.discover", description="top_events.fetch_events"):
+        with sentry_sdk.start_span(op="discover.discover", name="top_events.fetch_events"):
             top_events = query(
                 selected_columns,
                 query=user_query,
@@ -231,9 +231,7 @@ def format_top_events_timeseries_results(
             rollup,
         )
 
-    with sentry_sdk.start_span(
-        op="discover.discover", description="top_events.transform_results"
-    ) as span:
+    with sentry_sdk.start_span(op="discover.discover", name="top_events.transform_results") as span:
         result = query_builder.strip_alias_prefix(result)
 
         span.set_data("result_count", len(result.get("data", [])))

--- a/src/sentry/snuba/issue_platform.py
+++ b/src/sentry/snuba/issue_platform.py
@@ -145,7 +145,7 @@ def timeseries_query(
     allow_metric_aggregates (bool) Ignored here, only used in metric enhanced performance
     """
 
-    with sentry_sdk.start_span(op="issueplatform", description="timeseries.filter_transform"):
+    with sentry_sdk.start_span(op="issueplatform", name="timeseries.filter_transform"):
         equations, columns = categorize_columns(selected_columns)
         base_builder = IssuePlatformTimeseriesQueryBuilder(
             Dataset.IssuePlatform,
@@ -182,7 +182,7 @@ def timeseries_query(
             [query.get_snql_query() for query in query_list], referrer, query_source=query_source
         )
 
-    with sentry_sdk.start_span(op="issueplatform", description="timeseries.transform_results"):
+    with sentry_sdk.start_span(op="issueplatform", name="timeseries.transform_results"):
         results = []
         for snql_query, result in zip(query_list, query_results):
             results.append(

--- a/src/sentry/snuba/metrics_performance.py
+++ b/src/sentry/snuba/metrics_performance.py
@@ -53,7 +53,7 @@ def query(
     fallback_to_transactions=False,
     query_source: QuerySource | None = None,
 ):
-    with sentry_sdk.start_span(op="mep", description="MetricQueryBuilder"):
+    with sentry_sdk.start_span(op="mep", name="MetricQueryBuilder"):
         metrics_query = MetricsQueryBuilder(
             dataset=Dataset.PerformanceMetrics,
             params={},
@@ -80,7 +80,7 @@ def query(
         )
         metrics_referrer = referrer + ".metrics-enhanced"
         results = metrics_query.run_query(referrer=metrics_referrer, query_source=query_source)
-    with sentry_sdk.start_span(op="mep", description="query.transform_results"):
+    with sentry_sdk.start_span(op="mep", name="query.transform_results"):
         results = metrics_query.process_results(results)
         results["meta"]["isMetricsData"] = True
         results["meta"]["isMetricsExtractedData"] = metrics_query.use_on_demand
@@ -162,7 +162,7 @@ def bulk_timeseries_query(
         metrics_compatible = True
 
     if metrics_compatible:
-        with sentry_sdk.start_span(op="mep", description="TimeseriesMetricQueryBuilder"):
+        with sentry_sdk.start_span(op="mep", name="TimeseriesMetricQueryBuilder"):
             metrics_queries = []
             for query in queries:
                 metrics_query = TimeseriesMetricQueryBuilder(
@@ -190,7 +190,7 @@ def bulk_timeseries_query(
             for br in bulk_result:
                 _result["data"] = [*_result["data"], *br["data"]]
                 _result["meta"] = br["meta"]
-        with sentry_sdk.start_span(op="mep", description="query.transform_results"):
+        with sentry_sdk.start_span(op="mep", name="query.transform_results"):
             result = metrics_query.process_results(_result)
             sentry_sdk.set_tag("performance.dataset", "metrics")
             result["meta"]["isMetricsData"] = True
@@ -268,7 +268,7 @@ def timeseries_query(
     metrics_compatible = not equations
 
     def run_metrics_query(inner_params: SnubaParams):
-        with sentry_sdk.start_span(op="mep", description="TimeseriesMetricQueryBuilder"):
+        with sentry_sdk.start_span(op="mep", name="TimeseriesMetricQueryBuilder"):
             metrics_query = TimeseriesMetricQueryBuilder(
                 params={},
                 interval=rollup,
@@ -287,7 +287,7 @@ def timeseries_query(
             )
             metrics_referrer = referrer + ".metrics-enhanced"
             result = metrics_query.run_query(referrer=metrics_referrer, query_source=query_source)
-        with sentry_sdk.start_span(op="mep", description="query.transform_results"):
+        with sentry_sdk.start_span(op="mep", name="query.transform_results"):
             result = metrics_query.process_results(result)
             result["data"] = (
                 discover.zerofill(

--- a/src/sentry/snuba/spans_eap.py
+++ b/src/sentry/snuba/spans_eap.py
@@ -102,7 +102,7 @@ def timeseries_query(
     """
     equations, columns = categorize_columns(selected_columns)
 
-    with sentry_sdk.start_span(op="spans_indexed", description="TimeseriesSpanIndexedQueryBuilder"):
+    with sentry_sdk.start_span(op="spans_indexed", name="TimeseriesSpanIndexedQueryBuilder"):
         querybuilder = TimeseriesSpanEAPIndexedQueryBuilder(
             Dataset.SpansEAP,
             {},
@@ -115,7 +115,7 @@ def timeseries_query(
             ),
         )
         result = querybuilder.run_query(referrer, query_source=query_source)
-    with sentry_sdk.start_span(op="spans_indexed", description="query.transform_results"):
+    with sentry_sdk.start_span(op="spans_indexed", name="query.transform_results"):
         result = querybuilder.process_results(result)
         result["data"] = (
             discover.zerofill(
@@ -167,7 +167,7 @@ def top_events_timeseries(
     this API should match that of sentry.snuba.discover.top_events_timeseries
     """
     if top_events is None:
-        with sentry_sdk.start_span(op="spans_indexed", description="top_events.fetch_events"):
+        with sentry_sdk.start_span(op="spans_indexed", name="top_events.fetch_events"):
             top_events = query(
                 selected_columns,
                 query=user_query,
@@ -239,9 +239,7 @@ def top_events_timeseries(
             snuba_params.end_date,
             rollup,
         )
-    with sentry_sdk.start_span(
-        op="spans_indexed", description="top_events.transform_results"
-    ) as span:
+    with sentry_sdk.start_span(op="spans_indexed", name="top_events.transform_results") as span:
         span.set_data("result_count", len(result.get("data", [])))
         result = top_events_builder.process_results(result)
 

--- a/src/sentry/snuba/spans_indexed.py
+++ b/src/sentry/snuba/spans_indexed.py
@@ -98,7 +98,7 @@ def timeseries_query(
     """
     equations, columns = categorize_columns(selected_columns)
 
-    with sentry_sdk.start_span(op="spans_indexed", description="TimeseriesSpanIndexedQueryBuilder"):
+    with sentry_sdk.start_span(op="spans_indexed", name="TimeseriesSpanIndexedQueryBuilder"):
         query = TimeseriesSpanIndexedQueryBuilder(
             Dataset.SpansIndexed,
             {},
@@ -111,7 +111,7 @@ def timeseries_query(
             ),
         )
         result = query.run_query(referrer, query_source=query_source)
-    with sentry_sdk.start_span(op="spans_indexed", description="query.transform_results"):
+    with sentry_sdk.start_span(op="spans_indexed", name="query.transform_results"):
         result = query.process_results(result)
         result["data"] = (
             discover.zerofill(
@@ -163,7 +163,7 @@ def top_events_timeseries(
     """
 
     if top_events is None:
-        with sentry_sdk.start_span(op="spans_indexed", description="top_events.fetch_events"):
+        with sentry_sdk.start_span(op="spans_indexed", name="top_events.fetch_events"):
             top_events = query(
                 selected_columns,
                 query=user_query,
@@ -235,9 +235,7 @@ def top_events_timeseries(
             snuba_params.end_date,
             rollup,
         )
-    with sentry_sdk.start_span(
-        op="spans_indexed", description="top_events.transform_results"
-    ) as span:
+    with sentry_sdk.start_span(op="spans_indexed", name="top_events.transform_results") as span:
         span.set_data("result_count", len(result.get("data", [])))
         result = top_events_builder.process_results(result)
 

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -203,7 +203,7 @@ def delete_subscription_from_snuba(query_subscription_id, **kwargs):
 def _create_in_snuba(subscription: QuerySubscription) -> str:
     assert subscription.snuba_query is not None
 
-    with sentry_sdk.start_span(op="snuba.tasks", description="create_in_snuba") as span:
+    with sentry_sdk.start_span(op="snuba.tasks", name="create_in_snuba") as span:
         span.set_tag(
             "uses_metrics_layer",
             features.has("organizations:use-metrics-layer", subscription.project.organization),

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -209,7 +209,7 @@ def _expand_segments(should_process_segments: list[ProcessSegmentsContext]):
             client = RedisSpansBuffer()
             payload_context = {}
 
-            with txn.start_child(op="process", description="fetch_unprocessed_segments"):
+            with txn.start_child(op="process", name="fetch_unprocessed_segments"):
                 keys = client.get_unprocessed_segments_and_prune_bucket(timestamp, partition)
 
             sentry_sdk.set_measurement("segments.count", len(keys))
@@ -218,7 +218,7 @@ def _expand_segments(should_process_segments: list[ProcessSegmentsContext]):
 
             # With pipelining, redis server is forced to queue replies using
             # up memory, so batching the keys we fetch.
-            with txn.start_child(op="process", description="read_and_expire_many_segments"):
+            with txn.start_child(op="process", name="read_and_expire_many_segments"):
                 for i in range(0, len(keys), BATCH_SIZE):
                     segments = client.read_and_expire_many_segments(keys[i : i + BATCH_SIZE])
 

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -324,7 +324,7 @@ def normalize_stacktraces_for_grouping(
     # the trimming produces a different function than the function we have
     # otherwise stored in `function` to not make the payload larger
     # unnecessarily.
-    with sentry_sdk.start_span(op=op, description="iterate_frames"):
+    with sentry_sdk.start_span(op=op, name="iterate_frames"):
         stripped_querystring = False
         for frames in stacktrace_frames:
             for frame in frames:
@@ -347,7 +347,7 @@ def normalize_stacktraces_for_grouping(
 
     # If a grouping config is available, run grouping enhancers
     if grouping_config is not None:
-        with sentry_sdk.start_span(op=op, description="apply_modifications_to_frame"):
+        with sentry_sdk.start_span(op=op, name="apply_modifications_to_frame"):
             for frames, stacktrace_container in zip(stacktrace_frames, stacktrace_containers):
                 # This call has a caching mechanism when the same stacktrace and rules are used
                 grouping_config.enhancements.apply_modifications_to_frame(

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -131,7 +131,7 @@ def schedule_auto_transition_issues_new_to_ongoing(
         extra=logger_extra,
     )
 
-    with sentry_sdk.start_span(description="iterate_chunked_group_ids"):
+    with sentry_sdk.start_span(name="iterate_chunked_group_ids"):
         for groups in chunked(
             RangeQuerySetWrapper(
                 base_queryset,
@@ -172,7 +172,7 @@ def run_auto_transition_issues_new_to_ongoing(
     Child task of `auto_transition_issues_new_to_ongoing`
     to conduct the update of specified Groups to Ongoing.
     """
-    with sentry_sdk.start_span(description="bulk_transition_group_to_ongoing") as span:
+    with sentry_sdk.start_span(name="bulk_transition_group_to_ongoing") as span:
         span.set_tag("group_ids", group_ids)
         bulk_transition_group_to_ongoing(
             GroupStatus.UNRESOLVED,
@@ -220,7 +220,7 @@ def schedule_auto_transition_issues_regressed_to_ongoing(
         .filter(recent_regressed_history__lte=datetime.fromtimestamp(date_added_lte, timezone.utc))
     )
 
-    with sentry_sdk.start_span(description="iterate_chunked_group_ids"):
+    with sentry_sdk.start_span(name="iterate_chunked_group_ids"):
         for group_ids_with_regressed_history in chunked(
             RangeQuerySetWrapper(
                 base_queryset.values_list("id", flat=True),
@@ -260,7 +260,7 @@ def run_auto_transition_issues_regressed_to_ongoing(
     Child task of `auto_transition_issues_regressed_to_ongoing`
     to conduct the update of specified Groups to Ongoing.
     """
-    with sentry_sdk.start_span(description="bulk_transition_group_to_ongoing") as span:
+    with sentry_sdk.start_span(name="bulk_transition_group_to_ongoing") as span:
         span.set_tag("group_ids", group_ids)
         bulk_transition_group_to_ongoing(
             GroupStatus.UNRESOLVED,
@@ -308,7 +308,7 @@ def schedule_auto_transition_issues_escalating_to_ongoing(
         .filter(recent_escalating_history__lte=datetime.fromtimestamp(date_added_lte, timezone.utc))
     )
 
-    with sentry_sdk.start_span(description="iterate_chunked_group_ids"):
+    with sentry_sdk.start_span(name="iterate_chunked_group_ids"):
         for new_group_ids in chunked(
             RangeQuerySetWrapper(
                 base_queryset.values_list("id", flat=True),
@@ -348,7 +348,7 @@ def run_auto_transition_issues_escalating_to_ongoing(
     Child task of `auto_transition_issues_escalating_to_ongoing`
     to conduct the update of specified Groups to Ongoing.
     """
-    with sentry_sdk.start_span(description="bulk_transition_group_to_ongoing") as span:
+    with sentry_sdk.start_span(name="bulk_transition_group_to_ongoing") as span:
         span.set_tag("group_ids", group_ids)
         bulk_transition_group_to_ongoing(
             GroupStatus.UNRESOLVED,

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -633,9 +633,7 @@ def lookup_group_data_stacktrace_bulk(
         else:
             bulk_data = _make_nodestore_call(project, list(node_id_to_group_data.keys()))
 
-        with sentry_sdk.start_span(
-            op="lookup_event_bulk.loop", description="lookup_event_bulk.loop"
-        ):
+        with sentry_sdk.start_span(op="lookup_event_bulk.loop", name="lookup_event_bulk.loop"):
             for node_id, data in bulk_data.items():
                 if node_id in node_id_to_group_data:
                     event_id, group_id = (
@@ -649,7 +647,7 @@ def lookup_group_data_stacktrace_bulk(
 
         with sentry_sdk.start_span(
             op="lookup_event_bulk.individual_lookup",
-            description="lookup_event_bulk.individual_lookup",
+            name="lookup_event_bulk.individual_lookup",
         ):
             # look up individually any that may have failed during bulk lookup
             for node_id, (event_id, group_id) in node_id_to_group_data.items():

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -122,12 +122,9 @@ def detect_performance_problems(
         if rate and rate > random.random():
             # Add an experimental tag to be able to find these spans in production while developing. Should be removed later.
             sentry_sdk.set_tag("_did_analyze_performance_issue", "true")
-            with (
-                metrics.timer("performance.detect_performance_issue", sample_rate=0.01),
-                sentry_sdk.start_span(
-                    op="py.detect_performance_issue", description="none"
-                ) as sdk_span,
-            ):
+            with metrics.timer(
+                "performance.detect_performance_issue", sample_rate=0.01
+            ), sentry_sdk.start_span(op="py.detect_performance_issue", name="none") as sdk_span:
                 return _detect_performance_problems(
                     data, sdk_span, project, is_standalone_spans=is_standalone_spans
                 )
@@ -338,10 +335,10 @@ def _detect_performance_problems(
 ) -> list[PerformanceProblem]:
     event_id = data.get("event_id", None)
 
-    with sentry_sdk.start_span(op="function", description="get_detection_settings"):
+    with sentry_sdk.start_span(op="function", name="get_detection_settings"):
         detection_settings = get_detection_settings(project.id)
 
-    with sentry_sdk.start_span(op="initialize", description="PerformanceDetector"):
+    with sentry_sdk.start_span(op="initialize", name="PerformanceDetector"):
         detectors: list[PerformanceDetector] = [
             detector_class(detection_settings, data)
             for detector_class in DETECTOR_CLASSES
@@ -350,11 +347,11 @@ def _detect_performance_problems(
 
     for detector in detectors:
         with sentry_sdk.start_span(
-            op="function", description=f"run_detector_on_data.{detector.type.value}"
+            op="function", name=f"run_detector_on_data.{detector.type.value}"
         ):
             run_detector_on_data(detector, data)
 
-    with sentry_sdk.start_span(op="function", description="report_metrics_for_detectors"):
+    with sentry_sdk.start_span(op="function", name="report_metrics_for_detectors"):
         # Metrics reporting only for detection, not created issues.
         report_metrics_for_detectors(
             data,
@@ -368,7 +365,7 @@ def _detect_performance_problems(
     organization = project.organization
 
     problems: list[PerformanceProblem] = []
-    with sentry_sdk.start_span(op="performance_detection", description="is_creation_allowed"):
+    with sentry_sdk.start_span(op="performance_detection", name="is_creation_allowed"):
         for detector in detectors:
             if all(
                 [

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -612,7 +612,7 @@ def bind_organization_context(organization: Organization | RpcOrganization) -> N
     scope = Scope.get_isolation_scope()
 
     # XXX(dcramer): this is duplicated in organizationContext.jsx on the frontend
-    with sentry_sdk.start_span(op="other", description="bind_organization_context"):
+    with sentry_sdk.start_span(op="other", name="bind_organization_context"):
         # This can be used to find errors that may have been mistagged
         check_tag_for_scope_bleed("organization.slug", organization.slug)
 

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1284,11 +1284,11 @@ def _raw_delete_query(
     # Enter hub such that http spans are properly nested
     with timer("delete_query"):
         referrer = headers.get("referer", "unknown")
-        with sentry_sdk.start_span(op="snuba_delete.validation", description=referrer) as span:
+        with sentry_sdk.start_span(op="snuba_delete.validation", name=referrer) as span:
             span.set_tag("snuba.referrer", referrer)
             body = request.serialize()
 
-        with sentry_sdk.start_span(op="snuba_delete.run", description=body) as span:
+        with sentry_sdk.start_span(op="snuba_delete.run", name=body) as span:
             span.set_tag("snuba.referrer", referrer)
             return _snuba_pool.urlopen(
                 "DELETE", f"/{query.storage_name}", body=body, headers=headers
@@ -1302,11 +1302,11 @@ def _raw_mql_query(request: Request, headers: Mapping[str, str]) -> urllib3.resp
 
         # TODO: This can be changed back to just `serialize` after we remove SnQL support for MetricsQuery
         serialized_req = request.serialize()
-        with sentry_sdk.start_span(op="snuba_mql.validation", description=referrer) as span:
+        with sentry_sdk.start_span(op="snuba_mql.validation", name=referrer) as span:
             span.set_tag("snuba.referrer", referrer)
             body = serialized_req
 
-        with sentry_sdk.start_span(op="snuba_mql.run", description=serialized_req) as span:
+        with sentry_sdk.start_span(op="snuba_mql.run", name=serialized_req) as span:
             span.set_tag("snuba.referrer", referrer)
             return _snuba_pool.urlopen(
                 "POST", f"/{request.dataset}/mql", body=body, headers=headers
@@ -1319,11 +1319,11 @@ def _raw_snql_query(request: Request, headers: Mapping[str, str]) -> urllib3.res
         referrer = headers.get("referer", "<unknown>")
 
         serialized_req = request.serialize()
-        with sentry_sdk.start_span(op="snuba_snql.validation", description=referrer) as span:
+        with sentry_sdk.start_span(op="snuba_snql.validation", name=referrer) as span:
             span.set_tag("snuba.referrer", referrer)
             body = serialized_req
 
-        with sentry_sdk.start_span(op="snuba_snql.run", description=serialized_req) as span:
+        with sentry_sdk.start_span(op="snuba_snql.run", name=serialized_req) as span:
             span.set_tag("snuba.referrer", referrer)
             return _snuba_pool.urlopen(
                 "POST", f"/{request.dataset}/snql", body=body, headers=headers

--- a/src/sentry/utils/snuba_rpc.py
+++ b/src/sentry/utils/snuba_rpc.py
@@ -54,7 +54,7 @@ def rpc(req: SnubaRPCRequest, resp_type: type[RPCResponseType]) -> RPCResponseTy
     aggregate_resp = snuba.rpc(aggregate_req, AggregateBucketResponse)
     """
     referrer = req.meta.referrer
-    with sentry_sdk.start_span(op="snuba_rpc.run", description=req.__class__.__name__) as span:
+    with sentry_sdk.start_span(op="snuba_rpc.run", name=req.__class__.__name__) as span:
         span.set_tag("snuba.referrer", referrer)
 
         cls = req.__class__

--- a/static/app/components/events/interfaces/spans/inlineDocs.tsx
+++ b/static/app/components/events/interfaces/spans/inlineDocs.tsx
@@ -125,7 +125,7 @@ def eat_slice(slice):
 def eat_pizza(pizza):
     with sentry_sdk.start_transaction(op="task", name="Eat Pizza"):
         while pizza.slices > 0:
-            with sentry_sdk.start_span(description="Eat Slice"):
+            with sentry_sdk.start_span(name="Eat Slice"):
                 eat_slice(pizza.slices.pop())
 `}
       </StyledCodeSnippet>

--- a/static/app/components/events/interfaces/spans/inlineDocs.tsx
+++ b/static/app/components/events/interfaces/spans/inlineDocs.tsx
@@ -125,7 +125,7 @@ def eat_slice(slice):
 def eat_pizza(pizza):
     with sentry_sdk.start_transaction(op="task", name="Eat Pizza"):
         while pizza.slices > 0:
-            with sentry_sdk.start_span(name="Eat Slice"):
+            with sentry_sdk.start_span(description="Eat Slice"):
                 eat_slice(pizza.slices.pop())
 `}
       </StyledCodeSnippet>


### PR DESCRIPTION
And change all calls to `start_span(description="...")` to `start_span(name="...")` because `description` is deprecated and will be replaced with `name` in version 3.0.0.