### PR TITLE
feat(dashboards): Use MEP transition feature flag in frontend

### DIFF
--- a/static/app/utils/performance/contexts/metricsEnhancedSetting.tsx
+++ b/static/app/utils/performance/contexts/metricsEnhancedSetting.tsx
@@ -83,7 +83,14 @@ export function canUseMetricsData(organization: Organization) {
   const isRollingOut =
     samplingFeatureFlag && organization.features.includes('mep-rollout-flag');
 
-  return isDevFlagOn || isInternalViewOn || isRollingOut;
+  // For plans transitioning from AM2 to AM3, we still want to show metrics
+  // until 90d after 100% transaction ingestion to avoid spikes in charts
+  // coming from old sampling rates.
+  const isTransitioningPlan = organization.features.includes(
+    'dashboards-metrics-transition'
+  );
+
+  return isDevFlagOn || isInternalViewOn || isRollingOut || isTransitioningPlan;
 }
 
 export function MEPSettingProvider({

--- a/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
+++ b/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
@@ -26,6 +26,7 @@ export function getMetricDatasetQueryExtras({
     hasOnDemandMetricAlertFeature(organization) ||
     hasCustomMetrics(organization) ||
     organization.features.includes('mep-rollout-flag') ||
+    organization.features.includes('dashboards-metrics-transition') ||
     hasInsightsAlerts(organization);
   const disableMetricDataset =
     decodeScalar(location?.query?.disableMetricDataset) === 'true';


### PR DESCRIPTION
Add feature flag check to maintain querying `metricsEnhanced` for users transitioning from the AM2 to AM3 plan. This avoids large spikes in dashboards 