### PR TITLE
ref(dynamic-sampling): remove duplicate rule cleanup method

### DIFF
--- a/src/sentry/models/dynamicsampling.py
+++ b/src/sentry/models/dynamicsampling.py
@@ -304,15 +304,6 @@ class CustomDynamicSamplingRule(Model):
         return rules[:MAX_CUSTOM_RULES_PER_PROJECT]
 
     @staticmethod
-    def deactivate_expired_rules():
-        """
-        Deactivates all rules that have expired
-        """
-        CustomDynamicSamplingRule.objects.filter(
-            end_date__lt=timezone.now(), is_active=True
-        ).update(is_active=False)
-
-    @staticmethod
     def num_active_rules_for_project(project: Project) -> int:
         """
         Returns the number of active rules for the given project

--- a/tests/sentry/models/test_dynamicsampling.py
+++ b/tests/sentry/models/test_dynamicsampling.py
@@ -326,7 +326,7 @@ class TestCustomDynamicSamplingRuleProject(TestCase):
         for rule in CustomDynamicSamplingRule.objects.all():
             assert rule.is_active
 
-        CustomDynamicSamplingRule.deactivate_expired_rules()
+        CustomDynamicSamplingRule.deactivate_old_rules()
 
         # check that all expired rules are inactive and all active rules are still active
         for rule in CustomDynamicSamplingRule.objects.all():


### PR DESCRIPTION
The method deactivate_expired_rules on CustomDynamicSamplingRule was only used in a test, and nowhere else in the code; and the method deactivate_old_rules was used in the job to delete old rules, but not in the test. 