### PR TITLE
feat(insights): add domain view urls to new sidebar

### DIFF
--- a/static/app/components/nav/config.tsx
+++ b/static/app/components/nav/config.tsx
@@ -1,4 +1,4 @@
-import type {NavConfig} from 'sentry/components/nav/utils';
+import type {NavConfig, NavSidebarItem} from 'sentry/components/nav/utils';
 import {
   IconDashboard,
   IconGraph,
@@ -14,6 +14,10 @@ import type {Organization} from 'sentry/types/organization';
 import {getDiscoverLandingUrl} from 'sentry/utils/discover/urls';
 import {MODULE_BASE_URLS} from 'sentry/views/insights/common/utils/useModuleURL';
 import {MODULE_SIDEBAR_TITLE as MODULE_TITLE_HTTP} from 'sentry/views/insights/http/settings';
+import {AI_LANDING_TITLE} from 'sentry/views/insights/pages/ai/settings';
+import {BACKEND_LANDING_TITLE} from 'sentry/views/insights/pages/backend/settings';
+import {FRONTEND_LANDING_TITLE} from 'sentry/views/insights/pages/frontend/settings';
+import {MOBILE_LANDING_TITLE} from 'sentry/views/insights/pages/mobile/settings';
 import {INSIGHTS_BASE_URL, MODULE_TITLES} from 'sentry/views/insights/settings';
 import {getSearchForIssueGroup, IssueGroup} from 'sentry/views/issueList/utils';
 
@@ -26,6 +30,84 @@ import {getSearchForIssueGroup, IssueGroup} from 'sentry/views/issueList/utils';
 export function createNavConfig({organization}: {organization: Organization}): NavConfig {
   const prefix = `organizations/${organization.slug}`;
   const insightsPrefix = `${prefix}/${INSIGHTS_BASE_URL}`;
+  const hasPerfDomainViews = organization.features.includes('insights-domain-view');
+
+  const insights: NavSidebarItem = {
+    label: t('Insights'),
+    icon: <IconGraph />,
+    feature: {features: 'insights-entry-points'},
+    submenu: [
+      {
+        label: MODULE_TITLE_HTTP,
+        to: `/${insightsPrefix}/${MODULE_BASE_URLS.http}/`,
+      },
+      {label: MODULE_TITLES.db, to: `/${insightsPrefix}/${MODULE_BASE_URLS.db}/`},
+      {
+        label: MODULE_TITLES.resource,
+        to: `/${insightsPrefix}/${MODULE_BASE_URLS.resource}/`,
+      },
+      {
+        label: MODULE_TITLES.app_start,
+        to: `/${insightsPrefix}/${MODULE_BASE_URLS.app_start}/`,
+      },
+      {
+        label: MODULE_TITLES['mobile-screens'],
+        to: `/${insightsPrefix}/${MODULE_BASE_URLS['mobile-screens']}/`,
+        feature: {features: 'insights-mobile-screens-module'},
+      },
+      {
+        label: MODULE_TITLES.vital,
+        to: `/${insightsPrefix}/${MODULE_BASE_URLS.vital}/`,
+      },
+      {
+        label: MODULE_TITLES.cache,
+        to: `/${insightsPrefix}/${MODULE_BASE_URLS.cache}/`,
+      },
+      {
+        label: MODULE_TITLES.queue,
+        to: `/${insightsPrefix}/${MODULE_BASE_URLS.queue}/`,
+      },
+      {
+        label: MODULE_TITLES.ai,
+        to: `/${insightsPrefix}/${MODULE_BASE_URLS.ai}/`,
+        feature: {features: 'insights-entry-points'},
+      },
+    ],
+  };
+
+  const perf: NavSidebarItem = {
+    label: t('Perf.'),
+    to: '/performance/',
+    icon: <IconLightning />,
+    feature: {
+      features: 'performance-view',
+      hookName: 'feature-disabled:performance-sidebar-item',
+    },
+  };
+
+  const perfDomainViews: NavSidebarItem = {
+    label: t('Perf.'),
+    icon: <IconLightning />,
+    feature: {features: 'insights-domain-view'},
+    submenu: [
+      {
+        label: FRONTEND_LANDING_TITLE,
+        to: `/${prefix}/performance/${FRONTEND_LANDING_TITLE}/`,
+      },
+      {
+        label: BACKEND_LANDING_TITLE,
+        to: `/${prefix}/performance/${BACKEND_LANDING_TITLE}/`,
+      },
+      {
+        label: AI_LANDING_TITLE,
+        to: `/${prefix}/performance/${AI_LANDING_TITLE}/`,
+      },
+      {
+        label: MOBILE_LANDING_TITLE,
+        to: `/${prefix}/performance/${MOBILE_LANDING_TITLE}/`,
+      },
+    ],
+  };
 
   return {
     main: [
@@ -101,57 +183,6 @@ export function createNavConfig({organization}: {organization: Organization}): N
         ],
       },
       {
-        label: t('Insights'),
-        icon: <IconGraph />,
-        feature: {features: 'insights-entry-points'},
-        submenu: [
-          {
-            label: MODULE_TITLE_HTTP,
-            to: `/${insightsPrefix}/${MODULE_BASE_URLS.http}/`,
-          },
-          {label: MODULE_TITLES.db, to: `/${insightsPrefix}/${MODULE_BASE_URLS.db}/`},
-          {
-            label: MODULE_TITLES.resource,
-            to: `/${insightsPrefix}/${MODULE_BASE_URLS.resource}/`,
-          },
-          {
-            label: MODULE_TITLES.app_start,
-            to: `/${insightsPrefix}/${MODULE_BASE_URLS.app_start}/`,
-          },
-          {
-            label: MODULE_TITLES['mobile-screens'],
-            to: `/${insightsPrefix}/${MODULE_BASE_URLS['mobile-screens']}/`,
-            feature: {features: 'insights-mobile-screens-module'},
-          },
-          {
-            label: MODULE_TITLES.vital,
-            to: `/${insightsPrefix}/${MODULE_BASE_URLS.vital}/`,
-          },
-          {
-            label: MODULE_TITLES.cache,
-            to: `/${insightsPrefix}/${MODULE_BASE_URLS.cache}/`,
-          },
-          {
-            label: MODULE_TITLES.queue,
-            to: `/${insightsPrefix}/${MODULE_BASE_URLS.queue}/`,
-          },
-          {
-            label: MODULE_TITLES.ai,
-            to: `/${insightsPrefix}/${MODULE_BASE_URLS.ai}/`,
-            feature: {features: 'insights-entry-points'},
-          },
-        ],
-      },
-      {
-        label: t('Perf.'),
-        to: '/performance/',
-        icon: <IconLightning />,
-        feature: {
-          features: 'performance-view',
-          hookName: 'feature-disabled:performance-sidebar-item',
-        },
-      },
-      {
         label: t('Boards'),
         to: '/dashboards/',
         icon: <IconDashboard />,
@@ -161,6 +192,7 @@ export function createNavConfig({organization}: {organization: Organization}): N
           requireAll: false,
         },
       },
+      ...(hasPerfDomainViews ? [perfDomainViews] : [insights, perf]),
       {label: t('Alerts'), to: `/${prefix}/alerts/rules/`, icon: <IconSiren />},
     ],
     footer: [

--- a/static/app/components/nav/config.tsx
+++ b/static/app/components/nav/config.tsx
@@ -194,6 +194,7 @@ export function createNavConfig({organization}: {organization: Organization}): N
           {label: t('Crons'), to: `/${prefix}/crons/`},
         ],
       },
