### PR TITLE
:sparkles: feat(slack): multi team same channel linking

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -438,6 +438,8 @@ def register_temporary_features(manager: FeatureManager):
     # Add regression chart as image to slack message
     manager.add("organizations:slack-endpoint-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=False)
     manager.add("organizations:slack-function-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=False)
+    # Enable linking to Slack alerts from multiple teams to a single channel
+    manager.add("organizations:slack-multiple-team-single-channel-linking", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:stacktrace-processing-caching", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable SAML2 Single-logout
     manager.add("organizations:sso-saml2-slo", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=False)

--- a/src/sentry/integrations/slack/webhooks/command.py
+++ b/src/sentry/integrations/slack/webhooks/command.py
@@ -6,6 +6,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -102,7 +103,10 @@ class SlackCommandsEndpoint(SlackDMEndpoint):
 
         has_valid_role = False
         for organization_membership in organization_memberships:
-            if is_team_linked_to_channel(organization_membership.organization, slack_request):
+            if not features.has(
+                "organizations:slack-multiple-team-single-channel-linking",
+                organization_membership.organization,
+            ) and is_team_linked_to_channel(organization_membership.organization, slack_request):
                 return self.reply(slack_request, CHANNEL_ALREADY_LINKED_MESSAGE)
 
             if is_valid_role(organization_membership) or is_team_admin(organization_membership):


### PR DESCRIPTION
we have received a couple requests to allow multiple teams to link to the same channel. we have some logic that prevents this but we don't have have the context for why this decision was made. lets feature flag this logic and disable for our sentry org and see what happens

