### PR TITLE
fix(dashboard): Show on-demand warning if transaction

### DIFF
--- a/static/app/utils/onDemandMetrics/index.tsx
+++ b/static/app/utils/onDemandMetrics/index.tsx
@@ -79,7 +79,7 @@ export function shouldDisplayOnDemandWidgetWarning(
     !hasErrorCondition(query.conditions) &&
     isOnDemandQueryString(query.conditions) &&
     hasOnDemandMetricWidgetFeature(organization) &&
-    widgetType === WidgetType.DISCOVER
+    (widgetType === WidgetType.DISCOVER || widgetType === WidgetType.TRANSACTIONS)
   );
 }
 


### PR DESCRIPTION
Since the widget type we will show is now Transaction, we still need to inform AM2 customers if on-demand metrics are applying to their widget.