### PR TITLE
fix(issue-stream): reduce font size of events and user counts

### DIFF
--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -1,5 +1,4 @@
 import {Fragment, useCallback, useMemo, useRef} from 'react';
-import type {Theme} from '@emotion/react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {LocationDescriptor} from 'history';
@@ -445,10 +444,13 @@ function BaseGroupRow({
       >
         <PrimaryCount
           value={primaryCount}
-          smallFont={organization.features.includes('issue-stream-table-layout')}
+          hasNewLayout={organization.features.includes('issue-stream-table-layout')}
         />
         {secondaryCount !== undefined && useFilteredStats && (
-          <SecondaryCount value={secondaryCount} />
+          <SecondaryCount
+            value={secondaryCount}
+            hasNewLayout={organization.features.includes('issue-stream-table-layout')}
+          />
         )}
       </Tooltip>
     </GuideAnchor>
@@ -488,10 +490,14 @@ function BaseGroupRow({
     >
       <PrimaryCount
         value={primaryUserCount}
-        smallFont={organization.features.includes('issue-stream-table-layout')}
+        hasNewLayout={organization.features.includes('issue-stream-table-layout')}
       />
       {secondaryUserCount !== undefined && useFilteredStats && (
-        <SecondaryCount dark value={secondaryUserCount} />
+        <SecondaryCount
+          dark
+          value={secondaryUserCount}
+          hasNewLayout={organization.features.includes('issue-stream-table-layout')}
+        />
       )}
     </Tooltip>
   );
@@ -744,25 +750,23 @@ const GroupCheckBoxWrapper = styled('div')<{hasNewLayout: boolean}>`
     `}
 `;
 
-const PrimaryCount = styled(Count)<{smallFont: boolean}>`
-  font-size: ${p => (p.smallFont ? p.theme.fontSizeMedium : p.theme.fontSizeLarge)};
+const PrimaryCount = styled(Count)<{hasNewLayout: boolean}>`
+  font-size: ${p => (p.hasNewLayout ? p.theme.fontSizeMedium : p.theme.fontSizeLarge)};
   font-variant-numeric: tabular-nums;
 `;
 
-const secondaryStatStyle = (theme: Theme) => css`
-  font-size: ${theme.fontSizeLarge};
+const SecondaryCount = styled(({value, ...p}) => <Count {...p} value={value} />)<{
+  hasNewLayout: boolean;
+}>`
+  font-size: ${p => (p.hasNewLayout ? p.theme.fontSizeMedium : p.theme.fontSizeLarge)};
   font-variant-numeric: tabular-nums;
 
   :before {
     content: '/';
     padding-left: ${space(0.25)};
     padding-right: 2px;
-    color: ${theme.gray300};
+    color: ${p => p.theme.gray300};
   }
-`;
-
-const SecondaryCount = styled(({value, ...p}) => <Count {...p} value={value} />)`
-  ${p => secondaryStatStyle(p.theme)}
 `;
 
 const CountTooltipContent = styled('div')`

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -443,7 +443,10 @@ function BaseGroupRow({
           </CountTooltipContent>
         }
       >
-        <PrimaryCount value={primaryCount} />
+        <PrimaryCount
+          value={primaryCount}
+          smallFont={organization.features.includes('issue-stream-table-layout')}
+        />
         {secondaryCount !== undefined && useFilteredStats && (
           <SecondaryCount value={secondaryCount} />
         )}
@@ -483,7 +486,10 @@ function BaseGroupRow({
         </CountTooltipContent>
       }
     >
-      <PrimaryCount value={primaryUserCount} />
+      <PrimaryCount
+        value={primaryUserCount}
+        smallFont={organization.features.includes('issue-stream-table-layout')}
+      />
       {secondaryUserCount !== undefined && useFilteredStats && (
         <SecondaryCount dark value={secondaryUserCount} />
       )}
@@ -586,7 +592,7 @@ function BaseGroupRow({
           issueTypeConfig.stats.enabled &&
           organization.features.includes('issue-stream-table-layout') ? (
             <NarrowEventsOrUsersCountsWrapper breakpoint={COLUMN_BREAKPOINTS.EVENTS}>
-              <div style={{marginRight: space(2)}}>{groupCount}</div>
+              <InnerCountsWrapper>{groupCount}</InnerCountsWrapper>
             </NarrowEventsOrUsersCountsWrapper>
           ) : (
             <EventCountsWrapper
@@ -599,7 +605,7 @@ function BaseGroupRow({
           issueTypeConfig.stats.enabled &&
           organization.features.includes('issue-stream-table-layout') ? (
             <NarrowEventsOrUsersCountsWrapper breakpoint={COLUMN_BREAKPOINTS.USERS}>
-              <div style={{marginRight: space(2)}}>{groupUsersCount}</div>
+              <InnerCountsWrapper>{groupUsersCount}</InnerCountsWrapper>
             </NarrowEventsOrUsersCountsWrapper>
           ) : (
             <EventCountsWrapper>{groupUsersCount}</EventCountsWrapper>
@@ -738,13 +744,9 @@ const GroupCheckBoxWrapper = styled('div')<{hasNewLayout: boolean}>`
     `}
 `;
 
-const primaryStatStyle = (theme: Theme) => css`
-  font-size: ${theme.fontSizeLarge};
+const PrimaryCount = styled(Count)<{smallFont: boolean}>`
+  font-size: ${p => (p.smallFont ? p.theme.fontSizeMedium : p.theme.fontSizeLarge)};
   font-variant-numeric: tabular-nums;
-`;
-
-const PrimaryCount = styled(Count)`
-  ${p => primaryStatStyle(p.theme)};
 `;
 
 const secondaryStatStyle = (theme: Theme) => css`
@@ -822,6 +824,10 @@ const NarrowEventsOrUsersCountsWrapper = styled('div')<{breakpoint: string}>`
   @media (max-width: ${p => p.breakpoint}) {
     display: none;
   }
+`;
+
+const InnerCountsWrapper = styled('div')`
+  margin-right: ${space(2)};
 `;
 
 const EventCountsWrapper = styled('div')<{leftMargin?: string}>`


### PR DESCRIPTION
closes #79017

Reduces the font size of the events and user counts from 16px to 14px. Gated by the `issue-stream-table-layout` flag. Also  includes some minor code clean up 

Before: 

<img width="158" alt="Screenshot 2024-10-11 at 9 51 12 AM" src="https://github.com/user-attachments/assets/218da406-c5b1-44e1-bccc-655a653e3c9a">


After:

<img width="166" alt="Screenshot 2024-10-11 at 9 51 00 AM" src="https://github.com/user-attachments/assets/d66ce8e8-f137-4503-9b3b-d30d8727028a">
