### PR TITLE
ref(grouping): Refactor variants snapshot tests

### DIFF
--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -64,7 +64,7 @@ def get_grouping_inputs(inputs_dir: str) -> list[GroupingInput]:
     ]
 
 
-def with_grouping_input(name, inputs_dir):
+def with_grouping_inputs(name, inputs_dir):
     grouping_inputs = get_grouping_inputs(inputs_dir)
     return pytest.mark.parametrize(
         name, grouping_inputs, ids=lambda x: x.filename[:-5].replace("-", "_")

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -21,11 +21,8 @@ _grouping_fixture_path = os.path.join(os.path.dirname(__file__), "grouping_input
 class GroupingInput:
     def __init__(self, filename):
         self.filename = filename
-
-    @cached_property
-    def data(self):
         with open(os.path.join(_grouping_fixture_path, self.filename)) as f:
-            return json.load(f)
+            self.data = json.load(f)
 
     def create_event(self, config_name):
         grouping_config = get_default_grouping_config_dict(config_name)

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -23,9 +23,9 @@ FINGERPRINT_INPUTS_DIR = path.join(path.dirname(__file__), "fingerprint_inputs")
 
 
 class GroupingInput:
-    def __init__(self, filename):
+    def __init__(self, inputs_dir, filename):
         self.filename = filename  # Necessary for test naming
-        with open(path.join(GROUPING_INPUTS_DIR, self.filename)) as f:
+        with open(path.join(inputs_dir, self.filename)) as f:
             self.data = json.load(f)
 
     def _manually_save_event(self, grouping_config: GroupingConfig) -> Event:
@@ -58,7 +58,7 @@ class GroupingInput:
 
 def get_grouping_inputs(inputs_dir: str) -> list[GroupingInput]:
     return [
-        GroupingInput(filename)
+        GroupingInput(inputs_dir, filename)
         for filename in sorted(os.listdir(inputs_dir))
         if filename.endswith(".json")
     ]

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -82,11 +82,11 @@ class FingerprintInput:
         with open(path.join(FINGERPRINT_INPUTS_DIR, self.filename)) as f:
             return json.load(f)
 
-    def create_event(self, grouping_config=None):
+    def create_event(self):
         config = FingerprintingRules.from_json(
             {"rules": self.data.get("_fingerprinting_rules", [])},
         )
-        mgr = EventManager(data=self.data, grouping_config=grouping_config)
+        mgr = EventManager(data=self.data)
         mgr.normalize()
         data = mgr.get_data()
 

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -67,7 +67,9 @@ def get_grouping_inputs(inputs_dir: str) -> list[GroupingInput]:
 def with_grouping_inputs(test_param_name: str, inputs_dir: str) -> pytest.MarkDecorator:
     grouping_inputs = get_grouping_inputs(inputs_dir)
     return pytest.mark.parametrize(
-        test_param_name, grouping_inputs, ids=lambda x: x.filename[:-5].replace("-", "_")
+        test_param_name,
+        grouping_inputs,
+        ids=lambda grouping_input: grouping_input.filename[:-5].replace("-", "_"),
     )
 
 

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -5,7 +5,11 @@ from django.utils.functional import cached_property
 
 from sentry import eventstore
 from sentry.event_manager import EventManager, get_event_type, materialize_metadata
-from sentry.grouping.api import apply_server_fingerprinting, load_grouping_config
+from sentry.grouping.api import (
+    apply_server_fingerprinting,
+    get_default_grouping_config_dict,
+    load_grouping_config,
+)
 from sentry.grouping.enhancer import Enhancements
 from sentry.grouping.fingerprinting import FingerprintingRules
 from sentry.stacktraces.processing import normalize_stacktraces_for_grouping
@@ -23,7 +27,9 @@ class GroupingInput:
         with open(os.path.join(_grouping_fixture_path, self.filename)) as f:
             return json.load(f)
 
-    def create_event(self, grouping_config):
+    def create_event(self, config_name):
+        grouping_config = get_default_grouping_config_dict(config_name)
+
         grouping_input = dict(self.data)
         # Customize grouping config from the _grouping config
         grouping_info = grouping_input.pop("_grouping", None) or {}

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -56,7 +56,7 @@ class GroupingInput:
 
 grouping_input = list(
     GroupingInput(filename)
-    for filename in os.listdir(_grouping_fixture_path)
+    for filename in sorted(os.listdir(_grouping_fixture_path))
     if filename.endswith(".json")
 )
 

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -71,9 +71,10 @@ def get_grouping_inputs(inputs_dir: str) -> list[GroupingInput]:
     ]
 
 
-def with_grouping_input(name):
+def with_grouping_input(name, inputs_dir):
+    grouping_inputs = get_grouping_inputs(inputs_dir)
     return pytest.mark.parametrize(
-        name, grouping_input, ids=lambda x: x.filename[:-5].replace("-", "_")
+        name, grouping_inputs, ids=lambda x: x.filename[:-5].replace("-", "_")
     )
 
 

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -56,13 +56,6 @@ class GroupingInput:
         return event
 
 
-grouping_input = [
-    GroupingInput(filename)
-    for filename in sorted(os.listdir(GROUPING_INPUTS_DIR))
-    if filename.endswith(".json")
-]
-
-
 def get_grouping_inputs(inputs_dir: str) -> list[GroupingInput]:
     return [
         GroupingInput(filename)

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -64,10 +64,10 @@ def get_grouping_inputs(inputs_dir: str) -> list[GroupingInput]:
     ]
 
 
-def with_grouping_inputs(name: str, inputs_dir: str) -> pytest.MarkDecorator:
+def with_grouping_inputs(test_param_name: str, inputs_dir: str) -> pytest.MarkDecorator:
     grouping_inputs = get_grouping_inputs(inputs_dir)
     return pytest.mark.parametrize(
-        name, grouping_inputs, ids=lambda x: x.filename[:-5].replace("-", "_")
+        test_param_name, grouping_inputs, ids=lambda x: x.filename[:-5].replace("-", "_")
     )
 
 

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -22,7 +22,7 @@ _grouping_fixture_path = os.path.join(os.path.dirname(__file__), "grouping_input
 
 class GroupingInput:
     def __init__(self, filename):
-        self.filename = filename
+        self.filename = filename  # Necessary for test naming
         with open(os.path.join(_grouping_fixture_path, self.filename)) as f:
             self.data = json.load(f)
 

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -23,7 +23,7 @@ FINGERPRINT_INPUTS_DIR = path.join(path.dirname(__file__), "fingerprint_inputs")
 
 
 class GroupingInput:
-    def __init__(self, inputs_dir, filename):
+    def __init__(self, inputs_dir: str, filename: str):
         self.filename = filename  # Necessary for test naming
         with open(path.join(inputs_dir, self.filename)) as f:
             self.data = json.load(f)
@@ -42,7 +42,7 @@ class GroupingInput:
 
         return eventstore.backend.create_event(data=data)
 
-    def create_event(self, config_name):
+    def create_event(self, config_name: str) -> Event:
         grouping_config = get_default_grouping_config_dict(config_name)
 
         # Add in any extra grouping configuration from the input data
@@ -64,7 +64,7 @@ def get_grouping_inputs(inputs_dir: str) -> list[GroupingInput]:
     ]
 
 
-def with_grouping_inputs(name, inputs_dir):
+def with_grouping_inputs(name: str, inputs_dir: str) -> pytest.MarkDecorator:
     grouping_inputs = get_grouping_inputs(inputs_dir)
     return pytest.mark.parametrize(
         name, grouping_inputs, ids=lambda x: x.filename[:-5].replace("-", "_")

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -63,6 +63,14 @@ grouping_input = [
 ]
 
 
+def get_grouping_inputs(inputs_dir: str) -> list[GroupingInput]:
+    return [
+        GroupingInput(filename)
+        for filename in sorted(os.listdir(inputs_dir))
+        if filename.endswith(".json")
+    ]
+
+
 def with_grouping_input(name):
     return pytest.mark.parametrize(
         name, grouping_input, ids=lambda x: x.filename[:-5].replace("-", "_")

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -27,9 +27,8 @@ class GroupingInput:
     def create_event(self, config_name):
         grouping_config = get_default_grouping_config_dict(config_name)
 
-        grouping_input = dict(self.data)
         # Customize grouping config from the _grouping config
-        grouping_info = grouping_input.pop("_grouping", None) or {}
+        grouping_info = self.data.get("_grouping", None) or {}
         enhancements = grouping_info.get("enhancements")
         if enhancements:
             enhancement_bases = Enhancements.loads(grouping_config["enhancements"]).bases
@@ -37,7 +36,7 @@ class GroupingInput:
             grouping_config["enhancements"] = e.dumps()
 
         # Normalize the event
-        mgr = EventManager(data=grouping_input, grouping_config=grouping_config)
+        mgr = EventManager(data=self.data, grouping_config=grouping_config)
         mgr.normalize()
         data = mgr.get_data()
 
@@ -75,10 +74,10 @@ class FingerprintInput:
             return json.load(f)
 
     def create_event(self, grouping_config=None):
-        input = dict(self.data)
-
-        config = FingerprintingRules.from_json({"rules": input.pop("_fingerprinting_rules")})
-        mgr = EventManager(data=input, grouping_config=grouping_config)
+        config = FingerprintingRules.from_json(
+            {"rules": self.data.get("_fingerprinting_rules", [])},
+        )
+        mgr = EventManager(data=self.data, grouping_config=grouping_config)
         mgr.normalize()
         data = mgr.get_data()
 

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -18,13 +18,14 @@ from sentry.grouping.fingerprinting import FingerprintingRules
 from sentry.stacktraces.processing import normalize_stacktraces_for_grouping
 from sentry.utils import json
 
-_grouping_fixture_path = path.join(path.dirname(__file__), "grouping_inputs")
+GROUPING_INPUTS_DIR = path.join(path.dirname(__file__), "grouping_inputs")
+FINGERPRINT_INPUTS_DIR = path.join(path.dirname(__file__), "fingerprint_inputs")
 
 
 class GroupingInput:
     def __init__(self, filename):
         self.filename = filename  # Necessary for test naming
-        with open(path.join(_grouping_fixture_path, self.filename)) as f:
+        with open(path.join(GROUPING_INPUTS_DIR, self.filename)) as f:
             self.data = json.load(f)
 
     def _manually_save_event(self, grouping_config: GroupingConfig) -> Event:
@@ -57,7 +58,7 @@ class GroupingInput:
 
 grouping_input = [
     GroupingInput(filename)
-    for filename in sorted(os.listdir(_grouping_fixture_path))
+    for filename in sorted(os.listdir(GROUPING_INPUTS_DIR))
     if filename.endswith(".json")
 ]
 
@@ -68,16 +69,13 @@ def with_grouping_input(name):
     )
 
 
-_fingerprint_fixture_path = path.join(path.dirname(__file__), "fingerprint_inputs")
-
-
 class FingerprintInput:
     def __init__(self, filename):
         self.filename = filename
 
     @cached_property
     def data(self):
-        with open(path.join(_fingerprint_fixture_path, self.filename)) as f:
+        with open(path.join(FINGERPRINT_INPUTS_DIR, self.filename)) as f:
             return json.load(f)
 
     def create_event(self, grouping_config=None):
@@ -100,7 +98,7 @@ class FingerprintInput:
 
 fingerprint_input = list(
     FingerprintInput(filename)
-    for filename in os.listdir(_fingerprint_fixture_path)
+    for filename in os.listdir(FINGERPRINT_INPUTS_DIR)
     if filename.endswith(".json")
 )
 

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -1,4 +1,5 @@
 import os
+from os import path
 
 import pytest
 from django.utils.functional import cached_property
@@ -17,13 +18,13 @@ from sentry.grouping.fingerprinting import FingerprintingRules
 from sentry.stacktraces.processing import normalize_stacktraces_for_grouping
 from sentry.utils import json
 
-_grouping_fixture_path = os.path.join(os.path.dirname(__file__), "grouping_inputs")
+_grouping_fixture_path = path.join(path.dirname(__file__), "grouping_inputs")
 
 
 class GroupingInput:
     def __init__(self, filename):
         self.filename = filename  # Necessary for test naming
-        with open(os.path.join(_grouping_fixture_path, self.filename)) as f:
+        with open(path.join(_grouping_fixture_path, self.filename)) as f:
             self.data = json.load(f)
 
     def _manually_save_event(self, grouping_config: GroupingConfig) -> Event:
@@ -67,7 +68,7 @@ def with_grouping_input(name):
     )
 
 
-_fingerprint_fixture_path = os.path.join(os.path.dirname(__file__), "fingerprint_inputs")
+_fingerprint_fixture_path = path.join(path.dirname(__file__), "fingerprint_inputs")
 
 
 class FingerprintInput:
@@ -76,7 +77,7 @@ class FingerprintInput:
 
     @cached_property
     def data(self):
-        with open(os.path.join(_fingerprint_fixture_path, self.filename)) as f:
+        with open(path.join(_fingerprint_fixture_path, self.filename)) as f:
             return json.load(f)
 
     def create_event(self, grouping_config=None):

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -54,11 +54,11 @@ class GroupingInput:
         return event
 
 
-grouping_input = list(
+grouping_input = [
     GroupingInput(filename)
     for filename in sorted(os.listdir(_grouping_fixture_path))
     if filename.endswith(".json")
-)
+]
 
 
 def with_grouping_input(name):

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -69,7 +69,7 @@ def with_grouping_inputs(test_param_name: str, inputs_dir: str) -> pytest.MarkDe
     return pytest.mark.parametrize(
         test_param_name,
         grouping_inputs,
-        ids=lambda grouping_input: grouping_input.filename[:-5].replace("-", "_"),
+        ids=lambda grouping_input: grouping_input.filename.replace("-", "_").replace(".json", ""),
     )
 
 

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -27,13 +27,11 @@ class GroupingInput:
     def create_event(self, config_name):
         grouping_config = get_default_grouping_config_dict(config_name)
 
-        # Customize grouping config from the _grouping config
-        grouping_info = self.data.get("_grouping", None) or {}
-        enhancements = grouping_info.get("enhancements")
-        if enhancements:
-            enhancement_bases = Enhancements.loads(grouping_config["enhancements"]).bases
-            e = Enhancements.from_config_string(enhancements or "", bases=enhancement_bases)
-            grouping_config["enhancements"] = e.dumps()
+        # Add in any extra grouping configuration from the input data
+        grouping_config["enhancements"] = Enhancements.from_config_string(
+            self.data.get("_grouping", {}).get("enhancements", ""),
+            bases=Enhancements.loads(grouping_config["enhancements"]).bases,
+        ).dumps()
 
         # Normalize the event
         mgr = EventManager(data=self.data, grouping_config=grouping_config)

--- a/tests/sentry/grouping/test_benchmark.py
+++ b/tests/sentry/grouping/test_benchmark.py
@@ -29,7 +29,7 @@ def test_benchmark_grouping(config_name, benchmark):
 def run_configuration(grouping_input, config_name):
     event = grouping_input.create_event(config_name)
 
-    # Copied from test_variants.py, not sure if necessary
+    # This ensures we won't try to touch the DB when getting event hashes
     event.project = None
 
     event.get_hashes()

--- a/tests/sentry/grouping/test_benchmark.py
+++ b/tests/sentry/grouping/test_benchmark.py
@@ -1,10 +1,7 @@
 import pytest
 
-from sentry.grouping.api import get_default_grouping_config_dict
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
 from tests.sentry.grouping import grouping_input as grouping_inputs
-
-CONFIGS = {key: get_default_grouping_config_dict(key) for key in sorted(CONFIGURATIONS.keys())}
 
 
 def benchmark_available() -> bool:
@@ -21,17 +18,16 @@ def benchmark_available() -> bool:
     "config_name", sorted(CONFIGURATIONS.keys()), ids=lambda x: x.replace("-", "_")
 )
 def test_benchmark_grouping(config_name, benchmark):
