### PR TITLE
Revert "ref(replay): capture parse and value errors in search entrypoint"

### DIFF
--- a/src/sentry/replays/usecases/query/__init__.py
+++ b/src/sentry/replays/usecases/query/__init__.py
@@ -219,38 +219,33 @@ def query_using_optimized_search(
             SearchFilter(SearchKey("environment"), "IN", SearchValue(environments)),
         ]
 
-    try:
-        # Translate "viewed_by_me" filters, which are aliases for "viewed_by_id"
-        search_filters = handle_viewed_by_me_filters(search_filters, request_user_id)
+    # Translate "viewed_by_me" filters, which are aliases for "viewed_by_id"
+    search_filters = handle_viewed_by_me_filters(search_filters, request_user_id)
 
-        if preferred_source == "materialized-view":
-            query, referrer, source = _query_using_materialized_view_strategy(
-                search_filters,
-                sort,
-                project_ids,
-                period_start,
-                period_stop,
-            )
-        elif preferred_source == "aggregated":
-            query, referrer, source = _query_using_aggregated_strategy(
-                search_filters,
-                sort,
-                project_ids,
-                period_start,
-                period_stop,
-            )
-        else:
-            query, referrer, source = _query_using_scalar_strategy(
-                search_filters,
-                sort,
-                project_ids,
-                period_start,
-                period_stop,
-            )
-    except (ParseError, ValueError) as exc:
-        sentry_sdk.set_tag("org_id", organization.id if organization else None)
-        sentry_sdk.capture_exception(exc)
-        raise
+    if preferred_source == "materialized-view":
+        query, referrer, source = _query_using_materialized_view_strategy(
+            search_filters,
+            sort,
+            project_ids,
+            period_start,
+            period_stop,
+        )
+    elif preferred_source == "aggregated":
+        query, referrer, source = _query_using_aggregated_strategy(
+            search_filters,
+            sort,
+            project_ids,
+            period_start,
+            period_stop,
+        )
+    else:
+        query, referrer, source = _query_using_scalar_strategy(
+            search_filters,
+            sort,
+            project_ids,
+            period_start,
+            period_stop,
+        )
 
     query = query.set_limit(pagination.limit)
     query = query.set_offset(pagination.offset)


### PR DESCRIPTION
Reverts getsentry/sentry#78523

The cause of these exceptions is user error, so we'll get too much noise in issues and slack alerts from this. With the closing of https://github.com/getsentry/sentry/issues/78586, error msgs on the frontend will help our users write valid queries.