### PR TITLE
ref: forward signatures in silo mode base decorators

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -374,7 +374,7 @@ class IntegrationInstallation(abc.ABC):
         """
         raise NotImplementedError
 
-    def get_keyring_client(self, keyid: str) -> Any:
+    def get_keyring_client(self, keyid: int | str) -> Any:
         """
         Return an API client with a scoped key based on the key_name.
 

--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -239,7 +239,9 @@ class BaseRequestParser:
             regions=regions, identifier=integration.id, integration_id=integration.id
         )
 
-    def get_mailbox_identifier(self, integration: RpcIntegration, data: Mapping[str, Any]) -> str:
+    def get_mailbox_identifier(
+        self, integration: RpcIntegration | Integration, data: Mapping[str, Any]
+    ) -> str:
         """
         Used by integrations with higher hook volumes to create smaller mailboxes
         that can be delivered in parallel. Requires the integration to implement

--- a/src/sentry/integrations/opsgenie/integration.py
+++ b/src/sentry/integrations/opsgenie/integration.py
@@ -120,7 +120,7 @@ class InstallationConfigView(PipelineView):
 
 
 class OpsgenieIntegration(IntegrationInstallation):
-    def get_keyring_client(self, keyid: str) -> OpsgenieClient:
+    def get_keyring_client(self, keyid: int | str) -> OpsgenieClient:
         org_integration = self.org_integration
         assert org_integration, "OrganizationIntegration is required"
         team = get_team(team_id=keyid, org_integration=org_integration)

--- a/src/sentry/integrations/opsgenie/utils.py
+++ b/src/sentry/integrations/opsgenie/utils.py
@@ -59,7 +59,7 @@ def attach_custom_priority(
     return data
 
 
-def get_team(team_id: str | None, org_integration: RpcOrganizationIntegration | None):
+def get_team(team_id: int | str | None, org_integration: RpcOrganizationIntegration | None):
     if not org_integration:
         return None
     teams = org_integration.config.get("team_table")

--- a/src/sentry/integrations/pagerduty/integration.py
+++ b/src/sentry/integrations/pagerduty/integration.py
@@ -67,7 +67,7 @@ metadata = IntegrationMetadata(
 
 
 class PagerDutyIntegration(IntegrationInstallation):
-    def get_keyring_client(self, keyid: str) -> PagerDutyClient:
+    def get_keyring_client(self, keyid: int | str) -> PagerDutyClient:
         org_integration = self.org_integration
         assert org_integration, "Cannot get client without an organization integration"
 

--- a/src/sentry/integrations/utils/identities.py
+++ b/src/sentry/integrations/utils/identities.py
@@ -1,6 +1,7 @@
 import logging
 from collections.abc import Iterable, Mapping
 
+from django.contrib.auth.models import AnonymousUser
 from django.http import Http404
 
 from sentry.constants import ObjectStatus
@@ -19,17 +20,17 @@ _logger = logging.getLogger(__name__)
 @control_silo_function
 def get_identity_or_404(
     provider: ExternalProviders,
-    user: User,
+    user: User | AnonymousUser,
     integration_id: int,
     organization_id: int | None = None,
 ) -> tuple[RpcOrganization, Integration, IdentityProvider]:
+    """For endpoints, short-circuit with a 404 if we cannot find everything we need."""
     logger_metadata = {
         "integration_provider": provider,
         "integration_id": integration_id,
         "organization_id": organization_id,
         "user_id": user.id,
     }
-    """For endpoints, short-circuit with a 404 if we cannot find everything we need."""
     if provider not in EXTERNAL_PROVIDERS:
         _logger.info("provider is not part of supported external providers", extra=logger_metadata)
         raise Http404

--- a/src/sentry/integrations/utils/sync.py
+++ b/src/sentry/integrations/utils/sync.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING
 
 from sentry import features
+from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.assignment_source import AssignmentSource
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.tasks.sync_assignee_outbound import sync_assignee_outbound
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
 
 @region_silo_function
 def where_should_sync(
-    integration: RpcIntegration,
+    integration: RpcIntegration | Integration,
     key: str,
     organization_id: int | None = None,
 ) -> Sequence[Organization]:
@@ -63,9 +64,9 @@ def get_user_id(projects_by_user: Mapping[int, Sequence[int]], group: Group) -> 
 
 @region_silo_function
 def sync_group_assignee_inbound(
-    integration: RpcIntegration,
+    integration: RpcIntegration | Integration,
     email: str | None,
-    external_issue_key: str,
+    external_issue_key: str | None,
     assign: bool = True,
 ) -> Sequence[Group]:
     """

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -397,7 +397,7 @@ class GroupManager(BaseManager["Group"]):
         self,
         integration: RpcIntegration,
         organizations: Iterable[Organization],
