### PR TITLE
feat(issues): Make event id a dropdown

### DIFF
--- a/static/app/views/issueDetails/streamline/eventNavigation.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.spec.tsx
@@ -142,7 +142,8 @@ describe('EventNavigation', () => {
   it('can copy event ID', async () => {
     render(<EventNavigation {...defaultProps} />);
 
-    await userEvent.click(screen.getByText(testEvent.id));
+    await userEvent.click(screen.getByRole('button', {name: 'Event actions'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Copy Event ID'}));
 
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(testEvent.id);
   });

--- a/static/app/views/issueDetails/streamline/eventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.tsx
@@ -247,11 +247,6 @@ export const EventNavigation = forwardRef<HTMLDivElement, EventNavigationProps>(
                 trigger={(triggerProps, isOpen) => (
                   <DropdownButton
                     {...triggerProps}
-                    title={event.id}
-                    tooltipProps={{
-                      delay: 500,
-                      overlayStyle: {maxWidth: 'max-content'},
-                    }}
                     aria-label={t('Event actions')}
                     size="zero"
                     borderless
@@ -430,6 +425,7 @@ const EventIdInfo = styled('span')`
   display: flex;
   align-items: center;
   gap: ${space(0.25)};
+  line-height: 1.2;
 `;
 
 const EventTitle = styled('div')`

--- a/static/app/views/issueDetails/streamline/eventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.tsx
@@ -245,15 +245,23 @@ export const EventNavigation = forwardRef<HTMLDivElement, EventNavigationProps>(
               <EventTitle>{t('Event')}</EventTitle>
               <DropdownMenu
                 trigger={(triggerProps, isOpen) => (
-                  <DropdownButton
-                    {...triggerProps}
-                    aria-label={t('Event actions')}
-                    size="zero"
-                    borderless
-                    isOpen={isOpen}
+                  // Tooltip split from button to prevent re-opening w/ focus event on close
+                  <Tooltip
+                    title={event.id}
+                    delay={500}
+                    overlayStyle={{maxWidth: 'max-content'}}
+                    disabled={isOpen}
                   >
-                    {getShortEventId(event.id)}
-                  </DropdownButton>
+                    <DropdownButton
+                      {...triggerProps}
+                      aria-label={t('Event actions')}
+                      size="zero"
+                      borderless
+                      isOpen={isOpen}
+                    >
+                      {getShortEventId(event.id)}
+                    </DropdownButton>
+                  </Tooltip>
                 )}
                 position="bottom"
                 size="xs"

--- a/static/app/views/issueDetails/streamline/eventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.tsx
@@ -1,17 +1,16 @@
 import {type CSSProperties, forwardRef, Fragment, useMemo} from 'react';
 import {css, type SerializedStyles, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
-import color from 'color';
 
 import {Button, LinkButton} from 'sentry/components/button';
-import {Chevron} from 'sentry/components/chevron';
+import DropdownButton from 'sentry/components/dropdownButton';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {useActionableItems} from 'sentry/components/events/interfaces/crashContent/exception/useActionableItems';
 import {ScrollCarousel} from 'sentry/components/scrollCarousel';
 import {TabList, Tabs} from 'sentry/components/tabs';
 import TimeSince from 'sentry/components/timeSince';
 import {Tooltip} from 'sentry/components/tooltip';
-import {IconChevron, IconCopy, IconWarning} from 'sentry/icons';
+import {IconChevron, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
@@ -244,30 +243,23 @@ export const EventNavigation = forwardRef<HTMLDivElement, EventNavigationProps>(
           <EventInfo>
             <EventIdInfo>
               <EventTitle>{t('Event')}</EventTitle>
-              <Button
-                aria-label={t('Copy')}
-                borderless
-                onClick={copyEventId}
-                size="zero"
-                title={event.id}
-                tooltipProps={{overlayStyle: {maxWidth: 'max-content'}}}
-                translucentBorder
-              >
-                <EventId>
-                  {getShortEventId(event.id)}
-                  <CopyIconContainer>
-                    <IconCopy size="xs" />
-                  </CopyIconContainer>
-                </EventId>
-              </Button>
               <DropdownMenu
-                triggerProps={{
-                  'aria-label': t('Event actions'),
-                  icon: <Chevron direction="down" color={theme.subText} />,
-                  size: 'zero',
-                  borderless: true,
-                  showChevron: false,
-                }}
+                trigger={(triggerProps, isOpen) => (
+                  <DropdownButton
+                    {...triggerProps}
+                    title={event.id}
+                    tooltipProps={{
+                      delay: 500,
+                      overlayStyle: {maxWidth: 'max-content'},
+                    }}
+                    aria-label={t('Event actions')}
+                    size="zero"
+                    borderless
+                    isOpen={isOpen}
+                  >
+                    {getShortEventId(event.id)}
+                  </DropdownButton>
+                )}
                 position="bottom"
                 size="xs"
                 items={[
@@ -438,29 +430,6 @@ const EventIdInfo = styled('span')`
   display: flex;
   align-items: center;
   gap: ${space(0.25)};
-`;
-
-const EventId = styled('span')`
-  position: relative;
-  font-weight: ${p => p.theme.fontWeightBold};
-  text-decoration: underline;
-  text-decoration-color: ${p => color(p.theme.gray200).alpha(0.5).string()};
-  &:hover {
-    > span {
-      display: flex;
-    }
-  }
-`;
-
-const CopyIconContainer = styled('span')`
-  display: none;
-  align-items: center;
-  padding: ${space(0.25)};
-  background: ${p => p.theme.background};
-  position: absolute;
-  right: 0;
-  top: 50%;
-  transform: translateY(-50%);
 `;
 
 const EventTitle = styled('div')`


### PR DESCRIPTION
Previously event id was a button to copy the id and a small dropdown was next to it. now the entire thing is a dropdown menu

before
![image](https://github.com/user-attachments/assets/f5e4eb4a-0abc-45c4-ae3b-6b716f4f1c83)

after
![image](https://github.com/user-attachments/assets/ad9f7259-2aed-4fcc-b48b-6d79e640c8b3)
