### PR TITLE
ref: type iso_format(...)

### DIFF
--- a/src/sentry/testutils/helpers/datetime.py
+++ b/src/sentry/testutils/helpers/datetime.py
@@ -8,7 +8,7 @@ import time_machine
 __all__ = ["iso_format", "before_now", "timestamp_format"]
 
 
-def iso_format(date):
+def iso_format(date: datetime) -> str:
     return date.isoformat()[:19]
 
 

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -408,7 +408,8 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         # result is rounded down to nearest second
         assert iso_format(result["lastSeen"]) == iso_format(self.min_ago)
         assert iso_format(result["firstSeen"]) == iso_format(group_env.first_seen)
-        assert iso_format(group_env2.first_seen) > iso_format(group_env.first_seen)
+        assert group_env2.first_seen is not None
+        assert group_env2.first_seen > group_env.first_seen
         assert result["userCount"] == 3
 
         result = serialize(


### PR DESCRIPTION
I'm planning on removing this function, typing it helps ease that transition and avoid a bunch of manual fixes later

<!-- Describe your PR here. -->