### PR TITLE
build: Create `yarn https:proxy` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -245,6 +245,7 @@
     "build-js-loader": "ts-node scripts/build-js-loader.ts",
     "validate-api-examples": "yarn --cwd api-docs openapi-examples-validator ../tests/apidocs/openapi-derefed.json --no-additional-properties",
     "mkcert-localhost": "mkcert -key-file config/localhost-key.pem -cert-file config/localhost.pem localhost 127.0.0.1 dev.getsentry.net *.dev.getsentry.net && mkcert -install",
+    "https-proxy": "caddy run --config - <<< '{\"apps\":{\"http\":{\"servers\":{\"srv0\":{\"listen\":[\":8003\"],\"routes\":[{\"handle\":[{\"handler\":\"reverse_proxy\",\"upstreams\":[{\"dial\":\"localhost:8000\"}]}]}],\"tls_connection_policies\":[{\"certificate_selection\":{\"any_tag\":[\"cert0\"]}}]}}},\"tls\":{\"certificates\":{\"load_files\":[{\"certificate\":\"./config/localhost.pem\",\"key\":\"./config/localhost-key.pem\",\"tags\":[\"cert0\"]}]}}}}'",
     "extract-ios-device-names": "ts-node scripts/extract-ios-device-names.ts"
   },
   "browserslist": {


### PR DESCRIPTION
This creates a new command `yarn https-proxy` to help people use their dev servers over https.


The json file content was generated using `caddy adapt` with this config as input:
```
:8003
reverse_proxy localhost:8000
tls ./config/localhost.pem ./config/localhost-key.pem
```

Relates to https://github.com/getsentry/sentry-docs/pull/11520