### PR TITLE
ref(alerts): Define anomaly detection connection pool once

### DIFF
--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -1,11 +1,9 @@
 import logging
 
-from django.conf import settings
 from urllib3.exceptions import MaxRetryError, TimeoutError
 
 from sentry.conf.server import SEER_ANOMALY_DETECTION_ENDPOINT_URL
 from sentry.incidents.models.alert_rule import AlertRule
-from sentry.net.http import connection_from_url
 from sentry.seer.anomaly_detection.types import (
     AlertInSeer,
     AnomalyDetectionConfig,
@@ -13,18 +11,16 @@ from sentry.seer.anomaly_detection.types import (
     DetectAnomaliesResponse,
     TimeSeriesPoint,
 )
-from sentry.seer.anomaly_detection.utils import translate_direction
+from sentry.seer.anomaly_detection.utils import (
+    SEER_ANOMALY_DETECTION_CONNECTION_POOL,
+    translate_direction,
+)
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.snuba.models import QuerySubscription
 from sentry.utils import json
 from sentry.utils.json import JSONDecodeError
 
 logger = logging.getLogger(__name__)
-
-SEER_ANOMALY_DETECTION_CONNECTION_POOL = connection_from_url(
-    settings.SEER_ANOMALY_DETECTION_URL,
-    timeout=settings.SEER_ANOMALY_DETECTION_TIMEOUT,
-)
 
 
 def get_anomaly_data_from_seer(

--- a/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
+++ b/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
@@ -1,14 +1,12 @@
 import logging
 from datetime import datetime, timedelta
 
-from django.conf import settings
 from urllib3.exceptions import MaxRetryError, TimeoutError
 
 from sentry.api.bases.organization_events import get_query_columns
 from sentry.conf.server import SEER_ANOMALY_DETECTION_ENDPOINT_URL
 from sentry.incidents.models.alert_rule import AlertRule, AlertRuleStatus
 from sentry.models.project import Project
-from sentry.net.http import connection_from_url
 from sentry.seer.anomaly_detection.store_data import _get_start_and_end_indices
 from sentry.seer.anomaly_detection.types import (
     AnomalyDetectionConfig,
@@ -19,6 +17,7 @@ from sentry.seer.anomaly_detection.types import (
     TimeSeriesPoint,
 )
 from sentry.seer.anomaly_detection.utils import (
+    SEER_ANOMALY_DETECTION_CONNECTION_POOL,
     fetch_historical_data,
     format_historical_data,
     translate_direction,
@@ -30,11 +29,6 @@ from sentry.utils import json
 from sentry.utils.json import JSONDecodeError
 
 logger = logging.getLogger(__name__)
-
-seer_anomaly_detection_connection_pool = connection_from_url(
-    settings.SEER_ANOMALY_DETECTION_URL,
-    timeout=settings.SEER_ANOMALY_DETECTION_TIMEOUT,
-)
 
 
 def handle_seer_error_responses(response, config, context, log_params):
@@ -127,7 +121,7 @@ def get_historical_anomaly_data_from_seer_preview(
     }
     try:
         response = make_signed_seer_api_request(
-            connection_pool=seer_anomaly_detection_connection_pool,
+            connection_pool=SEER_ANOMALY_DETECTION_CONNECTION_POOL,
             path=SEER_ANOMALY_DETECTION_ENDPOINT_URL,
             body=json.dumps(body).encode("utf-8"),
         )
@@ -225,7 +219,7 @@ def get_historical_anomaly_data_from_seer(
     )
     try:
         response = make_signed_seer_api_request(
-            seer_anomaly_detection_connection_pool,
+            SEER_ANOMALY_DETECTION_CONNECTION_POOL,
             SEER_ANOMALY_DETECTION_ENDPOINT_URL,
             json.dumps(body).encode("utf-8"),
         )

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 from typing import Any
 
+from django.conf import settings
 from django.utils import timezone
 from django.utils.datastructures import MultiValueDict
 from rest_framework.exceptions import ParseError
@@ -11,6 +12,7 @@ from sentry.api.serializers.snuba import SnubaTSResultSerializer
 from sentry.incidents.models.alert_rule import AlertRule, AlertRuleThresholdType
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.net.http import connection_from_url
 from sentry.search.events.types import SnubaParams
 from sentry.seer.anomaly_detection.types import AnomalyType, TimeSeriesPoint
 from sentry.snuba import metrics_performance
@@ -22,6 +24,11 @@ from sentry.snuba.utils import DATASET_OPTIONS, get_dataset
 from sentry.utils.snuba import SnubaTSResult
 
 NUM_DAYS = 28
+
+SEER_ANOMALY_DETECTION_CONNECTION_POOL = connection_from_url(
+    settings.SEER_ANOMALY_DETECTION_URL,
+    timeout=settings.SEER_ANOMALY_DETECTION_TIMEOUT,
+)
 
 SNUBA_QUERY_EVENT_TYPE_TO_STRING = {
     SnubaQueryEventType.EventType.ERROR: "error",

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -94,8 +94,8 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.integrations.pagerduty.utils import add_service
 from sentry.integrations.services.integration.serial import serialize_integration
 from sentry.models.group import GroupStatus
-from sentry.seer.anomaly_detection.store_data import seer_anomaly_detection_connection_pool
 from sentry.seer.anomaly_detection.types import StoreDataResponse
+from sentry.seer.anomaly_detection.utils import SEER_ANOMALY_DETECTION_CONNECTION_POOL
 from sentry.shared_integrations.exceptions import ApiRateLimitedError, ApiTimeoutError
 from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
@@ -840,9 +840,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     def test_create_alert_rule_anomaly_detection(self, mock_seer_request):
         seer_return_value: StoreDataResponse = {"success": True}
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
@@ -890,9 +888,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     def test_create_alert_rule_anomaly_detection_not_enough_data(self, mock_seer_request):
         seer_return_value: StoreDataResponse = {"success": True}
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
@@ -913,9 +909,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     def test_create_alert_rule_anomaly_detection_no_data(self, mock_seer_request):
         seer_return_value: StoreDataResponse = {"success": True}
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
@@ -933,9 +927,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     @patch("sentry.seer.anomaly_detection.store_data.logger")
     def test_create_alert_rule_anomaly_detection_seer_timeout_max_retry(
         self, mock_logger, mock_seer_request
@@ -962,7 +954,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         mock_logger.reset_mock()
 
         mock_seer_request.side_effect = MaxRetryError(
-            seer_anomaly_detection_connection_pool, SEER_ANOMALY_DETECTION_STORE_DATA_URL
+            SEER_ANOMALY_DETECTION_CONNECTION_POOL, SEER_ANOMALY_DETECTION_STORE_DATA_URL
         )
 
         with pytest.raises(TimeoutError):
@@ -980,9 +972,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         assert mock_logger.warning.call_count == 1
         assert mock_seer_request.call_count == 1
 
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     def test_create_alert_rule_anomaly_detection_no_feature(self, mock_seer_request):
         with pytest.raises(ResourceDoesNotExist):
             create_alert_rule(
@@ -1490,12 +1480,8 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
-    @patch(
-        "sentry.seer.anomaly_detection.delete_rule.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     def test_update_detection_type(self, mock_seer_delete_request, mock_seer_request):
         seer_return_value: StoreDataResponse = {"success": True}
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
@@ -1607,9 +1593,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     def test_update_infer_detection_type(self, mock_seer_request):
         seer_return_value: StoreDataResponse = {"success": True}
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
@@ -1667,9 +1651,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     def test_update_dynamic_alerts(self, mock_seer_request):
         seer_return_value: StoreDataResponse = {"success": True}
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
@@ -1722,9 +1704,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     def test_update_dynamic_alert_static_to_dynamic(self, mock_seer_request):
         seer_return_value: StoreDataResponse = {"success": True}
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
@@ -1741,9 +1721,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     def test_update_dynamic_alert_percent_to_dynamic(self, mock_seer_request):
         seer_return_value: StoreDataResponse = {"success": True}
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
@@ -1761,9 +1739,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     def test_update_alert_rule_static_to_dynamic_enough_data(self, mock_seer_request):
         """
         Assert that the status is PENDING if enough data exists.
@@ -1790,9 +1766,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     def test_update_dynamic_alert_not_enough_to_pending(self, mock_seer_request):
         """
         Update a dynamic rule's aggregate so the rule's status changes from not enough data to enough/pending
@@ -1829,9 +1803,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     def test_update_dynamic_alert_pending_to_not_enough(self, mock_seer_request):
         """
         Update a dynamic rule's aggregate so the rule's status changes from enough/pending to not enough data
@@ -1871,9 +1843,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     def test_update_alert_rule_static_to_dynamic_not_enough_data(self, mock_seer_request):
         """
         Assert that the status is NOT_ENOUGH_DATA if we don't have 7 days of data.
@@ -1900,9 +1870,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     def test_update_alert_rule_dynamic_to_static_status(self, mock_seer_request):
         """
         Assert that the alert rule status changes to PENDING if we switch from a dynamic alert to another type of alert.
@@ -1937,9 +1905,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     @patch("sentry.seer.anomaly_detection.store_data.logger")
     def test_update_alert_rule_anomaly_detection_seer_timeout_max_retry(
         self, mock_logger, mock_seer_request
@@ -1975,7 +1941,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         mock_logger.reset_mock()
 
         mock_seer_request.side_effect = MaxRetryError(
-            seer_anomaly_detection_connection_pool, SEER_ANOMALY_DETECTION_STORE_DATA_URL
+            SEER_ANOMALY_DETECTION_CONNECTION_POOL, SEER_ANOMALY_DETECTION_STORE_DATA_URL
         )
         with pytest.raises(TimeoutError):
             # attempt to update query
@@ -1993,15 +1959,13 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     @patch("sentry.seer.anomaly_detection.store_data.logger")
     def test_update_alert_rule_static_to_anomaly_detection_seer_timeout(
         self, mock_logger, mock_seer_request
     ):
         mock_seer_request.side_effect = MaxRetryError(
-            seer_anomaly_detection_connection_pool, SEER_ANOMALY_DETECTION_STORE_DATA_URL
+            SEER_ANOMALY_DETECTION_CONNECTION_POOL, SEER_ANOMALY_DETECTION_STORE_DATA_URL
         )
         static_rule = self.create_alert_rule(time_window=30)
         with pytest.raises(TimeoutError):
@@ -2017,12 +1981,8 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.delete_rule.seer_anomaly_detection_connection_pool.urlopen"
-    )
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     def test_update_alert_rule_dynamic_to_static_delete_call(
         self, mock_store_request, mock_delete_request
     ):
@@ -2041,9 +2001,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
 
         assert mock_delete_request.call_count == 1
 
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     def test_update_alert_rule_anomaly_detection_no_feature(self, mock_seer_request):
         static_rule = self.create_alert_rule(time_window=30)
 
@@ -2061,9 +2019,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     def test_update_invalid_time_window(self, mock_seer_request):
         seer_return_value: StoreDataResponse = {"success": True}
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
@@ -2113,9 +2069,7 @@ class DeleteAlertRuleTest(TestCase, BaseIncidentsTest):
         return self.create_alert_rule()
 
     @cached_property
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     def dynamic_alert_rule(self, mock_seer_request):
         seer_return_value: StoreDataResponse = {"success": True}
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
@@ -2162,9 +2116,7 @@ class DeleteAlertRuleTest(TestCase, BaseIncidentsTest):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.delete_rule.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     def test_delete_anomaly_detection_rule(self, mock_seer_request):
         alert_rule = self.dynamic_alert_rule
         alert_rule_id = alert_rule.id
@@ -2187,9 +2139,7 @@ class DeleteAlertRuleTest(TestCase, BaseIncidentsTest):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.delete_rule.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     @patch("sentry.seer.anomaly_detection.delete_rule.logger")
     @patch("sentry.incidents.models.alert_rule.logger")
     def test_delete_anomaly_detection_rule_timeout(
@@ -2221,9 +2171,7 @@ class DeleteAlertRuleTest(TestCase, BaseIncidentsTest):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.delete_rule.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     @patch("sentry.seer.anomaly_detection.delete_rule.logger")
     @patch("sentry.incidents.models.alert_rule.logger")
     def test_delete_anomaly_detection_rule_error(
@@ -2255,9 +2203,7 @@ class DeleteAlertRuleTest(TestCase, BaseIncidentsTest):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.delete_rule.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     @patch("sentry.seer.anomaly_detection.delete_rule.logger")
     @patch("sentry.incidents.models.alert_rule.logger")
     def test_delete_anomaly_detection_rule_attribute_error(
@@ -2289,9 +2235,7 @@ class DeleteAlertRuleTest(TestCase, BaseIncidentsTest):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.delete_rule.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     @patch("sentry.seer.anomaly_detection.delete_rule.logger")
     @patch("sentry.incidents.models.alert_rule.logger")
     def test_delete_anomaly_detection_rule_failure(
@@ -2412,9 +2356,7 @@ class CreateAlertRuleTriggerTest(TestCase):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     def test_invalid_threshold_dynamic_alert(self, mock_seer_request):
         seer_return_value: StoreDataResponse = {"success": True}
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
@@ -2485,9 +2427,7 @@ class UpdateAlertRuleTriggerTest(TestCase):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
-    @patch(
-        "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
     def test_invalid_threshold_dynamic_alert(self, mock_seer_request):
         seer_return_value: StoreDataResponse = {"success": True}
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1481,13 +1481,10 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
     @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
-    @patch("sentry.seer.anomaly_detection.utils.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen")
-    def test_update_detection_type(self, mock_seer_delete_request, mock_seer_request):
+    def test_update_detection_type(self, mock_seer_request):
         seer_return_value: StoreDataResponse = {"success": True}
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
-        mock_seer_delete_request.return_value = HTTPResponse(
-            orjson.dumps(seer_return_value), status=200
-        )
+
         comparison_delta = 60
         # test percent to dynamic
         rule = self.create_alert_rule(


### PR DESCRIPTION
We had `seer_anomaly_detection_connection_pool` defined in a few places, this just moves it to be defined once in `utils.py` and imports it as needed. 


Some tests will fail until I can rebase on top of https://github.com/getsentry/sentry/pull/78652