### PR TITLE
ref: remove deprecated SENTRY_URL_PREFIX

### DIFF
--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -298,11 +298,6 @@ class OptionsManager:
         if not (opt.flags & FLAG_NOSTORE):
             result = self.store.get(opt, silent=silent)
             if result is not None:
-                # HACK(mattrobenolt): SENTRY_URL_PREFIX must be kept in sync
-                # when reading values from the database. This should
-                # be replaced by a signal.
-                if key == "system.url-prefix":
-                    settings.SENTRY_URL_PREFIX = result
                 return result
 
         # Some values we don't want to allow them to be configured through

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -203,15 +203,6 @@ def bootstrap_options(settings: Any, config: str | None = None) -> None:
     # these will be validated later after bootstrapping
     for k, v in options.items():
         settings.SENTRY_OPTIONS[k] = v
-        # If SENTRY_URL_PREFIX is used in config, show deprecation warning and
-        # set the newer SENTRY_OPTIONS['system.url-prefix']. Needs to be here
-        # to check from the config file directly before the django setup is done.
-        # TODO: delete when SENTRY_URL_PREFIX is removed
-        if k == "SENTRY_URL_PREFIX":
-            warnings.warn(
-                DeprecatedSettingWarning("SENTRY_URL_PREFIX", "SENTRY_OPTIONS['system.url-prefix']")
-            )
-            settings.SENTRY_OPTIONS["system.url-prefix"] = v
 
     # Now go back through all of SENTRY_OPTIONS and promote
     # back into settings. This catches the case when values are defined
@@ -581,13 +572,6 @@ def apply_legacy_settings(settings: Any) -> None:
         # deprecated. (This also assumes ``FLAG_NOSTORE`` on the configuration
         # option.)
         settings.SENTRY_REDIS_OPTIONS = options.get("redis.clusters")["default"]
-
-    if not hasattr(settings, "SENTRY_URL_PREFIX"):
-        url_prefix = options.get("system.url-prefix", silent=True)
-        if not url_prefix:
-            # HACK: We need to have some value here for backwards compatibility
-            url_prefix = "http://sentry.example.com"
-        settings.SENTRY_URL_PREFIX = url_prefix
 
     if settings.TIME_ZONE != "UTC":
         # non-UTC timezones are not supported

--- a/tests/sentry/runner/test_initializer.py
+++ b/tests/sentry/runner/test_initializer.py
@@ -185,21 +185,6 @@ def test_bootstrap_options_empty_file(settings, config_yml):
     assert settings.SENTRY_OPTIONS == {}
 
 
-def test_legacy_url_prefix_warning(settings, config_yml):
-    config_yml.write(
-        """\
-        SENTRY_URL_PREFIX: http://sentry.example.com
-        """
-    )
-    with pytest.warns(DeprecatedSettingWarning) as warninfo:
-        bootstrap_options(settings, str(config_yml))
-    assert settings.SENTRY_OPTIONS["system.url-prefix"] == "http://sentry.example.com"
-    assert settings.SENTRY_OPTIONS["SENTRY_URL_PREFIX"] == "http://sentry.example.com"
-    _assert_settings_warnings(
-        warninfo, {("SENTRY_URL_PREFIX", "SENTRY_OPTIONS['system.url-prefix']")}
-    )
-
-
 def test_apply_legacy_settings(settings):
     settings.ALLOWED_HOSTS = []
     settings.SENTRY_USE_QUEUE = True


### PR DESCRIPTION
nothing reads this, it has been warning since 2015 -- it accesses the database at import time

<!-- Describe your PR here. -->