### PR TITLE
feat(trace-explorer): Support endpoint on EAP

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -28,6 +28,7 @@ from sentry.models.project import Project
 from sentry.search.events.builder.base import BaseQueryBuilder
 from sentry.search.events.builder.discover import DiscoverQueryBuilder
 from sentry.search.events.builder.spans_indexed import (
+    SpansEAPQueryBuilder,
     SpansIndexedQueryBuilder,
     TimeseriesSpanIndexedQueryBuilder,
 )
@@ -82,6 +83,9 @@ class TraceResult(TypedDict):
 
 
 class OrganizationTracesSerializer(serializers.Serializer):
+    dataset = serializers.ChoiceField(
+        ["spans", "spansIndexed"], required=False, default="spansIndexed"
+    )
     metricsMax = serializers.FloatField(required=False)
     metricsMin = serializers.FloatField(required=False)
     metricsOp = serializers.CharField(required=False)
@@ -92,6 +96,13 @@ class OrganizationTracesSerializer(serializers.Serializer):
     query = serializers.ListField(
         required=False, allow_empty=True, child=serializers.CharField(allow_blank=True)
     )
+
+    def validate_dataset(self, value):
+        if value == "spans":
+            return Dataset.EventsAnalyticsPlatform
+        if value == "spansIndexed":
+            return Dataset.SpansIndexed
+        raise NotImplementedError
 
 
 @contextmanager
@@ -136,6 +147,7 @@ class OrganizationTracesEndpoint(OrganizationTracesEndpointBase):
         serialized = serializer.validated_data
 
         executor = TracesExecutor(
+            dataset=serialized["dataset"],
             snuba_params=snuba_params,
             user_queries=serialized.get("query", []),
             metrics_max=serialized.get("metricsMax"),
@@ -169,6 +181,9 @@ class OrganizationTracesEndpoint(OrganizationTracesEndpointBase):
 
 
 class OrganizationTraceSpansSerializer(serializers.Serializer):
+    dataset = serializers.ChoiceField(
+        ["spans", "spansIndexed"], required=False, default="spansIndexed"
+    )
     metricsMax = serializers.FloatField(required=False)
     metricsMin = serializers.FloatField(required=False)
     metricsOp = serializers.CharField(required=False)
@@ -180,6 +195,13 @@ class OrganizationTraceSpansSerializer(serializers.Serializer):
     query = serializers.ListField(
         required=False, allow_empty=True, child=serializers.CharField(allow_blank=True)
     )
+
+    def validate_dataset(self, value):
+        if value == "spans":
+            return Dataset.EventsAnalyticsPlatform
+        if value == "spansIndexed":
+            return Dataset.SpansIndexed
+        raise NotImplementedError
 
 
 @region_silo_endpoint
@@ -203,6 +225,7 @@ class OrganizationTraceSpansEndpoint(OrganizationTracesEndpointBase):
         serialized = serializer.validated_data
 
         executor = TraceSpansExecutor(
+            dataset=serialized["dataset"],
             snuba_params=snuba_params,
             trace_id=trace_id,
             fields=serialized["field"],
@@ -230,10 +253,20 @@ class OrganizationTraceSpansEndpoint(OrganizationTracesEndpointBase):
 
 
 class OrganizationTracesStatsSerializer(serializers.Serializer):
+    dataset = serializers.ChoiceField(
+        ["spans", "spansIndexed"], required=False, default="spansIndexed"
+    )
     query = serializers.ListField(
         required=False, allow_empty=True, child=serializers.CharField(allow_blank=True)
     )
     yAxis = serializers.ListField(required=True, child=serializers.CharField())
+
+    def validate_dataset(self, value):
+        if value == "spans":
+            return Dataset.EventsAnalyticsPlatform
+        if value == "spansIndexed":
+            return Dataset.SpansIndexed
+        raise NotImplementedError
 
 
 @region_silo_endpoint
@@ -277,6 +310,7 @@ class OrganizationTracesStatsEndpoint(OrganizationTracesEndpointBase):
             comparison_delta: timedelta | None,
         ) -> SnubaTSResult:
             executor = TraceStatsExecutor(
+                dataset=serialized["dataset"],
                 snuba_params=snuba_params,
                 columns=serialized["yAxis"],
                 user_queries=serialized.get("query", []),
@@ -306,6 +340,7 @@ class TracesExecutor:
     def __init__(
         self,
         *,
+        dataset: Dataset,
         snuba_params: SnubaParams,
         user_queries: list[str],
         metrics_max: float | None,
@@ -317,8 +352,9 @@ class TracesExecutor:
         breakdown_slices: int,
         get_all_projects: Callable[[], list[Project]],
     ):
+        self.dataset = dataset
         self.snuba_params = snuba_params
-        self.user_queries = process_user_queries(snuba_params, user_queries)
+        self.user_queries = process_user_queries(snuba_params, user_queries, dataset)
         self.metrics_max = metrics_max
         self.metrics_min = metrics_min
         self.metrics_operation = metrics_operation
@@ -344,10 +380,10 @@ class TracesExecutor:
                 self.snuba_params,
             )
 
-        self.refine_params(min_timestamp, max_timestamp)
-
         if not trace_ids:
             return []
+
+        self.refine_params(min_timestamp, max_timestamp)
 
         with handle_span_query_errors():
             snuba_params = self.params_with_all_projects()
@@ -572,6 +608,93 @@ class TracesExecutor:
         snuba_params: SnubaParams,
         sort: str | None = None,
     ) -> tuple[BaseQueryBuilder, str]:
