### PR TITLE
ref(trace) preserve context when zooming into spans

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceView.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceView.tsx
@@ -61,6 +61,14 @@ export class TraceView {
     );
   }
 
+  getSpanToPxForSpace(space: [number, number]): mat3 {
+    const view = new DOMView(space[0], 0, space[1], 0);
+    const traceViewToSpace = this.trace_space.between(view);
+    const tracePhysicalToView = this.trace_physical_space.between(this.trace_space);
+
+    return mat3.multiply(mat3.create(), traceViewToSpace, tracePhysicalToView);
+  }
+
   getConfigSpaceCursor(cursor: {x: number; y: number}): [number, number] {
     const left_percentage = cursor.x / this.trace_physical_space.width;
     const left_view = left_percentage * this.trace_view.width;

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -1103,11 +1103,11 @@ export class VirtualizedViewManager {
     span_space: [number, number],
     text: string
   ): [number, number] {
-    const TEXT_PADDING = 2;
+    const TEXT_PADDING = 3;
 
     const icon_width_config_space = (18 * this.span_to_px[0]) / 2;
     const text_anchor_left =
-      span_space[0] > this.view.to_origin + this.view.trace_space.width * 0.8;
+      span_space[0] > this.view.to_origin + this.view.trace_space.width * 0.5;
     const text_width = this.text_measurer.measure(text);
 
     const timestamps = getIconTimestamps(node, span_space, icon_width_config_space);


### PR DESCRIPTION
Add 1 px more to the label which gives the UI a bit more breathing room and zoom to spans so that we preserve enough space on the left and right side for the label and dont stretch the span end to end