### PR TITLE
ref(ts): Tighten withSentryRouter back up

### DIFF
--- a/static/app/utils/withSentryRouter.tsx
+++ b/static/app/utils/withSentryRouter.tsx
@@ -12,7 +12,7 @@ import useRouter from './useRouter';
  */
 function withSentryRouter<P extends Partial<WithRouterProps>>(
   WrappedComponent: React.ComponentType<P>
-): React.ComponentType<Omit<P, keyof WithRouterProps> & Partial<WithRouterProps>> {
+): React.ComponentType<Omit<P, keyof WithRouterProps>> {
   function WithSentryRouterWrapper(props: Omit<P, keyof WithRouterProps>) {
     const router = useRouter();
     const {location, params, routes} = router;


### PR DESCRIPTION
This was loosened for a change that needed to allow router to be
overriden. Let's tighten this back up