### PR TITLE
ref(toolbar): check queryReferrer from query param and refactor tests for readability

### DIFF
--- a/src/sentry/api/analytics.py
+++ b/src/sentry/api/analytics.py
@@ -39,15 +39,15 @@ class DevToolbarApiRequestEvent(analytics.Event):
     attributes = (
         analytics.Attribute("view_name"),
         analytics.Attribute("route"),
-        analytics.Attribute("query_string"),
-        analytics.Attribute("origin"),
+        analytics.Attribute("query_string", required=False),
+        analytics.Attribute("origin", required=False),
         analytics.Attribute("method"),
         analytics.Attribute("status_code", type=int),
         analytics.Attribute("organization_id", type=int, required=False),
         analytics.Attribute("organization_slug", required=False),
         analytics.Attribute("project_id", type=int, required=False),
         analytics.Attribute("project_slug", required=False),
-        analytics.Attribute("user_id", type=int),
+        analytics.Attribute("user_id", type=int, required=False),
     )
 
 

--- a/src/sentry/middleware/devtoolbar.py
+++ b/src/sentry/middleware/devtoolbar.py
@@ -45,7 +45,7 @@ def _record_api_request(request: HttpRequest, response: HttpResponse) -> None:
     project_id, project_slug = parse_id_or_slug_param(project_id_or_slug)
 
     origin = origin_from_request(request)
-    query_string: str = get_query_string(request) or None
+    query_string = get_query_string(request) or None
     if query_string:
         params = query_string.lstrip("?").split("&")
         params = list(filter(lambda s: s != "queryReferrer=devtoolbar", params))

--- a/src/sentry/middleware/devtoolbar.py
+++ b/src/sentry/middleware/devtoolbar.py
@@ -45,11 +45,7 @@ def _record_api_request(request: HttpRequest, response: HttpResponse) -> None:
     project_id, project_slug = parse_id_or_slug_param(project_id_or_slug)
 
     origin = origin_from_request(request)
