### PR TITLE
feat(insights): remove perf/insights from sidebar

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -138,6 +138,7 @@ function Sidebar() {
   const hasNewNav = organization?.features.includes('navigation-sidebar-v2');
   const hasOrganization = !!organization;
   const isSelfHostedErrorsOnly = ConfigStore.get('isSelfHostedErrorsOnly');
+  const hasPerfDomainViews = organization?.features.includes('insights-domain-view');
 
   const collapsed = hasNewNav ? true : !!preferences.collapsed;
   const horizontal = useMedia(`(max-width: ${theme.breakpoints.medium})`);
@@ -439,7 +440,7 @@ function Sidebar() {
     </Feature>
   );
 
-  const performance = hasOrganization && (
+  const performance = hasOrganization && !hasPerfDomainViews && (
     <Feature
       hookName="feature-disabled:performance-sidebar-item"
       features="performance-view"
@@ -646,7 +647,7 @@ function Sidebar() {
     </Feature>
   );
 
-  const insights = hasOrganization && (
+  const insights = hasOrganization && !hasPerfDomainViews && (
     <Feature key="insights" features="insights-entry-points" organization={organization}>
       <SidebarAccordion
         {...sidebarItemProps}

--- a/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.spec.tsx
@@ -119,7 +119,9 @@ describe('Screen Summary', function () {
         platform: 'react-native',
         hasInsightsScreenLoad: true,
       });
-      organization = OrganizationFixture({features: ['insights-initial-modules']});
+      organization = OrganizationFixture({
+        features: ['insights-initial-modules', 'insights-entry-points'],
+      });
       mockResponses(organization, project);
       localStorage.clear();
       browserHistory.push = jest.fn();
@@ -212,7 +214,9 @@ describe('Screen Summary', function () {
     let organization: Organization;
     beforeEach(function () {
       const project = ProjectFixture({platform: 'android', hasInsightsScreenLoad: true});
-      organization = OrganizationFixture({features: ['insights-initial-modules']});
+      organization = OrganizationFixture({
+        features: ['insights-initial-modules', 'insights-entry-points'],
+      });
       mockResponses(organization, project);
       localStorage.clear();
       browserHistory.push = jest.fn();

--- a/static/app/views/insights/mobile/screenload/views/screenloadLandingPage.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenloadLandingPage.spec.tsx
@@ -21,7 +21,7 @@ jest.mock('sentry/utils/useProjects');
 describe('PageloadModule', function () {
   const project = ProjectFixture({platform: 'react-native', hasInsightsScreenLoad: true});
   const organization = OrganizationFixture({
-    features: ['insights-initial-modules'],
+    features: ['insights-initial-modules', 'insights-entry-points'],
   });
   jest.mocked(useOnboardingProject).mockReturnValue(undefined);
 

--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -132,5 +132,8 @@ export function DomainViewHeader({
 }
 
 const filterEnabledModules = (modules: ModuleName[], organization: Organization) => {
+  if (!organization.features.includes('insights-entry-points')) {
+    return [];
+  }
   return modules.filter(module => isModuleEnabled(module, organization));
 };


### PR DESCRIPTION
Work for https://github.com/getsentry/sentry/issues/77572

1. Removes performance and insights from the sidebar if the `insights-domain-views` feature is enabled
<img width="229" alt="image" src="https://github.com/user-attachments/assets/1a91ee39-e6f8-4dba-81f7-1e95df1c57e3">

2. Check if `insights-entry-points` is enabled to decide wether to render the module tabs (i.e web vitals, requests, etc in screenshot below).
<img width="444" alt="image" src="https://github.com/user-attachments/assets/116421c6-509c-4b17-87bb-22784ebba02f">

