### PR TITLE
fix(alerts): Fix typing to allow for threshold_type of 0

### DIFF
--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -39,10 +39,10 @@ def get_anomaly_data_from_seer(
 
     # XXX: we know we have these things because the serializer makes sure we do, but mypy insists
     if (
-        not snuba_query.time_window
+        alert_rule.threshold_type is None
         or not alert_rule.sensitivity
-        or not alert_rule.threshold_type
         or not alert_rule.seasonality
+        or not snuba_query.time_window
     ):
         return None
 


### PR DESCRIPTION
We weren't seeing Seer calls for alerts with a `threshold_type` of 0 because of this typing mistake. This updates it to check that it's not None rather than `not alertrule.threshold_type` which evaluates to False for a 0 value. 