+      ...(hasPerfDomainViews ? [perfDomainViews] : [insights, perf]),
       {
         label: t('Boards'),
         to: '/dashboards/',
@@ -204,7 +205,6 @@ export function createNavConfig({organization}: {organization: Organization}): N
           requireAll: false,
         },
       },
-      ...(hasPerfDomainViews ? [perfDomainViews] : [insights, perf]),
       {label: t('Alerts'), to: `/${prefix}/alerts/rules/`, icon: <IconSiren />},
     ],
     footer: [

--- a/static/app/components/nav/config.tsx
+++ b/static/app/components/nav/config.tsx
@@ -14,10 +14,22 @@ import type {Organization} from 'sentry/types/organization';
 import {getDiscoverLandingUrl} from 'sentry/utils/discover/urls';
 import {MODULE_BASE_URLS} from 'sentry/views/insights/common/utils/useModuleURL';
 import {MODULE_SIDEBAR_TITLE as MODULE_TITLE_HTTP} from 'sentry/views/insights/http/settings';
-import {AI_LANDING_TITLE} from 'sentry/views/insights/pages/ai/settings';
-import {BACKEND_LANDING_TITLE} from 'sentry/views/insights/pages/backend/settings';
-import {FRONTEND_LANDING_TITLE} from 'sentry/views/insights/pages/frontend/settings';
-import {MOBILE_LANDING_TITLE} from 'sentry/views/insights/pages/mobile/settings';
+import {
+  AI_LANDING_SUB_PATH,
+  AI_LANDING_TITLE,
+} from 'sentry/views/insights/pages/ai/settings';
+import {
+  BACKEND_LANDING_SUB_PATH,
+  BACKEND_LANDING_TITLE,
+} from 'sentry/views/insights/pages/backend/settings';
+import {
+  FRONTEND_LANDING_SUB_PATH,
+  FRONTEND_LANDING_TITLE,
+} from 'sentry/views/insights/pages/frontend/settings';
+import {
+  MOBILE_LANDING_SUB_PATH,
+  MOBILE_LANDING_TITLE,
+} from 'sentry/views/insights/pages/mobile/settings';
 import {INSIGHTS_BASE_URL, MODULE_TITLES} from 'sentry/views/insights/settings';
 import {getSearchForIssueGroup, IssueGroup} from 'sentry/views/issueList/utils';
 
@@ -92,19 +104,19 @@ export function createNavConfig({organization}: {organization: Organization}): N
     submenu: [
       {
         label: FRONTEND_LANDING_TITLE,
-        to: `/${prefix}/performance/${FRONTEND_LANDING_TITLE}/`,
+        to: `/${prefix}/performance/${FRONTEND_LANDING_SUB_PATH}/`,
       },
       {
         label: BACKEND_LANDING_TITLE,
-        to: `/${prefix}/performance/${BACKEND_LANDING_TITLE}/`,
+        to: `/${prefix}/performance/${BACKEND_LANDING_SUB_PATH}/`,
       },
       {
         label: AI_LANDING_TITLE,
-        to: `/${prefix}/performance/${AI_LANDING_TITLE}/`,
+        to: `/${prefix}/performance/${AI_LANDING_SUB_PATH}/`,
       },
       {
         label: MOBILE_LANDING_TITLE,
-        to: `/${prefix}/performance/${MOBILE_LANDING_TITLE}/`,
+        to: `/${prefix}/performance/${MOBILE_LANDING_SUB_PATH}/`,
       },
     ],
   };


### PR DESCRIPTION
Adds the performance domain views to the sidebar. We conditionally render the domain view links, or the perf and insights links depending on if the feature is enabled. This corresponds to the changes made in the following PRs
https://github.com/getsentry/sentry/pull/77632
https://github.com/getsentry/sentry/pull/79491

I had to just use straight js logic to modify the config array, but perhaps a future improvement to the config is to add a `featureDisabled: string[]` property. If all features in the `featureDisabled` array are enabled, we don't render out that sidebar entry. This would eliminate the need to do any js logic here which would clean things up in cases like this. (although maybe not super common)