### PR TITLE
feat(discover): Update EAP dataset and entity key for discover builders

### DIFF
--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -56,7 +56,7 @@ from sentry.search.events.types import (
     SnubaParams,
     WhereType,
 )
-from sentry.snuba.dataset import Dataset
+from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.metrics.utils import MetricMeta
 from sentry.snuba.query_sources import QuerySource
 from sentry.users.services.user.service import user_service
@@ -74,6 +74,12 @@ from sentry.utils.snuba import (
     resolve_column,
 )
 from sentry.utils.validators import INVALID_ID_DETAILS, INVALID_SPAN_ID, WILDCARD_NOT_ALLOWED
+
+DATASET_TO_ENTITY_MAP: Mapping[Dataset, EntityKey] = {
+    Dataset.Events: EntityKey.Events,
+    Dataset.Transactions: EntityKey.Transactions,
+    Dataset.EventsAnalyticsPlatform: EntityKey.EAPSpans,
+}
 
 
 class BaseQueryBuilder:
@@ -1498,6 +1504,8 @@ class BaseQueryBuilder:
         return self.function_alias_map[function.alias].field
 
     def _get_entity_name(self) -> str:
+        if self.dataset in DATASET_TO_ENTITY_MAP:
+            return DATASET_TO_ENTITY_MAP[self.dataset]
         return self.dataset.value
 
     def get_snql_query(self) -> Request:

--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -1505,7 +1505,7 @@ class BaseQueryBuilder:
 
     def _get_entity_name(self) -> str:
         if self.dataset in DATASET_TO_ENTITY_MAP:
-            return DATASET_TO_ENTITY_MAP[self.dataset]
+            return DATASET_TO_ENTITY_MAP[self.dataset].value
         return self.dataset.value
 
     def get_snql_query(self) -> Request:

--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -1497,17 +1497,17 @@ class BaseQueryBuilder:
         """
         return self.function_alias_map[function.alias].field
 
-    def _get_dataset_name(self) -> str:
+    def _get_entity_name(self) -> str:
         return self.dataset.value
 
     def get_snql_query(self) -> Request:
         self.validate_having_clause()
 
         return Request(
-            dataset=self._get_dataset_name(),
+            dataset=self.dataset.value,
             app_id="default",
             query=Query(
-                match=Entity(self.dataset.value, sample=self.sample_rate),
+                match=Entity(self._get_entity_name(), sample=self.sample_rate),
                 select=self.columns,
                 array_join=self.array_join,
                 where=self.where,

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -221,10 +221,10 @@ class TimeseriesQueryBuilder(UnresolvedQuery):
 
     def get_snql_query(self) -> Request:
         return Request(
-            dataset=self._get_dataset_name(),
+            dataset=self.dataset.value,
             app_id="default",
             query=Query(
-                match=Entity(self.dataset.value),
+                match=Entity(self._get_entity_name()),
                 select=self.select,
                 where=self.where,
                 having=self.having,

--- a/src/sentry/search/events/builder/spans_indexed.py
+++ b/src/sentry/search/events/builder/spans_indexed.py
@@ -11,7 +11,6 @@ from sentry.search.events.datasets.spans_indexed import (
 )
 from sentry.search.events.fields import custom_time_processor
 from sentry.search.events.types import SelectType
-from sentry.snuba.dataset import Dataset, EntityKey
 
 SPAN_UUID_FIELDS = {
     "trace",
@@ -68,11 +67,6 @@ class SpansEAPQueryBuilder(SpansIndexedQueryBuilderMixin, BaseQueryBuilder):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-    def _get_entity_name(self) -> str:
-        if self.dataset == Dataset.EventsAnalyticsPlatform:
-            return EntityKey.EAPSpans.value
-        return self.dataset.value
 
     def resolve_field(self, raw_field: str, alias: bool = False) -> Column:
         # try the typed regex first

--- a/src/sentry/search/events/builder/spans_indexed.py
+++ b/src/sentry/search/events/builder/spans_indexed.py
@@ -11,7 +11,7 @@ from sentry.search.events.datasets.spans_indexed import (
 )
 from sentry.search.events.fields import custom_time_processor
 from sentry.search.events.types import SelectType
-from sentry.snuba.dataset import Dataset
+from sentry.snuba.dataset import Dataset, EntityKey
 
 SPAN_UUID_FIELDS = {
     "trace",
@@ -69,9 +69,9 @@ class SpansEAPQueryBuilder(SpansIndexedQueryBuilderMixin, BaseQueryBuilder):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def _get_dataset_name(self) -> str:
-        if self.dataset == Dataset.SpansEAP:
-            return "events_analytics_platform"
+    def _get_entity_name(self) -> str:
+        if self.dataset == Dataset.EventsAnalyticsPlatform:
+            return EntityKey.EAPSpans.value
         return self.dataset.value
 
     def resolve_field(self, raw_field: str, alias: bool = False) -> Column:

--- a/src/sentry/snuba/dataset.py
+++ b/src/sentry/snuba/dataset.py
@@ -52,7 +52,7 @@ class Dataset(Enum):
     indexed spans are similar to indexed transactions in the fields available to search
     """
 
