### PR TITLE
fix(ui): Add missing css template tags

### DIFF
--- a/static/app/components/links/styles.tsx
+++ b/static/app/components/links/styles.tsx
@@ -1,6 +1,6 @@
-import type {Theme} from '@emotion/react';
+import {css, type Theme} from '@emotion/react';
 
-export const linkStyles = ({disabled, theme}: {theme: Theme; disabled?: boolean}) => `
+export const linkStyles = ({disabled, theme}: {theme: Theme; disabled?: boolean}) => css`
   border-radius: ${theme.linkBorderRadius};
 
   &:focus-visible {
@@ -9,14 +9,12 @@ export const linkStyles = ({disabled, theme}: {theme: Theme; disabled?: boolean}
     outline: none;
   }
 
-  ${
-    disabled &&
-    `
-      color:${theme.disabled};
-      pointer-events: none;
-      :hover {
-        color: ${theme.disabled};
-      }
-    `
-  }
+  ${disabled &&
+  css`
+    color: ${theme.disabled};
+    pointer-events: none;
+    :hover {
+      color: ${theme.disabled};
+    }
+  `}
 `;

--- a/static/app/components/platformList.tsx
+++ b/static/app/components/platformList.tsx
@@ -117,7 +117,7 @@ function getOverlapWidth(size: number) {
   return Math.round(size / 4);
 }
 
-const commonStyles = ({theme}: {theme: Theme}) => `
+const commonStyles = ({theme}: {theme: Theme}) => css`
   cursor: default;
   border-radius: ${theme.borderRadius};
   box-shadow: 0 0 0 1px ${theme.background};

--- a/static/app/components/tabs/tab.tsx
+++ b/static/app/components/tabs/tab.tsx
@@ -1,5 +1,5 @@
 import {forwardRef, useCallback} from 'react';
-import type {Theme} from '@emotion/react';
+import {css, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {AriaTabProps} from '@react-aria/tabs';
 import {useTab} from '@react-aria/tabs';
@@ -288,27 +288,26 @@ const innerWrapStyles = ({
 }: {
   orientation: Orientation;
   theme: Theme;
-}) => `
+}) => css`
   display: flex;
   align-items: center;
   position: relative;
   height: calc(
-    ${theme.form.sm.height}px +
-      ${orientation === 'horizontal' ? space(0.75) : '0px'}
+    ${theme.form.sm.height}px + ${orientation === 'horizontal' ? space(0.75) : '0px'}
   );
   border-radius: ${theme.borderRadius};
   transform: translateY(1px);
 
-  ${
-    orientation === 'horizontal'
-      ? `
+  ${orientation === 'horizontal'
+    ? css`
         /* Extra padding + negative margin trick, to expand click area */
         padding: ${space(0.75)} ${space(1)} ${space(1.5)};
         margin-left: -${space(1)};
         margin-right: -${space(1)};
       `
-      : `padding: ${space(0.75)} ${space(2)};`
-  };
+    : css`
+        padding: ${space(0.75)} ${space(2)};
+      `};
 `;
 
 const TabLink = styled(Link)<{orientation: Orientation}>`


### PR DESCRIPTION
sort of related to rspack, but these should have css template tags on them to enable the babel plugin and stylelint/formatting
