### PR TITLE
fix(discord): ensure guild_id is numeric

### DIFF
--- a/src/sentry/integrations/discord/integration.py
+++ b/src/sentry/integrations/discord/integration.py
@@ -148,6 +148,12 @@ class DiscordIntegrationProvider(IntegrationProvider):
 
     def build_integration(self, state: Mapping[str, object]) -> Mapping[str, object]:
         guild_id = str(state.get("guild_id"))
+
+        if not guild_id.isdigit():
+            raise IntegrationError(
+                "Invalid guild ID. The Discord guild ID must be entirely numeric."
+            )
+
         try:
             guild_name = self.client.get_guild_name(guild_id=guild_id)
         except (ApiError, AttributeError):

--- a/tests/sentry/integrations/discord/test_integration.py
+++ b/tests/sentry/integrations/discord/test_integration.py
@@ -473,3 +473,28 @@ class DiscordIntegrationTest(DiscordSetupTestCase):
         )
         with pytest.raises(ApiError):
             provider.post_install(integration=self.integration, organization=self.organization)
+
+    def test_build_integration_invalid_guild_id(self):
+        provider = self.provider()
+
+        with pytest.raises(
+            IntegrationError,
+            match="Invalid guild ID. The Discord guild ID must be entirely numeric.",
+        ):
+            provider.build_integration(
+                {
+                    "guild_id": "123abc",  # Invalid guild ID (contains non-numeric characters)
+                    "code": "some_auth_code",
+                }
+            )
+
+        # Test that a valid numeric guild ID doesn't raise an exception
+        try:
+            provider.build_integration(
+                {
+                    "guild_id": "123456789",  # Valid guild ID (entirely numeric)
+                    "code": "some_auth_code",
+                }
+            )
+        except IntegrationError:
+            pytest.fail("Unexpected IntegrationError raised for valid guild ID")

--- a/tests/sentry/integrations/discord/test_integration.py
+++ b/tests/sentry/integrations/discord/test_integration.py
@@ -307,7 +307,7 @@ class DiscordIntegrationTest(DiscordSetupTestCase):
     def test_get_guild_name_failure(self):
         provider = self.provider()
 
-        responses.add(responses.GET, "https://discord.com/api/v10/guilds/guild_name", status=500),
+        (responses.add(responses.GET, "https://discord.com/api/v10/guilds/guild_name", status=500),)
         responses.add(
             responses.POST,
             url="https://discord.com/api/v10/oauth2/token",
@@ -487,14 +487,3 @@ class DiscordIntegrationTest(DiscordSetupTestCase):
                     "code": "some_auth_code",
                 }
             )
-
-        # Test that a valid numeric guild ID doesn't raise an exception
-        try:
-            provider.build_integration(
-                {
-                    "guild_id": "123456789",  # Valid guild ID (entirely numeric)
-                    "code": "some_auth_code",
-                }
-            )
-        except IntegrationError:
-            pytest.fail("Unexpected IntegrationError raised for valid guild ID")


### PR DESCRIPTION
Guild IDs are entirely numeric. By failing to validate the input, we are vulnerable to a path traversal attack.
