### PR TITLE
ref(onboarding): Tweak sidebar code for loader script

### DIFF
--- a/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
@@ -260,7 +260,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
                 t('I use NPM or Yarn')
               ),
             ],
-            ['jsLoader', t('I use HTML templates')],
+            ['jsLoader', t('I use HTML templates (Loader Script)')],
           ]}
           value={setupMode()}
           onChange={setSetupMode}

--- a/static/app/components/profiling/profilingOnboardingSidebar.tsx
+++ b/static/app/components/profiling/profilingOnboardingSidebar.tsx
@@ -340,6 +340,9 @@ const Introduction = styled('div')`
 
 const Content = styled('div')`
   padding: ${space(2)};
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
 `;
 
 const Heading = styled('div')`

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -193,7 +193,7 @@ function OnboardingContent({
       .filter((p): p is PlatformKey => p !== 'javascript')
       .includes(currentProject.platform);
 
-  const defaultTab = backendPlatform ? 'jsLoader' : 'npm';
+  const defaultTab: string = 'jsLoader';
   const {getParamValue: setupMode, setParamValue: setSetupMode} = useUrlParams(
     'mode',
     defaultTab
@@ -273,7 +273,7 @@ function OnboardingContent({
                 t('I use NPM or Yarn')
               ),
             ],
-            ['jsLoader', t('I use HTML templates')],
+            ['jsLoader', t('I use HTML templates (Loader Script)')],
           ]}
           value={setupMode()}
           onChange={setSetupMode}


### PR DESCRIPTION
Users may become confused if they have instrumented their SDK using the loader script and later encounter the following:

<img width="631" alt="image" src="https://github.com/user-attachments/assets/427bb2ab-e638-4408-86b7-96217b11b214">

To address this, we are making the 'HTML Templates' option the default one, aligning it with how we display the Loader Script during onboarding. Additionally, we are adding '(Loader Script)' as a prefix to clarify its use.

We do not completely name it "Loader Script" because old users might not be familiar with this term.

**Preview**

<img width="577" alt="image" src="https://github.com/user-attachments/assets/ee30e7ea-456b-4f68-a01a-cac00d8cb673">


closes https://github.com/getsentry/sentry/issues/79183