### PR TITLE
feat(trace): Handle span id when passed to the trace endpoint

### DIFF
--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -380,7 +380,10 @@ class DiscoverDatasetConfig(DatasetConfig):
                 SnQLFunction(
                     "to_other",
                     required_args=[
-                        ColumnArg("column", allowed_columns=["release", "trace.parent_span", "id"]),
+                        ColumnArg(
+                            "column",
+                            allowed_columns=["release", "trace.parent_span", "id", "trace.span"],
+                        ),
                         SnQLStringArg("value", unquote=True, unescape_quotes=True),
                     ],
                     optional_args=[


### PR DESCRIPTION
- The new eap spans don't have event id, so they pass a span id instead
- Question; Would the frontend be able to update to targetId=? instead of eventId=?