### PR TITLE
chore(bitbucket-server): installation step metrics

### DIFF
--- a/src/sentry/integrations/bitbucket_server/integration.py
+++ b/src/sentry/integrations/bitbucket_server/integration.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from typing import Any
 from urllib.parse import urlparse
 
@@ -16,6 +15,7 @@ from rest_framework.request import Request
 
 from sentry.integrations.base import (
     FeatureDescription,
+    IntegrationDomain,
     IntegrationFeatureNotImplementedError,
     IntegrationFeatures,
     IntegrationMetadata,
@@ -26,6 +26,10 @@ from sentry.integrations.services.repository import repository_service
 from sentry.integrations.services.repository.model import RpcRepository
 from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.integrations.tasks.migrate_repo import migrate_repo
+from sentry.integrations.utils.metrics import (
+    IntegrationPipelineViewEvent,
+    IntegrationPipelineViewType,
+)
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization import RpcOrganizationSummary
 from sentry.pipeline import PipelineView
@@ -35,8 +39,6 @@ from sentry.web.helpers import render_to_response
 
 from .client import BitbucketServerClient, BitbucketServerSetupClient
 from .repository import BitbucketServerRepositoryProvider
-
-logger = logging.getLogger("sentry.integrations.bitbucket_server")
 
 DESCRIPTION = """
 Connect your Sentry organization to Bitbucket Server, enabling the following features:
@@ -164,37 +166,38 @@ class OAuthLoginView(PipelineView):
 
     @method_decorator(csrf_exempt)
     def dispatch(self, request: Request, pipeline) -> HttpResponse:
-        if "oauth_token" in request.GET:
-            return pipeline.next_step()
+        with IntegrationPipelineViewEvent(
+            IntegrationPipelineViewType.OAUTH_LOGIN,
+            IntegrationDomain.SOURCE_CODE_MANAGEMENT,
+            BitbucketServerIntegrationProvider.key,
+        ).capture() as lifecycle:
+            if "oauth_token" in request.GET:
+                return pipeline.next_step()
 
-        config = pipeline.fetch_state("installation_data")
-        client = BitbucketServerSetupClient(
-            config.get("url"),
-            config.get("consumer_key"),
-            config.get("private_key"),
-            config.get("verify_ssl"),
-        )
-
-        try:
-            request_token = client.get_request_token()
-        except ApiError as error:
-            logger.info(
-                "identity.bitbucket-server.request-token",
-                extra={"url": config.get("url"), "error": error},
+            config = pipeline.fetch_state("installation_data")
+            client = BitbucketServerSetupClient(
+                config.get("url"),
+                config.get("consumer_key"),
+                config.get("private_key"),
+                config.get("verify_ssl"),
             )
-            return pipeline.error(f"Could not fetch a request token from Bitbucket. {error}")
 
-        pipeline.bind_state("request_token", request_token)
-        if not request_token.get("oauth_token"):
-            logger.info(
-                "identity.bitbucket-server.oauth-token",
-                extra={"url": config.get("url")},
-            )
-            return pipeline.error("Missing oauth_token")
+            try:
+                request_token = client.get_request_token()
+            except ApiError as error:
+                lifecycle.record_failure({"failure_reason": str(error), "url": config.get("url")})
+                return pipeline.error(f"Could not fetch a request token from Bitbucket. {error}")
 
-        authorize_url = client.get_authorize_url(request_token)
+            pipeline.bind_state("request_token", request_token)
+            if not request_token.get("oauth_token"):
+                lifecycle.record_failure(
+                    {"failure_reason": "missing oauth_token", "url": config.get("url")}
+                )
+                return pipeline.error("Missing oauth_token")
 
-        return self.redirect(authorize_url)
+            authorize_url = client.get_authorize_url(request_token)
+
+            return self.redirect(authorize_url)
 
 
 class OAuthCallbackView(PipelineView):
@@ -205,25 +208,32 @@ class OAuthCallbackView(PipelineView):
 
     @method_decorator(csrf_exempt)
     def dispatch(self, request: Request, pipeline) -> HttpResponse:
-        config = pipeline.fetch_state("installation_data")
-        client = BitbucketServerSetupClient(
-            config.get("url"),
-            config.get("consumer_key"),
-            config.get("private_key"),
-            config.get("verify_ssl"),
-        )
-
-        try:
-            access_token = client.get_access_token(
-                pipeline.fetch_state("request_token"), request.GET["oauth_token"]
+        with IntegrationPipelineViewEvent(
+            IntegrationPipelineViewType.OAUTH_CALLBACK,
+            IntegrationDomain.SOURCE_CODE_MANAGEMENT,
+            BitbucketServerIntegrationProvider.key,
+        ).capture() as lifecycle:
+            config = pipeline.fetch_state("installation_data")
+            client = BitbucketServerSetupClient(
+                config.get("url"),
+                config.get("consumer_key"),
+                config.get("private_key"),
+                config.get("verify_ssl"),
             )
 
-            pipeline.bind_state("access_token", access_token)
+            try:
+                access_token = client.get_access_token(
+                    pipeline.fetch_state("request_token"), request.GET["oauth_token"]
+                )
 
-            return pipeline.next_step()
-        except ApiError as error:
-            logger.info("identity.bitbucket-server.access-token", extra={"error": error})
-            return pipeline.error(f"Could not fetch an access token from Bitbucket. {str(error)}")
+                pipeline.bind_state("access_token", access_token)
+
+                return pipeline.next_step()
+            except ApiError as error:
+                lifecycle.record_failure({"failure_reason": str(error)})
+                return pipeline.error(
+                    f"Could not fetch an access token from Bitbucket. {str(error)}"
+                )
 
 
 class BitbucketServerIntegration(RepositoryIntegration):

--- a/tests/sentry/integrations/bitbucket_server/test_integration.py
+++ b/tests/sentry/integrations/bitbucket_server/test_integration.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import responses
 from requests.exceptions import ReadTimeout
 
@@ -5,6 +7,7 @@ from fixtures.bitbucket_server import EXAMPLE_PRIVATE_KEY
 from sentry.integrations.bitbucket_server.integration import BitbucketServerIntegrationProvider
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.utils.metrics import EventLifecycleOutcome
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.users.models.identity import Identity, IdentityProvider
@@ -13,6 +16,12 @@ from sentry.users.models.identity import Identity, IdentityProvider
 @control_silo_test
 class BitbucketServerIntegrationTest(IntegrationTestCase):
     provider = BitbucketServerIntegrationProvider
+
+    def assert_failure_metric(self, mock_record, error_msg):
+        (event_failures,) = (
+            call for call in mock_record.mock_calls if call.args[0] == EventLifecycleOutcome.FAILURE
+        )
+        assert event_failures.args[1]["failure_reason"] == error_msg
 
     def test_config_view(self):
         resp = self.client.get(self.init_path)
@@ -80,7 +89,8 @@ class BitbucketServerIntegrationTest(IntegrationTestCase):
         self.assertContains(resp, "Consumer key is limited to 200")
 
     @responses.activate
-    def test_authentication_request_token_timeout(self):
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_authentication_request_token_timeout(self, mock_record):
         timeout = ReadTimeout("Read timed out. (read timeout=30)")
         responses.add(
             responses.POST,
@@ -104,8 +114,13 @@ class BitbucketServerIntegrationTest(IntegrationTestCase):
         self.assertContains(resp, "request token from Bitbucket")
         self.assertContains(resp, "Timed out")
 
+        self.assert_failure_metric(
+            mock_record, "Timed out attempting to reach host: bitbucket.example.com"
+        )
+
     @responses.activate
-    def test_authentication_request_token_fails(self):
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_authentication_request_token_fails(self, mock_record):
         responses.add(
             responses.POST,
             "https://bitbucket.example.com/plugins/servlet/oauth/request-token",
@@ -126,6 +141,8 @@ class BitbucketServerIntegrationTest(IntegrationTestCase):
         assert resp.status_code == 200
         self.assertContains(resp, "Setup Error")
         self.assertContains(resp, "request token from Bitbucket")
+
+        self.assert_failure_metric(mock_record, "")
 
     @responses.activate
     def test_authentication_request_token_redirect(self):
@@ -155,7 +172,8 @@ class BitbucketServerIntegrationTest(IntegrationTestCase):
         assert redirect == resp["Location"]
 
     @responses.activate
-    def test_authentication_access_token_failure(self):
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_authentication_access_token_failure(self, mock_record):
         responses.add(
             responses.POST,
             "https://bitbucket.example.com/plugins/servlet/oauth/request-token",
@@ -163,12 +181,13 @@ class BitbucketServerIntegrationTest(IntegrationTestCase):
             content_type="text/plain",
             body="oauth_token=abc123&oauth_token_secret=def456",
         )
+        error_msg = "<html>it broke</html>"
         responses.add(
             responses.POST,
             "https://bitbucket.example.com/plugins/servlet/oauth/access-token",
             status=500,
             content_type="text/plain",
-            body="<html>it broke</html>",
+            body=error_msg,
         )
 
         # Get config page
@@ -190,6 +209,8 @@ class BitbucketServerIntegrationTest(IntegrationTestCase):
         assert resp.status_code == 200
         self.assertContains(resp, "Setup Error")
         self.assertContains(resp, "access token from Bitbucket")
+
+        self.assert_failure_metric(mock_record, error_msg)
 
     def install_integration(self):
         # Get config page
@@ -213,7 +234,8 @@ class BitbucketServerIntegrationTest(IntegrationTestCase):
         return resp
 
     @responses.activate
-    def test_authentication_verifier_expired(self):
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_authentication_verifier_expired(self, mock_record):
         responses.add(
             responses.POST,
             "https://bitbucket.example.com/plugins/servlet/oauth/request-token",
@@ -221,12 +243,13 @@ class BitbucketServerIntegrationTest(IntegrationTestCase):
             content_type="text/plain",
             body="oauth_token=abc123&oauth_token_secret=def456",
         )
+        error_msg = "oauth_error=token+expired"
         responses.add(
             responses.POST,
             "https://bitbucket.example.com/plugins/servlet/oauth/access-token",
             status=404,
             content_type="text/plain",
-            body="oauth_error=token+expired",
+            body=error_msg,
         )
 
         # Try getting the token but it has expired for some reason,
@@ -235,6 +258,8 @@ class BitbucketServerIntegrationTest(IntegrationTestCase):
 
         self.assertContains(resp, "Setup Error")
         self.assertContains(resp, "access token from Bitbucket")
+
+        self.assert_failure_metric(mock_record, error_msg)
 
     @responses.activate
     def test_authentication_success(self):


### PR DESCRIPTION
Installation step metrics for 2/3 `PipelineViews` for Bitbucket Server. The other `PipelineView` just renders a form so it's not terribly useful to capture metrics there.

This one has tests, strangely enough (and Bitbucket doesn't).