### PR TITLE
ref(flags): prefix js flags

### DIFF
--- a/static/app/utils/featureObserver.spec.ts
+++ b/static/app/utils/featureObserver.spec.ts
@@ -25,8 +25,8 @@ describe('FeatureObserver', () => {
       organization.features.includes('enable-issues');
       organization.features.includes('replay-mobile-ui');
       expect(inst.getFeatureFlags().values).toEqual([
-        {flag: 'enable-issues', result: true},
-        {flag: 'replay-mobile-ui', result: false},
+        {flag: 'feature.organizations:enable-issues', result: true},
+        {flag: 'feature.organizations:replay-mobile-ui', result: false},
       ]);
 
       // do more evaluations to fill up and overflow the buffer
@@ -34,9 +34,9 @@ describe('FeatureObserver', () => {
       organization.features.includes('autofix-ui');
       organization.features.includes('new-issue-details');
       expect(inst.getFeatureFlags().values).toEqual([
-        {flag: 'enable-replay', result: true},
-        {flag: 'autofix-ui', result: false},
-        {flag: 'new-issue-details', result: false},
+        {flag: 'feature.organizations:enable-replay', result: true},
+        {flag: 'feature.organizations:autofix-ui', result: false},
+        {flag: 'feature.organizations:new-issue-details', result: false},
       ]);
     });
 
@@ -49,34 +49,34 @@ describe('FeatureObserver', () => {
       organization.features.includes('replay-mobile-ui');
       organization.features.includes('enable-discover');
       expect(inst.getFeatureFlags().values).toEqual([
-        {flag: 'enable-issues', result: true},
-        {flag: 'replay-mobile-ui', result: false},
-        {flag: 'enable-discover', result: false},
+        {flag: 'feature.organizations:enable-issues', result: true},
+        {flag: 'feature.organizations:replay-mobile-ui', result: false},
+        {flag: 'feature.organizations:enable-discover', result: false},
       ]);
 
       // this is already in the queue; it should be removed and
       // added back to the end of the queue
       organization.features.includes('enable-issues');
       expect(inst.getFeatureFlags().values).toEqual([
-        {flag: 'replay-mobile-ui', result: false},
-        {flag: 'enable-discover', result: false},
-        {flag: 'enable-issues', result: true},
+        {flag: 'feature.organizations:replay-mobile-ui', result: false},
+        {flag: 'feature.organizations:enable-discover', result: false},
+        {flag: 'feature.organizations:enable-issues', result: true},
       ]);
 
       organization.features.includes('spam-ingest');
       expect(inst.getFeatureFlags().values).toEqual([
-        {flag: 'enable-discover', result: false},
-        {flag: 'enable-issues', result: true},
-        {flag: 'spam-ingest', result: false},
+        {flag: 'feature.organizations:enable-discover', result: false},
+        {flag: 'feature.organizations:enable-issues', result: true},
+        {flag: 'feature.organizations:spam-ingest', result: false},
       ]);
 
       // this is already in the queue but in the back
       // the queue should not change
       organization.features.includes('spam-ingest');
       expect(inst.getFeatureFlags().values).toEqual([
-        {flag: 'enable-discover', result: false},
-        {flag: 'enable-issues', result: true},
-        {flag: 'spam-ingest', result: false},
+        {flag: 'feature.organizations:enable-discover', result: false},
+        {flag: 'feature.organizations:enable-issues', result: true},
+        {flag: 'feature.organizations:spam-ingest', result: false},
       ]);
     });
 
@@ -88,24 +88,24 @@ describe('FeatureObserver', () => {
       organization.features.includes('enable-issues');
       organization.features.includes('replay-mobile-ui');
       expect(inst.getFeatureFlags().values).toEqual([
-        {flag: 'enable-issues', result: true},
-        {flag: 'replay-mobile-ui', result: false},
+        {flag: 'feature.organizations:enable-issues', result: true},
+        {flag: 'feature.organizations:replay-mobile-ui', result: false},
       ]);
 
       // this is already in the queue; it should be removed and
       // added back to the end of the queue
       organization.features.includes('enable-issues');
       expect(inst.getFeatureFlags().values).toEqual([
-        {flag: 'replay-mobile-ui', result: false},
-        {flag: 'enable-issues', result: true},
+        {flag: 'feature.organizations:replay-mobile-ui', result: false},
+        {flag: 'feature.organizations:enable-issues', result: true},
       ]);
 
       // this is already in the queue but in the back
       // the queue should not change
       organization.features.includes('enable-issues');
       expect(inst.getFeatureFlags().values).toEqual([
-        {flag: 'replay-mobile-ui', result: false},
-        {flag: 'enable-issues', result: true},
+        {flag: 'feature.organizations:replay-mobile-ui', result: false},
+        {flag: 'feature.organizations:enable-issues', result: true},
       ]);
     });
 
@@ -117,8 +117,8 @@ describe('FeatureObserver', () => {
       organization.features.includes('enable-issues');
       organization.features.includes('replay-mobile-ui');
       expect(inst.getFeatureFlags().values).toEqual([
-        {flag: 'enable-issues', result: true},
-        {flag: 'replay-mobile-ui', result: false},
+        {flag: 'feature.organizations:enable-issues', result: true},
+        {flag: 'feature.organizations:replay-mobile-ui', result: false},
       ]);
 
       expect(organization.features.includes('enable-issues')).toBe(true);

--- a/static/app/utils/featureObserver.ts
+++ b/static/app/utils/featureObserver.ts
@@ -39,8 +39,11 @@ export default class FeatureObserver {
         // Evaluate the result of .includes()
         const flagResult = target.apply(orgFeatures, flagName);
 
+        // Append `feature.organizations:` in front to match the Sentry options automator format
+        const name = 'feature.organizations:' + flagName[0];
+
         // Check if the flag is already in the buffer
-        const index = FLAGS.values.findIndex(f => f.flag === flagName[0]);
+        const index = FLAGS.values.findIndex(f => f.flag === name);
 
         // The flag is already in the buffer
         if (index !== -1) {
@@ -55,7 +58,7 @@ export default class FeatureObserver {
 
         // Store the flag and its result in the buffer
         FLAGS.values.push({
-          flag: flagName[0],
+          flag: name,
           result: flagResult,
         });
 


### PR DESCRIPTION
## context: 
the discrepancy in the way we're returning flag names (in the evaluated FF list vs audit log) currently makes it really hard to compare which flags are the same. 

if we have a flag that's returned as `session-replay` on JS and `features.organizations:session-replay` in the audit log then we need to do trimming in order to return that they're the same flag since the names are different. 

the way we evaluate flags on the frontend is by doing `organization.features.includes('flagName')` so the only thing we get is `flagName`. in options-automator it'd probably be `feature.organizations:flagName`. this PR updates the flag name in the buffer to match what's in options-automator, so that we can compare flag names easily in the frontend.