### PR TITLE
test(ui): Add types to test mocks

### DIFF
--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -26,7 +26,7 @@ jest.mock('echarts-for-react/lib/core', () => {
 
 const stubEl = (props: {children?: React.ReactNode}) => <div>{props.children}</div>;
 
-let eventsMetaMock;
+let eventsMetaMock: jest.Mock;
 
 const waitForMetaToHaveBeenCalled = async () => {
   await waitFor(() => {

--- a/static/app/components/quickTrace/index.spec.tsx
+++ b/static/app/components/quickTrace/index.spec.tsx
@@ -3,11 +3,12 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import QuickTrace from 'sentry/components/quickTrace';
 import type {Event} from 'sentry/types/event';
+import type {Organization} from 'sentry/types/organization';
 import type {QuickTraceEvent} from 'sentry/utils/performance/quickTrace/types';
 
 describe('Quick Trace', function () {
-  let location;
-  let organization;
+  let location: any;
+  let organization: Organization;
 
   const initialize = () => {
     const context = initializeOrg();

--- a/static/app/components/search/sources/apiSource.spec.tsx
+++ b/static/app/components/search/sources/apiSource.spec.tsx
@@ -15,13 +15,13 @@ import ConfigStore from 'sentry/stores/configStore';
 
 describe('ApiSource', function () {
   const {organization, router} = initializeOrg();
-  let orgsMock;
-  let projectsMock;
-  let teamsMock;
-  let membersMock;
-  let shortIdMock;
-  let eventIdMock;
-  let configState;
+  let orgsMock: jest.Mock;
+  let projectsMock: jest.Mock;
+  let teamsMock: jest.Mock;
+  let membersMock: jest.Mock;
+  let shortIdMock: jest.Mock;
+  let eventIdMock: jest.Mock;
+  let configState: ReturnType<typeof ConfigStore.getState>;
 
   const defaultProps: ComponentProps<typeof ApiSource> = {
     query: '',

--- a/static/app/stores/groupingStore.spec.tsx
+++ b/static/app/stores/groupingStore.spec.tsx
@@ -2,7 +2,7 @@ import * as GroupActionCreators from 'sentry/actionCreators/group';
 import GroupingStore from 'sentry/stores/groupingStore';
 
 describe('Grouping Store', function () {
-  let trigger;
+  let trigger!: jest.SpyInstance;
 
   beforeAll(function () {
     MockApiClient.asyncDelay = 1;

--- a/static/app/utils/replays/playback/providers/replayPlayerEventsContext.spec.tsx
+++ b/static/app/utils/replays/playback/providers/replayPlayerEventsContext.spec.tsx
@@ -44,7 +44,7 @@ describe('replayPlayerEventsContext', () => {
       errors: [],
       replayRecord: ReplayRecordFixture(),
     });
-    const mockRRwebFrames = [];
+    const mockRRwebFrames: any[] = [];
     mockReplay!.getRRWebFrames = jest.fn().mockReturnValue(mockRRwebFrames);
 
     const {result} = renderHook(useReplayPlayerEvents, {

--- a/static/app/utils/replays/playback/providers/replayPlayerPluginsContextProvider.spec.tsx
+++ b/static/app/utils/replays/playback/providers/replayPlayerPluginsContextProvider.spec.tsx
@@ -39,7 +39,7 @@ describe('replayPlayerPluginsContext', () => {
 
   it('should return no plugins if you dont use the Provider', () => {
     const mockOrganization = OrganizationFixture();
-    const mockEvents = [];
+    const mockEvents: any[] = [];
 
     const {result} = renderHook(useReplayPlayerPlugins, {
       wrapper: ({children}: {children?: ReactNode}) => (
@@ -57,7 +57,7 @@ describe('replayPlayerPluginsContext', () => {
     const mockOrganizationWithCanvas = OrganizationFixture({
       features: ['session-replay-enable-canvas-replayer'],
     });
-    const mockEvents = [];
+    const mockEvents: any[] = [];
 
     const {result: noCanvasResult} = renderHook(useReplayPlayerPlugins, {
       wrapper: makeWrapper(mockOrganizationNoCanvas),

--- a/static/app/views/dashboards/dashboard.spec.tsx
+++ b/static/app/views/dashboards/dashboard.spec.tsx
@@ -59,7 +59,8 @@ describe('Dashboards > Dashboard', () => {
     ],
   };
 
-  let initialData, tagsMock;
+  let initialData: ReturnType<typeof initializeOrg>;
+  let tagsMock: jest.Mock;
 
   beforeEach(() => {
     initialData = initializeOrg({organization, router: {}, projects: []});

--- a/static/app/views/dashboards/manage/dashboardList.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardList.spec.tsx
@@ -14,10 +14,13 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import DashboardList from 'sentry/views/dashboards/manage/dashboardList';
-import {DisplayType} from 'sentry/views/dashboards/types';
+import {type DashboardListItem, DisplayType} from 'sentry/views/dashboards/types';
 
 describe('Dashboards - DashboardList', function () {
-  let dashboards, deleteMock, dashboardUpdateMock, createMock;
+  let dashboards: DashboardListItem[];
+  let deleteMock: jest.Mock;
+  let dashboardUpdateMock: jest.Mock;
+  let createMock: jest.Mock;
   const organization = OrganizationFixture({
     features: ['global-views', 'dashboards-basic', 'dashboards-edit', 'discover-query'],
   });

--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -78,7 +78,7 @@ describe('Dashboards > WidgetCard', function () {
   };
 
   const api = new MockApiClient();
-  let eventsMock;
+  let eventsMock: jest.Mock;
 
   beforeEach(function () {
     MockApiClient.addMockResponse({

--- a/static/app/views/discover/savedQuery/index.spec.tsx
+++ b/static/app/views/discover/savedQuery/index.spec.tsx
@@ -3,7 +3,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {openAddToDashboardModal} from 'sentry/actionCreators/modal';
-import type {NewQuery} from 'sentry/types/organization';
+import type {NewQuery, Organization, SavedQuery} from 'sentry/types/organization';
 import EventView from 'sentry/utils/discover/eventView';
 import {DisplayModes, SavedQueryDatasets} from 'sentry/utils/discover/types';
 import {WidgetType} from 'sentry/views/dashboards/types';
@@ -41,12 +41,12 @@ function mount(
 }
 
 describe('Discover > SaveQueryButtonGroup', function () {
-  let organization,
-    errorsView,
-    savedQuery,
-    errorsViewSaved,
-    errorsViewModified,
-    errorsQuery;
+  let organization: Organization;
+  let errorsView: EventView;
+  let savedQuery: SavedQuery;
+  let errorsViewSaved: EventView;
+  let errorsViewModified: EventView;
+  let errorsQuery: NewQuery;
   const location = {
     pathname: '/organization/eventsv2/',
     query: {},
@@ -272,7 +272,7 @@ describe('Discover > SaveQueryButtonGroup', function () {
   });
 
   describe('viewing a saved query', () => {
-    let mockUtils;
+    let mockUtils: jest.SpyInstance;
 
     beforeEach(() => {
       mockUtils = jest
@@ -362,7 +362,7 @@ describe('Discover > SaveQueryButtonGroup', function () {
   });
 
   describe('modifying a saved query', () => {
-    let mockUtils;
+    let mockUtils: jest.SpyInstance;
 
     it('renders the correct set of buttons', async () => {
       mount(

--- a/static/app/views/discover/savedQuery/utils.spec.tsx
+++ b/static/app/views/discover/savedQuery/utils.spec.tsx
@@ -20,7 +20,7 @@ describe('SavedQueries API helpers', () => {
   errorsView.id = '1'; // set id manually as errorsView.id is undefined
   const yAxis = ['count()', 'failure_count()'];
 
-  let mockCall;
+  let mockCall: jest.Mock;
 
   afterEach(() => {
     MockApiClient.clearMockResponses();

--- a/static/app/views/discover/table/cellAction.spec.tsx
+++ b/static/app/views/discover/table/cellAction.spec.tsx
@@ -107,7 +107,7 @@ describe('Discover -> CellAction', function () {
   });
 
   describe('per cell actions', function () {
-    let handleCellAction;
+    let handleCellAction!: jest.Mock;
 
     beforeEach(function () {
       handleCellAction = jest.fn();

--- a/static/app/views/discover/table/columnEditModal.spec.tsx
+++ b/static/app/views/discover/table/columnEditModal.spec.tsx
@@ -16,7 +16,7 @@ import type {QueryFieldValue} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import ColumnEditModal from 'sentry/views/discover/table/columnEditModal';
 
-const stubEl = styled(p => p.children);
+const stubEl = styled((p: any) => p.children);
 
 function mountModal(
   {
@@ -277,7 +277,7 @@ describe('Discover -> ColumnEditModal', function () {
   });
 
   describe('function & column selection', function () {
-    let onApply;
+    let onApply!: jest.Mock;
     beforeEach(function () {
       onApply = jest.fn();
     });
@@ -632,7 +632,7 @@ describe('Discover -> ColumnEditModal', function () {
   });
 
   describe('equation automatic update', function () {
-    let onApply;
+    let onApply!: jest.Mock;
     beforeEach(function () {
       onApply = jest.fn();
     });

--- a/static/app/views/discover/table/tableView.spec.tsx
+++ b/static/app/views/discover/table/tableView.spec.tsx
@@ -7,12 +7,15 @@ import {act, render, screen, userEvent, within} from 'sentry-test/reactTestingLi
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TagStore from 'sentry/stores/tagStore';
 import {browserHistory} from 'sentry/utils/browserHistory';
+import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {SavedQueryDatasets} from 'sentry/utils/discover/types';
 import TableView from 'sentry/views/discover/table/tableView';
 
 describe('TableView > CellActions', function () {
-  let initialData, rows, onChangeShowTags;
+  let initialData: ReturnType<typeof initializeOrg>;
+  let rows: any;
+  let onChangeShowTags: jest.Mock;
 
   const location = LocationFixture({
     pathname: '/organizations/org-slug/discover/results/',
@@ -37,7 +40,11 @@ describe('TableView > CellActions', function () {
   });
   const eventView = EventView.fromLocation(location);
 
-  function renderComponent(context, tableData, view) {
+  function renderComponent(
+    context: ReturnType<typeof initializeOrg>,
+    tableData: TableData,
+    view: EventView
+  ) {
     return render(
       <TableView
         organization={context.organization}
@@ -57,7 +64,7 @@ describe('TableView > CellActions', function () {
     );
   }
 
-  async function openContextMenu(cellIndex) {
+  async function openContextMenu(cellIndex: number) {
     const firstRow = screen.getAllByRole('row')[1];
     const emptyValueCell = within(firstRow).getAllByRole('cell')[cellIndex];
 

--- a/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.spec.tsx
@@ -22,7 +22,7 @@ describe('PagePerformanceTable', function () {
   const organization = OrganizationFixture();
   const router = RouterFixture();
 
-  let eventsMock;
+  let eventsMock: jest.Mock;
 
   beforeEach(function () {
     jest.mocked(useLocation).mockReturnValue(router.location);

--- a/static/app/views/insights/database/views/databaseLandingPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.spec.tsx
@@ -17,7 +17,8 @@ jest.mock('sentry/views/insights/common/queries/useOnboardingProject');
 describe('DatabaseLandingPage', function () {
   const organization = OrganizationFixture();
 
-  let spanListRequestMock, spanChartsRequestMock;
+  let spanListRequestMock: jest.Mock;
+  let spanChartsRequestMock: jest.Mock;
 
   jest.mocked(useProjects).mockReturnValue({
     projects: [ProjectFixture({hasInsightsDb: true})],

--- a/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
@@ -17,7 +17,7 @@ jest.mock('sentry/utils/usePageFilters');
 describe('HTTPSamplesPanel', () => {
   const organization = OrganizationFixture();
 
-  let eventsRequestMock;
+  let eventsRequestMock: jest.Mock;
 
   jest.mocked(usePageFilters).mockReturnValue({
     isReady: true,
@@ -95,7 +95,9 @@ describe('HTTPSamplesPanel', () => {
   });
 
   describe('Status panel', () => {
-    let eventsStatsRequestMock, samplesRequestMock, spanFieldTagsMock;
+    let eventsStatsRequestMock: jest.Mock;
+    let samplesRequestMock: jest.Mock;
+    let spanFieldTagsMock: jest.Mock;
 
     beforeEach(() => {
       jest.mocked(useLocation).mockReturnValue({
@@ -307,7 +309,9 @@ describe('HTTPSamplesPanel', () => {
   });
 
   describe('Duration panel', () => {
-    let chartRequestMock, samplesRequestMock, spanFieldTagsMock;
+    let chartRequestMock: jest.Mock;
+    let samplesRequestMock: jest.Mock;
+    let spanFieldTagsMock: jest.Mock;
 
     beforeEach(() => {
       jest.mocked(useLocation).mockReturnValue({

--- a/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.spec.tsx
@@ -4,6 +4,8 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitFor, within} from 'sentry-test/reactTestingLibrary';
 
+import type {Organization} from 'sentry/types/organization';
+import type {Project} from 'sentry/types/project';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import localStorage from 'sentry/utils/localStorage';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -17,7 +19,7 @@ jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
 jest.mock('sentry/utils/useProjects');
 
-function mockResponses(organization, project) {
+function mockResponses(organization: Organization, project: Project) {
   jest.mocked(useOnboardingProject).mockReturnValue(undefined);
 
   jest.mocked(useProjects).mockReturnValue({
@@ -109,9 +111,9 @@ function mockResponses(organization, project) {
 
 describe('Screen Summary', function () {
   describe('Cross Platform Project', function () {
-    let eventsMock;
-    let eventsStatsMock;
-    let organization;
+    let eventsMock: jest.Mock;
+    let eventsStatsMock: jest.Mock;
+    let organization: Organization;
     beforeEach(function () {
       const project = ProjectFixture({
         platform: 'react-native',
@@ -205,9 +207,9 @@ describe('Screen Summary', function () {
   });
 
   describe('Native Project', function () {
-    let eventsMock;
-    let eventsStatsMock;
-    let organization;
+    let eventsMock: jest.Mock;
+    let eventsStatsMock: jest.Mock;
+    let organization: Organization;
     beforeEach(function () {
       const project = ProjectFixture({platform: 'android', hasInsightsScreenLoad: true});
       organization = OrganizationFixture({features: ['insights-initial-modules']});

--- a/static/app/views/insights/mobile/screenload/views/screenloadLandingPage.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenloadLandingPage.spec.tsx
@@ -63,7 +63,7 @@ describe('PageloadModule', function () {
     },
   });
 
-  let eventsMock;
+  let eventsMock: jest.Mock;
   beforeEach(function () {
     localStorage.clear();
     browserHistory.push = jest.fn();

--- a/static/app/views/insights/queues/charts/latencyChart.spec.tsx
+++ b/static/app/views/insights/queues/charts/latencyChart.spec.tsx
@@ -8,7 +8,7 @@ import {Referrer} from 'sentry/views/insights/queues/referrers';
 describe('latencyChart', () => {
   const organization = OrganizationFixture();
 
-  let eventsStatsMock;
+  let eventsStatsMock: jest.Mock;
 
   beforeEach(() => {
     eventsStatsMock = MockApiClient.addMockResponse({

--- a/static/app/views/insights/queues/components/messageSpanSamplesPanel.spec.tsx
+++ b/static/app/views/insights/queues/components/messageSpanSamplesPanel.spec.tsx
@@ -12,7 +12,10 @@ jest.mock('sentry/utils/usePageFilters');
 describe('messageSpanSamplesPanel', () => {
   const organization = OrganizationFixture();
 
-  let eventsRequestMock, eventsStatsRequestMock, samplesRequestMock, spanFieldTagsMock;
+  let eventsRequestMock: jest.Mock;
+  let eventsStatsRequestMock: jest.Mock;
+  let samplesRequestMock: jest.Mock;
+  let spanFieldTagsMock: jest.Mock;
 
   jest.mocked(usePageFilters).mockReturnValue({
     isReady: true,

--- a/static/app/views/insights/queues/components/tables/queuesTable.spec.tsx
+++ b/static/app/views/insights/queues/components/tables/queuesTable.spec.tsx
@@ -8,7 +8,7 @@ import {SpanIndexedField} from 'sentry/views/insights/types';
 describe('queuesTable', () => {
   const organization = OrganizationFixture();
 
-  let eventsMock;
+  let eventsMock: jest.Mock;
 
   const pageLinks =
     '<https://sentry.io/fake/previous>; rel="previous"; results="false"; cursor="0:0:1", ' +

--- a/static/app/views/insights/queues/components/tables/transactionsTable.spec.tsx
+++ b/static/app/views/insights/queues/components/tables/transactionsTable.spec.tsx
@@ -11,7 +11,7 @@ jest.mock('sentry/utils/useLocation');
 describe('transactionsTable', () => {
   const organization = OrganizationFixture();
 
-  let eventsMock;
+  let eventsMock: jest.Mock;
 
   const pageLinks =
     '<https://sentry.io/fake/previous>; rel="previous"; results="false"; cursor="0:0:1", ' +

--- a/static/app/views/insights/queues/views/destinationSummaryPage.spec.tsx
+++ b/static/app/views/insights/queues/views/destinationSummaryPage.spec.tsx
@@ -54,7 +54,9 @@ describe('destinationSummaryPage', () => {
     initiallyLoaded: false,
   });
 
-  let eventsMock, eventsStatsMock, spanFieldTagsMock;
+  let eventsMock: jest.Mock;
+  let eventsStatsMock: jest.Mock;
+  let spanFieldTagsMock: jest.Mock;
 
   beforeEach(() => {
     eventsMock = MockApiClient.addMockResponse({

--- a/static/app/views/integrationOrganizationLink/index.spec.tsx
+++ b/static/app/views/integrationOrganizationLink/index.spec.tsx
@@ -8,11 +8,14 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import selectEvent from 'sentry-test/selectEvent';
 
 import ConfigStore from 'sentry/stores/configStore';
+import type {Organization} from 'sentry/types/organization';
 import {generateOrgSlugUrl} from 'sentry/utils';
 import IntegrationOrganizationLink from 'sentry/views/integrationOrganizationLink';
 
 describe('IntegrationOrganizationLink', () => {
-  let org1, org2, getOrgsMock;
+  let org1: Organization;
+  let org2: Organization;
+  let getOrgsMock: jest.Mock;
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     window.location.assign = jest.fn();

--- a/static/app/views/integrationPipeline/awsLambdaProjectSelect.spec.tsx
+++ b/static/app/views/integrationPipeline/awsLambdaProjectSelect.spec.tsx
@@ -3,11 +3,12 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import selectEvent from 'sentry-test/selectEvent';
 
+import type {Project} from 'sentry/types/project';
 import AwsLambdaProjectSelect from 'sentry/views/integrationPipeline/awsLambdaProjectSelect';
 
 describe('AwsLambdaProjectSelect', () => {
-  let projects;
-  let windowAssignMock;
+  let projects: Project[];
+  let windowAssignMock: jest.Mock;
 
   beforeEach(() => {
     windowAssignMock = jest.fn();

--- a/static/app/views/issueDetails/groupEvents.spec.tsx
+++ b/static/app/views/issueDetails/groupEvents.spec.tsx
@@ -32,7 +32,7 @@ describe('groupEvents', () => {
   });
 
   let organization: Organization;
-  let router;
+  let router: ReturnType<typeof initializeOrg>['router'];
 
   beforeEach(() => {
     browserHistory.push = jest.fn();

--- a/static/app/views/issueDetails/groupSimilarIssues/similarIssues.spec.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarIssues.spec.tsx
@@ -20,7 +20,7 @@ jest.mock('sentry/utils/useNavigate', () => ({
 jest.mock('sentry/utils/analytics');
 
 describe('Issues Similar View', function () {
-  let mock;
+  let mock: jest.Mock;
 
   const project = ProjectFixture({
     features: ['similarity-view'],

--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -72,7 +72,7 @@ function getSearchInput() {
 }
 
 describe('IssueList', function () {
-  let props;
+  let props: any;
 
   const tags = TagsFixture();
   const group = GroupFixture({project});
@@ -170,11 +170,11 @@ describe('IssueList', function () {
       location: {query: {query: DEFAULT_QUERY}, search: `query=${DEFAULT_QUERY}`},
       params: {},
       organization,
-      tags: tags.reduce((acc, tag) => {
+      tags: tags.reduce<Record<string, (typeof tags)[number]>>((acc, tag) => {
         acc[tag.key] = tag;
 
         return acc;
-      }),
+      }, {}),
     };
   });
 
@@ -978,7 +978,7 @@ describe('IssueList', function () {
   });
 
   describe('componentDidUpdate fetching groups', function () {
-    let fetchDataMock;
+    let fetchDataMock: jest.Mock;
 
     beforeEach(function () {
       fetchDataMock = MockApiClient.addMockResponse({
@@ -1133,7 +1133,7 @@ describe('IssueList', function () {
   });
 
   describe('Error Robot', function () {
-    const createWrapper = async moreProps => {
+    const createWrapper = async (moreProps: any) => {
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/issues/',
         body: [],

--- a/static/app/views/performance/landing/queryBatcher.spec.tsx
+++ b/static/app/views/performance/landing/queryBatcher.spec.tsx
@@ -28,7 +28,7 @@ const BASIC_QUERY_PARAMS = {
   statsPeriod: '14d',
 };
 
-function WrappedComponent({data, ...rest}) {
+function WrappedComponent({data, ...rest}: any) {
   return (
     <OrganizationContext.Provider value={data.organization}>
       <MEPSettingProvider>
@@ -52,8 +52,8 @@ function WrappedComponent({data, ...rest}) {
 }
 
 describe('Performance > Widgets > Query Batching', function () {
-  let eventsMock;
-  let eventStatsMock;
+  let eventsMock: jest.Mock;
+  let eventStatsMock: jest.Mock;
 
   beforeEach(function () {
     eventsMock = MockApiClient.addMockResponse({

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -24,7 +24,7 @@ const initializeData = (query = {}, rest: InitializeDataSettings = {}) => {
   return data;
 };
 
-function WrappedComponent({data, withStaticFilters = false, ...rest}) {
+function WrappedComponent({data, withStaticFilters = false, ...rest}: any) {
   return (
     <OrganizationContext.Provider value={data.organization}>
       <MetricsCardinalityProvider
@@ -56,17 +56,17 @@ function WrappedComponent({data, withStaticFilters = false, ...rest}) {
   );
 }
 
-const issuesPredicate = (url, options) =>
+const issuesPredicate = (url: string, options: any) =>
   url.includes('events') && options.query?.query.includes('error');
 
 describe('Performance > Widgets > WidgetContainer', function () {
-  let wrapper;
+  let wrapper: ReturnType<typeof render> | undefined;
 
-  let eventStatsMock;
-  let eventsTrendsStats;
-  let eventsMock;
+  let eventStatsMock: jest.Mock;
+  let eventsTrendsStats: jest.Mock;
+  let eventsMock: jest.Mock;
 
-  let issuesListMock;
+  let issuesListMock: jest.Mock;
 
   beforeEach(function () {
     eventStatsMock = MockApiClient.addMockResponse({

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
@@ -39,11 +39,11 @@ function initializeData() {
 }
 
 describe('Performance Transaction Events Content', function () {
-  let fields;
-  let data;
-  let transactionName;
-  let eventView;
-  let initialData;
+  let fields: string[];
+  let data: any[];
+  let transactionName: string;
+  let eventView: EventView;
+  let initialData: ReturnType<typeof initializeData>;
   const query =
     'transaction.duration:<15m event.type:transaction transaction:/api/0/organizations/{organization_slug}/events/';
   beforeEach(function () {

--- a/static/app/views/performance/transactionSummary/transactionSpans/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/index.spec.tsx
@@ -42,9 +42,9 @@ function initializeData(options: {query: {}; additionalFeatures?: string[]}) {
 }
 
 describe('Performance > Transaction Spans', function () {
-  let eventsMock;
-  let eventsSpanOpsMock;
-  let eventsSpansPerformanceMock;
+  let eventsMock: jest.Mock;
+  let eventsSpanOpsMock: jest.Mock;
+  let eventsSpansPerformanceMock: jest.Mock;
   beforeEach(function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/projects/',

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/content.spec.tsx
@@ -56,10 +56,10 @@ describe('SpanSummaryPage', function () {
     },
   });
 
-  let headerDataMock;
-  let avgDurationChartMock;
-  let spanThroughputChartMock;
-  let transactionThroughputChartMock;
+  let headerDataMock: jest.Mock;
+  let avgDurationChartMock: jest.Mock;
+  let spanThroughputChartMock: jest.Mock;
+  let transactionThroughputChartMock: jest.Mock;
 
   beforeEach(() => {
     jest.mocked(useParams).mockReturnValue({

--- a/static/app/views/performance/trends/changeExplorer.spec.tsx
+++ b/static/app/views/performance/trends/changeExplorer.spec.tsx
@@ -287,8 +287,8 @@ const functionResults: EventsResultsDataRow<FunctionsField>[] = [
 ];
 
 describe('Performance > Trends > Performance Change Explorer', function () {
-  let eventsMockBefore;
-  let spansMock;
+  let eventsMockBefore: jest.Mock;
+  let spansMock: jest.Mock;
   beforeEach(function () {
     eventsMockBefore = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',

--- a/static/app/views/performance/trends/index.spec.tsx
+++ b/static/app/views/performance/trends/index.spec.tsx
@@ -55,13 +55,13 @@ async function waitForMockCall(mock: any) {
   });
 }
 
-function enterSearch(el, text) {
+function enterSearch(el: HTMLElement, text: string) {
   fireEvent.change(el, {target: {value: text}});
   fireEvent.submit(el);
 }
 
 // Might swap on/off the skiphover to check perf later.
-async function clickEl(el) {
+async function clickEl(el: HTMLElement) {
   await userEvent.click(el, {skipHover: true});
 }
 
@@ -150,7 +150,7 @@ function initializeTrendsData(
 }
 
 describe('Performance > Trends', function () {
-  let trendsStatsMock;
+  let trendsStatsMock: jest.Mock;
   beforeEach(function () {
     browserHistory.push = jest.fn();
     MockApiClient.addMockResponse({

--- a/static/app/views/projectDetail/projectCharts.spec.tsx
+++ b/static/app/views/projectDetail/projectCharts.spec.tsx
@@ -36,7 +36,7 @@ function renderProjectCharts(platform?: PlatformKey, chartDisplay?: string) {
 }
 
 describe('ProjectDetail > ProjectCharts', () => {
-  let mockSessions;
+  let mockSessions: jest.Mock;
   beforeEach(() => {
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/releases/stats/`,

--- a/static/app/views/projectDetail/projectScoreCards/projectAnrScoreCard.spec.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectAnrScoreCard.spec.tsx
@@ -5,7 +5,8 @@ import type {PageFilters} from 'sentry/types/core';
 import {ProjectAnrScoreCard} from 'sentry/views/projectDetail/projectScoreCards/projectAnrScoreCard';
 
 describe('ProjectDetail > ProjectAnr', function () {
-  let endpointMock, endpointMockPreviousPeriod;
+  let endpointMock: jest.Mock;
+  let endpointMockPreviousPeriod: jest.Mock;
 
   const {organization, router} = initializeOrg({
     router: {

--- a/static/app/views/releases/detail/overview/releaseIssues.spec.tsx
+++ b/static/app/views/releases/detail/overview/releaseIssues.spec.tsx
@@ -11,10 +11,10 @@ import ReleaseIssues from 'sentry/views/releases/detail/overview/releaseIssues';
 import {getReleaseBounds} from 'sentry/views/releases/utils';
 
 describe('ReleaseIssues', function () {
-  let newIssuesEndpoint,
-    resolvedIssuesEndpoint,
-    unhandledIssuesEndpoint,
-    allIssuesEndpoint;
+  let newIssuesEndpoint: jest.Mock;
+  let resolvedIssuesEndpoint: jest.Mock;
+  let unhandledIssuesEndpoint: jest.Mock;
+  let allIssuesEndpoint: jest.Mock;
 
   const props = {
     orgId: 'org',

--- a/static/app/views/releases/list/releasesRequest.spec.tsx
+++ b/static/app/views/releases/list/releasesRequest.spec.tsx
@@ -13,7 +13,9 @@ import {render, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {HealthStatsPeriodOption} from 'sentry/types/release';
 import {ReleasesDisplayOption} from 'sentry/views/releases/list/releasesDisplayOptions';
-import ReleasesRequest from 'sentry/views/releases/list/releasesRequest';
+import ReleasesRequest, {
+  type ReleasesRequestRenderProps,
+} from 'sentry/views/releases/list/releasesRequest';
 
 describe('ReleasesRequest', () => {
   const {organization, router} = initializeOrg();
@@ -176,7 +178,7 @@ describe('ReleasesRequest', () => {
   });
 
   it('calculates correct session health data', async () => {
-    let healthData;
+    let healthData!: ReleasesRequestRenderProps['getHealthData'];
 
     render(
       <ReleasesRequest
@@ -406,7 +408,7 @@ describe('ReleasesRequest', () => {
   });
 
   it('calculates correct user health data', async () => {
-    let healthData;
+    let healthData!: ReleasesRequestRenderProps['getHealthData'];
 
     render(
       <ReleasesRequest
@@ -634,7 +636,7 @@ describe('ReleasesRequest', () => {
   });
 
   it('calculates correct session count histogram (auto period)', async () => {
-    let healthData;
+    let healthData!: ReleasesRequestRenderProps['getHealthData'];
 
     render(
       <ReleasesRequest

--- a/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -204,18 +204,20 @@ type RowState = {
 };
 
 class LegacyBrowserFilterRow extends Component<RowProps, RowState> {
-  constructor(props) {
+  constructor(props: RowProps) {
     super(props);
 
     let initialSubfilters;
     if (props.data.active === true) {
       initialSubfilters = new Set(
         Object.keys(LEGACY_BROWSER_SUBFILTERS).filter(
-          key => !LEGACY_BROWSER_SUBFILTERS[key].legacy
+          key =>
+            !LEGACY_BROWSER_SUBFILTERS[key as keyof typeof LEGACY_BROWSER_SUBFILTERS]
+              .legacy
         )
       );
     } else if (props.data.active === false) {
-      initialSubfilters = new Set();
+      initialSubfilters = new Set<string>();
     } else {
       initialSubfilters = new Set(props.data.active);
     }
@@ -227,13 +229,15 @@ class LegacyBrowserFilterRow extends Component<RowProps, RowState> {
     };
   }
 
-  handleToggleSubfilters = (subfilter, e) => {
+  handleToggleSubfilters = (subfilter: boolean, e: React.MouseEvent) => {
     let {subfilters} = this.state;
 
     if (subfilter === true) {
       subfilters = new Set(
         Object.keys(LEGACY_BROWSER_SUBFILTERS).filter(
-          key => !LEGACY_BROWSER_SUBFILTERS[key].legacy
+          key =>
+            !LEGACY_BROWSER_SUBFILTERS[key as keyof typeof LEGACY_BROWSER_SUBFILTERS]
+              .legacy
         )
       );
     } else if (subfilter === false) {

--- a/static/app/views/traces/fieldRenderers.spec.tsx
+++ b/static/app/views/traces/fieldRenderers.spec.tsx
@@ -19,7 +19,7 @@ import {
 import type {SpanResult} from 'sentry/views/traces/hooks/useTraceSpans';
 
 describe('Renderers', function () {
-  let context;
+  let context: ReturnType<typeof initializeOrg>;
 
   const organization = OrganizationFixture({
     features: ['trace-view-v1'], // only testing against new trace view

--- a/static/app/views/unsubscribe/project.spec.tsx
+++ b/static/app/views/unsubscribe/project.spec.tsx
@@ -5,7 +5,8 @@ import UnsubscribeProject from 'sentry/views/unsubscribe/project';
 
 describe('UnsubscribeProject', function () {
   const params = {orgId: 'acme', id: '9876'};
-  let mockUpdate, mockGet;
+  let mockUpdate: jest.Mock;
+  let mockGet: jest.Mock;
   beforeEach(() => {
     mockUpdate = MockApiClient.addMockResponse({
       url: '/organizations/acme/unsubscribe/project/9876/?_=signature-value',


### PR DESCRIPTION
They are currently implicit any which we'd like to turn off.

didn't really focus on any area in particular just did a bunch of easy ones.

part of getsentry/frontend-tsc#79
