### PR TITLE
fix(replays): Use sigmoid_delay for GCS retries

### DIFF
--- a/tests/sentry/replays/unit/test_retry.py
+++ b/tests/sentry/replays/unit/test_retry.py
@@ -1,0 +1,10 @@
+from sentry.utils.retries import sigmoid_delay
+
+
+def test_sigmoid_delay():
+    results = [sigmoid_delay()(i) for i in range(125)]
+    assert results[0] == 0.0066928509242848554
+    assert results[5] == 0.5
+    assert results[10] == 0.9933071490757153
+    assert results[124] == 1
+    assert sum(results) == 119.4960857616948  # Max two minute sleep.


### PR DESCRIPTION
Fixes intermittent deploy failures when our consumer blows up thanks to Google.