### PR TITLE
ref: black 24.x manual forward compatibility

### DIFF
--- a/src/sentry/models/files/abstractfile.py
+++ b/src/sentry/models/files/abstractfile.py
@@ -204,7 +204,7 @@ if TYPE_CHECKING:
     # Django doesn't permit models to have parent classes that are Generic
     # this kludge lets satisfy both mypy and django
     class _Parent(Generic[BlobIndexType, BlobType]):
-        ...
+        pass
 
 else:
 

--- a/src/sentry/models/files/abstractfileblob.py
+++ b/src/sentry/models/files/abstractfileblob.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     # Django doesn't permit models to have parent classes that are Generic
     # this kludge lets satisfy both mypy and django
     class _Parent(Generic[BlobOwnerType]):
-        ...
+        pass
 
 else:
 

--- a/src/sentry/replays/consumers/recording_buffered.py
+++ b/src/sentry/replays/consumers/recording_buffered.py
@@ -101,7 +101,7 @@ def cast_payload_from_bytes(x: bytes) -> Any:
 
 
 class BufferCommitFailed(Exception):
-    ...
+    pass
 
 
 class RecordingBufferedStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):

--- a/src/sentry/replays/lib/http.py
+++ b/src/sentry/replays/lib/http.py
@@ -4,11 +4,11 @@ from typing import Protocol
 
 
 class MalformedRangeHeader(Exception):
-    ...
+    pass
 
 
 class UnsatisfiableRange(Exception):
-    ...
+    pass
 
 
 class RangeProtocol(Protocol):

--- a/src/sentry/snuba/metrics/mqb_query_transformer.py
+++ b/src/sentry/snuba/metrics/mqb_query_transformer.py
@@ -22,7 +22,7 @@ TEAM_KEY_TRANSACTION_OP = "team_key_transaction"
 
 
 class MQBQueryTransformationException(Exception):
-    ...
+    pass
 
 
 def _get_derived_op_metric_field_from_snuba_function(function: Function):

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -431,27 +431,27 @@ def combine_dictionary_of_list_values(main_dict, other_dict):
 
 
 class MetricDoesNotExistException(Exception):
-    ...
+    pass
 
 
 class MetricDoesNotExistInIndexer(Exception):
-    ...
+    pass
 
 
 class DerivedMetricException(Exception, ABC):
-    ...
+    pass
 
 
 class DerivedMetricParseException(DerivedMetricException):
-    ...
+    pass
 
 
 class NotSupportedOverCompositeEntityException(DerivedMetricException):
-    ...
+    pass
 
 
 class OrderByNotSupportedOverCompositeEntityException(NotSupportedOverCompositeEntityException):
-    ...
+    pass
 
 
 @overload

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -578,7 +578,7 @@ class SetCommitsTestCase(TestCase):
 
 @apply_feature_flag_on_cls("organizations:set-commits-updated")
 class SetCommitsTestUpdated(SetCommitsTestCase):
-    ...
+    pass
 
 
 class SetRefsTest(SetRefsTestCase):

--- a/tests/sentry/tasks/test_commits.py
+++ b/tests/sentry/tasks/test_commits.py
@@ -291,7 +291,7 @@ class FetchCommitsTest(TestCase):
 
 @apply_feature_flag_on_cls("organizations:set-commits-updated")
 class FetchCommitsTestUpdated(FetchCommitsTest):
-    ...
+    pass
 
 
 @control_silo_test


### PR DESCRIPTION
fixes flake8 errors when reformatted by black 24.x

`: ...` generally means "stubbed out" and is intended for typing overloads -- for real classes `: pass` makes more sense.  pycodestyle and black disagree on the formatting for "stubbed classes" (pycodestyle has a specialization for stubbed functions but not classes)

<!-- Describe your PR here. -->