### PR TITLE
fix(feedback): keep oldest date_added for duplicate user reports

### DIFF
--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -87,7 +87,6 @@ def save_userreport(
                 name=report.get("name", ""),
                 email=report["email"],
                 comments=report["comments"],
-                date_added=timezone.now(),
             )
             report_instance = existing_report
 


### PR DESCRIPTION
The `save_userreport` function allows some flexibility for duplicated requests by updating an existing report with the same project + event id, instead of failing. This is as long as that report was saved in the last 5min. 

We enforce this 5min time limit to prevent what the comments call "replay attacks" -- repeatedly spamming the API with reports on the same event. But atm the code updates `date_added`, so this 5min check is basically useless. `date_added` is always the time of the last request, so we could be spammed indefinitely.