### PR TITLE
feat(insights): hide module tabs if feature disabled

### DIFF
--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -6,13 +6,15 @@ import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidg
 import * as Layout from 'sentry/components/layouts/thirds';
 import {TabList, Tabs} from 'sentry/components/tabs';
 import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
 import {
   type RoutableModuleNames,
   useModuleURLBuilder,
 } from 'sentry/views/insights/common/utils/useModuleURL';
 import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
-import {MODULE_TITLES} from 'sentry/views/insights/settings';
+import {MODULE_FEATURE_MAP, MODULE_TITLES} from 'sentry/views/insights/settings';
 import type {ModuleName} from 'sentry/views/insights/types';
 
 type Props = {
@@ -42,6 +44,7 @@ export function DomainViewHeader({
   tabs,
 }: Props) {
   const navigate = useNavigate();
+  const organization = useOrganization();
   const moduleURLBuilder = useModuleURLBuilder();
 
   const baseCrumbs: Crumb[] = [
@@ -62,6 +65,8 @@ export function DomainViewHeader({
     },
     ...additionalBreadCrumbs,
   ];
+
+  const filteredModules = filterEnabledModules(modules, organization);
 
   const defaultHandleTabChange = (key: ModuleName | typeof OVERVIEW_PAGE_TITLE) => {
     if (key === selectedModule || (key === OVERVIEW_PAGE_TITLE && !module)) {
@@ -88,7 +93,10 @@ export function DomainViewHeader({
       key: OVERVIEW_PAGE_TITLE,
       label: OVERVIEW_PAGE_TITLE,
     },
-    ...modules.map(moduleName => ({key: moduleName, label: MODULE_TITLES[moduleName]})),
+    ...filteredModules.map(moduleName => ({
+      key: moduleName,
+      label: MODULE_TITLES[moduleName],
+    })),
   ];
 
   return (
@@ -119,3 +127,13 @@ export function DomainViewHeader({
     </Fragment>
   );
 }
+
+const filterEnabledModules = (modules: ModuleName[], organization: Organization) => {
+  return modules.filter(module => {
+    const moduleFeatures = MODULE_FEATURE_MAP[module];
+    if (!moduleFeatures) {
+      return false;
+    }
+    return moduleFeatures.every(feature => organization.features.includes(feature));
+  });
+};

--- a/static/app/views/insights/settings.ts
+++ b/static/app/views/insights/settings.ts
@@ -51,6 +51,7 @@ import {
   DATA_TYPE as MOBILE_SCREENS_DATA_TYPE,
   DATA_TYPE_PLURAL as MOBILE_SCREENS_DATA_TYPE_PLURAL,
   MODULE_DOC_LINK as MODULE_SCREENS_DOC_LINK,
+  MODULE_FEATURE as MOBILE_SCREENS_MODULE_FEATURE,
   MODULE_TITLE as MOBILE_SCREENS_MODULE_TITLE,
 } from 'sentry/views/insights/mobile/screens/settings';
 import {
@@ -128,4 +129,18 @@ export const MODULE_PRODUCT_DOC_LINKS: Record<ModuleName, string> = {
   [ModuleName.MOBILE_UI]: MODULE_UI_DOC_LINK,
   [ModuleName.MOBILE_SCREENS]: MODULE_SCREENS_DOC_LINK,
   [ModuleName.OTHER]: '',
+};
+
+export const MODULE_FEATURE_MAP: Partial<Record<ModuleName, string[]>> = {
+  [ModuleName.DB]: ['insights-initial-modules'],
+  [ModuleName.APP_START]: ['insights-initial-modules'],
+  [ModuleName.HTTP]: ['insights-initial-modules'],
+  [ModuleName.RESOURCE]: ['insights-initial-modules'],
+  [ModuleName.VITAL]: ['insights-initial-modules'],
+  [ModuleName.CACHE]: ['insights-addon-modules'],
+  [ModuleName.QUEUE]: ['insights-addon-modules'],
+  [ModuleName.AI]: ['insights-addon-modules'],
+  [ModuleName.SCREEN_LOAD]: ['insights-initial-modules'],
+  [ModuleName.MOBILE_UI]: ['insights-addon-modules', 'starfish-mobile-ui-module'],
+  [ModuleName.MOBILE_SCREENS]: [MOBILE_SCREENS_MODULE_FEATURE],
 };


### PR DESCRIPTION
Work for https://github.com/getsentry/sentry/issues/77572
If the organization doesn't have the module feature, we will hide the tab. The main case for this is AM1, as they don't have insights at all.

This what we already to in the sidebar.