### PR TITLE
feat(feedback): Delete feedback button

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackActions.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackActions.tsx
@@ -1,7 +1,6 @@
 import type {CSSProperties} from 'react';
 import {Fragment} from 'react';
 
-import {type ModalRenderProps, openModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/button';
 import {Flex} from 'sentry/components/container/flex';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
@@ -62,11 +61,9 @@ function LargeWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
 
   return (
     <Fragment>
-      {hasDelete && (
-        <Button size="xs" onClick={() => openDeleteModal(onDelete)} priority="danger">
-          {t('Delete')}
-        </Button>
-      )}
+      <Button size="xs" onClick={onDelete} priority="danger" disabled={!hasDelete}>
+        {t('Delete')}
+      </Button>
       <Button
         size="xs"
         priority={isResolved ? 'danger' : 'primary'}
@@ -98,11 +95,9 @@ function MediumWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
 
   return (
     <Fragment>
-      {hasDelete && (
-        <Button size="xs" onClick={() => openDeleteModal(onDelete)} priority={'danger'}>
-          {t('Delete')}
-        </Button>
-      )}
+      <Button size="xs" onClick={onDelete} priority={'danger'} disabled={!hasDelete}>
+        {t('Delete')}
+      </Button>
       <Button
         size="xs"
         priority={isResolved ? 'danger' : 'primary'}
@@ -162,8 +157,8 @@ function SmallWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
           key: 'delete',
           priority: 'danger' as const,
           label: t('Delete'),
-          hidden: !hasDelete,
-          onAction: () => openDeleteModal(onDelete),
+          disabled: !hasDelete,
+          onAction: onDelete,
         },
         {
           key: 'resolve',
@@ -184,22 +179,3 @@ function SmallWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
     />
   );
 }
-
-const openDeleteModal = onDelete =>
-  openModal(({Body, Footer, closeModal}: ModalRenderProps) => (
-    <Fragment>
-      <Body>
-        {t('Deleting this feedback is permanent. Are you sure you wish to continue?')}
-      </Body>
-      <Footer>
-        <Button onClick={closeModal}>{t('Cancel')}</Button>
-        <Button
-          style={{marginLeft: space(1)}}
-          priority="primary"
-          onClick={() => onDelete(closeModal)}
-        >
-          {t('Delete')}
-        </Button>
-      </Footer>
-    </Fragment>
-  ));

--- a/static/app/components/feedback/feedbackItem/feedbackActions.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackActions.tsx
@@ -1,6 +1,7 @@
 import type {CSSProperties} from 'react';
 import {Fragment} from 'react';
 
+import {type ModalRenderProps, openModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/button';
 import {Flex} from 'sentry/components/container/flex';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
@@ -48,11 +49,24 @@ export default function FeedbackActions({
 }
 
 function LargeWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
-  const {isResolved, onResolveClick, isSpam, onSpamClick, hasSeen, onMarkAsReadClick} =
-    useFeedbackActions({feedbackItem});
+  const {
+    hasDelete,
+    onDelete,
+    isResolved,
+    onResolveClick,
+    isSpam,
+    onSpamClick,
+    hasSeen,
+    onMarkAsReadClick,
+  } = useFeedbackActions({feedbackItem});
 
   return (
     <Fragment>
+      {hasDelete && (
+        <Button size="xs" onClick={() => openDeleteModal(onDelete)} priority="danger">
+          {t('Delete')}
+        </Button>
+      )}
       <Button
         size="xs"
         priority={isResolved ? 'danger' : 'primary'}
@@ -71,11 +85,24 @@ function LargeWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
 }
 
 function MediumWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
-  const {isResolved, onResolveClick, isSpam, onSpamClick, hasSeen, onMarkAsReadClick} =
-    useFeedbackActions({feedbackItem});
+  const {
+    hasDelete,
+    onDelete,
+    isResolved,
+    onResolveClick,
+    isSpam,
+    onSpamClick,
+    hasSeen,
+    onMarkAsReadClick,
+  } = useFeedbackActions({feedbackItem});
 
   return (
     <Fragment>
+      {hasDelete && (
+        <Button size="xs" onClick={() => openDeleteModal(onDelete)} priority={'danger'}>
+          {t('Delete')}
+        </Button>
+      )}
       <Button
         size="xs"
         priority={isResolved ? 'danger' : 'primary'}
@@ -110,8 +137,16 @@ function MediumWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
 }
 
 function SmallWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
-  const {isResolved, onResolveClick, isSpam, onSpamClick, hasSeen, onMarkAsReadClick} =
-    useFeedbackActions({feedbackItem});
+  const {
+    hasDelete,
+    onDelete,
+    isResolved,
+    onResolveClick,
+    isSpam,
+    onSpamClick,
+    hasSeen,
+    onMarkAsReadClick,
+  } = useFeedbackActions({feedbackItem});
 
   return (
     <DropdownMenu
@@ -123,6 +158,13 @@ function SmallWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
         size: 'xs',
       }}
       items={[
+        {
+          key: 'delete',
+          label: t('Delete'),
+          onAction: () => openDeleteModal(onDelete),
+          hidden: !hasDelete,
+          priority: 'danger',
+        },
         {
           key: 'resolve',
           label: isResolved ? t('Unresolve') : t('Resolve'),
@@ -142,3 +184,22 @@ function SmallWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
     />
   );
 }
+
+const openDeleteModal = onDelete =>
+  openModal(({Body, Footer, closeModal}: ModalRenderProps) => (
+    <Fragment>
+      <Body>
+        {t('Deleting this feedback is permanent. Are you sure you wish to continue?')}
+      </Body>
+      <Footer>
+        <Button onClick={closeModal}>{t('Cancel')}</Button>
+        <Button
+          style={{marginLeft: space(1)}}
+          priority="primary"
+          onClick={() => onDelete(closeModal)}
+        >
+          {t('Delete')}
+        </Button>
+      </Footer>
+    </Fragment>
+  ));

--- a/static/app/components/feedback/feedbackItem/feedbackActions.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackActions.tsx
@@ -49,6 +49,7 @@ export default function FeedbackActions({
 
 function LargeWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
   const {
+    disableDelete,
     hasDelete,
     onDelete,
     isResolved,
@@ -61,9 +62,6 @@ function LargeWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
 
   return (
     <Fragment>
-      <Button size="xs" onClick={onDelete} priority="danger" disabled={!hasDelete}>
-        {t('Delete')}
-      </Button>
       <Button
         size="xs"
         priority={isResolved ? 'danger' : 'primary'}
@@ -77,12 +75,18 @@ function LargeWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
       <Button size="xs" onClick={onMarkAsReadClick}>
         {hasSeen ? t('Mark Unread') : t('Mark Read')}
       </Button>
+      {hasDelete && (
+        <Button size="xs" onClick={onDelete} disabled={disableDelete}>
+          {t('Delete')}
+        </Button>
+      )}
     </Fragment>
   );
 }
 
 function MediumWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
   const {
+    disableDelete,
     hasDelete,
     onDelete,
     isResolved,
@@ -95,9 +99,6 @@ function MediumWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
 
   return (
     <Fragment>
-      <Button size="xs" onClick={onDelete} priority={'danger'} disabled={!hasDelete}>
-        {t('Delete')}
-      </Button>
       <Button
         size="xs"
         priority={isResolved ? 'danger' : 'primary'}
@@ -125,6 +126,14 @@ function MediumWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
             label: hasSeen ? t('Mark Unread') : t('Mark Read'),
             onAction: onMarkAsReadClick,
           },
+          {
+            key: 'delete',
+            priority: 'danger' as const,
+            label: t('Delete'),
+            hidden: !hasDelete,
+            disabled: disableDelete,
+            onAction: onDelete,
+          },
         ].filter(defined)}
       />
     </Fragment>
@@ -133,6 +142,7 @@ function MediumWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
 
 function SmallWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
   const {
+    disableDelete,
     hasDelete,
     onDelete,
     isResolved,
@@ -154,13 +164,6 @@ function SmallWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
       }}
       items={[
         {
-          key: 'delete',
-          priority: 'danger' as const,
-          label: t('Delete'),
-          disabled: !hasDelete,
-          onAction: onDelete,
-        },
-        {
           key: 'resolve',
           label: isResolved ? t('Unresolve') : t('Resolve'),
           onAction: onResolveClick,
@@ -174,6 +177,14 @@ function SmallWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
           key: 'read',
           label: hasSeen ? t('Mark Unread') : t('Mark Read'),
           onAction: onMarkAsReadClick,
+        },
+        {
+          key: 'delete',
+          priority: 'danger' as const,
+          label: t('Delete'),
+          hidden: !hasDelete,
+          disabled: disableDelete,
+          onAction: onDelete,
         },
       ].filter(defined)}
     />

--- a/static/app/components/feedback/feedbackItem/feedbackActions.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackActions.tsx
@@ -160,10 +160,10 @@ function SmallWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
       items={[
         {
           key: 'delete',
+          priority: 'danger' as const,
           label: t('Delete'),
-          onAction: () => openDeleteModal(onDelete),
           hidden: !hasDelete,
-          priority: 'danger',
+          onAction: () => openDeleteModal(onDelete),
         },
         {
           key: 'resolve',

--- a/static/app/components/feedback/feedbackItem/useFeedbackActions.ts
+++ b/static/app/components/feedback/feedbackItem/useFeedbackActions.ts
@@ -75,18 +75,7 @@ export default function useFeedbackActions({feedbackItem}: Props) {
         }
       );
     },
-    [
-      api,
-      feedbackItem.id,
-      navigate,
-      organization.slug,
-      pathname,
-      projectId,
-      query.mailbox,
-      query.project,
-      query.query,
-      query.statsPeriod,
-    ]
+    [api, feedbackItem.id, navigate, organization.slug, pathname, projectId, query]
   );
 
   // reuse the issues ignored category for spam feedbacks

--- a/static/app/components/feedback/feedbackItem/useFeedbackActions.ts
+++ b/static/app/components/feedback/feedbackItem/useFeedbackActions.ts
@@ -40,9 +40,7 @@ export default function useFeedbackActions({feedbackItem}: Props) {
   const hasDelete =
     organization.access.includes('event:admin') &&
     organization.features.includes('issue-platform-deletion-ui');
-  const onDelete = () => {
-    deleteFeedback();
-  };
+  const onDelete = deleteFeedback;
 
   // reuse the issues ignored category for spam feedbacks
   const isResolved = feedbackItem.status === GroupStatus.RESOLVED;

--- a/static/app/components/feedback/feedbackItem/useFeedbackActions.ts
+++ b/static/app/components/feedback/feedbackItem/useFeedbackActions.ts
@@ -37,9 +37,8 @@ export default function useFeedbackActions({feedbackItem}: Props) {
   });
   const deleteFeedback = useDeleteFeedback([feedbackItem.id], projectId);
 
-  const hasDelete =
-    organization.access.includes('event:admin') &&
-    organization.features.includes('issue-platform-deletion-ui');
+  const hasDelete = organization.features.includes('issue-platform-deletion-ui');
+  const disableDelete = !organization.access.includes('event:admin');
   const onDelete = deleteFeedback;
 
   // reuse the issues ignored category for spam feedbacks
@@ -71,6 +70,7 @@ export default function useFeedbackActions({feedbackItem}: Props) {
   }, [hasSeen, markAsRead]);
 
   return {
+    disableDelete,
     hasDelete,
     onDelete,
     isResolved,

--- a/static/app/components/feedback/list/feedbackListBulkSelection.tsx
+++ b/static/app/components/feedback/list/feedbackListBulkSelection.tsx
@@ -9,6 +9,7 @@ import {IconEllipsis} from 'sentry/icons/iconEllipsis';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {GroupStatus} from 'sentry/types/group';
+import useOrganization from 'sentry/utils/useOrganization';
 
 interface Props
   extends Pick<
@@ -24,7 +25,8 @@ export default function FeedbackListBulkSelection({
   selectedIds,
   deselectAll,
 }: Props) {
-  const {onToggleResovled, onMarkAsRead, onMarkUnread} = useBulkEditFeedbacks({
+  const organization = useOrganization();
+  const {onDelete, onToggleResolved, onMarkAsRead, onMarkUnread} = useBulkEditFeedbacks({
     selectedIds,
     deselectAll,
   });
@@ -36,6 +38,10 @@ export default function FeedbackListBulkSelection({
   const newMailboxSpam =
     mailbox === 'ignored' ? GroupStatus.UNRESOLVED : GroupStatus.IGNORED;
 
+  const hasDelete =
+    organization.access.includes('event:admin') &&
+    organization.features.includes('issue-platform-deletion-ui');
+
   return (
     <Flex gap={space(1)} align="center" justify="space-between" flex="1 0 auto">
       <span>
@@ -46,10 +52,17 @@ export default function FeedbackListBulkSelection({
         </strong>
       </span>
       <Flex gap={space(1)} justify="flex-end">
+        {selectedIds !== 'all' && (
+          <ErrorBoundary mini>
+            <Button size="xs" onClick={onDelete} disabled={!hasDelete}>
+              {t('Delete')}
+            </Button>
+          </ErrorBoundary>
+        )}
         <ErrorBoundary mini>
           <Button
             size="xs"
-            onClick={() => onToggleResovled({newMailbox: newMailboxResolve})}
+            onClick={() => onToggleResolved({newMailbox: newMailboxResolve})}
           >
             {mailbox === 'resolved' ? t('Unresolve') : t('Resolve')}
           </Button>
@@ -58,7 +71,7 @@ export default function FeedbackListBulkSelection({
           <Button
             size="xs"
             onClick={() =>
-              onToggleResovled({
+              onToggleResolved({
                 newMailbox: newMailboxSpam,
                 moveToInbox: mailbox === 'ignored',
               })

--- a/static/app/components/feedback/list/feedbackListBulkSelection.tsx
+++ b/static/app/components/feedback/list/feedbackListBulkSelection.tsx
@@ -39,8 +39,8 @@ export default function FeedbackListBulkSelection({
     mailbox === 'ignored' ? GroupStatus.UNRESOLVED : GroupStatus.IGNORED;
 
   const hasDelete =
-    organization.access.includes('event:admin') &&
-    organization.features.includes('issue-platform-deletion-ui');
+    organization.features.includes('issue-platform-deletion-ui') && selectedIds !== 'all';
+  const disableDelete = !organization.access.includes('event:admin');
 
   return (
     <Flex gap={space(1)} align="center" justify="space-between" flex="1 0 auto">
@@ -52,13 +52,6 @@ export default function FeedbackListBulkSelection({
         </strong>
       </span>
       <Flex gap={space(1)} justify="flex-end">
-        {selectedIds !== 'all' && (
-          <ErrorBoundary mini>
-            <Button size="xs" onClick={onDelete} disabled={!hasDelete}>
-              {t('Delete')}
-            </Button>
-          </ErrorBoundary>
-        )}
         <ErrorBoundary mini>
           <Button
             size="xs"
@@ -99,6 +92,14 @@ export default function FeedbackListBulkSelection({
                 key: 'mark unread',
                 label: t('Mark Unread'),
                 onAction: onMarkUnread,
+              },
+              {
+                key: 'delete',
+                priority: 'danger' as const,
+                label: t('Delete'),
+                hidden: !hasDelete,
+                disabled: disableDelete,
+                onAction: onDelete,
               },
             ]}
           />

--- a/static/app/components/feedback/list/useBulkEditFeedbacks.tsx
+++ b/static/app/components/feedback/list/useBulkEditFeedbacks.tsx
@@ -7,6 +7,7 @@ import {
 } from 'sentry/actionCreators/indicator';
 import {openConfirmModal} from 'sentry/components/confirm';
 import type useListItemCheckboxState from 'sentry/components/feedback/list/useListItemCheckboxState';
+import {useDeleteFeedback} from 'sentry/components/feedback/useDeleteFeedback';
 import useMutateFeedback from 'sentry/components/feedback/useMutateFeedback';
 import {t, tct} from 'sentry/locale';
 import {GroupStatus} from 'sentry/types/group';
@@ -45,8 +46,13 @@ export default function useBulkEditFeedbacks({deselectAll, selectedIds}: Props) 
     organization,
     projectIds: queryView.project,
   });
+  const deleteFeedback = useDeleteFeedback(selectedIds, queryView.project);
 
-  const onToggleResovled = useCallback(
+  const onDelete = () => {
+    deleteFeedback();
+  };
+
+  const onToggleResolved = useCallback(
     ({newMailbox, moveToInbox}: {newMailbox: GroupStatus; moveToInbox?: boolean}) => {
       openConfirmModal({
         bypass: Array.isArray(selectedIds) && selectedIds.length === 1,
@@ -125,7 +131,8 @@ export default function useBulkEditFeedbacks({deselectAll, selectedIds}: Props) 
   );
 
   return {
-    onToggleResovled,
+    onDelete,
+    onToggleResolved,
     onMarkAsRead,
     onMarkUnread,
   };

--- a/static/app/components/feedback/list/useBulkEditFeedbacks.tsx
+++ b/static/app/components/feedback/list/useBulkEditFeedbacks.tsx
@@ -48,9 +48,7 @@ export default function useBulkEditFeedbacks({deselectAll, selectedIds}: Props) 
   });
   const deleteFeedback = useDeleteFeedback(selectedIds, queryView.project);
 
-  const onDelete = () => {
-    deleteFeedback();
-  };
+  const onDelete = deleteFeedback;
 
   const onToggleResolved = useCallback(
     ({newMailbox, moveToInbox}: {newMailbox: GroupStatus; moveToInbox?: boolean}) => {

--- a/static/app/components/feedback/useDeleteFeedback.tsx
+++ b/static/app/components/feedback/useDeleteFeedback.tsx
@@ -47,7 +47,7 @@ export const useDeleteFeedback = (feedbackIds, projectId) => {
         );
       },
       message: t('Deleting feedbacks is permanent. Are you sure you wish to continue?'),
-      confirmText: 'Delete',
+      confirmText: t('Delete'),
     });
   }, [api, feedbackIds, locationQuery, navigate, organization.slug, projectId]);
 };

--- a/static/app/components/feedback/useDeleteFeedback.tsx
+++ b/static/app/components/feedback/useDeleteFeedback.tsx
@@ -1,0 +1,53 @@
+import {useCallback} from 'react';
+
+import {bulkDelete} from 'sentry/actionCreators/group';
+import {addLoadingMessage} from 'sentry/actionCreators/indicator';
+import {openConfirmModal} from 'sentry/components/confirm';
+import {t} from 'sentry/locale';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import useApi from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export const useDeleteFeedback = (feedbackIds, projectId) => {
+  const organization = useOrganization();
+  const api = useApi({
+    persistInFlight: false,
+  });
+  const navigate = useNavigate();
+  const {query: locationQuery} = useLocation();
+
+  return useCallback(() => {
+    openConfirmModal({
+      onConfirm: () => {
+        addLoadingMessage(t('Updating feedback...'));
+        bulkDelete(
+          api,
+          {
+            orgId: organization.slug,
+            projectId: projectId,
+            itemIds: feedbackIds,
+          },
+          {
+            complete: () => {
+              navigate(
+                normalizeUrl({
+                  pathname: '/feedback/',
+                  query: {
+                    mailbox: locationQuery.mailbox,
+                    project: locationQuery.project,
+                    query: locationQuery.query,
+                    statsPeriod: locationQuery.statsPeriod,
+                  },
+                })
+              );
+            },
+          }
+        );
+      },
+      message: t('Deleting feedbacks is permanent. Are you sure you wish to continue?'),
+      confirmText: 'Delete',
+    });
+  }, [api, feedbackIds, locationQuery, navigate, organization.slug, projectId]);
+};


### PR DESCRIPTION
Adds ability to delete feedbacks.

Delete button added on feedback items page and bulk edit
<img width="1466" alt="Screenshot 2024-10-09 at 11 31 37 AM" src="https://github.com/user-attachments/assets/0a4119a6-3a71-4369-9db6-d69cedadc9e1">

Delete button disappears when selecting all because we don't want users to delete all feedbacks
<img width="517" alt="image" src="https://github.com/user-attachments/assets/6dc0397c-a570-4119-ad8b-16001e986f77">
