### PR TITLE
fix(releases): disallow archive/release when no project-level access

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -246,7 +246,7 @@ class OrganizationReleasesEndpoint(
             organization,
             project_ids=project_ids,
             project_slugs=project_slugs,
-            include_all_accessible="GET" != request.method,
+            include_all_accessible=False,
         )
 
     def get(self, request: Request, organization) -> Response:


### PR DESCRIPTION
We restricted the GET method in https://github.com/getsentry/sentry/pull/37495
but POST (archive/publish) were not affected. Here we fix it as well.