### PR TITLE
fix(discovery): stricter permission check when saved queries cover all/my projects

### DIFF
--- a/src/sentry/discover/endpoints/bases.py
+++ b/src/sentry/discover/endpoints/bases.py
@@ -17,8 +17,23 @@ class DiscoverSavedQueryPermission(OrganizationPermission):
             return super().has_object_permission(request, view, obj)
 
         if isinstance(obj, DiscoverSavedQuery):
-            for project in obj.projects.all():
-                if not request.access.has_project_access(project):
-                    return False
+            # 1. Saved Query contains certain projects
+            if obj.projects.exists():
+                return request.access.has_projects_access(obj.projects.all())
 
+            # 2. Saved Query covers all projects or all my projects
+
+            # allow when Open Membership
+            if obj.organization.flags.allow_joinleave:
+                return True
+
+            # allow for Managers and Owners
+            if request.access.has_scope("org:write"):
+                return True
+
+            # allow for creator
+            if request.user.id == obj.created_by_id:
+                return True
+
+            return False
         return True


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/78615

When Open Membership is disabled, it is expected to have more granular access to certain objects that are associated with projects. First version of project-level access on saved queries was implemented in https://github.com/getsentry/sentry/pull/72159

However, saved queries that cover "All Projects" or "My Projects" do not have explicit project ids, therefore we need to do a different check. After this PR, we will allow access to such saved queries only in these cases:
* if Open Membership is enabled;
* if actor is a Manager/Owner (having `org:write` scope);
* if actor is the original creator of a saved query.