-    query_string = get_query_string(request) or None
-    if query_string:
-        params = query_string.lstrip("?").split("&")
-        params = list(filter(lambda s: s != "queryReferrer=devtoolbar", params))
-        query_string = f"?{'&'.join(params)}" if params else None
+    query_string: str = get_query_string(request)  # starts with ? if non-empty
 
     analytics.record(
         "devtoolbar.api_request",

--- a/src/sentry/middleware/devtoolbar.py
+++ b/src/sentry/middleware/devtoolbar.py
@@ -17,8 +17,8 @@ class DevToolbarAnalyticsMiddleware:
     def __call__(self, request):
         response = self.get_response(request)
         try:
-            # note ordering of conditions to avoid extra option queries.
-            if request.headers.get("queryReferrer") == "devtoolbar" and options.get(
+            # Note ordering of conditions to reduce option queries. GET contains the query params, regardless of method.
+            if request.GET.get("queryReferrer") == "devtoolbar" and options.get(
                 "devtoolbar.analytics.enabled"
             ):
                 _record_api_request(request, response)
@@ -45,7 +45,12 @@ def _record_api_request(request: HttpRequest, response: HttpResponse) -> None:
     project_id, project_slug = parse_id_or_slug_param(project_id_or_slug)
 
     origin = origin_from_request(request)
-    query_string: str = get_query_string(request)  # starts with '?'
+    query_string: str = get_query_string(request) or None
+    if query_string:
+        params = query_string.lstrip("?").split("&")
+        params = list(filter(lambda s: s != "queryReferrer=devtoolbar", params))
+        query_string = f"?{'&'.join(params)}" if params else None
+
     analytics.record(
         "devtoolbar.api_request",
         view_name=view_name,

--- a/tests/sentry/middleware/test_devtoolbar.py
+++ b/tests/sentry/middleware/test_devtoolbar.py
@@ -78,8 +78,8 @@ class DevToolbarAnalyticsMiddlewareUnitTest(TestCase):
     @override_options({"devtoolbar.analytics.enabled": True})
     @patch("sentry.analytics.record")
     def test_query_string(self, mock_record: MagicMock):
-        query = "?a=b&statsPeriod=14d"
-        request = self.factory.get(f"/{query}&queryReferrer=devtoolbar")
+        query = "?a=b&statsPeriod=14d&queryReferrer=devtoolbar"
+        request = self.factory.get("/" + query)
         request.resolver_match = MagicMock()
         self.middleware(request)
 
@@ -198,7 +198,7 @@ class DevToolbarAnalyticsMiddlewareIntegrationTest(APITestCase, SnubaTestCase):
             "GET",
             "sentry-api-0-organization-replay-index",
             "^api/0/organizations/(?P<organization_id_or_slug>[^\\/]+)/replays/$",
-            expected_query_string="?field=id",
+            expected_query_string="?field=id&queryReferrer=devtoolbar",
             expected_org_slug=self.organization.slug,
         )
         self._test_endpoint(
@@ -206,7 +206,7 @@ class DevToolbarAnalyticsMiddlewareIntegrationTest(APITestCase, SnubaTestCase):
             "GET",
             "sentry-api-0-organization-replay-index",
             "^api/0/organizations/(?P<organization_id_or_slug>[^\\/]+)/replays/$",
-            expected_query_string="?field=id",
+            expected_query_string="?queryReferrer=devtoolbar&field=id",
             expected_org_id=self.organization.id,
         )
 
@@ -217,6 +217,7 @@ class DevToolbarAnalyticsMiddlewareIntegrationTest(APITestCase, SnubaTestCase):
             "GET",
             "sentry-api-0-organization-group-group-details",
             "^api/0/organizations/(?P<organization_id_or_slug>[^\\/]+)/(?:issues|groups)/(?P<issue_id>[^\\/]+)/$",
+            expected_query_string="?queryReferrer=devtoolbar",
             expected_org_slug=self.organization.slug,
         )
 
@@ -227,6 +228,7 @@ class DevToolbarAnalyticsMiddlewareIntegrationTest(APITestCase, SnubaTestCase):
             "POST",
             "sentry-api-0-project-user-reports",
             r"^api/0/projects/(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/(?:user-feedback|user-reports)/$",
+            expected_query_string="?queryReferrer=devtoolbar",
             expected_org_slug=self.organization.slug,
             expected_proj_id=self.project.id,
         )

--- a/tests/sentry/middleware/test_devtoolbar.py
+++ b/tests/sentry/middleware/test_devtoolbar.py
@@ -158,17 +158,18 @@ class DevToolbarAnalyticsMiddlewareIntegrationTest(APITestCase, SnubaTestCase):
     @patch("sentry.analytics.record")
     def _test_endpoint(
         self,
-        url: str,
+        path: str,
+        query_string: str,
         method: str,
         expected_view_name: str,
         expected_route: str,
         mock_record: MagicMock,
-        expected_query_string=None,
         expected_org_id=None,
         expected_org_slug=None,
         expected_proj_id=None,
         expected_proj_slug=None,
     ):
