### PR TITLE
fix(grouping): Account for fingerprints in variants tests

### DIFF
--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:06:33.392969+00:00'
+created: '2024-10-15T17:23:20.437594+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -22,7 +22,7 @@ app:
           "ChunkLoadError"
         value (stacktrace and type take precedence)
           "ChunkLoadError: something else..."
-  info: null
+  info: {"client_fingerprint":["{{ default }}","dogs are great"]}
   values: ["{{ default }}","dogs are great"]
 --------------------------------------------------------------------------
 system:
@@ -44,5 +44,5 @@ system:
           "ChunkLoadError"
         value (stacktrace and type take precedence)
           "ChunkLoadError: something else..."
-  info: null
+  info: {"client_fingerprint":["{{ default }}","dogs are great"]}
   values: ["{{ default }}","dogs are great"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:08:15.854162+00:00'
+created: '2024-10-15T17:23:21.568140+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -203,7 +203,7 @@ app:
 --------------------------------------------------------------------------
 custom-fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
-  info: null
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
   values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T16:41:15.504668+00:00'
+created: '2024-10-15T17:23:21.483979+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -202,9 +202,9 @@ app:
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
 custom-fingerprint:
-  hash: "f30afa00b85f5cac5ee0bce01b31f08d"
-  info: null
-  values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]
+  hash: "554e214208f0372603dc9fa6c1c0965f"
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  values: ["soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:
   hash: null

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_server_rule.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-15T16:41:15.822164+00:00'
+created: '2024-10-15T17:23:21.675726+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "ecbcced60b5f2b2181c723e1d27068b4"
+  hash: null
   component:
-    app*
+    app (custom fingerprint takes precedence)
       exception*
         stacktrace*
           frame*
@@ -201,10 +201,15 @@ app:
         value (stacktrace and type take precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
+custom-fingerprint:
+  hash: "554e214208f0372603dc9fa6c1c0965f"
+  info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  values: ["soft-timelimit-exceeded"]
+--------------------------------------------------------------------------
 system:
-  hash: "170c099efaabaa2c022f7715328214af"
+  hash: null
   component:
-    system*
+    system (custom fingerprint takes precedence)
       exception*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/hybrid_fingerprint_base.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/hybrid_fingerprint_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:03:49.880856+00:00'
+created: '2024-10-15T17:23:30.431453+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,7 +12,7 @@ app:
           "FailedToFetchError"
         value*
           "FailedToFetchError: Charlie didn't bring the ball back!"
-  info: null
+  info: {"client_fingerprint":["{{ default }}","dogs are great"]}
   values: ["{{ default }}","dogs are great"]
 --------------------------------------------------------------------------
 system:
@@ -24,5 +24,5 @@ system:
           "FailedToFetchError"
         value*
           "FailedToFetchError: Charlie didn't bring the ball back!"
-  info: null
+  info: {"client_fingerprint":["{{ default }}","dogs are great"]}
   values: ["{{ default }}","dogs are great"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-15T17:03:50.003303+00:00'
+created: '2024-10-15T17:23:30.537570+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "12f8483a96ef9ed502d804b62eaa9f26"
   component:
-    app (custom fingerprint takes precedence)
+    app*
       exception*
         stacktrace*
           frame*
@@ -200,16 +200,13 @@ app:
           "SoftTimeLimitExceeded"
         value (stacktrace and type take precedence)
           "SoftTimeLimitExceeded()"
---------------------------------------------------------------------------
-custom-fingerprint:
-  hash: "f30afa00b85f5cac5ee0bce01b31f08d"
-  info: null
-  values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  values: ["{{ default }}","soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:
-  hash: null
+  hash: "2105fd0d38b9aff20e44d2597d3a776b"
   component:
-    system (custom fingerprint takes precedence)
+    system*
       exception*
         stacktrace*
           frame*
@@ -403,3 +400,5 @@ system:
           "SoftTimeLimitExceeded"
         value (stacktrace and type take precedence)
           "SoftTimeLimitExceeded()"
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  values: ["{{ default }}","soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-15T17:03:50.105333+00:00'
+created: '2024-10-15T17:23:30.691805+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "cf5ea061742f9c03116c74e386d6097d"
+  hash: null
   component:
-    app*
+    app (custom fingerprint takes precedence)
       exception*
         stacktrace*
           frame*
@@ -200,13 +200,16 @@ app:
           "SoftTimeLimitExceeded"
         value (stacktrace and type take precedence)
           "SoftTimeLimitExceeded()"
-  info: null
-  values: ["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]
+--------------------------------------------------------------------------
+custom-fingerprint:
+  hash: "554e214208f0372603dc9fa6c1c0965f"
+  info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  values: ["soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:
-  hash: "c3d1c4f4e3d378544a8b4e4a5a079a54"
+  hash: null
   component:
-    system*
+    system (custom fingerprint takes precedence)
       exception*
         stacktrace*
           frame*
@@ -400,5 +403,3 @@ system:
           "SoftTimeLimitExceeded"
         value (stacktrace and type take precedence)
           "SoftTimeLimitExceeded()"
-  info: null
-  values: ["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/hybrid_fingerprint_same_default_different_extra.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/hybrid_fingerprint_same_default_different_extra.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:03:50.216094+00:00'
+created: '2024-10-15T17:23:30.782465+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,7 +12,7 @@ app:
           "FailedToFetchError"
         value*
           "FailedToFetchError: Charlie didn't bring the ball back!"
-  info: null
+  info: {"client_fingerprint":["{{ default }}","adopt don't shop"]}
   values: ["{{ default }}","adopt don't shop"]
 --------------------------------------------------------------------------
 system:
@@ -24,5 +24,5 @@ system:
           "FailedToFetchError"
         value*
           "FailedToFetchError: Charlie didn't bring the ball back!"
-  info: null
+  info: {"client_fingerprint":["{{ default }}","adopt don't shop"]}
   values: ["{{ default }}","adopt don't shop"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/hybrid_fingerprint_same_extra_different_default.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/hybrid_fingerprint_same_extra_different_default.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:03:50.327327+00:00'
+created: '2024-10-15T17:23:30.884110+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,7 +12,7 @@ app:
           "FailedToFetchError"
         value*
           "FailedToFetchError: Maisey can't see the ball anymore :-("
-  info: null
+  info: {"client_fingerprint":["{{ default }}","dogs are great"]}
   values: ["{{ default }}","dogs are great"]
 --------------------------------------------------------------------------
 system:
@@ -24,5 +24,5 @@ system:
           "FailedToFetchError"
         value*
           "FailedToFetchError: Maisey can't see the ball anymore :-("
-  info: null
+  info: {"client_fingerprint":["{{ default }}","dogs are great"]}
   values: ["{{ default }}","dogs are great"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:06:40.627003+00:00'
+created: '2024-10-15T17:23:35.982635+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -20,7 +20,7 @@ app:
           "ChunkLoadError"
         value*
           "ChunkLoadError: something else..."
-  info: null
+  info: {"client_fingerprint":["{{ default }}","dogs are great"]}
   values: ["{{ default }}","dogs are great"]
 --------------------------------------------------------------------------
 system:
@@ -40,5 +40,5 @@ system:
           "ChunkLoadError"
         value (ignored because stacktrace takes precedence)
           "ChunkLoadError: something else..."
-  info: null
+  info: {"client_fingerprint":["{{ default }}","dogs are great"]}
   values: ["{{ default }}","dogs are great"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:08:22.517781+00:00'
+created: '2024-10-15T17:23:36.656187+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -169,7 +169,7 @@ app:
 --------------------------------------------------------------------------
 custom-fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
-  info: null
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
   values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T16:41:22.321319+00:00'
+created: '2024-10-15T17:23:36.590368+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -168,9 +168,9 @@ app:
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
 custom-fingerprint:
-  hash: "f30afa00b85f5cac5ee0bce01b31f08d"
-  info: null
-  values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]
+  hash: "554e214208f0372603dc9fa6c1c0965f"
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  values: ["soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:
   hash: null

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_server_rule.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-15T16:41:22.618329+00:00'
+created: '2024-10-15T17:23:36.712835+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "8b7562d89f377f87756e18c8005b32bc"
+  hash: null
   component:
-    app*
+    app (custom fingerprint takes precedence)
       exception*
         stacktrace*
           frame*
@@ -167,10 +167,15 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
+custom-fingerprint:
+  hash: "554e214208f0372603dc9fa6c1c0965f"
+  info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  values: ["soft-timelimit-exceeded"]
+--------------------------------------------------------------------------
 system:
-  hash: "230c61ce94218874c6833f3ceee5f080"
+  hash: null
   component:
-    system*
+    system (custom fingerprint takes precedence)
       exception*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_base.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:04:04.584664+00:00'
+created: '2024-10-15T17:23:41.868667+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,5 +12,5 @@ app:
           "FailedToFetchError"
         value*
           "FailedToFetchError: Charlie didn't bring the ball back!"
-  info: null
+  info: {"client_fingerprint":["{{ default }}","dogs are great"]}
   values: ["{{ default }}","dogs are great"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-15T17:04:04.650508+00:00'
+created: '2024-10-15T17:23:41.929197+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "19163f3ca34f5995c69d85351ce3d697"
   component:
-    app (custom fingerprint takes precedence)
+    app*
       exception*
         stacktrace*
           frame*
@@ -166,16 +166,13 @@ app:
           "SoftTimeLimitExceeded"
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
---------------------------------------------------------------------------
-custom-fingerprint:
-  hash: "f30afa00b85f5cac5ee0bce01b31f08d"
-  info: null
-  values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  values: ["{{ default }}","soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:
-  hash: null
+  hash: "847950eb44d280e6758d136c763d6ddc"
   component:
-    system (custom fingerprint takes precedence)
+    system*
       exception*
         stacktrace*
           frame*
@@ -335,3 +332,5 @@ system:
           "SoftTimeLimitExceeded"
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  values: ["{{ default }}","soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-15T17:04:04.713850+00:00'
+created: '2024-10-15T17:23:41.990664+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "a2efa999765c6659d10e6fda9a8c943e"
+  hash: null
   component:
-    app*
+    app (custom fingerprint takes precedence)
       exception*
         stacktrace*
           frame*
@@ -166,13 +166,16 @@ app:
           "SoftTimeLimitExceeded"
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
-  info: null
-  values: ["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]
+--------------------------------------------------------------------------
+custom-fingerprint:
+  hash: "554e214208f0372603dc9fa6c1c0965f"
+  info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  values: ["soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:
-  hash: "5882df860fa5e4868395fa7e5d13ef8a"
+  hash: null
   component:
-    system*
+    system (custom fingerprint takes precedence)
       exception*
         stacktrace*
           frame*
@@ -332,5 +335,3 @@ system:
           "SoftTimeLimitExceeded"
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
-  info: null
-  values: ["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_same_default_different_extra.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_same_default_different_extra.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:04:04.797537+00:00'
+created: '2024-10-15T17:23:42.052274+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,5 +12,5 @@ app:
           "FailedToFetchError"
         value*
           "FailedToFetchError: Charlie didn't bring the ball back!"
-  info: null
+  info: {"client_fingerprint":["{{ default }}","adopt don't shop"]}
   values: ["{{ default }}","adopt don't shop"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_same_extra_different_default.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_same_extra_different_default.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:04:04.880751+00:00'
+created: '2024-10-15T17:23:42.119710+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,5 +12,5 @@ app:
           "FailedToFetchError"
         value*
           "FailedToFetchError: Maisey can't see the ball anymore :-("
-  info: null
+  info: {"client_fingerprint":["{{ default }}","dogs are great"]}
   values: ["{{ default }}","dogs are great"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:06:54.272000+00:00'
+created: '2024-10-15T17:23:48.450416+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -20,7 +20,7 @@ app:
           "ChunkLoadError"
         value*
           "ChunkLoadError: something else..."
-  info: null
+  info: {"client_fingerprint":["{{ default }}","dogs are great"]}
   values: ["{{ default }}","dogs are great"]
 --------------------------------------------------------------------------
 system:
@@ -40,5 +40,5 @@ system:
           "ChunkLoadError"
         value (ignored because stacktrace takes precedence)
           "ChunkLoadError: something else..."
-  info: null
+  info: {"client_fingerprint":["{{ default }}","dogs are great"]}
   values: ["{{ default }}","dogs are great"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:08:29.266867+00:00'
+created: '2024-10-15T17:23:49.327010+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -169,7 +169,7 @@ app:
 --------------------------------------------------------------------------
 custom-fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
-  info: null
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
   values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T16:41:29.333732+00:00'
+created: '2024-10-15T17:23:49.262914+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -168,9 +168,9 @@ app:
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
 custom-fingerprint:
-  hash: "f30afa00b85f5cac5ee0bce01b31f08d"
-  info: null
-  values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]
+  hash: "554e214208f0372603dc9fa6c1c0965f"
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  values: ["soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:
   hash: null

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint_server_rule.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-15T16:41:29.995854+00:00'
+created: '2024-10-15T17:23:49.402010+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "8b7562d89f377f87756e18c8005b32bc"
+  hash: null
   component:
-    app*
+    app (custom fingerprint takes precedence)
       exception*
         stacktrace*
           frame*
@@ -167,10 +167,15 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
+custom-fingerprint:
+  hash: "554e214208f0372603dc9fa6c1c0965f"
+  info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  values: ["soft-timelimit-exceeded"]
+--------------------------------------------------------------------------
 system:
-  hash: "230c61ce94218874c6833f3ceee5f080"
+  hash: null
   component:
-    system*
+    system (custom fingerprint takes precedence)
       exception*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/hybrid_fingerprint_base.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/hybrid_fingerprint_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:04:17.940620+00:00'
+created: '2024-10-15T17:23:55.207223+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,5 +12,5 @@ app:
           "FailedToFetchError"
         value*
           "FailedToFetchError: Charlie didn't bring the ball back!"
-  info: null
+  info: {"client_fingerprint":["{{ default }}","dogs are great"]}
   values: ["{{ default }}","dogs are great"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-15T17:04:18.011475+00:00'
+created: '2024-10-15T17:23:55.272897+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "19163f3ca34f5995c69d85351ce3d697"
   component:
-    app (custom fingerprint takes precedence)
+    app*
       exception*
         stacktrace*
           frame*
@@ -166,16 +166,13 @@ app:
           "SoftTimeLimitExceeded"
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
---------------------------------------------------------------------------
-custom-fingerprint:
-  hash: "f30afa00b85f5cac5ee0bce01b31f08d"
-  info: null
-  values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  values: ["{{ default }}","soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:
-  hash: null
+  hash: "847950eb44d280e6758d136c763d6ddc"
   component:
-    system (custom fingerprint takes precedence)
+    system*
       exception*
         stacktrace*
           frame*
@@ -335,3 +332,5 @@ system:
           "SoftTimeLimitExceeded"
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  values: ["{{ default }}","soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-15T17:04:18.104571+00:00'
+created: '2024-10-15T17:23:55.354774+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "a2efa999765c6659d10e6fda9a8c943e"
+  hash: null
   component:
-    app*
+    app (custom fingerprint takes precedence)
       exception*
         stacktrace*
           frame*
@@ -166,13 +166,16 @@ app:
           "SoftTimeLimitExceeded"
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
-  info: null
-  values: ["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]
+--------------------------------------------------------------------------
+custom-fingerprint:
+  hash: "554e214208f0372603dc9fa6c1c0965f"
+  info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  values: ["soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:
-  hash: "5882df860fa5e4868395fa7e5d13ef8a"
+  hash: null
   component:
-    system*
+    system (custom fingerprint takes precedence)
       exception*
         stacktrace*
           frame*
@@ -332,5 +335,3 @@ system:
           "SoftTimeLimitExceeded"
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
-  info: null
-  values: ["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/hybrid_fingerprint_same_default_different_extra.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/hybrid_fingerprint_same_default_different_extra.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:04:18.201183+00:00'
+created: '2024-10-15T17:23:55.403205+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,5 +12,5 @@ app:
           "FailedToFetchError"
         value*
           "FailedToFetchError: Charlie didn't bring the ball back!"
-  info: null
+  info: {"client_fingerprint":["{{ default }}","adopt don't shop"]}
   values: ["{{ default }}","adopt don't shop"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/hybrid_fingerprint_same_extra_different_default.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/hybrid_fingerprint_same_extra_different_default.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:04:18.277736+00:00'
+created: '2024-10-15T17:23:55.462604+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,5 +12,5 @@ app:
           "FailedToFetchError"
         value*
           "FailedToFetchError: Maisey can't see the ball anymore :-("
-  info: null
+  info: {"client_fingerprint":["{{ default }}","dogs are great"]}
   values: ["{{ default }}","dogs are great"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-15T17:07:01.535326+00:00'
+created: '2024-10-15T17:24:00.902258+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
-    app (exception of system takes precedence)
+    app (custom fingerprint takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace
           frame (non app frame)
@@ -21,10 +21,15 @@ app:
         value*
           "ChunkLoadError: something something..."
 --------------------------------------------------------------------------
+built-in-fingerprint:
+  hash: "5d731dcf8ecc4f042eeacf528d8d8da9"
+  info: {"matched_rule":{"attributes":{},"fingerprint":["chunkloaderror"],"is_builtin":true,"matchers":[["family","javascript"],["type","ChunkLoadError"]]}}
+  values: ["chunkloaderror"]
+--------------------------------------------------------------------------
 system:
-  hash: "925057f3a51f4b7bf154e59a63eb3f86"
+  hash: null
   component:
-    system*
+    system (custom fingerprint takes precedence)
       exception*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-15T17:07:01.499701+00:00'
+created: '2024-10-15T17:24:00.829320+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
-    app (exception of system takes precedence)
+    app (custom fingerprint takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace
           frame (non app frame)
@@ -20,13 +20,16 @@ app:
           "ChunkLoadError"
         value*
           "ChunkLoadError: something else..."
-  info: null
-  values: ["{{ default }}","dogs are great"]
+--------------------------------------------------------------------------
+built-in-fingerprint:
+  hash: "5d731dcf8ecc4f042eeacf528d8d8da9"
+  info: {"client_fingerprint":["{{ default }}","dogs are great"],"matched_rule":{"attributes":{},"fingerprint":["chunkloaderror"],"is_builtin":true,"matchers":[["family","javascript"],["type","ChunkLoadError"]]}}
+  values: ["chunkloaderror"]
 --------------------------------------------------------------------------
 system:
-  hash: "8cce12f1da956a1fd4e7c6078bc311fb"
+  hash: null
   component:
-    system*
+    system (custom fingerprint takes precedence)
       exception*
         stacktrace*
           frame*
@@ -40,5 +43,3 @@ system:
           "ChunkLoadError"
         value (ignored because stacktrace takes precedence)
           "ChunkLoadError: something else..."
-  info: null
-  values: ["{{ default }}","dogs are great"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:08:42.312985+00:00'
+created: '2024-10-15T17:24:01.590598+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -169,7 +169,7 @@ app:
 --------------------------------------------------------------------------
 custom-fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
-  info: null
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
   values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T16:41:41.026484+00:00'
+created: '2024-10-15T17:24:01.543350+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -168,9 +168,9 @@ app:
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
 custom-fingerprint:
-  hash: "f30afa00b85f5cac5ee0bce01b31f08d"
-  info: null
-  values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]
+  hash: "554e214208f0372603dc9fa6c1c0965f"
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  values: ["soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:
   hash: null

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-15T16:41:41.763907+00:00'
+created: '2024-10-15T17:24:01.649651+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "8b7562d89f377f87756e18c8005b32bc"
+  hash: null
   component:
-    app*
+    app (custom fingerprint takes precedence)
       exception*
         stacktrace*
           frame*
@@ -167,10 +167,15 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
+custom-fingerprint:
+  hash: "554e214208f0372603dc9fa6c1c0965f"
+  info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  values: ["soft-timelimit-exceeded"]
+--------------------------------------------------------------------------
 system:
-  hash: "230c61ce94218874c6833f3ceee5f080"
+  hash: null
   component:
-    system*
+    system (custom fingerprint takes precedence)
       exception*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_base.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:04:31.419105+00:00'
+created: '2024-10-15T17:24:08.271543+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,5 +12,5 @@ app:
           "FailedToFetchError"
         value*
           "FailedToFetchError: Charlie didn't bring the ball back!"
-  info: null
+  info: {"client_fingerprint":["{{ default }}","dogs are great"]}
   values: ["{{ default }}","dogs are great"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-15T17:04:31.488751+00:00'
+created: '2024-10-15T17:24:08.426043+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: null
+  hash: "19163f3ca34f5995c69d85351ce3d697"
   component:
-    app (custom fingerprint takes precedence)
+    app*
       exception*
         stacktrace*
           frame*
@@ -166,16 +166,13 @@ app:
           "SoftTimeLimitExceeded"
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
---------------------------------------------------------------------------
-custom-fingerprint:
-  hash: "f30afa00b85f5cac5ee0bce01b31f08d"
-  info: null
-  values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  values: ["{{ default }}","soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:
-  hash: null
+  hash: "847950eb44d280e6758d136c763d6ddc"
   component:
-    system (custom fingerprint takes precedence)
+    system*
       exception*
         stacktrace*
           frame*
@@ -335,3 +332,5 @@ system:
           "SoftTimeLimitExceeded"
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  values: ["{{ default }}","soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-15T17:04:31.562445+00:00'
+created: '2024-10-15T17:24:08.483412+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "a2efa999765c6659d10e6fda9a8c943e"
+  hash: null
   component:
-    app*
+    app (custom fingerprint takes precedence)
       exception*
         stacktrace*
           frame*
@@ -166,13 +166,16 @@ app:
           "SoftTimeLimitExceeded"
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
-  info: null
-  values: ["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]
+--------------------------------------------------------------------------
+custom-fingerprint:
+  hash: "554e214208f0372603dc9fa6c1c0965f"
+  info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  values: ["soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:
-  hash: "5882df860fa5e4868395fa7e5d13ef8a"
+  hash: null
   component:
-    system*
+    system (custom fingerprint takes precedence)
       exception*
         stacktrace*
           frame*
@@ -332,5 +335,3 @@ system:
           "SoftTimeLimitExceeded"
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
-  info: null
-  values: ["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_same_default_different_extra.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_same_default_different_extra.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:04:31.642756+00:00'
+created: '2024-10-15T17:24:08.561627+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,5 +12,5 @@ app:
           "FailedToFetchError"
         value*
           "FailedToFetchError: Charlie didn't bring the ball back!"
-  info: null
+  info: {"client_fingerprint":["{{ default }}","adopt don't shop"]}
   values: ["{{ default }}","adopt don't shop"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_same_extra_different_default.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_same_extra_different_default.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:04:31.707455+00:00'
+created: '2024-10-15T17:24:08.668746+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,5 +12,5 @@ app:
           "FailedToFetchError"
         value*
           "FailedToFetchError: Maisey can't see the ball anymore :-("
-  info: null
+  info: {"client_fingerprint":["{{ default }}","dogs are great"]}
   values: ["{{ default }}","dogs are great"]


### PR DESCRIPTION
Until very recently, the grouping variants snapshot test inputs only included a single fingerprinting example, showing how the variants look given a custom client fingerprint. Now, however, there are examples showing custom server-side fingerprinting, built-in fingerprinting, hybrid fingerprinting, and various combinations thereof. Unfortunately, the corresponding snapshots are currently incorrect, because the variants tests don't take into account server-side fingerprinting.

This fixes that by calling `apply_server_fingerprinting` when creating the event. Because server-side fingerprinting can also affect the issue's title, we're also now updating the event metadata.

The changes this causes can be seen in the snapshots having to do with built-in, custom, and hybrid fingerprinting. (The details below aren't critical, so feel free to skim past them, but I'm including them for anyone who's curious because I think they actually really nicely illustrate how all of these pieces fit together.)

- Across all the inputs and all the configs, the `info` entry (which corresponds to `event._fingerprint_info`) was either null or missing before, and is now filled in.

- The inputs which only have a client fingerprint (i.e., a `fingerprint` entry but no `_fingerprinting_rules` entry) and aren't subject to built-in fingerprinting have no other changes. Inputs/snapshots in this category include `custom_fingerprint_client`, `hybrid_fingerprint_base`, `hybrid_fingerprint_same_default_different_extra`, and `hybrid_fingerprint_same_extra_different_default` (the latter three because they happen to have been implemented using client fingerprints).

- For the older configs, the "not subject to built-in fingerprinting, so only `info` changes" category mentioned above also includes `built_in_fingerprint_chunkload_error_hybrid_fingerpring`. That's obviously counterintuitive, but it's because only the current config knows how to create built-in fingerprints. Under the new config, we can see that not only does the fingerprint value (`values` right under `info`) change, but we switch from using the stacktrace for grouping to using the built-in fingerprint. The same thing happens with `built_in_fingerprint_chunkload_error`.

- The inputs which have both a client and server fingerprint (`custom_fingerprint_client_and_server_rule`, `hybrid_fingerprint_custom_client_hybrid_server`, and `hybrid_fingerprint_hybrid_client_custom_server`) switch from using the client fingerprint to the server one, because server fingerprinting takes precedence. 

- `hybrid_fingerprint_hybrid_client_custom_server` switches from using stacktrace hashing (the `{{ default }}` part of the hybrid) to fingerprint hashing. `hybrid_fingerprint_custom_client_hybrid_server` does the opposite, because the `{{ default }}` part of the hybrid now has an effect.

- Finally, `custom_fingerprint_server_rule` also switches from stacktrace hashing (which it was doing because it didn't know there was a server fingerprinting rule) to server fingerprinting.