### PR TITLE
feat(issue-details): Move release info into the sidebar

### DIFF
--- a/static/app/views/issueDetails/streamline/activitySection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/activitySection.spec.tsx
@@ -1,5 +1,6 @@
 import {GroupFixture} from 'sentry-fixture/group';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {ReleaseFixture} from 'sentry-fixture/release';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {
@@ -24,6 +25,9 @@ describe('StreamlinedActivitySection', function () {
   ProjectsStore.loadInitialData([project]);
   GroupStore.init();
 
+  const firstRelease = ReleaseFixture({id: '1'});
+  const lastRelease = ReleaseFixture({id: '2'});
+
   const group = GroupFixture({
     id: '1337',
     activity: [
@@ -45,6 +49,12 @@ describe('StreamlinedActivitySection', function () {
     const deleteMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/1337/comments/note-1/',
       method: 'DELETE',
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/first-last-release/`,
+      method: 'GET',
+      body: {firstRelease, lastRelease},
     });
 
     render(<StreamlinedActivitySection group={group} />);
@@ -80,6 +90,12 @@ describe('StreamlinedActivitySection', function () {
         },
       ],
       project,
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${updatedActivityGroup.id}/first-last-release/`,
+      method: 'GET',
+      body: {firstRelease, lastRelease},
     });
 
     render(<StreamlinedActivitySection group={updatedActivityGroup} />);

--- a/static/app/views/issueDetails/streamline/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/streamline/groupActivityItem.tsx
@@ -21,13 +21,15 @@ import type {Organization, Team} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import type {User} from 'sentry/types/user';
 import {isSemverRelease} from 'sentry/utils/versions/isSemverRelease';
+import type {GroupRelease} from 'sentry/views/issueDetails/streamline/activitySection';
 
 export default function getGroupActivityItem(
   activity: GroupActivity,
   organization: Organization,
   projectId: Project['id'],
   author: React.ReactNode,
-  teams: Team[]
+  teams: Team[],
+  groupReleaseData?: GroupRelease
 ) {
   const issuesLink = `/organizations/${organization.slug}/issues/`;
 
@@ -577,6 +579,24 @@ export default function getGroupActivityItem(
       }
       case GroupActivityType.FIRST_SEEN:
         if (activity.data.priority) {
+          const firstRelease = groupReleaseData?.firstRelease;
+
+          if (firstRelease) {
+            return {
+              title: t('First Seen'),
+              message: tct('in [firstRelease]. Marked as [priority] priority', {
+                priority: activity.data.priority,
+                firstRelease: (
+                  <Version
+                    version={firstRelease.version}
+                    projectId={projectId}
+                    tooltipRawVersion
+                  />
+                ),
+              }),
+            };
+          }
+
           return {
             title: t('First Seen'),
             message: tct('Marked as [priority] priority', {
@@ -589,6 +609,21 @@ export default function getGroupActivityItem(
           message: null,
         };
       case GroupActivityType.LAST_SEEN:
+        const lastRelease = groupReleaseData?.lastRelease;
+        if (lastRelease) {
+          return {
+            title: t('Last Seen'),
+            message: tct('in [lastRelease]', {
+              lastRelease: (
+                <Version
+                  version={lastRelease.version}
+                  projectId={projectId}
+                  tooltipRawVersion
+                />
+              ),
+            }),
+          };
+        }
         return {
           title: t('Last Seen'),
           message: null,

--- a/static/app/views/issueDetails/streamline/header.spec.tsx
+++ b/static/app/views/issueDetails/streamline/header.spec.tsx
@@ -2,13 +2,11 @@ import {GroupFixture} from 'sentry-fixture/group';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {ReleaseFixture} from 'sentry-fixture/release';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {TeamFixture} from 'sentry-fixture/team';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
-import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import type {TeamParticipant, UserParticipant} from 'sentry/types/group';
 import {IssueCategory} from 'sentry/types/group';
@@ -45,9 +43,6 @@ describe('UpdatedGroupHeader', () => {
       project,
     };
 
-    const firstRelease = ReleaseFixture({id: '1'});
-    const lastRelease = ReleaseFixture({id: '2'});
-
     beforeEach(() => {
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/replay-count/',
@@ -58,14 +53,7 @@ describe('UpdatedGroupHeader', () => {
         url: `/organizations/org-slug/repos/`,
         body: {},
       });
-      MockApiClient.addMockResponse({
-        url: `/projects/org-slug/project-slug/releases/${encodeURIComponent(firstRelease.version)}/`,
-        body: {},
-      });
-      MockApiClient.addMockResponse({
-        url: `/organizations/org-slug/releases/${encodeURIComponent(firstRelease.version)}/deploys/`,
-        body: {},
-      });
+
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/issues/${group.id}/attachments/`,
         body: [],
@@ -77,11 +65,6 @@ describe('UpdatedGroupHeader', () => {
     });
 
     it('shows all elements of header', async () => {
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/issues/${group.id}/first-last-release/`,
-        method: 'GET',
-        body: {firstRelease, lastRelease},
-      });
       const teams: TeamParticipant[] = [{...TeamFixture(), type: 'team'}];
       const users: UserParticipant[] = [
         {
@@ -133,11 +116,6 @@ describe('UpdatedGroupHeader', () => {
       expect(
         await screen.findByRole('link', {name: formatAbbreviatedNumber(group.userCount)})
       ).toBeInTheDocument();
-
-      expect(
-        await screen.findByText(textWithMarkupMatcher('Releases'))
-      ).toBeInTheDocument();
-
       expect(
         screen.getByRole('button', {name: 'Modify issue priority'})
       ).toBeInTheDocument();
@@ -155,36 +133,7 @@ describe('UpdatedGroupHeader', () => {
       expect(screen.getByRole('button', {name: 'Archive'})).toBeInTheDocument();
     });
 
-    it('only shows one release if possible', async function () {
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/issues/${group.id}/first-last-release/`,
-        method: 'GET',
-        // First and last release match
-        body: {firstRelease, lastRelease: firstRelease},
-      });
-      render(
-        <StreamlinedGroupHeader
-          {...defaultProps}
-          group={group}
-          project={project}
-          event={null}
-        />,
-        {
-          organization,
-          router,
-        }
-      );
-      expect(
-        await screen.findByText(textWithMarkupMatcher('Release'))
-      ).toBeInTheDocument();
-    });
-
     it('displays new experience button if flag is set', async () => {
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/issues/${group.id}/first-last-release/`,
-        method: 'GET',
-        body: {firstRelease, lastRelease},
-      });
       const flaggedOrganization = OrganizationFixture({
         features: ['issue-details-streamline'],
       });

--- a/static/app/views/issueDetails/streamline/header.tsx
+++ b/static/app/views/issueDetails/streamline/header.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo} from 'react';
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
 import Color from 'color';
 
@@ -9,16 +9,12 @@ import EventOrGroupTitle from 'sentry/components/eventOrGroupTitle';
 import EventMessage from 'sentry/components/events/eventMessage';
 import ParticipantList from 'sentry/components/group/streamlinedParticipantList';
 import Link from 'sentry/components/links/link';
-import Version from 'sentry/components/version';
-import VersionHoverCard from 'sentry/components/versionHoverCard';
 import {IconChevron, IconPanel} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group, TeamParticipant, UserParticipant} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
-import type {Release} from 'sentry/types/release';
-import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
@@ -32,11 +28,6 @@ import {ReplayBadge} from 'sentry/views/issueDetails/streamline/replayBadge';
 import {UserFeedbackBadge} from 'sentry/views/issueDetails/streamline/userFeedbackBadge';
 import {useIssueDetailsHeader} from 'sentry/views/issueDetails/useIssueDetailsHeader';
 import type {ReprocessingStatus} from 'sentry/views/issueDetails/utils';
-
-interface GroupRelease {
-  firstRelease: Release;
-  lastRelease: Release;
-}
 
 interface GroupHeaderProps {
   baseUrl: string;
@@ -58,16 +49,7 @@ export default function StreamlinedGroupHeader({
   const organization = useOrganization();
   const {sort: _sort, ...query} = location.query;
 
-  const {data: groupReleaseData} = useApiQuery<GroupRelease>(
-    [`/organizations/${organization.slug}/issues/${group.id}/first-last-release/`],
-    {
-      staleTime: 30000,
-      gcTime: 30000,
-    }
-  );
-
   const {count: eventCount, userCount} = group;
-  const {firstRelease, lastRelease} = groupReleaseData || {};
 
   const [sidebarOpen, setSidebarOpen] = useSyncedLocalStorageState(
     'issue-details-sidebar-open',
@@ -123,41 +105,6 @@ export default function StreamlinedGroupHeader({
               showUnhandled={group.isUnhandled}
               levelIndicatorSize={'10px'}
             />
-            {firstRelease && lastRelease && (
-              <Fragment>
-                <Divider />
-                <ReleaseWrapper>
-                  {firstRelease.id === lastRelease.id ? t('Release') : t('Releases')}
-                  <VersionHoverCard
-                    organization={organization}
-                    projectSlug={project.slug}
-                    releaseVersion={firstRelease.version}
-                  >
-                    <Version
-                      version={firstRelease.version}
-                      projectId={project.id}
-                      truncate
-                    />
-                  </VersionHoverCard>
-                  {firstRelease.id === lastRelease.id ? null : (
-                    <Fragment>
-                      -
-                      <VersionHoverCard
-                        organization={organization}
-                        projectSlug={project.slug}
-                        releaseVersion={lastRelease.version}
-                      >
-                        <Version
-                          version={lastRelease.version}
-                          projectId={project.id}
-                          truncate
-                        />
-                      </VersionHoverCard>
-                    </Fragment>
-                  )}
-                </ReleaseWrapper>
-              </Fragment>
-            )}
             <AttachmentsBadge group={group} />
             <UserFeedbackBadge group={group} project={project} />
             <ReplayBadge group={group} project={project} />
@@ -340,18 +287,6 @@ const Wrapper = styled('div')`
   display: flex;
   align-items: center;
   gap: ${space(0.5)};
-`;
-
-const ReleaseWrapper = styled('div')`
-  display: flex;
-  align-items: center;
-  max-width: 40%;
-  gap: ${space(0.25)};
-  a {
-    color: ${p => p.theme.gray300};
-    text-decoration: underline;
-    text-decoration-style: dotted;
-  }
 `;
 
 const Header = styled('div')`


### PR DESCRIPTION
this pr moves the release info from the header into the activity sidebar. now it will show in the first/last seen activities. 