-    SpansEAP = "eap_spans"
+    EventsAnalyticsPlatform = "events_analytics_platform"
 
     MetricsSummaries = "metrics_summaries"
     """
@@ -66,6 +66,7 @@ class EntityKey(Enum):
     Events = "events"
     Sessions = "sessions"
     Spans = "spans"
+    EAPSpans = "eap_spans"
     Transactions = "transactions"
     MetricsSets = "metrics_sets"
     MetricsCounters = "metrics_counters"

--- a/src/sentry/snuba/spans_eap.py
+++ b/src/sentry/snuba/spans_eap.py
@@ -52,7 +52,7 @@ def query(
     enable_rpc: bool | None = False,
 ):
     builder = SpansEAPQueryBuilder(
-        Dataset.SpansEAP,
+        Dataset.EventsAnalyticsPlatform,
         {},
         snuba_params=snuba_params,
         query=query,
@@ -105,7 +105,7 @@ def timeseries_query(
 
     with sentry_sdk.start_span(op="spans_indexed", name="TimeseriesSpanIndexedQueryBuilder"):
         querybuilder = TimeseriesSpanEAPIndexedQueryBuilder(
-            Dataset.SpansEAP,
+            Dataset.EventsAnalyticsPlatform,
             {},
             rollup,
             snuba_params=snuba_params,
@@ -185,7 +185,7 @@ def top_events_timeseries(
             )
 
     top_events_builder = TopEventsSpanEAPQueryBuilder(
-        Dataset.SpansEAP,
+        Dataset.EventsAnalyticsPlatform,
         {},
         rollup,
         top_events["data"],
@@ -202,7 +202,7 @@ def top_events_timeseries(
     )
     if len(top_events["data"]) == limit and include_other:
         other_events_builder = TopEventsSpanEAPQueryBuilder(
-            Dataset.SpansEAP,
+            Dataset.EventsAnalyticsPlatform,
             {},
             rollup,
             top_events["data"],

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -285,7 +285,7 @@ DATASETS: dict[Dataset, dict[str, str]] = {
     Dataset.MetricsSummaries: METRICS_SUMMARIES_COLUMN_MAP,
     Dataset.PerformanceMetrics: METRICS_COLUMN_MAP,
     Dataset.SpansIndexed: SPAN_COLUMN_MAP,
-    Dataset.SpansEAP: SPAN_EAP_COLUMN_MAP,
+    Dataset.EventsAnalyticsPlatform: SPAN_EAP_COLUMN_MAP,
     Dataset.IssuePlatform: ISSUE_PLATFORM_MAP,
     Dataset.Replays: {},
 }
@@ -300,7 +300,7 @@ DATASET_FIELDS = {
     Dataset.Sessions: SESSIONS_FIELD_LIST,
     Dataset.IssuePlatform: list(ISSUE_PLATFORM_MAP.values()),
     Dataset.SpansIndexed: list(SPAN_COLUMN_MAP.values()),
-    Dataset.SpansEAP: list(SPAN_EAP_COLUMN_MAP.values()),
+    Dataset.EventsAnalyticsPlatform: list(SPAN_EAP_COLUMN_MAP.values()),
     Dataset.MetricsSummaries: list(METRICS_SUMMARIES_COLUMN_MAP.values()),
 }
 
@@ -1417,7 +1417,7 @@ def resolve_column(dataset) -> Callable:
         if isinstance(col, int) or isinstance(col, float):
             return col
         if (
-            dataset != Dataset.SpansEAP
+            dataset != Dataset.EventsAnalyticsPlatform
             and isinstance(col, str)
             and (col.startswith("tags[") or QUOTED_LITERAL_RE.match(col))
         ):
@@ -1428,7 +1428,7 @@ def resolve_column(dataset) -> Callable:
 
             if isinstance(col, (list, tuple)) or col in ("project_id", "group_id"):
                 return col
-        elif dataset == Dataset.SpansEAP:
+        elif dataset == Dataset.EventsAnalyticsPlatform:
             if isinstance(col, str) and col.startswith("sentry_tags["):
                 # Replace the first instance of sentry tags with attr str instead
                 return col.replace("sentry_tags", "attr_str", 1)
@@ -1460,7 +1460,7 @@ def resolve_column(dataset) -> Callable:
         span_op_breakdown_name = get_span_op_breakdown_name(col)
         if "span_op_breakdowns_key" in DATASETS[dataset] and span_op_breakdown_name:
             return f"span_op_breakdowns[{span_op_breakdown_name}]"
-        if dataset == Dataset.SpansEAP:
+        if dataset == Dataset.EventsAnalyticsPlatform:
             return f"attr_str[{col}]"
         return f"tags[{col}]"
 


### PR DESCRIPTION
Updates EAP dataset to correctly be `events_analytics_platform` and add entity key for `eap_spans`.
Also updates discover builders to stop using `_get_dataset_name` and start using `_get_entity_name` instead.

This is needed because the AlertRule model obtains and stores it's `dataset` from the UI via POST api call. We need to use the proper `events_analytics_platform` dataset string so we can pass validation when creating the snuba subscription. With these changes, we will also be able to pass any discover builder validation when creating the query from the AlertRule.