### PR TITLE
chore(bitbucket): installation step metrics

### DIFF
--- a/src/sentry/identity/bitbucket/provider.py
+++ b/src/sentry/identity/bitbucket/provider.py
@@ -1,11 +1,6 @@
 from django.http import HttpResponse
 
 from sentry.identity.base import Provider
-from sentry.integrations.base import IntegrationDomain
-from sentry.integrations.utils.metrics import (
-    IntegrationPipelineViewEvent,
-    IntegrationPipelineViewType,
-)
 from sentry.pipeline import PipelineView
 from sentry.utils.http import absolute_uri
 
@@ -23,6 +18,12 @@ from rest_framework.request import Request
 
 class BitbucketLoginView(PipelineView):
     def dispatch(self, request: Request, pipeline) -> HttpResponse:
+        from sentry.integrations.base import IntegrationDomain
+        from sentry.integrations.utils.metrics import (
+            IntegrationPipelineViewEvent,
+            IntegrationPipelineViewType,
+        )
+
         with IntegrationPipelineViewEvent(
             IntegrationPipelineViewType.IDENTITY_LINK,
             IntegrationDomain.SOURCE_CODE_MANAGEMENT,

--- a/src/sentry/identity/bitbucket/provider.py
+++ b/src/sentry/identity/bitbucket/provider.py
@@ -1,6 +1,11 @@
 from django.http import HttpResponse
 
 from sentry.identity.base import Provider
+from sentry.integrations.base import IntegrationDomain
+from sentry.integrations.utils.metrics import (
+    IntegrationPipelineViewEvent,
+    IntegrationPipelineViewType,
+)
 from sentry.pipeline import PipelineView
 from sentry.utils.http import absolute_uri
 
@@ -18,10 +23,15 @@ from rest_framework.request import Request
 
 class BitbucketLoginView(PipelineView):
     def dispatch(self, request: Request, pipeline) -> HttpResponse:
-        jwt = request.GET.get("jwt")
-        if jwt is None:
-            return self.redirect(
-                "https://bitbucket.org/site/addons/authorize?descriptor_uri=%s"
-                % (absolute_uri("/extensions/bitbucket/descriptor/"),)
-            )
-        return pipeline.next_step()
+        with IntegrationPipelineViewEvent(
+            IntegrationPipelineViewType.IDENTITY_LINK,
+            IntegrationDomain.SOURCE_CODE_MANAGEMENT,
+            pipeline.provider.key,
+        ).capture():
+            jwt = request.GET.get("jwt")
+            if jwt is None:
+                return self.redirect(
+                    "https://bitbucket.org/site/addons/authorize?descriptor_uri=%s"
+                    % (absolute_uri("/extensions/bitbucket/descriptor/"),)
+                )
+            return pipeline.next_step()

--- a/src/sentry/identity/pipeline.py
+++ b/src/sentry/identity/pipeline.py
@@ -6,6 +6,11 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from sentry import features, options
+from sentry.integrations.base import IntegrationDomain
+from sentry.integrations.utils.metrics import (
+    IntegrationPipelineViewEvent,
+    IntegrationPipelineViewType,
+)
 from sentry.models.organization import Organization
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.pipeline import Pipeline, PipelineProvider
@@ -53,37 +58,42 @@ class IdentityProviderPipeline(Pipeline):
         return super().get_provider(provider_key)
 
     def finish_pipeline(self):
-        # NOTE: only reached in the case of linking a new identity
-        # via Social Auth pipelines
-        identity = self.provider.build_identity(self.state.data)
+        with IntegrationPipelineViewEvent(
+            IntegrationPipelineViewType.IDENTITY_PROVIDER,
+            IntegrationDomain.IDENTITY,
+            self.provider.key,
+        ).capture():
+            # NOTE: only reached in the case of linking a new identity
+            # via Social Auth pipelines
+            identity = self.provider.build_identity(self.state.data)
 
-        Identity.objects.link_identity(
-            user=self.request.user,
-            idp=self.provider_model,
-            external_id=identity["id"],
-            should_reattach=False,
-            defaults={
-                "scopes": identity.get("scopes", []),
-                "data": identity.get("data", {}),
-            },
-        )
+            Identity.objects.link_identity(
+                user=self.request.user,
+                idp=self.provider_model,
+                external_id=identity["id"],
+                should_reattach=False,
+                defaults={
+                    "scopes": identity.get("scopes", []),
+                    "data": identity.get("data", {}),
+                },
+            )
 
-        messages.add_message(
-            self.request,
-            messages.SUCCESS,
-            IDENTITY_LINKED.format(identity_provider=self.provider.name),
-        )
-        metrics.incr(
-            "identity_provider_pipeline.finish_pipeline",
-            tags={
-                "provider": self.provider.key,
-            },
-            skip_internal=False,
-        )
+            messages.add_message(
+                self.request,
+                messages.SUCCESS,
+                IDENTITY_LINKED.format(identity_provider=self.provider.name),
+            )
+            metrics.incr(
+                "identity_provider_pipeline.finish_pipeline",
+                tags={
+                    "provider": self.provider.key,
+                },
+                skip_internal=False,
+            )
 
-        self.state.clear()
+            self.state.clear()
 
-        # TODO(epurkhiser): When we have more identities and have built out an
-        # identity management page that supports these new identities (not
-        # social-auth ones), redirect to the identities page.
-        return HttpResponseRedirect(reverse("sentry-account-settings"))
+            # TODO(epurkhiser): When we have more identities and have built out an
+            # identity management page that supports these new identities (not
+            # social-auth ones), redirect to the identities page.
+            return HttpResponseRedirect(reverse("sentry-account-settings"))

--- a/src/sentry/identity/pipeline.py
+++ b/src/sentry/identity/pipeline.py
@@ -59,7 +59,7 @@ class IdentityProviderPipeline(Pipeline):
 
     def finish_pipeline(self):
         with IntegrationPipelineViewEvent(
-            IntegrationPipelineViewType.IDENTITY_PROVIDER,
+            IntegrationPipelineViewType.IDENTITY_LINK,
             IntegrationDomain.IDENTITY,
             self.provider.key,
         ).capture():

--- a/src/sentry/integrations/api/endpoints/organization_integrations_index.py
+++ b/src/sentry/integrations/api/endpoints/organization_integrations_index.py
@@ -21,7 +21,7 @@ from sentry.integrations.api.bases.organization_integrations import (
     OrganizationIntegrationBaseEndpoint,
 )
 from sentry.integrations.api.serializers.models.integration import OrganizationIntegrationResponse
-from sentry.integrations.base import INTEGRATION_TYPE_TO_PROVIDER
+from sentry.integrations.base import INTEGRATION_TYPE_TO_PROVIDER, IntegrationDomain
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.organizations.services.organization.model import (
@@ -112,14 +112,12 @@ class OrganizationIntegrationsEndpoint(OrganizationIntegrationBaseEndpoint):
             queryset = queryset.filter(integration__provider=provider_key.lower())
 
         if integration_type:
-            if integration_type not in INTEGRATION_TYPE_TO_PROVIDER:
-                return Response(
-                    {"detail": "Invalid integration type"},
-                    status=400,
-                )
+            try:
+                integration_domain = IntegrationDomain(integration_type)
+            except ValueError:
+                return Response({"detail": "Invalid integration type"}, status=400)
             provider_slugs = [
-                provider.value
-                for provider in INTEGRATION_TYPE_TO_PROVIDER.get(integration_type, [])
+                provider for provider in INTEGRATION_TYPE_TO_PROVIDER.get(integration_domain, [])
             ]
             queryset = queryset.filter(integration__provider__in=provider_slugs)
 

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -127,10 +127,12 @@ class IntegrationFeatures(Enum):
 
 
 # Integration Types
-MESSAGING = "messaging"
-PROJECT_MANAGEMENT = "project_management"
-SOURCE_CODE_MANAGEMENT = "source_code_management"
-ON_CALL_SCHEDULING = "on_call_scheduling"
+class IntegrationDomain(Enum):
+    MESSAGING = "messaging"
+    PROJECT_MANAGEMENT = "project_management"
+    SOURCE_CODE_MANAGEMENT = "source_code_management"
+    ON_CALL_SCHEDULING = "on_call_scheduling"
+    IDENTITY = "identity"  # for identity pipelines
 
 
 class IntegrationProviderSlug(Enum):
@@ -149,12 +151,12 @@ class IntegrationProviderSlug(Enum):
 
 
 INTEGRATION_TYPE_TO_PROVIDER = {
-    MESSAGING: [
+    IntegrationDomain.MESSAGING: [
         IntegrationProviderSlug.SLACK,
         IntegrationProviderSlug.DISCORD,
         IntegrationProviderSlug.MSTeams,
     ],
-    PROJECT_MANAGEMENT: [
+    IntegrationDomain.PROJECT_MANAGEMENT: [
         IntegrationProviderSlug.JIRA,
         IntegrationProviderSlug.JIRA_SERVER,
         IntegrationProviderSlug.GITHUB,
@@ -162,14 +164,14 @@ INTEGRATION_TYPE_TO_PROVIDER = {
         IntegrationProviderSlug.GITLAB,
         IntegrationProviderSlug.AZURE_DEVOPS,
     ],
-    SOURCE_CODE_MANAGEMENT: [
+    IntegrationDomain.SOURCE_CODE_MANAGEMENT: [
         IntegrationProviderSlug.GITHUB,
         IntegrationProviderSlug.GITHUB_ENTERPRISE,
         IntegrationProviderSlug.GITLAB,
         IntegrationProviderSlug.BITBUCKET,
         IntegrationProviderSlug.AZURE_DEVOPS,
     ],
-    ON_CALL_SCHEDULING: [
+    IntegrationDomain.ON_CALL_SCHEDULING: [
         IntegrationProviderSlug.PAGERDUTY,
         IntegrationProviderSlug.OPSGENIE,
     ],

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -4,7 +4,7 @@ import abc
 import logging
 import sys
 from collections.abc import Mapping, MutableMapping, Sequence
-from enum import Enum
+from enum import Enum, StrEnum
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, NamedTuple, NoReturn
 
@@ -127,7 +127,7 @@ class IntegrationFeatures(Enum):
 
 
 # Integration Types
-class IntegrationDomain(Enum):
+class IntegrationDomain(StrEnum):
     MESSAGING = "messaging"
     PROJECT_MANAGEMENT = "project_management"
     SOURCE_CODE_MANAGEMENT = "source_code_management"
@@ -135,7 +135,7 @@ class IntegrationDomain(Enum):
     IDENTITY = "identity"  # for identity pipelines
 
 
-class IntegrationProviderSlug(Enum):
+class IntegrationProviderSlug(StrEnum):
     SLACK = "slack"
     DISCORD = "discord"
     MSTeams = "msteams"

--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.integrations.base import (
     FeatureDescription,
+    IntegrationDomain,
     IntegrationFeatures,
     IntegrationMetadata,
     IntegrationProvider,
@@ -19,6 +20,10 @@ from sentry.integrations.services.repository import RpcRepository, repository_se
 from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.integrations.tasks.migrate_repo import migrate_repo
 from sentry.integrations.utils import AtlassianConnectValidationError, get_integration_from_request
+from sentry.integrations.utils.metrics import (
+    IntegrationPipelineViewEvent,
+    IntegrationPipelineViewType,
+)
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization import RpcOrganizationSummary
 from sentry.pipeline import NestedPipelineView, PipelineView
@@ -251,9 +256,18 @@ class BitbucketIntegrationProvider(IntegrationProvider):
 
 class VerifyInstallation(PipelineView):
     def dispatch(self, request: Request, pipeline) -> Response:
-        try:
-            integration = get_integration_from_request(request, BitbucketIntegrationProvider.key)
-        except AtlassianConnectValidationError:
-            return pipeline.error("Unable to verify installation.")
-        pipeline.bind_state("external_id", integration.external_id)
-        return pipeline.next_step()
+        with IntegrationPipelineViewEvent(
+            IntegrationPipelineViewType.VERIFY_INSTALLATION,
+            IntegrationDomain.SOURCE_CODE_MANAGEMENT,
+            BitbucketIntegrationProvider.key,
+        ).capture() as lifecycle:
+            try:
+                integration = get_integration_from_request(
+                    request, BitbucketIntegrationProvider.key
+                )
+            except AtlassianConnectValidationError as e:
+                lifecycle.record_failure({"failure_reason": str(e)})
+                return pipeline.error("Unable to verify installation.")
+
+            pipeline.bind_state("external_id", integration.external_id)
+            return pipeline.next_step()

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -19,6 +19,7 @@ from sentry.http import safe_urlopen, safe_urlread
 from sentry.identity.github import GitHubIdentityProvider, get_user_info
 from sentry.integrations.base import (
     FeatureDescription,
+    IntegrationDomain,
     IntegrationFeatures,
     IntegrationMetadata,
     IntegrationProvider,
@@ -415,7 +416,9 @@ class GitHubInstallationError(StrEnum):
 
 
 def record_event(event: IntegrationPipelineViewType):
-    return IntegrationPipelineViewEvent(event, "source_code", GitHubIntegrationProvider.key)
+    return IntegrationPipelineViewEvent(
+        event, IntegrationDomain.SOURCE_CODE_MANAGEMENT, GitHubIntegrationProvider.key
+    )
 
 
 class OAuthLoginView(PipelineView):

--- a/src/sentry/integrations/messaging/metrics.py
+++ b/src/sentry/integrations/messaging/metrics.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
+from sentry.integrations.base import IntegrationDomain
 from sentry.integrations.messaging.spec import MessagingIntegrationSpec
 from sentry.integrations.utils.metrics import EventLifecycleMetric, EventLifecycleOutcome
 from sentry.models.organization import Organization
@@ -56,7 +57,7 @@ class MessagingInteractionEvent(EventLifecycleMetric):
 
     def get_key(self, outcome: EventLifecycleOutcome) -> str:
         return self.get_standard_key(
-            domain="messaging",
+            domain=IntegrationDomain.MESSAGING,
             integration_name=self.spec.provider_slug,
             interaction_type=str(self.interaction_type),
             outcome=outcome,

--- a/src/sentry/integrations/on_call/metrics.py
+++ b/src/sentry/integrations/on_call/metrics.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 from attr import dataclass
 
+from sentry.integrations.base import IntegrationDomain
 from sentry.integrations.opsgenie.spec import OpsgenieOnCallSpec
 from sentry.integrations.utils.metrics import EventLifecycleMetric, EventLifecycleOutcome
 from sentry.models.organization import Organization
@@ -45,7 +46,7 @@ class OnCallInteractionEvent(EventLifecycleMetric):
 
     def get_key(self, outcome: EventLifecycleOutcome) -> str:
         return self.get_standard_key(
-            domain="on_call",
+            domain=IntegrationDomain.ON_CALL_SCHEDULING,
             integration_name=self.spec.provider_slug,
             interaction_type=str(self.interaction_type),
             outcome=outcome,

--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -210,7 +210,8 @@ class IntegrationPipelineViewType(Enum):
     """A specific step in an integration's pipeline that is not a static page."""
 
     # IdentityProviderPipeline
-    IDENTITY_PROVIDER = "IDENTITY_PROVIDER"
+    IDENTITY_LOGIN = "IDENTITY_LOGIN"
+    IDENTITY_LINK = "IDENTITY_LINK"
 
     # GitHub
     OAUTH_LOGIN = "OAUTH_LOGIN"

--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -9,6 +9,7 @@ from typing import Any, Self
 
 from django.conf import settings
 
+from sentry.integrations.base import IntegrationDomain
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -234,7 +235,7 @@ class IntegrationPipelineViewEvent(EventLifecycleMetric):
     """An instance to be recorded of a user going through an integration pipeline view (step)."""
 
     interaction_type: IntegrationPipelineViewType
-    domain: str
+    domain: IntegrationDomain
     provider_key: str
 
     def get_key(self, outcome: EventLifecycleOutcome) -> str:


### PR DESCRIPTION
1. Use a shared Enum for integration domains --> use the one in `integrations/base.py`
2. Add installation step metrics for Bitbucket `VerifyInstallation`
3. Add installation step metrics for `IdentityProviderPipeline` (which is always used inside a `NestedPipelineView` for integrations)
4. Add installation step metrics for `BitbucketIdentityProvider`, which is reached via the `IdentityProviderPipeline` and specifying the key as `bitbucket`
https://github.com/getsentry/sentry/blob/4443f93b615e25b7b03ac40b3f78e5cc7eb784a0/src/sentry/identity/pipeline.py#L27-L32

wrt 3), there are also no queryable data points for `identity_provider_pipeline.finish_pipeline` inside `IdentityProviderPipeline` `finish_pipeline` 🤷‍♀️ 
https://github.com/getsentry/sentry/blob/846bac2004b039146a5e52fd283553e791eae4f8/src/sentry/identity/pipeline.py#L86-L92