### PR TITLE
feat(dashboards): Implement `BigNumberWidget` Thresholds feature

### DIFF
--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -137,7 +137,7 @@ export function hasThresholdMaxValue(thresholdsConfig: ThresholdsConfig): boolea
   return Object.keys(thresholdsConfig.max_values).length > 0;
 }
 
-function normalizeUnit(value: number, unit: string, dataType: string): number {
+export function normalizeUnit(value: number, unit: string, dataType: string): number {
   const multiplier =
     dataType === 'rate'
       ? RATE_UNIT_MULTIPLIERS[unit]

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.spec.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.spec.tsx
@@ -216,4 +216,94 @@ describe('BigNumberWidget', () => {
       expect(screen.getByText('3.05%')).toBeInTheDocument();
     });
   });
+
+  describe('Thresholds', () => {
+    it('Evaluates the current value against a threshold', () => {
+      render(
+        <BigNumberWidget
+          data={[
+            {
+              'eps()': 14.227123,
+            },
+          ]}
+          meta={{
+            fields: {
+              'eps()': 'rate',
+            },
+            units: {
+              'eps()': '1/second',
+            },
+          }}
+          thresholds={{
+            max_values: {
+              max1: 10,
+              max2: 20,
+            },
+            unit: '1/second',
+          }}
+        />
+      );
+
+      expect(screen.getByRole('status')).toHaveAttribute('aria-label', 'meh');
+    });
+
+    it('Normalizes the units', () => {
+      render(
+        <BigNumberWidget
+          data={[
+            {
+              'mystery_error_rate()': 135, //  2.25/s
+            },
+          ]}
+          meta={{
+            fields: {
+              'mystery_error_rate()': 'rate',
+            },
+            units: {
+              'mystery_error_rate()': '1/minute',
+            },
+          }}
+          thresholds={{
+            max_values: {
+              max1: 2,
+              max2: 5,
+            },
+            unit: '1/second',
+          }}
+        />
+      );
+
+      expect(screen.getByRole('status')).toHaveAttribute('aria-label', 'meh');
+    });
+
+    it('Respects the preferred polarity', () => {
+      render(
+        <BigNumberWidget
+          data={[
+            {
+              'mystery_error_rate()': 135,
+            },
+          ]}
+          meta={{
+            fields: {
+              'mystery_error_rate()': 'rate',
+            },
+            units: {
+              'mystery_error_rate()': '1/second',
+            },
+          }}
+          thresholds={{
+            max_values: {
+              max1: 200,
+              max2: 500,
+            },
+            unit: '1/second',
+          }}
+          preferredPolarity="-"
+        />
+      );
+
+      expect(screen.getByRole('status')).toHaveAttribute('aria-label', 'good');
+    });
+  });
 });

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
@@ -247,6 +247,76 @@ export default storyBook(BigNumberWidget, story => {
       </Fragment>
     );
   });
