### PR TITLE
feat(issue-stream): Modify issue stream title to only use two rows

### DIFF
--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -140,7 +140,7 @@ function EventOrGroupExtraDetails({
         }
 
         if (!hasNewLayout) {
-          return item;
+          return <Fragment key={i}>{item}</Fragment>;
         }
 
         return (

--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -1,5 +1,7 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {ErrorLevelText} from 'sentry/components/events/errorLevelText';
 import EventAnnotation from 'sentry/components/events/eventAnnotation';
 import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
 import InboxShortId from 'sentry/components/group/inboxBadges/shortId';
@@ -16,6 +18,8 @@ import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
+import {getTitle} from 'sentry/utils/events';
 import {projectCanLinkToReplay} from 'sentry/utils/replays/projectSupportsReplay';
 import withOrganization from 'sentry/utils/withOrganization';
 
@@ -74,66 +78,86 @@ function EventOrGroupExtraDetails({
     organization.features.includes('session-replay') &&
     projectCanLinkToReplay(organization, project);
 
-  return (
-    <GroupExtra>
-      {shortId && (
-        <InboxShortId
-          shortId={shortId}
-          avatar={
-            project && (
-              <ShadowlessProjectBadge project={project} avatarSize={12} hideName />
-            )
-          }
-        />
-      )}
-      {isUnhandled && <UnhandledTag />}
-      {showLifetime ? (
-        <Lifetime firstSeen={firstSeen} lastSeen={lastSeen} lifetime={lifetime} />
-      ) : null}
-      {/* Always display comment count on inbox */}
-      {numComments > 0 && (
-        <CommentsLink to={`${issuesPath}${id}/activity/`} className="comments">
-          <IconChat
-            size="xs"
-            color={
-              subscriptionDetails?.reason === 'mentioned' ? 'successText' : undefined
-            }
-          />
-          <span>{numComments}</span>
-        </CommentsLink>
-      )}
-      {showReplayCount && <IssueReplayCount group={data as Group} />}
-      {logger && (
-        <LoggerAnnotation>
-          <GlobalSelectionLink
-            to={{
-              pathname: issuesPath,
-              query: {
-                query: `logger:${logger}`,
-              },
-            }}
-          >
-            {logger}
-          </GlobalSelectionLink>
-        </LoggerAnnotation>
-      )}
-      {annotations?.map((annotation, key) => (
-        <AnnotationNoMargin key={key}>
-          <ExternalLink href={annotation.url}>{annotation.displayName}</ExternalLink>
-        </AnnotationNoMargin>
-      ))}
+  const hasNewLayout = organization.features.includes('issue-stream-table-layout');
+  const {subtitle} = getTitle(data);
 
-      {showAssignee && assignedTo && (
-        <div>{tct('Assigned to [name]', {name: assignedTo.name})}</div>
-      )}
+  const level = 'level' in data ? data.level : null;
+
+  const items = [
+    shortId ? (
+      <InboxShortId
+        shortId={shortId}
+        avatar={
+          project && <ShadowlessProjectBadge project={project} avatarSize={12} hideName />
+        }
+      />
+    ) : null,
+    hasNewLayout && level ? <ErrorLevelText level={level} /> : null,
+    isUnhandled ? <UnhandledTag /> : null,
+    showLifetime ? (
+      <Lifetime firstSeen={firstSeen} lastSeen={lastSeen} lifetime={lifetime} />
+    ) : null,
+    hasNewLayout && subtitle ? <Location>{subtitle}</Location> : null,
+    numComments > 0 ? (
+      <CommentsLink to={`${issuesPath}${id}/activity/`} className="comments">
+        <IconChat
+          size="xs"
+          color={subscriptionDetails?.reason === 'mentioned' ? 'successText' : undefined}
+        />
+        <span>{numComments}</span>
+      </CommentsLink>
+    ) : null,
+    showReplayCount ? <IssueReplayCount group={data as Group} /> : null,
+    logger ? (
+      <LoggerAnnotation>
+        <GlobalSelectionLink
+          to={{
+            pathname: issuesPath,
+            query: {
+              query: `logger:${logger}`,
+            },
+          }}
+        >
+          {logger}
+        </GlobalSelectionLink>
+      </LoggerAnnotation>
+    ) : null,
+    ...(annotations?.map((annotation, key) => (
+      <AnnotationNoMargin key={key}>
+        <ExternalLink href={annotation.url}>{annotation.displayName}</ExternalLink>
+      </AnnotationNoMargin>
+    )) ?? []),
+    showAssignee && assignedTo ? (
+      <div>{tct('Assigned to [name]', {name: assignedTo.name})}</div>
+    ) : null,
+  ].filter(defined);
+
+  return (
+    <GroupExtra hasNewLayout={hasNewLayout}>
+      {items.map((item, i) => {
+        if (!item) {
+          return null;
+        }
+
+        if (!hasNewLayout) {
+          return item;
+        }
+
+        return (
+          <Fragment key={i}>
+            {item}
+            {i < items.length - 1 ? <Separator /> : null}
+          </Fragment>
+        );
+      })}
     </GroupExtra>
   );
 }
 
-const GroupExtra = styled('div')`
+const GroupExtra = styled('div')<{hasNewLayout: boolean}>`
   display: inline-grid;
   grid-auto-flow: column dense;
-  gap: ${space(1.5)};
+  gap: ${p => (p.hasNewLayout ? space(0.75) : space(1.5))};
   justify-content: start;
   align-items: center;
   color: ${p => p.theme.textColor};
@@ -150,6 +174,13 @@ const GroupExtra = styled('div')`
   @media (min-width: ${p => p.theme.breakpoints.xlarge}) {
     line-height: 1;
   }
+`;
+
+const Separator = styled('div')`
+  height: 10px;
+  width: 1px;
+  background-color: ${p => p.theme.innerBorder};
+  border-radius: 1px;
 `;
 
 const ShadowlessProjectBadge = styled(ProjectBadge)`
@@ -177,6 +208,11 @@ const AnnotationNoMargin = styled(EventAnnotation)`
 
 const LoggerAnnotation = styled(AnnotationNoMargin)`
   color: ${p => p.theme.textColor};
+`;
+
+const Location = styled('div')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.subText};
 `;
 
 export default withOrganization(EventOrGroupExtraDetails);

--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -46,6 +46,8 @@ function EventOrGroupHeader({
 }: EventOrGroupHeaderProps) {
   const location = useLocation();
 
+  const hasNewLayout = organization.features.includes('issue-stream-table-layout');
+
   function getTitleChildren() {
     const {isBookmarked, hasSeen} = data as Group;
     return (
@@ -120,13 +122,16 @@ function EventOrGroupHeader({
   return (
     <div data-test-id="event-issue-header">
       <Title>{getTitle()}</Title>
-      {eventLocation && <Location>{eventLocation}</Location>}
-      <StyledEventMessage
-        level={'level' in data ? data.level : undefined}
-        message={getMessage(data)}
-        type={data.type}
-        levelIndicatorSize="9px"
-      />
+      {eventLocation && !hasNewLayout ? <Location>{eventLocation}</Location> : null}
+      {!hasNewLayout ? (
+        <StyledEventMessage
+          data={data}
+          level={'level' in data ? data.level : undefined}
+          message={getMessage(data)}
+          type={data.type}
+          levelIndicatorSize="9px"
+        />
+      ) : null}
     </div>
   );
 }
@@ -140,6 +145,7 @@ const truncateStyles = css`
 
 const Title = styled('div')`
   margin-bottom: ${space(0.25)};
+  font-size: ${p => p.theme.fontSizeLarge};
   & em {
     font-size: ${p => p.theme.fontSizeMedium};
     font-style: normal;
@@ -174,6 +180,7 @@ function Location(props) {
 const StyledEventMessage = styled(EventMessage)`
   margin: 0 0 5px;
   gap: ${space(0.5)};
+  font-size: inherit;
 `;
 
 const IconWrapper = styled('span')`

--- a/static/app/components/events/eventMessage.spec.tsx
+++ b/static/app/components/events/eventMessage.spec.tsx
@@ -1,3 +1,5 @@
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -9,24 +11,47 @@ import EventMessage from './eventMessage';
 
 describe('EventMessage', () => {
   const defaultUser = UserFixture();
+  const group = GroupFixture();
 
   beforeEach(() => {
     ConfigStore.init();
   });
 
   it('renders error message', () => {
-    render(<EventMessage message="Test message" type={EventOrGroupType.ERROR} />);
+    render(
+      <EventMessage data={group} message="Test message" type={EventOrGroupType.ERROR} />
+    );
     expect(screen.getByText('Test message')).toBeInTheDocument();
   });
 
+  it('renders location (with issue-stream-table-layout)', () => {
+    const organization = OrganizationFixture({
+      features: ['issue-stream-table-layout'],
+    });
+
+    render(
+      <EventMessage data={group} message="Test message" type={EventOrGroupType.ERROR} />,
+      {organization}
+    );
+
+    expect(
+      screen.getByText('fetchData(app/components/group/suggestedOwners/suggestedOwners)')
+    ).toBeInTheDocument();
+  });
+
   it('renders "No error message" when message is not provided', () => {
-    render(<EventMessage message={null} type={EventOrGroupType.ERROR} />);
+    render(<EventMessage data={group} message={null} type={EventOrGroupType.ERROR} />);
     expect(screen.getByText('(No error message)')).toBeInTheDocument();
   });
 
   it('renders error level indicator dot', () => {
     render(
-      <EventMessage message="Test message" type={EventOrGroupType.ERROR} level="error" />
+      <EventMessage
+        data={group}
+        message="Test message"
+        type={EventOrGroupType.ERROR}
+        level="error"
+      />
     );
     expect(screen.getByText('Level: Error')).toBeInTheDocument();
   });
@@ -43,14 +68,24 @@ describe('EventMessage', () => {
       })
     );
     render(
-      <EventMessage message="Test message" type={EventOrGroupType.ERROR} level="error" />
+      <EventMessage
+        data={group}
+        message="Test message"
+        type={EventOrGroupType.ERROR}
+        level="error"
+      />
     );
     expect(screen.getByText('Error')).toBeInTheDocument();
   });
 
   it('renders unhandled tag', () => {
     render(
-      <EventMessage message="Test message" type={EventOrGroupType.ERROR} showUnhandled />
+      <EventMessage
+        data={group}
+        message="Test message"
+        type={EventOrGroupType.ERROR}
+        showUnhandled
+      />
     );
     expect(screen.getByText('Unhandled')).toBeInTheDocument();
   });

--- a/static/app/views/discover/eventDetails/content.tsx
+++ b/static/app/views/discover/eventDetails/content.tsx
@@ -70,7 +70,7 @@ function EventHeader({event}: {event: Event}) {
       </TitleWrapper>
       {message && (
         <MessageWrapper>
-          <EventMessage message={message} type={event.type} />
+          <EventMessage data={event} message={message} type={event.type} />
         </MessageWrapper>
       )}
     </EventHeaderContainer>

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -248,6 +248,7 @@ function GroupHeader({
               />
             </TitleHeading>
             <EventMessage
+              data={group}
               message={message}
               level={group.level}
               levelIndicatorSize="11px"

--- a/static/app/views/issueDetails/streamline/header.tsx
+++ b/static/app/views/issueDetails/streamline/header.tsx
@@ -116,6 +116,7 @@ export default function StreamlinedGroupHeader({
           </TitleHeading>
           <MessageWrapper>
             <EventMessage
+              data={group}
               message={message}
               type={group.type}
               level={group.level}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issueSummary.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issueSummary.tsx
@@ -91,6 +91,7 @@ export function IssueSummary({data, event_id}: EventOrGroupHeaderProps) {
       </Title>
       {eventLocation ? <Location>{eventLocation}</Location> : null}
       <StyledEventMessage
+        data={data}
         level={'level' in data ? data.level : undefined}
         message={getMessage(data)}
         type={data.type}

--- a/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
+++ b/static/app/views/sharedGroupDetails/sharedGroupHeader.tsx
@@ -62,6 +62,7 @@ function SharedGroupHeader({group}: Props) {
           message={group.culprit}
           level={group.level}
           type={group.type}
+          data={group}
         />
       </Details>
     </Wrapper>


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/77822

Previous layout:

```
**<title>** <location>
<error_type> | <error_message>
<project> <seen> <other things>
```

New layout:

```
**<title>** <error_message>
<project> | <error_type> | <location> | <other things>
```

Note that this does most of the work, but there are a couple things that still need polishing:

- Extra details line has some extra spaces due to the replay counts component returning null sometimes
- Extra details should all be gray text

Before:

![CleanShot 2024-10-10 at 17 08 33@2x](https://github.com/user-attachments/assets/f5fb32bf-bdc6-4700-b4ac-8c064974596f)

After:

![CleanShot 2024-10-10 at 17 08 51@2x](https://github.com/user-attachments/assets/e4d38efe-5528-434a-a242-d29bdb5c9ae5)

