### PR TITLE
fix(eap): Count takes arg

### DIFF
--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -222,12 +222,7 @@ SPAN_FUNCTION_DEFINITIONS = {
     "sum": FunctionDefinition(
         internal_function=Function.FUNCTION_SUM,
         search_type="duration",
-        arguments=[
-            ArgumentDefinition(
-                argument_type="duration",
-                default_arg="span.duration",
-            )
-        ],
+        arguments=[ArgumentDefinition(argument_type="duration", default_arg="span.duration")],
     ),
     "avg": FunctionDefinition(
         internal_function=Function.FUNCTION_AVERAGE,
@@ -237,7 +232,7 @@ SPAN_FUNCTION_DEFINITIONS = {
     "count": FunctionDefinition(
         internal_function=Function.FUNCTION_COUNT,
         search_type="number",
-        arguments=[ArgumentDefinition(ignored=True)],
+        arguments=[ArgumentDefinition(argument_type="duration", default_arg="span.duration")],
     ),
     "p50": FunctionDefinition(
         internal_function=Function.FUNCTION_P50,

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -318,12 +318,16 @@ class SearchResolverColumnTest(TestCase):
     def test_count(self):
         resolved_column, virtual_context = self.resolver.resolve_column("count()")
         assert resolved_column.proto_definition == AttributeAggregation(
-            aggregate=Function.FUNCTION_COUNT, key=None, label="count()"
+            aggregate=Function.FUNCTION_COUNT,
+            key=AttributeKey(name="duration_ms", type=AttributeKey.Type.TYPE_INT),
+            label="count()",
         )
         assert virtual_context is None
         resolved_column, virtual_context = self.resolver.resolve_column("count(span.duration)")
         assert resolved_column.proto_definition == AttributeAggregation(
-            aggregate=Function.FUNCTION_COUNT, key=None, label="count(span.duration)"
+            aggregate=Function.FUNCTION_COUNT,
+            key=AttributeKey(name="duration_ms", type=AttributeKey.Type.TYPE_INT),
+            label="count(span.duration)",
         )
         assert virtual_context is None
 


### PR DESCRIPTION
Unlike before, count() will now take an argument to count the numeric attribute with a default to count `span.duration`.