### PR TITLE
feat(features): Add an org feature to control the DS measure

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -115,8 +115,6 @@ def register_permanent_features(manager: FeatureManager):
         "organizations:sentry-pride-logo-footer": False,
         # Enable priority calculations using Seer's severity endpoint
         "organizations:seer-based-priority": False,
-        # Use spans instead of transactions for dynamic sampling calculations
-        "organizations:dynamic-sampling-spans": False,
     }
 
     permanent_project_features = {

--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -115,6 +115,8 @@ def register_permanent_features(manager: FeatureManager):
         "organizations:sentry-pride-logo-footer": False,
         # Enable priority calculations using Seer's severity endpoint
         "organizations:seer-based-priority": False,
+        # Use spans instead of transactions for dynamic sampling calculations
+        "organizations:dynamic-sampling-spans": False,
     }
 
     permanent_project_features = {

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -545,6 +545,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:webhooks-unresolved", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=True)
     # Enable EventUniqueUserFrequencyConditionWithConditions special alert condition
     manager.add("organizations:event-unique-user-frequency-condition-with-conditions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Use spans instead of transactions for dynamic sampling calculations. This will become the new default.
+    manager.add("organizations:dynamic-sampling-spans", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # NOTE: Don't add features down here! Add them to their specific group and sort
     #       them alphabetically! The order features are registered is not important.
 


### PR DESCRIPTION
Adds a new feature flag that, depending on the plan generation, controls
the measure used for DS computations. The default (disabled) is to use
transactions. Once enabled, DS will use span counts to do all
rebalancing.

This feature is temporary as we're planning to retire transaction-based
dynamic sampling entirely. Even on AM2, rebalancing can operate on
spans.

Closes https://github.com/getsentry/projects/issues/199