### PR TITLE
ref(grouping):  Clean up `event._fingerprint_info`

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -257,9 +257,6 @@ def apply_server_fingerprinting(event, config, allow_custom_title=True):
         # dictionary for later debugging.
         fingerprint_info["matched_rule"] = rule.to_json()
 
-        if rule.is_builtin:
-            fingerprint_info["is_builtin"] = True
-
     if fingerprint_info:
         event["_fingerprint_info"] = fingerprint_info
 
@@ -353,7 +350,7 @@ def get_grouping_variants_for_event(
             rv[key] = ComponentVariant(component, context.config)
 
         fingerprint = resolve_fingerprint_values(fingerprint, event.data)
-        if fingerprint_info and fingerprint_info.get("is_builtin", False):
+        if (fingerprint_info or {}).get("matched_rule", {}).get("is_builtin") is True:
             rv["built-in-fingerprint"] = BuiltInFingerprintVariant(fingerprint, fingerprint_info)
         else:
             rv["custom-fingerprint"] = CustomFingerprintVariant(fingerprint, fingerprint_info)

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -234,6 +234,8 @@ def get_fingerprinting_config_for_project(
 
 
 def apply_server_fingerprinting(event, config, allow_custom_title=True):
+    fingerprint_info = {}
+
     client_fingerprint = event.get("fingerprint")
     rv = config.get_fingerprint_values_for_event(event)
     if rv is not None:
@@ -247,13 +249,14 @@ def apply_server_fingerprinting(event, config, allow_custom_title=True):
 
         # Persist the rule that matched with the fingerprint in the event
         # dictionary for later debugging.
-        event["_fingerprint_info"] = {
-            "client_fingerprint": client_fingerprint,
-            "matched_rule": rule.to_json(),
-        }
+        fingerprint_info["client_fingerprint"] = client_fingerprint
+        fingerprint_info["matched_rule"] = rule.to_json()
 
         if rule.is_builtin:
-            event["_fingerprint_info"]["is_builtin"] = True
+            fingerprint_info["is_builtin"] = True
+
+    if fingerprint_info:
+        event["_fingerprint_info"] = fingerprint_info
 
 
 def _get_calculated_grouping_variants_for_event(

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -236,8 +236,12 @@ def get_fingerprinting_config_for_project(
 def apply_server_fingerprinting(event, config, allow_custom_title=True):
     fingerprint_info = {}
 
-    client_fingerprint = event.get("fingerprint")
-    fingerprint_info["client_fingerprint"] = client_fingerprint
+    client_fingerprint = event.get("fingerprint", [])
+    client_fingerprint_is_default = len(client_fingerprint) == 1 and is_default_fingerprint_var(
+        client_fingerprint[0]
+    )
+    if client_fingerprint and not client_fingerprint_is_default:
+        fingerprint_info["client_fingerprint"] = client_fingerprint
 
     rv = config.get_fingerprint_values_for_event(event)
     if rv is not None:

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -237,6 +237,8 @@ def apply_server_fingerprinting(event, config, allow_custom_title=True):
     fingerprint_info = {}
 
     client_fingerprint = event.get("fingerprint")
+    fingerprint_info["client_fingerprint"] = client_fingerprint
+
     rv = config.get_fingerprint_values_for_event(event)
     if rv is not None:
         rule, new_fingerprint, attributes = rv
@@ -249,7 +251,6 @@ def apply_server_fingerprinting(event, config, allow_custom_title=True):
 
         # Persist the rule that matched with the fingerprint in the event
         # dictionary for later debugging.
-        fingerprint_info["client_fingerprint"] = client_fingerprint
         fingerprint_info["matched_rule"] = rule.to_json()
 
         if rule.is_builtin:

--- a/tests/sentry/grouping/ingest/test_seer.py
+++ b/tests/sentry/grouping/ingest/test_seer.py
@@ -147,7 +147,7 @@ class ShouldCallSeerTest(TestCase):
             data={
                 **self.event_data,
                 "fingerprint": ["failedtofetcherror"],
-                "_fingerprint_info": {"is_builtin": True},
+                "_fingerprint_info": {"matched_rule": {"is_builtin": True}},
             },
         )
 

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-10-13T10:09:30.497241Z'
+created: '2024-10-09T13:42:58.974458+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -20,6 +20,9 @@ fingerprint:
 title: 'DatabaseUnavailable: For some reason the database went away'
 variants:
   app:
+    client_values:
+    - my-route
+    - '{{ default }}'
     component:
       contributes: false
       hint: exception of system takes precedence
@@ -28,6 +31,9 @@ variants:
     - my-route
     - '{{ default }}'
   system:
+    client_values:
+    - my-route
+    - '{{ default }}'
     component:
       contributes: true
       hint: null

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk_mismatch.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk_mismatch.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-01-10T17:07:19.931277Z'
+created: '2024-10-09T13:43:00.978539+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 # Shows that the custom fingerprinting rule is not applied when type matches, but SDK does not
@@ -21,6 +21,9 @@ fingerprint:
 title: 'DatabaseUnavailable: For some reason the database went away'
 variants:
   app:
+    client_values:
+    - my-route
+    - '{{ default }}'
     component:
       contributes: false
       hint: exception of system takes precedence
@@ -29,6 +32,9 @@ variants:
     - my-route
     - '{{ default }}'
   system:
+    client_values:
+    - my-route
+    - '{{ default }}'
     component:
       contributes: true
       hint: null

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-10-13T10:09:31.932012Z'
+created: '2024-10-09T13:43:01.647186+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -20,6 +20,9 @@ fingerprint:
 title: 'DatabaseUnavailable: For some reason the database went away'
 variants:
   app:
+    client_values:
+    - my-route
+    - '{{ default }}'
     component:
       contributes: false
       hint: exception of system takes precedence
@@ -28,6 +31,9 @@ variants:
     - my-route
     - '{{ default }}'
   system:
+    client_values:
+    - my-route
+    - '{{ default }}'
     component:
       contributes: true
       hint: null

--- a/tests/sentry/grouping/test_builtin_fingerprinting.py
+++ b/tests/sentry/grouping/test_builtin_fingerprinting.py
@@ -677,7 +677,6 @@ class BuiltInFingerprintingTest(TestCase):
 
         assert "built-in-fingerprint" not in variants
         assert event_transaction_no_tx.data["fingerprint"] == ["my-route", "{{ default }}"]
-        assert event_transaction_no_tx.data.get("_fingerprint_info") is None
 
     def test_hydration_rule_w_family_matcher(self):
         """


### PR DESCRIPTION
This makes two small changes to the data we store in `event._fingerprint_info`:

- Change the criterion for when we store the client fingerprint. Right now, we only store it if we've matched a server-side fingerprinting rule, and we store it even if it's the default value. After this change, we'll store it regardless of server-side matches, but only if it's not the default value.

- Stop storing `is_builtin` at the top level of `_fingerprint_info`, since it's already stored in `_fingerprint_info.matched_rule`.