### PR TITLE
feat(trace-explorer): Add way to skip recent data in trace explorer

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1791,6 +1791,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "performance.traces.trace-explorer-skip-recent-seconds",
+    type=Int,
+    default=0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "performance.traces.span_query_minimum_spans",
     type=Int,
     default=10000,


### PR DESCRIPTION
Due to delays in ingest, the most recent data may not be consistent across all storages yet leading to broken trace views. For now, add way to skip the recent data in trace explorer to minimize this issue.