### PR TITLE
feat(issue-stream): Update priority badge/selector

### DIFF
--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useMemo} from 'react';
 import type {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
+import {VisuallyHidden} from '@react-aria/visually-hidden';
 
 import bannerStar from 'sentry-images/spot/banner-star.svg';
 
@@ -114,13 +115,14 @@ export function GroupPriorityBadge({
 }: GroupPriorityBadgeProps) {
   const bars =
     priority === PriorityLevel.HIGH ? 3 : priority === PriorityLevel.MEDIUM ? 2 : 1;
+  const label = PRIORITY_KEY_TO_LABEL[priority] ?? t('Unknown');
 
   return (
     <StyledTag
       type={variant === 'signal' ? 'default' : getTagTypeForPriority(priority)}
       icon={variant === 'signal' && <IconCellSignal bars={bars} />}
     >
-      {(showLabel && PRIORITY_KEY_TO_LABEL[priority]) ?? t('Unknown')}
+      {showLabel ? label : <VisuallyHidden>{label}</VisuallyHidden>}
       {children}
     </StyledTag>
   );

--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -88,13 +88,20 @@ function useLastEditedBy({
 
 export function makeGroupPriorityDropdownOptions({
   onChange,
+  hasStreamlinedIssueStream,
 }: {
+  hasStreamlinedIssueStream: boolean;
   onChange: (value: PriorityLevel) => void;
 }) {
   return PRIORITY_OPTIONS.map(priority => ({
     textValue: PRIORITY_KEY_TO_LABEL[priority],
     key: priority,
-    label: <GroupPriorityBadge priority={priority} />,
+    label: (
+      <GroupPriorityBadge
+        variant={hasStreamlinedIssueStream ? 'streamlined' : 'default'}
+        priority={priority}
+      />
+    ),
     onAction: () => onChange(priority),
   }));
 }
@@ -201,14 +208,14 @@ export function GroupPriorityDropdown({
   onChange,
   lastEditedBy,
 }: GroupPriorityDropdownProps) {
-  const options: MenuItemProps[] = useMemo(
-    () => makeGroupPriorityDropdownOptions({onChange}),
-    [onChange]
-  );
-
   const organization = useOrganization();
   const hasStreamlinedIssueStream = organization.features.includes(
     'issue-stream-table-layout'
+  );
+
+  const options: MenuItemProps[] = useMemo(
+    () => makeGroupPriorityDropdownOptions({onChange, hasStreamlinedIssueStream}),
+    [onChange, hasStreamlinedIssueStream]
   );
 
   return (

--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -15,6 +15,7 @@ import HookOrDefault from 'sentry/components/hookOrDefault';
 import Placeholder from 'sentry/components/placeholder';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconClose} from 'sentry/icons';
+import {IconCellSignal} from 'sentry/icons/iconCellSignal';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Activity} from 'sentry/types/group';
@@ -34,6 +35,8 @@ type GroupPriorityDropdownProps = {
 type GroupPriorityBadgeProps = {
   priority: PriorityLevel;
   children?: React.ReactNode;
+  showLabel?: boolean;
+  variant?: 'default' | 'streamlined';
 };
 
 const PRIORITY_KEY_TO_LABEL: Record<PriorityLevel, string> = {
@@ -96,10 +99,21 @@ export function makeGroupPriorityDropdownOptions({
   }));
 }
 
-export function GroupPriorityBadge({priority, children}: GroupPriorityBadgeProps) {
+export function GroupPriorityBadge({
+  priority,
+  showLabel = true,
+  variant = 'default',
+  children,
+}: GroupPriorityBadgeProps) {
+  const bars =
+    priority === PriorityLevel.HIGH ? 3 : priority === PriorityLevel.MEDIUM ? 2 : 1;
+
   return (
-    <StyledTag type={getTagTypeForPriority(priority)}>
-      {PRIORITY_KEY_TO_LABEL[priority] ?? t('Unknown')}
+    <StyledTag
+      type={variant === 'streamlined' ? 'default' : getTagTypeForPriority(priority)}
+      icon={variant === 'streamlined' && <IconCellSignal bars={bars} />}
+    >
+      {(showLabel && PRIORITY_KEY_TO_LABEL[priority]) ?? t('Unknown')}
       {children}
     </StyledTag>
   );
@@ -192,6 +206,11 @@ export function GroupPriorityDropdown({
     [onChange]
   );
 
+  const organization = useOrganization();
+  const hasStreamlinedIssueStream = organization.features.includes(
+    'issue-stream-table-layout'
+  );
+
   return (
     <DropdownMenu
       size="sm"
@@ -207,7 +226,11 @@ export function GroupPriorityDropdown({
           aria-label={t('Modify issue priority')}
           size="zero"
         >
-          <GroupPriorityBadge priority={value}>
+          <GroupPriorityBadge
+            showLabel={!hasStreamlinedIssueStream}
+            variant={hasStreamlinedIssueStream ? 'streamlined' : 'default'}
+            priority={value}
+          >
             <Chevron light direction={isOpen ? 'up' : 'down'} size="small" />
           </GroupPriorityBadge>
         </DropdownButton>

--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -36,7 +36,7 @@ type GroupPriorityBadgeProps = {
   priority: PriorityLevel;
   children?: React.ReactNode;
   showLabel?: boolean;
-  variant?: 'default' | 'streamlined';
+  variant?: 'default' | 'signal';
 };
 
 const PRIORITY_KEY_TO_LABEL: Record<PriorityLevel, string> = {
@@ -88,9 +88,9 @@ function useLastEditedBy({
 
 export function makeGroupPriorityDropdownOptions({
   onChange,
-  hasStreamlinedIssueStream,
+  hasIssueStreamTableLayout,
 }: {
-  hasStreamlinedIssueStream: boolean;
+  hasIssueStreamTableLayout: boolean;
   onChange: (value: PriorityLevel) => void;
 }) {
   return PRIORITY_OPTIONS.map(priority => ({
@@ -98,7 +98,7 @@ export function makeGroupPriorityDropdownOptions({
     key: priority,
     label: (
       <GroupPriorityBadge
-        variant={hasStreamlinedIssueStream ? 'streamlined' : 'default'}
+        variant={hasIssueStreamTableLayout ? 'signal' : 'default'}
         priority={priority}
       />
     ),
@@ -117,8 +117,8 @@ export function GroupPriorityBadge({
 
   return (
     <StyledTag
-      type={variant === 'streamlined' ? 'default' : getTagTypeForPriority(priority)}
-      icon={variant === 'streamlined' && <IconCellSignal bars={bars} />}
+      type={variant === 'signal' ? 'default' : getTagTypeForPriority(priority)}
+      icon={variant === 'signal' && <IconCellSignal bars={bars} />}
     >
       {(showLabel && PRIORITY_KEY_TO_LABEL[priority]) ?? t('Unknown')}
       {children}
@@ -209,13 +209,13 @@ export function GroupPriorityDropdown({
   lastEditedBy,
 }: GroupPriorityDropdownProps) {
   const organization = useOrganization();
-  const hasStreamlinedIssueStream = organization.features.includes(
+  const hasIssueStreamTableLayout = organization.features.includes(
     'issue-stream-table-layout'
   );
 
   const options: MenuItemProps[] = useMemo(
-    () => makeGroupPriorityDropdownOptions({onChange, hasStreamlinedIssueStream}),
-    [onChange, hasStreamlinedIssueStream]
+    () => makeGroupPriorityDropdownOptions({onChange, hasIssueStreamTableLayout}),
+    [onChange, hasIssueStreamTableLayout]
   );
 
   return (
@@ -234,8 +234,8 @@ export function GroupPriorityDropdown({
           size="zero"
         >
           <GroupPriorityBadge
-            showLabel={!hasStreamlinedIssueStream}
-            variant={hasStreamlinedIssueStream ? 'streamlined' : 'default'}
+            showLabel={!hasIssueStreamTableLayout}
+            variant={hasIssueStreamTableLayout ? 'signal' : 'default'}
             priority={value}
           >
             <Chevron light direction={isOpen ? 'up' : 'down'} size="small" />

--- a/static/app/icons/iconCellSignal.tsx
+++ b/static/app/icons/iconCellSignal.tsx
@@ -1,0 +1,26 @@
+import {forwardRef} from 'react';
+import {useTheme} from '@emotion/react';
+
+import {SvgIcon, type SVGIconProps} from 'sentry/icons/svgIcon';
+
+interface Props extends SVGIconProps {
+  bars?: 0 | 1 | 2 | 3;
+}
+const IconCellSignal = forwardRef<SVGSVGElement, Props>(({bars = 3, ...props}, ref) => {
+  const theme = useTheme();
+  const firstBarColor = bars > 0 ? theme.gray300 : theme.gray100;
+  const secondBarColor = bars > 1 ? theme.gray300 : theme.gray100;
+  const thirdBarColor = bars > 2 ? theme.gray300 : theme.gray100;
+
+  return (
+    <SvgIcon {...props} ref={ref}>
+      <rect x="0" y="10" width="4" height="5" fill={firstBarColor} rx="1" />
+      <rect x="6.2" y="5" width="4" height="10" fill={secondBarColor} rx="1" />
+      <rect x="12.4" y="0" width="4" height="15" fill={thirdBarColor} rx="1" />
+    </SvgIcon>
+  );
+});
+
+IconCellSignal.displayName = 'IconCellSignal';
+
+export {IconCellSignal};

--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -234,7 +234,7 @@ function ActionSet({
               confirmText: label('reprioritize'),
             });
           },
-          hasStreamlinedIssueStream: organization.features.includes(
+          hasIssueStreamTableLayout: organization.features.includes(
             'issue-stream-table-layout'
           ),
         })}

--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -13,6 +13,7 @@ import type {BaseGroup} from 'sentry/types/group';
 import {GroupStatus} from 'sentry/types/group';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import type {IssueTypeConfig} from 'sentry/utils/issueTypeConfig/types';
+import useOrganization from 'sentry/utils/useOrganization';
 import type {IssueUpdateData} from 'sentry/views/issueList/types';
 import {FOR_REVIEW_QUERIES} from 'sentry/views/issueList/utils';
 
@@ -47,6 +48,7 @@ function ActionSet({
   onMerge,
   selectedProjectSlug,
 }: Props) {
+  const organization = useOrganization();
   const numIssues = issues.size;
   const confirm = getConfirm({
     numIssues,
@@ -232,6 +234,9 @@ function ActionSet({
               confirmText: label('reprioritize'),
             });
           },
+          hasStreamlinedIssueStream: organization.features.includes(
+            'issue-stream-table-layout'
+          ),
         })}
       />
       {!nestReview && <ReviewAction disabled={!canMarkReviewed} onUpdate={onUpdate} />}


### PR DESCRIPTION
closes #77819

Creates the new design for the issue priority badge under the `variant` prop within the `<GroupPriorityBadge/>` component. This design is currently under a feature flag, so it is not visible. 

Demo with flag manually set to true: 

https://github.com/user-attachments/assets/d6f388a7-7c21-498c-afd2-7fc2f6faef23

