### PR TITLE
fix(replay): fix replay count tab query

### DIFF
--- a/static/app/utils/replayCount/useReplayCount.tsx
+++ b/static/app/utils/replayCount/useReplayCount.tsx
@@ -62,7 +62,10 @@ export default function useReplayCount({
             data_source: dataSource,
             project: -1,
             statsPeriod,
-            query: `${fieldName}:[${ids.join(',')}]`,
+            query:
+              fieldName === 'transaction'
+                ? `${fieldName}:[${ids.map(id => `"${id}"`).join(',')}]`
+                : `${fieldName}:[${ids.join(',')}]`,
           },
         },
       ],


### PR DESCRIPTION
sometimes transaction names have spaces. having something in the query like:

```
transaction:[/alerts/]
``` 
is fine, but

```
transaction:[GET 123]
``` 
breaks. this PR modifies the query so that we can query for transaction names with spaces and make our `replay-count` endpoint happy.

something like
```
transaction:["GET 123"]
``` 
now works.

before: 
<img width="1282" alt="SCR-20241015-kyit" src="https://github.com/user-attachments/assets/8169caa5-2155-4c7c-82a2-f45c2f9d7bcf">
see endpoint failure
<img width="649" alt="SCR-20241015-kyns" src="https://github.com/user-attachments/assets/eaf300ec-b81a-47a5-93f7-7649a552c409">
this results in badge with no number.

after: 
<img width="1291" alt="SCR-20241015-kyju" src="https://github.com/user-attachments/assets/3f92fb3e-57eb-4986-851e-6908246b12c2">
endpoint is happy, badge shows 0 as expected
<img width="651" alt="SCR-20241015-kypo" src="https://github.com/user-attachments/assets/85b7b4fc-414b-415d-a2e8-3dbcabbe95c7">

closes https://github.com/getsentry/sentry/issues/79086