### PR TITLE
fix(Jira): Fixes fill for text fields on edit

### DIFF
--- a/static/app/views/alerts/rules/issue/ticketRuleModal.spec.tsx
+++ b/static/app/views/alerts/rules/issue/ticketRuleModal.spec.tsx
@@ -214,6 +214,19 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
       await submitSuccess();
     });
 
+    it('should persist non-choice value when the modal is reopened', async function () {
+      const textField: IssueConfigField = {
+        label: 'Text Field',
+        required: true,
+        type: 'string',
+        name: 'textField',
+      };
+      renderComponent({data: {textField: 'foo'}}, textField);
+
+      expect(screen.getByRole('textbox', {name: 'Text Field'})).toHaveValue('foo');
+      await submitSuccess();
+    });
+
     it('should get async options from URL', async function () {
       renderComponent();
       addMockConfigsAPICall({

--- a/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
+++ b/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
@@ -178,16 +178,24 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
         const prevChoice = instance?.[field.name];
         // Note that field.choices is an array of tuples, where each tuple
         // contains a numeric id and string label, eg. ("10000", "EX") or ("1", "Bug")
-        if (
-          prevChoice && field.choices && Array.isArray(prevChoice)
-            ? // Multi-select fields have an array of values, eg: ['a', 'b'] so we
-              // check that every value exists in choices
-              prevChoice.every(value => field.choices?.some(tuple => tuple[0] === value))
+
+        if (!prevChoice) {
+          return field;
+        }
+
+        let should_default_choice = true;
+
+        if (field.choices) {
+          should_default_choice = !!(Array.isArray(prevChoice)
+            ? prevChoice.every(value => field.choices?.some(tuple => tuple[0] === value))
             : // Single-select fields have a single value, eg: 'a'
-              field.choices?.some(item => item[0] === prevChoice)
-        ) {
+              field.choices?.some(item => item[0] === prevChoice));
+        }
+
+        if (should_default_choice) {
           field.default = prevChoice;
         }
+
         return field;
       });
     return [...fields, ...cleanedFields];

--- a/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
+++ b/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
@@ -183,16 +183,16 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
           return field;
         }
 
-        let should_default_choice = true;
+        let shouldDefaultChoice = true;
 
         if (field.choices) {
-          should_default_choice = !!(Array.isArray(prevChoice)
+          shouldDefaultChoice = !!(Array.isArray(prevChoice)
             ? prevChoice.every(value => field.choices?.some(tuple => tuple[0] === value))
             : // Single-select fields have a single value, eg: 'a'
               field.choices?.some(item => item[0] === prevChoice));
         }
 
-        if (should_default_choice) {
+        if (shouldDefaultChoice) {
           field.default = prevChoice;
         }
 


### PR DESCRIPTION
When editing Jira alert rules, reopening the `Issue Link Settings` dialog will not render prevoiusly entered text or integer fields.

This fixes the bug by modifying some of the default fill logic, which previously only considered select and choice fields. Jira is the only integration affected by this that I've found so far thankfully.

## Screenshots
**Initially rendering the modal:**
<img width="2054" alt="image" src="https://github.com/user-attachments/assets/d60f34a3-72d8-4252-9a7f-de0e4d9f3df9">

**After reopening the modal, prior to saving**
All settings are restored, as you'd expect them to be.
<img width="2056" alt="image" src="https://github.com/user-attachments/assets/e9841a62-f9a9-4519-998a-1f324745340a">

**After saving and reopening the modal**
Settings are restored, same as above
<img width="2056" alt="image" src="https://github.com/user-attachments/assets/922428df-7793-4d78-87ea-606465842db7">

**BEFORE: when reopening the modal without the fix applied**
Select/choice fields are filled, but any free-form text boxes are not.
<img width="2056" alt="image" src="https://github.com/user-attachments/assets/d695951f-d5a6-48c6-8512-0abb31785558">

