### PR TITLE
fix: add info to post process TypeErrors for debugging

### DIFF
--- a/src/sentry/interfaces/contexts.py
+++ b/src/sentry/interfaces/contexts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import string
 from typing import Any, ClassVar, TypeVar
 
+import sentry_sdk
 from django.utils.encoding import force_str
 
 from sentry.interfaces.base import Interface
@@ -232,7 +233,12 @@ class Contexts(Interface):
     @classmethod
     def normalize_context(cls, alias, data):
         ctx_type = data.get("type", alias)
-        ctx_cls = context_types.get(ctx_type, DefaultContextType)
+        try:
+            ctx_cls = context_types.get(ctx_type, DefaultContextType)
+        except TypeError:
+            # Debugging information for SENTRY-FOR-SENTRY-2NH2.
+            sentry_sdk.set_context("ctx_type", ctx_type)
+            raise
         return ctx_cls(alias, data)
 
     def iter_contexts(self):


### PR DESCRIPTION
Add debugging info to the errors logged to `SENTRY-FOR-SENTRY-2NH2` (a `TypeError`: `unhashable
type: 'list'` in `sentry.tasks.post_process.post_process_group`). Lists shouldn't ever show up in the `type` field - trying to track down what's going on.