### PR TITLE
ref(grouping): Provide default value for fingerprint rule version

### DIFF
--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -245,7 +245,7 @@ class FingerprintingRules:
     def _from_config_structure(
         cls, data: dict[str, Any], bases: Sequence[str] | None = None
     ) -> Self:
-        version = data["version"]
+        version = data.get("version", VERSION)
         if version != VERSION:
             raise ValueError("Unknown version")
         return cls(

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -74,9 +74,7 @@ class FingerprintInput:
     def create_event(self, grouping_config=None):
         input = dict(self.data)
 
-        config = FingerprintingRules.from_json(
-            {"rules": input.pop("_fingerprinting_rules"), "version": 1}
-        )
+        config = FingerprintingRules.from_json({"rules": input.pop("_fingerprinting_rules")})
         mgr = EventManager(data=input, grouping_config=grouping_config)
         mgr.normalize()
         data = mgr.get_data()

--- a/tests/sentry/grouping/test_builtin_fingerprinting.py
+++ b/tests/sentry/grouping/test_builtin_fingerprinting.py
@@ -432,7 +432,6 @@ def test_builtinfingerprinting_rules_from_config_structure_overrides_is_builtin(
                     "is_builtin": is_builtin,
                 },
             ],
-            "version": 1,
         },
         bases=[],
     )
@@ -452,7 +451,6 @@ def test_fingerprinting_rules_from_config_structure_preserves_is_builtin(is_buil
                     "is_builtin": is_builtin,
                 },
             ],
-            "version": 1,
         },
         bases=[],
     )


### PR DESCRIPTION
This adds a default value for `version` to FingerprintingRules.from_config_structure`, in order to clean up current tests a bit and make future tests a touch easier to write.