-    config = CONFIGS[config_name]
     input_iter = iter(grouping_inputs)
 
     def setup():
-        return (next(input_iter), config), {}
+        return (next(input_iter), config_name), {}
 
     benchmark.pedantic(run_configuration, setup=setup, rounds=len(grouping_inputs))
 
 
-def run_configuration(grouping_input, config):
-    event = grouping_input.create_event(config)
+def run_configuration(grouping_input, config_name):
+    event = grouping_input.create_event(config_name)
 
     # Copied from test_variants.py, not sure if necessary
     event.project = None

--- a/tests/sentry/grouping/test_benchmark.py
+++ b/tests/sentry/grouping/test_benchmark.py
@@ -1,7 +1,7 @@
 import pytest
 
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
-from tests.sentry.grouping import GROUPING_INPUTS_DIR, get_grouping_inputs
+from tests.sentry.grouping import GROUPING_INPUTS_DIR, GroupingInput, get_grouping_inputs
 
 GROUPING_INPUTS = get_grouping_inputs(GROUPING_INPUTS_DIR)
 
@@ -28,7 +28,7 @@ def test_benchmark_grouping(config_name, benchmark):
     benchmark.pedantic(run_configuration, setup=setup, rounds=len(GROUPING_INPUTS))
 
 
-def run_configuration(grouping_input, config_name):
+def run_configuration(grouping_input: GroupingInput, config_name: str) -> None:
     event = grouping_input.create_event(config_name)
 
     # This ensures we won't try to touch the DB when getting event hashes

