### PR TITLE
ref(uptiem): Replace autodetection flag w/ option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2755,6 +2755,14 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Disables URL autodetection during post-process
+register(
+    "uptime.disable_auto_detection",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 register(
     "releases.no_snuba_for_release_creation",
     type=Bool,

--- a/src/sentry/uptime/detectors/detector.py
+++ b/src/sentry/uptime/detectors/detector.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from sentry import features
+from sentry import options
 from sentry.uptime.detectors.ranking import (
     add_base_url_to_rank,
     should_detect_for_organization,
@@ -19,11 +19,11 @@ def detect_base_url_for_project(project: Project, url: str) -> None:
     # Note: We might end up removing the `should_detect_for_project` check here if/when we decide to use detected
     # urls as suggestions as well.
     if (
-        not features.has("organizations:uptime-automatic-hostname-detection", project.organization)
+        options.get("uptime.disable_auto_detection")
         or not should_detect_for_project(project)
         or not should_detect_for_organization(project.organization)
     ):
-        metrics.incr("uptime.detectors.url_add_skipped_due_to_feature_flag")
+        metrics.incr("uptime.detectors.url_add_skipped")
         return
 
     base_url = extract_base_url(url)

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2157,7 +2157,6 @@ class DetectBaseUrlsForUptimeTestMixin(BasePostProgressGroupMixin):
         cluster = _get_cluster()
         assert exists == cluster.sismember(key, str(organization.id))
 
-    @with_feature("organizations:uptime-automatic-hostname-detection")
     def test_uptime_detection_feature_url(self):
         event = self.create_event(
             data={"request": {"url": "http://sentry.io"}},
@@ -2171,7 +2170,6 @@ class DetectBaseUrlsForUptimeTestMixin(BasePostProgressGroupMixin):
         )
         self.assert_organization_key(self.organization, True)
 
-    @with_feature("organizations:uptime-automatic-hostname-detection")
     def test_uptime_detection_feature_no_url(self):
         event = self.create_event(
             data={},

--- a/tests/sentry/uptime/detectors/test_detector.py
+++ b/tests/sentry/uptime/detectors/test_detector.py
@@ -1,6 +1,5 @@
 from sentry.models.organization import Organization
 from sentry.testutils.cases import UptimeTestCase
-from sentry.testutils.helpers import with_feature
 from sentry.uptime.detectors.detector import detect_base_url_for_project
 from sentry.uptime.detectors.ranking import _get_cluster, get_organization_bucket_key
 
@@ -11,22 +10,20 @@ class DetectBaseUrlForProjectTest(UptimeTestCase):
         cluster = _get_cluster()
         assert exists == cluster.sismember(key, str(organization.id))
 
-    @with_feature("organizations:uptime-automatic-hostname-detection")
     def test(self):
         detect_base_url_for_project(self.project, "https://sentry.io")
         self.assert_organization_key(self.organization, True)
 
-    def test_no_feature(self):
-        detect_base_url_for_project(self.project, "https://sentry.io")
+    def test_killswitch(self):
+        with self.options({"uptime.disable_auto_detection": True}):
+            detect_base_url_for_project(self.project, "https://sentry.io")
         self.assert_organization_key(self.organization, False)
 
-    @with_feature("organizations:uptime-automatic-hostname-detection")
     def test_disabled_for_project(self):
         self.project.update_option("sentry:uptime_autodetection", False)
         detect_base_url_for_project(self.project, "https://sentry.io")
         self.assert_organization_key(self.organization, False)
 
-    @with_feature("organizations:uptime-automatic-hostname-detection")
     def test_disabled_for_organization(self):
         self.organization.update_option("sentry:uptime_autodetection", False)
         detect_base_url_for_project(self.project, "https://sentry.io")


### PR DESCRIPTION
Since we don't need to be as granular now and would like to reduce the
number of feature flags we have, we can move this behind an option.