### PR TITLE
feat(issue-stream): Update issue stream header design and column breakpoints

### DIFF
--- a/static/app/components/IssueStreamHeaderLabel.tsx
+++ b/static/app/components/IssueStreamHeaderLabel.tsx
@@ -1,3 +1,4 @@
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {space} from 'sentry/styles/space';

--- a/static/app/components/IssueStreamHeaderLabel.tsx
+++ b/static/app/components/IssueStreamHeaderLabel.tsx
@@ -11,7 +11,7 @@ const IssueStreamHeaderLabel = styled('div')<{breakpoint?: string}>`
   font-weight: ${p => p.theme.fontWeightBold};
   color: ${p => p.theme.subText};
 
-  ${p => p.breakpoint && `@media (max-width: ${p.breakpoint}) { display: none; }`}
+  ${p => p.breakpoint && css`@media (max-width: ${p.breakpoint}) { display: none; }`}
 `;
 
 export default IssueStreamHeaderLabel;

--- a/static/app/components/IssueStreamHeaderLabel.tsx
+++ b/static/app/components/IssueStreamHeaderLabel.tsx
@@ -1,0 +1,17 @@
+import styled from '@emotion/styled';
+
+import {space} from 'sentry/styles/space';
+
+const IssueStreamHeaderLabel = styled('div')<{breakpoint?: string}>`
+  position: relative;
+  display: inline-block;
+  margin-right: ${space(2)};
+  justify-content: space-between;
+  font-size: ${p => p.theme.fontSizeMedium};
+  font-weight: ${p => p.theme.fontWeightBold};
+  color: ${p => p.theme.subText};
+
+  ${p => p.breakpoint && `@media (max-width: ${p.breakpoint}) { display: none; }`}
+`;
+
+export default IssueStreamHeaderLabel;

--- a/static/app/components/IssueStreamHeaderLabel.tsx
+++ b/static/app/components/IssueStreamHeaderLabel.tsx
@@ -8,7 +8,7 @@ const IssueStreamHeaderLabel = styled('div')<{breakpoint?: string}>`
   display: inline-block;
   margin-right: ${space(2)};
   justify-content: space-between;
-  font-size: ${p => p.theme.fontSizeMedium};
+  font-size: 13px;
   font-weight: ${p => p.theme.fontWeightBold};
   color: ${p => p.theme.subText};
 

--- a/static/app/components/IssueStreamHeaderLabel.tsx
+++ b/static/app/components/IssueStreamHeaderLabel.tsx
@@ -11,7 +11,13 @@ const IssueStreamHeaderLabel = styled('div')<{breakpoint?: string}>`
   font-weight: ${p => p.theme.fontWeightBold};
   color: ${p => p.theme.subText};
 
-  ${p => p.breakpoint && css`@media (max-width: ${p.breakpoint}) { display: none; }`}
+  ${p =>
+    p.breakpoint &&
+    css`
+      @media (max-width: ${p.breakpoint}) {
+        display: none;
+      }
+    `}
 `;
 
 export default IssueStreamHeaderLabel;

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -757,9 +757,8 @@ const ChartWrapper = styled('div')<{margin: boolean; narrowGroups: boolean}>`
   align-self: center;
   margin-right: ${p => (p.margin ? space(2) : 0)};
 
-  /* prettier-ignore */
   @media (max-width: ${p =>
-    p.narrowGroups ? p.theme.breakpoints.xlarge : p.theme.breakpoints.large}) {
+      p.narrowGroups ? p.theme.breakpoints.xlarge : p.theme.breakpoints.large}) {
     display: none;
   }
 `;
@@ -769,7 +768,6 @@ const NarrowChartWrapper = styled('div')<{breakpoint: string}>`
   align-self: center;
   margin-right: ${space(2)};
 
-  /* prettier-ignore */
   @media (max-width: ${p => p.breakpoint}) {
     display: none;
   }
@@ -818,7 +816,6 @@ const NarrowPriorityWrapper = styled('div')<{breakpoint: string}>`
   display: flex;
   justify-content: flex-start;
 
-  /* prettier-ignore */
   @media (max-width: ${p => p.theme.breakpoints.large}) {
     display: none;
   }
@@ -831,9 +828,8 @@ const PriorityWrapper = styled('div')<{narrowGroups: boolean}>`
   display: flex;
   justify-content: flex-end;
 
-  /* prettier-ignore */
   @media (max-width: ${p =>
-    p.narrowGroups ? p.theme.breakpoints.large : p.theme.breakpoints.medium}) {
+      p.narrowGroups ? p.theme.breakpoints.large : p.theme.breakpoints.medium}) {
     display: none;
   }
 `;
@@ -843,9 +839,8 @@ const AssigneeWrapper = styled('div')<{narrowGroups: boolean}>`
   margin: 0 ${space(2)};
   align-self: center;
 
