### PR TITLE
ref(dashboards): Prefix `Props` interface names

### DIFF
--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
@@ -4,11 +4,11 @@ import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import {
   BigNumberWidgetVisualization,
-  type Props as BigNumberWidgetVisualizationProps,
+  type BigNumberWidgetVisualizationProps,
 } from 'sentry/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization';
 import {
-  type Props as WidgetFrameProps,
   WidgetFrame,
+  type WidgetFrameProps,
 } from 'sentry/views/dashboards/widgets/common/widgetFrame';
 
 import {MISSING_DATA_MESSAGE, NON_FINITE_NUMBER_MESSAGE} from '../common/settings';

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
@@ -19,7 +19,7 @@ import {DEFAULT_FIELD} from '../common/settings';
 
 import {ThresholdsIndicator} from './thresholdsIndicator';
 
-export interface Props {
+export interface BigNumberWidgetVisualizationProps {
   value: number;
   field?: string;
   maximumValue?: number;
@@ -29,7 +29,7 @@ export interface Props {
   thresholds?: Thresholds;
 }
 
-export function BigNumberWidgetVisualization(props: Props) {
+export function BigNumberWidgetVisualization(props: BigNumberWidgetVisualizationProps) {
   const {
     field = DEFAULT_FIELD,
     value,

--- a/static/app/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodValue.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodValue.tsx
@@ -17,7 +17,7 @@ import type {TableData} from 'sentry/views/dashboards/widgets/common/types';
 
 import {DEFAULT_FIELD} from '../common/settings';
 
-interface Props {
+interface DifferenceToPreviousPeriodValueProps {
   previousPeriodValue: number;
   renderer: (datum: TableData[number]) => React.ReactNode;
   value: number;
@@ -31,7 +31,7 @@ export function DifferenceToPreviousPeriodValue({
   preferredPolarity = '',
   field = DEFAULT_FIELD,
   renderer,
-}: Props) {
+}: DifferenceToPreviousPeriodValueProps) {
   if (!isNumber(currentValue) || !isNumber(previousValue)) {
     return <Deemphasize>{LOADING_PLACEHOLDER}</Deemphasize>;
   }

--- a/static/app/views/dashboards/widgets/common/errorPanel.tsx
+++ b/static/app/views/dashboards/widgets/common/errorPanel.tsx
@@ -5,11 +5,11 @@ import {space} from 'sentry/styles/space';
 import {DEEMPHASIS_COLOR_NAME} from 'sentry/views/dashboards/widgets/bigNumberWidget/settings';
 import type {StateProps} from 'sentry/views/dashboards/widgets/common/types';
 
-interface Props {
+interface ErrorPanelProps {
   error: StateProps['error'];
 }
 
-export function ErrorPanel({error}: Props) {
+export function ErrorPanel({error}: ErrorPanelProps) {
   return (
     <Panel>
       <NonShrinkingWarningIcon color={DEEMPHASIS_COLOR_NAME} size="md" />

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -16,7 +16,7 @@ import {TooltipIconTrigger} from './tooltipIconTrigger';
 import type {StateProps} from './types';
 import {WarningsList} from './warningsList';
 
-export interface Props extends StateProps {
+export interface WidgetFrameProps extends StateProps {
   actions?: MenuItemProps[];
   badgeProps?: BadgeProps;
   children?: React.ReactNode;
@@ -26,7 +26,7 @@ export interface Props extends StateProps {
   warnings?: string[];
 }
 
-export function WidgetFrame(props: Props) {
+export function WidgetFrame(props: WidgetFrameProps) {
   const {error} = props;
 
   // The error state has its own set of available actions


### PR DESCRIPTION
More descriptive and useful to have the component name. Also prevents weird collisions when multiple components are in the same file.
