### PR TITLE
feat: Generate JWT tokens for logged in users, and add middleware to accept them for auth

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.utils.crypto import constant_time_compare
 from django.utils.encoding import force_str
+from jwt import InvalidTokenError
 from rest_framework.authentication import (
     BaseAuthentication,
     BasicAuthentication,
@@ -21,7 +22,7 @@ from sentry_relay.exceptions import UnpackError
 from sentry import options
 from sentry.auth.services.auth import AuthenticatedToken
 from sentry.auth.system import SystemToken, is_internal_ip
-from sentry.auth.user_jwt import InvalidTokenError, UserJWTToken
+from sentry.auth.user_jwt import UserJWTToken
 from sentry.hybridcloud.models import ApiKeyReplica, ApiTokenReplica, OrgAuthTokenReplica
 from sentry.hybridcloud.rpc.service import compare_signature
 from sentry.models.apiapplication import ApiApplication

--- a/src/sentry/auth/services/auth/model.py
+++ b/src/sentry/auth/services/auth/model.py
@@ -68,6 +68,7 @@ class AuthenticatedToken(RpcModel):
     @classmethod
     def kinds(cls) -> Mapping[str, Collection[type[Any]]]:
         from sentry.auth.system import SystemToken
+        from sentry.auth.user_jwt import UserJWTToken
         from sentry.hybridcloud.models import ApiKeyReplica, ApiTokenReplica, OrgAuthTokenReplica
         from sentry.models.apikey import ApiKey
         from sentry.models.apitoken import ApiToken
@@ -75,7 +76,7 @@ class AuthenticatedToken(RpcModel):
 
         return {
             "system": frozenset([SystemToken]),
-            "api_token": frozenset([ApiToken, ApiTokenReplica]),
+            "api_token": frozenset([ApiToken, ApiTokenReplica, UserJWTToken]),
             "org_auth_token": frozenset([OrgAuthToken, OrgAuthTokenReplica]),
             "api_key": frozenset([ApiKey, ApiKeyReplica]),
         }

--- a/src/sentry/auth/user_jwt.py
+++ b/src/sentry/auth/user_jwt.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any
+
+import jwt as pyjwt
+from django.http import HttpRequest
+from jwt import InvalidTokenError
+
+from sentry import options
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.users.models.user import User
+from sentry.users.services.user import RpcUser
+from sentry.utils.jwt import peek_header
+
+logger = logging.getLogger(__name__)
+
+
+TOKEN_LIFETIME = timedelta(days=30)
+
+
+def get_secret_key() -> str:
+    # this is the same secret that is used for session cookies
+    return options.get("system.secret-key")
+
+
+def get_issuer() -> str:
+    return options.get("system.base-hostname")
+
+
+def get_jwt_token(
+    user: User | RpcUser,
+    organization: Organization,
+    project: Project,
+    expiration: datetime,
+) -> str:
+    algorithm = "HS256"
+    return pyjwt.encode(
+        payload={
+            # For help with the names see: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1
+            # Registered claim names are three characters long, and sentry
+            # vspecific ones are shortend as JWT is meant to be compact.
+            "exp": int(expiration.timestamp()),
+            "iss": get_issuer(),
+            "iat": int(datetime.now().timestamp()),
+            "sub": user.id,
+            "org": organization.id,
+            "proj": project.id,
+        },
+        key=get_secret_key(),
+        algorithm=algorithm,
+        headers={"alg": algorithm, "typ": "JWT"},
+    )
+
+
+class UserJWTToken:
+    @classmethod
+    def from_request(cls, request: HttpRequest, context: dict[str, Any]):
+        if not (request.user.is_authenticated and request.user.is_active):
+            return None
+
+        organization: Organization | None = context.get("organization")
+        if not organization:
+            return None
+
+        project: Project | None = context.get("project")
+        if not project:
+            return None
+
+        return get_jwt_token(request.user, organization, project, datetime.now() + TOKEN_LIFETIME)
+
+    @classmethod
+    def is_jwt(cls, token: str) -> bool:
+        try:
+            header = peek_header(token)
+            return header.get("typ") == "JWT"
+        except ValueError:
+            raise InvalidTokenError("Invalid token")
+
+    @classmethod
+    def decode_verified_user(cls, token: str) -> int:
+        try:
+            header = pyjwt.get_unverified_header(token.encode("UTF-8"))
+            body = pyjwt.decode(
+                jwt=token,
+                key=get_secret_key(),
+                algorithms=[header.get("alg"), "HS256"],
+                options={
+                    "verify_signature": True,
+                    "verify_exp": True,
+                    "verify_iss": True,
+                },
+                issuer=get_issuer(),
+            )
+            return body.get("sub")
+        except ValueError:
+            raise InvalidTokenError("Invalid token")

--- a/src/sentry/auth/user_jwt.py
+++ b/src/sentry/auth/user_jwt.py
@@ -94,6 +94,6 @@ class UserJWTToken:
                 },
                 issuer=get_issuer(),
             )
