### PR TITLE
ref(quick-start): Sorted tasks & update counter logic

### DIFF
--- a/static/app/components/onboardingWizard/filterSupportedTasks.tsx
+++ b/static/app/components/onboardingWizard/filterSupportedTasks.tsx
@@ -18,9 +18,11 @@ export function filterSupportedTasks(
   projects: Project[] | undefined,
   allTasks: OnboardingTask[]
 ): OnboardingTask[] {
-  if (!projects) {
-    return [];
+  // If no projects, we can not know which tasks are supported
+  if (!projects || (Array.isArray(projects) && projects.length === 0)) {
+    return allTasks;
   }
+
   // Remove tasks for features that are not supported
   const excludeList = allTasks.filter(
     task =>

--- a/static/app/components/onboardingWizard/newSidebar.tsx
+++ b/static/app/components/onboardingWizard/newSidebar.tsx
@@ -21,7 +21,7 @@ import {space} from 'sentry/styles/space';
 import {
   type OnboardingTask,
   OnboardingTaskGroup,
-  type OnboardingTaskKey,
+  OnboardingTaskKey,
 } from 'sentry/types/onboarding';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
@@ -42,6 +42,24 @@ const INITIAL_MARK_COMPLETE_TIMEOUT = 600;
  * How long (in ms) to delay between marking each unseen task as complete.
  */
 const COMPLETION_SEEN_TIMEOUT = 800;
+
+const orderedGettingStartedTasks = [
+  OnboardingTaskKey.FIRST_PROJECT,
+  OnboardingTaskKey.FIRST_EVENT,
+  OnboardingTaskKey.INVITE_MEMBER,
+  OnboardingTaskKey.ALERT_RULE,
+  OnboardingTaskKey.SOURCEMAPS,
+  OnboardingTaskKey.LINK_SENTRY_TO_SOURCE_CODE,
+  OnboardingTaskKey.RELEASE_TRACKING,
+];
+
+const orderedBeyondBasicsTasks = [
+  OnboardingTaskKey.REAL_TIME_NOTIFICATIONS,
+  OnboardingTaskKey.SESSION_REPLAY,
+  OnboardingTaskKey.FIRST_TRANSACTION,
+  OnboardingTaskKey.METRIC_ALERT,
+  OnboardingTaskKey.SECOND_PLATFORM,
+];
 
 export function useOnboardingTasks(
   organization: Organization,
@@ -350,6 +368,17 @@ export function NewOnboardingSidebar({
     };
   }, [markSeenOnOpen]);
 
+  const sortedGettingStartedTasks = gettingStartedTasks.sort(
+    (a, b) =>
+      orderedGettingStartedTasks.indexOf(a.task) -
+      orderedGettingStartedTasks.indexOf(b.task)
+  );
+
+  const sortedBeyondBasicsTasks = beyondBasicsTasks.sort(
+    (a, b) =>
+      orderedBeyondBasicsTasks.indexOf(a.task) - orderedBeyondBasicsTasks.indexOf(b.task)
+  );
+
   return (
     <Wrapper
       collapsed={collapsed}
@@ -364,7 +393,7 @@ export function NewOnboardingSidebar({
           description={t(
             'Learn the essentials to set up monitoring, capture errors, and track releases.'
           )}
-          tasks={gettingStartedTasks}
+          tasks={sortedGettingStartedTasks}
           hidePanel={onClose}
           expanded={
             groupTasksByCompletion(gettingStartedTasks).incompletedTasks.length > 0
@@ -375,7 +404,7 @@ export function NewOnboardingSidebar({
           description={t(
             'Explore advanced features like release tracking, performance alerts and more to enhance your monitoring.'
           )}
-          tasks={beyondBasicsTasks}
+          tasks={sortedBeyondBasicsTasks}
           hidePanel={onClose}
           expanded={
             groupTasksByCompletion(gettingStartedTasks).incompletedTasks.length === 0

--- a/static/app/components/onboardingWizard/newSidebar.tsx
+++ b/static/app/components/onboardingWizard/newSidebar.tsx
@@ -57,7 +57,6 @@ const orderedBeyondBasicsTasks = [
   OnboardingTaskKey.REAL_TIME_NOTIFICATIONS,
   OnboardingTaskKey.SESSION_REPLAY,
   OnboardingTaskKey.FIRST_TRANSACTION,
-  OnboardingTaskKey.METRIC_ALERT,
   OnboardingTaskKey.SECOND_PLATFORM,
 ];
 

--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -461,7 +461,9 @@ export function getOnboardingTasks({
       actionType: 'app',
       location: getMetricAlertUrl({projects, organization, onboardingContext}),
       // Use `features?.` because getsentry has a different `Organization` type/payload
-      display: organization.features?.includes('incidents'),
+      display:
+        organization.features?.includes('incidents') &&
+        !hasQuickStartUpdatesFeature(organization),
     },
   ];
 }

--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -243,7 +243,6 @@ export function getOnboardingTasks({
       actionType: 'app',
       location: `/settings/${organization.slug}/integrations/`,
       display: !hasQuickStartUpdatesFeature(organization),
-      group: OnboardingTaskGroup.GETTING_STARTED,
     },
     {
       task: OnboardingTaskKey.REAL_TIME_NOTIFICATIONS,
@@ -256,7 +255,6 @@ export function getOnboardingTasks({
       actionType: 'app',
       location: `/settings/${organization.slug}/integrations/?category=chat`,
       display: hasQuickStartUpdatesFeature(organization),
-      group: OnboardingTaskGroup.GETTING_STARTED,
     },
     {
       task: OnboardingTaskKey.LINK_SENTRY_TO_SOURCE_CODE,
@@ -363,7 +361,7 @@ export function getOnboardingTasks({
       actionType: 'external',
       location:
         'https://docs.sentry.io/platform-redirect/?next=/enriching-events/identify-user/',
-      display: true,
+      display: !hasQuickStartUpdatesFeature(organization),
     },
     {
       task: OnboardingTaskKey.SESSION_REPLAY,

--- a/static/app/components/sidebar/newOnboardingStatus.tsx
+++ b/static/app/components/sidebar/newOnboardingStatus.tsx
@@ -95,7 +95,7 @@ export function NewOnboardingStatus({
             font-size: ${theme.fontSizeMedium};
             font-weight: ${theme.fontWeightBold};
           `}
-          text={totalRemainingTasks}
+          text={completeTasks.length}
           value={(completeTasks.length / allTasks.length) * 100}
           backgroundColor="rgba(255, 255, 255, 0.15)"
           progressEndcaps="round"
@@ -106,10 +106,13 @@ export function NewOnboardingStatus({
           <div>
             <Heading>{label}</Heading>
             <Remaining>
-              {tct('[totalRemainingTasks] Remaining [task]', {
-                totalRemainingTasks,
-                task: walkthrough ? 'tours' : 'tasks',
-              })}
+              {walkthrough
+                ? tct('[totalCompletedTasks] completed tours', {
+                    totalCompletedTasks: completeTasks.length,
+                  })
+                : tct('[totalCompletedTasks] completed tasks', {
+                    totalCompletedTasks: completeTasks.length,
+                  })}
               {pendingCompletionSeen && <PendingSeenIndicator />}
             </Remaining>
           </div>


### PR DESCRIPTION
This PR includes:

- Updated counter logic to display the total number of completed tasks instead of remaining tasks.
- Reordered tasks to align with the sequence defined in [projects doc](https://www.notion.so/sentry/Update-Quick-Start-Guide-1118b10e4b5d806a8f7bca043bf6266a) (Internal only).

**Preview**

<img width="713" alt="Screenshot 2024-10-22 at 09 10 45" src="https://github.com/user-attachments/assets/1d50a724-4092-4f94-8441-06675230525a">
<img width="674" alt="Screenshot 2024-10-22 at 09 10 35" src="https://github.com/user-attachments/assets/e43d640a-6729-4eab-879b-92cad7babb4b">



closes https://github.com/getsentry/projects/issues/299
closes https://github.com/getsentry/projects/issues/298
