### PR TITLE
rfc(taskworker) First pass at storing inflight tasks in sqlite

### DIFF
--- a/bin/taskworker-test
+++ b/bin/taskworker-test
@@ -22,9 +22,16 @@ configure()
 @click.option("--seed", "-s", help="pseudo random number generator seed", default=None)
 @click.option("--workers", help="Number of worker processes", default=1)
 @click.option("--mode", help="The worker/consumer mode to use", default="pull")
+@click.option("--storage", help="The storage mode to use", default="postgres")
 @click.option("--report-only", help="Run report output only", is_flag=True, default=False)
 def main(
-    number: int, verbose: bool, workers: int, seed: float | None, mode: str, report_only: bool
+    number: int,
+    verbose: bool,
+    workers: int,
+    seed: float | None,
+    mode: str,
+    report_only: bool,
+    storage: str,
 ):
     from sentry.taskdemo import variable_time
 
@@ -57,7 +64,7 @@ def main(
         processes.append(
             {
                 "name": "grpc",
-                "cmd": ["sentry", "run", "kafka-task-grpc-pull"],
+                "cmd": ["sentry", "run", "kafka-task-grpc-pull", "--storage", storage],
             },
         )
         processes.append(
@@ -72,6 +79,9 @@ def main(
                     "taskworker-pull",
                     "--log-level",
                     "warning",
+                    "--",
+                    "--storage",
+                    storage,
                 ],
             }
         )
@@ -101,6 +111,8 @@ def main(
                     "kafka-task-grpc-push",
                     "--worker-addrs",
                     worker_addrs,
+                    "--storage",
+                    storage,
                 ],
             },
         )
@@ -116,6 +128,9 @@ def main(
                     "taskworker-pull",
                     "--log-level",
                     "warning",
+                    "--",
+                    "--storage",
+                    storage,
                 ],
             }
         )

--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -61,6 +61,19 @@ def multiprocessing_options(
     ]
 
 
+def taskworker_options(
+    default_max_batch_size: int | None = None,
+    default_max_batch_time_ms: int | None = 1000,
+) -> list[click.Option]:
+    options = multiprocessing_options(
+        default_max_batch_size=default_max_batch_size,
+        default_max_batch_time_ms=default_max_batch_time_ms,
+    )
+    options.append(click.Option(["--storage"], type=str, default="postgres"))
+
+    return options
+
+
 def issue_occurrence_options() -> list[click.Option]:
     """Return a list of issue-occurrence options."""
     return [
@@ -392,7 +405,7 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
     "taskworker": {
         "topic": Topic.HACKWEEK,
         "strategy_factory": "sentry.taskworker.processors.strategy_factory.StrategyFactory",
-        "click_options": multiprocessing_options(default_max_batch_size=100),
+        "click_options": taskworker_options(default_max_batch_size=100),
         "dlq_topic": Topic.HACKWEEK_DLQ,
     },
     **settings.SENTRY_KAFKA_CONSUMERS,

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -313,23 +313,33 @@ def taskworker_pull(**options: Any) -> None:
         "Example: -W 127.0.0.1:50051,127.0.0.1:50052"
     ),
 )
+@click.option(
+    "--storage",
+    help="The storage backend to use.",
+    default="postgres",
+)
 @log_options()
 @configuration
-def kafka_task_grpc_push(worker_addrs: str) -> None:
+def kafka_task_grpc_push(worker_addrs: str, storage: str) -> None:
     from sentry.taskworker.consumer_grpc_push import start
 
     with managed_bgtasks(role="taskworker"):
-        start(worker_addrs.split(","))
+        start(worker_addrs.split(","), storage)
 
 
 @run.command()
 @log_options()
 @configuration
-def kafka_task_grpc_pull(**options: Any) -> None:
+@click.option(
+    "--storage",
+    help="The storage backend to use.",
+    default="postgres",
+)
+def kafka_task_grpc_pull(storage: str, **options: Any) -> None:
     from sentry.taskworker.consumer_grpc_pull import serve
 
     with managed_bgtasks(role="taskworker"):
-        serve()
+        serve(storage=storage)
 
 
 @run.command()

--- a/src/sentry/taskworker/consumer_grpc_pull.py
+++ b/src/sentry/taskworker/consumer_grpc_pull.py
@@ -19,7 +19,7 @@ from sentry_protos.sentry.v1alpha.taskworker_pb2_grpc import (
 )
 from sentry_protos.sentry.v1alpha.taskworker_pb2_grpc import add_ConsumerServiceServicer_to_server
 
-from sentry.taskworker.pending_task_store import PendingTaskStore
+from sentry.taskworker.pending_task_store import InflightTaskStoreSqlite, PendingTaskStore
 
 logger = logging.getLogger("sentry.taskworker.grpc_server")
 
@@ -27,7 +27,8 @@ logger = logging.getLogger("sentry.taskworker.grpc_server")
 class ConsumerServicer(BaseConsumerServicer):
     def __init__(self) -> None:
         super().__init__()
-        self.pending_task_store = PendingTaskStore()
+        # self.pending_task_store = PendingTaskStore()
+        self.pending_task_store = InflightTaskStoreSqlite("taskdemo-1")
 
     def GetTask(self, request: GetTaskRequest, context) -> GetTaskResponse:
         inflight = self.pending_task_store.get_pending_task()

