### PR TITLE
ref(insights): move module features into settings.ts

### DIFF
--- a/static/app/views/insights/browser/resources/settings.ts
+++ b/static/app/views/insights/browser/resources/settings.ts
@@ -20,3 +20,5 @@ export const DEFAULT_RESOURCE_TYPES = [
 ];
 
 export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/assets/';
+
+export const MODULE_FEATURES = ['insights-initial-modules'];

--- a/static/app/views/insights/browser/webVitals/settings.ts
+++ b/static/app/views/insights/browser/webVitals/settings.ts
@@ -12,3 +12,5 @@ export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/web-vita
 
 export const DEFAULT_QUERY_FILTER =
   'transaction.op:[pageload,""] span.op:[ui.interaction.click,ui.interaction.hover,ui.interaction.drag,ui.interaction.press,ui.webvital.cls,""] !transaction:"<< unparameterized >>"';
+
+export const MODULE_FEATURES = ['insights-initial-modules'];

--- a/static/app/views/insights/cache/settings.ts
+++ b/static/app/views/insights/cache/settings.ts
@@ -18,3 +18,5 @@ export const MODULE_DESCRIPTION = t(
   'Discover whether your application is utilizing caching effectively and understand the latency associated with cache misses.'
 );
 export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/caches/';
+
+export const MODULE_FEATURES = ['insights-addon-modules'];

--- a/static/app/views/insights/database/settings.ts
+++ b/static/app/views/insights/database/settings.ts
@@ -60,3 +60,5 @@ export const MODULE_DESCRIPTION = t(
   'Investigate the performance of database queries and get the information necessary to improve them.'
 );
 export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/queries/';
+
+export const MODULE_FEATURES = ['insights-initial-modules'];

--- a/static/app/views/insights/http/settings.ts
+++ b/static/app/views/insights/http/settings.ts
@@ -21,3 +21,5 @@ export const MODULE_DESCRIPTION = t(
   'Monitor outgoing HTTP requests and investigate errors and performance bottlenecks tied to domains.'
 );
 export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/requests/';
+
+export const MODULE_FEATURES = ['insights-initial-modules'];

--- a/static/app/views/insights/llmMonitoring/settings.ts
+++ b/static/app/views/insights/llmMonitoring/settings.ts
@@ -10,3 +10,5 @@ export const DATA_TYPE_PLURAL = t('LLMs');
 export const RELEASE_LEVEL: BadgeType = 'beta';
 
 export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/llm-monitoring/';
+
+export const MODULE_FEATURES = ['insights-addon-modules'];

--- a/static/app/views/insights/mobile/appStarts/settings.ts
+++ b/static/app/views/insights/mobile/appStarts/settings.ts
@@ -10,3 +10,5 @@ export const MODULE_DESCRIPTION = t(
 );
 export const MODULE_DOC_LINK =
   'https://docs.sentry.io/product/insights/mobile-vitals/app-starts/';
+
+export const MODULE_FEATURES = ['insights-initial-modules'];

--- a/static/app/views/insights/mobile/screenload/settings.ts
+++ b/static/app/views/insights/mobile/screenload/settings.ts
@@ -10,3 +10,5 @@ export const MODULE_DESCRIPTION = t(
 );
 export const MODULE_DOC_LINK =
   'https://docs.sentry.io/product/insights/mobile-vitals/screen-loads/';
+
+export const MODULE_FEATURES = ['insights-initial-modules'];

