### PR TITLE
fix(security): delete recovery codes after last authenticator is deleted

### DIFF
--- a/src/sentry/users/api/endpoints/user_authenticator_details.py
+++ b/src/sentry/users/api/endpoints/user_authenticator_details.py
@@ -223,7 +223,7 @@ class UserAuthenticatorDetailsEndpoint(UserEndpoint):
                 backup_interfaces = [x for x in interfaces if x.is_backup_interface]
                 # ensures that backup interfaces are removed when the last non-backup interface is removed.
                 # The "- 1" accounts for the authenticator that was just deleted.
-                if len(backup_interfaces) == len(interfaces):
+                if len(backup_interfaces) == len(interfaces) - 1:
                     for iface in backup_interfaces:
                         assert iface.authenticator, "Interface must have an authenticator to delete"
                         iface.authenticator.delete()

--- a/src/sentry/users/api/endpoints/user_authenticator_details.py
+++ b/src/sentry/users/api/endpoints/user_authenticator_details.py
@@ -221,6 +221,8 @@ class UserAuthenticatorDetailsEndpoint(UserEndpoint):
             # process.
             if not interface.is_backup_interface:
                 backup_interfaces = [x for x in interfaces if x.is_backup_interface]
+                # ensures that backup interfaces are removed when the last non-backup interface is removed.
+                # The "- 1" accounts for the authenticator that was just deleted.
                 if len(backup_interfaces) == len(interfaces):
                     for iface in backup_interfaces:
                         assert iface.authenticator, "Interface must have an authenticator to delete"

--- a/tests/sentry/users/api/endpoints/test_user_authenticator_details.py
+++ b/tests/sentry/users/api/endpoints/test_user_authenticator_details.py
@@ -290,6 +290,31 @@ class UserAuthenticatorDetailsTest(UserAuthenticatorDetailsTestBase):
 
         assert_security_email_sent("recovery-codes-regenerated")
 
+    def test_delete_last_authenticator_removes_recovery_codes(self):
+        # Enroll the user in TOTP
+        totp_interface = TotpInterface()
+        totp_interface.enroll(self.user)
+        totp_auth = totp_interface.authenticator
+
+        # Enroll the user in recovery codes
+        recovery_interface = RecoveryCodeInterface()
+        recovery_interface.enroll(self.user)
+        recovery_auth = recovery_interface.authenticator
+
+        # Confirm both authenticators exist
+        assert Authenticator.objects.filter(user=self.user).count() == 2
+
+        # Delete the TOTP authenticator
+        with self.tasks():
+            self.get_success_response(self.user.id, totp_auth.id, method="delete", status_code=204)
+
+        # Confirm that both the TOTP and recovery code authenticators are deleted
+        assert Authenticator.objects.filter(user=self.user).count() == 0
+        assert not Authenticator.objects.filter(id=totp_auth.id).exists()
+        assert not Authenticator.objects.filter(id=recovery_auth.id).exists()
+
+        assert_security_email_sent("mfa-removed")
+
     def test_delete_superuser(self):
         user = self.create_user(email="a@example.com", is_superuser=True)
 

--- a/tests/sentry/users/api/endpoints/test_user_authenticator_details.py
+++ b/tests/sentry/users/api/endpoints/test_user_authenticator_details.py
@@ -294,11 +294,13 @@ class UserAuthenticatorDetailsTest(UserAuthenticatorDetailsTestBase):
         # Enroll the user in TOTP
         totp_interface = TotpInterface()
         totp_interface.enroll(self.user)
+        assert totp_interface.authenticator is not None
         totp_auth = totp_interface.authenticator
 
         # Enroll the user in recovery codes
         recovery_interface = RecoveryCodeInterface()
         recovery_interface.enroll(self.user)
+        assert recovery_interface.authenticator is not None
         recovery_auth = recovery_interface.authenticator
 
         # Confirm both authenticators exist


### PR DESCRIPTION
Fixes a bug where recovery codes would persist after the last primary MFA interface had been deleted.

Before (the TOTP interface is deleted, but the recovery codes are still there):
![image](https://github.com/user-attachments/assets/4366b7c0-3ad6-4cc9-9b38-7e8edd2d6acb)

After (recovery codes are removed):
![Oct-21-2024 16-55-07](https://github.com/user-attachments/assets/5215cb6a-6095-4336-a895-e8138dc3b3e7)