--- a/tests/sentry/grouping/test_benchmark.py
+++ b/tests/sentry/grouping/test_benchmark.py
@@ -17,7 +17,9 @@ def benchmark_available() -> bool:
 
 @pytest.mark.skipif(not benchmark_available(), reason="requires pytest-benchmark")
 @pytest.mark.parametrize(
-    "config_name", sorted(CONFIGURATIONS.keys()), ids=lambda x: x.replace("-", "_")
+    "config_name",
+    sorted(CONFIGURATIONS.keys()),
+    ids=lambda config_name: config_name.replace("-", "_"),
 )
 def test_benchmark_grouping(config_name, benchmark):
     input_iter = iter(GROUPING_INPUTS)

--- a/tests/sentry/grouping/test_benchmark.py
+++ b/tests/sentry/grouping/test_benchmark.py
@@ -1,7 +1,9 @@
 import pytest
 
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
-from tests.sentry.grouping import grouping_input as grouping_inputs
+from tests.sentry.grouping import GROUPING_INPUTS_DIR, get_grouping_inputs
+
+GROUPING_INPUTS = get_grouping_inputs(GROUPING_INPUTS_DIR)
 
 
 def benchmark_available() -> bool:
@@ -18,12 +20,12 @@ def benchmark_available() -> bool:
     "config_name", sorted(CONFIGURATIONS.keys()), ids=lambda x: x.replace("-", "_")
 )
 def test_benchmark_grouping(config_name, benchmark):
