### PR TITLE
Revert "feat(sentry-sdk): Enable HTTP2 transport"

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -280,9 +280,6 @@ def _get_sdk_options() -> tuple[SdkConfig, Dsns]:
     sdk_options["release"] = (
         f"backend@{sdk_options['release']}" if "release" in sdk_options else None
     )
-    sdk_options.setdefault("_experiments", {}).update(
-        transport_http2=True,
-    )
 
     # Modify SENTRY_SDK_CONFIG in your deployment scripts to specify your desired DSN
     dsns = Dsns(


### PR DESCRIPTION
Reverts getsentry/sentry#79278

It's possible that this caused S4S to stop getting data from sentry.