### PR TITLE
deps(ui): Upgrade platformicons

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "papaparse": "^5.3.2",
     "pegjs": "^0.10.0",
     "pegjs-loader": "^0.5.8",
-    "platformicons": "^6.0.3",
+    "platformicons": "^7.0.0",
     "po-catalog-loader": "2.1.0",
     "prettier": "3.3.2",
     "prismjs": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "papaparse": "^5.3.2",
     "pegjs": "^0.10.0",
     "pegjs-loader": "^0.5.8",
-    "platformicons": "^7.0.0",
+    "platformicons": "^7.0.1",
     "po-catalog-loader": "2.1.0",
     "prettier": "3.3.2",
     "prismjs": "^1.29.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9810,10 +9810,10 @@ platform@^1.3.3:
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
   integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
-platformicons@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-7.0.0.tgz#e88cae57dac67ac7079fadbba38ec851087944b3"
-  integrity sha512-uDDEk+CqD+mvaGyj05LcVHhwHorhOMX/9fVHL5CSvMIFf+2VkiRc7DOxDP2fatyoQvj0yH+kVl0N+hR2l2Zhvg==
+platformicons@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-7.0.1.tgz#eaf6a1e18fe8516b135df458ed603c4554ae050f"
+  integrity sha512-M/aNCZw4RJ8yIhkFBFhoQtOYgvwn+99upggQYy7BSaQxKaGS3Yb5/c1qC8+lKqzWWMZ+uafFOpEK6jLFPIkpww==
   dependencies:
     "@types/node" "*"
     "@types/react" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9810,10 +9810,10 @@ platform@^1.3.3:
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
   integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
-platformicons@^6.0.3:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-6.0.3.tgz#c167ab68c1cdb1a4d97665118b65ebccf7dcbe00"
-  integrity sha512-Z83ePiRqlA8yXQI1Y28/xv/7hGW/2BajJESxbnTjQkBjs2vGFAQjMs5E/mkOJoNuDKfEeaHgD7xOqajvARd4AQ==
+platformicons@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-7.0.0.tgz#e88cae57dac67ac7079fadbba38ec851087944b3"
+  integrity sha512-uDDEk+CqD+mvaGyj05LcVHhwHorhOMX/9fVHL5CSvMIFf+2VkiRc7DOxDP2fatyoQvj0yH+kVl0N+hR2l2Zhvg==
   dependencies:
     "@types/node" "*"
     "@types/react" "*"


### PR DESCRIPTION
v7 just changes how its built (dual esm+cjs & not minified)
