### PR TITLE
fix(perf-issues): Fix HTTP Overhead Detector

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/http_overhead_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/http_overhead_detector.py
@@ -65,10 +65,12 @@ class HTTPOverheadDetector(PerformanceDetector):
 
         url = span_data.get("url", "")
         span_start = span.get("start_timestamp", 0) * 1000
-        request_start = span_data.get("http.request.request_start", 0) * 1000
+        request_start = span_data.get("http.request.request_start", 0)
 
         if not url or not span_start or not request_start:
             return
+
+        request_start *= 1000
 
         if url.startswith("/"):
             location = "/"

--- a/tests/sentry/utils/performance_issues/test_http_overhead_detector.py
+++ b/tests/sentry/utils/performance_issues/test_http_overhead_detector.py
@@ -260,3 +260,23 @@ class HTTPOverheadDetectorTest(TestCase):
                 evidence_display=[],
             )
         ]
+
+    def test_none_request_start(self):
+        url = "https://example.com/api/endpoint/123"
+        event = _valid_http_overhead_event("/api/endpoint/123")
+
+        # Include an invalid span to ensure it's not processed
+        span = create_span(
+            "http.client",
+            desc=url,
+            duration=1000,
+            data={
+                "url": url,
+                "network.protocol.version": "1.1",
+                # request_start is not present
+            },
+        )
+
+        event["spans"] = [span]
+
+        assert self.find_problems(event) == []

--- a/tests/sentry/utils/performance_issues/test_http_overhead_detector.py
+++ b/tests/sentry/utils/performance_issues/test_http_overhead_detector.py
@@ -273,7 +273,7 @@ class HTTPOverheadDetectorTest(TestCase):
             data={
                 "url": url,
                 "network.protocol.version": "1.1",
-                "request_start": None,
+                "http.request.request_start": None,
             },
         )
 

--- a/tests/sentry/utils/performance_issues/test_http_overhead_detector.py
+++ b/tests/sentry/utils/performance_issues/test_http_overhead_detector.py
@@ -273,7 +273,7 @@ class HTTPOverheadDetectorTest(TestCase):
             data={
                 "url": url,
                 "network.protocol.version": "1.1",
-                # request_start is not present
+                "request_start": None,
             },
         )
 


### PR DESCRIPTION
Fixes SENTRY-FOR-SENTRY-1WGT

Changes the detection code to first ensure that `request_start` is not None before multiplying the value to convert it to ms