### PR TITLE
fix(issues): Remove highlights all tags link

### DIFF
--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import {hasEveryAccess} from 'sentry/components/acl/access';
-import {Button, LinkButton} from 'sentry/components/button';
+import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {ContextCardContent} from 'sentry/components/events/contexts/contextCard';
@@ -37,8 +37,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
-import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
-import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 interface HighlightsDataSectionProps {
@@ -259,32 +257,19 @@ export default function HighlightsDataSection({
 }: HighlightsDataSectionProps) {
   const organization = useOrganization();
   const hasStreamlinedUI = useHasStreamlinedUI();
-  const location = useLocation();
-  const {baseUrl} = useGroupDetailsRoute();
 
-  const viewAllButton = hasStreamlinedUI ? (
-    // Streamline details ui has "Jump to" feature, instead we'll show the drawer button
-    <LinkButton
-      to={{
-        pathname: `${baseUrl}${TabPaths[Tab.TAGS]}`,
-        query: location.query,
-        replace: true,
-      }}
-      size="xs"
-    >
-      {t('View All Issue Tags')}
-    </LinkButton>
-  ) : viewAllRef ? (
-    <Button
-      onClick={() => {
-        trackAnalytics('highlights.issue_details.view_all_clicked', {organization});
-        viewAllRef?.current?.scrollIntoView({behavior: 'smooth'});
-      }}
-      size="xs"
-    >
-      {t('View All')}
-    </Button>
-  ) : null;
+  const viewAllButton =
+    !hasStreamlinedUI && viewAllRef ? (
+      <Button
+        onClick={() => {
+          trackAnalytics('highlights.issue_details.view_all_clicked', {organization});
+          viewAllRef?.current?.scrollIntoView({behavior: 'smooth'});
+        }}
+        size="xs"
+      >
+        {t('View All')}
+      </Button>
+    ) : null;
 
   return (
     <InterimSection

--- a/static/app/views/issueDetails/streamline/eventNavigation.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.spec.tsx
@@ -128,13 +128,13 @@ describe('EventNavigation', () => {
     expect(screen.queryByText('Jump To:')).not.toBeInTheDocument();
     expect(screen.queryByText('Replay')).not.toBeInTheDocument();
     expect(screen.queryByText('Tags')).not.toBeInTheDocument();
-    expect(screen.queryByText('Event Highlights')).not.toBeInTheDocument();
+    expect(screen.queryByText('Highlights')).not.toBeInTheDocument();
   });
 
   it('does show jump to sections when the sections render', () => {
     render(<EventNavigation {...defaultProps} />);
     expect(screen.getByText('Jump to:')).toBeInTheDocument();
-    expect(screen.getByText('Event Highlights')).toBeInTheDocument();
+    expect(screen.getByText('Highlights')).toBeInTheDocument();
     expect(screen.getByText('Replay')).toBeInTheDocument();
     expect(screen.getByText('Tags')).toBeInTheDocument();
   });

--- a/static/app/views/issueDetails/streamline/eventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.tsx
@@ -76,7 +76,7 @@ const EventNavOrder = [
 ];
 
 const sectionLabels = {
-  [SectionKey.HIGHLIGHTS]: t('Event Highlights'),
+  [SectionKey.HIGHLIGHTS]: t('Highlights'),
   [SectionKey.STACKTRACE]: t('Stack Trace'),
   [SectionKey.TRACE]: t('Trace'),
   [SectionKey.EXCEPTION]: t('Stack Trace'),


### PR DESCRIPTION
Removes the "view all issue tags" from the highlights section for streamline
