### PR TITLE
fix(issue-stream): Fix bug where replay divider was shown despite no replays

### DIFF
--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -80,7 +80,7 @@ function EventOrGroupExtraDetails({
     organization.features.includes('session-replay') &&
     projectCanLinkToReplay(organization, project) &&
     data.issueCategory &&
-    getReplayCountForIssue(data.id, data.issueCategory);
+    !!getReplayCountForIssue(data.id, data.issueCategory);
 
   const hasNewLayout = organization.features.includes('issue-stream-table-layout');
   const {subtitle} = getTitle(data);

--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -20,6 +20,7 @@ import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {getTitle} from 'sentry/utils/events';
+import useReplayCountForIssues from 'sentry/utils/replayCount/useReplayCountForIssues';
 import {projectCanLinkToReplay} from 'sentry/utils/replays/projectSupportsReplay';
 import withOrganization from 'sentry/utils/withOrganization';
 
@@ -73,10 +74,13 @@ function EventOrGroupExtraDetails({
   } = data as Group;
 
   const issuesPath = `/organizations/${organization.slug}/issues/`;
+  const {getReplayCountForIssue} = useReplayCountForIssues();
 
   const showReplayCount =
     organization.features.includes('session-replay') &&
-    projectCanLinkToReplay(organization, project);
+    projectCanLinkToReplay(organization, project) &&
+    data.issueCategory &&
+    getReplayCountForIssue(data.id, data.issueCategory);
 
   const hasNewLayout = organization.features.includes('issue-stream-table-layout');
   const {subtitle} = getTitle(data);


### PR DESCRIPTION
closes #79020
before: 

<img width="363" alt="image" src="https://github.com/user-attachments/assets/73e0283c-0d3f-4bb0-8f4f-053bfd703ab3">

after:

<img width="369" alt="image" src="https://github.com/user-attachments/assets/e74a0573-2da5-460d-a1eb-2affe9620953">

