### PR TITLE
feat(dashboards): Implement widget frame full screen view button feature

### DIFF
--- a/static/app/views/dashboards/widgets/common/widgetFrame.spec.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.spec.tsx
@@ -83,4 +83,25 @@ describe('WidgetFrame', () => {
       expect(onAction2).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('Full Screen View Button', () => {
+    it('Renders a full screen view button', async () => {
+      const onFullScreenViewClick = jest.fn();
+      const {rerender} = render(<WidgetFrame title="count()" />);
+
+      expect(
+        screen.queryByRole('button', {name: 'Open Full-Screen View'})
+      ).not.toBeInTheDocument();
+
+      rerender(
+        <WidgetFrame title="count()" onFullScreenViewClick={onFullScreenViewClick} />
+      );
+
+      const $button = screen.getByRole('button', {name: 'Open Full-Screen View'});
+      expect($button).toBeInTheDocument();
+      await userEvent.click($button);
+
+      expect(onFullScreenViewClick).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/static/app/views/dashboards/widgets/common/widgetFrame.stories.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.stories.tsx
@@ -127,6 +127,24 @@ export default storyBook(WidgetFrame, story => {
       </Fragment>
     );
   });
+
+  story('Full Screen View Button', () => {
+    return (
+      <Fragment>
+        <p>
+          <JSXNode name="WidgetFrame" /> supports a <code>onOpenFullScreenView</code>{' '}
+          prop. This is a special action that always appears as an individual icon to the
+          right of the normal actions.
+        </p>
+
+        <SideBySide>
+          <NormalWidget>
+            <WidgetFrame title="count()" onFullScreenViewClick={() => {}} />
+          </NormalWidget>
+        </SideBySide>
+      </Fragment>
+    );
+  });
 });
 
 const NormalWidget = styled('div')`

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -5,7 +5,7 @@ import {HeaderTitle} from 'sentry/components/charts/styles';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {Tooltip} from 'sentry/components/tooltip';
-import {IconEllipsis, IconWarning} from 'sentry/icons';
+import {IconEllipsis, IconExpand, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
@@ -19,6 +19,7 @@ export interface Props extends StateProps {
   actions?: MenuItemProps[];
   children?: React.ReactNode;
   description?: string;
+  onFullScreenViewClick?: () => void;
   title?: string;
   warnings?: string[];
 }
@@ -55,7 +56,9 @@ export function WidgetFrame(props: Props) {
           <TitleText>{props.title}</TitleText>
         </Tooltip>
 
-        {(props.description || (actions && actions.length > 0)) && (
+        {(props.description ||
+          props.onFullScreenViewClick ||
+          (actions && actions.length > 0)) && (
           <TitleActions>
             {props.description && (
               <QuestionTooltip title={props.description} size="sm" icon="info" />
@@ -86,6 +89,18 @@ export function WidgetFrame(props: Props) {
                 position="bottom-end"
               />
             ) : null}
+
+            {props.onFullScreenViewClick && (
+              <Button
+                aria-label={t('Open Full-Screen View')}
+                borderless
+                size="xs"
+                icon={<IconExpand />}
+                onClick={() => {
+                  props.onFullScreenViewClick?.();
+                }}
+              />
+            )}
           </TitleActions>
         )}
       </Header>


### PR DESCRIPTION
Very simple, just shows a special button in the top right. Contributes to https://github.com/getsentry/sentry/issues/77779

**e.g.,**
<img width="271" alt="Screenshot 2024-10-11 at 12 43 35 PM" src="https://github.com/user-attachments/assets/693f5b6a-319a-4a0c-b8f2-fca4daea5181">
