### PR TITLE
fix(ui): Add scroll overflow to crons service incident card

### DIFF
--- a/static/app/views/monitors/components/timeline/serviceIncidents.tsx
+++ b/static/app/views/monitors/components/timeline/serviceIncidents.tsx
@@ -118,6 +118,8 @@ function CronServiceIncidents({timeWindowConfig}: CronServiceIncidentsProps) {
 
 const IncidentHovercard = styled(Hovercard)`
   width: 400px;
+  max-height: 500px;
+  overflow-y: scroll;
 `;
 
 const IncidentOverlay = styled('div')`


### PR DESCRIPTION
Before

<img alt="clipboard.png" width="525" src="https://i.imgur.com/I1GEDXl.png" />

After

<img alt="clipboard.png" width="629" src="https://i.imgur.com/sedEq1A.png" />