### PR TITLE
fix(docs): RN V6 and V5.32 moved profiles sample rate to the root options

### DIFF
--- a/static/app/gettingStartedDocs/react-native/react-native.spec.tsx
+++ b/static/app/gettingStartedDocs/react-native/react-native.spec.tsx
@@ -47,7 +47,7 @@ describe('getting started with react-native', function () {
     ).toBeInTheDocument();
     expect(
       await screen.findByText(
-        textWithMarkupMatcher(/React Native Profiling beta is available/)
+        textWithMarkupMatcher(/React Native Profiling is available/)
       )
     ).toBeInTheDocument();
   });

--- a/static/app/gettingStartedDocs/react-native/react-native.tsx
+++ b/static/app/gettingStartedDocs/react-native/react-native.tsx
@@ -37,11 +37,9 @@ Sentry.init({
   }${
     params.isProfilingSelected
       ? `
-  _experiments: {
-    // profilesSampleRate is relative to tracesSampleRate.
-    // Here, we'll capture profiles for 100% of transactions.
-    profilesSampleRate: 1.0,
-  },`
+  // profilesSampleRate is relative to tracesSampleRate.
+  // Here, we'll capture profiles for 100% of transactions.
+  profilesSampleRate: 1.0,`
       : ''
   }
 });`;
@@ -155,7 +153,7 @@ const onboarding: OnboardingConfig = {
           ? [
               {
                 description: t(
-                  'React Native Profiling beta is available since SDK version 5.8.0.'
+                  'React Native Profiling is available since SDK version 5.32.0.'
                 ),
               },
             ]


### PR DESCRIPTION
Profiles sample rate moved from `_experiments.profilesSampleRate` to `profilesSampleRate`.

RN SDK v6 release https://github.com/getsentry/sentry-react-native/releases/tag/6.0.0

RN SDK v5.32 release https://github.com/getsentry/sentry-react-native/releases/5.32.0
