### PR TITLE
ref(issue-details): Thinner highlights for streamlined page 

### DIFF
--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -560,9 +560,11 @@ export function getContextSummary({
 }): {
   subtitle: React.ReactNode;
   title: React.ReactNode;
+  subtitleType?: string;
 } {
   let title: React.ReactNode = null;
   let subtitle: React.ReactNode = null;
+  let subtitleType: string | undefined = undefined;
   switch (type) {
     case 'device':
       title = (
@@ -571,16 +573,19 @@ export function getContextSummary({
         </DeviceName>
       );
       if (defined(data?.arch)) {
-        subtitle = t('Arch: ') + data?.arch;
+        subtitle = data?.arch;
+        subtitleType = t('Architecture');
       } else if (defined(data?.model)) {
-        subtitle = t('Model: ') + data?.model;
+        subtitle = data?.model;
+        subtitleType = t('Model');
       }
       break;
 
     case 'gpu':
       title = data?.name ?? null;
       if (defined(data?.vendor_name)) {
-        subtitle = t('Vendor: ') + data?.vendor_name;
+        subtitle = data?.vendor_name;
+        subtitleType = t('Vendor');
       }
       break;
 
@@ -588,9 +593,11 @@ export function getContextSummary({
     case 'client_os':
       title = data?.name ?? null;
       if (defined(data?.version) && typeof data?.version === 'string') {
-        subtitle = t('Version: ') + data?.version;
+        subtitle = data?.version;
+        subtitleType = t('Version');
       } else if (defined(data?.kernel_version)) {
-        subtitle = t('Kernel: ') + data?.kernel_version;
+        subtitle = data?.kernel_version;
+        subtitleType = t('Kernel');
       }
       break;
 
@@ -603,11 +610,13 @@ export function getContextSummary({
       }
       if (defined(data?.id)) {
         title = title ? title : data?.id;
-        subtitle = t('ID: ') + data?.id;
+        subtitle = data?.id;
+        subtitleType = t('ID');
       }
       if (defined(data?.username)) {
         title = title ? title : data?.username;
-        subtitle = t('Username: ') + data?.username;
+        subtitle = data?.username;
+        subtitleType = t('Username');
       }
       if (title === subtitle) {
         return {
@@ -620,7 +629,8 @@ export function getContextSummary({
     case 'browser':
       title = data?.name ?? null;
       if (defined(data?.version)) {
-        subtitle = t('Version: ') + data?.version;
+        subtitle = data?.version;
+        subtitleType = t('Version');
       }
       break;
     default:
@@ -629,6 +639,7 @@ export function getContextSummary({
   return {
     title,
     subtitle,
+    subtitleType,
   };
 }
 

--- a/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
@@ -1,6 +1,6 @@
 import {EventFixture} from 'sentry-fixture/event';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {HighlightsIconSummary} from 'sentry/components/events/highlights/highlightsIconSummary';
 import {
@@ -39,7 +39,7 @@ describe('HighlightsIconSummary', function () {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('renders user if there is id, email, username, etc', function () {
+  it('renders user if there is id, email, username, etc', async function () {
     const eventWithUser = EventFixture({
       contexts: {
         user: {
@@ -52,15 +52,21 @@ describe('HighlightsIconSummary', function () {
 
     render(<HighlightsIconSummary event={eventWithUser} />);
     expect(screen.getByText('user email')).toBeInTheDocument();
-    expect(screen.getByText('Username: user username')).toBeInTheDocument();
+    expect(screen.getByText('user username')).toBeInTheDocument();
+    await userEvent.hover(screen.getByText('user username'));
+    expect(await screen.findByText('Username')).toBeInTheDocument();
   });
 
-  it('renders appropriate icons and text', function () {
+  it('renders appropriate icons and text', async function () {
     render(<HighlightsIconSummary event={event} />);
     expect(screen.getByText('Mac OS X')).toBeInTheDocument();
-    expect(screen.getByText('Version: 10.15')).toBeInTheDocument();
+    expect(screen.getByText('10.15')).toBeInTheDocument();
+    await userEvent.hover(screen.getByText('10.15'));
+    expect(await screen.findByText('Version')).toBeInTheDocument();
     expect(screen.getByText('CPython')).toBeInTheDocument();
-    expect(screen.getByText('Version: 3.8.13')).toBeInTheDocument();
+    expect(screen.getByText('3.8.13')).toBeInTheDocument();
+    await userEvent.hover(screen.getByText('3.8.13'));
+    expect(await screen.findByText('Version')).toBeInTheDocument();
     expect(screen.getAllByRole('img')).toHaveLength(2);
   });
 
@@ -75,10 +81,10 @@ describe('HighlightsIconSummary', function () {
 
     render(<HighlightsIconSummary event={eventWithDevice} />);
     expect(screen.queryByText('iPhone 13')).not.toBeInTheDocument();
-    expect(screen.queryByText('Arch: x86')).not.toBeInTheDocument();
+    expect(screen.queryByText('x86')).not.toBeInTheDocument();
   });
 
-  it('displays device for mobile/native event platforms', function () {
+  it('displays device for mobile/native event platforms', async function () {
     const eventWithDevice = EventFixture({
       contexts: {
         ...TEST_EVENT_CONTEXTS,
@@ -89,6 +95,8 @@ describe('HighlightsIconSummary', function () {
 
     render(<HighlightsIconSummary event={eventWithDevice} />);
     expect(screen.getByText('iPhone 13')).toBeInTheDocument();
-    expect(screen.getByText('Arch: x86')).toBeInTheDocument();
+    expect(screen.getByText('x86')).toBeInTheDocument();
+    await userEvent.hover(screen.getByText('x86'));
+    expect(await screen.findByText('Architecture')).toBeInTheDocument();
   });
 });

--- a/static/app/components/events/highlights/highlightsIconSummary.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.tsx
@@ -1,9 +1,11 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {Flex} from 'sentry/components/container/flex';
 import {getOrderedContextItems} from 'sentry/components/events/contexts';
 import {getContextIcon, getContextSummary} from 'sentry/components/events/contexts/utils';
 import {ScrollCarousel} from 'sentry/components/scrollCarousel';
+import {Tooltip} from 'sentry/components/tooltip';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import {isMobilePlatform, isNativePlatform} from 'sentry/utils/platform';
@@ -28,7 +30,7 @@ export function HighlightsIconSummary({event}: HighlightsIconSummaryProps) {
         type,
         value,
         contextIconProps: {
-          size: 'xl',
+          size: 'md',
         },
       }),
     }))
@@ -46,13 +48,15 @@ export function HighlightsIconSummary({event}: HighlightsIconSummaryProps) {
       <IconBar>
         <ScrollCarousel gap={4}>
           {items.map((item, index) => (
-            <IconSummary key={index}>
+            <Flex key={index} gap={space(1)} align="center">
               <IconWrapper>{item.icon}</IconWrapper>
               <IconDescription>
-                <IconTitle>{item.title}</IconTitle>
-                {item.subtitle && <IconSubtitle>{item.subtitle}</IconSubtitle>}
+                <div>{item.title}</div>
+                {item.subtitle && (
+                  <IconSubtitle title={item.subtitleType}>{item.subtitle}</IconSubtitle>
+                )}
               </IconDescription>
-            </IconSummary>
+            </Flex>
           ))}
         </ScrollCarousel>
       </IconBar>
@@ -63,32 +67,21 @@ export function HighlightsIconSummary({event}: HighlightsIconSummaryProps) {
 
 const IconBar = styled('div')`
   position: relative;
-  padding: ${space(1)} ${space(0.5)};
-`;
-
-const IconSummary = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${space(1)};
-  flex: none;
+  padding: ${space(0.5)} ${space(0.5)};
 `;
 
 const IconDescription = styled('div')`
   display: flex;
-  flex-direction: column;
-  gap: ${space(0.5)};
+  gap: ${space(0.75)};
+  font-size: ${p => p.theme.fontSizeMedium};
 `;
 
 const IconWrapper = styled('div')`
   flex: none;
-`;
-
-const IconTitle = styled('div')`
   line-height: 1;
 `;
 
-const IconSubtitle = styled('div')`
+const IconSubtitle = styled(Tooltip)`
+  display: block;
   color: ${p => p.theme.subText};
-  font-size: ${p => p.theme.fontSizeSmall};
-  line-height: 1;
 `;


### PR DESCRIPTION
Per designs, implements thinner version of context icons.

Before: 
<img width="1199" alt="image" src="https://github.com/user-attachments/assets/740f9901-bd84-41d3-9b88-ae7ab9ed67ee">


After:
<img width="1179" alt="image" src="https://github.com/user-attachments/assets/51fa8ad1-bbd6-480a-aaec-fc9f8a43be59">