-    input_iter = iter(grouping_inputs)
+    input_iter = iter(GROUPING_INPUTS)
 
     def setup():
         return (next(input_iter), config_name), {}
 
-    benchmark.pedantic(run_configuration, setup=setup, rounds=len(grouping_inputs))
+    benchmark.pedantic(run_configuration, setup=setup, rounds=len(GROUPING_INPUTS))
 
 
 def run_configuration(grouping_input, config_name):

--- a/tests/sentry/grouping/test_benchmark.py
+++ b/tests/sentry/grouping/test_benchmark.py
@@ -34,6 +34,6 @@ def run_configuration(grouping_input: GroupingInput, config_name: str) -> None:
     event = grouping_input.create_event(config_name)
 
     # This ensures we won't try to touch the DB when getting event hashes
-    event.project = None
+    event.project = None  # type: ignore[assignment]
 
     event.get_hashes()

--- a/tests/sentry/grouping/test_fingerprinting.py
+++ b/tests/sentry/grouping/test_fingerprinting.py
@@ -4,8 +4,9 @@ import pytest
 
 from sentry.grouping.api import get_default_grouping_config_dict
 from sentry.grouping.fingerprinting import FingerprintingRules, InvalidFingerprintingConfig
-from sentry.testutils.pytest.fixtures import django_db_all
-from tests.sentry.grouping import with_fingerprint_input
+from sentry.grouping.variants import BaseVariant
+from sentry.testutils.pytest.fixtures import InstaSnapshotter, django_db_all
+from tests.sentry.grouping import FingerprintInput, with_fingerprint_input
 
 GROUPING_CONFIG = get_default_grouping_config_dict()
 
