### PR TITLE
ref(ui):  Add missing object types

### DIFF
--- a/static/app/actionCreators/events.tsx
+++ b/static/app/actionCreators/events.tsx
@@ -51,7 +51,7 @@ type Options = {
   project?: Readonly<number[]>;
   query?: string;
   queryBatching?: QueryBatching;
-  queryExtras?: Record<string, string>;
+  queryExtras?: Record<string, string | boolean | number>;
   referrer?: string;
   start?: DateString;
   team?: Readonly<string | string[]>;

--- a/static/app/actionCreators/plugins.tsx
+++ b/static/app/actionCreators/plugins.tsx
@@ -9,7 +9,7 @@ import {t} from 'sentry/locale';
 import PluginsStore from 'sentry/stores/pluginsStore';
 import type {Plugin} from 'sentry/types/integrations';
 
-const activeFetch = {};
+const activeFetch: Record<string, Promise<any> | null> = {};
 // PluginsStore always exists, so api client should be independent of component lifecycle
 const api = new Client();
 

--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -189,7 +189,7 @@ type EventsRequestPartialProps = {
   /**
    * Extra query parameters to be added.
    */
-  queryExtras?: Record<string, string>;
+  queryExtras?: Record<string, string | boolean | number>;
   /**
    * A unique name for what's triggering this request, see organization_events_stats for an allowlist
    */

--- a/static/app/components/charts/releaseSeries.tsx
+++ b/static/app/components/charts/releaseSeries.tsx
@@ -46,7 +46,7 @@ function getOrganizationReleases(
   organization: Organization,
   conditions: ReleaseConditions
 ) {
-  const query = {};
+  const query: Record<string, string> = {};
   Object.keys(conditions).forEach(key => {
     let value = conditions[key];
     if (value && (key === 'start' || key === 'end')) {

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -201,7 +201,7 @@ function AutofixInsightCard({
                   <div>
                     {insight.stacktrace_context
                       .map((stacktrace, i) => {
-                        let vars = {};
+                        let vars: any = {};
                         try {
                           vars = JSON.parse(stacktrace.vars_as_json);
                         } catch {

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -83,7 +83,7 @@ function Content({
   }
 
   function setInitialFrameMap(): {[frameIndex: number]: boolean} {
-    const indexMap = {};
+    const indexMap: Record<string, boolean> = {};
     (data.frames ?? []).forEach((frame, frameIdx) => {
       const nextFrame = (data.frames ?? [])[frameIdx + 1];
       const repeatedFrame = isRepeatedFrame(frame, nextFrame);
@@ -96,7 +96,7 @@ function Content({
 
   function getInitialFrameCounts(): {[frameIndex: number]: number} {
     let count = 0;
-    const countMap = {};
+    const countMap: Record<string, number> = {};
     (data.frames ?? []).forEach((frame, frameIdx) => {
       const nextFrame = (data.frames ?? [])[frameIdx + 1];
       const repeatedFrame = isRepeatedFrame(frame, nextFrame);

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -330,7 +330,7 @@ class SpanTreeModel {
 
     const groupedDescendants: DescendantGroup[] = [];
     // Used to number sibling groups in case there are multiple groups with the same op and description
-    const siblingGroupOccurrenceMap = {};
+    const siblingGroupOccurrenceMap: Record<string, number> = {};
 
     const addGroupToMap = (prevSpanModel: SpanTreeModel, group: SpanTreeModel[]) => {
       if (!group.length) {

--- a/static/app/components/globalSelectionLink.tsx
+++ b/static/app/components/globalSelectionLink.tsx
@@ -64,7 +64,7 @@ function GlobalSelectionLink(props: Props) {
     return <Link {...routerProps} />;
   }
 
-  let queryStringObject = {};
+  let queryStringObject: typeof globalQuery = {};
   if (typeof to === 'object' && to.search) {
     queryStringObject = qs.parse(to.search);
   }

--- a/static/app/components/loadingIndicator.tsx
+++ b/static/app/components/loadingIndicator.tsx
@@ -39,7 +39,7 @@ function LoadingIndicator(props: Props) {
     'loading-indicator': true,
   });
 
-  let loadingStyle = {};
+  let loadingStyle: React.CSSProperties = {};
   if (size) {
     loadingStyle = {
       width: size,

--- a/static/app/plugins/jira/components/issueActions.tsx
+++ b/static/app/plugins/jira/components/issueActions.tsx
@@ -30,9 +30,9 @@ class IssueActions extends DefaultIssueActions {
                 // Try not to change things the user might have edited
                 // unless they're no longer valid
                 const oldData = this.state.createFormData;
-                const createFormData = {};
+                const createFormData: Record<string, any> = {};
                 data?.forEach(field => {
-                  let val;
+                  let val: any;
                   if (
                     field.choices &&
                     !field.choices.find(c => c[0] === oldData[field.name])

--- a/static/app/utils/__mocks__/localStorage.tsx
+++ b/static/app/utils/__mocks__/localStorage.tsx
@@ -1,5 +1,5 @@
 const localStorageMock = function () {
-  let store = {};
+  let store: Record<string, string | null> = {};
   return {
     getItem: jest.fn(key => store[key]),
     setItem: jest.fn((key, value) => {

--- a/static/app/utils/getProjectsByTeams.tsx
+++ b/static/app/utils/getProjectsByTeams.tsx
@@ -6,7 +6,7 @@ export default function getProjectsByTeams(
   projects: Project[],
   isSuperuser: boolean = false
 ): {projectsByTeam: {[teamSlug: string]: Project[]}; teamlessProjects: Project[]} {
-  const projectsByTeam = {};
+  const projectsByTeam: Record<string, Project[]> = {};
   const teamlessProjects: Project[] = [];
   let usersTeams = new Set(teams.filter(team => team.isMember).map(team => team.slug));
 

--- a/static/app/utils/profiling/colors/utils.tsx
+++ b/static/app/utils/profiling/colors/utils.tsx
@@ -11,7 +11,7 @@ function uniqueCountBy<T>(
   arr: ReadonlyArray<T>,
   predicate: (t: T) => string | boolean
 ): number {
-  const visited = {};
+  const visited: Record<string, number> = {};
 
   let count = 0;
   for (let i = 0; i < arr.length; i++) {

--- a/static/app/views/admin/installWizard/index.tsx
+++ b/static/app/views/admin/installWizard/index.tsx
@@ -54,7 +54,7 @@ export default class InstallWizard extends DeprecatedAsyncView<
     }
 
     // A mapping of option name to Field object
-    const fields = {};
+    const fields: Record<string, React.ReactNode> = {};
 
     for (const key of missingOptions) {
       const option = options[key];

--- a/static/app/views/admin/options.tsx
+++ b/static/app/views/admin/options.tsx
@@ -661,21 +661,20 @@ export function getOptionField(option: string, field: Field) {
   );
 }
 
-function getSectionFieldSet(section: Section, fields: Field[]) {
+function getSectionFieldSet(section: Section, fields: React.ReactNode[]) {
   return (
     <fieldset key={section.key}>
       {section.heading && <legend>{section.heading}</legend>}
-      {/* TODO(TS): Types indicate fields can be an object */}
-      {fields as React.ReactNode}
+      {fields}
     </fieldset>
   );
 }
 
-export function getForm(fieldMap: Record<string, Field>) {
+export function getForm(fieldMap: Record<string, React.ReactNode>) {
   const sets: React.ReactNode[] = [];
 
   for (const section of sections) {
-    const set: Field[] = [];
+    const set: React.ReactNode[] = [];
 
     for (const option of optionsForSection(section)) {
       if (fieldMap[option.key]) {

--- a/static/app/views/explore/contexts/spanTagsContext.tsx
+++ b/static/app/views/explore/contexts/spanTagsContext.tsx
@@ -143,7 +143,7 @@ function useTypedSpanTags({
   });
 
   const tags: TagCollection = useMemo(() => {
-    const allTags = {};
+    const allTags: TagCollection = {};
 
     for (const tag of result.data ?? []) {
       // For now, skip all the sentry. prefixed tags as they

--- a/static/app/views/insights/http/views/httpLandingPage.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.tsx
@@ -63,7 +63,7 @@ export function HTTPLandingPage() {
     },
   });
 
-  const ADDITIONAL_FILTERS = {};
+  const ADDITIONAL_FILTERS: {[SpanMetricsField.USER_GEO_SUBREGION]?: string} = {};
 
   if (query[SpanMetricsField.USER_GEO_SUBREGION].length > 0) {
     ADDITIONAL_FILTERS[SpanMetricsField.USER_GEO_SUBREGION] =

--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -179,7 +179,7 @@ function MonitorForm({
   const {selection} = usePageFilters();
 
   function formDataFromConfig(type: MonitorType, config: MonitorConfig) {
-    const rv = {};
+    const rv: Record<string, MonitorConfig[keyof MonitorConfig]> = {};
     switch (type) {
       case 'cron_job':
         rv['config.scheduleType'] = config.schedule_type;

--- a/static/app/views/performance/landing/widgets/utils.tsx
+++ b/static/app/views/performance/landing/widgets/utils.tsx
@@ -31,13 +31,13 @@ function setWidgetStorageObject(localObject: Record<string, string>) {
   localStorage.setItem(getContainerLocalStorageObjectKey, JSON.stringify(localObject));
 }
 
-const mepQueryParamBase = {};
+const mepQueryParamBase: Record<string, string> = {};
 
 export function getMEPQueryParams(
   mepContext: MetricsEnhancedSettingContext,
   forceAuto?: boolean
 ) {
-  let queryParams = {};
+  let queryParams: Record<string, string> = {};
   const base = mepQueryParamBase;
   if (mepContext.shouldQueryProvideMEPAutoParams || forceAuto) {
     queryParams = {

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -321,7 +321,8 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
         fields: field,
         component: provided => {
           const eventView = props.eventView.clone();
-          let extraQueryParams = getMEPParamsIfApplicable(mepSetting, props.chartSetting);
+          let extraQueryParams: Record<string, string | boolean | number> =
+            getMEPParamsIfApplicable(mepSetting, props.chartSetting)!;
           const pageFilterDatetime = {
             start: provided.start,
             end: provided.end,

--- a/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
@@ -108,7 +108,7 @@ function EventsContentWrapper(props: ChildProps) {
       eventsDisplayFilterName
     ].sort;
     const currentSort = eventView?.sorts?.[0];
-    let sortQuery = {};
+    let sortQuery: Record<string, string> = {};
 
     if (
       eventsFilterOptionSort?.kind === currentSort?.kind &&

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/spanSummaryTable.tsx
@@ -188,7 +188,7 @@ export default function SpanSummaryTable(props: Props) {
   });
 
   // Restructure the transaction durations into a map for faster lookup
-  const transactionDurationMap = {};
+  const transactionDurationMap: Record<string, number> = {};
   txnDurationData?.data.forEach(datum => {
     transactionDurationMap[datum.id] = datum['transaction.duration'];
   });

--- a/static/app/views/performance/trends/content.tsx
+++ b/static/app/views/performance/trends/content.tsx
@@ -90,7 +90,7 @@ class TrendsContent extends Component<Props, State> {
   handleTrendFunctionChange = (field: string) => {
     const {organization, location} = this.props;
 
-    const offsets = {};
+    const offsets: Record<string, undefined> = {};
 
     Object.values(TrendChangeType).forEach(trendChangeType => {
       const queryKey = getSelectedQueryKey(trendChangeType);

--- a/static/app/views/performance/trends/utils/index.tsx
+++ b/static/app/views/performance/trends/utils/index.tsx
@@ -146,7 +146,7 @@ export const trendCursorNames = {
 const TOKEN_KEYS_SUPPORTED_IN_METRICS_TRENDS = ['transaction', 'tpm()'];
 
 export function resetCursors() {
-  const cursors = {};
+  const cursors: Record<string, undefined> = {};
   Object.values(trendCursorNames).forEach(cursor => (cursors[cursor] = undefined)); // Resets both cursors
   return cursors;
 }

--- a/static/app/views/replays/detail/tagPanel/useTagFilters.tsx
+++ b/static/app/views/replays/detail/tagPanel/useTagFilters.tsx
@@ -47,7 +47,7 @@ function useTagFilters({tags}: Options): Return {
   );
 
   // Get from type Record<string, string[]>[] to Record<string, string[]>
-  const items = {};
+  const items: Record<string, string[]> = {};
   Object.values(filteredItems).forEach(item => {
     for (const key in item) {
       items[key] = item[key];

--- a/static/app/views/settings/projectDebugFiles/sources/customRepositories/utils.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/customRepositories/utils.tsx
@@ -54,7 +54,7 @@ export function getRequestMessages(
 }
 
 export function expandKeys(obj: CustomRepo) {
-  const result = {};
+  const result: Record<string, string> = {};
   forEach(obj, (value, key) => {
     set(result, key.split('.'), value);
   });

--- a/static/app/views/stories/storyTree.tsx
+++ b/static/app/views/stories/storyTree.tsx
@@ -64,7 +64,7 @@ function FolderContent({path, content}: {content: TreeMapping; path: string}) {
 interface TreeMapping extends Record<string, TreeMapping> {}
 
 function toTree(files: string[]): TreeMapping {
-  const root = {};
+  const root: Record<string, TreeMapping> = {};
   for (const file of files) {
     const parts = file.split('/');
     let tree = root;

--- a/tests/js/sentry-test/loadFixtures.ts
+++ b/tests/js/sentry-test/loadFixtures.ts
@@ -18,7 +18,7 @@ export function loadFixtures(dir: string, opts: Options = {}) {
   const from = path.join(FIXTURES_ROOT, dir);
   const files = fs.readdirSync(from);
 
-  const fixtures = {};
+  const fixtures: Record<string, any> = {};
 
   for (const file of files) {
     const filePath = path.join(from, file);
@@ -32,7 +32,7 @@ export function loadFixtures(dir: string, opts: Options = {}) {
   }
 
   if (opts.flatten) {
-    const flattenedFixtures = {};
+    const flattenedFixtures: Record<string, any> = {};
 
     for (const moduleKey in fixtures) {
       for (const moduleExport in fixtures[moduleKey]) {


### PR DESCRIPTION
Instead of the implicit `{}` type, add types to various objects.

part of https://github.com/getsentry/frontend-tsc/issues/79
