### PR TITLE
chore(js): Upgrade from abandoned PEG.js to Peggy

### DIFF
--- a/build-utils/peggy-loader.ts
+++ b/build-utils/peggy-loader.ts
@@ -1,6 +1,7 @@
 import peggy from 'peggy';
+import type {LoaderDefinitionFunction} from 'webpack';
 
-export default function peggyLoader(source) {
+const peggyLoader: LoaderDefinitionFunction = source => {
   // https://peggyjs.org/documentation.html#generating-a-parser-javascript-api
   const peggyOptions: peggy.OutputFormatAmdCommonjsEs = {
     cache: false,
@@ -12,4 +13,6 @@ export default function peggyLoader(source) {
   };
 
   return peggy.generate(source, peggyOptions);
-}
+};
+
+export default peggyLoader;

--- a/build-utils/peggy-loader.ts
+++ b/build-utils/peggy-loader.ts
@@ -1,0 +1,15 @@
+import peggy from 'peggy';
+
+export default function peggyLoader(source) {
+  // https://peggyjs.org/documentation.html#generating-a-parser-javascript-api
+  const peggyOptions: peggy.OutputFormatAmdCommonjsEs = {
+    cache: false,
+    dependencies: {},
+    format: 'commonjs',
+    optimize: 'speed',
+    trace: false,
+    output: 'source',
+  };
+
+  return peggy.generate(source, peggyOptions);
+}

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "@types/lodash": "^4.14.182",
     "@types/mini-css-extract-plugin": "^2.5.1",
     "@types/papaparse": "^5.3.5",
-    "@types/pegjs": "^0.10.3",
     "@types/prismjs": "^1.26.0",
     "@types/react": "18.2.55",
     "@types/react-date-range": "^1.4.4",
@@ -139,8 +138,7 @@
     "mockdate": "3.0.5",
     "moment-timezone": "0.5.44",
     "papaparse": "^5.3.2",
-    "pegjs": "^0.10.0",
-    "pegjs-loader": "^0.5.8",
+    "peggy": "^4.1.1",
     "platformicons": "^7.0.1",
     "po-catalog-loader": "2.1.0",
     "prettier": "3.3.2",
@@ -265,7 +263,9 @@
       "last 3 iOS major versions",
       "Firefox ESR"
     ],
-    "test": ["current node"]
+    "test": [
+      "current node"
+    ]
   },
   "volta": {
     "extends": ".volta.json"

--- a/static/app/components/arithmeticInput/parser.tsx
+++ b/static/app/components/arithmeticInput/parser.tsx
@@ -1,4 +1,4 @@
-import type {LocationRange} from 'pegjs';
+import type {LocationRange} from 'peggy';
 
 import {t} from 'sentry/locale';
 

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/react';
 import merge from 'lodash/merge';
 import moment from 'moment-timezone';
-import type {LocationRange} from 'pegjs';
+import type {LocationRange} from 'peggy';
 
 import {t} from 'sentry/locale';
 import type {TagCollection} from 'sentry/types/group';

--- a/static/app/components/searchSyntax/renderer.spec.tsx
+++ b/static/app/components/searchSyntax/renderer.spec.tsx
@@ -18,6 +18,7 @@ const query: ParseResult = [
       location: {
         start: {offset: 0, line: 1, column: 1},
         end: {offset: 10, line: 1, column: 11},
+        source: {},
       },
     },
     operator: TermOperator.DEFAULT,
@@ -29,6 +30,7 @@ const query: ParseResult = [
       location: {
         start: {offset: 11, line: 1, column: 12},
         end: {offset: 27, line: 1, column: 28},
+        source: {},
       },
     },
     invalid: null,
@@ -37,6 +39,7 @@ const query: ParseResult = [
     location: {
       start: {offset: 0, line: 1, column: 1},
       end: {offset: 27, line: 1, column: 28},
+      source: {},
     },
   } satisfies TokenResult<Token.FILTER>,
 ];

--- a/static/app/components/searchSyntax/utils.tsx
+++ b/static/app/components/searchSyntax/utils.tsx
@@ -1,4 +1,4 @@
-import type {LocationRange} from 'pegjs';
+import type {LocationRange} from 'peggy';
 
 import type {TokenResult} from './parser';
 import {allOperators, Token} from './parser';

--- a/tests/js/jest-pegjs-transform.js
+++ b/tests/js/jest-pegjs-transform.js
@@ -1,7 +1,7 @@
 /* eslint-env node */
 
 const crypto = require('node:crypto');
