### PR TITLE
feat(dashboards): Allow creation of span widgets

### DIFF
--- a/src/sentry/models/dashboard_widget.py
+++ b/src/sentry/models/dashboard_widget.py
@@ -62,6 +62,7 @@ class DashboardWidgetTypes(TypesClass):
     """
     This targets transaction-like data from the split from discover. Itt may either use 'Transactions' events or 'PerformanceMetrics' depending on on-demand, MEP metrics, etc.
     """
+    SPANS = 102
 
     TYPES = [
         (DISCOVER, "discover"),
@@ -73,6 +74,7 @@ class DashboardWidgetTypes(TypesClass):
         (METRICS, "custom-metrics"),
         (ERROR_EVENTS, "error-events"),
         (TRANSACTION_LIKE, "transaction-like"),
+        (SPANS, "spans"),
     ]
     TYPE_NAMES = [t[1] for t in TYPES]
 

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -1105,3 +1105,26 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         assert "columns" in warnings
         assert len(warnings["columns"]) == 1
         assert warnings["columns"]["sometag"] == "disabled:high-cardinality"
+
+    def test_widget_type_spans(self):
+        data = {
+            "title": "Test Query",
+            "widgetType": "spans",
+            "displayType": "table",
+            "queries": [
+                {
+                    "name": "",
+                    "conditions": "",
+                    "fields": ["span.op", "count()"],
+                    "columns": ["span.op"],
+                    "aggregates": ["count()"],
+                },
+            ],
+        }
+
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
+        assert response.status_code == 200, response.data


### PR DESCRIPTION
To allow creation of span widgets, I need to add the spans enum to the allowed widget types. This is purely Django and shouldn't require a migration. If we find that we want to merge the datasets later then we can just delete these widgets for ourselves without issues. Likewise, changing the name of this enum is also easy.