### PR TITLE
ref(flags): change help tooltip for flags section

### DIFF
--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -197,7 +197,7 @@ export function EventFeatureFlagList({
     <ErrorBoundary mini message={t('There was a problem loading feature flags.')}>
       <InterimSection
         help={t(
-          "The last 10 flags evaluated in the user's session leading up to this event."
+          "The last 100 flags evaluated in the user's session leading up to this event."
         )}
         isHelpHoverable
         title={t('Feature Flags')}


### PR DESCRIPTION
the tooltip won't be around when the new issues UI becomes default, but for now change the clarifying help text since we updated the buffer size.