### PR TITLE
ref(alerts): Don't allow 'is:unresolved' queries for dynamic alerts

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -919,7 +919,7 @@ def update_alert_rule(
                 raise ResourceDoesNotExist(
                     "Your organization does not have access to this feature."
                 )
-            if "is:unresolved" in query:
+            if query and "is:unresolved" in query:
                 raise ValidationError("Dynamic alerts do not support 'is:unresolved' queries")
             # NOTE: if adding a new metric alert type, take care to check that it's handled here
             project = projects[0] if projects else alert_rule.projects.get()

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -578,10 +578,12 @@ def create_alert_rule(
         resolution = time_window
         # NOTE: we hardcode seasonality for EA
         seasonality = AlertRuleSeasonality.AUTO
-        if not (sensitivity):
+        if not sensitivity:
             raise ValidationError("Dynamic alerts require a sensitivity level")
         if time_window not in DYNAMIC_TIME_WINDOWS:
             raise ValidationError(INVALID_TIME_WINDOW)
+        if "is:unresolved" in query:
+            raise ValidationError("Dynamic alerts do not support 'is:unresolved' queries")
     else:
         resolution = get_alert_resolution(time_window, organization)
         seasonality = None
@@ -917,6 +919,8 @@ def update_alert_rule(
                 raise ResourceDoesNotExist(
                     "Your organization does not have access to this feature."
                 )
+            if "is:unresolved" in query:
+                raise ValidationError("Dynamic alerts do not support 'is:unresolved' queries")
             # NOTE: if adding a new metric alert type, take care to check that it's handled here
             project = projects[0] if projects else alert_rule.projects.get()
             update_rule_data(alert_rule, project, snuba_query, updated_fields, updated_query_fields)

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1703,12 +1703,12 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         # update query
         update_alert_rule(
             dynamic_rule,
-            query="is:unresolved",
+            query="message:*post_process*",
             detection_type=AlertRuleDetectionType.DYNAMIC,
         )
         assert mock_seer_request.call_count == 1
         snuba_query.refresh_from_db()
-        assert snuba_query.query == "is:unresolved"
+        assert snuba_query.query == "message:*post_process*"
         mock_seer_request.reset_mock()
         # update aggregate
         update_alert_rule(
@@ -1962,7 +1962,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
             update_alert_rule(
                 dynamic_rule,
                 time_window=30,
-                query="is:unresolved",
+                query="message:*post_process*",
                 detection_type=AlertRuleDetectionType.DYNAMIC,
                 sensitivity=AlertRuleSensitivity.HIGH,
                 seasonality=AlertRuleSeasonality.AUTO,
@@ -1982,7 +1982,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
             update_alert_rule(
                 dynamic_rule,
                 time_window=30,
-                query="is:unresolved",
+                query="message:*post_process*",
                 detection_type=AlertRuleDetectionType.DYNAMIC,
                 sensitivity=AlertRuleSensitivity.HIGH,
                 seasonality=AlertRuleSeasonality.AUTO,


### PR DESCRIPTION
When you create a dynamic alert we query snuba for 28 days of historical data for the given metric and filter (if using). If you're using the `is:unresolved` filter and then resolve or archive an issue (or issues), Seer's historical data no longer matches Sentry's because it's frozen in time from when the alert was created. This means that Seer potentially thinks the threshold for an anomaly is higher than it really is, and it may miss alerting when it should have.

If we prevent using `is:unresolved` for dynamic alerts we do risk the inverse problem but the results aren't as bad - we'd prefer to err on alerting too frequently rather than not frequently enough. If the user finds it to be a problem, they can change the `sensitivity` (if it's not already as low as it can go). 

Another option would be to re-query Snuba and update Seer every time an issue is resolved or archived and we have a dynamic alert in the same project, but the risks with this approach are potentially missing data due to Snuba rate limits and we're not sure if Seer can keep up with this increased volume. 

Additionally, this may only be a problem for a small period of time in a given alert's lifecycle - presumably (need to confirm with Seer team) the initial historical data will be replaced with the subscription processor data over time.

Closes https://getsentry.atlassian.net/browse/ALRT-344