### PR TITLE
chore(alerts): clean up alert-filters flag

### DIFF
--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -27,7 +27,6 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
 
         available_ticket_actions = set()
 
-        project_has_filters = features.has("projects:alert-filters", project)
         can_create_tickets = features.has(
             "organizations:integrations-ticket-rules", project.organization
         )
@@ -36,7 +35,7 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
         for rule_type, rule_cls in rules:
             node = rule_cls(project=project)
             # skip over conditions if they are not in the migrated set for a project with alert-filters
-            if project_has_filters and node.id in MIGRATED_CONDITIONS:
+            if node.id in MIGRATED_CONDITIONS:
                 continue
 
             if not can_create_tickets and node.id in TICKET_ACTIONS:

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -539,8 +539,6 @@ def register_temporary_features(manager: FeatureManager):
     ###########################
     # Enable AI Autofix feture on the Issue Details page.
     manager.add("projects:ai-autofix", ProjectFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
-    # Adds additional filters and a new section to issue alert rules.
-    manager.add("projects:alert-filters", ProjectFeature, FeatureHandlerStrategy.INTERNAL, default=True)
     manager.add("projects:discard-transaction", ProjectFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable calculating a severity score for events which create a new group
     manager.add("projects:first-event-severity-calculation", ProjectFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)


### PR DESCRIPTION
This feature has been rolled out for a while, so remove all references to the flag (Sentry PR).