### PR TITLE
chore(deps): Upgrade Sentry Python SDK to 2.16.0

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -70,7 +70,7 @@ sentry-ophio==1.0.0
 sentry-protos>=0.1.23
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.9.2
-sentry-sdk>=2.15.0
+sentry-sdk>=2.16.0
 slack-sdk>=3.27.2
 snuba-sdk>=3.0.43
 simplejson>=3.17.6

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -187,7 +187,7 @@ sentry-ophio==1.0.0
 sentry-protos==0.1.23
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.2
-sentry-sdk==2.15.0
+sentry-sdk==2.16.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -128,7 +128,7 @@ sentry-ophio==1.0.0
 sentry-protos==0.1.23
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.2
-sentry-sdk==2.15.0
+sentry-sdk==2.16.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -280,9 +280,6 @@ def _get_sdk_options() -> tuple[SdkConfig, Dsns]:
     sdk_options["release"] = (
         f"backend@{sdk_options['release']}" if "release" in sdk_options else None
     )
-    sdk_options.setdefault("_experiments", {}).update(
-        transport_http2=True,
-    )
 
     # Modify SENTRY_SDK_CONFIG in your deployment scripts to specify your desired DSN
     dsns = Dsns(

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -280,6 +280,9 @@ def _get_sdk_options() -> tuple[SdkConfig, Dsns]:
     sdk_options["release"] = (
         f"backend@{sdk_options['release']}" if "release" in sdk_options else None
     )
+    sdk_options.setdefault("_experiments", {}).update(
+        transport_http2=True,
+    )
 
     # Modify SENTRY_SDK_CONFIG in your deployment scripts to specify your desired DSN
     dsns = Dsns(


### PR DESCRIPTION
This version comes with Brotli compression and HTTP2Transport which are enabled as part of this patch.

We already have `httpcore>=1.*` and `Brotli` as part of our dependencies so no changes needed in this patch regarding getting these installed.
