### PR TITLE
ref(replay): improve search error messages

### DIFF
--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -267,7 +267,9 @@ describe('GroupReplays', () => {
       });
 
       expect(
-        await screen.findByText('Invalid number: asdf. Expected number.')
+        await screen.findByText(
+          'Sorry, the list of replays could not be loaded. Invalid number: asdf. Expected number.'
+        )
       ).toBeInTheDocument();
 
       await waitFor(() => {

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import {Alert} from 'sentry/components/alert';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {PanelTable} from 'sentry/components/panels/panelTable';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import EventView from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
@@ -46,27 +46,19 @@ type Props = {
 
 function getErrorMessage(fetchError: RequestError) {
   if (typeof fetchError === 'string') {
-    return tct('Sorry, the list of replays could not be loaded. [errorMessage]', {
-      errorMessage: fetchError,
-    });
+    return fetchError;
   }
   if (typeof fetchError?.responseJSON?.detail === 'string') {
-    return tct('Sorry, the list of replays could not be loaded. [errorMessage]', {
-      errorMessage: fetchError.responseJSON.detail,
-    });
+    return fetchError.responseJSON.detail;
   }
   if (fetchError?.responseJSON?.detail?.message) {
-    return tct('Sorry, the list of replays could not be loaded. [errorMessage]', {
-      errorMessage: fetchError.responseJSON.detail.message,
-    });
+    return fetchError.responseJSON.detail.message;
   }
   if (fetchError.name === ERROR_MAP[500]) {
-    return t(
-      'Sorry, the list of replays could not be loaded. There was an internal systems error.'
-    );
+    return t('There was an internal systems error.');
   }
   return t(
-    'Sorry, the list of replays could not be loaded. This could be due to invalid search parameters or an internal systems error.'
+    'This could be due to invalid search parameters or an internal systems error.'
   );
 }
 
@@ -108,6 +100,7 @@ function ReplayTable({
         gridRows={undefined}
       >
         <StyledAlert type="error" showIcon>
+          {t('Sorry, the list of replays could not be loaded. ')}
           {getErrorMessage(fetchError)}
         </StyledAlert>
       </StyledPanelTable>

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -45,35 +45,28 @@ type Props = {
 };
 
 function getErrorMessage(fetchError: RequestError) {
-  const defaultString = t('Sorry, the list of replays could not be loaded.');
   if (typeof fetchError === 'string') {
-    return tct('[defaultString] [errorMessage]', {
-      defaultString,
+    return tct('Sorry, the list of replays could not be loaded. [errorMessage]', {
       errorMessage: fetchError,
     });
   }
   if (typeof fetchError?.responseJSON?.detail === 'string') {
-    return tct('[defaultString] [errorMessage]', {
-      defaultString,
+    return tct('Sorry, the list of replays could not be loaded. [errorMessage]', {
       errorMessage: fetchError.responseJSON.detail,
     });
   }
   if (fetchError?.responseJSON?.detail?.message) {
-    return tct('[defaultString] [errorMessage]', {
-      defaultString,
+    return tct('Sorry, the list of replays could not be loaded. [errorMessage]', {
       errorMessage: fetchError.responseJSON.detail.message,
     });
   }
   if (fetchError.name === ERROR_MAP[500]) {
-    return tct('[defaultString] There was an internal systems error.', {
-      defaultString,
-    });
+    return t(
+      'Sorry, the list of replays could not be loaded. There was an internal systems error.'
+    );
   }
-  return tct(
-    '[defaultString] This could be due to invalid search parameters or an internal systems error.',
-    {
-      defaultString,
-    }
+  return t(
+    'Sorry, the list of replays could not be loaded. This could be due to invalid search parameters or an internal systems error.'
   );
 }
 

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -46,6 +46,12 @@ type Props = {
 
 function getErrorMessage(fetchError: RequestError) {
   const defaultString = t('Sorry, the list of replays could not be loaded.');
+  if (typeof fetchError === 'string') {
+    return tct('[defaultString] [errorMessage]', {
+      defaultString,
+      errorMessage: fetchError,
+    });
+  }
   if (typeof fetchError?.responseJSON?.detail === 'string') {
     return tct('[defaultString] [errorMessage]', {
       defaultString,


### PR DESCRIPTION
improve replay search error messaging:

before: we show this default message no matter what the error is.

![image](https://github.com/user-attachments/assets/cf03b5c1-e8bf-456d-8c39-f71bdee45982)

after:

for 400 (`BadRequestError`) errors and other errors that have response JSON details, we show the response JSON, which gives us what field could not be parsed.

<img width="819" alt="SCR-20241004-kswq" src="https://github.com/user-attachments/assets/e1742def-0c9b-4d5f-ad08-f9e497826895">

<img width="797" alt="SCR-20241004-ksgy" src="https://github.com/user-attachments/assets/6b2ef6e9-6934-4ede-b9af-e2f47a81c067">

for 500 (`InternalServerError`) errors, we show that without ambiguity:

<img width="807" alt="SCR-20241004-kvja" src="https://github.com/user-attachments/assets/4310d8e7-f12c-48a9-917c-d8b8ea540d21">

For all other uncategorizable errors or those without response JSON, we show the same default message as before.


closes https://github.com/getsentry/sentry/issues/78586
