### PR TITLE
fix(ui): Always show active incidents

### DIFF
--- a/static/app/components/serviceIncidentDetails.tsx
+++ b/static/app/components/serviceIncidentDetails.tsx
@@ -181,6 +181,7 @@ type UpdateStatus = StatusPageIncidentUpdate['status'];
 
 const indicatorColor: Record<UpdateStatus, ColorOrAlias> = {
   investigating: 'red200',
+  identified: 'blue200',
   monitoring: 'yellow200',
   resolved: 'green200',
 };

--- a/static/app/components/sidebar/serviceIncidents.tsx
+++ b/static/app/components/sidebar/serviceIncidents.tsx
@@ -22,7 +22,7 @@ function ServiceIncidents({
   collapsed,
   orientation,
 }: Props) {
-  const {data: incidents} = useServiceIncidents({statusFilter: 'unresolved'});
+  const {data: incidents} = useServiceIncidents();
 
   if (!incidents) {
     return null;

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -383,7 +383,7 @@ export interface StatusPageIncidentUpdate {
   /**
    * Status of the incident for tihs update
    */
-  status: 'resolved' | 'monitoring' | 'investigating';
+  status: 'resolved' | 'monitoring' | 'identified' | 'investigating';
   /**
    * ISO Update update time
    */
@@ -439,7 +439,7 @@ export interface StatuspageIncident {
   /**
    * Current status of the incident
    */
-  status: 'resolved' | 'unresolved';
+  status: 'resolved' | 'unresolved' | 'monitoring';
   /**
    * ISO 8601 last updated time
    */

--- a/static/app/views/monitors/components/timeline/serviceIncidents.tsx
+++ b/static/app/views/monitors/components/timeline/serviceIncidents.tsx
@@ -32,6 +32,7 @@ function CronServiceIncidents({timeWindowConfig}: CronServiceIncidentsProps) {
     // TODO(epurkhiser): There is also the EU region. We should make sure we
     // filter down to that region as well
     componentFilter: [StatusPageComponent.US_CRON_MONITORING],
+    includeResolved: true,
   });
 
   const getIncidentTimes = useCallback(


### PR DESCRIPTION
Prior to this change incidents in a 'monitoring' state would not be
shown in the sidebar.