### PR TITLE
fix(issues): Align header baseline

### DIFF
--- a/static/app/views/issueDetails/streamline/header.tsx
+++ b/static/app/views/issueDetails/streamline/header.tsx
@@ -189,6 +189,7 @@ export default function StreamlinedGroupHeader({
 
 const StyledEventOrGroupTitle = styled(EventOrGroupTitle)`
   font-size: inherit;
+  align-items: baseline;
 `;
 
 const HeadingGrid = styled('div')`


### PR DESCRIPTION
since this is shared between issue stream and issue details we want issue details to always align baseline. changed in https://github.com/getsentry/sentry/pull/78981

not baseline
![image](https://github.com/user-attachments/assets/f2d796df-be1d-48f3-b68c-1b2a24b58dcf)
