### PR TITLE
fix(discover): Add `"platform"` to list of known Discover fields

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1742,6 +1742,7 @@ export const DISCOVER_FIELDS = [
   FieldKey.CULPRIT,
   FieldKey.LOCATION,
   FieldKey.MESSAGE,
+  FieldKey.PLATFORM,
   FieldKey.PLATFORM_NAME,
   FieldKey.ENVIRONMENT,
   FieldKey.RELEASE,

--- a/static/app/views/discover/utils.spec.tsx
+++ b/static/app/views/discover/utils.spec.tsx
@@ -873,4 +873,36 @@ describe('generateFieldOptions', function () {
       },
     });
   });
+
+  it('disambiguates tags that are also fields', function () {
+    expect(
+      generateFieldOptions({
+        organization: initializeOrg().organization,
+        tagKeys: ['environment'],
+        fieldKeys: ['environment'],
+        aggregations: {},
+      })
+    ).toEqual({
+      'field:environment': {
+        label: 'environment',
+        value: {
+          kind: 'field',
+          meta: {
+            dataType: 'string',
+            name: 'environment',
+          },
+        },
+      },
+      'tag:environment': {
+        label: 'environment',
+        value: {
+          kind: 'tag',
+          meta: {
+            dataType: 'string',
+            name: 'tags[environment]',
+          },
+        },
+      },
+    });
+  });
 });


### PR DESCRIPTION
This fixes a small bug related to another ongoing UI problem.

The symptoms are somewhat complicated.

- A customer creates a tag called `"platform"`
- Sentry has a built-in field called `"platform"`
- The customer opens Discover and adds `"platform (tag)"` to the columns
- The application puts `&field=platform` in the URL
- Discover resolves `platform` to the built-in field

The filter doesn't work, it's not filtering on the tag! We should have put `&field=tags[platform]` in the URL

This works for other fields like `"environment"` because they're added to the hard-coded list of known fields. `"platform"` was missing from that list, so the disambiguation wasn't working.

Adding to the list, and adding a little spec to test this behaviour.
