### PR TITLE
feat(dashboards): Add hover effects to `WidgetFrame`

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/deletableToken.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/deletableToken.tsx
@@ -143,13 +143,7 @@ const Wrapper = styled('div')`
     }
 
     ${FloatingCloseButton} {
-      clip: rect(0 0 0 0);
-      clip-path: inset(50%);
-      height: 1px;
-      overflow: hidden;
-      position: absolute;
-      white-space: nowrap;
-      width: 1px;
+      ${p => p.theme.visuallyHidden}
     }
   }
 `;

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -648,6 +648,16 @@ const generateUtils = (colors: BaseColors, aliases: Aliases) => ({
     overflow: 'hidden',
     textOverflow: 'ellipsis',
   }),
+  // https://css-tricks.com/inclusively-hidden/
+  visuallyHidden: css({
+    clip: 'rect(0 0 0 0)',
+    clipPath: 'inset(50%)',
+    height: '1px',
+    overflow: 'hidden',
+    position: 'absolute',
+    whiteSpace: 'nowrap',
+    width: '1px',
+  }),
 });
 
 const generatePrismVariables = (

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -511,13 +511,7 @@ export const WidgetCardPanel = styled(Panel, {
   &:not(:hover):not(:focus-within) {
     ${WidgetCardContextMenuContainer} {
       opacity: 0;
-      clip: rect(0 0 0 0);
-      clip-path: inset(50%);
-      height: 1px;
-      overflow: hidden;
-      position: absolute;
-      white-space: nowrap;
-      width: 1px;
+      ${p => p.theme.visuallyHidden}
     }
   }
 

--- a/static/app/views/dashboards/widgets/common/widgetFrame.stories.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.stories.tsx
@@ -19,19 +19,49 @@ export default storyBook(WidgetFrame, story => {
       </Fragment>
     );
   });
-  story('Action Menu', () => {
+
+  story('Layout', () => {
     return (
       <Fragment>
         <p>
-          <JSXNode name="WidgetFrame" /> supports an action menu. If only one action is
-          passed, the single action is rendered as a small button. If multiple actions are
-          passed, they are grouped into a dropdown menu.
+          <JSXNode name="WidgetFrame" /> supports a few basic props that control its
+          content. This includes a title, a description, and the <code>children</code>.
+          The title is automatically wrapped in a tooltip if it does not fit.
         </p>
 
         <SideBySide>
           <NormalWidget>
             <WidgetFrame
               title="Count"
+              description="This counts up the amount of something that happens."
+            />
+          </NormalWidget>
+          <NormalWidget>
+            <WidgetFrame
+              title="p95(measurements.lcp) / p95(measurements.inp)"
+              description="This is a tough formula to reason about"
+            />
+          </NormalWidget>
+        </SideBySide>
+      </Fragment>
+    );
+  });
+
+  story('Action Menu', () => {
+    return (
+      <Fragment>
+        <p>
+          <JSXNode name="WidgetFrame" /> supports an action menu. If only one action is
+          passed, the single action is rendered as a small button. If multiple actions are
+          passed, they are grouped into a dropdown menu. Menu actions appear on hover or
+          keyboard focus.
+        </p>
+
+        <SideBySide>
+          <NormalWidget>
+            <WidgetFrame
+              title="Count"
+              description="This counts up the amount of something that happens."
               actions={[
                 {
                   key: 'see-more',
@@ -48,6 +78,7 @@ export default storyBook(WidgetFrame, story => {
           <NormalWidget>
             <WidgetFrame
               title="Count"
+              description="This is a tough formula to reason about"
               actions={[
                 {
                   key: 'see-more',

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -45,14 +45,12 @@ export function WidgetFrame(props: Props) {
             <TitleText>{props.title}</TitleText>
           </Tooltip>
 
-          {props.description && (
-            <TooltipAligner>
-              <QuestionTooltip size="sm" title={props.description} />
-            </TooltipAligner>
-          )}
-
-          {actions && actions.length > 0 && (
+          {(props.description || (actions && actions.length > 0)) && (
             <TitleActions>
+              {props.description && (
+                <QuestionTooltip title={props.description} size="sm" icon="info" />
+              )}
+
               {actions.length === 1 ? (
                 actions[0].to ? (
                   <LinkButton size="xs" onClick={actions[0].onAction} to={actions[0].to}>
@@ -117,10 +115,12 @@ const Frame = styled('div')`
   }
 `;
 
+const HEADER_HEIGHT = 20;
+
 const Header = styled('div')`
   display: flex;
   flex-direction: column;
-  min-height: 20px;
+  min-height: ${HEADER_HEIGHT}px;
 `;
 
 const Title = styled('div')`
@@ -135,13 +135,10 @@ const TitleText = styled(HeaderTitle)`
 `;
 
 const TitleActions = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
   margin-left: auto;
-`;
-
-const TooltipAligner = styled('div')`
-  font-size: 0;
-  line-height: 1;
-  margin-bottom: 2px;
 `;
 
 const VisualizationWrapper = styled('div')`

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -107,6 +107,14 @@ const Frame = styled('div')`
   border: 1px ${p => 'solid ' + p.theme.border};
 
   background: ${p => p.theme.background};
+
+  :hover {
+    background-color: ${p => p.theme.surface200};
+    transition:
+      background-color 100ms linear,
+      box-shadow 100ms linear;
+    box-shadow: ${p => p.theme.dropShadowLight};
+  }
 `;
 
 const Header = styled('div')`

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -106,7 +106,7 @@ const Frame = styled('div')`
   width: 100%;
   min-width: ${MIN_WIDTH}px;
 
-  padding: ${space(2)};
+  padding: ${space(1.5)} ${space(2)};
 
   border-radius: ${p => p.theme.panelBorderRadius};
   border: ${p => p.theme.border};

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -40,45 +40,43 @@ export function WidgetFrame(props: Props) {
   return (
     <Frame>
       <Header>
-        <Title>
-          <Tooltip title={props.title} containerDisplayMode="grid" showOnlyOnOverflow>
-            <TitleText>{props.title}</TitleText>
-          </Tooltip>
+        <Tooltip title={props.title} containerDisplayMode="grid" showOnlyOnOverflow>
+          <TitleText>{props.title}</TitleText>
+        </Tooltip>
 
-          {(props.description || (actions && actions.length > 0)) && (
-            <TitleActions>
-              {props.description && (
-                <QuestionTooltip title={props.description} size="sm" icon="info" />
-              )}
+        {(props.description || (actions && actions.length > 0)) && (
+          <TitleActions>
+            {props.description && (
+              <QuestionTooltip title={props.description} size="sm" icon="info" />
+            )}
 
-              {actions.length === 1 ? (
-                actions[0].to ? (
-                  <LinkButton size="xs" onClick={actions[0].onAction} to={actions[0].to}>
-                    {actions[0].label}
-                  </LinkButton>
-                ) : (
-                  <Button size="xs" onClick={actions[0].onAction}>
-                    {actions[0].label}
-                  </Button>
-                )
-              ) : null}
+            {actions.length === 1 ? (
+              actions[0].to ? (
+                <LinkButton size="xs" onClick={actions[0].onAction} to={actions[0].to}>
+                  {actions[0].label}
+                </LinkButton>
+              ) : (
+                <Button size="xs" onClick={actions[0].onAction}>
+                  {actions[0].label}
+                </Button>
+              )
+            ) : null}
 
-              {actions.length > 1 ? (
-                <DropdownMenu
-                  items={actions}
-                  triggerProps={{
-                    'aria-label': t('Actions'),
-                    size: 'xs',
-                    borderless: true,
-                    showChevron: false,
-                    icon: <IconEllipsis direction="down" size="sm" />,
-                  }}
-                  position="bottom-end"
-                />
-              ) : null}
-            </TitleActions>
-          )}
-        </Title>
+            {actions.length > 1 ? (
+              <DropdownMenu
+                items={actions}
+                triggerProps={{
+                  'aria-label': t('Actions'),
+                  size: 'xs',
+                  borderless: true,
+                  showChevron: false,
+                  icon: <IconEllipsis direction="down" size="sm" />,
+                }}
+                position="bottom-end"
+              />
+            ) : null}
+          </TitleActions>
+        )}
       </Header>
 
       <VisualizationWrapper>
@@ -136,14 +134,8 @@ const HEADER_HEIGHT = 26;
 
 const Header = styled('div')`
   display: flex;
-  min-height: ${HEADER_HEIGHT}px;
   align-items: center;
-`;
-
-const Title = styled('div')`
-  display: flex;
-  flex-grow: 1;
-  align-items: center;
+  height: ${HEADER_HEIGHT}px;
   gap: ${space(0.75)};
 `;
 

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -88,6 +88,16 @@ export function WidgetFrame(props: Props) {
   );
 }
 
+const TitleActions = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
+  margin-left: auto;
+
+  opacity: 1;
+  transition: opacity 0.1s;
+`;
+
 const Frame = styled('div')`
   position: relative;
   display: flex;
@@ -113,18 +123,26 @@ const Frame = styled('div')`
       box-shadow 100ms linear;
     box-shadow: ${p => p.theme.dropShadowLight};
   }
+
+  &:not(:hover):not(:focus-within) {
+    ${TitleActions} {
+      opacity: 0;
+      ${p => p.theme.visuallyHidden}
+    }
+  }
 `;
 
-const HEADER_HEIGHT = 20;
+const HEADER_HEIGHT = 26;
 
 const Header = styled('div')`
   display: flex;
-  flex-direction: column;
   min-height: ${HEADER_HEIGHT}px;
+  align-items: center;
 `;
 
 const Title = styled('div')`
-  display: inline-flex;
+  display: flex;
+  flex-grow: 1;
   align-items: center;
   gap: ${space(0.75)};
 `;
@@ -132,13 +150,6 @@ const Title = styled('div')`
 const TitleText = styled(HeaderTitle)`
   ${p => p.theme.overflowEllipsis};
   font-weight: ${p => p.theme.fontWeightBold};
-`;
-
-const TitleActions = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${space(0.5)};
-  margin-left: auto;
 `;
 
 const VisualizationWrapper = styled('div')`


### PR DESCRIPTION
Matches the work done in https://github.com/getsentry/sentry/pull/78477 and https://github.com/getsentry/sentry/pull/78231 but adds it to `WidgetFrame`

- hover effect: the background turns grey on hover
- hover effect: widget frame actions only show on hover

Plus improvement to stories, padding/spacing, etc.

**e.g.,**

https://github.com/user-attachments/assets/d1c6aa8f-e82a-477d-bea5-e8776db2c64f

One difference from the previous PRs is the use of `QuestionTooltip`. The previous PRs opted not to use it because it doesn't hold keyboard focus, which is a good reason. I'm opting to use `QuestionTooltip` here with an implicit promise to give it keyboard focus in a separate PR.