### PR TITLE
fix(autofix): Check for gen AI consent without API request

### DIFF
--- a/static/app/components/events/autofix/useAutofixSetup.tsx
+++ b/static/app/components/events/autofix/useAutofixSetup.tsx
@@ -47,7 +47,6 @@ export function useAutofixSetup(
     canStartAutofix: Boolean(
       queryData.data?.integration.ok && queryData.data?.genAIConsent.ok
     ),
-    genAIConsent: Boolean(queryData.data?.genAIConsent.ok ?? false),
     canCreatePullRequests: Boolean(queryData.data?.githubWriteIntegration.ok),
   };
 }

--- a/static/app/views/issueDetails/resourcesAndPossibleSolutions.tsx
+++ b/static/app/views/issueDetails/resourcesAndPossibleSolutions.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 
 import {AiSuggestedSolution} from 'sentry/components/events/aiSuggestedSolution';
 import {Autofix} from 'sentry/components/events/autofix';
-import {useAutofixSetup} from 'sentry/components/events/autofix/useAutofixSetup';
 import {Resources} from 'sentry/components/events/interfaces/performance/resources';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
@@ -52,14 +51,11 @@ export function ResourcesAndPossibleSolutions({event, project, group}: Props) {
   const config = getConfigForIssueType(group, project);
   const isSelfHostedErrorsOnly = ConfigStore.get('isSelfHostedErrorsOnly');
   const isSampleError = useIsSampleEvent();
-  const {genAIConsent} = useAutofixSetup({
-    groupId: group.id,
-  });
 
   const displayAiAutofix =
     ((organization.features.includes('autofix') &&
       organization.features.includes('issue-details-autofix-ui')) ||
-      genAIConsent) &&
+      organization.genAIConsent) &&
     !shouldShowCustomErrorResourceConfig(group, project) &&
     config.autofix &&
     hasStacktraceWithFrames(event) &&


### PR DESCRIPTION
Before we were using the useAutofix hook to make an API request to check for gen AI consent. Now we can just read the Organization object and cut that out.

It should stop a lot of errors we're seeing in Sentry and Seer where gitlab users are getting an error when hitting this endpoint just by opening the issue details page (not that any user or functionality is actually affected, but it'll stop the events from piling up)