### PR TITLE
chore(opsgenie): remove calls to auth endpoint

### DIFF
--- a/src/sentry/integrations/on_call/metrics.py
+++ b/src/sentry/integrations/on_call/metrics.py
@@ -18,7 +18,7 @@ class OnCallInteractionType(Enum):
     # General interactions
     ADD_KEY = "ADD_KEY"
     POST_INSTALL = "POST_INSTALL"
-    VERIFY_TEAM = "VALIDATE_TEAM"
+    VERIFY_TEAM = "VERIFY_TEAM"
     # Interacting with external alerts
     CREATE = "CREATE"  # create an alert in Opsgenie/Pagerduty
     RESOLVE = "RESOLVE"  # resolve an alert in Opsgenie/Pagerduty

--- a/src/sentry/integrations/on_call/metrics.py
+++ b/src/sentry/integrations/on_call/metrics.py
@@ -18,6 +18,7 @@ class OnCallInteractionType(Enum):
     # General interactions
     ADD_KEY = "ADD_KEY"
     POST_INSTALL = "POST_INSTALL"
+    VERIFY_TEAM = "VALIDATE_TEAM"
     # Interacting with external alerts
     CREATE = "CREATE"  # create an alert in Opsgenie/Pagerduty
     RESOLVE = "RESOLVE"  # resolve an alert in Opsgenie/Pagerduty

--- a/src/sentry/integrations/opsgenie/actions/form.py
+++ b/src/sentry/integrations/opsgenie/actions/form.py
@@ -84,9 +84,7 @@ class OpsgenieNotifyTeamForm(forms.Form):
                     params=params,
                 )
 
-            team_status = self._get_team_status(
-                team_id=team_id, integration=integration, org_integration=org_integration
-            )
+            team_status = self._get_team_status(team_id=team_id, org_integration=org_integration)
             if team_status == INVALID_TEAM:
                 raise forms.ValidationError(
                     _('The team "%(team)s" does not belong to the %(account)s Opsgenie account.'),

--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -38,11 +38,6 @@ class OpsgenieClient(ApiClient):
         path = f"/alerts?limit={limit}"
         return self.get(path=path, headers=self._get_auth_headers())
 
-    def authorize_integration(self, type: str) -> BaseApiResponseX:
-        body = {"type": type}
-        path = "/integrations/authenticate"
-        return self.post(path=path, headers=self._get_auth_headers(), data=body)
-
     def _get_rule_urls(self, group, rules):
         organization = group.project.organization
         rule_urls = []

--- a/tests/sentry/integrations/opsgenie/test_client.py
+++ b/tests/sentry/integrations/opsgenie/test_client.py
@@ -49,22 +49,6 @@ class OpsgenieClientTest(APITestCase):
         assert client.integration_key == METADATA["api_key"]
 
     @responses.activate
-    def test_authorize_integration(self):
-        client = self.installation.get_keyring_client("team-123")
-
-        resp_data = {
-            "result": "Integration [sentry] is valid",
-            "took": 1,
-            "requestId": "hello-world",
-        }
-        responses.add(
-            responses.POST, url=f"{client.base_url}/integrations/authenticate", json=resp_data
-        )
-
-        resp = client.authorize_integration(type="sentry")
-        assert resp == resp_data
-
-    @responses.activate
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_send_notification(self, mock_record):
         resp_data = {


### PR DESCRIPTION
We validate keys by calling GET on the alerts endpoint when they're added to the Opsgenie configuration, but we didn't remove the POST call to the authentication endpoint when adding an Opsgenie action to an issue alert. This is a problem, because the authentication endpoint now requires configuration access, which is not necessary to send alerts. This PR removes all calls to the integration authentication endpoint.