### PR TITLE
fix(issue-stream): Increase group summary margin to match headers

### DIFF
--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -706,7 +706,7 @@ const Wrapper = styled(PanelItem)<{
 const GroupSummary = styled('div')<{canSelect: boolean; hasNewLayout: boolean}>`
   overflow: hidden;
   margin-left: ${p => space(p.canSelect ? 1 : 2)};
-  margin-right: ${space(1)};
+  margin-right: ${p => (p.hasNewLayout ? space(2) : space(1))};
   flex: 1;
   width: 66.66%;
 


### PR DESCRIPTION
before: 


<img width="1354" alt="Screenshot 2024-10-11 at 3 07 43 PM" src="https://github.com/user-attachments/assets/b90ed41e-cd26-4be0-be21-cd3a34fe2294">


after: 


<img width="1468" alt="Screenshot 2024-10-11 at 3 06 58 PM" src="https://github.com/user-attachments/assets/8bb6b989-3a3b-4420-984e-1b84f4501e06">
