### PR TITLE
Split RC-Processing into two (errors and transactions

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1665,6 +1665,11 @@ SENTRY_EVENT_PROCESSING_STORE = (
 )
 SENTRY_EVENT_PROCESSING_STORE_OPTIONS: dict[str, str] = {}
 
+SENTRY_TRANSACTIONS_PROCESSING_STORE = (
+    "sentry.eventstore.processing.redis.RedisClusterEventProcessingStore"
+)
+SENTRY_TRANSACTIONS_PROCESSING_STORE_OPTIONS: dict[str, str] = {}
+
 # The internal Django cache is still used in many places
 # TODO(dcramer): convert uses over to Sentry's backend
 CACHES = {"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}

--- a/src/sentry/eventstore/processing/__init__.py
+++ b/src/sentry/eventstore/processing/__init__.py
@@ -9,5 +9,11 @@ event_processing_store = LazyServiceWrapper(
     settings.SENTRY_EVENT_PROCESSING_STORE_OPTIONS,
 )
 
+transaction_processing_store = LazyServiceWrapper(
+    EventProcessingStore,
+    settings.SENTRY_TRANSACTIONS_PROCESSING_STORE,
+    settings.SENTRY_TRANSACTIONS_PROCESSING_STORE_OPTIONS,
+)
 
-__all__ = ["event_processing_store"]
+
+__all__ = ["event_processing_store", "transaction_processing_store"]

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2785,3 +2785,5 @@ register(
     default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+register("rc-processing-split-write-double", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -507,6 +507,10 @@ def _do_save_event(
 
     if cache_key and data is None:
         data = processing.event_processing_store.get(cache_key)
+
+        if options.get("rc-processing-split-write-double") and data is None:
+            data = processing.transactions_processing_store.get(cache_key)
+
         if data is not None:
             event_type = data.get("type") or "none"
 
@@ -563,10 +567,19 @@ def _do_save_event(
             if not isinstance(data, dict):
                 data = dict(data.items())
             processing.event_processing_store.store(data)
+
+            event_type = data.get("type")
+            if event_type == "transaction" and options.get("rc-processing-split-write-double"):
+                processing.transactions_processing_store.store(data)
         except HashDiscarded:
             # Delete the event payload from cache since it won't show up in post-processing.
             if cache_key:
                 processing.event_processing_store.delete_by_key(cache_key)
+
+                event_type = data.get("type")
+                if event_type == "transaction" and options.get("rc-processing-split-write-double"):
+                    processing.transactions_processing_store.store(data)
+
         except Exception:
             metrics.incr("events.save_event.exception", tags={"event_type": event_type})
             raise

--- a/src/sentry/testutils/helpers/eventprocessing.py
+++ b/src/sentry/testutils/helpers/eventprocessing.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from sentry.event_manager import EventManager
 from sentry.eventstore.models import Event
-from sentry.eventstore.processing import event_processing_store
+from sentry.eventstore.processing import event_processing_store, transactions_processing_store
 from sentry.models.project import Project
 from sentry.testutils.helpers.task_runner import TaskRunner
 from sentry.testutils.outbox import outbox_runner
@@ -13,6 +13,13 @@ def write_event_to_cache(event):
     cache_data["event_id"] = event.event_id
     cache_data["project"] = event.project_id
     return event_processing_store.store(cache_data)
+
+
+def write_transaction_to_cache(event):
+    cache_data = dict(event.data)
+    cache_data["event_id"] = event.event_id
+    cache_data["project"] = event.project_id
+    return transactions_processing_store.store(cache_data)
 
 
 def save_new_event(event_data: dict[str, Any], project: Project) -> Event:

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -63,6 +63,12 @@ def mock_event_processing_store():
 
 
 @pytest.fixture
+def mock_transaction_processing_store():
+    with mock.patch("sentry.eventstore.processing.transaction_processing_store") as m:
+        yield m
+
+
+@pytest.fixture
 def mock_refund():
     with mock.patch.object(quotas, "refund") as m:
         yield m


### PR DESCRIPTION
WIP, need to fix the test cases, but this is splitting rc processing into two so that errors and transactions are reading and writing from different eventstores. 

This adds an option that first enables it to double write two the new eventstore. 