### PR TITLE
chore(issue-details): Hide sidebar button on small screens

### DIFF
--- a/static/app/views/issueDetails/streamline/header.tsx
+++ b/static/app/views/issueDetails/streamline/header.tsx
@@ -215,21 +215,23 @@ export default function StreamlinedGroupHeader({
               </Wrapper>
             )}
           </WorkflowWrapper>
-          <Divider />
-          <Button
-            icon={
-              sidebarOpen ? (
-                <IconChevron direction="right" />
-              ) : (
-                <IconPanel direction="right" />
-              )
-            }
-            title={sidebarOpen ? t('Close Sidebar') : t('Open Sidebar')}
-            aria-label={sidebarOpen ? t('Close Sidebar') : t('Open Sidebar')}
-            size="sm"
-            borderless
-            onClick={() => setSidebarOpen(!sidebarOpen)}
-          />
+          <CollapseSidebarWrapper>
+            <Divider />
+            <Button
+              icon={
+                sidebarOpen ? (
+                  <IconChevron direction="right" />
+                ) : (
+                  <IconPanel direction="right" />
+                )
+              }
+              title={sidebarOpen ? t('Close Sidebar') : t('Open Sidebar')}
+              aria-label={sidebarOpen ? t('Close Sidebar') : t('Open Sidebar')}
+              size="sm"
+              borderless
+              onClick={() => setSidebarOpen(!sidebarOpen)}
+            />
+          </CollapseSidebarWrapper>
         </SidebarWorkflowWrapper>
       </InfoWrapper>
     </Header>
@@ -364,4 +366,14 @@ const Header = styled('div')`
 
 const StyledBreadcrumbs = styled(Breadcrumbs)`
   margin-top: ${space(2)};
+`;
+
+const CollapseSidebarWrapper = styled('div')`
+  display: flex;
+  gap: ${space(0.5)};
+  align-items: center;
+
+  @media (max-width: ${p => p.theme.breakpoints.large}) {
+    display: none;
+  }
 `;


### PR DESCRIPTION
this pr updates the header so that the sidebar button won't show on small screens, since the sidebar is at the bottom of the page. 