### PR TITLE
feat(Auth): Adding orglevelaccess to ApiApplication serializer

### DIFF
--- a/src/sentry/api/serializers/models/apiapplication.py
+++ b/src/sentry/api/serializers/models/apiapplication.py
@@ -21,4 +21,5 @@ class ApiApplicationSerializer(Serializer):
             "allowedOrigins": obj.get_allowed_origins(),
             "redirectUris": obj.get_redirect_uris(),
             "scopes": obj.scopes,
+            "requiresOrgLevelAccess": obj.requires_org_level_access,
         }


### PR DESCRIPTION
I added this field to the model a while back but didn't add it to the serializer. Tests are in the getsentry upcoming PR where the serializer is being used: https://github.com/getsentry/getsentry/pull/15428

