### PR TITLE
fix(issue alerts): rule conditions with a value of 0 get reset on edit

### DIFF
--- a/static/app/views/alerts/rules/issue/index.spec.tsx
+++ b/static/app/views/alerts/rules/issue/index.spec.tsx
@@ -230,6 +230,43 @@ describe('IssueRuleEditor', function () {
       );
     });
 
+    it('saves rule with condition value of 0', async function () {
+      const rule = ProjectAlertRuleFixture({
+        conditions: [
+          {id: 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition'},
+          {
+            id: 'sentry.rules.conditions.event_frequency.EventFrequencyCondition',
+            value: 0,
+          },
+        ],
+      });
+      MockApiClient.addMockResponse({
+        url: endpoint,
+        method: 'GET',
+        body: rule,
+      });
+      createWrapper();
+      await userEvent.click(screen.getByText('Save Rule'));
+
+      await waitFor(() =>
+        expect(mock).toHaveBeenCalledWith(
+          endpoint,
+          expect.objectContaining({
+            data: expect.objectContaining({
+              conditions: [
+                {id: 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition'},
+                {
+                  id: 'sentry.rules.conditions.event_frequency.EventFrequencyCondition',
+                  value: '0', // Verify that the 0 is converted to a string by the serializer
+                },
+              ],
+            }),
+          })
+        )
+      );
+      expect(addErrorMessage).toHaveBeenCalledTimes(0);
+    });
+
     it('sends correct environment value', async function () {
       createWrapper();
       await selectEvent.select(screen.getByText('staging'), 'production');

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -528,6 +528,10 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
             delete action.name;
           }
           for (const condition of rule.conditions) {
+            // values of 0 must be manually changed to strings, otherwise they will be interpreted as missing by the serializer
+            if ('value' in condition && condition.value === 0) {
+              condition.value = '0';
+            }
             delete condition.name;
           }
           for (const filter of rule.filters) {

--- a/static/app/views/alerts/rules/issue/ruleNode.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.tsx
@@ -54,7 +54,10 @@ function NumberField({
   fieldConfig,
   onPropertyChange,
 }: FieldProps) {
-  const value = data[name] && typeof data[name] !== 'boolean' ? Number(data[name]) : NaN;
+  const value =
+    (data[name] && typeof data[name] !== 'boolean') || data[name] === 0
+      ? Number(data[name])
+      : NaN;
 
   // Set default value of number fields to the placeholder value
   useEffect(() => {


### PR DESCRIPTION
Rule conditions with values of 0 were being reset on edit. This PR fixes this by updating the reset condition and manually converting 0s to '0's upon PUT.

Related issues:
https://github.com/getsentry/team-core-product-foundations/issues/340
https://github.com/getsentry/sentry/issues/75700