### PR TITLE
feat(wizard-ui): Prefill org from URL param

### DIFF
--- a/static/app/views/setupWizard/index.tsx
+++ b/static/app/views/setupWizard/index.tsx
@@ -129,7 +129,16 @@ function ProjectSelection({hash, organizations = []}: Omit<Props, 'allowSelectio
     if (organizations.length === 1) {
       return organizations[0].id;
     }
-    // Pre-fill the last used org if there are multiple
+
+    const urlParams = new URLSearchParams(location.search);
+    const orgSlug = urlParams.get('org_slug');
+    const orgMatchingSlug = orgSlug && organizations.find(org => org.slug === orgSlug);
+
+    if (orgMatchingSlug) {
+      return orgMatchingSlug.id;
+    }
+
+    // Pre-fill the last used org if there are multiple and no URL param
     if (lastOrganization) {
       return lastOrganization.id;
     }


### PR DESCRIPTION
Prefill the org select field from the `org_slug` URL param.

In a follow-up PR:
If `org_slug` and `project_slug` are set, it will be handled on the BE and the selection step can be skipped.

Part of https://github.com/getsentry/sentry/issues/78323