+
+  story('Thresholds', () => {
+    const meta = {
+      fields: {
+        'eps()': 'rate',
+      },
+      units: {
+        'eps()': '1/second',
+      },
+    };
+
+    const thresholds = {
+      max_values: {
+        max1: 20,
+        max2: 50,
+      },
+      unit: '1/second',
+    };
+
+    return (
+      <Fragment>
+        <p>
+          <JSXNode name="BigNumberWidget" /> supports a <code>thresholds</code> prop. If
+          specified, the value of the data in the widget will be evaluated against these
+          thresholds, and indicated using a colorful circle next to the value.
+        </p>
+
+        <SideBySide>
+          <NormalWidget>
+            <BigNumberWidget
+              title="eps()"
+              data={[
+                {
+                  'eps()': 7.1,
+                },
+              ]}
+              meta={meta}
+              thresholds={thresholds}
+            />
+          </NormalWidget>
+
+          <NormalWidget>
+            <BigNumberWidget
+              title="eps()"
+              data={[
+                {
+                  'eps()': 27.781,
+                },
+              ]}
+              meta={meta}
+              thresholds={thresholds}
+            />
+          </NormalWidget>
+
+          <NormalWidget>
+            <BigNumberWidget
+              title="eps()"
+              data={[
+                {
+                  'eps()': 78.1,
+                },
+              ]}
+              meta={meta}
+              thresholds={thresholds}
+            />
+          </NormalWidget>
+        </SideBySide>
+      </Fragment>
+    );
+  });
 });
 
 const SmallSizingWindow = styled(SizingWindow)`

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
@@ -49,6 +49,13 @@ export default storyBook(BigNumberWidget, story => {
                   'eps()': '1/second',
                 },
               }}
+              thresholds={{
+                max_values: {
+                  max1: 1,
+                  max2: 2,
+                },
+                unit: '1/second',
+              }}
             />
           </SmallSizingWindow>
           <SmallSizingWindow>
@@ -285,6 +292,7 @@ export default storyBook(BigNumberWidget, story => {
               ]}
               meta={meta}
               thresholds={thresholds}
+              preferredPolarity="+"
             />
           </NormalWidget>
 
@@ -298,6 +306,7 @@ export default storyBook(BigNumberWidget, story => {
               ]}
               meta={meta}
               thresholds={thresholds}
+              preferredPolarity="-"
             />
           </NormalWidget>
 
@@ -311,6 +320,56 @@ export default storyBook(BigNumberWidget, story => {
               ]}
               meta={meta}
               thresholds={thresholds}
+              preferredPolarity="+"
+            />
+          </NormalWidget>
+        </SideBySide>
+
+        <p>
+          The thresholds respect the preferred polarity. By default, the preferred
+          polarity is positive (higher numbers are good).
+        </p>
+
+        <SideBySide>
+          <NormalWidget>
+            <BigNumberWidget
+              title="eps()"
+              data={[
+                {
+                  'eps()': 7.1,
+                },
+              ]}
+              meta={meta}
+              thresholds={thresholds}
+              preferredPolarity="-"
+            />
+          </NormalWidget>
+
+          <NormalWidget>
+            <BigNumberWidget
+              title="eps()"
+              data={[
+                {
+                  'eps()': 27.781,
+                },
+              ]}
+              meta={meta}
+              thresholds={thresholds}
+              preferredPolarity="-"
+            />
+          </NormalWidget>
+
+          <NormalWidget>
+            <BigNumberWidget
+              title="eps()"
+              data={[
+                {
+                  'eps()': 78.1,
+                },
+              ]}
+              meta={meta}
+              thresholds={thresholds}
+              preferredPolarity="-"
             />
           </NormalWidget>
         </SideBySide>

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
@@ -65,6 +65,7 @@ export function BigNumberWidget(props: Props) {
           maximumValue={props.maximumValue}
           preferredPolarity={props.preferredPolarity}
           meta={props.meta}
+          thresholds={props.thresholds}
         />
       </BigNumberResizeWrapper>
     </WidgetFrame>

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
@@ -9,9 +9,15 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {AutoSizedText} from 'sentry/views/dashboards/widgetCard/autoSizedText';
 import {DifferenceToPreviousPeriodValue} from 'sentry/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodValue';
-import type {Meta, TableData} from 'sentry/views/dashboards/widgets/common/types';
+import type {
+  Meta,
+  TableData,
+  Thresholds,
+} from 'sentry/views/dashboards/widgets/common/types';
 
 import {DEFAULT_FIELD} from '../common/settings';
+
+import {ThresholdsIndicator} from './thresholdsIndicator';
 
 export interface Props {
   value: number;
@@ -20,6 +26,7 @@ export interface Props {
   meta?: Meta;
   preferredPolarity?: Polarity;
   previousPeriodValue?: number;
+  thresholds?: Thresholds;
 }
 
 export function BigNumberWidgetVisualization(props: Props) {
@@ -45,6 +52,7 @@ export function BigNumberWidgetVisualization(props: Props) {
   const clampedValue = Math.min(value, maximumValue);
 
   const unit = meta?.units?.[field];
+  const type = meta?.fields?.[field];
 
   const baggage = {
     location,
@@ -55,6 +63,16 @@ export function BigNumberWidgetVisualization(props: Props) {
   return (
     <Wrapper>
       <NumberAndDifferenceContainer>
+        {props.thresholds && (
+          <ThresholdsIndicator
+            preferredPolarity={props.preferredPolarity}
+            thresholds={props.thresholds}
+            unit={unit ?? ''}
+            value={clampedValue}
+            type={type ?? 'integer'}
+          />
+        )}
+
         <NumberContainerOverride>
           <Tooltip
             title={value}

--- a/static/app/views/dashboards/widgets/bigNumberWidget/thresholdsIndicator.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/thresholdsIndicator.tsx
@@ -1,7 +1,6 @@
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import CircleIndicator from 'sentry/components/circleIndicator';
 import type {Polarity} from 'sentry/components/percentChange';
 
 import {normalizeUnit} from '../../utils';
@@ -40,19 +39,20 @@ export function ThresholdsIndicator({
 
   const colorName = COLOR_NAME_FOR_STATE[state];
 
-  return (
-    <RigidCircleIndicator
-      role="status"
-      aria-label={state}
-      color={theme[colorName]}
-      size={12}
-    />
-  );
+  return <Circle role="status" aria-label={state} color={theme[colorName]} />;
 }
 
-const RigidCircleIndicator = styled(CircleIndicator)`
+const Circle = styled('div')<{color: string}>`
+  display: inline-block;
+  height: max(12px, 20cqh);
+  width: max(12px, 20cqh);
+
+  position: relative;
   align-self: center;
   flex-shrink: 0;
+
+  border-radius: 50%;
+  background: ${p => p.color};
 `;
 
 type ThresholdState = 'poor' | 'meh' | 'good';

