### PR TITLE
feat(insights): filter frontend by relevant transaction ops

### DIFF
--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -25,6 +25,7 @@ import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {ViewTrendsButton} from 'sentry/views/insights/common/components/viewTrendsButton';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
+import {OVERVIEW_PAGE_ALLOWED_OPS} from 'sentry/views/insights/pages/frontend/settings';
 import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
 import {generateFrontendOtherPerformanceEventView} from 'sentry/views/performance/data';
 import {
@@ -50,8 +51,6 @@ export const FRONTEND_COLUMN_TITLES = [
   'users',
   'user misery',
 ];
-
-const allowedTransactionOps = ['pageload', 'navigation', 'ui.render', 'interaction'];
 
 function FrontendOverviewPage() {
   const organization = useOrganization();
@@ -86,7 +85,7 @@ function FrontendOverviewPage() {
   const doubleChartRowEventView = eventView.clone(); // some of the double chart rows rely on span metrics, so they can't be queried the same way
 
   const existingQuery = new MutableSearch(eventView.query);
-  existingQuery.addDisjunctionFilterValues('transaction.op', allowedTransactionOps);
+  existingQuery.addDisjunctionFilterValues('transaction.op', OVERVIEW_PAGE_ALLOWED_OPS);
   eventView.query = existingQuery.formatString();
 
   const showOnboarding = onboardingProject !== undefined;

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -51,6 +51,8 @@ export const FRONTEND_COLUMN_TITLES = [
   'user misery',
 ];
 
+const allowedTransactionOps = ['pageload', 'navigation', 'ui.render', 'interaction'];
+
 function FrontendOverviewPage() {
   const organization = useOrganization();
   const location = useLocation();
@@ -80,6 +82,10 @@ function FrontendOverviewPage() {
     {field: 'count_miserable(user)'},
     {field: 'user_misery()'},
   ].map(field => ({...field, width: COL_WIDTH_UNDEFINED}));
+
+  const existingQuery = new MutableSearch(eventView.query);
+  existingQuery.addDisjunctionFilterValues('transaction.op', allowedTransactionOps);
+  eventView.query = existingQuery.formatString();
 
   const showOnboarding = onboardingProject !== undefined;
 

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -83,6 +83,8 @@ function FrontendOverviewPage() {
     {field: 'user_misery()'},
   ].map(field => ({...field, width: COL_WIDTH_UNDEFINED}));
 
+  const doubleChartRowEventView = eventView.clone(); // some of the double chart rows rely on span metrics, so they can't be queried the same way
+
   const existingQuery = new MutableSearch(eventView.query);
   existingQuery.addDisjunctionFilterValues('transaction.op', allowedTransactionOps);
   eventView.query = existingQuery.formatString();
@@ -176,7 +178,11 @@ function FrontendOverviewPage() {
                 <PerformanceDisplayProvider
                   value={{performanceType: ProjectPerformanceType.FRONTEND_OTHER}}
                 >
-                  <DoubleChartRow allowedCharts={doubleChartRowCharts} {...sharedProps} />
+                  <DoubleChartRow
+                    allowedCharts={doubleChartRowCharts}
+                    {...sharedProps}
+                    eventView={doubleChartRowEventView}
+                  />
                   <TripleChartRow allowedCharts={tripleChartRowCharts} {...sharedProps} />
                   <Table
                     projects={projects}

--- a/static/app/views/insights/pages/frontend/settings.ts
+++ b/static/app/views/insights/pages/frontend/settings.ts
@@ -2,3 +2,10 @@ import {t} from 'sentry/locale';
 
 export const FRONTEND_LANDING_SUB_PATH = 'frontend';
 export const FRONTEND_LANDING_TITLE = t('Frontend');
+
+export const OVERVIEW_PAGE_ALLOWED_OPS = [
+  'pageload',
+  'navigation',
+  'ui.render',
+  'interaction',
+];


### PR DESCRIPTION
Work for https://github.com/getsentry/sentry/issues/77572

Filter frontend overview page by relevant transaction ops. This does not apply to the double chart rows, as some of them use span metrics, which means we cant filter them the same way due to missing tags.