+        url = path + query_string
         response: HttpResponse = getattr(self.client, method.lower())(
             url,
             headers={
@@ -181,7 +182,7 @@ class DevToolbarAnalyticsMiddlewareIntegrationTest(APITestCase, SnubaTestCase):
             "devtoolbar.api_request",
             view_name=expected_view_name,
             route=expected_route,
-            query_string=expected_query_string,
+            query_string=query_string,
             origin=self.origin,
             method=method,
             status_code=response.status_code,
@@ -194,41 +195,41 @@ class DevToolbarAnalyticsMiddlewareIntegrationTest(APITestCase, SnubaTestCase):
 
     def test_organization_replays(self):
         self._test_endpoint(
-            f"/api/0/organizations/{self.organization.slug}/replays/?field=id&queryReferrer=devtoolbar",
+            f"/api/0/organizations/{self.organization.slug}/replays/",
+            "?field=id&queryReferrer=devtoolbar",
             "GET",
             "sentry-api-0-organization-replay-index",
             "^api/0/organizations/(?P<organization_id_or_slug>[^\\/]+)/replays/$",
-            expected_query_string="?field=id&queryReferrer=devtoolbar",
             expected_org_slug=self.organization.slug,
         )
         self._test_endpoint(
-            f"/api/0/organizations/{self.organization.id}/replays/?queryReferrer=devtoolbar&field=id",
+            f"/api/0/organizations/{self.organization.id}/replays/",
+            "?queryReferrer=devtoolbar&field=id",
             "GET",
             "sentry-api-0-organization-replay-index",
             "^api/0/organizations/(?P<organization_id_or_slug>[^\\/]+)/replays/$",
-            expected_query_string="?queryReferrer=devtoolbar&field=id",
             expected_org_id=self.organization.id,
         )
 
     def test_group_details(self):
         group = self.create_group(substatus=GroupSubStatus.NEW)
         self._test_endpoint(
-            f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/?queryReferrer=devtoolbar",
+            f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/",
+            "?queryReferrer=devtoolbar",
             "GET",
             "sentry-api-0-organization-group-group-details",
             "^api/0/organizations/(?P<organization_id_or_slug>[^\\/]+)/(?:issues|groups)/(?P<issue_id>[^\\/]+)/$",
-            expected_query_string="?queryReferrer=devtoolbar",
             expected_org_slug=self.organization.slug,
         )
 
     def test_project_user_feedback(self):
         # Should return 400 (no POST data)
         self._test_endpoint(
-            f"/api/0/projects/{self.organization.slug}/{self.project.id}/user-feedback/?queryReferrer=devtoolbar",
+            f"/api/0/projects/{self.organization.slug}/{self.project.id}/user-feedback/",
+            "?queryReferrer=devtoolbar",
             "POST",
             "sentry-api-0-project-user-reports",
             r"^api/0/projects/(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/(?:user-feedback|user-reports)/$",
-            expected_query_string="?queryReferrer=devtoolbar",
             expected_org_slug=self.organization.slug,
             expected_proj_id=self.project.id,
         )

--- a/tests/sentry/middleware/test_devtoolbar.py
+++ b/tests/sentry/middleware/test_devtoolbar.py
@@ -21,28 +21,13 @@ class DevToolbarAnalyticsMiddlewareUnitTest(TestCase):
 
     def setUp(self):
         # Allows changing the get_response mock for each test.
-        self.get_response = MagicMock(return_value=HttpResponse(status=200))
-        self.middleware.get_response = self.get_response
-
-    def make_toolbar_request(
-        self,
-        path="/",
-        method="GET",
-        headers=None,
-        incl_toolbar_header=True,
-        resolver_match="mock",
-    ):
-        headers = headers or {}
-        if incl_toolbar_header:
-            headers["queryReferrer"] = "devtoolbar"
-        request = getattr(self.factory, method.lower())(path, headers=headers)
-        request.resolver_match = MagicMock() if resolver_match == "mock" else resolver_match
-        return request
+        self.middleware.get_response = MagicMock(return_value=HttpResponse(status=200))
 
     @override_options({"devtoolbar.analytics.enabled": True})
     @patch("sentry.analytics.record")
     def test_basic(self, mock_record: MagicMock):
-        request = self.make_toolbar_request()
+        request = self.factory.get("/?queryReferrer=devtoolbar")
+        request.resolver_match = MagicMock()
         self.middleware(request)
         mock_record.assert_called()
         assert mock_record.call_args[0][0] == self.analytics_event_name
@@ -50,13 +35,13 @@ class DevToolbarAnalyticsMiddlewareUnitTest(TestCase):
     @override_options({"devtoolbar.analytics.enabled": True})
     @patch("sentry.analytics.record")
     def test_no_devtoolbar_header(self, mock_record: MagicMock):
-        request = self.make_toolbar_request(incl_toolbar_header=False)
+        request = self.factory.get("/")
+        request.resolver_match = MagicMock()
         self.middleware(request)
         mock_record.assert_not_called()
 
-        request = self.make_toolbar_request(
-            headers={"queryReferrer": "not-toolbar"}, incl_toolbar_header=False
-        )
+        request = self.factory.get("/?queryReferrer=not-toolbar")
+        request.resolver_match = MagicMock()
         self.middleware(request)
         mock_record.assert_not_called()
 
@@ -64,7 +49,7 @@ class DevToolbarAnalyticsMiddlewareUnitTest(TestCase):
     @patch("sentry.middleware.devtoolbar.logger.exception")
     @patch("sentry.analytics.record")
     def test_request_not_resolved(self, mock_record: MagicMock, mock_logger: MagicMock):
-        request = self.make_toolbar_request()
+        request = self.factory.get("/?queryReferrer=devtoolbar")
         request.resolver_match = None
         self.middleware(request)
 
@@ -81,9 +66,8 @@ class DevToolbarAnalyticsMiddlewareUnitTest(TestCase):
         # Integration tests do a better job of testing these fields, since they involve route resolver.
         view_name = "my-endpoint"
         route = "/issues/(?P<issue_id>)/"
-        request = self.make_toolbar_request(
-            resolver_match=MagicMock(view_name=view_name, route=route),
-        )
+        request = self.factory.get("/?queryReferrer=devtoolbar")
+        request.resolver_match = MagicMock(view_name=view_name, route=route)
         self.middleware(request)
 
         mock_record.assert_called()
@@ -95,9 +79,8 @@ class DevToolbarAnalyticsMiddlewareUnitTest(TestCase):
     @patch("sentry.analytics.record")
     def test_query_string(self, mock_record: MagicMock):
         query = "?a=b&statsPeriod=14d"
-        request = self.make_toolbar_request(
-            path="https://sentry.io/replays/" + query,
-        )
+        request = self.factory.get(f"/{query}&queryReferrer=devtoolbar")
+        request.resolver_match = MagicMock()
         self.middleware(request)
 
         mock_record.assert_called()
@@ -108,7 +91,10 @@ class DevToolbarAnalyticsMiddlewareUnitTest(TestCase):
     @patch("sentry.analytics.record")
     def test_origin(self, mock_record: MagicMock):
         origin = "https://potato.com"
-        request = self.make_toolbar_request(headers={"Origin": origin})
+        request = self.factory.get(
+            f"{origin}/?queryReferrer=devtoolbar", headers={"Origin": origin}
+        )
+        request.resolver_match = MagicMock()
         self.middleware(request)
 
         mock_record.assert_called()
@@ -119,7 +105,9 @@ class DevToolbarAnalyticsMiddlewareUnitTest(TestCase):
     @patch("sentry.analytics.record")
     def test_origin_from_referrer(self, mock_record: MagicMock):
         origin = "https://potato.com"
-        request = self.make_toolbar_request(headers={"Referer": origin + "/issues/?a=b"})
+        url = origin + "/issues/?a=b&queryReferrer=devtoolbar"
+        request = self.factory.get(url, headers={"Referer": url})
+        request.resolver_match = MagicMock()
         self.middleware(request)
 
         mock_record.assert_called()
@@ -129,8 +117,9 @@ class DevToolbarAnalyticsMiddlewareUnitTest(TestCase):
     @override_options({"devtoolbar.analytics.enabled": True})
     @patch("sentry.analytics.record")
     def test_response_status_code(self, mock_record: MagicMock):
-        request = self.make_toolbar_request()
-        self.get_response.return_value = HttpResponse(status=420)
+        request = self.factory.get("/?queryReferrer=devtoolbar")
+        request.resolver_match = MagicMock()
+        self.middleware.get_response.return_value = HttpResponse(status=420)
         self.middleware(request)
 
         mock_record.assert_called()
@@ -141,7 +130,8 @@ class DevToolbarAnalyticsMiddlewareUnitTest(TestCase):
     @patch("sentry.analytics.record")
     def test_methods(self, mock_record: MagicMock):
         for method in ["GET", "POST", "PUT", "DELETE"]:
-            request = self.make_toolbar_request(method=method)
+            request = getattr(self.factory, method.lower())("/?queryReferrer=devtoolbar")
+            request.resolver_match = MagicMock()
             self.middleware(request)
 
             mock_record.assert_called()
@@ -168,18 +158,17 @@ class DevToolbarAnalyticsMiddlewareIntegrationTest(APITestCase, SnubaTestCase):
     @patch("sentry.analytics.record")
     def _test_endpoint(
         self,
-        path: str,
-        query_string: str,
+        url: str,
         method: str,
         expected_view_name: str,
         expected_route: str,
         mock_record: MagicMock,
+        expected_query_string=None,
         expected_org_id=None,
         expected_org_slug=None,
         expected_proj_id=None,
         expected_proj_slug=None,
     ):
-        url = path + query_string
         response: HttpResponse = getattr(self.client, method.lower())(
             url,
             headers={
@@ -192,7 +181,7 @@ class DevToolbarAnalyticsMiddlewareIntegrationTest(APITestCase, SnubaTestCase):
             "devtoolbar.api_request",
             view_name=expected_view_name,
             route=expected_route,
-            query_string=query_string,
+            query_string=expected_query_string,
             origin=self.origin,
             method=method,
             status_code=response.status_code,
@@ -205,27 +194,26 @@ class DevToolbarAnalyticsMiddlewareIntegrationTest(APITestCase, SnubaTestCase):
 
     def test_organization_replays(self):
         self._test_endpoint(
-            f"/api/0/organizations/{self.organization.slug}/replays/",
-            "?field=id",
+            f"/api/0/organizations/{self.organization.slug}/replays/?field=id&queryReferrer=devtoolbar",
             "GET",
             "sentry-api-0-organization-replay-index",
             "^api/0/organizations/(?P<organization_id_or_slug>[^\\/]+)/replays/$",
+            expected_query_string="?field=id",
             expected_org_slug=self.organization.slug,
         )
         self._test_endpoint(
-            f"/api/0/organizations/{self.organization.id}/replays/",
-            "?field=id",
+            f"/api/0/organizations/{self.organization.id}/replays/?queryReferrer=devtoolbar&field=id",
             "GET",
             "sentry-api-0-organization-replay-index",
             "^api/0/organizations/(?P<organization_id_or_slug>[^\\/]+)/replays/$",
+            expected_query_string="?field=id",
             expected_org_id=self.organization.id,
         )
 
     def test_group_details(self):
         group = self.create_group(substatus=GroupSubStatus.NEW)
         self._test_endpoint(
-            f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/",
-            "",
+            f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/?queryReferrer=devtoolbar",
             "GET",
             "sentry-api-0-organization-group-group-details",
             "^api/0/organizations/(?P<organization_id_or_slug>[^\\/]+)/(?:issues|groups)/(?P<issue_id>[^\\/]+)/$",
@@ -235,8 +223,7 @@ class DevToolbarAnalyticsMiddlewareIntegrationTest(APITestCase, SnubaTestCase):
     def test_project_user_feedback(self):
         # Should return 400 (no POST data)
         self._test_endpoint(
-            f"/api/0/projects/{self.organization.slug}/{self.project.id}/user-feedback/",
-            "",
+            f"/api/0/projects/{self.organization.slug}/{self.project.id}/user-feedback/?queryReferrer=devtoolbar",
             "POST",
             "sentry-api-0-project-user-reports",
             r"^api/0/projects/(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/(?:user-feedback|user-reports)/$",


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/78778

Confirmed with Ryan the toolbar sends `queryReferrer` as a query param, not a HTTP header. For ex, `<path>/?queryReferrer=devtoolbar`. For SQL query convenience, the analytics event will exclude this from the query string.

Also refactors tests for better readability, removing the helper in the unit test class completely.

Also marks some more fields as `required=False` in the event definition. We need this for `user_id` in case of unauthenticated or anonymous requests. Note events with null user_id won't be sent to amplitude. Fixes [SENTRY-3GMT](https://sentry.sentry.io/issues/5994359552/) 