### PR TITLE
feat(ingest): Add span instrumentation for `process_transaction_no_celery`

### DIFF
--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -72,7 +72,8 @@ def process_transaction_no_celery(
     ):
         # Delete the event payload from cache since it won't show up in post-processing.
         if cache_key:
-            event_processing_store.delete_by_key(cache_key)
+            with sentry_sdk.start_span(op="event_processing_store.delete_by_key"):
+                event_processing_store.delete_by_key(cache_key)
         return
 
     manager = EventManager(data)
@@ -88,7 +89,9 @@ def process_transaction_no_celery(
     data = manager.get_data()
     if not isinstance(data, dict):
         data = dict(data.items())
-    event_processing_store.store(data)
+
+    with sentry_sdk.start_span(op="event_processing_store.store"):
+        event_processing_store.store(data)
 
 
 @trace_func(name="ingest_consumer.process_event")
@@ -230,7 +233,8 @@ def process_event(
 
         if data.get("type") == "transaction":
             if no_celery_mode:
-                process_transaction_no_celery(data, project_id, cache_key, start_time)
+                with sentry_sdk.start_span(op="ingest_consumer.process_transaction_no_celery"):
+                    process_transaction_no_celery(data, project_id, cache_key, start_time)
             else:
                 # No need for preprocess/process for transactions thus submit
                 # directly transaction specific save_event task.

--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -234,6 +234,11 @@ def process_event(
         if data.get("type") == "transaction":
             if no_celery_mode:
                 with sentry_sdk.start_span(op="ingest_consumer.process_transaction_no_celery"):
+                    transaction = sentry_sdk.get_current_scope().transaction
+
+                    if transaction:
+                        transaction.set_tag("no_celery_mode", True)
+
                     process_transaction_no_celery(data, project_id, cache_key, start_time)
             else:
                 # No need for preprocess/process for transactions thus submit

--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -236,7 +236,7 @@ def process_event(
                 with sentry_sdk.start_span(op="ingest_consumer.process_transaction_no_celery"):
                     transaction = sentry_sdk.get_current_scope().transaction
 
-                    if transaction:
+                    if transaction is not None:
                         transaction.set_tag("no_celery_mode", True)
 
                     process_transaction_no_celery(data, project_id, cache_key, start_time)


### PR DESCRIPTION
We have a new function that process transactions in the Kafka consumer itself instead of starting a celery task, this PR adds some spans some we can get some observability into the performance of this code path