### PR TITLE
fix(priority): Add priority and first_release to fields that trigger GroupAttributes updates

### DIFF
--- a/src/sentry/issues/attributes.py
+++ b/src/sentry/issues/attributes.py
@@ -252,7 +252,7 @@ def process_update_fields(updated_fields) -> set[str]:
         # we'll need to assume any of the attributes are updated in that case
         updated_fields = {"all"}
     else:
-        VALID_FIELDS = {"status", "substatus", "num_comments"}
+        VALID_FIELDS = {"status", "substatus", "num_comments", "priority", "first_release"}
         updated_fields = VALID_FIELDS.intersection(updated_fields or ())
     if updated_fields:
         _log_group_attributes_changed(Operation.UPDATED, "group", "-".join(sorted(updated_fields)))

--- a/src/sentry/issues/priority.py
+++ b/src/sentry/issues/priority.py
@@ -51,7 +51,8 @@ def update_priority(
         return
 
     previous_priority = PriorityLevel(group.priority) if group.priority is not None else None
-    group.update(priority=priority)
+    group.priority = priority
+    group.save()
     Activity.objects.create_group_activity(
         group=group,
         type=ActivityType.SET_PRIORITY,

--- a/src/sentry/issues/priority.py
+++ b/src/sentry/issues/priority.py
@@ -51,8 +51,7 @@ def update_priority(
         return
 
     previous_priority = PriorityLevel(group.priority) if group.priority is not None else None
-    group.priority = priority
-    group.save()
+    group.update(priority=priority)
     Activity.objects.create_group_activity(
         group=group,
         type=ActivityType.SET_PRIORITY,

--- a/tests/sentry/issues/test_priority.py
+++ b/tests/sentry/issues/test_priority.py
@@ -113,7 +113,7 @@ class TestUpdatesPriority(TestCase):
         assert GroupHistory.objects.filter(group=self.group).count() == 0
 
     @patch("sentry.issues.attributes.send_snapshot_values")
-    def test_priority_update_sends_snapshot(self, mock_send_snapshot_values) -> None:
+    def test_priority_update_sends_snapshot(self, mock_send_snapshot_values: MagicMock) -> None:
         self.group = self.create_group(
             status=GroupStatus.UNRESOLVED,
             substatus=GroupSubStatus.ONGOING,

--- a/tests/sentry/issues/test_priority.py
+++ b/tests/sentry/issues/test_priority.py
@@ -4,6 +4,7 @@ from sentry.issues.priority import (
     PRIORITY_TO_GROUP_HISTORY_STATUS,
     PriorityChangeReason,
     auto_update_priority,
+    update_priority,
 )
 from sentry.models.activity import Activity
 from sentry.models.group import Group, GroupStatus
@@ -110,3 +111,21 @@ class TestUpdatesPriority(TestCase):
 
         assert Activity.objects.filter(group=self.group).count() == 0
         assert GroupHistory.objects.filter(group=self.group).count() == 0
+
+    @patch("sentry.issues.attributes.send_snapshot_values")
+    def test_priority_update_sends_snapshot(self, mock_send_snapshot_values) -> None:
+        self.group = self.create_group(
+            status=GroupStatus.UNRESOLVED,
+            substatus=GroupSubStatus.ONGOING,
+            priority=PriorityLevel.HIGH,
+        )
+
+        update_priority(
+            group=self.group,
+            priority=PriorityLevel.MEDIUM,
+            sender="test",
+            reason=PriorityChangeReason.ONGOING,
+            project=self.project,
+        )
+        assert self.group.priority == PriorityLevel.MEDIUM
+        mock_send_snapshot_values.assert_called_with(None, self.group, False)


### PR DESCRIPTION
The snapshots to kafka are produced with the post_save signal if the updated fields match a preset list. We added priority and first_release to GroupAttributes but never extended the list of supported fields for a snapshot. This PR fixes that in order to fix the snuba search [bug](https://sentry.sentry.io/feedback/?referrer=slack&notification_uuid=a89100e3-90f1-409e-88cf-19cd8d8d7cf7&alert_rule_id=15210908&alert_type=issue&feedbackSlug=javascript%3A5983986729&project=11276) where manual updates to priority were not reflected in the search results. 

We'll need to re-backfill group attributes since any manual updates will not have been captured by these snapshots.