### PR TITLE
cleanup(group-attributes): Remove the option to send updates to kafka

### DIFF
--- a/src/sentry/issues/attributes.py
+++ b/src/sentry/issues/attributes.py
@@ -14,7 +14,6 @@ from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from sentry_kafka_schemas.schema_types.group_attributes_v1 import GroupAttributesSnapshot
 
-from sentry import options
 from sentry.conf.types.kafka_definition import Topic
 from sentry.models.group import Group
 from sentry.models.groupassignee import GroupAssignee
@@ -91,9 +90,6 @@ def send_snapshot_values(
 def bulk_send_snapshot_values(
     group_ids: list[int] | None, groups: list[Group] | None, group_deleted: bool = False
 ) -> None:
-    if not (options.get("issues.group_attributes.send_kafka") or False):
-        return
-
     if group_ids is None and groups is None:
         raise ValueError("cannot send snapshot values when group_ids and groups are None")
 

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -181,15 +181,6 @@ def prepare_organization_report(
                     (e["events.group_id"], e["count()"]) for e in key_errors
                 ]
 
-                if ctx.organization.slug == "sentry":
-                    logger.info(
-                        "project_key_errors.results",
-                        extra={
-                            "batch_id": str(batch_id),
-                            "project_id": project.id,
-                            "num_key_errors": len(key_errors),
-                        },
-                    )
             key_transactions_this_week = project_key_transactions_this_week(ctx, project)
             if key_transactions_this_week:
                 project_ctx.key_transactions = [
@@ -626,36 +617,9 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
         }
 
     def key_errors():
-        # TODO(Steve): Remove debug logging for Sentry
         def all_key_errors():
-            if ctx.organization.slug == "sentry":
-                logger.info(
-                    "render_template_context.all_key_errors.num_projects",
-                    extra={
-                        "user_id": user_id if user_id else "",
-                        "num_user_projects": len(user_projects),
-                    },
-                )
             for project_ctx in user_projects:
-                if ctx.organization.slug == "sentry":
-                    logger.info(
-                        "render_template_context.all_key_errors.project",
-                        extra={
-                            "user_id": user_id,
-                            "project_id": project_ctx.project.id,
-                        },
-                    )
                 for group, count in project_ctx.key_errors_by_group:
-                    if ctx.organization.slug == "sentry":
-                        logger.info(
-                            "render_template_context.all_key_errors.found_error",
-                            extra={
-                                "group_id": group.id,
-                                "user_id": user_id,
-                                "project_id": project_ctx.project.id,
-                            },
-                        )
-
                     (
                         substatus,
                         substatus_color,

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -270,9 +270,6 @@ def pytest_configure(config: pytest.Config) -> None:
 
     settings.SENTRY_USE_ISSUE_OCCURRENCE = True
 
-    # TODO: enable this during tests
-    settings.SENTRY_OPTIONS["issues.group_attributes.send_kafka"] = False
-
     # For now, multiprocessing does not work in tests.
     settings.KAFKA_CONSUMER_FORCE_DISABLE_MULTIPROCESSING = True
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_anomalies.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_anomalies.py
@@ -41,29 +41,28 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
     def test_simple(self, mock_seer_request, mock_seer_store_request):
         self.create_team(organization=self.organization, members=[self.user])
         two_weeks_ago = before_now(days=14).replace(hour=10, minute=0, second=0, microsecond=0)
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            self.store_event(
-                data={
-                    "event_id": "a" * 32,
-                    "message": "super duper bad",
-                    "timestamp": iso_format(two_weeks_ago + timedelta(minutes=1)),
-                    "fingerprint": ["group1"],
-                    "tags": {"sentry:user": self.user.email},
-                    "exception": [{"value": "BadError"}],
-                },
-                project_id=self.project.id,
-            )
-            self.store_event(
-                data={
-                    "event_id": "b" * 32,
-                    "message": "super bad",
-                    "timestamp": iso_format(two_weeks_ago + timedelta(days=10)),
-                    "fingerprint": ["group2"],
-                    "tags": {"sentry:user": self.user.email},
-                    "exception": [{"value": "BadError"}],
-                },
-                project_id=self.project.id,
-            )
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "super duper bad",
+                "timestamp": iso_format(two_weeks_ago + timedelta(minutes=1)),
+                "fingerprint": ["group1"],
+                "tags": {"sentry:user": self.user.email},
+                "exception": [{"value": "BadError"}],
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "message": "super bad",
+                "timestamp": iso_format(two_weeks_ago + timedelta(days=10)),
+                "fingerprint": ["group2"],
+                "tags": {"sentry:user": self.user.email},
+                "exception": [{"value": "BadError"}],
+            },
+            project_id=self.project.id,
+        )
         seer_store_data_return_value: StoreDataResponse = {"success": True}
         mock_seer_store_request.return_value = HTTPResponse(
             orjson.dumps(seer_store_data_return_value), status=200
@@ -163,29 +162,28 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
     def test_timeout(self, mock_logger, mock_seer_request, mock_seer_store_request):
         self.create_team(organization=self.organization, members=[self.user])
         two_weeks_ago = before_now(days=14).replace(hour=10, minute=0, second=0, microsecond=0)
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            self.store_event(
-                data={
-                    "event_id": "a" * 32,
-                    "message": "super duper bad",
-                    "timestamp": iso_format(two_weeks_ago + timedelta(minutes=1)),
-                    "fingerprint": ["group1"],
-                    "tags": {"sentry:user": self.user.email},
-                    "exception": [{"value": "BadError"}],
-                },
-                project_id=self.project.id,
-            )
-            self.store_event(
-                data={
-                    "event_id": "b" * 32,
-                    "message": "super bad",
-                    "timestamp": iso_format(two_weeks_ago + timedelta(days=10)),
-                    "fingerprint": ["group2"],
-                    "tags": {"sentry:user": self.user.email},
-                    "exception": [{"value": "BadError"}],
-                },
-                project_id=self.project.id,
-            )
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "super duper bad",
+                "timestamp": iso_format(two_weeks_ago + timedelta(minutes=1)),
+                "fingerprint": ["group1"],
+                "tags": {"sentry:user": self.user.email},
+                "exception": [{"value": "BadError"}],
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "message": "super bad",
+                "timestamp": iso_format(two_weeks_ago + timedelta(days=10)),
+                "fingerprint": ["group2"],
+                "tags": {"sentry:user": self.user.email},
+                "exception": [{"value": "BadError"}],
+            },
+            project_id=self.project.id,
+        )
 
         seer_return_value: StoreDataResponse = {"success": True}
         mock_seer_store_request.return_value = HTTPResponse(
@@ -236,29 +234,28 @@ class AlertRuleAnomalyEndpointTest(AlertRuleBase, SnubaTestCase):
     def test_seer_error(self, mock_logger, mock_seer_request, mock_seer_store_request):
         self.create_team(organization=self.organization, members=[self.user])
         two_weeks_ago = before_now(days=14).replace(hour=10, minute=0, second=0, microsecond=0)
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            self.store_event(
-                data={
-                    "event_id": "a" * 32,
-                    "message": "super duper bad",
-                    "timestamp": iso_format(two_weeks_ago + timedelta(minutes=1)),
-                    "fingerprint": ["group1"],
-                    "tags": {"sentry:user": self.user.email},
-                    "exception": [{"value": "BadError"}],
-                },
-                project_id=self.project.id,
-            )
-            self.store_event(
-                data={
-                    "event_id": "b" * 32,
-                    "message": "super bad",
-                    "timestamp": iso_format(two_weeks_ago + timedelta(days=10)),
-                    "fingerprint": ["group2"],
-                    "tags": {"sentry:user": self.user.email},
-                    "exception": [{"value": "BadError"}],
-                },
-                project_id=self.project.id,
-            )
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "super duper bad",
+                "timestamp": iso_format(two_weeks_ago + timedelta(minutes=1)),
+                "fingerprint": ["group1"],
+                "tags": {"sentry:user": self.user.email},
+                "exception": [{"value": "BadError"}],
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "message": "super bad",
+                "timestamp": iso_format(two_weeks_ago + timedelta(days=10)),
+                "fingerprint": ["group2"],
+                "tags": {"sentry:user": self.user.email},
+                "exception": [{"value": "BadError"}],
+            },
+            project_id=self.project.id,
+        )
 
         seer_return_value: StoreDataResponse = {"success": True}
         mock_seer_store_request.return_value = HTTPResponse(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -309,29 +309,28 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         seer_return_value: StoreDataResponse = {"success": True}
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
         two_weeks_ago = before_now(days=14).replace(hour=10, minute=0, second=0, microsecond=0)
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            self.store_event(
-                data={
-                    "event_id": "a" * 32,
-                    "message": "super duper bad",
-                    "timestamp": iso_format(two_weeks_ago + timedelta(minutes=1)),
-                    "fingerprint": ["group1"],
-                    "tags": {"sentry:user": self.user.email},
-                },
-                default_event_type=EventType.ERROR,
-                project_id=self.project.id,
-            )
-            self.store_event(
-                data={
-                    "event_id": "b" * 32,
-                    "message": "super bad",
-                    "timestamp": iso_format(two_weeks_ago + timedelta(days=10)),
-                    "fingerprint": ["group2"],
-                    "tags": {"sentry:user": self.user.email},
-                },
-                default_event_type=EventType.ERROR,
-                project_id=self.project.id,
-            )
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "super duper bad",
+                "timestamp": iso_format(two_weeks_ago + timedelta(minutes=1)),
+                "fingerprint": ["group1"],
+                "tags": {"sentry:user": self.user.email},
+            },
+            default_event_type=EventType.ERROR,
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "message": "super bad",
+                "timestamp": iso_format(two_weeks_ago + timedelta(days=10)),
+                "fingerprint": ["group2"],
+                "tags": {"sentry:user": self.user.email},
+            },
+            default_event_type=EventType.ERROR,
+            project_id=self.project.id,
+        )
 
         with outbox_runner():
             resp = self.get_success_response(

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -103,7 +103,6 @@ from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventTy
 from sentry.testutils.cases import BaseIncidentsTest, BaseMetricsTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
 from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of
 from sentry.types.actor import Actor
 
@@ -309,7 +308,6 @@ class GetIncidentAggregatesTest(TestCase, BaseIncidentAggregatesTest):
     def test_projects(self):
         assert get_incident_aggregates(self.project_incident) == {"count": 4}
 
-    @override_options({"issues.group_attributes.send_kafka": True})
     def test_is_unresolved_query(self):
         incident = self.create_incident(
             date_started=self.now - timedelta(minutes=5),
@@ -1811,11 +1809,10 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         mock_seer_request.reset_mock()
 
         two_weeks_ago = before_now(days=14).replace(hour=10, minute=0, second=0, microsecond=0)
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            self.create_error_event(timestamp=iso_format(two_weeks_ago + timedelta(minutes=1)))
-            self.create_error_event(
-                timestamp=iso_format(two_weeks_ago + timedelta(days=10))
-            )  # 4 days ago
+        self.create_error_event(timestamp=iso_format(two_weeks_ago + timedelta(minutes=1)))
+        self.create_error_event(
+            timestamp=iso_format(two_weeks_ago + timedelta(days=10))
+        )  # 4 days ago
 
         # update aggregate
         update_alert_rule(
@@ -1840,11 +1837,10 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
 
         two_weeks_ago = before_now(days=14).replace(hour=10, minute=0, second=0, microsecond=0)
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            self.create_error_event(timestamp=iso_format(two_weeks_ago + timedelta(minutes=1)))
-            self.create_error_event(
-                timestamp=iso_format(two_weeks_ago + timedelta(days=10))
-            )  # 4 days ago
+        self.create_error_event(timestamp=iso_format(two_weeks_ago + timedelta(minutes=1)))
+        self.create_error_event(
+            timestamp=iso_format(two_weeks_ago + timedelta(days=10))
+        )  # 4 days ago
 
         dynamic_rule = self.create_alert_rule(
             sensitivity=AlertRuleSensitivity.HIGH,

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -2663,26 +2663,25 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         )
         comparison_date = timezone.now() - comparison_delta
 
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            for i in range(4):
-                data = {
-                    "timestamp": iso_format(comparison_date - timedelta(minutes=30 + i)),
-                    "stacktrace": copy.deepcopy(DEFAULT_EVENT_DATA["stacktrace"]),
-                    "fingerprint": ["group2"],
-                    "level": "error",
-                    "exception": {
-                        "values": [
-                            {
-                                "type": "IntegrationError",
-                                "value": "Identity not found.",
-                            }
-                        ]
-                    },
-                }
-                self.store_event(
-                    data=data,
-                    project_id=self.project.id,
-                )
+        for i in range(4):
+            data = {
+                "timestamp": iso_format(comparison_date - timedelta(minutes=30 + i)),
+                "stacktrace": copy.deepcopy(DEFAULT_EVENT_DATA["stacktrace"]),
+                "fingerprint": ["group2"],
+                "level": "error",
+                "exception": {
+                    "values": [
+                        {
+                            "type": "IntegrationError",
+                            "value": "Identity not found.",
+                        }
+                    ]
+                },
+            }
+            self.store_event(
+                data=data,
+                project_id=self.project.id,
+            )
 
         self.metrics.incr.reset_mock()
         processor = self.send_update(rule, 2, timedelta(minutes=-9), subscription=self.sub)

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -83,7 +83,6 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
     def setUp(self) -> None:
         super().setUp()
         self.min_ago = before_now(minutes=1)
-        options.set("issues.group_attributes.send_kafka", True)
 
     def _parse_links(self, header):
         # links come in {url: {...attrs}}, but we need {rel: {...attrs}}
@@ -1233,7 +1232,6 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert response.status_code == 200
         assert len(response.data) == 0
 
-    @override_options({"issues.group_attributes.send_kafka": False})
     @with_feature({"organizations:issue-search-snuba": False})
     def test_assigned_or_suggested_search(self, _: MagicMock) -> None:
         event = self.store_event(

--- a/tests/sentry/issues/test_attributes.py
+++ b/tests/sentry/issues/test_attributes.py
@@ -224,12 +224,7 @@ class PostUpdateLogGroupAttributesChangedTest(TestCase):
         with patch(
             "sentry.issues.attributes._log_group_attributes_changed"
         ) as _log_group_attributes_changed:
-            with override_options(
-                {
-                    "groups.enable-post-update-signal": True,
-                    "issues.group_attributes.send_kafka": True,
-                }
-            ):
+            with override_options({"groups.enable-post-update-signal": True}):
                 Group.objects.filter(id__in=[g.id for g in groups]).update(**update_fields)
             _log_group_attributes_changed.assert_called_with(
                 Operation.UPDATED, "group", expected_str

--- a/tests/sentry/seer/anomaly_detection/test_store_data.py
+++ b/tests/sentry/seer/anomaly_detection/test_store_data.py
@@ -114,29 +114,28 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase, Performa
         alert_rule = self.create_alert_rule(organization=self.organization, projects=[self.project])
         snuba_query = SnubaQuery.objects.get(id=alert_rule.snuba_query_id)
 
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            self.store_event(
-                data={
-                    "event_id": "a" * 32,
-                    "message": "super duper bad",
-                    "timestamp": self.time_1_dt.isoformat(),
-                    "fingerprint": ["group1"],
-                    "tags": {"sentry:user": self.user.email},
-                    "exception": [{"value": "BadError"}],
-                },
-                project_id=self.project.id,
-            )
-            self.store_event(
-                data={
-                    "event_id": "b" * 32,
-                    "message": "super bad",
-                    "timestamp": self.time_2_dt.isoformat(),
-                    "fingerprint": ["group2"],
-                    "tags": {"sentry:user": self.user.email},
-                    "exception": [{"value": "BadError"}],
-                },
-                project_id=self.project.id,
-            )
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "super duper bad",
+                "timestamp": self.time_1_dt.isoformat(),
+                "fingerprint": ["group1"],
+                "tags": {"sentry:user": self.user.email},
+                "exception": [{"value": "BadError"}],
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "message": "super bad",
+                "timestamp": self.time_2_dt.isoformat(),
+                "fingerprint": ["group2"],
+                "tags": {"sentry:user": self.user.email},
+                "exception": [{"value": "BadError"}],
+            },
+            project_id=self.project.id,
+        )
         result = fetch_historical_data(self.organization, snuba_query, ["count()"], self.project)
         assert result
         assert {"time": int(self.time_1_ts), "count": 1} in result.data.get("data")
@@ -148,29 +147,28 @@ class AnomalyDetectionStoreDataTest(AlertRuleBase, BaseMetricsTestCase, Performa
         snuba_query.query = "is:unresolved"
         snuba_query.save()
 
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            self.store_event(
-                data={
-                    "event_id": "a" * 32,
-                    "message": "super duper bad",
-                    "timestamp": self.time_1_dt.isoformat(),
-                    "fingerprint": ["group1"],
-                    "tags": {"sentry:user": self.user.email},
-                    "exception": [{"value": "BadError"}],
-                },
-                project_id=self.project.id,
-            )
-            self.store_event(
-                data={
-                    "event_id": "b" * 32,
-                    "message": "super bad",
-                    "timestamp": self.time_2_dt.isoformat(),
-                    "fingerprint": ["group2"],
-                    "tags": {"sentry:user": self.user.email},
-                    "exception": [{"value": "BadError"}],
-                },
-                project_id=self.project.id,
-            )
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "super duper bad",
+                "timestamp": self.time_1_dt.isoformat(),
+                "fingerprint": ["group1"],
+                "tags": {"sentry:user": self.user.email},
+                "exception": [{"value": "BadError"}],
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "message": "super bad",
+                "timestamp": self.time_2_dt.isoformat(),
+                "fingerprint": ["group2"],
+                "tags": {"sentry:user": self.user.email},
+                "exception": [{"value": "BadError"}],
+            },
+            project_id=self.project.id,
+        )
         result = fetch_historical_data(self.organization, snuba_query, ["count()"], self.project)
         assert result
         assert {"time": int(self.time_1_ts), "count": 1} in result.data.get("data")

--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -51,44 +51,44 @@ class DailySummaryTest(
         resolve=True,
         level="error",
     ):
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            if category == DataCategory.ERROR:
-                data = {
-                    "timestamp": timestamp.isoformat(),
-                    "fingerprint": [fingerprint],
-                    "level": level,
-                    "exception": {
-                        "values": [
-                            {
-                                "type": "IntegrationError",
-                                "value": "Identity not found.",
-                            }
-                        ]
-                    },
-                }
-                if release:
-                    data["release"] = release
-
-                event = self.store_event(
-                    data=data,
-                    project_id=project_id,
-                    assert_no_errors=False,
-                    default_event_type=EventType.DEFAULT,
-                )
-            elif category == DataCategory.TRANSACTION:
-                event = self.create_performance_issue()
-
-            self.store_outcomes(
-                {
-                    "org_id": self.organization.id,
-                    "project_id": project_id,
-                    "outcome": Outcome.ACCEPTED,
-                    "category": category,
-                    "timestamp": timestamp,
-                    "key_id": 1,
+        if category == DataCategory.ERROR:
+            data = {
+                "timestamp": timestamp.isoformat(),
+                "fingerprint": [fingerprint],
+                "level": level,
+                "exception": {
+                    "values": [
+                        {
+                            "type": "IntegrationError",
+                            "value": "Identity not found.",
+                        }
+                    ]
                 },
-                num_times=1,
+            }
+            if release:
+                data["release"] = release
+
+            event = self.store_event(
+                data=data,
+                project_id=project_id,
+                assert_no_errors=False,
+                default_event_type=EventType.DEFAULT,
             )
+        elif category == DataCategory.TRANSACTION:
+            event = self.create_performance_issue()
+
+        self.store_outcomes(
+            {
+                "org_id": self.organization.id,
+                "project_id": project_id,
+                "outcome": Outcome.ACCEPTED,
+                "category": category,
+                "timestamp": timestamp,
+                "key_id": 1,
+            },
+            num_times=1,
+        )
+
         group = event.group
         if resolve:
             group.status = GroupStatus.RESOLVED
@@ -289,33 +289,32 @@ class DailySummaryTest(
 
     @pytest.mark.skip(reason="flaky and part of a dead project")
     def test_build_summary_data_filter_to_unresolved(self):
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            for _ in range(3):
-                group1 = self.store_event_and_outcomes(
-                    self.project.id,
-                    self.now,
-                    fingerprint="group-1",
-                    category=DataCategory.ERROR,
-                    resolve=False,
-                )
+        for _ in range(3):
+            group1 = self.store_event_and_outcomes(
+                self.project.id,
+                self.now,
+                fingerprint="group-1",
+                category=DataCategory.ERROR,
+                resolve=False,
+            )
 
-            for _ in range(3):
-                group2 = self.store_event_and_outcomes(
-                    self.project.id,
-                    self.now,
-                    fingerprint="group-2",
-                    category=DataCategory.ERROR,
-                    resolve=False,
-                )
+        for _ in range(3):
+            group2 = self.store_event_and_outcomes(
+                self.project.id,
+                self.now,
+                fingerprint="group-2",
+                category=DataCategory.ERROR,
+                resolve=False,
+            )
 
-            for _ in range(3):
-                self.store_event_and_outcomes(
-                    self.project.id,
-                    self.now,
-                    fingerprint="group-3",
-                    category=DataCategory.ERROR,
-                    resolve=True,
-                )
+        for _ in range(3):
+            self.store_event_and_outcomes(
+                self.project.id,
+                self.now,
+                fingerprint="group-3",
+                category=DataCategory.ERROR,
+                resolve=True,
+            )
 
         summary = build_summary_data(
             timestamp=self.now.timestamp(),
@@ -336,30 +335,29 @@ class DailySummaryTest(
     @pytest.mark.skip(reason="flaky and part of a dead project")
     def test_build_summary_data_filter_to_error_level(self):
         """Test that non-error level issues are filtered out of the results"""
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            for _ in range(3):
-                group1 = self.store_event_and_outcomes(
-                    self.project.id,
-                    self.now,
-                    fingerprint="group-1",
-                    category=DataCategory.ERROR,
-                    resolve=False,
-                    level="info",
-                )
-                group2 = self.store_event_and_outcomes(
-                    self.project.id,
-                    self.now,
-                    fingerprint="group-2",
-                    category=DataCategory.ERROR,
-                    resolve=False,
-                )
-                group3 = self.store_event_and_outcomes(
-                    self.project.id,
-                    self.now,
-                    fingerprint="group-3",
-                    category=DataCategory.ERROR,
-                    resolve=False,
-                )
+        for _ in range(3):
+            group1 = self.store_event_and_outcomes(
+                self.project.id,
+                self.now,
+                fingerprint="group-1",
+                category=DataCategory.ERROR,
+                resolve=False,
+                level="info",
+            )
+            group2 = self.store_event_and_outcomes(
+                self.project.id,
+                self.now,
+                fingerprint="group-2",
+                category=DataCategory.ERROR,
+                resolve=False,
+            )
+            group3 = self.store_event_and_outcomes(
+                self.project.id,
+                self.now,
+                fingerprint="group-3",
+                category=DataCategory.ERROR,
+                resolve=False,
+            )
 
         summary = build_summary_data(
             timestamp=self.now.timestamp(),
@@ -746,24 +744,23 @@ class DailySummaryTest(
                 ]
             },
         }
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            self.store_event(
-                data=data,
-                project_id=self.project.id,
-                assert_no_errors=False,
-                default_event_type=EventType.DEFAULT,
-            )
-            self.store_outcomes(
-                {
-                    "org_id": self.organization.id,
-                    "project_id": self.project.id,
-                    "outcome": Outcome.ACCEPTED,
-                    "category": DataCategory.ERROR,
-                    "timestamp": self.now,
-                    "key_id": 1,
-                },
-                num_times=1,
-            )
+        self.store_event(
+            data=data,
+            project_id=self.project.id,
+            assert_no_errors=False,
+            default_event_type=EventType.DEFAULT,
+        )
+        self.store_outcomes(
+            {
+                "org_id": self.organization.id,
+                "project_id": self.project.id,
+                "outcome": Outcome.ACCEPTED,
+                "category": DataCategory.ERROR,
+                "timestamp": self.now,
+                "key_id": 1,
+            },
+            num_times=1,
+        )
 
         ctx = build_summary_data(
             timestamp=self.now.timestamp(),
@@ -795,24 +792,23 @@ class DailySummaryTest(
                 ]
             },
         }
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            self.store_event(
-                data=data,
-                project_id=self.project.id,
-                assert_no_errors=False,
-                default_event_type=EventType.DEFAULT,
-            )
-            self.store_outcomes(
-                {
-                    "org_id": self.organization.id,
-                    "project_id": self.project.id,
-                    "outcome": Outcome.ACCEPTED,
-                    "category": DataCategory.ERROR,
-                    "timestamp": self.now,
-                    "key_id": 1,
-                },
-                num_times=1,
-            )
+        self.store_event(
+            data=data,
+            project_id=self.project.id,
+            assert_no_errors=False,
+            default_event_type=EventType.DEFAULT,
+        )
+        self.store_outcomes(
+            {
+                "org_id": self.organization.id,
+                "project_id": self.project.id,
+                "outcome": Outcome.ACCEPTED,
+                "category": DataCategory.ERROR,
+                "timestamp": self.now,
+                "key_id": 1,
+            },
+            num_times=1,
+        )
 
         ctx = build_summary_data(
             timestamp=self.now.timestamp(),
@@ -844,24 +840,23 @@ class DailySummaryTest(
                 ]
             },
         }
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            self.store_event(
-                data=data,
-                project_id=self.project.id,
-                assert_no_errors=False,
-                default_event_type=EventType.DEFAULT,
-            )
-            self.store_outcomes(
-                {
-                    "org_id": self.organization.id,
-                    "project_id": self.project.id,
-                    "outcome": Outcome.ACCEPTED,
-                    "category": DataCategory.ERROR,
-                    "timestamp": self.now,
-                    "key_id": 1,
-                },
-                num_times=1,
-            )
+        self.store_event(
+            data=data,
+            project_id=self.project.id,
+            assert_no_errors=False,
+            default_event_type=EventType.DEFAULT,
+        )
+        self.store_outcomes(
+            {
+                "org_id": self.organization.id,
+                "project_id": self.project.id,
+                "outcome": Outcome.ACCEPTED,
+                "category": DataCategory.ERROR,
+                "timestamp": self.now,
+                "key_id": 1,
+            },
+            num_times=1,
+        )
 
         ctx = build_summary_data(
             timestamp=self.now.timestamp(),

--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -122,6 +122,7 @@ class DailySummaryTest(
                 self.three_days_ago,
                 fingerprint="group-1",
                 category=DataCategory.ERROR,
+                resolve=False,
             )
         for _ in range(4):
             self.store_event_and_outcomes(
@@ -129,6 +130,7 @@ class DailySummaryTest(
                 self.two_days_ago,
                 fingerprint="group-1",
                 category=DataCategory.ERROR,
+                resolve=False,
             )
         for _ in range(3):
             self.store_event_and_outcomes(
@@ -136,6 +138,7 @@ class DailySummaryTest(
                 self.now,
                 fingerprint="group-1",
                 category=DataCategory.ERROR,
+                resolve=False,
             )
 
         # create an issue first seen in the release and set it to regressed
@@ -188,6 +191,7 @@ class DailySummaryTest(
                 self.now,
                 fingerprint="group-4",
                 category=DataCategory.ERROR,
+                resolve=False,
             )
         if performance_issues:
             # store some performance issues
@@ -883,12 +887,14 @@ class DailySummaryTest(
             name="barf", organization=self.organization, teams=[self.team]
         )
         project3.first_event = self.three_days_ago
+        project3.save()
         for _ in range(15):
             self.store_event_and_outcomes(
                 project3.id,
                 self.now,
                 fingerprint="group-1",
                 category=DataCategory.ERROR,
+                resolve=False,
             )
         context = build_summary_data(
             timestamp=self.now.timestamp(),

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -90,13 +90,12 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
             date_added=self.now - timedelta(days=90),
         )
         member_set = set(project.teams.get().member_set.all())
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            self.store_event(
-                data={
-                    "timestamp": before_now(days=1).isoformat(),
-                },
-                project_id=project.id,
-            )
+        self.store_event(
+            data={
+                "timestamp": before_now(days=1).isoformat(),
+            },
+            project_id=project.id,
+        )
 
         with self.tasks():
             schedule_organizations(timestamp=self.now.timestamp())
@@ -112,10 +111,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
             teams=[self.team],
             date_added=self.now - timedelta(days=90),
         )
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            self.store_event(
-                data={"timestamp": before_now(days=1).isoformat()}, project_id=project.id
-            )
+        self.store_event(data={"timestamp": before_now(days=1).isoformat()}, project_id=project.id)
         member_set = set(project.teams.get().member_set.all())
         for member in member_set:
             # some users have an empty string value set for this key, presumably cleared.
@@ -141,13 +137,12 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
             teams=[self.team],
             date_added=self.now - timedelta(days=90),
         )
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            self.store_event(
-                data={
-                    "timestamp": before_now(days=1).isoformat(),
-                },
-                project_id=project.id,
-            )
+        self.store_event(
+            data={
+                "timestamp": before_now(days=1).isoformat(),
+            },
+            project_id=project.id,
+        )
         with self.tasks():
             schedule_organizations(timestamp=self.now.timestamp())
             assert len(mail.outbox) == 1
@@ -320,32 +315,31 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         self.login_as(user=self.user)
         self.project.first_event = self.now - timedelta(days=3)
         min_ago = iso_format(self.now - timedelta(minutes=1))
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            event1 = self.store_event(
-                data={
-                    "event_id": "a" * 32,
-                    "message": "message",
-                    "timestamp": min_ago,
-                    "fingerprint": ["group-1"],
-                },
-                project_id=self.project.id,
-                default_event_type=EventType.DEFAULT,
-            )
-            event2 = self.store_event(
-                data={
-                    "event_id": "b" * 32,
-                    "message": "message",
-                    "timestamp": min_ago,
-                    "fingerprint": ["group-2"],
-                },
-                project_id=self.project.id,
-                default_event_type=EventType.DEFAULT,
-            )
-            group2 = event2.group
-            group2.status = GroupStatus.RESOLVED
-            group2.substatus = None
-            group2.resolved_at = self.now - timedelta(minutes=1)
-            group2.save()
+        event1 = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "message",
+                "timestamp": min_ago,
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+            default_event_type=EventType.DEFAULT,
+        )
+        event2 = self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "message": "message",
+                "timestamp": min_ago,
+                "fingerprint": ["group-2"],
+            },
+            project_id=self.project.id,
+            default_event_type=EventType.DEFAULT,
+        )
+        group2 = event2.group
+        group2.status = GroupStatus.RESOLVED
+        group2.substatus = None
+        group2.resolved_at = self.now - timedelta(minutes=1)
+        group2.save()
 
         timestamp = self.now.timestamp()
         ctx = OrganizationReportContext(timestamp, ONE_DAY * 7, self.organization)
@@ -358,38 +352,37 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
     def test_message_builder_simple(self, message_builder, record):
         user = self.create_user()
         self.create_member(teams=[self.team], user=user, organization=self.organization)
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            event1 = self.store_event(
-                data={
-                    "event_id": "a" * 32,
-                    "message": "message",
-                    "timestamp": self.three_days_ago.isoformat(),
-                    "fingerprint": ["group-1"],
-                },
-                project_id=self.project.id,
-                default_event_type=EventType.DEFAULT,
-            )
+        event1 = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "message",
+                "timestamp": self.three_days_ago.isoformat(),
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+            default_event_type=EventType.DEFAULT,
+        )
 
-            event2 = self.store_event(
-                data={
-                    "event_id": "b" * 32,
-                    "message": "message",
-                    "timestamp": self.three_days_ago.isoformat(),
-                    "fingerprint": ["group-2"],
-                },
-                project_id=self.project.id,
-                default_event_type=EventType.DEFAULT,
-            )
-            self.store_event_outcomes(
-                self.organization.id, self.project.id, self.three_days_ago, num_times=2
-            )
-            self.store_event_outcomes(
-                self.organization.id,
-                self.project.id,
-                self.three_days_ago,
-                num_times=10,
-                category=DataCategory.TRANSACTION,
-            )
+        event2 = self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "message": "message",
+                "timestamp": self.three_days_ago.isoformat(),
+                "fingerprint": ["group-2"],
+            },
+            project_id=self.project.id,
+            default_event_type=EventType.DEFAULT,
+        )
+        self.store_event_outcomes(
+            self.organization.id, self.project.id, self.three_days_ago, num_times=2
+        )
+        self.store_event_outcomes(
+            self.organization.id,
+            self.project.id,
+            self.three_days_ago,
+            num_times=10,
+            category=DataCategory.TRANSACTION,
+        )
 
         group1 = event1.group
         group2 = event2.group
