### PR TITLE
fix(py): Log to stderr not stdout

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.metadata
 import logging
 import os
+import sys
 from typing import IO, Any
 
 import click
@@ -259,7 +260,14 @@ def configure_structlog() -> None:
 
         kwargs["processors"].append(JSONRenderer())
 
+    is_s4s = os.environ.get("CUSTOMER_ID") == "sentry4sentry"
+    if is_s4s:
+        kwargs["logger_factory"] = structlog.PrintLoggerFactory(sys.stderr)
+
     structlog.configure(**kwargs)
+
+    if is_s4s:
+        logging.info("Writing logs to stderr. Expected only in s4s")
 
     lvl = os.environ.get("SENTRY_LOG_LEVEL")
 


### PR DESCRIPTION
By default structlog is configured to write to stdout via it's default
`PrintLogger`. This change explicitly sets the PrintLogger to write to
stderr instead.