### PR TITLE
fix(dashboards): Don't show Add an Equation when dataset incompatible

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/columnsStep/columnFields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/columnsStep/columnFields.tsx
@@ -4,6 +4,7 @@ import FieldGroup from 'sentry/components/forms/fieldGroup';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import type {QueryFieldValue} from 'sentry/utils/discover/fields';
+import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import type {WidgetType} from 'sentry/views/dashboards/types';
 import {DisplayType} from 'sentry/views/dashboards/types';
 import ColumnEditCollection from 'sentry/views/discover/table/columnEditCollection';
@@ -37,6 +38,7 @@ export function ColumnFields({
   noFieldsMessage,
   isOnDemandWidget,
 }: Props) {
+  const datasetConfig = getDatasetConfig(widgetType);
   return (
     <FieldGroup
       inline={false}
@@ -56,6 +58,7 @@ export function ColumnFields({
           filterPrimaryOptions={filterPrimaryOptions}
           noFieldsMessage={noFieldsMessage}
           isOnDemandWidget={isOnDemandWidget}
+          supportsEquations={datasetConfig.enableEquations}
         />
       ) : (
         // The only other display type this component
@@ -72,6 +75,7 @@ export function ColumnFields({
           filterPrimaryOptions={filterPrimaryOptions}
           noFieldsMessage={noFieldsMessage}
           isOnDemandWidget={isOnDemandWidget}
+          supportsEquations={datasetConfig.enableEquations}
         />
       )}
     </FieldGroup>

--- a/static/app/views/discover/table/columnEditCollection.spec.tsx
+++ b/static/app/views/discover/table/columnEditCollection.spec.tsx
@@ -1,0 +1,41 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import type {Organization} from 'sentry/types/organization';
+import ColumnEditCollection from 'sentry/views/discover/table/columnEditCollection';
+
+describe('ColumnEditCollection', () => {
+  let organization: Organization;
+
+  beforeEach(() => {
+    organization = OrganizationFixture();
+  });
+
+  it('does not render the Add an Equation button when equations are not supported', () => {
+    render(
+      <ColumnEditCollection
+        columns={[]}
+        fieldOptions={{}}
+        onChange={jest.fn()}
+        organization={organization}
+        supportsEquations={false}
+      />
+    );
+    expect(screen.queryByText('Add an Equation')).not.toBeInTheDocument();
+  });
+
+  it('renders the Add an Equation button when equations are supported', () => {
+    render(
+      <ColumnEditCollection
+        columns={[]}
+        fieldOptions={{}}
+        onChange={jest.fn()}
+        organization={organization}
+        supportsEquations
+      />
+    );
+
+    expect(screen.getByText('Add an Equation')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/discover/table/columnEditCollection.tsx
+++ b/static/app/views/discover/table/columnEditCollection.tsx
@@ -55,6 +55,7 @@ type Props = {
   noFieldsMessage?: string;
   showAliasField?: boolean;
   source?: Sources;
+  supportsEquations?: boolean;
 };
 
 type State = {
@@ -582,7 +583,7 @@ class ColumnEditCollection extends Component<Props, State> {
   }
 
   render() {
-    const {className, columns, showAliasField, source} = this.props;
+    const {className, columns, showAliasField, source, supportsEquations} = this.props;
     const canDelete = columns.filter(field => field.kind !== 'equation').length > 1;
     const canDrag = columns.length > 1;
     const canAdd = columns.length < MAX_COL_COUNT;
@@ -672,20 +673,18 @@ class ColumnEditCollection extends Component<Props, State> {
             >
               {t('Add a Column')}
             </Button>
-            {WidgetType.ISSUE &&
-              source !== WidgetType.RELEASE &&
-              source !== WidgetType.METRICS && (
-                <Button
-                  size="sm"
-                  aria-label={t('Add an Equation')}
-                  onClick={this.handleAddEquation}
-                  title={title}
-                  disabled={!canAdd}
-                  icon={<IconAdd isCircled />}
-                >
-                  {t('Add an Equation')}
-                </Button>
-              )}
+            {supportsEquations && (
+              <Button
+                size="sm"
+                aria-label={t('Add an Equation')}
+                onClick={this.handleAddEquation}
+                title={title}
+                disabled={!canAdd}
+                icon={<IconAdd isCircled />}
+              >
+                {t('Add an Equation')}
+              </Button>
+            )}
           </Actions>
         </RowContainer>
       </div>

--- a/static/app/views/discover/table/columnEditModal.tsx
+++ b/static/app/views/discover/table/columnEditModal.tsx
@@ -138,6 +138,7 @@ function ColumnEditModal(props: Props) {
           }
           onChange={setColumns}
           organization={organization}
+          supportsEquations
         />
       </Body>
       <Footer>


### PR DESCRIPTION
Issue widgets were displaying an "Add an Equation" button. The check for it was a conditional rendering check which had a typo in it, instead control the button from the caller and use the enableEquations field from the datasets in the widget builder.

This field is always true in Discover, so set that to always true as well.