### PR TITLE
ref(replay): Timeline gaps based on video events

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -40,6 +40,7 @@ export default function ReplayTimeline() {
   const durationMs = replay.getDurationMs();
   const startTimestampMs = replay.getStartTimestampMs();
   const chapterFrames = replay.getChapterFrames();
+  const videoEvents = replay.getVideoEvents();
 
   // timeline is in the middle
   const initialTranslate = 0.5 / timelineScale;
@@ -75,6 +76,7 @@ export default function ReplayTimeline() {
             durationMs={durationMs}
             startTimestampMs={startTimestampMs}
             frames={chapterFrames}
+            videoEvents={videoEvents}
           />
         ) : null}
         <TimelineEventsContainer>

--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -75,7 +75,6 @@ export default function ReplayTimeline() {
           <TimelineGaps
             durationMs={durationMs}
             startTimestampMs={startTimestampMs}
-            frames={chapterFrames}
             videoEvents={videoEvents}
           />
         ) : null}

--- a/static/app/components/replays/breadcrumbs/timelineGaps.tsx
+++ b/static/app/components/replays/breadcrumbs/timelineGaps.tsx
@@ -19,7 +19,8 @@ export default function TimelineGaps({durationMs, startTimestampMs, videoEvents}
 
   // create gap in timeline when there is a gap between video events
   for (const video of videoEvents) {
-    if (start < video.timestamp) {
+    // arbitrarily set minimum gap to 1 second
+    if (video.timestamp - start > 1000) {
       ranges.push({
         left: toPercent((start - startTimestampMs) / durationMs),
         width: toPercent((video.timestamp - start) / durationMs),
@@ -43,7 +44,7 @@ export default function TimelineGaps({durationMs, startTimestampMs, videoEvents}
         return (
           <Range key={`${rangeCss.left}-${rangeCss.width}`} style={rangeCss}>
             <Tooltip
-              title={t('App is suspended')}
+              title={t('Video Unavailable')}
               isHoverable
               containerDisplayMode="block"
               position="top"

--- a/static/app/components/replays/breadcrumbs/timelineGaps.tsx
+++ b/static/app/components/replays/breadcrumbs/timelineGaps.tsx
@@ -3,66 +3,37 @@ import styled from '@emotion/styled';
 
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
-import {trackAnalytics} from 'sentry/utils/analytics';
 import toPercent from 'sentry/utils/number/toPercent';
-import {
-  getFrameOpOrCategory,
-  isBackgroundFrame,
-  isErrorFrame,
-  type ReplayFrame,
-} from 'sentry/utils/replays/types';
-import useOrganization from 'sentry/utils/useOrganization';
+import type {ReplayFrame, VideoEvent} from 'sentry/utils/replays/types';
 
 interface Props {
   durationMs: number;
   frames: ReplayFrame[];
   startTimestampMs: number;
+  videoEvents: VideoEvent[];
 }
 
-// create gaps in the timeline by finding all columns between a background frame and foreground frame
-// or background frame to end of replay
-export default function TimelineGaps({durationMs, startTimestampMs, frames}: Props) {
-  const organization = useOrganization();
+export default function TimelineGaps({durationMs, startTimestampMs, videoEvents}: Props) {
   const ranges: Array<{left: string; width: string}> = [];
 
-  let start = -1;
-  let end = -1;
+  let start = startTimestampMs;
 
-  for (const currFrame of frames) {
-    // add metrics for frame coming after a background frame to see how often we have bad data
-    if (start !== -1) {
-      trackAnalytics('replay.frame-after-background', {
-        organization,
-        frame: getFrameOpOrCategory(currFrame),
-      });
-    }
-
-    // only considered start of gap if background frame hasn't been found yet
-    if (start === -1 && isBackgroundFrame(currFrame)) {
-      start = currFrame.timestampMs - startTimestampMs;
-    }
-
-    // gap only ends if a frame that's not a background frame or error frame has been found
-    if (start !== -1 && !isBackgroundFrame(currFrame) && !isErrorFrame(currFrame)) {
-      end = currFrame.timestampMs - startTimestampMs;
-    }
-
-    // create gap if we found have start (background frame) and end (another frame)
-    if (start !== -1 && end !== -1) {
+  // create gap in timeline when there is a gap between video events
+  for (const video of videoEvents) {
+    if (start < video.timestamp) {
       ranges.push({
-        left: toPercent(start / durationMs),
-        width: toPercent((end - start) / durationMs),
+        left: toPercent((start - startTimestampMs) / durationMs),
+        width: toPercent((video.timestamp - start) / durationMs),
       });
-      start = -1;
-      end = -1;
     }
+    start = video.timestamp + video.duration;
   }
 
-  // create gap if we still have start (background frame) until end of replay
-  if (start !== -1) {
+  // add gap at the end if the last video segment ends before the replay ends
+  if (videoEvents.length && start < startTimestampMs + durationMs) {
     ranges.push({
-      left: toPercent(start / durationMs),
-      width: toPercent((durationMs - start) / durationMs),
+      left: toPercent((start - startTimestampMs) / durationMs),
+      width: toPercent(durationMs / durationMs),
     });
   }
 

--- a/static/app/components/replays/breadcrumbs/timelineGaps.tsx
+++ b/static/app/components/replays/breadcrumbs/timelineGaps.tsx
@@ -4,11 +4,10 @@ import styled from '@emotion/styled';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import toPercent from 'sentry/utils/number/toPercent';
-import type {ReplayFrame, VideoEvent} from 'sentry/utils/replays/types';
+import type {VideoEvent} from 'sentry/utils/replays/types';
 
 interface Props {
   durationMs: number;
-  frames: ReplayFrame[];
   startTimestampMs: number;
   videoEvents: VideoEvent[];
 }

--- a/static/app/components/replays/breadcrumbs/timelineGaps.tsx
+++ b/static/app/components/replays/breadcrumbs/timelineGaps.tsx
@@ -19,8 +19,7 @@ export default function TimelineGaps({durationMs, startTimestampMs, videoEvents}
 
   // create gap in timeline when there is a gap between video events
   for (const video of videoEvents) {
-    // arbitrarily set minimum gap to 1 second
-    if (video.timestamp - start > 1000) {
+    if (start < video.timestamp) {
       ranges.push({
         left: toPercent((start - startTimestampMs) / durationMs),
         width: toPercent((video.timestamp - start) / durationMs),


### PR DESCRIPTION
Timeline gaps based on gaps in video events instead of background and foreground frames

Example:
<img width="1488" alt="image" src="https://github.com/user-attachments/assets/eb23a788-433c-442f-803d-05aeff0ead5e">

relates to https://github.com/getsentry/sentry/issues/71665