### PR TITLE
ref(issue-details): Fix some styling on streamlined stacktrace

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -320,7 +320,6 @@ function Content({
 
 const Wrapper = styled('div')<{hasIconMargin: boolean}>`
   position: relative;
-
   margin-left: ${p => (p.hasIconMargin ? space(2) : 0)};
   @media (max-width: ${p => p.theme.breakpoints.medium}) {
     margin-left: 0;

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -5,12 +5,14 @@ import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import type {FrameSourceMapDebuggerData} from 'sentry/components/events/interfaces/sourceMapsDebuggerModal';
 import Panel from 'sentry/components/panels/panel';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {Event, Frame} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
 import type {PlatformKey} from 'sentry/types/project';
 import type {StackTraceMechanism, StacktraceType} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
 import withOrganization from 'sentry/utils/withOrganization';
+import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 import type {DeprecatedLineProps} from '../../frame/deprecatedLine';
 import DeprecatedLine from '../../frame/deprecatedLine';
@@ -66,6 +68,7 @@ function Content({
   frameSourceMapDebuggerData,
   hideSourceMapDebugger,
 }: Props) {
+  const hasStreamlinedUI = useHasStreamlinedUI();
   const [showingAbsoluteAddresses, setShowingAbsoluteAddresses] = useState(false);
   const [showCompleteFunctionName, setShowCompleteFunctionName] = useState(false);
   const [toggleFrameMap, setToggleFrameMap] = useState(setInitialFrameMap());
@@ -299,7 +302,7 @@ function Content({
   const platformIcon = stackTracePlatformIcon(platform, data.frames ?? []);
 
   return (
-    <Wrapper>
+    <Wrapper hasIconMargin={!hideIcon && hasStreamlinedUI}>
       {!hideIcon && <StacktracePlatformIcon platform={platformIcon} />}
       <StackTraceContentPanel
         className={wrapperClassName}
@@ -315,13 +318,21 @@ function Content({
   );
 }
 
-const Wrapper = styled('div')`
+const Wrapper = styled('div')<{hasIconMargin: boolean}>`
   position: relative;
+
+  margin-left: ${p => (p.hasIconMargin ? space(2) : 0)};
+  @media (max-width: ${p => p.theme.breakpoints.medium}) {
+    margin-left: 0;
+  }
 `;
 
 export const StackTraceContentPanel = styled(Panel)`
   position: relative;
   border-top-left-radius: 0;
+  @media (max-width: ${p => p.theme.breakpoints.medium}) {
+    border-top-left-radius: ${p => p.theme.borderRadius};
+  }
   overflow: hidden;
 `;
 

--- a/static/app/components/events/interfaces/crashContent/stackTrace/platformIcon.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/platformIcon.tsx
@@ -22,7 +22,7 @@ function StacktracePlatformIcon({platform}: Props) {
 const StyledPlatformIcon = styled(PlatformIcon)`
   position: absolute;
   top: 0;
-  left: -${p => p.size};
+  right: 100%;
   border-radius: 3px 0 0 3px;
 
   @media (max-width: ${p => p.theme.breakpoints.medium}) {

--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -226,106 +226,9 @@ export function Threads({data, event, projectSlug, groupingCurrentLevel, group}:
 
   const {id: activeThreadId, name: activeThreadName} = activeThread ?? {};
   const hideThreadTags = activeThreadId === undefined || !activeThreadName;
-  const threadContent = (
-    <TraceEventDataSection
-      type={EntryType.THREADS}
-      projectSlug={projectSlug}
-      eventId={event.id}
-      recentFirst={isStacktraceNewestFirst()}
-      fullStackTrace={stackView === StackView.FULL}
-      title={hasMoreThanOneThread ? t('Thread Stack Trace') : t('Stack Trace')}
-      platform={platform}
-      isNestedSection={hasMoreThanOneThread}
-      hasMinified={
-        !!exception?.values?.find(value => value.rawStacktrace) ||
-        !!activeThread?.rawStacktrace
-      }
-      hasVerboseFunctionNames={
-        !!exception?.values?.some(
-          value =>
-            !!value.stacktrace?.frames?.some(
-              frame =>
-                !!frame.rawFunction &&
-                !!frame.function &&
-                frame.rawFunction !== frame.function
-            )
-        ) ||
-        !!activeThread?.stacktrace?.frames?.some(
-          frame =>
-            !!frame.rawFunction &&
-            !!frame.function &&
-            frame.rawFunction !== frame.function
-        )
-      }
-      hasAbsoluteFilePaths={
-        !!exception?.values?.some(
-          value => !!value.stacktrace?.frames?.some(frame => !!frame.filename)
-        ) || !!activeThread?.stacktrace?.frames?.some(frame => !!frame.filename)
-      }
-      hasAbsoluteAddresses={
-        !!exception?.values?.some(
-          value => !!value.stacktrace?.frames?.some(frame => !!frame.instructionAddr)
-        ) || !!activeThread?.stacktrace?.frames?.some(frame => !!frame.instructionAddr)
-      }
-      hasAppOnlyFrames={
-        !!exception?.values?.some(
-          value => !!value.stacktrace?.frames?.some(frame => frame.inApp !== true)
-        ) || !!activeThread?.stacktrace?.frames?.some(frame => frame.inApp !== true)
-      }
-      hasNewestFirst={
-        !!exception?.values?.some(value => (value.stacktrace?.frames ?? []).length > 1) ||
-        (activeThread?.stacktrace?.frames ?? []).length > 1
-      }
-      stackTraceNotFound={stackTraceNotFound}
-    >
-      {childrenProps => {
-        // TODO(scttcper): These are duplicated from renderContent, should consolidate
-        const stackType = childrenProps.display.includes('minified')
-          ? StackType.MINIFIED
-          : StackType.ORIGINAL;
-        const isRaw = childrenProps.display.includes('raw-stack-trace');
-        const stackTrace = getThreadStacktrace(
-          stackType !== StackType.ORIGINAL,
-          activeThread
-        );
-
-        return (
-          <Fragment>
-            {stackTrace && !isRaw && !isSampleError && (
-              <ErrorBoundary customComponent={null}>
-                <StacktraceBanners event={event} stacktrace={stackTrace} />
-              </ErrorBoundary>
-            )}
-            {renderContent(childrenProps)}
-            {hasStreamlinedUI && group && (
-              <ErrorBoundary
-                mini
-                message={t('There was an error loading the suspect commits')}
-              >
-                <SuspectCommits
-                  projectSlug={projectSlug}
-                  eventId={event.id}
-                  commitRow={CommitRow}
-                  group={group}
-                />
-              </ErrorBoundary>
-            )}
-          </Fragment>
-        );
-      }}
-    </TraceEventDataSection>
-  );
 
   const threadComponent = (
-    <ThreadTraceWrapper
-      style={{
-        // TODO(issues): Remove on streamline issues ui GA
-        padding:
-          !hasMoreThanOneThread || hasStreamlinedUI
-            ? undefined
-            : `${space(1)} ${space(4)}`,
-      }}
-    >
+    <Fragment>
       {hasMoreThanOneThread && (
         <Fragment>
           <Grid>
@@ -373,8 +276,95 @@ export function Threads({data, event, projectSlug, groupingCurrentLevel, group}:
           )}
         </Fragment>
       )}
-      {threadContent}
-    </ThreadTraceWrapper>
+      <TraceEventDataSection
+        type={EntryType.THREADS}
+        projectSlug={projectSlug}
+        eventId={event.id}
+        recentFirst={isStacktraceNewestFirst()}
+        fullStackTrace={stackView === StackView.FULL}
+        title={hasMoreThanOneThread ? t('Thread Stack Trace') : t('Stack Trace')}
+        platform={platform}
+        isNestedSection={hasMoreThanOneThread}
+        hasMinified={
+          !!exception?.values?.find(value => value.rawStacktrace) ||
+          !!activeThread?.rawStacktrace
+        }
+        hasVerboseFunctionNames={
+          !!exception?.values?.some(
+            value =>
+              !!value.stacktrace?.frames?.some(
+                frame =>
+                  !!frame.rawFunction &&
+                  !!frame.function &&
+                  frame.rawFunction !== frame.function
+              )
+          ) ||
+          !!activeThread?.stacktrace?.frames?.some(
+            frame =>
+              !!frame.rawFunction &&
+              !!frame.function &&
+              frame.rawFunction !== frame.function
+          )
+        }
+        hasAbsoluteFilePaths={
+          !!exception?.values?.some(
+            value => !!value.stacktrace?.frames?.some(frame => !!frame.filename)
+          ) || !!activeThread?.stacktrace?.frames?.some(frame => !!frame.filename)
+        }
+        hasAbsoluteAddresses={
+          !!exception?.values?.some(
+            value => !!value.stacktrace?.frames?.some(frame => !!frame.instructionAddr)
+          ) || !!activeThread?.stacktrace?.frames?.some(frame => !!frame.instructionAddr)
+        }
+        hasAppOnlyFrames={
+          !!exception?.values?.some(
+            value => !!value.stacktrace?.frames?.some(frame => frame.inApp !== true)
+          ) || !!activeThread?.stacktrace?.frames?.some(frame => frame.inApp !== true)
+        }
+        hasNewestFirst={
+          !!exception?.values?.some(
+            value => (value.stacktrace?.frames ?? []).length > 1
+          ) || (activeThread?.stacktrace?.frames ?? []).length > 1
+        }
+        stackTraceNotFound={stackTraceNotFound}
+      >
+        {childrenProps => {
+          // TODO(scttcper): These are duplicated from renderContent, should consolidate
+          const stackType = childrenProps.display.includes('minified')
+            ? StackType.MINIFIED
+            : StackType.ORIGINAL;
+          const isRaw = childrenProps.display.includes('raw-stack-trace');
+          const stackTrace = getThreadStacktrace(
+            stackType !== StackType.ORIGINAL,
+            activeThread
+          );
+
+          return (
+            <Fragment>
+              {stackTrace && !isRaw && !isSampleError && (
+                <ErrorBoundary customComponent={null}>
+                  <StacktraceBanners event={event} stacktrace={stackTrace} />
+                </ErrorBoundary>
+              )}
+              {renderContent(childrenProps)}
+              {hasStreamlinedUI && group && (
+                <ErrorBoundary
+                  mini
+                  message={t('There was an error loading the suspect commits')}
+                >
+                  <SuspectCommits
+                    projectSlug={projectSlug}
+                    eventId={event.id}
+                    commitRow={CommitRow}
+                    group={group}
+                  />
+                </ErrorBoundary>
+              )}
+            </Fragment>
+          );
+        }}
+      </TraceEventDataSection>
+    </Fragment>
   );
 
   // If there is only one thread, we expect the stacktrace to wrap itself in a section
@@ -383,10 +373,20 @@ export function Threads({data, event, projectSlug, groupingCurrentLevel, group}:
       title={tn('Stack Trace', 'Stack Traces', threads.length)}
       type={SectionKey.STACKTRACE}
     >
-      {threadComponent}
+      <ThreadTraceWrapper
+        style={{
+          // TODO(issues): Remove on streamline issues ui GA
+          padding:
+            !hasMoreThanOneThread || hasStreamlinedUI
+              ? undefined
+              : `${space(1)} ${space(4)}`,
+        }}
+      >
+        {threadComponent}
+      </ThreadTraceWrapper>
     </InterimSection>
   ) : (
-    threadContent
+    threadComponent
   );
 }
 


### PR DESCRIPTION
Does a few things:

- Fixes divider not appearing on single threaded stack traces (it uses `SectionChild` uses :last child to render these, so nesting it caused issues

**Before**
<img width="1180" alt="image" src="https://github.com/user-attachments/assets/3adf13b6-1762-4a2a-8a86-d11c53a1b469">

**After**
<img width="932" alt="image" src="https://github.com/user-attachments/assets/be53bccd-17bd-433b-9663-1e1b935b605a">

- Keeps stack trace icon within section margins. If this is the pattern going forward, having anything leave the margins is a bit odd


**Before**
<img width="1219" alt="image" src="https://github.com/user-attachments/assets/162bc3dc-1634-4810-9dcf-b4f692d01e9f">

**After**
<img width="910" alt="image" src="https://github.com/user-attachments/assets/888993b6-d3b8-4cf8-9627-f74b6e84129f">

- Rounds corner at small screen width, since it was always assuming the icon is present, but we hide it at < medium sizes

**Before**
<img width="522" alt="image" src="https://github.com/user-attachments/assets/cf8cb423-fde2-4172-ad0c-56d36345f142">

**After**
<img width="324" alt="image" src="https://github.com/user-attachments/assets/4b4e3e82-8f33-452f-8f62-64309f92778d">

