### PR TITLE
ref(grouping): Improve representation of grouping objects

### DIFF
--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -79,7 +79,8 @@ class GroupingComponent:
 
         if items and items[-1]:
             return " ".join(items[-1])
-        return self.name or "others"
+
+        return self.name or self.id
 
     def get_subcomponent(
         self, id: str, only_contributing: bool = False

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -485,6 +485,7 @@ class Rule:
 
     def _to_config_structure(self) -> dict[str, Any]:
         config_structure: dict[str, Any] = {
+            "text": self.text,
             "matchers": [x._to_config_structure() for x in self.matchers],
             "fingerprint": self.fingerprint,
             "attributes": self.attributes,

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_abs_path.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_abs_path.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-01-11T19:06:29.175447Z'
+created: '2024-10-16T22:32:30.800129+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -11,6 +11,7 @@ config:
     matchers:
     - - type
       - DatabaseUnavailable
+    text: type:"DatabaseUnavailable" -> "{{ stack.abs_path }}"
   version: 1
 fingerprint:
 - '{{ stack.abs_path }}'

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_escape_chars.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_escape_chars.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-10T13:31:47.690454Z'
+created: '2024-10-16T22:32:31.788940+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -12,6 +12,7 @@ config:
     matchers:
     - - message
       - \{\[\*\?\]\}
+    text: message:"\{\[\*\?\]\}" -> "escaped{{ message }}"
   version: 1
 fingerprint:
 - escaped

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-12-08T17:25:04.610129Z'
+created: '2024-10-16T22:32:29.876535+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -11,6 +11,7 @@ config:
     matchers:
     - - type
       - DatabaseUnavailable
+    text: type:"DatabaseUnavailable" -> "database-unavailable"
   version: 1
 fingerprint:
 - database-unavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-12-08T17:25:05.043711Z'
+created: '2024-10-16T22:32:32.297082+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -13,6 +13,7 @@ config:
       - DatabaseUnavailable
     - - module
       - io.sentry.example.*
+    text: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable"
   version: 1
 fingerprint:
 - database-unavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-09T13:42:58.974458+00:00'
+created: '2024-10-16T22:32:28.545402+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -13,6 +13,7 @@ config:
       - DatabaseUnavailable
     - - module
       - invalid.databasestuff.*
+    text: type:"DatabaseUnavailable" module:"invalid.databasestuff.*" -> "database-unavailable"
   version: 1
 fingerprint:
 - my-route

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk.pysnap
@@ -1,8 +1,7 @@
 ---
-created: '2024-01-10T17:07:19.615751Z'
+created: '2024-10-16T22:32:28.751675+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
-# Shows that the custom fingerprinting rule is applied when both SDK and type match
 ---
 config:
   rules:
@@ -14,6 +13,7 @@ config:
       - sentry.java
     - - type
       - DatabaseUnavailable
+    text: sdk:"sentry.java" type:"DatabaseUnavailable" -> "database-unavailable"
   version: 1
 fingerprint:
 - database-unavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk_mismatch.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk_mismatch.pysnap
@@ -1,8 +1,7 @@
 ---
-created: '2024-10-09T13:43:00.978539+00:00'
+created: '2024-10-16T22:32:31.555178+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
-# Shows that the custom fingerprinting rule is not applied when type matches, but SDK does not
 ---
 config:
   rules:
@@ -14,6 +13,7 @@ config:
       - sentry.java
     - - type
       - DatabaseUnavailable
+    text: sdk:"sentry.java" type:"DatabaseUnavailable" -> "database-unavailable"
   version: 1
 fingerprint:
 - my-route

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_value.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_value.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-01-11T19:06:29.281374Z'
+created: '2024-10-16T22:32:32.087925+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -12,6 +12,7 @@ config:
     matchers:
     - - value
       - '*went wrong*'
+    text: value:"*went wrong*" -> "something-went-wrong{{ error.value }}"
   version: 1
 fingerprint:
 - something-went-wrong

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-12-08T17:25:03.888626Z'
+created: '2024-10-16T22:32:28.227754+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -14,6 +14,8 @@ config:
       - DatabaseUnavailable
     - - module
       - io.sentry.example.*
+    text: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
+      function }}"
   version: 1
 fingerprint:
 - database-unavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-01-11T19:06:29.250247Z'
+created: '2024-10-16T22:32:31.887130+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -12,6 +12,7 @@ config:
     matchers:
     - - message
       - '*love*'
+    text: message:"*love*" -> "what-is-love{{ message }}"
   version: 1
 fingerprint:
 - what-is-love

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message_on_value.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message_on_value.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-01-11T19:06:27.995697Z'
+created: '2024-10-16T22:32:28.849683+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -12,6 +12,7 @@ config:
     matchers:
     - - message
       - '*love*'
+    text: message:"*love*" -> "what-is-love{{ message }}"
   version: 1
 fingerprint:
 - what-is-love

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-12-08T17:25:04.926320Z'
+created: '2024-10-16T22:32:30.109890+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -13,6 +13,7 @@ config:
       - SymCacheError
     - - function
       - symbolicator::actors::symcaches::*
