### PR TITLE
chore(issue-details): Update column headers in all events table

### DIFF
--- a/static/app/views/issueDetails/allEventsTable.tsx
+++ b/static/app/views/issueDetails/allEventsTable.tsx
@@ -168,19 +168,19 @@ export const useEventColumns = (group: Group, organization: Organization): Colum
     ];
 
     const columnTitles: string[] = [
-      t('event id'),
-      t('transaction'),
-      t('title'),
-      t('trace'),
-      t('timestamp'),
-      t('release'),
-      t('environment'),
-      t('user'),
-      t('device'),
-      t('os'),
+      t('Event ID'),
+      t('Transaction'),
+      t('Title'),
+      t('Trace'),
+      t('Timestamp'),
+      t('Release'),
+      t('Environment'),
+      t('User'),
+      t('Device'),
+      t('OS'),
       ...platformSpecificColumnTitles,
-      ...(isPerfIssue ? [t('total duration')] : []),
-      t('minidump'),
+      ...(isPerfIssue ? [t('Total Duration')] : []),
+      t('Minidump'),
     ];
 
     return {
@@ -196,7 +196,7 @@ const getPlatformColumns = (
 ): ColumnInfo => {
   const backendServerlessColumnInfo = {
     fields: ['url', 'runtime'],
-    columnTitles: [t('url'), t('runtime')],
+    columnTitles: [t('URL'), t('Runtime')],
   };
 
   const categoryToColumnMap: Record<PlatformCategory, ColumnInfo> = {
@@ -204,11 +204,11 @@ const getPlatformColumns = (
     [PlatformCategory.SERVERLESS]: backendServerlessColumnInfo,
     [PlatformCategory.FRONTEND]: {
       fields: ['url', 'browser'],
-      columnTitles: [t('url'), t('browser')],
+      columnTitles: [t('URL'), t('Browser')],
     },
     [PlatformCategory.MOBILE]: {
       fields: ['url'],
-      columnTitles: [t('url')],
+      columnTitles: [t('URL')],
     },
     [PlatformCategory.DESKTOP]: {
       fields: [],
@@ -225,11 +225,11 @@ const getPlatformColumns = (
 
   if (options.isReplayEnabled) {
     platformColumns.fields.push('replayId');
-    platformColumns.columnTitles.push(t('replay'));
+    platformColumns.columnTitles.push(t('Replay'));
   }
 
   if (options.isProfilingEnabled && platform && PROFILING_PLATFORMS.includes(platform)) {
-    platformColumns.columnTitles.push(t('profile'));
+    platformColumns.columnTitles.push(t('Profile'));
     platformColumns.fields.push('profile.id');
   }
 

--- a/static/app/views/issueDetails/groupEvents.spec.tsx
+++ b/static/app/views/issueDetails/groupEvents.spec.tsx
@@ -207,7 +207,7 @@ describe('groupEvents', () => {
       {router, organization}
     );
     await waitFor(() => {
-      expect(screen.getByText('transaction')).toBeInTheDocument();
+      expect(screen.getByText('Transaction')).toBeInTheDocument();
     });
     expect(requests.discover).toHaveBeenCalledWith(
       '/organizations/org-slug/events/',
@@ -238,7 +238,7 @@ describe('groupEvents', () => {
       })
     );
     await waitFor(() => {
-      expect(screen.getByText('transaction')).toBeInTheDocument();
+      expect(screen.getByText('Transaction')).toBeInTheDocument();
     });
   });
 
@@ -273,7 +273,7 @@ describe('groupEvents', () => {
     );
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
-    const attachmentsColumn = screen.queryByText('attachments');
+    const attachmentsColumn = screen.queryByText('Attachments');
     expect(attachmentsColumn).not.toBeInTheDocument();
     expect(requests.attachments).not.toHaveBeenCalled();
   });
@@ -288,7 +288,7 @@ describe('groupEvents', () => {
     );
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
-    const attachmentsColumn = screen.queryByText('attachments');
+    const attachmentsColumn = screen.queryByText('Attachments');
     expect(attachmentsColumn).not.toBeInTheDocument();
     expect(requests.attachments).toHaveBeenCalled();
   });
@@ -303,7 +303,7 @@ describe('groupEvents', () => {
     );
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
-    const minidumpColumn = screen.queryByText('minidump');
+    const minidumpColumn = screen.queryByText('Minidump');
     expect(minidumpColumn).not.toBeInTheDocument();
   });
 
@@ -335,7 +335,7 @@ describe('groupEvents', () => {
       {router, organization}
     );
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
-    const minidumpColumn = screen.queryByText('minidump');
+    const minidumpColumn = screen.queryByText('Minidump');
     expect(minidumpColumn).toBeInTheDocument();
   });
 
@@ -367,8 +367,8 @@ describe('groupEvents', () => {
       {router, organization}
     );
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
-    const attachmentsColumn = screen.queryByText('attachments');
-    const minidumpColumn = screen.queryByText('minidump');
+    const attachmentsColumn = screen.queryByText('Attachments');
+    const minidumpColumn = screen.queryByText('Minidump');
     expect(attachmentsColumn).not.toBeInTheDocument();
     expect(minidumpColumn).toBeInTheDocument();
     expect(requests.attachments).toHaveBeenCalled();
@@ -393,7 +393,7 @@ describe('groupEvents', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('transaction')).toBeInTheDocument();
+      expect(screen.getByText('Transaction')).toBeInTheDocument();
     });
   });
 
@@ -410,7 +410,7 @@ describe('groupEvents', () => {
       expect.objectContaining({query: expect.not.objectContaining({sort: 'user'})})
     );
     await waitFor(() => {
-      expect(screen.getByText('transaction')).toBeInTheDocument();
+      expect(screen.getByText('Transaction')).toBeInTheDocument();
     });
   });
 
@@ -439,7 +439,7 @@ describe('groupEvents', () => {
       })
     );
     await waitFor(() => {
-      expect(screen.getByText('transaction')).toBeInTheDocument();
+      expect(screen.getByText('Transaction')).toBeInTheDocument();
     });
   });
 

--- a/static/app/views/issueDetails/streamline/eventList.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventList.spec.tsx
@@ -150,7 +150,7 @@ describe('EventList', () => {
     ).toBeInTheDocument();
 
     // Returns minidump column, but we omit it as a custom column
-    const columns = result.current.columnTitles.filter(t => t !== 'minidump');
+    const columns = result.current.columnTitles.filter(t => t !== 'Minidump');
     for (const title of columns) {
       expect(screen.getByRole('columnheader', {name: title})).toBeInTheDocument();
     }

--- a/static/app/views/issueDetails/streamline/eventList.tsx
+++ b/static/app/views/issueDetails/streamline/eventList.tsx
@@ -193,7 +193,6 @@ const StreamlineEventsTable = styled('div')`
     padding: 0 ${space(1.5)};
     white-space: nowrap;
     text-overflow: ellipsis;
-    text-transform: capitalize;
     border-width: 0 1px 0 0;
     border-style: solid;
     border-image: linear-gradient(

--- a/static/app/views/issueDetails/streamline/eventList.tsx
+++ b/static/app/views/issueDetails/streamline/eventList.tsx
@@ -193,6 +193,7 @@ const StreamlineEventsTable = styled('div')`
     padding: 0 ${space(1.5)};
     white-space: nowrap;
     text-overflow: ellipsis;
+    text-transform: none;
     border-width: 0 1px 0 0;
     border-style: solid;
     border-image: linear-gradient(


### PR DESCRIPTION
this pr updates the column headers in the all events table. Previously, was only capitalizing the first letter. default is having everything upper case so this won't change the current all events table