-            return body.get("sub")
+            return int(body.get("sub"))
         except ValueError:
             raise InvalidTokenError("Invalid token")

--- a/src/sentry/templates/sentry/toolbar/login-success.html
+++ b/src/sentry/templates/sentry/toolbar/login-success.html
@@ -17,7 +17,7 @@
     <script>
       (function() {
         const delay = {{ delay|escapejs }};
-        const cookie = '{{ cookie|escapejs }}';
+        const token = '{{ token|escapejs }}';
 
         document.getElementById('close-popup').addEventListener('click', () => {
           window.close();
@@ -31,7 +31,7 @@
           window.opener.postMessage({
             source: 'sentry-toolbar',
             message: 'did-login',
-            cookie: cookie,
+            token,
           }, window.location.origin);
 
           if (delay && typeof delay === 'number') {

--- a/src/sentry/toolbar/views/login_success_view.py
+++ b/src/sentry/toolbar/views/login_success_view.py
@@ -1,21 +1,23 @@
-from django.conf import settings
 from django.http import HttpRequest
 
-from sentry.web.frontend.base import OrganizationView, region_silo_view
+from sentry.auth.user_jwt import UserJWTToken
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.web.frontend.base import ProjectView, region_silo_view
 
 TEMPLATE = "sentry/toolbar/login-success.html"
 
-session_cookie_name = settings.SESSION_COOKIE_NAME
-
 
 @region_silo_view
-class LoginSuccessView(OrganizationView):
-    def get(self, request: HttpRequest, organization, project_id_or_slug):
+class LoginSuccessView(ProjectView):
+    def get(
+        self, request: HttpRequest, organization: Organization, project: Project, *args, **kwargs
+    ):
         return self.respond(
             TEMPLATE,
             status=200,
             context={
                 "delay": int(request.GET.get("delay", 3000)),
-                "cookie": f"{session_cookie_name}={request.COOKIES.get(session_cookie_name)}",
+                "token": UserJWTToken.from_request(request, self.default_context),
             },
         )

--- a/src/sentry/toolbar/views/login_success_view.py
+++ b/src/sentry/toolbar/views/login_success_view.py
@@ -21,3 +21,6 @@ class LoginSuccessView(ProjectView):
                 "token": UserJWTToken.from_request(request, self.default_context),
             },
         )
+
+
+3

--- a/tests/sentry/auth/test_user_jwt.py
+++ b/tests/sentry/auth/test_user_jwt.py
@@ -1,0 +1,99 @@
+from datetime import datetime, timedelta
+from math import isclose
+from unittest import mock
+
+import pytest
+from django.contrib.auth.models import AnonymousUser
+from django.http import HttpRequest
+
+from sentry import options
+from sentry.auth.user_jwt import InvalidTokenError, UserJWTToken, get_jwt_token
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import control_silo_test
+from sentry.utils.jwt import peek_claims
+
+
+@control_silo_test
+class UserJWTTokenTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.organization)
+        self.expiration = datetime.now() + timedelta(days=30)
+
+    def test_from_request_requires_active_user(self):
+        request = HttpRequest()
+        request.user = AnonymousUser()
+
+        result = UserJWTToken.from_request(request, {})
+        assert result is None
+
+    def test_from_request_requires_organization_in_context(self):
+        request = HttpRequest()
+        request.user = self.user
+
+        result = UserJWTToken.from_request(request, {"organization": None})
+        assert result is None
+
+    def test_from_request_requires_project_in_context(self):
+        request = HttpRequest()
+        request.user = self.user
+
+        result = UserJWTToken.from_request(
+            request, {"organization": self.organization, "project": None}
+        )
+        assert result is None
+
+    def test_from_request_requires_sets_claims(self):
+        request = HttpRequest()
+        request.user = self.user
+
+        result = UserJWTToken.from_request(
+            request, {"organization": self.organization, "project": self.project}
+        )
+        assert result is not None
+        claims = peek_claims(result)
+        assert claims.get("exp") == int(self.expiration.timestamp())
+        assert claims.get("iss") == options.get("system.base-hostname")
+        assert isclose(claims.get("iat"), datetime.now().timestamp())
+        assert claims.get("sub") == self.user.id
+        assert claims.get("org") == self.organization.id
+        assert claims.get("proj") == self.project.id
+
+    def test_is_jwt_accepts_any_jwt_shape(self):
+        # minimal JWT with header=`{"typ": "JWT","alg": "HS256"}` with empty body & secret
+        assert (
+            UserJWTToken.is_jwt(
+                "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.e30.uJKHM4XyWv1bC_-rpkjK19GUy0Fgrkm_pGHi8XghjWM"
+            )
+            is True
+        )
+
+    def test_is_jwt_rejects_random_strings(self):
+        with pytest.raises(InvalidTokenError):
+            UserJWTToken.is_jwt("foo")
+        with pytest.raises(InvalidTokenError):
+            UserJWTToken.is_jwt("abc.def.ace")
+        with pytest.raises(InvalidTokenError):
+            UserJWTToken.is_jwt("abc.e30.uJKHM4XyWv1bC_-rpkjK19GUy0Fgrkm_pGHi8XghjWM")
+
+    def test_decode_verified_user_raises_when_signature_invalid(self):
+        with pytest.raises(InvalidTokenError):
+            UserJWTToken.decode_verified_user("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.e30.FOOBAR")
+
+    @mock.patch("sentry.options.get", side_effect=iter(["a", "b", "c", "d"]))
+    def test_decode_verified_user_raises_when_issuer_invalid(self, mock_options_get):
+        token = get_jwt_token(self.user, self.organization, self.project, self.expiration)
+
+        with pytest.raises(InvalidTokenError):
+            UserJWTToken.decode_verified_user(token)
+
+    def test_decode_verified_user_raises_when_expiration_passed(self):
+        three_days_ago = datetime.now() - timedelta(days=3)
+        token = get_jwt_token(self.user, self.organization, self.project, three_days_ago)
+        with pytest.raises(InvalidTokenError):
+            UserJWTToken.decode_verified_user(token)
+
+    def test_decode_verified_user_returns_signed_userid(self):
+        token = get_jwt_token(self.user, self.organization, self.project, self.expiration)
+        assert UserJWTToken.decode_verified_user(token) == self.user.id


### PR DESCRIPTION
This adds a new class, `UserJWTToken` for minting and checking JWT tokens that relate to a user.

You can mess with JWT tokens at https://jwt.io/ and read more about claims at https://datatracker.ietf.org/doc/html/rfc7519#section-4

The token contains a few claims:
- `exp` expiration date, `from_request()` sets this to 30 days. it's kind of arbitrary right now though for our use-case (see also middleware below)
- `iss` issuer, this is set to `system.base-hostname` and exists to help fingerprint that tokens are coming from our system, specifically which instance of sentry. in prod this will be something like `sentry.io`
- `iat` issued at date, this is for tracking purposes, we record the timestamp the token was issued. could be dropped later.
- `sub` the subject, set to the user id who owns the ticket, the token will get access to the system as this user
- `org` and `proj` organization and project id's, these are a convenience, by putting these claims in the token we know some more information about the context from which the token was created.

As with cookies, tokens are minted after the user has already logged in, and they provide continuing access to sentry. so tokens must be protected in transit and at rest on systems. (see the login-success template below).

With the `UserJWTToken` we've got two callsites:
1. `LoginSuccessView`
    This is an essentially static page that is called by the dev toolbar sdk. it's purpose is to shuttle the jwt into the toolbar so that it can be used for api requests. Look at the [html template](https://github.com/getsentry/sentry/blob/8e6d278ac36441a8263508d7273b265686f5c589/src/sentry/templates/sentry/toolbar/login-success.html#L6) and it's possible to see how we're using `window.location.origin` to push the token only to a page which is on the same domain as where is hosted. 
2.  `UserJWTTokenAuthentication` middleware
    This is the middleware that checks the token. The token is signed with the same `options.get("system.secret-key")` that we use for cookies, so provided that the token signature is valid we can trust the claims inside of it. `decode_verified_user` handles all this; it can emit a number of different types of exceptions (token expired, invalid formats, bad signature, etc) and they all get converted into `AuthenticationFailed` which is part of our framework.