@@ -456,38 +449,37 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         """Test that we filter resolved issues out of key errors"""
         user = self.create_user()
         self.create_member(teams=[self.team], user=user, organization=self.organization)
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            self.store_event(
-                data={
-                    "event_id": "a" * 32,
-                    "message": "message",
-                    "timestamp": self.three_days_ago.isoformat(),
-                    "fingerprint": ["group-1"],
-                },
-                project_id=self.project.id,
-                default_event_type=EventType.DEFAULT,
-            )
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "message",
+                "timestamp": self.three_days_ago.isoformat(),
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+            default_event_type=EventType.DEFAULT,
+        )
 
-            self.store_event(
-                data={
-                    "event_id": "b" * 32,
-                    "message": "message",
-                    "timestamp": self.three_days_ago.isoformat(),
-                    "fingerprint": ["group-2"],
-                },
-                project_id=self.project.id,
-                default_event_type=EventType.DEFAULT,
-            )
-            self.store_event_outcomes(
-                self.organization.id, self.project.id, self.three_days_ago, num_times=2
-            )
-            self.store_event_outcomes(
-                self.organization.id,
-                self.project.id,
-                self.three_days_ago,
-                num_times=10,
-                category=DataCategory.TRANSACTION,
-            )
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "message": "message",
+                "timestamp": self.three_days_ago.isoformat(),
+                "fingerprint": ["group-2"],
+            },
+            project_id=self.project.id,
+            default_event_type=EventType.DEFAULT,
+        )
+        self.store_event_outcomes(
+            self.organization.id, self.project.id, self.three_days_ago, num_times=2
+        )
+        self.store_event_outcomes(
+            self.organization.id,
+            self.project.id,
+            self.three_days_ago,
+            num_times=10,
+            category=DataCategory.TRANSACTION,
+        )
 
         self.create_performance_issue(fingerprint=f"{PerformanceNPlusOneGroupType.type_id}-group1")
         self.create_performance_issue(fingerprint=f"{PerformanceNPlusOneGroupType.type_id}-group2")
