### PR TITLE
feat(Auth): Adding scope to ApiApplication serializer

### DIFF
--- a/src/sentry/api/serializers/models/apiapplication.py
+++ b/src/sentry/api/serializers/models/apiapplication.py
@@ -20,4 +20,5 @@ class ApiApplicationSerializer(Serializer):
             "termsUrl": obj.terms_url,
             "allowedOrigins": obj.get_allowed_origins(),
             "redirectUris": obj.get_redirect_uris(),
+            "scopes": obj.scopes,
         }


### PR DESCRIPTION
I added scope to the model in the previous PR but not to the serializer. Adding it now. The value is empty for every object atm.