### PR TITLE
feat(issue-details): Styling fixes for streamlined page

### DIFF
--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
@@ -271,7 +271,12 @@ const GroupContent = styled(Layout.Main)`
   flex-direction: column;
   padding: ${space(1.5)};
   gap: ${space(1.5)};
-  box-shadow: 0 0 0 1px ${p => p.theme.translucentInnerBorder};
+  @media (min-width: ${p => p.theme.breakpoints.large}) {
+    border-right: 1px solid ${p => p.theme.translucentBorder};
+  }
+  @media (max-width: ${p => p.theme.breakpoints.large}) {
+    border-bottom-width: 1px solid ${p => p.theme.translucentBorder};
+  }
 `;
 
 const StyledLayoutSide = styled(Layout.Side)<{hasStreamlinedUi: boolean}>`

--- a/static/app/views/issueDetails/streamline/eventDetails.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetails.tsx
@@ -199,7 +199,7 @@ const FloatingEventNavigation = styled(EventNavigation)`
     top: ${p => p.theme.sidebar.mobileHeight};
   }
   background: ${p => p.theme.background};
-  z-index: 500;
+  z-index: ${p => p.theme.zIndex.header};
   border-radius: ${p => p.theme.borderRadiusTop};
 
   &[data-stuck='true'] {

--- a/static/app/views/issueDetails/streamline/eventList.tsx
+++ b/static/app/views/issueDetails/streamline/eventList.tsx
@@ -159,7 +159,7 @@ const EventListHeader = styled('div')`
   border-bottom: 1px solid ${p => p.theme.translucentBorder};
   position: sticky;
   top: 0;
-  z-index: 500;
+  z-index: ${p => p.theme.zIndex.header};
   border-radius: ${p => p.theme.borderRadiusTop};
 `;
 


### PR DESCRIPTION
Consistent border color:
![image](https://github.com/user-attachments/assets/8410dbbc-a815-4837-830b-5b1fb46c5d20)


No more z-index issues with trace view (which I can't recreate for some reason)

