### PR TITLE
ref(feedback): fix show/hide logic for trace section, use placeholder while loading

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -97,11 +97,9 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
         />
 
         {eventData ? (
-          <TraceDataSection
-            eventData={eventData}
-            crashReportId={crashReportId}
-            hasProject={!!feedbackItem.project}
-          />
+          <ErrorBoundary mini>
+            <TraceDataSection eventData={eventData} crashReportId={crashReportId} />
+          </ErrorBoundary>
         ) : null}
 
         <Section icon={<IconTag size="xs" />} title={t('Tags')}>

--- a/static/app/components/feedback/feedbackItem/traceDataSection.tsx
+++ b/static/app/components/feedback/feedbackItem/traceDataSection.tsx
@@ -61,7 +61,7 @@ export default function TraceDataSection({
   return organization.features.includes('user-feedback-trace-section') &&
     !isError &&
     traceEvents.length > 1 &&
-    isCrashReportDup ? (
+    !isCrashReportDup ? (
     <Section icon={<IconSpan size="xs" />} title={t('Data From The Same Trace')}>
       {isLoading ? (
         <Placeholder height="114px" />

--- a/static/app/components/feedback/feedbackItem/traceDataSection.tsx
+++ b/static/app/components/feedback/feedbackItem/traceDataSection.tsx
@@ -1,6 +1,7 @@
 import {useEffect} from 'react';
 
 import Section from 'sentry/components/feedback/feedbackItem/feedbackItemSection';
+import Placeholder from 'sentry/components/placeholder';
 import {IconSpan} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
@@ -17,11 +18,9 @@ import {useTraceTimelineEvents} from 'sentry/views/issueDetails/traceTimeline/us
 export default function TraceDataSection({
   eventData,
   crashReportId,
-  hasProject,
 }: {
   crashReportId: string | undefined;
   eventData: Event;
-  hasProject: boolean;
 }) {
   // If there's a linked error from a crash report and only one other issue, showing both could be redundant.
   // TODO: we could add a jest test .spec for this ^
@@ -29,11 +28,7 @@ export default function TraceDataSection({
   const {oneOtherIssueEvent, traceEvents, isLoading, isError} = useTraceTimelineEvents({
     event: eventData,
   });
-  const show =
-    !isLoading &&
-    !isError &&
-    traceEvents.length > 1 && // traceEvents include the current event.
-    (!hasProject || !crashReportId || oneOtherIssueEvent?.id === crashReportId);
+  // Note traceEvents includes the current event (feedback).
 
   useEffect(() => {
     if (isError) {
@@ -45,13 +40,12 @@ export default function TraceDataSection({
           organization,
         });
       }
-      if (hasProject && !!crashReportId && oneOtherIssueEvent?.id === crashReportId) {
+      if (!!crashReportId && oneOtherIssueEvent?.id === crashReportId) {
         trackAnalytics('feedback.trace-section.crash-report-dup', {organization});
       }
     }
   }, [
     crashReportId,
-    hasProject,
     isError,
     isLoading,
     oneOtherIssueEvent?.id,
@@ -59,9 +53,16 @@ export default function TraceDataSection({
     traceEvents.length,
   ]);
 
-  return show && organization.features.includes('user-feedback-trace-section') ? (
+  return organization.features.includes('user-feedback-trace-section') &&
+    !isError &&
+    traceEvents.length > 1 &&
+    (!crashReportId || oneOtherIssueEvent?.id !== crashReportId) ? (
     <Section icon={<IconSpan size="xs" />} title={t('Data From The Same Trace')}>
-      <IssuesTraceDataSection event={eventData} />
+      {isLoading ? (
+        <Placeholder height="114px" />
+      ) : (
+        <IssuesTraceDataSection event={eventData} />
+      )}
     </Section>
   ) : null;
 }

--- a/static/app/components/feedback/feedbackItem/traceDataSection.tsx
+++ b/static/app/components/feedback/feedbackItem/traceDataSection.tsx
@@ -61,7 +61,7 @@ export default function TraceDataSection({
   return organization.features.includes('user-feedback-trace-section') &&
     !isError &&
     traceEvents.length > 1 &&
-    !isCrashReportDup ? (
+    isCrashReportDup ? (
     <Section icon={<IconSpan size="xs" />} title={t('Data From The Same Trace')}>
       {isLoading ? (
         <Placeholder height="114px" />

--- a/static/app/components/feedback/feedbackItem/traceDataSection.tsx
+++ b/static/app/components/feedback/feedbackItem/traceDataSection.tsx
@@ -8,7 +8,10 @@ import type {Event} from 'sentry/types/event';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 import {TraceDataSection as IssuesTraceDataSection} from 'sentry/views/issueDetails/traceDataSection';
-import {useTraceTimelineEvents} from 'sentry/views/issueDetails/traceTimeline/useTraceTimelineEvents';
+import {
+  type TimelineEvent,
+  useTraceTimelineEvents,
+} from 'sentry/views/issueDetails/traceTimeline/useTraceTimelineEvents';
 
 /**
  * Doesn't require a Section wrapper. Rendered conditionally if
@@ -40,7 +43,7 @@ export default function TraceDataSection({
           organization,
         });
       }
-      if (!!crashReportId && oneOtherIssueEvent?.id === crashReportId) {
+      if (eventIsCrashReportDup(oneOtherIssueEvent, crashReportId)) {
         trackAnalytics('feedback.trace-section.crash-report-dup', {organization});
       }
     }
@@ -48,7 +51,7 @@ export default function TraceDataSection({
     crashReportId,
     isError,
     isLoading,
-    oneOtherIssueEvent?.id,
+    oneOtherIssueEvent,
     organization,
     traceEvents.length,
   ]);
@@ -56,7 +59,7 @@ export default function TraceDataSection({
   return organization.features.includes('user-feedback-trace-section') &&
     !isError &&
     traceEvents.length > 1 &&
-    (!crashReportId || oneOtherIssueEvent?.id !== crashReportId) ? (
+    !eventIsCrashReportDup(oneOtherIssueEvent, crashReportId) ? (
     <Section icon={<IconSpan size="xs" />} title={t('Data From The Same Trace')}>
       {isLoading ? (
         <Placeholder height="114px" />
@@ -65,4 +68,11 @@ export default function TraceDataSection({
       )}
     </Section>
   ) : null;
+}
+
+function eventIsCrashReportDup(
+  event: TimelineEvent | undefined,
+  crashReportId: string | undefined
+) {
+  return !!crashReportId && event?.id === crashReportId;
 }

--- a/static/app/components/feedback/feedbackItem/traceDataSection.tsx
+++ b/static/app/components/feedback/feedbackItem/traceDataSection.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useEffect} from 'react';
 
 import Section from 'sentry/components/feedback/feedbackItem/feedbackItemSection';
 import Placeholder from 'sentry/components/placeholder';
@@ -30,8 +30,6 @@ export default function TraceDataSection({
   });
   // Note traceEvents includes the current event (feedback).
 
-  const [isCrashReportDup, setIsCrashReportDup] = useState(false);
-
   useEffect(() => {
     if (isError) {
       trackAnalytics('feedback.trace-section.error', {organization});
@@ -44,9 +42,6 @@ export default function TraceDataSection({
       }
       if (!!crashReportId && oneOtherIssueEvent?.id === crashReportId) {
         trackAnalytics('feedback.trace-section.crash-report-dup', {organization});
-        setIsCrashReportDup(true);
-      } else {
-        setIsCrashReportDup(false);
       }
     }
   }, [
@@ -61,7 +56,7 @@ export default function TraceDataSection({
   return organization.features.includes('user-feedback-trace-section') &&
     !isError &&
     traceEvents.length > 1 &&
-    isCrashReportDup ? (
+    (!crashReportId || oneOtherIssueEvent?.id !== crashReportId) ? (
     <Section icon={<IconSpan size="xs" />} title={t('Data From The Same Trace')}>
       {isLoading ? (
         <Placeholder height="114px" />

--- a/static/app/components/feedback/feedbackItem/traceDataSection.tsx
+++ b/static/app/components/feedback/feedbackItem/traceDataSection.tsx
@@ -1,4 +1,4 @@
-import {useEffect} from 'react';
+import {useEffect, useState} from 'react';
 
 import Section from 'sentry/components/feedback/feedbackItem/feedbackItemSection';
 import Placeholder from 'sentry/components/placeholder';
@@ -30,6 +30,8 @@ export default function TraceDataSection({
   });
   // Note traceEvents includes the current event (feedback).
 
+  const [isCrashReportDup, setIsCrashReportDup] = useState(false);
+
   useEffect(() => {
     if (isError) {
       trackAnalytics('feedback.trace-section.error', {organization});
@@ -42,6 +44,9 @@ export default function TraceDataSection({
       }
       if (!!crashReportId && oneOtherIssueEvent?.id === crashReportId) {
         trackAnalytics('feedback.trace-section.crash-report-dup', {organization});
+        setIsCrashReportDup(true);
+      } else {
+        setIsCrashReportDup(false);
       }
     }
   }, [
@@ -56,7 +61,7 @@ export default function TraceDataSection({
   return organization.features.includes('user-feedback-trace-section') &&
     !isError &&
     traceEvents.length > 1 &&
-    (!crashReportId || oneOtherIssueEvent?.id !== crashReportId) ? (
+    isCrashReportDup ? (
     <Section icon={<IconSpan size="xs" />} title={t('Data From The Same Trace')}>
       {isLoading ? (
         <Placeholder height="114px" />


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/68481

The show/hide logic had a bug where we were showing only if the same-trace issue is a duplicate of a crash report linked error. Which is the opposite of what we want. Example: [JAVASCRIPT-2VE1](https://sentry.sentry.io/feedback/?feedbackSlug=javascript%3A5735318217&project=11276). _Analytics are still correct, but atm no timelines (2+ events) are shown_.

Also: 
- use placeholder when the data is fetching.
- use error boundary.
- remove the `hasProject` prop. It makes the logic hard to read, and was only used for the crash-report-dup condition. Comparing the issue ids is sufficient for this.
