### PR TITLE
feat(issues): Add suggested assignees to new header

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackAssignedTo.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackAssignedTo.tsx
@@ -52,7 +52,7 @@ export default function FeedbackAssignedTo({
     projectIds: [feedbackIssue.project.id],
   });
 
-  const owners = getOwnerList([], eventOwners ?? null, feedbackIssue.assignedTo);
+  const owners = getOwnerList([], eventOwners, feedbackIssue.assignedTo);
 
   // A new `key` will make the component re-render when showActorName changes
   const key = showActorName ? 'showActor' : 'hideActor';

--- a/static/app/components/group/assigneeSelector.tsx
+++ b/static/app/components/group/assigneeSelector.tsx
@@ -5,6 +5,7 @@ import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {AssigneeBadge} from 'sentry/components/assigneeBadge';
 import AssigneeSelectorDropdown, {
   type AssignableEntity,
+  type SuggestedAssignee,
 } from 'sentry/components/assigneeSelectorDropdown';
 import {Button} from 'sentry/components/button';
 import type {OnAssignCallback} from 'sentry/components/deprecatedAssigneeSelectorDropdown';
@@ -20,6 +21,7 @@ interface AssigneeSelectorProps {
   group: Group;
   handleAssigneeChange: (assignedActor: AssignableEntity | null) => void;
   memberList?: User[];
+  owners?: Omit<SuggestedAssignee, 'assignee'>[];
 }
 
 export function useHandleAssigneeChange({
@@ -73,12 +75,14 @@ export function AssigneeSelector({
   memberList,
   assigneeLoading,
   handleAssigneeChange,
+  owners,
 }: AssigneeSelectorProps) {
   return (
     <AssigneeSelectorDropdown
       group={group}
       loading={assigneeLoading}
       memberList={memberList}
+      owners={owners}
       onAssign={(assignedActor: AssignableEntity | null) =>
         handleAssigneeChange(assignedActor)
       }

--- a/static/app/utils/displayReprocessEventAction.spec.tsx
+++ b/static/app/utils/displayReprocessEventAction.spec.tsx
@@ -7,7 +7,7 @@ import {displayReprocessEventAction} from 'sentry/utils/displayReprocessEventAct
 
 describe('DisplayReprocessEventAction', function () {
   it('returns false in case of no event', function () {
-    expect(displayReprocessEventAction()).toBe(false);
+    expect(displayReprocessEventAction(null)).toBe(false);
   });
 
   it('returns false if no exception entry is found', function () {

--- a/static/app/utils/displayReprocessEventAction.tsx
+++ b/static/app/utils/displayReprocessEventAction.tsx
@@ -21,7 +21,7 @@ const MAYBE_DEBUG_FILE_PLATFORMS: Set<PlatformKey> = new Set(['csharp', 'java'])
  * Debug Files for proper processing, as those Debug Files could have been uploaded *after*
  * the Event was ingested.
  */
-export function displayReprocessEventAction(event?: Event): boolean {
+export function displayReprocessEventAction(event: Event | null): boolean {
   if (!event) {
     return false;
   }

--- a/static/app/utils/useCommitters.tsx
+++ b/static/app/utils/useCommitters.tsx
@@ -29,6 +29,7 @@ function useCommitters(
     {
       staleTime: Infinity,
       retry: false,
+      enabled: !!eventId,
       ...options,
     }
   );

--- a/static/app/utils/useIssueEventOwners.tsx
+++ b/static/app/utils/useIssueEventOwners.tsx
@@ -1,0 +1,31 @@
+import type {EventOwners} from 'sentry/components/group/assignedTo';
+import type {ApiQueryKey, UseApiQueryOptions} from 'sentry/utils/queryClient';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+
+interface UseIssueEventOwnersProps {
+  eventId: string;
+  projectSlug: string;
+}
+
+const makeCommittersQueryKey = (
+  orgSlug: string,
+  projectSlug: string,
+  eventId: string
+): ApiQueryKey => [`/projects/${orgSlug}/${projectSlug}/events/${eventId}/owners/`];
+
+export function useIssueEventOwners(
+  {eventId, projectSlug}: UseIssueEventOwnersProps,
+  options: Partial<UseApiQueryOptions<EventOwners>> = {}
+) {
+  const org = useOrganization();
+  return useApiQuery<EventOwners>(
+    makeCommittersQueryKey(org.slug, projectSlug, eventId),
+    {
+      staleTime: Infinity,
+      retry: false,
+      enabled: !!eventId,
+      ...options,
+    }
+  );
+}

--- a/static/app/views/issueDetails/actions/index.spec.tsx
+++ b/static/app/views/issueDetails/actions/index.spec.tsx
@@ -64,6 +64,7 @@ describe('GroupActions', function () {
           project={project}
           organization={organization}
           disabled={false}
+          event={null}
         />
       );
       expect(await screen.findByRole('button', {name: 'Resolve'})).toBeInTheDocument();
@@ -87,6 +88,7 @@ describe('GroupActions', function () {
           project={project}
           organization={organization}
           disabled={false}
+          event={null}
         />
       );
       await userEvent.click(screen.getByRole('button', {name: 'Subscribe'}));
@@ -118,6 +120,7 @@ describe('GroupActions', function () {
           project={project}
           organization={organization}
           disabled={false}
+          event={null}
         />
       );
 
@@ -202,6 +205,7 @@ describe('GroupActions', function () {
           project={project}
           organization={org}
           disabled={false}
+          event={null}
         />
       </Fragment>,
       {organization: org}
@@ -239,6 +243,7 @@ describe('GroupActions', function () {
             project={project}
             organization={org}
             disabled={false}
+            event={null}
           />
         </Fragment>,
         {organization: org}
@@ -271,6 +276,7 @@ describe('GroupActions', function () {
           project={project}
           organization={org}
           disabled={false}
+          event={null}
         />,
         {organization: org}
       );
@@ -296,6 +302,7 @@ describe('GroupActions', function () {
           project={project}
           organization={org}
           disabled={false}
+          event={null}
         />,
         {organization: org}
       );
@@ -324,6 +331,7 @@ describe('GroupActions', function () {
         project={project}
         organization={organization}
         disabled={false}
+        event={null}
       />,
       {organization}
     );
@@ -349,6 +357,7 @@ describe('GroupActions', function () {
         project={project}
         organization={organization}
         disabled={false}
+        event={null}
       />
     );
 
@@ -375,6 +384,7 @@ describe('GroupActions', function () {
         project={project}
         organization={organization}
         disabled={false}
+        event={null}
       />,
       {organization}
     );

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -66,10 +66,10 @@ const isResolutionStatus = (data: UpdateData): data is GroupStatusResolution => 
 type Props = {
   api: Client;
   disabled: boolean;
+  event: Event | null;
   group: Group;
   organization: Organization;
   project: Project;
-  event?: Event;
   query?: Query;
 };
 

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -708,7 +708,7 @@ function GroupDetailsContent({
       <GroupHeader
         organization={organization}
         groupReprocessingStatus={groupReprocessingStatus}
-        event={event ?? undefined}
+        event={event}
         group={group}
         baseUrl={baseUrl}
         project={project as Project}

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -677,6 +677,7 @@ function GroupDetailsContent({
   return hasStreamlinedUI ? (
     <div>
       <StreamlinedGroupHeader
+        event={event}
         group={group}
         project={project}
         groupReprocessingStatus={groupReprocessingStatus}

--- a/static/app/views/issueDetails/header.spec.tsx
+++ b/static/app/views/issueDetails/header.spec.tsx
@@ -25,6 +25,7 @@ describe('GroupHeader', () => {
       group: GroupFixture({issueCategory: IssueCategory.ERROR}),
       groupReprocessingStatus: ReprocessingStatus.NO_STATUS,
       project,
+      event: null,
     };
 
     it('displays the correct tabs with all features enabled', async () => {
@@ -113,6 +114,7 @@ describe('GroupHeader', () => {
       group: GroupFixture({issueCategory: IssueCategory.ERROR}),
       groupReprocessingStatus: ReprocessingStatus.NO_STATUS,
       project,
+      event: null,
     };
 
     it('displays the correct tabs with all features enabled', async () => {
@@ -160,6 +162,7 @@ describe('GroupHeader', () => {
       group: GroupFixture({issueCategory: IssueCategory.PERFORMANCE}),
       groupReprocessingStatus: ReprocessingStatus.NO_STATUS,
       project,
+      event: null,
     };
 
     it('displays the correct tabs with all features enabled', async () => {
@@ -241,6 +244,7 @@ describe('GroupHeader', () => {
           })}
           project={ProjectFixture()}
           groupReprocessingStatus={ReprocessingStatus.NO_STATUS}
+          event={null}
         />
       );
 
@@ -262,6 +266,7 @@ describe('GroupHeader', () => {
           group={GroupFixture({priority: PriorityLevel.MEDIUM})}
           project={ProjectFixture()}
           groupReprocessingStatus={ReprocessingStatus.NO_STATUS}
+          event={null}
         />
       );
 

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -40,11 +40,11 @@ import type {ReprocessingStatus} from './utils';
 
 type Props = {
   baseUrl: string;
+  event: Event | null;
   group: Group;
   groupReprocessingStatus: ReprocessingStatus;
   organization: Organization;
   project: Project;
-  event?: Event;
 };
 
 interface GroupHeaderTabsProps extends Pick<Props, 'baseUrl' | 'group' | 'project'> {

--- a/static/app/views/issueDetails/streamline/assigneeSelector.spec.tsx
+++ b/static/app/views/issueDetails/streamline/assigneeSelector.spec.tsx
@@ -1,0 +1,63 @@
+import {ActorFixture} from 'sentry-fixture/actor';
+import {EventFixture} from 'sentry-fixture/event';
+import {GroupFixture} from 'sentry-fixture/group';
+import {MemberFixture} from 'sentry-fixture/member';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+import {UserFixture} from 'sentry-fixture/user';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import type {EventOwners} from 'sentry/components/group/assignedTo';
+import MemberListStore from 'sentry/stores/memberListStore';
+import type {Committer} from 'sentry/types/integrations';
+
+import {GroupHeaderAssigneeSelector} from './assigneeSelector';
+
+describe('GroupHeaderAssigneeSelector', () => {
+  const organization = OrganizationFixture();
+  const group = GroupFixture();
+  const project = ProjectFixture();
+  const event = EventFixture();
+
+  beforeEach(() => {
+    MemberListStore.reset();
+  });
+
+  it('should render suggested assignees', async () => {
+    const commitUser = UserFixture({id: '91', email: 'frodo@sentry.io', name: 'Frodo'});
+    const committer: Committer = {
+      author: commitUser,
+      commits: [],
+    };
+    const ownerActor = ActorFixture({id: '101', email: 'sam@sentry.io', name: 'Sam'});
+    const eventOwners: EventOwners = {
+      owners: [ownerActor],
+      rule: ['codeowners', '/issues'],
+      rules: [[['codeowners', '/issues'], [['user', ownerActor.email!]]]],
+    };
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/owners/`,
+      body: eventOwners,
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/committers/`,
+      body: {committers: [committer]},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/users/`,
+      body: [
+        MemberFixture({user: commitUser}),
+        MemberFixture({user: UserFixture({...ownerActor})}),
+      ],
+    });
+    render(<GroupHeaderAssigneeSelector group={group} project={project} event={event} />);
+
+    await userEvent.click(await screen.findByLabelText('Modify issue assignee'));
+    expect(await screen.findByText(commitUser.name)).toBeInTheDocument();
+    expect(screen.getByText('Suspect commit author')).toBeInTheDocument();
+
+    expect(screen.getByText(ownerActor.name)).toBeInTheDocument();
+    expect(screen.getByText('Codeowners:/issues')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/issueDetails/streamline/assigneeSelector.tsx
+++ b/static/app/views/issueDetails/streamline/assigneeSelector.tsx
@@ -1,0 +1,62 @@
+import {useEffect} from 'react';
+
+import {fetchOrgMembers} from 'sentry/actionCreators/members';
+import {getOwnerList} from 'sentry/components/group/assignedTo';
+import {
+  AssigneeSelector,
+  useHandleAssigneeChange,
+} from 'sentry/components/group/assigneeSelector';
+import type {Event} from 'sentry/types/event';
+import type {Group} from 'sentry/types/group';
+import type {Project} from 'sentry/types/project';
+import useApi from 'sentry/utils/useApi';
+import useCommitters from 'sentry/utils/useCommitters';
+import {useIssueEventOwners} from 'sentry/utils/useIssueEventOwners';
+import useOrganization from 'sentry/utils/useOrganization';
+
+interface GroupHeaderAssigneeSelectorProps {
+  event: Event | null;
+  group: Group;
+  project: Project;
+}
+
+export function GroupHeaderAssigneeSelector({
+  group,
+  project,
+  event,
+}: GroupHeaderAssigneeSelectorProps) {
+  const api = useApi();
+  const organization = useOrganization();
+  const {handleAssigneeChange, assigneeLoading} = useHandleAssigneeChange({
+    organization,
+    group,
+  });
+  const {data: eventOwners} = useIssueEventOwners({
+    eventId: event?.id ?? '',
+    projectSlug: project.slug,
+  });
+  const {data: committersResponse} = useCommitters({
+    eventId: event?.id ?? '',
+    projectSlug: project.slug,
+  });
+
+  useEffect(() => {
+    // TODO: We should check if this is already loaded
+    fetchOrgMembers(api, organization.slug, [project.id]);
+  }, [api, organization, project]);
+
+  const owners = getOwnerList(
+    committersResponse?.committers ?? [],
+    eventOwners,
+    group.assignedTo
+  );
+
+  return (
+    <AssigneeSelector
+      group={group}
+      owners={owners}
+      assigneeLoading={assigneeLoading}
+      handleAssigneeChange={handleAssigneeChange}
+    />
+  );
+}

--- a/static/app/views/issueDetails/streamline/header.spec.tsx
+++ b/static/app/views/issueDetails/streamline/header.spec.tsx
@@ -70,6 +70,10 @@ describe('UpdatedGroupHeader', () => {
         url: `/organizations/${organization.slug}/issues/${group.id}/attachments/`,
         body: [],
       });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/users/`,
+        body: [],
+      });
     });
 
     it('shows all elements of header', async () => {
@@ -109,6 +113,7 @@ describe('UpdatedGroupHeader', () => {
           {...defaultProps}
           group={participantGroup}
           project={project}
+          event={null}
         />,
         {
           organization,
@@ -159,7 +164,12 @@ describe('UpdatedGroupHeader', () => {
         body: {firstRelease, lastRelease: firstRelease},
       });
       render(
-        <StreamlinedGroupHeader {...defaultProps} group={group} project={project} />,
+        <StreamlinedGroupHeader
+          {...defaultProps}
+          group={group}
+          project={project}
+          event={null}
+        />,
         {
           organization,
           router,
@@ -180,7 +190,12 @@ describe('UpdatedGroupHeader', () => {
         features: ['issue-details-streamline'],
       });
       render(
-        <StreamlinedGroupHeader {...defaultProps} group={group} project={project} />,
+        <StreamlinedGroupHeader
+          {...defaultProps}
+          group={group}
+          project={project}
+          event={null}
+        />,
         {
           organization: flaggedOrganization,
           router,


### PR DESCRIPTION
Adds back suggested assignees and suspect committers to the assignee dropdown. Fixes a bug where only teams were available to select.

Part of the issue was that event was an optional prop and it was not being passed.