+        if self.dataset == Dataset.EventsAnalyticsPlatform:
+            return self.get_traces_matching_span_conditions_query_eap(snuba_params, sort)
+        return self.get_traces_matching_span_conditions_query_indexed(snuba_params, sort)
+
+    def get_traces_matching_span_conditions_query_eap(
+        self,
+        snuba_params: SnubaParams,
+        sort: str | None = None,
+    ) -> tuple[BaseQueryBuilder, str]:
+        if len(self.user_queries) < 2:
+            timestamp_column = "timestamp"
+        else:
+            timestamp_column = "min(timestamp)"
+
+        if sort == "-timestamp":
+            orderby = [f"-{timestamp_column}"]
+        else:
+            # The orderby is intentionally `None` here as this query is much faster
+            # if we let Clickhouse decide which order to return the results in.
+            # This also means we cannot order by any columns or paginate.
+            orderby = None
+
+        if len(self.user_queries) < 2:
+            # Optimization: If there is only a condition for a single span,
+            # we can take the fast path and query without using aggregates.
+            query = SpansEAPQueryBuilder(
+                Dataset.EventsAnalyticsPlatform,
+                params={},
+                snuba_params=snuba_params,
+                query=None,
+                selected_columns=["trace", timestamp_column],
+                orderby=orderby,
+                limit=self.limit,
+                limitby=("trace", 1),
+                config=QueryBuilderConfig(
+                    transform_alias_to_input_format=True,
+                ),
+            )
+
+            for where in self.user_queries.values():
+                query.where.extend(where)
+        else:
+            query = SpansEAPQueryBuilder(
+                Dataset.EventsAnalyticsPlatform,
+                params={},
+                snuba_params=snuba_params,
+                query=None,
+                selected_columns=["trace", timestamp_column],
+                orderby=orderby,
+                limit=self.limit,
+                limitby=("trace", 1),
+                config=QueryBuilderConfig(
+                    auto_aggregations=True,
+                    transform_alias_to_input_format=True,
+                ),
+            )
+
+            trace_conditions = []
+            for where in self.user_queries.values():
+                if len(where) == 1:
+                    trace_conditions.extend(where)
+                elif len(where) > 1:
+                    trace_conditions.append(BooleanCondition(op=BooleanOp.AND, conditions=where))
+
+                # Transform the condition into it's aggregate form so it can be used to
+                # match on the trace.
+                new_condition = generate_trace_condition(where)
+                if new_condition:
+                    query.having.append(new_condition)
+
+            if len(trace_conditions) == 1:
+                # This should never happen since it should use a flat query
+                # but handle it just in case.
+                query.where.extend(trace_conditions)
+            elif len(trace_conditions) > 1:
+                query.where.append(BooleanCondition(op=BooleanOp.OR, conditions=trace_conditions))
+
+        if options.get("performance.traces.trace-explorer-skip-floating-spans"):
+            query.add_conditions([Condition(Column("segment_id"), Op.NEQ, "00")])
+
+        return query, timestamp_column
+
+    def get_traces_matching_span_conditions_query_indexed(
+        self,
+        snuba_params: SnubaParams,
+        sort: str | None = None,
+    ) -> tuple[BaseQueryBuilder, str]:
         if len(self.user_queries) < 2:
             timestamp_column = "timestamp"
         else:
