### PR TITLE
feat(feedback): add banner to clarify alert settings

### DIFF
--- a/static/app/views/alerts/rules/issue/feedbackAlertBanner.tsx
+++ b/static/app/views/alerts/rules/issue/feedbackAlertBanner.tsx
@@ -1,0 +1,35 @@
+import styled from '@emotion/styled';
+
+import Alert from 'sentry/components/alert';
+import Link from 'sentry/components/links/link';
+import {tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {IssueAlertFilterType, type IssueAlertRuleCondition} from 'sentry/types/alerts';
+
+export default function FeedbackAlertBanner({
+  filters,
+  projectSlug,
+}: {
+  filters: IssueAlertRuleCondition[] | undefined;
+  projectSlug: string;
+}) {
+  const filterSet = filters?.filter(r => r.id === IssueAlertFilterType.ISSUE_CATEGORY);
+  if (!filterSet || !filterSet.length) {
+    return null;
+  }
+  const filterFeedback = filterSet.find(f => f.value === '6'); // category: feedback
+  return filterFeedback ? (
+    <StyledFeedbackAlert showIcon type="info">
+      {tct(
+        'This issue category condition is ONLY for feedbacks from the built-in widget. Crash-report feedback alerts can be enabled in [link:Project Settings.]',
+        {
+          link: <Link to={`/settings/projects/${projectSlug}/user-feedback/`} />,
+        }
+      )}
+    </StyledFeedbackAlert>
+  ) : null;
+}
+
+const StyledFeedbackAlert = styled(Alert)`
+  margin: ${space(1)} 0 0 0;
+`;

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -34,6 +34,7 @@ import IdBadge from 'sentry/components/idBadge';
 import Input from 'sentry/components/input';
 import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
+import Link from 'sentry/components/links/link';
 import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
 import LoadingMask from 'sentry/components/loadingMask';
@@ -1144,6 +1145,28 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
     );
   }
 
+  renderFeedbackBanner() {
+    const filterSet = this.state.rule?.filters.filter(
+      r => r.id === IssueAlertFilterType.ISSUE_CATEGORY
+    );
+    if (!filterSet || !filterSet.length) {
+      return null;
+    }
+    const filterFeedback = filterSet.find(f => f.value === '6'); // category: feedback
+    return filterFeedback ? (
+      <StyledFeedbackAlert type="info">
+        {tct(
+          'This issue category condition is ONLY for feedbacks from the built-in widget. Crash-report feedback alerts can be enabled in [link:Project Settings.]',
+          {
+            link: (
+              <Link to={`/settings/projects/${this.state.project.slug}/user-feedback/`} />
+            ),
+          }
+        )}
+      </StyledFeedbackAlert>
+    ) : null;
+  }
+
   renderBody() {
     const {organization, members} = this.props;
     const {
@@ -1395,6 +1418,7 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
                             incompatibleFilters ? incompatibleFilters.at(-1) : null
                           }
                         />
+                        {this.renderFeedbackBanner()}
                       </StepContent>
                     </StepContainer>
                   </Step>
@@ -1761,4 +1785,8 @@ const AcknowledgeField = styled(FieldGroup)`
     flex: unset;
     gap: ${space(1)};
   }
+`;
+
+const StyledFeedbackAlert = styled(Alert)`
+  margin: ${space(1)} 0;
 `;

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -34,7 +34,6 @@ import IdBadge from 'sentry/components/idBadge';
 import Input from 'sentry/components/input';
 import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
-import Link from 'sentry/components/links/link';
 import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
 import LoadingMask from 'sentry/components/loadingMask';
@@ -70,6 +69,7 @@ import routeTitleGen from 'sentry/utils/routeTitle';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import withOrganization from 'sentry/utils/withOrganization';
 import withProjects from 'sentry/utils/withProjects';
+import FeedbackAlertBanner from 'sentry/views/alerts/rules/issue/feedbackAlertBanner';
 import {PreviewIssues} from 'sentry/views/alerts/rules/issue/previewIssues';
 import SetupMessagingIntegrationButton, {
   MessagingIntegrationAnalyticsView,
@@ -1145,28 +1145,6 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
     );
   }
 
-  renderFeedbackBanner() {
-    const filterSet = this.state.rule?.filters.filter(
-      r => r.id === IssueAlertFilterType.ISSUE_CATEGORY
-    );
-    if (!filterSet || !filterSet.length) {
-      return null;
-    }
-    const filterFeedback = filterSet.find(f => f.value === '6'); // category: feedback
-    return filterFeedback ? (
-      <StyledFeedbackAlert type="info">
-        {tct(
-          'This issue category condition is ONLY for feedbacks from the built-in widget. Crash-report feedback alerts can be enabled in [link:Project Settings.]',
-          {
-            link: (
-              <Link to={`/settings/projects/${this.state.project.slug}/user-feedback/`} />
-            ),
-          }
-        )}
-      </StyledFeedbackAlert>
-    ) : null;
-  }
-
   renderBody() {
     const {organization, members} = this.props;
     const {
@@ -1418,7 +1396,10 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
                             incompatibleFilters ? incompatibleFilters.at(-1) : null
                           }
                         />
-                        {this.renderFeedbackBanner()}
+                        <FeedbackAlertBanner
+                          filters={this.state.rule?.filters}
+                          projectSlug={this.state.project.slug}
+                        />
                       </StepContent>
                     </StepContainer>
                   </Step>
@@ -1785,8 +1766,4 @@ const AcknowledgeField = styled(FieldGroup)`
     flex: unset;
     gap: ${space(1)};
   }
-`;
-
-const StyledFeedbackAlert = styled(Alert)`
-  margin: ${space(1)} 0;
 `;


### PR DESCRIPTION
When creating a new alert, it's not clear that the alert condition "The issue's category is equal to... [FEEDBACK]" only applies to widget feedbacks. Crash-report feedbacks need to be configured in project settings.

This PR adds an info banner whenever this specific rule condition is selected, to bring awareness to users on how to configure crash-report feedbacks if they haven't read the docs.

https://github.com/user-attachments/assets/ad525def-3d67-48a0-ae9b-aa7a6c943a5d


added the icon post screen recording:

<img width="836" alt="SCR-20241010-lgtc" src="https://github.com/user-attachments/assets/4ddc0a4f-c9cb-436f-9385-c78328924b12">

closes https://github.com/getsentry/sentry/issues/78132