### PR TITLE
chore(models): Default the `enable-post-update-signal` option to True

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2383,7 +2383,7 @@ register(
 # Enable sending a post update signal after we update groups using a queryset update
 register(
     "groups.enable-post-update-signal",
-    default=False,
+    default=True,
     flags=FLAG_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 


### PR DESCRIPTION
Before we can cleanup and remove this option, we need to default it to True globally. Cleanup in https://github.com/getsentry/sentry/pull/79381