### PR TITLE
Revert "chore(deps): Upgrade Sentry Python SDK to 2.16.0"

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -70,7 +70,7 @@ sentry-ophio==1.0.0
 sentry-protos>=0.1.23
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.9.2
-sentry-sdk>=2.16.0
+sentry-sdk>=2.15.0
 slack-sdk>=3.27.2
 snuba-sdk>=3.0.43
 simplejson>=3.17.6

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -187,7 +187,7 @@ sentry-ophio==1.0.0
 sentry-protos==0.1.23
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.2
-sentry-sdk==2.16.0
+sentry-sdk==2.15.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -128,7 +128,7 @@ sentry-ophio==1.0.0
 sentry-protos==0.1.23
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.2
-sentry-sdk==2.16.0
+sentry-sdk==2.15.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0


### PR DESCRIPTION
Reverts getsentry/sentry#78998 
I tested `sentry-sdk` version 2.15 works, but 2.16 gives this error

```
server |   File ".../sentry_sdk/spotlight.py", line 118, in setup_spotlight
server |     settings.MIDDLEWARE.append("sentry_sdk.spotlight.SpotlightMiddleware")
server |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
server | AttributeError: 'tuple' object has no attribute 'append'
```

because the MIDDLEWARE is a tuple not a list 