### PR TITLE
feat(issue-stream): Make group details text all subtext colored

### DIFF
--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -209,6 +209,14 @@ const AnnotationNoMargin = styled(EventAnnotation)<{hasNewLayout: boolean}>`
   border-left: none;
 
   ${p =>
+    !p.hasNewLayout &&
+    css`
+      & > a {
+        color: ${p.theme.textColor};
+      }
+    `}
+
+  ${p =>
     p.hasNewLayout &&
     css`
       & > a:hover {

--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -1,10 +1,11 @@
 import {Fragment} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {ErrorLevelText} from 'sentry/components/events/errorLevelText';
 import EventAnnotation from 'sentry/components/events/eventAnnotation';
 import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
-import InboxShortId from 'sentry/components/group/inboxBadges/shortId';
+import ShortId from 'sentry/components/group/inboxBadges/shortId';
 import TimesTag from 'sentry/components/group/inboxBadges/timesTag';
 import UnhandledTag from 'sentry/components/group/inboxBadges/unhandledTag';
 import IssueReplayCount from 'sentry/components/group/issueReplayCount';
@@ -85,7 +86,7 @@ function EventOrGroupExtraDetails({
 
   const items = [
     shortId ? (
-      <InboxShortId
+      <ShortId
         shortId={shortId}
         avatar={
           project && <ShadowlessProjectBadge project={project} avatarSize={12} hideName />
@@ -109,7 +110,7 @@ function EventOrGroupExtraDetails({
     ) : null,
     showReplayCount ? <IssueReplayCount group={data as Group} /> : null,
     logger ? (
-      <LoggerAnnotation>
+      <LoggerAnnotation hasNewLayout={hasNewLayout}>
         <GlobalSelectionLink
           to={{
             pathname: issuesPath,
@@ -123,7 +124,7 @@ function EventOrGroupExtraDetails({
       </LoggerAnnotation>
     ) : null,
     ...(annotations?.map((annotation, key) => (
-      <AnnotationNoMargin key={key}>
+      <AnnotationNoMargin key={key} hasNewLayout={hasNewLayout}>
         <ExternalLink href={annotation.url}>{annotation.displayName}</ExternalLink>
       </AnnotationNoMargin>
     )) ?? []),
@@ -167,9 +168,14 @@ const GroupExtra = styled('div')<{hasNewLayout: boolean}>`
   white-space: nowrap;
   line-height: 1.2;
 
-  a {
-    color: inherit;
-  }
+  ${p =>
+    p.hasNewLayout &&
+    css`
+      color: ${p.theme.subText};
+      & > a {
+        color: ${p.theme.subText};
+      }
+    `}
 
   @media (min-width: ${p => p.theme.breakpoints.xlarge}) {
     line-height: 1;
@@ -197,13 +203,18 @@ const CommentsLink = styled(Link)`
   color: ${p => p.theme.textColor};
 `;
 
-const AnnotationNoMargin = styled(EventAnnotation)`
+const AnnotationNoMargin = styled(EventAnnotation)<{hasNewLayout: boolean}>`
   margin-left: 0;
   padding-left: 0;
   border-left: none;
-  & > a {
-    color: ${p => p.theme.textColor};
-  }
+
+  ${p =>
+    p.hasNewLayout &&
+    css`
+      & > a:hover {
+        color: ${p.theme.linkHoverColor};
+      }
+    `}
 `;
 
 const LoggerAnnotation = styled(AnnotationNoMargin)`

--- a/static/app/components/group/inboxBadges/shortId.tsx
+++ b/static/app/components/group/inboxBadges/shortId.tsx
@@ -37,5 +37,4 @@ const IdWrapper = styled('div')`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  margin-top: 1px;
 `;

--- a/static/app/components/group/issueReplayCount.tsx
+++ b/static/app/components/group/issueReplayCount.tsx
@@ -54,6 +54,10 @@ const ReplayCountLink = styled(Link)`
   color: ${p => p.theme.gray400};
   font-size: ${p => p.theme.fontSizeSmall};
   gap: 0 ${space(0.5)};
+
+  &:hover {
+    color: ${p => p.theme.linkHoverColor};
+  }
 `;
 
 export default IssueReplayCount;


### PR DESCRIPTION
closes #79019

Before: 

<img width="1954" alt="image" src="https://github.com/user-attachments/assets/6902ef61-148a-4d30-ba90-b4797bdca9e9">

After: 

<img width="1995" alt="image" src="https://github.com/user-attachments/assets/c79768c3-2b4f-4073-b19b-b56a46c3e83e">
