### PR TITLE
fix(anomaly detection): store full anomalies response

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -1099,7 +1099,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
     };
 
     try {
-      const [anomalies] = await this.api.requestPromise(
+      const anomalies = await this.api.requestPromise(
         `/organizations/${organization.slug}/events/anomalies/`,
         {method: 'POST', data: params}
       );


### PR DESCRIPTION
We were accidentally destructuring the anomalies response, which meant we only passed a single event into the chart. This PR should now pass all anomaly events to the chart properly.