### PR TITLE
fix(grouping): Add missing hints to non-contributing stacktrace components

### DIFF
--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/android_anr.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:45.454523Z'
+created: '2024-10-24T14:22:44.625605+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "com.android.internal.os.ZygoteInit"
@@ -770,7 +770,7 @@ app:
         value* (stripped event-specific values)
           "Application Not Responding for at least <int> ms."
       threads (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "java.lang.Thread"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/bugly.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/bugly.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-07-12T13:33:40.148674Z'
+created: '2024-10-24T14:22:44.771569+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
           frame (non app frame)
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/built_in_fingerprint_chunkload_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:06:40.667451+00:00'
+created: '2024-10-24T14:22:44.865151+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "foo.bar"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:23:35.982635+00:00'
+created: '2024-10-24T14:22:44.819980+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "bar.bar"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:37.676056Z'
+created: '2024-10-24T14:22:46.827152+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "app/components/modals/createTeamModal"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/fallback_prefix_level_1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-07-30T14:13:51.282688Z'
+created: '2024-10-24T14:22:47.066832+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_comput_hashes_ignores_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_comput_hashes_ignores_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:37.743245Z'
+created: '2024-10-24T14:22:47.122601+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "sentry_clojure_example.core$_main$fn__<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_empty_list.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_empty_list.pysnap
@@ -1,10 +1,13 @@
 ---
+created: '2024-10-24T14:22:47.170014+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
     app
+      stacktrace (ignored because it contains no frames)
 --------------------------------------------------------------------------
 fallback:
   hash: "d41d8cd98f00b204e9800998ecf8427e"
@@ -13,3 +16,4 @@ system:
   hash: null
   component:
     system
+      stacktrace (ignored because it contains no frames)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
@@ -1,11 +1,13 @@
 ---
+created: '2024-10-24T14:22:47.228494+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "com.example.api.OutboundController$$EnhancerByGuice$$ae46b1bf"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
@@ -1,11 +1,13 @@
 ---
+created: '2024-10-24T14:22:47.283008+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "com.example.api.OutboundController$$FastClassByGuice$$ae46b1bf"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:37.763198Z'
+created: '2024-10-24T14:22:47.334512+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "invalid.gruml.talkytalkyhub.common.config.JipJipConfig$$EnhancerBySpringCGLIB$$<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:37.778807Z'
+created: '2024-10-24T14:22:47.430850+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "sentry_clojure_example.core$_main$fn__<auto>$fn__<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
@@ -1,11 +1,13 @@
 ---
+created: '2024-10-24T14:22:47.486368+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "com.example.api.OutboundController$$EnhancerByGuice$$ae46b1bf$$FastClassByGuice$$caceacd2"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_extra_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_extra_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:37.793977Z'
+created: '2024-10-24T14:22:47.535650+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "invalid.gruml.talkytalkyhub.common.config.JipJipConfig$$EnhancerBySpringCGLIB$$<auto>$$EnhancerBySpringCGLIB$$<auto>$$FastClassBySpringCGLIB$$<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_filename_from_url_origin_corner_cases.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_filename_from_url_origin_corner_cases.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:37.816777Z'
+created: '2024-10-24T14:22:47.586991+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)
             "foo.js"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_filename_if_abs_path_is_http.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_filename_if_abs_path_is_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:37.833174Z'
+created: '2024-10-24T14:22:47.634203+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)
             "foo.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_filename_if_blob.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_filename_if_blob.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:37.851426Z'
+created: '2024-10-24T14:22:47.679869+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)
             "7f7aaadf-a006-4217-9ed5-5fbf8585c6c0"
@@ -19,7 +19,7 @@ system:
   hash: null
   component:
     system
-      stacktrace
+      stacktrace (ignored because it contains no contributing frames)
         frame
           filename (ignored because frame points to a URL)
             "7f7aaadf-a006-4217-9ed5-5fbf8585c6c0"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_filename_if_http.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_filename_if_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:37.870382Z'
+created: '2024-10-24T14:22:47.724150+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)
             "foo.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_filename_if_https.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_filename_if_https.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:37.886136Z'
+created: '2024-10-24T14:22:47.767444+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)
             "foo.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_hibernate_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_hibernate_classes.pysnap
@@ -1,11 +1,13 @@
 ---
+created: '2024-10-24T14:22:47.857304+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "com.example.model.User$HibernateProxy$oRWxjAWT"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_java8_lambda_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_java8_lambda_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:37.901852Z'
+created: '2024-10-24T14:22:47.904907+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "foo.bar.Baz"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_java8_lambda_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_java8_lambda_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:37.921782Z'
+created: '2024-10-24T14:22:47.950604+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module (ignored java lambda)
             "foo.bar.Baz$$Lambda$40/1673859467"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_javassist.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_javassist.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:37.937295Z'
+created: '2024-10-24T14:22:48.141596+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "com.example.api.entry.EntriesResource_$$_javassist<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_javassist_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_javassist_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:37.955687Z'
+created: '2024-10-24T14:22:47.997466+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "com.example.api.entry.EntriesResource_$$_javassist<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_javassist_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_javassist_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:37.975599Z'
+created: '2024-10-24T14:22:48.094009+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename* (cleaned javassist parts)
             "entriesresource_$$_javassist<auto>.java"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_module_if_page_url.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_module_if_page_url.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:37.990011Z'
+created: '2024-10-24T14:22:48.300081+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "foo/bar/baz"
@@ -21,7 +21,7 @@ system:
   hash: null
   component:
     system
-      stacktrace
+      stacktrace (ignored because it contains no contributing frames)
         frame (ignored single non-URL JavaScript frame)
           module*
             "foo/bar/baz"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_module_if_page_url_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_module_if_page_url_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.006050Z'
+created: '2024-10-24T14:22:48.251464+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module (ignored bad javascript module)
             "foo/bar/baz"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_safari_native_code.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_safari_native_code.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.025362Z'
+created: '2024-10-24T14:22:48.362142+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (native code indicated by filename)
             "[native code]"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sun_java_generated_constructors.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sun_java_generated_constructors.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.040990Z'
+created: '2024-10-24T14:22:48.627109+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "sun.reflect.GeneratedSerializationConstructorAccessor<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sun_java_generated_constructors_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sun_java_generated_constructors_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.057001Z'
+created: '2024-10-24T14:22:48.576441+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "sun.reflect.GeneratedConstructorAccessor<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sun_java_generated_methods.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_sun_java_generated_methods.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.076395Z'
+created: '2024-10-24T14:22:48.679059+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed reflection marker)
             "sun.reflect.GeneratedMethodAccessor"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_sanitizes_block_functions.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_sanitizes_block_functions.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.092722Z'
+created: '2024-10-24T14:22:48.740377+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_sanitizes_erb_templates.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_sanitizes_erb_templates.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.110078Z'
+created: '2024-10-24T14:22:48.798972+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo.html.erb"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_sanitizes_versioned_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_sanitizes_versioned_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.127506Z'
+created: '2024-10-24T14:22:48.895464+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo.html.erb"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_sanitizes_versioned_filenames_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_sanitizes_versioned_filenames_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.142312Z'
+created: '2024-10-24T14:22:48.849079+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo.html.erb"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_skips_symbol_if_unknown.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_skips_symbol_if_unknown.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.161422Z'
+created: '2024-10-24T14:22:48.946926+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "libfoo"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_uses_context_line_over_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_uses_context_line_over_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.180396Z'
+created: '2024-10-24T14:22:48.994771+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_uses_function_over_lineno.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_uses_function_over_lineno.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.195410Z'
+created: '2024-10-24T14:22:49.045473+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_uses_module_over_filename.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_uses_module_over_filename.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.216829Z'
+created: '2024-10-24T14:22:49.094620+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "foo"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_uses_symbol_instead_of_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_uses_symbol_instead_of_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.233074Z'
+created: '2024-10-24T14:22:49.177935+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "libfoo"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_with_only_required_vars.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_with_only_required_vars.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.248062Z'
+created: '2024-10-24T14:22:49.218521+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_125_event_126.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:45.101610Z'
+created: '2024-10-24T14:22:49.323580+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_200_event_200.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:44.999327Z'
+created: '2024-10-24T14:22:49.378779+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "RtlUserThreadStart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_275_event_275.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:44.345609Z'
+created: '2024-10-24T14:22:49.435066+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "_dispatch_root_queues_init_once"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_289_event_312.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:45.017226Z'
+created: '2024-10-24T14:22:49.499654+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
               "thread.cpp"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_294_event_294.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:45.258389Z'
+created: '2024-10-24T14:22:49.562266+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_294_event_329.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:46.519996Z'
+created: '2024-10-24T14:22:49.626196+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "_dispatch_root_queues_init_once"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_307_event_307.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:44.276537Z'
+created: '2024-10-24T14:22:49.671390+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "stripped_application_code"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_307_event_657.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:45.711654Z'
+created: '2024-10-24T14:22:49.728829+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "stripped_application_code"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_313_event_313.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:46.833576Z'
+created: '2024-10-24T14:22:49.795050+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_313_event_333.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:47.853251Z'
+created: '2024-10-24T14:22:49.850861+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_319_event_321.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:46.107045Z'
+created: '2024-10-24T14:22:49.913480+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_389_event_389.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:44.024026Z'
+created: '2024-10-24T14:22:49.962085+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "stripped_application_code"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_432_event_432.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:45.121305Z'
+created: '2024-10-24T14:22:50.019896+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "RtlUserThreadStart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_432_event_453.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:45.206253Z'
+created: '2024-10-24T14:22:50.079646+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "RtlUserThreadStart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/group_445_event_445.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:44.630887Z'
+created: '2024-10-24T14:22:50.140412+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "RtlUserThreadStart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-25T09:17:19.930253Z'
+created: '2024-10-24T14:22:50.570082+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,7 +9,7 @@ app:
     app*
       chained-exception*
         exception*
-          stacktrace
+          stacktrace (ignored because it contains no in-app frames)
             frame (non app frame)
               module*
                 "io.sentry.example.Application"
@@ -176,7 +176,7 @@ app:
           value*
             "Address already in use"
         exception*
-          stacktrace
+          stacktrace (ignored because it contains no in-app frames)
             frame (non app frame)
               module*
                 "io.sentry.example.Application"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/java_minimal.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.423672Z'
+created: '2024-10-24T14:22:50.776441+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "java.lang.Thread"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_exception_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_exception_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.550497Z'
+created: '2024-10-24T14:22:50.950702+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
               "react-dom.development.js"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_polyfills.pysnap
@@ -1,4 +1,6 @@
 ---
+created: '2024-10-24T14:22:51.093603+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
@@ -6,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "@babel/runtime/helpers/asyncToGenerator"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_regression_tree_labels.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_regression_tree_labels.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-09-01T09:11:06.764404Z'
+created: '2024-10-24T14:22:51.755647+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "app/utils/handleXhrErrorResponse"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_unpkg.pysnap
@@ -1,4 +1,6 @@
 ---
+created: '2024-10-24T14:22:51.142135+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
@@ -6,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "react-dom@16.13.1/umd/react-dom.production"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.603805Z'
+created: '2024-10-24T14:22:51.190216+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
               "test.html"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.636819Z'
+created: '2024-10-24T14:22:51.238927+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
               "test.html"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.667342Z'
+created: '2024-10-24T14:22:51.288313+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
               "test.html"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_http_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.693715Z'
+created: '2024-10-24T14:22:51.339062+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "test"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_http_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_http_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.725744Z'
+created: '2024-10-24T14:22:51.387623+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "test"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_http_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.747385Z'
+created: '2024-10-24T14:22:51.508293+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "test"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_http_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.782914Z'
+created: '2024-10-24T14:22:51.561420+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "test"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_xbrowser_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.816076Z'
+created: '2024-10-24T14:22:51.608365+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
               "test.html"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/macos_amd_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:46.734885Z'
+created: '2024-10-24T14:22:51.999715+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/macos_intel_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:46.747890Z'
+created: '2024-10-24T14:22:52.060030+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/malloc_sentinel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-07-08T15:46:23.885265Z'
+created: '2024-10-24T14:22:52.115809+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "_pthread_start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/minified_javascript.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:39.152108Z'
+created: '2024-10-24T14:22:52.302945+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "sentry/dist/vendor"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:39.183941Z'
+created: '2024-10-24T14:22:52.348809+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_driver_crash1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:45.553298Z'
+created: '2024-10-24T14:22:52.396928+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "CUseCountedObject<T>::UCDestroy"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_driver_crash2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:44.504030Z'
+created: '2024-10-24T14:22:52.442949+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "CUseCountedObject<T>::UCDestroy"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_driver_crash3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:44.555058Z'
+created: '2024-10-24T14:22:52.492429+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "CUseCountedObject<T>::UCDestroy"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_limit_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-11-12T10:57:15.472277Z'
+created: '2024-10-24T14:22:52.543416+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_malloc_chain.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:45.700334Z'
+created: '2024-10-24T14:22:52.593514+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "application_frame"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_unlimited_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:39.480854Z'
+created: '2024-10-24T14:22:52.704961+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_windows_anon_namespace.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:39.537362Z'
+created: '2024-10-24T14:22:52.756722+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
               "exe_common.inl"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_with_function_name.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-02-12T22:47:10.140603Z'
+created: '2024-10-24T14:22:52.804564+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
               "main.cpp"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/node_low_level_async.pysnap
@@ -1,4 +1,6 @@
 ---
+created: '2024-10-24T14:22:52.912333+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
@@ -6,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "task_queues"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/python_exception_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-02-15T10:11:52.004400Z'
+created: '2024-10-24T14:22:52.962304+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -18,7 +18,7 @@ app:
           value (ignored because stacktrace takes precedence)
             "hello world"
         exception*
-          stacktrace
+          stacktrace (ignored because it contains no in-app frames)
             frame (non app frame)
               filename*
                 "baz.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/python_grouping_enhancer_towards_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-11-12T10:57:14.976508Z'
+created: '2024-10-24T14:22:53.069985+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no contributing frames)
           frame (non app frame)
             module*
               "django.core.handlers.base"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_collapse_recursion.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-11-28T16:31:38.255775Z'
+created: '2024-10-24T14:22:53.265932+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "com.example.Application"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_discards_seemingly_useless_stack.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_discards_seemingly_useless_stack.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:39.861883Z'
+created: '2024-10-24T14:22:53.364822+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)
             "foo"
@@ -19,7 +19,7 @@ system:
   hash: null
   component:
     system
-      stacktrace
+      stacktrace (ignored because it contains no contributing frames)
         frame
           filename (ignored because frame points to a URL)
             "foo"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_does_not_discard_non_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_does_not_discard_non_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:39.881778Z'
+created: '2024-10-24T14:22:53.413112+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_does_not_group_different_js_errors.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_does_not_group_different_js_errors.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:39.896798Z'
+created: '2024-10-24T14:22:53.459362+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)
             "index.js"
@@ -19,7 +19,7 @@ system:
   hash: null
   component:
     system
-      stacktrace
+      stacktrace (ignored because it contains no contributing frames)
         frame
           filename (ignored because frame points to a URL)
             "index.js"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_excludes_single_frame_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_excludes_single_frame_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:40.010450Z'
+created: '2024-10-24T14:22:53.558019+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "<unknown module>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_ignores_singular_anonymous_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_ignores_singular_anonymous_frame.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:40.071450Z'
+created: '2024-10-24T14:22:53.691793+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (anonymous filename discarded)
             "<anonymous>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_negated_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-03-22T11:57:34.334708+00:00'
+created: '2024-10-24T14:22:53.952144+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "_main"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/android_anr.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:47.669871Z'
+created: '2024-10-24T14:22:33.833759+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "com.android.internal.os.ZygoteInit"
@@ -770,7 +770,7 @@ app:
         value* (stripped event-specific values)
           "Application Not Responding for at least <int> ms."
       threads (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "java.lang.Thread"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/bugly.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/bugly.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-07-12T13:33:40.209204Z'
+created: '2024-10-24T14:22:33.970745+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
           frame (non app frame)
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/built_in_fingerprint_chunkload_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:06:54.309126+00:00'
+created: '2024-10-24T14:22:34.066699+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "foo.bar"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:23:48.450416+00:00'
+created: '2024-10-24T14:22:34.024531+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "bar.bar"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.149808Z'
+created: '2024-10-24T14:22:35.925999+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "app/components/modals/createTeamModal"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/fallback_prefix_level_1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-07-30T14:13:52.212124Z'
+created: '2024-10-24T14:22:36.109533+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_comput_hashes_ignores_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_comput_hashes_ignores_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.240456Z'
+created: '2024-10-24T14:22:36.154597+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "sentry_clojure_example.core$_main$fn__<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_empty_list.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_empty_list.pysnap
@@ -1,10 +1,13 @@
 ---
+created: '2024-10-24T14:22:36.198672+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
     app
+      stacktrace (ignored because it contains no frames)
 --------------------------------------------------------------------------
 fallback:
   hash: "d41d8cd98f00b204e9800998ecf8427e"
@@ -13,3 +16,4 @@ system:
   hash: null
   component:
     system
+      stacktrace (ignored because it contains no frames)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
@@ -1,11 +1,13 @@
 ---
+created: '2024-10-24T14:22:36.243813+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "com.example.api.OutboundController$$EnhancerByGuice$$ae46b1bf"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
@@ -1,11 +1,13 @@
 ---
+created: '2024-10-24T14:22:36.286478+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "com.example.api.OutboundController$$FastClassByGuice$$ae46b1bf"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.291521Z'
+created: '2024-10-24T14:22:36.332986+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "invalid.gruml.talkytalkyhub.common.config.JipJipConfig$$EnhancerBySpringCGLIB$$<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.320814Z'
+created: '2024-10-24T14:22:36.420756+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "sentry_clojure_example.core$_main$fn__<auto>$fn__<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
@@ -1,11 +1,13 @@
 ---
+created: '2024-10-24T14:22:36.463341+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "com.example.api.OutboundController$$EnhancerByGuice$$ae46b1bf$$FastClassByGuice$$caceacd2"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_extra_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_extra_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.345110Z'
+created: '2024-10-24T14:22:36.507462+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "invalid.gruml.talkytalkyhub.common.config.JipJipConfig$$EnhancerBySpringCGLIB$$<auto>$$EnhancerBySpringCGLIB$$<auto>$$FastClassBySpringCGLIB$$<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_filename_from_url_origin_corner_cases.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_filename_from_url_origin_corner_cases.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.375761Z'
+created: '2024-10-24T14:22:36.553913+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)
             "foo.js"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_filename_if_abs_path_is_http.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_filename_if_abs_path_is_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.393203Z'
+created: '2024-10-24T14:22:36.600400+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)
             "foo.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_filename_if_blob.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_filename_if_blob.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.414147Z'
+created: '2024-10-24T14:22:36.645443+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)
             "7f7aaadf-a006-4217-9ed5-5fbf8585c6c0"
@@ -19,7 +19,7 @@ system:
   hash: null
   component:
     system
-      stacktrace
+      stacktrace (ignored because it contains no contributing frames)
         frame
           filename (ignored because frame points to a URL)
             "7f7aaadf-a006-4217-9ed5-5fbf8585c6c0"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_filename_if_http.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_filename_if_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.436719Z'
+created: '2024-10-24T14:22:36.689024+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)
             "foo.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_filename_if_https.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_filename_if_https.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.458306Z'
+created: '2024-10-24T14:22:36.735459+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)
             "foo.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_hibernate_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_hibernate_classes.pysnap
@@ -1,11 +1,13 @@
 ---
+created: '2024-10-24T14:22:36.837706+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "com.example.model.User$HibernateProxy$oRWxjAWT"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_java8_lambda_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_java8_lambda_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.479090Z'
+created: '2024-10-24T14:22:36.888259+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "foo.bar.Baz"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_java8_lambda_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_java8_lambda_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.500404Z'
+created: '2024-10-24T14:22:36.953777+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module (ignored java lambda)
             "foo.bar.Baz$$Lambda$40/1673859467"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_javassist.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_javassist.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.523246Z'
+created: '2024-10-24T14:22:37.116660+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "com.example.api.entry.EntriesResource_$$_javassist<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_javassist_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_javassist_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.541997Z'
+created: '2024-10-24T14:22:37.007786+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "com.example.api.entry.EntriesResource_$$_javassist<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_javassist_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_javassist_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.561905Z'
+created: '2024-10-24T14:22:37.057065+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename* (cleaned javassist parts)
             "entriesresource_$$_javassist<auto>.java"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_module_if_page_url.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_module_if_page_url.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.584191Z'
+created: '2024-10-24T14:22:37.245158+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "foo/bar/baz"
@@ -21,7 +21,7 @@ system:
   hash: null
   component:
     system
-      stacktrace
+      stacktrace (ignored because it contains no contributing frames)
         frame (ignored single non-URL JavaScript frame)
           module*
             "foo/bar/baz"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_module_if_page_url_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_module_if_page_url_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.601344Z'
+created: '2024-10-24T14:22:37.176376+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module (ignored bad javascript module)
             "foo/bar/baz"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_safari_native_code.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_safari_native_code.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.621228Z'
+created: '2024-10-24T14:22:37.300944+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (native code indicated by filename)
             "[native code]"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_sun_java_generated_constructors.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_sun_java_generated_constructors.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.638974Z'
+created: '2024-10-24T14:22:37.597758+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "sun.reflect.GeneratedSerializationConstructorAccessor<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_sun_java_generated_constructors_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_sun_java_generated_constructors_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.660295Z'
+created: '2024-10-24T14:22:37.548719+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "sun.reflect.GeneratedConstructorAccessor<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_sun_java_generated_methods.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_ignores_sun_java_generated_methods.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.680262Z'
+created: '2024-10-24T14:22:37.635713+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed reflection marker)
             "sun.reflect.GeneratedMethodAccessor"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_sanitizes_block_functions.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_sanitizes_block_functions.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.697075Z'
+created: '2024-10-24T14:22:37.676550+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_sanitizes_erb_templates.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_sanitizes_erb_templates.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.714986Z'
+created: '2024-10-24T14:22:37.712878+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo.html.erb"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_sanitizes_versioned_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_sanitizes_versioned_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.733027Z'
+created: '2024-10-24T14:22:37.814255+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo.html.erb"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_sanitizes_versioned_filenames_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_sanitizes_versioned_filenames_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.748575Z'
+created: '2024-10-24T14:22:37.752310+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo.html.erb"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_skips_symbol_if_unknown.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_skips_symbol_if_unknown.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.770915Z'
+created: '2024-10-24T14:22:37.875908+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "libfoo"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_uses_context_line_over_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_uses_context_line_over_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.787544Z'
+created: '2024-10-24T14:22:37.928768+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_uses_function_over_lineno.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_uses_function_over_lineno.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.803644Z'
+created: '2024-10-24T14:22:38.003589+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_uses_module_over_filename.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_uses_module_over_filename.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.824366Z'
+created: '2024-10-24T14:22:38.057881+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "foo"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_uses_symbol_instead_of_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_uses_symbol_instead_of_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.840190Z'
+created: '2024-10-24T14:22:38.116442+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "libfoo"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_with_only_required_vars.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_with_only_required_vars.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.854977Z'
+created: '2024-10-24T14:22:38.169558+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_125_event_126.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:47.075499Z'
+created: '2024-10-24T14:22:38.299204+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_200_event_200.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:47.344722Z'
+created: '2024-10-24T14:22:38.367533+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "RtlUserThreadStart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_275_event_275.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:45.603868Z'
+created: '2024-10-24T14:22:38.436482+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "_dispatch_root_queues_init_once"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_289_event_312.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:46.497295Z'
+created: '2024-10-24T14:22:38.513976+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
               "thread.cpp"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_294_event_294.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:45.999748Z'
+created: '2024-10-24T14:22:38.573957+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_294_event_329.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:45.522472Z'
+created: '2024-10-24T14:22:38.638191+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "_dispatch_root_queues_init_once"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_307_event_307.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:47.345277Z'
+created: '2024-10-24T14:22:38.704859+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "stripped_application_code"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_307_event_657.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:45.806564Z'
+created: '2024-10-24T14:22:38.769640+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "stripped_application_code"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_313_event_313.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:46.803902Z'
+created: '2024-10-24T14:22:38.841053+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_313_event_333.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:47.833121Z'
+created: '2024-10-24T14:22:38.907106+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_319_event_321.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:47.771509Z'
+created: '2024-10-24T14:22:38.970695+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_389_event_389.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:45.907139Z'
+created: '2024-10-24T14:22:39.024442+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "stripped_application_code"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_432_event_432.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:45.733833Z'
+created: '2024-10-24T14:22:39.097323+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "RtlUserThreadStart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_432_event_453.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:46.820401Z'
+created: '2024-10-24T14:22:39.163825+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "RtlUserThreadStart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/group_445_event_445.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:46.207776Z'
+created: '2024-10-24T14:22:39.247413+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "RtlUserThreadStart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-25T09:17:15.905761Z'
+created: '2024-10-24T14:22:39.688455+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,7 +9,7 @@ app:
     app*
       chained-exception*
         exception*
-          stacktrace
+          stacktrace (ignored because it contains no in-app frames)
             frame (non app frame)
               module*
                 "io.sentry.example.Application"
@@ -176,7 +176,7 @@ app:
           value*
             "Address already in use"
         exception*
-          stacktrace
+          stacktrace (ignored because it contains no in-app frames)
             frame (non app frame)
               module*
                 "io.sentry.example.Application"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/java_minimal.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:42.020404Z'
+created: '2024-10-24T14:22:39.763252+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "java.lang.Thread"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_exception_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_exception_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:42.092360Z'
+created: '2024-10-24T14:22:39.961798+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
               "react-dom.development.js"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_polyfills.pysnap
@@ -1,4 +1,6 @@
 ---
+created: '2024-10-24T14:22:40.157138+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
@@ -6,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "@babel/runtime/helpers/asyncToGenerator"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_regression_tree_labels.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_regression_tree_labels.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-09-01T09:11:07.313744Z'
+created: '2024-10-24T14:22:41.618630+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "app/utils/handleXhrErrorResponse"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_unpkg.pysnap
@@ -1,4 +1,6 @@
 ---
+created: '2024-10-24T14:22:40.238646+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
@@ -6,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "react-dom@16.13.1/umd/react-dom.production"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_xbrowser_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:42.147528Z'
+created: '2024-10-24T14:22:40.325734+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
               "test.html"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_xbrowser_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:42.181080Z'
+created: '2024-10-24T14:22:40.471305+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
               "test.html"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:42.207014Z'
+created: '2024-10-24T14:22:40.568631+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
               "test.html"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_xbrowser_http_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:42.233368Z'
+created: '2024-10-24T14:22:40.663439+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "test"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_xbrowser_http_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_xbrowser_http_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:42.259937Z'
+created: '2024-10-24T14:22:40.724033+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "test"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_xbrowser_http_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:42.285667Z'
+created: '2024-10-24T14:22:40.808684+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "test"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_xbrowser_http_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:42.315367Z'
+created: '2024-10-24T14:22:40.867925+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "test"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_xbrowser_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:42.344202Z'
+created: '2024-10-24T14:22:40.945352+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
               "test.html"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/macos_amd_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:48.267768Z'
+created: '2024-10-24T14:22:42.020382+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/macos_intel_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:47.070569Z'
+created: '2024-10-24T14:22:42.106338+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/malloc_sentinel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-07-08T15:46:26.994351Z'
+created: '2024-10-24T14:22:42.200958+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "_pthread_start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/minified_javascript.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:42.632833Z'
+created: '2024-10-24T14:22:42.557219+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "sentry/dist/vendor"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:42.676363Z'
+created: '2024-10-24T14:22:42.682302+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/native_driver_crash1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:47.508066Z'
+created: '2024-10-24T14:22:42.780582+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "CUseCountedObject<T>::UCDestroy"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/native_driver_crash2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:48.468822Z'
+created: '2024-10-24T14:22:42.921094+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "CUseCountedObject<T>::UCDestroy"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/native_driver_crash3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:45.034552Z'
+created: '2024-10-24T14:22:43.016429+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "CUseCountedObject<T>::UCDestroy"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/native_limit_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-11-12T10:57:07.640226Z'
+created: '2024-10-24T14:22:43.094090+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/native_malloc_chain.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-02T10:31:45.238752Z'
+created: '2024-10-24T14:22:43.171111+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "application_frame"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/native_unlimited_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:42.858642Z'
+created: '2024-10-24T14:22:43.289627+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/native_windows_anon_namespace.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:42.929939Z'
+created: '2024-10-24T14:22:43.351198+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
               "exe_common.inl"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/native_with_function_name.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-02-12T22:47:12.669017Z'
+created: '2024-10-24T14:22:43.406041+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
               "main.cpp"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/node_low_level_async.pysnap
@@ -1,4 +1,6 @@
 ---
+created: '2024-10-24T14:22:43.526313+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
@@ -6,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "task_queues"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/python_exception_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-02-15T10:11:55.608178Z'
+created: '2024-10-24T14:22:43.579421+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -18,7 +18,7 @@ app:
           value (ignored because stacktrace takes precedence)
             "hello world"
         exception*
-          stacktrace
+          stacktrace (ignored because it contains no in-app frames)
             frame (non app frame)
               filename*
                 "baz.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/python_grouping_enhancer_towards_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-11-12T10:57:07.141342Z'
+created: '2024-10-24T14:22:43.683886+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no contributing frames)
           frame (non app frame)
             module*
               "django.core.handlers.base"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/stacktrace_collapse_recursion.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-11-28T16:31:41.147500Z'
+created: '2024-10-24T14:22:43.877887+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "com.example.Application"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/stacktrace_discards_seemingly_useless_stack.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/stacktrace_discards_seemingly_useless_stack.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:43.229542Z'
+created: '2024-10-24T14:22:43.956102+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)
             "foo"
@@ -19,7 +19,7 @@ system:
   hash: null
   component:
     system
-      stacktrace
+      stacktrace (ignored because it contains no contributing frames)
         frame
           filename (ignored because frame points to a URL)
             "foo"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/stacktrace_does_not_discard_non_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/stacktrace_does_not_discard_non_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:43.247501Z'
+created: '2024-10-24T14:22:43.994426+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/stacktrace_does_not_group_different_js_errors.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/stacktrace_does_not_group_different_js_errors.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:43.268685Z'
+created: '2024-10-24T14:22:44.041763+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)
             "index.js"
@@ -19,7 +19,7 @@ system:
   hash: null
   component:
     system
-      stacktrace
+      stacktrace (ignored because it contains no contributing frames)
         frame
           filename (ignored because frame points to a URL)
             "index.js"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/stacktrace_excludes_single_frame_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/stacktrace_excludes_single_frame_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:43.372155Z'
+created: '2024-10-24T14:22:44.134461+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "<unknown module>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/stacktrace_ignores_singular_anonymous_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/stacktrace_ignores_singular_anonymous_frame.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:43.404771Z'
+created: '2024-10-24T14:22:44.219355+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (anonymous filename discarded)
             "<anonymous>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/stacktrace_negated_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-03-22T11:57:42.480291+00:00'
+created: '2024-10-24T14:22:44.263377+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "_main"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/android_anr.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T13:53:09.636718Z'
+created: '2024-10-24T14:16:43.547735+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "com.android.internal.os.ZygoteInit"
@@ -770,7 +770,7 @@ app:
         value* (stripped event-specific values)
           "Application Not Responding for at least <int> ms."
       threads (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (module:java.* -app))
             module*
               "java.lang.Thread"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/bugly.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/bugly.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.705060Z'
+created: '2024-10-24T14:16:52.018184+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
           frame (non app frame)
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:21:18.239532+00:00'
+created: '2024-10-24T14:16:56.151196+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (custom fingerprint takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "foo.bar"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:21:16.136903+00:00'
+created: '2024-10-24T14:16:54.232771+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (custom fingerprint takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "bar.bar"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:28.065705Z'
+created: '2024-10-24T14:18:07.623162+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "app/components/modals/createTeamModal"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T14:07:26.922870Z'
+created: '2024-10-24T14:18:18.413371+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_comput_hashes_ignores_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_comput_hashes_ignores_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:28.263070Z'
+created: '2024-10-24T14:18:20.552361+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "sentry_clojure_example.core$_main$fn__<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_empty_list.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_empty_list.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.973989Z'
+created: '2024-10-24T14:18:22.752355+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,6 +7,7 @@ app:
   hash: null
   component:
     app
+      stacktrace (ignored because it contains no frames)
 --------------------------------------------------------------------------
 fallback:
   hash: "d41d8cd98f00b204e9800998ecf8427e"
@@ -15,3 +16,4 @@ system:
   hash: null
   component:
     system
+      stacktrace (ignored because it contains no frames)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
@@ -1,11 +1,13 @@
 ---
+created: '2024-10-24T14:18:24.523926+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "com.example.api.OutboundController$$EnhancerByGuice$$<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
@@ -1,11 +1,13 @@
 ---
+created: '2024-10-24T14:18:26.372895+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "com.example.api.OutboundController$$FastClassByGuice$$<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:28.390049Z'
+created: '2024-10-24T14:18:28.068231+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "invalid.gruml.talkytalkyhub.common.config.JipJipConfig$$EnhancerBySpringCGLIB$$<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_dartlang_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_dartlang_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:07.524066Z'
+created: '2024-10-24T14:18:29.686779+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by stack trace rule (family:javascript path:org-dartlang-sdk:///** -app -group))
           filename*
             "async_patch.dart"
@@ -21,7 +21,7 @@ system:
   hash: null
   component:
     system
-      stacktrace
+      stacktrace (ignored because it contains no contributing frames)
         frame (ignored by stack trace rule (family:javascript path:org-dartlang-sdk:///** -app -group))
           filename*
             "async_patch.dart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:29.355945Z'
+created: '2024-10-24T14:18:31.450868+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "sentry_clojure_example.core$_main$fn__<auto>$fn__<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
@@ -1,11 +1,13 @@
 ---
+created: '2024-10-24T14:18:33.073763+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "com.example.api.OutboundController$$EnhancerByGuice$$<auto>$$FastClassByGuice$$<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:26.760432Z'
+created: '2024-10-24T14:18:34.744358+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "invalid.gruml.talkytalkyhub.common.config.JipJipConfig$$EnhancerBySpringCGLIB$$<auto>$$EnhancerBySpringCGLIB$$<auto>$$FastClassBySpringCGLIB$$<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.492305Z'
+created: '2024-10-24T14:18:36.366819+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)
             "foo.js"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_filename_if_abs_path_is_http.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_filename_if_abs_path_is_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.476915Z'
+created: '2024-10-24T14:18:38.222179+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)
             "foo.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_filename_if_blob.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_filename_if_blob.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:28.601702Z'
+created: '2024-10-24T14:18:40.004180+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)
             "7f7aaadf-a006-4217-9ed5-5fbf8585c6c0"
@@ -19,7 +19,7 @@ system:
   hash: null
   component:
     system
-      stacktrace
+      stacktrace (ignored because it contains no contributing frames)
         frame
           filename (ignored because frame points to a URL)
             "7f7aaadf-a006-4217-9ed5-5fbf8585c6c0"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:29.062217Z'
+created: '2024-10-24T14:18:41.873921+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)
             "foo.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:26.688055Z'
+created: '2024-10-24T14:18:43.664755+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)
             "foo.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:01.298242Z'
+created: '2024-10-24T14:18:45.285371+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by stack trace rule (family:javascript module:**/packages/flutter/** -app))
           module*
             "opt/hostedtoolcache/flutter/2.5.0-stable/x64/packages/flutter/lib/src/gestures/binding"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_hibernate_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_hibernate_classes.pysnap
@@ -1,11 +1,13 @@
 ---
+created: '2024-10-24T14:18:46.992203+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "com.example.model.User$HibernateProxy$<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_java8_lambda_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_java8_lambda_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:29.260980Z'
+created: '2024-10-24T14:18:48.716773+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "foo.bar.Baz"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_java8_lambda_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_java8_lambda_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:29.702241Z'
+created: '2024-10-24T14:18:50.500466+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module (ignored java lambda)
             "foo.bar.Baz$$Lambda$40/1673859467"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_javassist.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_javassist.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:29.115841Z'
+created: '2024-10-24T14:18:56.048388+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "com.example.api.entry.EntriesResource_$$_javassist<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_javassist_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_javassist_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:28.473785Z'
+created: '2024-10-24T14:18:52.150429+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module* (removed codegen marker)
             "com.example.api.entry.EntriesResource_$$_javassist<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_javassist_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_javassist_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:29.463021Z'
+created: '2024-10-24T14:18:54.012446+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename* (cleaned javassist parts)
             "entriesresource_$$_javassist<auto>.java"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_module_if_page_url.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_module_if_page_url.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.850441Z'
+created: '2024-10-24T14:18:59.215288+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "foo/bar/baz"
@@ -21,7 +21,7 @@ system:
   hash: null
   component:
     system
-      stacktrace
+      stacktrace (ignored because it contains no contributing frames)
         frame (ignored single non-URL JavaScript frame)
           module*
             "foo/bar/baz"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_module_if_page_url_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_module_if_page_url_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:28.095927Z'
+created: '2024-10-24T14:18:57.587351+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module (ignored bad javascript module)
             "foo/bar/baz"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_safari_native_code.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_safari_native_code.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.807198Z'
+created: '2024-10-24T14:19:00.992971+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (native code indicated by filename)
             "[native code]"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sentry_dart_packages.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-06-05T14:22:42.534841+00:00'
+created: '2024-10-24T14:19:02.687514+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by stack trace rule (path:package:sentry_logging/** -app -group))
           filename*
             "sentry_logging.dart"
@@ -51,7 +51,7 @@ system:
   hash: null
   component:
     system
-      stacktrace
+      stacktrace (ignored because it contains no contributing frames)
         frame (ignored by stack trace rule (path:package:sentry_logging/** -app -group))
           filename*
             "sentry_logging.dart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sentry_dart_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-05-28T08:36:54.891911+00:00'
+created: '2024-10-24T14:19:04.313945+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by stack trace rule (path:package:sentry/** -app -group))
           filename*
             "sentry_exception_factory.dart"
@@ -21,7 +21,7 @@ system:
   hash: null
   component:
     system
-      stacktrace
+      stacktrace (ignored because it contains no contributing frames)
         frame (ignored by stack trace rule (path:package:sentry/** -app -group))
           filename*
             "sentry_exception_factory.dart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sentry_flutter_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-05-28T08:36:54.505879+00:00'
+created: '2024-10-24T14:19:06.131971+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by stack trace rule (path:package:sentry_flutter/** -app -group))
           filename*
             "sentry_exception_factory.dart"
@@ -21,7 +21,7 @@ system:
   hash: null
   component:
     system
-      stacktrace
+      stacktrace (ignored because it contains no contributing frames)
         frame (ignored by stack trace rule (path:package:sentry_flutter/** -app -group))
           filename*
             "sentry_exception_factory.dart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
@@ -1,11 +1,13 @@
 ---
+created: '2024-10-24T14:19:09.259608+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by stack trace rule (module:sun.* -app))
           module* (removed codegen marker)
             "sun.reflect.GeneratedSerializationConstructorAccessor<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
@@ -1,11 +1,13 @@
 ---
+created: '2024-10-24T14:19:07.714331+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by stack trace rule (module:sun.* -app))
           module* (removed codegen marker)
             "sun.reflect.GeneratedConstructorAccessor<auto>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
@@ -1,11 +1,13 @@
 ---
+created: '2024-10-24T14:19:11.212073+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (marked out of app by stack trace rule (module:sun.* -app))
           module* (removed reflection marker)
             "sun.reflect.GeneratedMethodAccessor"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_sanitizes_block_functions.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_sanitizes_block_functions.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.898678Z'
+created: '2024-10-24T14:19:12.938605+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_sanitizes_erb_templates.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_sanitizes_erb_templates.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:30.026166Z'
+created: '2024-10-24T14:19:14.568116+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo.html.erb"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_sanitizes_versioned_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_sanitizes_versioned_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:26.842541Z'
+created: '2024-10-24T14:19:18.273307+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo.html.erb"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_sanitizes_versioned_filenames_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_sanitizes_versioned_filenames_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:29.307155Z'
+created: '2024-10-24T14:19:16.511952+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo.html.erb"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_skips_symbol_if_unknown.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_skips_symbol_if_unknown.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:28.489229Z'
+created: '2024-10-24T14:19:19.961076+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "libfoo"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:30.011534Z'
+created: '2024-10-24T14:19:21.893315+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_uses_function_over_lineno.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_uses_function_over_lineno.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.912497Z'
+created: '2024-10-24T14:19:23.554917+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_uses_module_over_filename.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_uses_module_over_filename.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:28.970153Z'
+created: '2024-10-24T14:19:25.337468+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "foo"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_uses_symbol_instead_of_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_uses_symbol_instead_of_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.643256Z'
+created: '2024-10-24T14:19:26.915840+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "libfoo"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_with_only_required_vars.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_with_only_required_vars.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:26.906961Z'
+created: '2024-10-24T14:19:29.196459+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_125_event_126.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T13:53:07.554820Z'
+created: '2024-10-24T14:19:33.047230+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_200_event_200.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T14:07:28.313265Z'
+created: '2024-10-24T14:19:34.856344+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "RtlUserThreadStart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_275_event_275.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-13T13:53:22.841379Z'
+created: '2024-10-24T14:19:37.942436+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "_dispatch_root_queues_init_once"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_289_event_312.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T15:27:59.106711Z'
+created: '2024-10-24T14:19:41.120779+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
               "thread.cpp"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_294_event_294.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T15:27:58.915158Z'
+created: '2024-10-24T14:19:43.254158+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_294_event_329.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-13T13:53:29.891562Z'
+created: '2024-10-24T14:19:44.961372+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "_dispatch_root_queues_init_once"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_307_event_307.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:00.668495Z'
+created: '2024-10-24T14:19:48.031572+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "stripped_application_code"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_307_event_657.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:05.948420Z'
+created: '2024-10-24T14:19:51.968492+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "stripped_application_code"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_313_event_313.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T15:28:00.792724Z'
+created: '2024-10-24T14:19:54.964615+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_313_event_333.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T15:28:01.041311Z'
+created: '2024-10-24T14:19:58.332928+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_319_event_321.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T15:27:56.059424Z'
+created: '2024-10-24T14:20:00.008644+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_389_event_389.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:21:59.678104Z'
+created: '2024-10-24T14:20:01.810693+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "stripped_application_code"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_432_event_432.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T15:27:56.301049Z'
+created: '2024-10-24T14:20:03.666963+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "RtlUserThreadStart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_432_event_453.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T15:27:55.917350Z'
+created: '2024-10-24T14:20:05.311947+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "RtlUserThreadStart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_445_event_445.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T15:27:54.534928Z'
+created: '2024-10-24T14:20:07.125969+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "RtlUserThreadStart"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-11-28T16:01:07.159219Z'
+created: '2024-10-24T14:20:20.681033+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,7 +9,7 @@ app:
     app (exception of system takes precedence)
       chained-exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         exception*
-          stacktrace
+          stacktrace (ignored because it contains no in-app frames)
             frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
               module*
                 "io.sentry.example.Application"
@@ -176,7 +176,7 @@ app:
           value*
             "Address already in use"
         exception*
-          stacktrace
+          stacktrace (ignored because it contains no in-app frames)
             frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
               module*
                 "io.sentry.example.Application"
@@ -287,7 +287,7 @@ app:
           value*
             "service.getName(): \"Tomcat\";  Protocol handler start failed"
         exception*
-          stacktrace
+          stacktrace (ignored because it contains no in-app frames)
             frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
               module*
                 "io.sentry.example.Application"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/java_minimal.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-11-28T16:01:06.243244Z'
+created: '2024-10-24T14:20:22.615944+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (module:java.* -app))
             module*
               "java.lang.Thread"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
@@ -1,4 +1,6 @@
 ---
+created: '2024-10-24T14:20:28.174303+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
@@ -6,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (path:**/node_modules/** -app))
             filename*
               "react-dom.development.js"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_polyfills.pysnap
@@ -1,4 +1,6 @@
 ---
+created: '2024-10-24T14:20:33.386709+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
@@ -6,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because hash matches system variant)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (module:@babel/** -app -group))
             module*
               "@babel/runtime/helpers/asyncToGenerator"
@@ -32,7 +34,7 @@ system:
   component:
     system*
       exception*
-        stacktrace
+        stacktrace (ignored because it contains no contributing frames)
           frame (ignored by stack trace rule (module:@babel/** -app -group))
             module*
               "@babel/runtime/helpers/asyncToGenerator"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_regression_tree_labels.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_regression_tree_labels.pysnap
@@ -1,4 +1,6 @@
 ---
+created: '2024-10-24T14:20:57.203202+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
@@ -6,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "app/utils/handleXhrErrorResponse"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_unpkg.pysnap
@@ -1,4 +1,6 @@
 ---
+created: '2024-10-24T14:20:35.288899+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
@@ -6,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (path:**https://unpkg.com/** -app))
             module*
               "react-dom@16.13.1/umd/react-dom.production"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.221047Z'
+created: '2024-10-24T14:20:36.932461+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
               "test.html"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:28.955060Z'
+created: '2024-10-24T14:20:38.621975+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
               "test.html"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.198714Z'
+created: '2024-10-24T14:20:42.048911+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
               "test.html"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.679091Z'
+created: '2024-10-24T14:20:43.963406+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "test"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:26.659658Z'
+created: '2024-10-24T14:20:45.856109+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "test"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:29.081335Z'
+created: '2024-10-24T14:20:47.591432+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "test"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:26.863929Z'
+created: '2024-10-24T14:20:49.349900+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "test"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.870955Z'
+created: '2024-10-24T14:20:51.319218+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
               "test.html"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_amd_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T15:27:56.927636Z'
+created: '2024-10-24T14:21:07.393338+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_intel_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T15:27:58.522542Z'
+created: '2024-10-24T14:21:09.339902+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/malloc_sentinel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T15:28:01.679476Z'
+created: '2024-10-24T14:21:11.162184+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "_pthread_start"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/minified_javascript.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:29.842689Z'
+created: '2024-10-24T14:21:20.105415+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             module*
               "sentry/dist/vendor"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:06.052955Z'
+created: '2024-10-24T14:21:22.066885+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T13:53:14.096424Z'
+created: '2024-10-24T14:21:24.787277+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "CUseCountedObject<T>::UCDestroy"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T13:53:10.012806Z'
+created: '2024-10-24T14:21:27.604345+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "CUseCountedObject<T>::UCDestroy"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T13:53:11.913366Z'
+created: '2024-10-24T14:21:31.037438+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "CUseCountedObject<T>::UCDestroy"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_limit_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:05.441437Z'
+created: '2024-10-24T14:21:34.408864+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_malloc_chain.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T14:07:28.469899Z'
+created: '2024-10-24T14:21:37.090199+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "application_frame"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_unlimited_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:00.202278Z'
+created: '2024-10-24T14:21:43.538257+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:07.289846Z'
+created: '2024-10-24T14:21:45.737100+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
               "exe_common.inl"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_with_function_name.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:28.135789Z'
+created: '2024-10-24T14:21:47.863209+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             filename*
               "main.cpp"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/node_low_level_async.pysnap
@@ -1,4 +1,6 @@
 ---
+created: '2024-10-24T14:21:52.204150+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
@@ -6,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because hash matches system variant)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by stack trace rule (function:processTicksAndRejections -app -group))
             module*
               "task_queues"
@@ -29,7 +31,7 @@ system:
   component:
     system*
       exception*
-        stacktrace
+        stacktrace (ignored because it contains no contributing frames)
           frame (ignored by stack trace rule (function:processTicksAndRejections -app -group))
             module*
               "task_queues"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/python_exception_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:28.760089Z'
+created: '2024-10-24T14:21:54.035915+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -18,7 +18,7 @@ app:
           value (ignored because stacktrace takes precedence)
             "hello world"
         exception*
-          stacktrace
+          stacktrace (ignored because it contains no in-app frames)
             frame (non app frame)
               filename*
                 "baz.py"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
@@ -1,4 +1,6 @@
 ---
+created: '2024-10-24T14:21:57.991389+00:00'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
@@ -6,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no contributing frames)
           frame (marked out of app by stack trace rule (path:**/site-packages/** -app))
             module*
               "django.core.handlers.base"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-11-28T16:31:48.761745Z'
+created: '2024-10-24T14:22:06.044305+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "com.example.Application"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_discards_seemingly_useless_stack.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_discards_seemingly_useless_stack.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:28.723898Z'
+created: '2024-10-24T14:22:09.432897+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)
             "foo"
@@ -19,7 +19,7 @@ system:
   hash: null
   component:
     system
-      stacktrace
+      stacktrace (ignored because it contains no contributing frames)
         frame
           filename (ignored because frame points to a URL)
             "foo"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_does_not_discard_non_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_does_not_discard_non_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:28.906471Z'
+created: '2024-10-24T14:22:11.127045+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename*
             "foo"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_does_not_group_different_js_errors.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_does_not_group_different_js_errors.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:26.731813Z'
+created: '2024-10-24T14:22:12.770464+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (ignored because frame points to a URL)
             "index.js"
@@ -19,7 +19,7 @@ system:
   hash: null
   component:
     system
-      stacktrace
+      stacktrace (ignored because it contains no contributing frames)
         frame
           filename (ignored because frame points to a URL)
             "index.js"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_excludes_single_frame_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_excludes_single_frame_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.175244Z'
+created: '2024-10-24T14:22:16.290311+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           module*
             "<unknown module>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:26.776316Z'
+created: '2024-10-24T14:22:19.986729+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace
+      stacktrace (ignored because it contains no in-app frames)
         frame (non app frame)
           filename (anonymous filename discarded)
             "<anonymous>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_negated_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-03-22T11:58:01.620488+00:00'
+created: '2024-10-24T14:22:21.683897+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,7 +8,7 @@ app:
   component:
     app (exception of system takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
+        stacktrace (ignored because it contains no in-app frames)
           frame (non app frame)
             function*
               "_main"


### PR DESCRIPTION
When a stacktrace has contributing frames but the number of contributing frames is small enough that it violates a `min-frames` stacktrace rule (causing the stacktrace as a whole not to contribute to grouping), the rust enhancer adds that information as a [hint on the stacktrace component](https://github.com/getsentry/ophio/blob/6691b83c758afc4bc781a86948b9499d614cc31e/rust/src/enhancers/mod.rs#L308). The same is not true in cases where there are no contributing frames, though.

This adds such hints, handling three cases:
- A stacktrace with no frames
- A stacktrace with frames, but no contributing frames
- For the `app` variant, a stacktrace with frames, including potentially some otherwise-contributing frames, but no in-app frames