-        external_issue_key: str,
+        external_issue_key: str | None,
     ) -> QuerySet[Group]:
         from sentry.integrations.models.external_issue import ExternalIssue
         from sentry.integrations.services.integration import integration_service

--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Collection, Container, Iterable
+from collections.abc import Collection, Iterable
 from enum import Enum
 from typing import Any
 from urllib.parse import urljoin
@@ -321,7 +321,7 @@ def _find_orgs_for_user(user_id: int) -> set[int]:
 
 
 @control_silo_function
-def find_regions_for_orgs(org_ids: Container[int]) -> set[str]:
+def find_regions_for_orgs(org_ids: Iterable[int]) -> set[str]:
     from sentry.models.organizationmapping import OrganizationMapping
 
     if SiloMode.get_current_mode() == SiloMode.MONOLITH:

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
@@ -103,6 +103,7 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
                 metadata={"services": SERVICES},
             )
             org_integration = integration.add_organization(self.organization, self.user)
+            assert org_integration is not None
             service = add_service(
                 org_integration,
                 service_name=service_name,

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -3146,7 +3146,7 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest):
             self.action,
             type,
             target_type,
-            target_identifier=target_identifier,
+            target_identifier=str(target_identifier),
             integration_id=integration.id,
         )
 

--- a/tests/sentry/integrations/pagerduty/test_client.py
+++ b/tests/sentry/integrations/pagerduty/test_client.py
@@ -47,7 +47,7 @@ class PagerDutyClientTest(APITestCase):
             metadata={"services": SERVICES},
         )
         self.service = add_service(
-            self.integration.organizationintegration_set.first(),
+            self.integration.organizationintegration_set.get(),
             service_name=SERVICES[0]["service_name"],
             integration_key=SERVICES[0]["integration_key"],
         )
@@ -157,11 +157,7 @@ class PagerDutyClientTest(APITestCase):
             "https://events.pagerduty.com/v2/enqueue/",
             body=b"{}",
             match=[
-                matchers.header_matcher(
-                    {
-                        "Content-Type": "application/json",
-                    }
-                ),
+                matchers.header_matcher({"Content-Type": "application/json"}),
                 matchers.json_params_matcher(expected_data),
             ],
         )

--- a/tests/sentry/integrations/pagerduty/test_notify_action.py
+++ b/tests/sentry/integrations/pagerduty/test_notify_action.py
@@ -312,7 +312,7 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
                 metadata={"services": [service_info]},
             )
             integration.add_organization(self.organization, self.user)
-            org_integration = integration.organizationintegration_set.first()
+            org_integration = integration.organizationintegration_set.get()
             service = add_service(
                 org_integration,
                 service_name=service_info["service_name"],

--- a/tests/sentry/middleware/integrations/parsers/test_gitlab.py
+++ b/tests/sentry/middleware/integrations/parsers/test_gitlab.py
@@ -227,6 +227,7 @@ class GitlabRequestParserTest(TestCase):
         )
         parser = GitlabRequestParser(request=request, response_handler=self.get_response)
         result = parser.get_integration_from_request()
+        assert result is not None
         assert result.id == integration.id
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)

--- a/tests/sentry/shared_integrations/client/test_proxy.py
+++ b/tests/sentry/shared_integrations/client/test_proxy.py
@@ -76,11 +76,11 @@ class IntegrationProxyClientTest(TestCase):
             return prepared_request
 
         client = self.client_cls(org_integration_id=self.oi_id)
-        client.authorize_request = authorize_request
 
-        assert prepared_request.headers.get("Authorization") is None
-        client.authorize_request(prepared_request)
-        assert prepared_request.headers.get("Authorization") == "Bearer tkn"
+        with patch.object(client, "authorize_request", authorize_request):
+            assert prepared_request.headers.get("Authorization") is None
+            client.authorize_request(prepared_request)
+            assert prepared_request.headers.get("Authorization") == "Bearer tkn"
 
     @patch.object(IntegrationProxyClient, "authorize_request")
     def test_finalize_request_noop(self, mock_authorize):


### PR DESCRIPTION
previously these decorators changed all of their targets to `Callable[..., Any]` (unshaped callable) losing type information

<!-- Describe your PR here. -->