### PR TITLE
ref(test-alerts): Adds exception filtering for IntegrationErrors to be shown in the UI:

### DIFF
--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -1,5 +1,6 @@
 import logging
 
+import sentry_sdk
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -110,7 +111,10 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
                     logger.warning(
                         "%s.test_alert.unexpected_exception", callback_name, exc_info=True
                     )
-                    break
+                    error_id = sentry_sdk.capture_exception(exc)
+                    action_exceptions.append(
+                        f"An unexpected error occurred. Error ID: '{error_id}'"
+                    )
 
         status = None
         data = None

--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -14,7 +14,7 @@ from sentry.api.serializers.rest_framework import RuleActionSerializer
 from sentry.eventstore.models import GroupEvent
 from sentry.models.rule import Rule
 from sentry.rules.processing.processor import activate_downstream_actions
-from sentry.shared_integrations.exceptions import IntegrationError
+from sentry.shared_integrations.exceptions import IntegrationFormError
 from sentry.utils.safe import safe_execute
 from sentry.utils.samples import create_sample_event
 
@@ -98,7 +98,7 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
 
                 # safe_execute logs these as exceptions, which can result in
                 # noisy sentry issues, so log with a warning instead.
-                if isinstance(exc, IntegrationError):
+                if isinstance(exc, IntegrationFormError):
                     logger.warning(
                         "%s.test_alert.integration_error", callback_name, extra={"exc": exc}
                     )

--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -116,6 +116,8 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
                         f"An unexpected error occurred. Error ID: '{error_id}'"
                     )
 
+                break
+
         status = None
         data = None
         # Presence of "actions" here means we have exceptions to surface to the user

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -36,6 +36,7 @@ from sentry.shared_integrations.constants import (
 from sentry.shared_integrations.exceptions import (
     ApiError,
     ApiHostError,
+    ApiInvalidRequest,
     ApiUnauthorized,
     IntegrationError,
     IntegrationFormError,
@@ -431,7 +432,7 @@ class IntegrationInstallation(abc.ABC):
             raise InvalidIdentity(self.message_from_error(exc), identity=identity).with_traceback(
                 sys.exc_info()[2]
             )
-        elif isinstance(exc, ApiError):
+        elif isinstance(exc, ApiInvalidRequest):
             if exc.json:
                 error_fields = self.error_fields_from_json(exc.json)
                 if error_fields is not None:

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -36,7 +36,7 @@ from sentry.shared_integrations.constants import (
 from sentry.shared_integrations.exceptions import (
     ApiError,
     ApiHostError,
-    ApiInvalidRequest,
+    ApiInvalidRequestError,
     ApiUnauthorized,
     IntegrationError,
     IntegrationFormError,
@@ -432,7 +432,7 @@ class IntegrationInstallation(abc.ABC):
             raise InvalidIdentity(self.message_from_error(exc), identity=identity).with_traceback(
                 sys.exc_info()[2]
             )
-        elif isinstance(exc, ApiInvalidRequest):
+        elif isinstance(exc, ApiInvalidRequestError):
             if exc.json:
                 error_fields = self.error_fields_from_json(exc.json)
                 if error_fields is not None:

--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -125,6 +125,7 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
                     "provider": provider,
                     "integration_id": integration.id,
                     "error_message": str(e),
+                    "exception_type": type(e).__name__,
                 },
             )
             metrics.incr(

--- a/src/sentry/shared_integrations/exceptions/__init__.py
+++ b/src/sentry/shared_integrations/exceptions/__init__.py
@@ -84,6 +84,8 @@ class ApiError(Exception):
             return ApiRateLimitedError(response.text, url=url)
         elif response.status_code == 409:
             return ApiConflictError(response.text, url=url)
+        elif response.status_code == 400:
+            return ApiInvalidRequest(response.text, url=url)
 
         return cls(response.text, response.status_code, url=url)
 
@@ -149,6 +151,10 @@ class ApiConflictError(ApiError):
 
 class ApiConnectionResetError(ApiError):
     code = errno.ECONNRESET
+
+
+class ApiInvalidRequest(ApiError):
+    code = 400
 
 
 class UnsupportedResponseType(ApiError):

--- a/src/sentry/shared_integrations/exceptions/__init__.py
+++ b/src/sentry/shared_integrations/exceptions/__init__.py
@@ -20,7 +20,10 @@ __all__ = (
     "ApiTimeoutError",
     "ApiUnauthorized",
     "ApiRateLimitedError",
+    "ApiInvalidRequestError",
     "IntegrationError",
+    "IntegrationFormError",
+    "UnsupportedResponseType",
 )
 
 
@@ -85,7 +88,7 @@ class ApiError(Exception):
         elif response.status_code == 409:
             return ApiConflictError(response.text, url=url)
         elif response.status_code == 400:
-            return ApiInvalidRequest(response.text, url=url)
+            return ApiInvalidRequestError(response.text, url=url)
 
         return cls(response.text, response.status_code, url=url)
 
@@ -153,7 +156,7 @@ class ApiConnectionResetError(ApiError):
     code = errno.ECONNRESET
 
 
-class ApiInvalidRequest(ApiError):
+class ApiInvalidRequestError(ApiError):
     code = 400
 
 


### PR DESCRIPTION
- Adds a new `ApiInvalidRequestError` type, to better differentiate between 400 and unhandled non-400 responses from downstream APIs.
- Adds filtering to our ticket creation utils which only propagates `IntegrationFormErrors` when a known 400 status response is received by requests to an integration's API
- Adds sentry error IDs to unhandled test notification errors for easier customer triage.

When an unhandled error type is provided, we will show it + the event ID associated with it for easier triage:
<img width="1128" alt="image" src="https://github.com/user-attachments/assets/0faa1928-0436-4ab7-b1b5-3a61e3c6a1e9">


_Note:_ This does not fix the brunt of the `IntegrationFormError` sentry issues we're getting for Jira, which I'll address in a follow-up PR, but this does give me more confidence to GA the UI error reporting for test notifications. 
