### PR TITLE
WIP Rc processing split pt2

### DIFF
--- a/src/sentry/eventstore/processing/service_delegator.py
+++ b/src/sentry/eventstore/processing/service_delegator.py
@@ -1,0 +1,35 @@
+from sentry.utils.services import ServiceDelegator, make_writebehind_selector
+
+backends_config = {
+    "errors": {
+        "path": "sentry.eventstore.processing.event_processing_store",
+        "executor": {
+            "path": "sentry.utils.services.ThreadedExecutor",
+            "options": {
+                "worker_count": 1,
+            },
+        },
+    },
+    "transactions": {
+        "path": "sentry.eventstore.processing.transaction_processing_store",
+        "executor": {
+            "path": "sentry.utils.services.ThreadedExecutor",
+            "options": {
+                "worker_count": 1,
+            },
+        },
+    },
+}
+
+selector = make_writebehind_selector(
+    option_name="rc-processing-split.rollout",
+    move_to="transactions",
+    move_from="errors",
+    key_fetch=lambda *args: "a-consistent-key",
+)
+
+eventstore_delegator = ServiceDelegator(
+    backend_base="sentry.eventstore.processing.base.EventProcessingStore",
+    backends=backends_config,
+    selector_func=selector,
+)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2793,3 +2793,5 @@ register(
     default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+register("rc-processing-split.rollout", type=float, default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)


### PR DESCRIPTION
Using the ServiceDelegator to rollout the cutover of transactions from rc-processing to rc-processing-transaction. 