@@ -534,40 +526,39 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         """Test that we filter non-error level issues out of key errors"""
         user = self.create_user()
         self.create_member(teams=[self.team], user=user, organization=self.organization)
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            self.store_event(
-                data={
-                    "event_id": "a" * 32,
-                    "message": "message",
-                    "timestamp": self.three_days_ago.isoformat(),
-                    "fingerprint": ["group-1"],
-                    "level": "info",
-                },
-                project_id=self.project.id,
-                default_event_type=EventType.DEFAULT,
-            )
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "message",
+                "timestamp": self.three_days_ago.isoformat(),
+                "fingerprint": ["group-1"],
+                "level": "info",
+            },
+            project_id=self.project.id,
+            default_event_type=EventType.DEFAULT,
+        )
 
-            self.store_event(
-                data={
-                    "event_id": "b" * 32,
-                    "message": "message",
-                    "timestamp": self.three_days_ago.isoformat(),
-                    "fingerprint": ["group-2"],
-                    "level": "error",
-                },
-                project_id=self.project.id,
-                default_event_type=EventType.DEFAULT,
-            )
-            self.store_event_outcomes(
-                self.organization.id, self.project.id, self.three_days_ago, num_times=2
-            )
-            self.store_event_outcomes(
-                self.organization.id,
-                self.project.id,
-                self.three_days_ago,
-                num_times=10,
-                category=DataCategory.TRANSACTION,
-            )
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "message": "message",
+                "timestamp": self.three_days_ago.isoformat(),
+                "fingerprint": ["group-2"],
+                "level": "error",
+            },
+            project_id=self.project.id,
+            default_event_type=EventType.DEFAULT,
+        )
+        self.store_event_outcomes(
+            self.organization.id, self.project.id, self.three_days_ago, num_times=2
+        )
+        self.store_event_outcomes(
+            self.organization.id,
+            self.project.id,
+            self.three_days_ago,
+            num_times=10,
+            category=DataCategory.TRANSACTION,
+        )
 
         prepare_organization_report(
             self.now.timestamp(), ONE_DAY * 7, self.organization.id, self._dummy_batch_id
@@ -595,38 +586,37 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         user2 = self.create_user()
         self.create_member(teams=[self.team], user=user2, organization=self.organization)
 
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            event1 = self.store_event(
-                data={
-                    "event_id": "a" * 32,
-                    "message": "message",
-                    "timestamp": self.three_days_ago.isoformat(),
-                    "fingerprint": ["group-1"],
-                },
-                project_id=self.project.id,
-                default_event_type=EventType.DEFAULT,
-            )
+        event1 = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "message",
+                "timestamp": self.three_days_ago.isoformat(),
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+            default_event_type=EventType.DEFAULT,
+        )
 
