### PR TITLE
chore(autofix): Show banner if gen AI consent is given, even if no feature flag

### DIFF
--- a/static/app/components/events/autofix/useAutofixSetup.tsx
+++ b/static/app/components/events/autofix/useAutofixSetup.tsx
@@ -47,6 +47,7 @@ export function useAutofixSetup(
     canStartAutofix: Boolean(
       queryData.data?.integration.ok && queryData.data?.genAIConsent.ok
     ),
+    genAIConsent: Boolean(queryData.data?.genAIConsent.ok ?? false),
     canCreatePullRequests: Boolean(queryData.data?.githubWriteIntegration.ok),
   };
 }

--- a/static/app/views/issueDetails/resourcesAndPossibleSolutions.tsx
+++ b/static/app/views/issueDetails/resourcesAndPossibleSolutions.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {AiSuggestedSolution} from 'sentry/components/events/aiSuggestedSolution';
 import {Autofix} from 'sentry/components/events/autofix';
+import {useAutofixSetup} from 'sentry/components/events/autofix/useAutofixSetup';
 import {Resources} from 'sentry/components/events/interfaces/performance/resources';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
@@ -51,10 +52,14 @@ export function ResourcesAndPossibleSolutions({event, project, group}: Props) {
   const config = getConfigForIssueType(group, project);
   const isSelfHostedErrorsOnly = ConfigStore.get('isSelfHostedErrorsOnly');
   const isSampleError = useIsSampleEvent();
-  // NOTE:  Autofix is for INTERNAL testing only for now.
+  const {genAIConsent} = useAutofixSetup({
+    groupId: group.id,
+  });
+
   const displayAiAutofix =
-    organization.features.includes('autofix') &&
-    organization.features.includes('issue-details-autofix-ui') &&
+    ((organization.features.includes('autofix') &&
+      organization.features.includes('issue-details-autofix-ui')) ||
+      genAIConsent) &&
     !shouldShowCustomErrorResourceConfig(group, project) &&
     config.autofix &&
     hasStacktraceWithFrames(event) &&


### PR DESCRIPTION
This allows orgs with access to the Copilot Extension to see and set up Autofix in the UI.