### PR TITLE
ref(feedback): add classification: spam tag if spam feedback

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -3,6 +3,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {openNavigateToExternalLinkModal} from 'sentry/actionCreators/modal';
+import Tag from 'sentry/components/badge/tag';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import CrashReportSection from 'sentry/components/feedback/feedbackItem/crashReportSection';
 import FeedbackActivitySection from 'sentry/components/feedback/feedbackItem/feedbackActivitySection';
@@ -12,11 +13,13 @@ import FeedbackReplay from 'sentry/components/feedback/feedbackItem/feedbackRepl
 import MessageSection from 'sentry/components/feedback/feedbackItem/messageSection';
 import TagsSection from 'sentry/components/feedback/feedbackItem/tagsSection';
 import TraceDataSection from 'sentry/components/feedback/feedbackItem/traceDataSection';
+import ExternalLink from 'sentry/components/links/externalLink';
 import PanelItem from 'sentry/components/panels/panelItem';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import TextCopyInput from 'sentry/components/textCopyInput';
-import {IconChat, IconFire, IconLink, IconTag} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconChat, IconFire, IconInfo, IconLink, IconTag} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
@@ -36,6 +39,7 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
     eventData?.tags?.find(tag => tag.key === 'url')?.value;
   const crashReportId = eventData?.contexts?.feedback?.associated_event_id;
   const theme = useTheme();
+  const isSpam = eventData?.occurrence?.evidenceData.isSpam;
 
   const overflowRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -126,6 +130,27 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
             <FeedbackActivitySection feedbackItem={feedbackItem as unknown as Group} />
           </Section>
         ) : null}
+
+        {isSpam ? (
+          <Section icon={<IconInfo size="xs" />} title={t('Classification')}>
+            <StyledTag key="spam" type="error">
+              <Tooltip
+                isHoverable
+                position="right"
+                title={tct(
+                  'This feedback was automatically marked as spam. Learn more by [link:reading our docs.]',
+                  {
+                    link: (
+                      <ExternalLink href="https://docs.sentry.io/product/user-feedback/#spam-detection-for-user-feedback" />
+                    ),
+                  }
+                )}
+              >
+                {t('spam')}
+              </Tooltip>
+            </StyledTag>
+          </Section>
+        ) : null}
       </OverflowPanelItem>
     </Fragment>
   );
@@ -139,4 +164,8 @@ const OverflowPanelItem = styled(PanelItem)`
   flex-grow: 1;
   gap: ${space(2)};
   padding: ${space(2)} ${space(2)} 0 ${space(2)};
+`;
+
+const StyledTag = styled(Tag)`
+  margin-bottom: ${space(3)};
 `;

--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -3,7 +3,6 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {openNavigateToExternalLinkModal} from 'sentry/actionCreators/modal';
-import Tag from 'sentry/components/badge/tag';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import CrashReportSection from 'sentry/components/feedback/feedbackItem/crashReportSection';
 import FeedbackActivitySection from 'sentry/components/feedback/feedbackItem/feedbackActivitySection';
@@ -13,13 +12,11 @@ import FeedbackReplay from 'sentry/components/feedback/feedbackItem/feedbackRepl
 import MessageSection from 'sentry/components/feedback/feedbackItem/messageSection';
 import TagsSection from 'sentry/components/feedback/feedbackItem/tagsSection';
 import TraceDataSection from 'sentry/components/feedback/feedbackItem/traceDataSection';
-import ExternalLink from 'sentry/components/links/externalLink';
 import PanelItem from 'sentry/components/panels/panelItem';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import TextCopyInput from 'sentry/components/textCopyInput';
-import {Tooltip} from 'sentry/components/tooltip';
-import {IconChat, IconFire, IconInfo, IconLink, IconTag} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
+import {IconChat, IconFire, IconLink, IconTag} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
@@ -39,7 +36,6 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
     eventData?.tags?.find(tag => tag.key === 'url')?.value;
   const crashReportId = eventData?.contexts?.feedback?.associated_event_id;
   const theme = useTheme();
-  const isSpam = eventData?.occurrence?.evidenceData.isSpam;
 
   const overflowRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -130,27 +126,6 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
             <FeedbackActivitySection feedbackItem={feedbackItem as unknown as Group} />
           </Section>
         ) : null}
