### PR TITLE
ref(grouping): Sort keys in variant snapshots

### DIFF
--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-02-11T15:54:24.675584Z'
+created: '2024-10-15T23:12:31.575228+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,7 +11,7 @@ app:
         type*
           "iOS_Swift.SampleError"
         value*
-          "Code=0 Description=The operation couldn\u2019t be completed. (iOS_Swift.SampleError error 0.)"
+          "Code=0 Description=The operation couldn’t be completed. (iOS_Swift.SampleError error 0.)"
       threads (ignored because contains 11 threads)
 --------------------------------------------------------------------------
 system:
@@ -22,5 +22,5 @@ system:
         type*
           "iOS_Swift.SampleError"
         value*
-          "Code=0 Description=The operation couldn\u2019t be completed. (iOS_Swift.SampleError error 0.)"
+          "Code=0 Description=The operation couldn’t be completed. (iOS_Swift.SampleError error 0.)"
       threads (ignored because contains 11 threads)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-22T14:32:47.514771Z'
+created: '2024-10-15T23:12:19.141419+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,7 +14,7 @@ app:
           "iOS_Swift.SampleError"
           0
         value (ignored because ns-error info takes precedence)
-          "Code=<int> Description=The operation couldn\u2019t be completed. (iOS_Swift.SampleError error <int>.)"
+          "Code=<int> Description=The operation couldn’t be completed. (iOS_Swift.SampleError error <int>.)"
       threads (exception of app takes precedence)
         stacktrace*
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-22T14:32:51.341008Z'
+created: '2024-10-15T23:12:43.125658+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,7 +14,7 @@ app:
           "iOS_Swift.SampleError"
           0
         value (ignored because ns-error info takes precedence)
-          "Code=<int> Description=The operation couldn\u2019t be completed. (iOS_Swift.SampleError error <int>.)"
+          "Code=<int> Description=The operation couldn’t be completed. (iOS_Swift.SampleError error <int>.)"
       threads (exception of app takes precedence)
         stacktrace*
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-18T12:12:51.554639Z'
+created: '2024-10-15T23:06:55.018299+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,7 +14,7 @@ app:
           "iOS_Swift.SampleError"
           0
         value (ignored because ns-error info takes precedence)
-          "Code=<int> Description=The operation couldn\u2019t be completed. (iOS_Swift.SampleError error <int>.)"
+          "Code=<int> Description=The operation couldn’t be completed. (iOS_Swift.SampleError error <int>.)"
       threads (exception of app takes precedence)
         stacktrace*
           frame (non app frame)

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+from typing import Any
+
+import orjson
 import pytest
 
 from sentry.grouping.api import get_default_grouping_config_dict
 from sentry.grouping.component import GroupingComponent
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
-from sentry.utils import json
 from tests.sentry.grouping import with_grouping_input
+
+
+def to_json(value: Any) -> str:
+    return orjson.dumps(value, option=orjson.OPT_SORT_KEYS).decode()
 
 
 def dump_variant(variant, lines=None, indent=0):
@@ -29,9 +35,9 @@ def dump_variant(variant, lines=None, indent=0):
             if isinstance(value, GroupingComponent):
                 _dump_component(value, indent + 1)
             else:
-                lines.append("{}{}".format("  " * (indent + 1), json.dumps(value)))
+                lines.append("{}{}".format("  " * (indent + 1), to_json(value)))
 
-    lines.append("{}hash: {}".format("  " * indent, json.dumps(variant.get_hash())))
+    lines.append("{}hash: {}".format("  " * indent, to_json(variant.get_hash())))
 
     for key, value in sorted(variant.__dict__.items()):
         if isinstance(value, GroupingComponent):
@@ -41,7 +47,7 @@ def dump_variant(variant, lines=None, indent=0):
             # We do not want to dump the config
             continue
         else:
-            lines.append("{}{}: {}".format("  " * indent, key, json.dumps(value)))
+            lines.append("{}{}: {}".format("  " * indent, key, to_json(value)))
 
     return lines
 


### PR DESCRIPTION
This sorts the keys when variant snapshots are dumped to JSON. That way, random key reordering won't pollute upcoming changes to snapshots.

It happens that right now the keys are already in order in the snapshots, so this doesn't have any immediate effect*, but changes in an upcoming PR were reordering them without this.

*The only exception to that is a set of snapshots where a unicode code point is now getting rendered correctly. To get key sorting, I had to switch to using `orjson`, and `orjson` requires encoding of its results, resulting in the snapshot change.