### PR TITLE
fix(flags): Catch and suppress silo limit errors

### DIFF
--- a/src/sentry/flags/providers.py
+++ b/src/sentry/flags/providers.py
@@ -2,10 +2,14 @@ import datetime
 from typing import Any, TypedDict
 
 from sentry.flags.models import ACTION_MAP, CREATED_BY_TYPE_MAP, FlagAuditLogModel
+from sentry.silo.base import SiloLimit
 
 
 def write(rows: list["FlagAuditLogRow"]) -> None:
-    FlagAuditLogModel.objects.bulk_create(FlagAuditLogModel(**row) for row in rows)
+    try:
+        FlagAuditLogModel.objects.bulk_create(FlagAuditLogModel(**row) for row in rows)
+    except SiloLimit.AvailabilityError:
+        pass
 
 
 """Provider definitions.


### PR DESCRIPTION
We only want to write logs when the control region is updated.