### PR TITLE
feat(wizard-ui): Skip selection if slugs are given

### DIFF
--- a/src/sentry/projects/services/project/impl.py
+++ b/src/sentry/projects/services/project/impl.py
@@ -35,6 +35,19 @@ class DatabaseBackedProjectService(ProjectService):
             return serialize_project(project)
         return None
 
+    def get_by_slug(self, *, organization_id: int, slug: str) -> RpcProject | None:
+        try:
+            project: Project | None = Project.objects.get_from_cache(
+                slug=slug, organization=organization_id
+            )
+        except ValueError:
+            project = Project.objects.filter(slug=slug, organization=organization_id).first()
+        except Project.DoesNotExist:
+            return None
+        if project:
+            return serialize_project(project)
+        return None
+
     def get_many_by_organizations(
         self,
         *,

--- a/src/sentry/projects/services/project/impl.py
+++ b/src/sentry/projects/services/project/impl.py
@@ -36,14 +36,9 @@ class DatabaseBackedProjectService(ProjectService):
         return None
 
     def get_by_slug(self, *, organization_id: int, slug: str) -> RpcProject | None:
-        try:
-            project: Project | None = Project.objects.get_from_cache(
-                slug=slug, organization=organization_id
-            )
-        except ValueError:
-            project = Project.objects.filter(slug=slug, organization=organization_id).first()
-        except Project.DoesNotExist:
-            return None
+        project: Project | None = Project.objects.filter(
+            slug=slug, organization=organization_id
+        ).first()
         if project:
             return serialize_project(project)
         return None

--- a/src/sentry/projects/services/project/service.py
+++ b/src/sentry/projects/services/project/service.py
@@ -61,6 +61,11 @@ class ProjectService(RpcService):
 
     @regional_rpc_method(resolve=ByOrganizationId())
     @abstractmethod
+    def get_by_slug(self, *, organization_id: int, slug: str) -> RpcProject | None:
+        pass
+
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
     def serialize_many(
         self,
         *,

--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -76,7 +76,7 @@ class SetupWizardView(BaseView):
         member_org_ids = OrganizationMemberMapping.objects.filter(
             user_id=request.user.id
         ).values_list("organization_id", flat=True)
-        org_mappings: list[OrganizationMapping] = OrganizationMapping.objects.filter(
+        org_mappings = OrganizationMapping.objects.filter(
             organization_id__in=member_org_ids,
             status=OrganizationStatus.ACTIVE,
         ).order_by("-date_created")

--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -64,16 +64,19 @@ class SetupWizardView(BaseView):
         Redirects to organization whenever cache has been deleted
         """
         context = {"hash": wizard_hash, "enableProjectSelection": False}
-        key = f"{SETUP_WIZARD_CACHE_KEY}{wizard_hash}"
+        cache_key = f"{SETUP_WIZARD_CACHE_KEY}{wizard_hash}"
 
-        wizard_data = default_cache.get(key)
+        org_slug = request.GET.get("org_slug", None)
+        project_slug = request.GET.get("project_slug", None)
+
+        wizard_data = default_cache.get(cache_key)
         if wizard_data is None:
             return self.redirect_to_org(request)
 
         member_org_ids = OrganizationMemberMapping.objects.filter(
             user_id=request.user.id
         ).values_list("organization_id", flat=True)
-        org_mappings = OrganizationMapping.objects.filter(
+        org_mappings: list[OrganizationMapping] = OrganizationMapping.objects.filter(
             organization_id__in=member_org_ids,
             status=OrganizationStatus.ACTIVE,
         ).order_by("-date_created")
@@ -94,6 +97,26 @@ class SetupWizardView(BaseView):
         context["organizations"] = list(org_mappings_map.values())
 
         if features.has("users:new-setup-wizard-ui", user=request.user, actor=request.user):
+            # If org_slug and project_slug are provided, we will use them to select the project
+            # If the project is not found or the slugs are not provided, we will show the project selection
+            if org_slug is not None and project_slug is not None:
+                target_org_mapping = next(
+                    (mapping for mapping in org_mappings if mapping.slug == org_slug), None
+                )
+                if target_org_mapping is not None:
+                    target_project = project_service.get_by_slug(
+                        slug=project_slug, organization_id=target_org_mapping.organization_id
+                    )
+
+                    if target_project is not None:
+                        cache_data = get_cache_data(
+                            mapping=target_org_mapping, project=target_project, user=request.user
+                        )
+                        default_cache.set(cache_key, cache_data, SETUP_WIZARD_CACHE_TIMEOUT)
+
+                        context["enableProjectSelection"] = False
+                        return render_to_response("sentry/setup-wizard.html", context, request)
+
             context["enableProjectSelection"] = True
             return render_to_response("sentry/setup-wizard.html", context, request)
 
@@ -132,9 +155,7 @@ class SetupWizardView(BaseView):
         serialized_token = get_token(org_mappings, request.user)
 
         result = {"apiKeys": serialized_token, "projects": filled_projects}
-
-        key = f"{SETUP_WIZARD_CACHE_KEY}{wizard_hash}"
-        default_cache.set(key, result, SETUP_WIZARD_CACHE_TIMEOUT)
+        default_cache.set(cache_key, result, SETUP_WIZARD_CACHE_TIMEOUT)
 
         return render_to_response("sentry/setup-wizard.html", context, request)
 
@@ -162,24 +183,7 @@ class SetupWizardView(BaseView):
         if project is None:
             raise Http404()
 
-        project_key = project_key_service.get_project_key(
-            organization_id=mapping.organization_id,
-            project_id=project.id,
-            role=ProjectKeyRole.store,
-        )
-        if project_key is None:
-            raise Http404()
-
-        serialized_token = get_org_token(mapping, request.user)
-
-        enriched_project = serialize_project(
-            project=project,
-            # The wizard only reads the a few fields so serializing the mapping should work fine
-            organization=serialize_org_mapping(mapping),
-            keys=[serialize_project_key(project_key)],
-        )
-
-        cache_data = {"apiKeys": serialized_token, "projects": [enriched_project]}
+        cache_data = get_cache_data(mapping=mapping, project=project, user=request.user)
 
         key = f"{SETUP_WIZARD_CACHE_KEY}{wizard_hash}"
         default_cache.set(key, cache_data, SETUP_WIZARD_CACHE_TIMEOUT)
@@ -214,6 +218,27 @@ def serialize_project(project: RpcProject, organization: dict, keys: list[dict])
         "organization": organization,
         "keys": keys,
     }
+
+
+def get_cache_data(mapping: OrganizationMapping, project: RpcProject, user: RpcUser):
+    project_key = project_key_service.get_project_key(
+        organization_id=mapping.organization_id,
+        project_id=project.id,
+        role=ProjectKeyRole.store,
+    )
+    if project_key is None:
+        raise Http404()
+
+    enriched_project = serialize_project(
+        project=project,
+        # The wizard only reads the a few fields so serializing the mapping should work fine
+        organization=serialize_org_mapping(mapping),
+        keys=[serialize_project_key(project_key)],
+    )
+
+    serialized_token = get_org_token(mapping, user)
+
+    return {"apiKeys": serialized_token, "projects": [enriched_project]}
 
 
 def get_token(mappings: list[OrganizationMapping], user: RpcUser):

--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -66,8 +66,8 @@ class SetupWizardView(BaseView):
         context = {"hash": wizard_hash, "enableProjectSelection": False}
         cache_key = f"{SETUP_WIZARD_CACHE_KEY}{wizard_hash}"
 
-        org_slug = request.GET.get("org_slug", None)
-        project_slug = request.GET.get("project_slug", None)
+        org_slug = request.GET.get("org_slug")
+        project_slug = request.GET.get("project_slug")
 
         wizard_data = default_cache.get(cache_key)
         if wizard_data is None:


### PR DESCRIPTION
Skip the project selection screen when org and project slug are given.
Add RPC method `get_by_slug ` on the projects service.

Closes https://github.com/getsentry/sentry/issues/78323