### PR TITLE
fix(issue-views): Only send request on drag end instead of on reorder

### DIFF
--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -138,7 +138,6 @@ function Tabs({
   ariaProps: AriaTabListOptions<DraggableTabListItemProps>;
   hoveringKey: Key | 'addView' | null;
   onReorder: (newOrder: Node<DraggableTabListItemProps>[]) => void;
-  onReorderComplete: () => void;
   orientation: 'horizontal' | 'vertical';
   overflowingTabs: Node<DraggableTabListItemProps>[];
   setHoveringKey: (key: Key | 'addView' | null) => void;
@@ -150,6 +149,7 @@ function Tabs({
   disabled?: boolean;
   editingTabKey?: string;
   onChange?: (key: string | number) => void;
+  onReorderComplete?: () => void;
   tabVariant?: BaseTabProps['variant'];
   value?: string | number;
 }) {
@@ -237,7 +237,7 @@ function Tabs({
               onDrag={() => setIsDragging(true)}
               onDragEnd={() => {
                 setIsDragging(false);
-                onReorderComplete();
+                onReorderComplete?.();
               }}
               onHoverStart={() => setHoveringKey(item.key)}
               onHoverEnd={() => setHoveringKey(null)}
@@ -333,7 +333,7 @@ function BaseDraggableTabList({
         state={state}
         className={className}
         onReorder={onReorder}
-        onReorderComplete={() => onReorderComplete?.()}
+        onReorderComplete={onReorderComplete}
         tabVariant={tabVariant}
         setTabRefs={setTabElements}
         tabs={persistentTabs}
@@ -399,11 +399,11 @@ export interface DraggableTabListProps
   extends AriaTabListOptions<DraggableTabListItemProps>,
     TabListStateOptions<DraggableTabListItemProps> {
   onReorder: (newOrder: Node<DraggableTabListItemProps>[]) => void;
-  onReorderComplete: () => void;
   className?: string;
   editingTabKey?: string;
   hideBorder?: boolean;
   onAddView?: React.MouseEventHandler;
+  onReorderComplete?: () => void;
   outerWrapStyles?: React.CSSProperties;
   showTempTab?: boolean;
   tabVariant?: BaseTabProps['variant'];

--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -125,6 +125,7 @@ function Tabs({
   state,
   className,
   onReorder,
+  onReorderComplete,
   tabVariant,
   setTabRefs,
   tabs,
@@ -137,6 +138,7 @@ function Tabs({
   ariaProps: AriaTabListOptions<DraggableTabListItemProps>;
   hoveringKey: Key | 'addView' | null;
   onReorder: (newOrder: Node<DraggableTabListItemProps>[]) => void;
+  onReorderComplete: () => void;
   orientation: 'horizontal' | 'vertical';
   overflowingTabs: Node<DraggableTabListItemProps>[];
   setHoveringKey: (key: Key | 'addView' | null) => void;
@@ -233,7 +235,10 @@ function Tabs({
               layout
               drag={item.key !== editingTabKey} // Disable dragging if the tab is being edited
               onDrag={() => setIsDragging(true)}
-              onDragEnd={() => setIsDragging(false)}
+              onDragEnd={() => {
+                setIsDragging(false);
+                onReorderComplete();
+              }}
               onHoverStart={() => setHoveringKey(item.key)}
               onHoverEnd={() => setHoveringKey(null)}
               initial={false}
@@ -260,6 +265,7 @@ function BaseDraggableTabList({
   className,
   outerWrapStyles,
   onReorder,
+  onReorderComplete,
   onAddView,
   tabVariant = 'filled',
   ...props
@@ -327,6 +333,7 @@ function BaseDraggableTabList({
         state={state}
         className={className}
         onReorder={onReorder}
+        onReorderComplete={() => onReorderComplete?.()}
         tabVariant={tabVariant}
         setTabRefs={setTabElements}
         tabs={persistentTabs}
@@ -392,6 +399,7 @@ export interface DraggableTabListProps
   extends AriaTabListOptions<DraggableTabListItemProps>,
     TabListStateOptions<DraggableTabListItemProps> {
   onReorder: (newOrder: Node<DraggableTabListItemProps>[]) => void;
+  onReorderComplete: () => void;
   className?: string;
   editingTabKey?: string;
   hideBorder?: boolean;

--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
@@ -137,7 +137,6 @@ export function DraggableTabBar({
       })
       .filter(defined);
     setTabs(newTabs);
-    onReorder?.(newTabs);
     trackAnalytics('issue_views.reordered_views', {
       organization,
     });
@@ -435,6 +434,7 @@ export function DraggableTabBar({
   return (
     <DraggableTabList
       onReorder={handleOnReorder}
+      onReorderComplete={() => onReorder?.(tabs)}
       defaultSelectedKey={initialTabKey}
       onAddView={handleCreateNewView}
       orientation="horizontal"


### PR DESCRIPTION
This PR changes the request behavior when reordering tabs. Previously, a request to save the tabs to the backend was made every time framer-motion's `onReorder` was fired. This led to excessive requests being made, since it fires even before the tab order has stabilized (aka, when the user releases the tab from dragging). 

Now, it will only fire when the user has let go of a tab, which will reduce the number of unnecessary requests being made. 