### PR TITLE
Migrate off of Deprecated Async Views for accountSubscriptions (FE TSC)

### DIFF
--- a/static/app/views/settings/account/accountSubscriptions.spec.tsx
+++ b/static/app/views/settings/account/accountSubscriptions.spec.tsx
@@ -32,6 +32,8 @@ describe('AccountSubscriptions', function () {
 
     expect(mock).not.toHaveBeenCalled();
 
+    expect(await screen.findByText('Product & Feature Updates')).toBeInTheDocument();
+
     await userEvent.click(
       screen.getByRole('checkbox', {name: 'Product & Feature Updates'})
     );
@@ -40,10 +42,10 @@ describe('AccountSubscriptions', function () {
       ENDPOINT,
       expect.objectContaining({
         method: 'PUT',
-        data: {
+        data: expect.objectContaining({
           listId: 2,
           subscribed: false,
-        },
+        }),
       })
     );
   });
@@ -62,6 +64,10 @@ describe('AccountSubscriptions', function () {
     });
     render(<AccountSubscriptions />);
 
+    // wait for the mock GET Request to resolve
+    const elements = await screen.findAllByText('Sentry Newsletter');
+    expect(elements).toHaveLength(2);
+
     await userEvent.click(
       screen.getAllByRole('checkbox', {name: 'Sentry Newsletter'})[0]
     );
@@ -70,10 +76,10 @@ describe('AccountSubscriptions', function () {
       ENDPOINT,
       expect.objectContaining({
         method: 'PUT',
-        data: {
+        data: expect.objectContaining({
           listId: 1,
           subscribed: true,
-        },
+        }),
       })
     );
   });

--- a/static/app/views/settings/account/accountSubscriptions.tsx
+++ b/static/app/views/settings/account/accountSubscriptions.tsx
@@ -1,7 +1,5 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
-import groupBy from 'lodash/groupBy';
-import orderBy from 'lodash/orderBy';
 import moment from 'moment-timezone';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -15,7 +13,13 @@ import Switch from 'sentry/components/switchButton';
 import {IconToggle} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import DeprecatedAsyncView from 'sentry/views/deprecatedAsyncView';
+import {
+  setApiQueryData,
+  useApiQuery,
+  useMutation,
+  useQueryClient,
+} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
@@ -31,173 +35,162 @@ export type Subscription = {
   unsubscribedDate: string | null;
 };
 
