### PR TITLE
chore(perf): Private threshold endpoints

### DIFF
--- a/src/sentry/api/endpoints/organization_transaction_anomaly_detection.py
+++ b/src/sentry/api/endpoints/organization_transaction_anomaly_detection.py
@@ -99,7 +99,7 @@ def get_time_params(start: datetime, end: datetime) -> MappedParams:
 @region_silo_endpoint
 class OrganizationTransactionAnomalyDetectionEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def has_feature(self, organization, request):

--- a/src/sentry/api/endpoints/project_transaction_threshold_override.py
+++ b/src/sentry/api/endpoints/project_transaction_threshold_override.py
@@ -58,9 +58,9 @@ class ProjectTransactionThresholdOverrideSerializer(serializers.Serializer):
 @region_silo_endpoint
 class ProjectTransactionThresholdOverrideEndpoint(OrganizationEventsV2EndpointBase):
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
-        "POST": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (ProjectTransactionThresholdOverridePermission,)
 


### PR DESCRIPTION
It doesn't really make sense to make these public (one is just a very specific project setting and the other is just used in the UI)