### PR TITLE
fix(grouping): Fix template strategy `description` value

### DIFF
--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -19,6 +19,7 @@ KNOWN_MAJOR_COMPONENT_NAMES = {
     "violation": "violation",
     "uri": "URL",
     "message": "message",
+    "template": "template",
 }
 
 


### PR DESCRIPTION
Despite the fact that it is a [stand-alone grouping strategy](https://github.com/getsentry/sentry/blob/70062c3b122ee98c9978147e20eaf6971dbefe4f/src/sentry/grouping/strategies/template.py#L14-L31), `template` is missing from the list of known grouping components, with the result that it's `description` property shows up as "others" rather than as "template." Adding it to the list fixes that.