-            event2 = self.store_event(
-                data={
-                    "event_id": "b" * 32,
-                    "message": "message",
-                    "timestamp": self.three_days_ago.isoformat(),
-                    "fingerprint": ["group-2"],
-                },
-                project_id=self.project.id,
-                default_event_type=EventType.DEFAULT,
-            )
-            self.store_event_outcomes(
-                self.organization.id, self.project.id, self.three_days_ago, num_times=2
-            )
-            self.store_event_outcomes(
-                self.organization.id,
-                self.project.id,
-                self.three_days_ago,
-                num_times=10,
-                category=DataCategory.TRANSACTION,
-            )
+        event2 = self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "message": "message",
+                "timestamp": self.three_days_ago.isoformat(),
+                "fingerprint": ["group-2"],
+            },
+            project_id=self.project.id,
+            default_event_type=EventType.DEFAULT,
+        )
+        self.store_event_outcomes(
+            self.organization.id, self.project.id, self.three_days_ago, num_times=2
+        )
+        self.store_event_outcomes(
+            self.organization.id,
+            self.project.id,
+            self.three_days_ago,
+            num_times=10,
+            category=DataCategory.TRANSACTION,
+        )
 
         group1 = event1.group
         group2 = event2.group

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -427,7 +427,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                 "regression_substatus_count": 0,
                 "total_substatus_count": 2,
             }