+    text: type:"SymCacheError" function:"symbolicator::actors::symcaches::*" -> "symcache-error"
   version: 1
 fingerprint:
 - symcache-error

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-12-08T17:25:04.277740Z'
+created: '2024-10-16T22:32:29.262373+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -13,6 +13,7 @@ config:
       - symbolicator::actors::symcaches::*
     - - app
       - 'true'
+    text: function:"symbolicator::actors::symcaches::*" app:"true" -> "symcache-error"
   version: 1
 fingerprint:
 - symcache-error

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_non_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_non_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-10-13T10:09:31.365749Z'
+created: '2024-10-16T22:32:29.636422+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -13,6 +13,7 @@ config:
       - symbolicator::actors::symcaches::*
     - - app
       - 'false'
+    text: function:"symbolicator::actors::symcaches::*" app:"false" -> "symcache-error"
   version: 1
 fingerprint:
 - '{{ default }}'

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-12-08T17:25:05.057772Z'
+created: '2024-10-16T22:32:32.422008+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -14,6 +14,8 @@ config:
       - DatabaseUnavailable
     - - module
       - io.sentry.example.*
+    text: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
+      function }}"
   version: 1
 fingerprint:
 - database-unavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-09T13:43:01.647186+00:00'
+created: '2024-10-16T22:32:32.190012+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -13,6 +13,7 @@ config:
       - DatabaseUnavailable
     - - module
       - invalid.databasestuff.*
+    text: type:"DatabaseUnavailable" module:"invalid.databasestuff.*" -> "database-unavailable"
   version: 1
 fingerprint:
 - my-route

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_package.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_package.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-12-08T17:25:03.931600Z'
+created: '2024-10-16T22:32:28.644068+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -11,6 +11,7 @@ config:
     matchers:
     - - type
       - DatabaseUnavailable
+    text: type:"DatabaseUnavailable" -> "{{ package }}"
   version: 1
 fingerprint:
 - '{{ package }}'

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_transaction.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_transaction.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-12-08T17:25:03.959890Z'
+created: '2024-10-16T22:32:29.100447+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -14,6 +14,8 @@ config:
       - DatabaseUnavailable
     - - module
       - io.sentry.example.*
+    text: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
+      transaction }}"
   version: 1
 fingerprint:
 - database-unavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_type_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_type_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-12-08T17:25:03.857235Z'
+created: '2024-10-16T22:32:27.906317+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -13,6 +13,7 @@ config:
     matchers:
     - - function
       - main
+    text: function:"main" -> "{{ type }}{{ module }}{{ function }}"
   version: 1
 fingerprint:
 - '{{ type }}'

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_log_info.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_log_info.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-12-08T17:25:04.978501Z'
+created: '2024-10-16T22:32:31.694343+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -16,6 +16,7 @@ config:
       - sentry.*
     - - level
       - ERROR
+    text: logger:"sentry.*" level:"ERROR" -> "log-{{ logger }}-{{ level }}"
   version: 1
 fingerprint:
 - log-

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_sdk.pysnap
@@ -1,8 +1,7 @@
 ---
-created: '2024-01-09T23:55:15.059223Z'
+created: '2024-10-16T22:32:28.968353+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
-# Shows that the custom fingerprinting rule is applied when SDK is nextj
 ---
 config:
   rules:
@@ -12,6 +11,7 @@ config:
     matchers:
     - - sdk
       - sentry.javascript.nextjs
+    text: sdk:"sentry.javascript.nextjs" -> "sdk-nextjs"
   version: 1
 fingerprint:
 - sdk-nextjs

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_tags.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_tags.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-12-08T17:25:04.966299Z'
+created: '2024-10-16T22:32:31.414158+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -12,6 +12,7 @@ config:
     matchers:
     - - tags.foobar
       - '*stuff*'
+    text: tags.foobar:"*stuff*" -> "foobar-matched-stuff-{{ tags.barfoo }}"
   version: 1
 fingerprint:
 - foobar-matched-stuff-

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_override_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_override_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-12-08T17:25:03.900569Z'
+created: '2024-10-16T22:32:28.357412+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -11,6 +11,7 @@ config:
     matchers:
     - - message
       - '*love*'
+    text: message:"*love*" -> "what-is-love"
   version: 1
 fingerprint:
 - what-is-love

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_package.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_package.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-12-08T17:25:04.941471Z'
+created: '2024-10-16T22:32:30.956554+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -11,6 +11,7 @@ config:
     matchers:
     - - type
       - DatabaseUnavailable
+    text: type:"DatabaseUnavailable" -> "{{ package }}"
   version: 1
 fingerprint:
 - '{{ package }}'

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_python.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_python.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-12-08T17:25:03.875766Z'
+created: '2024-10-16T22:32:28.104840+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -13,6 +13,7 @@ config:
       - ReadTimeout
     - - path
       - '**/requests/adapters.py'
