### PR TITLE
fix(issues): Attachments link opens tags

### DIFF
--- a/static/app/views/issueDetails/streamline/attachmentsBadge.spec.tsx
+++ b/static/app/views/issueDetails/streamline/attachmentsBadge.spec.tsx
@@ -50,8 +50,8 @@ describe('AttachmentsBadge', () => {
 
     render(<AttachmentsBadge group={group} />);
 
-    expect(
-      await screen.findByRole('button', {name: '50+ Attachments'})
-    ).toBeInTheDocument();
+    const button = await screen.findByRole('button', {name: '50+ Attachments'});
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute('href', expect.stringContaining('/attachments/'));
   });
 });

--- a/static/app/views/issueDetails/streamline/attachmentsBadge.tsx
+++ b/static/app/views/issueDetails/streamline/attachmentsBadge.tsx
@@ -43,7 +43,7 @@ export function AttachmentsBadge({group}: {group: Group}) {
         size="zero"
         icon={<IconAttachment size="xs" />}
         to={{
-          pathname: `${baseUrl}${TabPaths[Tab.TAGS]}`,
+          pathname: `${baseUrl}${TabPaths[Tab.ATTACHMENTS]}`,
           query: location.query,
           replace: true,
         }}


### PR DESCRIPTION
missed this when setting up the new routes

fixes JAVASCRIPT-2W9P