### PR TITLE
fix(insights): domain view header layout shifts

### DIFF
--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -93,19 +93,19 @@ export function DomainViewHeader({
 
   return (
     <Fragment>
-      <Tabs value={tabValue} onChange={handleTabChange}>
-        <Layout.Header>
-          <Layout.HeaderContent>
-            <Breadcrumbs crumbs={baseCrumbs} />
+      <Layout.Header>
+        <Layout.HeaderContent>
+          <Breadcrumbs crumbs={baseCrumbs} />
 
-            <Layout.Title>{headerTitle}</Layout.Title>
-          </Layout.HeaderContent>
-          <Layout.HeaderActions>
-            <ButtonBar gap={1}>
-              {additonalHeaderActions}
-              <FeedbackWidgetButton />
-            </ButtonBar>
-          </Layout.HeaderActions>
+          <Layout.Title>{headerTitle}</Layout.Title>
+        </Layout.HeaderContent>
+        <Layout.HeaderActions>
+          <ButtonBar gap={1}>
+            {additonalHeaderActions}
+            <FeedbackWidgetButton />
+          </ButtonBar>
+        </Layout.HeaderActions>
+        <Tabs value={tabValue} onChange={handleTabChange}>
           {!hideDefaultTabs && (
             <TabList hideBorder>
               {tabList.map(tab => (
@@ -114,8 +114,8 @@ export function DomainViewHeader({
             </TabList>
           )}
           {hideDefaultTabs && tabs && tabs.tabList}
-        </Layout.Header>
-      </Tabs>
+        </Tabs>
+      </Layout.Header>
     </Fragment>
   );
 }


### PR DESCRIPTION
This bug was pointed out here (see for screenshot) https://github.com/getsentry/sentry/pull/78640#pullrequestreview-2352541286

While the modules are loading, they header would have extra spacing (only on larger monitors). You can also replicate this, by just continuing to zoom out, until the main content does not reach the bottom of the viewport.
While the modules load the main content did not take up the entire screen and because the Tabs component has a flex-grow property set, it will try to take up more space relative to the parent.

This PR moves the Tabs component so that it's parent is the header component instead of the entire page, (as we want spacing of the Tabs to be relative to the header not the entire page!)