### PR TITLE
fix(sentryapps) Stop passing event to celery task

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2785,3 +2785,10 @@ register(
     default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+register(
+    "sentryapps.process-resource-change.use-eventid",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -9,7 +9,7 @@ from celery import Task, current_task
 from django.urls import reverse
 from requests.exceptions import RequestException
 
-from sentry import analytics
+from sentry import analytics, eventstore
 from sentry.api.serializers import serialize
 from sentry.constants import SentryAppInstallationStatus
 from sentry.db.models.base import Model
@@ -181,18 +181,26 @@ def _process_resource_change(
     # The class is serialized as a string when enqueueing the class.
     model: type[Event] | type[Model] = TYPES[sender]
     instance: Event | Model | None = None
-    # The Event model has different hooks for the different event types. The sender
-    # determines which type eg. Error and therefore the 'name' eg. error
-    if issubclass(model, Event):
-        if not kwargs.get("instance"):
-            extra = {"sender": sender, "action": action, "event_id": instance_id}
-            logger.info("process_resource_change.event_missing_event", extra=extra)
-            return
+
+    project_id: int | None = kwargs.get("project_id", None)
+    if sender == "Error" and not instance and project_id:
+        kwargs["instance"] = eventstore.backend.get_event_by_id(
+            project_id=project_id, event_id=str(instance_id)
+        )
         name = sender.lower()
     else:
-        # Some resources are named differently than their model. eg. Group vs Issue.
-        # Looks up the human name for the model. Defaults to the model name.
-        name = RESOURCE_RENAMES.get(model.__name__, model.__name__.lower())
+        # The Event model has different hooks for the different event types. The sender
+        # determines which type eg. Error and therefore the 'name' eg. error
+        if issubclass(model, Event):
+            if not kwargs.get("instance"):
+                extra = {"sender": sender, "action": action, "event_id": instance_id}
+                logger.info("process_resource_change.event_missing_event", extra=extra)
+                return
+            name = sender.lower()
+        else:
+            # Some resources are named differently than their model. eg. Group vs Issue.
+            # Looks up the human name for the model. Defaults to the model name.
+            name = RESOURCE_RENAMES.get(model.__name__, model.__name__.lower())
 
     # By default, use Celery's `current_task` but allow a value to be passed for the
     # bound Task.

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -36,6 +36,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.eventprocessing import write_event_to_cache
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode_of, control_silo_test
 from sentry.testutils.skips import requires_snuba
@@ -285,6 +286,53 @@ class TestProcessResourceChange(TestCase):
 
     @with_feature("organizations:integrations-event-hooks")
     def test_error_created_sends_webhook(self, safe_urlopen):
+        sentry_app = self.create_sentry_app(
+            organization=self.project.organization, events=["error.created"]
+        )
+        install = self.create_sentry_app_installation(
+            organization=self.project.organization, slug=sentry_app.slug
+        )
+
+        one_min_ago = before_now(minutes=1).timestamp()
+        event = self.store_event(
+            data={
+                "message": "Foo bar",
+                "exception": {"type": "Foo", "value": "oh no"},
+                "level": "error",
+                "timestamp": one_min_ago,
+            },
+            project_id=self.project.id,
+            assert_no_errors=False,
+        )
+
+        with self.tasks():
+            post_process_group(
+                is_new=False,
+                is_regression=False,
+                is_new_group_environment=False,
+                cache_key=write_event_to_cache(event),
+                group_id=event.group_id,
+                project_id=self.project.id,
+            )
+
+        ((args, kwargs),) = safe_urlopen.call_args_list
+        data = json.loads(kwargs["data"])
+
+        assert data["action"] == "created"
+        assert data["installation"]["uuid"] == install.uuid
+        assert data["data"]["error"]["event_id"] == event.event_id
+        assert data["data"]["error"]["issue_id"] == str(event.group_id)
+        assert kwargs["headers"].keys() >= {
+            "Content-Type",
+            "Request-ID",
+            "Sentry-Hook-Resource",
+            "Sentry-Hook-Timestamp",
+            "Sentry-Hook-Signature",
+        }
+
+    @with_feature("organizations:integrations-event-hooks")
+    @override_options({"sentryapps.process-resource-change.use-eventid": True})
+    def test_error_created_sends_webhook_no_event_payload_eventid_only(self, safe_urlopen):
         sentry_app = self.create_sentry_app(
             organization=self.project.organization, events=["error.created"]
         )

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -685,6 +685,7 @@ class ResourceChangeBoundsTestMixin(BasePostProgressGroupMixin):
             action="created",
             sender="Error",
             instance_id=event.event_id,
+            project_id=event.project_id,
             instance=EventMatcher(event),
         )
 


### PR DESCRIPTION
Passing the event greatly inflates the size of task messages which can contribute to backlogs and memory pressure in rabbit. Instead we can only pass the event_id and refetch the event in the task.