-  /* prettier-ignore */
   @media (max-width: ${p =>
-    p.narrowGroups ? p.theme.breakpoints.large : p.theme.breakpoints.medium}) {
+      p.narrowGroups ? p.theme.breakpoints.large : p.theme.breakpoints.medium}) {
     display: none;
   }
 `;
@@ -858,7 +853,6 @@ const NarrowAssigneeWrapper = styled('div')<{breakpoint: string}>`
   margin-right: ${space(2)};
   align-self: center;
 
-  /* prettier-ignore */
   @media (max-width: ${p => p.breakpoint}) {
     display: none;
   }

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -54,6 +54,7 @@ import withOrganization from 'sentry/utils/withOrganization';
 import type {TimePeriodType} from 'sentry/views/alerts/rules/metric/details/constants';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import GroupPriority from 'sentry/views/issueDetails/groupPriority';
+import {COLUMN_BREAKPOINTS} from 'sentry/views/issueList/actions/utils';
 import {
   DISCOVER_EXCLUSION_FIELDS,
   getTabs,
@@ -531,7 +532,22 @@ function BaseGroupRow({
       </GroupSummary>
       {hasGuideAnchor && issueStreamAnchor}
 
-      {withChart && !displayReprocessingLayout && issueTypeConfig.stats.enabled && (
+      {withChart &&
+      !displayReprocessingLayout &&
+      issueTypeConfig.stats.enabled &&
+      organization.features.includes('issue-stream-table-layout') ? (
+        <NarrowChartWrapper breakpoint={COLUMN_BREAKPOINTS.TREND}>
+          <GroupStatusChart
+            hideZeros
+            loading={!defined(groupStats)}
+            stats={groupStats}
+            secondaryStats={groupSecondaryStats}
+            showSecondaryPoints={showSecondaryPoints}
+            groupStatus={getBadgeProperties(group.status, group.substatus)?.status}
+            showMarkLine
+          />
+        </NarrowChartWrapper>
+      ) : (
         <ChartWrapper
           narrowGroups={narrowGroups}
           margin={withColumns.includes('firstSeen')}
@@ -552,42 +568,72 @@ function BaseGroupRow({
       ) : (
         <Fragment>
           {withColumns.includes('firstSeen') && (
-            <TimestampWrapper>
+            <TimestampWrapper breakpoint={COLUMN_BREAKPOINTS.AGE}>
               <GroupTimestamp date={group.firstSeen} label={t('First Seen')} />
             </TimestampWrapper>
           )}
           {withColumns.includes('lastSeen') && (
-            <TimestampWrapper>
+            <TimestampWrapper breakpoint={COLUMN_BREAKPOINTS.SEEN}>
               <GroupTimestamp date={group.lastSeen} label={t('Last Seen')} />
             </TimestampWrapper>
           )}
-          {withColumns.includes('event') && issueTypeConfig.stats.enabled && (
+          {withColumns.includes('event') &&
+          issueTypeConfig.stats.enabled &&
+          organization.features.includes('issue-stream-table-layout') ? (
+            <NarrowEventsOrUsersCountsWrapper breakpoint={COLUMN_BREAKPOINTS.EVENTS}>
+              <div style={{marginRight: space(2)}}>{groupCount}</div>
+            </NarrowEventsOrUsersCountsWrapper>
+          ) : (
             <EventCountsWrapper
               leftMargin={withColumns.includes('lastSeen') ? undefined : '0px'}
             >
               {groupCount}
             </EventCountsWrapper>
           )}
-          {withColumns.includes('users') && issueTypeConfig.stats.enabled && (
+          {withColumns.includes('users') &&
+          issueTypeConfig.stats.enabled &&
+          organization.features.includes('issue-stream-table-layout') ? (
+            <NarrowEventsOrUsersCountsWrapper breakpoint={COLUMN_BREAKPOINTS.USERS}>
+              <div style={{marginRight: space(2)}}>{groupUsersCount}</div>
+            </NarrowEventsOrUsersCountsWrapper>
+          ) : (
             <EventCountsWrapper>{groupUsersCount}</EventCountsWrapper>
           )}
           {withColumns.includes('priority') ? (
-            <PriorityWrapper narrowGroups={narrowGroups}>
-              {group.priority ? (
-                <GroupPriority group={group} onChange={onPriorityChange} />
-              ) : null}
-            </PriorityWrapper>
+            organization.features.includes('issue-stream-table-layout') ? (
+              <NarrowPriorityWrapper breakpoint={COLUMN_BREAKPOINTS.PRIORITY}>
+                {group.priority ? (
+                  <GroupPriority group={group} onChange={onPriorityChange} />
+                ) : null}
+              </NarrowPriorityWrapper>
+            ) : (
+              <PriorityWrapper narrowGroups={narrowGroups}>
+                {group.priority ? (
+                  <GroupPriority group={group} onChange={onPriorityChange} />
+                ) : null}
+              </PriorityWrapper>
+            )
           ) : null}
-          {withColumns.includes('assignee') && (
-            <AssigneeWrapper narrowGroups={narrowGroups}>
-              <AssigneeSelector
-                group={group}
-                assigneeLoading={assigneeLoading}
-                handleAssigneeChange={handleAssigneeChange}
-                memberList={memberList}
-              />
-            </AssigneeWrapper>
-          )}
+          {withColumns.includes('assignee') &&
+            (organization.features.includes('issue-stream-table-layout') ? (
+              <NarrowAssigneeWrapper breakpoint={COLUMN_BREAKPOINTS.ASSIGNEE}>
+                <AssigneeSelector
+                  group={group}
+                  assigneeLoading={assigneeLoading}
+                  handleAssigneeChange={handleAssigneeChange}
+                  memberList={memberList}
+                />
+              </NarrowAssigneeWrapper>
+            ) : (
+              <AssigneeWrapper narrowGroups={narrowGroups}>
+                <AssigneeSelector
+                  group={group}
+                  assigneeLoading={assigneeLoading}
+                  handleAssigneeChange={handleAssigneeChange}
+                  memberList={memberList}
+                />
+              </AssigneeWrapper>
+            ))}
           {showLastTriggered && <EventCountsWrapper>{lastTriggered}</EventCountsWrapper>}
         </Fragment>
       )}
@@ -718,11 +764,38 @@ const ChartWrapper = styled('div')<{margin: boolean; narrowGroups: boolean}>`
   }
 `;
 
-const TimestampWrapper = styled('div')`
+const NarrowChartWrapper = styled('div')<{breakpoint: string}>`
+  width: 200px;
+  align-self: center;
+  margin-right: ${space(2)};
+
+  /* prettier-ignore */
+  @media (max-width: ${p => p.breakpoint}) {
+    display: none;
+  }
+`;
+
+const TimestampWrapper = styled('div')<{breakpoint: string}>`
   display: flex;
   align-self: center;
-  width: 40px;
-  margin: 0 ${space(1)};
+  width: 60px;
+  margin-right: ${space(2)};
+
+  @media (max-width: ${p => p.breakpoint}) {
+    display: none;
+  }
+`;
+
+const NarrowEventsOrUsersCountsWrapper = styled('div')<{breakpoint: string}>`
+  display: flex;
+  justify-content: flex-end;
+  align-self: center;
+  margin-right: ${space(2)};
+  width: 60px;
+
+  @media (max-width: ${p => p.breakpoint}) {
+    display: none;
+  }
 `;
 
 const EventCountsWrapper = styled('div')<{leftMargin?: string}>`
@@ -735,6 +808,19 @@ const EventCountsWrapper = styled('div')<{leftMargin?: string}>`
 
   @media (min-width: ${p => p.theme.breakpoints.xlarge}) {
     width: 80px;
+  }
+`;
+
+const NarrowPriorityWrapper = styled('div')<{breakpoint: string}>`
+  width: 70px;
+  margin-right: ${space(2)};
+  align-self: center;
+  display: flex;
+  justify-content: flex-start;
+
+  /* prettier-ignore */
+  @media (max-width: ${p => p.theme.breakpoints.large}) {
+    display: none;
   }
 `;
 
@@ -760,6 +846,20 @@ const AssigneeWrapper = styled('div')<{narrowGroups: boolean}>`
   /* prettier-ignore */
   @media (max-width: ${p =>
     p.narrowGroups ? p.theme.breakpoints.large : p.theme.breakpoints.medium}) {
+    display: none;
+  }
+`;
+
+const NarrowAssigneeWrapper = styled('div')<{breakpoint: string}>`
+  display: flex;
+  justify-content: flex-start;
+  text-align: right;
+  width: 60px;
+  margin-right: ${space(2)};
+  align-self: center;
+
+  /* prettier-ignore */
+  @media (max-width: ${p => p.breakpoint}) {
     display: none;
   }
 `;

--- a/static/app/views/issueList/actions/headers.tsx
+++ b/static/app/views/issueList/actions/headers.tsx
@@ -134,9 +134,8 @@ const GraphHeaderWrapper = styled('div')<{isSavedSearchesOpen?: boolean}>`
   width: 200px;
   margin-right: ${space(2)};
 
-  /* prettier-ignore */
   @media (max-width: ${p =>
-    p.isSavedSearchesOpen ? p.theme.breakpoints.xlarge : p.theme.breakpoints.large}) {
+      p.isSavedSearchesOpen ? p.theme.breakpoints.xlarge : p.theme.breakpoints.large}) {
     display: none;
   }
 `;
@@ -210,9 +209,8 @@ const PriorityLabel = styled(ToolbarHeader)<{isSavedSearchesOpen?: boolean}>`
   width: 70px;
   margin: 0 ${space(2)};
 
-  /* prettier-ignore */
   @media (max-width: ${p =>
-    p.isSavedSearchesOpen ? p.theme.breakpoints.large : p.theme.breakpoints.medium}) {
+      p.isSavedSearchesOpen ? p.theme.breakpoints.large : p.theme.breakpoints.medium}) {
     display: none;
   }
 `;
@@ -222,7 +220,6 @@ const NarrowPriorityLabel = styled(IssueStreamHeaderLabel)`
   justify-content: space-between;
   width: 70px;
 
-  /* prettier-ignore */
   @media (max-width: ${p => p.theme.breakpoints.large}) {
     display: none;
   }
@@ -235,9 +232,8 @@ const AssigneeLabel = styled(ToolbarHeader)<{isSavedSearchesOpen?: boolean}>`
   margin-left: ${space(2)};
   margin-right: ${space(2)};
 
-  /* prettier-ignore */
   @media (max-width: ${p =>
-    p.isSavedSearchesOpen ? p.theme.breakpoints.large : p.theme.breakpoints.medium}) {
+      p.isSavedSearchesOpen ? p.theme.breakpoints.large : p.theme.breakpoints.medium}) {
     display: none;
   }
 `;

--- a/static/app/views/issueList/actions/headers.tsx
+++ b/static/app/views/issueList/actions/headers.tsx
@@ -39,23 +39,25 @@ function Headers({
         <Fragment>
           {organization.features.includes('issue-stream-table-layout') ? (
             <NarrowGraphLabel breakpoint={COLUMN_BREAKPOINTS.TREND}>
-              {t('Trend')}
-              <NarrowGraphToggles>
-                {selection.datetime.period !== '24h' && (
+              <NarrowGraphLabelContents>
+                {t('Trend')}
+                <NarrowGraphToggles>
+                  {selection.datetime.period !== '24h' && (
+                    <GraphToggle
+                      active={statsPeriod === '24h'}
+                      onClick={() => onSelectStatsPeriod('24h')}
+                    >
+                      {t('24h')}
+                    </GraphToggle>
+                  )}
                   <GraphToggle
-                    active={statsPeriod === '24h'}
-                    onClick={() => onSelectStatsPeriod('24h')}
+                    active={statsPeriod === 'auto'}
+                    onClick={() => onSelectStatsPeriod('auto')}
                   >
-                    {t('24h')}
+                    {selection.datetime.period || t('Custom')}
                   </GraphToggle>
-                )}
-                <GraphToggle
-                  active={statsPeriod === 'auto'}
-                  onClick={() => onSelectStatsPeriod('auto')}
-                >
-                  {selection.datetime.period || t('Custom')}
-                </GraphToggle>
-              </NarrowGraphToggles>
+                </NarrowGraphToggles>
+              </NarrowGraphLabelContents>
               <HeaderDivider />
             </NarrowGraphLabel>
           ) : (
@@ -145,6 +147,17 @@ const NarrowGraphLabel = styled(IssueStreamHeaderLabel)`
   flex: 1;
   display: flex;
   justify-content: space-between;
+`;
+
+const NarrowGraphLabelContents = styled('div')`
+  display: flex;
+  flex: 1;
+  justify-content: space-between;
+`;
+
+const NarrowGraphToggles = styled('div')`
+  font-weight: ${p => p.theme.fontWeightNormal};
+  margin-right: ${space(2)};
 `;
 
 const GraphHeader = styled('div')`
@@ -242,10 +255,6 @@ const NarrowAssigneeLabel = styled(IssueStreamHeaderLabel)`
   justify-content: flex-end;
   text-align: right;
   width: 60px;
-`;
-
-const NarrowGraphToggles = styled('div')`
-  font-weight: ${p => p.theme.fontWeightNormal};
 `;
 
 // Reprocessing

--- a/static/app/views/issueList/actions/headers.tsx
+++ b/static/app/views/issueList/actions/headers.tsx
@@ -1,11 +1,14 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import IssueStreamHeaderLabel from 'sentry/components/IssueStreamHeaderLabel';
 import ToolbarHeader from 'sentry/components/toolbarHeader';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types/core';
 import useOrganization from 'sentry/utils/useOrganization';
+import {HeaderDivider} from 'sentry/views/issueList/actions';
+import {COLUMN_BREAKPOINTS} from 'sentry/views/issueList/actions/utils';
 
 type Props = {
   isReprocessingQuery: boolean;
@@ -34,39 +37,91 @@ function Headers({
         </Fragment>
       ) : (
         <Fragment>
-          <GraphHeaderWrapper isSavedSearchesOpen={isSavedSearchesOpen}>
-            <GraphHeader>
-              <StyledToolbarHeader>{t('Graph:')}</StyledToolbarHeader>
-              {selection.datetime.period !== '24h' && (
+          {organization.features.includes('issue-stream-table-layout') ? (
+            <NarrowGraphLabel breakpoint={COLUMN_BREAKPOINTS.TREND}>
+              {t('Trend')}
+              <NarrowGraphToggles>
+                {selection.datetime.period !== '24h' && (
+                  <GraphToggle
+                    active={statsPeriod === '24h'}
+                    onClick={() => onSelectStatsPeriod('24h')}
+                  >
+                    {t('24h')}
+                  </GraphToggle>
+                )}
                 <GraphToggle
-                  active={statsPeriod === '24h'}
-                  onClick={() => onSelectStatsPeriod('24h')}
+                  active={statsPeriod === 'auto'}
+                  onClick={() => onSelectStatsPeriod('auto')}
                 >
-                  {t('24h')}
+                  {selection.datetime.period || t('Custom')}
                 </GraphToggle>
-              )}
-              <GraphToggle
-                active={statsPeriod === 'auto'}
-                onClick={() => onSelectStatsPeriod('auto')}
-              >
-                {selection.datetime.period || t('Custom')}
-              </GraphToggle>
-            </GraphHeader>
-          </GraphHeaderWrapper>
+              </NarrowGraphToggles>
+              <HeaderDivider />
+            </NarrowGraphLabel>
+          ) : (
+            <GraphHeaderWrapper isSavedSearchesOpen={isSavedSearchesOpen}>
+              <GraphHeader>
+                <StyledToolbarHeader>{t('Graph:')}</StyledToolbarHeader>
+                {selection.datetime.period !== '24h' && (
+                  <GraphToggle
+                    active={statsPeriod === '24h'}
+                    onClick={() => onSelectStatsPeriod('24h')}
+                  >
+                    {t('24h')}
+                  </GraphToggle>
+                )}
+                <GraphToggle
+                  active={statsPeriod === 'auto'}
+                  onClick={() => onSelectStatsPeriod('auto')}
+                >
+                  {selection.datetime.period || t('Custom')}
+                </GraphToggle>
+              </GraphHeader>
+            </GraphHeaderWrapper>
+          )}
+
           {organization.features.includes('issue-stream-table-layout') ? (
             <Fragment>
-              <TimestampLabel>{t('Age')}</TimestampLabel>
-              <TimestampLabel>{t('Seen')}</TimestampLabel>
+              <TimestampLabel breakpoint={COLUMN_BREAKPOINTS.AGE}>
+                {t('Age')}
+                <HeaderDivider />
+              </TimestampLabel>
+              <TimestampLabel breakpoint={COLUMN_BREAKPOINTS.SEEN}>
+                {t('Seen')}
+                <HeaderDivider />
+              </TimestampLabel>
             </Fragment>
           ) : null}
-          <EventsOrUsersLabel>{t('Events')}</EventsOrUsersLabel>
-          <EventsOrUsersLabel>{t('Users')}</EventsOrUsersLabel>
-          <PriorityLabel isSavedSearchesOpen={isSavedSearchesOpen}>
-            <ToolbarHeader>{t('Priority')}</ToolbarHeader>
-          </PriorityLabel>
-          <AssigneeLabel isSavedSearchesOpen={isSavedSearchesOpen}>
-            <ToolbarHeader>{t('Assignee')}</ToolbarHeader>
-          </AssigneeLabel>
+          {organization.features.includes('issue-stream-table-layout') ? (
+            <Fragment>
+              <NarrowEventsOrUsersLabel breakpoint={COLUMN_BREAKPOINTS.EVENTS}>
+                {t('Events')}
+                <HeaderDivider />
+              </NarrowEventsOrUsersLabel>
+              <NarrowEventsOrUsersLabel breakpoint={COLUMN_BREAKPOINTS.USERS}>
+                {t('Users')}
+                <HeaderDivider />
+              </NarrowEventsOrUsersLabel>
+              <NarrowPriorityLabel breakpoint={COLUMN_BREAKPOINTS.PRIORITY}>
+                {t('Priority')}
+                <HeaderDivider />
+              </NarrowPriorityLabel>
+              <NarrowAssigneeLabel breakpoint={COLUMN_BREAKPOINTS.ASSIGNEE}>
+                {t('Assignee')}
+              </NarrowAssigneeLabel>
+            </Fragment>
+          ) : (
+            <Fragment>
+              <EventsOrUsersLabel>{t('Events')}</EventsOrUsersLabel>
+              <EventsOrUsersLabel>{t('Users')}</EventsOrUsersLabel>
+              <PriorityLabel isSavedSearchesOpen={isSavedSearchesOpen}>
+                <ToolbarHeader>{t('Priority')}</ToolbarHeader>
+              </PriorityLabel>
+              <AssigneeLabel isSavedSearchesOpen={isSavedSearchesOpen}>
+                <ToolbarHeader>{t('Assignee')}</ToolbarHeader>
+              </AssigneeLabel>
+            </Fragment>
+          )}
         </Fragment>
       )}
     </Fragment>
@@ -84,6 +139,13 @@ const GraphHeaderWrapper = styled('div')<{isSavedSearchesOpen?: boolean}>`
     p.isSavedSearchesOpen ? p.theme.breakpoints.xlarge : p.theme.breakpoints.large}) {
     display: none;
   }
+`;
+
+const NarrowGraphLabel = styled(IssueStreamHeaderLabel)`
+  width: 200px;
+  flex: 1;
+  display: flex;
+  justify-content: space-between;
 `;
 
 const GraphHeader = styled('div')`
@@ -107,13 +169,16 @@ const GraphToggle = styled('a')<{active: boolean}>`
   }
 `;
 
-const TimestampLabel = styled(ToolbarHeader)`
-  display: inline-grid;
-  align-items: center;
-  justify-content: flex-start;
+const TimestampLabel = styled(IssueStreamHeaderLabel)`
+  width: 60px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
   text-align: left;
-  width: 40px;
-  margin: 0 ${space(1)};
+
+  @media (max-width: ${p => p.theme.breakpoints.xlarge}) {
+    display: none;
+  }
 `;
 
 const EventsOrUsersLabel = styled(ToolbarHeader)`
@@ -126,6 +191,16 @@ const EventsOrUsersLabel = styled(ToolbarHeader)`
 
   @media (min-width: ${p => p.theme.breakpoints.xlarge}) {
     width: 80px;
+  }
+`;
+
+const NarrowEventsOrUsersLabel = styled(IssueStreamHeaderLabel)`
+  display: flex;
+  justify-content: space-between;
+  width: 60px;
+
+  @media (max-width: ${p => p.theme.breakpoints.medium}) {
+    display: none;
   }
 `;
 
@@ -142,6 +217,17 @@ const PriorityLabel = styled(ToolbarHeader)<{isSavedSearchesOpen?: boolean}>`
   }
 `;
 
+const NarrowPriorityLabel = styled(IssueStreamHeaderLabel)`
+  display: flex;
+  justify-content: space-between;
+  width: 70px;
+
+  /* prettier-ignore */
+  @media (max-width: ${p => p.theme.breakpoints.large}) {
+    display: none;
+  }
+`;
+
 const AssigneeLabel = styled(ToolbarHeader)<{isSavedSearchesOpen?: boolean}>`
   justify-content: flex-end;
   text-align: right;
@@ -154,6 +240,16 @@ const AssigneeLabel = styled(ToolbarHeader)<{isSavedSearchesOpen?: boolean}>`
     p.isSavedSearchesOpen ? p.theme.breakpoints.large : p.theme.breakpoints.medium}) {
     display: none;
   }
+`;
+
+const NarrowAssigneeLabel = styled(IssueStreamHeaderLabel)`
+  justify-content: flex-end;
+  text-align: right;
+  width: 60px;
+`;
+
+const NarrowGraphToggles = styled('div')`
+  font-weight: ${p => p.theme.fontWeightNormal};
 `;
 
 // Reprocessing

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -534,7 +534,6 @@ const ActionsBarContainer = styled('div')<{narrowHeader: boolean}>`
   align-items: center;
   background: ${p => p.theme.backgroundSecondary};
   border-radius: ${p => p.theme.panelBorderRadius} ${p => p.theme.panelBorderRadius} 0 0;
-  line-height: 1.6;
 `;
 
 const ActionsCheckbox = styled('div')<{isReprocessingQuery: boolean}>`

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -10,8 +10,8 @@ import {
 } from 'sentry/actionCreators/indicator';
 import {Alert} from 'sentry/components/alert';
 import Checkbox from 'sentry/components/checkbox';
+import IssueStreamHeaderLabel from 'sentry/components/IssueStreamHeaderLabel';
 import {Sticky} from 'sentry/components/sticky';
-import ToolbarHeader from 'sentry/components/toolbarHeader';
 import {t, tct, tn} from 'sentry/locale';
 import GroupStore from 'sentry/stores/groupStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
@@ -23,6 +23,7 @@ import type {Group} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {uniq} from 'sentry/utils/array/uniq';
+import {useBreakpoints} from 'sentry/utils/metrics/useBreakpoints';
 import {useQueryClient} from 'sentry/utils/queryClient';
 import theme from 'sentry/utils/theme';
 import useApi from 'sentry/utils/useApi';
@@ -102,9 +103,12 @@ function ActionsBarPriority({
 }) {
   const organization = useOrganization();
   const shouldDisplayActions = anySelected && !narrowViewport;
+  const screen = useBreakpoints();
 
   return (
-    <ActionsBarContainer>
+    <ActionsBarContainer
+      narrowHeader={organization.features.includes('issue-stream-table-layout')}
+    >
       {!narrowViewport && (
         <ActionsCheckbox isReprocessingQuery={displayReprocessingActions}>
           <Checkbox
@@ -117,7 +121,7 @@ function ActionsBarPriority({
       )}
       {!displayReprocessingActions && (
         <AnimatePresence initial={false} mode="wait">
-          {shouldDisplayActions && (
+          {shouldDisplayActions ? (
             <HeaderButtonsWrapper key="actions" {...animationProps}>
               <ActionSet
                 queryCount={queryCount}
@@ -135,14 +139,15 @@ function ActionsBarPriority({
                 onUpdate={handleUpdate}
               />
             </HeaderButtonsWrapper>
-          )}
-          {!anySelected && (
+          ) : organization.features.includes('issue-stream-table-layout') ? (
+            <NarrowHeaderButtonsWrapper>
+              <IssueStreamHeaderLabel>{t('Issue')}</IssueStreamHeaderLabel>
+              {/* Ideally we could use a smaller option, xxsmall */}
+              {screen.xsmall && <HeaderDivider />}
+            </NarrowHeaderButtonsWrapper>
+          ) : (
             <HeaderButtonsWrapper key="sort" {...animationProps}>
-              {!organization.features.includes('issue-stream-table-layout') ? (
-                <IssueListSortOptions sort={sort} query={query} onSelect={onSortChange} />
-              ) : (
-                <ToolbarHeader>{t('Issue')}</ToolbarHeader>
-              )}
+              <IssueListSortOptions sort={sort} query={query} onSelect={onSortChange} />
             </HeaderButtonsWrapper>
           )}
         </AnimatePresence>
@@ -159,11 +164,13 @@ function ActionsBarPriority({
             />
           </AnimatedHeaderItemsContainer>
         ) : (
-          <motion.div key="sort" {...animationProps}>
-            <SortDropdownMargin>
-              <IssueListSortOptions sort={sort} query={query} onSelect={onSortChange} />
-            </SortDropdownMargin>
-          </motion.div>
+          !organization.features.includes('issue-stream-table-layout') && (
+            <motion.div key="sort" {...animationProps}>
+              <SortDropdownMargin>
+                <IssueListSortOptions sort={sort} query={query} onSelect={onSortChange} />
+              </SortDropdownMargin>
+            </motion.div>
+          )
         )}
       </AnimatePresence>
     </ActionsBarContainer>
@@ -396,7 +403,7 @@ function IssueListActions({
         onSelectStatsPeriod={onSelectStatsPeriod}
       />
       {!allResultsVisible && pageSelected && (
-        <Alert type="warning" system>
+        <StyledAlert type="warning" system>
           <SelectAllNotice data-test-id="issue-list-select-all-notice">
             {allInQuerySelected ? (
               queryCount >= BULK_LIMIT ? (
@@ -436,7 +443,7 @@ function IssueListActions({
               </Fragment>
             )}
           </SelectAllNotice>
-        </Alert>
+        </StyledAlert>
       )}
     </StickyActions>
   );
@@ -499,6 +506,12 @@ function shouldConfirm(
   }
 }
 
+export const HeaderDivider = styled(motion.div)`
+  background-color: ${p => p.theme.gray200};
+  width: 1px;
+  border-radius: ${p => p.theme.borderRadius};
+`;
+
 const StickyActions = styled(Sticky)`
   z-index: ${p => p.theme.zIndex.issuesList.stickyHeader};
 
@@ -507,19 +520,21 @@ const StickyActions = styled(Sticky)`
   &[data-stuck] > div {
     border-radius: 0;
   }
+
   border-bottom: 1px solid ${p => p.theme.border};
   border-top: none;
   border-radius: ${p => p.theme.panelBorderRadius} ${p => p.theme.panelBorderRadius} 0 0;
 `;
 
-const ActionsBarContainer = styled('div')`
+const ActionsBarContainer = styled('div')<{narrowHeader: boolean}>`
   display: flex;
-  min-height: 45px;
-  padding-top: ${space(1)};
-  padding-bottom: ${space(1)};
+  min-height: ${p => (p.narrowHeader ? '36px' : '45px')};
+  padding-top: ${p => (p.narrowHeader ? space(0.5) : space(1))};
+  padding-bottom: ${p => (p.narrowHeader ? space(0.5) : space(1))};
   align-items: center;
   background: ${p => p.theme.backgroundSecondary};
   border-radius: ${p => p.theme.panelBorderRadius} ${p => p.theme.panelBorderRadius} 0 0;
+  line-height: 1.6;
 `;
 
 const ActionsCheckbox = styled('div')<{isReprocessingQuery: boolean}>`
@@ -540,6 +555,20 @@ const HeaderButtonsWrapper = styled(motion.div)`
   gap: ${space(0.5)};
   grid-auto-flow: column;
   justify-content: flex-start;
+  white-space: nowrap;
+`;
+
+const NarrowHeaderButtonsWrapper = styled(motion.div)`
+  @media (min-width: ${p => p.theme.breakpoints.large}) {
+    width: 50%;
+  }
+  flex: 1;
+  margin-left: ${space(1)};
+  margin-right: ${space(2)};
+  display: grid;
+  gap: ${space(0.5)};
+  grid-auto-flow: column;
+  justify-content: space-between;
   white-space: nowrap;
 `;
 
@@ -565,6 +594,12 @@ const SortDropdownMargin = styled('div')`
 const AnimatedHeaderItemsContainer = styled(motion.div)`
   display: flex;
   align-items: center;
+  line-height: 1.6;
+`;
+
+const StyledAlert = styled(Alert)`
+  margin-bottom: 0;
+  border-bottom: none;
 `;
 
 export {IssueListActions};

--- a/static/app/views/issueList/actions/utils.tsx
+++ b/static/app/views/issueList/actions/utils.tsx
@@ -5,6 +5,7 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct, tn} from 'sentry/locale';
 import type {IgnoredStatusDetails} from 'sentry/types/group';
 import {capitalize} from 'sentry/utils/string/capitalize';
+import commonTheme from 'sentry/utils/theme';
 
 import ExtraDescription from './extraDescription';
 
@@ -161,3 +162,16 @@ export function performanceIssuesSupportsIgnoreAction(
 ) {
   return !(statusDetails.ignoreWindow || statusDetails.ignoreUserWindow);
 }
+
+// A mapping of which screen sizes will trigger the column to disappear
+// e.g. 'Trend': screen.small => 'Trend' column will disappear on screen.small widths
+export const COLUMN_BREAKPOINTS = {
+  ISSUE: undefined, // Issue column is always visible
+  TREND: commonTheme.breakpoints.small,
+  AGE: commonTheme.breakpoints.xlarge,
+  SEEN: commonTheme.breakpoints.xlarge,
+  EVENTS: commonTheme.breakpoints.medium,
+  USERS: commonTheme.breakpoints.medium,
+  PRIORITY: commonTheme.breakpoints.large,
+  ASSIGNEE: commonTheme.breakpoints.xsmall,
+};


### PR DESCRIPTION
closes #77824
closes #77825

This PR makes two major changes to the issue stream (both under the `issue-stream-table-layout` flag):
1. Updates the design of the header to be narrower, to use "Trend" instead of "Graph:", and to have dividers
2. Updates the order at which the columns disappear to reflect the spec in #77825. it is now: last & age -> priority -> events 
 & users -> trend -> assignee

Header design before:

<img width="983" alt="image" src="https://github.com/user-attachments/assets/f02dfd89-a372-4aec-bd7f-26f770355415">


Header design after:

<img width="1206" alt="image" src="https://github.com/user-attachments/assets/27d31684-5df2-4d4c-9656-0fbc6e2b961f">

Column breakpoint behavior: 

https://github.com/user-attachments/assets/9492cfbc-8e64-4c64-b6eb-0ab02d229879



