### PR TITLE
chore(insights): Set MongoDB feature badge to `new`

### DIFF
--- a/static/app/views/insights/database/components/useSystemSelectorOptions.tsx
+++ b/static/app/views/insights/database/components/useSystemSelectorOptions.tsx
@@ -45,7 +45,7 @@ export function useSystemSelectorOptions() {
         label = (
           <LabelContainer>
             {textValue}
-            <StyledFeatureBadge type={'beta'} />
+            <StyledFeatureBadge type={'new'} />
           </LabelContainer>
         );
       } else {


### PR DESCRIPTION
Will merge this in after https://github.com/getsentry/sentry-options-automator/pull/2460

Setting the feature badge to 'new', as this feature is being rolled out to GA