-const peg = require('pegjs');
+const peggy = require('peggy');
 
 function getCacheKey(fileData, _filePath, config, _options) {
   return crypto
@@ -13,7 +13,7 @@ function getCacheKey(fileData, _filePath, config, _options) {
 
 function process(sourceText) {
   return {
-    code: `module.exports = ${peg.generate(sourceText, {output: 'source'})}`,
+    code: `module.exports = ${peggy.generate(sourceText, {output: 'source'})}`,
   };
 }
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -271,7 +271,7 @@ const appConfig: webpack.Configuration = {
       },
       {
         test: /\.pegjs$/,
-        use: ['pegjs-loader?cache=false&optimize=speed'],
+        use: [{loader: path.resolve('./build-utils/peggy-loader.ts')}],
       },
       {
         test: /\.css/,

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -271,7 +271,7 @@ const appConfig: webpack.Configuration = {
       },
       {
         test: /\.pegjs$/,
-        use: [{loader: path.resolve('./build-utils/peggy-loader.ts')}],
+        use: [{loader: path.resolve(__dirname, './build-utils/peggy-loader.ts')}],
       },
       {
         test: /\.css/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,6 +2493,13 @@
   dependencies:
     "@opentelemetry/core" "^1.1.0"
 
+"@peggyjs/from-mem@1.3.4":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@peggyjs/from-mem/-/from-mem-1.3.4.tgz#430ebc635b2f8ebeeadbc796937bab89e15be2cf"
+  integrity sha512-6DqaCO73ihyM2AJ2Vl4QQGmmU3MoD4hFh0RFRzxPdLkSLfE0QMEyDfaojE/R3KbsL1UP4VQyJA2clwX4agSTBw==
+  dependencies:
+    semver "7.6.3"
+
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
@@ -4038,11 +4045,6 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/pegjs@^0.10.3":
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/@types/pegjs/-/pegjs-0.10.3.tgz#9e254036c6bf2254cd98caec447a1d79b6607bff"
-  integrity sha512-C/ZkUNe7HONOaDHXfNTZOUzrOvOgrWdrJj1JZ3QTEPi5gOIygcjCpXyxpdJTKVvWFzbobajRbMbQY8d0WrZ6fg==
-
 "@types/pg-pool@2.0.6":
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/pg-pool/-/pg-pool-2.0.6.tgz#1376d9dc5aec4bb2ec67ce28d7e9858227403c77"
@@ -5422,6 +5424,11 @@ commander@^10.0.0, commander@^10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
   integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
+
+commander@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-12.1.0.tgz#01423b36f501259fdaac4d0e4d60c96c991585d3"
+  integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
 
 commander@^2.20.0:
   version "2.20.3"
@@ -9742,17 +9749,14 @@ path-type@^5.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-5.0.0.tgz#14b01ed7aea7ddf9c7c3f46181d4d04f9c785bb8"
   integrity sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==
 
-pegjs-loader@^0.5.8:
-  version "0.5.8"
-  resolved "https://registry.yarnpkg.com/pegjs-loader/-/pegjs-loader-0.5.8.tgz#f40dbdb6d2678611dcde421c6e8aebca530ec4d7"
-  integrity sha512-FcqC07tFiDN5kEOVcYw0wSJcHu3d6YrT2sCJM5xkNwOeTAEkk/gFcxnkJH4D/ZNfUaBLQ7fbCUwMWLFfJ/06Mg==
+peggy@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/peggy/-/peggy-4.1.1.tgz#654cd0fe07856172896cca33ae51aefc57cc3db7"
+  integrity sha512-2emciJQKahHJpT7f1asizGSnJ8bq0TKgWMXnCrtAaSH1NIXaGifYxL5m5KMrCdlaqaQJz3SVexNkx+I+Vz66VA==
   dependencies:
-    loader-utils "^1.4.2"
-
-pegjs@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/pegjs/-/pegjs-0.10.0.tgz#cf8bafae6eddff4b5a7efb185269eaaf4610ddbd"
-  integrity sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0=
+    "@peggyjs/from-mem" "1.3.4"
+    commander "^12.1.0"
+    source-map-generator "0.8.0"
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -10885,6 +10889,11 @@ selfsigned@^2.4.1:
     "@types/node-forge" "^1.3.0"
     node-forge "^1"
 
+semver@7.6.3, semver@^7.3.5, semver@^7.3.7, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.3:
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
+  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
+
 semver@^5.6.0:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
@@ -10894,11 +10903,6 @@ semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
-
-semver@^7.3.5, semver@^7.3.7, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.3:
-  version "7.6.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
-  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
 send@0.18.0:
   version "0.18.0"
@@ -11146,6 +11150,11 @@ sockjs@^0.3.24:
     faye-websocket "^0.11.3"
     uuid "^8.3.2"
     websocket-driver "^0.7.4"
+
+source-map-generator@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/source-map-generator/-/source-map-generator-0.8.0.tgz#10d5ca0651e2c9302ea338739cbd4408849c5d00"
+  integrity sha512-psgxdGMwl5MZM9S3FWee4EgsEaIjahYV5AzGnwUvPhWeITz/j6rKpysQHlQ4USdxvINlb8lKfWGIXwfkrgtqkA==
 
 source-map-js@^1.0.1, source-map-js@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
PEG.js has been [unmaintained since 2020](https://github.com/pegjs/pegjs/issues/639), replaced by [Peggy](https://github.com/peggyjs/peggy).

The API is [entirely compatible](https://github.com/peggyjs/peggy?tab=readme-ov-file#migrating-from-pegjs), so I'm just doing a simple replacement of packages. I couldn't find a webpack loader for the `.pegjs` files to replace `pegjs-loader`, so I added a very simple one.