+    text: type:"ReadTimeout" path:"**/requests/adapters.py" -> "timeout-in-requests"
   version: 1
 fingerprint:
 - timeout-in-requests

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_release.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_release.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-04-02T20:25:06.571127+00:00'
+created: '2024-10-16T22:32:31.117234+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -11,6 +11,7 @@ config:
     matchers:
     - - release
       - foo.bar@*
+    text: release:"foo.bar@*" -> "foo.bar-release"
   version: 1
 fingerprint:
 - foo.bar-release

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_transaction.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_transaction.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-12-08T17:25:05.003284Z'
+created: '2024-10-16T22:32:31.988821+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -15,6 +15,8 @@ config:
       - DatabaseUnavailable
     - - module
       - io.sentry.example.*
+    text: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
+      transaction }}" title="DatabaseUnavailable ({{ transaction }})"
   version: 1
 fingerprint:
 - database-unavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_two_threads.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_two_threads.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-10-09T08:26:55.655641Z'
+created: '2024-10-16T22:32:30.528301+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -11,6 +11,7 @@ config:
     matchers:
     - - function
       - main
+    text: function:"main" -> "in-main"
   version: 1
 fingerprint:
 - in-main

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_type_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_type_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-12-08T17:25:04.954793Z'
+created: '2024-10-16T22:32:31.280581+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -14,6 +14,8 @@ config:
       - DatabaseUnavailable
     - - module
       - io.sentry.example.*
+    text: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "{{ type }}{{
+      module }}"
   version: 1
 fingerprint:
 - '{{ type }}'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:23:21.483979+00:00'
+created: '2024-10-16T19:26:47.033154+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -203,7 +203,7 @@ app:
 --------------------------------------------------------------------------
 custom-fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
-  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:23:21.675726+00:00'
+created: '2024-10-16T19:26:47.124257+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -203,7 +203,7 @@ app:
 --------------------------------------------------------------------------
 custom-fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
-  info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:23:30.537570+00:00'
+created: '2024-10-16T19:26:51.182801+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -200,7 +200,7 @@ app:
           "SoftTimeLimitExceeded"
         value (stacktrace and type take precedence)
           "SoftTimeLimitExceeded()"
