### PR TITLE
feat(dynamic-sampling): Add settings page

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -962,6 +962,11 @@ function buildRoutes() {
         name={t('Early Features')}
         component={make(() => import('sentry/views/settings/earlyFeatures'))}
       />
+      <Route
+        path="dynamic-sampling/"
+        name={t('Dynamic Sampling')}
+        component={make(() => import('sentry/views/settings/dynamicSampling'))}
+      />
     </Route>
   );
 

--- a/static/app/utils/dynamicSampling/features.tsx
+++ b/static/app/utils/dynamicSampling/features.tsx
@@ -1,0 +1,8 @@
+import type {Organization} from 'sentry/types/organization';
+
+export function hasDynamicSamplingCustomFeature(organization: Organization) {
+  return (
+    organization.features.includes('dynamic-sampling') &&
+    organization.features.includes('dynamic-sampling-custom')
+  );
+}

--- a/static/app/views/settings/dynamicSampling/index.tsx
+++ b/static/app/views/settings/dynamicSampling/index.tsx
@@ -1,0 +1,25 @@
+import {Fragment} from 'react';
+
+import {Alert} from 'sentry/components/alert';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {t} from 'sentry/locale';
+import {hasDynamicSamplingCustomFeature} from 'sentry/utils/dynamicSampling/features';
+import useOrganization from 'sentry/utils/useOrganization';
+import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
+
+export default function DynamicSamplingSettings() {
+  const organization = useOrganization();
+
+  if (!hasDynamicSamplingCustomFeature(organization)) {
+    return <Alert type="warning">{t("You don't have access to this feature")}</Alert>;
+  }
+
+  return (
+    <Fragment>
+      <SentryDocumentTitle title={t('Dynamic Sampling')} orgSlug={organization.slug} />
+      <div>
+        <SettingsPageHeader title={t('Dynamic Sampling')} />
+      </div>
+    </Fragment>
+  );
+}

--- a/static/app/views/settings/organization/navigationConfiguration.tsx
+++ b/static/app/views/settings/organization/navigationConfiguration.tsx
@@ -1,5 +1,6 @@
 import FeatureBadge from 'sentry/components/badge/featureBadge';
 import {t} from 'sentry/locale';
+import {hasDynamicSamplingCustomFeature} from 'sentry/utils/dynamicSampling/features';
 import type {NavigationSection} from 'sentry/views/settings/types';
 
 const organizationSettingsPathPrefix = '/settings/:orgId';
@@ -108,6 +109,17 @@ const organizationNavigation: NavigationSection[] = [
         show: ({isSelfHosted}) => isSelfHosted || false,
         id: 'early-features',
         recordAnalytics: true,
+      },
+      {
+        path: `${organizationSettingsPathPrefix}/dynamic-sampling/`,
+        title: t('Dynamic Sampling'),
+        description: t('Manage your sampling rate'),
+        show: ({organization, isSelfHosted}) =>
+          !!(
+            organization &&
+            hasDynamicSamplingCustomFeature(organization) &&
+            isSelfHosted
+          ),
       },
     ],
   },


### PR DESCRIPTION
Add an (empty) settings page for dynamic sampling.

Part of https://github.com/getsentry/projects/issues/217