### PR TITLE
feat(metric-alert): Add dataset prop to analytics tracking code

### DIFF
--- a/src/sentry/analytics/events/alert_created.py
+++ b/src/sentry/analytics/events/alert_created.py
@@ -15,6 +15,7 @@ class AlertCreatedEvent(analytics.Event):
         analytics.Attribute("alert_rule_ui_component", required=False),
         analytics.Attribute("duplicate_rule", required=False),
         analytics.Attribute("wizard_v3", required=False),
+        analytics.Attribute("dataset", required=False),
     )
 
 

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -159,6 +159,7 @@ class AlertRuleIndexMixin(Endpoint):
                     is_api_token=request.auth is not None,
                     duplicate_rule=duplicate_rule,
                     wizard_v3=wizard_v3,
+                    dataset=alert_rule.dataset,
                 )
             return Response(serialize(alert_rule, request.user), status=status.HTTP_201_CREATED)
 

--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -301,6 +301,7 @@ def record_alert_rule_created(
     rule_id: int,
     rule_type: str,
     is_api_token: bool,
+    dataset=None,
     referrer=None,
     session_id=None,
     alert_rule_ui_component=None,
@@ -334,6 +335,7 @@ def record_alert_rule_created(
         alert_rule_ui_component=alert_rule_ui_component,
         duplicate_rule=duplicate_rule,
         wizard_v3=wizard_v3,
+        dataset=dataset,
     )
 
 

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -135,7 +135,7 @@ save_search_created = BetterSignal()  # ["project", "user"]
 inbound_filter_toggled = BetterSignal()  # ["project"]
 sso_enabled = BetterSignal()  # ["organization_id", "user_id", "provider"]
 data_scrubber_enabled = BetterSignal()  # ["organization"]
-# ["project", "rule", "user", "rule_type", "is_api_token", "duplicate_rule", "wizard_v3"]
+# ["project", "rule", "user", "rule_type", "is_api_token", "duplicate_rule", "wizard_v3", "dataset"]
 alert_rule_created = BetterSignal()
 alert_rule_edited = BetterSignal()  # ["project", "rule", "user", "rule_type", "is_api_token"]
 repo_linked = BetterSignal()  # ["repo", "user"]


### PR DESCRIPTION
We want to track when a 'performance' alert is created, and we can achieve this by filtering the dataset. If the alert type is 'transactions,' it indicates a performance alert.

Contributes to https://github.com/getsentry/projects/issues/262