### PR TITLE
chore(alerts): Clean up more flags

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -78,6 +78,8 @@ def register_permanent_features(manager: FeatureManager):
         "organizations:integrations-stacktrace-link": True,
         # Allow orgs to automatically create Tickets in Issue Alerts
         "organizations:integrations-ticket-rules": True,
+        # Enable metric alert charts in email/slack
+        "organizations:metric-alert-chartcuterie": False,
         # Enable Performance view
         "organizations:performance-view": True,
         # Enable profiling view

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -197,8 +197,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:messaging-integration-onboarding", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable messaging-integration onboarding when creating a new project
     manager.add("organizations:messaging-integration-onboarding-project-creation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable metric alert charts in email/slack
-    manager.add("organizations:metric-alert-chartcuterie", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enable threshold period in metric alert rule builder
     manager.add("organizations:metric-alert-threshold-period", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables the search bar for metrics samples list
@@ -216,7 +214,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:more-slow-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     manager.add("organizations:navigation-sidebar-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:new-page-filter", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=True, api_expose=True)
-    manager.add("organizations:new-weekly-report", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Display warning banner for every event issue alerts
     manager.add("organizations:noisy-alert-warning", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Notify all project members when fallthrough is disabled, instead of just the auto-assignee


### PR DESCRIPTION
`new-weekly-report` is an abandoned flag that isn't checked anywhere and I'm removing it from flagpole [here](https://github.com/getsentry/sentry-options-automator/pull/2469).

`metric-alert-chartcuterie` is a permanent flag that's managed in [getsentry](https://github.com/getsentry/getsentry/blob/master/getsentry/conf/settings/defaults.py#L470-L470) because it's not available for single tenant.