### PR TITLE
ref(quick-start): Remove unused tasks

### DIFF
--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -442,30 +442,6 @@ export function getOnboardingTasks({
       display: hasPlatformWithSourceMaps(projects),
     },
     {
-      task: OnboardingTaskKey.USER_REPORTS,
-      title: t('User crash reports'),
-      description: t('Collect user feedback when your application crashes'),
-      skippable: true,
-      requisites: [
-        OnboardingTaskKey.FIRST_PROJECT,
-        OnboardingTaskKey.FIRST_EVENT,
-        OnboardingTaskKey.USER_CONTEXT,
-      ],
-      actionType: 'app',
-      location: `/settings/${organization.slug}/projects/:projectId/user-reports/`,
-      display: false,
-    },
-    {
-      task: OnboardingTaskKey.ISSUE_TRACKER,
-      title: t('Set up issue tracking'),
-      description: t('Link to Sentry issues within your issue tracker'),
-      skippable: true,
-      requisites: [OnboardingTaskKey.FIRST_PROJECT, OnboardingTaskKey.FIRST_EVENT],
-      actionType: 'app',
-      location: `/settings/${organization.slug}/projects/:projectId/plugins/`,
-      display: false,
-    },
-    {
       task: OnboardingTaskKey.ALERT_RULE,
       title: t('Configure an Issue Alert'),
       description: t(

--- a/static/app/types/onboarding.tsx
+++ b/static/app/types/onboarding.tsx
@@ -24,8 +24,6 @@ export enum OnboardingTaskKey {
   USER_CONTEXT = 'setup_user_context',
   RELEASE_TRACKING = 'setup_release_tracking',
   SOURCEMAPS = 'setup_sourcemaps',
-  USER_REPORTS = 'setup_user_reports',
-  ISSUE_TRACKER = 'setup_issue_tracker',
   ALERT_RULE = 'setup_alert_rules',
   FIRST_TRANSACTION = 'setup_transactions',
   METRIC_ALERT = 'setup_metric_alert_rules',

--- a/static/app/types/onboarding.tsx
+++ b/static/app/types/onboarding.tsx
@@ -24,6 +24,7 @@ export enum OnboardingTaskKey {
   USER_CONTEXT = 'setup_user_context',
   RELEASE_TRACKING = 'setup_release_tracking',
   SOURCEMAPS = 'setup_sourcemaps',
+  USER_REPORTS = 'setup_user_reports',
   ALERT_RULE = 'setup_alert_rules',
   FIRST_TRANSACTION = 'setup_transactions',
   METRIC_ALERT = 'setup_metric_alert_rules',


### PR DESCRIPTION
After tracing the code, I found that this hasn't been visible in the UI for many years, so we might just delete it.