### PR TITLE
fix(useNavigate): Normalize path before navigating

### DIFF
--- a/static/app/utils/useNavigate.tsx
+++ b/static/app/utils/useNavigate.tsx
@@ -2,6 +2,7 @@ import {useCallback, useEffect, useRef} from 'react';
 import {useNavigate as useReactRouter6Navigate} from 'react-router-dom';
 import type {LocationDescriptor} from 'history';
 
+import {locationDescriptorToTo} from 'sentry/utils/reactRouter6Compat/location';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 
 import {useRouteContext} from './useRouteContext';
@@ -42,7 +43,7 @@ export function useNavigate(): ReactRouter3Navigate {
           return;
         }
 
-        router6Navigate(normalizeUrl(to), options);
+        router6Navigate(locationDescriptorToTo(normalizeUrl(to)), options);
       },
       [router6Navigate]
     );

--- a/static/app/utils/useNavigate.tsx
+++ b/static/app/utils/useNavigate.tsx
@@ -4,7 +4,6 @@ import type {LocationDescriptor} from 'history';
 
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 
-import {locationDescriptorToTo} from './reactRouter6Compat/location';
 import {useRouteContext} from './useRouteContext';
 
 type NavigateOptions = {
@@ -37,10 +36,14 @@ export function useNavigate(): ReactRouter3Navigate {
 
     // biome-ignore lint/correctness/useHookAtTopLevel: react-router-6 migration
     const navigate = useCallback<ReactRouter3Navigate>(
-      (to: LocationDescriptor | number, options: NavigateOptions = {}) =>
-        typeof to === 'number'
-          ? router6Navigate(to)
-          : router6Navigate(locationDescriptorToTo(to), options),
+      (to: LocationDescriptor | number, options: NavigateOptions = {}) => {
+        if (typeof to === 'number') {
+          router6Navigate(to);
+          return;
+        }
+
+        router6Navigate(normalizeUrl(to), options);
+      },
       [router6Navigate]
     );
 


### PR DESCRIPTION
It looks like the old `navigate()` function normalized the path, but the new one does not. I assume we want this?