### PR TITLE
ref(sentry_apps): Turn AlertRuleActionCreator to a dataclass

### DIFF
--- a/src/sentry/mediators/alert_rule_actions/__init__.py
+++ b/src/sentry/mediators/alert_rule_actions/__init__.py
@@ -1,3 +1,0 @@
-from ...sentry_apps.creator import AlertRuleActionCreator
-
-__all__ = ("AlertRuleActionCreator",)

--- a/src/sentry/mediators/alert_rule_actions/__init__.py
+++ b/src/sentry/mediators/alert_rule_actions/__init__.py
@@ -1,3 +1,3 @@
-from .creator import AlertRuleActionCreator
+from ...sentry_apps.creator import AlertRuleActionCreator
 
 __all__ = ("AlertRuleActionCreator",)

--- a/src/sentry/sentry_apps/alert_rule_action_creator.py
+++ b/src/sentry/sentry_apps/alert_rule_action_creator.py
@@ -1,9 +1,10 @@
-from django.db import router
+from dataclasses import dataclass, field
+from typing import Any
+
+from django.db import router, transaction
 from django.utils.functional import cached_property
 
 from sentry.coreapi import APIError
-from sentry.mediators.mediator import Mediator
-from sentry.mediators.param import Param
 from sentry.sentry_apps.external_requests.alert_rule_action_requester import (
     AlertRuleActionRequester,
     AlertRuleActionResult,
@@ -12,15 +13,16 @@ from sentry.sentry_apps.models.sentry_app_component import SentryAppComponent
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
 
 
-class AlertRuleActionCreator(Mediator):
-    using = router.db_for_write(SentryAppComponent)
-    install = Param(SentryAppInstallation)
-    fields = Param(list, default=[])  # array of dicts
+@dataclass
+class AlertRuleActionCreator:
+    install: SentryAppInstallation
+    fields: list[dict[str, Any]] = field(default_factory=list)
 
-    def call(self) -> AlertRuleActionResult:
-        uri = self._fetch_sentry_app_uri()
-        self._make_external_request(uri)
-        return self.response
+    def run(self) -> AlertRuleActionResult:
+        with transaction.atomic(router.db_for_write(SentryAppComponent)):
+            uri = self._fetch_sentry_app_uri()
+            response = self._make_external_request(uri)
+            return response
 
     def _fetch_sentry_app_uri(self):
         component = SentryAppComponent.objects.get(
@@ -32,11 +34,13 @@ class AlertRuleActionCreator(Mediator):
     def _make_external_request(self, uri=None):
         if uri is None:
             raise APIError("Sentry App request url not found")
-        self.response = AlertRuleActionRequester(
+        response = AlertRuleActionRequester(
             install=self.install,
             uri=uri,
             fields=self.fields,
         ).run()
+
+        return response
 
     @cached_property
     def sentry_app(self):

--- a/src/sentry/sentry_apps/alert_rule_action_creator.py
+++ b/src/sentry/sentry_apps/alert_rule_action_creator.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -16,7 +17,7 @@ from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallat
 @dataclass
 class AlertRuleActionCreator:
     install: SentryAppInstallation
-    fields: list[dict[str, Any]] = field(default_factory=list)
+    fields: list[Mapping[str, Any]] = field(default_factory=list)
 
     def run(self) -> AlertRuleActionResult:
         with transaction.atomic(router.db_for_write(SentryAppComponent)):

--- a/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import TypedDict
 from urllib.parse import urlparse, urlunparse
@@ -30,7 +30,7 @@ class AlertRuleActionResult(TypedDict):
 class AlertRuleActionRequester:
     install: SentryAppInstallation | RpcSentryAppInstallation
     uri: str
-    fields: list[Mapping[str, str]] = field(default_factory=list)
+    fields: Sequence[Mapping[str, str]] = field(default_factory=list)
     http_method: str | None = "POST"
 
     def run(self) -> AlertRuleActionResult:

--- a/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TypedDict
 from urllib.parse import urlparse, urlunparse
@@ -29,7 +30,7 @@ class AlertRuleActionResult(TypedDict):
 class AlertRuleActionRequester:
     install: SentryAppInstallation | RpcSentryAppInstallation
     uri: str
-    fields: list[dict[str, str]] = field(default_factory=list)
+    fields: list[Mapping[str, str]] = field(default_factory=list)
     http_method: str | None = "POST"
 
     def run(self) -> AlertRuleActionResult:

--- a/src/sentry/sentry_apps/services/app/impl.py
+++ b/src/sentry/sentry_apps/services/app/impl.py
@@ -10,7 +10,7 @@ from sentry.api.serializers import Serializer, serialize
 from sentry.auth.services.auth import AuthenticationContext
 from sentry.constants import SentryAppInstallationStatus, SentryAppStatus
 from sentry.hybridcloud.rpc.filter_query import FilterQueryDatabaseImpl, OpaqueSerializedResponse
-from sentry.mediators import alert_rule_actions
+from sentry.sentry_apps.alert_rule_action_creator import AlertRuleActionCreator
 from sentry.sentry_apps.api.serializers.sentry_app_component import (
     SentryAppAlertRuleActionSerializer,
 )
@@ -255,7 +255,7 @@ class DatabaseBackedAppService(AppService):
             install = SentryAppInstallation.objects.get(uuid=install_uuid)
         except SentryAppInstallation.DoesNotExist:
             return RpcAlertRuleActionResult(success=False, message="Installation does not exist")
-        result = alert_rule_actions.AlertRuleActionCreator.run(install=install, fields=fields)
+        result = AlertRuleActionCreator(install=install, fields=fields).run()
         return RpcAlertRuleActionResult(success=result["success"], message=result["message"])
 
     def find_service_hook_sentry_app(self, *, api_application_id: int) -> RpcSentryApp | None:

--- a/tests/sentry/sentry_apps/external_requests/test_alert_rule_action_requester.py
+++ b/tests/sentry/sentry_apps/external_requests/test_alert_rule_action_requester.py
@@ -1,3 +1,5 @@
+from collections.abc import Mapping
+
 import responses
 
 from sentry.sentry_apps.external_requests.alert_rule_action_requester import (
@@ -34,7 +36,7 @@ class TestAlertRuleActionRequester(TestCase):
         self.install = self.create_sentry_app_installation(
             slug="foo", organization=self.org, user=self.user
         )
-        self.fields = [
+        self.fields: list[Mapping[str, str]] = [
             {"name": "title", "value": "An Alert"},
             {"name": "description", "value": "threshold reached"},
             {"name": "assignee_id", "value": "user-1"},
@@ -61,14 +63,7 @@ class TestAlertRuleActionRequester(TestCase):
         request = responses.calls[0].request
 
         data = {
-            "fields": [
-                {"name": "title", "value": "An Alert"},
-                {"name": "description", "value": "threshold reached"},
-                {
-                    "name": "assignee_id",
-                    "value": "user-1",
-                },
-            ],
+            "fields": self.fields,
             "installationId": self.install.uuid,
         }
         payload = json.loads(request.body)


### PR DESCRIPTION
Convert `AlertRuleActionCreator` to a dataclass. No related test I could find so we're safe there. Also a bit of a workflow experiment in how git tracks files.