### PR TITLE
ref(pr-comments): move queuing task into CommitContextIntegration ABC

### DIFF
--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -9,6 +9,7 @@ from django.urls import reverse
 from requests import PreparedRequest
 
 from sentry.identity.services.identity.model import RpcIdentity
+from sentry.integrations.base import IntegrationFeatureNotImplementedError
 from sentry.integrations.gitlab.blame import fetch_file_blames
 from sentry.integrations.gitlab.utils import GitLabApiClientPath
 from sentry.integrations.source_code_management.commit_context import (
@@ -308,6 +309,9 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         See https://docs.gitlab.com/ee/api/commits.html#get-a-single-commit
         """
         return self.get_cached(GitLabApiClientPath.commit.format(project=project_id, sha=sha))
+
+    def get_merge_commit_sha_from_commit(self, repo: str, sha: str) -> str | None:
+        raise IntegrationFeatureNotImplementedError
 
     def compare_commits(self, project_id, start_sha, end_sha):
         """Compare commits between two SHAs

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping, Sequence
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from typing import Any
 
-import sentry_sdk
 from celery import Task
 from celery.exceptions import MaxRetriesExceededError
 from django.utils import timezone as django_timezone
@@ -13,7 +12,7 @@ from sentry_sdk import set_tag
 
 from sentry import analytics
 from sentry.api.serializers.models.release import get_users_for_authors
-from sentry.integrations.base import IntegrationInstallation
+from sentry.integrations.source_code_management.commit_context import CommitContextIntegration
 from sentry.integrations.utils.code_mapping import get_sorted_code_mapping_configs
 from sentry.integrations.utils.commit_context import (
     find_commit_context_for_event_all_frames,
@@ -22,24 +21,14 @@ from sentry.integrations.utils.commit_context import (
 from sentry.locks import locks
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
-from sentry.models.group import Group
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
-from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.project import Project
 from sentry.models.projectownership import ProjectOwnership
-from sentry.models.pullrequest import (
-    CommentType,
-    PullRequest,
-    PullRequestComment,
-    PullRequestCommit,
-)
-from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.groupowner import process_suspect_commits
 from sentry.utils import metrics
-from sentry.utils.cache import cache
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.utils.sdk import set_current_event_project
 
@@ -49,85 +38,9 @@ PR_COMMENT_TASK_TTL = timedelta(minutes=5).total_seconds()
 PR_COMMENT_WINDOW = 14  # days
 
 # TODO: replace this with isinstance(installation, CommitContextIntegration)
-PR_COMMENT_SUPPORTED_PROVIDERS = {"integrations:github"}
+PR_COMMENT_SUPPORTED_PROVIDERS = {"github"}
 
 logger = logging.getLogger(__name__)
-
-
-def queue_comment_task_if_needed(
-    commit: Commit, group_owner: GroupOwner, repo: Repository, installation: IntegrationInstallation
-) -> None:
-    from sentry.integrations.github.tasks.pr_comment import github_comment_workflow
-
-    logger.info(
-        "github.pr_comment.queue_comment_check",
-        extra={"organization_id": commit.organization_id, "merge_commit_sha": commit.key},
-    )
-
-    # client will raise an Exception if the request is not successful
-    try:
-        client = installation.get_client()
-        merge_commit_sha = client.get_merge_commit_sha_from_commit(repo=repo.name, sha=commit.key)
-    except Exception as e:
-        sentry_sdk.capture_exception(e)
-        return
-
-    if merge_commit_sha is None:
-        logger.info(
-            "github.pr_comment.queue_comment_check.commit_not_in_default_branch",
-            extra={
-                "organization_id": commit.organization_id,
-                "repository_id": repo.id,
-                "commit_sha": commit.key,
-            },
-        )
-        return
-
-    pr_query = PullRequest.objects.filter(
-        organization_id=commit.organization_id,
-        repository_id=commit.repository_id,
-        merge_commit_sha=merge_commit_sha,
-    )
-    if not pr_query.exists():
-        logger.info(
-            "github.pr_comment.queue_comment_check.missing_pr",
-            extra={
-                "organization_id": commit.organization_id,
-                "repository_id": repo.id,
-                "commit_sha": commit.key,
-            },
-        )
-        return
-
-    pr = pr_query.first()
-    assert pr is not None
-    # need to query explicitly for merged PR comments since we can have multiple comments per PR
-    merged_pr_comment_query = PullRequestComment.objects.filter(
-        pull_request_id=pr.id, comment_type=CommentType.MERGED_PR
-    )
-    if pr.date_added >= datetime.now(tz=timezone.utc) - timedelta(days=PR_COMMENT_WINDOW) and (
-        not merged_pr_comment_query.exists()
-        or group_owner.group_id not in merged_pr_comment_query[0].group_ids
-    ):
-        lock = locks.get(
-            DEBOUNCE_PR_COMMENT_LOCK_KEY(pr.id), duration=10, name="queue_comment_task"
-        )
-        with lock.acquire():
-            cache_key = DEBOUNCE_PR_COMMENT_CACHE_KEY(pullrequest_id=pr.id)
-            if cache.get(cache_key) is not None:
-                return
-
-            # create PR commit row for suspect commit and PR
-            PullRequestCommit.objects.get_or_create(commit=commit, pull_request=pr)
-
-            logger.info(
-                "github.pr_comment.queue_comment_workflow",
-                extra={"pullrequest_id": pr.id, "project_id": group_owner.project_id},
-            )
-
-            cache.set(cache_key, True, PR_COMMENT_TASK_TTL)
-
-            github_comment_workflow.delay(pullrequest_id=pr.id, project_id=group_owner.project_id)
 
 
 @instrumented_task(
@@ -270,29 +183,13 @@ def process_commit_context(
                 },  # Updates date of an existing owner, since we just matched them with this new event
             )
 
-            if OrganizationOption.objects.get_value(
-                organization=project.organization,
-                key="sentry:github_pr_bot",
-                default=True,
+            if (
+                installation
+                and isinstance(installation, CommitContextIntegration)
+                and installation.integration_name
+                in PR_COMMENT_SUPPORTED_PROVIDERS  # TODO: remove this check
             ):
-                logger.info(
-                    "github.pr_comment",
-                    extra={"organization_id": project.organization_id},
-                )
-                repo = Repository.objects.filter(id=commit.repository_id).order_by("-date_added")
-                group = Group.objects.get_from_cache(id=group_id)
-                if (
-                    group.level is not logging.INFO  # Don't comment on info level issues
-                    and installation is not None
-                    and repo.exists()
-                    and repo.get().provider in PR_COMMENT_SUPPORTED_PROVIDERS
-                ):
-                    queue_comment_task_if_needed(commit, group_owner, repo.get(), installation)
-                else:
-                    logger.info(
-                        "github.pr_comment.incorrect_repo_config",
-                        extra={"organization_id": project.organization_id},
-                    )
+                installation.queue_comment_task_if_needed(project, commit, group_owner, group_id)
 
             ProjectOwnership.handle_auto_assignment(
                 project_id=project.id,


### PR DESCRIPTION
The `CommitContextIntegration` abstract base class should encapsulate the functionality of commit context integrations, which currently include the suspect commit feature. The merged PR comment feature builds off of suspect commits and should be moved to a base class.

This allows us to:
1. Define the functions expected on the integration client to implement the merged PR comments feature
2. Add generalized metrics and logging for the feature (now and later)
3. Queue the PR comment task from inside the ABC where we know the appropriate functions are implemented

NOTE: Gitlab is a `CommitContextIntegration` but does not currently support PR comments. I added a `raise IntegrationFeatureNotImplemented` for the client function that is not yet implemented, but PR comments should not be triggered for Gitlab anyway because of this hack:

https://github.com/getsentry/sentry/blob/3fd221e84d69ff3134d5a1abe95030f9470209c0/src/sentry/tasks/commit_context.py#L189-L190