### PR TITLE
ref: try to remove the save_event_transaction queue name (again)

### DIFF
--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -135,12 +135,9 @@ def instrumented_task(name, stat_suffix=None, silo_mode=None, record_timing=Fals
 
         # If the split task router is configured for the task, always use queues defined
         # in the split task configuration
-        if name in settings.CELERY_SPLIT_QUEUE_TASK_ROUTES:
+        if name in settings.CELERY_SPLIT_QUEUE_TASK_ROUTES and "queue" in kwargs:
             q = kwargs.pop("queue")
-            if q:
-                logger.warning(
-                    "ignoring queue: %s, using value from CELERY_SPLIT_QUEUE_TASK_ROUTES", q
-                )
+            logger.warning("ignoring queue: %s, using value from CELERY_SPLIT_QUEUE_TASK_ROUTES", q)
 
         # We never use result backends in Celery. Leaving `trail=True` means that if we schedule
         # many tasks from a parent task, each task leaks memory. This can lead to the scheduler

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -609,7 +609,6 @@ def save_event(
 
 @instrumented_task(
     name="sentry.tasks.store.save_event_transaction",
-    queue="events.save_event_transaction",
     time_limit=65,
     soft_time_limit=60,
     silo_mode=SiloMode.REGION,


### PR DESCRIPTION
reissue of https://github.com/getsentry/sentry/pull/79205 with a fix to instrumented_task decorator
