### PR TITLE
fix(stacktrace): Omit the platform icon for stack trace previews

### DIFF
--- a/static/app/components/groupPreviewTooltip/stackTracePreview.spec.tsx
+++ b/static/app/components/groupPreviewTooltip/stackTracePreview.spec.tsx
@@ -105,5 +105,7 @@ describe('StackTracePreview', () => {
     await userEvent.hover(screen.getByText(/Preview Trigger/));
 
     expect(await screen.findByTestId(component)).toBeInTheDocument();
+    // Hide the platform icon for stack trace previews
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/groupPreviewTooltip/stackTracePreview.tsx
+++ b/static/app/components/groupPreviewTooltip/stackTracePreview.tsx
@@ -83,7 +83,7 @@ export function StackTracePreviewContent({
     return <NativeContent {...commonProps} groupingCurrentLevel={groupingCurrentLevel} />;
   }
 
-  return <StackTraceContent {...commonProps} />;
+  return <StackTraceContent {...commonProps} hideIcon />;
 }
 
 type StackTracePreviewProps = {


### PR DESCRIPTION
This was actually getting rendered before, but `position:absolute` put it outside the element which had `overflow:hidden`. This will prevent it from rendering in the first place.