### PR TITLE
fix(ci): Specify docker compose file when checking for logs and status

### DIFF
--- a/.github/workflows/test_docker_compose_acceptance.yml
+++ b/.github/workflows/test_docker_compose_acceptance.yml
@@ -127,8 +127,8 @@ jobs:
       - name: Inspect failure
         if: failure()
         run: |
-          docker compose ps
-          docker compose logs --tail 1000
+          docker compose -f devservices/docker-compose-testing.yml ps
+          docker compose -f devservices/docker-compose-testing.yml logs --tail 1000
 
   docker-compose-acceptance-required-checks:
     # this is a required check so we need this job to always run and report a status.

--- a/.github/workflows/test_docker_compose_backend.yml
+++ b/.github/workflows/test_docker_compose_backend.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Inspect failure
         if: failure()
         run: |
-          docker compose ps
-          docker compose logs --tail 1000
+          docker compose -f devservices/docker-compose-testing.yml ps
+          docker compose -f devservices/docker-compose-testing.yml logs --tail 1000
 
   docker-compose-backend-test:
     name: backend test
@@ -108,8 +108,8 @@ jobs:
       - name: Inspect failure
         if: failure()
         run: |
-          docker compose ps
-          docker compose logs --tail 1000
+          docker compose -f devservices/docker-compose-testing.yml ps
+          docker compose -f devservices/docker-compose-testing.yml logs --tail 1000
 
   docker-compose-backend-migration-tests:
     name: backend migration tests
@@ -147,8 +147,8 @@ jobs:
       - name: Inspect failure
         if: failure()
         run: |
-          docker compose ps
-          docker compose logs --tail 1000
+          docker compose -f devservices/docker-compose-testing.yml ps
+          docker compose -f devservices/docker-compose-testing.yml logs --tail 1000
 
   docker-compose-cli:
     name: cli test
@@ -185,8 +185,8 @@ jobs:
       - name: Inspect failure
         if: failure()
         run: |
-          docker compose ps
-          docker compose logs --tail 1000
+          docker compose -f devservices/docker-compose-testing.yml ps
+          docker compose -f devservices/docker-compose-testing.yml logs --tail 1000
 
   docker-compose-migration:
     name: check migration
@@ -218,8 +218,8 @@ jobs:
       - name: Inspect failure
         if: failure()
         run: |
-          docker compose ps
-          docker compose logs --tail 1000
+          docker compose -f devservices/docker-compose-testing.yml ps
+          docker compose -f devservices/docker-compose-testing.yml logs --tail 1000
 
   docker-compose-monolith-dbs:
     name: monolith-dbs test
@@ -266,8 +266,8 @@ jobs:
       - name: Inspect failure
         if: failure()
         run: |
-          docker compose ps
-          docker compose logs --tail 1000
+          docker compose -f devservices/docker-compose-testing.yml ps
+          docker compose -f devservices/docker-compose-testing.yml logs --tail 1000
 
   # This check runs once all dependent jobs have passed
   # It symbolizes that all required Backend checks have succesfully passed (Or skipped)


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/actions/runs/11338166056/job/31530927543

We need to specify the docker compose configuration file. 🤦‍♂️