### PR TITLE
feat(explore): flip span id and project name

### DIFF
--- a/static/app/views/explore/hooks/useResultsMode.spec.tsx
+++ b/static/app/views/explore/hooks/useResultsMode.spec.tsx
@@ -39,8 +39,8 @@ describe('useResultMode', function () {
 
     expect(resultMode).toEqual('samples'); // default
     expect(sampleFields).toEqual([
-      'project',
       'span_id',
+      'project',
       'span.op',
       'span.description',
       'span.duration',
@@ -56,8 +56,8 @@ describe('useResultMode', function () {
     expect(resultMode).toEqual('samples');
 
     expect(sampleFields).toEqual([
-      'project',
       'span_id',
+      'project',
       'span.op',
       'span.description',
       'span.duration',

--- a/static/app/views/explore/hooks/useSampleFields.spec.tsx
+++ b/static/app/views/explore/hooks/useSampleFields.spec.tsx
@@ -14,8 +14,8 @@ describe('useSampleFields', function () {
     render(<TestPage />, {disableRouterMocks: true});
 
     expect(sampleFields).toEqual([
-      'project',
       'span_id',
+      'project',
       'span.op',
       'span.description',
       'span.duration',
@@ -27,8 +27,8 @@ describe('useSampleFields', function () {
 
     act(() => setSampleFields([]));
     expect(sampleFields).toEqual([
-      'project',
       'span_id',
+      'project',
       'span.op',
       'span.description',
       'span.duration',

--- a/static/app/views/explore/hooks/useSampleFields.tsx
+++ b/static/app/views/explore/hooks/useSampleFields.tsx
@@ -32,8 +32,8 @@ function useSampleFieldsImpl({
     }
 
     return [
-      'project',
       'span_id',
+      'project',
       'span.op',
       'span.description',
       'span.duration',

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -53,8 +53,8 @@ describe('ExploreToolbar', function () {
     expect(resultMode).toEqual('samples');
 
     expect(sampleFields).toEqual([
-      'project',
       'span_id',
+      'project',
       'span.op',
       'span.description',
       'span.duration',
@@ -80,8 +80,8 @@ describe('ExploreToolbar', function () {
     expect(resultMode).toEqual('samples');
 
     expect(sampleFields).toEqual([
-      'project',
       'span_id',
+      'project',
       'span.op',
       'span.description',
       'span.duration',
@@ -187,8 +187,8 @@ describe('ExploreToolbar', function () {
 
     // check the default field options
     const fields = [
-      'project',
       'span_id',
+      'project',
       'span.op',
       'span.description',
       'span.duration',


### PR DESCRIPTION
Flipping the order to match the trace tab

![Screenshot 2024-10-10 at 2 29 06 PM](https://github.com/user-attachments/assets/bb0bf852-bb23-4665-8918-a0e43f0a2472)
![Screenshot 2024-10-10 at 2 29 23 PM](https://github.com/user-attachments/assets/7385a7b9-faf8-49d2-8e80-36b0d61a51a6)