### PR TITLE
fix(discover): Not loading for team plan users

### DIFF
--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -990,6 +990,9 @@ function ResultsContainer(props: Props) {
       skipLoadLastUsed={
         props.organization.features.includes('global-views') && !!props.savedQuery
       }
+      // The Discover Results component will manage URL params, including page filters state
+      // This avoids an unnecessary re-render when forcing a project filter for team plan users
+      skipInitializeUrlParams
     >
       <SavedQueryAPI {...props} />
     </PageFiltersContainer>


### PR DESCRIPTION
With the move to react router 6, the behaviour with the deprecated async component seems to have changed and it's picking up an extra re-render. The results component is highly tied to the order of operations and the extra re-render is causing issues.

I've narrowed it down to team plan and the cause is enforcing the single project condition (because multiple projects is a higher plan feature), so I disabled initializing the URL params and this project query param update is skipped, avoiding an unnecessary re-render.

The root of the issue is that `confirmedQuery` is something we use to enforce if a query is "runnable", this is because we know as users request more data, the endpoint is more likely to timeout so we confirm with the user if they're aware of this and still want to run anyway. The issue is that there's some state management that's set up to ensure we block the query while there are other updates happening and the extra re-render is making us stuck in the state where we're unable to run the query.

This fix is a bandaid fix and the component should be refactored to avoid being tied to the order of rendering, or possibly deprecated when we have Explore.