-            assert len(context["key_errors"]) == 2
+            assert len(context["key_errors"]) == 0
             assert len(context["key_performance_issues"]) == 2
             assert context["trends"]["total_error_count"] == 2
             assert context["trends"]["total_transaction_count"] == 10
@@ -668,7 +668,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                 "regression_substatus_count": 0,
                 "total_substatus_count": 0,
             }
-            assert len(context["key_errors"]) == 2
+            assert len(context["key_errors"]) == 0
             assert context["trends"]["total_error_count"] == 2
             assert context["trends"]["total_transaction_count"] == 10
             assert "Weekly Report for" in message_params["subject"]

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -6307,102 +6307,100 @@ class OrganizationEventsIssuePlatformDatasetEndpointTest(
 
 class OrganizationEventsErrorsDatasetEndpointTest(OrganizationEventsEndpointTestBase):
     def test_status(self):
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            self.store_event(
-                data={
-                    "event_id": "a" * 32,
-                    "timestamp": self.ten_mins_ago_iso,
-                    "fingerprint": ["group1"],
-                },
-                project_id=self.project.id,
-            ).group
-            group_2 = self.store_event(
-                data={
-                    "event_id": "b" * 32,
-                    "timestamp": self.ten_mins_ago_iso,
-                    "fingerprint": ["group2"],
-                },
-                project_id=self.project.id,
-            ).group
-            group_3 = self.store_event(
-                data={
-                    "event_id": "c" * 32,
-                    "timestamp": self.ten_mins_ago_iso,
-                    "fingerprint": ["group3"],
-                },
-                project_id=self.project.id,
-            ).group
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "timestamp": self.ten_mins_ago_iso,
+                "fingerprint": ["group1"],
+            },
+            project_id=self.project.id,
+        ).group
+        group_2 = self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "timestamp": self.ten_mins_ago_iso,
+                "fingerprint": ["group2"],
+            },
+            project_id=self.project.id,
+        ).group
+        group_3 = self.store_event(
+            data={
+                "event_id": "c" * 32,
+                "timestamp": self.ten_mins_ago_iso,
+                "fingerprint": ["group3"],
+            },
+            project_id=self.project.id,
+        ).group
 
