### PR TITLE
chore(alerts): Enable latest adopted release filter

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -188,7 +188,7 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:issue-stream-table-layout", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:large-debug-files", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enabled latest adopted release filter for issue alerts
-    manager.add("organizations:latest-adopted-release-filter", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:latest-adopted-release-filter", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
     # Enable members to invite teammates to organizations
     manager.add("organizations:members-invite-teammates", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:mep-rollout-flag", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -34,7 +34,7 @@ class ProjectRuleConfigurationTest(APITestCase):
         response = self.get_success_response(self.organization.slug, project1.slug)
         assert len(response.data["actions"]) == 12
         assert len(response.data["conditions"]) == 9
-        assert len(response.data["filters"]) == 8
+        assert len(response.data["filters"]) == 9
 
     @property
     def rules(self):
@@ -149,7 +149,7 @@ class ProjectRuleConfigurationTest(APITestCase):
             },
         } in response.data["actions"]
         assert len(response.data["conditions"]) == 9
-        assert len(response.data["filters"]) == 8
+        assert len(response.data["filters"]) == 9
 
     @patch("sentry.sentry_apps.components.SentryAppComponentPreparer.run")
     def test_sentry_app_alert_rules(self, mock_sentry_app_components_preparer):
@@ -180,13 +180,13 @@ class ProjectRuleConfigurationTest(APITestCase):
             "sentryAppInstallationUuid": str(install.uuid),
         } in response.data["actions"]
         assert len(response.data["conditions"]) == 9
-        assert len(response.data["filters"]) == 8
+        assert len(response.data["filters"]) == 9
 
     def test_issue_type_and_category_filter_feature(self):
         response = self.get_success_response(self.organization.slug, self.project.slug)
         assert len(response.data["actions"]) == 12
         assert len(response.data["conditions"]) == 9
-        assert len(response.data["filters"]) == 8
+        assert len(response.data["filters"]) == 9
 
         filter_ids = {f["id"] for f in response.data["filters"]}
         assert IssueCategoryFilter.id in filter_ids


### PR DESCRIPTION
The latest adopted release filter feature has been out for several months now, so this is step 1 to removing the flag. Next I'll remove the flag in the options automator, and then I'll remove all references to the flag in sentry.