### PR TITLE
chore(group-attributes): Unregister the `issues.group_attributes.send_kafka ` option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2004,13 +2004,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# The flag activates whether to send group attributes messages to kafka
-register(
-    "issues.group_attributes.send_kafka",
-    default=True,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # Enables statistical detectors for a project
 register(
     "statistical_detectors.enable",


### PR DESCRIPTION
All uses of the option have been removed in https://github.com/getsentry/sentry/pull/79334. This PR finally unregisters the option.