### PR TITLE
fix(grouping): Use built-in fingerprints in fingerprint tests

### DIFF
--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -15,6 +15,8 @@ from sentry.grouping.api import (
 )
 from sentry.grouping.enhancer import Enhancements
 from sentry.grouping.fingerprinting import FingerprintingRules
+from sentry.grouping.strategies.configurations import CONFIGURATIONS
+from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG
 from sentry.stacktraces.processing import normalize_stacktraces_for_grouping
 from sentry.utils import json
 
@@ -85,6 +87,7 @@ class FingerprintInput:
     def create_event(self):
         config = FingerprintingRules.from_json(
             {"rules": self.data.get("_fingerprinting_rules", [])},
+            bases=CONFIGURATIONS[DEFAULT_GROUPING_CONFIG].fingerprinting_bases,
         )
         mgr = EventManager(data=self.data)
         mgr.normalize()

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/built_in_fingerprint_chunkload_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:14:07.393318+00:00'
+created: '2024-10-15T17:19:43.335885+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -7,16 +7,21 @@ config:
   rules: []
   version: 1
 fingerprint:
-- '{{ default }}'
+- chunkloaderror
 title: 'ChunkLoadError: ChunkLoadError: something something...'
 variants:
   app:
     component:
       contributes: false
-      hint: exception of system takes precedence
+      hint: custom fingerprint takes precedence
     type: component
+  built-in-fingerprint:
+    matched_rule: family:"javascript" type:"ChunkLoadError" -> "chunkloaderror"
+    type: built-in-fingerprint
+    values:
+    - chunkloaderror
   system:
     component:
-      contributes: true
-      hint: null
+      contributes: false
+      hint: custom fingerprint takes precedence
     type: component


### PR DESCRIPTION
When built-in fingerprinting was added earlier this year, we added corresponding unit tests, but forgot to update the fingerprinting snapshot tests to include it. This fixes that by setting the `bases` value in the snapshot tests' `FingerprintingRules` object. As can be seen in the updated snapshot, this causes matching events to switch from default grouping to built-in fingerprinting.