### PR TITLE
fix(insights): DB domain & action dropdown empty options

### DIFF
--- a/static/app/views/insights/common/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/actionSelector.tsx
@@ -72,7 +72,7 @@ export function ActionSelector({value = '', moduleName, spanCategory, filters}: 
       ];
 
   // The empty option is not necessary for MongoDB, since all queries will have a command
-  if (filters && filters['span.system'] === SupportedDatabaseSystem.MONGODB) {
+  if (filters?.['span.system'] === SupportedDatabaseSystem.MONGODB) {
     options.pop();
   }
 

--- a/static/app/views/insights/common/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/actionSelector.tsx
@@ -15,6 +15,7 @@ import {useSpansQuery} from 'sentry/views/insights/common/queries/useSpansQuery'
 import {buildEventViewQuery} from 'sentry/views/insights/common/utils/buildEventViewQuery';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {EmptyContainer} from 'sentry/views/insights/common/views/spans/selectors/emptyOption';
+import {SupportedDatabaseSystem} from 'sentry/views/insights/database/utils/constants';
 import {ModuleName, SpanMetricsField} from 'sentry/views/insights/types';
 
 const {SPAN_ACTION} = SpanMetricsField;
@@ -69,6 +70,11 @@ export function ActionSelector({value = '', moduleName, spanCategory, filters}: 
           ),
         },
       ];
+
+  // The empty option is not necessary for MongoDB, since all queries will have a command
+  if (filters && filters['span.system'] === SupportedDatabaseSystem.MONGODB) {
+    options.pop();
+  }
 
   return (
     <CompactSelect

--- a/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
@@ -94,12 +94,15 @@ export function DomainSelector({
 
   const {options: domainOptions, clear: clearDomainOptionsCache} =
     useCompactSelectOptionsCache(
-      incomingDomains.filter(Boolean).map(datum => {
-        return {
-          value: datum,
-          label: datum,
-        };
-      })
+      incomingDomains
+        .filter(Boolean)
+        .filter(domain => domain !== '(empty)')
+        .map(datum => {
+          return {
+            value: datum,
+            label: datum,
+          };
+        })
     );
 
   useEffect(() => {

--- a/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
@@ -96,7 +96,7 @@ export function DomainSelector({
     useCompactSelectOptionsCache(
       incomingDomains
         .filter(Boolean)
-        .filter(domain => domain !== '(empty)')
+        .filter(domain => domain !== EMPTY_OPTION_VALUE)
         .map(datum => {
           return {
             value: datum,


### PR DESCRIPTION
- The `(No Command)` option has been removed specifically for MongoDB, since MongoDB queries cannot have no command
- We were adding `(empty)` as an extra option in the domain selector (also in the Assets module) because the backend returns this, but we also manually append it in the component. Now we filter out this option so there is no redundancy