### PR TITLE
fix(dashboard): Check all aggregates in metrics request

### DIFF
--- a/src/sentry/discover/dashboard_widget_split.py
+++ b/src/sentry/discover/dashboard_widget_split.py
@@ -5,6 +5,7 @@ import sentry_sdk
 from snuba_sdk.query_visitors import InvalidQueryError
 
 from sentry import features
+from sentry.api.serializers.rest_framework.dashboard import is_aggregate
 from sentry.constants import ObjectStatus
 from sentry.discover.arithmetic import ArithmeticParseError
 from sentry.discover.dataset_split import (
@@ -138,7 +139,7 @@ def _get_and_save_split_decision_for_dashboard_widget(
             _save_split_decision_for_widget(
                 widget,
                 widget_dataset,
-                DatasetSourcesTypes.SPLIT_VERSION_1,
+                DatasetSourcesTypes.SPLIT_VERSION_2,
             )
         return widget_dataset, False
 
@@ -156,9 +157,22 @@ def _get_and_save_split_decision_for_dashboard_widget(
                 offset=None,
                 limit=1,
                 referrer="tasks.performance.split_discover_dataset",
+                transform_alias_to_input_format=True,
             )
 
-            if metrics_query_result.get("data") and len(metrics_query_result["data"]) > 0:
+            has_metrics_data = (
+                metrics_query_result.get("data")
+                # No results were returned at all
+                and len(metrics_query_result["data"]) > 0
+                # All of the aggregates in any possible row return 0
+                and any(
+                    metrics_query_result["data"][row][column] > 0
+                    for column in selected_columns
+                    if is_aggregate(column)
+                    for row in range(len(metrics_query_result["data"]))
+                )
+            )
+            if has_metrics_data:
                 if dry_run:
                     logger.info(
                         "Split decision for %s: %s (inferred from running metrics query)",
@@ -169,7 +183,7 @@ def _get_and_save_split_decision_for_dashboard_widget(
                     _save_split_decision_for_widget(
                         widget,
                         DashboardWidgetTypes.TRANSACTION_LIKE,
-                        DatasetSourcesTypes.SPLIT_VERSION_1,
+                        DatasetSourcesTypes.SPLIT_VERSION_2,
                     )
 
                 return DashboardWidgetTypes.TRANSACTION_LIKE, True
@@ -246,7 +260,7 @@ def _get_and_save_split_decision_for_dashboard_widget(
             _save_split_decision_for_widget(
                 widget,
                 DashboardWidgetTypes.TRANSACTION_LIKE,
-                DatasetSourcesTypes.SPLIT_VERSION_1,
+                DatasetSourcesTypes.SPLIT_VERSION_2,
             )
 
         return DashboardWidgetTypes.TRANSACTION_LIKE, True

--- a/src/sentry/discover/dashboard_widget_split.py
+++ b/src/sentry/discover/dashboard_widget_split.py
@@ -164,12 +164,10 @@ def _get_and_save_split_decision_for_dashboard_widget(
                 metrics_query_result.get("data")
                 # No results were returned at all
                 and len(metrics_query_result["data"]) > 0
-                # All of the aggregates in any possible row return 0
                 and any(
-                    metrics_query_result["data"][row][column] > 0
+                    metrics_query_result["data"][0][column] > 0
                     for column in selected_columns
                     if is_aggregate(column)
-                    for row in range(len(metrics_query_result["data"]))
                 )
             )
             if has_metrics_data:
@@ -227,7 +225,7 @@ def _get_and_save_split_decision_for_dashboard_widget(
             _save_split_decision_for_widget(
                 widget,
                 DashboardWidgetTypes.ERROR_EVENTS,
-                DatasetSourcesTypes.SPLIT_VERSION_1,
+                DatasetSourcesTypes.SPLIT_VERSION_2,
             )
         return DashboardWidgetTypes.ERROR_EVENTS, True
 

--- a/src/sentry/models/dashboard_widget.py
+++ b/src/sentry/models/dashboard_widget.py
@@ -97,9 +97,13 @@ class DatasetSourcesTypes(Enum):
     """
     FORCED = 3
     """
-     Dataset inferred by split querscript, version 1
+     Dataset inferred by split script, version 1
     """
     SPLIT_VERSION_1 = 4
+    """
+     Dataset inferred by split script, version 2
+    """
+    SPLIT_VERSION_2 = 5
 
     @classmethod
     def as_choices(cls):

--- a/tests/sentry/discover/test_dashboard_widget_split.py
+++ b/tests/sentry/discover/test_dashboard_widget_split.py
@@ -158,7 +158,7 @@ class DashboardWidgetDatasetSplitTestCase(BaseMetricsLayerTestCase, TestCase, Sn
         )
         assert queried_snuba
 
-    def test_metrics_compatible_query_blah(self):
+    def test_metrics_compatible_query_no_data_only_aggregates(self):
         metrics_widget = DashboardWidget.objects.create(
             dashboard=self.dashboard,
             order=0,
@@ -168,9 +168,12 @@ class DashboardWidgetDatasetSplitTestCase(BaseMetricsLayerTestCase, TestCase, Sn
             interval="1d",
             detail={"layout": {"x": 0, "y": 0, "w": 1, "h": 1, "minH": 2}},
         )
+
+        # When only aggregates are requested, the response has a row but it's
+        # completely empty.
         metrics_query = DashboardWidgetQuery.objects.create(
             widget=metrics_widget,
-            fields=["count()"],
+            fields=["count()", "count_unique(user)"],
             columns=[],
             aggregates=[],
             conditions=f"project:[{self.project_2.slug}]",

--- a/tests/sentry/discover/test_dashboard_widget_split.py
+++ b/tests/sentry/discover/test_dashboard_widget_split.py
@@ -158,6 +158,37 @@ class DashboardWidgetDatasetSplitTestCase(BaseMetricsLayerTestCase, TestCase, Sn
         )
         assert queried_snuba
 
+    def test_metrics_compatible_query_blah(self):
+        metrics_widget = DashboardWidget.objects.create(
+            dashboard=self.dashboard,
+            order=0,
+            title="widget",
+            display_type=DashboardWidgetDisplayTypes.LINE_CHART,
+            widget_type=DashboardWidgetTypes.DISCOVER,
+            interval="1d",
+            detail={"layout": {"x": 0, "y": 0, "w": 1, "h": 1, "minH": 2}},
+        )
+        metrics_query = DashboardWidgetQuery.objects.create(
+            widget=metrics_widget,
+            fields=["count()"],
+            columns=[],
+            aggregates=[],
+            conditions=f"project:[{self.project_2.slug}]",
+            order=0,
+        )
+
+        with self.feature({"organizations:dynamic-sampling": True}):
+            _, queried_snuba = _get_and_save_split_decision_for_dashboard_widget(
+                metrics_query, self.dry_run
+            )
+        metrics_widget.refresh_from_db()
+        assert (
+            metrics_widget.discover_widget_split is None
+            if self.dry_run
+            else metrics_widget.discover_widget_split == 100
+        )
+        assert queried_snuba
+
     def test_metrics_query_with_no_dynamic_sampling(self):
         metrics_widget = DashboardWidget.objects.create(
             dashboard=self.dashboard,


### PR DESCRIPTION
The split code for metrics needs to check that the aggregates returned aren't just 0s. Also adds another split version to run another series of splits.