### PR TITLE
fix(issues): Avoid streamline issue layout rerenders

### DIFF
--- a/static/app/views/issueDetails/streamline/eventDetails.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetails.tsx
@@ -24,6 +24,7 @@ import {
 } from 'sentry/views/issueDetails/groupEventDetails/groupEventDetailsContent';
 import {
   EventDetailsContext,
+  useEventDetails,
   useEventDetailsReducer,
 } from 'sentry/views/issueDetails/streamline/context';
 import {EventGraph} from 'sentry/views/issueDetails/streamline/eventGraph';
@@ -124,12 +125,7 @@ export function EventDetails({
           message={t('There was an error loading the event content')}
         >
           <GroupContent>
-            <StickyEventNav
-              event={event}
-              group={group}
-              searchQuery={searchQuery}
-              dispatch={dispatch}
-            />
+            <StickyEventNav event={event} group={group} searchQuery={searchQuery} />
             <ContentPadding>
               <EventDetailsContent group={group} event={event} project={project} />
             </ContentPadding>
@@ -151,9 +147,7 @@ function StickyEventNav({
   event,
   group,
   searchQuery,
-  dispatch,
 }: {
-  dispatch: ReturnType<typeof useEventDetailsReducer>['dispatch'];
   event: Event;
   group: Group;
   searchQuery: string;
@@ -162,6 +156,7 @@ function StickyEventNav({
   const [nav, setNav] = useState<HTMLDivElement | null>(null);
   const isStuck = useIsStuck(nav);
   const isScreenMedium = useMedia(`(max-width: ${theme.breakpoints.medium})`);
+  const {dispatch} = useEventDetails();
 
   useLayoutEffect(() => {
     if (!nav) {

--- a/static/app/views/issueDetails/streamline/eventDetails.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetails.tsx
@@ -158,7 +158,11 @@ function StickyEventNav({
   const {dispatch} = useEventDetailsReducer();
 
   useLayoutEffect(() => {
-    const navHeight = nav?.offsetHeight ?? 0;
+    if (!nav) {
+      return;
+    }
+
+    const navHeight = nav.offsetHeight ?? 0;
     const sidebarHeight = isScreenMedium ? theme.sidebar.mobileHeightNumber : 0;
     dispatch({
       type: 'UPDATE_DETAILS',

--- a/static/app/views/issueDetails/streamline/eventDetails.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetails.tsx
@@ -124,7 +124,12 @@ export function EventDetails({
           message={t('There was an error loading the event content')}
         >
           <GroupContent>
-            <StickyEventNav event={event} group={group} searchQuery={searchQuery} />
+            <StickyEventNav
+              event={event}
+              group={group}
+              searchQuery={searchQuery}
+              dispatch={dispatch}
+            />
             <ContentPadding>
               <EventDetailsContent group={group} event={event} project={project} />
             </ContentPadding>
@@ -146,7 +151,9 @@ function StickyEventNav({
   event,
   group,
   searchQuery,
+  dispatch,
 }: {
+  dispatch: ReturnType<typeof useEventDetailsReducer>['dispatch'];
   event: Event;
   group: Group;
   searchQuery: string;
@@ -155,7 +162,6 @@ function StickyEventNav({
   const [nav, setNav] = useState<HTMLDivElement | null>(null);
   const isStuck = useIsStuck(nav);
   const isScreenMedium = useMedia(`(max-width: ${theme.breakpoints.medium})`);
-  const {dispatch} = useEventDetailsReducer();
 
   useLayoutEffect(() => {
     if (!nav) {


### PR DESCRIPTION
the page seems to rerender when scrolling the page due to setNav + isStuck triggering dispatch. by containing it in its own component we can avoid rerendering
