### PR TITLE
feat(ui): Add focus trigger to `QuestionTooltip`

### DIFF
--- a/static/app/components/questionTooltip.stories.tsx
+++ b/static/app/components/questionTooltip.stories.tsx
@@ -13,10 +13,10 @@ export default storyBook(QuestionTooltip, story => {
       <Fragment>
         <p>
           The <JSXNode name="QuestionTooltip" /> component is a small{' '}
-          <JSXNode name="IconQuestion" /> where you can specify a tooltip to go with it.
-          It is useful for placing after headers and titles to include additional
-          information. You'll see it often at the top of Sentry's pages, near the page
-          titles.
+          <JSXNode name="IconQuestion" /> or <JSXNode name="IconInfo" /> where you can
+          specify a tooltip to go with it. It is useful for placing after headers and
+          titles to include additional information. You'll see it often at the top of
+          Sentry's pages, near the page titles.
         </p>
         <p>
           An example <JSXNode name="QuestionTooltip" /> looks like this:
@@ -39,7 +39,7 @@ export default storyBook(QuestionTooltip, story => {
     );
   });
 
-  story('size', () => {
+  story('Size', () => {
     return (
       <Fragment>
         <p>
@@ -65,6 +65,26 @@ export default storyBook(QuestionTooltip, story => {
           </div>
           <div>
             "xxl" <QuestionTooltip size="xxl" title="xxl" />
+          </div>
+        </IconExamples>
+      </Fragment>
+    );
+  });
+
+  story('Icon', () => {
+    return (
+      <Fragment>
+        <p>
+          You can set the <JSXProperty name="icon" value /> prop to either{' '}
+          <code>"question"</code> or <code>"info"</code>
+        </p>
+
+        <IconExamples>
+          <div>
+            "question" <QuestionTooltip size="sm" title="Question" icon="question" />
+          </div>
+          <div>
+            "info" <QuestionTooltip size="sm" title="Info" icon="info" />
           </div>
         </IconExamples>
       </Fragment>

--- a/static/app/components/questionTooltip.tsx
+++ b/static/app/components/questionTooltip.tsx
@@ -5,6 +5,8 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {IconInfo, IconQuestion} from 'sentry/icons';
 import type {IconSize} from 'sentry/utils/theme';
 
+import {Button} from './button';
+
 interface QuestionProps
   extends Partial<
     Pick<
@@ -36,11 +38,13 @@ function QuestionTooltip({
   return (
     <QuestionIconContainer size={size} className={className}>
       <Tooltip title={title} {...tooltipProps}>
-        {icon === 'info' ? (
-          <IconInfo size={size} color="subText" data-test-id="more-information" />
-        ) : (
-          <IconQuestion size={size} color="subText" data-test-id="more-information" />
-        )}
+        <TooltipTriggerButton borderless size="xs">
+          {icon === 'info' ? (
+            <IconInfo size={size} color="subText" data-test-id="more-information" />
+          ) : (
+            <IconQuestion size={size} color="subText" data-test-id="more-information" />
+          )}
+        </TooltipTriggerButton>
       </Tooltip>
     </QuestionIconContainer>
   );
@@ -59,6 +63,13 @@ const QuestionIconContainer = styled('span')<Pick<QuestionProps, 'size' | 'class
       opacity: 1;
     }
   }
+`;
+
+const TooltipTriggerButton = styled(Button)`
+  padding: 0;
+  min-height: 0;
+  width: auto;
+  height: auto;
 `;
 
 export default QuestionTooltip;


### PR DESCRIPTION
`QuestionTooltip` has an unpleasant A11y downside, in which it doesn't appear on keyboard focus because it doesn't receive keyboard focus. This PR wraps it in an invisible button which receives focus, and makes it possible to see the tooltip while navigating with a keyboard.

The problem is, I'm a little wary of using `Button`. I _want_ the focus state from it (the border including the animation) but it has a lot of styling I had to override. Is there a better way to achieve this? I could rip those styles out, but I didn't like that, either.

Also, it would probably be nice to use React ARIA's `Tooltip` but one thing at a time.

**e.g.,**
![Screenshot 2024-10-09 at 10 20 00 AM](https://github.com/user-attachments/assets/7c20a678-75c9-4191-a38c-62d4be3f42a6)
