### PR TITLE
feat(metrics): Register MRI for spans/count_per_root_project

### DIFF
--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -230,6 +230,7 @@ SPAN_METRICS_NAMES = {
     "g:spans/self_time@millisecond": PREFIX + 419,
     "g:spans/self_time_light@millisecond": PREFIX + 420,
     "g:spans/total_time@millisecond": PREFIX + 421,
+    "c:spans/count_per_root_project@none": PREFIX + 422,
     # Last possible index: 499
 }
 

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -163,6 +163,7 @@ class TransactionMRI(Enum):
 class SpanMRI(Enum):
     USER = "s:spans/user@none"
     DURATION = "d:spans/duration@millisecond"
+    COUNT_PER_ROOT_PROJECT = "c:spans/count_per_root_project@none"
     SELF_TIME = "d:spans/exclusive_time@millisecond"
     SELF_TIME_LIGHT = "d:spans/exclusive_time_light@millisecond"
 

--- a/tests/sentry/sentry_metrics/test_prevent_modifications_to_indexer_strings.py
+++ b/tests/sentry/sentry_metrics/test_prevent_modifications_to_indexer_strings.py
@@ -1,7 +1,7 @@
 from hashlib import sha256
 
 LOCKED_FILE = "src/sentry/sentry_metrics/indexer/strings.py"
-LOCKED_DIGEST = "c667a458c2cc081103a289c84bb4a2d7b6c6d785e542e6f22d997657568ddf68"
+LOCKED_DIGEST = "a0395ac3cc5c59712f1875c69b107575a13a5c79b730a37508eea0aa4ab73675"
 MESSAGE = f"""{LOCKED_FILE} is locked.
 
 * We have detected you made changes to this file.


### PR DESCRIPTION
Adds a new shared string for `c:spans/count_per_root_project@none`, which is
going to be used for dynamic sampling on spans. The metric is not yet emitted or
used.

The string must be shared because Dynamic Sampling runs a cross-org metrics
query for this metric.

Ref https://github.com/getsentry/projects/issues/198
See also https://github.com/getsentry/relay/pull/4134


