### PR TITLE
feat(crons): Sort environments intentionally

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -34,6 +34,8 @@ from sentry.db.models.query import in_iexact
 from sentry.models.environment import Environment
 from sentry.models.organization import Organization
 from sentry.monitors.models import (
+    DEFAULT_STATUS_ORDER,
+    MONITOR_ENVIRONMENT_ORDERING,
     Monitor,
     MonitorEnvironment,
     MonitorLimitsExceeded,
@@ -65,18 +67,6 @@ def map_value_to_constant(constant, value):
 
 from rest_framework.request import Request
 from rest_framework.response import Response
-
-DEFAULT_ORDERING = [
-    MonitorStatus.ERROR,
-    MonitorStatus.OK,
-    MonitorStatus.ACTIVE,
-    MonitorStatus.DISABLED,
-]
-
-MONITOR_ENVIRONMENT_ORDERING = Case(
-    *[When(status=s, then=Value(i)) for i, s in enumerate(DEFAULT_ORDERING)],
-    output_field=IntegerField(),
-)
 
 
 def flip_sort_direction(sort_field: str) -> str:
@@ -163,8 +153,8 @@ class OrganizationMonitorIndexEndpoint(OrganizationEndpoint):
             queryset = queryset.annotate(
                 environment_status_ordering=Case(
                     # Sort DISABLED and is_muted monitors to the bottom of the list
-                    When(status=ObjectStatus.DISABLED, then=Value(len(DEFAULT_ORDERING) + 1)),
-                    When(is_muted=True, then=Value(len(DEFAULT_ORDERING))),
+                    When(status=ObjectStatus.DISABLED, then=Value(len(DEFAULT_STATUS_ORDER) + 1)),
+                    When(is_muted=True, then=Value(len(DEFAULT_STATUS_ORDER))),
                     default=Subquery(
                         monitor_environments_query.annotate(
                             status_ordering=MONITOR_ENVIRONMENT_ORDERING

--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -10,6 +10,7 @@ from sentry.api.serializers.models.actor import ActorSerializer, ActorSerializer
 from sentry.models.environment import Environment
 from sentry.models.project import Project
 from sentry.monitors.models import (
+    MONITOR_ENVIRONMENT_ORDERING,
     Monitor,
     MonitorCheckIn,
     MonitorEnvBrokenDetection,
@@ -198,7 +199,8 @@ class MonitorSerializer(Serializer):
 
         monitor_environments_qs = (
             MonitorEnvironment.objects.filter(monitor__in=item_list)
-            .order_by("-last_checkin")
+            .annotate(status_ordering=MONITOR_ENVIRONMENT_ORDERING)
+            .order_by("status_ordering", "-last_checkin", "environment_id")
             .exclude(
                 status__in=[MonitorStatus.PENDING_DELETION, MonitorStatus.DELETION_IN_PROGRESS]
             )


### PR DESCRIPTION
Orders them as

 - Muted at the end
 - Errors first, followed by other statuses
 - finally sorted by last check-in times

Fixes [JAVASCRIPT-2W9T](https://sentry.sentry.io/feedback/?feedbackSlug=javascript%3A5989234934&project=11276)