### PR TITLE
ref(hydration errors): hide html diff

### DIFF
--- a/static/app/components/replays/diff/replayDiffChooser.tsx
+++ b/static/app/components/replays/diff/replayDiffChooser.tsx
@@ -39,7 +39,9 @@ export default function ReplayDiffChooser({
         <TabList>
           <TabList.Item key={DiffType.SLIDER}>{t('Slider Diff')}</TabList.Item>
           <TabList.Item key={DiffType.VISUAL}>{t('Side By Side Diff')}</TabList.Item>
-          <TabList.Item key={DiffType.HTML}>{t('HTML Diff')}</TabList.Item>
+          <TabList.Item key={DiffType.HTML} hidden>
+            {t('HTML Diff')}
+          </TabList.Item>
         </TabList>
 
         <StyledTabPanels>


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/78687

the HTML diff tab is hidden in hydration error issues & from replay breadcrumbs:

<img width="1465" alt="SCR-20241007-mmem" src="https://github.com/user-attachments/assets/d44df7c7-c7e6-418c-af73-c9c202d61a93">
