### PR TITLE
fix(jira): Makes team an autofill field in integration forms

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -108,7 +108,7 @@ metadata = IntegrationMetadata(
 
 # Some Jira errors for invalid field values don't actually provide the field
 # ID in an easily mappable way, so we have to manually map known error types
-# here to make it easier
+# here to make it explicit to the user what failed.
 CUSTOM_ERROR_MESSAGE_MATCHERS = [(re.compile("Team with id '.*' not found.$"), "Team Field")]
 
 # Hide linked issues fields because we don't have the necessary UI for fully specifying

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -515,7 +515,12 @@ class JiraIntegration(IssueSyncIntegration):
         elif (
             # Assignee and reporter fields
             field_meta.get("autoCompleteUrl")
-            and (schema.get("items") == "user" or schema["type"] == "user")
+            and (
+                schema.get("items") == "user"
+                or schema["type"] == "user"
+                or schema["type"] == "team"
+                or schema.get("items") == "team"
+            )
             # Sprint and "Epic Link" fields
             or schema.get("custom")
             in (JIRA_CUSTOM_FIELD_TYPES["sprint"], JIRA_CUSTOM_FIELD_TYPES["epic"])


### PR DESCRIPTION
Makes the `Team` field an autofillable field.

Currently, selecting a team is a painful experience. It requires manually looking up and pasting the team UUID into the UI:
![image](https://github.com/user-attachments/assets/c0e39190-9f33-4ec2-b819-3ec51a0fe061)

Even with the UI error fixes we've made recently, the errors for entering an incorrect team ID results in a vague, non-descriptive error.

Making team a queryable field similar to user selection removes this problem entirely, disallowing a user from selecting an invalid team:
![image](https://github.com/user-attachments/assets/1a0f21f5-c866-40fe-afb9-e252a20b11e0)

This PR also adds error handling for team errors to show an explicit error for previously configured alerts:
![image](https://github.com/user-attachments/assets/c88215a4-4d74-4632-ba70-6d6532953eef)
