### PR TITLE
feat(wizard-ui): Skip fetching projects

### DIFF
--- a/src/sentry/templates/sentry/setup-wizard.html
+++ b/src/sentry/templates/sentry/setup-wizard.html
@@ -25,6 +25,7 @@
       props: {
         hash: {{ hash|to_json|safe }},
         organizations: {{ organizations|to_json|safe }},
+        enableProjectSelection: {{ enableProjectSelection|to_json|safe }},
       },
     });
   </script>


### PR DESCRIPTION
Skip fetching projects when the feature flag for the new UI is enabled.
Pass a flag to the frontend component that instructs it to render the project selection.

Closes https://github.com/getsentry/sentry/issues/78314