### PR TITLE
feat(insights): add app starts and screen loads to mobile domain view

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1755,6 +1755,14 @@ function buildRoutes() {
           />
         </Route>
         <Route path={`${MODULE_BASE_URLS[ModuleName.APP_START]}/`}>
+          <IndexRoute
+            component={make(
+              () =>
+                import(
+                  'sentry/views/insights/mobile/appStarts/views/appStartsLandingPage'
+                )
+            )}
+          />
           <Route
             path="spans/"
             component={make(
@@ -1773,6 +1781,25 @@ function buildRoutes() {
             path="spans/"
             component={make(
               () => import('sentry/views/insights/mobile/ui/views/screenSummaryPage')
+            )}
+          />
+        </Route>
+        <Route path={`${MODULE_BASE_URLS[ModuleName.SCREEN_LOAD]}/`}>
+          <IndexRoute
+            component={make(
+              () =>
+                import(
+                  'sentry/views/insights/mobile/screenload/views/screenloadLandingPage'
+                )
+            )}
+          />
+          <Route
+            path="spans/"
+            component={make(
+              () =>
+                import(
+                  'sentry/views/insights/mobile/screenload/views/screenLoadSpansPage'
+                )
             )}
           />
         </Route>

--- a/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.spec.tsx
+++ b/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.spec.tsx
@@ -85,7 +85,7 @@ describe('Screen Summary', function () {
         action: 'PUSH',
         hash: '',
         key: '',
-        pathname: '/organizations/org-slug/performance/mobile/screens/spans/',
+        pathname: '/organizations/org-slug/insights/mobile/screens/spans/',
         query: {
           project: project.id,
           transaction: 'MainActivity',

--- a/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.tsx
+++ b/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.tsx
@@ -15,6 +15,7 @@ import {DurationUnit} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
 import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
 import {HeaderContainer} from 'sentry/views/insights/common/components/headerContainer';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
@@ -34,6 +35,7 @@ import {SpanSamplesPanel} from 'sentry/views/insights/mobile/common/components/s
 import {MobileMetricsRibbon} from 'sentry/views/insights/mobile/screenload/components/metricsRibbon';
 import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
+import {isModuleEnabled} from 'sentry/views/insights/pages/utils';
 import {ModuleName, SpanMetricsField} from 'sentry/views/insights/types';
 
 import AppStartWidgets from '../components/widgets';
@@ -53,8 +55,11 @@ type Query = {
 export function ScreenSummary() {
   const location = useLocation<Query>();
   const {transaction: transactionName} = location.query;
+  const organization = useOrganization();
   const crumbs = useModuleBreadcrumbs('app_start');
   const {isInDomainView} = useDomainViewFilters();
+
+  const isMobileScreensEnabled = isModuleEnabled(ModuleName.MOBILE_SCREENS, organization);
 
   return (
     <Layout.Page>
@@ -76,8 +81,10 @@ export function ScreenSummary() {
         )}
         {isInDomainView && (
           <MobileHeader
-            hideDefaultTabs
-            module={ModuleName.MOBILE_SCREENS}
+            hideDefaultTabs={isMobileScreensEnabled}
+            module={
+              isMobileScreensEnabled ? ModuleName.MOBILE_SCREENS : ModuleName.APP_START
+            }
             headerTitle={transactionName}
             breadcrumbs={[
               {

--- a/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.tsx
+++ b/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.tsx
@@ -82,9 +82,7 @@ export function ScreenSummary() {
         {isInDomainView && (
           <MobileHeader
             hideDefaultTabs={isMobileScreensEnabled}
-            module={
-              isMobileScreensEnabled ? ModuleName.MOBILE_SCREENS : ModuleName.APP_START
-            }
+            module={ModuleName.APP_START}
             headerTitle={transactionName}
             breadcrumbs={[
               {

--- a/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.tsx
+++ b/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.tsx
@@ -82,7 +82,9 @@ export function ScreenSummary() {
         {isInDomainView && (
           <MobileHeader
             hideDefaultTabs={isMobileScreensEnabled}
-            module={ModuleName.APP_START}
+            module={
+              isMobileScreensEnabled ? ModuleName.MOBILE_SCREENS : ModuleName.APP_START
+            }
             headerTitle={transactionName}
             breadcrumbs={[
               {

--- a/static/app/views/insights/mobile/common/components/screensTemplate.tsx
+++ b/static/app/views/insights/mobile/common/components/screensTemplate.tsx
@@ -18,7 +18,9 @@ import {ReleaseComparisonSelector} from 'sentry/views/insights/common/components
 import {useModuleBreadcrumbs} from 'sentry/views/insights/common/utils/useModuleBreadcrumbs';
 import useCrossPlatformProject from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
 import {PlatformSelector} from 'sentry/views/insights/mobile/screenload/components/platformSelector';
-import type {ModuleName} from 'sentry/views/insights/types';
+import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
+import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
+import {ModuleName} from 'sentry/views/insights/types';
 
 type ScreensTemplateProps = {
   content: ReactNode;
@@ -39,6 +41,7 @@ export default function ScreensTemplate({
 }: ScreensTemplateProps) {
   const location = useLocation();
   const {isProjectCrossPlatform} = useCrossPlatformProject();
+  const {isInDomainView} = useDomainViewFilters();
 
   const handleProjectChange = useCallback(() => {
     browserHistory.replace({
@@ -54,24 +57,42 @@ export default function ScreensTemplate({
   return (
     <Layout.Page>
       <PageAlertProvider>
-        <Layout.Header>
-          <Layout.HeaderContent>
-            <Breadcrumbs crumbs={crumbs} />
-            <Layout.Title>
-              {title}
-              <PageHeadingQuestionTooltip
-                docsUrl={moduleDocLink}
-                title={moduleDescription}
-              />
-            </Layout.Title>
-          </Layout.HeaderContent>
-          <Layout.HeaderActions>
-            <ButtonBar gap={1}>
-              {isProjectCrossPlatform && <PlatformSelector />}
-              <FeedbackWidgetButton />
-            </ButtonBar>
-          </Layout.HeaderActions>
-        </Layout.Header>
+        {!isInDomainView && (
+          <Layout.Header>
+            <Layout.HeaderContent>
+              <Breadcrumbs crumbs={crumbs} />
+              <Layout.Title>
+                {title}
+                <PageHeadingQuestionTooltip
+                  docsUrl={moduleDocLink}
+                  title={moduleDescription}
+                />
+              </Layout.Title>
+            </Layout.HeaderContent>
+            <Layout.HeaderActions>
+              <ButtonBar gap={1}>
+                {isProjectCrossPlatform && <PlatformSelector />}
+                <FeedbackWidgetButton />
+              </ButtonBar>
+            </Layout.HeaderActions>
+          </Layout.Header>
+        )}
+
+        {isInDomainView && (
+          <MobileHeader
+            headerTitle={
+              <Fragment>
+                {title}
+                <PageHeadingQuestionTooltip
+                  docsUrl={moduleDocLink}
+                  title={moduleDescription}
+                />
+              </Fragment>
+            }
+            module={ModuleName.APP_START}
+            headerActions={isProjectCrossPlatform && <PlatformSelector />}
+          />
+        )}
 
         <Layout.Body>
           <Layout.Main fullWidth>

--- a/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.tsx
@@ -42,6 +42,8 @@ import {
   MobileCursors,
   MobileSortKeys,
 } from 'sentry/views/insights/mobile/screenload/constants';
+import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
+import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {ModuleName} from 'sentry/views/insights/types';
 
 type Query = {
@@ -63,31 +65,48 @@ function ScreenLoadSpans() {
 
   const {transaction: transactionName} = location.query;
 
+  const {isInDomainView} = useDomainViewFilters();
+
   return (
     <Layout.Page>
       <PageAlertProvider>
-        <Layout.Header>
-          <Layout.HeaderContent>
-            <Breadcrumbs
-              crumbs={[
-                ...crumbs,
-                {
-                  label: t('Screen Summary'),
-                },
-              ]}
-            />
-            <HeaderWrapper>
-              <Layout.Title>{transactionName}</Layout.Title>
-              {organization.features.includes('insights-initial-modules') &&
-                isProjectCrossPlatform && <PlatformSelector />}
-            </HeaderWrapper>
-          </Layout.HeaderContent>
-          <Layout.HeaderActions>
-            <ButtonBar gap={1}>
-              <FeedbackWidgetButton />
-            </ButtonBar>
-          </Layout.HeaderActions>
-        </Layout.Header>
+        {!isInDomainView && (
+          <Layout.Header>
+            <Layout.HeaderContent>
+              <Breadcrumbs
+                crumbs={[
+                  ...crumbs,
+                  {
+                    label: t('Screen Summary'),
+                  },
+                ]}
+              />
+              <HeaderWrapper>
+                <Layout.Title>{transactionName}</Layout.Title>
+                {organization.features.includes('insights-initial-modules') &&
+                  isProjectCrossPlatform && <PlatformSelector />}
+              </HeaderWrapper>
+            </Layout.HeaderContent>
+            <Layout.HeaderActions>
+              <ButtonBar gap={1}>
+                <FeedbackWidgetButton />
+              </ButtonBar>
+            </Layout.HeaderActions>
+          </Layout.Header>
+        )}
+
+        {isInDomainView && (
+          <MobileHeader
+            module={ModuleName.SCREEN_LOAD}
+            headerTitle={transactionName}
+            headerActions={isProjectCrossPlatform && <PlatformSelector />}
+            breadcrumbs={[
+              {
+                label: t('Screen Summary'),
+              },
+            ]}
+          />
+        )}
         <Layout.Body>
           <Layout.Main fullWidth>
             <PageAlert />

--- a/static/app/views/insights/mobile/screenload/views/screenloadLandingPage.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenloadLandingPage.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
@@ -24,6 +25,8 @@ import {
   MODULE_DOC_LINK,
   MODULE_TITLE,
 } from 'sentry/views/insights/mobile/screenload/settings';
+import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
+import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {ModuleName} from 'sentry/views/insights/types';
 import Onboarding from 'sentry/views/performance/onboarding';
 
@@ -31,32 +34,51 @@ export function PageloadModule() {
   const organization = useOrganization();
   const onboardingProject = useOnboardingProject();
   const {isProjectCrossPlatform} = useCrossPlatformProject();
+  const {isInDomainView} = useDomainViewFilters();
 
   const crumbs = useModuleBreadcrumbs('screen_load');
 
   return (
     <Layout.Page>
       <PageAlertProvider>
-        <Layout.Header>
-          <Layout.HeaderContent>
-            <Breadcrumbs crumbs={crumbs} />
-            <HeaderWrapper>
-              <Layout.Title>
+        {!isInDomainView && (
+          <Layout.Header>
+            <Layout.HeaderContent>
+              <Breadcrumbs crumbs={crumbs} />
+              <HeaderWrapper>
+                <Layout.Title>
+                  {MODULE_TITLE}
+                  <PageHeadingQuestionTooltip
+                    docsUrl={MODULE_DOC_LINK}
+                    title={MODULE_DESCRIPTION}
+                  />
+                </Layout.Title>
+              </HeaderWrapper>
+            </Layout.HeaderContent>
+            <Layout.HeaderActions>
+              <ButtonBar gap={1}>
+                {isProjectCrossPlatform && <PlatformSelector />}
+                <FeedbackWidgetButton />
+              </ButtonBar>
+            </Layout.HeaderActions>
+          </Layout.Header>
+        )}
+
+        {isInDomainView && (
+          <MobileHeader
+            module={ModuleName.SCREEN_LOAD}
+            headerTitle={
+              <Fragment>
                 {MODULE_TITLE}
                 <PageHeadingQuestionTooltip
                   docsUrl={MODULE_DOC_LINK}
                   title={MODULE_DESCRIPTION}
                 />
-              </Layout.Title>
-            </HeaderWrapper>
-          </Layout.HeaderContent>
-          <Layout.HeaderActions>
-            <ButtonBar gap={1}>
-              {isProjectCrossPlatform && <PlatformSelector />}
-              <FeedbackWidgetButton />
-            </ButtonBar>
-          </Layout.HeaderActions>
-        </Layout.Header>
+              </Fragment>
+            }
+            headerActions={isProjectCrossPlatform && <PlatformSelector />}
+          />
+        )}
 
         <Layout.Body>
           <Layout.Main fullWidth>

--- a/static/app/views/insights/mobile/ui/views/screenSummaryPage.tsx
+++ b/static/app/views/insights/mobile/ui/views/screenSummaryPage.tsx
@@ -11,6 +11,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
 import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
 import {HeaderContainer} from 'sentry/views/insights/common/components/headerContainer';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
@@ -22,6 +23,7 @@ import {SamplesTables} from 'sentry/views/insights/mobile/common/components/tabl
 import {SpanOperationTable} from 'sentry/views/insights/mobile/ui/components/tables/spanOperationTable';
 import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
+import {isModuleEnabled} from 'sentry/views/insights/pages/utils';
 import {ModuleName, SpanMetricsField} from 'sentry/views/insights/types';
 
 type Query = {
@@ -38,9 +40,11 @@ type Query = {
 function ScreenSummary() {
   const location = useLocation<Query>();
   const {isInDomainView} = useDomainViewFilters();
+  const organization = useOrganization();
   const {transaction: transactionName} = location.query;
 
   const crumbs = useModuleBreadcrumbs('mobile-ui');
+  const isMobileScreensEnabled = isModuleEnabled(ModuleName.MOBILE_SCREENS, organization);
 
   return (
     <Layout.Page>
@@ -63,7 +67,7 @@ function ScreenSummary() {
 
         {isInDomainView && (
           <MobileHeader
-            hideDefaultTabs
+            hideDefaultTabs={isMobileScreensEnabled}
             module={ModuleName.MOBILE_SCREENS}
             headerTitle={transactionName}
             breadcrumbs={[

--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -14,7 +14,8 @@ import {
   useModuleURLBuilder,
 } from 'sentry/views/insights/common/utils/useModuleURL';
 import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
-import {MODULE_FEATURE_MAP, MODULE_TITLES} from 'sentry/views/insights/settings';
+import {isModuleEnabled} from 'sentry/views/insights/pages/utils';
+import {MODULE_TITLES} from 'sentry/views/insights/settings';
 import type {ModuleName} from 'sentry/views/insights/types';
 
 type Props = {
@@ -129,11 +130,5 @@ export function DomainViewHeader({
 }
 
 const filterEnabledModules = (modules: ModuleName[], organization: Organization) => {
-  return modules.filter(module => {
-    const moduleFeatures = MODULE_FEATURE_MAP[module];
-    if (!moduleFeatures) {
-      return false;
-    }
-    return moduleFeatures.every(feature => organization.features.includes(feature));
-  });
+  return modules.filter(module => isModuleEnabled(module, organization));
 };

--- a/static/app/views/insights/pages/mobile/mobilePageHeader.tsx
+++ b/static/app/views/insights/pages/mobile/mobilePageHeader.tsx
@@ -7,6 +7,7 @@ import {
   MOBILE_LANDING_TITLE,
 } from 'sentry/views/insights/pages/mobile/settings';
 import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
+import {isModuleEnabled} from 'sentry/views/insights/pages/utils';
 import {ModuleName} from 'sentry/views/insights/types';
 
 type Props = {
@@ -27,13 +28,17 @@ export function MobileHeader({
   tabs,
   breadcrumbs,
 }: Props) {
-  const {slug} = useOrganization();
+  const organization = useOrganization();
 
   const mobileBaseUrl = normalizeUrl(
-    `/organizations/${slug}/${DOMAIN_VIEW_BASE_URL}/${MOBILE_LANDING_SUB_PATH}/`
+    `/organizations/${organization.slug}/${DOMAIN_VIEW_BASE_URL}/${MOBILE_LANDING_SUB_PATH}/`
   );
 
-  const modules = [ModuleName.MOBILE_SCREENS];
+  const hasMobileScreens = isModuleEnabled(ModuleName.MOBILE_SCREENS, organization);
+
+  const modules = hasMobileScreens
+    ? [ModuleName.MOBILE_SCREENS]
+    : [ModuleName.APP_START, ModuleName.SCREEN_LOAD, ModuleName.MOBILE_UI];
 
   return (
     <DomainViewHeader

--- a/static/app/views/insights/pages/utils.ts
+++ b/static/app/views/insights/pages/utils.ts
@@ -1,0 +1,12 @@
+import type {ModuleName} from 'webpack-cli';
+
+import type {Organization} from 'sentry/types/organization';
+import {MODULE_FEATURE_MAP} from 'sentry/views/insights/settings';
+
+export const isModuleEnabled = (module: ModuleName, organization: Organization) => {
+  const moduleFeatures: string[] | undefined = MODULE_FEATURE_MAP[module];
+  if (!moduleFeatures) {
+    return false;
+  }
+  return moduleFeatures.every(feature => organization.features.includes(feature));
+};


### PR DESCRIPTION
Work for https://github.com/getsentry/sentry/issues/77572

Originally we were hoping that the screen loads module will be available to release domain views, so we didn't add app starts/screen loads. However, it looks like there's a good chance it won't be. This PR adds the app starts and screen loads module into the mobile domain view (we conditionally render it if the mobile screens flag is off, the same way we do in the sidebar).