### PR TITLE
fix(issue-stream): fix multi project bug when clicking on sidebar

### DIFF
--- a/static/app/components/organizations/pageFilters/container.tsx
+++ b/static/app/components/organizations/pageFilters/container.tsx
@@ -142,7 +142,7 @@ function PageFiltersContainer({
     // We may need to re-initialize the URL state if we completely clear
     // out the global selection URL state, for example by navigating with
     // the sidebar on the same view.
-    if (location.state?.source === SIDEBAR_NAVIGATION_SOURCE) {
+    if (location.query?.referrer === SIDEBAR_NAVIGATION_SOURCE) {
       doInitialization();
       lastQuery.current = location.query;
       return;


### PR DESCRIPTION
resolves #78207
resolves #78807

Clicking on the sidebar no longer causes the "Error: You do not have the multi project stream feature enabled" banner from appearing. 

credit to @malwilley for finding this bug  
