### PR TITLE
fix(discover): Fix `has:measurements.*` queries

### DIFF
--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -1309,6 +1309,11 @@ class BaseQueryBuilder:
         if search_filter.operator in ("=", "!=") and search_filter.value.value == "":
             if is_tag or is_attr or is_context or name in self.config.non_nullable_keys:
                 return Condition(lhs, Op(search_filter.operator), value)
+            elif is_measurement(name):
+                # Measurements are nullable, but are a `Function` not a `Column`. Check if null
+                return Condition(
+                    Function("isNull", [lhs]), Op.EQ, 1 if search_filter.operator == "=" else 0
+                )
             elif isinstance(lhs, Column):
                 # If not a tag, we can just check that the column is null.
                 return Condition(Function("isNull", [lhs]), Op(search_filter.operator), 1)

--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -1310,7 +1310,7 @@ class BaseQueryBuilder:
             if is_tag or is_attr or is_context or name in self.config.non_nullable_keys:
                 return Condition(lhs, Op(search_filter.operator), value)
             elif is_measurement(name):
-                # Measurements are nullable, but are a `Function` not a `Column`. Check if null
+                # Measurements can be a `Column` (e.g., `"lcp"`) or a `Function` (e.g., `"frames_frozen_rate"`). In either cause, since they are nullable, return a simple null check
                 return Condition(
                     Function("isNull", [lhs]), Op.EQ, 1 if search_filter.operator == "=" else 0
                 )

--- a/tests/sentry/search/events/builder/test_discover.py
+++ b/tests/sentry/search/events/builder/test_discover.py
@@ -498,12 +498,7 @@ class DiscoverQueryBuilderTest(TestCase):
         self.assertCountEqual(
             query.where,
             [
-                Or(
-                    conditions=[
-                        Condition(Function("isNull", [frames_frozen_rate]), Op.EQ, 1),
-                        Condition(frames_frozen_rate, Op.NEQ, ""),
-                    ]
-                ),
+                Condition(Function("isNull", [frames_frozen_rate]), Op.EQ, 0),
                 *self.default_conditions,
             ],
         )

--- a/tests/sentry/search/events/builder/test_discover.py
+++ b/tests/sentry/search/events/builder/test_discover.py
@@ -479,6 +479,23 @@ class DiscoverQueryBuilderTest(TestCase):
         query = DiscoverQueryBuilder(
             Dataset.Discover,
             self.params,
+            query="has:measurements.lcp",
+        )
+
+        lcp = Column("measurements[lcp]")
+
+        self.assertCountEqual(
+            query.where,
+            [
+                Condition(Function("isNull", [lcp]), Op.EQ, 0),
+                *self.default_conditions,
+            ],
+        )
+
+    def test_not_empty_function_measurement(self):
+        query = DiscoverQueryBuilder(
+            Dataset.Discover,
+            self.params,
             query="has:measurements.frames_frozen_rate",
         )
 


### PR DESCRIPTION
Fixes SENTRY-3DB9

We're seeing Snuba errors for comparisons of a numeric value to a string. e.g.,

```sql
`measurements.frames_frozen_rate` != ''
```

Measurements are numeric, so this errors out. This comparison is created for queries like `has:measurements.frozen_frame_rate`. That measurement is "synthetic", it's a function that divides two other measurements. It returns a numeric value, so comparison to string fails. The query builder's current logic doesn't account for measurement _functions_ (i.e., plain measurements like `measurements.lcp` still work), and creates the comparison incorrectly.

The fix is to check for measurements, and return early with a basic check for null.
