### PR TITLE
fix(discover): Split when org has no projects

### DIFF
--- a/src/sentry/discover/dashboard_widget_split.py
+++ b/src/sentry/discover/dashboard_widget_split.py
@@ -80,13 +80,33 @@ def _get_and_save_split_decision_for_dashboard_widget(
     # We use all projects for the clickhouse query but don't do anything
     # with the data returned other than check if data exists. So this
     # all projects query should be a safe operation.
-    projects = (
-        dashboard.projects.all()
-        if dashboard.projects.exists()
-        else Project.objects.filter(
-            organization_id=dashboard.organization.id, status=ObjectStatus.ACTIVE
-        )
+    projects = dashboard.projects.all() or Project.objects.filter(
+        organization_id=dashboard.organization.id, status=ObjectStatus.ACTIVE
     )
+
+    # Handle cases where the organization has no projects at all.
+    # No projects means a downstream check will fail and we can default
+    # to the errors dataset.
+    if not projects.exists():
+        if not dry_run:
+            sentry_sdk.set_context(
+                "dashboard",
+                {
+                    "dashboard_id": dashboard.id,
+                    "widget_id": widget.id,
+                    "org_slug": dashboard.organization.slug,
+                },
+            )
+            sentry_sdk.capture_message(
+                "No projects found for dashboard, defaulting to errors dataset"
+            )
+            _save_split_decision_for_widget(
+                widget,
+                DashboardWidgetTypes.ERROR_EVENTS,
+                DatasetSourcesTypes.FORCED,
+            )
+        return DashboardWidgetTypes.ERROR_EVENTS, False
+
     snuba_dataclass = _get_snuba_dataclass_for_dashboard_widget(widget, list(projects))
 
     selected_columns = _get_field_list(widget_query.fields or [])

--- a/src/sentry/discover/dashboard_widget_split.py
+++ b/src/sentry/discover/dashboard_widget_split.py
@@ -98,7 +98,7 @@ def _get_and_save_split_decision_for_dashboard_widget(
                 },
             )
             sentry_sdk.capture_message(
-                "No projects found for dashboard, defaulting to errors dataset"
+                "No projects found in organization for dashboard, defaulting to errors dataset"
             )
             _save_split_decision_for_widget(
                 widget,

--- a/src/sentry/discover/dataset_split.py
+++ b/src/sentry/discover/dataset_split.py
@@ -391,6 +391,29 @@ def _get_and_save_split_decision_for_query(
     projects = saved_query.projects.all() or Project.objects.filter(
         organization_id=saved_query.organization.id, status=ObjectStatus.ACTIVE
     )
+
+    # Handle cases where the organization has no projects at all.
+    # No projects means a downstream check will fail and we can default
+    # to the errors dataset.
+    if not projects.exists():
+        if not dry_run:
+            sentry_sdk.set_context(
+                "query",
+                {
+                    "saved_query_id": saved_query.id,
+                    "org_slug": saved_query.organization.slug,
+                },
+            )
+            sentry_sdk.capture_message(
+                "No projects found for dashboard, defaulting to errors dataset"
+            )
+            _save_split_decision_for_query(
+                saved_query,
+                DiscoverSavedQueryTypes.ERROR_EVENTS,
+                DatasetSourcesTypes.FORCED,
+            )
+        return DiscoverSavedQueryTypes.ERROR_EVENTS, False
+
     snuba_dataclass = _get_snuba_dataclass_for_saved_query(saved_query, list(projects))
     selected_columns = _get_field_list(saved_query.query.get("fields", []))
     equations = _get_equation_list(saved_query.query.get("fields", []))

--- a/src/sentry/discover/dataset_split.py
+++ b/src/sentry/discover/dataset_split.py
@@ -405,7 +405,7 @@ def _get_and_save_split_decision_for_query(
                 },
             )
             sentry_sdk.capture_message(
-                "No projects found for dashboard, defaulting to errors dataset"
+                "No projects found in organization for saved query, defaulting to errors dataset"
             )
             _save_split_decision_for_query(
                 saved_query,

--- a/tests/sentry/discover/test_dashboard_widget_split.py
+++ b/tests/sentry/discover/test_dashboard_widget_split.py
@@ -452,7 +452,13 @@ class DashboardWidgetDatasetSplitTestCase(BaseMetricsLayerTestCase, TestCase, Sn
             assert error_widget.dataset_source == DashboardDatasetSourcesTypes.FORCED.value
 
     def test_dashboard_projects_empty(self):
-        self.dashboard.projects.clear()
+        # Dashboard belonging to an org with no projects
+        self.organization = self.create_organization()
+        self.dashboard = Dashboard.objects.create(
+            title="Dashboard With Split Widgets",
+            created_by_id=self.user.id,
+            organization=self.organization,
+        )
         error_widget = DashboardWidget.objects.create(
             dashboard=self.dashboard,
             order=0,


### PR DESCRIPTION
An org with no projects is likely being unused, so these dashboard objects are just dangling because the org is still around. Default them to error widgets to remove noise from script runs.

Originally this case triggered a list index out of bounds issue because resolving some fields expected a project to exist.