### PR TITLE
chore(issue-views): Fix ul/li semantics

### DIFF
--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -238,6 +238,7 @@ function Tabs({
                 orientation={orientation}
                 overflowing={overflowingTabs.some(tab => tab.key === item.key)}
                 variant={tabVariant}
+                as="div"
               />
             </TabItemWrap>
             <TabDivider isVisible={isTabDividerVisible(item.key)} initial={false} />

--- a/static/app/components/draggableTabs/draggableTabList.tsx
+++ b/static/app/components/draggableTabs/draggableTabList.tsx
@@ -151,7 +151,7 @@ function Tabs({
   tabVariant?: BaseTabProps['variant'];
   value?: string | number;
 }) {
-  const tabListRef = useRef<HTMLUListElement>(null);
+  const tabListRef = useRef<HTMLDivElement>(null);
   const {tabListProps} = useTabList({orientation, ...ariaProps}, state, tabListRef);
 
   const values = useMemo(() => [...state.collection], [state.collection]);
@@ -202,13 +202,7 @@ function Tabs({
 
   return (
     <TabListWrap {...tabListProps} className={className} ref={tabListRef}>
-      <ReorderGroup
-        axis="x"
-        values={values}
-        onReorder={onReorder}
-        as="div"
-        initial={false}
-      >
+      <ReorderGroup axis="x" values={values} onReorder={onReorder} initial={false}>
         {tabs.map((item, i) => (
           <Fragment key={item.key}>
             <TabItemWrap
@@ -225,7 +219,6 @@ function Tabs({
                 })
               }
               value={item}
-              as="div"
               data-key={item.key}
               dragConstraints={dragConstraints} // dragConstraints are the bounds that the tab can be dragged within
               dragElastic={0} // Prevents the tab from being dragged outside of the dragConstraints (w/o this you can drag it outside but it'll spring back)
@@ -494,7 +487,7 @@ const AddViewTempTabWrap = styled('div')`
   align-items: center;
 `;
 
-const TabListWrap = styled('ul')`
+const TabListWrap = styled('div')`
   padding: 0;
   margin: 0;
   list-style-type: none;
@@ -507,6 +500,9 @@ const ReorderGroup = styled(Reorder.Group<Node<DraggableTabListItemProps>>)`
   overflow: hidden;
   width: max-content;
   position: relative;
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
 `;
 
 const AddViewButton = styled(Button)`

--- a/static/app/components/tabs/tab.tsx
+++ b/static/app/components/tabs/tab.tsx
@@ -28,6 +28,7 @@ interface TabProps extends AriaTabProps {
    */
   overflowing: boolean;
   state: TabListState<any>;
+  as?: React.ElementType;
   borderStyle?: BaseTabProps['borderStyle'];
   variant?: BaseTabProps['variant'];
 }
@@ -51,6 +52,7 @@ export interface BaseTabProps {
   orientation: Orientation;
   overflowing: boolean;
   tabProps: DOMAttributes<FocusableElement>;
+  as?: React.ElementType;
   /**
    * This controls the border style of the tab. Only active when
    * `variant='filled'` since other variants do not have a border
@@ -71,6 +73,7 @@ export const BaseTab = forwardRef(
       isSelected,
       variant = 'flat',
       borderStyle = 'solid',
+      as = 'li',
     } = props;
 
     const ref = useObjectRef(forwardedRef);
@@ -99,6 +102,7 @@ export const BaseTab = forwardRef(
           overflowing={overflowing}
           borderStyle={borderStyle}
           ref={ref}
+          as={as}
         >
           {!isSelected && (
             <VariantStyledInteractionStateLayer hasSelectedBackground={false} />
@@ -116,6 +120,7 @@ export const BaseTab = forwardRef(
           hidden={hidden}
           overflowing={overflowing}
           ref={ref}
+          as={as}
         >
           <VariantStyledInteractionStateLayer hasSelectedBackground={false} />
           <VariantFocusLayer />
@@ -131,6 +136,7 @@ export const BaseTab = forwardRef(
         selected={isSelected}
         overflowing={overflowing}
         ref={ref}
+        as={as}
       >
         <InnerWrap>
           <StyledInteractionStateLayer
@@ -153,7 +159,15 @@ export const BaseTab = forwardRef(
  */
 export const Tab = forwardRef(
   (
-    {item, state, orientation, overflowing, variant, borderStyle = 'solid'}: TabProps,
+    {
+      item,
+      state,
+      orientation,
+      overflowing,
+      variant,
+      borderStyle = 'solid',
+      as = 'li',
+    }: TabProps,
     forwardedRef: React.ForwardedRef<HTMLLIElement>
   ) => {
     const ref = useObjectRef(forwardedRef);
@@ -176,13 +190,13 @@ export const Tab = forwardRef(
         ref={ref}
         borderStyle={borderStyle}
         variant={variant}
+        as={as}
       >
         {rendered}
       </BaseTab>
     );
   }
 );
-
 const FloatingTabWrap = styled('li', {shouldForwardProp: tabsShouldForwardProp})<{
   overflowing: boolean;
 }>`


### PR DESCRIPTION
Fixes a non-visual issue where the tab `<li>` elements were not direct children of the tablist `<ul>` element. 

![image](https://github.com/user-attachments/assets/4563641f-d8c3-45ec-8d01-adb375ef4fd3)
