### PR TITLE
feat(issue-details): Make buttons in header smaller

### DIFF
--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -422,9 +422,6 @@ export function Actions(props: Props) {
               disabled={disabled}
               disableArchiveUntilOccurrence={!archiveUntilOccurrenceCap.enabled}
             />
-            {!hasStreamlinedUI && (
-              <EnvironmentPageFilter position="bottom-end" size="xs" />
-            )}
             <SubscribeAction
               className="hidden-xs"
               disabled={disabled}

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -384,7 +384,7 @@ export function Actions(props: Props) {
             </ResolvedWrapper>
             <Divider />
             <Button
-              size="sm"
+              size="xs"
               disabled={disabled || isAutoResolved}
               onClick={() =>
                 onUpdate({
@@ -410,20 +410,20 @@ export function Actions(props: Props) {
                 projectSlug={project.slug}
                 isResolved={isResolved}
                 isAutoResolved={isAutoResolved}
-                size="sm"
+                size="xs"
                 priority="primary"
               />
             </GuideAnchor>
             <ArchiveActions
               className="hidden-xs"
-              size="sm"
+              size="xs"
               isArchived={isIgnored}
               onUpdate={onUpdate}
               disabled={disabled}
               disableArchiveUntilOccurrence={!archiveUntilOccurrenceCap.enabled}
             />
             {!hasStreamlinedUI && (
-              <EnvironmentPageFilter position="bottom-end" size="sm" />
+              <EnvironmentPageFilter position="bottom-end" size="xs" />
             )}
             <SubscribeAction
               className="hidden-xs"
@@ -432,7 +432,7 @@ export function Actions(props: Props) {
               group={group}
               onClick={handleClick(onToggleSubscribe)}
               icon={group.isSubscribed ? <IconSubscribed /> : <IconUnsubscribed />}
-              size="sm"
+              size="xs"
             />
           </Fragment>
         ))}
@@ -442,7 +442,7 @@ export function Actions(props: Props) {
           'aria-label': t('More Actions'),
           icon: <IconEllipsis />,
           showChevron: false,
-          size: 'sm',
+          size: hasStreamlinedUI ? 'xs' : 'sm',
         }}
         items={[
           ...(isIgnored

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -27,7 +27,7 @@ export function NewIssueExperienceButton() {
 
   const feedbackButton = openForm ? (
     <Button
-      size="sm"
+      size={hasStreamlinedUI ? 'xs' : 'sm'}
       aria-label={t('Give feedback on new UI')}
       onClick={() =>
         openForm({
@@ -51,7 +51,7 @@ export function NewIssueExperienceButton() {
     <ButtonBar merged>
       <StyledButton
         enabled={hasStreamlinedUI}
-        size="sm"
+        size={hasStreamlinedUI ? 'xs' : 'sm'}
         icon={<IconLab isSolid={hasStreamlinedUI} />}
         title={label}
         aria-label={label}

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -51,7 +51,7 @@ export function NewIssueExperienceButton() {
     <ButtonBar merged>
       <StyledButton
         enabled={hasStreamlinedUI}
-        size="xs"
+        size={hasStreamlinedUI ? 'xs' : 'sm'}
         icon={<IconLab isSolid={hasStreamlinedUI} />}
         title={label}
         aria-label={label}

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -27,7 +27,7 @@ export function NewIssueExperienceButton() {
 
   const feedbackButton = openForm ? (
     <Button
-      size={hasStreamlinedUI ? 'xs' : 'sm'}
+      size="xs"
       aria-label={t('Give feedback on new UI')}
       onClick={() =>
         openForm({
@@ -51,7 +51,7 @@ export function NewIssueExperienceButton() {
     <ButtonBar merged>
       <StyledButton
         enabled={hasStreamlinedUI}
-        size={hasStreamlinedUI ? 'xs' : 'sm'}
+        size="xs"
         icon={<IconLab isSolid={hasStreamlinedUI} />}
         title={label}
         aria-label={label}

--- a/static/app/views/issueDetails/streamline/header.tsx
+++ b/static/app/views/issueDetails/streamline/header.tsx
@@ -269,7 +269,7 @@ const InfoWrapper = styled('div')<{isResolvedOrIgnored: boolean}>`
       ? `linear-gradient(to right, ${p.theme.background}, ${Color(p.theme.success).lighten(0.5).alpha(0.15).string()})`
       : p.theme.background};
   color: ${p => p.theme.gray300};
-  padding: ${space(1)} 24px;
+  padding: ${space(0.5)} 24px;
   margin-right: 0;
   margin-left: 0;
   flex-wrap: wrap;


### PR DESCRIPTION
this pr decreases the size of the buttons in the header with the changes to spacing in the header 

before: 
<img width="509" alt="Screenshot 2024-10-15 at 4 29 21 PM" src="https://github.com/user-attachments/assets/5c6f942c-63b5-471c-87da-ef15f5eb92e3">

after:
<img width="532" alt="Screenshot 2024-10-15 at 4 29 18 PM" src="https://github.com/user-attachments/assets/05260b55-137c-4a2d-9a7a-2f3777f206ba">

