### PR TITLE
chore(sentryapps): better logging and errors for select requester

### DIFF
--- a/src/sentry/sentry_apps/api/endpoints/installation_external_requests.py
+++ b/src/sentry/sentry_apps/api/endpoints/installation_external_requests.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.client import ApiError
 from sentry.models.project import Project
 from sentry.sentry_apps.api.bases.sentryapps import SentryAppInstallationBaseEndpoint
 from sentry.sentry_apps.external_requests.select_requester import SelectRequester
@@ -36,6 +37,12 @@ class SentryAppInstallationExternalRequestsEndpoint(SentryAppInstallationBaseEnd
 
         try:
             choices = SelectRequester(**kwargs).run()
+        except ApiError:
+            message = f"Error validating response options from {installation.sentry_app.slug} for {request.GET.get('uri')}"
+            return Response(
+                {"error": message},
+                status=400,
+            )
         except Exception:
             message = f'Error retrieving select field options from {request.GET.get("uri")}'
             return Response(

--- a/src/sentry/sentry_apps/api/endpoints/installation_external_requests.py
+++ b/src/sentry/sentry_apps/api/endpoints/installation_external_requests.py
@@ -36,7 +36,11 @@ class SentryAppInstallationExternalRequestsEndpoint(SentryAppInstallationBaseEnd
 
         try:
             choices = SelectRequester(**kwargs).run()
-        except Exception as e:
-            return Response({"error": str(e)}, status=400)
+        except Exception:
+            message = f'Error retrieving select field options from {request.GET.get("uri")}'
+            return Response(
+                {"error": message},
+                status=400,
+            )
 
         return Response(choices)

--- a/src/sentry/sentry_apps/api/endpoints/installation_external_requests.py
+++ b/src/sentry/sentry_apps/api/endpoints/installation_external_requests.py
@@ -1,13 +1,18 @@
+import logging
+
+from jsonschema import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.client import ApiError
+from sentry.coreapi import APIError
 from sentry.models.project import Project
 from sentry.sentry_apps.api.bases.sentryapps import SentryAppInstallationBaseEndpoint
 from sentry.sentry_apps.external_requests.select_requester import SelectRequester
+
+logger = logging.getLogger("sentry.sentry-apps")
 
 
 @region_silo_endpoint
@@ -37,13 +42,12 @@ class SentryAppInstallationExternalRequestsEndpoint(SentryAppInstallationBaseEnd
 
         try:
             choices = SelectRequester(**kwargs).run()
-        except ApiError:
-            message = f"Error validating response options from {installation.sentry_app.slug} for {request.GET.get('uri')}"
+        except ValidationError as e:
             return Response(
-                {"error": message},
+                {"error": e.message},
                 status=400,
             )
-        except Exception:
+        except APIError:
             message = f'Error retrieving select field options from {request.GET.get("uri")}'
             return Response(
                 {"error": message},

--- a/src/sentry/sentry_apps/api/endpoints/installation_external_requests.py
+++ b/src/sentry/sentry_apps/api/endpoints/installation_external_requests.py
@@ -36,7 +36,7 @@ class SentryAppInstallationExternalRequestsEndpoint(SentryAppInstallationBaseEnd
 
         try:
             choices = SelectRequester(**kwargs).run()
-        except Exception:
-            return Response({"error": "Error communicating with Sentry App service"}, status=400)
+        except Exception as e:
+            return Response({"error": str(e)}, status=400)
 
         return Response(choices)

--- a/src/sentry/sentry_apps/external_requests/select_requester.py
+++ b/src/sentry/sentry_apps/external_requests/select_requester.py
@@ -56,7 +56,6 @@ class SelectRequester:
                     "sentry_app_slug": self.sentry_app.slug,
                     "install_uuid": self.install.uuid,
                     "project_slug": self.project_slug,
-                    "uri": self.uri,
                     "error_message": str(e),
                     "url": url,
                 },
@@ -71,7 +70,6 @@ class SelectRequester:
                     "sentry_app_slug": self.sentry_app.slug,
                     "install_uuid": self.install.uuid,
                     "project_slug": self.project_slug,
-                    "uri": self.uri,
                     "url": url,
                 },
             )

--- a/src/sentry/sentry_apps/external_requests/select_requester.py
+++ b/src/sentry/sentry_apps/external_requests/select_requester.py
@@ -62,7 +62,7 @@ class SelectRequester:
             )
             raise APIError from e
 
-        if not self._validate_response(response) or not response:
+        if not self._validate_response(response):
             logger.info(
                 "select-requester.invalid-response",
                 extra={

--- a/src/sentry/sentry_apps/external_requests/select_requester.py
+++ b/src/sentry/sentry_apps/external_requests/select_requester.py
@@ -36,9 +36,10 @@ class SelectRequester:
     def run(self) -> dict[str, Any]:
         response: list[dict[str, str]] = []
         try:
+            url = self._build_url()
             body = safe_urlread(
                 send_and_save_sentry_app_request(
-                    self._build_url(),
+                    url,
                     self.sentry_app,
                     self.install.organization_id,
                     "select_options.requested",
@@ -56,10 +57,23 @@ class SelectRequester:
                     "project_slug": self.project_slug,
                     "uri": self.uri,
                     "error_message": str(e),
+                    "url": url,
                 },
             )
+            raise
 
         if not self._validate_response(response) or not response:
+            logger.info(
+                "select-requester.invalid-response",
+                extra={
+                    "response": response,
+                    "sentry_app_slug": self.sentry_app.slug,
+                    "install_uuid": self.install.uuid,
+                    "project_slug": self.project_slug,
+                    "uri": self.uri,
+                    "url": url,
+                },
+            )
             raise APIError(
                 f"Invalid response format for SelectField in {self.sentry_app} from uri: {self.uri}"
             )

--- a/src/sentry/sentry_apps/models/sentry_app_installation.py
+++ b/src/sentry/sentry_apps/models/sentry_app_installation.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, overload
 from django.db import models
 from django.db.models import QuerySet
 from django.utils import timezone
+from jsonschema import ValidationError
 
 from sentry.auth.services.auth import AuthenticatedToken
 from sentry.backup.scopes import RelocationScope
@@ -241,6 +242,6 @@ def prepare_ui_component(
             component=component, install=installation, project_slug=project_slug, values=values
         ).run()
         return component
-    except APIError:
+    except (APIError, ValidationError):
         # TODO(nisanthan): For now, skip showing the UI Component if the API requests fail
         return None

--- a/tests/sentry/sentry_apps/external_requests/test_select_requester.py
+++ b/tests/sentry/sentry_apps/external_requests/test_select_requester.py
@@ -1,5 +1,6 @@
 import pytest
 import responses
+from jsonschema import ValidationError
 
 from sentry.coreapi import APIError
 from sentry.sentry_apps.external_requests.select_requester import SelectRequester
@@ -69,7 +70,7 @@ class TestSelectRequester(TestCase):
             content_type="application/json",
         )
 
-        with pytest.raises(APIError):
+        with pytest.raises(ValidationError):
             SelectRequester(
                 install=self.install,
                 project_slug=self.project.slug,
@@ -90,7 +91,7 @@ class TestSelectRequester(TestCase):
             content_type="application/json",
         )
 
-        with pytest.raises(APIError):
+        with pytest.raises(ValidationError):
             SelectRequester(
                 install=self.install,
                 project_slug=self.project.slug,
@@ -106,7 +107,7 @@ class TestSelectRequester(TestCase):
             status=500,
         )
 
-        with pytest.raises(Exception):
+        with pytest.raises(APIError):
             SelectRequester(
                 install=self.install,
                 project_slug=self.project.slug,

--- a/tests/sentry/sentry_apps/external_requests/test_select_requester.py
+++ b/tests/sentry/sentry_apps/external_requests/test_select_requester.py
@@ -106,7 +106,7 @@ class TestSelectRequester(TestCase):
             status=500,
         )
 
-        with pytest.raises(APIError):
+        with pytest.raises(Exception):
             SelectRequester(
                 install=self.install,
                 project_slug=self.project.slug,


### PR DESCRIPTION
Ok more like let's differentiate between when we fail due to external requests failing or due to validation errors
Changes:
- Endpoint now throws a ValidationError if we fail to validate the resp or the resp is missing fields
- APIError is only thrown if the request fails
- We still only return 400s so there should be no client side changes 
- Update tests to reflect the new exceptions
- Make empty arrays valid response 