### PR TITLE
feat: handle errors sent by snuba in RPC calls

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -67,7 +67,7 @@ rfc3986-validator>=0.1.1
 sentry-arroyo>=2.16.5
 sentry-kafka-schemas>=0.1.111
 sentry-ophio==1.0.0
-sentry-protos>=0.1.23
+sentry-protos>=0.1.26
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.9.2
 sentry-sdk>=2.15.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -184,7 +184,7 @@ sentry-forked-django-stubs==5.1.0.post2
 sentry-forked-djangorestframework-stubs==3.15.1.post2
 sentry-kafka-schemas==0.1.111
 sentry-ophio==1.0.0
-sentry-protos==0.1.23
+sentry-protos==0.1.26
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.2
 sentry-sdk==2.15.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -125,7 +125,7 @@ s3transfer==0.10.0
 sentry-arroyo==2.16.5
 sentry-kafka-schemas==0.1.111
 sentry-ophio==1.0.0
-sentry-protos==0.1.23
+sentry-protos==0.1.26
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.2
 sentry-sdk==2.15.0

--- a/src/sentry/utils/snuba_rpc.py
+++ b/src/sentry/utils/snuba_rpc.py
@@ -25,8 +25,8 @@ class SnubaRPCRequest(Protocol):
 
 class SnubaRPCException(Exception):
     def __init__(self, status_code: int, message: str):
-        self.status_code = status_code
         super().__init__(f"HTTP {status_code} while executing RPC call: {message}")
+        self.status_code = status_code
 
 
 def rpc(req: SnubaRPCRequest, resp_type: type[RPCResponseType]) -> RPCResponseType:


### PR DESCRIPTION
Fixes https://github.com/getsentry/eap-planning/issues/60, consumes errors by https://github.com/getsentry/snuba/pull/6402

If snuba understands its error, it will create a protobuf error message and send that over the wire. We still need to handle the general case where a proxy failed.