### PR TITLE
ref(mediators): Turn project rule creator to dataclass

### DIFF
--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -844,7 +844,18 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         created_alert_rule_ui_component = trigger_sentry_app_action_creators_for_issues(
             kwargs["actions"]
         )
-        rule = ProjectRuleCreator(request=request, **kwargs).run()
+        rule = ProjectRuleCreator(
+            name=kwargs.get("name"),
+            project=kwargs.get("project"),
+            action_match=kwargs.get("action_match"),
+            actions=kwargs.get("actions"),
+            conditions=kwargs.get("conditions"),
+            frequency=kwargs.get("frequency"),
+            environment=kwargs.get("environment"),
+            owner=kwargs.get("owner"),
+            filter_match=kwargs.get("filter_match"),
+            request=request,
+        ).run()
 
         RuleActivity.objects.create(
             rule=rule, user_id=request.user.id, type=RuleActivityType.CREATED.value

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -27,8 +27,8 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ObjectStatus
 from sentry.integrations.slack.tasks.find_channel_id_for_rule import find_channel_id_for_rule
 from sentry.integrations.slack.utils.rule_status import RedisRuleStatus
-from sentry.mediators.project_rules.creator import Creator
 from sentry.models.rule import Rule, RuleActivity, RuleActivityType
+from sentry.projects.project_rules.creator import ProjectRuleCreator
 from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.rules.actions.base import instantiate_action
 from sentry.rules.processing.processor import is_condition_slow
@@ -844,7 +844,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         created_alert_rule_ui_component = trigger_sentry_app_action_creators_for_issues(
             kwargs["actions"]
         )
-        rule = Creator.run(request=request, **kwargs)
+        rule = ProjectRuleCreator(request=request, **kwargs).run()
 
         RuleActivity.objects.create(
             rule=rule, user_id=request.user.id, type=RuleActivityType.CREATED.value

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -845,15 +845,15 @@ class ProjectRulesEndpoint(ProjectEndpoint):
             kwargs["actions"]
         )
         rule = ProjectRuleCreator(
-            name=kwargs.get("name"),
-            project=kwargs.get("project"),
-            action_match=kwargs.get("action_match"),
-            actions=kwargs.get("actions"),
-            conditions=kwargs.get("conditions"),
-            frequency=kwargs.get("frequency"),
-            environment=kwargs.get("environment"),
-            owner=kwargs.get("owner"),
-            filter_match=kwargs.get("filter_match"),
+            name=kwargs["name"],
+            project=project,
+            action_match=kwargs["action_match"],
+            actions=kwargs["actions"],
+            conditions=conditions,
+            frequency=kwargs["frequency"],
+            environment=kwargs["environment"],
+            owner=owner,
+            filter_match=kwargs["filter_match"],
             request=request,
         ).run()
 

--- a/src/sentry/integrations/slack/tasks/find_channel_id_for_rule.py
+++ b/src/sentry/integrations/slack/tasks/find_channel_id_for_rule.py
@@ -110,12 +110,12 @@ def find_channel_id_for_rule(
             rule = Updater.run(rule=rule, pending_save=False, **kwargs)
         else:
             rule = ProjectRuleCreator(
-                name=kwargs.get("name"),
-                project=kwargs.get("project"),
-                action_match=kwargs.get("action_match"),
-                actions=kwargs.get("actions"),
-                conditions=kwargs.get("conditions"),
-                frequency=kwargs.get("frequency"),
+                name=kwargs["name"],
+                project=project,
+                action_match=kwargs["action_match"],
+                actions=actions,
+                conditions=kwargs["conditions"],
+                frequency=kwargs["frequency"],
                 environment=kwargs.get("environment"),
                 owner=kwargs.get("owner"),
                 filter_match=kwargs.get("filter_match"),

--- a/src/sentry/integrations/slack/tasks/find_channel_id_for_rule.py
+++ b/src/sentry/integrations/slack/tasks/find_channel_id_for_rule.py
@@ -10,10 +10,10 @@ from sentry.integrations.slack.utils.channel import (
 )
 from sentry.integrations.slack.utils.constants import SLACK_RATE_LIMITED_MESSAGE
 from sentry.integrations.slack.utils.rule_status import RedisRuleStatus
-from sentry.mediators.project_rules.creator import Creator
 from sentry.mediators.project_rules.updater import Updater
 from sentry.models.project import Project
 from sentry.models.rule import Rule, RuleActivity, RuleActivityType
+from sentry.projects.project_rules.creator import ProjectRuleCreator
 from sentry.shared_integrations.exceptions import ApiRateLimitedError, DuplicateDisplayNameError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -109,7 +109,7 @@ def find_channel_id_for_rule(
             rule = Rule.objects.get(id=rule_id)
             rule = Updater.run(rule=rule, pending_save=False, **kwargs)
         else:
-            rule = Creator.run(pending_save=False, **kwargs)
+            rule = ProjectRuleCreator(pending_save=False, **kwargs).run()
             if user_id:
                 RuleActivity.objects.create(
                     rule=rule, user_id=user_id, type=RuleActivityType.CREATED.value

--- a/src/sentry/integrations/slack/tasks/find_channel_id_for_rule.py
+++ b/src/sentry/integrations/slack/tasks/find_channel_id_for_rule.py
@@ -117,7 +117,9 @@ def find_channel_id_for_rule(
                 conditions=kwargs.get("conditions"),
                 frequency=kwargs.get("frequency"),
                 environment=kwargs.get("environment"),
+                owner=kwargs.get("owner"),
                 filter_match=kwargs.get("filter_match"),
+                request=kwargs.get("request"),
             ).run()
             if user_id:
                 RuleActivity.objects.create(

--- a/src/sentry/integrations/slack/tasks/find_channel_id_for_rule.py
+++ b/src/sentry/integrations/slack/tasks/find_channel_id_for_rule.py
@@ -109,7 +109,16 @@ def find_channel_id_for_rule(
             rule = Rule.objects.get(id=rule_id)
             rule = Updater.run(rule=rule, pending_save=False, **kwargs)
         else:
-            rule = ProjectRuleCreator(pending_save=False, **kwargs).run()
+            rule = ProjectRuleCreator(
+                name=kwargs.get("name"),
+                project=kwargs.get("project"),
+                action_match=kwargs.get("action_match"),
+                actions=kwargs.get("actions"),
+                conditions=kwargs.get("conditions"),
+                frequency=kwargs.get("frequency"),
+                environment=kwargs.get("environment"),
+                filter_match=kwargs.get("filter_match"),
+            ).run()
             if user_id:
                 RuleActivity.objects.create(
                     rule=rule, user_id=user_id, type=RuleActivityType.CREATED.value

--- a/src/sentry/mediators/project_rules/__init__.py
+++ b/src/sentry/mediators/project_rules/__init__.py
@@ -1,2 +1,1 @@
-from .creator import Creator  # NOQA
 from .updater import Updater  # NOQA

--- a/src/sentry/monitors/utils.py
+++ b/src/sentry/monitors/utils.py
@@ -7,13 +7,13 @@ from rest_framework.request import Request
 
 from sentry.api.serializers.rest_framework.rule import RuleSerializer
 from sentry.db.models import BoundedPositiveIntegerField
-from sentry.mediators.project_rules.creator import Creator
 from sentry.mediators.project_rules.updater import Updater
 from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.models.rule import Rule, RuleActivity, RuleActivityType, RuleSource
 from sentry.monitors.constants import DEFAULT_CHECKIN_MARGIN, MAX_TIMEOUT, TIMEOUT
 from sentry.monitors.models import CheckInStatus, Monitor, MonitorCheckIn
+from sentry.projects.project_rules.creator import ProjectRuleCreator
 from sentry.signals import (
     cron_monitor_created,
     first_cron_checkin_received,
@@ -243,7 +243,7 @@ def create_issue_alert_rule(
         "user_id": request.user.id,
     }
 
-    rule = Creator.run(request=request, **kwargs)
+    rule = ProjectRuleCreator(request=request, **kwargs).run()
     rule.update(source=RuleSource.CRON_MONITOR)
     RuleActivity.objects.create(
         rule=rule, user_id=request.user.id, type=RuleActivityType.CREATED.value

--- a/src/sentry/monitors/utils.py
+++ b/src/sentry/monitors/utils.py
@@ -242,8 +242,18 @@ def create_issue_alert_rule(
         "frequency": data.get("frequency"),
         "user_id": request.user.id,
     }
-
-    rule = ProjectRuleCreator(request=request, **kwargs).run()
+    rule = ProjectRuleCreator(
+        name=kwargs.get("name"),
+        project=kwargs.get("project"),
+        action_match=kwargs.get("action_match"),
+        actions=kwargs.get("actions"),
+        conditions=kwargs.get("conditions"),
+        frequency=kwargs.get("frequency"),
+        environment=kwargs.get("environment"),
+        owner=kwargs.get("owner"),
+        filter_match=kwargs.get("filter_match"),
+        request=request,
+    ).run()
     rule.update(source=RuleSource.CRON_MONITOR)
     RuleActivity.objects.create(
         rule=rule, user_id=request.user.id, type=RuleActivityType.CREATED.value

--- a/src/sentry/monitors/utils.py
+++ b/src/sentry/monitors/utils.py
@@ -231,27 +231,15 @@ def create_issue_alert_rule(
     if "filters" in data:
         conditions.extend(data["filters"])
 
-    kwargs = {
-        "name": data["name"],
-        "environment": data.get("environment"),
-        "project": project,
-        "action_match": data["actionMatch"],
-        "filter_match": data.get("filterMatch"),
-        "conditions": conditions,
-        "actions": data.get("actions", []),
-        "frequency": data.get("frequency"),
-        "user_id": request.user.id,
-    }
     rule = ProjectRuleCreator(
-        name=kwargs.get("name"),
-        project=kwargs.get("project"),
-        action_match=kwargs.get("action_match"),
-        actions=kwargs.get("actions"),
-        conditions=kwargs.get("conditions"),
-        frequency=kwargs.get("frequency"),
-        environment=kwargs.get("environment"),
-        owner=kwargs.get("owner"),
-        filter_match=kwargs.get("filter_match"),
+        name=data["name"],
+        project=project,
+        action_match=data["actionMatch"],
+        actions=data.get("actions", []),
+        conditions=conditions,
+        frequency=data.get("frequency"),
+        environment=data.get("environment"),
+        filter_match=data.get("filterMatch"),
         request=request,
     ).run()
     rule.update(source=RuleSource.CRON_MONITOR)

--- a/src/sentry/projects/project_rules/creator.py
+++ b/src/sentry/projects/project_rules/creator.py
@@ -15,8 +15,8 @@ class ProjectRuleCreator:
     name: str
     project: Project
     action_match: str
-    actions: Sequence
-    conditions: Sequence
+    actions: Sequence[dict[str, Any]]
+    conditions: Sequence[dict[str, Any]]
     frequency: int
     environment: int | None = None
     owner: Actor | None = None

--- a/src/sentry/projects/project_rules/creator.py
+++ b/src/sentry/projects/project_rules/creator.py
@@ -1,29 +1,31 @@
-from django.db import router
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from django.db import router, transaction
 from rest_framework.request import Request
 
-from sentry.mediators.mediator import Mediator
-from sentry.mediators.param import Param
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.types.actor import Actor
 
 
-class Creator(Mediator):
-    name = Param(str)
-    environment = Param(int, required=False)
-    owner = Param(Actor, required=False)
-    project = Param(Project)
-    action_match = Param(str)
-    filter_match = Param(str, required=False)
-    actions = Param(list)
-    conditions = Param(list)
-    frequency = Param(int)
-    request = Param(Request, required=False)
-    using = router.db_for_write(Project)
+@dataclass
+class ProjectRuleCreator:
+    name: str
+    environment: int | None
+    owner: Actor | None
+    project: Project
+    action_match: str
+    filter_match: str | None
+    actions: Sequence
+    conditions: Sequence
+    frequency: int
+    request: Request | None
 
-    def call(self):
-        self.rule = self._create_rule()
-        return self.rule
+    def run(self):
+        with transaction.atomic(router.db_for_write(Rule)):
+            self.rule = self._create_rule()
+            return self.rule
 
     def _create_rule(self):
         kwargs = self._get_kwargs()

--- a/src/sentry/projects/project_rules/creator.py
+++ b/src/sentry/projects/project_rules/creator.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import Any
 
 from django.db import router, transaction
 from rest_framework.request import Request
@@ -12,28 +13,28 @@ from sentry.types.actor import Actor
 @dataclass
 class ProjectRuleCreator:
     name: str
-    environment: int | None
-    owner: Actor | None
     project: Project
     action_match: str
-    filter_match: str | None
     actions: Sequence
     conditions: Sequence
     frequency: int
-    request: Request | None
+    environment: int | None = None
+    owner: Actor | None = None
+    filter_match: str | None = None
+    request: Request | None = None
 
-    def run(self):
+    def run(self) -> Rule:
         with transaction.atomic(router.db_for_write(Rule)):
             self.rule = self._create_rule()
             return self.rule
 
-    def _create_rule(self):
+    def _create_rule(self) -> Rule:
         kwargs = self._get_kwargs()
         rule = Rule.objects.create(**kwargs)
 
         return rule
 
-    def _get_kwargs(self):
+    def _get_kwargs(self) -> dict[str, Any]:
         data = {
             "filter_match": self.filter_match,
             "action_match": self.action_match,

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3263,7 +3263,7 @@ class MonitorTestCase(APITestCase):
             name="New Cool Rule",
             project=self.project,
             conditions=conditions,
-            filterMatch="all",
+            filter_match="all",
             action_match="any",
             actions=actions,
             frequency=5,

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3268,7 +3268,7 @@ class MonitorTestCase(APITestCase):
             actions=actions,
             frequency=5,
             environment=self.environment.id,
-        ).call()
+        ).run()
         rule.update(source=RuleSource.CRON_MONITOR)
 
         config = monitor.config

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -83,7 +83,6 @@ from sentry.issues.grouptype import (
 )
 from sentry.issues.ingest import send_issue_occurrence_to_eventstream
 from sentry.mail import mail_adapter
-from sentry.mediators.project_rules.creator import Creator
 from sentry.models.apitoken import ApiToken
 from sentry.models.authprovider import AuthProvider as AuthProviderModel
 from sentry.models.commit import Commit
@@ -114,6 +113,7 @@ from sentry.notifications.notifications.base import alert_page_needs_org_id
 from sentry.notifications.types import FineTuningAPIKey
 from sentry.organizations.services.organization.serial import serialize_rpc_organization
 from sentry.plugins.base import plugins
+from sentry.projects.project_rules.creator import ProjectRuleCreator
 from sentry.replays.lib.event_linking import transform_event_for_linking_payload
 from sentry.replays.models import ReplayRecordingSegment
 from sentry.rules.base import RuleBase
@@ -3259,7 +3259,7 @@ class MonitorTestCase(APITestCase):
                 "uuid": str(uuid4()),
             },
         ]
-        rule = Creator(
+        rule = ProjectRuleCreator(
             name="New Cool Rule",
             project=self.project,
             conditions=conditions,

--- a/tests/sentry/projects/project_rules/test_creator.py
+++ b/tests/sentry/projects/project_rules/test_creator.py
@@ -1,10 +1,10 @@
-from sentry.mediators.project_rules.creator import Creator
 from sentry.models.rule import Rule
+from sentry.projects.project_rules.creator import ProjectRuleCreator
 from sentry.testutils.cases import TestCase
 from sentry.types.actor import Actor
 
 
-class TestCreator(TestCase):
+class TestProjectRuleCreator(TestCase):
     def setUp(self):
         self.user = self.create_user()
         self.org = self.create_organization(name="bloop", owner=self.user)
@@ -12,7 +12,7 @@ class TestCreator(TestCase):
             teams=[self.create_team()], name="foo", fire_project_created=True
         )
 
-        self.creator = Creator(
+        self.creator = ProjectRuleCreator(
             name="New Cool Rule",
             owner=Actor.from_id(user_id=self.user.id),
             project=self.project,
@@ -36,7 +36,7 @@ class TestCreator(TestCase):
         )
 
     def test_creates_rule(self):
-        r = self.creator.call()
+        r = self.creator.run()
         rule = Rule.objects.get(id=r.id)
         assert rule.label == "New Cool Rule"
         assert rule.owner_user_id == self.user.id

--- a/tests/sentry/projects/project_rules/test_creator.py
+++ b/tests/sentry/projects/project_rules/test_creator.py
@@ -37,7 +37,7 @@ class TestProjectRuleCreator(TestCase):
 
     def test_creates_rule(self):
         r = self.creator.run()
-        rule = Rule.objects.get(id=r.id)
+        rule: Rule = Rule.objects.get(id=r.id)
         assert rule.label == "New Cool Rule"
         assert rule.owner_user_id == self.user.id
         assert rule.owner_team_id is None

--- a/tests/sentry/projects/project_rules/test_creator.py
+++ b/tests/sentry/projects/project_rules/test_creator.py
@@ -1,5 +1,3 @@
-import pytest
-
 from sentry.models.rule import Rule
 from sentry.projects.project_rules.creator import ProjectRuleCreator
 from sentry.testutils.cases import TestCase
@@ -63,7 +61,3 @@ class TestProjectRuleCreator(TestCase):
             "filter_match": "any",
             "frequency": 5,
         }
-
-    def test_error_missing_fields(self):
-        with pytest.raises(TypeError):
-            ProjectRuleCreator(frequency=2).run()

--- a/tests/sentry/projects/project_rules/test_creator.py
+++ b/tests/sentry/projects/project_rules/test_creator.py
@@ -37,7 +37,7 @@ class TestProjectRuleCreator(TestCase):
 
     def test_creates_rule(self):
         r = self.creator.run()
-        rule: Rule = Rule.objects.get(id=r.id)
+        rule = Rule.objects.get(id=r.id)
         assert rule.label == "New Cool Rule"
         assert rule.owner_user_id == self.user.id
         assert rule.owner_team_id is None

--- a/tests/sentry/projects/project_rules/test_creator.py
+++ b/tests/sentry/projects/project_rules/test_creator.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sentry.models.rule import Rule
 from sentry.projects.project_rules.creator import ProjectRuleCreator
 from sentry.testutils.cases import TestCase
@@ -61,3 +63,7 @@ class TestProjectRuleCreator(TestCase):
             "filter_match": "any",
             "frequency": 5,
         }
+
+    def test_error_missing_fields(self):
+        with pytest.raises(TypeError):
+            ProjectRuleCreator(frequency=2).run()


### PR DESCRIPTION
Turns Creator -> ProjectRuleCreator to dataclass and update uses to be explicit in passing in params
