### PR TITLE
fix(new-trace-replay) Remove duplicate vitals from web vitals tab

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceVitals.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceVitals.tsx
@@ -30,6 +30,7 @@ export function TraceVitals(props: TraceVitalsProps) {
     <TraceDrawerComponents.DetailContainer>
       {measurements.map(([node, vital]) => {
         const op = isTransactionNode(node) ? node.value['transaction.op'] : '';
+        const transaction = isTransactionNode(node) ? node.value.transaction : '';
         const project = projects.find(p => p.slug === node.metadata.project_slug);
 
         return (
@@ -45,7 +46,7 @@ export function TraceVitals(props: TraceVitalsProps) {
                 </Tooltip>
                 <div>
                   <div>{t('transaction')}</div>
-                  <TraceDrawerComponents.TitleOp text={op} />
+                  <TraceDrawerComponents.TitleOp text={op + ' - ' + transaction} />
                 </div>
               </TraceDrawerComponents.Title>
             </TraceDrawerComponents.HeaderContainer>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceVitals.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceVitals.tsx
@@ -46,7 +46,9 @@ export function TraceVitals(props: TraceVitalsProps) {
                 </Tooltip>
                 <div>
                   <div>{t('transaction')}</div>
-                  <TraceDrawerComponents.TitleOp text={op + ' - ' + transaction} />
+                  <TraceDrawerComponents.TitleOp
+                    text={transaction ? `${op} - ${transaction}` : op}
+                  />
                 </div>
               </TraceDrawerComponents.Title>
             </TraceDrawerComponents.HeaderContainer>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceVitals.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceVitals.tsx
@@ -47,7 +47,13 @@ export function TraceVitals(props: TraceVitalsProps) {
                 <div>
                   <div>{t('transaction')}</div>
                   <TraceDrawerComponents.TitleOp
-                    text={transaction ? `${op} - ${transaction}` : op}
+                    text={
+                      transaction && op
+                        ? `${op} - ${transaction}`
+                        : transaction
+                          ? transaction
+                          : op
+                    }
                   />
                 </div>
               </TraceDrawerComponents.Title>

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -803,10 +803,6 @@ export class TraceTree {
       baseTraceNode.profiles.push(profile);
     }
 
-    for (const [node, vitals] of tree.vitals) {
-      this.vitals.set(node, vitals);
-    }
-
     for (const [node, _] of tree.vitals) {
       if (
         baseTraceNode.space?.[0] &&


### PR DESCRIPTION
We were collecting the vitals from the incrementally loaded tree twice during the append. `collectMeasurements` collects the vitals from the tree being appended and adds it to the root `tree.vitals`, which is the map used to render the content in the Web vitals tab in the trace drawer. 

Added transaction to vital headers to make them easier to distinguish.

Before:
<img width="795" alt="Screenshot 2024-10-04 at 12 12 53 PM" src="https://github.com/user-attachments/assets/3256b9c5-1dff-483c-8df5-d2e88b3c9e9d">

After: 
<img width="788" alt="Screenshot 2024-10-04 at 12 17 01 PM" src="https://github.com/user-attachments/assets/2c9dd775-4a11-48ab-8868-e3b8dfdbb581">