### PR TITLE
ref(crons): Add types to monitor bucket merge

### DIFF
--- a/static/app/views/monitors/components/timeline/utils/mergeEnvMappings.spec.tsx
+++ b/static/app/views/monitors/components/timeline/utils/mergeEnvMappings.spec.tsx
@@ -1,17 +1,19 @@
+import type {MonitorBucketEnvMapping} from 'sentry/views/monitors/components/timeline/types';
+
 import {mergeEnvMappings} from './mergeEnvMappings';
 
 describe('mergeEnvMappings', function () {
   it('merges two empty mappings', function () {
-    const envMappingA = {};
-    const envMappingB = {};
+    const envMappingA: MonitorBucketEnvMapping = {};
+    const envMappingB: MonitorBucketEnvMapping = {};
     const mergedMapping = mergeEnvMappings(envMappingA, envMappingB);
 
     expect(mergedMapping).toEqual({});
   });
 
   it('merges one empty mapping with one filled mapping', function () {
-    const envMappingA = {};
-    const envMappingB = {
+    const envMappingA: MonitorBucketEnvMapping = {};
+    const envMappingB: MonitorBucketEnvMapping = {
       prod: {in_progress: 0, ok: 1, missed: 0, timeout: 0, error: 0},
     };
     const mergedMapping = mergeEnvMappings(envMappingA, envMappingB);
@@ -20,13 +22,13 @@ describe('mergeEnvMappings', function () {
   });
 
   it('merges two filled mappings', function () {
-    const envMappingA = {
+    const envMappingA: MonitorBucketEnvMapping = {
       prod: {in_progress: 0, ok: 0, missed: 1, timeout: 2, error: 1},
     };
-    const envMappingB = {
+    const envMappingB: MonitorBucketEnvMapping = {
       prod: {in_progress: 2, ok: 1, missed: 1, timeout: 0, error: 2},
     };
-    const expectedMerged = {
+    const expectedMerged: MonitorBucketEnvMapping = {
       prod: {in_progress: 2, ok: 1, missed: 2, timeout: 2, error: 3},
     };
     const mergedMapping = mergeEnvMappings(envMappingA, envMappingB);
@@ -35,11 +37,13 @@ describe('mergeEnvMappings', function () {
   });
 
   it('merges two filled mappings with differing envs', function () {
-    const envMappingA = {
+    const envMappingA: MonitorBucketEnvMapping = {
       prod: {in_progress: 1, ok: 0, missed: 1, timeout: 2, error: 1},
     };
-    const envMappingB = {dev: {in_progress: 0, ok: 1, missed: 1, timeout: 0, error: 2}};
-    const expectedMerged = {
+    const envMappingB: MonitorBucketEnvMapping = {
+      dev: {in_progress: 0, ok: 1, missed: 1, timeout: 0, error: 2},
+    };
+    const expectedMerged: MonitorBucketEnvMapping = {
       prod: {in_progress: 1, ok: 0, missed: 1, timeout: 2, error: 1},
       dev: {in_progress: 0, ok: 1, missed: 1, timeout: 0, error: 2},
     };

--- a/static/app/views/monitors/components/timeline/utils/mergeEnvMappings.tsx
+++ b/static/app/views/monitors/components/timeline/utils/mergeEnvMappings.tsx
@@ -1,4 +1,4 @@
-import type {MonitorBucketEnvMapping} from '../types';
+import type {MonitorBucketEnvMapping, StatsBucket} from '../types';
 
 import {CHECKIN_STATUS_PRECEDENT} from './constants';
 
@@ -9,18 +9,18 @@ import {CHECKIN_STATUS_PRECEDENT} from './constants';
 export function mergeEnvMappings(
   envMappingA: MonitorBucketEnvMapping,
   envMappingB: MonitorBucketEnvMapping
-) {
+): MonitorBucketEnvMapping {
   const combinedEnvs = new Set([
     ...Object.keys(envMappingA),
     ...Object.keys(envMappingB),
   ]);
-  return [...combinedEnvs].reduce((mergedEnvs, env) => {
-    const mergedStatusCounts = {};
+  return [...combinedEnvs].reduce<MonitorBucketEnvMapping>((mergedEnvs, env) => {
+    const mergedStatusCounts: Partial<StatsBucket> = {};
     for (const status of CHECKIN_STATUS_PRECEDENT) {
       mergedStatusCounts[status] =
         (envMappingA[env]?.[status] ?? 0) + (envMappingB[env]?.[status] ?? 0);
     }
-    mergedEnvs[env] = mergedStatusCounts;
+    mergedEnvs[env] = mergedStatusCounts as StatsBucket;
     return mergedEnvs;
   }, {});
 }


### PR DESCRIPTION
using `{}` as the type in a few places

part of https://github.com/getsentry/frontend-tsc/issues/79
