### PR TITLE
feat(grouping): Support errors that only have the stack trace (no exceptions)

### DIFF
--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 MAX_FRAME_COUNT = 30
 MAX_EXCEPTION_COUNT = 30
 FULLY_MINIFIED_STACKTRACE_MAX_FRAME_COUNT = 20
-SEER_ELIGIBLE_PLATFORMS_EVENTS = frozenset(["python", "javascript", "node", "ruby", "php"])
+SEER_ELIGIBLE_PLATFORMS_EVENTS = frozenset(["python", "javascript", "node", "ruby"])
 SEER_ELIGIBLE_PLATFORMS = frozenset(
     [
         "bun",
@@ -63,7 +63,6 @@ SEER_ELIGIBLE_PLATFORMS = frozenset(
         "node-profiling-onboarding-2-configure-performance",
         "node-profiling-onboarding-3-configure-profiling",
         "node-serverlesscloud",
-        "php",
         "python",
         "python-aiohttp",
         "python-asgi",

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 MAX_FRAME_COUNT = 30
 MAX_EXCEPTION_COUNT = 30
 FULLY_MINIFIED_STACKTRACE_MAX_FRAME_COUNT = 20
-SEER_ELIGIBLE_PLATFORMS_EVENTS = frozenset(["python", "javascript", "node", "ruby"])
+SEER_ELIGIBLE_PLATFORMS_EVENTS = frozenset(["python", "javascript", "node", "ruby", "php"])
 SEER_ELIGIBLE_PLATFORMS = frozenset(
     [
         "bun",
@@ -204,13 +204,16 @@ def get_stacktrace_string(data: dict[str, Any]) -> str:
 
         # For each exception, extract its type, value, and up to limit number of stacktrace frames
         exc_type, exc_value, frame_strings = "", "", []
-        for exception_value in exception.get("values", []):
-            if exception_value.get("id") == "type":
-                exc_type = _get_value_if_exists(exception_value)
-            elif exception_value.get("id") == "value":
-                exc_value = _get_value_if_exists(exception_value)
-            elif exception_value.get("id") == "stacktrace" and frame_count < MAX_FRAME_COUNT:
-                frame_strings = _process_frames(exception_value["values"])
+        if exception_type == "stacktrace":
+            frame_strings = _process_frames(exception.get("values", []))
+        else:
+            for exception_value in exception.get("values", []):
+                if exception_value.get("id") == "type":
+                    exc_type = _get_value_if_exists(exception_value)
+                elif exception_value.get("id") == "value":
+                    exc_value = _get_value_if_exists(exception_value)
+                elif exception_value.get("id") == "stacktrace" and frame_count < MAX_FRAME_COUNT:
+                    frame_strings = _process_frames(exception_value["values"])
         # Only exceptions have the type and value properties, so we don't need to handle the threads
         # case here
         header = f"{exc_type}: {exc_value}\n" if exception["id"] == "exception" else ""
@@ -252,9 +255,10 @@ def event_content_has_stacktrace(event: Event) -> bool:
     # If an event has no stacktrace, there's no data for Seer to analyze, so no point in making the
     # API call. If we ever start analyzing message-only events, we'll need to add `event.title in
     # PLACEHOLDER_EVENT_TITLES` to this check.
-    return get_path(event.data, "exception", "values", -1, "stacktrace", "frames") or get_path(
-        event.data, "threads", "values", -1, "stacktrace", "frames"
-    )
+    exception_stacktrace = get_path(event.data, "exception", "values", -1, "stacktrace", "frames")
+    threads_stacktrace = get_path(event.data, "threads", "values", -1, "stacktrace", "frames")
+    only_stacktrace = get_path(event.data, "stacktrace", "frames")
+    return exception_stacktrace or threads_stacktrace or only_stacktrace
 
 
 def event_content_is_seer_eligible(event: Event) -> bool:

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -139,14 +139,16 @@ def get_stacktrace_string(data: dict[str, Any]) -> str:
     stacktrace_str = ""
     found_non_snipped_context_line = False
     result_parts = []
+    frame_strings = []
 
     metrics.distribution("seer.grouping.exceptions.length", len(exceptions))
 
     def _process_frames(frames: list[dict[str, Any]]) -> None:
-        nonlocal found_non_snipped_context_line
-        nonlocal html_frame_count
         nonlocal frame_count
+        nonlocal html_frame_count
+        nonlocal found_non_snipped_context_line
         nonlocal result_parts
+        nonlocal frame_strings
 
         contributing_frames = [
             frame for frame in frames if frame.get("id") == "frame" and frame.get("contributes")
@@ -200,7 +202,7 @@ def get_stacktrace_string(data: dict[str, Any]) -> str:
             continue
 
         # For each exception, extract its type, value, and up to limit number of stacktrace frames
-        exc_type, exc_value, frame_strings = "", "", []
+        exc_type, exc_value = "", ""
         for exception_value in exception.get("values", []):
             if exception_value.get("id") == "type":
                 exc_type = _get_value_if_exists(exception_value)

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -116,18 +116,19 @@ def _get_value_if_exists(exception_value: dict[str, Any]) -> str:
 
 def get_stacktrace_string(data: dict[str, Any]) -> str:
     """Format a stacktrace string from the grouping information."""
-    if not (
-        get_path(data, "app", "hash") and get_path(data, "app", "component", "values")
-    ) and not (
-        get_path(data, "system", "hash") and get_path(data, "system", "component", "values")
-    ):
+    app_hash = get_path(data, "app", "hash")
+    app_component = get_path(data, "app", "component", "values")
+    system_hash = get_path(data, "system", "hash")
+    system_component = get_path(data, "system", "component", "values")
+
+    if not (app_hash or system_hash):
         return ""
 
     # Get the data used for grouping
-    if get_path(data, "app", "hash"):
-        exceptions = data["app"]["component"]["values"]
+    if app_hash:
+        exceptions = app_component
     else:
-        exceptions = data["system"]["component"]["values"]
+        exceptions = system_component
 
     # Handle chained exceptions
     if exceptions and exceptions[0].get("id") == "chained-exception":

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -134,10 +134,12 @@ def get_stacktrace_string(data: dict[str, Any]) -> str:
     if exceptions and exceptions[0].get("id") == "chained-exception":
         exceptions = exceptions[0].get("values")
 
-    found_non_snipped_context_line = False
-    html_frame_count = 0  # for a temporary metric
     frame_count = 0
+    html_frame_count = 0  # for a temporary metric
+    stacktrace_str = ""
+    found_non_snipped_context_line = False
     result_parts = []
+
     metrics.distribution("seer.grouping.exceptions.length", len(exceptions))
 
     def _process_frames(frames: list[dict[str, Any]]) -> None:
@@ -212,8 +214,8 @@ def get_stacktrace_string(data: dict[str, Any]) -> str:
 
         result_parts.append((header, frame_strings))
 
-    stacktrace_str = ""
     final_frame_count = 0
+
     for header, frame_strings in result_parts:
         # For performance reasons, if the entire stacktrace is made of minified frames, restrict the
         # result to include only the first 20 frames, since minified frames are significantly more
@@ -239,6 +241,7 @@ def get_stacktrace_string(data: dict[str, Any]) -> str:
             )
         },
     )
+
     return stacktrace_str.strip()
 
 

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -63,6 +63,7 @@ SEER_ELIGIBLE_PLATFORMS = frozenset(
         "node-profiling-onboarding-2-configure-performance",
         "node-profiling-onboarding-3-configure-profiling",
         "node-serverlesscloud",
+        "php",
         "python",
         "python-aiohttp",
         "python-asgi",

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -199,7 +199,11 @@ def get_stacktrace_string(data: dict[str, Any]) -> str:
     # Limit the number of chained exceptions
     for exception in reversed(exceptions[-MAX_EXCEPTION_COUNT:]):
         exception_type = exception.get("id")
-        if not exception.get("contributes") or exception_type not in ["exception", "threads"]:
+        if not exception.get("contributes") or exception_type not in [
+            "exception",
+            "threads",
+            "stacktrace",
+        ]:
             continue
 
         # For each exception, extract its type, value, and up to limit number of stacktrace frames

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -354,6 +354,67 @@ class GetStacktraceStringTest(TestCase):
         }
     }
 
+    ONLY_STACKTRACE = {
+        "app": {
+            "key": "app",
+            "type": "component",
+            "description": "in-app stack-trace",
+            "hash": "cb220adbea9b2575459b64285f9a3605",
+            "component": {
+                "id": "app",
+                "name": "in-app",
+                "contributes": True,
+                "hint": None,
+                "values": [
+                    {
+                        "id": "stacktrace",
+                        "name": "stack-trace",
+                        "contributes": True,
+                        "hint": None,
+                        "values": [
+                            {
+                                "id": "frame",
+                                "name": None,
+                                "contributes": True,
+                                "hint": None,
+                                "values": [
+                                    {
+                                        "id": "module",
+                                        "name": None,
+                                        "contributes": None,
+                                        "hint": None,
+                                        "values": [],
+                                    },
+                                    {
+                                        "id": "filename",
+                                        "name": None,
+                                        "contributes": True,
+                                        "hint": None,
+                                        "values": ["index.php"],
+                                    },
+                                    {
+                                        "id": "function",
+                                        "name": None,
+                                        "contributes": None,
+                                        "hint": None,
+                                        "values": [],
+                                    },
+                                    {
+                                        "id": "context-line",
+                                        "name": None,
+                                        "contributes": True,
+                                        "hint": None,
+                                        "values": ["$server->emit($server->run());"],
+                                    },
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        }
+    }
+
     def create_exception(
         self,
         exception_type_str: str = "Exception",
@@ -746,6 +807,10 @@ class GetStacktraceStringTest(TestCase):
             stacktrace_str = get_stacktrace_string(data_base64_encoded_filename)
             assert stacktrace_str == "ZeroDivisionError: division by zero"
 
+    def test_only_stacktrace_frames(self):
+        stacktrace_str = get_stacktrace_string(self.ONLY_STACKTRACE)
+        assert stacktrace_str == self.EXPECTED_STACKTRACE_STRING
+
 
 class EventContentIsSeerEligibleTest(TestCase):
     def get_eligible_event_data(self) -> dict[str, Any]:
@@ -769,21 +834,6 @@ class EventContentIsSeerEligibleTest(TestCase):
                 ]
             },
             "platform": "python",
-        }
-
-    def get_only_stacktrace_frames_event_data(self) -> dict[str, Any]:
-        return {
-            "title": "FailedToFetchPotato('GibPotato failed to fetch poutine')",
-            "stacktrace": {
-                "frames": [
-                    {
-                        "filename": "/index.php",
-                        "abs_path": "/var/www/gib-potato/webroot/index.php",
-                        "context_line": "$server->emit($server->run());",
-                    },
-                ]
-            },
-            "platform": "php",
         }
 
     def test_no_stacktrace(self):
@@ -825,15 +875,6 @@ class EventContentIsSeerEligibleTest(TestCase):
         assert bad_event_data["platform"] not in SEER_ELIGIBLE_PLATFORMS
         assert event_content_is_seer_eligible(good_event) is True
         assert event_content_is_seer_eligible(bad_event) is False
-
-    def test_only_stacktrace_frames(self):
-        event_data = self.get_only_stacktrace_frames_event_data()
-        event = Event(
-            project_id=self.project.id,
-            event_id=uuid1().hex,
-            data=event_data,
-        )
-        assert event_content_is_seer_eligible(event) is True
 
 
 class SeerUtilsTest(TestCase):

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -809,7 +809,7 @@ class GetStacktraceStringTest(TestCase):
 
     def test_only_stacktrace_frames(self):
         stacktrace_str = get_stacktrace_string(self.ONLY_STACKTRACE)
-        assert stacktrace_str == self.EXPECTED_STACKTRACE_STRING
+        assert stacktrace_str == 'File "index.php", function \n    $server->emit($server->run());'
 
 
 class EventContentIsSeerEligibleTest(TestCase):

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -356,54 +356,27 @@ class GetStacktraceStringTest(TestCase):
 
     ONLY_STACKTRACE = {
         "app": {
-            "key": "app",
-            "type": "component",
-            "description": "in-app stack-trace",
-            "hash": "cb220adbea9b2575459b64285f9a3605",
+            "hash": "foo",
             "component": {
                 "id": "app",
-                "name": "in-app",
                 "contributes": True,
-                "hint": None,
                 "values": [
                     {
                         "id": "stacktrace",
-                        "name": "stack-trace",
                         "contributes": True,
-                        "hint": None,
                         "values": [
                             {
                                 "id": "frame",
-                                "name": None,
                                 "contributes": True,
-                                "hint": None,
                                 "values": [
                                     {
-                                        "id": "module",
-                                        "name": None,
-                                        "contributes": None,
-                                        "hint": None,
-                                        "values": [],
-                                    },
-                                    {
                                         "id": "filename",
-                                        "name": None,
                                         "contributes": True,
-                                        "hint": None,
                                         "values": ["index.php"],
                                     },
                                     {
-                                        "id": "function",
-                                        "name": None,
-                                        "contributes": None,
-                                        "hint": None,
-                                        "values": [],
-                                    },
-                                    {
                                         "id": "context-line",
-                                        "name": None,
                                         "contributes": True,
-                                        "hint": None,
                                         "values": ["$server->emit($server->run());"],
                                     },
                                 ],

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -771,6 +771,21 @@ class EventContentIsSeerEligibleTest(TestCase):
             "platform": "python",
         }
 
+    def get_only_stacktrace_frames_event_data(self) -> dict[str, Any]:
+        return {
+            "title": "FailedToFetchPotato('GibPotato failed to fetch poutine')",
+            "stacktrace": {
+                "frames": [
+                    {
+                        "filename": "/index.php",
+                        "abs_path": "/var/www/gib-potato/webroot/index.php",
+                        "context_line": "$server->emit($server->run());",
+                    },
+                ]
+            },
+            "platform": "php",
+        }
+
     def test_no_stacktrace(self):
         good_event_data = self.get_eligible_event_data()
         good_event = Event(
@@ -810,6 +825,15 @@ class EventContentIsSeerEligibleTest(TestCase):
         assert bad_event_data["platform"] not in SEER_ELIGIBLE_PLATFORMS
         assert event_content_is_seer_eligible(good_event) is True
         assert event_content_is_seer_eligible(bad_event) is False
+
+    def test_only_stacktrace_frames(self):
+        event_data = self.get_only_stacktrace_frames_event_data()
+        event = Event(
+            project_id=self.project.id,
+            event_id=uuid1().hex,
+            data=event_data,
+        )
+        assert event_content_is_seer_eligible(event) is True
 
 
 class SeerUtilsTest(TestCase):


### PR DESCRIPTION
Errors in PHP contain the stack trace under the `stack trace` property in the event; thus, seer was not extracting the stack trace string properly.