### PR TITLE
fix(jira): Makes sync status selection project-specific

### DIFF
--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -25,6 +25,7 @@ class JiraCloudClient(ApiClient):
     COMMENTS_URL = "/rest/api/2/issue/%s/comment"
     COMMENT_URL = "/rest/api/2/issue/%s/comment/%s"
     STATUS_URL = "/rest/api/2/status"
+    STATUS_SEARCH_URL = "/rest/api/2/statuses/search"
     CREATE_URL = "/rest/api/2/issue"
     ISSUE_URL = "/rest/api/2/issue/%s"
     META_URL = "/rest/api/2/issue/createmeta"
@@ -224,3 +225,6 @@ class JiraCloudClient(ApiClient):
         return self.get_cached(
             self.AUTOCOMPLETE_URL, params={"fieldName": jql_name, "fieldValue": value}
         )
+
+    def get_project_statuses(self, project_id: str) -> dict[str, Any]:
+        return dict(self.get_cached(self.STATUS_SEARCH_URL, params={"projectId": project_id}))


### PR DESCRIPTION
Addresses #73733, #64787, and potentially #71643

Refines our Jira status selectors, which currently show _all available statuses globally_, many of which have duplicate labels, making it trivial for a user to misconfigure their integration. When a mismatched status for the given project is selected, status syncing will silently fail.

This PR addresses this issue by doing the following:
1. For each project available, makes an HTTP request to Jira to request the project's available statuses
    - These are served by Jira's `/rest/api/2/statuses/search` endpoint, which allows per-project filtering
2. Creates mappings per project with the available statuses
3. Sets per-item mapping in the ChoiceMapper config allowing each project's available options to be unique.

While this means we'll be issuing a much larger number of HTTP requests per configuration load, it seems like a reasonable tradeoff for now. If this becomes problematic, we can potentially bulk query these and have the response include per-project usage per their [docs](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-status/#api-rest-api-2-statuses-search-get); however, the results are paginated which presents its own set of challenges for users with large numbers of projects and statuses.

