### PR TITLE
plugins(phabricator): Make phabricator hidden

### DIFF
--- a/src/sentry/plugins/__init__.py
+++ b/src/sentry/plugins/__init__.py
@@ -6,4 +6,5 @@ HIDDEN_PLUGINS = (
     "jira",
     "pagerduty",
     "opsgenie",
+    "phabricator",
 )


### PR DESCRIPTION
Adds Phabricator to HIDDEN_PLUGINS. The plugin won't be discoverable for on the integrations page, but users still can access via direct uri (plugins/phabricator/) 

Need to look into best way to disable installs next (frontend or backend change)