### PR TITLE
chore(autofix+copilot) Allow autofix without FF if gen AI consent given

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -163,6 +163,7 @@ class GroupAutofixEndpoint(GroupEndpoint):
         if not (
             features.has("projects:ai-autofix", group.project)
             or features.has("organizations:autofix", group.organization)
+            or group.organization.get_option("sentry:gen_ai_consent", False)
         ):
             return self._respond_with_error("AI Autofix is not enabled for this project.", 403)
 

--- a/src/sentry/api/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/api/endpoints/group_autofix_setup_check.py
@@ -108,12 +108,6 @@ class GroupAutofixSetupCheck(GroupEndpoint):
         """
         Checks if we are able to run Autofix on the given group.
         """
-        if not (
-            features.has("projects:ai-autofix", group.project)
-            or features.has("organizations:autofix", group.organization)
-        ):
-            return Response({"detail": "Feature not enabled for project"}, status=403)
-
         org: Organization = request.organization
         has_gen_ai_consent = org.get_option("sentry:gen_ai_consent", False)
 

--- a/src/sentry/api/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/api/endpoints/group_autofix_setup_check.py
@@ -111,13 +111,6 @@ class GroupAutofixSetupCheck(GroupEndpoint):
         org: Organization = request.organization
         has_gen_ai_consent = org.get_option("sentry:gen_ai_consent", False)
 
-        if not (
-            features.has("projects:ai-autofix", group.project)
-            or features.has("organizations:autofix", group.organization)
-            or has_gen_ai_consent
-        ):
-            return Response({"detail": "Feature not enabled for project"}, status=403)
-
         is_codebase_indexing_disabled = features.has(
             "organizations:autofix-disable-codebase-indexing",
             group.organization,

--- a/src/sentry/api/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/api/endpoints/group_autofix_setup_check.py
@@ -111,6 +111,13 @@ class GroupAutofixSetupCheck(GroupEndpoint):
         org: Organization = request.organization
         has_gen_ai_consent = org.get_option("sentry:gen_ai_consent", False)
 
+        if not (
+            features.has("projects:ai-autofix", group.project)
+            or features.has("organizations:autofix", group.organization)
+            or has_gen_ai_consent
+        ):
+            return Response({"detail": "Feature not enabled for project"}, status=403)
+
         is_codebase_indexing_disabled = features.has(
             "organizations:autofix-disable-codebase-indexing",
             group.organization,


### PR DESCRIPTION
This allows orgs who we're giving access to the Copilot extension to call Autofix as long as they have given us Gen AI consent, even if they are not feature flagged into our LA.

In the autofix start endpoint, we allow it if either they have the FF or have gen AI consent.
In the setup endpoint, we remove the FF check so that we can check set up status regardless.