### PR TITLE
fix(alerts): Link external provider to test event

### DIFF
--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -136,5 +136,4 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
 
             raise
 
-        if not event.get_tag("sample_event") == "yes":
-            create_link(integration, installation, event, response)
+        create_link(integration, installation, event, response)

--- a/tests/sentry/api/endpoints/test_project_rule_actions.py
+++ b/tests/sentry/api/endpoints/test_project_rule_actions.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 from sentry.integrations.jira.integration import JiraIntegration
-from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.rules.actions.notify_event import NotifyEventAction
 from sentry.shared_integrations.exceptions import IntegrationFormError
 from sentry.silo.base import SiloMode
@@ -31,27 +30,6 @@ class ProjectRuleActionsEndpointTest(APITestCase):
         self.get_success_response(self.organization.slug, self.project.slug, actions=action_data)
 
         assert action.called
-
-    @mock.patch.object(JiraIntegration, "create_issue")
-    def test_sample_event_does_not_create_external_issue(self, mock_create_issue):
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.jira_integration = self.create_provider_integration(
-                provider="jira", name="Jira", external_id="jira:1"
-            )
-            self.jira_integration.add_organization(self.organization, self.user)
-
-        action_data = [
-            {
-                "id": "sentry.integrations.jira.notify_action.JiraCreateTicketAction",
-                "dynamic_form_fields": {
-                    "fake_field": "fake_value",
-                },
-            }
-        ]
-
-        self.get_success_response(self.organization.slug, self.project.slug, actions=action_data)
-        assert mock_create_issue.call_count == 1
-        assert ExternalIssue.objects.count() == 0
 
     @mock.patch.object(JiraIntegration, "create_issue")
     @with_feature(


### PR DESCRIPTION
We used to not show the test event created when clicking the `Send a Test Notification` button on the project issues page.
In https://github.com/getsentry/sentry/pull/58314 I removed the external linking because the user could never see the event.
<img width="380" alt="Screenshot 2024-10-07 at 4 01 01 PM" src="https://github.com/user-attachments/assets/dde1259b-6cd3-4ba9-a0af-8d1c2301696b">

Now that users can see it, we want to add it back.

Fixes https://github.com/getsentry/sentry/issues/78667