### PR TITLE
fix(test-alerts): Passes a unique fingerprint for every notification test alert

### DIFF
--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -1,6 +1,7 @@
 import logging
 
 import sentry_sdk
+from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -62,8 +63,13 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
         )
         rule = Rule(id=-1, project=project, data=data)
 
+        sample_event_fingerprint = f"sample_evt:{str(timezone.now())}"
         test_event = create_sample_event(
-            project, platform=project.platform, default="javascript", tagged=True
+            project,
+            platform=project.platform,
+            default="javascript",
+            tagged=True,
+            fingerprint=[sample_event_fingerprint],
         )
 
         if features.has(


### PR DESCRIPTION
# WIP - Want input on this change
When users currently test a notification, a new event is created in the sample issue group. This is fine for initially testing an alert, but subsequent tests for ticketing integrations will result in skips + success messages, providing no feedback to the user as to whether their alert rule is correctly configured.

This passes a unique fingerprint for every single test alert we trigger, which causes a new issue group to be created. While this may result in a more spammy test button that requires cleaning up the issues feed, it addresses the problem by ensuring a user can check Ticket creation and linking behavior every time they trigger a test notification.