### PR TITLE
chore(issue-details): Adjust all events header styling

### DIFF
--- a/static/app/views/issueDetails/streamline/eventList.tsx
+++ b/static/app/views/issueDetails/streamline/eventList.tsx
@@ -154,7 +154,7 @@ const EventListHeader = styled('div')`
   grid-template-columns: 1fr auto auto auto;
   gap: ${space(1.5)};
   align-items: center;
-  padding: ${space(0.75)} ${space(2)};
+  padding: ${space(1)} ${space(2)};
   background: ${p => p.theme.background};
   border-bottom: 1px solid ${p => p.theme.translucentBorder};
   position: sticky;
@@ -166,7 +166,7 @@ const EventListHeader = styled('div')`
 const EventListTitle = styled('div')`
   color: ${p => p.theme.textColor};
   font-weight: ${p => p.theme.fontWeightBold};
-  font-size: ${p => p.theme.fontSizeLarge};
+  font-size: ${p => p.theme.fontSizeMedium};
 `;
 
 const EventListHeaderItem = styled('div')`


### PR DESCRIPTION
this pr updates the styling for the all events header to better align it with the rest of the page

before: 
![Screenshot 2024-10-09 at 9 34 10 AM](https://github.com/user-attachments/assets/53223310-11af-461f-88d6-b30f3c46c34f)


after: 
![Screenshot 2024-10-09 at 9 34 15 AM](https://github.com/user-attachments/assets/b2787994-777b-4f49-a5ec-586ed7dfd6c6)
