### PR TITLE
ref(ingest): annotate transaction consumer with spans

### DIFF
--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -88,37 +88,42 @@ def process_event(
     # This code has been ripped from the old python store endpoint. We're
     # keeping it around because it does provide some protection against
     # reprocessing good events if a single consumer is in a restart loop.
-    deduplication_key = f"ev:{project_id}:{event_id}"
+    with sentry_sdk.start_span(op="deduplication_check"):
+        deduplication_key = f"ev:{project_id}:{event_id}"
 
-    try:
-        cached_value = cache.get(deduplication_key)
-    except Exception as exc:
-        raise Retriable(exc)
+        try:
+            cached_value = cache.get(deduplication_key)
+        except Exception as exc:
+            raise Retriable(exc)
 
-    if cached_value is not None:
-        logger.warning(
-            "pre-process-forwarder detected a duplicated event" " with id:%s for project:%s.",
-            event_id,
-            project_id,
-        )
-        return  # message already processed do not reprocess
+        if cached_value is not None:
+            logger.warning(
+                "pre-process-forwarder detected a duplicated event" " with id:%s for project:%s.",
+                event_id,
+                project_id,
+            )
+            return  # message already processed do not reprocess
 
-    if killswitch_matches_context(
-        "store.load-shed-pipeline-projects",
-        {
-            "project_id": project_id,
-            "event_id": event_id,
-            "has_attachments": bool(attachments),
-        },
+    with sentry_sdk.start_span(
+        op="killswitch_matches_context", name="store.load-shed-pipeline-projects"
     ):
-        # This killswitch is for the worst of scenarios and should probably not
-        # cause additional load on our logging infrastructure
-        return
+        if killswitch_matches_context(
+            "store.load-shed-pipeline-projects",
+            {
+                "project_id": project_id,
+                "event_id": event_id,
+                "has_attachments": bool(attachments),
+            },
+        ):
+            # This killswitch is for the worst of scenarios and should probably not
+            # cause additional load on our logging infrastructure
+            return
 
     # Parse the JSON payload. This is required to compute the cache key and
     # call process_event. The payload will be put into Kafka raw, to avoid
     # serializing it again.
-    data = orjson.loads(payload)
+    with sentry_sdk.start_span(op="orjson.loads"):
+        data = orjson.loads(payload)
 
     if project_id == settings.SENTRY_PROJECT:
         metrics.incr(
@@ -126,17 +131,20 @@ def process_event(
             tags={"event_type": data.get("type") or "null"},
         )
 
-    if killswitch_matches_context(
-        "store.load-shed-parsed-pipeline-projects",
-        {
-            "organization_id": project.organization_id,
-            "project_id": project.id,
-            "event_type": data.get("type") or "null",
-            "has_attachments": bool(attachments),
-            "event_id": event_id,
-        },
+    with sentry_sdk.start_span(
+        op="killswitch_matches_context", name="store.load-shed-parsed-pipeline-projects"
     ):
-        return
+        if killswitch_matches_context(
+            "store.load-shed-parsed-pipeline-projects",
+            {
+                "organization_id": project.organization_id,
+                "project_id": project.id,
+                "event_type": data.get("type") or "null",
+                "has_attachments": bool(attachments),
+                "event_id": event_id,
+            },
+        ):
+            return
 
     # Raise the retriable exception and skip DLQ if anything below this point fails as it may be caused by
     # intermittent network issue
@@ -144,8 +152,10 @@ def process_event(
         # If we only want to reprocess "stuck" events, we check if this event is already in the
         # `processing_store`. We only continue here if the event *is* present, as that will eventually
         # process and consume the event from the `processing_store`, whereby getting it "unstuck".
-        if reprocess_only_stuck_events and not event_processing_store.exists(data):
-            return
+        if reprocess_only_stuck_events:
+            with sentry_sdk.start_span(op="event_processing_store.exists"):
+                if not event_processing_store.exists(data):
+                    return
 
         with metrics.timer("ingest_consumer._store_event"):
             cache_key = event_processing_store.store(data)


### PR DESCRIPTION
Occasionally we're seeing long `ingest_consumer.process_event` transactions, but the span tree doesn't reveal the bottleneck. There's a big (200ms+) gap at the start of the trace before the first child span (`ingest_consumer._store_event`). To track down what's happening during this time, add spans around each potentially time-consuming operation before that span.

![Screenshot 2024-10-15 at 10 52 33 AM](https://github.com/user-attachments/assets/05ced6a5-6efb-4f6d-8a45-5807cf35d185)