--- a/src/sentry/taskworker/models.py
+++ b/src/sentry/taskworker/models.py
@@ -152,6 +152,7 @@ class InflightActivationModel(Model):
     @classmethod
     def to_proto_status(cls, status: Status) -> TaskActivationStatus.ValueType:
         return {
+            "pending": TASK_ACTIVATION_STATUS_PENDING,
             "processing": TASK_ACTIVATION_STATUS_PROCESSING,
             "complete": TASK_ACTIVATION_STATUS_COMPLETE,
             "failure": TASK_ACTIVATION_STATUS_FAILURE,

--- a/src/sentry/taskworker/processors/strategy_factory.py
+++ b/src/sentry/taskworker/processors/strategy_factory.py
@@ -25,7 +25,7 @@ from sentry_protos.sentry.v1alpha.taskworker_pb2 import (
 )
 
 from sentry.conf.types.kafka_definition import Topic
-from sentry.taskworker.pending_task_store import InflightTaskStoreSqlite, PendingTaskStore
+from sentry.taskworker.pending_task_store import get_storage_backend
 
 logger = logging.getLogger("sentry.taskworker.consumer")
 
@@ -56,6 +56,7 @@ class StrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         num_processes: int,
         input_block_size: int | None,
         output_block_size: int | None,
+        storage: str | None,
     ) -> None:
         super().__init__()
         self.pool = MultiprocessingPool(num_processes)
@@ -71,8 +72,7 @@ class StrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         # Maximum number of pending inflight activations in the store before backpressure is emitted
         self.max_inflight_activation_in_store = 1000  # make this configurable
 
-        # self.pending_task_store = PendingTaskStore()
-        self.pending_task_store = InflightTaskStoreSqlite("taskdemo-1")
+        self.pending_task_store = get_storage_backend(storage)
 
     def create_with_partitions(
         self, commit: Commit, _: Mapping[Partition, int]

--- a/src/sentry/taskworker/processors/strategy_factory.py
+++ b/src/sentry/taskworker/processors/strategy_factory.py
@@ -25,7 +25,7 @@ from sentry_protos.sentry.v1alpha.taskworker_pb2 import (
 )
 
 from sentry.conf.types.kafka_definition import Topic
-from sentry.taskworker.pending_task_store import PendingTaskStore
+from sentry.taskworker.pending_task_store import InflightTaskStoreSqlite, PendingTaskStore
 
 logger = logging.getLogger("sentry.taskworker.consumer")
 
@@ -71,7 +71,8 @@ class StrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         # Maximum number of pending inflight activations in the store before backpressure is emitted
         self.max_inflight_activation_in_store = 1000  # make this configurable
 
-        self.pending_task_store = PendingTaskStore()
+        # self.pending_task_store = PendingTaskStore()
+        self.pending_task_store = InflightTaskStoreSqlite("taskdemo-1")
 
     def create_with_partitions(
         self, commit: Commit, _: Mapping[Partition, int]

--- a/src/sentry/taskworker/service/client.py
+++ b/src/sentry/taskworker/service/client.py
@@ -11,8 +11,6 @@ from sentry_protos.sentry.v1alpha.taskworker_pb2 import (
 )
 from sentry_protos.sentry.v1alpha.taskworker_pb2_grpc import ConsumerServiceStub
 
-from sentry.taskworker.pending_task_store import PendingTaskStore
-
 logger = logging.getLogger("sentry.taskworker")
 
 
@@ -26,7 +24,6 @@ class TaskClient:
     """
 
     def __init__(self):
-        self.pending_task_store = PendingTaskStore()
         self.host = "localhost"
         self.server_port = 50051
         self.channel = grpc.insecure_channel(f"{self.host}:{self.server_port}")

--- a/src/sentry/taskworker/worker_pull.py
+++ b/src/sentry/taskworker/worker_pull.py
@@ -127,7 +127,7 @@ class Worker:
             result = self.__pool.apply_async(
                 func=worker_process._process_activation,
                 args=(
-                    smainelf.options["namespace"],
+                    self.options["namespace"],
                     activation.taskname,
                     task_data_parameters["args"],
                     task_data_parameters["kwargs"],

--- a/src/sentry/taskworker/worker_pull.py
+++ b/src/sentry/taskworker/worker_pull.py
@@ -127,7 +127,7 @@ class Worker:
             result = self.__pool.apply_async(
                 func=worker_process._process_activation,
                 args=(
-                    self.options["namespace"],
+                    smainelf.options["namespace"],
                     activation.taskname,
                     task_data_parameters["args"],
                     task_data_parameters["kwargs"],


### PR DESCRIPTION
I've implemented the `PendingTaskStore` "interface" with sqlite backed storage. Because the sqlite databases will be roughly dynamic using django ORM would be challenging to configure connections. I'm also concerned that using the django admin for inflight tasks on SQLite could be confusing as the table won't be in postgres like all our other django models. 

For those reasons I chose to use the basic sqlite3 APIs which are a bit verbose and tedious to operate.

## What is done

- Basic operations and simple task execution

## What still needs to be done

- [x] Making the pending task store pluggable in the grpc servers + consumers.
- [x] Connecting sqlite to the test harness.

I plan on getting the outstanding items complete tomorrow.