--- a/static/app/views/dashboards/widgets/bigNumberWidget/thresholdsIndicator.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/thresholdsIndicator.tsx
@@ -1,0 +1,84 @@
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import CircleIndicator from 'sentry/components/circleIndicator';
+import type {Polarity} from 'sentry/components/percentChange';
+
+import {normalizeUnit} from '../../utils';
+import type {Thresholds} from '../common/types';
+
+interface ThresholdsIndicatorProps {
+  thresholds: Thresholds;
+  type: string;
+  unit: string;
+  value: number;
+  preferredPolarity?: Polarity;
+}
+
+export function ThresholdsIndicator({
+  thresholds,
+  value,
+  type,
+  preferredPolarity = '+',
+  unit: valueUnit,
+}: ThresholdsIndicatorProps) {
+  const theme = useTheme();
+
+  const {max_values, unit: thresholdUnit} = thresholds;
+  const {max1, max2} = max_values;
+
+  const normalizedValue = normalizeUnit(value, valueUnit, type);
+  const normalizedMax1 = normalizeUnit(max1, thresholdUnit, type);
+  const normalizedMax2 = normalizeUnit(max2, thresholdUnit, type);
+
+  const state = getThresholdState(
+    normalizedValue,
+    normalizedMax1,
+    normalizedMax2,
+    preferredPolarity
+  );
+
+  const colorName = COLOR_NAME_FOR_STATE[state];
+
+  return (
+    <RigidCircleIndicator
+      role="status"
+      aria-label={state}
+      color={theme[colorName]}
+      size={12}
+    />
+  );
+}
+
+const RigidCircleIndicator = styled(CircleIndicator)`
+  align-self: center;
+  flex-shrink: 0;
+`;
+
+type ThresholdState = 'poor' | 'meh' | 'good';
+
+const COLOR_NAME_FOR_STATE: Record<ThresholdState, string> = {
+  poor: 'red300',
+  meh: 'yellow300',
+  good: 'green300',
+};
+
+function getThresholdState(
+  value: number,
+  max1: number,
+  max2: number,
+  preferredPolarity: Polarity
+): string {
+  const [belowMax1, belowMax2, aboveMax2] =
+    preferredPolarity === '+' ? ['poor', 'meh', 'good'] : ['good', 'meh', 'poor'];
+
+  if (value <= max1) {
+    return belowMax1;
+  }
+
+  if (value <= max2) {
+    return belowMax2;
+  }
+
+  return aboveMax2;
+}

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -18,3 +18,14 @@ export interface StateProps {
   isLoading?: boolean;
   onRetry?: () => void;
 }
+
+export type MaxValues = {
+  max1: number;
+  max2: number;
+};
+
+// `max_values` is Snake Case to preserve compatibility with the current widget serializer. We _do_ want to change it to Camel Case!
+export interface Thresholds {
+  max_values: MaxValues;
+  unit: string;
+}


### PR DESCRIPTION
See [spec](https://www.notion.so/sentry/Widget-Components-Spec-c8aec2bc216a446b9616e31085204ce0?pvs=4#1158b10e4b5d80b98769ea7002c39b72) for details. Adds the "Thresholds" feature to `BigNumberWidget`. It works a lot like the current Big Number thresholds, but the indicator is shown to the left of the value instead of to the right of the title.

Contributes to https://github.com/getsentry/sentry/issues/77779

There's no great ARIA role for this specific kind of element, but I didn't want to have _no_ role. I think indicator suits it relatively well as a start, and makes testing a lot easier.

**e.g.,**
![Screenshot 2024-10-09 at 2 23 36 PM](https://github.com/user-attachments/assets/cda53d60-d128-4b14-98b3-99ef701e4160)
![Screenshot 2024-10-09 at 2 29 56 PM](https://github.com/user-attachments/assets/a353ad1c-ccb7-430c-a5f4-88191b72e85a)
