### PR TITLE
fix(perf-issues): Large payload detector comparison types

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/large_payload_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/large_payload_detector.py
@@ -54,6 +54,10 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
             return
 
         payload_size_threshold = self.settings.get("payload_size_threshold")
+
+        if not encoded_body_size.isdigit():
+            encoded_body_size = int(encoded_body_size)
+
         if encoded_body_size > payload_size_threshold:
             self._store_performance_problem(span)
 

--- a/src/sentry/utils/performance_issues/detectors/large_payload_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/large_payload_detector.py
@@ -55,7 +55,7 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
 
         payload_size_threshold = self.settings.get("payload_size_threshold")
 
-        if type(encoded_body_size) is str:
+        if isinstance(encoded_body_size, str):
             encoded_body_size = int(encoded_body_size)
 
         if encoded_body_size > payload_size_threshold:

--- a/src/sentry/utils/performance_issues/detectors/large_payload_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/large_payload_detector.py
@@ -55,7 +55,7 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
 
         payload_size_threshold = self.settings.get("payload_size_threshold")
 
-        if not encoded_body_size.isdigit():
+        if type(encoded_body_size) is str:
             encoded_body_size = int(encoded_body_size)
 
         if encoded_body_size > payload_size_threshold:

--- a/tests/sentry/utils/performance_issues/test_large_http_payload_detector.py
+++ b/tests/sentry/utils/performance_issues/test_large_http_payload_detector.py
@@ -43,17 +43,6 @@ class LargeHTTPPayloadDetectorTest(TestCase):
                     "http.decoded_response_content_length": 50_000_000,
                 },
             ),
-            create_span(
-                "http.client",
-                1000,
-                "GET /api/0/organizations/endpoint1",
-                "hash2",
-                data={
-                    "http.response_transfer_size": 50_000_000,
-                    "http.response_content_length": "12345",
-                    "http.decoded_response_content_length": 50_000_000,
-                },
-            ),
         ]
 
         event = create_event(spans)

--- a/tests/sentry/utils/performance_issues/test_large_http_payload_detector.py
+++ b/tests/sentry/utils/performance_issues/test_large_http_payload_detector.py
@@ -42,7 +42,18 @@ class LargeHTTPPayloadDetectorTest(TestCase):
                     "http.response_content_length": 50_000_000,
                     "http.decoded_response_content_length": 50_000_000,
                 },
-            )
+            ),
+            create_span(
+                "http.client",
+                1000,
+                "GET /api/0/organizations/endpoint1",
+                "hash2",
+                data={
+                    "http.response_transfer_size": 50_000_000,
+                    "http.response_content_length": "12345",
+                    "http.decoded_response_content_length": 50_000_000,
+                },
+            ),
         ]
 
         event = create_event(spans)
@@ -250,3 +261,39 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         ]
         event = create_event(spans)
         assert self.find_problems(event) == []
+
+    def test_handles_string_payload_size_threshold(self):
+
+        spans = [
+            create_span(
+                "http.client",
+                1000,
+                "GET /api/0/organizations/endpoint1",
+                "hash2",
+                data={
+                    "http.response_transfer_size": "50_000_000",
+                    "http.response_content_length": "50_000_000",
+                    "http.decoded_response_content_length": "50_000_000",
+                },
+            ),
+        ]
+
+        event = create_event(spans)
+        assert self.find_problems(event) == [
+            PerformanceProblem(
+                fingerprint="1-1015-5e5543895c0f1f12c2d468da8c7f2d9e4dca81dc",
+                op="http",
+                desc="GET /api/0/organizations/endpoint1",
+                type=PerformanceLargeHTTPPayloadGroupType,
+                parent_span_ids=None,
+                cause_span_ids=[],
+                offender_span_ids=["bbbbbbbbbbbbbbbb"],
+                evidence_data={
+                    "parent_span_ids": [],
+                    "cause_span_ids": [],
+                    "offender_span_ids": ["bbbbbbbbbbbbbbbb"],
+                    "op": "http",
+                },
+                evidence_display=[],
+            )
+        ]


### PR DESCRIPTION
Fixes SENTRY-FOR-SENTRY-1WGS

Sometimes the `encoded_body_size` is stored as a string, so it will need to be converted to an int or the comparison will result in an error