### PR TITLE
ref(alerts): Add query_type to analytics tracking code

### DIFF
--- a/src/sentry/analytics/events/alert_created.py
+++ b/src/sentry/analytics/events/alert_created.py
@@ -15,6 +15,7 @@ class AlertCreatedEvent(analytics.Event):
         analytics.Attribute("alert_rule_ui_component", required=False),
         analytics.Attribute("duplicate_rule", required=False),
         analytics.Attribute("wizard_v3", required=False),
+        analytics.Attribute("query_type", required=False),
     )
 
 

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -159,6 +159,7 @@ class AlertRuleIndexMixin(Endpoint):
                     is_api_token=request.auth is not None,
                     duplicate_rule=duplicate_rule,
                     wizard_v3=wizard_v3,
+                    query_type=data.get("queryType", None),
                 )
             return Response(serialize(alert_rule, request.user), status=status.HTTP_201_CREATED)
 

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -54,6 +54,7 @@ from sentry.models.team import Team
 from sentry.sentry_apps.services.app import app_service
 from sentry.signals import alert_rule_created
 from sentry.snuba.dataset import Dataset
+from sentry.snuba.models import SnubaQuery
 from sentry.uptime.models import (
     ProjectUptimeSubscription,
     ProjectUptimeSubscriptionMode,
@@ -159,9 +160,15 @@ class AlertRuleIndexMixin(Endpoint):
                     is_api_token=request.auth is not None,
                     duplicate_rule=duplicate_rule,
                     wizard_v3=wizard_v3,
-                    query_type=data.get("queryType", None),
+                    query_type=self.get_query_type_description(data.get("queryType", None)),
                 )
             return Response(serialize(alert_rule, request.user), status=status.HTTP_201_CREATED)
+
+    def get_query_type_description(self, value):
+        try:
+            return SnubaQuery.Type(value).name
+        except ValueError:
+            return "Unknown"
 
 
 @region_silo_endpoint

--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -306,6 +306,7 @@ def record_alert_rule_created(
     alert_rule_ui_component=None,
     duplicate_rule=None,
     wizard_v3=None,
+    query_type=None,
     **kwargs,
 ):
     # NOTE: This intentionally does not fire for the default issue alert rule
@@ -334,6 +335,7 @@ def record_alert_rule_created(
         alert_rule_ui_component=alert_rule_ui_component,
         duplicate_rule=duplicate_rule,
         wizard_v3=wizard_v3,
+        query_type=query_type,
     )
 
 

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -135,7 +135,7 @@ save_search_created = BetterSignal()  # ["project", "user"]
 inbound_filter_toggled = BetterSignal()  # ["project"]
 sso_enabled = BetterSignal()  # ["organization_id", "user_id", "provider"]
 data_scrubber_enabled = BetterSignal()  # ["organization"]
-# ["project", "rule", "user", "rule_type", "is_api_token", "duplicate_rule", "wizard_v3"]
+# ["project", "rule", "user", "rule_type", "is_api_token", "duplicate_rule", "wizard_v3", "query_type"]
 alert_rule_created = BetterSignal()
 alert_rule_edited = BetterSignal()  # ["project", "rule", "user", "rule_type", "is_api_token"]
 repo_linked = BetterSignal()  # ["repo", "user"]

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -1317,6 +1317,19 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             )
         assert resp.data["name"][0] == "Ensure this field has no more than 256 characters."
 
+    @patch("sentry.analytics.record")
+    def test_performance_alert(self, record_analytics):
+        valid_alert_rule = {
+            **self.alert_rule_dict,
+            "queryType": 1,
+            "dataset": "transactions",
+            "eventTypes": ["transaction"],
+        }
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            resp = self.get_response(self.organization.slug, **valid_alert_rule)
+            assert resp.status_code == 201
+            assert self.analytics_called_with_args(record_analytics, "alert.created", query_type=1)
+
 
 @freeze_time()
 class AlertRuleCreateEndpointTestCrashRateAlert(AlertRuleIndexBase):

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -1328,7 +1328,9 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
             resp = self.get_response(self.organization.slug, **valid_alert_rule)
             assert resp.status_code == 201
-            assert self.analytics_called_with_args(record_analytics, "alert.created", query_type=1)
+            assert self.analytics_called_with_args(
+                record_analytics, "alert.created", query_type="PERFORMANCE"
+            )
 
 
 @freeze_time()


### PR DESCRIPTION
Contributes to https://github.com/getsentry/projects/issues/262

We want to track whether users create a performance alert after clicking the "Create Performance Alert" quick start task. To complete our analysis, we need to filter the type of alert being created. We can achieve this by checking the `query_type` property; according to our [code base](https://github.com/getsentry/sentry/blob/c122518b6677567a1dac7475f452cfbe5fe9ea11/static/app/views/alerts/wizard/options.tsx#L53-L57), if its value is 1, it indicates a performance alert.