### PR TITLE
feat(transactions): remove queue name from save_event_transaction task

### DIFF
--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -609,7 +609,6 @@ def save_event(
 
 @instrumented_task(
     name="sentry.tasks.store.save_event_transaction",
-    queue="events.save_event_transaction",
     time_limit=65,
     soft_time_limit=60,
     silo_mode=SiloMode.REGION,


### PR DESCRIPTION
we cannot pass the default queue name here anymore as we are moving to split queues to increase throughput
