### PR TITLE
fix(issues): Fix timer name

### DIFF
--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -167,7 +167,7 @@ class ProjectOwnership(Model):
         return result
 
     @classmethod
-    @metrics.wraps("projectownership.get_autoassign_owners")
+    @metrics.wraps("projectownership.get_issue_owners")
     def get_issue_owners(
         cls, project_id, data, limit=2
     ) -> Sequence[tuple[Rule, Sequence[Team | RpcUser], str]]:


### PR DESCRIPTION
This name is also used on line 266 which is causing metrics to be incorrect. We lose the ability to compare to historical data with this change but that seems ok given it probably wasn't very accurate anyway.