### PR TITLE
feat(quick-start): Add new onboarding status

### DIFF
--- a/static/app/components/onboardingWizard/newSidebar.tsx
+++ b/static/app/components/onboardingWizard/newSidebar.tsx
@@ -1,12 +1,4 @@
-import {
-  forwardRef,
-  Fragment,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import partition from 'lodash/partition';
@@ -104,126 +96,124 @@ interface TaskProps {
   completed?: boolean;
 }
 
-const Task = forwardRef(
-  ({task, completed, hidePanel}: TaskProps, ref: React.Ref<HTMLDivElement>) => {
-    const api = useApi();
-    const organization = useOrganization();
-    const router = useRouter();
+function Task({task, completed, hidePanel}: TaskProps) {
+  const api = useApi();
+  const organization = useOrganization();
+  const router = useRouter();
 
-    const handleClick = useCallback(
-      (e: React.MouseEvent) => {
-        trackAnalytics('quick_start.task_card_clicked', {
-          organization,
-          todo_id: task.task,
-          todo_title: task.title,
-          action: 'clickthrough',
-        });
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      trackAnalytics('quick_start.task_card_clicked', {
+        organization,
+        todo_id: task.task,
+        todo_title: task.title,
+        action: 'clickthrough',
+      });
 
-        e.stopPropagation();
+      e.stopPropagation();
 
-        if (isDemoWalkthrough()) {
-          DemoWalkthroughStore.activateGuideAnchor(task.task);
-        }
+      if (isDemoWalkthrough()) {
+        DemoWalkthroughStore.activateGuideAnchor(task.task);
+      }
 
-        if (task.actionType === 'external') {
-          window.open(task.location, '_blank');
-        }
+      if (task.actionType === 'external') {
+        window.open(task.location, '_blank');
+      }
 
-        if (task.actionType === 'action') {
-          task.action(router);
-        }
+      if (task.actionType === 'action') {
+        task.action(router);
+      }
 
-        if (task.actionType === 'app') {
-          // Convert all paths to a location object
-          let to =
-            typeof task.location === 'string' ? {pathname: task.location} : task.location;
-          // Add referrer to all links
-          to = {...to, query: {...to.query, referrer: 'onboarding_task'}};
+      if (task.actionType === 'app') {
+        // Convert all paths to a location object
+        let to =
+          typeof task.location === 'string' ? {pathname: task.location} : task.location;
+        // Add referrer to all links
+        to = {...to, query: {...to.query, referrer: 'onboarding_task'}};
 
-          navigateTo(to, router);
-        }
-        hidePanel();
-      },
-      [task, organization, router, hidePanel]
-    );
+        navigateTo(to, router);
+      }
+      hidePanel();
+    },
+    [task, organization, router, hidePanel]
+  );
 
-    const handleMarkComplete = useCallback(
-      (taskKey: OnboardingTaskKey) => {
-        updateOnboardingTask(api, organization, {
-          task: taskKey,
-          status: 'complete',
-          completionSeen: true,
-        });
-      },
-      [api, organization]
-    );
+  const handleMarkComplete = useCallback(
+    (taskKey: OnboardingTaskKey) => {
+      updateOnboardingTask(api, organization, {
+        task: taskKey,
+        status: 'complete',
+        completionSeen: true,
+      });
+    },
+    [api, organization]
+  );
 
-    const handleMarkSkipped = useCallback(
-      (taskKey: OnboardingTaskKey) => {
-        trackAnalytics('quick_start.task_card_clicked', {
-          organization,
-          todo_id: task.task,
-          todo_title: task.title,
-          action: 'skipped',
-        });
-        updateOnboardingTask(api, organization, {
-          task: taskKey,
-          status: 'skipped',
-          completionSeen: true,
-        });
-      },
-      [task, organization, api]
-    );
+  const handleMarkSkipped = useCallback(
+    (taskKey: OnboardingTaskKey) => {
+      trackAnalytics('quick_start.task_card_clicked', {
+        organization,
+        todo_id: task.task,
+        todo_title: task.title,
+        action: 'skipped',
+      });
+      updateOnboardingTask(api, organization, {
+        task: taskKey,
+        status: 'skipped',
+        completionSeen: true,
+      });
+    },
+    [task, organization, api]
+  );
 
-    if (completed) {
-      return (
-        <TaskWrapper completed>
-          <strong>{task.title}</strong>
-          <IconCheckmark color="green300" isCircled />
-        </TaskWrapper>
-      );
-    }
-
+  if (completed) {
     return (
-      <TaskWrapper onClick={handleClick} ref={ref}>
-        <InteractionStateLayer />
-        <div>
-          <strong>{task.title}</strong>
-          <p>{task.description}</p>
-        </div>
-        {task.requisiteTasks.length === 0 && (
-          <TaskActions>
-            {task.skippable && (
-              <SkipConfirm onSkip={() => handleMarkSkipped(task.task)}>
-                {({skip}) => (
-                  <Button
-                    borderless
-                    size="zero"
-                    aria-label={t('Close')}
-                    icon={<IconClose size="xs" color="gray300" />}
-                    onClick={skip}
-                    css={css`
-                      /* If the pulsing indicator is active, the close button
-                     * should be above it so it's clickable.
-                     */
-                      z-index: 1;
-                    `}
-                  />
-                )}
-              </SkipConfirm>
-            )}
-            {task.SupplementComponent && (
-              <task.SupplementComponent
-                task={task}
-                onCompleteTask={() => handleMarkComplete(task.task)}
-              />
-            )}
-          </TaskActions>
-        )}
+      <TaskWrapper completed>
+        <strong>{task.title}</strong>
+        <IconCheckmark color="green300" isCircled />
       </TaskWrapper>
     );
   }
-);
+
+  return (
+    <TaskWrapper onClick={handleClick}>
+      <InteractionStateLayer />
+      <div>
+        <strong>{task.title}</strong>
+        <p>{task.description}</p>
+      </div>
+      {task.requisiteTasks.length === 0 && (
+        <TaskActions>
+          {task.skippable && (
+            <SkipConfirm onSkip={() => handleMarkSkipped(task.task)}>
+              {({skip}) => (
+                <Button
+                  borderless
+                  size="zero"
+                  aria-label={t('Close')}
+                  icon={<IconClose size="xs" color="gray300" />}
+                  onClick={skip}
+                  css={css`
+                    /* If the pulsing indicator is active, the close button
+                     * should be above it so it's clickable.
+                     */
+                    z-index: 1;
+                  `}
+                />
+              )}
+            </SkipConfirm>
+          )}
+          {task.SupplementComponent && (
+            <task.SupplementComponent
+              task={task}
+              onCompleteTask={() => handleMarkComplete(task.task)}
+            />
+          )}
+        </TaskActions>
+      )}
+    </TaskWrapper>
+  );
+}
 
 interface TaskGroupProps {
   description: string;

--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -532,7 +532,7 @@ const EventWaitingIndicator = styled(
     if (quickStartUpdatesFeature) {
       return (
         <div {...p}>
-          <Tooltip title={text || t('Waiting for event')}>
+          <Tooltip title={text || t('Waiting for event')} position="auto">
             <PulsingIndicator hasQuickStartUpdatesFeature />
           </Tooltip>
         </div>

--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -532,7 +532,7 @@ const EventWaitingIndicator = styled(
     if (quickStartUpdatesFeature) {
       return (
         <div {...p}>
-          <Tooltip title={text || t('Waiting for event')} position="auto">
+          <Tooltip title={text || t('Waiting for event')}>
             <PulsingIndicator hasQuickStartUpdatesFeature />
           </Tooltip>
         </div>

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -10,12 +10,14 @@ import FeedbackOnboardingSidebar from 'sentry/components/feedback/feedbackOnboar
 import Hook from 'sentry/components/hook';
 import {OnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import {getMergedTasks} from 'sentry/components/onboardingWizard/taskConfig';
+import {hasQuickStartUpdatesFeature} from 'sentry/components/onboardingWizard/utils';
 import PerformanceOnboardingSidebar from 'sentry/components/performanceOnboarding/sidebar';
 import ReplaysOnboardingSidebar from 'sentry/components/replaysOnboarding/sidebar';
 import {
   ExpandedContext,
   ExpandedContextProvider,
 } from 'sentry/components/sidebar/expandedContextProvider';
+import {NewOnboardingStatus} from 'sentry/components/sidebar/newOnboardingStatus';
 import {isDone} from 'sentry/components/sidebar/utils';
 import {
   IconDashboard,
@@ -793,13 +795,22 @@ function Sidebar() {
               {...sidebarItemProps}
             />
             <SidebarSection hasNewNav={hasNewNav} noMargin noPadding>
-              <OnboardingStatus
-                org={organization}
-                currentPanel={activePanel}
-                onShowPanel={() => togglePanel(SidebarPanelKey.ONBOARDING_WIZARD)}
-                hidePanel={hidePanel}
-                {...sidebarItemProps}
-              />
+              {hasQuickStartUpdatesFeature(organization) ? (
+                <NewOnboardingStatus
+                  currentPanel={activePanel}
+                  onShowPanel={() => togglePanel(SidebarPanelKey.ONBOARDING_WIZARD)}
+                  hidePanel={hidePanel}
+                  {...sidebarItemProps}
+                />
+              ) : (
+                <OnboardingStatus
+                  org={organization}
+                  currentPanel={activePanel}
+                  onShowPanel={() => togglePanel(SidebarPanelKey.ONBOARDING_WIZARD)}
+                  hidePanel={hidePanel}
+                  {...sidebarItemProps}
+                />
+              )}
             </SidebarSection>
 
             <SidebarSection hasNewNav={hasNewNav}>


### PR DESCRIPTION
The `newOnboardingStatus` file is essentially a copy of the `OnboardingStatus` file, but it includes updated logic for the quick start counter. I opted to create a separate file to maintain clarity and readability, and to accommodate the use of hooks.