### PR TITLE
fix(onboarding): fix `setupMessagingIntegrationButton` tooltip and API query refetch

### DIFF
--- a/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
+++ b/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/button';
-import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import PluginIcon from 'sentry/plugins/components/pluginIcon';
 import {space} from 'sentry/styles/space';
@@ -23,11 +22,11 @@ export enum MessagingIntegrationAnalyticsView {
 }
 
 type Props = {
-  refetchConfigs: () => void;
   analyticsParams?: {
     view: MessagingIntegrationAnalyticsView;
   };
   projectId?: string;
+  refetchConfigs?: () => void;
 };
 
 function SetupMessagingIntegrationButton({
@@ -40,7 +39,9 @@ function SetupMessagingIntegrationButton({
 
   const onAddIntegration = () => {
     messagingIntegrationsQuery.refetch();
-    refetchConfigs();
+    if (refetchConfigs) {
+      refetchConfigs();
+    }
   };
 
   const messagingIntegrationsQuery = useApiQuery<OrganizationIntegration[]>(
@@ -85,13 +86,7 @@ function SetupMessagingIntegrationButton({
       features={integrationProvidersQuery[0].data.providers[0]?.metadata?.features}
     >
       {({disabled, disabledReason}) => (
-        <Tooltip
-          title={
-            disabled
-              ? disabledReason
-              : t('Send alerts to your messaging service. Install the integration now.')
-          }
-        >
+        <div>
           <Button
             size="sm"
             icon={
@@ -102,6 +97,11 @@ function SetupMessagingIntegrationButton({
               </IconWrapper>
             }
             disabled={disabled}
+            title={
+              disabled
+                ? disabledReason
+                : t('Send alerts to your messaging service. Install the integration now.')
+            }
             onClick={() => {
               openModal(
                 deps => (
@@ -131,7 +131,7 @@ function SetupMessagingIntegrationButton({
           >
             {t('Connect to messaging')}
           </Button>
-        </Tooltip>
+        </div>
       )}
     </IntegrationFeatures>
   );

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
@@ -24,7 +24,6 @@ describe('MessagingIntegrationAlertRule', function () {
     providersToIntegrations: {},
     querySuccess: true,
     shouldRenderSetupButton: false,
-    refetchConfigs: jest.fn(),
     setActions: mockSetAction,
     setChannel: jest.fn(),
     setIntegration: jest.fn(),

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -68,7 +68,6 @@ export type IssueAlertNotificationProps = {
   provider: string | undefined;
   providersToIntegrations: Record<string, OrganizationIntegration[]>;
   querySuccess: boolean;
-  refetchConfigs: () => void;
   setActions: (action: MultipleCheckboxOptions[]) => void;
   setChannel: (channel: string | undefined) => void;
   setIntegration: (integration: OrganizationIntegration | undefined) => void;
@@ -214,7 +213,6 @@ export function useCreateNotificationAction() {
       setIntegration,
       setChannel,
       providersToIntegrations,
-      refetchConfigs: messagingIntegrationsQuery.refetch,
       querySuccess: messagingIntegrationsQuery.isSuccess,
       shouldRenderSetupButton,
     },
@@ -224,8 +222,7 @@ export function useCreateNotificationAction() {
 export default function IssueAlertNotificationOptions(
   notificationProps: IssueAlertNotificationProps
 ) {
-  const {actions, setActions, refetchConfigs, querySuccess, shouldRenderSetupButton} =
-    notificationProps;
+  const {actions, setActions, querySuccess, shouldRenderSetupButton} = notificationProps;
 
   const shouldRenderNotificationConfigs = actions.some(
     v => v !== MultipleCheckboxOptions.EMAIL
@@ -260,7 +257,6 @@ export default function IssueAlertNotificationOptions(
       </MultipleCheckbox>
       {shouldRenderSetupButton && (
         <SetupMessagingIntegrationButton
-          refetchConfigs={refetchConfigs}
           analyticsParams={{
             view: MessagingIntegrationAnalyticsView.ALERT_RULE_CREATION,
           }}

--- a/static/app/views/projectInstall/issueAlertOptions.spec.tsx
+++ b/static/app/views/projectInstall/issueAlertOptions.spec.tsx
@@ -27,7 +27,6 @@ describe('IssueAlertOptions', function () {
     providersToIntegrations: {},
     querySuccess: true,
     shouldRenderSetupButton: false,
-    refetchConfigs: jest.fn(),
     setActions: jest.fn(),
     setChannel: jest.fn(),
     setIntegration: jest.fn(),

--- a/static/app/views/projectInstall/messagingIntegrationAlertRule.spec.tsx
+++ b/static/app/views/projectInstall/messagingIntegrationAlertRule.spec.tsx
@@ -3,6 +3,7 @@ import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegr
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 import selectEvent from 'sentry-test/selectEvent';
 
+import type {IssueAlertNotificationProps} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import MessagingIntegrationAlertRule from 'sentry/views/projectInstall/messagingIntegrationAlertRule';
 
 describe('MessagingIntegrationAlertRule', function () {
@@ -35,7 +36,7 @@ describe('MessagingIntegrationAlertRule', function () {
   const mockSetIntegration = jest.fn();
   const mockSetProvider = jest.fn();
 
-  const notificationProps = {
+  const notificationProps: IssueAlertNotificationProps = {
     actions: [],
     channel: 'channel',
     integration: slackIntegrations[0],
@@ -43,7 +44,6 @@ describe('MessagingIntegrationAlertRule', function () {
     providersToIntegrations: providersToIntegrations,
     querySuccess: true,
     shouldRenderSetupButton: false,
-    refetchConfigs: jest.fn(),
     setActions: jest.fn(),
     setChannel: mockSetChannel,
     setIntegration: mockSetIntegration,


### PR DESCRIPTION
fixed issue of tooltip being centered across the whole screen instead of just the button

before:

![image](https://github.com/user-attachments/assets/298c2f53-a970-4daa-8c9c-502cc2ff39b4)

after:

![image](https://github.com/user-attachments/assets/eccb7690-8fa6-4928-be42-9b61deb34a1f)

also made `refetchConfigs` optional, since I realized that passing this from `IssueAlertNotificationOptions` was actually refetching the same API query twice