### PR TITLE
Fix issue where a[0] is undefined in localeCompare

### DIFF
--- a/static/app/views/settings/account/accountSubscriptions.tsx
+++ b/static/app/views/settings/account/accountSubscriptions.tsx
@@ -105,7 +105,7 @@ function AccountSubscriptions() {
     }, {})
   );
 
-  subGroups.sort(([a], [b]) => a[0].localeCompare(b[0]));
+  subGroups.sort(([a], [b]) => a[0]?.localeCompare(b[0]));
 
   const handleToggle = (subscription: Subscription) => {
     const subscribed = !subscription.subscribed;


### PR DESCRIPTION
## Description
Quick fix for: https://sentry.sentry.io/issues/5999776137/?project=11276&referrer=github-pr-bot