### PR TITLE
feat(crons): Includes dates when the window spans days

### DIFF
--- a/static/app/views/monitors/components/timeline/utils/getConfigFromTimeRange.spec.tsx
+++ b/static/app/views/monitors/components/timeline/utils/getConfigFromTimeRange.spec.tsx
@@ -82,4 +82,24 @@ describe('getConfigFromTimeRange', function () {
       timelineWidth,
     });
   });
+
+  it('Includes dates when the window spans days', function () {
+    const start = new Date('2023-05-14T20:00:00Z');
+    const end = new Date('2023-05-15T10:00:00Z');
+    const config = getConfigFromTimeRange(start, end, timelineWidth);
+    expect(config).toEqual({
+      start,
+      end,
+      dateLabelFormat: getFormat(),
+      // 14 hours
+      elapsedMinutes: 14 * 60,
+      intervals: {
+        normalMarkerInterval: 120,
+        minimumMarkerInterval: 115.5,
+        referenceMarkerInterval: 120.75,
+      },
+      dateTimeProps: {timeOnly: false},
+      timelineWidth,
+    });
+  });
 });

--- a/static/app/views/monitors/components/timeline/utils/getConfigFromTimeRange.tsx
+++ b/static/app/views/monitors/components/timeline/utils/getConfigFromTimeRange.tsx
@@ -50,8 +50,8 @@ export function getConfigFromTimeRange(
 ): TimeWindowConfig {
   const elapsedMinutes = (end.getTime() - start.getTime()) / (1000 * 60);
 
-  // Display only the time (no date) when the window is less than 24 hours
-  const timeOnly = elapsedMinutes <= ONE_HOUR * 24;
+  // Display only the time (no date) when the start and end times are the same day
+  const timeOnly = elapsedMinutes <= ONE_HOUR * 24 && start.getDate() === end.getDate();
 
   // When one pixel represents less than at least one minute we also want to
   // display second values on our labels.


### PR DESCRIPTION
This makes it easier to see the day boundary

<img alt="clipboard.png" width="919" src="https://i.imgur.com/zd18meo.png" />