### PR TITLE
fix(sidebar): Fix page selection reset when clicking sidebar links

### DIFF
--- a/static/app/components/links/link.tsx
+++ b/static/app/components/links/link.tsx
@@ -1,5 +1,8 @@
 import {forwardRef} from 'react';
-import {Link as RouterLink} from 'react-router-dom';
+import {
+  Link as RouterLink,
+  type LinkProps as ReactRouterLinkProps,
+} from 'react-router-dom';
 import styled from '@emotion/styled';
 import type {LocationDescriptor} from 'history';
 
@@ -36,6 +39,7 @@ export interface LinkProps
    * Forwarded ref
    */
   forwardedRef?: React.Ref<HTMLAnchorElement>;
+  state?: ReactRouterLinkProps['state'];
 }
 
 /**

--- a/static/app/components/nav/sidebar.tsx
+++ b/static/app/components/nav/sidebar.tsx
@@ -11,7 +11,7 @@ import {
   isNavItemActive,
   isNonEmptyArray,
   isSubmenuItemActive,
-  makeLocationDescriptorFromTo,
+  makeLinkPropsFromTo,
   type NavSidebarItem,
   resolveNavItemTo,
 } from 'sentry/components/nav/utils';
@@ -95,7 +95,7 @@ function SidebarItem({item}: {item: NavSidebarItem}) {
   const isActive = isNavItemActive(item, location);
   const isSubmenuActive = isSubmenuItemActive(item, location);
   const _to = resolveNavItemTo(item);
-  const to = _to ? makeLocationDescriptorFromTo(_to) : '#';
+  const linkProps = _to ? makeLinkPropsFromTo(_to) : {to: '#'};
 
   const FeatureGuard = item.feature ? Feature : Fragment;
   const featureGuardProps: any = item.feature ?? {};
@@ -104,7 +104,7 @@ function SidebarItem({item}: {item: NavSidebarItem}) {
     <FeatureGuard {...featureGuardProps}>
       <SidebarItemWrapper>
         <Link
-          to={to}
+          {...linkProps}
           className={isActive || isSubmenuActive ? 'active' : undefined}
           aria-current={isActive ? 'page' : undefined}
         >

--- a/static/app/components/nav/submenu.tsx
+++ b/static/app/components/nav/submenu.tsx
@@ -10,7 +10,7 @@ import type {NavSubmenuItem} from 'sentry/components/nav/utils';
 import {
   isNavItemActive,
   isNonEmptyArray,
-  makeLocationDescriptorFromTo,
+  makeLinkPropsFromTo,
 } from 'sentry/components/nav/utils';
 import {space} from 'sentry/styles/space';
 import theme from 'sentry/utils/theme';
@@ -57,7 +57,7 @@ const SubmenuWrapper = styled(motion.div)`
 function SubmenuItem({item}: {item: NavSubmenuItem}) {
   const location = useLocation();
   const isActive = isNavItemActive(item, location);
-  const to = makeLocationDescriptorFromTo(item.to);
+  const linkProps = makeLinkPropsFromTo(item.to);
 
   const FeatureGuard = item.feature ? Feature : Fragment;
   const featureGuardProps: any = item.feature ?? {};
@@ -66,7 +66,7 @@ function SubmenuItem({item}: {item: NavSubmenuItem}) {
     <FeatureGuard {...featureGuardProps}>
       <SubmenuItemWrapper>
         <Link
-          to={to}
+          {...linkProps}
           className={isActive ? 'active' : undefined}
           aria-current={isActive ? 'page' : undefined}
         >

--- a/static/app/components/nav/utils.tsx
+++ b/static/app/components/nav/utils.tsx
@@ -98,12 +98,17 @@ export function isSubmenuItemActive(
 }
 
 /** Creates a `LocationDescriptor` from a URL string that may contain search params */
-export function makeLocationDescriptorFromTo(to: string): LocationDescriptor {
+export function makeLinkPropsFromTo(to: string): {
+  state: object;
+  to: LocationDescriptor;
+} {
   const [pathname, search] = to.split('?');
 
   return {
-    pathname,
-    search: search ? `?${search}` : undefined,
+    to: {
+      pathname,
+      search: search ? `?${search}` : undefined,
+    },
     state: {source: SIDEBAR_NAVIGATION_SOURCE},
   };
 }

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -1,5 +1,4 @@
 import {Fragment, isValidElement, useCallback, useContext, useMemo} from 'react';
-import isPropValid from '@emotion/is-prop-valid';
 import type {Theme} from '@emotion/react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -194,7 +193,6 @@ function SidebarItem({
     return {
       pathname: to ? to : href,
       search,
-      state: {source: SIDEBAR_NAVIGATION_SOURCE},
     };
   }, [to, href, search]);
 
@@ -239,6 +237,7 @@ function SidebarItem({
             isInFloatingAccordion={isInFloatingAccordion}
             active={isActive ? 'true' : undefined}
             to={toProps}
+            state={{source: SIDEBAR_NAVIGATION_SOURCE}}
             disabled={!hasLink && isInFloatingAccordion}
             className={className}
             aria-current={isActive ? 'page' : undefined}
@@ -391,7 +390,7 @@ const getActiveStyle = ({
 };
 
 const StyledSidebarItem = styled(Link, {
-  shouldForwardProp: p => typeof p === 'string' && isPropValid(p),
+  shouldForwardProp: p => !['isInFloatingAccordion', 'hasNewNav', 'index'].includes(p),
 })`
   display: flex;
   color: ${p => (p.isInFloatingAccordion ? p.theme.gray400 : 'inherit')};


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/78207

When you click the sidebar links, the URL no longer contains any page selection query params, so the selection store will reset. For free orgs, this also results in an error due to multi-project selection not being enabled. This was originally solved with [this PR](https://github.com/getsentry/sentry/pull/59205), but the react router upgrade changed the way that `state` was passed. Now it is no longer included in the LocationDescriptor object, but passed in as a `Link` prop ([described in this section of the docs](https://reactrouter.com/en/v6.3.0/upgrading/v5#use-usenavigate-instead-of-usehistory))