### PR TITLE
feat(issue-stream): Move sort selector to the right of search

### DIFF
--- a/static/app/views/issueList/actions/headers.tsx
+++ b/static/app/views/issueList/actions/headers.tsx
@@ -76,8 +76,7 @@ function Headers({
 export default Headers;
 
 const GraphHeaderWrapper = styled('div')<{isSavedSearchesOpen?: boolean}>`
-  width: 160px;
-  margin-left: ${space(2)};
+  width: 200px;
   margin-right: ${space(2)};
 
   /* prettier-ignore */
@@ -89,6 +88,7 @@ const GraphHeaderWrapper = styled('div')<{isSavedSearchesOpen?: boolean}>`
 
 const GraphHeader = styled('div')`
   display: flex;
+  margin-right: ${space(1.5)};
 `;
 
 const StyledToolbarHeader = styled(ToolbarHeader)`

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -99,6 +99,7 @@ function ActionsBarPriority({
   sort: string;
   statsPeriod: string;
 }) {
+  const organization = useOrganization();
   const shouldDisplayActions = anySelected && !narrowViewport;
 
   return (
@@ -136,7 +137,9 @@ function ActionsBarPriority({
           )}
           {!anySelected && (
             <HeaderButtonsWrapper key="sort" {...animationProps}>
-              <IssueListSortOptions sort={sort} query={query} onSelect={onSortChange} />
+              {!organization.features.includes('issue-stream-table-layout') && (
+                <IssueListSortOptions sort={sort} query={query} onSelect={onSortChange} />
+              )}
             </HeaderButtonsWrapper>
           )}
         </AnimatePresence>

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -11,6 +11,7 @@ import {
 import {Alert} from 'sentry/components/alert';
 import Checkbox from 'sentry/components/checkbox';
 import {Sticky} from 'sentry/components/sticky';
+import ToolbarHeader from 'sentry/components/toolbarHeader';
 import {t, tct, tn} from 'sentry/locale';
 import GroupStore from 'sentry/stores/groupStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
@@ -137,8 +138,10 @@ function ActionsBarPriority({
           )}
           {!anySelected && (
             <HeaderButtonsWrapper key="sort" {...animationProps}>
-              {!organization.features.includes('issue-stream-table-layout') && (
+              {!organization.features.includes('issue-stream-table-layout') ? (
                 <IssueListSortOptions sort={sort} query={query} onSelect={onSortChange} />
+              ) : (
+                <ToolbarHeader>{t('Issue')}</ToolbarHeader>
               )}
             </HeaderButtonsWrapper>
           )}

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -507,6 +507,9 @@ const StickyActions = styled(Sticky)`
   &[data-stuck] > div {
     border-radius: 0;
   }
+  border-bottom: 1px solid ${p => p.theme.border};
+  border-top: none;
+  border-radius: ${p => p.theme.panelBorderRadius} ${p => p.theme.panelBorderRadius} 0 0;
 `;
 
 const ActionsBarContainer = styled('div')`
@@ -516,10 +519,7 @@ const ActionsBarContainer = styled('div')`
   padding-bottom: ${space(1)};
   align-items: center;
   background: ${p => p.theme.backgroundSecondary};
-  border: 1px solid ${p => p.theme.border};
-  border-top: none;
   border-radius: ${p => p.theme.panelBorderRadius} ${p => p.theme.panelBorderRadius} 0 0;
-  margin: 0 -1px -1px;
 `;
 
 const ActionsCheckbox = styled('div')<{isReprocessingQuery: boolean}>`

--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -1,4 +1,5 @@
 import {CompactSelect} from 'sentry/components/compactSelect';
+import type {DropdownButtonProps} from 'sentry/components/dropdownButton';
 import {IconSort} from 'sentry/icons/iconSort';
 import {t} from 'sentry/locale';
 import {
@@ -11,9 +12,11 @@ type Props = {
   onSelect: (sort: string) => void;
   query: string;
   sort: string;
+  showIcon?: boolean;
+  triggerSize?: DropdownButtonProps['size'];
 };
 
-function getSortTooltip(key: IssueSortOptions) {
+export function getSortTooltip(key: IssueSortOptions) {
   switch (key) {
     case IssueSortOptions.INBOX:
       return t('When issue was flagged for review.');
@@ -31,7 +34,13 @@ function getSortTooltip(key: IssueSortOptions) {
   }
 }
 
-function IssueListSortOptions({onSelect, sort, query}: Props) {
+function IssueListSortOptions({
+  onSelect,
+  sort,
+  query,
+  triggerSize = 'xs',
+  showIcon = true,
+}: Props) {
   const sortKey = sort || IssueSortOptions.DATE;
   const sortKeys = [
     ...(FOR_REVIEW_QUERIES.includes(query || '') ? [IssueSortOptions.INBOX] : []),
@@ -44,7 +53,7 @@ function IssueListSortOptions({onSelect, sort, query}: Props) {
 
   return (
     <CompactSelect
-      size="sm"
+      size="md"
       onChange={opt => onSelect(opt.value)}
       options={sortKeys.map(key => ({
         value: key,
@@ -54,8 +63,8 @@ function IssueListSortOptions({onSelect, sort, query}: Props) {
       menuWidth={240}
       value={sortKey}
       triggerProps={{
-        size: 'xs',
-        icon: <IconSort />,
+        size: triggerSize,
+        icon: showIcon && <IconSort />,
       }}
     />
   );

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -5,14 +5,20 @@ import {EnvironmentPageFilter} from 'sentry/components/organizations/environment
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {space} from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
+import IssueListSortOptions from 'sentry/views/issueList/actions/sortOptions';
 import {IssueSearchWithSavedSearches} from 'sentry/views/issueList/issueSearchWithSavedSearches';
 
 interface Props {
   onSearch: (query: string) => void;
+  onSortChange: (sort: string) => void;
   query: string;
+  sort: string;
 }
 
-function IssueListFilters({query, onSearch}: Props) {
+function IssueListFilters({query, sort, onSortChange, onSearch}: Props) {
+  const organization = useOrganization();
+
   return (
     <SearchContainer>
       <StyledPageFilterBar>
@@ -22,6 +28,16 @@ function IssueListFilters({query, onSearch}: Props) {
       </StyledPageFilterBar>
 
       <IssueSearchWithSavedSearches {...{query, onSearch}} />
+
+      {organization.features.includes('issue-stream-table-layout') && (
+        <IssueListSortOptions
+          query={query}
+          sort={sort}
+          onSelect={onSortChange}
+          triggerSize="md"
+          showIcon={false}
+        />
+      )}
     </SearchContainer>
   );
 }

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -1217,7 +1217,12 @@ class IssueListOverview extends Component<Props, State> {
           <StyledBody>
             <StyledMain>
               <IssuesDataConsentBanner source="issues" />
-              <IssueListFilters query={query} onSearch={this.onSearch} />
+              <IssueListFilters
+                query={query}
+                sort={this.getSort()}
+                onSortChange={this.onSortChange}
+                onSearch={this.onSearch}
+              />
               <IssueListTable
                 selection={selection}
                 query={query}


### PR DESCRIPTION
closes #77817 

Moves the sort selector on the issue stream to the right of the search bar, and removes it from the previous location inside the issue list table headers. No functionality has been altered - the new sort selector uses the exact same component and `onSelect` callback as the previous sort selector. 

This change is gated by the `issue-stream-table-layout` feature flag 

Before: 

<img width="1277" alt="image" src="https://github.com/user-attachments/assets/334bcc8d-3d97-410b-a771-5110348e3d8c">

After:

<img width="1277" alt="image" src="https://github.com/user-attachments/assets/4b95b668-9567-4750-8030-257a180aafa4">

