### PR TITLE
feat(wizard-ui): Autofocus org select

### DIFF
--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -215,6 +215,7 @@ export interface ControlProps
  */
 export function Control({
   // Control props
+  autoFocus,
   trigger,
   triggerLabel: triggerLabelProp,
   triggerProps,
@@ -394,6 +395,20 @@ export function Control({
     updateOverlay?.();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [menuBody, hideOptions]);
+
+  const wasRefAvailable = useRef(false);
+  useEffect(() => {
+    // Trigger ref is set by a setState in useOverlay, so we need to wait for it to be available
+    // We also need to make sure we only focus once
+    if (!triggerRef.current || wasRefAvailable.current) {
+      return;
+    }
+    wasRefAvailable.current = true;
+
+    if (autoFocus && !disabled) {
+      triggerRef.current.focus();
+    }
+  }, [autoFocus, disabled, triggerRef]);
 
   /**
    * The menu's full width, before any option has been filtered out. Used to maintain a

--- a/static/app/views/setupWizard/index.tsx
+++ b/static/app/views/setupWizard/index.tsx
@@ -241,6 +241,7 @@ function ProjectSelection({hash, organizations = []}: Omit<Props, 'allowSelectio
       <FieldWrapper>
         <label>{t('Organization')}</label>
         <StyledCompactSelect
+          autoFocus
           value={selectedOrgId as string}
           searchable
           options={orgOptions}


### PR DESCRIPTION
Handle autofocus prop in `CompactSelect`.
Use autofocus prop on org select in wizard ui.

Closes https://github.com/getsentry/sentry/issues/78894