### PR TITLE
fix(ui): Remove extra T in admin Queue page

### DIFF
--- a/static/app/views/admin/adminQueue.tsx
+++ b/static/app/views/admin/adminQueue.tsx
@@ -75,7 +75,7 @@ export default function AdminQueue() {
   return (
     <div>
       <Header>
-        <h3>t{'Queue Overview'}</h3>
+        <h3>{'Queue Overview'}</h3>
 
         <ButtonBar merged active={state.timeWindow}>
           {TIME_WINDOWS.map(r => (
@@ -98,7 +98,7 @@ export default function AdminQueue() {
         </PanelBody>
       </Panel>
 
-      <h3>t{'Task Details'}</h3>
+      <h3>{'Task Details'}</h3>
 
       <div>
         <div className="m-b-1">


### PR DESCRIPTION
Removes an extra T in the two headers in the admin/queues page. 
This is the smallest PR ever, but I've been looking at those for a while, and figured - Might as well, while I was in "Sentry Ruby SDK"-mood.

<img width="807" alt="image" src="https://github.com/user-attachments/assets/9914283d-bcf5-4df3-bc61-5dcc61b43fb6">


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
