### PR TITLE
fix(discover): Environment overrides for homepage query

### DIFF
--- a/static/app/views/discover/homepage.tsx
+++ b/static/app/views/discover/homepage.tsx
@@ -71,6 +71,8 @@ class HomepageQueryAPI extends DeprecatedAsyncComponent<Props, HomepageQueryStat
               start: normalizeDateTimeString(start),
               end: normalizeDateTimeString(end),
             };
+          } else if (pinnedFilter === 'environments') {
+            query.environment = pageFilterState.state.environment;
           } else {
             query[pinnedFilter] = pageFilterState.state[pinnedFilter];
           }


### PR DESCRIPTION
Homepage queries weren't correctly applying selected environment filter
because the page filter key did not match the query & state key that's expected
(ie `environments` vs `environment`).

fixes https://github.com/getsentry/sentry/issues/79087