### PR TITLE
chore(alerts): Add 'adopted' to latest adopted release filter text

### DIFF
--- a/src/sentry/rules/filters/latest_adopted_release_filter.py
+++ b/src/sentry/rules/filters/latest_adopted_release_filter.py
@@ -52,7 +52,7 @@ class LatestAdoptedReleaseForm(forms.Form):
 class LatestAdoptedReleaseFilter(EventFilter):
     id = "sentry.rules.filters.latest_adopted_release_filter.LatestAdoptedReleaseFilter"
     form_cls = LatestAdoptedReleaseForm
-    label = "The {oldest_or_newest} release associated with the event's issue is {older_or_newer} than the latest release in {environment}"
+    label = "The {oldest_or_newest} adopted release associated with the event's issue is {older_or_newer} than the latest adopted release in {environment}"
 
     form_fields = {
         "oldest_or_newest": {"type": "choice", "choices": list(model_age_choices)},

--- a/static/app/views/alerts/rules/issue/index.spec.tsx
+++ b/static/app/views/alerts/rules/issue/index.spec.tsx
@@ -368,7 +368,7 @@ describe('IssueRuleEditor', function () {
       // Add the adopted release filter
       await selectEvent.select(
         screen.getByText('Add optional filter...'),
-        /The {oldest_or_newest} release associated/
+        /The {oldest_or_newest} adopted release associated/
       );
 
       const filtersContainer = await screen.findByTestId('rule-filters');

--- a/tests/js/fixtures/projectAlertRuleConfiguration.ts
+++ b/tests/js/fixtures/projectAlertRuleConfiguration.ts
@@ -184,7 +184,7 @@ export function ProjectAlertRuleConfigurationFixture(
       {
         id: 'sentry.rules.filters.latest_adopted_release_filter.LatestAdoptedReleaseFilter',
         label:
-          "The {oldest_or_newest} release associated with the event's issue is {older_or_newer} than the latest release in {environment}",
+          "The {oldest_or_newest} adopted release associated with the event's issue is {older_or_newer} than the latest adopted release in {environment}",
         enabled: true,
         formFields: {
           oldest_or_newest: {


### PR DESCRIPTION
Add the word "adopted" to the latest adopted release filter text so it's more obvious the releases need to be adopted for the filter to work.

**Before**
<img width="954" alt="Screenshot 2024-10-09 at 10 47 12 AM" src="https://github.com/user-attachments/assets/b19ca3ff-3bbb-41a3-95d7-ca19b1cbad5a">
**After**
<img width="965" alt="Screenshot 2024-10-09 at 10 46 38 AM" src="https://github.com/user-attachments/assets/dc5f0ed2-afde-44a3-a96f-4fec523922e2">
