### PR TITLE
ref: remove redundant region_silo_mode decorator

### DIFF
--- a/src/sentry/integrations/tasks/create_comment.py
+++ b/src/sentry/integrations/tasks/create_comment.py
@@ -2,12 +2,11 @@ from sentry import analytics
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.tasks import should_comment_sync
 from sentry.models.activity import Activity
-from sentry.silo.base import SiloMode, region_silo_function
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.types.activity import ActivityType
 
 
-@region_silo_function
 @instrumented_task(
     name="sentry.integrations.tasks.create_comment",
     queue="integrations",


### PR DESCRIPTION
this is covered by silo_mode=... below

type checker noticed this oddity when making the silo mode decorators forward their signatures

<!-- Describe your PR here. -->