### PR TITLE
fix(trace-explorer): Use first span as default trace name

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -834,25 +834,44 @@ class TracesExecutor:
             context = {"traces": list(sorted(traces_range.keys()))}
             sentry_sdk.capture_exception(e, contexts={"bad_traces": context})
 
+        # This is the name of the trace's root span without a parent span
+        traces_primary_names: MutableMapping[str, tuple[str, str]] = {}
+
+        # This is the name of a span that can take the place of the trace's root
+        # based on some heuristics for that type of trace
+        traces_fallback_names: MutableMapping[str, tuple[str, str]] = {}
+
+        # This is the name of the first span in the trace that will be used if
+        # no other candidates names are found
+        traces_default_names: MutableMapping[str, tuple[str, str]] = {}
+
         # Normally, the name given to a trace is the name of the first root transaction
         # found within the trace.
         #
         # But there are some cases where traces do not have any root transactions. For
         # these traces, we try to pick out a name from the first span that is a good
         # candidate for the trace name.
-        traces_primary_names: MutableMapping[str, tuple[str, str]] = {}
-        traces_fallback_names: MutableMapping[str, tuple[str, str]] = {}
         for row in traces_breakdown_projects_results["data"]:
             if row["trace"] in traces_primary_names:
                 continue
-            else:
-                # The underlying column is a Nullable(UInt64) but we write a default of 0 to it.
-                # So make sure to handle both in case something changes.
-                if not row["parent_span"] or int(row["parent_span"], 16) == 0:
-                    traces_primary_names[row["trace"]] = (row["project"], row["transaction"])
 
+            # The underlying column is a Nullable(UInt64) but we write a default of 0 to it.
+            # So make sure to handle both in case something changes.
+            if not row["parent_span"] or int(row["parent_span"], 16) == 0:
+                traces_primary_names[row["trace"]] = (row["project"], row["transaction"])
+
+            if row["trace"] in traces_fallback_names:
+                continue
+
+            # This span is a good candidate for the trace name so use it.
             if row["trace"] not in traces_fallback_names and is_trace_name_candidate(row):
                 traces_fallback_names[row["trace"]] = (row["project"], row["transaction"])
+
+            if row["trace"] in traces_default_names:
+                continue
+
+            # This is the first span in this trace.
+            traces_default_names[row["trace"]] = (row["project"], row["transaction"])
 
         def get_trace_name(trace):
             if trace in traces_primary_names:
@@ -860,6 +879,9 @@ class TracesExecutor:
 
             if trace in traces_fallback_names:
                 return traces_fallback_names[trace]
+
+            if trace in traces_default_names:
+                return traces_default_names[trace]
 
             return (None, None)
 

--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -436,8 +436,69 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
             exception, contexts={"bad_traces": {"traces": list(sorted([trace_id_1, trace_id_2]))}}
         )
 
+    def test_use_first_span_for_name(self):
+        trace_id = uuid4().hex
+        span_id = "1" + uuid4().hex[:15]
+        parent_span_id = "1" + uuid4().hex[:15]
+        now = before_now().replace(hour=0, minute=0, second=0, microsecond=0)
+        ts = now - timedelta(minutes=10)
+
+        self.double_write_segment(
+            project=self.project,
+            trace_id=trace_id,
+            transaction_id=uuid4().hex,
+            span_id=span_id,
+            parent_span_id=parent_span_id,
+            timestamp=ts,
+            transaction="foo",
+            duration=60_100,
+            exclusive_time=60_100,
+            sdk_name="sentry.javascript.node",
+            op="bar",
+        )
+
+        timestamp = int(ts.timestamp() * 1000)
+
+        query = {
+            "project": [],
+            "field": ["id", "parent_span", "span.duration"],
+            "query": "",
+            "maxSpansPerTrace": 3,
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200, response.data
+
+        assert response.data["data"] == [
+            {
+                "breakdowns": [
+                    {
+                        "duration": 60100,
+                        "start": timestamp,
+                        "end": timestamp + 60100,
+                        "sliceStart": 0,
+                        "sliceEnd": 40,
+                        "sliceWidth": 40,
+                        "isRoot": False,
+                        "kind": "project",
+                        "project": self.project.slug,
+                        "sdkName": "sentry.javascript.node",
+                    },
+                ],
+                "duration": 60100,
+                "end": timestamp + 60100,
+                "name": "foo",
+                "numErrors": 0,
+                "numOccurrences": 0,
+                "numSpans": 1,
+                "matchingSpans": 1,
+                "project": self.project.slug,
+                "start": timestamp,
+                "trace": trace_id,
+            },
+        ]
+
     def test_use_root_span_for_name(self):
-        project = self.create_project()
         trace_id = uuid4().hex
         span_id_1 = "1" + uuid4().hex[:15]
         span_id_2 = "1" + uuid4().hex[:15]
@@ -445,7 +506,7 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
         ts = now - timedelta(minutes=10)
 
         self.double_write_segment(
-            project=project,
+            project=self.project,
             trace_id=trace_id,
             transaction_id=uuid4().hex,
             span_id=span_id_1,
@@ -457,7 +518,7 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
         )
 
         self.double_write_segment(
-            project=project,
+            project=self.project,
             trace_id=trace_id,
             transaction_id=uuid4().hex,
             span_id=span_id_2,
@@ -494,7 +555,7 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
                         "sliceWidth": 40,
                         "isRoot": False,
                         "kind": "project",
-                        "project": project.slug,
+                        "project": self.project.slug,
                         "sdkName": "sentry.javascript.remix",
                     },
                     {
@@ -506,7 +567,7 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
                         "sliceWidth": 10,
                         "isRoot": False,
                         "kind": "project",
-                        "project": project.slug,
+                        "project": self.project.slug,
                         "sdkName": "sentry.javascript.node",
                     },
                 ],
@@ -517,14 +578,13 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
                 "numOccurrences": 0,
                 "numSpans": 2,
                 "matchingSpans": 2,
-                "project": project.slug,
+                "project": self.project.slug,
                 "start": timestamp,
                 "trace": trace_id,
             },
         ]
 
     def test_use_pageload_for_name(self):
-        project = self.create_project()
         trace_id = uuid4().hex
         span_id = "1" + uuid4().hex[:15]
         parent_span_id = "1" + uuid4().hex[:15]
@@ -532,7 +592,7 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
         ts = now - timedelta(minutes=10)
 
         self.double_write_segment(
-            project=project,
+            project=self.project,
             trace_id=trace_id,
             transaction_id=uuid4().hex,
             span_id=span_id,
@@ -569,7 +629,7 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
                         "sliceWidth": 40,
                         "isRoot": False,
                         "kind": "project",
-                        "project": project.slug,
+                        "project": self.project.slug,
                         "sdkName": "sentry.javascript.node",
                     },
                 ],
@@ -580,7 +640,7 @@ class OrganizationTracesEndpointTest(OrganizationTracesEndpointTestBase):
                 "numOccurrences": 0,
                 "numSpans": 1,
                 "matchingSpans": 1,
-                "project": project.slug,
+                "project": self.project.slug,
                 "start": timestamp,
                 "trace": trace_id,
             },


### PR DESCRIPTION
We use the first span in the trace as the default name when all else fails.