### PR TITLE
feat(dashboards): Add base config for new EAP dataset

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1025,7 +1025,7 @@ type TraceFields =
   | SpanIndexedField.SPAN_STATUS
   | SpanIndexedField.RESPONSE_CODE;
 
-const TRACE_FIELD_DEFINITIONS: Record<TraceFields, FieldDefinition> = {
+export const TRACE_FIELD_DEFINITIONS: Record<TraceFields, FieldDefinition> = {
   /** Indexed Fields */
   [SpanIndexedField.SPAN_ACTION]: {
     desc: t(

--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -26,6 +26,7 @@ import {ErrorsConfig} from './errors';
 import {ErrorsAndTransactionsConfig} from './errorsAndTransactions';
 import {IssuesConfig} from './issues';
 import {ReleasesConfig} from './releases';
+import {SpansConfig} from './spans';
 import {TransactionsConfig} from './transactions';
 
 export type WidgetBuilderSearchBarProps = {
@@ -244,6 +245,8 @@ export function getDatasetConfig(
       return ErrorsConfig;
     case WidgetType.TRANSACTIONS:
       return TransactionsConfig;
+    case WidgetType.SPANS:
+      return SpansConfig;
     case WidgetType.DISCOVER:
     default:
       return ErrorsAndTransactionsConfig;

--- a/static/app/views/dashboards/datasetConfig/errors.tsx
+++ b/static/app/views/dashboards/datasetConfig/errors.tsx
@@ -60,8 +60,6 @@ const DEFAULT_WIDGET_QUERY: WidgetQuery = {
 
 export type SeriesWithOrdering = [order: number, series: Series];
 
-// TODO: Commented out functions will be given implementations
-// to be able to make events-stats requests
 export const ErrorsConfig: DatasetConfig<
   EventsStats | MultiSeriesEventsStats,
   TableData | EventsTableData

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -1,0 +1,156 @@
+import type {Client} from 'sentry/api';
+import type {PageFilters} from 'sentry/types/core';
+import type {TagCollection} from 'sentry/types/group';
+import type {
+  EventsStats,
+  MultiSeriesEventsStats,
+  Organization,
+} from 'sentry/types/organization';
+import toArray from 'sentry/utils/array/toArray';
+import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
+import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
+import {getAggregations} from 'sentry/utils/discover/fields';
+import {
+  type DiscoverQueryExtras,
+  type DiscoverQueryRequestParams,
+  doDiscoverQuery,
+} from 'sentry/utils/discover/genericDiscoverQuery';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {TRACE_FIELD_DEFINITIONS} from 'sentry/utils/fields';
+import type {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
+import type {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
+import {
+  type DatasetConfig,
+  handleOrderByReset,
+} from 'sentry/views/dashboards/datasetConfig/base';
+import {
+  filterAggregateParams,
+  getCustomEventsFieldRenderer,
+  getTableSortOptions,
+  transformEventsResponseToSeries,
+  transformEventsResponseToTable,
+} from 'sentry/views/dashboards/datasetConfig/errorsAndTransactions';
+import {DisplayType, type Widget, type WidgetQuery} from 'sentry/views/dashboards/types';
+import {eventViewFromWidget} from 'sentry/views/dashboards/utils';
+import {generateFieldOptions} from 'sentry/views/discover/utils';
+
+const DEFAULT_WIDGET_QUERY: WidgetQuery = {
+  name: '',
+  fields: ['span.op', 'count()'],
+  columns: ['span.op'],
+  fieldAliases: [],
+  aggregates: ['count()'],
+  conditions: '',
+  orderby: '-count()',
+};
+
+export const SpansConfig: DatasetConfig<
+  EventsStats | MultiSeriesEventsStats,
+  TableData | EventsTableData
+> = {
+  defaultWidgetQuery: DEFAULT_WIDGET_QUERY,
+  enableEquations: false, // TODO: Should EAP support equations?
+  getCustomFieldRenderer: getCustomEventsFieldRenderer,
+  SearchBar: () => <div />,
+  filterSeriesSortOptions: () => () => true,
+  filterYAxisAggregateParams: () => () => true,
+  filterYAxisOptions: () => () => true,
+  getTableFieldOptions: getEventsTableFieldOptions,
+  // getTimeseriesSortOptions: (organization, widgetQuery, tags) =>
+  //  getTimeseriesSortOptions(organization, widgetQuery, tags, getEventsTableFieldOptions),
+  getTableSortOptions: getTableSortOptions,
+  getGroupByFieldOptions: getEventsTableFieldOptions,
+  handleOrderByReset,
+  supportedDisplayTypes: [
+    // DisplayType.AREA,
+    // DisplayType.BAR,
+    // DisplayType.BIG_NUMBER,
+    // DisplayType.LINE,
+    DisplayType.TABLE,
+    // DisplayType.TOP_N,
+  ],
+  getTableRequest: (
+    api: Client,
+    _widget: Widget,
+    query: WidgetQuery,
+    organization: Organization,
+    pageFilters: PageFilters,
+    _onDemandControlContext?: OnDemandControlContext,
+    limit?: number,
+    cursor?: string,
+    referrer?: string,
+    _mepSetting?: MEPState | null
+  ) => {
+    return getEventsRequest(
+      api,
+      query,
+      organization,
+      pageFilters,
+      limit,
+      cursor,
+      referrer
+    );
+  },
+  // getSeriesRequest: getErrorsSeriesRequest,
+  transformTable: transformEventsResponseToTable,
+  transformSeries: transformEventsResponseToSeries,
+  filterAggregateParams,
+};
+
+// TODO: Update tags to use EAP tags
+function getEventsTableFieldOptions(
+  organization: Organization,
+  tags?: TagCollection,
+  _customMeasurements?: CustomMeasurementCollection
+) {
+  return generateFieldOptions({
+    organization,
+    tagKeys: Object.values(tags ?? {}).map(({key}) => key),
+    fieldKeys: Object.keys(TRACE_FIELD_DEFINITIONS),
+    // TODO: Use EAP specific aggregations
+    aggregations: getAggregations(DiscoverDatasets.TRANSACTIONS),
+  });
+}
+
+function getEventsRequest(
+  api: Client,
+  query: WidgetQuery,
+  organization: Organization,
+  pageFilters: PageFilters,
+  limit?: number,
+  cursor?: string,
+  referrer?: string,
+  _mepSetting?: MEPState | null,
+  queryExtras?: DiscoverQueryExtras
+) {
+  const url = `/organizations/${organization.slug}/events/`;
+  const eventView = eventViewFromWidget('', query, pageFilters);
+
+  const params: DiscoverQueryRequestParams = {
+    per_page: limit,
+    cursor,
+    referrer,
+    dataset: DiscoverDatasets.SPANS_EAP,
+    ...queryExtras,
+  };
+
+  if (query.orderby) {
+    params.sort = toArray(query.orderby);
+  }
+
+  return doDiscoverQuery<EventsTableData>(
+    api,
+    url,
+    {
+      ...eventView.generateQueryStringObject(),
+      ...params,
+    },
+    // Tries events request up to 3 times on rate limit
+    {
+      retry: {
+        statusCodes: [429],
+        tries: 3,
+      },
+    }
+  );
+}

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -32,6 +32,7 @@ import {
 } from 'sentry/views/dashboards/datasetConfig/errorsAndTransactions';
 import {DisplayType, type Widget, type WidgetQuery} from 'sentry/views/dashboards/types';
 import {eventViewFromWidget} from 'sentry/views/dashboards/utils';
+import {EventsSearchBar} from 'sentry/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar';
 import {generateFieldOptions} from 'sentry/views/discover/utils';
 
 const DEFAULT_WIDGET_QUERY: WidgetQuery = {
@@ -51,7 +52,7 @@ export const SpansConfig: DatasetConfig<
   defaultWidgetQuery: DEFAULT_WIDGET_QUERY,
   enableEquations: false, // TODO: Should EAP support equations?
   getCustomFieldRenderer: getCustomEventsFieldRenderer,
-  SearchBar: () => <div />,
+  SearchBar: EventsSearchBar, // TODO: Replace with a custom EAP search bar
   filterSeriesSortOptions: () => () => true,
   filterYAxisAggregateParams: () => () => true,
   filterYAxisOptions: () => () => true,

--- a/static/app/views/dashboards/datasetConfig/transactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/transactions.tsx
@@ -64,8 +64,6 @@ const DEFAULT_WIDGET_QUERY: WidgetQuery = {
 
 export type SeriesWithOrdering = [order: number, series: Series];
 
-// TODO: Commented out functions will be given implementations
-// to be able to make events-stats requests
 export const TransactionsConfig: DatasetConfig<
   EventsStats | MultiSeriesEventsStats,
   TableData | EventsTableData

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -29,6 +29,7 @@ export enum WidgetType {
   METRICS = 'custom-metrics',
   ERRORS = 'error-events',
   TRANSACTIONS = 'transaction-like',
+  SPANS = 'spans',
 }
 
 // These only pertain to on-demand warnings at this point in time

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.spec.tsx
@@ -1,0 +1,26 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {DisplayType} from 'sentry/views/dashboards/types';
+import {DataSetStep} from 'sentry/views/dashboards/widgetBuilder/buildSteps/dataSetStep';
+import {DataSet} from 'sentry/views/dashboards/widgetBuilder/utils';
+
+describe('DataSetStep', () => {
+  it('renders the spans dataset with the EAP feature flag', () => {
+    render(
+      <DataSetStep
+        dataSet={DataSet.ISSUES}
+        displayType={DisplayType.TABLE}
+        onChange={jest.fn()}
+      />,
+      {
+        organization: OrganizationFixture({
+          features: ['dashboards-eap'],
+        }),
+      }
+    );
+
+    expect(screen.getByText('Spans')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
@@ -90,6 +90,11 @@ export function DataSetStep({
   if (!hasDatasetSelectorFeature) {
     datasetChoices.set(DataSet.EVENTS, t('Errors and Transactions'));
   }
+
+  if (organization.features.includes('dashboards-eap')) {
+    datasetChoices.set(DataSet.SPANS, t('Spans'));
+  }
+
   datasetChoices.set(DataSet.ISSUES, t('Issues (States, Assignment, Time, etc.)'));
 
   datasetChoices.set(DataSet.RELEASES, t('Releases (Sessions, Crash rates)'));

--- a/static/app/views/dashboards/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils.tsx
@@ -52,6 +52,7 @@ export enum DataSet {
   METRICS = 'metrics',
   ERRORS = 'error-events',
   TRANSACTIONS = 'transaction-like',
+  SPANS = 'spans',
 }
 
 export enum SortDirection {

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -111,6 +111,7 @@ const WIDGET_TYPE_TO_DATA_SET = {
   [WidgetType.METRICS]: DataSet.METRICS,
   [WidgetType.ERRORS]: DataSet.ERRORS,
   [WidgetType.TRANSACTIONS]: DataSet.TRANSACTIONS,
+  [WidgetType.SPANS]: DataSet.SPANS,
 };
 
 export const DATA_SET_TO_WIDGET_TYPE = {
@@ -120,6 +121,7 @@ export const DATA_SET_TO_WIDGET_TYPE = {
   [DataSet.METRICS]: WidgetType.METRICS,
   [DataSet.ERRORS]: WidgetType.ERRORS,
   [DataSet.TRANSACTIONS]: WidgetType.TRANSACTIONS,
+  [DataSet.SPANS]: WidgetType.SPANS,
 };
 
 interface RouteParams {


### PR DESCRIPTION
Adds a new dataset config for the "Spans" dataset. Adding a dataset requires a number of changes so I'm breaking it down. This mostly introduces the file and uses an existing enum used in the trace explorer for span-specific values. It only works with Table and big number widgets right now.

I need to fill out custom implementations for the other parts of the dataset config, including but not limited to:
- Add more fields that we extract
- Implement a search bar that will expose span tags and values
- Implement the functionality for querying timeseries data
- Add insights/EAP specific aggregations