-type State = DeprecatedAsyncView['state'] & {
-  subscriptions: Subscription[];
-};
+function AccountSubscriptions() {
+  const {data: subscriptions = [], isLoading} = useApiQuery<Subscription[]>([ENDPOINT], {
+    staleTime: 2 * 60 * 1000,
+  });
 
-class AccountSubscriptions extends DeprecatedAsyncView<
-  DeprecatedAsyncView['props'],
-  State
-> {
-  getEndpoints(): ReturnType<DeprecatedAsyncView['getEndpoints']> {
-    return [['subscriptions', ENDPOINT]];
-  }
+  const queryClient = useQueryClient();
+  const api = useApi();
 
-  getTitle() {
-    return t('Subscriptions');
-  }
-
-  handleToggle = (
-    subscription: Subscription,
-    email: string,
-    listId: number,
-    _e: React.MouseEvent
-  ) => {
-    const subscribed = !subscription.subscribed;
-    const oldSubscriptions = this.state.subscriptions;
-
-    this.setState(state => {
-      const newSubscriptions = [...state.subscriptions];
-      const index = newSubscriptions.findIndex(
-        sub => sub.listId === listId && sub.email === email
+  const {mutate: updateSubscription} = useMutation({
+    mutationFn: (data: Subscription) =>
+      api.requestPromise(ENDPOINT, {
+        method: 'PUT',
+        data,
+      }),
+    onSuccess: (_resp, subscription: Subscription) => {
+      addSuccessMessage(
+        `${subscription.subscribed ? 'Subscribed' : 'Unsubscribed'} to ${subscription.listName}`
       );
-      newSubscriptions[index] = {
-        ...subscription,
-        subscribed,
-        subscribedDate: new Date().toString(),
-      };
-      return {
-        ...state,
-        subscriptions: newSubscriptions,
-      };
-    });
 
-    this.api.request(ENDPOINT, {
-      method: 'PUT',
-      data: {
-        listId: subscription.listId,
-        subscribed,
-      },
-      success: () => {
-        addSuccessMessage(
-          `${subscribed ? 'Subscribed' : 'Unsubscribed'} to ${subscription.listName}`
-        );
-      },
-      error: () => {
+      // Update the subscription in the list
+      setApiQueryData<Subscription[]>(queryClient, [ENDPOINT], subs => {
+        return subs.map(sub => {
+          if (sub.listId === subscription.listId) {
+            return subscription;
+          }
+
+          return sub;
+        });
+      });
+    },
+    onError: (subscription: Subscription) => {
+      if (subscription) {
         addErrorMessage(
-          `Unable to ${subscribed ? '' : 'un'}subscribe to ${subscription.listName}`
+          `Unable to ${subscription.subscribed ? '' : 'un'}subscribe to ${subscription.listName}`
         );
-        this.setState({subscriptions: oldSubscriptions});
-      },
+      } else {
+        addErrorMessage('An unknown error occurred, please try again later.');
+      }
+    },
+  });
+
+  if (isLoading) {
+    return null;
+  }
+
+  const subGroups: Array<[string, Subscription[]]> = Object.entries(
+    subscriptions.reduce((acc, sub) => {
+      (acc[sub.email] = acc[sub.email] || []).push(sub);
+      return acc;
+    }, {})
+  );
+
+  subGroups.sort(([a], [b]) => a[0].localeCompare(b[0]));
+
+  const handleToggle = (subscription: Subscription) => {
+    const subscribed = !subscription.subscribed;
+
+    updateSubscription({
+      ...subscription,
+      subscribed,
     });
   };
 
-  renderBody() {
-    // Group by does not guarantee order, so we sort by email
-    const subGroups = orderBy(
-      Object.entries(groupBy(this.state.subscriptions, sub => sub.email)),
-      ([email]) => email
-    );
-
-    return (
-      <div>
-        <SettingsPageHeader title={this.getTitle()} />
-        <TextBlock>
-          {t(`Sentry is committed to respecting your inbox. Our goal is to
+  return (
+    <div>
+      <SettingsPageHeader title={t('Subscriptions')} />
+      <TextBlock>
+        {t(`Sentry is committed to respecting your inbox. Our goal is to
               provide useful content and resources that make fixing errors less
               painful. Enjoyable even.`)}
-        </TextBlock>
+      </TextBlock>
 
-        <TextBlock>
-          {t(`As part of our compliance with the EU’s General Data Protection
+      <TextBlock>
+        {t(`As part of our compliance with the EU’s General Data Protection
               Regulation (GDPR), starting on 25 May 2018, we’ll only email you
               according to the marketing categories to which you’ve explicitly
               opted-in.`)}
-        </TextBlock>
+      </TextBlock>
 
-        <Panel>
-          {this.state.subscriptions.length ? (
-            <div>
-              <PanelHeader>{t('Subscription')}</PanelHeader>
-              <PanelBody>
-                {subGroups.map(([email, subscriptions]) => (
-                  <Fragment key={email}>
-                    {subGroups.length > 1 && (
-                      <Heading>
-                        <IconToggle /> {t('Subscriptions for %s', email)}
-                      </Heading>
-                    )}
+      <Panel>
+        {subscriptions?.length ? (
+          <div>
+            <PanelHeader>{t('Subscription')}</PanelHeader>
+            <PanelBody>
+              {subGroups.map(([email, subs]) => (
+                <Fragment key={email}>
+                  {subGroups.length > 1 && (
+                    <Heading>
+                      <IconToggle /> {t('Subscriptions for %s', email)}
+                    </Heading>
+                  )}
 
-                    {subscriptions
-                      .sort((a, b) => a.listId - b.listId)
-                      .map(subscription => (
-                        <PanelItem center key={subscription.listId}>
-                          <SubscriptionDetails
-                            htmlFor={`${subscription.email}-${subscription.listId}`}
-                            aria-label={subscription.listName}
-                          >
-                            <SubscriptionName>{subscription.listName}</SubscriptionName>
-                            {subscription.listDescription && (
-                              <Description>{subscription.listDescription}</Description>
-                            )}
-                            {subscription.subscribed ? (
-                              <SubscribedDescription>
-                                <div>
-                                  {tct('[email] on [date]', {
-                                    email: subscription.email,
-                                    date: (
-                                      <DateTime
-                                        date={moment(subscription.subscribedDate!)}
-                                      />
-                                    ),
-                                  })}
-                                </div>
-                              </SubscribedDescription>
-                            ) : (
-                              <SubscribedDescription>
-                                {t('Not currently subscribed')}
-                              </SubscribedDescription>
-                            )}
-                          </SubscriptionDetails>
-                          <div>
-                            <Switch
-                              id={`${subscription.email}-${subscription.listId}`}
-                              isActive={subscription.subscribed}
-                              size="lg"
-                              toggle={this.handleToggle.bind(
-                                this,
-                                subscription,
-                                email,
-                                subscription.listId
-                              )}
-                            />
-                          </div>
-                        </PanelItem>
-                      ))}
-                  </Fragment>
-                ))}
-              </PanelBody>
-            </div>
-          ) : (
-            <EmptyMessage>{t("There's no subscription backend present.")}</EmptyMessage>
-          )}
-        </Panel>
-        <TextBlock>
-          {t(`We’re applying GDPR consent and privacy policies to all Sentry
+                  {subs
+                    .sort((a, b) => a.listId - b.listId)
+                    .map(subscription => (
+                      <PanelItem center key={subscription.listId}>
+                        <SubscriptionDetails
+                          htmlFor={`${subscription.email}-${subscription.listId}`}
+                          aria-label={subscription.listName}
+                        >
+                          <SubscriptionName>{subscription.listName}</SubscriptionName>
+                          {subscription.listDescription && (
+                            <Description>{subscription.listDescription}</Description>
+                          )}
+                          {subscription.subscribed ? (
+                            <SubscribedDescription>
+                              <div>
+                                {tct('[email] on [date]', {
+                                  email: subscription.email,
+                                  date: (
+                                    <DateTime
+                                      date={moment(subscription.subscribedDate!)}
+                                    />
+                                  ),
+                                })}
+                              </div>
+                            </SubscribedDescription>
+                          ) : (
+                            <SubscribedDescription>
+                              {t('Not currently subscribed')}
+                            </SubscribedDescription>
+                          )}
+                        </SubscriptionDetails>
+                        <div>
+                          <Switch
+                            id={`${subscription.email}-${subscription.listId}`}
+                            isActive={subscription.subscribed}
+                            size="lg"
+                            toggle={() => handleToggle(subscription)}
+                          />
+                        </div>
+                      </PanelItem>
+                    ))}
+                </Fragment>
+              ))}
+            </PanelBody>
+          </div>
+        ) : (
+          <EmptyMessage>{t("There's no subscription backend present.")}</EmptyMessage>
+        )}
+      </Panel>
+      <TextBlock>
+        {t(`We’re applying GDPR consent and privacy policies to all Sentry
               contacts, regardless of location. You’ll be able to manage your
               subscriptions here and from an Unsubscribe link in the footer of
               all marketing emails.`)}
-        </TextBlock>
+      </TextBlock>
 
-        <TextBlock>
-          {tct(
-            'Please contact [email:learn@sentry.io] with any questions or suggestions.',
-            {email: <a href="mailto:learn@sentry.io" />}
-          )}
-        </TextBlock>
-      </div>
-    );
-  }
+      <TextBlock>
+        {tct(
+          'Please contact [email:learn@sentry.io] with any questions or suggestions.',
+          {email: <a href="mailto:learn@sentry.io" />}
+        )}
+      </TextBlock>
+    </div>
+  );
 }
 
 const Heading = styled(PanelItem)`

--- a/static/app/views/settings/account/accountSubscriptions.tsx
+++ b/static/app/views/settings/account/accountSubscriptions.tsx
@@ -5,6 +5,7 @@ import moment from 'moment-timezone';
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {DateTime} from 'sentry/components/dateTime';
 import EmptyMessage from 'sentry/components/emptyMessage';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
@@ -36,7 +37,7 @@ export type Subscription = {
 };
 
 function AccountSubscriptions() {
-  const {data: subscriptions = [], isLoading} = useApiQuery<Subscription[]>([ENDPOINT], {
+  const {data: subscriptions = [], isPending} = useApiQuery<Subscription[]>([ENDPOINT], {
     staleTime: 2 * 60 * 1000,
   });
 
@@ -76,8 +77,8 @@ function AccountSubscriptions() {
     },
   });
 
-  if (isLoading) {
-    return null;
+  if (isPending) {
+    <LoadingIndicator />;
   }
 
   const subGroups: Array<[string, Subscription[]]> = Object.entries(
@@ -129,8 +130,8 @@ function AccountSubscriptions() {
 
                   {subs
                     .sort((a, b) => a.listId - b.listId)
-                    .map(subscription => (
-                      <PanelItem center key={subscription.listId}>
+                    .map((subscription, i) => (
+                      <PanelItem center key={`${email}-${subscription.listId}-${i}`}>
                         <SubscriptionDetails
                           htmlFor={`${subscription.email}-${subscription.listId}`}
                           aria-label={subscription.listName}


### PR DESCRIPTION
## Description
- Migrate `accountSubscriptions` off of the deprecatedAsyncView
- Remove `groupBy` an `orderBy` lodash functions (converted to es6)

[Task info](https://github.com/orgs/getsentry/projects/157/views/1?pane=issue&itemId=37995518&issue=getsentry%7Cfrontend-tsc%7C2)