### PR TITLE
fix(feedback): Reload after feedback deletion

### DIFF
--- a/static/app/components/feedback/useDeleteFeedback.tsx
+++ b/static/app/components/feedback/useDeleteFeedback.tsx
@@ -33,7 +33,7 @@ export const useDeleteFeedback = (feedbackIds, projectId) => {
             complete: () => {
               navigate(
                 normalizeUrl({
-                  pathname: '/feedback/',
+                  pathname: `/organizations/${organization.slug}/feedback/`,
                   query: {
                     mailbox: locationQuery.mailbox,
                     project: locationQuery.project,


### PR DESCRIPTION
Fixes issue where pathname was missing the organization, which resulted in this error: 
<img width="1158" alt="image" src="https://github.com/user-attachments/assets/326f00bb-408f-4118-a48b-feaabfbefb9e">
