### PR TITLE
feat(crons): Fetch timelines using parallel requests

### DIFF
--- a/static/app/views/monitors/components/detailsTimeline.tsx
+++ b/static/app/views/monitors/components/detailsTimeline.tsx
@@ -19,7 +19,6 @@ import {makeMonitorDetailsQueryKey} from 'sentry/views/monitors/utils';
 
 import {OverviewRow} from './overviewTimeline/overviewRow';
 import {GridLineLabels, GridLineOverlay} from './timeline/gridLines';
-import {useMonitorStats} from './timeline/hooks/useMonitorStats';
 import {useTimeWindowConfig} from './timeline/hooks/useTimeWindowConfig';
 
 interface Props {
@@ -36,11 +35,6 @@ export function DetailsTimeline({monitor, organization}: Props) {
   const {width: timelineWidth} = useDimensions<HTMLDivElement>({elementRef});
 
   const timeWindowConfig = useTimeWindowConfig({timelineWidth});
-
-  const {data: monitorStats, isPending} = useMonitorStats({
-    monitors: [monitor.id],
-    timeWindowConfig,
-  });
 
   const monitorDetailsQueryKey = makeMonitorDetailsQueryKey(
     organization,
@@ -103,14 +97,13 @@ export function DetailsTimeline({monitor, organization}: Props) {
         <GridLineLabels timeWindowConfig={timeWindowConfig} />
       </Header>
       <AlignedGridLineOverlay
-        allowZoom={!isPending}
-        showCursor={!isPending}
-        showIncidents={!isPending}
+        allowZoom
+        showCursor
+        showIncidents
         timeWindowConfig={timeWindowConfig}
       />
       <OverviewRow
         monitor={monitor}
-        bucketedData={monitorStats?.[monitor.id]}
         timeWindowConfig={timeWindowConfig}
         onDeleteEnvironment={handleDeleteEnvironment}
         onToggleMuteEnvironment={handleToggleMuteEnvironment}

--- a/static/app/views/monitors/components/overviewTimeline/index.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/index.tsx
@@ -20,7 +20,6 @@ import {makeMonitorListQueryKey} from 'sentry/views/monitors/utils';
 import {DateNavigator} from '../timeline/dateNavigator';
 import {GridLineLabels, GridLineOverlay} from '../timeline/gridLines';
 import {useDateNavigation} from '../timeline/hooks/useDateNavigation';
-import {useMonitorStats} from '../timeline/hooks/useMonitorStats';
 import {useTimeWindowConfig} from '../timeline/hooks/useTimeWindowConfig';
 
 import {OverviewRow} from './overviewRow';
@@ -42,11 +41,6 @@ export function OverviewTimeline({monitorList}: Props) {
 
   const timeWindowConfig = useTimeWindowConfig({timelineWidth});
   const dateNavigation = useDateNavigation();
-
-  const {data: monitorStats, isPending} = useMonitorStats({
-    monitors: monitorList.map(m => m.id),
-    timeWindowConfig,
-  });
 
   const handleDeleteEnvironment = async (monitor: Monitor, env: string) => {
     const success = await deleteMonitorEnvironment(api, organization.slug, monitor, env);
@@ -148,8 +142,8 @@ export function OverviewTimeline({monitorList}: Props) {
       <AlignedGridLineOverlay
         stickyCursor
         allowZoom
-        showCursor={!isPending}
-        showIncidents={!isPending}
+        showCursor
+        showIncidents
         timeWindowConfig={timeWindowConfig}
       />
 
@@ -159,7 +153,6 @@ export function OverviewTimeline({monitorList}: Props) {
             key={monitor.id}
             monitor={monitor}
             timeWindowConfig={timeWindowConfig}
-            bucketedData={monitorStats?.[monitor.id]}
             onDeleteEnvironment={env => handleDeleteEnvironment(monitor, env)}
             onToggleMuteEnvironment={(env, isMuted) =>
               handleToggleMuteEnvironment(monitor, env, isMuted)


### PR DESCRIPTION
This should improve performance of loading cron timelines

Loading in bulk via the backend: 18.3s
Loading in paralell one-by-one on the frontend:
  max: 1.5s
  min: 250ms

<img alt="clipboard.png" width="557" src="https://i.imgur.com/Q1AJ4yb.png" />