### PR TITLE
fix(apidocs): remove private from endpoints

### DIFF
--- a/src/sentry/api/endpoints/event_ai_suggested_fix.py
+++ b/src/sentry/api/endpoints/event_ai_suggested_fix.py
@@ -297,8 +297,6 @@ class EventAiSuggestedFixEndpoint(ProjectEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    # go away
-    private = True
     enforce_rate_limit = True
     rate_limits = {
         "GET": {

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -39,8 +39,6 @@ class GroupAutofixEndpoint(GroupEndpoint):
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.ML_AI
-    # go away
-    private = True
     enforce_rate_limit = True
     rate_limits = {
         "POST": {

--- a/src/sentry/api/endpoints/group_ai_summary.py
+++ b/src/sentry/api/endpoints/group_ai_summary.py
@@ -44,7 +44,6 @@ class GroupAiSummaryEndpoint(GroupEndpoint):
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.ML_AI
-    private = True
     enforce_rate_limit = True
     rate_limits = {
         "POST": {

--- a/src/sentry/api/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/api/endpoints/group_autofix_setup_check.py
@@ -102,7 +102,6 @@ class GroupAutofixSetupCheck(GroupEndpoint):
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.ML_AI
-    private = True
 
     def get(self, request: Request, group: Group) -> Response:
         """

--- a/src/sentry/api/endpoints/group_autofix_update.py
+++ b/src/sentry/api/endpoints/group_autofix_update.py
@@ -26,7 +26,6 @@ class GroupAutofixUpdateEndpoint(GroupEndpoint):
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.ML_AI
-    private = True
 
     def post(self, request: Request, group: Group) -> Response:
         """

--- a/src/sentry/api/endpoints/notification_defaults.py
+++ b/src/sentry/api/endpoints/notification_defaults.py
@@ -17,7 +17,6 @@ class NotificationDefaultsEndpoints(Endpoint):
     }
     owner = ApiOwner.ALERTS_NOTIFICATIONS
     permission_classes = ()
-    private = True
 
     def get(self, request: Request) -> Response:
         """

--- a/src/sentry/api/endpoints/project_autofix_codebase_index_status.py
+++ b/src/sentry/api/endpoints/project_autofix_codebase_index_status.py
@@ -22,7 +22,6 @@ class ProjectAutofixCodebaseIndexStatusEndpoint(ProjectEndpoint):
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.ML_AI
-    private = True
 
     def get(self, request: Request, project: Project) -> Response:
         """

--- a/src/sentry/api/endpoints/project_autofix_create_codebase_index.py
+++ b/src/sentry/api/endpoints/project_autofix_create_codebase_index.py
@@ -33,7 +33,6 @@ class ProjectAutofixCreateCodebaseIndexEndpoint(ProjectEndpoint):
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.ML_AI
-    private = True
 
     permission_classes = (ProjectAutofixCreateCodebaseIndexPermission,)
 

--- a/src/sentry/api/endpoints/user_notification_settings_options.py
+++ b/src/sentry/api/endpoints/user_notification_settings_options.py
@@ -22,8 +22,6 @@ class UserNotificationSettingsOptionsEndpoint(UserEndpoint):
         "PUT": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ALERTS_NOTIFICATIONS
-    # TODO(Steve): Make not private when we launch new system
-    private = True
 
     def get(self, request: Request, user: User) -> Response:
         """

--- a/src/sentry/api/endpoints/user_notification_settings_options_detail.py
+++ b/src/sentry/api/endpoints/user_notification_settings_options_detail.py
@@ -17,8 +17,6 @@ class UserNotificationSettingsOptionsDetailEndpoint(UserEndpoint):
         "DELETE": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ALERTS_NOTIFICATIONS
-    # TODO(Steve): Make not private when we launch new system
-    private = True
 
     def convert_args(
         self,

--- a/src/sentry/api/endpoints/user_notification_settings_providers.py
+++ b/src/sentry/api/endpoints/user_notification_settings_providers.py
@@ -25,8 +25,6 @@ class UserNotificationSettingsProvidersEndpoint(UserEndpoint):
         "PUT": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ALERTS_NOTIFICATIONS
-    # TODO(Steve): Make not private when we launch new system
-    private = True
 
     def get(self, request: Request, user: User) -> Response:
         """


### PR DESCRIPTION
this field has been superseeded by `publish_status`, so it is not used by anything. it is confusing as some folks took it to mean "this endpoint can't be hit by anyone".