### PR TITLE
fix(autofix): Allow github extension orgs to use autofix

### DIFF
--- a/src/sentry/api/endpoints/seer_rpc.py
+++ b/src/sentry/api/endpoints/seer_rpc.py
@@ -17,6 +17,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_sdk import Scope, capture_exception
 
+from sentry import options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import AuthenticationSiloLimit, StandardAuthentication
@@ -153,8 +154,9 @@ def get_organization_slug(*, org_id: int) -> dict:
 def get_organization_autofix_consent(*, org_id: int) -> dict:
     org: Organization = Organization.objects.get(id=org_id)
     consent = org.get_option("sentry:gen_ai_consent", False)
+    github_extension_enabled = org_id in options.get("github-extension.enabled-orgs")
     return {
-        "consent": consent,
+        "consent": consent or github_extension_enabled,
     }
 
 


### PR DESCRIPTION
We check for orgs that we gave permission to use the github extension as giving autofix consent, even if they haven't given the standard gen AI consent.