--- a/static/app/views/insights/mobile/ui/settings.ts
+++ b/static/app/views/insights/mobile/ui/settings.ts
@@ -7,3 +7,5 @@ export const MODULE_DESCRIPTION = t("Improve your application's responsiveness."
 
 // TODO: Update this link once we have the proper docs.
 export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/mobile-vitals/';
+
+export const MODULE_FEATURES = ['insights-addon-modules', 'starfish-mobile-ui-module'];

--- a/static/app/views/insights/queues/settings.ts
+++ b/static/app/views/insights/queues/settings.ts
@@ -47,3 +47,5 @@ export const MODULE_DOC_LINK =
   'https://docs.sentry.io/product/insights/queue-monitoring/';
 
 export const TABLE_ROWS_LIMIT = 25;
+
+export const MODULE_FEATURES = ['insights-addon-modules'];

--- a/static/app/views/insights/settings.ts
+++ b/static/app/views/insights/settings.ts
@@ -3,48 +3,56 @@ import {
   DATA_TYPE as RESOURCE_DATA_TYPE,
   DATA_TYPE_PLURAL as RESOURCE_DATA_TYPE_PLURAL,
   MODULE_DOC_LINK as RESOURCES_MODULE_DOC_LINK,
+  MODULE_FEATURES as RESOURCE_MODULE_FEATURES,
   MODULE_TITLE as RESOURCES_MODULE_TITLE,
 } from 'sentry/views/insights/browser/resources/settings';
 import {
   DATA_TYPE as WEB_VITALS_DATA_TYPE,
   DATA_TYPE_PLURAL as WEB_VITALS_DATA_TYPE_PLURAL,
   MODULE_DOC_LINK as VITALS_MODULE_DOC_LINK,
+  MODULE_FEATURES as VITALS_MODULE_FEATURES,
   MODULE_TITLE as VITALS_MODULE_TITLE,
 } from 'sentry/views/insights/browser/webVitals/settings';
 import {
   DATA_TYPE as CACHE_DATA_TYPE,
   DATA_TYPE_PLURAL as CACHE_DATA_TYPE_PLURAL,
   MODULE_DOC_LINK as CACHE_MODULE_DOC_LINK,
+  MODULE_FEATURES as CACHE_MODULE_FEATURES,
   MODULE_TITLE as CACHE_MODULE_TITLE,
 } from 'sentry/views/insights/cache/settings';
 import {
   DATA_TYPE as DB_DATA_TYPE,
   DATA_TYPE_PLURAL as DB_DATA_TYPE_PLURAL,
   MODULE_DOC_LINK as DB_MODULE_DOC_LINK,
+  MODULE_FEATURES as DB_MODULE_FEATURES,
   MODULE_TITLE as DB_MODULE_TITLE,
 } from 'sentry/views/insights/database/settings';
 import {
   DATA_TYPE as HTTP_DATA_TYPE,
   DATA_TYPE_PLURAL as HTTP_DATA_TYPE_PLURAL,
   MODULE_DOC_LINK as HTTP_MODULE_DOC_LINK,
+  MODULE_FEATURES as HTTP_MODULE_FEATURES,
   MODULE_TITLE as HTTP_MODULE_TITLE,
 } from 'sentry/views/insights/http/settings';
 import {
   DATA_TYPE as AI_DATA_TYPE,
   DATA_TYPE_PLURAL as AI_DATA_TYPE_PLURAL,
   MODULE_DOC_LINK as AI_MODULE_DOC_LINK,
+  MODULE_FEATURES as AI_MODULE_FEATURES,
   MODULE_TITLE as AI_MODULE_TITLE,
 } from 'sentry/views/insights/llmMonitoring/settings';
 import {
   DATA_TYPE as APP_STARTS_DATA_TYPE,
   DATA_TYPE_PLURAL as APP_STARTS_DATA_TYPE_PLURAL,
   MODULE_DOC_LINK as APP_STARTS_MODULE_DOC_LINK,
+  MODULE_FEATURES as APP_STARTS_MODULE_FEATURES,
   MODULE_TITLE as APP_STARTS_MODULE_TITLE,
 } from 'sentry/views/insights/mobile/appStarts/settings';
 import {
   DATA_TYPE as SCREEN_LOAD_DATA_TYPE,
   DATA_TYPE_PLURAL as SCREEN_LOAD_DATA_TYPE_PLURAL,
   MODULE_DOC_LINK as SCREEN_LOADS_MODULE_DOC_LINK,
+  MODULE_FEATURES as SCREEN_LOADS_MODULE_FEATURES,
   MODULE_TITLE as SCREEN_LOADS_MODULE_TITLE,
 } from 'sentry/views/insights/mobile/screenload/settings';
 import {
@@ -56,12 +64,14 @@ import {
 } from 'sentry/views/insights/mobile/screens/settings';
 import {
   MODULE_DOC_LINK as MODULE_UI_DOC_LINK,
+  MODULE_FEATURES as MOBILE_UI_MODULE_FEATURES,
   MODULE_TITLE as MOBILE_UI_MODULE_TITLE,
 } from 'sentry/views/insights/mobile/ui/settings';
 import {
   DATA_TYPE as QUEUE_DATA_TYPE,
   DATA_TYPE_PLURAL as QUEUE_DATA_TYPE_PLURAL,
   MODULE_DOC_LINK as QUEUE_MODULE_DOC_LINK,
+  MODULE_FEATURES as QUEUE_MODULE_FEATURES,
   MODULE_TITLE as QUEUE_MODULE_TITLE,
 } from 'sentry/views/insights/queues/settings';
 import {ModuleName} from 'sentry/views/insights/types';
@@ -132,15 +142,15 @@ export const MODULE_PRODUCT_DOC_LINKS: Record<ModuleName, string> = {
 };
 
 export const MODULE_FEATURE_MAP: Partial<Record<ModuleName, string[]>> = {
-  [ModuleName.DB]: ['insights-initial-modules'],
-  [ModuleName.APP_START]: ['insights-initial-modules'],
-  [ModuleName.HTTP]: ['insights-initial-modules'],
-  [ModuleName.RESOURCE]: ['insights-initial-modules'],
-  [ModuleName.VITAL]: ['insights-initial-modules'],
-  [ModuleName.CACHE]: ['insights-addon-modules'],
-  [ModuleName.QUEUE]: ['insights-addon-modules'],
-  [ModuleName.AI]: ['insights-addon-modules'],
-  [ModuleName.SCREEN_LOAD]: ['insights-initial-modules'],
-  [ModuleName.MOBILE_UI]: ['insights-addon-modules', 'starfish-mobile-ui-module'],
+  [ModuleName.DB]: DB_MODULE_FEATURES,
+  [ModuleName.APP_START]: APP_STARTS_MODULE_FEATURES,
+  [ModuleName.HTTP]: HTTP_MODULE_FEATURES,
+  [ModuleName.RESOURCE]: RESOURCE_MODULE_FEATURES,
+  [ModuleName.VITAL]: VITALS_MODULE_FEATURES,
+  [ModuleName.CACHE]: CACHE_MODULE_FEATURES,
+  [ModuleName.QUEUE]: QUEUE_MODULE_FEATURES,
+  [ModuleName.AI]: AI_MODULE_FEATURES,
+  [ModuleName.SCREEN_LOAD]: SCREEN_LOADS_MODULE_FEATURES,
+  [ModuleName.MOBILE_UI]: MOBILE_UI_MODULE_FEATURES,
   [ModuleName.MOBILE_SCREENS]: [MOBILE_SCREENS_MODULE_FEATURE],
 };


### PR DESCRIPTION
To be consistent with how we do insight settings, this PR moves the declaration of each module's features into its respective `settings.ts`