### PR TITLE
ref(trace) remove captureMessage when span parent is missing

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -460,13 +460,6 @@ export class TraceTree extends TraceTreeEventDispatcher {
 
       // If the parent span does not exist in the span tree, the transaction will remain under the current node
       if (!parent) {
-        Sentry.withScope(scope => {
-          scope.setFingerprint(['trace-span-parent']);
-          scope.captureMessage(
-            'A transaction was found to have a span parent that does not exist in the span list'
-          );
-        });
-
         if (transaction.parent?.children.indexOf(transaction) === -1) {
           transaction.parent.children.push(transaction);
         }


### PR DESCRIPTION
This is a legit case which we had no log for before. I added it because I wanted to see how often it happens, but it might turn out to be toon noisy to care about (we have a fallback for it in the tree rendering logic)