@@ -766,6 +889,50 @@ class TracesExecutor:
         snuba_params: SnubaParams,
         trace_ids: list[str],
     ) -> tuple[BaseQueryBuilder, Referrer]:
+        if self.dataset == Dataset.EventsAnalyticsPlatform:
+            return self.get_traces_breakdown_projects_query_eap(snuba_params, trace_ids)
+        return self.get_traces_breakdown_projects_query_indexed(snuba_params, trace_ids)
+
+    def get_traces_breakdown_projects_query_eap(
+        self,
+        snuba_params: SnubaParams,
+        trace_ids: list[str],
+    ) -> tuple[BaseQueryBuilder, Referrer]:
+        query = SpansEAPQueryBuilder(
+            Dataset.EventsAnalyticsPlatform,
+            params={},
+            snuba_params=snuba_params,
+            query="is_transaction:1",
+            selected_columns=[
+                "trace",
+                "project",
+                "sdk.name",
+                "span.op",
+                "parent_span",
+                "transaction",
+                "precise.start_ts",
+                "precise.finish_ts",
+            ],
+            orderby=["precise.start_ts", "-precise.finish_ts"],
+            # limit the number of segments we fetch per trace so a single
+            # large trace does not result in the rest being blank
+            limitby=("trace", int(MAX_SNUBA_RESULTS / len(trace_ids))),
+            limit=MAX_SNUBA_RESULTS,
+            config=QueryBuilderConfig(
+                transform_alias_to_input_format=True,
+            ),
+        )
+
+        # restrict the query to just this subset of trace ids
+        query.add_conditions([Condition(Column("trace_id"), Op.IN, trace_ids)])
+
+        return query, Referrer.API_TRACE_EXPLORER_TRACES_BREAKDOWNS
+
+    def get_traces_breakdown_projects_query_indexed(
+        self,
+        snuba_params: SnubaParams,
+        trace_ids: list[str],
+    ) -> tuple[BaseQueryBuilder, Referrer]:
         query = SpansIndexedQueryBuilder(
             Dataset.SpansIndexed,
             params={},
@@ -797,6 +964,74 @@ class TracesExecutor:
         return query, Referrer.API_TRACE_EXPLORER_TRACES_BREAKDOWNS
 
     def get_traces_metas_query(
+        self,
+        snuba_params: SnubaParams,
+        trace_ids: list[str],
+    ) -> tuple[BaseQueryBuilder, Referrer]:
+        if self.dataset == Dataset.EventsAnalyticsPlatform:
+            return self.get_traces_metas_query_eap(snuba_params, trace_ids)
+        return self.get_traces_metas_query_indexed(snuba_params, trace_ids)
+
+    def get_traces_metas_query_eap(
+        self,
+        snuba_params: SnubaParams,
+        trace_ids: list[str],
+    ) -> tuple[BaseQueryBuilder, Referrer]:
+        query = SpansEAPQueryBuilder(
+            Dataset.EventsAnalyticsPlatform,
+            params={},
+            snuba_params=snuba_params,
+            query=None,
+            selected_columns=[
+                "trace",
+                "count()",
+                "first_seen()",
+                "last_seen()",
+            ],
+            limit=len(trace_ids),
+            config=QueryBuilderConfig(
+                functions_acl=["first_seen", "last_seen"],
+                transform_alias_to_input_format=True,
+            ),
+        )
+
+        # restrict the query to just this subset of trace ids
+        query.add_conditions([Condition(Column("trace_id"), Op.IN, trace_ids)])
+
+        """
+        We want to get a count of the number of matching spans. To do this, we have to
+        translate the user queries into conditions, and get a count of spans that match
+        any one of the user queries.
+        """
+
+        # Translate each user query into a condition to match one
+        trace_conditions = []
+        for where in self.user_queries.values():
+            trace_condition = format_as_trace_conditions(where)
+            if not trace_condition:
+                continue
+            elif len(trace_condition) == 1:
+                trace_conditions.append(trace_condition[0])
+            else:
+                trace_conditions.append(Function("and", trace_condition))
+
+        # Join all the user queries together into a single one where at least 1 have
+        # to be true.
+        if not trace_conditions:
+            query.columns.append(Function("count", [], MATCHING_COUNT_ALIAS))
+        elif len(trace_conditions) == 1:
+            query.columns.append(Function("countIf", trace_conditions, MATCHING_COUNT_ALIAS))
+        else:
+            query.columns.append(
+                Function("countIf", [Function("or", trace_conditions)], MATCHING_COUNT_ALIAS)
+            )
+
+        if options.get("performance.traces.trace-explorer-skip-floating-spans"):
+            query.add_conditions([Condition(Column("segment_id"), Op.NEQ, "00")])
+
+        return query, Referrer.API_TRACE_EXPLORER_TRACES_META
+
+    def get_traces_metas_query_indexed(
         self,
         snuba_params: SnubaParams,
         trace_ids: list[str],
@@ -904,6 +1139,7 @@ class TraceSpansExecutor:
     def __init__(
         self,
         *,
+        dataset: Dataset,
         snuba_params: SnubaParams,
         trace_id: str,
         fields: list[str],
@@ -915,6 +1151,7 @@ class TraceSpansExecutor:
         metrics_query: str | None,
         mri: str | None,
     ):
+        self.dataset = dataset
         self.snuba_params = snuba_params
         self.trace_id = trace_id
         self.fields = fields
@@ -927,6 +1164,9 @@ class TraceSpansExecutor:
         self.sort = sort
 
     def execute(self, offset: int, limit: int):
+        if self.dataset == Dataset.EventsAnalyticsPlatform:
+            assert 0, "TraceSpansExecutor"
+
         with handle_span_query_errors():
             span_keys = self.get_metrics_span_keys()
 
@@ -1104,12 +1344,14 @@ class TraceStatsExecutor:
     def __init__(
         self,
         *,
+        dataset: Dataset,
         snuba_params: SnubaParams,
         columns: list[str],
         user_queries: list[str],
         rollup: int,
         zerofill_results: bool,
     ):
+        self.dataset = dataset
         self.snuba_params = snuba_params
         self.columns = columns
         self.user_queries = process_user_queries(snuba_params, user_queries)
@@ -1117,6 +1359,9 @@ class TraceStatsExecutor:
         self.zerofill_results = zerofill_results
 
     def execute(self) -> SnubaTSResult:
+        if self.dataset == Dataset.EventsAnalyticsPlatform:
+            assert 0, "TraceStatsExecutor"
+
         query = self.get_timeseries_query()
         result = query.run_query(Referrer.API_TRACE_EXPLORER_STATS.value)
         result = query.process_results(result)
@@ -1474,18 +1719,33 @@ def process_breakdowns(data, traces_range):
 def process_user_queries(
     snuba_params: SnubaParams,
     user_queries: list[str],
+    dataset: Dataset = Dataset.SpansIndexed,
 ) -> dict[str, list[list[WhereType]]]:
     with handle_span_query_errors():
-        builder = SpansIndexedQueryBuilder(
-            Dataset.SpansIndexed,
-            params={},
-            snuba_params=snuba_params,
-            query=None,  # Note: conditions are added below
-            selected_columns=[],
-            config=QueryBuilderConfig(
-                transform_alias_to_input_format=True,
-            ),
-        )
+        if dataset == Dataset.EventsAnalyticsPlatform:
+            span_indexed_builder = SpansEAPQueryBuilder(
+                dataset,
+                params={},
+                snuba_params=snuba_params,
+                query=None,  # Note: conditions are added below
+                selected_columns=[],
+                config=QueryBuilderConfig(
+                    transform_alias_to_input_format=True,
+                ),
+            )
+            resolve_conditions = span_indexed_builder.resolve_conditions
+        else:
+            span_eap_builder = SpansIndexedQueryBuilder(
+                dataset,
+                params={},
+                snuba_params=snuba_params,
+                query=None,  # Note: conditions are added below
+                selected_columns=[],
+                config=QueryBuilderConfig(
+                    transform_alias_to_input_format=True,
+                ),
+            )
+            resolve_conditions = span_eap_builder.resolve_conditions
 
         queries: dict[str, list[list[WhereType]]] = {}
 
@@ -1498,7 +1758,7 @@ def process_user_queries(
 
             # We want to ignore all the aggregate conditions here because we're strictly
             # searching on span attributes, not aggregates
-            where, _ = builder.resolve_conditions(user_query)
+            where, _ = resolve_conditions(user_query)
             queries[user_query] = where
 
     set_measurement("user_queries_count", len(queries))

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -915,6 +915,26 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
                     snql_aggregate=self._resolve_upper_limit,
                     default_result_type="number",
                 ),
+                SnQLFunction(
+                    "first_seen",
+                    snql_aggregate=lambda args, alias: Function(
+                        "toUnixTimestamp64Milli",
+                        [Function("min", [Column("start_timestamp")])],
+                        alias,
+                    ),
+                    default_result_type="duration",
+                    private=True,
+                ),
+                SnQLFunction(
+                    "last_seen",
+                    snql_aggregate=lambda args, alias: Function(
+                        "toUnixTimestamp64Milli",
+                        [Function("max", [Column("end_timestamp")])],
+                        alias,
+                    ),
+                    default_result_type="duration",
+                    private=True,
+                ),
             ]
         }
 
