### PR TITLE
ref(insights): create and use shared domain view header

### DIFF
--- a/static/app/views/insights/pages/ai/aiPageHeader.tsx
+++ b/static/app/views/insights/pages/ai/aiPageHeader.tsx
@@ -1,93 +1,35 @@
-import {Fragment} from 'react';
-
-import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
-import ButtonBar from 'sentry/components/buttonBar';
-import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
-import * as Layout from 'sentry/components/layouts/thirds';
-import {TabList, Tabs} from 'sentry/components/tabs';
-import {t} from 'sentry/locale';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import {
-  type RoutableModuleNames,
-  useModuleURLBuilder,
-} from 'sentry/views/insights/common/utils/useModuleURL';
 import {
   AI_LANDING_SUB_PATH,
   AI_LANDING_TITLE,
 } from 'sentry/views/insights/pages/ai/settings';
-import {
-  DOMAIN_VIEW_BASE_URL,
-  OVERVIEW_PAGE_TITLE,
-} from 'sentry/views/insights/pages/settings';
-import {MODULE_TITLES} from 'sentry/views/insights/settings';
+import {DomainViewHeader} from 'sentry/views/insights/pages/domainViewHeader';
+import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
 import {ModuleName} from 'sentry/views/insights/types';
 
 type Props = {
+  headerActions?: React.ReactNode;
   module?: ModuleName;
 };
 
 // TODO - add props to append to breadcrumbs and change title
