### PR TITLE
fix(migrations): Fix migration failing in production

### DIFF
--- a/migrations_lockfile.txt
+++ b/migrations_lockfile.txt
@@ -13,4 +13,4 @@ replays: 0004_index_together
 sentry: 0777_add_related_name_to_dashboard_permissions
 social_auth: 0002_default_auto_field
 uptime: 0017_unique_on_timeout
-workflow_engine: 0011_test
+workflow_engine: 0010_detector_state_unique_group

--- a/migrations_lockfile.txt
+++ b/migrations_lockfile.txt
@@ -13,4 +13,4 @@ replays: 0004_index_together
 sentry: 0777_add_related_name_to_dashboard_permissions
 social_auth: 0002_default_auto_field
 uptime: 0017_unique_on_timeout
-workflow_engine: 0010_detector_state_unique_group
+workflow_engine: 0011_test

--- a/src/sentry/workflow_engine/migrations/0010_detector_state_unique_group.py
+++ b/src/sentry/workflow_engine/migrations/0010_detector_state_unique_group.py
@@ -29,9 +29,12 @@ class Migration(CheckedMigration):
         migrations.SeparateDatabaseAndState(
             database_operations=[
                 migrations.RunSQL(
+                    """DROP INDEX CONCURRENTLY IF EXISTS "detector_state_unique_group_key";"""
+                ),
+                migrations.RunSQL(
                     """CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "detector_state_unique_group_key"
                     ON "workflow_engine_detectorstate" ("detector_id", (COALESCE("detector_group_key", '')))"""
-                )
+                ),
             ],
             state_operations=[
                 migrations.AddConstraint(

--- a/src/sentry/workflow_engine/migrations/0010_detector_state_unique_group.py
+++ b/src/sentry/workflow_engine/migrations/0010_detector_state_unique_group.py
@@ -26,14 +26,24 @@ class Migration(CheckedMigration):
     ]
 
     operations = [
-        migrations.AddConstraint(
-            model_name="detectorstate",
-            constraint=models.UniqueConstraint(
-                models.F("detector"),
-                django.db.models.functions.comparison.Coalesce(
-                    "detector_group_key", models.Value("")
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    """CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "detector_state_unique_group_key"
+                    ON "workflow_engine_detectorstate" ("detector_id", (COALESCE("detector_group_key", '')))"""
+                )
+            ],
+            state_operations=[
+                migrations.AddConstraint(
+                    model_name="detectorstate",
+                    constraint=models.UniqueConstraint(
+                        models.F("detector"),
+                        django.db.models.functions.comparison.Coalesce(
+                            "detector_group_key", models.Value("")
+                        ),
+                        name="detector_state_unique_group_key",
+                    ),
                 ),
-                name="detector_state_unique_group_key",
-            ),
+            ],
         ),
     ]


### PR DESCRIPTION
This migration is failing in our US region. It looks like we hit a lock timeout that caused the migration to fail, but even though we cancelled the statement the creation ended up succeeding, and so when the migration re-ran it hit an issue with the index already existing.

<!-- Describe your PR here. -->