### PR TITLE
fix(insights): Silence dropdown with non-plain text warning

### DIFF
--- a/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
@@ -4,7 +4,7 @@ import type {Location} from 'history';
 import debounce from 'lodash/debounce';
 import omit from 'lodash/omit';
 
-import {CompactSelect} from 'sentry/components/compactSelect';
+import {CompactSelect, type SelectOption} from 'sentry/components/compactSelect';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {uniq} from 'sentry/utils/array/uniq';
@@ -115,16 +115,17 @@ export function DomainSelector({
     }
   }, [additionalQuery, clearDomainOptionsCache]);
 
-  const emptyOption = {
+  const emptyOption: SelectOption<string> = {
     value: EMPTY_OPTION_VALUE,
     label: (
       <EmptyContainer>
         {t('(No %s)', domainAlias ?? LABEL_FOR_MODULE_NAME[moduleName])}
       </EmptyContainer>
     ),
+    textValue: t('(No %s)', domainAlias ?? LABEL_FOR_MODULE_NAME[moduleName]),
   };
 
-  const options = [
+  const options: SelectOption<string>[] = [
     {value: '', label: 'All'},
     ...(emptyOptionLocation === 'top' ? [emptyOption] : []),
     ...domainOptions,


### PR DESCRIPTION
fixes warning`<Item> with non-plain text contents is unsupported by type to select for accessibility.` https://github.com/getsentry/sentry/actions/runs/11374975969/job/31644763725?pr=79247#step:6:3103
