### PR TITLE
feat(teams): Prune outdated team invites if they no longer apply

### DIFF
--- a/src/sentry/api/endpoints/organization_access_request_details.py
+++ b/src/sentry/api/endpoints/organization_access_request_details.py
@@ -79,8 +79,6 @@ class OrganizationAccessRequestDetailsEndpoint(OrganizationEndpoint):
         Get a list of requests to join org/team.
         If any requests are outdated, take this opportunity to prune them.
         """
-        OrganizationAccessRequest.objects.prune_outdated_team_requests(organization=organization)
-
         if request.access.has_scope("org:write"):
             access_requests = list(
                 OrganizationAccessRequest.objects.filter(

--- a/src/sentry/api/endpoints/organization_access_request_details.py
+++ b/src/sentry/api/endpoints/organization_access_request_details.py
@@ -77,7 +77,7 @@ class OrganizationAccessRequestDetailsEndpoint(OrganizationEndpoint):
     def get(self, request: Request, organization) -> Response:
         """
         Get a list of requests to join org/team.
-        If any requests are outdated, take this opportunity to prune them.
+        If any requests are redundant (user already joined the team), they are not returned.
         """
         if request.access.has_scope("org:write"):
             access_requests = list(

--- a/src/sentry/api/endpoints/organization_access_request_details.py
+++ b/src/sentry/api/endpoints/organization_access_request_details.py
@@ -103,6 +103,8 @@ class OrganizationAccessRequestDetailsEndpoint(OrganizationEndpoint):
             return Response([])
 
         teams_by_user = OrganizationMember.objects.get_teams_by_user(organization=organization)
+
+        # We omit any requests which are now redundant (i.e. the user joined that team some other way)
         valid_access_requests: list[OrganizationAccessRequest] = []
         for access_request in access_requests:
             if access_request.member.user_id is None:

--- a/src/sentry/api/endpoints/organization_access_request_details.py
+++ b/src/sentry/api/endpoints/organization_access_request_details.py
@@ -103,13 +103,12 @@ class OrganizationAccessRequestDetailsEndpoint(OrganizationEndpoint):
         teams_by_user = OrganizationMember.objects.get_teams_by_user(organization=organization)
 
         # We omit any requests which are now redundant (i.e. the user joined that team some other way)
-        valid_access_requests: list[OrganizationAccessRequest] = []
-        for access_request in access_requests:
-            if access_request.member.user_id is None:
-                continue
-            if access_request.team_id in teams_by_user[access_request.member.user_id]:
-                continue
-            valid_access_requests.append(access_request)
+        valid_access_requests = [
+            access_request
+            for access_request in access_requests
+            if access_request.member.user_id is not None
+            and access_request.team_id not in teams_by_user[access_request.member.user_id]
+        ]
 
         return Response(serialize(valid_access_requests, request.user))
 

--- a/tests/sentry/api/endpoints/test_organization_access_request_details.py
+++ b/tests/sentry/api/endpoints/test_organization_access_request_details.py
@@ -5,6 +5,40 @@ from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.testutils.cases import APITestCase
 
 
+class GetOrganizationAccessRequestTest(APITestCase):
+    def test_only_returns_valid_requests(self):
+        owner_user = self.create_user("owner@example.com")
+        organization = self.create_organization(owner=owner_user)
+        team = self.create_team(organization=organization)
+        self.create_team_membership(team=team, user=owner_user)
+        joined_team_member = self.create_member(
+            organization=organization,
+            role="member",
+            user=self.create_user("joined-team@example.com"),
+        )
+        not_joined_team_member = self.create_member(
+            organization=organization,
+            role="member",
+            user=self.create_user("not-joined-team@example.com"),
+        )
+        OrganizationAccessRequest.objects.create(member=joined_team_member, team=team)
+        not_joined_request = OrganizationAccessRequest.objects.create(
+            member=not_joined_team_member, team=team
+        )
+        self.create_team_membership(team=team, member=joined_team_member)
+
+        self.login_as(owner_user)
+        resp = self.client.get(
+            reverse("sentry-api-0-organization-access-requests", args=[organization.slug])
+        )
+
+        # We omit the request that has already been fulfilled by a user joining the team some other way.
+        assert len(resp.data) == 1
+        assert resp.data[0]["id"] == str(not_joined_request.id)
+        assert resp.data[0]["member"]["id"] == str(not_joined_request.member.id)
+        assert resp.data[0]["team"]["id"] == str(not_joined_request.team.id)
+
+
 class UpdateOrganizationAccessRequestTest(APITestCase):
     def test_approve_request(self):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_organization_access_request_details.py
+++ b/tests/sentry/api/endpoints/test_organization_access_request_details.py
@@ -16,12 +16,18 @@ class GetOrganizationAccessRequestTest(APITestCase):
             role="member",
             user=self.create_user("joined-team@example.com"),
         )
+        invite_email_member = self.create_member(
+            organization=organization,
+            role="member",
+            email="invite-email@example.com",
+        )
         not_joined_team_member = self.create_member(
             organization=organization,
             role="member",
             user=self.create_user("not-joined-team@example.com"),
         )
         OrganizationAccessRequest.objects.create(member=joined_team_member, team=team)
+        OrganizationAccessRequest.objects.create(member=invite_email_member, team=team)
         not_joined_request = OrganizationAccessRequest.objects.create(
             member=not_joined_team_member, team=team
         )
@@ -33,6 +39,7 @@ class GetOrganizationAccessRequestTest(APITestCase):
         )
 
         # We omit the request that has already been fulfilled by a user joining the team some other way.
+        # We also omit email invites to teams (since those cannot be approved until the user creates a Sentry account)
         assert len(resp.data) == 1
         assert resp.data[0]["id"] == str(not_joined_request.id)
         assert resp.data[0]["member"]["id"] == str(not_joined_request.member.id)


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry/issues/77945. Not sure about this approach, but the code works. I think this makes more sense to implement as a celery-beat task, so I may investigate that  in a follow up.

For now though, querying the list access requests endpoint will first remove any outdated team requests (from users already having joined those teams, before returning a list to the frontend. While I considered trying to ensure everywhere a user joins a team we could query and remove any team requests, there would be no way to ensure that logic stays linked, and ultimately doesn't help the existing organizations with these requests that can be pruned.

**todo**
- [x] Add tests to verify this new behavior