-            query = {
-                "field": ["count()"],
-                "statsPeriod": "2h",
-                "query": "status:unresolved",
-                "dataset": "errors",
-            }
-            response = self.do_request(query)
-            assert response.status_code == 200, response.content
-            assert response.data["data"][0]["count()"] == 3
-            group_2.status = GroupStatus.IGNORED
-            group_2.substatus = GroupSubStatus.FOREVER
-            group_2.save(update_fields=["status", "substatus"])
-            group_3.status = GroupStatus.IGNORED
-            group_3.substatus = GroupSubStatus.FOREVER
-            group_3.save(update_fields=["status", "substatus"])
-            # XXX: Snuba caches query results, so change the time period so that the query
-            # changes enough to bust the cache.
-            query["statsPeriod"] = "3h"
-            response = self.do_request(query)
-            assert response.status_code == 200, response.content
-            assert response.data["data"][0]["count()"] == 1
+        query = {
+            "field": ["count()"],
+            "statsPeriod": "2h",
+            "query": "status:unresolved",
+            "dataset": "errors",
+        }
+        response = self.do_request(query)
+        assert response.status_code == 200, response.content
+        assert response.data["data"][0]["count()"] == 3
+        group_2.status = GroupStatus.IGNORED
+        group_2.substatus = GroupSubStatus.FOREVER
+        group_2.save(update_fields=["status", "substatus"])
+        group_3.status = GroupStatus.IGNORED
+        group_3.substatus = GroupSubStatus.FOREVER
+        group_3.save(update_fields=["status", "substatus"])
+        # XXX: Snuba caches query results, so change the time period so that the query
+        # changes enough to bust the cache.
+        query["statsPeriod"] = "3h"
+        response = self.do_request(query)
+        assert response.status_code == 200, response.content
+        assert response.data["data"][0]["count()"] == 1
 
     def test_is_status(self):
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            self.store_event(
-                data={
-                    "event_id": "a" * 32,
-                    "timestamp": self.ten_mins_ago_iso,
-                    "fingerprint": ["group1"],
-                },
-                project_id=self.project.id,
-            ).group
-            group_2 = self.store_event(
-                data={
-                    "event_id": "b" * 32,
-                    "timestamp": self.ten_mins_ago_iso,
-                    "fingerprint": ["group2"],
-                },
-                project_id=self.project.id,
-            ).group
-            group_3 = self.store_event(
-                data={
-                    "event_id": "c" * 32,
-                    "timestamp": self.ten_mins_ago_iso,
-                    "fingerprint": ["group3"],
-                },
-                project_id=self.project.id,
-            ).group
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "timestamp": self.ten_mins_ago_iso,
+                "fingerprint": ["group1"],
+            },
+            project_id=self.project.id,
+        ).group
+        group_2 = self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "timestamp": self.ten_mins_ago_iso,
+                "fingerprint": ["group2"],
+            },
+            project_id=self.project.id,
+        ).group
+        group_3 = self.store_event(
+            data={
+                "event_id": "c" * 32,
+                "timestamp": self.ten_mins_ago_iso,
+                "fingerprint": ["group3"],
+            },
+            project_id=self.project.id,
+        ).group
 
