### PR TITLE
devenv: minimum 1.13.0 version

### DIFF
--- a/devenv/config.ini
+++ b/devenv/config.ini
@@ -1,5 +1,5 @@
 [devenv]
-minimum_version = 1.10.2
+minimum_version = 1.12.0
 
 [venv.sentry]
 python = 3.12.6

--- a/devenv/config.ini
+++ b/devenv/config.ini
@@ -1,5 +1,5 @@
 [devenv]
-minimum_version = 1.12.0
+minimum_version = 1.13.0
 
 [venv.sentry]
 python = 3.12.6

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import os
 import shlex
 import subprocess
@@ -70,7 +71,33 @@ failed command (code {p.returncode}):
     return all_good
 
 
+# Temporary, see https://github.com/getsentry/sentry/pull/78881
+def check_minimum_version(minimum_version: str):
+    version = importlib.metadata.version("sentry-devenv")
+
+    parsed_version = tuple(map(int, version.split(".")))
+    parsed_minimum_version = tuple(map(int, minimum_version.split(".")))
+
+    if parsed_version < parsed_minimum_version:
+        raise SystemExit(
+            f"""
+Hi! To reduce potential breakage we've defined a minimum
+devenv version ({minimum_version}) to run sync.
+
+Please run the following to update your global devenv to the minimum:
+
+{constants.root}/bin/devenv update {minimum_version}
+
+Then, use it to run sync this one time.
+
+{constants.root}/bin/devenv sync
+"""
+        )
+
+
 def main(context: dict[str, str]) -> int:
+    check_minimum_version("1.12.0")
+
     repo = context["repo"]
     reporoot = context["reporoot"]
     repo_config = config.get_config(f"{reporoot}/devenv/config.ini")
@@ -82,20 +109,15 @@ def main(context: dict[str, str]) -> int:
 
     # repo-local devenv needs to update itself first with a successful sync
     # so it'll take 2 syncs to get onto devenv-managed node, it is what it is
-    try:
-        from devenv.lib import node
+    from devenv.lib import node
 
-        node.install(
-            repo_config["node"]["version"],
-            repo_config["node"][constants.SYSTEM_MACHINE],
-            repo_config["node"][f"{constants.SYSTEM_MACHINE}_sha256"],
-            reporoot,
-        )
-        node.install_yarn(repo_config["node"]["yarn_version"], reporoot)
-    except ImportError:
-        from devenv.lib import volta  # type: ignore[attr-defined]
-
-        volta.install(reporoot)
+    node.install(
+        repo_config["node"]["version"],
+        repo_config["node"][constants.SYSTEM_MACHINE],
+        repo_config["node"][f"{constants.SYSTEM_MACHINE}_sha256"],
+        reporoot,
+    )
+    node.install_yarn(repo_config["node"]["yarn_version"], reporoot)
 
     # no more imports from devenv past this point! if the venv is recreated
     # then we won't have access to devenv libs until it gets reinstalled
@@ -114,16 +136,12 @@ def main(context: dict[str, str]) -> int:
             repo_config["colima"][f"{constants.SYSTEM_MACHINE}_sha256"],
             reporoot,
         )
-        try:
-            limactl.install(reporoot)  # type: ignore[call-arg]
-        except TypeError:
-            # again, it'll take 2 syncs to get here
-            limactl.install(
-                repo_config["lima"]["version"],
-                repo_config["lima"][constants.SYSTEM_MACHINE],
-                repo_config["lima"][f"{constants.SYSTEM_MACHINE}_sha256"],
-                reporoot,
-            )
+        limactl.install(
+            repo_config["lima"]["version"],
+            repo_config["lima"][constants.SYSTEM_MACHINE],
+            repo_config["lima"][f"{constants.SYSTEM_MACHINE}_sha256"],
+            reporoot,
+        )
 
     if not run_procs(
         repo,

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -86,7 +86,7 @@ devenv version ({minimum_version}) to run sync.
 
 Please run the following to update your global devenv to the minimum:
 
-{constants.root}/bin/devenv update {minimum_version}
+{constants.root}/venv/bin/pip install -U 'sentry-devenv=={minimum_version}'
 
 Then, use it to run sync this one time.
 

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -96,7 +96,7 @@ Then, use it to run sync this one time.
 
 
 def main(context: dict[str, str]) -> int:
-    check_minimum_version("1.12.0")
+    check_minimum_version("1.13.0")
 
     repo = context["repo"]
     reporoot = context["reporoot"]

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -179,7 +179,7 @@ s3transfer==0.10.0
 selenium==4.16.0
 sentry-arroyo==2.16.5
 sentry-cli==2.16.0
-sentry-devenv==1.11.0
+sentry-devenv==1.12.0
 sentry-forked-django-stubs==5.1.0.post2
 sentry-forked-djangorestframework-stubs==3.15.1.post2
 sentry-kafka-schemas==0.1.111

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -179,7 +179,7 @@ s3transfer==0.10.0
 selenium==4.16.0
 sentry-arroyo==2.16.5
 sentry-cli==2.16.0
-sentry-devenv==1.12.0
+sentry-devenv==1.13.0
 sentry-forked-django-stubs==5.1.0.post2
 sentry-forked-djangorestframework-stubs==3.15.1.post2
 sentry-kafka-schemas==0.1.111

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 
-sentry-devenv>=1.11.0
+sentry-devenv>=1.12.0
 
 covdefaults>=2.3.0
 docker>=6

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 
-sentry-devenv>=1.12.0
+sentry-devenv>=1.13.0
 
 covdefaults>=2.3.0
 docker>=6


### PR DESCRIPTION
Let's get everyone on 1.12.0!

edit: might wait until 1.13.0 so i can get a `devenv update` update out: https://github.com/getsentry/devenv/pull/166
