### PR TITLE
fix(scim): Repair DELETE SCIM Team endpoint

### DIFF
--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -60,9 +60,9 @@ class TeamDetailsEndpoint(TeamEndpoint):
     _allow_idp_changes = False
 
     def can_modify_team(self, team: Team):
-        if not team.idp_provisioned:
-            return True
-        return team.idp_provisioned and self._allow_idp_changes
+        if team.idp_provisioned:
+            return self._allow_idp_changes
+        return True
 
     @extend_schema(
         operation_id="Retrieve a Team",

--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -56,6 +56,11 @@ class TeamDetailsEndpoint(TeamEndpoint):
         "GET": ApiPublishStatus.PUBLIC,
         "PUT": ApiPublishStatus.PUBLIC,
     }
+    # OrganizationSCIMTeamDetails inherits this endpoint, but toggles this setting
+    _allow_idp_changes = False
+
+    def is_permitted_idp_change(self, team: Team):
+        return team.idp_provisioned and self._allow_idp_changes
 
     @extend_schema(
         operation_id="Retrieve a Team",
@@ -108,7 +113,7 @@ class TeamDetailsEndpoint(TeamEndpoint):
         team.
         """
 
-        if team.idp_provisioned:
+        if not self.is_permitted_idp_change(team):
             return Response(
                 {"detail": "This team is managed through your organization's identity provider."},
                 status=403,
@@ -149,7 +154,7 @@ class TeamDetailsEndpoint(TeamEndpoint):
         immediate. Teams will have their slug released while waiting for deletion.
         """
 
-        if team.idp_provisioned:
+        if not self.is_permitted_idp_change(team):
             return Response(
                 {"detail": "This team is managed through your organization's identity provider."},
                 status=403,

--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -59,10 +59,10 @@ class TeamDetailsEndpoint(TeamEndpoint):
     # OrganizationSCIMTeamDetails inherits this endpoint, but toggles this setting
     _allow_idp_changes = False
 
-    def can_modify_team(self, team: Team):
-        if team.idp_provisioned:
-            return self._allow_idp_changes
-        return True
+    def can_modify_idp_team(self, team: Team):
+        if not team.idp_provisioned:
+            return True
+        return self._allow_idp_changes
 
     @extend_schema(
         operation_id="Retrieve a Team",
@@ -115,7 +115,7 @@ class TeamDetailsEndpoint(TeamEndpoint):
         team.
         """
 
-        if not self.can_modify_team(team):
+        if not self.can_modify_idp_team(team):
             return Response(
                 {"detail": "This team is managed through your organization's identity provider."},
                 status=403,
@@ -156,7 +156,7 @@ class TeamDetailsEndpoint(TeamEndpoint):
         immediate. Teams will have their slug released while waiting for deletion.
         """
 
-        if not self.can_modify_team(team):
+        if not self.can_modify_idp_team(team):
             return Response(
                 {"detail": "This team is managed through your organization's identity provider."},
                 status=403,

--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -59,7 +59,9 @@ class TeamDetailsEndpoint(TeamEndpoint):
     # OrganizationSCIMTeamDetails inherits this endpoint, but toggles this setting
     _allow_idp_changes = False
 
-    def is_permitted_idp_change(self, team: Team):
+    def can_modify_team(self, team: Team):
+        if not team.idp_provisioned:
+            return True
         return team.idp_provisioned and self._allow_idp_changes
 
     @extend_schema(
@@ -113,7 +115,7 @@ class TeamDetailsEndpoint(TeamEndpoint):
         team.
         """
 
-        if not self.is_permitted_idp_change(team):
+        if not self.can_modify_team(team):
             return Response(
                 {"detail": "This team is managed through your organization's identity provider."},
                 status=403,
@@ -154,7 +156,7 @@ class TeamDetailsEndpoint(TeamEndpoint):
         immediate. Teams will have their slug released while waiting for deletion.
         """
 
-        if not self.is_permitted_idp_change(team):
+        if not self.can_modify_team(team):
             return Response(
                 {"detail": "This team is managed through your organization's identity provider."},
                 status=403,

--- a/src/sentry/scim/endpoints/teams.py
+++ b/src/sentry/scim/endpoints/teams.py
@@ -302,6 +302,7 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
         "PATCH": ApiPublishStatus.PUBLIC,
     }
     permission_classes = (OrganizationSCIMTeamPermission,)
+    _allow_idp_changes = True
 
     def convert_args(
         self, request: Request, organization_id_or_slug: int | str, team_id, *args, **kwargs

--- a/tests/sentry/api/endpoints/test_scim_team_details.py
+++ b/tests/sentry/api/endpoints/test_scim_team_details.py
@@ -23,7 +23,9 @@ class SCIMDetailGetTest(SCIMTestCase):
         }
 
     def test_scim_team_details_basic(self):
-        team = self.create_team(organization=self.organization, name="test-scimv2")
+        team = self.create_team(
+            organization=self.organization, name="test-scimv2", idp_provisioned=True
+        )
         url = reverse(
             "sentry-api-0-organization-scim-team-details",
             args=[self.organization.slug, team.id],
@@ -39,7 +41,9 @@ class SCIMDetailGetTest(SCIMTestCase):
         }
 
     def test_scim_team_details_excluded_attributes(self):
-        team = self.create_team(organization=self.organization, name="test-scimv2")
+        team = self.create_team(
+            organization=self.organization, name="test-scimv2", idp_provisioned=True
+        )
         url = reverse(
             "sentry-api-0-organization-scim-team-details",
             args=[self.organization.slug, team.id],
@@ -81,7 +85,7 @@ class SCIMDetailPatchTest(SCIMTestCase):
 
     def setUp(self):
         super().setUp()
-        self.team = self.create_team(organization=self.organization)
+        self.team = self.create_team(organization=self.organization, idp_provisioned=True)
         self.base_data: dict[str, Any] = {
             "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
         }
@@ -310,7 +314,7 @@ class SCIMDetailDeleteTest(SCIMTestCase):
 
     @patch("sentry.scim.endpoints.teams.metrics")
     def test_delete_team(self, mock_metrics):
-        team = self.create_team(organization=self.organization)
+        team = self.create_team(organization=self.organization, idp_provisioned=True)
         self.get_success_response(self.organization.slug, team.id, status_code=204)
 
         assert Team.objects.get(id=team.id).status == TeamStatus.PENDING_DELETION


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/getsentry/sentry/pull/78722 where the SCIM team details endpoint inherited the DELETE method and assumed it'd work for SCIM teams in tests.

Added a failing test to catch a regression and allows the inherited method to skip the SCIM check.