### PR TITLE
fix(ui): Align columns on teams for members page

### DIFF
--- a/static/app/views/settings/components/teamSelect/teamSelectForMember.tsx
+++ b/static/app/views/settings/components/teamSelect/teamSelectForMember.tsx
@@ -98,7 +98,6 @@ function TeamSelect({
     <Panel>
       <TeamPanelHeader hasButtons>
         <div>{t('Team')}</div>
-        <div />
         <div>
           <TeamRoleColumnLabel />
         </div>

--- a/static/app/views/settings/components/teamSelect/teamSelectForMember.tsx
+++ b/static/app/views/settings/components/teamSelect/teamSelectForMember.tsx
@@ -150,7 +150,7 @@ function TeamRow({
         </Link>
       </div>
 
-      <div>
+      <div style={{whiteSpace: 'nowrap'}}>
         <TeamRoleSelect
           disabled={disabled}
           size="xs"


### PR DESCRIPTION
There was an extra div misaligning things.
Resolves https://github.com/getsentry/sentry/issues/69882

Before: 
<img width="1416" alt="image" src="https://github.com/user-attachments/assets/5d717e4a-4e15-4738-ace4-9ce7a1756ea7">


After:

<img width="1102" alt="image" src="https://github.com/user-attachments/assets/58425040-f3e9-4af1-a55e-6cce24496de4">