### PR TITLE
:wrench: chore(data-secrecy): update data secrecy tests & attempt to fix delete endpoint

### DIFF
--- a/src/sentry/data_secrecy/api/waive_data_secrecy.py
+++ b/src/sentry/data_secrecy/api/waive_data_secrecy.py
@@ -119,12 +119,12 @@ class WaiveDataSecrecyEndpoint(OrganizationEndpoint):
             serialize(ds, request.user, DataSecrecyWaiverSerializer()), status=status.HTTP_200_OK
         )
 
-    def delete(self, request: Request, organization):
+    def delete(self, request: Request, organization: Organization):
         """
         Reinstates data secrecy for an organization.
         """
         try:
-            ds = get_object_or_404(DataSecrecyWaiver, organization=organization)
+            ds = DataSecrecyWaiver.objects.get(organization=organization)
             ds.delete()
 
             self.create_audit_entry(
@@ -136,7 +136,7 @@ class WaiveDataSecrecyEndpoint(OrganizationEndpoint):
                 {"detail": "Data secrecy has been reinstated."},
                 status=status.HTTP_204_NO_CONTENT,
             )
-        except Http404:
+        except DataSecrecyWaiver.DoesNotExist:
             return Response(
                 {"detail": "No data secrecy waiver found for this organization."},
                 status=status.HTTP_404_NOT_FOUND,

--- a/tests/sentry/data_secrecy/api/test_waive_data_secrecy.py
+++ b/tests/sentry/data_secrecy/api/test_waive_data_secrecy.py
@@ -89,6 +89,11 @@ class DataSecrecyTest(APITestCase):
         assert ds.access_start == datetime.now(tz=timezone.utc) + timedelta(days=1)
         assert ds.access_end == datetime.now(tz=timezone.utc) + timedelta(days=2)
 
+        assert_org_audit_log_exists(
+            organization=self.org,
+            event=audit_log.get_event_id("DATA_SECRECY_WAIVED"),
+        )
+
     @freeze_time(datetime(2024, 7, 18, 0, 0, 0, tzinfo=timezone.utc))
     def test_put_invalid_dates(self):
         self.body_params["accessEnd"] = self.body_params["accessStart"]
@@ -123,6 +128,11 @@ class DataSecrecyTest(APITestCase):
             self.get_success_response(self.org.slug, method="delete")
 
         assert DataSecrecyWaiver.objects.filter(organization=self.org).first() is None
+
+        assert_org_audit_log_exists(
+            organization=self.org,
+            event=audit_log.get_event_id("DATA_SECRECY_REINSTATED"),
+        )
 
     @freeze_time(datetime(2024, 7, 18, 0, 0, 0, tzinfo=timezone.utc))
     def test_delete_non_existing_waiver(self):

--- a/tests/sentry/data_secrecy/api/test_waive_data_secrecy.py
+++ b/tests/sentry/data_secrecy/api/test_waive_data_secrecy.py
@@ -125,7 +125,7 @@ class DataSecrecyTest(APITestCase):
         )
 
         with outbox_runner():
-            self.get_success_response(self.org.slug, method="delete")
+            self.get_success_response(self.org.slug, method="delete", status_code=204)
 
         assert DataSecrecyWaiver.objects.filter(organization=self.org).first() is None
 


### PR DESCRIPTION
i am trying to use another way to get the waiver entry and delete it because i have a bizarre issue that i can't replicate where the delete method returns a 404 when the waiver exists.

also improved the tests