### PR TITLE
fix(grouping): Fix `FallbackVariant.description` property

### DIFF
--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -58,7 +58,7 @@ class ChecksumVariant(BaseVariant):
 
 
 class FallbackVariant(BaseVariant):
-    id = "fallback"
+    type = "fallback"
     contributes = True
 
     def get_hash(self) -> str | None:


### PR DESCRIPTION
When we calculate event grouping, we generate instances of various `BaseVariant` subclasses. Probably the most common variant is `ComponentVariant`, which is a hierarchical structure consisting of nested `GroupingComponent`s. Both variants and components identify themselves using a `description` attribute, which variants base on their `type` and components base on their `id`. 

A much less common variant is the `FallbackVariant`, which we use when we don't have enough data for any of the other grouping methods to work. Perhaps its rarity (combined with the infrequency with which people pay close attention to grouping info data) explains why we've never noticed this, but fallback variants have an `id` (as if they were components) rather than a `type` (as they should as variants). As a result, their description is `None` rather than a real, useful value.

This fixes that by switching the attribute name from `id` to `type`.