-export function AiHeader({module}: Props) {
-  const navigate = useNavigate();
+export function AiHeader({module, headerActions}: Props) {
   const {slug} = useOrganization();
-  const moduleURLBuilder = useModuleURLBuilder();
 
   const aiBaseUrl = normalizeUrl(
     `/organizations/${slug}/${DOMAIN_VIEW_BASE_URL}/${AI_LANDING_SUB_PATH}/`
   );
 
-  const crumbs: Crumb[] = [
-    {
-      label: t('Performance'),
-      to: '/performance', // There is no page at `/insights/` so there is nothing to link to
-      preservePageFilters: true,
-    },
-    {
-      label: AI_LANDING_TITLE,
-      to: aiBaseUrl,
-      preservePageFilters: true,
-    },
-    {
-      label: module ? MODULE_TITLES[module] : OVERVIEW_PAGE_TITLE,
-      to: undefined,
-      preservePageFilters: true,
-    },
-  ];
-
-  const handleTabChange = (key: ModuleName | typeof OVERVIEW_PAGE_TITLE) => {
-    if (key === module || (key === OVERVIEW_PAGE_TITLE && !module)) {
-      return;
-    }
-    if (!key) {
-      return;
-    }
-    if (key === OVERVIEW_PAGE_TITLE) {
-      navigate(aiBaseUrl);
-      return;
-    }
-    navigate(`${moduleURLBuilder(key as RoutableModuleNames)}/`);
-  };
+  const modules = [ModuleName.AI];
 
   return (
-    <Fragment>
-      <Tabs value={module ?? OVERVIEW_PAGE_TITLE} onChange={handleTabChange}>
-        <Layout.HeaderContent>
-          <Breadcrumbs crumbs={crumbs} />
-
-          <Layout.Title>{AI_LANDING_TITLE}</Layout.Title>
-        </Layout.HeaderContent>
-        <Layout.HeaderActions>
-          <ButtonBar gap={1}>
-            <FeedbackWidgetButton />
-          </ButtonBar>
-        </Layout.HeaderActions>
-        <TabList hideBorder>
-          <TabList.Item key={OVERVIEW_PAGE_TITLE}>{OVERVIEW_PAGE_TITLE}</TabList.Item>
-          <TabList.Item key={ModuleName.AI}>{MODULE_TITLES[ModuleName.AI]}</TabList.Item>
-        </TabList>
-      </Tabs>
-    </Fragment>
+    <DomainViewHeader
+      domainBaseUrl={aiBaseUrl}
+      headerTitle={AI_LANDING_TITLE}
+      modules={modules}
+      selectedModule={module}
+      additonalHeaderActions={headerActions}
+    />
   );
 }

--- a/static/app/views/insights/pages/backend/backendPageHeader.tsx
+++ b/static/app/views/insights/pages/backend/backendPageHeader.tsx
@@ -1,25 +1,11 @@
-import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
-import ButtonBar from 'sentry/components/buttonBar';
-import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
-import * as Layout from 'sentry/components/layouts/thirds';
-import {TabList, Tabs} from 'sentry/components/tabs';
-import {t} from 'sentry/locale';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import {
-  type RoutableModuleNames,
-  useModuleURLBuilder,
-} from 'sentry/views/insights/common/utils/useModuleURL';
 import {
   BACKEND_LANDING_SUB_PATH,
   BACKEND_LANDING_TITLE,
 } from 'sentry/views/insights/pages/backend/settings';
-import {
-  DOMAIN_VIEW_BASE_URL,
-  OVERVIEW_PAGE_TITLE,
-} from 'sentry/views/insights/pages/settings';
-import {MODULE_TITLES} from 'sentry/views/insights/settings';
+import {DomainViewHeader} from 'sentry/views/insights/pages/domainViewHeader';
+import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
 import {ModuleName} from 'sentry/views/insights/types';
 
 type Props = {
@@ -29,74 +15,20 @@ type Props = {
 
 // TODO - add props to append to breadcrumbs and change title
 export function BackendHeader({module, headerActions}: Props) {
-  const navigate = useNavigate();
   const {slug} = useOrganization();
-  const moduleURLBuilder = useModuleURLBuilder();
 
   const backendBaseUrl = normalizeUrl(
     `/organizations/${slug}/${DOMAIN_VIEW_BASE_URL}/${BACKEND_LANDING_SUB_PATH}/`
   );
-
-  const crumbs: Crumb[] = [
-    {
-      label: t('Performance'),
-      to: '/performance', // There is no page at `/insights/` so there is nothing to link to
-      preservePageFilters: true,
-    },
-    {
-      label: BACKEND_LANDING_TITLE,
-      to: backendBaseUrl,
-      preservePageFilters: true,
-    },
-    {
-      label: module ? MODULE_TITLES[module] : OVERVIEW_PAGE_TITLE,
-      to: undefined,
-      preservePageFilters: true,
-    },
-  ];
-
-  const handleTabChange = (key: ModuleName | typeof OVERVIEW_PAGE_TITLE) => {
-    if (key === module || (key === OVERVIEW_PAGE_TITLE && !module)) {
-      return;
-    }
-    if (!key) {
-      return;
-    }
-    if (key === OVERVIEW_PAGE_TITLE) {
-      navigate(backendBaseUrl);
-      return;
-    }
-    navigate(`${moduleURLBuilder(key as RoutableModuleNames)}/`);
-  };
+  const modules = [ModuleName.DB, ModuleName.HTTP, ModuleName.CACHE, ModuleName.QUEUE];
 
   return (
-    <Tabs value={module ?? OVERVIEW_PAGE_TITLE} onChange={handleTabChange}>
-      <Layout.Header>
-        <Layout.HeaderContent>
-          <Breadcrumbs crumbs={crumbs} />
-
-          <Layout.Title>{BACKEND_LANDING_TITLE}</Layout.Title>
-        </Layout.HeaderContent>
-        <Layout.HeaderActions>
-          <ButtonBar gap={1}>
-            {headerActions}
-            <FeedbackWidgetButton />
-          </ButtonBar>
-        </Layout.HeaderActions>
-        <TabList hideBorder>
-          <TabList.Item key={OVERVIEW_PAGE_TITLE}>{OVERVIEW_PAGE_TITLE}</TabList.Item>
-          <TabList.Item key={ModuleName.DB}>{MODULE_TITLES[ModuleName.DB]}</TabList.Item>
-          <TabList.Item key={ModuleName.HTTP}>
-            {MODULE_TITLES[ModuleName.HTTP]}
-          </TabList.Item>
-          <TabList.Item key={ModuleName.CACHE}>
-            {MODULE_TITLES[ModuleName.CACHE]}
-          </TabList.Item>
-          <TabList.Item key={ModuleName.QUEUE}>
-            {MODULE_TITLES[ModuleName.QUEUE]}
-          </TabList.Item>
-        </TabList>
-      </Layout.Header>
-    </Tabs>
+    <DomainViewHeader
+      domainBaseUrl={backendBaseUrl}
+      headerTitle={BACKEND_LANDING_TITLE}
+      additonalHeaderActions={headerActions}
+      modules={modules}
+      selectedModule={module}
+    />
   );
 }

--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -1,0 +1,121 @@
+import {Fragment} from 'react';
+
+import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
+import ButtonBar from 'sentry/components/buttonBar';
+import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
+import * as Layout from 'sentry/components/layouts/thirds';
+import {TabList, Tabs} from 'sentry/components/tabs';
+import {t} from 'sentry/locale';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {
+  type RoutableModuleNames,
+  useModuleURLBuilder,
+} from 'sentry/views/insights/common/utils/useModuleURL';
+import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
+import {MODULE_TITLES} from 'sentry/views/insights/settings';
+import type {ModuleName} from 'sentry/views/insights/types';
+
+type Props = {
+  domainBaseUrl: string;
+  headerTitle: React.ReactNode;
+  modules: ModuleName[];
+  selectedModule: ModuleName | undefined;
+  additionalBreadCrumbs?: Crumb[];
+  additonalHeaderActions?: React.ReactNode;
+  hideDefaultTabs?: boolean;
+  tabs?: {onTabChange: (key: string) => void; tabList: React.ReactNode; value: string};
+};
+
+type Tab = {
+  key: string;
+  label: string;
+};
+
+export function DomainViewHeader({
+  modules,
+  headerTitle,
+  selectedModule,
+  hideDefaultTabs,
+  additonalHeaderActions,
+  additionalBreadCrumbs = [],
+  domainBaseUrl,
+  tabs,
+}: Props) {
+  const navigate = useNavigate();
+  const moduleURLBuilder = useModuleURLBuilder();
+
+  const baseCrumbs: Crumb[] = [
+    {
+      label: t('Performance'),
+      to: undefined, // There is no base /performance/ page
+      preservePageFilters: true,
+    },
+    {
+      label: headerTitle,
+      to: domainBaseUrl,
+      preservePageFilters: true,
+    },
+    {
+      label: selectedModule ? MODULE_TITLES[selectedModule] : OVERVIEW_PAGE_TITLE,
+      to: `${moduleURLBuilder(selectedModule as RoutableModuleNames)}/`,
+      preservePageFilters: true,
+    },
+    ...additionalBreadCrumbs,
+  ];
+
+  const defaultHandleTabChange = (key: ModuleName | typeof OVERVIEW_PAGE_TITLE) => {
+    if (key === selectedModule || (key === OVERVIEW_PAGE_TITLE && !module)) {
+      return;
+    }
+    if (!key) {
+      return;
+    }
+    if (key === OVERVIEW_PAGE_TITLE) {
+      navigate(domainBaseUrl);
+      return;
+    }
+    navigate(`${moduleURLBuilder(key as RoutableModuleNames)}/`);
+  };
+
+  const tabValue =
+    hideDefaultTabs && tabs?.value ? tabs.value : selectedModule ?? OVERVIEW_PAGE_TITLE;
+
+  const handleTabChange =
+    hideDefaultTabs && tabs ? tabs.onTabChange : defaultHandleTabChange;
+
+  const tabList: Tab[] = [
+    {
+      key: OVERVIEW_PAGE_TITLE,
+      label: OVERVIEW_PAGE_TITLE,
+    },
+    ...modules.map(moduleName => ({key: moduleName, label: MODULE_TITLES[moduleName]})),
+  ];
+
+  return (
+    <Fragment>
+      <Tabs value={tabValue} onChange={handleTabChange}>
+        <Layout.Header>
+          <Layout.HeaderContent>
+            <Breadcrumbs crumbs={baseCrumbs} />
+
+            <Layout.Title>{headerTitle}</Layout.Title>
+          </Layout.HeaderContent>
+          <Layout.HeaderActions>
+            <ButtonBar gap={1}>
+              {additonalHeaderActions}
+              <FeedbackWidgetButton />
+            </ButtonBar>
+          </Layout.HeaderActions>
+          {!hideDefaultTabs && (
+            <TabList hideBorder>
+              {tabList.map(tab => (
+                <TabList.Item key={tab.key}>{tab.label}</TabList.Item>
+              ))}
+            </TabList>
+          )}
+          {hideDefaultTabs && tabs && tabs.tabList}
+        </Layout.Header>
+      </Tabs>
+    </Fragment>
+  );
+}

--- a/static/app/views/insights/pages/frontend/frontendPageHeader.tsx
+++ b/static/app/views/insights/pages/frontend/frontendPageHeader.tsx
@@ -1,25 +1,11 @@
-import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
-import ButtonBar from 'sentry/components/buttonBar';
-import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
-import * as Layout from 'sentry/components/layouts/thirds';
-import {TabList, Tabs} from 'sentry/components/tabs';
-import {t} from 'sentry/locale';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import {
-  type RoutableModuleNames,
-  useModuleURLBuilder,
-} from 'sentry/views/insights/common/utils/useModuleURL';
+import {DomainViewHeader} from 'sentry/views/insights/pages/domainViewHeader';
 import {
   FRONTEND_LANDING_SUB_PATH,
   FRONTEND_LANDING_TITLE,
 } from 'sentry/views/insights/pages/frontend/settings';
-import {
-  DOMAIN_VIEW_BASE_URL,
-  OVERVIEW_PAGE_TITLE,
-} from 'sentry/views/insights/pages/settings';
-import {MODULE_TITLES} from 'sentry/views/insights/settings';
+import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
 import {ModuleName} from 'sentry/views/insights/types';
 
 type Props = {
@@ -29,74 +15,21 @@ type Props = {
 
 // TODO - add props to append to breadcrumbs and change title
 export function FrontendHeader({module, headerActions}: Props) {
-  const navigate = useNavigate();
   const {slug} = useOrganization();
-  const moduleURLBuilder = useModuleURLBuilder();
 
-  // TODO - we can probably tweek useModuleURLBuilder to also return the base domain view url i.e useDomainViewUrl('frontend', 'http')
   const frontendBaseUrl = normalizeUrl(
     `/organizations/${slug}/${DOMAIN_VIEW_BASE_URL}/${FRONTEND_LANDING_SUB_PATH}/`
   );
 
-  const crumbs: Crumb[] = [
-    {
-      label: t('Performance'),
-      to: '/performance', // There is no page at `/insights/` so there is nothing to link to
-      preservePageFilters: true,
-    },
-    {
-      label: FRONTEND_LANDING_TITLE,
-      to: frontendBaseUrl,
-      preservePageFilters: true,
-    },
-    {
-      label: module ? MODULE_TITLES[module] : OVERVIEW_PAGE_TITLE,
-      to: undefined,
-      preservePageFilters: true,
-    },
-  ];
-
-  const handleTabChange = (key: ModuleName | typeof OVERVIEW_PAGE_TITLE) => {
-    if (key === module || (key === OVERVIEW_PAGE_TITLE && !module)) {
-      return;
-    }
-    if (!key) {
-      return;
-    }
-    if (key === OVERVIEW_PAGE_TITLE) {
-      navigate(frontendBaseUrl);
-      return;
-    }
-    navigate(`${moduleURLBuilder(key as RoutableModuleNames)}/`);
-  };
+  const modules = [ModuleName.VITAL, ModuleName.HTTP, ModuleName.RESOURCE];
 
   return (
-    <Tabs value={module ?? OVERVIEW_PAGE_TITLE} onChange={handleTabChange}>
-      <Layout.Header>
-        <Layout.HeaderContent>
-          <Breadcrumbs crumbs={crumbs} />
-
-          <Layout.Title>{FRONTEND_LANDING_TITLE}</Layout.Title>
-        </Layout.HeaderContent>
-        <Layout.HeaderActions>
-          <ButtonBar gap={1}>
-            {headerActions}
-            <FeedbackWidgetButton />
-          </ButtonBar>
-        </Layout.HeaderActions>
-        <TabList hideBorder>
-          <TabList.Item key={OVERVIEW_PAGE_TITLE}>{'Overview'}</TabList.Item>
-          <TabList.Item key={ModuleName.VITAL}>
-            {MODULE_TITLES[ModuleName.VITAL]}
-          </TabList.Item>
-          <TabList.Item key={ModuleName.HTTP}>
-            {MODULE_TITLES[ModuleName.HTTP]}
-          </TabList.Item>
-          <TabList.Item key={ModuleName.RESOURCE}>
-            {MODULE_TITLES[ModuleName.RESOURCE]}
-          </TabList.Item>
-        </TabList>
-      </Layout.Header>
-    </Tabs>
+    <DomainViewHeader
+      domainBaseUrl={frontendBaseUrl}
+      modules={modules}
+      selectedModule={module}
+      additonalHeaderActions={headerActions}
+      headerTitle={FRONTEND_LANDING_TITLE}
+    />
   );
 }

--- a/static/app/views/insights/pages/mobile/mobilePageHeader.tsx
+++ b/static/app/views/insights/pages/mobile/mobilePageHeader.tsx
@@ -1,27 +1,11 @@
-import {Fragment} from 'react';
-
-import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
-import ButtonBar from 'sentry/components/buttonBar';
-import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
-import * as Layout from 'sentry/components/layouts/thirds';
-import {TabList, Tabs} from 'sentry/components/tabs';
-import {t} from 'sentry/locale';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import {
-  type RoutableModuleNames,
-  useModuleURLBuilder,
-} from 'sentry/views/insights/common/utils/useModuleURL';
+import {DomainViewHeader} from 'sentry/views/insights/pages/domainViewHeader';
 import {
   MOBILE_LANDING_SUB_PATH,
   MOBILE_LANDING_TITLE,
 } from 'sentry/views/insights/pages/mobile/settings';
-import {
-  DOMAIN_VIEW_BASE_URL,
-  OVERVIEW_PAGE_TITLE,
-} from 'sentry/views/insights/pages/settings';
-import {MODULE_TITLES} from 'sentry/views/insights/settings';
+import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
 import {ModuleName} from 'sentry/views/insights/types';
 
 type Props = {
@@ -33,78 +17,23 @@ type Props = {
 
 // TODO - add props to append to breadcrumbs and change title
 export function MobileHeader({module, hideDefaultTabs, headerActions, tabs}: Props) {
-  const navigate = useNavigate();
   const {slug} = useOrganization();
-  const moduleURLBuilder = useModuleURLBuilder();
 
   const mobileBaseUrl = normalizeUrl(
     `/organizations/${slug}/${DOMAIN_VIEW_BASE_URL}/${MOBILE_LANDING_SUB_PATH}/`
   );
 
-  const crumbs: Crumb[] = [
-    {
-      label: t('Performance'),
-      to: '/performance', // There is no page at `/insights/` so there is nothing to link to
-      preservePageFilters: true,
-    },
-    {
-      label: MOBILE_LANDING_TITLE,
-      to: mobileBaseUrl,
-      preservePageFilters: true,
-    },
-    {
-      label: module ? MODULE_TITLES[module] : OVERVIEW_PAGE_TITLE,
-      to: undefined,
-      preservePageFilters: true,
-    },
-  ];
-
-  const defaultHandleTabChange = (key: ModuleName | typeof OVERVIEW_PAGE_TITLE) => {
-    if (key === module || (key === OVERVIEW_PAGE_TITLE && !module)) {
-      return;
-    }
-    if (!key) {
-      return;
-    }
-    if (key === OVERVIEW_PAGE_TITLE) {
-      navigate(mobileBaseUrl);
-      return;
-    }
-    navigate(`${moduleURLBuilder(key as RoutableModuleNames)}/`);
-  };
-
-  const tabValue =
-    hideDefaultTabs && tabs?.value ? tabs.value : module ?? OVERVIEW_PAGE_TITLE;
-
-  const handleTabChange =
-    hideDefaultTabs && tabs ? tabs.onTabChange : defaultHandleTabChange;
+  const modules = [ModuleName.MOBILE_SCREENS];
 
   return (
-    <Fragment>
-      <Tabs value={tabValue} onChange={handleTabChange}>
-        <Layout.Header>
-          <Layout.HeaderContent>
-            <Breadcrumbs crumbs={crumbs} />
-
-            <Layout.Title>{MOBILE_LANDING_TITLE}</Layout.Title>
-          </Layout.HeaderContent>
-          <Layout.HeaderActions>
-            <ButtonBar gap={1}>
-              {headerActions}
-              <FeedbackWidgetButton />
-            </ButtonBar>
-          </Layout.HeaderActions>
-          {!hideDefaultTabs && (
-            <TabList hideBorder>
-              <TabList.Item key={OVERVIEW_PAGE_TITLE}>{OVERVIEW_PAGE_TITLE}</TabList.Item>
-              <TabList.Item key={ModuleName.MOBILE_SCREENS}>
-                {MODULE_TITLES[ModuleName.MOBILE_SCREENS]}
-              </TabList.Item>
-            </TabList>
-          )}
-          {hideDefaultTabs && tabs && tabs.tabList}
-        </Layout.Header>
-      </Tabs>
-    </Fragment>
+    <DomainViewHeader
+      domainBaseUrl={mobileBaseUrl}
+      headerTitle={MOBILE_LANDING_TITLE}
+      modules={modules}
+      selectedModule={module}
+      tabs={tabs}
+      hideDefaultTabs={hideDefaultTabs}
+      additonalHeaderActions={headerActions}
+    />
   );
 }


### PR DESCRIPTION
The header for each domain view is almost identical (as it should be), and now that we've ported most if not all features from the performance landing page, its pretty easy to see the abstraction we can make, and what code we can share here.

This PR makes a shared domain view header and uses it in all views, this makes it much easier to maintain and ensure consistent behaviour.