### PR TITLE
fix(issue-stream): Hide log level dot when not applicable to issue type

### DIFF
--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -20,7 +20,7 @@ import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
-import {getTitle} from 'sentry/utils/events';
+import {eventTypeHasLogLevel, getTitle} from 'sentry/utils/events';
 import useReplayCountForIssues from 'sentry/utils/replayCount/useReplayCountForIssues';
 import {projectCanLinkToReplay} from 'sentry/utils/replays/projectSupportsReplay';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -86,7 +86,7 @@ function EventOrGroupExtraDetails({
   const hasNewLayout = organization.features.includes('issue-stream-table-layout');
   const {subtitle} = getTitle(data);
 
-  const level = 'level' in data ? data.level : null;
+  const level = eventTypeHasLogLevel(data.type) && 'level' in data ? data.level : null;
 
   const items = [
     hasNewLayout && level ? <ErrorLevel level={level} size={'10px'} /> : null,

--- a/static/app/components/events/eventMessage.tsx
+++ b/static/app/components/events/eventMessage.tsx
@@ -4,9 +4,9 @@ import ErrorLevel from 'sentry/components/events/errorLevel';
 import UnhandledTag from 'sentry/components/group/inboxBadges/unhandledTag';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {type Event, EventOrGroupType, type Level} from 'sentry/types/event';
+import type {Event, EventOrGroupType, Level} from 'sentry/types/event';
 import type {BaseGroup, GroupTombstoneHelper} from 'sentry/types/group';
-import {getTitle} from 'sentry/utils/events';
+import {eventTypeHasLogLevel, getTitle} from 'sentry/utils/events';
 import useOrganization from 'sentry/utils/useOrganization';
 import {Divider} from 'sentry/views/issueDetails/divider';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
@@ -23,16 +23,6 @@ type Props = {
   levelIndicatorSize?: '9px' | '10px' | '11px';
   showUnhandled?: boolean;
 };
-
-const EVENT_TYPES_WITH_LOG_LEVEL = new Set([
-  EventOrGroupType.ERROR,
-  EventOrGroupType.CSP,
-  EventOrGroupType.EXPECTCT,
-  EventOrGroupType.DEFAULT,
-  EventOrGroupType.EXPECTSTAPLE,
-  EventOrGroupType.HPKP,
-  EventOrGroupType.NEL,
-]);
 
 function EventMessage({
   data,
@@ -51,7 +41,7 @@ function EventMessage({
     'issue-stream-table-layout'
   );
 
-  const showEventLevel = level && EVENT_TYPES_WITH_LOG_LEVEL.has(type);
+  const showEventLevel = level && eventTypeHasLogLevel(type);
   const {subtitle} = getTitle(data);
   const renderedMessage = message ? (
     <Message>{message}</Message>

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -24,6 +24,20 @@ import {getDaysSinceDatePrecise} from 'sentry/utils/getDaysSinceDate';
 import {isMobilePlatform, isNativePlatform} from 'sentry/utils/platform';
 import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
 
+const EVENT_TYPES_WITH_LOG_LEVEL = new Set([
+  EventOrGroupType.ERROR,
+  EventOrGroupType.CSP,
+  EventOrGroupType.EXPECTCT,
+  EventOrGroupType.DEFAULT,
+  EventOrGroupType.EXPECTSTAPLE,
+  EventOrGroupType.HPKP,
+  EventOrGroupType.NEL,
+]);
+
+export function eventTypeHasLogLevel(type: EventOrGroupType) {
+  return EVENT_TYPES_WITH_LOG_LEVEL.has(type);
+}
+
 export function isTombstone(
   maybe: BaseGroup | Event | GroupTombstoneHelper
 ): maybe is GroupTombstoneHelper {


### PR DESCRIPTION
The log level dot was being shown for all issue types, but it should be hidden for most non-errors. The logic exists in EventMessage so I extracted it to a util function/