### PR TITLE
fix(dashboard): Handle widgets with equations and no selected aggregates

### DIFF
--- a/src/sentry/discover/dashboard_widget_split.py
+++ b/src/sentry/discover/dashboard_widget_split.py
@@ -26,7 +26,7 @@ from sentry.models.dashboard_widget import (
 from sentry.models.project import Project
 from sentry.search.events.builder.discover import DiscoverQueryBuilder
 from sentry.search.events.builder.errors import ErrorsQueryBuilder
-from sentry.search.events.types import SnubaParams
+from sentry.search.events.types import QueryBuilderConfig, SnubaParams
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics_performance import query as metrics_query
 from sentry.snuba.query_sources import QuerySource
@@ -125,6 +125,13 @@ def _get_and_save_split_decision_for_dashboard_widget(
             selected_columns=selected_columns,
             equations=equations,
             limit=1,
+            config=QueryBuilderConfig(
+                auto_fields=True,
+                auto_aggregations=True,
+                equation_config={
+                    "auto_add": True,
+                },
+            ),
         )
 
         transactions_builder = DiscoverQueryBuilder(
@@ -135,6 +142,13 @@ def _get_and_save_split_decision_for_dashboard_widget(
             selected_columns=selected_columns,
             equations=equations,
             limit=1,
+            config=QueryBuilderConfig(
+                auto_fields=True,
+                auto_aggregations=True,
+                equation_config={
+                    "auto_add": True,
+                },
+            ),
         )
     except (InvalidSearchQuery, InvalidQueryError):
         if dry_run:

--- a/src/sentry/discover/dashboard_widget_split.py
+++ b/src/sentry/discover/dashboard_widget_split.py
@@ -128,7 +128,6 @@ def _get_and_save_split_decision_for_dashboard_widget(
             equations=equations,
             limit=1,
             config=QueryBuilderConfig(
-                auto_fields=True,
                 auto_aggregations=True,
                 equation_config={
                     "auto_add": True,
@@ -145,7 +144,6 @@ def _get_and_save_split_decision_for_dashboard_widget(
             equations=equations,
             limit=1,
             config=QueryBuilderConfig(
-                auto_fields=True,
                 auto_aggregations=True,
                 equation_config={
                     "auto_add": True,

--- a/src/sentry/discover/dashboard_widget_split.py
+++ b/src/sentry/discover/dashboard_widget_split.py
@@ -75,6 +75,8 @@ def _save_split_decision_for_widget(
 def _get_and_save_split_decision_for_dashboard_widget(
     widget_query: DashboardWidgetQuery, dry_run: bool
 ) -> tuple[int, bool]:
+    sentry_sdk.set_tag("dry_run", dry_run)
+
     widget: DashboardWidget = widget_query.widget
     dashboard: Dashboard = widget.dashboard
     # We use all projects for the clickhouse query but don't do anything
@@ -150,7 +152,8 @@ def _get_and_save_split_decision_for_dashboard_widget(
                 },
             ),
         )
-    except (InvalidSearchQuery, InvalidQueryError):
+    except (InvalidSearchQuery, InvalidQueryError) as e:
+        sentry_sdk.capture_exception(e)
         if dry_run:
             logger.info(
                 "Split decision for %s: %s (forced)",

--- a/tests/sentry/discover/test_dashboard_widget_split.py
+++ b/tests/sentry/discover/test_dashboard_widget_split.py
@@ -487,6 +487,42 @@ class DashboardWidgetDatasetSplitTestCase(BaseMetricsLayerTestCase, TestCase, Sn
         if not self.dry_run:
             assert error_widget.dataset_source == DashboardDatasetSourcesTypes.FORCED.value
 
+    def test_dashboard_split_equation_without_aggregates(self):
+        transaction_widget = DashboardWidget.objects.create(
+            dashboard=self.dashboard,
+            order=0,
+            title="transaction widget",
+            display_type=DashboardWidgetDisplayTypes.LINE_CHART,
+            widget_type=DashboardWidgetTypes.DISCOVER,
+            interval="1d",
+            detail={"layout": {"x": 0, "y": 0, "w": 1, "h": 1, "minH": 2}},
+        )
+        transaction_widget_query = DashboardWidgetQuery.objects.create(
+            widget=transaction_widget,
+            fields=[
+                "equation|count_if(blah-key-set,equals,True) / count()",
+            ],
+            columns=[],
+            aggregates=[
+                "equation|count_if(blah-key-set,equals,True) / count()",
+            ],
+            conditions="event.type:transaction transaction:foo",
+            order=0,
+        )
+
+        _get_and_save_split_decision_for_dashboard_widget(transaction_widget_query, self.dry_run)
+        transaction_widget.refresh_from_db()
+        assert (
+            transaction_widget.discover_widget_split is None
+            if self.dry_run
+            else transaction_widget.discover_widget_split == 101
+        )
+        if not self.dry_run:
+            assert (
+                transaction_widget.dataset_source
+                == DashboardDatasetSourcesTypes.SPLIT_VERSION_2.value
+            )
+
 
 class DashboardWidgetDatasetSplitDryRunTestCase(DashboardWidgetDatasetSplitTestCase):
     def setUp(self):


### PR DESCRIPTION
There are widgets with equations where the subcomponents are not selected as fields (i.e. a line chart that only plots an equation). The dashboard script needs to auto-add these fields or else they fail and get forced to errors

Also adds a call to collect a sentry exception so we can get a better idea of why initializing the query builders fails.