### PR TITLE
fix(new-trace): Correctly adjusting txn space when zooming.

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -523,7 +523,10 @@ export class TraceTree extends TraceTreeEventDispatcher {
       subTreeSpaceBounds[1] = 0;
     }
 
-    root.space = subTreeSpaceBounds;
+    root.space = [
+      Math.min(subTreeSpaceBounds[0], root.space[0]),
+      Math.max(subTreeSpaceBounds[1], root.space[1]),
+    ];
 
     // @TODO: each of these steps runs in On. If n becomes an issue as
     // some traces can have tens of thousands of spans, we can optimize this by trying


### PR DESCRIPTION
We were just pasting the span subtree bounds to it's parent, when zooming in. 

Before:
<img width="881" alt="Screenshot 2024-10-21 at 11 41 05 AM" src="https://github.com/user-attachments/assets/5e5e29e4-e1c4-457a-80e1-b258df9bed33">

After:
<img width="870" alt="Screenshot 2024-10-21 at 11 51 10 AM" src="https://github.com/user-attachments/assets/15ea9d70-6cba-4d53-9eb9-4cb2e3080a5b">
