### PR TITLE
fix(dashboard): OnDemand widget creation also includes transaction type

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -343,7 +343,8 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
 
                 if (
                     ondemand_feature
-                    and data.get("widget_type") == DashboardWidgetTypes.DISCOVER
+                    and data.get("widget_type")
+                    in [DashboardWidgetTypes.DISCOVER, DashboardWidgetTypes.TRANSACTION_LIKE]
                     and not query.get("on_demand_extraction_disabled", False)
                 ):
                     if query.get("columns"):
@@ -654,7 +655,10 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
 
         DashboardWidgetQuery.objects.bulk_create(new_queries)
 
-        if widget.widget_type == DashboardWidgetTypes.DISCOVER:
+        if widget.widget_type in [
+            DashboardWidgetTypes.DISCOVER,
+            DashboardWidgetTypes.TRANSACTION_LIKE,
+        ]:
             self._check_query_cardinality(new_queries)
 
     def _check_query_cardinality(self, new_queries: Sequence[DashboardWidgetQuery]):
@@ -734,7 +738,10 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
                 raise serializers.ValidationError("You cannot use a query not owned by this widget")
         DashboardWidgetQuery.objects.bulk_create(new_queries)
 
-        if widget.widget_type == DashboardWidgetTypes.DISCOVER:
+        if widget.widget_type in [
+            DashboardWidgetTypes.DISCOVER,
+            DashboardWidgetTypes.TRANSACTION_LIKE,
+        ]:
             self._check_query_cardinality(new_queries + update_queries)
 
     def update_widget_query(self, query, data, order):

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -1769,6 +1769,33 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         )
         assert response.status_code == 200, response.data
 
+
+class OrganizationDashboardDetailsOnDemandTest(OrganizationDashboardDetailsTestCase):
+    widget_type = DashboardWidgetTypes.DISCOVER
+
+    def setUp(self):
+        super().setUp()
+        self.project = self.create_project()
+        self.create_user_member_role()
+        self.widget_3 = DashboardWidget.objects.create(
+            dashboard=self.dashboard,
+            order=2,
+            title="Widget 3",
+            display_type=DashboardWidgetDisplayTypes.LINE_CHART,
+            widget_type=self.widget_type,
+        )
+        self.widget_4 = DashboardWidget.objects.create(
+            dashboard=self.dashboard,
+            order=3,
+            title="Widget 4",
+            display_type=DashboardWidgetDisplayTypes.LINE_CHART,
+            widget_type=self.widget_type,
+        )
+        self.widget_ids = [self.widget_1.id, self.widget_2.id, self.widget_3.id, self.widget_4.id]
+
+    def get_widget_queries(self, widget):
+        return DashboardWidgetQuery.objects.filter(widget=widget).order_by("order")
+
     def test_ondemand_without_flags(self):
         data: dict[str, Any] = {
             "title": "First dashboard",
@@ -1777,6 +1804,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
                     "title": "Errors per project",
                     "displayType": "table",
                     "interval": "5m",
+                    "widgetType": DashboardWidgetTypes.get_type_name(self.widget_type),
                     "queries": [
                         {
                             "name": "Errors",
@@ -1813,6 +1841,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
                     "title": "Errors per project",
                     "displayType": "table",
                     "interval": "5m",
+                    "widgetType": DashboardWidgetTypes.get_type_name(self.widget_type),
                     "queries": [
                         {
                             "name": "Errors",
@@ -1850,6 +1879,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
                     "title": "Errors per project",
                     "displayType": "table",
                     "interval": "5m",
+                    "widgetType": DashboardWidgetTypes.get_type_name(self.widget_type),
                     "queries": [
                         {
                             "name": "Errors",
@@ -1888,6 +1918,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
                     "title": "Errors per project",
                     "displayType": "table",
                     "interval": "5m",
+                    "widgetType": DashboardWidgetTypes.get_type_name(self.widget_type),
                     "queries": [
                         {
                             "name": "Errors",
@@ -1932,6 +1963,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
                     "title": "errors per project",
                     "displayType": "table",
                     "interval": "5m",
+                    "widgetType": DashboardWidgetTypes.get_type_name(self.widget_type),
                     "queries": [
                         {
                             "name": "errors",
@@ -1973,6 +2005,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
                     "title": "errors per project",
                     "displayType": "table",
                     "interval": "5m",
+                    "widgetType": DashboardWidgetTypes.get_type_name(self.widget_type),
                     "queries": [
                         {
                             "name": "errors",
@@ -2009,6 +2042,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
                     "title": "errors per project",
                     "displayType": "table",
                     "interval": "5m",
+                    "widgetType": DashboardWidgetTypes.get_type_name(self.widget_type),
                     "queries": [
                         {
                             "id": str(queries[0].id),
@@ -2055,6 +2089,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
                     "title": "errors per project",
                     "displayType": "table",
                     "interval": "5m",
+                    "widgetType": DashboardWidgetTypes.get_type_name(self.widget_type),
                     "queries": [
                         {
                             "name": "errors",
@@ -2091,6 +2126,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
                     "title": "errors per project",
                     "displayType": "table",
                     "interval": "5m",
+                    "widgetType": DashboardWidgetTypes.get_type_name(self.widget_type),
                     "queries": [
                         {
                             # without id here we'll make a new query and delete the old one
@@ -2137,6 +2173,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
                     "title": "errors per project",
                     "displayType": "table",
                     "interval": "5m",
+                    "widgetType": DashboardWidgetTypes.get_type_name(self.widget_type),
                     "queries": [
                         {
                             "name": "errors",
@@ -2265,6 +2302,13 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
 
         assert widgets[2].widget_type == DashboardWidgetTypes.get_id_for_type_name("issue")
         assert widgets[2].discover_widget_split is None
+
+
+class OrganizationDashboardDetailsOnDemandTransactionLikeTest(
+    OrganizationDashboardDetailsOnDemandTest
+):
+    # Re-run the on-demand tests with the transaction-like widget type
+    widget_type = DashboardWidgetTypes.TRANSACTION_LIKE
 
 
 class OrganizationDashboardVisitTest(OrganizationDashboardDetailsTestCase):


### PR DESCRIPTION
Ensures that the proper on-demand objects are created when widgets are updated and created.

Since the discover split can create transaction types, we need to catch these types when creating the corresponding on demand objects. I've colocated the ondemand tests into one test class and parameterized the widget type so we can test the functionality against transaction widgets as well.