### PR TITLE
ref: clean up queue_name from save_event_transaction

### DIFF
--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -609,7 +609,6 @@ def save_event(
 
 @instrumented_task(
     name="sentry.tasks.store.save_event_transaction",
-    queue="events.save_event_transaction",
     time_limit=65,
     soft_time_limit=60,
     silo_mode=SiloMode.REGION,


### PR DESCRIPTION
routing for this task is done by the split queue task router now, remove the hardcoded queue name
