### PR TITLE
ref(issue-details): Fix some styling with streamlined header

### DIFF
--- a/static/app/components/group/externalIssuesList/streamlinedExternalIssueList.tsx
+++ b/static/app/components/group/externalIssuesList/streamlinedExternalIssueList.tsx
@@ -14,6 +14,8 @@ import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import useOrganization from 'sentry/utils/useOrganization';
 import {Divider} from 'sentry/views/issueDetails/divider';
+import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
+import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
 
 import useStreamLinedExternalIssueData from './hooks/useGroupExternalIssues';
 
@@ -47,92 +49,94 @@ export function StreamlinedExternalIssueList({
   }
 
   return (
-    <div data-test-id="linked-issues">
-      <StyledSectionTitle>{t('Issue Tracking')}</StyledSectionTitle>
-      <SidebarSection.Content>
-        {integrations.length || linkedIssues.length ? (
-          <IssueActionWrapper>
-            {linkedIssues.map(linkedIssue => (
-              <ErrorBoundary key={linkedIssue.key} mini>
-                <Tooltip
-                  overlayStyle={{maxWidth: '400px'}}
-                  position="bottom"
-                  title={
-                    <LinkedIssueTooltipWrapper>
-                      <LinkedIssueName>{linkedIssue.title}</LinkedIssueName>
-                      <HorizontalSeparator />
-                      <UnlinkButton
-                        priority="link"
-                        size="zero"
-                        onClick={linkedIssue.onUnlink}
-                      >
-                        {t('Unlink issue')}
-                      </UnlinkButton>
-                    </LinkedIssueTooltipWrapper>
-                  }
-                  isHoverable
+    <FoldSection
+      preventCollapse
+      sectionKey={SectionKey.SIDEBAR_ISSUE_TRACKING}
+      data-test-id="linked-issues"
+      title={t('Issue Tracking')}
+    >
+      {integrations.length || linkedIssues.length ? (
+        <IssueActionWrapper>
+          {linkedIssues.map(linkedIssue => (
+            <ErrorBoundary key={linkedIssue.key} mini>
+              <Tooltip
+                overlayStyle={{maxWidth: '400px'}}
+                position="bottom"
+                title={
+                  <LinkedIssueTooltipWrapper>
+                    <LinkedIssueName>{linkedIssue.title}</LinkedIssueName>
+                    <HorizontalSeparator />
+                    <UnlinkButton
+                      priority="link"
+                      size="zero"
+                      onClick={linkedIssue.onUnlink}
+                    >
+                      {t('Unlink issue')}
+                    </UnlinkButton>
+                  </LinkedIssueTooltipWrapper>
+                }
+                isHoverable
+              >
+                <LinkedIssue
+                  href={linkedIssue.url}
+                  external
+                  size="zero"
+                  icon={linkedIssue.displayIcon}
                 >
-                  <LinkedIssue
-                    href={linkedIssue.url}
-                    external
-                    size="zero"
-                    icon={linkedIssue.displayIcon}
-                  >
-                    <IssueActionName>{linkedIssue.displayName}</IssueActionName>
-                  </LinkedIssue>
-                </Tooltip>
-              </ErrorBoundary>
-            ))}
-            {integrations.length > 0 && linkedIssues.length > 0 ? <Divider /> : null}
-            {integrations.map(integration => {
-              const sharedButtonProps: ButtonProps = {
-                size: 'zero',
-                icon: integration.displayIcon,
-                children: <IssueActionName>{integration.displayName}</IssueActionName>,
-              };
+                  <IssueActionName>{linkedIssue.displayName}</IssueActionName>
+                </LinkedIssue>
+              </Tooltip>
+            </ErrorBoundary>
+          ))}
+          {integrations.length > 0 && linkedIssues.length > 0 ? <Divider /> : null}
+          {integrations.map(integration => {
+            const sharedButtonProps: ButtonProps = {
+              size: 'zero',
+              icon: integration.displayIcon,
+              children: <IssueActionName>{integration.displayName}</IssueActionName>,
+            };
 
-              if (integration.actions.length === 1) {
-                return (
-                  <ErrorBoundary key={integration.key} mini>
-                    <IssueActionButton
-                      {...sharedButtonProps}
-                      disabled={integration.disabled}
-                      title={integration.disabled ? integration.disabledText : undefined}
-                      onClick={integration.actions[0].onClick}
-                    />
-                  </ErrorBoundary>
-                );
-              }
-
+            if (integration.actions.length === 1) {
               return (
                 <ErrorBoundary key={integration.key} mini>
-                  <DropdownMenu
-                    trigger={triggerProps => (
-                      <IssueActionButton {...sharedButtonProps} {...triggerProps} />
-                    )}
-                    items={integration.actions.map(action => ({
-                      key: action.name,
-                      label: action.name,
-                      onAction: action.onClick,
-                      disabled: integration.disabled,
-                    }))}
+                  <IssueActionButton
+                    {...sharedButtonProps}
+                    disabled={integration.disabled}
+                    title={integration.disabled ? integration.disabledText : undefined}
+                    onClick={integration.actions[0].onClick}
                   />
                 </ErrorBoundary>
               );
-            })}
-          </IssueActionWrapper>
-        ) : (
-          <AlertLink
-            priority="muted"
-            size="small"
-            to={`/settings/${organization.slug}/integrations/?category=issue%20tracking`}
-            withoutMarginBottom
-          >
-            {t('Track this issue in Jira, GitHub, etc.')}
-          </AlertLink>
-        )}
-      </SidebarSection.Content>
-    </div>
+            }
+
+            return (
+              <ErrorBoundary key={integration.key} mini>
+                <DropdownMenu
+                  trigger={triggerProps => (
+                    <IssueActionButton {...sharedButtonProps} {...triggerProps} />
+                  )}
+                  items={integration.actions.map(action => ({
+                    key: action.name,
+                    label: action.name,
+                    onAction: action.onClick,
+                    disabled: integration.disabled,
+                  }))}
+                />
+              </ErrorBoundary>
+            );
+          })}
+        </IssueActionWrapper>
+      ) : (
+        <AlertLink
+          priority="muted"
+          size="small"
+          to={`/settings/${organization.slug}/integrations/?category=issue%20tracking`}
+          withoutMarginBottom
+        >
+          {t('Track this issue in Jira, GitHub, etc.')}
+        </AlertLink>
+      )}
+    </FoldSection>
   );
 }
 

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -384,7 +384,7 @@ export function Actions(props: Props) {
             </ResolvedWrapper>
             <Divider />
             <Button
-              size="xs"
+              size="sm"
               disabled={disabled || isAutoResolved}
               onClick={() =>
                 onUpdate({
@@ -410,13 +410,13 @@ export function Actions(props: Props) {
                 projectSlug={project.slug}
                 isResolved={isResolved}
                 isAutoResolved={isAutoResolved}
-                size="xs"
+                size="sm"
                 priority="primary"
               />
             </GuideAnchor>
             <ArchiveActions
-              className="hidden-xs"
-              size="xs"
+              className={hasStreamlinedUI ? undefined : 'hidden-xs'}
+              size="sm"
               isArchived={isIgnored}
               onUpdate={onUpdate}
               disabled={disabled}
@@ -429,7 +429,7 @@ export function Actions(props: Props) {
               group={group}
               onClick={handleClick(onToggleSubscribe)}
               icon={group.isSubscribed ? <IconSubscribed /> : <IconUnsubscribed />}
-              size="xs"
+              size="sm"
             />
           </Fragment>
         ))}
@@ -439,10 +439,10 @@ export function Actions(props: Props) {
           'aria-label': t('More Actions'),
           icon: <IconEllipsis />,
           showChevron: false,
-          size: hasStreamlinedUI ? 'xs' : 'sm',
+          size: 'sm',
         }}
         items={[
-          ...(isIgnored
+          ...(isIgnored || hasStreamlinedUI
             ? []
             : [
                 {

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -27,7 +27,7 @@ export function NewIssueExperienceButton() {
 
   const feedbackButton = openForm ? (
     <Button
-      size="xs"
+      size="sm"
       aria-label={t('Give feedback on new UI')}
       onClick={() =>
         openForm({
@@ -51,7 +51,7 @@ export function NewIssueExperienceButton() {
     <ButtonBar merged>
       <StyledButton
         enabled={hasStreamlinedUI}
-        size={hasStreamlinedUI ? 'xs' : 'sm'}
+        size="sm"
         icon={<IconLab isSolid={hasStreamlinedUI} />}
         title={label}
         aria-label={label}

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -681,7 +681,6 @@ function GroupDetailsContent({
         group={group}
         project={project}
         groupReprocessingStatus={groupReprocessingStatus}
-        baseUrl={baseUrl}
       />
       <GroupEventDetails
         location={router.location}

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
@@ -271,7 +271,12 @@ const GroupContent = styled(Layout.Main)`
   flex-direction: column;
   padding: ${space(1.5)};
   gap: ${space(1.5)};
-  box-shadow: 0 0 0 1px ${p => p.theme.translucentInnerBorder};
+  @media (min-width: ${p => p.theme.breakpoints.large}) {
+    border-right: 1px solid ${p => p.theme.translucentBorder};
+  }
+  @media (max-width: ${p => p.theme.breakpoints.large}) {
+    border-bottom-width: 1px solid ${p => p.theme.translucentBorder};
+  }
 `;
 
 const StyledLayoutSide = styled(Layout.Side)<{hasStreamlinedUi: boolean}>`

--- a/static/app/views/issueDetails/streamline/context.tsx
+++ b/static/app/views/issueDetails/streamline/context.tsx
@@ -69,6 +69,12 @@ export const enum SectionKey {
   REGRESSION_EVENT_COMPARISON = 'regression-event-comparison',
   REGRESSION_POTENTIAL_CAUSES = 'regression-potential-causes',
   REGRESSION_AFFECTED_TRANSACTIONS = 'regression-affected-transactions',
+
+  SIDEBAR_PEOPLE = 'sidebar-people',
+  SIDEBAR_ACTIVITY = 'sidebar-activity',
+  SIDEBAR_ISSUE_TRACKING = 'sidebar-issue-tracking',
+  SIDEBAR_SIMILAR_ISSUES = 'sidebar-similar',
+  SIDEBAR_GROUPING = 'sidebar-grouping',
 }
 
 /**

--- a/static/app/views/issueDetails/streamline/eventDetails.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetails.tsx
@@ -176,7 +176,7 @@ const FloatingEventNavigation = styled(EventNavigation)`
     top: ${p => p.theme.sidebar.mobileHeight};
   }
   background: ${p => p.theme.background};
-  z-index: 500;
+  z-index: ${p => p.theme.zIndex.header};
   border-radius: ${p => p.theme.borderRadiusTop};
 
   &[data-stuck='true'] {

--- a/static/app/views/issueDetails/streamline/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/streamline/groupActivityItem.tsx
@@ -21,7 +21,7 @@ import type {Organization, Team} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import type {User} from 'sentry/types/user';
 import {isSemverRelease} from 'sentry/utils/versions/isSemverRelease';
-import type {GroupRelease} from 'sentry/views/issueDetails/streamline/activitySection';
+import type {GroupRelease} from 'sentry/views/issueDetails/streamline/sidebar/activitySection';
 
 export default function getGroupActivityItem(
   activity: GroupActivity,

--- a/static/app/views/issueDetails/streamline/sidebar.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar.tsx
@@ -1,12 +1,9 @@
-import styled from '@emotion/styled';
-
-import ErrorBoundary from 'sentry/components/errorBoundary';
 import {StreamlinedExternalIssueList} from 'sentry/components/group/externalIssuesList/streamlinedExternalIssueList';
-import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
-import StreamlinedActivitySection from 'sentry/views/issueDetails/streamline/activitySection';
+import ActivitySection from 'sentry/views/issueDetails/streamline/sidebar/activitySection';
+import {PeopleSection} from 'sentry/views/issueDetails/streamline/sidebar/peopleSection';
 
 type Props = {
   group: Group;
@@ -17,19 +14,11 @@ type Props = {
 export default function StreamlinedSidebar({group, event, project}: Props) {
   return (
     <div>
+      <PeopleSection group={group} />
       {event && (
-        <ErrorBoundary mini>
-          <StreamlinedExternalIssueList group={group} event={event} project={project} />
-        </ErrorBoundary>
+        <StreamlinedExternalIssueList group={group} event={event} project={project} />
       )}
-      <StyledBreak />
-      <StreamlinedActivitySection group={group} />
+      <ActivitySection group={group} />
     </div>
   );
 }
-
-const StyledBreak = styled('hr')`
-  margin-top: ${space(2)};
-  margin-bottom: ${space(2)};
-  border-color: ${p => p.theme.border};
-`;

--- a/static/app/views/issueDetails/streamline/sidebar/activitySection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/activitySection.spec.tsx
@@ -14,9 +14,9 @@ import ConfigStore from 'sentry/stores/configStore';
 import GroupStore from 'sentry/stores/groupStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {GroupActivityType} from 'sentry/types/group';
-import StreamlinedActivitySection from 'sentry/views/issueDetails/streamline/activitySection';
+import ActivitySection from 'sentry/views/issueDetails/streamline/sidebar/activitySection';
 
-describe('StreamlinedActivitySection', function () {
+describe('ActivitySection', function () {
   const project = ProjectFixture();
   const user = UserFixture();
   user.options.prefersIssueDetailsStreamlinedUI = true;
@@ -57,7 +57,7 @@ describe('StreamlinedActivitySection', function () {
       body: {firstRelease, lastRelease},
     });
 
-    render(<StreamlinedActivitySection group={group} />);
+    render(<ActivitySection group={group} />);
     renderGlobalModal();
     expect(await screen.findByText('Test Note')).toBeInTheDocument();
 
@@ -98,7 +98,7 @@ describe('StreamlinedActivitySection', function () {
       body: {firstRelease, lastRelease},
     });
 
-    render(<StreamlinedActivitySection group={updatedActivityGroup} />);
+    render(<ActivitySection group={updatedActivityGroup} />);
     expect(await screen.findByText('Test Note')).toBeInTheDocument();
 
     expect(

--- a/static/app/views/issueDetails/streamline/sidebar/activitySection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/activitySection.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useMemo, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -20,6 +20,8 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useTeamsById} from 'sentry/utils/useTeamsById';
 import {useUser} from 'sentry/utils/useUser';
+import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
+import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
 import {groupActivityTypeIconMapping} from 'sentry/views/issueDetails/streamline/groupActivityIcons';
 import getGroupActivityItem from 'sentry/views/issueDetails/streamline/groupActivityItem';
 import {NoteDropdown} from 'sentry/views/issueDetails/streamline/noteDropdown';
@@ -28,7 +30,7 @@ export interface GroupRelease {
   firstRelease: Release;
   lastRelease: Release;
 }
-function StreamlinedActivitySection({group}: {group: Group}) {
+function ActivitySection({group}: {group: Group}) {
   const organization = useOrganization();
   const {teams} = useTeamsById();
 
@@ -128,7 +130,11 @@ function StreamlinedActivitySection({group}: {group: Group}) {
   }, [group.activity.length, group.lastSeen, group.project]);
 
   return (
-    <Fragment>
+    <FoldSection
+      sectionKey={SectionKey.SIDEBAR_ACTIVITY}
+      title={t('Activity')}
+      preventCollapse
+    >
       <Timeline.Container>
         <NoteInputWithStorage
           key={inputId}
@@ -185,7 +191,7 @@ function StreamlinedActivitySection({group}: {group: Group}) {
           );
         })}
       </Timeline.Container>
-    </Fragment>
+    </FoldSection>
   );
 }
 
@@ -211,4 +217,4 @@ const SmallTimestamp = styled(TimeSince)`
   font-size: ${p => p.theme.fontSizeSmall};
 `;
 
-export default StreamlinedActivitySection;
+export default ActivitySection;

--- a/static/app/views/issueDetails/streamline/sidebar/peopleSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/peopleSection.tsx
@@ -1,0 +1,53 @@
+import {useMemo} from 'react';
+
+import {Flex} from 'sentry/components/container/flex';
+import ParticipantList from 'sentry/components/group/streamlinedParticipantList';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Group, TeamParticipant, UserParticipant} from 'sentry/types/group';
+import {useUser} from 'sentry/utils/useUser';
+import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
+import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
+
+export function PeopleSection({group}: {group: Group}) {
+  const activeUser = useUser();
+  const {userParticipants, teamParticipants, viewers} = useMemo(() => {
+    return {
+      userParticipants: group.participants.filter(
+        (p): p is UserParticipant => p.type === 'user'
+      ),
+      teamParticipants: group.participants.filter(
+        (p): p is TeamParticipant => p.type === 'team'
+      ),
+      viewers: group.seenBy.filter(user => activeUser.id !== user.id),
+    };
+  }, [group, activeUser.id]);
+
+  const hasParticipants = group.participants.length > 0;
+  const hasViewers = viewers.length > 0;
+
+  if (!hasParticipants && !hasViewers) {
+    return null;
+  }
+
+  return (
+    <FoldSection
+      sectionKey={SectionKey.SIDEBAR_PEOPLE}
+      title={t('People')}
+      preventCollapse
+    >
+      {hasParticipants && (
+        <Flex gap={space(0.5)} align="center">
+          <ParticipantList users={userParticipants} teams={teamParticipants} />
+          {t('participating')}
+        </Flex>
+      )}
+      {hasViewers && (
+        <Flex gap={space(0.5)} align="center">
+          <ParticipantList users={viewers} />
+          {t('viewed this issue')}
+        </Flex>
+      )}
+    </FoldSection>
+  );
+}


### PR DESCRIPTION
This PR makes a few changes to the header portion of the event nav:
- overflow long values for message
- align stats with title/message as a grid
- remove divider after level
- makes action buttons bigger again (sorry richard)
- consistent border color on event panel
- simpler dom for header (removed EventMessage and EventGroupOrTitle), less elements for flexboxing actions
- Moves sidebar button and participant list

<img width="638" alt="image" src="https://github.com/user-attachments/assets/9c5f8c5f-4d29-492f-9585-738dd88cd5f7">

<img width="597" alt="image" src="https://github.com/user-attachments/assets/27ae3769-8fe7-4f16-9ba3-57d4ced9e5d7">

<img width="618" alt="image" src="https://github.com/user-attachments/assets/7fc9b36a-e24e-424c-8fa8-126f2ce7c443">

<img width="369" alt="image" src="https://github.com/user-attachments/assets/95ffec4e-dc95-4144-94b4-1b7987a580b7">


