### PR TITLE
fix(discover): Preserve `"fields"` key in Discover response `"meta"` key

### DIFF
--- a/static/app/utils/discover/discoverQuery.tsx
+++ b/static/app/utils/discover/discoverQuery.tsx
@@ -56,7 +56,7 @@ function DiscoverQuery(props: DiscoverQueryComponentProps) {
     const {fields, ...otherMeta} = data.meta ?? {};
     return {
       ...data,
-      meta: {...fields, ...otherMeta},
+      meta: {...fields, ...otherMeta, fields},
     };
   };
   return (
@@ -74,7 +74,7 @@ export function useDiscoverQuery(props: Omit<DiscoverQueryComponentProps, 'child
     const {fields, ...otherMeta} = data.meta ?? {};
     return {
       ...data,
-      meta: {...fields, ...otherMeta},
+      meta: {...fields, ...otherMeta, fields},
     };
   };
 

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -55,6 +55,7 @@ import {getSortField} from './fieldRenderers';
 
 // Metadata mapping for discover results.
 export type MetaType = Record<string, any> & {
+  fields?: Record<string, string>;
   isMetricsData?: boolean;
   isMetricsExtractedData?: boolean;
   tips?: {columns: string; query: string};

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -55,7 +55,6 @@ import {getSortField} from './fieldRenderers';
 
 // Metadata mapping for discover results.
 export type MetaType = Record<string, any> & {
-  fields?: Record<string, string>;
   isMetricsData?: boolean;
   isMetricsExtractedData?: boolean;
   tips?: {columns: string; query: string};

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.spec.tsx
@@ -1,12 +1,49 @@
 import {ProjectFixture} from 'sentry-fixture/project';
 import {UserFixture} from 'sentry-fixture/user';
+import {WidgetQueryFixture} from 'sentry-fixture/widgetQuery';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
+import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import type {EventViewOptions} from 'sentry/utils/discover/eventView';
 import EventView from 'sentry/utils/discover/eventView';
-import {getCustomEventsFieldRenderer} from 'sentry/views/dashboards/datasetConfig/errorsAndTransactions';
+import {
+  getCustomEventsFieldRenderer,
+  transformEventsResponseToTable,
+} from 'sentry/views/dashboards/datasetConfig/errorsAndTransactions';
+
+describe('transformEventsResponseToTable', function () {
+  it('unsplats table meta field types', function () {
+    const rawData = {
+      data: [{'p75(measurements.inp)': null}],
+      meta: {
+        'p75(measurements.inp)': 'duration',
+        units: {
+          'p75(measurements.inp)': 'millisecond',
+        },
+        dataset: 'metricsEnhanced',
+        fields: {
+          'p75(measurements.inp)': 'duration',
+        },
+      },
+      title: 'A Query',
+    } as unknown as TableData;
+
+    const widgetQuery = WidgetQueryFixture();
+
+    expect(transformEventsResponseToTable(rawData, widgetQuery).meta).toEqual({
+      'p75(measurements.inp)': 'duration',
+      units: {
+        'p75(measurements.inp)': 'millisecond',
+      },
+      dataset: 'metricsEnhanced',
+      fields: {
+        'p75(measurements.inp)': 'duration',
+      },
+    });
+  });
+});
 
 describe('getCustomFieldRenderer', function () {
   const {organization, router} = initializeOrg();

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -272,7 +272,7 @@ export function transformEventsResponseToTable(
   const {fields, ...otherMeta} = (data as EventsTableData).meta ?? {};
   tableData = {
     ...data,
-    meta: {...fields, ...otherMeta},
+    meta: {...fields, ...otherMeta, fields},
   } as TableData;
   return tableData as TableData;
 }

--- a/static/app/views/discover/table/index.tsx
+++ b/static/app/views/discover/table/index.tsx
@@ -220,7 +220,7 @@ class Table extends PureComponent<TableProps, TableState> {
         // events api uses a different response format so we need to construct tableData differently
         const tableData = {
           ...data,
-          meta: {...fields, ...nonFieldsMeta},
+          meta: {...fields, ...nonFieldsMeta, fields},
         };
 
         trackAnalytics('discover_search.success', {


### PR DESCRIPTION
In a few places, we transform `meta` for compatibility. `meta` used to look like:

```json
{
 "epm()": "number", // Field type!
 "units": {
   "epm()": "1/minute"
 }
 ... other fields
}
```

The field types were on the `meta` object itself. At some point the `"fields"` key was added to the server responses, and the fields types were moved there:

```json
{
 "fields": {
   "epm()": "number",
 },
 "units": {
   "epm()": "1/minute"
 }
 ... other fields
}
```

In the code, since not all features knew about the `fields` change, we unsplatted the contents of `fields` back into the response. However, newer Dashboards code _does_ expect the `fields` key to be there! Preserve the field. All new code should respect the real server response format, but for now have it in _both_ places.
