### PR TITLE
log save event error to sentry every minute

### DIFF
--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Mapping, MutableMapping, Sequence
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
@@ -30,6 +31,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
         self.transactions_topic = Topic.TRANSACTIONS
         self.issue_platform_topic = Topic.EVENTSTREAM_GENERIC
         self.__producers: MutableMapping[Topic, Producer] = {}
+        self.error_last_logged_time: int | None = None
 
     def get_transactions_topic(self, project_id: int) -> Topic:
         return self.transactions_topic
@@ -43,8 +45,11 @@ class KafkaEventStream(SnubaProtocolEventStream):
         return self.__producers[topic]
 
     def delivery_callback(self, error: KafkaError | None, message: KafkaMessage) -> None:
+        now = int(time.time())
         if error is not None:
-            logger.warning("Could not publish message (error: %s): %r", error, message)
+            if self.error_last_logged_time is None or now > self.error_last_logged_time + 60:
+                self.error_last_logged_time = now
+                logger.error("Could not publish message (error: %s): %r", error, message)
 
     def _get_headers_for_insert(
         self,


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/SRE-348
warning level logs are not sent to sentry, only error level entries are. Adding a limit to send only once per minute in case there are too many errors and it will clog our ingestion.