### PR TITLE
taskworker: Use long-lived processpool instead of forked process

### DIFF
--- a/bin/taskworker-test
+++ b/bin/taskworker-test
@@ -188,10 +188,12 @@ def print_results(log_file: str, worker_count: int) -> None:
     click.echo("")
     click.echo("## Task latency")
     click.echo("")
-    click.echo(f"Startup Latency: {startup_latency}")
-    click.echo(f"Raw Min / Max / Avg latency: {min_latency} / {max_latency} / {avg_latency}")
+    click.echo(f"Startup Latency: {startup_latency:.5f}")
     click.echo(
-        f"Adjusted Min / Max / Avg latency: {adj_min_latency} / {adj_max_latency} / {adj_avg_latency}"
+        f"Raw Min / Max / Avg latency: {min_latency:.5f} / {max_latency:.5f} / {avg_latency:.5f}"
+    )
+    click.echo(
+        f"Adjusted Min / Max / Avg latency: {adj_min_latency:.5f} / {adj_max_latency:.5f} / {adj_avg_latency:.5f}"
     )
 
     click.echo("")
@@ -206,7 +208,7 @@ def print_results(log_file: str, worker_count: int) -> None:
         bars.append((bucket_upper, bar))
 
     for (bucket_upper, bar) in sorted(bars, key=lambda x: x[0]):
-        click.echo(f"{bucket_upper:.4f} {bar}")
+        click.echo(f"{bucket_upper:.5f} {bar}")
 
 
 if __name__ == "__main__":

--- a/bin/taskworker-test
+++ b/bin/taskworker-test
@@ -156,24 +156,29 @@ def print_results(log_file: str, worker_count: int) -> None:
 
     fieldnames = ["event", "worker_id", "task_add_time", "execution_time", "latency"]
     latency_times = []
+    execution_times = []
     with open(log_file) as logs:
         results = csv.DictReader(logs, fieldnames=fieldnames)
         for row in results:
             latency_times.append(float(row["latency"].strip()))
+            execution_times.append(float(row["execution_time"].strip()))
 
     # We append tasks and then start applications. The first
     # message always has long latency as application startup
     # and kafka take some time to get going.
-    startup_latency = latency_times[0]
+    first_latency = latency_times[0]
 
     min_latency = min(latency_times)
     max_latency = max(latency_times)
     avg_latency = sum(latency_times) / len(latency_times)
 
+    processing_time = execution_times[-1] - execution_times[0]
+    task_throughput = len(latency_times) / processing_time
+
     # Remove the startup overhead to get relative latency.
-    adj_min_latency = min_latency - startup_latency
-    adj_max_latency = max_latency - startup_latency
-    adj_avg_latency = avg_latency - startup_latency
+    adj_min_latency = min_latency - first_latency
+    adj_max_latency = max_latency - first_latency
+    adj_avg_latency = avg_latency - first_latency
 
     # Bucket latency and count totals in each bucket
     latency_spread = adj_max_latency - adj_min_latency
@@ -181,14 +186,21 @@ def print_results(log_file: str, worker_count: int) -> None:
     bucket_width = latency_spread / bucket_count
     buckets = defaultdict(int)
     for value in latency_times:
-        adjusted = max(value - startup_latency, 0)
+        adjusted = max(value - first_latency, 0)
         bucket = int(adjusted / bucket_width)
         buckets[bucket] += 1
 
     click.echo("")
+    click.echo("## Run summary")
+    click.echo("")
+    click.echo(f"Task count: {len(latency_times)}")
+    click.echo(f"Processing time: {processing_time:.4f}")
+    click.echo(f"Throughput: {task_throughput:.4f}")
+
+    click.echo("")
     click.echo("## Task latency")
     click.echo("")
-    click.echo(f"Startup Latency: {startup_latency:.5f}")
+    click.echo(f"First task Latency: {first_latency:.5f}")
     click.echo(
         f"Raw Min / Max / Avg latency: {min_latency:.5f} / {max_latency:.5f} / {avg_latency:.5f}"
     )

--- a/src/sentry/taskdemo/__init__.py
+++ b/src/sentry/taskdemo/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import time
+from datetime import timedelta
 from multiprocessing.context import TimeoutError
 
 logger = logging.getLogger(__name__)
@@ -35,6 +36,16 @@ def variable_time(wait=None, taskno=None):
     logger.info("running task %s with %s delay", taskno, wait)
     if wait is not None:
         time.sleep(wait)
