### PR TITLE
fix(discover): Query title for team plans

### DIFF
--- a/static/app/views/discover/resultsHeader.tsx
+++ b/static/app/views/discover/resultsHeader.tsx
@@ -159,6 +159,7 @@ class ResultsHeader extends Component<Props, State> {
       splitDecision,
     } = this.props;
     const {savedQuery, loading, homepageQuery} = this.state;
+    const hasDiscoverQueryFeature = organization.features.includes('discover-query');
 
     return (
       <Layout.Header>
@@ -175,22 +176,33 @@ class ResultsHeader extends Component<Props, State> {
                 />
               </Layout.Title>
             </GuideAnchor>
-          ) : (
+          ) : hasDiscoverQueryFeature ? (
             <Fragment>
-              <Feature features="organizations:discover-query">
-                <DiscoverBreadcrumb
-                  eventView={eventView}
-                  organization={organization}
-                  location={location}
-                  isHomepage={isHomepage}
-                />
-              </Feature>
+              <DiscoverBreadcrumb
+                eventView={eventView}
+                organization={organization}
+                location={location}
+                isHomepage={isHomepage}
+              />
               <EventInputName
                 savedQuery={savedQuery}
                 organization={organization}
                 eventView={eventView}
                 isHomepage={isHomepage}
               />
+            </Fragment>
+          ) : (
+            // Only has discover-basic
+            <Fragment>
+              <Layout.Title>
+                {t('Discover')}
+                <PageHeadingQuestionTooltip
+                  docsUrl="https://docs.sentry.io/product/discover-queries/"
+                  title={t(
+                    'Create queries to get insights into the health of your system.'
+                  )}
+                />
+              </Layout.Title>
             </Fragment>
           )}
           {this.renderAuthor()}


### PR DESCRIPTION
Previously, this referenced the event view name, but changing it to be Discover for team plans.
To test locally, set `organizations:discover-query` flag to False

![Screenshot 2024-10-21 at 6 58 20 PM](https://github.com/user-attachments/assets/f21b9427-1251-426c-acf7-cc898c285eb8)

![Screenshot 2024-10-21 at 6 57 59 PM](https://github.com/user-attachments/assets/41f3732b-32ec-4733-926a-4bafd848093d)