@@ -923,6 +943,31 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
                 function_converter[alias] = function_converter[name].alias_as(alias)
 
         return function_converter
+
+    @property
+    def field_alias_converter(self) -> Mapping[str, Callable[[str], SelectType]]:
+        existing_field_aliases: dict[str, Callable[[str], SelectType]] = {**super().field_alias_converter}
+
+        field_alias_converter: Mapping[str, Callable[[str], SelectType]] = {
+            constants.PRECISE_START_TS: lambda alias: Function(
+                "divide",
+                [
+                    Function("toUnixTimestamp64Milli", [Column("start_timestamp")]),
+                    1000,
+                ],
+                alias,
+            ),
+            constants.PRECISE_FINISH_TS: lambda alias: Function(
+                "divide",
+                [
+                    Function("toUnixTimestamp64Milli", [Column("end_timestamp")]),
+                    1000,
+                ],
+                alias,
+            ),
+        }
+        existing_field_aliases.update(field_alias_converter)
+        return existing_field_aliases
 
     def _resolve_sum_weighted(
         self,

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -946,7 +946,9 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
 
     @property
     def field_alias_converter(self) -> Mapping[str, Callable[[str], SelectType]]:
-        existing_field_aliases: dict[str, Callable[[str], SelectType]] = {**super().field_alias_converter}
+        existing_field_aliases: dict[str, Callable[[str], SelectType]] = {
+            **super().field_alias_converter
+        }
 
         field_alias_converter: Mapping[str, Callable[[str], SelectType]] = {
             constants.PRECISE_START_TS: lambda alias: Function(

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1551,6 +1551,7 @@ class BaseSpansTestCase(SnubaTestCase):
             payload["tags"] = tags
         if transaction_id:
             payload["event_id"] = transaction_id
+            payload["segment_id"] = transaction_id[:16]
         if profile_id:
             payload["profile_id"] = profile_id
         if measurements:
@@ -1592,6 +1593,8 @@ class BaseSpansTestCase(SnubaTestCase):
         store_metrics_summary: Mapping[str, Sequence[Mapping[str, Any]]] | None = None,
         group: str = "00",
         category: str | None = None,
+        organization_id: int = 1,
+        is_eap: bool = False,
     ):
         if span_id is None:
             span_id = self._random_span_id()
@@ -1600,7 +1603,7 @@ class BaseSpansTestCase(SnubaTestCase):
 
         payload = {
             "project_id": project_id,
-            "organization_id": 1,
+            "organization_id": organization_id,
             "span_id": span_id,
             "trace_id": trace_id,
             "duration_ms": int(duration),
@@ -1626,6 +1629,7 @@ class BaseSpansTestCase(SnubaTestCase):
             }
         if transaction_id:
             payload["event_id"] = transaction_id
+            payload["segment_id"] = transaction_id[:16]
         if profile_id:
             payload["profile_id"] = profile_id
         if store_metrics_summary:
@@ -1638,7 +1642,7 @@ class BaseSpansTestCase(SnubaTestCase):
         # We want to give the caller the possibility to store only a summary since the database does not deduplicate
         # on the span_id which makes the assumptions of a unique span_id in the database invalid.
         if not store_only_summary:
-            self.store_span(payload)
+            self.store_span(payload, is_eap=is_eap)
 
         if "_metrics_summary" in payload:
             self.store_metrics_summary(payload)

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -176,6 +176,7 @@ SPAN_COLUMN_MAP = {
 SPAN_EAP_COLUMN_MAP = {
     "id": "span_id",
     "span_id": "span_id",  # ideally this would be temporary, but unfortunately its heavily hardcoded in the FE
+    "parent_span": "parent_span_id",
     "organization.id": "organization_id",
     "project": "project_id",
     "project.id": "project_id",


### PR DESCRIPTION
This moves the /traces endpoint onto EAP using SnQL for the time being.