+
+
+@demotasks.register(name="demos.run_forever", deadline=timedelta(seconds=8))
+def run_forever():
+    from random import randint
+
+    id = randint(1, 999999)
+    while True:
+        print(f"{id}: Running forever")  # noqa
+        time.sleep(1)
 
 
 @demotasks.register(name="demos.broken", retry=Retry(times=5, on=(KeyError,)))

--- a/src/sentry/taskworker/pending_task_store.py
+++ b/src/sentry/taskworker/pending_task_store.py
@@ -43,7 +43,7 @@ class PendingTaskStore:
                 return None
 
             # TODO this duration should be a tasknamespace setting, or with an option
-            deadline = datetime.now() + timedelta(minutes=3)
+            deadline = datetime.now() + timedelta(seconds=30)
 
             task.update(
                 status=InflightActivationModel.Status.PROCESSING, processing_deadline=deadline

--- a/src/sentry/taskworker/service/client.py
+++ b/src/sentry/taskworker/service/client.py
@@ -6,6 +6,7 @@ from sentry_protos.sentry.v1alpha.taskworker_pb2 import (
     GetTaskRequest,
     GetTaskResponse,
     SetTaskStatusRequest,
+    SetTaskStatusResponse,
     TaskActivationStatus,
 )
 from sentry_protos.sentry.v1alpha.taskworker_pb2_grpc import ConsumerServiceStub
@@ -41,12 +42,14 @@ class TaskClient:
             return response
         return None
 
-    def set_task_status(self, task_id: str, task_status: TaskActivationStatus.ValueType):
-        request = SetTaskStatusRequest(id=task_id, status=task_status)
-        self.stub.SetTaskStatus(request)
+    def set_task_status(
+        self, task_id: str, task_status: TaskActivationStatus.ValueType
+    ) -> SetTaskStatusResponse:
+        request = SetTaskStatusRequest(id=task_id, status=task_status, fetch_next=True)
+        return self.stub.SetTaskStatus(request)
 
-    def complete_task(self, task_id: str):
-        self.set_task_status(task_id=task_id, task_status=TASK_ACTIVATION_STATUS_COMPLETE)
+    def complete_task(self, task_id: str) -> SetTaskStatusResponse:
+        return self.set_task_status(task_id=task_id, task_status=TASK_ACTIVATION_STATUS_COMPLETE)
 
 
 task_client = TaskClient()

--- a/src/sentry/taskworker/worker_pull.py
+++ b/src/sentry/taskworker/worker_pull.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import time
-from concurrent.futures import Executor, ThreadPoolExecutor
+from concurrent.futures import Executor, ProcessPoolExecutor
 from datetime import datetime
 from uuid import uuid4
 
@@ -56,7 +56,7 @@ class Worker:
         next_task = None
         processing_deadline = None
         try:
-            with ThreadPoolExecutor(max_workers=2) as executor:
+            with ProcessPoolExecutor(max_workers=2) as executor:
                 while True:
                     if next_task:
                         task = next_task

--- a/src/sentry/taskworker/worker_push.py
+++ b/src/sentry/taskworker/worker_push.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import logging
 import time
-from concurrent import futures
-from concurrent.futures.thread import ThreadPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from datetime import datetime
 from uuid import uuid4
 
@@ -38,7 +37,7 @@ class WorkerServicer(BaseWorkerServiceServicer):
         self.do_imports()
         self.__worker_id = uuid4().hex
         # TODO we are not waiting for threads to complete on shutdown
-        self.executor = ThreadPoolExecutor(max_workers=2)
+        self.executor = ProcessPoolExecutor(max_workers=2)
 
     @property
     def namespace(self) -> TaskNamespace:
@@ -100,7 +99,7 @@ class WorkerServicer(BaseWorkerServiceServicer):
 
 def serve(port: int, **options):
     logger.info("Starting server on: %s", port)
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+    server = grpc.server(ThreadPoolExecutor(max_workers=10))
     add_WorkerServiceServicer_to_server(WorkerServicer(**options), server)
     server.add_insecure_port(f"[::]:{port}")
     server.start()


### PR DESCRIPTION
- Improve the throughput of the prototypes by using long lived process pools instead of making a new process for each task.
- Improve the pull model by having status updates return the next task. This halves the amount of network requests that pull model needs to make.
- Improve the output of the test harness to make throughput more obvious and format numbers so they are easier to read.