### PR TITLE
chore(invite-members): add logging for new invite modal

### DIFF
--- a/static/app/components/modals/inviteMembersModal/useInviteModal.tsx
+++ b/static/app/components/modals/inviteMembersModal/useInviteModal.tsx
@@ -181,19 +181,10 @@ export default function useInviteModal({organization, initialData, source}: Prop
     });
   }, []);
 
-  const statuses = useMemo(() => {
-    return Object.values(state.inviteStatus) as InviteStatus[];
-  }, [state.inviteStatus]);
-
-  const sentCount = useMemo(() => {
-    return statuses.filter(i => i.sent).length;
-  }, [statuses]);
-
-  const errorCount = useMemo(() => {
-    return statuses.filter(i => i.error).length;
-  }, [statuses]);
-
   useEffect(() => {
+    const statuses = Object.values(state.inviteStatus) as InviteStatus[];
+    const sentCount = statuses.filter(i => i.sent).length;
+    const errorCount = statuses.filter(i => i.error).length;
     // Don't track if no invites have been sent or invites are still sending
     if ((sentCount === 0 && errorCount === 0) || state.sendingInvites) {
       return;
@@ -208,7 +199,7 @@ export default function useInviteModal({organization, initialData, source}: Prop
         is_new_modal: organization.features.includes('invite-members-new-modal'),
       }
     );
-  }, [organization, sentCount, errorCount, state.sendingInvites, willInvite]);
+  }, [organization, state.inviteStatus, state.sendingInvites, willInvite]);
 
   const sendInvites = useCallback(async () => {
     setState(prev => ({...prev, sendingInvites: true}));

--- a/static/app/components/modals/inviteMembersModal/useInviteModal.tsx
+++ b/static/app/components/modals/inviteMembersModal/useInviteModal.tsx
@@ -194,6 +194,7 @@ export default function useInviteModal({organization, initialData, source}: Prop
       {
         organization,
         modal_session: sessionId.current,
+        is_new_modal: organization.features.includes('invite-members-new-modal'),
       }
     );
   }, [organization, invites, sendInvite, willInvite, removeSentInvites]);

--- a/static/app/components/modals/inviteMembersModal/useInviteModal.tsx
+++ b/static/app/components/modals/inviteMembersModal/useInviteModal.tsx
@@ -96,6 +96,16 @@ export default function useInviteModal({organization, initialData, source}: Prop
     );
   }, [state.pendingInvites]);
 
+  const sentCount = useMemo(() => {
+    const statuses = Object.values(state.inviteStatus) as InviteStatus[];
+    return statuses.filter(i => i.sent).length;
+  }, [state.inviteStatus]);
+
+  const errorCount = useMemo(() => {
+    const statuses = Object.values(state.inviteStatus) as InviteStatus[];
+    return statuses.filter(i => i.error).length;
+  }, [state.inviteStatus]);
+
   const reset = useCallback(() => {
     setState({
       pendingInvites: [defaultInvite()],
@@ -194,10 +204,20 @@ export default function useInviteModal({organization, initialData, source}: Prop
       {
         organization,
         modal_session: sessionId.current,
+        sent_invites: sentCount,
+        failed_invites: errorCount,
         is_new_modal: organization.features.includes('invite-members-new-modal'),
       }
     );
-  }, [organization, invites, sendInvite, willInvite, removeSentInvites]);
+  }, [
+    organization,
+    invites,
+    sentCount,
+    errorCount,
+    sendInvite,
+    willInvite,
+    removeSentInvites,
+  ]);
 
   const addInviteRow = useCallback(() => {
     setState(prev => ({

--- a/static/app/utils/analytics/growthAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/growthAnalyticsEvents.tsx
@@ -119,7 +119,9 @@ export type GrowthEventParameters = {
   'growth.submitted_mobile_prompt_ask_teammate': MobilePromptBannerParams;
   'invite_modal.add_more': InviteModal;
   'invite_modal.closed': InviteModal;
-  'invite_modal.invites_sent': InviteModal;
+  'invite_modal.invites_sent': InviteModal & {
+    is_new_modal: boolean;
+  };
   'invite_modal.opened': InviteModal & {
     can_invite: boolean;
     source?: string;

--- a/static/app/utils/analytics/growthAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/growthAnalyticsEvents.tsx
@@ -120,7 +120,9 @@ export type GrowthEventParameters = {
   'invite_modal.add_more': InviteModal;
   'invite_modal.closed': InviteModal;
   'invite_modal.invites_sent': InviteModal & {
+    failed_invites: number;
     is_new_modal: boolean;
+    sent_invites: number;
   };
   'invite_modal.opened': InviteModal & {
     can_invite: boolean;


### PR DESCRIPTION
we want to add logging to be able to tell how many Send button clicks came from the new invite modal vs. the old design

this will help us later with calculating the average number of invites sent per button click