### PR TITLE
Add `*/up` to `HEALTH_CHECK_GLOBS`

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -781,6 +781,7 @@ HEALTH_CHECK_GLOBS = [
     "*/ready",
     "*/readyz",
     "*/ping",
+    "*/up",
 ]
 
 

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/REGION.pysnap
@@ -93,6 +93,7 @@ config:
       - '*/ready'
       - '*/readyz'
       - '*/ping'
+      - '*/up'
   groupingConfig:
     enhancements: KLUv_SAYwQAAkwKRs25ld3N0eWxlOjIwMjMtMDEtMTGQ
     id: newstyle:2023-01-11


### PR DESCRIPTION
Both Rails 7 and Laravel 11 expose an `/up` health-check endpoint which we should ignore.

Refs https://github.com/getsentry/relay/pull/4117