### PR TITLE
chore(issue-stream): Reduce font size of title and message

### DIFF
--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -14,6 +14,7 @@ import type {Group, GroupTombstoneHelper} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import {getLocation, getMessage, isTombstone} from 'sentry/utils/events';
 import {useLocation} from 'sentry/utils/useLocation';
+import withOrganization from 'sentry/utils/withOrganization';
 import {createIssueLink} from 'sentry/views/issueList/utils';
 
 import EventTitleError from './eventTitleError';
@@ -181,7 +182,7 @@ const TitleWithoutLink = styled('span')`
   display: inline-flex;
 `;
 
-export default EventOrGroupHeader;
+export default withOrganization(EventOrGroupHeader);
 
 const StyledEventOrGroupTitle = styled(EventOrGroupTitle)<{
   hasSeen: boolean;

--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -14,7 +14,6 @@ import type {Group, GroupTombstoneHelper} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import {getLocation, getMessage, isTombstone} from 'sentry/utils/events';
 import {useLocation} from 'sentry/utils/useLocation';
-import withOrganization from 'sentry/utils/withOrganization';
 import {createIssueLink} from 'sentry/views/issueList/utils';
 
 import EventTitleError from './eventTitleError';
@@ -182,7 +181,7 @@ const TitleWithoutLink = styled('span')`
   display: inline-flex;
 `;
 
-export default withOrganization(EventOrGroupHeader);
+export default EventOrGroupHeader;
 
 const StyledEventOrGroupTitle = styled(EventOrGroupTitle)<{
   hasSeen: boolean;

--- a/static/app/components/eventOrGroupTitle.tsx
+++ b/static/app/components/eventOrGroupTitle.tsx
@@ -90,12 +90,14 @@ const Message = styled('span')`
   height: 100%;
   color: ${p => p.theme.textColor};
   font-weight: ${p => p.theme.fontWeightNormal};
+  font-size: ${p => p.theme.fontSizeMedium};
 `;
 
 const Title = styled('span')`
   ${p => p.theme.overflowEllipsis};
   display: inline-block;
   color: ${p => p.theme.textColor};
+  font-size: ${p => p.theme.fontSizeMedium};
 `;
 
 const Wrapper = styled('span')<{hasNewLayout: boolean}>`


### PR DESCRIPTION
Reduces the font size of the title and message of issues on the issue stream.

Before: 

<img width="1994" alt="image" src="https://github.com/user-attachments/assets/0d27529a-0c20-49be-a368-71814aaab58a">

After:

<img width="1996" alt="image" src="https://github.com/user-attachments/assets/84b79069-cfd8-43aa-8d99-8ea4de4fa5ff">