### PR TITLE
feat(autofix): Add controllable code changes

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.spec.tsx
+++ b/static/app/components/events/autofix/autofixChanges.spec.tsx
@@ -18,6 +18,7 @@ import {
 describe('AutofixChanges', function () {
   const defaultProps = {
     groupId: '1',
+    runId: '1',
     onRetry: jest.fn(),
     step: AutofixStepFixture({
       type: AutofixStepType.CHANGES,

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -29,6 +29,7 @@ import useApi from 'sentry/utils/useApi';
 type AutofixChangesProps = {
   groupId: string;
   onRetry: () => void;
+  runId: string;
   step: AutofixChangesStep;
 };
 
@@ -168,9 +169,11 @@ function PullRequestLinkOrCreateButton({
 function AutofixRepoChange({
   change,
   groupId,
+  runId,
 }: {
   change: AutofixCodebaseChange;
   groupId: string;
+  runId: string;
 }) {
   return (
     <Content>
@@ -181,7 +184,12 @@ function AutofixRepoChange({
         </div>
         <PullRequestLinkOrCreateButton change={change} groupId={groupId} />
       </RepoChangesHeader>
-      <AutofixDiff diff={change.diff} />
+      <AutofixDiff
+        diff={change.diff}
+        groupId={groupId}
+        runId={runId}
+        repoId={change.repo_external_id}
+      />
     </Content>
   );
 }
@@ -193,7 +201,7 @@ const cardAnimationProps: AnimationProps = {
   transition: testableTransition({duration: 0.3}),
 };
 
-export function AutofixChanges({step, onRetry, groupId}: AutofixChangesProps) {
+export function AutofixChanges({step, onRetry, groupId, runId}: AutofixChangesProps) {
   const data = useAutofixData({groupId});
 
   if (step.status === 'ERROR' || data?.status === 'ERROR') {
@@ -242,7 +250,7 @@ export function AutofixChanges({step, onRetry, groupId}: AutofixChangesProps) {
             {step.changes.map((change, i) => (
               <Fragment key={change.repo_external_id}>
                 {i > 0 && <Separator />}
-                <AutofixRepoChange change={change} groupId={groupId} />
+                <AutofixRepoChange change={change} groupId={groupId} runId={runId} />
               </Fragment>
             ))}
           </ClippedBox>

--- a/static/app/components/events/autofix/autofixDiff.spec.tsx
+++ b/static/app/components/events/autofix/autofixDiff.spec.tsx
@@ -1,14 +1,30 @@
 import {AutofixDiffFilePatch} from 'sentry-fixture/autofixDiffFilePatch';
 
-import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {AutofixDiff} from 'sentry/components/events/autofix/autofixDiff';
+
+jest.mock('sentry/actionCreators/indicator');
 
 describe('AutofixDiff', function () {
   const defaultProps = {
     diff: [AutofixDiffFilePatch()],
+    groupId: '1',
+    runId: '1',
   };
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    (addErrorMessage as jest.Mock).mockClear();
+  });
 
   it('displays a modified file diff correctly', function () {
     render(<AutofixDiff {...defaultProps} />);
@@ -67,5 +83,72 @@ describe('AutofixDiff', function () {
     // Clicking again shows file context
     await userEvent.click(screen.getByRole('button', {name: 'Toggle file diff'}));
     expect(screen.getAllByTestId('line-context')).toHaveLength(6);
+  });
+
+  it('can edit changes', async function () {
+    render(<AutofixDiff {...defaultProps} />);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Edit changes'}));
+
+    expect(
+      screen.getByText('Editing src/sentry/processing/backpressure/memory.py')
+    ).toBeInTheDocument();
+
+    const textarea = screen.getByRole('textbox');
+    await userEvent.clear(textarea);
+    await userEvent.type(textarea, 'New content');
+
+    MockApiClient.addMockResponse({
+      url: '/issues/1/autofix/update/',
+      method: 'POST',
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Editing src/sentry/processing/backpressure/memory.py')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('can reject changes', async function () {
+    render(<AutofixDiff {...defaultProps} />);
+
+    MockApiClient.addMockResponse({
+      url: '/issues/1/autofix/update/',
+      method: 'POST',
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Reject changes'}));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('line-added')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('line-removed')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows error message on failed edit', async function () {
+    render(<AutofixDiff {...defaultProps} />);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Edit changes'}));
+
+    const textarea = screen.getByRole('textbox');
+    await userEvent.clear(textarea);
+    await userEvent.type(textarea, 'New content');
+
+    MockApiClient.addMockResponse({
+      url: '/issues/1/autofix/update/',
+      method: 'POST',
+      statusCode: 500,
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+    await waitFor(() => {
+      expect(addErrorMessage).toHaveBeenCalledWith(
+        'Something went wrong when updating changes.'
+      );
+    });
   });
 });

--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -344,6 +344,36 @@ function DiffHunkContent({
     setEditedLines([]);
   };
 
+  const getDeletedLineTitle = (index: number) => {
+    return t(
+      '%s deleted line%s%s',
+      linesWithChanges
+        .slice(index, lineGroups.find(g => g.start === index)?.end! + 1)
+        .filter(l => l.line_type === DiffLineType.REMOVED).length,
+      linesWithChanges
+        .slice(index, lineGroups.find(g => g.start === index)?.end)
+        .filter(l => l.line_type === DiffLineType.REMOVED).length === 1
+        ? ''
+        : 's',
+      linesWithChanges
+        .slice(index, lineGroups.find(g => g.start === index)?.end)
+        .filter(l => l.line_type === DiffLineType.REMOVED).length > 0
+        ? t(' from line %s', getStartLineNumber(index, DiffLineType.REMOVED))
+        : ''
+    );
+  };
+
+  const getNewLineTitle = (index: number) => {
+    return t(
+      '%s new line%s%s',
+      editedLines.length,
+      editedLines.length === 1 ? '' : 's',
+      editedLines.length > 0
+        ? t(' from line %s', getStartLineNumber(index, DiffLineType.ADDED))
+        : ''
+    );
+  };
+
   return (
     <Fragment>
       <HunkHeaderEmptySpace />
@@ -378,27 +408,7 @@ function DiffHunkContent({
             {editingGroup === index && (
               <EditOverlay ref={overlayRef}>
                 <OverlayTitle>{t('Editing %s', fileName)}</OverlayTitle>
-                <SectionTitle>
-                  {t(
-                    '%s deleted line%s%s',
-                    linesWithChanges
-                      .slice(index, lineGroups.find(g => g.start === index)?.end! + 1)
-                      .filter(l => l.line_type === DiffLineType.REMOVED).length,
-                    linesWithChanges
-                      .slice(index, lineGroups.find(g => g.start === index)?.end)
-                      .filter(l => l.line_type === DiffLineType.REMOVED).length === 1
-                      ? ''
-                      : 's',
-                    linesWithChanges
-                      .slice(index, lineGroups.find(g => g.start === index)?.end)
-                      .filter(l => l.line_type === DiffLineType.REMOVED).length > 0
-                      ? t(
-                          ' from line %s',
-                          getStartLineNumber(index, DiffLineType.REMOVED)
-                        )
-                      : ''
-                  )}
-                </SectionTitle>
+                <SectionTitle>{getDeletedLineTitle(index)}</SectionTitle>
                 {linesWithChanges
                   .slice(index, lineGroups.find(g => g.start === index)?.end! + 1)
                   .filter(l => l.line_type === DiffLineType.REMOVED).length > 0 ? (
@@ -413,16 +423,7 @@ function DiffHunkContent({
                 ) : (
                   <NoChangesMessage>{t('No lines are being deleted.')}</NoChangesMessage>
                 )}
-                <SectionTitle>
-                  {t(
-                    '%s new line%s%s',
-                    editedLines.length,
-                    editedLines.length === 1 ? '' : 's',
-                    editedLines.length > 0
-                      ? t(' from line %s', getStartLineNumber(index, DiffLineType.ADDED))
-                      : ''
-                  )}
-                </SectionTitle>
+                <SectionTitle>{getNewLineTitle(index)}</SectionTitle>
                 <TextAreaWrapper>
                   <StyledTextArea
                     value={editedContent}

--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -1,20 +1,27 @@
-import {Fragment, useMemo, useState} from 'react';
+import {Fragment, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {type Change, diffWords} from 'diff';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Button} from 'sentry/components/button';
 import {
   type DiffLine,
   DiffLineType,
   type FilePatch,
 } from 'sentry/components/events/autofix/types';
+import TextArea from 'sentry/components/forms/controls/textarea';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
-import {IconChevron} from 'sentry/icons';
+import {IconChevron, IconClose, IconDelete, IconEdit} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {useMutation} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
 
 type AutofixDiffProps = {
   diff: FilePatch[];
+  groupId: string;
+  runId: string;
+  repoId?: string;
 };
 
 interface DiffLineWithChanges extends DiffLine {
@@ -91,17 +98,258 @@ function HunkHeader({lines, sectionHeader}: {lines: DiffLine[]; sectionHeader: s
   );
 }
 
-function DiffHunkContent({lines, header}: {header: string; lines: DiffLine[]}) {
-  const linesWithChanges = useMemo(() => {
-    return addChangesToDiffLines(lines);
+function useUpdateHunk({groupId, runId}: {groupId: string; runId: string}) {
+  const api = useApi({persistInFlight: true});
+
+  return useMutation({
+    mutationFn: (params: {
+      fileName: string;
+      hunkIndex: number;
+      lines: DiffLine[];
+      repoId?: string;
+    }) => {
+      return api.requestPromise(`/issues/${groupId}/autofix/update/`, {
+        method: 'POST',
+        data: {
+          run_id: runId,
+          payload: {
+            type: 'update_code_change',
+            repo_id: params.repoId ?? null,
+            hunk_index: params.hunkIndex,
+            lines: params.lines,
+            file_path: params.fileName,
+          },
+        },
+      });
+    },
+    onError: () => {
+      addErrorMessage(t('Something went wrong when updating changes.'));
+    },
+  });
+}
+
+function DiffHunkContent({
+  groupId,
+  runId,
+  repoId,
+  hunkIndex,
+  lines,
+  header,
+  fileName,
+}: {
+  fileName: string;
+  groupId: string;
+  header: string;
+  hunkIndex: number;
+  lines: DiffLine[];
+  runId: string;
+  repoId?: string;
+}) {
+  const [linesWithChanges, setLinesWithChanges] = useState<DiffLineWithChanges[]>([]);
+
+  useEffect(() => {
+    setLinesWithChanges(addChangesToDiffLines(lines));
   }, [lines]);
+
+  const [editingGroup, setEditingGroup] = useState<number | null>(null);
+  const [editedContent, setEditedContent] = useState<string>('');
+  const [editedLines, setEditedLines] = useState<string[]>([]);
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (overlayRef.current && !overlayRef.current.contains(event.target as Node)) {
+        setEditingGroup(null);
+        setEditedContent('');
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  const lineGroups = useMemo(() => {
+    const groups: {end: number; start: number; type: 'change' | DiffLineType}[] = [];
+    let currentGroup: (typeof groups)[number] | null = null;
+
+    linesWithChanges.forEach((line, index) => {
+      if (line.line_type !== DiffLineType.CONTEXT) {
+        if (!currentGroup) {
+          currentGroup = {start: index, end: index, type: 'change'};
+        } else if (currentGroup.type === 'change') {
+          currentGroup.end = index;
+        } else {
+          groups.push(currentGroup);
+          currentGroup = {start: index, end: index, type: 'change'};
+        }
+      } else if (currentGroup) {
+        groups.push(currentGroup);
+        currentGroup = null;
+      }
+    });
+
+    if (currentGroup) {
+      groups.push(currentGroup);
+    }
+
+    return groups;
+  }, [linesWithChanges]);
+
+  const handleEditClick = (index: number) => {
+    const group = lineGroups.find(g => g.start === index);
+    if (group) {
+      const content = linesWithChanges
+        .slice(group.start, group.end + 1)
+        .filter(line => line.line_type === DiffLineType.ADDED)
+        .map(line => line.value)
+        .join('');
+      const splitLines = content.split('\n');
+      if (splitLines[splitLines.length - 1] === '') {
+        splitLines.pop();
+      }
+      setEditedLines(splitLines);
+      if (content === '\n') {
+        setEditedContent('');
+      } else {
+        setEditedContent(content.endsWith('\n') ? content.slice(0, -1) : content);
+      }
+      setEditingGroup(index);
+    }
+  };
+
+  const handleTextAreaChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newContent = e.target.value;
+    setEditedContent(newContent);
+    setEditedLines(newContent.split('\n'));
+  };
+
+  const updateHunk = useUpdateHunk({groupId, runId});
+  const handleSaveEdit = () => {
+    if (editingGroup === null) {
+      return;
+    }
+    const group = lineGroups.find(g => g.start === editingGroup);
+    if (!group) {
+      return;
+    }
+
+    let lastSourceLineNo = 0;
+    let lastTargetLineNo = 0;
+    let lastDiffLineNo = 0;
+
+    const updatedLines = linesWithChanges
+      .map((line, index) => {
+        if (index < group.start) {
+          lastSourceLineNo = line.source_line_no ?? lastSourceLineNo;
+          lastTargetLineNo = line.target_line_no ?? lastTargetLineNo;
+          lastDiffLineNo = line.diff_line_no ?? lastDiffLineNo;
+        }
+        if (index >= group.start && index <= group.end) {
+          if (line.line_type === DiffLineType.ADDED) {
+            return null; // Remove existing added lines
+          }
+          if (line.line_type === DiffLineType.REMOVED) {
+            lastSourceLineNo = line.source_line_no ?? lastSourceLineNo;
+          }
+          return line; // Keep other lines (removed and context) as is
+        }
+        return line;
+      })
+      .filter((line): line is DiffLine => line !== null);
+
+    // Insert new added lines
+    const newAddedLines: DiffLine[] = editedContent.split('\n').map((content, i) => {
+      lastDiffLineNo++;
+      lastTargetLineNo++;
+      return {
+        diff_line_no: lastDiffLineNo,
+        source_line_no: null,
+        target_line_no: lastTargetLineNo,
+        line_type: DiffLineType.ADDED,
+        value: content + (i === editedContent.split('\n').length - 1 ? '' : '\n'),
+      };
+    });
+
+    // Find the insertion point (after the last removed line or at the start of the group)
+    const insertionIndex = updatedLines.findIndex(
+      (line, index) => index >= group.start && line.line_type !== DiffLineType.REMOVED
+    );
+
+    updatedLines.splice(
+      insertionIndex === -1 ? group.start : insertionIndex,
+      0,
+      ...newAddedLines
+    );
+
+    // Update diff_line_no for all lines after the insertion
+    for (let i = insertionIndex + newAddedLines.length; i < updatedLines.length; i++) {
+      updatedLines[i].diff_line_no = ++lastDiffLineNo;
+    }
+
+    updateHunk.mutate({hunkIndex, lines: updatedLines, repoId, fileName});
+    setLinesWithChanges(addChangesToDiffLines(updatedLines));
+    setEditingGroup(null);
+    setEditedContent('');
+  };
+
+  const handleCancelEdit = () => {
+    setEditingGroup(null);
+    setEditedContent('');
+  };
+
+  const rejectChanges = (index: number) => {
+    const group = lineGroups.find(g => g.start === index);
+    if (!group) {
+      return;
+    }
+
+    const updatedLines = linesWithChanges
+      .map((line, i) => {
+        if (i >= group.start && i <= group.end) {
+          if (line.line_type === DiffLineType.ADDED) {
+            return null; // Remove added lines
+          }
+          if (line.line_type === DiffLineType.REMOVED) {
+            return {...line, line_type: DiffLineType.CONTEXT}; // Convert removed lines to context
+          }
+        }
+        return line;
+      })
+      .filter((line): line is DiffLine => line !== null);
+
+    updateHunk.mutate({hunkIndex, lines: updatedLines, repoId, fileName});
+    setLinesWithChanges(addChangesToDiffLines(updatedLines));
+  };
+
+  const getStartLineNumber = (index: number, lineType: DiffLineType) => {
+    const line = linesWithChanges[index];
+    if (lineType === DiffLineType.REMOVED) {
+      return line.source_line_no;
+    }
+    if (lineType === DiffLineType.ADDED) {
+      // Find the first non-null target_line_no
+      for (let i = index; i < linesWithChanges.length; i++) {
+        if (linesWithChanges[i].target_line_no !== null) {
+          return linesWithChanges[i].target_line_no;
+        }
+      }
+    }
+    return null;
+  };
+
+  const handleClearChanges = () => {
+    setEditedContent('');
+    setEditedLines([]);
+  };
 
   return (
     <Fragment>
       <HunkHeaderEmptySpace />
       <HunkHeader lines={lines} sectionHeader={header} />
-      {linesWithChanges.map(line => (
-        <Fragment key={line.diff_line_no}>
+      {linesWithChanges.map((line, index) => (
+        <Fragment key={index}>
           <LineNumber lineType={line.line_type}>{line.source_line_no}</LineNumber>
           <LineNumber lineType={line.line_type}>{line.target_line_no}</LineNumber>
           <DiffContent
@@ -109,6 +357,100 @@ function DiffHunkContent({lines, header}: {header: string; lines: DiffLine[]}) {
             data-test-id={makeTestIdFromLineType(line.line_type)}
           >
             <DiffLineCode line={line} />
+            {lineGroups.some(group => index === group.start) && (
+              <ButtonGroup>
+                <ActionButton
+                  size="xs"
+                  icon={<IconEdit size="xs" />}
+                  aria-label={t('Edit changes')}
+                  title={t('Edit')}
+                  onClick={() => handleEditClick(index)}
+                />
+                <ActionButton
+                  size="xs"
+                  icon={<IconClose size="xs" />}
+                  aria-label={t('Reject changes')}
+                  title={t('Reject')}
+                  onClick={() => rejectChanges(index)}
+                />
+              </ButtonGroup>
+            )}
+            {editingGroup === index && (
+              <EditOverlay ref={overlayRef}>
+                <OverlayTitle>{t('Editing %s', fileName)}</OverlayTitle>
+                <SectionTitle>
+                  {t(
+                    '%s deleted line%s%s',
+                    linesWithChanges
+                      .slice(index, lineGroups.find(g => g.start === index)?.end! + 1)
+                      .filter(l => l.line_type === DiffLineType.REMOVED).length,
+                    linesWithChanges
+                      .slice(index, lineGroups.find(g => g.start === index)?.end)
+                      .filter(l => l.line_type === DiffLineType.REMOVED).length === 1
+                      ? ''
+                      : 's',
+                    linesWithChanges
+                      .slice(index, lineGroups.find(g => g.start === index)?.end)
+                      .filter(l => l.line_type === DiffLineType.REMOVED).length > 0
+                      ? t(
+                          ' from line %s',
+                          getStartLineNumber(index, DiffLineType.REMOVED)
+                        )
+                      : ''
+                  )}
+                </SectionTitle>
+                {linesWithChanges
+                  .slice(index, lineGroups.find(g => g.start === index)?.end! + 1)
+                  .filter(l => l.line_type === DiffLineType.REMOVED).length > 0 ? (
+                  <RemovedLines>
+                    {linesWithChanges
+                      .slice(index, lineGroups.find(g => g.start === index)?.end! + 1)
+                      .filter(l => l.line_type === DiffLineType.REMOVED)
+                      .map((l, i) => (
+                        <RemovedLine key={i}>{l.value}</RemovedLine>
+                      ))}
+                  </RemovedLines>
+                ) : (
+                  <NoChangesMessage>{t('No lines are being deleted.')}</NoChangesMessage>
+                )}
+                <SectionTitle>
+                  {t(
+                    '%s new line%s%s',
+                    editedLines.length,
+                    editedLines.length === 1 ? '' : 's',
+                    editedLines.length > 0
+                      ? t(' from line %s', getStartLineNumber(index, DiffLineType.ADDED))
+                      : ''
+                  )}
+                </SectionTitle>
+                <TextAreaWrapper>
+                  <StyledTextArea
+                    value={editedContent}
+                    onChange={handleTextAreaChange}
+                    rows={5}
+                    autosize
+                    placeholder={
+                      editedLines.length === 0 ? t('No lines are being added...') : ''
+                    }
+                  />
+                  <ClearButton
+                    size="xs"
+                    onClick={handleClearChanges}
+                    aria-label={t('Clear changes')}
+                    icon={<IconDelete size="xs" />}
+                    title={t('Clear all new lines')}
+                  />
+                </TextAreaWrapper>
+                <OverlayButtonGroup>
+                  <Button size="xs" onClick={handleCancelEdit}>
+                    {t('Cancel')}
+                  </Button>
+                  <Button size="xs" priority="primary" onClick={handleSaveEdit}>
+                    {t('Save')}
+                  </Button>
+                </OverlayButtonGroup>
+              </EditOverlay>
+            )}
           </DiffContent>
         </Fragment>
       ))}
@@ -116,7 +458,17 @@ function DiffHunkContent({lines, header}: {header: string; lines: DiffLine[]}) {
   );
 }
 
-function FileDiff({file}: {file: FilePatch}) {
+function FileDiff({
+  file,
+  groupId,
+  runId,
+  repoId,
+}: {
+  file: FilePatch;
+  groupId: string;
+  runId: string;
+  repoId?: string;
+}) {
   const [isExpanded, setIsExpanded] = useState(true);
 
   return (
@@ -138,9 +490,18 @@ function FileDiff({file}: {file: FilePatch}) {
       </FileHeader>
       {isExpanded && (
         <DiffContainer>
-          {file.hunks.map(({section_header, source_start, lines}) => {
+          {file.hunks.map(({section_header, source_start, lines}, index) => {
             return (
-              <DiffHunkContent key={source_start} lines={lines} header={section_header} />
+              <DiffHunkContent
+                key={source_start}
+                repoId={repoId}
+                groupId={groupId}
+                runId={runId}
+                hunkIndex={index}
+                lines={lines}
+                header={section_header}
+                fileName={file.path}
+              />
             );
           })}
         </DiffContainer>
@@ -149,7 +510,7 @@ function FileDiff({file}: {file: FilePatch}) {
   );
 }
 
-export function AutofixDiff({diff}: AutofixDiffProps) {
+export function AutofixDiff({diff, groupId, runId, repoId}: AutofixDiffProps) {
   if (!diff || !diff.length) {
     return null;
   }
@@ -157,7 +518,13 @@ export function AutofixDiff({diff}: AutofixDiffProps) {
   return (
     <DiffsColumn>
       {diff.map(file => (
-        <FileDiff key={file.path} file={file} />
+        <FileDiff
+          key={file.path}
+          file={file}
+          groupId={groupId}
+          runId={runId}
+          repoId={repoId}
+        />
       ))}
     </DiffsColumn>
   );
@@ -248,7 +615,10 @@ const LineNumber = styled('div')<{lineType: DiffLineType}>`
 const DiffContent = styled('div')<{lineType: DiffLineType}>`
   position: relative;
   padding-left: ${space(4)};
+  padding-right: ${space(4)};
   white-space: pre-wrap;
+  word-break: break-all;
+  word-wrap: break-word;
 
   ${p =>
     p.lineType === DiffLineType.ADDED &&
@@ -274,4 +644,102 @@ const CodeDiff = styled('span')<{added?: boolean; removed?: boolean}>`
   vertical-align: middle;
   ${p => p.added && `background-color: ${p.theme.diff.added};`};
   ${p => p.removed && `background-color: ${p.theme.diff.removed};`};
+`;
+
+const ButtonGroup = styled('div')`
+  position: absolute;
+  top: 0;
+  right: ${space(0.25)};
+  display: flex;
+  opacity: 0;
+  transition: opacity 0.1s ease-in-out;
+
+  ${DiffContent}:hover & {
+    opacity: 1;
+  }
+`;
+
+const ActionButton = styled(Button)`
+  margin-left: ${space(0.5)};
+  font-family: ${p => p.theme.text.family};
+`;
+
+const EditOverlay = styled('div')`
+  position: fixed;
+  bottom: 200px;
+  right: ${space(2)};
+  left: calc(50% + ${space(2)});
+  background: ${p => p.theme.backgroundElevated};
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+  box-shadow: ${p => p.theme.dropShadowHeavy};
+  padding: ${space(2)};
+  z-index: 1;
+`;
+
+const OverlayButtonGroup = styled('div')`
+  display: flex;
+  justify-content: flex-end;
+  gap: ${space(1)};
+  margin-top: ${space(1)};
+  font-family: ${p => p.theme.text.family};
+`;
+
+const RemovedLines = styled('div')`
+  margin-bottom: ${space(1)};
+  font-family: ${p => p.theme.text.familyMono};
+  border-radius: ${p => p.theme.borderRadius};
+  overflow: hidden;
+`;
+
+const RemovedLine = styled('div')`
+  background-color: ${p => p.theme.diff.removedRow};
+  color: ${p => p.theme.textColor};
+  padding: ${space(0.25)} ${space(0.5)};
+`;
+
+const StyledTextArea = styled(TextArea)`
+  font-family: ${p => p.theme.text.familyMono};
+  font-size: ${p => p.theme.fontSizeSmall};
+  background-color: ${p => p.theme.diff.addedRow};
+  border-color: ${p => p.theme.border};
+  position: relative;
+
+  &:focus {
+    border-color: ${p => p.theme.focusBorder};
+    box-shadow: inset 0 0 0 1px ${p => p.theme.focusBorder};
+  }
+`;
+
+const ClearButton = styled(Button)`
+  position: absolute;
+  top: -${space(1)};
+  right: -${space(1)};
+  z-index: 1;
+`;
+
+const TextAreaWrapper = styled('div')`
+  position: relative;
+`;
+
+const SectionTitle = styled('p')`
+  margin: ${space(1)} 0;
+  font-size: ${p => p.theme.fontSizeMedium};
+  font-weight: bold;
+  color: ${p => p.theme.textColor};
+  font-family: ${p => p.theme.text.family};
+`;
+
+const NoChangesMessage = styled('p')`
+  margin: ${space(1)} 0;
+  color: ${p => p.theme.subText};
+  font-family: ${p => p.theme.text.family};
+`;
+
+const OverlayTitle = styled('h3')`
+  margin: 0 0 ${space(2)} 0;
+  font-size: ${p => p.theme.fontSizeMedium};
+  font-weight: bold;
+  color: ${p => p.theme.textColor};
+  font-family: ${p => p.theme.text.family};
 `;

--- a/static/app/components/events/autofix/autofixInsightCards.spec.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.spec.tsx
@@ -159,20 +159,20 @@ describe('AutofixInsightCards', () => {
 
   it('renders "Rethink from here" buttons', () => {
     renderComponent();
-    const rethinkButtons = screen.getAllByText('Rethink from here');
+    const rethinkButtons = screen.getAllByRole('button', {name: 'Rethink from here'});
     expect(rethinkButtons.length).toBeGreaterThan(0);
   });
 
   it('shows rethink input overlay when "Rethink from here" is clicked', async () => {
     renderComponent();
-    const rethinkButton = screen.getAllByText('Rethink from here')[0];
+    const rethinkButton = screen.getByRole('button', {name: 'Rethink from here'});
     await userEvent.click(rethinkButton);
     expect(screen.getByPlaceholderText('Say something...')).toBeInTheDocument();
   });
 
   it('hides rethink input overlay when clicked outside', async () => {
     renderComponent();
-    const rethinkButton = screen.getAllByText('Rethink from here')[0];
+    const rethinkButton = screen.getByRole('button', {name: 'Rethink from here'});
     await userEvent.click(rethinkButton);
     expect(screen.getByPlaceholderText('Say something...')).toBeInTheDocument();
 
@@ -187,7 +187,7 @@ describe('AutofixInsightCards', () => {
     });
 
     renderComponent();
-    const rethinkButton = screen.getAllByText('Rethink from here')[0];
+    const rethinkButton = screen.getByRole('button', {name: 'Rethink from here'});
     await userEvent.click(rethinkButton);
 
     const input = screen.getByPlaceholderText('Say something...');
@@ -208,7 +208,7 @@ describe('AutofixInsightCards', () => {
             type: 'restart_from_point_with_feedback',
             message: 'Rethink this part',
             step_index: 0,
-            retain_insight_card_index: null,
+            retain_insight_card_index: 0,
           }),
         }),
       })
@@ -222,7 +222,7 @@ describe('AutofixInsightCards', () => {
     });
 
     renderComponent();
-    const rethinkButton = screen.getAllByText('Rethink from here')[0];
+    const rethinkButton = screen.getByRole('button', {name: 'Rethink from here'});
     await userEvent.click(rethinkButton);
 
     const input = screen.getByPlaceholderText('Say something...');
@@ -246,7 +246,7 @@ describe('AutofixInsightCards', () => {
     });
 
     renderComponent();
-    const rethinkButton = screen.getAllByText('Rethink from here')[0];
+    const rethinkButton = screen.getByRole('button', {name: 'Rethink from here'});
     await userEvent.click(rethinkButton);
 
     const input = screen.getByPlaceholderText('Say something...');

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -29,6 +29,7 @@ import {
   IconArrow,
   IconChevron,
   IconCode,
+  IconEdit,
   IconFire,
   IconRefresh,
   IconUser,
@@ -302,17 +303,6 @@ function AutofixInsightCards({
 }: AutofixInsightCardsProps) {
   return (
     <InsightsContainer>
-      {!hasStepAbove && (
-        <div>
-          <TitleText>Insights</TitleText>
-          <ChainLink
-            insightCardAboveIndex={null}
-            stepIndex={stepIndex}
-            groupId={groupId}
-            runId={runId}
-          />
-        </div>
-      )}
       {insights.length > 0 ? (
         insights.map((insight, index) =>
           !insight ? null : (
@@ -412,13 +402,13 @@ function ChainLink({
     <ArrowContainer>
       <IconArrow direction={'down'} className="arrow-icon" />
       <RethinkButton
-        icon={<IconRefresh />}
+        icon={<IconEdit size="xs" />}
         size="zero"
-        className="hover-button"
+        className="rethink-button"
+        title={t('Rethink from here')}
+        aria-label={t('Rethink from here')}
         onClick={() => setShowOverlay(true)}
-      >
-        Rethink from here
-      </RethinkButton>
+      />
 
       {showOverlay && (
         <RethinkInput ref={overlayRef}>
@@ -486,14 +476,6 @@ const NoInsightsYet = styled('div')`
   text-align: center;
 `;
 
-const TitleText = styled('p')`
-  font-size: ${p => p.theme.fontSizeLarge};
-  font-weight: ${p => p.theme.fontWeightBold};
-  margin: 0;
-  display: flex;
-  justify-content: center;
-`;
-
 const InsightsContainer = styled('div')``;
 
 const InsightContainer = styled(motion.div)`
@@ -517,15 +499,10 @@ const ArrowContainer = styled('div')`
     justify-self: center;
   }
 
-  .hover-button {
-    opacity: 0;
+  .rethink-button {
     grid-column: 3 / 4;
     justify-self: end;
     transition: opacity 0.1s ease-in-out;
-  }
-
-  &:hover .hover-button {
-    opacity: 1;
   }
 `;
 

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -97,7 +97,12 @@ export function Step({
                 />
               )}
               {step.type === AutofixStepType.CHANGES && (
-                <AutofixChanges step={step} groupId={groupId} onRetry={onRetry} />
+                <AutofixChanges
+                  step={step}
+                  groupId={groupId}
+                  onRetry={onRetry}
+                  runId={runId}
+                />
               )}
               {hasErroredStepBefore && hasStepBelow && (
                 <StepMessage>


### PR DESCRIPTION
Gives the user the ability to reject or edit the proposed code diff.

This PR also removes the insights header and restyles the "rethink" buttons.

<img width="460" alt="Screenshot 2024-10-16 at 1 51 16 PM" src="https://github.com/user-attachments/assets/de1a75b8-8459-4da1-9ba2-00206f4f8cf2">
<img width="495" alt="Screenshot 2024-10-16 at 1 51 19 PM" src="https://github.com/user-attachments/assets/9ad50fbf-8e65-49ec-a915-79fcd46ed02e">
<img width="471" alt="Screenshot 2024-10-16 at 1 51 25 PM" src="https://github.com/user-attachments/assets/336cb76e-a786-4447-92af-7d70340207ff">
<img width="529" alt="Screenshot 2024-10-16 at 1 51 34 PM" src="https://github.com/user-attachments/assets/1af3eacc-1912-4df3-aa79-e015786e6703">
