### PR TITLE
feat(scim): Disable form for updating teams on the frontend

### DIFF
--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -107,6 +107,13 @@ class TeamDetailsEndpoint(TeamEndpoint):
         Update various attributes and configurable settings for the given
         team.
         """
+
+        if team.idp_provisioned:
+            return Response(
+                {"detail": "This team is managed through your organization's identity provider."},
+                status=403,
+            )
+
         serializer = TeamDetailsSerializer(team, data=request.data, partial=True)
         if serializer.is_valid():
             team = serializer.save()
@@ -141,6 +148,13 @@ class TeamDetailsEndpoint(TeamEndpoint):
         **Note:** Deletion happens asynchronously and therefore is not
         immediate. Teams will have their slug released while waiting for deletion.
         """
+
+        if team.idp_provisioned:
+            return Response(
+                {"detail": "This team is managed through your organization's identity provider."},
+                status=403,
+            )
+
         suffix = uuid4().hex
         new_slug = f"{team.slug}-{suffix}"[0:50]
         try:

--- a/static/app/views/settings/organizationTeams/teamSettings/index.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamSettings/index.spec.tsx
@@ -103,4 +103,21 @@ describe('TeamSettings', function () {
 
     expect(TeamStore.getAll()).toEqual([]);
   });
+
+  it('cannot modify idp:provisioned teams regardless of role', function () {
+    const team = TeamFixture({hasAccess: true, flags: {'idp:provisioned': true}});
+    const organization = OrganizationFixture({access: []});
+
+    render(<TeamSettings {...routerProps} team={team} params={{teamId: team.slug}} />, {
+      organization,
+    });
+
+    expect(
+      screen.getByText(
+        "This team is managed through your organization's identity provider. These settings cannot be modified."
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Team Slug'})).toBeDisabled();
+    expect(screen.getByTestId('button-remove-team')).toBeDisabled();
+  });
 });


### PR DESCRIPTION
Disables the team settings form when it has the `idp:provisioned` flag set to true.

<img width="766" alt="image" src="https://github.com/user-attachments/assets/05103d75-8869-4806-9edf-81cd4a1c6c42">


Requires https://github.com/getsentry/sentry/pull/78722