### PR TITLE
chore(tests): Add types to `insta_snapshot`

### DIFF
--- a/src/sentry/testutils/pytest/fixtures.py
+++ b/src/sentry/testutils/pytest/fixtures.py
@@ -9,8 +9,10 @@ import difflib
 import os
 import re
 import sys
+from collections.abc import Callable, Generator
 from concurrent.futures import ThreadPoolExecutor
 from string import Template
+from typing import Any, Protocol
 
 import pytest
 import requests
@@ -193,14 +195,29 @@ def read_snapshot_file(reference_file: str) -> tuple[str, str]:
         return (header, refval)
 
 
+InequalityComparator = Callable[[str, str], bool | str]
+default_comparator = lambda refval, output: refval != output
+
+
+class InstaSnapshotter(Protocol):
+    def __call__(
+        self,
+        output: str | Any,
+        reference_file: str | None = None,
+        subname: str | None = None,
+        inequality_comparator: InequalityComparator = default_comparator,
+    ) -> None:
+        ...
+
+
 @pytest.fixture
-def insta_snapshot(request, log):
+def insta_snapshot(request: pytest.FixtureRequest) -> Generator[InstaSnapshotter]:
     def inner(
-        output,
-        reference_file=None,
-        subname=None,
-        inequality_comparator=lambda refval, output: refval != output,
-    ):
+        output: str | Any,
+        reference_file: str | None = None,
+        subname: str | None = None,
+        inequality_comparator: InequalityComparator = default_comparator,
+    ) -> None:
         from sentry.testutils.silo import strip_silo_mode_test_suffix
 
         if reference_file is None:


### PR DESCRIPTION
This adds typing to the `insta_snapshot` fixture. The function which is returned is typed using a protocol rather a callable in order to account for the optional parameters/default values, and to allow passing things via keyword.

Note that rather than add a type for the unused `log` parameter, I just removed it.