-  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
   values: ["{{ default }}","soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:
@@ -400,5 +400,5 @@ system:
           "SoftTimeLimitExceeded"
         value (stacktrace and type take precedence)
           "SoftTimeLimitExceeded()"
-  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
   values: ["{{ default }}","soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:23:30.691805+00:00'
+created: '2024-10-16T19:26:51.228424+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -203,7 +203,7 @@ app:
 --------------------------------------------------------------------------
 custom-fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
-  info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:23:36.590368+00:00'
+created: '2024-10-16T19:27:04.024202+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -169,7 +169,7 @@ app:
 --------------------------------------------------------------------------
 custom-fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
-  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:23:36.712835+00:00'
+created: '2024-10-16T19:27:04.120102+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -169,7 +169,7 @@ app:
 --------------------------------------------------------------------------
 custom-fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
-  info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:23:41.929197+00:00'
+created: '2024-10-16T19:27:07.939679+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -166,7 +166,7 @@ app:
           "SoftTimeLimitExceeded"
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
-  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
   values: ["{{ default }}","soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:
@@ -332,5 +332,5 @@ system:
           "SoftTimeLimitExceeded"
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
-  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
   values: ["{{ default }}","soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:23:41.990664+00:00'
+created: '2024-10-16T19:27:07.987767+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -169,7 +169,7 @@ app:
 --------------------------------------------------------------------------
 custom-fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
-  info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:23:49.262914+00:00'
+created: '2024-10-16T19:26:55.742395+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -169,7 +169,7 @@ app:
 --------------------------------------------------------------------------
 custom-fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
-  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:23:49.402010+00:00'
+created: '2024-10-16T19:26:56.036770+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -169,7 +169,7 @@ app:
 --------------------------------------------------------------------------
 custom-fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
-  info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:23:55.272897+00:00'
+created: '2024-10-16T19:27:00.095990+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -166,7 +166,7 @@ app:
           "SoftTimeLimitExceeded"
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
-  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
   values: ["{{ default }}","soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:
@@ -332,5 +332,5 @@ system:
           "SoftTimeLimitExceeded"
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
-  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
   values: ["{{ default }}","soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:23:55.354774+00:00'
+created: '2024-10-16T19:27:00.140364+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -169,7 +169,7 @@ app:
 --------------------------------------------------------------------------
 custom-fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
-  info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:24:00.902258+00:00'
+created: '2024-10-16T19:21:18.239532+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -23,7 +23,7 @@ app:
 --------------------------------------------------------------------------
 built-in-fingerprint:
   hash: "5d731dcf8ecc4f042eeacf528d8d8da9"
-  info: {"matched_rule":{"attributes":{},"fingerprint":["chunkloaderror"],"is_builtin":true,"matchers":[["family","javascript"],["type","ChunkLoadError"]]}}
+  info: {"matched_rule":{"attributes":{},"fingerprint":["chunkloaderror"],"is_builtin":true,"matchers":[["family","javascript"],["type","ChunkLoadError"]],"text":"family:\"javascript\" type:\"ChunkLoadError\" -> \"chunkloaderror\""}}
   values: ["chunkloaderror"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:24:00.829320+00:00'
+created: '2024-10-16T19:21:16.136903+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -23,7 +23,7 @@ app:
 --------------------------------------------------------------------------
 built-in-fingerprint:
   hash: "5d731dcf8ecc4f042eeacf528d8d8da9"
-  info: {"client_fingerprint":["{{ default }}","dogs are great"],"matched_rule":{"attributes":{},"fingerprint":["chunkloaderror"],"is_builtin":true,"matchers":[["family","javascript"],["type","ChunkLoadError"]]}}
+  info: {"client_fingerprint":["{{ default }}","dogs are great"],"matched_rule":{"attributes":{},"fingerprint":["chunkloaderror"],"is_builtin":true,"matchers":[["family","javascript"],["type","ChunkLoadError"]],"text":"family:\"javascript\" type:\"ChunkLoadError\" -> \"chunkloaderror\""}}
   values: ["chunkloaderror"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:24:01.543350+00:00'
+created: '2024-10-16T19:21:42.560447+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -169,7 +169,7 @@ app:
 --------------------------------------------------------------------------
 custom-fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
-  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:24:01.649651+00:00'
+created: '2024-10-16T19:21:47.347557+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -169,7 +169,7 @@ app:
 --------------------------------------------------------------------------
 custom-fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
-  info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:24:08.426043+00:00'
+created: '2024-10-16T19:24:29.370529+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -166,7 +166,7 @@ app:
           "SoftTimeLimitExceeded"
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
-  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
   values: ["{{ default }}","soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:
@@ -332,5 +332,5 @@ system:
           "SoftTimeLimitExceeded"
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
-  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["{{ default }}","soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"{{ default }}soft-timelimit-exceeded\""}}
   values: ["{{ default }}","soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:24:08.483412+00:00'
+created: '2024-10-16T19:24:31.061837+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -169,7 +169,7 @@ app:
 --------------------------------------------------------------------------
 custom-fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
-  info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]]}}
+  info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/test_builtin_fingerprinting.py
+++ b/tests/sentry/grouping/test_builtin_fingerprinting.py
@@ -36,18 +36,21 @@ def test_default_bases(default_bases):
     } == {
         "javascript@2024-02-02": [
             {
+                "text": 'family:"javascript" type:"ChunkLoadError" -> "chunkloaderror"',
                 "matchers": [["family", "javascript"], ["type", "ChunkLoadError"]],
                 "fingerprint": ["chunkloaderror"],
                 "attributes": {},
                 "is_builtin": True,
             },
             {
+                "text": 'family:"javascript" value:"ChunkLoadError*" -> "chunkloaderror"',
                 "matchers": [["family", "javascript"], ["value", "ChunkLoadError*"]],
                 "fingerprint": ["chunkloaderror"],
                 "attributes": {},
                 "is_builtin": True,
             },
             {
+                "text": 'family:"javascript" tags.transaction:"*" message:"Hydration failed because the initial UI does not match what was rendered on the server." -> "hydrationerror{{tags.transaction}}"',
                 "matchers": [
                     ["family", "javascript"],
                     ["tags.transaction", "*"],
@@ -61,6 +64,7 @@ def test_default_bases(default_bases):
                 "is_builtin": True,
             },
             {
+                "text": 'family:"javascript" tags.transaction:"*" message:"The server could not finish this Suspense boundary, likely due to an error during server rendering. Switched to client rendering." -> "hydrationerror{{tags.transaction}}"',
                 "matchers": [
                     ["family", "javascript"],
                     ["tags.transaction", "*"],
@@ -74,6 +78,7 @@ def test_default_bases(default_bases):
                 "is_builtin": True,
             },
             {
+                "text": 'family:"javascript" tags.transaction:"*" message:"There was an error while hydrating this Suspense boundary. Switched to client rendering." -> "hydrationerror{{tags.transaction}}"',
                 "matchers": [
                     ["family", "javascript"],
                     ["tags.transaction", "*"],
@@ -87,6 +92,7 @@ def test_default_bases(default_bases):
                 "is_builtin": True,
             },
             {
+                "text": 'family:"javascript" tags.transaction:"*" message:"There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering." -> "hydrationerror{{tags.transaction}}"',
                 "matchers": [
                     ["family", "javascript"],
                     ["tags.transaction", "*"],
@@ -100,6 +106,7 @@ def test_default_bases(default_bases):
                 "is_builtin": True,
             },
             {
+                "text": 'family:"javascript" tags.transaction:"*" message:"Text content does not match server-rendered HTML." -> "hydrationerror{{tags.transaction}}"',
                 "matchers": [
                     ["family", "javascript"],
                     ["tags.transaction", "*"],
@@ -120,18 +127,21 @@ def test_built_in_nextjs_rules_base(default_bases):
     assert rules._to_config_structure(include_builtin=True) == {
         "rules": [
             {
+                "text": 'family:"javascript" type:"ChunkLoadError" -> "chunkloaderror"',
                 "matchers": [["family", "javascript"], ["type", "ChunkLoadError"]],
                 "fingerprint": ["chunkloaderror"],
                 "attributes": {},
                 "is_builtin": True,
             },
             {
+                "text": 'family:"javascript" value:"ChunkLoadError*" -> "chunkloaderror"',
                 "matchers": [["family", "javascript"], ["value", "ChunkLoadError*"]],
                 "fingerprint": ["chunkloaderror"],
                 "attributes": {},
                 "is_builtin": True,
             },
             {
+                "text": 'family:"javascript" tags.transaction:"*" message:"Hydration failed because the initial UI does not match what was rendered on the server." -> "hydrationerror{{tags.transaction}}"',
                 "matchers": [
                     ["family", "javascript"],
                     ["tags.transaction", "*"],
@@ -145,6 +155,7 @@ def test_built_in_nextjs_rules_base(default_bases):
                 "is_builtin": True,
             },
             {
+                "text": 'family:"javascript" tags.transaction:"*" message:"The server could not finish this Suspense boundary, likely due to an error during server rendering. Switched to client rendering." -> "hydrationerror{{tags.transaction}}"',
                 "matchers": [
                     ["family", "javascript"],
                     ["tags.transaction", "*"],
@@ -158,6 +169,7 @@ def test_built_in_nextjs_rules_base(default_bases):
                 "is_builtin": True,
             },
             {
+                "text": 'family:"javascript" tags.transaction:"*" message:"There was an error while hydrating this Suspense boundary. Switched to client rendering." -> "hydrationerror{{tags.transaction}}"',
                 "matchers": [
                     ["family", "javascript"],
                     ["tags.transaction", "*"],
@@ -171,6 +183,7 @@ def test_built_in_nextjs_rules_base(default_bases):
                 "is_builtin": True,
             },
             {
+                "text": 'family:"javascript" tags.transaction:"*" message:"There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering." -> "hydrationerror{{tags.transaction}}"',
                 "matchers": [
                     ["family", "javascript"],
                     ["tags.transaction", "*"],
@@ -184,6 +197,7 @@ def test_built_in_nextjs_rules_base(default_bases):
                 "is_builtin": True,
             },
             {
+                "text": 'family:"javascript" tags.transaction:"*" message:"Text content does not match server-rendered HTML." -> "hydrationerror{{tags.transaction}}"',
                 "matchers": [
                     ["family", "javascript"],
                     ["tags.transaction", "*"],
@@ -205,18 +219,21 @@ def test_built_in_nextjs_rules_from_empty_config_string(default_bases):
     assert rules._to_config_structure(include_builtin=True) == {
         "rules": [
             {
+                "text": 'family:"javascript" type:"ChunkLoadError" -> "chunkloaderror"',
                 "matchers": [["family", "javascript"], ["type", "ChunkLoadError"]],
                 "fingerprint": ["chunkloaderror"],
                 "attributes": {},
                 "is_builtin": True,
             },
             {
+                "text": 'family:"javascript" value:"ChunkLoadError*" -> "chunkloaderror"',
                 "matchers": [["family", "javascript"], ["value", "ChunkLoadError*"]],
                 "fingerprint": ["chunkloaderror"],
                 "attributes": {},
                 "is_builtin": True,
             },
             {
+                "text": 'family:"javascript" tags.transaction:"*" message:"Hydration failed because the initial UI does not match what was rendered on the server." -> "hydrationerror{{tags.transaction}}"',
                 "matchers": [
                     ["family", "javascript"],
                     ["tags.transaction", "*"],
@@ -230,6 +247,7 @@ def test_built_in_nextjs_rules_from_empty_config_string(default_bases):
                 "is_builtin": True,
             },
             {
+                "text": 'family:"javascript" tags.transaction:"*" message:"The server could not finish this Suspense boundary, likely due to an error during server rendering. Switched to client rendering." -> "hydrationerror{{tags.transaction}}"',
                 "matchers": [
                     ["family", "javascript"],
                     ["tags.transaction", "*"],
@@ -243,6 +261,7 @@ def test_built_in_nextjs_rules_from_empty_config_string(default_bases):
                 "is_builtin": True,
             },
             {
+                "text": 'family:"javascript" tags.transaction:"*" message:"There was an error while hydrating this Suspense boundary. Switched to client rendering." -> "hydrationerror{{tags.transaction}}"',
                 "matchers": [
                     ["family", "javascript"],
                     ["tags.transaction", "*"],
@@ -256,6 +275,7 @@ def test_built_in_nextjs_rules_from_empty_config_string(default_bases):
                 "is_builtin": True,
             },
             {
+                "text": 'family:"javascript" tags.transaction:"*" message:"There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering." -> "hydrationerror{{tags.transaction}}"',
                 "matchers": [
                     ["family", "javascript"],
                     ["tags.transaction", "*"],
@@ -269,6 +289,7 @@ def test_built_in_nextjs_rules_from_empty_config_string(default_bases):
                 "is_builtin": True,
             },
             {
+                "text": 'family:"javascript" tags.transaction:"*" message:"Text content does not match server-rendered HTML." -> "hydrationerror{{tags.transaction}}"',
                 "matchers": [
                     ["family", "javascript"],
                     ["tags.transaction", "*"],
@@ -291,6 +312,7 @@ def test_built_in_nextjs_rules_from_config_string_with_custom(default_bases):
     assert rules._to_config_structure(include_builtin=False) == {
         "rules": [
             {
+                "text": 'type:"DatabaseUnavailable" -> "DatabaseUnavailable"',
                 "matchers": [["type", "DatabaseUnavailable"]],
                 "fingerprint": ["DatabaseUnavailable"],
                 "attributes": {},
@@ -301,23 +323,27 @@ def test_built_in_nextjs_rules_from_config_string_with_custom(default_bases):
     assert rules._to_config_structure(include_builtin=True) == {
         "rules": [
             {
+                "text": 'type:"DatabaseUnavailable" -> "DatabaseUnavailable"',
                 "matchers": [["type", "DatabaseUnavailable"]],
                 "fingerprint": ["DatabaseUnavailable"],
                 "attributes": {},
             },
             {
+                "text": 'family:"javascript" type:"ChunkLoadError" -> "chunkloaderror"',
                 "matchers": [["family", "javascript"], ["type", "ChunkLoadError"]],
                 "fingerprint": ["chunkloaderror"],
                 "attributes": {},
                 "is_builtin": True,
             },
             {
+                "text": 'family:"javascript" value:"ChunkLoadError*" -> "chunkloaderror"',
                 "matchers": [["family", "javascript"], ["value", "ChunkLoadError*"]],
                 "fingerprint": ["chunkloaderror"],
                 "attributes": {},
                 "is_builtin": True,
             },
             {
+                "text": 'family:"javascript" tags.transaction:"*" message:"Hydration failed because the initial UI does not match what was rendered on the server." -> "hydrationerror{{tags.transaction}}"',
                 "matchers": [
                     ["family", "javascript"],
                     ["tags.transaction", "*"],
@@ -331,6 +357,7 @@ def test_built_in_nextjs_rules_from_config_string_with_custom(default_bases):
                 "is_builtin": True,
             },
             {
+                "text": 'family:"javascript" tags.transaction:"*" message:"The server could not finish this Suspense boundary, likely due to an error during server rendering. Switched to client rendering." -> "hydrationerror{{tags.transaction}}"',
                 "matchers": [
                     ["family", "javascript"],
                     ["tags.transaction", "*"],
@@ -344,6 +371,7 @@ def test_built_in_nextjs_rules_from_config_string_with_custom(default_bases):
                 "is_builtin": True,
             },
             {
+                "text": 'family:"javascript" tags.transaction:"*" message:"There was an error while hydrating this Suspense boundary. Switched to client rendering." -> "hydrationerror{{tags.transaction}}"',
                 "matchers": [
                     ["family", "javascript"],
                     ["tags.transaction", "*"],
@@ -357,6 +385,7 @@ def test_built_in_nextjs_rules_from_config_string_with_custom(default_bases):
                 "is_builtin": True,
             },
             {
+                "text": 'family:"javascript" tags.transaction:"*" message:"There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering." -> "hydrationerror{{tags.transaction}}"',
                 "matchers": [
                     ["family", "javascript"],
                     ["tags.transaction", "*"],
@@ -376,6 +405,7 @@ def test_built_in_nextjs_rules_from_config_string_with_custom(default_bases):
                     ["message", "Text content does not match server-rendered HTML."],
                 ],
                 "fingerprint": ["hydrationerror", "{{tags.transaction}}"],
+                "text": 'family:"javascript" tags.transaction:"*" message:"Text content does not match server-rendered HTML." -> "hydrationerror{{tags.transaction}}"',
                 "attributes": {},
                 "is_builtin": True,
             },
@@ -412,6 +442,7 @@ def test_load_configs_borked_file_doesnt_blow_up(tmp_path):
 
     assert [r._to_config_structure() for r in rules] == [
         {
+            "text": 'type:"DatabaseUnavailable" -> "DatabaseUnavailable"',
             "matchers": [["type", "DatabaseUnavailable"]],
             "fingerprint": ["DatabaseUnavailable"],
             "attributes": {},
@@ -520,6 +551,7 @@ class BuiltInFingerprintingTest(TestCase):
             "attributes": {},
             "fingerprint": ["chunkloaderror"],
             "matchers": [["family", "javascript"], ["type", "ChunkLoadError"]],
+            "text": 'family:"javascript" type:"ChunkLoadError" -> "chunkloaderror"',
             "is_builtin": True,
         }
 
@@ -552,6 +584,7 @@ class BuiltInFingerprintingTest(TestCase):
             "attributes": {},
             "fingerprint": ["chunkloaderror"],
             "matchers": [["family", "javascript"], ["value", "ChunkLoadError*"]],
+            "text": 'family:"javascript" value:"ChunkLoadError*" -> "chunkloaderror"',
             "is_builtin": True,
         }
 
@@ -568,6 +601,7 @@ class BuiltInFingerprintingTest(TestCase):
             "attributes": {},
             "fingerprint": ["chunkloaderror"],
             "matchers": [["family", "javascript"], ["type", "ChunkLoadError"]],
+            "text": 'family:"javascript" type:"ChunkLoadError" -> "chunkloaderror"',
             "is_builtin": True,
         }
 
@@ -593,6 +627,7 @@ class BuiltInFingerprintingTest(TestCase):
                 ["tags.transaction", "*"],
                 ["message", self.hydration_error_trace["message"]],
             ],
+            "text": 'family:"javascript" tags.transaction:"*" message:"Text content does not match server-rendered HTML." -> "hydrationerror{{tags.transaction}}"',
             "is_builtin": True,
         }
         assert event_message2.data.data["fingerprint"] == ["hydrationerror", "{{tags.transaction}}"]
@@ -604,6 +639,7 @@ class BuiltInFingerprintingTest(TestCase):
                 ["tags.transaction", "*"],
                 ["message", data_message2["message"]],
             ],
+            "text": 'family:"javascript" tags.transaction:"*" message:"Hydration failed because the initial UI does not match what was rendered on the server." -> "hydrationerror{{tags.transaction}}"',
             "is_builtin": True,
         }
 
@@ -636,6 +672,7 @@ class BuiltInFingerprintingTest(TestCase):
                 ["tags.transaction", "*"],
                 ["message", self.hydration_error_trace["message"]],
             ],
+            "text": 'family:"javascript" tags.transaction:"*" message:"Text content does not match server-rendered HTML." -> "hydrationerror{{tags.transaction}}"',
             "is_builtin": True,
         }
         assert event_transaction_text.data.data["fingerprint"] == [
@@ -650,6 +687,7 @@ class BuiltInFingerprintingTest(TestCase):
                 ["tags.transaction", "*"],
                 ["message", self.hydration_error_trace["message"]],
             ],
+            "text": 'family:"javascript" tags.transaction:"*" message:"Text content does not match server-rendered HTML." -> "hydrationerror{{tags.transaction}}"',
             "is_builtin": True,
         }
 
@@ -703,4 +741,5 @@ class BuiltInFingerprintingTest(TestCase):
                 ["tags.transaction", "*"],
                 ["message", self.hydration_error_trace["message"]],
             ],
+            "text": 'family:"javascript" tags.transaction:"*" message:"Text content does not match server-rendered HTML." -> "hydrationerror{{tags.transaction}}"',
         }

--- a/tests/sentry/grouping/test_fingerprinting.py
+++ b/tests/sentry/grouping/test_fingerprinting.py
@@ -30,31 +30,61 @@ logger:sentry.*                                 -> logger-{{ logger }} title="Me
     assert rules._to_config_structure() == {
         "rules": [
             {
+                "text": 'type:"DatabaseUnavailable" -> "DatabaseUnavailable"',
                 "matchers": [["type", "DatabaseUnavailable"]],
                 "fingerprint": ["DatabaseUnavailable"],
                 "attributes": {},
             },
             {
+                "text": 'function:"assertion_failed" module:"foo" -> "AssertionFailedfoo"',
                 "matchers": [["function", "assertion_failed"], ["module", "foo"]],
                 "fingerprint": ["AssertionFailed", "foo"],
                 "attributes": {},
             },
-            {"matchers": [["app", "true"]], "fingerprint": ["aha"], "attributes": {}},
-            {"matchers": [["app", "true"]], "fingerprint": ["{{ default }}"], "attributes": {}},
-            {"matchers": [["!path", "**/foo/**"]], "fingerprint": ["everything"], "attributes": {}},
-            {"matchers": [["!path", "**/foo/**"]], "fingerprint": ["everything"], "attributes": {}},
             {
+                "text": 'app:"true" -> "aha"',
+                "matchers": [["app", "true"]],
+                "fingerprint": ["aha"],
+                "attributes": {},
+            },
+            {
+                "text": 'app:"true" -> "{{ default }}"',
+                "matchers": [["app", "true"]],
+                "fingerprint": ["{{ default }}"],
+                "attributes": {},
+            },
+            {
+                "text": '!path:"**/foo/**" -> "everything"',
+                "matchers": [["!path", "**/foo/**"]],
+                "fingerprint": ["everything"],
+                "attributes": {},
+            },
+            {
+                "text": '!path:"**/foo/**" -> "everything"',
+                "matchers": [["!path", "**/foo/**"]],
+                "fingerprint": ["everything"],
+                "attributes": {},
+            },
+            {
+                "text": 'logger:"sentry.*" -> "logger-{{ logger }}"',
                 "matchers": [["logger", "sentry.*"]],
                 "fingerprint": ["logger-", "{{ logger }}"],
                 "attributes": {},
             },
-            {"matchers": [["message", "\\x\xff"]], "fingerprint": ["stuff"], "attributes": {}},
             {
+                "text": 'message:"\\xÿ" -> "stuff"',
+                "matchers": [["message", "\\x\xff"]],
+                "fingerprint": ["stuff"],
+                "attributes": {},
+            },
+            {
+                "text": 'logger:"sentry.*" -> "logger-{{ logger }}" title="Message from {{ logger }}"',
                 "matchers": [["logger", "sentry.*"]],
                 "fingerprint": ["logger-", "{{ logger }}"],
                 "attributes": {"title": "Message from {{ logger }}"},
             },
             {
+                "text": 'logger:"sentry.*" -> "logger-{{ logger }}" title="Message from {{ logger }}"',
                 "matchers": [["logger", "sentry.*"]],
                 "fingerprint": ["logger-", "{{ logger }}"],
                 "attributes": {"title": "Message from {{ logger }}"},
@@ -81,6 +111,7 @@ logger:sentry.*                                 -> logger, {{ logger }}, title="
         "attributes": {"title": "Message from {{ logger }}"},
         "fingerprint": ["logger", "{{ logger }}"],
         "matchers": [["logger", "sentry.*"]],
+        "text": 'logger:"sentry.*" -> "logger{{ logger }}" title="Message from {{ logger }}"',
     }
 
 
@@ -101,21 +132,25 @@ logger:test2 -> logger-, {{ logger }}, -, {{ level }}
     assert rules._to_config_structure() == {
         "rules": [
             {
+                "text": 'logger:"test" -> "logger-{{ logger }}"',
                 "matchers": [["logger", "test"]],
                 "fingerprint": ["logger-", "{{ logger }}"],
                 "attributes": {},
             },
             {
+                "text": 'logger:"test" -> "logger-{{ logger }}"',
                 "matchers": [["logger", "test"]],
                 "fingerprint": ["logger-", "{{ logger }}"],
                 "attributes": {},
             },
             {
+                "text": 'logger:"test2" -> "logger-{{ logger }}-{{ level }}"',
                 "matchers": [["logger", "test2"]],
                 "fingerprint": ["logger-", "{{ logger }}", "-", "{{ level }}"],
                 "attributes": {},
             },
             {
+                "text": 'logger:"test2" -> "logger-{{ logger }}-{{ level }}"',
                 "matchers": [["logger", "test2"]],
                 "fingerprint": ["logger-", "{{ logger }}", "-", "{{ level }}"],
                 "attributes": {},
@@ -139,18 +174,35 @@ release:foo                                     -> release-foo
     assert rules._to_config_structure() == {
         "rules": [
             {
+                "text": 'type:"DatabaseUnavailable" -> "DatabaseUnavailable"',
                 "matchers": [["type", "DatabaseUnavailable"]],
                 "fingerprint": ["DatabaseUnavailable"],
                 "attributes": {},
             },
             {
+                "text": 'function:"assertion_failed" module:"foo" -> "AssertionFailedfoo"',
                 "matchers": [["function", "assertion_failed"], ["module", "foo"]],
                 "fingerprint": ["AssertionFailed", "foo"],
                 "attributes": {},
             },
-            {"matchers": [["app", "true"]], "fingerprint": ["aha"], "attributes": {}},
-            {"matchers": [["app", "true"]], "fingerprint": ["{{ default }}"], "attributes": {}},
-            {"matchers": [["release", "foo"]], "fingerprint": ["release-foo"], "attributes": {}},
+            {
+                "text": 'app:"true" -> "aha"',
+                "matchers": [["app", "true"]],
+                "fingerprint": ["aha"],
+                "attributes": {},
+            },
+            {
+                "text": 'app:"true" -> "{{ default }}"',
+                "matchers": [["app", "true"]],
+                "fingerprint": ["{{ default }}"],
+                "attributes": {},
+            },
+            {
+                "text": 'release:"foo" -> "release-foo"',
+                "matchers": [["release", "foo"]],
+                "fingerprint": ["release-foo"],
+                "attributes": {},
+            },
         ],
         "version": 1,
     }


### PR DESCRIPTION
This makes two small changes to the way objects used in our grouping algorithm represent and then eventually jsonify themselves.

- For `GroupingComponent.description`, fall back to the `id` value rather than using the generic value `"others"`.
- Add the original text of a fingerprinting rule to its dictified version. This results in a more human-readable way to display which rule matched a given event.