### PR TITLE
fix(trace) zoom on column click

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceRow/traceErrorRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceErrorRow.tsx
@@ -41,12 +41,12 @@ export function TraceErrorRow(props: TraceRowProps<TraceTreeNode<TraceTree.Trace
       onKeyDown={props.onRowKeyDown}
       style={props.style}
     >
-      <div className="TraceLeftColumn" ref={props.registerListColumnRef}>
-        <div
-          className="TraceLeftColumnInner"
-          style={props.listColumnStyle}
-          onDoubleClick={props.onRowDoubleClick}
-        >
+      <div
+        className="TraceLeftColumn"
+        ref={props.registerListColumnRef}
+        onDoubleClick={props.onRowDoubleClick}
+      >
+        <div className="TraceLeftColumnInner" style={props.listColumnStyle}>
           <div className="TraceChildrenCountWrapper">
             <TraceRowConnectors node={props.node} manager={props.manager} />{' '}
           </div>

--- a/static/app/views/performance/newTraceDetails/traceRow/traceMissingInstrumentationRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceMissingInstrumentationRow.tsx
@@ -30,12 +30,12 @@ export function TraceMissingInstrumentationRow(
       onKeyDown={props.onRowKeyDown}
       style={props.style}
     >
-      <div className="TraceLeftColumn" ref={props.registerListColumnRef}>
-        <div
-          className="TraceLeftColumnInner"
-          style={props.listColumnStyle}
-          onDoubleClick={props.onRowDoubleClick}
-        >
+      <div
+        className="TraceLeftColumn"
+        ref={props.registerListColumnRef}
+        onDoubleClick={props.onRowDoubleClick}
+      >
+        <div className="TraceLeftColumnInner" style={props.listColumnStyle}>
           <div className="TraceChildrenCountWrapper">
             <TraceRowConnectors node={props.node} manager={props.manager} />
           </div>

--- a/static/app/views/performance/newTraceDetails/traceRow/traceRootNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceRootNode.tsx
@@ -38,12 +38,12 @@ export function TraceRootRow(props: TraceRowProps<TraceTreeNode<TraceTree.Trace>
       onKeyDown={props.onRowKeyDown}
       style={props.style}
     >
-      <div className="TraceLeftColumn" ref={props.registerListColumnRef}>
-        <div
-          className="TraceLeftColumnInner"
-          style={props.listColumnStyle}
-          onDoubleClick={props.onRowDoubleClick}
-        >
+      <div
+        className="TraceLeftColumn"
+        ref={props.registerListColumnRef}
+        onDoubleClick={props.onRowDoubleClick}
+      >
+        <div className="TraceLeftColumnInner" style={props.listColumnStyle}>
           {' '}
           <div className="TraceChildrenCountWrapper Root">
             <TraceRowConnectors node={props.node} manager={props.manager} />

--- a/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
@@ -27,12 +27,12 @@ export function TraceSpanRow(props: TraceRowProps<TraceTreeNode<TraceTree.Span>>
       onKeyDown={props.onRowKeyDown}
       style={props.style}
     >
-      <div className="TraceLeftColumn" ref={props.registerListColumnRef}>
-        <div
-          className="TraceLeftColumnInner"
-          style={props.listColumnStyle}
-          onDoubleClick={props.onRowDoubleClick}
-        >
+      <div
+        className="TraceLeftColumn"
+        ref={props.registerListColumnRef}
+        onDoubleClick={props.onRowDoubleClick}
+      >
+        <div className="TraceLeftColumnInner" style={props.listColumnStyle}>
           <div className={props.listColumnClassName}>
             <TraceRowConnectors node={props.node} manager={props.manager} />
             {props.node.children.length > 0 || props.node.canFetch ? (

--- a/static/app/views/performance/newTraceDetails/traceRow/traceTransactionRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceTransactionRow.tsx
@@ -29,12 +29,12 @@ export function TraceTransactionRow(
       onClick={props.onRowClick}
       style={props.style}
     >
-      <div className="TraceLeftColumn" ref={props.registerListColumnRef}>
-        <div
-          className="TraceLeftColumnInner"
-          style={props.listColumnStyle}
-          onDoubleClick={props.onRowDoubleClick}
-        >
+      <div
+        className="TraceLeftColumn"
+        ref={props.registerListColumnRef}
+        onDoubleClick={props.onRowDoubleClick}
+      >
+        <div className="TraceLeftColumnInner" style={props.listColumnStyle}>
           <div className={props.listColumnClassName}>
             <TraceRowConnectors node={props.node} manager={props.manager} />
             {props.node.children.length > 0 || props.node.canFetch ? (


### PR DESCRIPTION
I must have missed this somehow, but we were requiring users to click on the inner node to be able to zoom into a span whereas we should have detected it on the entire column