### PR TITLE
fix(onboarding): Remove `tracePropagationTargets` in Nuxt

### DIFF
--- a/static/app/gettingStartedDocs/javascript/nuxt.tsx
+++ b/static/app/gettingStartedDocs/javascript/nuxt.tsx
@@ -84,9 +84,7 @@ Sentry.init({
       ? `
   // Tracing
   // We recommend adjusting this value in production, or using a tracesSampler for finer control.
-  tracesSampleRate: 1.0, // Capture 100% of the transactions
-  // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
-  tracePropagationTargets: ["localhost", /^https:\\/\\/yourserver\\.io\\/api/],`
+  tracesSampleRate: 1.0, // Capture 100% of the transactions`
       : ''
   }${
     params.isProfilingSelected


### PR DESCRIPTION
This PR removes the `tracePropagationTargets` configuration for `@sentry/nuxt` on the server side. The default behavior for server-side is to propagate traces to all outbound requests, unlike the browser where it is necessary to limit tracing to avoid attaching it to meaningless outbound requests.


