### PR TITLE
feat: Convert subdomain origins into the root sentry.io origin when logged in to the toolbar

### DIFF
--- a/src/sentry/templates/sentry/toolbar/login-success.html
+++ b/src/sentry/templates/sentry/toolbar/login-success.html
@@ -16,7 +16,7 @@
     {% script %}
     <script>
       (function() {
-        const delay = '{{ delay|escapejs }}';
+        const delay = {{ delay|escapejs }};
         const cookie = '{{ cookie|escapejs }}';
 
         document.getElementById('close-popup').addEventListener('click', () => {
@@ -24,6 +24,10 @@
         });
 
         if (window.opener) {
+          const origin = window.location.origin.endsWith('.sentry.io')
+            ? 'https://sentry.io'
+            : window.location.origin;
+
           window.opener.postMessage({
             source: 'sentry-toolbar',
             message: 'did-login',


### PR DESCRIPTION
The situation is this:
1. When the toolbar renders into a page, it's also rendering a page from sentry.io into an iframe. That page is specifically `https://sentry.io/toolbar/:org/:project/iframe/` -> note: no subdomain
2. This page renders a button, which tries to open `https://sentry.io/toolbar/:org/:project/login-success/` -> note: no subdomain
   - We remove the subdomain here so that the login flow remembers what the target path is and redirects there. If we included subdomain then the redirect path wouldn't work and we endup at `/issues`
   - But it turns out we also redirect to the subdomain of the org as well, we now we've ended up at `https://:org.sentry.io/toolbar/:org/:project/login-success/`
3. This PR makes the change to convert `window.location.origin` from `org.sentry.io` into `sentry.io` so that we can call `postMessage` against the original origin from step 1 above. The origins need to match and now they will!