### PR TITLE
fix(ui): Add org slug to project settings links

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidence.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidence.spec.tsx
@@ -120,7 +120,7 @@ describe('spanEvidence', () => {
     expect(settingsBtn).toBeInTheDocument();
     expect(settingsBtn).toHaveAttribute(
       'href',
-      `/settings/projects/project-slug/performance/?issueType=${
+      `/settings/${organization.slug}/projects/${project.slug}/performance/?issueType=${
         IssueType.PERFORMANCE_SLOW_DB_QUERY
       }#${sanitizeQuerySelector(IssueTitle.PERFORMANCE_SLOW_DB_QUERY)}`
     );

--- a/static/app/components/events/interfaces/performance/spanEvidence.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidence.tsx
@@ -62,7 +62,11 @@ export function SpanEvidenceSection({event, organization, projectSlug}: Props) {
         hasSetting && (
           <LinkButton
             data-test-id="span-evidence-settings-btn"
-            to={`/settings/projects/${projectSlug}/performance/?issueType=${issueType}#${sanitizedIssueTitle}`}
+            to={{
+              pathname: `/settings/${organization.slug}/projects/${projectSlug}/performance/`,
+              query: {issueType},
+              hash: sanitizedIssueTitle,
+            }}
             size="xs"
             icon={<IconSettings />}
           >

--- a/static/app/components/metrics/mriSelect/metricListItemDetails.tsx
+++ b/static/app/components/metrics/mriSelect/metricListItemDetails.tsx
@@ -156,8 +156,8 @@ export function MetricListItemDetails({
               size="xs"
               to={
                 isVirtualMetric
-                  ? `/settings/projects/${firstMetricProject.slug}/metrics/`
-                  : `/settings/projects/${firstMetricProject.slug}/metrics/${encodeURIComponent(metric.mri)}`
+                  ? `/settings/${organization.slug}/projects/${firstMetricProject.slug}/metrics/`
+                  : `/settings/${organization.slug}/projects/${firstMetricProject.slug}/metrics/${encodeURIComponent(metric.mri)}`
               }
               aria-label={t('Open metric settings')}
               icon={<IconSettings />}
@@ -169,7 +169,7 @@ export function MetricListItemDetails({
               size="xs"
               onClick={() =>
                 navigateTo(
-                  `/settings/projects/:projectId/metrics/${encodeURIComponent(metric.mri)}`,
+                  `/settings/${organization.slug}/projects/:projectId/metrics/${encodeURIComponent(metric.mri)}`,
                   router
                 )
               }

--- a/static/app/components/modals/metricWidgetViewerModal/queries.tsx
+++ b/static/app/components/modals/metricWidgetViewerModal/queries.tsx
@@ -334,7 +334,7 @@ function QueryContextMenu({
       disabled: !customMetric,
       onAction: () => {
         navigateTo(
-          `/settings/projects/:projectId/metrics/${encodeURIComponent(metricsQuery.mri)}`,
+          `/settings/${organization.slug}/projects/:projectId/metrics/${encodeURIComponent(metricsQuery.mri)}`,
           router
         );
       },

--- a/static/app/views/alerts/rules/issue/feedbackAlertBanner.tsx
+++ b/static/app/views/alerts/rules/issue/feedbackAlertBanner.tsx
@@ -6,6 +6,7 @@ import Link from 'sentry/components/links/link';
 import {tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {IssueAlertFilterType, type IssueAlertRuleCondition} from 'sentry/types/alerts';
+import useOrganization from 'sentry/utils/useOrganization';
 
 export default function FeedbackAlertBanner({
   filters,
@@ -14,6 +15,7 @@ export default function FeedbackAlertBanner({
   filters: IssueAlertRuleCondition[] | undefined;
   projectSlug: string;
 }) {
+  const organization = useOrganization();
   const filterSet = filters?.filter(r => r.id === IssueAlertFilterType.ISSUE_CATEGORY);
   if (!filterSet || !filterSet.length) {
     return null;
@@ -24,7 +26,11 @@ export default function FeedbackAlertBanner({
       {tct(
         'This issue category condition is ONLY for feedbacks from the [linkWidget:built-in widget]. [linkModal: Crash-report modal] alerts can be enabled in [link:Project Settings].',
         {
-          link: <Link to={`/settings/projects/${projectSlug}/user-feedback/`} />,
+          link: (
+            <Link
+              to={`/settings/${organization.slug}/projects/${projectSlug}/user-feedback/`}
+            />
+          ),
           linkWidget: (
             <ExternalLink href="https://docs.sentry.io/platforms/javascript/user-feedback/#user-feedback-widget" />
           ),

--- a/static/app/views/insights/browser/resources/components/sampleImages.tsx
+++ b/static/app/views/insights/browser/resources/components/sampleImages.tsx
@@ -10,9 +10,9 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconImage} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {safeURL} from 'sentry/utils/url/safeURL';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
+import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import ResourceSize from 'sentry/views/insights/browser/resources/components/resourceSize';
@@ -158,6 +158,7 @@ function SampleImagesChartPanelBody(props: {
 
 function DisabledImages(props: {onClickShowLinks?: () => void}) {
   const {onClickShowLinks} = props;
+  const organization = useOrganization();
   const {
     selection: {projects: selectedProjects},
   } = usePageFilters();
@@ -178,9 +179,7 @@ function DisabledImages(props: {onClickShowLinks?: () => void}) {
       <ButtonContainer>
         <Button onClick={onClickShowLinks}>Only show links</Button>
         <Link
-          to={normalizeUrl(
-            `/settings/projects/${firstProjectSelected?.slug}/performance/`
-          )}
+          to={`/settings/${organization.slug}/projects/${firstProjectSelected?.slug}/performance/`}
         >
           <Button priority="primary" data-test-id="enable-sample-images-button">
             {t(' Enable in Settings')}

--- a/static/app/views/metrics/metricQueryContextMenu.tsx
+++ b/static/app/views/metrics/metricQueryContextMenu.tsx
@@ -148,7 +148,7 @@ export function MetricQueryContextMenu({
 
         if (!isVirtualMetric(metricsQuery)) {
           navigateTo(
-            `/settings/projects/:projectId/metrics/${encodeURIComponent(
+            `/settings/${organization.slug}/projects/:projectId/metrics/${encodeURIComponent(
               metricsQuery.mri
             )}`,
             router

--- a/static/app/views/metrics/pageHeaderActions.tsx
+++ b/static/app/views/metrics/pageHeaderActions.tsx
@@ -98,7 +98,8 @@ export function PageHeaderActions({showAddMetricButton, addCustomMetric}: Props)
       leadingItems: [<IconSettings key="icon" />],
       key: 'Metrics Settings',
       label: t('Metrics Settings'),
-      onAction: () => navigateTo(`/settings/projects/:projectId/metrics/`, router),
+      onAction: () =>
+        navigateTo(`/settings/${organization.slug}/projects/:projectId/metrics/`, router),
     };
 
     if (hasCustomMetrics(organization)) {

--- a/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -547,7 +547,7 @@ export function ProjectFiltersSettings({project, params, features}: Props) {
                         {
                           replaySettings: (
                             <Link
-                              to={`/settings/projects/${project.slug}/replays/#sentry-replay_hydration_error_issues_help`}
+                              to={`/settings/${organization.slug}/projects/${project.slug}/replays/#sentry-replay_hydration_error_issues_help`}
                             />
                           ),
                         }

--- a/static/app/views/settings/project/projectReplays.tsx
+++ b/static/app/views/settings/project/projectReplays.tsx
@@ -48,7 +48,7 @@ function ProjectReplaySettings({organization, project, params: {projectId}}: Pro
               {
                 inboundFilters: (
                   <Link
-                    to={`/settings/projects/${project.slug}/filters/data-filters/#filters-react-hydration-errors_help`}
+                    to={`/settings/${organization.slug}/projects/${project.slug}/filters/data-filters/#filters-react-hydration-errors_help`}
                   />
                 ),
               }

--- a/static/app/views/settings/projectMetrics/customMetricsTable.tsx
+++ b/static/app/views/settings/projectMetrics/customMetricsTable.tsx
@@ -19,6 +19,7 @@ import {useBlockMetric} from 'sentry/utils/metrics/useBlockMetric';
 import {useCardinalityLimitedMetricVolume} from 'sentry/utils/metrics/useCardinalityLimitedMetricVolume';
 import {useMetricsMeta} from 'sentry/utils/metrics/useMetricsMeta';
 import {middleEllipsis} from 'sentry/utils/string/middleEllipsis';
+import useOrganization from 'sentry/utils/useOrganization';
 import {useAccess} from 'sentry/views/settings/projectMetrics/access';
 import {BlockButton} from 'sentry/views/settings/projectMetrics/blockButton';
 import {useSearchQueryParam} from 'sentry/views/settings/projectMetrics/utils/useSearchQueryParam';
@@ -139,6 +140,7 @@ interface MetricsTableProps {
 
 function MetricsTable({metrics, isLoading, query, project}: MetricsTableProps) {
   const blockMetricMutation = useBlockMetric(project);
+  const organization = useOrganization();
   const {hasAccess} = useAccess({access: ['project:write'], project});
 
   return (
@@ -182,7 +184,7 @@ function MetricsTable({metrics, isLoading, query, project}: MetricsTableProps) {
                 </Tooltip>
               )}
               <Link
-                to={`/settings/projects/${project.slug}/metrics/${encodeURIComponent(
+                to={`/settings/${organization.slug}/projects/${project.slug}/metrics/${encodeURIComponent(
                   mri
                 )}`}
               >


### PR DESCRIPTION
Project settings links should still include the organization slug for non-hybrid cloud environments.
