### PR TITLE
chore(alerts): Add info log when sending subscription update data to Seer

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -405,6 +405,16 @@ class SubscriptionProcessor:
                 aggregation_value=aggregation_value,
             )
             if potential_anomalies is None:
+                logger.info(
+                    "No potential anomalies found",
+                    extra={
+                        "subscription_id": self.subscription.id,
+                        "dataset": self.alert_rule.snuba_query.dataset,
+                        "organization_id": self.subscription.project.organization.id,
+                        "project_id": self.subscription.project_id,
+                        "alert_rule_id": self.alert_rule.id,
+                    },
+                )
                 return []
 
         # Trigger callbacks for any AlertRules that may need to know about the subscription update

--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -70,6 +70,7 @@ def get_anomaly_data_from_seer(
         "alert_rule_id": alert_rule.id,
     }
     try:
+        logger.info("Sending subscription update data to Seer", extra=extra_data)
         response = make_signed_seer_api_request(
             SEER_ANOMALY_DETECTION_CONNECTION_POOL,
             SEER_ANOMALY_DETECTION_ENDPOINT_URL,


### PR DESCRIPTION
Add some temporary logging to help debug why some alerts are missing streaming data in Seer.