### PR TITLE
ref(rr6): Use generatePath in withDomainRedirect

### DIFF
--- a/static/app/utils/withDomainRedirect.spec.tsx
+++ b/static/app/utils/withDomainRedirect.spec.tsx
@@ -19,7 +19,7 @@ const projectRoutes = [
   {childRoutes: []},
   {path: '/settings/', name: 'Settings', indexRoute: {}, childRoutes: []},
   {name: 'Organizations', path: ':orgId/', childRoutes: []},
-  {name: 'Projects', path: ':projectId/(searches/:searchId/)', childRoutes: []},
+  {name: 'Projects', path: ':projectId/', childRoutes: []},
   {name: 'Alerts', path: 'alerts/'},
 ];
 

--- a/static/app/utils/withDomainRedirect.tsx
+++ b/static/app/utils/withDomainRedirect.tsx
@@ -1,5 +1,5 @@
-// biome-ignore lint/nursery/noRestrictedImports: Will be removed with react router 6
-import {formatPattern} from 'react-router';
+import {generatePath} from 'react-router-dom';
+import trim from 'lodash/trim';
 import trimEnd from 'lodash/trimEnd';
 import trimStart from 'lodash/trimStart';
 
@@ -70,8 +70,8 @@ function withDomainRedirect<P extends RouteComponentProps<{}, {}>>(
         return <WrappedComponent {...props} />;
       }
 
-      const orglessRedirectPath = formatPattern(orglessSlugRoute, params);
-      const redirectOrgURL = `/${trimStart(orglessRedirectPath, '/')}${
+      const orglessRedirectPath = generatePath(orglessSlugRoute, params);
+      const redirectOrgURL = `/${trim(orglessRedirectPath, '/')}/${
         window.location.search
       }${window.location.hash}`;
 


### PR DESCRIPTION
This causes tests to change slightly, since the (/path/:slug) syntax no
logner exists in react-router 6 we remove that test case.

We also always append a trailing slash to the generated path, since
react-router 6 seems to maybe do something funny with this.