### PR TITLE
fix(eap): Handle missing attributes in aggregation

### DIFF
--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -643,6 +643,24 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
             function.name: function
             for function in [
                 SnQLFunction(
+                    "eps",
+                    snql_aggregate=lambda args, alias: Function(
+                        "divide", [Function("count", []), args["interval"]], alias
+                    ),
+                    optional_args=[IntervalDefault("interval", 1, None)],
+                    default_result_type="rate",
+                ),
+                SnQLFunction(
+                    "epm",
+                    snql_aggregate=lambda args, alias: Function(
+                        "divide",
+                        [Function("count", []), Function("divide", [args["interval"], 60])],
+                        alias,
+                    ),
+                    optional_args=[IntervalDefault("interval", 1, None)],
+                    default_result_type="rate",
+                ),
+                SnQLFunction(
                     "count",
                     optional_args=[
                         with_default("span.duration", NumericColumn("column", spans=True)),
@@ -899,6 +917,10 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
                 ),
             ]
         }
+
+        for alias, name in constants.SPAN_FUNCTION_ALIASES.items():
+            if name in function_converter:
+                function_converter[alias] = function_converter[name].alias_as(alias)
 
         return function_converter
 

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -651,6 +651,12 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
                     default_result_type="integer",
                 ),
                 SnQLFunction(
+                    "count_unique",
+                    required_args=[ColumnTagArg("column")],
+                    snql_aggregate=lambda args, alias: Function("uniq", [args["column"]], alias),
+                    default_result_type="integer",
+                ),
+                SnQLFunction(
                     "sum",
                     required_args=[NumericColumn("column", spans=True)],
                     snql_aggregate=self._resolve_aggregate_if("sum"),

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -565,12 +565,184 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
             alias,
         )
 
+    def _resolve_aggregate_if(
+        self, aggregate: str
+    ) -> Callable[[Mapping[str, str | Column | SelectType | int | float], str | None], SelectType]:
+        def extract_attr(
+            column: str | Column | SelectType | int | float,
+        ) -> tuple[Column, str] | None:
+            # This check exists to handle the temporay prefixing.
+            # Once that's removed, this condition should become much simpler
+
+            if not isinstance(column, Function):
+                return None
+
+            if column.function != "if":
+                return None
+
+            if len(column.parameters) != 3:
+                return None
+
+            if (
+                not isinstance(column.parameters[0], Function)
+                or column.parameters[0].function != "mapContains"
+                or len(column.parameters[0].parameters) != 2
+            ):
+                return None
+
+            attr_col = column.parameters[0].parameters[0]
+            attr_name = column.parameters[0].parameters[1]
+
+            if not isinstance(attr_col, Column) or not isinstance(attr_name, str):
+                return None
+
+            return attr_col, attr_name
+
+        def resolve_aggregate_if(
+            args: Mapping[str, str | Column | SelectType | int | float],
+            alias: str | None = None,
+        ) -> SelectType:
+            attr = extract_attr(args["column"])
+
+            # If we're not aggregating on an attr column,
+            # we can directly aggregate on the column
+            if attr is None:
+                return Function(
+                    f"{aggregate}",
+                    [args["column"]],
+                    alias,
+                )
+
+            # When aggregating on an attr column, we have to make sure that we skip rows
+            # where the attr does not exist.
+            attr_col, attr_name = attr
+
+            function = (
+                aggregate.replace("quantile", "quantileIf")
+                if aggregate.startswith("quantile(")
+                else f"{aggregate}If"
+            )
+
+            unprefixed = Function("mapContains", [attr_col, attr_name])
+            prefixed = Function("mapContains", [attr_col, f"sentry.{attr_name}"])
+
+            return Function(
+                function,
+                [
+                    args["column"],
+                    Function("or", [unprefixed, prefixed]),
+                ],
+                alias,
+            )
+
+        return resolve_aggregate_if
+
     @property
     def function_converter(self) -> dict[str, SnQLFunction]:
