### PR TITLE
fix(sentry_apps): dont pass in self 

### DIFF
--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -49,7 +49,7 @@ def process_resource_change_bound(
     self: Task, action: str, sender: str, instance_id: int, **kwargs: Any
 ) -> None:
     old_process_resource_change_bound(
-        self=self, action=action, sender=sender, instance_id=instance_id, **kwargs
+        action=action, sender=sender, instance_id=instance_id, **kwargs
     )
 
 


### PR DESCRIPTION
Task is not forward compatible/ will error as seen below :C . Because we're trying to pass in the caller to `self` & the receiving function is also trying to assign `self` to it's own instance. That alotta self :bufo-dizzy:

ref [error](https://sentry.sentry.io/issues/5964362225/?project=1)