### PR TITLE
test(ui): Add label to autofix segmented control

### DIFF
--- a/static/app/components/events/autofix/autofixMessageBox.tsx
+++ b/static/app/components/events/autofix/autofixMessageBox.tsx
@@ -178,6 +178,7 @@ function AutofixMessageBox({
                 size="xs"
                 value={rootCauseMode}
                 onChange={setRootCauseMode}
+                aria-label={t('Root cause selection')}
               >
                 <SegmentedControl.Item key="suggested_root_cause">
                   {t('Use suggested root cause')}


### PR DESCRIPTION
silences warning `If you do not provide a visible label, you must specify an aria-label or aria-labelledby attribute for accessibility` https://github.com/getsentry/sentry/actions/runs/11374975969/job/31644764046?pr=79247#step:6:96
