### PR TITLE
fix(issue-search): Use platform.name instead of platform

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1697,7 +1697,7 @@ export const ISSUE_EVENT_PROPERTY_FIELDS: FieldKey[] = [
   FieldKey.MESSAGE,
   FieldKey.OS_BUILD,
   FieldKey.OS_KERNEL_VERSION,
-  FieldKey.PLATFORM,
+  FieldKey.PLATFORM_NAME,
   FieldKey.RELEASE_BUILD,
   FieldKey.RELEASE_PACKAGE,
   FieldKey.RELEASE_VERSION,


### PR DESCRIPTION
We've been displaying `platform` as a valid key for the longest time, but after testing it looks like `platform.name` is actually what we want. You can see it defined here in the backend: https://github.com/getsentry/sentry/blob/4cc71a43536d72fb40154a4df8ba204e1a4059d1/src/sentry/snuba/events.py#L119