### PR TITLE
feat(explore): added tooltips to clauses and chart options'

### DIFF
--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {getInterval} from 'sentry/components/charts/utils';
 import {CompactSelect} from 'sentry/components/compactSelect';
+import {Tooltip} from 'sentry/components/tooltip';
 import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 import {IconClock, IconGraph} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -154,32 +155,40 @@ export function ExploreCharts({query}: ExploreChartsProps) {
               <ChartHeader>
                 <ChartTitle>{formattedYAxes.join(',')}</ChartTitle>
                 <ChartSettingsContainer>
-                  <CompactSelect
-                    triggerLabel=""
-                    triggerProps={{
-                      icon: <IconGraph type={chartIcon} />,
-                      borderless: true,
-                      showChevron: false,
-                      size: 'sm',
-                    }}
-                    value={chartType}
-                    menuTitle="Type"
-                    options={exploreChartTypeOptions}
-                    onChange={option => handleChartTypeChange(option.value, index)}
-                  />
-                  <CompactSelect
-                    triggerLabel=""
-                    value={interval}
-                    onChange={({value}) => setInterval(value)}
-                    triggerProps={{
-                      icon: <IconClock />,
-                      borderless: true,
-                      showChevron: false,
-                      size: 'sm',
-                    }}
-                    menuTitle="Interval"
-                    options={intervalOptions}
-                  />
+                  <Tooltip
+                    title={t('Type of chart displayed in this visualization (ex. line)')}
+                  >
+                    <CompactSelect
+                      triggerLabel=""
+                      triggerProps={{
+                        icon: <IconGraph type={chartIcon} />,
+                        borderless: true,
+                        showChevron: false,
+                        size: 'sm',
+                      }}
+                      value={chartType}
+                      menuTitle="Type"
+                      options={exploreChartTypeOptions}
+                      onChange={option => handleChartTypeChange(option.value, index)}
+                    />
+                  </Tooltip>
+                  <Tooltip
+                    title={t('Time interval displayed in this visualization (ex. 5m)')}
+                  >
+                    <CompactSelect
+                      triggerLabel=""
+                      value={interval}
+                      onChange={({value}) => setInterval(value)}
+                      triggerProps={{
+                        icon: <IconClock />,
+                        borderless: true,
+                        showChevron: false,
+                        size: 'sm',
+                      }}
+                      menuTitle="Interval"
+                      options={intervalOptions}
+                    />
+                  </Tooltip>
                 </ChartSettingsContainer>
               </ChartHeader>
               <Chart

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -3,6 +3,7 @@ import {useCallback, useMemo} from 'react';
 import {Button} from 'sentry/components/button';
 import type {SelectOption} from 'sentry/components/compactSelect';
 import {CompactSelect} from 'sentry/components/compactSelect';
+import {Tooltip} from 'sentry/components/tooltip';
 import {IconAdd} from 'sentry/icons/iconAdd';
 import {IconDelete} from 'sentry/icons/iconDelete';
 import {t} from 'sentry/locale';
@@ -84,7 +85,14 @@ export function ToolbarGroupBy({disabled}: ToolbarGroupByProps) {
   return (
     <ToolbarSection data-test-id="section-group-by">
       <ToolbarHeader>
-        <ToolbarLabel disabled={disabled}>{t('Group By')}</ToolbarLabel>
+        <Tooltip
+          position="right"
+          title={t(
+            'Aggregated data by a key attribute to calculate averages, percentiles, count and more'
+          )}
+        >
+          <ToolbarLabel disabled={disabled}>{t('Group By')}</ToolbarLabel>
+        </Tooltip>
         <ToolbarHeaderButton
           disabled={disabled}
           size="zero"

--- a/static/app/views/explore/toolbar/toolbarSortBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarSortBy.tsx
@@ -2,6 +2,7 @@ import {useCallback, useMemo} from 'react';
 
 import type {SelectOption} from 'sentry/components/compactSelect';
 import {CompactSelect} from 'sentry/components/compactSelect';
+import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {formatParsedFunction, parseFunction} from 'sentry/utils/discover/fields';
@@ -100,7 +101,12 @@ export function ToolbarSortBy({fields, setSorts, sorts}: ToolbarSortByProps) {
   return (
     <ToolbarSection data-test-id="section-sort-by">
       <ToolbarHeader>
-        <ToolbarLabel>{t('Sort By')}</ToolbarLabel>
+        <Tooltip
+          position="right"
+          title={t('Results you see first and last in your samples or aggregates.')}
+        >
+          <ToolbarLabel>{t('Sort By')}</ToolbarLabel>
+        </Tooltip>
       </ToolbarHeader>
       <div>
         <ToolbarRow>

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -2,6 +2,7 @@ import {Fragment, useCallback, useMemo} from 'react';
 
 import {Button} from 'sentry/components/button';
 import {CompactSelect, type SelectOption} from 'sentry/components/compactSelect';
+import {Tooltip} from 'sentry/components/tooltip';
 import {IconAdd} from 'sentry/icons';
 import {IconDelete} from 'sentry/icons/iconDelete';
 import {t} from 'sentry/locale';
@@ -137,7 +138,14 @@ export function ToolbarVisualize({}: ToolbarVisualizeProps) {
   return (
     <ToolbarSection data-test-id="section-visualizes">
       <ToolbarHeader>
-        <ToolbarLabel>{t('Visualize')}</ToolbarLabel>
+        <Tooltip
+          position="right"
+          title={t(
+            'Primary metric that appears in your chart, overlays and/or equations.'
+          )}
+        >
+          <ToolbarLabel>{t('Visualize')}</ToolbarLabel>
+        </Tooltip>
         <ToolbarHeaderButton
           size="zero"
           icon={<IconAdd />}


### PR DESCRIPTION
<img width="330" alt="Screenshot 2024-10-17 at 11 07 29 AM" src="https://github.com/user-attachments/assets/88f9bcb6-723a-4aa3-a44c-a410fb2ffd30">
<img width="319" alt="Screenshot 2024-10-17 at 11 06 55 AM" src="https://github.com/user-attachments/assets/79c9779c-eb48-4828-8c6d-1130ab04497e">
<img width="311" alt="Screenshot 2024-10-17 at 11 08 39 AM" src="https://github.com/user-attachments/assets/6453049e-ccb5-48e1-be96-daa63488a6f6">
<img width="242" alt="Screenshot 2024-10-17 at 11 08 44 AM" src="https://github.com/user-attachments/assets/a4f78a1b-be1c-4773-9e18-e3890cabad04">
<img width="246" alt="Screenshot 2024-10-17 at 11 09 00 AM" src="https://github.com/user-attachments/assets/ca4d9862-797a-44b6-9a10-4e6878cf36f7">
