### PR TITLE
fix(empty-states): Remove non-errors onboarding from empty state

### DIFF
--- a/static/app/components/updatedEmptyState.tsx
+++ b/static/app/components/updatedEmptyState.tsx
@@ -70,9 +70,9 @@ export default function UpdatedEmptyState({project}: {project?: Project}) {
     projectId: project.id,
     projectSlug: project.slug,
     isFeedbackSelected: false,
-    isPerformanceSelected: true,
-    isProfilingSelected: true,
-    isReplaySelected: true,
+    isPerformanceSelected: false,
+    isProfilingSelected: false,
+    isReplaySelected: false,
     sourcePackageRegistries: {
       isLoading: isLoadingRegistry,
       data: registryData,


### PR DESCRIPTION
this pr removes the non-errors onboarding instructions from the issues empty state. 