### PR TITLE
ref(events): Add `has_stacktrace` property to `BaseEvent` class

### DIFF
--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -240,6 +240,8 @@ def get_stacktrace_string(data: dict[str, Any]) -> str:
     return stacktrace_str.strip()
 
 
+# TODO: Once `get_stacktrace_string` learns to handle top-level stacktraces, this can go away in
+# favor of `event.has_stacktrace`
 def event_content_has_stacktrace(event: Event) -> bool:
     # If an event has no stacktrace, there's no data for Seer to analyze, so no point in making the
     # API call. If we ever start analyzing message-only events, we'll need to add `event.title in


### PR DESCRIPTION
This adds a new property, `has_stacktrace`, to the `BaseEvent` class. It does exactly what you'd expect, given the name, handling the obvious cases (a single stacktrace in either `exception` or `threads`) as well as the less obvious ones (top-level stacktraces, such as you might get by using `attach_stacktrace` with `capture_exception`, and cases where there are multiple stacktraces, such as with a chained exception).

Note: We currently have a similar utility function, `event_content_has_stacktrace`, which we use when deciding whether or not to send a given event to Seer. The reasons I chose not to just move that function to a more neutral location and use it are a) that function doesn't handle top-level stacktraces, and b) in cases where there are multiple exceptions, it only looks at the last one in the chain. These are things we probably want to fix, but we can't do that without also changing `get_stacktrace_string` and adding a bunch of new tests. At that point it felt like I would be straying too far afield from the core purpose of this PR, so instead I just left a TODO.