### PR TITLE
fix: transaction queue config

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -836,7 +836,7 @@ CELERY_ROUTES = ("sentry.queue.routers.SplitQueueTaskRouter",)
 # and a default one as destination. The default one is used when the
 # rollout option is not active.
 CELERY_SPLIT_QUEUE_TASK_ROUTES_REGION: Mapping[str, SplitQueueTaskRoute] = {
-    "events.save_event_transaction": {
+    "sentry.tasks.store.save_event_transaction": {
         "default_queue": "events.save_event_transaction",
         "queues_config": {
             "total": 3,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2785,3 +2785,11 @@ register(
     default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# TODO: Temporary, to be removed
+register(
+    "split_queue_task_router.enable",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -12,6 +12,7 @@ from celery import current_task
 from django.conf import settings
 from django.db.models import Model
 
+from sentry import options
 from sentry.celery import app
 from sentry.silo.base import SiloLimit, SiloMode
 from sentry.utils import metrics
@@ -136,11 +137,13 @@ def instrumented_task(name, stat_suffix=None, silo_mode=None, record_timing=Fals
         # If the split task router is configured for the task, always use queues defined
         # in the split task configuration
         if name in settings.CELERY_SPLIT_QUEUE_TASK_ROUTES:
-            q = kwargs.pop("queue")
-            if q:
-                logger.warning(
-                    "ignoring queue: %s, using value from CELERY_SPLIT_QUEUE_TASK_ROUTES", q
-                )
+            # TODO: remove this option once rolled out
+            if options.get("split_queue_task_router.enable"):
+                q = kwargs.pop("queue")
+                if q:
+                    logger.warning(
+                        "ignoring queue: %s, using value from CELERY_SPLIT_QUEUE_TASK_ROUTES", q
+                    )
 
         # We never use result backends in Celery. Leaving `trail=True` means that if we schedule
         # many tasks from a parent task, each task leaks memory. This can lead to the scheduler


### PR DESCRIPTION
this fixes a couple of issues that led to #inc-922

- the config task had the wrong name and wasn't being picked up
- the split queue config was not being respected if a queue_name was defined

this change enables split queue config to be rolled out via config only (and thus to be tested and reverted via ops) and no longer requires additional code changes, making the process less prone to error.
