### PR TITLE
feat(transactions): Use the split queue router for save_event_transaction

### DIFF
--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -53,6 +53,11 @@ def trace_func(**span_kwargs):
     return wrapper
 
 
+from sentry.queue.routers import SplitQueueRouter
+
+split_queue_router = SplitQueueRouter()
+
+
 @trace_func(name="ingest_consumer.process_event")
 @metrics.wraps("ingest_consumer.process_event")
 def process_event(
@@ -186,6 +191,7 @@ def process_event(
                 start_time=start_time,
                 event_id=event_id,
                 project_id=project_id,
+                queue=split_queue_router.route_for_queue("event.save_event_transaction"),
             )
 
             try:

--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -191,7 +191,7 @@ def process_event(
                 start_time=start_time,
                 event_id=event_id,
                 project_id=project_id,
-                queue=split_queue_router.route_for_queue("event.save_event_transaction"),
+                queue=split_queue_router.route_for_queue("events.save_event_transaction"),
             )
 
             try:

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -155,6 +155,7 @@ def test_transactions_spawn_save_event_transaction(
         start_time=start_time,
         event_id=event_id,
         project_id=project_id,
+        queue="events.save_event_transaction",
     )
 
 


### PR DESCRIPTION
so that once we configure the new queues tasks will be dispatched correctly

since they are not configured yet, merging this code does not do anything by itself