@@ -164,10 +165,10 @@ release:foo                                     -> release-foo
 
 @with_fingerprint_input("input")
 @django_db_all  # because of `options` usage
-def test_event_hash_variant(insta_snapshot: Any, input: Any) -> None:
+def test_event_hash_variant(insta_snapshot: InstaSnapshotter, input: FingerprintInput) -> None:
     config, event = input.create_event()
 
-    def dump_variant(variant: Any) -> dict[str, Any]:
+    def dump_variant(variant: BaseVariant) -> dict[str, Any]:
         rv = variant.as_dict()
 
         for key in "hash", "description", "config":

--- a/tests/sentry/grouping/test_fingerprinting.py
+++ b/tests/sentry/grouping/test_fingerprinting.py
@@ -165,7 +165,7 @@ release:foo                                     -> release-foo
 @with_fingerprint_input("input")
 @django_db_all  # because of `options` usage
 def test_event_hash_variant(insta_snapshot: Any, input: Any) -> None:
-    config, evt = input.create_event()
+    config, event = input.create_event()
 
     def dump_variant(v: Any) -> dict[str, Any]:
         rv = v.as_dict()
@@ -182,11 +182,11 @@ def test_event_hash_variant(insta_snapshot: Any, input: Any) -> None:
     insta_snapshot(
         {
             "config": config.to_json(),
-            "fingerprint": evt.data["fingerprint"],
-            "title": evt.data["title"],
+            "fingerprint": event.data["fingerprint"],
+            "title": event.data["title"],
             "variants": {
                 k: dump_variant(v)
-                for (k, v) in evt.get_grouping_variants(force_config=GROUPING_CONFIG).items()
+                for (k, v) in event.get_grouping_variants(force_config=GROUPING_CONFIG).items()
             },
         }
     )

--- a/tests/sentry/grouping/test_fingerprinting.py
+++ b/tests/sentry/grouping/test_fingerprinting.py
@@ -167,8 +167,8 @@ release:foo                                     -> release-foo
 def test_event_hash_variant(insta_snapshot: Any, input: Any) -> None:
     config, event = input.create_event()
 
-    def dump_variant(v: Any) -> dict[str, Any]:
-        rv = v.as_dict()
+    def dump_variant(variant: Any) -> dict[str, Any]:
+        rv = variant.as_dict()
 
         for key in "hash", "description", "config":
             rv.pop(key, None)
@@ -185,8 +185,10 @@ def test_event_hash_variant(insta_snapshot: Any, input: Any) -> None:
             "fingerprint": event.data["fingerprint"],
             "title": event.data["title"],
             "variants": {
-                k: dump_variant(v)
-                for (k, v) in event.get_grouping_variants(force_config=GROUPING_CONFIG).items()
+                variant_name: dump_variant(variant)
+                for (variant_name, variant) in event.get_grouping_variants(
+                    force_config=GROUPING_CONFIG
+                ).items()
             },
         }
     )

