### PR TITLE
ref(grouping): Use `save` in variants tests of default config

### DIFF
--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -73,7 +73,12 @@ class GroupingInput:
         ):
             return save_new_event(self.data, project)
 
-    def create_event(self, config_name: str) -> Event:
+    def create_event(
+        self,
+        config_name: str,
+        use_full_ingest_pipeline: bool = True,
+        project: Project | None = None,
+    ) -> Event:
         grouping_config = get_default_grouping_config_dict(config_name)
 
         # Add in any extra grouping configuration from the input data
@@ -86,7 +91,11 @@ class GroupingInput:
             bases=CONFIGURATIONS[config_name].fingerprinting_bases,
         )
 
-        event = self._manually_save_event(grouping_config, fingerprinting_config)
+        if use_full_ingest_pipeline:
+            assert project, "'project' is required to use full pipeline"
+            event = self._save_event_with_pipeline(grouping_config, fingerprinting_config, project)
+        else:
+            event = self._manually_save_event(grouping_config, fingerprinting_config)
 
         return event
 

--- a/tests/sentry/grouping/test_benchmark.py
+++ b/tests/sentry/grouping/test_benchmark.py
@@ -31,7 +31,7 @@ def test_benchmark_grouping(config_name, benchmark):
 
 
 def run_configuration(grouping_input: GroupingInput, config_name: str) -> None:
-    event = grouping_input.create_event(config_name)
+    event = grouping_input.create_event(config_name, use_full_ingest_pipeline=False)
 
     # This ensures we won't try to touch the DB when getting event hashes
     event.project = None  # type: ignore[assignment]

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -10,7 +10,9 @@ from sentry.eventstore.models import Event
 from sentry.grouping.component import GroupingComponent
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
 from sentry.grouping.variants import BaseVariant
-from sentry.testutils.pytest.fixtures import InstaSnapshotter
+from sentry.models.project import Project
+from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG
+from sentry.testutils.pytest.fixtures import InstaSnapshotter, django_db_all
 from tests.sentry.grouping import GROUPING_INPUTS_DIR, GroupingInput, with_grouping_inputs
 
 
@@ -59,17 +61,60 @@ def dump_variant(
 
 @with_grouping_inputs("grouping_input", GROUPING_INPUTS_DIR)
 @pytest.mark.parametrize(
-    "config_name", CONFIGURATIONS.keys(), ids=lambda config_name: config_name.replace("-", "_")
+    "config_name",
+    set(CONFIGURATIONS.keys()) - {DEFAULT_GROUPING_CONFIG},
+    ids=lambda config_name: config_name.replace("-", "_"),
 )
-def test_event_hash_variant(
+def test_variants_with_legacy_configs(
     config_name: str, grouping_input: GroupingInput, insta_snapshot: InstaSnapshotter
 ) -> None:
+    """
+    Run the variant snapshot tests using an minimal (and much more performant) save process.
+
+    Because manually cherry-picking only certain parts of the save process to run makes us much more
+    likely to fall out of sync with reality, for safety we only do this when testing legacy,
+    inactive grouping configs.
+    """
     event = grouping_input.create_event(config_name, use_full_ingest_pipeline=False)
 
     # This ensures we won't try to touch the DB when getting event variants
     event.project = None  # type: ignore[assignment]
 
     _assert_and_snapshot_results(event, config_name, grouping_input.filename, insta_snapshot)
+
+
+@django_db_all
+@with_grouping_inputs("grouping_input", GROUPING_INPUTS_DIR)
+@pytest.mark.parametrize(
+    "config_name",
+    # Technically we don't need to parameterize this since there's only one option, but doing it
+    # this way makes snapshots from this test organize themselves neatly alongside snapshots from
+    # the test of the legacy configs above
+    {DEFAULT_GROUPING_CONFIG},
+    ids=lambda config_name: config_name.replace("-", "_"),
+)
+def test_variants_with_current_default_config(
+    config_name: str,
+    grouping_input: GroupingInput,
+    insta_snapshot: InstaSnapshotter,
+    default_project: Project,
+):
+    """
+    Run the variant snapshot tests using the full `EventManager.save` process.
+
+    This is the most realistic way to test, but it's also slow, because it requires the overhead of
+    set-up/tear-down/general interaction with our full postgres database. We therefore only do it
+    when testing the current grouping config, and rely on a much faster manual test (below) for
+    previous grouping configs.
+    """
+
+    event = grouping_input.create_event(
+        config_name, use_full_ingest_pipeline=True, project=default_project
+    )
+
+    _assert_and_snapshot_results(
+        event, DEFAULT_GROUPING_CONFIG, grouping_input.filename, insta_snapshot
+    )
 
 
 def _assert_and_snapshot_results(
@@ -89,6 +134,8 @@ def _assert_and_snapshot_results(
 
     insta_snapshot(
         output,
+        # Manually set the snapshot path so that both of the tests above will file their snapshots
+        # in the same spot
         reference_file=path.join(
             path.dirname(__file__),
             "snapshots",

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -64,7 +64,7 @@ def dump_variant(
 def test_event_hash_variant(
     config_name: str, grouping_input: GroupingInput, insta_snapshot: InstaSnapshotter
 ) -> None:
-    event = grouping_input.create_event(config_name)
+    event = grouping_input.create_event(config_name, use_full_ingest_pipeline=False)
 
     # This ensures we won't try to touch the DB when getting event variants
     event.project = None  # type: ignore[assignment]


### PR DESCRIPTION
Prior to https://github.com/getsentry/sentry/pull/79188, the variants grouping snapshot tests were not taking into account server-side fingerprinting, which is a key part of our grouping process. This bug was only even possible because we cherry-pick parts of the save pipeline to run, in order to improve performance, rather than running the whole thing. (Doing it that way is faster because it allows us to bypass postgres entirely, which saves a lot of setup and tear-down overhead.)

As we are now making various changes to grouping, it seems a lot safer to just run `save`, so we know no other parts of the process are missed. That said, there are a _lot_ of snapshot inputs, and we run each one through the test four times, once for each grouping config. Rather than slow them all down by switching them all to use `save`, this PR splits the difference and changes only the tests of the current grouping config, since it's the only one we really care about (now that customers can no longer choose to keep themselves on older configs).

Using the full `save` process also will allow us to reuse this test framework for testing other parts of grouping (including, in the near future, grouphash metadata).