### PR TITLE
feat(issue-details): Add last seen to activity sidebar

### DIFF
--- a/static/app/views/issueDetails/streamline/activitySection.tsx
+++ b/static/app/views/issueDetails/streamline/activitySection.tsx
@@ -7,6 +7,7 @@ import {NoteInputWithStorage} from 'sentry/components/activity/note/inputWithSto
 import useMutateActivity from 'sentry/components/feedback/useMutateActivity';
 import Timeline from 'sentry/components/timeline';
 import TimeSince from 'sentry/components/timeSince';
+import {IconFlag} from 'sentry/icons/iconFlag';
 import {t} from 'sentry/locale';
 import GroupStore from 'sentry/stores/groupStore';
 import {space} from 'sentry/styles/space';
@@ -95,6 +96,11 @@ function StreamlinedActivitySection({group}: {group: Group}) {
           }}
           source="issue-details"
           {...noteProps}
+        />
+        <ActivityTimelineItem
+          title={t('Last Seen')}
+          icon={<IconFlag />}
+          timestamp={<SmallTimestamp date={group.lastSeen} />}
         />
         {group.activity.map(item => {
           const authorName = item.user ? item.user.name : 'Sentry';

--- a/static/app/views/issueDetails/streamline/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/streamline/groupActivityItem.tsx
@@ -580,7 +580,6 @@ export default function getGroupActivityItem(
           return {
             title: t('First Seen'),
             message: tct('Marked as [priority] priority', {
-              author,
               priority: activity.data.priority,
             }),
           };


### PR DESCRIPTION
this pr adds back last seen to streamlined issue details by putting it in the activity sidebar

![Screenshot 2024-10-10 at 10 30 31 AM](https://github.com/user-attachments/assets/32115768-a0d6-43a1-adfa-496ca4fe64d7)
