### PR TITLE
chore(group-resolution): Add test to guarantee has_resolution is implemented

### DIFF
--- a/tests/sentry/models/test_groupresolution.py
+++ b/tests/sentry/models/test_groupresolution.py
@@ -194,3 +194,19 @@ class GroupResolutionTest(TestCase):
 
     def test_no_release_with_no_resolution(self):
         assert not GroupResolution.has_resolution(self.group, None)
+
+    def test_all_resolutions_are_implemented(self):
+        resolution_types = [
+            attr for attr in vars(GroupResolution.Type) if not attr.startswith("__")
+        ]
+        for resolution_type in resolution_types:
+            resolution = GroupResolution.objects.create(
+                release=self.new_release,
+                group=self.group,
+                type=getattr(GroupResolution.Type, resolution_type),
+            )
+            assert (
+                GroupResolution.has_resolution(self.group, self.old_release) is not NotImplemented
+            )
+
+            resolution.delete()


### PR DESCRIPTION
this pr adds a test to make sure all resolution types have `has_resolution` implemented. any new resolution type that is added and does not update `has_resolution` will fail.