### PR TITLE
ref(toolbar): Refactor is_origin_allowed so we only parse the url once

### DIFF
--- a/src/sentry/toolbar/views/iframe_view.py
+++ b/src/sentry/toolbar/views/iframe_view.py
@@ -4,7 +4,7 @@ from django.http import HttpRequest, HttpResponse
 
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.toolbar.utils.url import check_origin
+from sentry.toolbar.utils.url import is_origin_allowed
 from sentry.web.frontend.base import OrganizationView, region_silo_view
 
 REFERRER_HEADER = "HTTP_REFERER"  # 1 R is the spelling used here: https://docs.djangoproject.com/en/5.1/ref/request-response/
@@ -59,7 +59,7 @@ class IframeView(OrganizationView):
             )
 
         allowed_origins: list[str] = project.get_option("sentry:toolbar_allowed_origins")
-        origin_allowed, info_msg = check_origin(referrer, allowed_origins)
+        origin_allowed = is_origin_allowed(referrer, allowed_origins)
         if not origin_allowed:
             return self.respond(
                 INVALID_TEMPLATE,

--- a/tests/sentry/toolbar/utils/test_url.py
+++ b/tests/sentry/toolbar/utils/test_url.py
@@ -1,29 +1,53 @@
-from sentry.toolbar.utils.url import url_matches
+from urllib.parse import urlparse
+
+from sentry.toolbar.utils.url import is_origin_allowed, url_matches
 
 
 def test_url_matches_basic():
-    assert url_matches("http://abc.net", "http://abc.net")
-    assert not url_matches("http://pocketpair.io", "http://sentry.io")
-    assert url_matches("http://sentry.io/issues/", "http://sentry.io")
-    assert url_matches("http://sentry.io", "http://sentry.io/issues/")
-    assert not url_matches("https://cmu.edu", "https://cmu.com")
-    assert url_matches("https://youtube.com:443/watch?v=3xhb", "https://youtube.com/profile")
+    assert url_matches(urlparse("http://abc.net"), "http://abc.net")
+    assert not url_matches(urlparse("http://pocketpair.io"), "http://sentry.io")
+    assert url_matches(urlparse("http://sentry.io/issues/"), "http://sentry.io")
+    assert url_matches(urlparse("http://sentry.io"), "http://sentry.io/issues/")
+    assert not url_matches(urlparse("https://cmu.edu"), "https://cmu.com")
+    assert url_matches(
+        urlparse("https://youtube.com:443/watch?v=3xhb"), "https://youtube.com/profile"
+    )
 
 
 def test_url_matches_wildcard():
-    assert url_matches("https://nugettrends.sentry.io", "https://*.sentry.io")
-    assert not url_matches("https://nugettrends.sentry.com", "https://*.sentry.io")
-    assert not url_matches("https://nugettrends.sentry.io", "https://*.io")
-    assert not url_matches("https://sentry.io", "https://*.sentry.io")
+    assert url_matches(urlparse("https://nugettrends.sentry.io"), "https://*.sentry.io")
+    assert not url_matches(urlparse("https://nugettrends.sentry.com"), "https://*.sentry.io")
+    assert not url_matches(urlparse("https://nugettrends.sentry.io"), "https://*.io")
+    assert not url_matches(urlparse("https://sentry.io"), "https://*.sentry.io")
 
 
 def test_url_matches_port():
-    assert url_matches("https://sentry.io:42", "https://sentry.io:42")
-    assert not url_matches("https://sentry.io", "https://sentry.io:42")
-    assert url_matches("https://sentry.io:42", "https://sentry.io")
+    assert url_matches(urlparse("https://sentry.io:42"), "https://sentry.io:42")
+    assert not url_matches(urlparse("https://sentry.io"), "https://sentry.io:42")
+    assert url_matches(urlparse("https://sentry.io:42"), "https://sentry.io")
 
 
 def test_url_matches_scheme():
-    assert url_matches("https://sentry.io", "sentry.io")
-    assert url_matches("http://sentry.io", "sentry.io")
-    assert not url_matches("http://sentry.io", "https://sentry.io")
+    assert url_matches(urlparse("https://sentry.io"), "sentry.io")
+    assert url_matches(urlparse("http://sentry.io"), "sentry.io")
+    assert not url_matches(urlparse("http://sentry.io"), "https://sentry.io")
+
+
+def test_url_is_empty():
+    assert not url_matches(urlparse(""), "sentry.io")
+
+
+def test_is_origin_allowed_allows_some():
+    assert is_origin_allowed("http://sentry.io", ["http://abc.net", "http://sentry.io"])
+
+
+def test_is_origin_allowed_rejects_all():
+    assert not is_origin_allowed("http://sentry.io", ["http://abc.net", "http://xyz.net"])
+
+
+def test_is_origin_allowed_rejects_empty():
+    assert not is_origin_allowed("", ["http://abc.net", "http://xyz.net"])
+
+
+def test_is_origin_allowed_prepends_http():
+    assert is_origin_allowed("sentry.io", ["http://abc.net", "http://sentry.io"])


### PR DESCRIPTION
Quick refactor to add missing tests for `is_origin_allowed` and move the statement that parses the url outside of the loop.