--- a/tests/sentry/grouping/test_fingerprinting.py
+++ b/tests/sentry/grouping/test_fingerprinting.py
@@ -11,7 +11,7 @@ from tests.sentry.grouping import FingerprintInput, with_fingerprint_input
 GROUPING_CONFIG = get_default_grouping_config_dict()
 
 
-def test_basic_parsing(insta_snapshot: object) -> None:
+def test_basic_parsing() -> None:
     rules = FingerprintingRules.from_config_string(
         """
 # This is a config
@@ -125,7 +125,7 @@ logger:test2 -> logger-, {{ logger }}, -, {{ level }}
     }
 
 
-def test_discover_field_parsing(insta_snapshot: object) -> None:
+def test_discover_field_parsing() -> None:
     rules = FingerprintingRules.from_config_string(
         """
 # This is a config

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -58,7 +58,9 @@ def dump_variant(
 
 
 @with_grouping_inputs("grouping_input", GROUPING_INPUTS_DIR)
-@pytest.mark.parametrize("config_name", CONFIGURATIONS.keys(), ids=lambda x: x.replace("-", "_"))
+@pytest.mark.parametrize(
+    "config_name", CONFIGURATIONS.keys(), ids=lambda config_name: config_name.replace("-", "_")
+)
 def test_event_hash_variant(
     config_name: str, grouping_input: GroupingInput, insta_snapshot: InstaSnapshotter
 ) -> None:

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -59,8 +59,7 @@ def dump_variant(variant, lines=None, indent=0):
 def test_event_hash_variant(config_name, grouping_input, insta_snapshot):
     event = grouping_input.create_event(config_name)
 
-    # Make sure we don't need to touch the DB here because this would
-    # break stuff later on.
+    # This ensures we won't try to touch the DB when getting event variants
     event.project = None
 
     _assert_and_snapshot_results(event, config_name, grouping_input.filename, insta_snapshot)

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -61,11 +61,11 @@ def test_event_hash_variant(config_name, grouping_input, insta_snapshot):
     event.project = None
 
     rv: list[str] = []
-    for key, value in sorted(event.get_grouping_variants().items()):
+    for variant_name, variant in sorted(event.get_grouping_variants().items()):
         if rv:
             rv.append("-" * 74)
-        rv.append("%s:" % key)
-        dump_variant(value, rv, 1)
+        rv.append("%s:" % variant_name)
+        dump_variant(variant, rv, 1)
     output = "\n".join(rv)
 
     # Make sure the event was annotated with the grouping config

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -60,13 +60,13 @@ def test_event_hash_variant(config_name, grouping_input, insta_snapshot):
     # break stuff later on.
     event.project = None
 
-    rv: list[str] = []
+    lines: list[str] = []
     for variant_name, variant in sorted(event.get_grouping_variants().items()):
-        if rv:
-            rv.append("-" * 74)
-        rv.append("%s:" % variant_name)
-        dump_variant(variant, rv, 1)
-    output = "\n".join(rv)
+        if lines:
+            lines.append("-" * 74)
+        lines.append("%s:" % variant_name)
+        dump_variant(variant, lines, 1)
+    output = "\n".join(lines)
 
     # Make sure the event was annotated with the grouping config
     assert event.get_grouping_config()["id"] == config_name

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -5,8 +5,10 @@ from typing import Any
 import orjson
 import pytest
 
+from sentry.eventstore.models import Event
 from sentry.grouping.component import GroupingComponent
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
+from sentry.testutils.pytest.fixtures import InstaSnapshotter
 from tests.sentry.grouping import with_grouping_input
 
 
@@ -60,6 +62,12 @@ def test_event_hash_variant(config_name, grouping_input, insta_snapshot):
     # break stuff later on.
     event.project = None
 
+    _assert_and_snapshot_results(event, config_name, insta_snapshot)
+
+
+def _assert_and_snapshot_results(
+    event: Event, config_name: str, insta_snapshot: InstaSnapshotter
+) -> None:
     # Make sure the event was annotated with the grouping config
     assert event.get_grouping_config()["id"] == config_name
 

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -67,7 +67,7 @@ def test_event_hash_variant(
     event = grouping_input.create_event(config_name)
 
     # This ensures we won't try to touch the DB when getting event variants
-    event.project = None
+    event.project = None  # type: ignore[assignment]
 
     _assert_and_snapshot_results(event, config_name, grouping_input.filename, insta_snapshot)
 

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -5,7 +5,6 @@ from typing import Any
 import orjson
 import pytest
 
-from sentry.grouping.api import get_default_grouping_config_dict
 from sentry.grouping.component import GroupingComponent
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
 from tests.sentry.grouping import with_grouping_input
@@ -55,8 +54,7 @@ def dump_variant(variant, lines=None, indent=0):
 @with_grouping_input("grouping_input")
 @pytest.mark.parametrize("config_name", CONFIGURATIONS.keys(), ids=lambda x: x.replace("-", "_"))
 def test_event_hash_variant(config_name, grouping_input, insta_snapshot, log):
-    grouping_config = get_default_grouping_config_dict(config_name)
-    evt = grouping_input.create_event(grouping_config)
+    evt = grouping_input.create_event(config_name)
 
     # Make sure we don't need to touch the DB here because this would
     # break stuff later on.
@@ -73,6 +71,7 @@ def test_event_hash_variant(config_name, grouping_input, insta_snapshot, log):
     hashes = evt.get_hashes()
     log(repr(hashes))
 
-    assert evt.get_grouping_config() == grouping_config
+    # Make sure the event was annotated with the grouping config
+    assert evt.get_grouping_config()["id"] == config_name
 
     insta_snapshot(output)

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -54,14 +54,14 @@ def dump_variant(variant, lines=None, indent=0):
 @with_grouping_input("grouping_input")
 @pytest.mark.parametrize("config_name", CONFIGURATIONS.keys(), ids=lambda x: x.replace("-", "_"))
 def test_event_hash_variant(config_name, grouping_input, insta_snapshot):
-    evt = grouping_input.create_event(config_name)
+    event = grouping_input.create_event(config_name)
 
     # Make sure we don't need to touch the DB here because this would
     # break stuff later on.
-    evt.project = None
+    event.project = None
 
     rv: list[str] = []
-    for key, value in sorted(evt.get_grouping_variants().items()):
+    for key, value in sorted(event.get_grouping_variants().items()):
         if rv:
             rv.append("-" * 74)
         rv.append("%s:" % key)
@@ -69,6 +69,6 @@ def test_event_hash_variant(config_name, grouping_input, insta_snapshot):
     output = "\n".join(rv)
 
     # Make sure the event was annotated with the grouping config
-    assert evt.get_grouping_config()["id"] == config_name
+    assert event.get_grouping_config()["id"] == config_name
 
     insta_snapshot(output)

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -9,19 +9,22 @@ import pytest
 from sentry.eventstore.models import Event
 from sentry.grouping.component import GroupingComponent
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
+from sentry.grouping.variants import BaseVariant
 from sentry.testutils.pytest.fixtures import InstaSnapshotter
-from tests.sentry.grouping import GROUPING_INPUTS_DIR, with_grouping_inputs
+from tests.sentry.grouping import GROUPING_INPUTS_DIR, GroupingInput, with_grouping_inputs
 
 
 def to_json(value: Any) -> str:
     return orjson.dumps(value, option=orjson.OPT_SORT_KEYS).decode()
 
 
-def dump_variant(variant, lines=None, indent=0):
+def dump_variant(
+    variant: BaseVariant, lines: list[str] | None = None, indent: int = 0
+) -> list[str]:
     if lines is None:
         lines = []
 
-    def _dump_component(component, indent):
+    def _dump_component(component: GroupingComponent, indent: int) -> None:
         if not component.hint and not component.values:
             return
         lines.append(
@@ -56,7 +59,9 @@ def dump_variant(variant, lines=None, indent=0):
 
 @with_grouping_inputs("grouping_input", GROUPING_INPUTS_DIR)
 @pytest.mark.parametrize("config_name", CONFIGURATIONS.keys(), ids=lambda x: x.replace("-", "_"))
-def test_event_hash_variant(config_name, grouping_input, insta_snapshot):
+def test_event_hash_variant(
+    config_name: str, grouping_input: GroupingInput, insta_snapshot: InstaSnapshotter
+) -> None:
     event = grouping_input.create_event(config_name)
 
     # This ensures we won't try to touch the DB when getting event variants

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from os import path
 from typing import Any
 
 import orjson
@@ -62,11 +63,11 @@ def test_event_hash_variant(config_name, grouping_input, insta_snapshot):
     # break stuff later on.
     event.project = None
 
-    _assert_and_snapshot_results(event, config_name, insta_snapshot)
+    _assert_and_snapshot_results(event, config_name, grouping_input.filename, insta_snapshot)
 
 
 def _assert_and_snapshot_results(
-    event: Event, config_name: str, insta_snapshot: InstaSnapshotter
+    event: Event, config_name: str, input_file: str, insta_snapshot: InstaSnapshotter
 ) -> None:
     # Make sure the event was annotated with the grouping config
     assert event.get_grouping_config()["id"] == config_name
@@ -80,4 +81,14 @@ def _assert_and_snapshot_results(
         dump_variant(variant, lines, 1)
     output = "\n".join(lines)
 
-    insta_snapshot(output)
+    insta_snapshot(
+        output,
+        reference_file=path.join(
+            path.dirname(__file__),
+            "snapshots",
+            path.basename(__file__).replace(".py", ""),
+            "test_event_hash_variant",
+            config_name.replace("-", "_").replace(":", "@"),
+            input_file.replace("-", "_").replace(".json", ".pysnap"),
+        ),
+    )

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -60,15 +60,16 @@ def test_event_hash_variant(config_name, grouping_input, insta_snapshot):
     # break stuff later on.
     event.project = None
 
+    # Make sure the event was annotated with the grouping config
+    assert event.get_grouping_config()["id"] == config_name
+
     lines: list[str] = []
+
     for variant_name, variant in sorted(event.get_grouping_variants().items()):
         if lines:
             lines.append("-" * 74)
         lines.append("%s:" % variant_name)
         dump_variant(variant, lines, 1)
     output = "\n".join(lines)
-
-    # Make sure the event was annotated with the grouping config
-    assert event.get_grouping_config()["id"] == config_name
 
     insta_snapshot(output)

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -53,7 +53,7 @@ def dump_variant(variant, lines=None, indent=0):
 
 @with_grouping_input("grouping_input")
 @pytest.mark.parametrize("config_name", CONFIGURATIONS.keys(), ids=lambda x: x.replace("-", "_"))
-def test_event_hash_variant(config_name, grouping_input, insta_snapshot, log):
+def test_event_hash_variant(config_name, grouping_input, insta_snapshot):
     evt = grouping_input.create_event(config_name)
 
     # Make sure we don't need to touch the DB here because this would
@@ -67,9 +67,6 @@ def test_event_hash_variant(config_name, grouping_input, insta_snapshot, log):
         rv.append("%s:" % key)
         dump_variant(value, rv, 1)
     output = "\n".join(rv)
-
-    hashes = evt.get_hashes()
-    log(repr(hashes))
 
     # Make sure the event was annotated with the grouping config
     assert evt.get_grouping_config()["id"] == config_name

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -10,7 +10,7 @@ from sentry.eventstore.models import Event
 from sentry.grouping.component import GroupingComponent
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
 from sentry.testutils.pytest.fixtures import InstaSnapshotter
-from tests.sentry.grouping import with_grouping_input
+from tests.sentry.grouping import GROUPING_INPUTS_DIR, with_grouping_input
 
 
 def to_json(value: Any) -> str:
@@ -54,7 +54,7 @@ def dump_variant(variant, lines=None, indent=0):
     return lines
 
 
-@with_grouping_input("grouping_input")
+@with_grouping_input("grouping_input", GROUPING_INPUTS_DIR)
 @pytest.mark.parametrize("config_name", CONFIGURATIONS.keys(), ids=lambda x: x.replace("-", "_"))
 def test_event_hash_variant(config_name, grouping_input, insta_snapshot):
     event = grouping_input.create_event(config_name)

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -10,7 +10,7 @@ from sentry.eventstore.models import Event
 from sentry.grouping.component import GroupingComponent
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
 from sentry.testutils.pytest.fixtures import InstaSnapshotter
-from tests.sentry.grouping import GROUPING_INPUTS_DIR, with_grouping_input
+from tests.sentry.grouping import GROUPING_INPUTS_DIR, with_grouping_inputs
 
 
 def to_json(value: Any) -> str:
@@ -54,7 +54,7 @@ def dump_variant(variant, lines=None, indent=0):
     return lines
 
 
-@with_grouping_input("grouping_input", GROUPING_INPUTS_DIR)
+@with_grouping_inputs("grouping_input", GROUPING_INPUTS_DIR)
 @pytest.mark.parametrize("config_name", CONFIGURATIONS.keys(), ids=lambda x: x.replace("-", "_"))
 def test_event_hash_variant(config_name, grouping_input, insta_snapshot):
     event = grouping_input.create_event(config_name)


### PR DESCRIPTION
As part of both fixing a bug with the fingerprint and variants tests and adapting the variants tests for grouphash metadata testing, I ended up doing a fairly large refactor. In order make it easier to review, I've split all of the changes which don't affect behavior (all of the rearrangements, renamings, etc.) into this PR. The commits should cleanly pretty cleanly walk through the steps for anyone who's curious about the details, but the bonus of the fact that these are snapshot tests is that it demonstrates that indeed, nothing has actually fundamentally changed, since all of the snapshots stayed the same. (In other words, this PR should be safe to more or less just mash approve on, which then gets a good deal of the overall work of the review out of the way easily.)

Note that while the vast majority of changes are to the variants tests, there are a few changes to the fingerprint tests as well. I didn't do a ton in that realm, though, because the overarching goal of my refactor was to make the variants test machinery more general; mostly that was in order to use it for testing grouphash metadata, but it also means that at some point I can move the fingerprint tests to use it as well. Given that, it didn't make sense to spend a lot of effort on the fingerprint tests now. There are also a small handful of changes to the benchmark tests, because they turn out also to use the variants inputs and testing machinery.