### PR TITLE
fix(scm): don't fetch repositories with empty query

### DIFF
--- a/static/app/views/settings/organizationIntegrations/integrationRepos.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationRepos.spec.tsx
@@ -36,6 +36,10 @@ describe('IntegrationRepos', function () {
       });
 
       render(<IntegrationRepos integration={integration} />);
+      // we only attempt to fetch repositories upon typing
+      await userEvent.click(screen.getByText('Add Repository'));
+      await userEvent.type(screen.getByRole('textbox'), 'asdf');
+
       expect(
         await screen.findByText(
           /We were unable to fetch repositories for this integration/
@@ -65,6 +69,7 @@ describe('IntegrationRepos', function () {
 
       render(<IntegrationRepos integration={integration} />);
       await userEvent.click(screen.getByText('Add Repository'));
+      await userEvent.type(screen.getByRole('textbox'), 'repo-name');
       await userEvent.click(screen.getByText('repo-name'));
 
       expect(addRepo).toHaveBeenCalledWith(
@@ -107,6 +112,7 @@ describe('IntegrationRepos', function () {
 
       render(<IntegrationRepos integration={integration} />);
       await userEvent.click(screen.getByText('Add Repository'));
+      await userEvent.type(screen.getByRole('textbox'), 'sentry-repo');
       await userEvent.click(screen.getByText('sentry-repo'));
 
       expect(addRepo).toHaveBeenCalled();
@@ -163,6 +169,7 @@ describe('IntegrationRepos', function () {
       render(<IntegrationRepos integration={integration} />);
 
       await userEvent.click(screen.getByText('Add Repository'));
+      await userEvent.type(screen.getByRole('textbox'), 'repo-name');
       await userEvent.click(screen.getByText('repo-name'));
 
       expect(updateRepo).toHaveBeenCalledWith(
@@ -195,6 +202,7 @@ describe('IntegrationRepos', function () {
       render(<IntegrationRepos integration={integration} />);
 
       await userEvent.click(screen.getByText('Add Repository'));
+      await userEvent.type(screen.getByRole('textbox'), 'repo-name');
       await userEvent.click(screen.getByText('repo-name'));
 
       expect(getItems).toHaveBeenCalled();

--- a/static/app/views/settings/organizationIntegrations/integrationRepos.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationRepos.spec.tsx
@@ -46,6 +46,21 @@ describe('IntegrationRepos', function () {
         )
       ).toBeInTheDocument();
     });
+
+    it('does not fetch repositories with empty query', async function () {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/repos/`,
+        method: 'GET',
+        body: [],
+      });
+
+      render(<IntegrationRepos integration={integration} />);
+      await userEvent.click(screen.getByText('Add Repository'));
+
+      expect(
+        await screen.findByText(/Please type to search for repositories/)
+      ).toBeInTheDocument();
+    });
   });
 
   describe('Adding repositories', function () {

--- a/static/app/views/settings/organizationIntegrations/integrationRepos.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationRepos.spec.tsx
@@ -58,7 +58,7 @@ describe('IntegrationRepos', function () {
       await userEvent.click(screen.getByText('Add Repository'));
 
       expect(
-        await screen.findByText(/Please type to search for repositories/)
+        await screen.findByText(/Please enter a repository name/)
       ).toBeInTheDocument();
     });
   });

--- a/static/app/views/settings/organizationIntegrations/integrationReposAddRepository.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationReposAddRepository.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 
@@ -25,7 +25,6 @@ interface IntegrationReposAddRepositoryProps {
 
 interface IntegrationRepoSearchResult {
   repos: IntegrationRepository[];
-  searchable: boolean;
 }
 
 export function IntegrationReposAddRepository({
@@ -36,11 +35,10 @@ export function IntegrationReposAddRepository({
 }: IntegrationReposAddRepositoryProps) {
   const api = useApi({persistInFlight: true});
   const organization = useOrganization();
-  const [dropdownBusy, setDropdownBusy] = useState(true);
+  const [dropdownBusy, setDropdownBusy] = useState(false);
   const [adding, setAdding] = useState(false);
   const [searchResult, setSearchResult] = useState<IntegrationRepoSearchResult>({
     repos: [],
-    searchable: false,
   });
 
   const searchRepositoriesRequest = useCallback(
@@ -59,11 +57,6 @@ export function IntegrationReposAddRepository({
     [api, integration, organization, onSearchError]
   );
 
-  useEffect(() => {
-    // Load the repositories before the dropdown is opened
-    searchRepositoriesRequest();
-  }, [searchRepositoriesRequest]);
-
   const debouncedSearchRepositoriesRequest = useMemo(
     () => debounce(query => searchRepositoriesRequest(query), 200),
     [searchRepositoriesRequest]
@@ -71,9 +64,15 @@ export function IntegrationReposAddRepository({
 
   const handleSearchRepositories = useCallback(
     (e?: React.ChangeEvent<HTMLInputElement>) => {
-      setDropdownBusy(true);
-      onSearchError(null);
-      debouncedSearchRepositoriesRequest(e?.target.value);
+      if (e?.target.value) {
+        setDropdownBusy(true);
+        onSearchError(null);
+        debouncedSearchRepositoriesRequest(e?.target.value);
+      } else {
+        setDropdownBusy(false);
+        onSearchError(null);
+        setSearchResult({repos: []});
+      }
     },
     [debouncedSearchRepositoriesRequest, onSearchError]
   );
@@ -144,8 +143,8 @@ export function IntegrationReposAddRepository({
       <DropdownAutoComplete
         items={dropdownItems}
         onSelect={addRepo}
-        onChange={searchResult.searchable ? handleSearchRepositories : undefined}
-        emptyMessage={t('No repositories available')}
+        onChange={handleSearchRepositories}
+        emptyMessage={t('Please type to search for repositories')}
         noResultsMessage={t('No repositories found')}
         searchPlaceholder={t('Search Repositories')}
         busy={dropdownBusy}

--- a/static/app/views/settings/organizationIntegrations/integrationReposAddRepository.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationReposAddRepository.tsx
@@ -144,7 +144,7 @@ export function IntegrationReposAddRepository({
         items={dropdownItems}
         onSelect={addRepo}
         onChange={handleSearchRepositories}
-        emptyMessage={t('Please type to search for repositories')}
+        emptyMessage={t('Please enter a repository name')}
         noResultsMessage={t('No repositories found')}
         searchPlaceholder={t('Search Repositories')}
         busy={dropdownBusy}


### PR DESCRIPTION
https://github.com/user-attachments/assets/23b7809d-e708-492f-bcb6-4856592a3ea3

For any integration with a lot of repositories, adding a new repository is currently painful because it might take a long time for the dropdown to initially populate with ALL the repositories. This PR changes the behavior such that we do not query for all repositories when the search query is empty -- in fact, we don't make any external API calls at all. Only when a user starts typing do we start searching.

Note that sometimes the latest results stay if you delete too quickly and end up in the empty query state.