-        existing_functions = super().function_converter
         function_converter = {
             function.name: function
             for function in [
+                SnQLFunction(
+                    "count",
+                    optional_args=[
+                        with_default("span.duration", NumericColumn("column", spans=True)),
+                    ],
+                    snql_aggregate=self._resolve_aggregate_if("count"),
+                    default_result_type="integer",
+                ),
+                SnQLFunction(
+                    "sum",
+                    required_args=[NumericColumn("column", spans=True)],
+                    snql_aggregate=self._resolve_aggregate_if("sum"),
+                    result_type_fn=self.reflective_result_type(),
+                    default_result_type="duration",
+                ),
+                SnQLFunction(
+                    "avg",
+                    optional_args=[
+                        with_default("span.duration", NumericColumn("column", spans=True)),
+                    ],
+                    snql_aggregate=self._resolve_aggregate_if("avg"),
+                    result_type_fn=self.reflective_result_type(),
+                    default_result_type="duration",
+                    redundant_grouping=True,
+                ),
+                SnQLFunction(
+                    "p50",
+                    optional_args=[
+                        with_default("span.duration", NumericColumn("column", spans=True)),
+                    ],
+                    snql_aggregate=self._resolve_aggregate_if("quantile(0.5)"),
+                    result_type_fn=self.reflective_result_type(),
+                    default_result_type="duration",
+                    redundant_grouping=True,
+                ),
+                SnQLFunction(
+                    "p75",
+                    optional_args=[
+                        with_default("span.duration", NumericColumn("column", spans=True)),
+                    ],
+                    snql_aggregate=self._resolve_aggregate_if("quantile(0.75)"),
+                    result_type_fn=self.reflective_result_type(),
+                    default_result_type="duration",
+                    redundant_grouping=True,
+                ),
+                SnQLFunction(
+                    "p90",
+                    optional_args=[
+                        with_default("span.duration", NumericColumn("column", spans=True)),
+                    ],
+                    snql_aggregate=self._resolve_aggregate_if("quantile(0.90)"),
+                    result_type_fn=self.reflective_result_type(),
+                    default_result_type="duration",
+                    redundant_grouping=True,
+                ),
+                SnQLFunction(
+                    "p95",
+                    optional_args=[
+                        with_default("span.duration", NumericColumn("column", spans=True)),
+                    ],
+                    snql_aggregate=self._resolve_aggregate_if("quantile(0.95)"),
+                    result_type_fn=self.reflective_result_type(),
+                    default_result_type="duration",
+                    redundant_grouping=True,
+                ),
+                SnQLFunction(
+                    "p99",
+                    optional_args=[
+                        with_default("span.duration", NumericColumn("column", spans=True)),
+                    ],
+                    snql_aggregate=self._resolve_aggregate_if("quantile(0.99)"),
+                    result_type_fn=self.reflective_result_type(),
+                    default_result_type="duration",
+                    redundant_grouping=True,
+                ),
+                SnQLFunction(
+                    "p100",
+                    optional_args=[
+                        with_default("span.duration", NumericColumn("column", spans=True)),
+                    ],
+                    snql_aggregate=self._resolve_aggregate_if("max"),
+                    result_type_fn=self.reflective_result_type(),
+                    default_result_type="duration",
+                    redundant_grouping=True,
+                ),
+                SnQLFunction(
+                    "min",
+                    required_args=[NumericColumn("column", spans=True)],
+                    snql_aggregate=self._resolve_aggregate_if("min"),
+                    result_type_fn=self.reflective_result_type(),
+                    default_result_type="duration",
+                    redundant_grouping=True,
+                ),
+                SnQLFunction(
+                    "max",
+                    required_args=[NumericColumn("column", spans=True)],
+                    snql_aggregate=self._resolve_aggregate_if("max"),
+                    result_type_fn=self.reflective_result_type(),
+                    default_result_type="duration",
+                    redundant_grouping=True,
+                ),
                 SnQLFunction(
                     "count_weighted",
                     optional_args=[NullColumn("column")],
@@ -722,8 +894,7 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
             ]
         }
 
-        existing_functions.update(function_converter)
-        return existing_functions
+        return function_converter
 
     def _resolve_sum_weighted(
         self,

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -823,6 +823,7 @@ class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsSpanIndexedEndpoin
                     {
                         "description": "foo",
                         "sentry_tags": {"status": "success"},
+                        "tags": {"bar": "bar1"},
                     },
                     start_ts=self.ten_mins_ago,
                 ),
@@ -830,6 +831,7 @@ class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsSpanIndexedEndpoin
                     {
                         "description": "foo",
                         "sentry_tags": {"status": "success"},
+                        "tags": {"bar": "bar2"},
                     },
                     measurements={"foo": {"value": 5}},
                     start_ts=self.ten_mins_ago,
@@ -842,6 +844,9 @@ class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsSpanIndexedEndpoin
             {
                 "field": [
                     "description",
+                    "count_unique(bar)",
+                    "count_unique(tags[bar])",
+                    "count_unique(tags[bar,string])",
                     "count()",
                     "count(span.duration)",
                     "count(tags[foo,     number])",
@@ -867,6 +872,9 @@ class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsSpanIndexedEndpoin
         data = response.data["data"]
         assert data[0] == {
             "description": "foo",
+            "count_unique(bar)": 2,
+            "count_unique(tags[bar])": 2,
+            "count_unique(tags[bar,string])": 2,
             "count()": 2,
             "count(span.duration)": 2,
             "count(tags[foo,     number])": 1,

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -593,7 +593,7 @@ class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsSpanIndexedEndpoin
         )
         response = self.do_request(
             {
-                "field": ["span.duration", "description", "count()"],
+                "field": ["span.duration", "description"],
                 "query": "",
                 "orderby": "description",
                 "project": self.project.id,
@@ -607,14 +607,12 @@ class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsSpanIndexedEndpoin
         assert len(data) == 2
         assert data == [
             {
-                "span.duration": 1000,
+                "span.duration": 1000.0,
                 "description": "bar",
-                "count()": 1,
             },
             {
-                "span.duration": 1000,
+                "span.duration": 1000.0,
                 "description": "foo",
-                "count()": 1,
             },
         ]
         assert meta["dataset"] == self.dataset
@@ -826,6 +824,13 @@ class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsSpanIndexedEndpoin
                         "description": "foo",
                         "sentry_tags": {"status": "success"},
                     },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "description": "foo",
+                        "sentry_tags": {"status": "success"},
+                    },
                     measurements={"foo": {"value": 5}},
                     start_ts=self.ten_mins_ago,
                 ),
@@ -835,7 +840,21 @@ class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsSpanIndexedEndpoin
 
         response = self.do_request(
             {
-                "field": ["description", "avg(tags[foo,number])", "p50(tags[foo,      number])"],
+                "field": [
+                    "description",
+                    "count()",
+                    "count(span.duration)",
+                    "count(tags[foo,     number])",
+                    "sum(tags[foo,number])",
+                    "avg(tags[foo,number])",
+                    "p50(tags[foo,number])",
+                    "p75(tags[foo,number])",
+                    "p95(tags[foo,number])",
+                    "p99(tags[foo,number])",
+                    "p100(tags[foo,number])",
+                    "min(tags[foo,number])",
+                    "max(tags[foo,number])",
+                ],
                 "query": "",
                 "orderby": "description",
                 "project": self.project.id,
@@ -846,8 +865,21 @@ class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsSpanIndexedEndpoin
         assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 1
         data = response.data["data"]
-        assert data[0]["avg(tags[foo,number])"] == 5
-        assert data[0]["p50(tags[foo,      number])"] == 5
+        assert data[0] == {
+            "description": "foo",
+            "count()": 2,
+            "count(span.duration)": 2,
+            "count(tags[foo,     number])": 1,
+            "sum(tags[foo,number])": 5.0,
+            "avg(tags[foo,number])": 5.0,
+            "p50(tags[foo,number])": 5.0,
+            "p75(tags[foo,number])": 5.0,
+            "p95(tags[foo,number])": 5.0,
+            "p99(tags[foo,number])": 5.0,
+            "p100(tags[foo,number])": 5.0,
+            "min(tags[foo,number])": 5.0,
+            "max(tags[foo,number])": 5.0,
+        }
 
     def test_margin_of_error(self):
         total_samples = 10


### PR DESCRIPTION
Clickhouse defaults 0 when the map does not contain the key. This uses the -If combinator to skip the missing keys to get an accurate aggregation.