### PR TITLE
fix(wizard-ui): Clear project cache on org change

### DIFF
--- a/static/app/views/setupWizard/index.tsx
+++ b/static/app/views/setupWizard/index.tsx
@@ -205,7 +205,8 @@ function ProjectSelection({hash, organizations = []}: Omit<Props, 'allowSelectio
     [orgProjectsRequest.data]
   );
 
-  const {options: cachedProjectOptions} = useCompactSelectOptionsCache(projectOptions);
+  const {options: cachedProjectOptions, clear: clearProjectOptions} =
+    useCompactSelectOptionsCache(projectOptions);
 
   // As the cache hook sorts the options by value, we need to sort them afterwards
   const sortedProjectOptions = useMemo(
@@ -246,6 +247,7 @@ function ProjectSelection({hash, organizations = []}: Omit<Props, 'allowSelectio
             if (value !== selectedOrgId) {
               setSelectedOrgId(value as string);
               setSelectedProjectId(null);
+              clearProjectOptions();
             }
           }}
         />


### PR DESCRIPTION
As `useCompactSelectOptionsCache` mixes the project options of the last requests, we need to clear the cache once the org changes to avoid mixing projects from different orgs.