### PR TITLE
chore(comments): fix some typos and unify comments

### DIFF
--- a/src/flagpole/conditions.py
+++ b/src/flagpole/conditions.py
@@ -20,7 +20,7 @@ class ConditionOperatorKind(str, Enum):
     """Provided a single value, check if the property (a list) is not included"""
 
     EQUALS = "equals"
-    """Comprare a value to another. Values are compared with types"""
+    """Compare a value to another. Values are compared with types"""
 
     NOT_EQUALS = "not_equals"
     """Compare a value to not be equal to another. Values are compared with types"""

--- a/src/sentry/api/endpoints/admin_project_configs.py
+++ b/src/sentry/api/endpoints/admin_project_configs.py
@@ -46,7 +46,7 @@ class AdminRelayProjectConfigsEndpoint(Endpoint):
             else:
                 configs[key] = None
 
-        # TODO if we don't think we'll add anything to the endpoint
+        # TODO: if we don't think we'll add anything to the endpoint
         # we may as well return just the configs
         return Response({"configs": configs}, status=200)
 

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -762,7 +762,7 @@ def build_span_query(trace_id: str, spans_params: SnubaParams, query_spans: list
     sentry_sdk.set_measurement("trace_view.spans.span_minimum", span_minimum)
     sentry_sdk.set_tag("trace_view.split_by_char.optimization", len(query_spans) > span_minimum)
     if len(query_spans) > span_minimum:
-        # TODO because we're not doing an IN on a list of literals, snuba will not optimize the query with the HexInt
+        # TODO: because we're not doing an IN on a list of literals, snuba will not optimize the query with the HexInt
         # column processor which means we won't be taking advantage of the span_id index but if we only do this when we
         # have a lot of query_spans we should have a great performance improvement still once we do that we can simplify
         # this code and always apply this optimization

--- a/src/sentry/api/endpoints/organization_events_trends.py
+++ b/src/sentry/api/endpoints/organization_events_trends.py
@@ -54,7 +54,7 @@ REGRESSION = "regression"
 TREND_TYPES = [IMPROVED, REGRESSION]
 
 
-# TODO move this to the builder file and introduce a top-events version instead
+# TODO: move this to the builder file and introduce a top-events version instead
 class TrendQueryBuilder(DiscoverQueryBuilder):
     def convert_aggregate_filter_to_condition(
         self, aggregate_filter: AggregateFilter

--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -177,7 +177,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                     results[result_key]["data"].append(row)
                 else:
                     discarded += 1
-                    # TODO filter out entries that don't have transaction or trend_function
+                    # TODO: filter out entries that don't have transaction or trend_function
                     logger.warning(
                         "trends.top-events.timeseries.key-mismatch",
                         extra={

--- a/src/sentry/api/endpoints/organization_metrics_tag_details.py
+++ b/src/sentry/api/endpoints/organization_metrics_tag_details.py
@@ -41,7 +41,7 @@ class OrganizationMetricsTagDetailsEndpoint(OrganizationEndpoint):
             for project in projects
         ):
             if len(metric_names) == 1 and metric_names[0].startswith("d:eap"):
-                # TODO hack for EAP, hardcode some metric names
+                # TODO: hack for EAP, hardcode some metric names
                 if tag_name == "color":
                     return Response(
                         [

--- a/src/sentry/api/endpoints/organization_metrics_tags.py
+++ b/src/sentry/api/endpoints/organization_metrics_tags.py
@@ -58,7 +58,7 @@ class OrganizationMetricsTagsEndpoint(OrganizationEndpoint):
             for project in projects
         ):
             if metric_name.startswith("d:eap"):
-                # TODO hack for EAP, return a fixed list
+                # TODO: hack for EAP, return a fixed list
                 return Response([Tag(key="color"), Tag(key="location")])
 
         try:

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -205,7 +205,7 @@ class DuplicateRuleEvaluator:
             raw_left = {k: v for k, v in left.items() if k not in keys_to_ignore}
             raw_right = {k: v for k, v in right.items() if k not in keys_to_ignore}
 
-            # TODO (Yash): This code commented below is the corrected logic which accounts for bad key values.
+            # TODO: (Yash): This code commented below is the corrected logic which accounts for bad key values.
             # clean_left = cls._get_clean_actions_dict(raw_left)
             # clean_right = cls._get_clean_actions_dict(raw_right)
             # if clean_left != clean_right:

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -205,7 +205,7 @@ class DuplicateRuleEvaluator:
             raw_left = {k: v for k, v in left.items() if k not in keys_to_ignore}
             raw_right = {k: v for k, v in right.items() if k not in keys_to_ignore}
 
-            # TODO: (Yash): This code commented below is the corrected logic which accounts for bad key values.
+            # TODO (Yash): This code commented below is the corrected logic which accounts for bad key values.
             # clean_left = cls._get_clean_actions_dict(raw_left)
             # clean_right = cls._get_clean_actions_dict(raw_right)
             # if clean_left != clean_right:

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -537,7 +537,7 @@ class GenericOffsetPaginator:
             prev=Cursor(0, max(0, offset - limit), True, offset > 0),
             next=Cursor(0, max(0, offset + limit), False, has_more),
         )
-        # TODO use Cursor.value as the `end` argument to data_fn() so that
+        # TODO: use Cursor.value as the `end` argument to data_fn() so that
         # subsequent pages returned using these cursors are using the same end
         # date for queries, this should stop drift from new incoming events.
 

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -421,7 +421,7 @@ class OnboardingTasksSerializer(Serializer):
 
 
 class _DetailedOrganizationSerializerResponseOptional(OrganizationSerializerResponse, total=False):
-    role: Any  # TODO replace with enum/literal
+    role: Any  # TODO: replace with enum/literal
     orgRole: str
     uptimeAutodetection: bool
 

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -275,7 +275,7 @@ class ProjectSerializerResponse(ProjectSerializerBaseResponse):
     isPublic: bool
     avatar: SerializedAvatarFields
     color: str
-    status: str  # TODO enum/literal
+    status: str  # TODO: enum/literal
 
 
 @register(Project)

--- a/src/sentry/backup/dependencies.py
+++ b/src/sentry/backup/dependencies.py
@@ -25,7 +25,7 @@ from sentry.utils import json
 #
 # NOTE TO FUTURE EDITORS: please keep the `DELETED_FIELDS` dict, and the subsequent `if` clause,
 # around even if the dict is empty, to ensure that there is a ready place to pop shims into. For
-# each entry in this dict, please leave a TODO: comment pointed to a github issue for removing
+# each entry in this dict, please leave a TODO comment pointed to a github issue for removing
 # the shim, noting in the comment which self-hosted release will trigger the removal.
 DELETED_FIELDS: dict[str, set[str]] = {
     # TODO(mark): Safe to remove after july 2024 after self-hosted 24.6.0 is released
@@ -43,7 +43,7 @@ DELETED_FIELDS: dict[str, set[str]] = {
 #
 # NOTE TO FUTURE EDITORS: please keep the `DELETED_MODELS` set, and the subsequent `if` clause,
 # around even if the set is empty, to ensure that there is a ready place to pop shims into. For
-# each entry in this set, please leave a TODO: comment pointed to a github issue for removing
+# each entry in this set, please leave a TODO comment pointed to a github issue for removing
 # the shim, noting in the comment which self-hosted release will trigger the removal.
 DELETED_MODELS = {
     # TODO(mark): Safe to remove after july 2024 after self-hosted 24.6.0 is released

--- a/src/sentry/backup/dependencies.py
+++ b/src/sentry/backup/dependencies.py
@@ -25,7 +25,7 @@ from sentry.utils import json
 #
 # NOTE TO FUTURE EDITORS: please keep the `DELETED_FIELDS` dict, and the subsequent `if` clause,
 # around even if the dict is empty, to ensure that there is a ready place to pop shims into. For
-# each entry in this dict, please leave a TODO comment pointed to a github issue for removing
+# each entry in this dict, please leave a TODO: comment pointed to a github issue for removing
 # the shim, noting in the comment which self-hosted release will trigger the removal.
 DELETED_FIELDS: dict[str, set[str]] = {
     # TODO(mark): Safe to remove after july 2024 after self-hosted 24.6.0 is released
@@ -43,7 +43,7 @@ DELETED_FIELDS: dict[str, set[str]] = {
 #
 # NOTE TO FUTURE EDITORS: please keep the `DELETED_MODELS` set, and the subsequent `if` clause,
 # around even if the set is empty, to ensure that there is a ready place to pop shims into. For
-# each entry in this set, please leave a TODO comment pointed to a github issue for removing
+# each entry in this set, please leave a TODO: comment pointed to a github issue for removing
 # the shim, noting in the comment which self-hosted release will trigger the removal.
 DELETED_MODELS = {
     # TODO(mark): Safe to remove after july 2024 after self-hosted 24.6.0 is released

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -34,7 +34,7 @@ T = TypeVar("T", str, bytes)
 # load everywhere
 _last_validation_log: float | None = None
 Pipeline = Any
-# TODO type Pipeline instead of using Any here
+# TODO: type Pipeline instead of using Any here
 
 
 def _get_model_key(model: type[models.Model]) -> str:

--- a/src/sentry/db/models/fields/node.py
+++ b/src/sentry/db/models/fields/node.py
@@ -192,7 +192,7 @@ class NodeField(GzippedDictField):
                 try:
                     value = pickle.loads(decompress(value))
                 except Exception as e:
-                    # TODO this is a bit dangerous as a failure to read/decode the
+                    # TODO: this is a bit dangerous as a failure to read/decode the
                     # node_id will end up with this record being replaced with an
                     # empty value under a new key, potentially orphaning an
                     # original value in nodestore. OTOH if we can't decode the info

--- a/src/sentry/deletions/defaults/repository.py
+++ b/src/sentry/deletions/defaults/repository.py
@@ -29,7 +29,7 @@ class RepositoryDeletionTask(ModelDeletionTask[Repository]):
         return _get_repository_child_relations(instance)
 
     def delete_instance(self, instance: Repository) -> None:
-        # TODO child_relations should also send pending_delete so we
+        # TODO: child_relations should also send pending_delete so we
         # don't have to do this here.
         pending_delete.send(sender=type(instance), instance=instance, actor=self.get_actor())
 

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -602,7 +602,7 @@ class Event(BaseEvent):
     def group_id(self, value: int | None) -> None:
         self._group_id = value
 
-    # TODO We need a better way to cache these properties. functools
+    # TODO: We need a better way to cache these properties. functools
     # doesn't quite do the trick as there is a reference bug with unsaved
     # models. But the current _group_cache thing is also clunky because these
     # properties need to be stripped out in __getstate__.

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -168,7 +168,7 @@ class PushEventWebhook(Webhook):
 
         authors = {}
 
-        # TODO gitlab only sends a max of 20 commits. If a push contains
+        # TODO: gitlab only sends a max of 20 commits. If a push contains
         # more commits they provide a total count and require additional API
         # requests to fetch the commit details
         for commit in event.get("commits", []):

--- a/src/sentry/integrations/slack/message_builder/notifications/rule_save_edit.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/rule_save_edit.py
@@ -48,7 +48,7 @@ class SlackRuleSaveEditMessageBuilder(BlockSlackMessageBuilder):
         else:
             rule_text = "*Alert rule updated*\n\n"
             rule_text += f"{rule_url} in the {project_url} project was recently updated."
-            # TODO potentially use old name if it's changed?
+            # TODO: potentially use old name if it's changed?
 
         blocks.append(self.get_markdown_block(rule_text))
 

--- a/src/sentry/issues/endpoints/group_notes_details.py
+++ b/src/sentry/issues/endpoints/group_notes_details.py
@@ -84,7 +84,7 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
 
         if serializer.is_valid():
             payload = serializer.validated_data
-            # TODO adding mentions to a note doesn't send notifications. Should it?
+            # TODO: adding mentions to a note doesn't send notifications. Should it?
             # Remove mentions as they shouldn't go into the database
             payload.pop("mentions", [])
 

--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -303,7 +303,7 @@ class BaseQueryBuilder:
         self.end = self.params.end
 
     def resolve_column_name(self, col: str) -> str:
-        # TODO when utils/snuba.py becomes typed don't need this extra annotation
+        # TODO: when utils/snuba.py becomes typed don't need this extra annotation
         column_resolver: Callable[[str], str] = resolve_column(self.dataset)
         column_name = column_resolver(col)
         # If the original column was passed in as tag[X], then there won't be a conflict

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1027,7 +1027,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
             # * we started with Postgres candidates and so only do one Snuba query max
             # * the paginator is returning enough results to satisfy the query (>= the limit)
             # * there are no more groups in Snuba to post-filter
-            # TODO do we actually have to rebuild this SequencePaginator every time
+            # TODO: do we actually have to rebuild this SequencePaginator every time
             # or can we just make it after we've broken out of the loop?
             paginator_results = SequencePaginator(
                 [(score, id) for (id, score) in result_groups], reverse=True, **paginator_options

--- a/src/sentry/sentry_metrics/indexer/cache.py
+++ b/src/sentry/sentry_metrics/indexer/cache.py
@@ -284,7 +284,7 @@ class CachingIndexer(StringIndexer):
                 _INDEXER_CACHE_RESOLVE_METRIC,
                 tags={"cache_hit": "false", "use_case": use_case_id.value},
             )
-            # TODO this random rollout is backwards
+            # TODO: this random rollout is backwards
             if random.random() >= options.get(
                 "sentry-metrics.indexer.disable-memcache-replenish-rollout"
             ):

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -487,7 +487,7 @@ def to_intervals(
     assert interval_seconds > 0
 
     # horrible hack for backward compatibility
-    # TODO Try to fix this upstream
+    # TODO: Try to fix this upstream
     if start is None or end is None:
         return None, None, 0
 

--- a/src/sentry/statistical_detectors/issue_platform_adapter.py
+++ b/src/sentry/statistical_detectors/issue_platform_adapter.py
@@ -24,7 +24,7 @@ def send_regression_to_platform(regression: BreakpointData):
     displayed_new_baseline = round(float(regression["aggregate_range_2"]), 2)
 
     # For legacy reasons, we're passing project id as project
-    # TODO fix this in the breakpoint microservice and in trends v2
+    # TODO: fix this in the breakpoint microservice and in trends v2
     project_id = int(regression["project"])
 
     issue_type: type[GroupType] = PerformanceP95EndpointRegressionGroupType

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -320,7 +320,7 @@ class OrganizationReportBatch:
                 user_project_count=template_ctx["user_project_count"],
             )
 
-            # TODO see if we can use the UUID to track if the email was sent or not
+            # TODO: see if we can use the UUID to track if the email was sent or not
             logger.info(
                 "weekly_report.send_email",
                 extra={

--- a/src/sentry/users/api/endpoints/user_authenticator_details.py
+++ b/src/sentry/users/api/endpoints/user_authenticator_details.py
@@ -131,7 +131,7 @@ class UserAuthenticatorDetailsEndpoint(UserEndpoint):
 
         :auth required:
         """
-        # TODO temporary solution for both renaming and regenerating recovery code.
+        # TODO: temporary solution for both renaming and regenerating recovery code.
         # Need to find new home for regenerating recovery codes as it doesn't really do what put is supposed to do
         try:
             authenticator = Authenticator.objects.get(user=user, id=auth_id)

--- a/src/sentry/users/api/serializers/user.py
+++ b/src/sentry/users/api/serializers/user.py
@@ -61,7 +61,7 @@ class _Identity(TypedDict):
 class _UserOptions(TypedDict):
     theme: str  # TODO: enum/literal for theme options
     language: str
-    stacktraceOrder: int  # TODO enum/literal
+    stacktraceOrder: int  # TODO: enum/literal
     defaultIssueEvent: str
     timezone: str
     clock24Hours: bool

--- a/src/sentry/utils/performance_issues/detectors/consecutive_db_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/consecutive_db_detector.py
@@ -125,7 +125,7 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
         self.stored_problems[fingerprint] = PerformanceProblem(
             fingerprint,
             "db",
-            desc=query,  # TODO - figure out which query to use for description
+            desc=query,  # TODO: figure out which query to use for description
             type=PerformanceConsecutiveDBQueriesGroupType,
             cause_span_ids=cause_span_ids,
             parent_span_ids=None,

--- a/src/sentry/utils/performance_issues/performance_problem.py
+++ b/src/sentry/utils/performance_issues/performance_problem.py
@@ -18,7 +18,7 @@ class PerformanceProblem:
     # The actual bad spans
     offender_span_ids: Sequence[str]
     # Evidence to be used for the group
-    # TODO make evidence_data and evidence_display required once all detectors have been migrated to platform
+    # TODO: make evidence_data and evidence_display required once all detectors have been migrated to platform
     # We can't make it required until we stop loading these from nodestore via EventPerformanceProblem,
     # since there's legacy data in there that won't have these fields.
     # So until we disable transaction based perf issues we'll need to keep this optional.

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -787,7 +787,7 @@ def _prepare_query_params(query_params: SnubaQueryParams, referrer: str | None =
             "groupby": query_params.groupby,
             "conditions": query_params_conditions,
             "aggregations": query_params.aggregations,
-            "granularity": query_params.rollup,  # TODO name these things the same
+            "granularity": query_params.rollup,  # TODO: name these things the same
         }
     )
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
@@ -1644,7 +1644,7 @@ def aliased_query_params(
     )
 
 
-# TODO (evanh) Since we are assuming that all string values are columns,
+# TODO: (evanh) Since we are assuming that all string values are columns,
 # this will get tricky if we ever have complex columns where there are
 # string arguments to the functions that aren't columns
 def resolve_complex_column(col, resolve_func, ignored):

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -82,7 +82,7 @@ class OrganizationEventsEndpointTestBase(APITransactionTestCase, SnubaTestCase, 
         self, per_transaction_threshold: bool = False, project: Project | None = None
     ) -> None:
         _project = project or self.project
-        # If duration is > 300 * 4 then the user is fruistrated
+        # If duration is > 300 * 4 then the user is frustrated
         # There's a total of 4 users and three of them reach the frustration threshold
         events = [
             ("one", 300),

--- a/tests/snuba/api/endpoints/test_organization_events_has_measurements.py
+++ b/tests/snuba/api/endpoints/test_organization_events_has_measurements.py
@@ -108,7 +108,7 @@ class OrganizationEventsHasMeasurementsTest(APITestCase, SnubaTestCase):
         assert response.data == {"measurements": False}
 
     def test_has_event_but_no_web_measurements(self):
-        # make sure the transaction doesnt have measurements
+        # make sure the transaction doesn't have measurements
         self.transaction_data["measurements"] = {}
         self.store_event(self.transaction_data, self.project.id)
 


### PR DESCRIPTION
This PR fixes some minor typos I stumbled upon and unifies most of the `TODO` comments to be highlighted. 

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
