### PR TITLE
ref(alerts): Pass org instead of rule

### DIFF
--- a/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
+++ b/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
@@ -151,10 +151,18 @@ def get_historical_anomaly_data_from_seer(
     """
     if alert_rule.status == AlertRuleStatus.NOT_ENOUGH_DATA.value:
         return []
-    # don't think this can happen but mypy is yelling
+    # don't think these can happen but mypy is yelling
     if not alert_rule.snuba_query:
         logger.error(
             "No snuba query associated with alert rule",
+            extra={
+                "alert_rule_id": alert_rule.id,
+            },
+        )
+        return None
+    if not alert_rule.organization:
+        logger.error(
+            "No organization associated with alert rule",
             extra={
                 "alert_rule_id": alert_rule.id,
             },

--- a/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
+++ b/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
@@ -175,7 +175,7 @@ def get_historical_anomaly_data_from_seer(
     end = datetime.fromisoformat(end_string)
     query_columns = get_query_columns([snuba_query.aggregate], snuba_query.time_window)
     historical_data = fetch_historical_data(
-        alert_rule=alert_rule,
+        organization=alert_rule.organization,
         snuba_query=snuba_query,
         query_columns=query_columns,
         project=project,

--- a/src/sentry/seer/anomaly_detection/store_data.py
+++ b/src/sentry/seer/anomaly_detection/store_data.py
@@ -164,7 +164,7 @@ def send_historical_data_to_seer(
     query_columns = get_query_columns([snuba_query.aggregate], window_min)
     event_types = get_event_types(snuba_query, event_types)
     historical_data = fetch_historical_data(
-        alert_rule=alert_rule,
+        organization=alert_rule.organization,
         snuba_query=snuba_query,
         query_columns=query_columns,
         project=project,

--- a/src/sentry/seer/anomaly_detection/store_data.py
+++ b/src/sentry/seer/anomaly_detection/store_data.py
@@ -163,6 +163,9 @@ def send_historical_data_to_seer(
     dataset = get_dataset_from_label(snuba_query.dataset)
     query_columns = get_query_columns([snuba_query.aggregate], window_min)
     event_types = get_event_types(snuba_query, event_types)
+    if not alert_rule.organization:
+        raise ValidationError("Alert rule doesn't belong to an organization")
+
     historical_data = fetch_historical_data(
         organization=alert_rule.organization,
         snuba_query=snuba_query,

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -8,7 +8,7 @@ from rest_framework.exceptions import ParseError
 from sentry import release_health
 from sentry.api.bases.organization_events import resolve_axis_column
 from sentry.api.serializers.snuba import SnubaTSResultSerializer
-from sentry.incidents.models.alert_rule import AlertRule, AlertRuleThresholdType
+from sentry.incidents.models.alert_rule import AlertRuleThresholdType
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.search.events.types import SnubaParams
@@ -213,7 +213,7 @@ def get_dataset_from_label(dataset_label: str):
 
 
 def fetch_historical_data(
-    alert_rule: AlertRule,
+    organization: Organization,
     snuba_query: SnubaQuery,
     query_columns: list[str],
     project: Project,
@@ -245,7 +245,7 @@ def fetch_historical_data(
         dataset_label = "metricsEnhanced"
     dataset = get_dataset_from_label(dataset_label)
 
-    if not project or not dataset or not alert_rule.organization:
+    if not project or not dataset or not organization:
         return None
 
     environments = []
@@ -253,7 +253,7 @@ def fetch_historical_data(
         environments = [snuba_query.environment]
 
     snuba_params = SnubaParams(
-        organization=alert_rule.organization,
+        organization=organization,
         projects=[project],
         start=start,
         end=end,
@@ -262,9 +262,7 @@ def fetch_historical_data(
     )
 
     if dataset == metrics_performance:
-        return get_crash_free_historical_data(
-            start, end, project, alert_rule.organization, granularity
-        )
+        return get_crash_free_historical_data(start, end, project, organization, granularity)
     else:
         event_types = get_event_types(snuba_query, event_types)
         snuba_query_string = get_snuba_query_string(snuba_query, event_types)

--- a/tests/sentry/seer/anomaly_detection/test_store_data.py
+++ b/tests/sentry/seer/anomaly_detection/test_store_data.py
@@ -137,7 +137,7 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase, Performa
                 },
                 project_id=self.project.id,
             )
-        result = fetch_historical_data(alert_rule, snuba_query, ["count()"], self.project)
+        result = fetch_historical_data(self.organization, snuba_query, ["count()"], self.project)
         assert result
         assert {"time": int(self.time_1_ts), "count": 1} in result.data.get("data")
         assert {"time": int(self.time_2_ts), "count": 1} in result.data.get("data")
@@ -171,7 +171,7 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase, Performa
                 },
                 project_id=self.project.id,
             )
-        result = fetch_historical_data(alert_rule, snuba_query, ["count()"], self.project)
+        result = fetch_historical_data(self.organization, snuba_query, ["count()"], self.project)
         assert result
         assert {"time": int(self.time_1_ts), "count": 1} in result.data.get("data")
         assert {"time": int(self.time_2_ts), "count": 1} in result.data.get("data")
@@ -188,7 +188,7 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase, Performa
 
         event2 = self.create_performance_issue(event_data=make_event(**event_data))
 
-        result = fetch_historical_data(alert_rule, snuba_query, ["count()"], self.project)
+        result = fetch_historical_data(self.organization, snuba_query, ["count()"], self.project)
         assert result
         assert {"time": int(event1.datetime.timestamp()), "count": 1} in result.data.get("data")
         assert {"time": int(event2.datetime.timestamp()), "count": 1} in result.data.get("data")
@@ -238,7 +238,7 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase, Performa
             threshold_period=1,
         )
         snuba_query = SnubaQuery.objects.get(id=alert_rule.snuba_query_id)
-        result = fetch_historical_data(alert_rule, snuba_query, ["count()"], self.project)
+        result = fetch_historical_data(self.organization, snuba_query, ["count()"], self.project)
         assert result
         assert self.time_1 in result.data.get("data").get("intervals")
         assert 1 in result.data.get("data").get("groups")[0].get("series").get("sum(session)")


### PR DESCRIPTION
We only ever use `alert_rule.organization` here so we can just pass the organization instead of the alert rule. As I'm writing the migration spec for ACI I noticed this and wanted to remove the reference to alert rule.