### PR TITLE
fix(migrations): Mark group message migration as dangerous

### DIFF
--- a/src/sentry/migrations/0776_drop_group_score_in_database.py
+++ b/src/sentry/migrations/0776_drop_group_score_in_database.py
@@ -18,7 +18,7 @@ class Migration(CheckedMigration):
     #   is a schema change, it's completely safe to run the operation after the code has deployed.
     # Once deployed, run these manually via: https://develop.sentry.dev/database-migrations/#migration-deployment
 
-    is_post_deployment = False
+    is_post_deployment = True
 
     dependencies = [
         ("sentry", "0775_add_dashboard_permissions_model"),


### PR DESCRIPTION
This migration took down sentry due to our statement timeouts failing. Marking it dangerous for now so that we can resume deploys.

<!-- Describe your PR here. -->