### PR TITLE
chore(alerts): Remove latest adopted release flag

### DIFF
--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -31,9 +31,6 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
         can_create_tickets = features.has(
             "organizations:integrations-ticket-rules", project.organization
         )
-        has_latest_adopted_release = features.has(
-            "organizations:latest-adopted-release-filter", project.organization
-        )
 
         # TODO: conditions need to be based on actions
         for rule_type, rule_cls in rules:
@@ -76,12 +73,6 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
             if rule_type.startswith("condition/"):
                 condition_list.append(context)
             elif rule_type.startswith("filter/"):
-                if (
-                    context["id"]
-                    == "sentry.rules.filters.latest_adopted_release_filter.LatestAdoptedReleaseFilter"
-                    and not has_latest_adopted_release
-                ):
-                    continue
                 filter_list.append(context)
             elif rule_type.startswith("action/"):
                 action_list.append(context)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -189,8 +189,6 @@ def register_temporary_features(manager: FeatureManager):
     # Enable issue stream table layout changes
     manager.add("organizations:issue-stream-table-layout", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:large-debug-files", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
-    # Enabled latest adopted release filter for issue alerts
-    manager.add("organizations:latest-adopted-release-filter", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
     # Enable members to invite teammates to organizations
     manager.add("organizations:members-invite-teammates", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:mep-rollout-flag", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -903,7 +903,6 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             == "Select a valid choice. bad data is not one of the available choices."
         )
 
-    @with_feature("organizations:latest-adopted-release-filter")
     def test_latest_adopted_release_filter_validation(self):
         filter = {
             "id": "sentry.rules.filters.latest_adopted_release_filter.LatestAdoptedReleaseFilter",


### PR DESCRIPTION
Final follow up to https://github.com/getsentry/sentry-options-automator/pull/2466 and https://github.com/getsentry/sentry/pull/78869 to fully remove the latest adopted release flag.