-
-        {isSpam ? (
-          <Section icon={<IconInfo size="xs" />} title={t('Classification')}>
-            <StyledTag key="spam" type="error">
-              <Tooltip
-                isHoverable
-                position="right"
-                title={tct(
-                  'This feedback was automatically marked as spam. Learn more by [link:reading our docs.]',
-                  {
-                    link: (
-                      <ExternalLink href="https://docs.sentry.io/product/user-feedback/#spam-detection-for-user-feedback" />
-                    ),
-                  }
-                )}
-              >
-                {t('spam')}
-              </Tooltip>
-            </StyledTag>
-          </Section>
-        ) : null}
       </OverflowPanelItem>
     </Fragment>
   );
@@ -164,8 +139,4 @@ const OverflowPanelItem = styled(PanelItem)`
   flex-grow: 1;
   gap: ${space(2)};
   padding: ${space(2)} ${space(2)} 0 ${space(2)};
-`;
-
-const StyledTag = styled(Tag)`
-  margin-bottom: ${space(3)};
 `;

--- a/static/app/components/feedback/feedbackItem/messageSection.tsx
+++ b/static/app/components/feedback/feedbackItem/messageSection.tsx
@@ -2,13 +2,16 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {useRole} from 'sentry/components/acl/useRole';
+import Tag from 'sentry/components/badge/tag';
 import {Flex} from 'sentry/components/container/flex';
 import FeedbackItemUsername from 'sentry/components/feedback/feedbackItem/feedbackItemUsername';
 import FeedbackTimestampsTooltip from 'sentry/components/feedback/feedbackItem/feedbackTimestampsTooltip';
 import FeedbackViewers from 'sentry/components/feedback/feedbackItem/feedbackViewers';
 import {ScreenshotSection} from 'sentry/components/feedback/feedbackItem/screenshotSection';
+import ExternalLink from 'sentry/components/links/externalLink';
 import TimeSince from 'sentry/components/timeSince';
-import {t} from 'sentry/locale';
+import {Tooltip} from 'sentry/components/tooltip';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {FeedbackIssue} from 'sentry/utils/feedback/types';
@@ -23,20 +26,41 @@ export default function MessageSection({eventData, feedbackItem}: Props) {
   const organization = useOrganization();
   const {hasRole} = useRole({role: 'attachmentsRole'});
   const project = feedbackItem.project;
+  const isSpam = eventData?.occurrence?.evidenceData.isSpam;
+
   return (
     <Fragment>
       <Flex wrap="wrap" flex="1 1 auto" gap={space(1)} justify="space-between">
         <FeedbackItemUsername feedbackIssue={feedbackItem} />
-
-        <StyledTimeSince
-          date={feedbackItem.firstSeen}
-          tooltipProps={{
-            title: eventData ? (
-              <FeedbackTimestampsTooltip feedbackItem={feedbackItem} />
-            ) : undefined,
-            overlayStyle: {maxWidth: 300},
-          }}
-        />
+        <Flex gap={space(1)}>
+          {isSpam ? (
+            <Tag key="spam" type="error">
+              <Tooltip
+                isHoverable
+                position="left"
+                title={tct(
+                  'This feedback was automatically marked as spam. Learn more by [link:reading our docs.]',
+                  {
+                    link: (
+                      <ExternalLink href="https://docs.sentry.io/product/user-feedback/#spam-detection-for-user-feedback" />
+                    ),
+                  }
+                )}
+              >
+                {t('spam')}
+              </Tooltip>
+            </Tag>
+          ) : null}
+          <StyledTimeSince
+            date={feedbackItem.firstSeen}
+            tooltipProps={{
+              title: eventData ? (
+                <FeedbackTimestampsTooltip feedbackItem={feedbackItem} />
+              ) : undefined,
+              overlayStyle: {maxWidth: 300},
+            }}
+          />
+        </Flex>
       </Flex>
       <Blockquote>
         <pre>{feedbackItem.metadata.message}</pre>


### PR DESCRIPTION
for spam feedbacks (those automatically marked as spam), show this classification tag at the top of feedback details:

<img width="330" alt="SCR-20241010-ksxm" src="https://github.com/user-attachments/assets/edf973a9-c0a4-4b34-8f4f-04adc4509698">
<img width="741" alt="SCR-20241010-ksvj" src="https://github.com/user-attachments/assets/ae295d53-11d7-4ebb-a661-5426a1d391a3">


links to https://docs.sentry.io/product/user-feedback/#spam-detection-for-user-feedback


closes https://github.com/getsentry/sentry/issues/70830