### PR TITLE
ref(ui): Improve auto expand of cron check-in errors

### DIFF
--- a/static/app/views/monitors/components/processingErrors/monitorProcessingErrors.tsx
+++ b/static/app/views/monitors/components/processingErrors/monitorProcessingErrors.tsx
@@ -56,6 +56,7 @@ export default function MonitorProcessingErrors({
     <StyledHovercard
       skipWrapper
       showUnderline
+      position="bottom"
       header={tct('Check-in on [datetime]', {datetime: <DateTime date={checkin.ts} />})}
       body={
         // Prevent clicks inside the hovercard from closing the expandable alert
@@ -65,6 +66,7 @@ export default function MonitorProcessingErrors({
             maxDefaultDepth={3}
             withAnnotatedText
             forceDefaultExpand
+            initialExpandedPaths={['$']}
           />
         </div>
       }


### PR DESCRIPTION
Before it looked like this:

<img alt="clipboard.png" width="868" src="https://i.imgur.com/wOJTCkK.png" />

Now it auto expands correctly

<img alt="clipboard.png" width="800" src="https://i.imgur.com/Nchq3BB.png" />

\