### PR TITLE
ref: make escalated_today ordering deterministic in daily_summary

### DIFF
--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -442,7 +442,7 @@ class DailySummaryTest(
         project_context_map = cast(
             DailySummaryProjectContext, summary.projects_context_map[project_id]
         )
-        assert project_context_map.escalated_today == [self.group2, self.group3]
+        assert project_context_map.escalated_today == [self.group3, self.group2]
         assert project_context_map.regressed_today == []
 
     def test_build_summary_data_group_regressed_twice_and_escalated(self):
@@ -485,7 +485,7 @@ class DailySummaryTest(
         project_context_map = cast(
             DailySummaryProjectContext, summary.projects_context_map[project_id]
         )
-        assert project_context_map.escalated_today == [self.group2, self.group3]
+        assert project_context_map.escalated_today == [self.group3, self.group2]
         assert project_context_map.regressed_today == []
 
     def test_build_summary_data_group_regressed_escalated_in_the_past(self):


### PR DESCRIPTION
previously this relied on `set` ordering and introduced a bunch of test flakiness (and probably actual feature flakiness too!)

<!-- Describe your PR here. -->