### PR TITLE
fix(dashboards): Clamp `BigNumberWidget` threshold indicator size

### DIFF
--- a/static/app/views/dashboards/widgets/bigNumberWidget/thresholdsIndicator.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/thresholdsIndicator.tsx
@@ -49,8 +49,8 @@ export function ThresholdsIndicator({
 
 const Circle = styled('div')<{color: string}>`
   display: inline-block;
-  height: max(12px, 20cqh);
-  width: max(12px, 20cqh);
+  height: clamp(12px, 20cqh, 50px);
+  width: clamp(12px, 20cqh, 50px);
 
   position: relative;
   align-self: center;


### PR DESCRIPTION
**Before:**
![Screenshot 2024-10-17 at 2 38 51 PM](https://github.com/user-attachments/assets/94546870-d017-4b44-a106-4291291737f7)

**After:**
![Screenshot 2024-10-17 at 2 49 39 PM](https://github.com/user-attachments/assets/38b14ae9-c4a6-42f4-b64f-740782826756)

