### PR TITLE
fix(onboarding): save integration notification configurations on project creation page

### DIFF
--- a/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
+++ b/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo} from 'react';
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import SelectControl from 'sentry/components/forms/controls/selectControl';
@@ -37,17 +37,6 @@ export default function MessagingIntegrationAlertRule({
         : [],
     [providersToIntegrations, provider]
   );
-
-  useEffect(() => {
-    const providerKeys = Object.keys(providersToIntegrations);
-    if (providerKeys.length > 0) {
-      const firstProvider = providerKeys[0];
-      setProvider(firstProvider);
-
-      const firstIntegration = providersToIntegrations[firstProvider][0];
-      setIntegration(firstIntegration);
-    }
-  }, [providersToIntegrations, setProvider, setIntegration]);
 
   if (!provider) {
     return null;


### PR DESCRIPTION
fix problem of integration notification configurations being reset every time the user deselected "Notify via integration" or selected "I'll create my own alerts later"

https://github.com/user-attachments/assets/6c9759ba-ffe0-49d2-8660-1b9d94c4822d