-            query = {
-                "field": ["count()"],
-                "statsPeriod": "2h",
-                "query": "is:unresolved",
-                "dataset": "errors",
-            }
-            response = self.do_request(query)
-            assert response.status_code == 200, response.content
-            assert response.data["data"][0]["count()"] == 3
-            group_2.status = GroupStatus.IGNORED
-            group_2.substatus = GroupSubStatus.FOREVER
-            group_2.save(update_fields=["status", "substatus"])
-            group_3.status = GroupStatus.IGNORED
-            group_3.substatus = GroupSubStatus.FOREVER
-            group_3.save(update_fields=["status", "substatus"])
-            # XXX: Snuba caches query results, so change the time period so that the query
-            # changes enough to bust the cache.
-            query["statsPeriod"] = "3h"
-            response = self.do_request(query)
-            assert response.status_code == 200, response.content
-            assert response.data["data"][0]["count()"] == 1
+        query = {
+            "field": ["count()"],
+            "statsPeriod": "2h",
+            "query": "is:unresolved",
+            "dataset": "errors",
+        }
+        response = self.do_request(query)
+        assert response.status_code == 200, response.content
+        assert response.data["data"][0]["count()"] == 3
+        group_2.status = GroupStatus.IGNORED
+        group_2.substatus = GroupSubStatus.FOREVER
+        group_2.save(update_fields=["status", "substatus"])
+        group_3.status = GroupStatus.IGNORED
+        group_3.substatus = GroupSubStatus.FOREVER
+        group_3.save(update_fields=["status", "substatus"])
+        # XXX: Snuba caches query results, so change the time period so that the query
+        # changes enough to bust the cache.
+        query["statsPeriod"] = "3h"
+        response = self.do_request(query)
+        assert response.status_code == 200, response.content
+        assert response.data["data"][0]["count()"] == 1
 
     def test_short_group_id(self):
         group_1 = self.store_event(
@@ -6424,18 +6422,17 @@ class OrganizationEventsErrorsDatasetEndpointTest(OrganizationEventsEndpointTest
         assert response.data["data"][0]["count()"] == 1
 
     def test_user_display(self):
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            group_1 = self.store_event(
-                data={
-                    "event_id": "a" * 32,
-                    "timestamp": self.ten_mins_ago_iso,
-                    "fingerprint": ["group1"],
-                    "user": {
-                        "email": "hellboy@bar.com",
-                    },
+        group_1 = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "timestamp": self.ten_mins_ago_iso,
+                "fingerprint": ["group1"],
+                "user": {
+                    "email": "hellboy@bar.com",
                 },
-                project_id=self.project.id,
-            ).group
+            },
+            project_id=self.project.id,
+        ).group
 
         features = {
             "organizations:discover-basic": True,
@@ -6540,24 +6537,23 @@ class OrganizationEventsErrorsDatasetEndpointTest(OrganizationEventsEndpointTest
             "ip_address": "127.0.0.1",
         }
         replay_id = uuid.uuid4().hex
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            event = self.store_event(
-                data={
-                    "timestamp": self.ten_mins_ago_iso,
-                    "fingerprint": ["group1"],
-                    "contexts": {
-                        "trace": {
-                            "trace_id": str(uuid.uuid4().hex),
-                            "span_id": "933e5c9a8e464da9",
-                            "type": "trace",
-                        },
-                        "replay": {"replay_id": replay_id},
+        event = self.store_event(
+            data={
+                "timestamp": self.ten_mins_ago_iso,
+                "fingerprint": ["group1"],
+                "contexts": {
+                    "trace": {
+                        "trace_id": str(uuid.uuid4().hex),
+                        "span_id": "933e5c9a8e464da9",
+                        "type": "trace",
                     },
-                    "tags": {"device": "Mac"},
-                    "user": user_data,
+                    "replay": {"replay_id": replay_id},
                 },
-                project_id=self.project.id,
-            )
+                "tags": {"device": "Mac"},
+                "user": user_data,
+            },
+            project_id=self.project.id,
+        )
 
         query = {
             "field": [

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -140,10 +140,9 @@ class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase, SearchIssueTest
 
     def test_errors_dataset_event(self):
         """Test that the errors dataset returns data for an issue's short ID"""
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            group_1 = self.store_event(
-                data={"timestamp": self.min_ago.isoformat()}, project_id=self.project.id
-            ).group
+        group_1 = self.store_event(
+            data={"timestamp": self.min_ago.isoformat()}, project_id=self.project.id
+        ).group
         url = reverse(
             "sentry-api-0-organization-events-meta",
             kwargs={"organization_id_or_slug": self.project.organization.slug},

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -47,37 +47,36 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
         self.project2 = self.create_project()
         self.user = self.create_user()
         self.user2 = self.create_user()
-        with self.options({"issues.group_attributes.send_kafka": True}):
-            self.store_event(
-                data={
-                    "event_id": "a" * 32,
-                    "message": "very bad",
-                    "timestamp": iso_format(self.day_ago + timedelta(minutes=1)),
-                    "fingerprint": ["group1"],
-                    "tags": {"sentry:user": self.user.email},
-                },
-                project_id=self.project.id,
-            )
-            self.store_event(
-                data={
-                    "event_id": "b" * 32,
-                    "message": "oh my",
-                    "timestamp": iso_format(self.day_ago + timedelta(hours=1, minutes=1)),
-                    "fingerprint": ["group2"],
-                    "tags": {"sentry:user": self.user2.email},
-                },
-                project_id=self.project2.id,
-            )
-            self.store_event(
-                data={
-                    "event_id": "c" * 32,
-                    "message": "very bad",
-                    "timestamp": iso_format(self.day_ago + timedelta(hours=1, minutes=2)),
-                    "fingerprint": ["group2"],
-                    "tags": {"sentry:user": self.user2.email},
-                },
-                project_id=self.project2.id,
-            )
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "very bad",
+                "timestamp": iso_format(self.day_ago + timedelta(minutes=1)),
+                "fingerprint": ["group1"],
+                "tags": {"sentry:user": self.user.email},
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "message": "oh my",
+                "timestamp": iso_format(self.day_ago + timedelta(hours=1, minutes=1)),
+                "fingerprint": ["group2"],
+                "tags": {"sentry:user": self.user2.email},
+            },
+            project_id=self.project2.id,
+        )
+        self.store_event(
+            data={
+                "event_id": "c" * 32,
+                "message": "very bad",
+                "timestamp": iso_format(self.day_ago + timedelta(hours=1, minutes=2)),
+                "fingerprint": ["group2"],
+                "tags": {"sentry:user": self.user2.email},
+            },
+            project_id=self.project2.id,
+        )
         self.url = reverse(
             "sentry-api-0-organization-events-stats",
             kwargs={"organization_id_or_slug": self.project.organization.slug},

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2587,10 +2587,7 @@ class EventsJoinedGroupAttributesSnubaSearchTest(TransactionTestCase, EventsSnub
             except urllib3.exceptions.HTTPError as err:
                 raise snuba.SnubaError(err)
 
-        with (
-            self.options({"issues.group_attributes.send_kafka": True}),
-            mock.patch("sentry.issues.attributes.produce_snapshot_to_kafka", post_insert),
-        ):
+        with (mock.patch("sentry.issues.attributes.produce_snapshot_to_kafka", post_insert),):
             super().setUp()
 
     @mock.patch("sentry.utils.metrics.timer")


### PR DESCRIPTION
Removing the option `issues.group_attributes.send_kafka` which gates whether snapshots are sent to kafka to update the fields in GroupAttributes. The option is enabled globally and has been on for a few months. This PR enabled the options in tests and cleans up any references to the the options.

Some unit tests for daily summary and weekly reports modified groups outside of the `with self.options({"issues.group_attributes.send_kafka": True}):` block, meaning those changes were not published to GroupAttributes. Since the queries for these two features uses a join on GroupAttributes, the tested behavior was inaccurate. Namely, the tests expected resolved groups to appear in the generated reports. This PR also fixes those inconsistencies. 