### PR TITLE
fix(dashboard): OnDemand extraction for Transaction widgets

### DIFF
--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -258,7 +258,10 @@ def _get_widget_metric_specs(
     widget_queries = (
         DashboardWidgetQuery.objects.filter(
             widget__dashboard__organization=project.organization,
-            widget__widget_type=DashboardWidgetTypes.DISCOVER,
+            widget__widget_type__in=[
+                DashboardWidgetTypes.DISCOVER,
+                DashboardWidgetTypes.TRANSACTION_LIKE,
+            ],
         )
         .prefetch_related("dashboardwidgetqueryondemand_set", "widget")
         .order_by("-widget__dashboard__last_visited", "widget__order")

--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -126,7 +126,10 @@ def schedule_on_demand_check() -> None:
 
     for (widget_query_id,) in RangeQuerySetWrapper(
         DashboardWidgetQuery.objects.filter(
-            widget__widget_type=DashboardWidgetTypes.DISCOVER
+            widget__widget_type__in=[
+                DashboardWidgetTypes.DISCOVER,
+                DashboardWidgetTypes.TRANSACTION_LIKE,
+            ]
         ).values_list("id"),
         result_value_getter=lambda item: item[0],
     ):

--- a/src/sentry/testutils/helpers/on_demand.py
+++ b/src/sentry/testutils/helpers/on_demand.py
@@ -20,6 +20,7 @@ def create_widget(
     dashboard: Dashboard | None = None,
     widget: DashboardWidget | None = None,
     discover_widget_split: int | None = None,
+    widget_type: int = DashboardWidgetTypes.DISCOVER,
 ) -> tuple[DashboardWidgetQuery, DashboardWidget, Dashboard]:
     columns = columns or []
     dashboard = dashboard or Dashboard.objects.create(
@@ -31,7 +32,7 @@ def create_widget(
     widget = widget or DashboardWidget.objects.create(
         dashboard=dashboard,
         order=order,
-        widget_type=DashboardWidgetTypes.DISCOVER,
+        widget_type=widget_type,
         display_type=DashboardWidgetDisplayTypes.LINE_CHART,
         discover_widget_split=discover_widget_split,
     )

--- a/tests/sentry/tasks/test_on_demand_metrics.py
+++ b/tests/sentry/tasks/test_on_demand_metrics.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from sentry.models.dashboard_widget import DashboardWidgetQueryOnDemand
+from sentry.models.dashboard_widget import DashboardWidgetQueryOnDemand, DashboardWidgetTypes
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.tasks import on_demand_metrics
@@ -456,6 +456,9 @@ def test_schedule_on_demand_check(
 )
 @mock.patch("sentry.tasks.on_demand_metrics._set_cardinality_cache")
 @mock.patch("sentry.search.events.builder.base.raw_snql_query")
+@pytest.mark.parametrize(
+    "widget_type", [DashboardWidgetTypes.DISCOVER, DashboardWidgetTypes.TRANSACTION_LIKE]
+)
 @django_db_all
 def test_process_widget_specs(
     raw_snql_query: Any,
@@ -467,6 +470,7 @@ def test_process_widget_specs(
     expected_discover_queries_run: int,
     expected_low_cardinality: bool,
     project: Project,
+    widget_type: int,
 ) -> None:
     cache.clear()
     raw_snql_query.return_value = (
@@ -489,6 +493,7 @@ def test_process_widget_specs(
         columns=query_columns,
         id=2,
         dashboard=dashboard,
+        widget_type=widget_type,
     )
     create_widget(
         ["count()"],
@@ -497,6 +502,7 @@ def test_process_widget_specs(
         columns=[],
         id=3,
         dashboard=dashboard,
+        widget_type=widget_type,
     )
 
     with override_options(options), Feature(feature_flags):


### PR DESCRIPTION
Since we're splitting the datasets up, a user can create or update a widget to have DashboardWidgetTypes.TRANSACTION_LIKE as their widget type natively. Widgets like this aren't picked up by on-demand.

Update the queries for on-demand widgets to also search for DashboardWidgetTypes.TRANSACTION_LIKE.