### PR TITLE
feat: Add reply consumer to taskworker prototypes

### DIFF
--- a/bin/taskworker-test
+++ b/bin/taskworker-test
@@ -165,8 +165,6 @@ def main(
                     "taskworker-reply-consumer",
                     "--consumer-group",
                     "taskworker-pull",
-                    # TODO group-instance-id would need to change depending
-                    # on the number of consumers.
                     "--group-instance-id",
                     str(1),
                     "--loglevel",

--- a/bin/taskworker-test
+++ b/bin/taskworker-test
@@ -162,11 +162,9 @@ def main(
                 "cmd": [
                     "sentry",
                     "run",
-                    "taskworker-reply-consumer",
+                    "taskworker-reply",
                     "--consumer-group",
                     "taskworker-pull",
-                    "--group-instance-id",
-                    str(1),
                     "--loglevel",
                     "warning",
                     "--",

--- a/bin/taskworker-test
+++ b/bin/taskworker-test
@@ -152,9 +152,50 @@ def main(
                     ],
                 },
             )
+    elif mode == "reply":
+        worker_ports = [50051 + i for i in range(workers)]
+        worker_addrs = ",".join([f"127.0.0.1:{port}" for port in worker_ports])
 
+        processes.append(
+            {
+                "name": "consumer",
+                "cmd": [
+                    "sentry",
+                    "run",
+                    "taskworker-reply-consumer",
+                    "--consumer-group",
+                    "taskworker-pull",
+                    # TODO group-instance-id would need to change depending
+                    # on the number of consumers.
+                    "--group-instance-id",
+                    str(1),
+                    "--loglevel",
+                    "warning",
+                    "--",
+                    "--storage",
+                    storage,
+                    "--worker-addrs",
+                    worker_addrs,
+                ],
+            }
+        )
+        for port in worker_ports:
+            processes.append(
+                {
+                    "name": f"worker-{port}",
+                    "cmd": [
+                        "sentry",
+                        "run",
+                        "taskworker-reply",
+                        "--namespace",
+                        "demos",
+                        "--port",
+                        str(port),
+                    ],
+                },
+            )
     else:
-        raise RuntimeError(f"Unexpected mode of {mode}. Use `push` or `pull` instead.")
+        raise RuntimeError(f"Unexpected mode of {mode}. Use `push`, `pull`, or `reply` instead.")
 
     for process in processes:
         manager.add_process(process["name"], list2cmdline(process["cmd"]), cwd=cwd)

--- a/bin/taskworker-test
+++ b/bin/taskworker-test
@@ -162,10 +162,11 @@ def main(
                 "cmd": [
                     "sentry",
                     "run",
+                    "consumer",
                     "taskworker-reply",
                     "--consumer-group",
                     "taskworker-pull",
-                    "--loglevel",
+                    "--log-level",
                     "warning",
                     "--",
                     "--storage",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2933,6 +2933,7 @@ KAFKA_TOPIC_TO_CLUSTER: Mapping[str, str] = {
     "hackweek": "default",
     "hackweek-reply": "default",
     "hackweek-dlq": "default",
+    "^(hackweek-reply|hackweek)$": "default",
 }
 
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2931,6 +2931,7 @@ KAFKA_TOPIC_TO_CLUSTER: Mapping[str, str] = {
     "buffered-segments": "default",
     "buffered-segments-dlq": "default",
     "hackweek": "default",
+    "hackweek-reply": "default",
     "hackweek-dlq": "default",
 }
 

--- a/src/sentry/conf/types/kafka_definition.py
+++ b/src/sentry/conf/types/kafka_definition.py
@@ -60,6 +60,7 @@ class Topic(Enum):
     HACKWEEK = "hackweek"
     HACKWEEK_REPLY = "hackweek-reply"
     HACKWEEK_DLQ = "hackweek-dlq"
+    HACKWEEK_GLOB = "^(hackweek-reply|hackweek)$"
 
 
 class ConsumerDefinition(TypedDict, total=False):

--- a/src/sentry/conf/types/kafka_definition.py
+++ b/src/sentry/conf/types/kafka_definition.py
@@ -58,6 +58,7 @@ class Topic(Enum):
     BUFFERED_SEGMENTS = "buffered-segments"
     BUFFERED_SEGMENTS_DLQ = "buffered-segments-dlq"
     HACKWEEK = "hackweek"
+    HACKWEEK_REPLY = "hackweek-reply"
     HACKWEEK_DLQ = "hackweek-dlq"
 
 

--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -70,6 +70,7 @@ def taskworker_options(
         default_max_batch_time_ms=default_max_batch_time_ms,
     )
     options.append(click.Option(["--storage"], type=str, default="postgres"))
+    options.append(click.Option(["--worker-addrs"], type=str, default="127.0.0.1:50051"))
 
     return options
 
@@ -415,6 +416,18 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
     "taskworker": {
         "topic": Topic.HACKWEEK,
         "strategy_factory": "sentry.taskworker.processors.strategy_factory.StrategyFactory",
+        "click_options": taskworker_options(default_max_batch_size=100),
+        "dlq_topic": Topic.HACKWEEK_DLQ,
+    },
+    "taskworker-consumer": {
+        "topic": Topic.HACKWEEK,
+        "strategy_factory": "sentry.taskworker.processors.reply.StrategyFactory",
+        "click_options": taskworker_options(default_max_batch_size=100),
+        "dlq_topic": Topic.HACKWEEK_DLQ,
+    },
+    "taskworker-consumer-reply": {
+        "topic": Topic.HACKWEEK_REPLY,
+        "strategy_factory": "sentry.taskworker.processors.reply.ReplyStrategyFactory",
         "click_options": taskworker_options(default_max_batch_size=100),
         "dlq_topic": Topic.HACKWEEK_DLQ,
     },

--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -64,13 +64,15 @@ def multiprocessing_options(
 def taskworker_options(
     default_max_batch_size: int | None = None,
     default_max_batch_time_ms: int | None = 1000,
+    include_worker_addrs: bool = False,
 ) -> list[click.Option]:
     options = multiprocessing_options(
         default_max_batch_size=default_max_batch_size,
         default_max_batch_time_ms=default_max_batch_time_ms,
     )
     options.append(click.Option(["--storage"], type=str, default="postgres"))
-    options.append(click.Option(["--worker-addrs"], type=str, default="127.0.0.1:50051"))
+    if include_worker_addrs:
+        options.append(click.Option(["--worker-addrs"], type=str, default="127.0.0.1:50051"))
 
     return options
 
@@ -422,7 +424,7 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
     "taskworker-reply": {
         "topic": Topic.HACKWEEK_GLOB,
         "strategy_factory": "sentry.taskworker.processors.reply.StrategyFactory",
-        "click_options": taskworker_options(default_max_batch_size=100),
+        "click_options": taskworker_options(default_max_batch_size=100, include_worker_addrs=True),
         "dlq_topic": Topic.HACKWEEK_DLQ,
     },
     **settings.SENTRY_KAFKA_CONSUMERS,

--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -419,15 +419,9 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
         "click_options": taskworker_options(default_max_batch_size=100),
         "dlq_topic": Topic.HACKWEEK_DLQ,
     },
-    "taskworker-consumer": {
-        "topic": Topic.HACKWEEK,
+    "taskworker-reply": {
+        "topic": Topic.HACKWEEK_GLOB,
         "strategy_factory": "sentry.taskworker.processors.reply.StrategyFactory",
-        "click_options": taskworker_options(default_max_batch_size=100),
-        "dlq_topic": Topic.HACKWEEK_DLQ,
-    },
-    "taskworker-consumer-reply": {
-        "topic": Topic.HACKWEEK_REPLY,
-        "strategy_factory": "sentry.taskworker.processors.reply.ReplyStrategyFactory",
         "click_options": taskworker_options(default_max_batch_size=100),
         "dlq_topic": Topic.HACKWEEK_DLQ,
     },

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -287,64 +287,6 @@ def taskworker_reply(port: int, **options: Any) -> None:
 
 
 @run.command()
-@click.argument("consumer_args", nargs=-1)
-@click.option(
-    "--group-instance-id",
-    type=str,
-    default=None,
-)
-@click.option(
-    "--consumer-group",
-    "group_id",
-    required=True,
-    help="Kafka consumer group for the consumer.",
-)
-# more options in the consumer definitions.
-@log_options()
-@configuration
-def taskworker_reply_consumer(
-    consumer_args: tuple[str, ...],
-    group_id: str,
-    group_instance_id: str,
-    **options: Any,
-) -> None:
-    from sentry.consumers import get_stream_processor
-    from sentry.utils.arroyo import initialize_arroyo_main
-
-    initialize_arroyo_main()
-
-    processors = []
-    for consumer_name in ["taskworker-consumer", "taskworker-consumer-reply"]:
-        if "reply" in consumer_name:
-            group_id = f"{group_id}-reply"
-
-        processor = get_stream_processor(
-            consumer_name,
-            consumer_args,
-            topic=None,
-            cluster=None,
-            group_id=group_id,
-            group_instance_id=group_instance_id,
-            auto_offset_reset="latest",
-            strict_offset_reset=False,
-            join_timeout=None,
-            max_poll_interval_ms=None,
-            synchronize_commit_group=None,
-            synchronize_commit_log_topic=None,
-            enable_dlq=False,
-            healthcheck_file_path=None,
-            enforce_schema=True,
-            **options,
-        )
-        processors.append(processor)
-    # TODO this is a giant hack. Ideally Arroyo would support
-    # consuming from multiple topics.
-    while True:
-        for processor in processors:
-            processor._run_once()
-
-
-@run.command()
 @click.option(
     "--hostname",
     "-n",

--- a/src/sentry/taskworker/processors/reply.py
+++ b/src/sentry/taskworker/processors/reply.py
@@ -195,11 +195,15 @@ class StrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
             if topic.name == "hackweek":
                 limit_tasks(message)
                 activation = process_message(message)
+                logger.info("store activation for id=%s", activation.id)
+
                 self.pending_task_store.store([activation])
 
             if topic.name == "hackweek-reply":
                 result = ActivationResult()
                 result.ParseFromString(message.payload.value)
+                logger.info("process activation-result for id=%s", result.task_id)
+
                 self.pending_task_store.set_task_status(result.task_id, result.status)
 
                 # TODO only do once and a while, perhaps every 5s?

--- a/src/sentry/taskworker/processors/reply.py
+++ b/src/sentry/taskworker/processors/reply.py
@@ -66,12 +66,6 @@ class StrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         )
         self.current_connections = set()
         self.__send_thread: Thread | None = None
-        self.__shutdown = False
-
-    def shutdown(self):
-        super().shutdown()
-        self.__shutdown = True
-        self.__send_thread = None
 
     def start_worker_push(self):
         with ThreadPoolExecutor(max_workers=len(self.available_stubs)) as executor:

--- a/src/sentry/taskworker/processors/reply.py
+++ b/src/sentry/taskworker/processors/reply.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import logging
+import time
+from collections import deque
+from collections.abc import Mapping, MutableSequence
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
+from datetime import timedelta
+from threading import Thread
+
+import grpc
+from arroyo.backends.kafka.consumer import KafkaPayload
+from arroyo.processing.strategies import (
+    CommitOffsets,
+    ProcessingStrategy,
+    ProcessingStrategyFactory,
+    Reduce,
+    RunTask,
+)
+from arroyo.processing.strategies.abstract import MessageRejected
+from arroyo.types import BaseValue, Commit, Message, Partition
+from django.utils import timezone
+from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_protos.sentry.v1alpha.taskworker_pb2 import (
+    TASK_ACTIVATION_STATUS_PENDING,
+    ActivationResult,
+    ExecuteActivationRequest,
+    InflightActivation,
+    TaskActivation,
+)
+from sentry_protos.sentry.v1alpha.taskworker_pb2_grpc import WorkerReplyServiceStub
+
+from sentry.taskworker.pending_task_store import get_storage_backend
+
+logger = logging.getLogger("sentry.taskworker.consumer")
+
+
+class StrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
+    """Process new work/tasks and deliver tasks to workers."""
+
+    def __init__(
+        self,
+        max_batch_size: int,
+        max_batch_time: int,
+        num_processes: int,
+        input_block_size: int | None,
+        output_block_size: int | None,
+        storage: str | None,
+        worker_addrs: str,
+    ) -> None:
+        super().__init__()
+
+        # Maximum amount of time tasks are allowed to live in pending task
+        # after this time tasks should be deadlettered if they are followed
+        # by completed records. Should come from CLI/options
+        self.max_pending_timeout = 8 * 60
+
+        # Maximum number of pending inflight activations in the store before backpressure is emitted
+        self.max_inflight_activation_in_store = 1000  # make this configurable
+
+        self.pending_task_store = get_storage_backend(storage)
+        self.available_stubs = deque(
+            [
+                WorkerReplyServiceStub(grpc.insecure_channel(worker_addr))
+                for worker_addr in worker_addrs.split(",")
+            ]
+        )
+        self.current_connections = set()
+        self.__send_thread: Thread | None = None
+
+    def start_worker_push(self):
+        with ThreadPoolExecutor(max_workers=len(self.available_stubs)) as executor:
+            logger.info("Starting grpc clients with %s threads", len(self.available_stubs))
+            while True:
+                if len(self.available_stubs) == 0:
+                    done, not_done = wait(self.current_connections, return_when=FIRST_COMPLETED)
+                    self.available_stubs.extend([future.result() for future in done])
+                    self.current_connections = not_done
+
+                self.current_connections.add(
+                    executor.submit(
+                        self._dispatch_activation,
+                        self.available_stubs.popleft(),
+                        self._poll_pending_task(),
+                    )
+                )
+
+    def _poll_pending_task(self) -> InflightActivation:
+        while True:
+            inflight_activation = self.pending_task_store.get_pending_task()
+            if inflight_activation:
+                logger.info("Polled task %s", inflight_activation.activation.id)
+                return inflight_activation
+            time.sleep(0.5)
+
+    def _dispatch_activation(
+        self,
+        stub: WorkerReplyServiceStub,
+        inflight_activation: InflightActivation,
+    ) -> WorkerReplyServiceStub:
+        try:
+            logger.info(
+                "invoke ExecuteActivation for task_id=%s", inflight_activation.activation.id
+            )
+            execute_response = stub.ExecuteActivation(
+                ExecuteActivationRequest(
+                    activation=inflight_activation.activation,
+                    processing_deadline=inflight_activation.processing_deadline,
+                    # TODO with work + reply consumers being separate this will be hard to get
+                    # correct.
+                    reply_partition=0,
+                ),
+            )
+            if not execute_response.ok:
+                logger.error(
+                    "Received an error dispatching a task id=%s error=%s",
+                    inflight_activation.activation.id,
+                    execute_response.error,
+                )
+        except grpc.RpcError as rpc_error:
+            logger.exception(
+                "gRPC failed, code: %s, details: %s",
+                rpc_error.code(),
+                rpc_error.details(),
+            )
+            self.pending_task_store.set_task_status(
+                task_id=inflight_activation.activation.id,
+                task_status=TASK_ACTIVATION_STATUS_PENDING,
+            )
+            self.pending_task_store.set_task_deadline(
+                task_id=inflight_activation.activation.id, task_deadline=None
+            )
+            time.sleep(1)
+        return stub
+
+    def create_with_partitions(
+        self, commit: Commit, _: Mapping[Partition, int]
+    ) -> ProcessingStrategy[KafkaPayload]:
+        def process_message(message: Message[KafkaPayload]) -> InflightActivation:
+            activation = TaskActivation()
+            activation.ParseFromString(message.payload.value)
+            ((_partition, offset),) = message.committable.items()
+
+            # TODO this should read from task namespace configuration
+            deadletter_at = timezone.now() + timedelta(minutes=10)
+
+            return InflightActivation(
+                activation=activation,
+                status=TASK_ACTIVATION_STATUS_PENDING,
+                offset=offset,
+                added_at=Timestamp(seconds=int(time.time())),
+                deadletter_at=Timestamp(seconds=int(deadletter_at.timestamp())),
+                processing_deadline=None,
+            )
+
+        def accumulator(
+            batched_results: MutableSequence[InflightActivation],
+            message: BaseValue[InflightActivation],
+        ) -> MutableSequence[InflightActivation]:
+            batched_results.append(message.payload)
+            return batched_results
+
+        def flush_batch(
+            message: Message[MutableSequence[InflightActivation]],
+        ) -> Message[MutableSequence[InflightActivation]]:
+            logger.info("Flushing batch. Messages: %r...", len(message.payload))
+            self.pending_task_store.store(message.value.payload)
+            return message
+
+        def limit_tasks(
+            message: Message[KafkaPayload],
+        ) -> KafkaPayload:
+            count = self.pending_task_store.count_pending_task()
+            if count >= self.max_inflight_activation_in_store:
+                # The number of pending inflight activations in the store exceeds the limit.
+                # Wait for workers to complete tasks before adding the next offset to the queue.
+                logger.info(
+                    "Number of inflight activation: %s exceeds the limit: %s. Retrying in 3 seconds",
+                    count,
+                    self.max_inflight_activation_in_store,
+                )
+                raise MessageRejected()
+            return message.payload
+
+        self.__send_thread = Thread(target=self.start_worker_push)
+        self.__send_thread.start()
+
+        flush = RunTask(
+            function=flush_batch,
+            next_step=CommitOffsets(commit),
+        )
+
+        collect = Reduce(
+            # TODO use CLI options
+            max_batch_size=2,
+            max_batch_time=2,
+            accumulator=accumulator,
+            initial_value=list,
+            next_step=flush,
+        )
+
+        process = RunTask(
+            function=process_message,
+            next_step=collect,
+        )
+
+        return RunTask(
+            function=limit_tasks,
+            next_step=process,
+        )
+
+
+class ReplyStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
+    """
+    Process task activation results from a reply topic
+    """
+
+    def __init__(
+        self,
+        max_batch_size: int,
+        max_batch_time: int,
+        num_processes: int,
+        input_block_size: int | None,
+        output_block_size: int | None,
+        storage: str | None,
+        worker_addrs: str,
+    ) -> None:
+        super().__init__()
+
+        # Maximum amount of time tasks are allowed to live in pending task
+        # after this time tasks should be deadlettered if they are followed
+        # by completed records. Should come from CLI/options
+        self.max_pending_timeout = 8 * 60
+
+        # Maximum number of pending inflight activations in the store before backpressure is emitted
+        self.max_inflight_activation_in_store = 1000  # make this configurable
+        self.pending_task_store = get_storage_backend(storage)
+
+    def create_with_partitions(
+        self, commit: Commit, partitions: Mapping[Partition, int]
+    ) -> ProcessingStrategy[KafkaPayload]:
+        def process_reply_message(message: Message[KafkaPayload]) -> None:
+            result = ActivationResult()
+            result.ParseFromString(message.payload.value)
+            self.pending_task_store.set_task_status(result.task_id, result.status)
+
+            return None
+
+        def do_upkeep(
+            message: Message[KafkaPayload],
+        ) -> KafkaPayload:
+            # Do upkeep tasks after processing replies.
+            # We should account for processing lag for replies here.
+            self.pending_task_store.handle_processing_deadlines()
+            self.pending_task_store.handle_retry_state_tasks()
+            self.pending_task_store.handle_deadletter_at()
+            self.pending_task_store.handle_failed_tasks()
+            self.pending_task_store.remove_completed()
+
+            return message.payload
+
+        run_upkeep = RunTask(
+            function=do_upkeep,
+            next_step=CommitOffsets(commit),
+        )
+
+        return RunTask(
+            function=process_reply_message,
+            next_step=run_upkeep,
+        )

--- a/src/sentry/taskworker/processors/reply.py
+++ b/src/sentry/taskworker/processors/reply.py
@@ -195,7 +195,7 @@ class StrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
             if topic.name == "hackweek":
                 limit_tasks(message)
                 activation = process_message(message)
-                logger.info("store activation for id=%s", activation.id)
+                logger.info("store activation for id=%s", activation.activation.id)
 
                 self.pending_task_store.store([activation])
 

--- a/src/sentry/taskworker/worker_pull.py
+++ b/src/sentry/taskworker/worker_pull.py
@@ -156,16 +156,6 @@ class Worker:
         task_latency = execution_time - task_added_time
         self.__execution_count += 1
 
-        # Dump results to a log file that is CSV shaped
-        result_logger.info(
-            "task.complete, %s, %s, %s, %s, %s",
-            self.__worker_id,
-            task_added_time,
-            execution_time,
-            task_latency,
-            activation.id,
-        )
-
         if next_state == TASK_ACTIVATION_STATUS_COMPLETE:
             logger.info(
                 "taskworker.task.complete", extra={"task": activation.taskname, "id": activation.id}
@@ -180,6 +170,16 @@ class Worker:
                 task_id=activation.id,
                 task_status=next_state,
             )
+
+        # Dump results to a log file that is CSV shaped
+        result_logger.info(
+            "task.complete, %s, %s, %s, %s, %s",
+            self.__worker_id,
+            task_added_time,
+            execution_time,
+            task_latency,
+            activation.id,
+        )
 
         if response.HasField("task") and response.HasField("processing_deadline"):
             new_task = response.task

--- a/src/sentry/taskworker/worker_pull.py
+++ b/src/sentry/taskworker/worker_pull.py
@@ -118,7 +118,6 @@ class Worker:
 
         # TODO: Check idempotency
         task_added_time = activation.received_at.seconds
-        execution_time = time.time()
         next_state = TASK_ACTIVATION_STATUS_FAILURE
         result = None
         try:
@@ -153,6 +152,7 @@ class Worker:
                 logger.info("taskworker.task.retry", extra={"task": activation.taskname})
                 next_state = TASK_ACTIVATION_STATUS_RETRY
 
+        execution_time = time.time()
         task_latency = execution_time - task_added_time
         self.__execution_count += 1
 

--- a/src/sentry/taskworker/worker_push.py
+++ b/src/sentry/taskworker/worker_push.py
@@ -65,7 +65,6 @@ class WorkerServicer(BaseWorkerServiceServicer):
 
         # TODO: Check idempotency
         task_added_time = activation.received_at.seconds
-        execution_time = time.time()
         next_state = TASK_ACTIVATION_STATUS_FAILURE
         result = None
         try:
@@ -95,6 +94,8 @@ class WorkerServicer(BaseWorkerServiceServicer):
             if self.namespace.get(activation.taskname).should_retry(activation.retry_state, err):
                 logger.info("taskworker.task.retry", extra={"task": activation.taskname})
                 next_state = TASK_ACTIVATION_STATUS_RETRY
+
+        execution_time = time.time()
         task_latency = execution_time - task_added_time
 
         # Dump results to a log file that is CSV shaped

--- a/src/sentry/taskworker/worker_reply.py
+++ b/src/sentry/taskworker/worker_reply.py
@@ -103,7 +103,6 @@ class WorkerReplyServicer(BaseWorkerReplyServiceServicer):
 
         # TODO: Check idempotency
         task_added_time = activation.received_at.seconds
-        execution_time = time.time()
         next_state = TASK_ACTIVATION_STATUS_FAILURE
         result = None
         try:
@@ -133,6 +132,8 @@ class WorkerReplyServicer(BaseWorkerReplyServiceServicer):
             if self.namespace.get(activation.taskname).should_retry(activation.retry_state, err):
                 logger.info("taskworker.task.retry", extra={"task": activation.taskname})
                 next_state = TASK_ACTIVATION_STATUS_RETRY
+
+        execution_time = time.time()
         task_latency = execution_time - task_added_time
 
         reply = ActivationResult(status=next_state, task_id=activation.id)

--- a/src/sentry/taskworker/worker_reply.py
+++ b/src/sentry/taskworker/worker_reply.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import logging
+import time
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from multiprocessing.context import TimeoutError
+from multiprocessing.pool import Pool
+from threading import Thread
+from typing import Any
+from uuid import uuid4
+
+import grpc
+import orjson
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer
+from arroyo.types import Partition as ArroyoPartition
+from arroyo.types import Topic as ArroyoTopic
+from django.conf import settings
+from sentry_protos.sentry.v1alpha.taskworker_pb2 import (
+    TASK_ACTIVATION_STATUS_COMPLETE,
+    TASK_ACTIVATION_STATUS_FAILURE,
+    TASK_ACTIVATION_STATUS_RETRY,
+    ActivationResult,
+    ExecuteActivationRequest,
+    ExecuteActivationResponse,
+)
+from sentry_protos.sentry.v1alpha.taskworker_pb2_grpc import (
+    WorkerReplyServiceServicer as BaseWorkerReplyServiceServicer,
+)
+from sentry_protos.sentry.v1alpha.taskworker_pb2_grpc import (
+    add_WorkerReplyServiceServicer_to_server,
+)
+
+from sentry.conf.types.kafka_definition import Topic
+from sentry.taskworker import worker_process
+from sentry.taskworker.config import TaskNamespace, taskregistry
+from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
+
+logger = logging.getLogger("sentry.taskworker")
+result_logger = logging.getLogger("taskworker.results")
+
+
+class WorkerReplyServicer(BaseWorkerReplyServiceServicer):
+    __namespace: TaskNamespace | None = None
+    __reply_producer: KafkaProducer | None = None
+
+    def __init__(self, **options) -> None:
+        super().__init__()
+        self.options = options
+        self.do_imports()
+        self.__worker_id = uuid4().hex
+        self._build_pool()
+
+    def _build_pool(self) -> None:
+        self.__pool = Pool(processes=2)
+
+    @property
+    def namespace(self) -> TaskNamespace:
+        # TODO task namespace should be based on the current task activation.
+        if self.__namespace:
+            return self.__namespace
+
+        name = self.options["namespace"]
+        self.__namespace = taskregistry.get(name)
+        return self.__namespace
+
+    @property
+    def reply_producer(self) -> KafkaProducer:
+        if self.__reply_producer:
+            return self.__reply_producer
+        cluster_name = get_topic_definition(Topic.HACKWEEK_REPLY)["cluster"]
+        producer_config = get_kafka_producer_cluster_options(cluster_name)
+        self.__reply_producer = KafkaProducer(producer_config)
+
+        return self.__reply_producer
+
+    def do_imports(self) -> None:
+        for module in settings.TASKWORKER_IMPORTS:
+            __import__(module)
+
+    def ExecuteActivation(
+        self, request: ExecuteActivationRequest, context: Any
+    ) -> ExecuteActivationResponse:
+        activation = request.activation
+
+        if not self.namespace.contains(activation.taskname):
+            logger.exception("Could not resolve task with name %s", activation.taskname)
+            return ExecuteActivationResponse(ok=False, error="Unknown task")
+
+        # TODO fix threading crimes
+        thread = Thread(
+            target=self._execute_task,
+            kwargs={
+                "request": request,
+            },
+        )
+        thread.start()
+
+        return ExecuteActivationResponse(ok=True)
+
+    def _execute_task(self, request: ExecuteActivationRequest) -> None:
+        activation = request.activation
+
+        # TODO: Check idempotency
+        task_added_time = activation.received_at.seconds
+        execution_time = time.time()
+        next_state = TASK_ACTIVATION_STATUS_FAILURE
+        result = None
+        try:
+            task_data_parameters = orjson.loads(activation.parameters)
+            result = self.__pool.apply_async(
+                worker_process._process_activation,
+                args=[
+                    self.namespace.name,
+                    activation.taskname,
+                    task_data_parameters["args"],
+                    task_data_parameters["kwargs"],
+                ],
+            )
+            result.get(
+                timeout=(request.processing_deadline.ToDatetime() - datetime.now()).total_seconds()
+            )
+            next_state = TASK_ACTIVATION_STATUS_COMPLETE
+        except TimeoutError:
+            logger.info("taskworker.task_execution_timeout")
+            # When a task times out we kill the entire pool. This is necessary because
+            # stdlib multiprocessing.Pool doesn't expose ways to terminate individual tasks.
+            self.__pool.terminate()
+            self._build_pool()
+        except Exception as err:
+            logger.info("taskworker.task_errored", extra={"error": str(err)})
+            # TODO check retry policy
+            if self.namespace.get(activation.taskname).should_retry(activation.retry_state, err):
+                logger.info("taskworker.task.retry", extra={"task": activation.taskname})
+                next_state = TASK_ACTIVATION_STATUS_RETRY
+        task_latency = execution_time - task_added_time
+
+        # Dump results to a log file that is CSV shaped
+        result_logger.info(
+            "task.complete, %s, %s, %s, %s, %s",
+            self.__worker_id,
+            task_added_time,
+            execution_time,
+            task_latency,
+            activation.id,
+        )
+        reply = ActivationResult(status=next_state, task_id=activation.id)
+        self.reply_producer.produce(
+            ArroyoPartition(
+                topic=ArroyoTopic(name="hackweek-reply"), index=request.reply_partition
+            ),
+            KafkaPayload(key=None, value=reply.SerializeToString(), headers=[]),
+        )
+
+
+def serve(port: int, **options):
+    logger.info("Starting server on: %s", port)
+    server = grpc.server(ThreadPoolExecutor(max_workers=10))
+    add_WorkerReplyServiceServicer_to_server(WorkerReplyServicer(**options), server)
+    server.add_insecure_port(f"[::]:{port}")
+    server.start()
+    server.wait_for_termination()


### PR DESCRIPTION
I wanted to see how using kafka to consume task results would behave in comparison grpc results. In this arrangement, consumers would consume from both a 'work' and 'result' topic. workers would receive tasks via grpc 'webhooks', execute the task and publish results over kafka.

This allows consumers to not have a grpc interface which I think will make them easier to operate, and give us a centralized place to control ratelimiting and throughput to workers.

There are several code-crimes that will need to be resolved before we could take this approach any further. Most important is that Arroyo does not support consuming from multiple topics in the way I have been thinking about this.