### PR TITLE
fix(issues): Increase size of issue details container, events overflow

### DIFF
--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
@@ -240,6 +240,7 @@ const StyledLayoutBody = styled(Layout.Body)<{
   ${p =>
     p.hasStreamlinedUi &&
     css`
+      min-height: 100vh;
       @media (min-width: ${p.theme.breakpoints.large}) {
         gap: ${space(1.5)};
         display: ${p.sidebarOpen ? 'grid' : 'block'};

--- a/static/app/views/issueDetails/streamline/eventDetails.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetails.tsx
@@ -123,7 +123,8 @@ export function EventDetails({
       {/* TODO(issues): We should use the router for this */}
       {currentTab === Tab.EVENTS && (
         <PageErrorBoundary mini message={t('There was an error loading the event list')}>
-          <GroupContent>
+          {/* Overflow added only to this instance to scroll table. Acts weird with sticky nav. */}
+          <GroupContent style={{overflowX: 'auto'}}>
             <EventList group={group} project={project} />
           </GroupContent>
         </PageErrorBoundary>

--- a/static/app/views/issueDetails/streamline/eventList.tsx
+++ b/static/app/views/issueDetails/streamline/eventList.tsx
@@ -178,6 +178,7 @@ const EventListHeaderItem = styled('div')`
 const StreamlineEventsTable = styled('div')`
   ${Panel} {
     border: 0;
+    margin-bottom: 0;
   }
 
   ${GridHead} {


### PR DESCRIPTION
- makes sure the body/sidebar always reaches down to the footer
- removes extra padding on all events table

extra padding below scroll bar that was removed
![image](https://github.com/user-attachments/assets/f905e31b-6fad-4ba7-8a10-fb367ee99918)
