### PR TITLE
feat(issues): Add suspect commit directly to stack trace

### DIFF
--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -82,7 +82,7 @@ function EventEntries({
       )}
       {!isShare && isNotSharedOrganization(organization) && (
         <SuspectCommits
-          project={project}
+          projectSlug={project.slug}
           eventId={event.id}
           group={group}
           commitRow={CommitRow}

--- a/static/app/components/events/eventEntry.tsx
+++ b/static/app/components/events/eventEntry.tsx
@@ -47,6 +47,7 @@ function EventEntryContent({
       return (
         <Exception
           event={event}
+          group={group}
           data={entry.data}
           projectSlug={projectSlug}
           groupingCurrentLevel={groupingCurrentLevel}
@@ -98,6 +99,7 @@ function EventEntryContent({
       return (
         <Threads
           event={event}
+          group={group}
           data={entry.data}
           projectSlug={projectSlug}
           groupingCurrentLevel={groupingCurrentLevel}

--- a/static/app/components/events/interfaces/exception.tsx
+++ b/static/app/components/events/interfaces/exception.tsx
@@ -1,9 +1,15 @@
+import {Fragment} from 'react';
+
+import {CommitRow} from 'sentry/components/commitRow';
+import ErrorBoundary from 'sentry/components/errorBoundary';
+import {SuspectCommits} from 'sentry/components/events/suspectCommits';
 import {t} from 'sentry/locale';
 import type {Event, ExceptionType} from 'sentry/types/event';
 import {EntryType} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {StackType, StackView} from 'sentry/types/stacktrace';
+import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 import {TraceEventDataSection} from '../traceEventDataSection';
 
@@ -14,13 +20,21 @@ import {isStacktraceNewestFirst} from './utils';
 type Props = {
   data: ExceptionType;
   event: Event;
+  group: Group | undefined;
   projectSlug: Project['slug'];
   groupingCurrentLevel?: Group['metadata']['current_level'];
   hideGuide?: boolean;
 };
 
-export function Exception({event, data, projectSlug, groupingCurrentLevel}: Props) {
+export function Exception({
+  event,
+  data,
+  projectSlug,
+  group,
+  groupingCurrentLevel,
+}: Props) {
   const eventHasThreads = !!event.entries.some(entry => entry.type === EntryType.THREADS);
+  const hasStreamlinedUI = useHasStreamlinedUI();
 
   // in case there are threads in the event data, we don't render the
   // exception block.  Instead the exception is contained within the
@@ -78,30 +92,45 @@ export function Exception({event, data, projectSlug, groupingCurrentLevel}: Prop
       }
       stackTraceNotFound={stackTraceNotFound}
     >
-      {({recentFirst, display, fullStackTrace}) =>
-        stackTraceNotFound ? (
+      {({recentFirst, display, fullStackTrace}) => {
+        return stackTraceNotFound ? (
           <NoStackTraceMessage />
         ) : (
-          <ExceptionContent
-            stackType={
-              display.includes('minified') ? StackType.MINIFIED : StackType.ORIGINAL
-            }
-            stackView={
-              display.includes('raw-stack-trace')
-                ? StackView.RAW
-                : fullStackTrace
-                  ? StackView.FULL
-                  : StackView.APP
-            }
-            projectSlug={projectSlug}
-            newestFirst={recentFirst}
-            event={event}
-            values={data.values}
-            groupingCurrentLevel={groupingCurrentLevel}
-            meta={meta}
-          />
-        )
-      }
+          <Fragment>
+            <ExceptionContent
+              stackType={
+                display.includes('minified') ? StackType.MINIFIED : StackType.ORIGINAL
+              }
+              stackView={
+                display.includes('raw-stack-trace')
+                  ? StackView.RAW
+                  : fullStackTrace
+                    ? StackView.FULL
+                    : StackView.APP
+              }
+              projectSlug={projectSlug}
+              newestFirst={recentFirst}
+              event={event}
+              values={data.values}
+              groupingCurrentLevel={groupingCurrentLevel}
+              meta={meta}
+            />
+            {hasStreamlinedUI && (
+              <ErrorBoundary
+                mini
+                message={t('There was an error loading the suspect commits')}
+              >
+                <SuspectCommits
+                  projectSlug={projectSlug}
+                  eventId={event.id}
+                  group={group}
+                  commitRow={CommitRow}
+                />
+              </ErrorBoundary>
+            )}
+          </Fragment>
+        );
+      }}
     </TraceEventDataSection>
   );
 }

--- a/static/app/components/events/interfaces/exception.tsx
+++ b/static/app/components/events/interfaces/exception.tsx
@@ -115,7 +115,7 @@ export function Exception({
               groupingCurrentLevel={groupingCurrentLevel}
               meta={meta}
             />
-            {hasStreamlinedUI && (
+            {hasStreamlinedUI && group && (
               <ErrorBoundary
                 mini
                 message={t('There was an error loading the suspect commits')}

--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
+import {CommitRow} from 'sentry/components/commitRow';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {StacktraceBanners} from 'sentry/components/events/interfaces/crashContent/exception/banners/stacktraceBanners';
 import {getLockReason} from 'sentry/components/events/interfaces/threads/threadSelector/lockReason';
@@ -9,6 +10,7 @@ import {
   getThreadStateHelpText,
   ThreadStates,
 } from 'sentry/components/events/interfaces/threads/threadSelector/threadStates';
+import {SuspectCommits} from 'sentry/components/events/suspectCommits';
 import Pill from 'sentry/components/pill';
 import Pills from 'sentry/components/pills';
 import QuestionTooltip from 'sentry/components/questionTooltip';
@@ -18,6 +20,7 @@ import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event, Thread} from 'sentry/types/event';
 import {EntryType} from 'sentry/types/event';
+import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {StackType, StackView} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
@@ -43,6 +46,7 @@ type Props = Pick<ExceptionProps, 'groupingCurrentLevel'> & {
     values?: Array<Thread>;
   };
   event: Event;
+  group: Group | undefined;
   projectSlug: Project['slug'];
 };
 
@@ -96,7 +100,7 @@ const useActiveThreadState = (
   return [activeThread, setActiveThread];
 };
 
-export function Threads({data, event, projectSlug, groupingCurrentLevel}: Props) {
+export function Threads({data, event, projectSlug, groupingCurrentLevel, group}: Props) {
   const threads = data.values ?? [];
   const hasStreamlinedUI = useHasStreamlinedUI();
   const [activeThread, setActiveThread] = useActiveThreadState(event, threads);
@@ -350,6 +354,19 @@ export function Threads({data, event, projectSlug, groupingCurrentLevel}: Props)
                 </ErrorBoundary>
               )}
               {renderContent(childrenProps)}
+              {hasStreamlinedUI && (
+                <ErrorBoundary
+                  mini
+                  message={t('There was an error loading the suspect commits')}
+                >
+                  <SuspectCommits
+                    projectSlug={projectSlug}
+                    eventId={event.id}
+                    commitRow={CommitRow}
+                    group={group}
+                  />
+                </ErrorBoundary>
+              )}
             </Fragment>
           );
         }}

--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -354,7 +354,7 @@ export function Threads({data, event, projectSlug, groupingCurrentLevel, group}:
                 </ErrorBoundary>
               )}
               {renderContent(childrenProps)}
-              {hasStreamlinedUI && (
+              {hasStreamlinedUI && group && (
                 <ErrorBoundary
                   mini
                   message={t('There was an error loading the suspect commits')}

--- a/static/app/components/events/suspectCommits.spec.tsx
+++ b/static/app/components/events/suspectCommits.spec.tsx
@@ -68,6 +68,10 @@ describe('SuspectCommits', function () {
           committers,
         },
       });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/projects/`,
+        body: [project],
+      });
     });
 
     it('Renders base commit row', async function () {

--- a/static/app/components/events/suspectCommits.spec.tsx
+++ b/static/app/components/events/suspectCommits.spec.tsx
@@ -73,7 +73,7 @@ describe('SuspectCommits', function () {
     it('Renders base commit row', async function () {
       render(
         <SuspectCommits
-          project={project}
+          projectSlug={project.slug}
           commitRow={CommitRow}
           eventId={event.id}
           group={group}
@@ -88,7 +88,7 @@ describe('SuspectCommits', function () {
     it('Renders quick context commit row', async function () {
       render(
         <SuspectCommits
-          project={project}
+          projectSlug={project.slug}
           commitRow={QuickContextCommitRow}
           eventId={event.id}
           group={group}
@@ -112,7 +112,7 @@ describe('SuspectCommits', function () {
 
       render(
         <SuspectCommits
-          project={project}
+          projectSlug={project.slug}
           commitRow={CommitRow}
           eventId={event.id}
           group={group}
@@ -126,7 +126,7 @@ describe('SuspectCommits', function () {
     it('expands', async function () {
       render(
         <SuspectCommits
-          project={project}
+          projectSlug={project.slug}
           commitRow={CommitRow}
           eventId={event.id}
           group={group}
@@ -165,7 +165,7 @@ describe('SuspectCommits', function () {
 
       render(
         <SuspectCommits
-          project={project}
+          projectSlug={project.slug}
           commitRow={CommitRow}
           eventId={event.id}
           group={group}
@@ -237,7 +237,7 @@ describe('SuspectCommits', function () {
     it('Renders base commit row', async function () {
       render(
         <SuspectCommits
-          project={project}
+          projectSlug={project.slug}
           commitRow={CommitRow}
           eventId={event.id}
           group={group}
@@ -253,7 +253,7 @@ describe('SuspectCommits', function () {
     it('Renders quick context commit row', async function () {
       render(
         <SuspectCommits
-          project={project}
+          projectSlug={project.slug}
           commitRow={QuickContextCommitRow}
           eventId={event.id}
           group={group}
@@ -275,7 +275,7 @@ describe('SuspectCommits', function () {
       });
       render(
         <SuspectCommits
-          project={project}
+          projectSlug={project.slug}
           commitRow={CommitRow}
           eventId={event.id}
           group={group}

--- a/static/app/components/events/suspectCommits.tsx
+++ b/static/app/components/events/suspectCommits.tsx
@@ -2,8 +2,6 @@ import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 import uniqBy from 'lodash/uniqBy';
 
-import bannerIllustration from 'sentry-images/spot/alerts-empty-state.svg';
-
 import type {CommitRowProps} from 'sentry/components/commitRow';
 import {SuspectCommitHeader} from 'sentry/components/events/styles';
 import Panel from 'sentry/components/panels/panel';
@@ -13,27 +11,34 @@ import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
 import type {Commit} from 'sentry/types/integrations';
-import type {AvatarProject} from 'sentry/types/project';
+import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getAnalyticsDataForGroup} from 'sentry/utils/events';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import useCommitters from 'sentry/utils/useCommitters';
 import useOrganization from 'sentry/utils/useOrganization';
+import useProjectFromSlug from 'sentry/utils/useProjectFromSlug';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 interface Props {
   commitRow: React.ComponentType<CommitRowProps>;
   eventId: string;
-  project: AvatarProject;
+  projectSlug: Project['slug'];
   group?: Group;
 }
 
-export function SuspectCommits({group, eventId, project, commitRow: CommitRow}: Props) {
+export function SuspectCommits({
+  group,
+  eventId,
+  projectSlug,
+  commitRow: CommitRow,
+}: Props) {
   const organization = useOrganization();
   const [isExpanded, setIsExpanded] = useState(false);
+  const project = useProjectFromSlug({organization, projectSlug});
   const {data} = useCommitters({
     eventId,
-    projectSlug: project.slug,
+    projectSlug,
   });
   const committers = data?.committers ?? [];
 
@@ -66,7 +71,7 @@ export function SuspectCommits({group, eventId, project, commitRow: CommitRow}: 
   const handlePullRequestClick = (commit: Commit, commitIndex: number) => {
     trackAnalytics('issue_details.suspect_commits.pull_request_clicked', {
       organization,
-      project_id: parseInt(project.id as string, 10),
+      project_id: parseInt(project?.id as string, 10),
       suspect_commit_calculation: commit.suspectCommitType ?? 'unknown',
       suspect_commit_index: commitIndex,
       ...getAnalyticsDataForGroup(group),
@@ -76,7 +81,7 @@ export function SuspectCommits({group, eventId, project, commitRow: CommitRow}: 
   const handleCommitClick = (commit: Commit, commitIndex: number) => {
     trackAnalytics('issue_details.suspect_commits.commit_clicked', {
       organization,
-      project_id: parseInt(project.id as string, 10),
+      project_id: parseInt(project?.id as string, 10),
       has_pull_request: commit.pullRequest?.id !== undefined,
       suspect_commit_calculation: commit.suspectCommitType ?? 'unknown',
       suspect_commit_index: commitIndex,
@@ -101,9 +106,6 @@ export function SuspectCommits({group, eventId, project, commitRow: CommitRow}: 
                 project={project}
               />
             </div>
-            <IllustrationContainer>
-              <Illustration src={bannerIllustration} />
-            </IllustrationContainer>
           </StreamlinedPanel>
         ))}
       </ScrollCarousel>
@@ -166,21 +168,6 @@ const StreamlinedPanel = styled(Panel)`
   margin-bottom: 0;
   width: 100%;
   min-width: 85%;
-`;
-
-const IllustrationContainer = styled('div')`
-  position: absolute;
-  top: 0px;
-  right: 50px;
-
-  @media (max-width: ${p => p.theme.breakpoints.xlarge}) {
-    display: none;
-    pointer-events: none;
-  }
-`;
-
-const Illustration = styled('img')`
-  height: 110px;
 `;
 
 const SuspectCommitWrapper = styled('div')`

--- a/static/app/views/discover/table/quickContext/issueContext.spec.tsx
+++ b/static/app/views/discover/table/quickContext/issueContext.spec.tsx
@@ -56,6 +56,10 @@ describe('Quick Context Content Issue Column', function () {
       method: 'GET',
       body: mockedGroup,
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/projects/`,
+      body: [ProjectFixture()],
+    });
   });
 
   afterEach(function () {

--- a/static/app/views/discover/table/quickContext/issueContext.tsx
+++ b/static/app/views/discover/table/quickContext/issueContext.tsx
@@ -159,7 +159,7 @@ function IssueContext(props: BaseContextProps) {
     issue && (
       <SuspectCommitsContainer data-test-id="quick-context-suspect-commits-container">
         <SuspectCommits
-          project={issue.project}
+          projectSlug={issue.project.slug}
           eventId={event.eventID}
           commitRow={QuickContextCommitRow}
         />

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -160,7 +160,7 @@ export function EventDetailsContent({
         {!hasStreamlinedUI && <TraceDataSection event={event} />}
         {!hasStreamlinedUI && (
           <SuspectCommits
-            project={project}
+            projectSlug={project.slug}
             eventId={event.id}
             group={group}
             commitRow={CommitRow}
@@ -255,7 +255,8 @@ export function EventDetailsContent({
           <Exception
             event={event}
             data={eventEntries[EntryType.EXCEPTION].data}
-            projectSlug={projectSlug}
+            projectSlug={project.slug}
+            group={group}
             groupingCurrentLevel={groupingCurrentLevel}
           />
         </EntryErrorBoundary>
@@ -275,8 +276,9 @@ export function EventDetailsContent({
           <Threads
             event={event}
             data={eventEntries[EntryType.THREADS].data}
-            projectSlug={projectSlug}
+            projectSlug={project.slug}
             groupingCurrentLevel={groupingCurrentLevel}
+            group={group}
           />
         </EntryErrorBoundary>
       )}

--- a/static/app/views/issueDetails/streamline/eventDetails.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetails.spec.tsx
@@ -4,7 +4,6 @@ import {GroupFixture} from 'sentry-fixture/group';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RepositoryFixture} from 'sentry-fixture/repository';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {TagsFixture} from 'sentry-fixture/tags';
 
@@ -36,21 +35,9 @@ describe('EventDetails', function () {
   const project = ProjectFixture();
   const group = GroupFixture();
   const event = EventFixture({id: 'event-id'});
-  const committer = {
-    author: {name: 'Butter the Dog', id: '2021'},
-    commits: [
-      {
-        message: 'fix(training): Adjust noise level for meeting other dogs (#2024)',
-        id: 'ab2709293d0c9000829084ac7b1c9221fb18437c',
-        dateCreated: '2024-09-09T04:15:12',
-        repository: RepositoryFixture(),
-      },
-    ],
-  };
   const defaultProps = {project, group, event};
 
   let mockActionableItems: jest.Mock;
-  let mockCommitters: jest.Mock;
   let mockTags: jest.Mock;
   let mockStats: jest.Mock;
   let mockList: jest.Mock;
@@ -71,11 +58,6 @@ describe('EventDetails', function () {
     mockActionableItems = MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/actionable-items/`,
       body: {errors: []},
-      method: 'GET',
-    });
-    mockCommitters = MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/committers/`,
-      body: {committers: [committer]},
       method: 'GET',
     });
     mockTags = MockApiClient.addMockResponse({
@@ -129,10 +111,6 @@ describe('EventDetails', function () {
     render(<EventDetails {...defaultProps} />, {organization});
     await screen.findByText(event.id);
 
-    // Suspect Commits
-    expect(mockCommitters).toHaveBeenCalled();
-    expect(screen.getByText('Suspect Commit')).toBeInTheDocument();
-    expect(screen.getByText(committer.author.name)).toBeInTheDocument();
     // Filtering
     expect(mockTags).toHaveBeenCalled();
     expect(screen.getByTestId('page-filter-environment-selector')).toBeInTheDocument();

--- a/static/app/views/issueDetails/streamline/eventDetails.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetails.tsx
@@ -4,9 +4,7 @@ import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
 import Alert from 'sentry/components/alert';
-import {CommitRow} from 'sentry/components/commitRow';
 import ErrorBoundary from 'sentry/components/errorBoundary';
-import {SuspectCommits} from 'sentry/components/events/suspectCommits';
 import {GroupSummary} from 'sentry/components/group/groupSummary';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
@@ -86,17 +84,6 @@ export function EventDetails({
       <Feature features={['organizations:ai-summary']}>
         <GroupSummary groupId={group.id} groupCategory={group.issueCategory} />
       </Feature>
-      <PageErrorBoundary
-        mini
-        message={t('There was an error loading the suspect commits')}
-      >
-        <SuspectCommits
-          project={project}
-          eventId={event.id}
-          group={group}
-          commitRow={CommitRow}
-        />
-      </PageErrorBoundary>
       <PageErrorBoundary mini message={t('There was an error loading the event filter')}>
         <FilterContainer>
           <EnvironmentPageFilter />


### PR DESCRIPTION
removes the image and puts suspect commits below the stack trace

threaded stack trace example 
![image](https://github.com/user-attachments/assets/4420a60c-f80a-49fd-8361-a0166d9cff82)
