### PR TITLE
feat(flags): add proj feature observer

### DIFF
--- a/static/app/actionCreators/organization.tsx
+++ b/static/app/actionCreators/organization.tsx
@@ -15,7 +15,7 @@ import TeamStore from 'sentry/stores/teamStore';
 import type {Organization, Team} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import FeatureFlagOverrides from 'sentry/utils/featureFlagOverrides';
-import FeatureObserver, {FEATURE_FLAG_BUFFER_SIZE} from 'sentry/utils/featureObserver';
+import FeatureObserver from 'sentry/utils/featureObserver';
 import {getPreloadedDataPromise} from 'sentry/utils/getPreloadedData';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 
@@ -42,9 +42,7 @@ async function fetchOrg(
   }
 
   FeatureFlagOverrides.singleton().loadOrg(org);
-  FeatureObserver.singleton({
-    bufferSize: FEATURE_FLAG_BUFFER_SIZE,
-  }).observeOrganizationFlags({
+  FeatureObserver.singleton({}).observeOrganizationFlags({
     organization: org,
   });
 

--- a/static/app/actionCreators/organization.tsx
+++ b/static/app/actionCreators/organization.tsx
@@ -42,9 +42,10 @@ async function fetchOrg(
   }
 
   FeatureFlagOverrides.singleton().loadOrg(org);
-  FeatureObserver.singleton().observeOrganizationFlags({
-    organization: org,
+  FeatureObserver.singleton({
     bufferSize: FEATURE_FLAG_BUFFER_SIZE,
+  }).observeOrganizationFlags({
+    organization: org,
   });
 
   OrganizationStore.onUpdate(org, {replace: true});

--- a/static/app/actionCreators/organization.tsx
+++ b/static/app/actionCreators/organization.tsx
@@ -42,7 +42,10 @@ async function fetchOrg(
   }
 
   FeatureFlagOverrides.singleton().loadOrg(org);
-  FeatureObserver.singleton().observeFlags({organization: org, bufferSize: 100});
+  FeatureObserver.singleton().observeOrganizationFlags({
+    organization: org,
+    bufferSize: 100,
+  });
 
   OrganizationStore.onUpdate(org, {replace: true});
   setActiveOrganization(org);

--- a/static/app/actionCreators/organization.tsx
+++ b/static/app/actionCreators/organization.tsx
@@ -15,7 +15,7 @@ import TeamStore from 'sentry/stores/teamStore';
 import type {Organization, Team} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import FeatureFlagOverrides from 'sentry/utils/featureFlagOverrides';
-import FeatureObserver from 'sentry/utils/featureObserver';
+import FeatureObserver, {FEATURE_FLAG_BUFFER_SIZE} from 'sentry/utils/featureObserver';
 import {getPreloadedDataPromise} from 'sentry/utils/getPreloadedData';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 
@@ -44,7 +44,7 @@ async function fetchOrg(
   FeatureFlagOverrides.singleton().loadOrg(org);
   FeatureObserver.singleton().observeOrganizationFlags({
     organization: org,
-    bufferSize: 100,
+    bufferSize: FEATURE_FLAG_BUFFER_SIZE,
   });
 
   OrganizationStore.onUpdate(org, {replace: true});

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -15,7 +15,7 @@ import {
   useNavigationType,
 } from 'react-router-dom';
 import {useEffect} from 'react';
-import FeatureObserver, {FEATURE_FLAG_BUFFER_SIZE} from 'sentry/utils/featureObserver';
+import FeatureObserver from 'sentry/utils/featureObserver';
 
 const SPA_MODE_ALLOW_URLS = [
   'localhost',
@@ -185,9 +185,7 @@ export function initializeSdk(config: Config) {
 
       // attach feature flags to the event context
       if (event.contexts) {
-        const flags = FeatureObserver.singleton({
-          bufferSize: FEATURE_FLAG_BUFFER_SIZE,
-        }).getFeatureFlags();
+        const flags = FeatureObserver.singleton({}).getFeatureFlags();
         event.contexts.flags = flags;
       }
 

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -15,7 +15,7 @@ import {
   useNavigationType,
 } from 'react-router-dom';
 import {useEffect} from 'react';
-import FeatureObserver from 'sentry/utils/featureObserver';
+import FeatureObserver, {FEATURE_FLAG_BUFFER_SIZE} from 'sentry/utils/featureObserver';
 
 const SPA_MODE_ALLOW_URLS = [
   'localhost',
@@ -185,7 +185,9 @@ export function initializeSdk(config: Config) {
 
       // attach feature flags to the event context
       if (event.contexts) {
-        const flags = FeatureObserver.singleton().getFeatureFlags();
+        const flags = FeatureObserver.singleton({
+          bufferSize: FEATURE_FLAG_BUFFER_SIZE,
+        }).getFeatureFlags();
         event.contexts.flags = flags;
       }
 

--- a/static/app/utils/featureObserver.spec.ts
+++ b/static/app/utils/featureObserver.spec.ts
@@ -18,14 +18,14 @@ describe('FeatureObserver', () => {
 
   describe('observeOrganizationFlags', () => {
     it('should add recently evaluated org flags to the flag queue', () => {
-      const inst = new FeatureObserver();
+      const inst = new FeatureObserver({bufferSize: 3});
       expect(organization.features).toEqual([
         'enable-issues',
         'enable-profiling',
         'enable-replay',
       ]);
 
-      inst.observeOrganizationFlags({organization, bufferSize: 3});
+      inst.observeOrganizationFlags({organization});
       expect(inst.getFeatureFlags().values).toEqual([]);
 
       organization.features.includes('enable-issues');
@@ -47,8 +47,8 @@ describe('FeatureObserver', () => {
     });
 
     it('should remove duplicate flags with a full queue', () => {
-      const inst = new FeatureObserver();
-      inst.observeOrganizationFlags({organization, bufferSize: 3});
+      const inst = new FeatureObserver({bufferSize: 3});
+      inst.observeOrganizationFlags({organization});
       expect(inst.getFeatureFlags().values).toEqual([]);
 
       organization.features.includes('enable-issues');
@@ -87,8 +87,8 @@ describe('FeatureObserver', () => {
     });
 
     it('should remove duplicate flags with an unfilled queue', () => {
-      const inst = new FeatureObserver();
-      inst.observeOrganizationFlags({organization, bufferSize: 3});
+      const inst = new FeatureObserver({bufferSize: 3});
+      inst.observeOrganizationFlags({organization});
       expect(inst.getFeatureFlags().values).toEqual([]);
 
       organization.features.includes('enable-issues');
@@ -116,8 +116,8 @@ describe('FeatureObserver', () => {
     });
 
     it('should not change the functionality of `includes`', () => {
-      const inst = new FeatureObserver();
-      inst.observeOrganizationFlags({organization, bufferSize: 3});
+      const inst = new FeatureObserver({bufferSize: 3});
+      inst.observeOrganizationFlags({organization});
       expect(inst.getFeatureFlags().values).toEqual([]);
 
       organization.features.includes('enable-issues');
@@ -134,10 +134,10 @@ describe('FeatureObserver', () => {
 
   describe('observeProjectFlags', () => {
     it('should add recently evaluated proj flags to the flag queue', () => {
-      const inst = new FeatureObserver();
+      const inst = new FeatureObserver({bufferSize: 3});
       expect(project.features).toEqual(['enable-proj-flag', 'enable-performance']);
 
-      inst.observeProjectFlags({project, bufferSize: 3});
+      inst.observeProjectFlags({project});
       expect(inst.getFeatureFlags().values).toEqual([]);
 
       project.features.includes('enable-proj-flag');
@@ -159,8 +159,8 @@ describe('FeatureObserver', () => {
     });
 
     it('should not change the functionality of `includes`', () => {
-      const inst = new FeatureObserver();
-      inst.observeProjectFlags({project, bufferSize: 3});
+      const inst = new FeatureObserver({bufferSize: 3});
+      inst.observeProjectFlags({project});
       expect(inst.getFeatureFlags().values).toEqual([]);
 
       project.features.includes('enable-proj-flag');
@@ -177,7 +177,7 @@ describe('FeatureObserver', () => {
 
   describe('observeProjectFlags and observeOrganizationFlags', () => {
     it('should add recently evaluated org and proj flags to the flag queue', () => {
-      const inst = new FeatureObserver();
+      const inst = new FeatureObserver({bufferSize: 3});
       expect(project.features).toEqual(['enable-proj-flag', 'enable-performance']);
       expect(organization.features).toEqual([
         'enable-issues',
@@ -185,8 +185,8 @@ describe('FeatureObserver', () => {
         'enable-replay',
       ]);
 
-      inst.observeProjectFlags({project, bufferSize: 3});
-      inst.observeOrganizationFlags({organization, bufferSize: 3});
+      inst.observeProjectFlags({project});
+      inst.observeOrganizationFlags({organization});
       expect(inst.getFeatureFlags().values).toEqual([]);
 
       project.features.includes('enable-proj-flag');

--- a/static/app/utils/featureObserver.spec.ts
+++ b/static/app/utils/featureObserver.spec.ts
@@ -207,5 +207,45 @@ describe('FeatureObserver', () => {
         {flag: 'feature.organizations:enable-replay', result: true},
       ]);
     });
+
+    it('should keep the same queue if the project changes', () => {
+      const inst = new FeatureObserver({bufferSize: 3});
+      expect(project.features).toEqual(['enable-proj-flag', 'enable-performance']);
+      expect(organization.features).toEqual([
+        'enable-issues',
+        'enable-profiling',
+        'enable-replay',
+      ]);
+
+      inst.observeProjectFlags({project});
+      inst.observeOrganizationFlags({organization});
+      expect(inst.getFeatureFlags().values).toEqual([]);
+
+      project.features.includes('enable-proj-flag');
+      project.features.includes('enable-replay');
+      organization.features.includes('enable-issues');
+      expect(inst.getFeatureFlags().values).toEqual([
+        {flag: 'feature.projects:enable-proj-flag', result: true},
+        {flag: 'feature.projects:enable-replay', result: false},
+        {flag: 'feature.organizations:enable-issues', result: true},
+      ]);
+
+      project = ProjectFixture({
+        features: ['enable-new-flag'],
+      });
+      inst.observeProjectFlags({project});
+      expect(inst.getFeatureFlags().values).toEqual([
+        {flag: 'feature.projects:enable-proj-flag', result: true},
+        {flag: 'feature.projects:enable-replay', result: false},
+        {flag: 'feature.organizations:enable-issues', result: true},
+      ]);
+
+      project.features.includes('enable-new-flag');
+      expect(inst.getFeatureFlags().values).toEqual([
+        {flag: 'feature.projects:enable-replay', result: false},
+        {flag: 'feature.organizations:enable-issues', result: true},
+        {flag: 'feature.projects:enable-new-flag', result: true},
+      ]);
+    });
   });
 });

--- a/static/app/utils/featureObserver.spec.ts
+++ b/static/app/utils/featureObserver.spec.ts
@@ -1,11 +1,13 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
+import type {Organization} from 'sentry/types/organization';
+import type {Project} from 'sentry/types/project';
 import FeatureObserver from 'sentry/utils/featureObserver';
 
 describe('FeatureObserver', () => {
-  let organization;
-  let project;
+  let organization: Organization;
+  let project: Project;
 
   beforeEach(() => {
     organization = OrganizationFixture({

--- a/static/app/utils/featureObserver.ts
+++ b/static/app/utils/featureObserver.ts
@@ -38,14 +38,11 @@ export default class FeatureObserver {
   public updateFlagBuffer({
     flagName,
     flagResult,
-    flagBuffer,
-    bufferSize,
   }: {
-    bufferSize: number;
-    flagBuffer: Flags;
     flagName: string;
     flagResult: boolean;
   }) {
+    const flagBuffer = this.FEATURE_FLAGS;
     // Check if the flag is already in the buffer
     const index = flagBuffer.values.findIndex(f => f.flag === flagName);
 
@@ -56,7 +53,7 @@ export default class FeatureObserver {
 
     // If at capacity, we need to remove the earliest flag
     // This will only happen if not a duplicate flag
-    if (flagBuffer.values.length === bufferSize) {
+    if (flagBuffer.values.length === this._bufferSize) {
       flagBuffer.values.shift();
     }
 
@@ -68,7 +65,6 @@ export default class FeatureObserver {
   }
 
   public observeOrganizationFlags({organization}: {organization: Organization}) {
-    const flagBuffer = this.FEATURE_FLAGS;
     // Track names of features that are passed into the .includes() function.
     const handler = {
       apply: (target: any, orgFeatures: string[], flagName: string[]) => {
@@ -81,8 +77,6 @@ export default class FeatureObserver {
         this.updateFlagBuffer({
           flagName: name,
           flagResult,
-          flagBuffer,
-          bufferSize: this._bufferSize,
         });
 
         return flagResult;
@@ -93,7 +87,6 @@ export default class FeatureObserver {
   }
 
   public observeProjectFlags({project}: {project: Project}) {
-    const flagBuffer = this.FEATURE_FLAGS;
     // Track names of features that are passed into the .includes() function.
     const handler = {
       apply: (target: any, projFeatures: string[], flagName: string[]) => {
@@ -106,8 +99,6 @@ export default class FeatureObserver {
         this.updateFlagBuffer({
           flagName: name,
           flagResult,
-          flagBuffer,
-          bufferSize: this._bufferSize,
         });
 
         return flagResult;

--- a/static/app/utils/featureObserver.ts
+++ b/static/app/utils/featureObserver.ts
@@ -40,7 +40,7 @@ export default class FeatureObserver {
     bufferSize: number;
     flagBuffer: Flags;
     flagName: string;
-    flagResult: any;
+    flagResult: boolean;
   }) {
     // Check if the flag is already in the buffer
     const index = flagBuffer.values.findIndex(f => f.flag === flagName);
@@ -69,7 +69,7 @@ export default class FeatureObserver {
     const updateFlagBuffer = this.updateFlagBuffer;
     // Track names of features that are passed into the .includes() function.
     const handler = {
-      apply: (target, orgFeatures, flagName) => {
+      apply: (target: any, orgFeatures: string[], flagName: string[]) => {
         // Evaluate the result of .includes()
         const flagResult = target.apply(orgFeatures, flagName);
 
@@ -91,7 +91,7 @@ export default class FeatureObserver {
     const updateFlagBuffer = this.updateFlagBuffer;
     // Track names of features that are passed into the .includes() function.
     const handler = {
-      apply: function (target, projFeatures, flagName) {
+      apply: function (target: any, projFeatures: string[], flagName: string[]) {
         // Evaluate the result of .includes()
         const flagResult = target.apply(projFeatures, flagName);
 

--- a/static/app/utils/featureObserver.ts
+++ b/static/app/utils/featureObserver.ts
@@ -1,5 +1,6 @@
 import type {Flags} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
+import type {Project} from 'sentry/types/project';
 
 let __SINGLETON: FeatureObserver | null = null;
 
@@ -24,15 +25,47 @@ export default class FeatureObserver {
     return this.FEATURE_FLAGS;
   }
 
-  public observeFlags({
+  public updateFlagBuffer({
+    flagName,
+    flagResult,
+    bufferSize,
+    flagBuffer,
+  }: {
+    bufferSize: number;
+    flagBuffer: Flags;
+    flagName: any;
+    flagResult: any;
+  }) {
+    // Check if the flag is already in the buffer
+    const index = flagBuffer.values.findIndex(f => f.flag === flagName);
+
+    // The flag is already in the buffer
+    if (index !== -1) {
+      flagBuffer.values.splice(index, 1);
+    }
+
+    // If at capacity, we need to remove the earliest flag
+    // This will only happen if not a duplicate flag
+    if (flagBuffer.values.length === bufferSize) {
+      flagBuffer.values.shift();
+    }
+
+    // Store the flag and its result in the buffer
+    flagBuffer.values.push({
+      flag: flagName,
+      result: flagResult,
+    });
+  }
+
+  public observeOrganizationFlags({
     organization,
     bufferSize,
   }: {
     bufferSize: number;
     organization: Organization;
   }) {
-    const FLAGS = this.FEATURE_FLAGS;
-
+    const flagBuffer = this.FEATURE_FLAGS;
+    const updateFlagBuffer = this.updateFlagBuffer;
     // Track names of features that are passed into the .includes() function.
     const handler = {
       apply: function (target, orgFeatures, flagName) {
@@ -42,30 +75,39 @@ export default class FeatureObserver {
         // Append `feature.organizations:` in front to match the Sentry options automator format
         const name = 'feature.organizations:' + flagName[0];
 
-        // Check if the flag is already in the buffer
-        const index = FLAGS.values.findIndex(f => f.flag === name);
-
-        // The flag is already in the buffer
-        if (index !== -1) {
-          FLAGS.values.splice(index, 1);
-        }
-
-        // If at capacity, we need to remove the earliest flag
-        // This will only happen if not a duplicate flag
-        if (FLAGS.values.length === bufferSize) {
-          FLAGS.values.shift();
-        }
-
-        // Store the flag and its result in the buffer
-        FLAGS.values.push({
-          flag: name,
-          result: flagResult,
-        });
+        updateFlagBuffer({flagName: name, flagResult, bufferSize, flagBuffer});
 
         return flagResult;
       },
     };
     const proxy = new Proxy(organization.features.includes, handler);
     organization.features.includes = proxy;
+  }
+
+  public observeProjectFlags({
+    project,
+    bufferSize,
+  }: {
+    bufferSize: number;
+    project: Project;
+  }) {
+    const flagBuffer = this.FEATURE_FLAGS;
+    const updateFlagBuffer = this.updateFlagBuffer;
+    // Track names of features that are passed into the .includes() function.
+    const handler = {
+      apply: function (target, projFeatures, flagName) {
+        // Evaluate the result of .includes()
+        const flagResult = target.apply(projFeatures, flagName);
+
+        // Append `feature.projects:` in front to match the Sentry options automator format
+        const name = 'feature.projects:' + flagName[0];
+
+        updateFlagBuffer({flagName: name, flagResult, bufferSize, flagBuffer});
+
+        return flagResult;
+      },
+    };
+    const proxy = new Proxy(project.features.includes, handler);
+    project.features.includes = proxy;
   }
 }

--- a/static/app/utils/featureObserver.ts
+++ b/static/app/utils/featureObserver.ts
@@ -2,6 +2,8 @@ import type {Flags} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 
+// Both org and project instances should pass in the same buffer size
+export const FEATURE_FLAG_BUFFER_SIZE = 100;
 let __SINGLETON: FeatureObserver | null = null;
 
 export default class FeatureObserver {

--- a/static/app/utils/featureObserver.ts
+++ b/static/app/utils/featureObserver.ts
@@ -10,24 +10,19 @@ export default class FeatureObserver {
    * Return the same instance of FeatureObserver in each part of the app.
    * Multiple instances of FeatureObserver are needed by tests only.
    */
-  public static singleton({
-    bufferSize = FEATURE_FLAG_BUFFER_SIZE,
-  }: {
-    bufferSize?: number;
-  }) {
+  public static singleton({bufferSize}: {bufferSize?: number}) {
     if (!__SINGLETON) {
-      __SINGLETON = new FeatureObserver(bufferSize);
+      __SINGLETON = new FeatureObserver({bufferSize});
     }
     return __SINGLETON;
   }
 
   private _bufferSize = 0;
+  private FEATURE_FLAGS: Flags = {values: []};
 
-  constructor(bufferSize) {
+  constructor({bufferSize = FEATURE_FLAG_BUFFER_SIZE}: {bufferSize?: number}) {
     this._bufferSize = bufferSize;
   }
-
-  private FEATURE_FLAGS: Flags = {values: []};
 
   /**
    * Return list of recently accessed feature flags.
@@ -40,7 +35,9 @@ export default class FeatureObserver {
     flagName,
     flagResult,
     flagBuffer,
+    bufferSize,
   }: {
+    bufferSize: number;
     flagBuffer: Flags;
     flagName: any;
     flagResult: any;
@@ -55,7 +52,7 @@ export default class FeatureObserver {
 
     // If at capacity, we need to remove the earliest flag
     // This will only happen if not a duplicate flag
-    if (flagBuffer.values.length === this._bufferSize) {
+    if (flagBuffer.values.length === bufferSize) {
       flagBuffer.values.shift();
     }
 
@@ -68,6 +65,7 @@ export default class FeatureObserver {
 
   public observeOrganizationFlags({organization}: {organization: Organization}) {
     const flagBuffer = this.FEATURE_FLAGS;
+    const bufferSize = this._bufferSize;
     const updateFlagBuffer = this.updateFlagBuffer;
     // Track names of features that are passed into the .includes() function.
     const handler = {
@@ -78,7 +76,7 @@ export default class FeatureObserver {
         // Append `feature.organizations:` in front to match the Sentry options automator format
         const name = 'feature.organizations:' + flagName[0];
 
-        updateFlagBuffer({flagName: name, flagResult, flagBuffer});
+        updateFlagBuffer({flagName: name, flagResult, flagBuffer, bufferSize});
 
         return flagResult;
       },
@@ -89,6 +87,7 @@ export default class FeatureObserver {
 
   public observeProjectFlags({project}: {project: Project}) {
     const flagBuffer = this.FEATURE_FLAGS;
+    const bufferSize = this._bufferSize;
     const updateFlagBuffer = this.updateFlagBuffer;
     // Track names of features that are passed into the .includes() function.
     const handler = {
@@ -99,7 +98,7 @@ export default class FeatureObserver {
         // Append `feature.projects:` in front to match the Sentry options automator format
         const name = 'feature.projects:' + flagName[0];
 
-        updateFlagBuffer({flagName: name, flagResult, flagBuffer});
+        updateFlagBuffer({flagName: name, flagResult, flagBuffer, bufferSize});
 
         return flagResult;
       },

--- a/static/app/utils/featureObserver.ts
+++ b/static/app/utils/featureObserver.ts
@@ -39,7 +39,7 @@ export default class FeatureObserver {
   }: {
     bufferSize: number;
     flagBuffer: Flags;
-    flagName: any;
+    flagName: string;
     flagResult: any;
   }) {
     // Check if the flag is already in the buffer

--- a/static/app/views/projects/projectContext.tsx
+++ b/static/app/views/projects/projectContext.tsx
@@ -17,7 +17,7 @@ import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import type {User} from 'sentry/types/user';
-import FeatureObserver, {FEATURE_FLAG_BUFFER_SIZE} from 'sentry/utils/featureObserver';
+import FeatureObserver from 'sentry/utils/featureObserver';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 import withProjects from 'sentry/utils/withProjects';
@@ -181,9 +181,7 @@ class ProjectContextProvider extends Component<Props, State> {
 
         // assuming here that this means the project is considered the active project
         setActiveProject(project);
-        FeatureObserver.singleton({
-          bufferSize: FEATURE_FLAG_BUFFER_SIZE,
-        }).observeProjectFlags({
+        FeatureObserver.singleton({}).observeProjectFlags({
           project,
         });
       } catch (error) {

--- a/static/app/views/projects/projectContext.tsx
+++ b/static/app/views/projects/projectContext.tsx
@@ -17,7 +17,7 @@ import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import type {User} from 'sentry/types/user';
-import FeatureObserver from 'sentry/utils/featureObserver';
+import FeatureObserver, {FEATURE_FLAG_BUFFER_SIZE} from 'sentry/utils/featureObserver';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 import withProjects from 'sentry/utils/withProjects';
@@ -183,7 +183,7 @@ class ProjectContextProvider extends Component<Props, State> {
         setActiveProject(project);
         FeatureObserver.singleton().observeProjectFlags({
           project,
-          bufferSize: 100,
+          bufferSize: FEATURE_FLAG_BUFFER_SIZE,
         });
       } catch (error) {
         this.setState({

--- a/static/app/views/projects/projectContext.tsx
+++ b/static/app/views/projects/projectContext.tsx
@@ -17,6 +17,7 @@ import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import type {User} from 'sentry/types/user';
+import FeatureObserver from 'sentry/utils/featureObserver';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 import withProjects from 'sentry/utils/withProjects';
@@ -180,6 +181,10 @@ class ProjectContextProvider extends Component<Props, State> {
 
         // assuming here that this means the project is considered the active project
         setActiveProject(project);
+        FeatureObserver.singleton().observeProjectFlags({
+          project,
+          bufferSize: 100,
+        });
       } catch (error) {
         this.setState({
           loading: false,

--- a/static/app/views/projects/projectContext.tsx
+++ b/static/app/views/projects/projectContext.tsx
@@ -181,9 +181,10 @@ class ProjectContextProvider extends Component<Props, State> {
 
         // assuming here that this means the project is considered the active project
         setActiveProject(project);
-        FeatureObserver.singleton().observeProjectFlags({
-          project,
+        FeatureObserver.singleton({
           bufferSize: FEATURE_FLAG_BUFFER_SIZE,
+        }).observeProjectFlags({
+          project,
         });
       } catch (error) {
         this.setState({


### PR DESCRIPTION
followup to 
- https://github.com/getsentry/sentry/pull/77532
- https://github.com/getsentry/sentry/pull/79445


add a feature observer for calls to `project.features.includes(...)` similar to the one we have for `organization.features.includes(...)`. 

this one behaves the same way as the old one. i refactored out the buffer updating code so we can reuse it for both cases. the flag evaluations for both org + project are pushed into the same flag queue, which is already being used in the `beforeSend` in `initializeSdk`.