### PR TITLE
ref(grouping): Move and update variant test helpers

### DIFF
--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -164,8 +164,12 @@ def with_fingerprint_input(name):
     )
 
 
-def to_json(value: Any) -> str:
-    return orjson.dumps(value, option=orjson.OPT_SORT_KEYS).decode()
+def to_json(value: Any, pretty_print: bool = False) -> str:
+    option = orjson.OPT_SORT_KEYS
+    if pretty_print:
+        option = option | orjson.OPT_INDENT_2
+
+    return orjson.dumps(value, option=option).decode()
 
 
 def dump_variant(

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -169,7 +169,10 @@ def to_json(value: Any) -> str:
 
 
 def dump_variant(
-    variant: BaseVariant, lines: list[str] | None = None, indent: int = 0
+    variant: BaseVariant,
+    lines: list[str] | None = None,
+    indent: int = 0,
+    include_non_contributing: bool = True,
 ) -> list[str]:
     if lines is None:
         lines = []
@@ -177,20 +180,21 @@ def dump_variant(
     def _dump_component(component: GroupingComponent, indent: int) -> None:
         if not component.hint and not component.values:
             return
-        lines.append(
-            "%s%s%s%s"
-            % (
-                "  " * indent,
-                component.id,
-                component.contributes and "*" or "",
-                component.hint and " (%s)" % component.hint or "",
+        if component.contributes or include_non_contributing:
+            lines.append(
+                "%s%s%s%s"
+                % (
+                    "  " * indent,
+                    component.id,
+                    component.contributes and "*" or "",
+                    component.hint and " (%s)" % component.hint or "",
+                )
             )
-        )
-        for value in component.values:
-            if isinstance(value, GroupingComponent):
-                _dump_component(value, indent + 1)
-            else:
-                lines.append("{}{}".format("  " * (indent + 1), to_json(value)))
+            for value in component.values:
+                if isinstance(value, GroupingComponent):
+                    _dump_component(value, indent + 1)
+                else:
+                    lines.append("{}{}".format("  " * (indent + 1), to_json(value)))
 
     lines.append("{}hash: {}".format("  " * indent, to_json(variant.get_hash())))
 

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -205,3 +205,21 @@ def dump_variant(
             lines.append("{}{}: {}".format("  " * indent, key, to_json(value)))
 
     return lines
+
+
+def get_snapshot_path(
+    test_file: str, input_file: str, test_name: str, grouping_config_name: str
+) -> str:
+    """
+    Get the path to the snapshot file. This mirrors the default behavior, but is useful if you want
+    multiple tests' snapshots to wind up in the same folder, as might happen if different grouping
+    configs are tested differently.
+    """
+    return path.join(
+        path.dirname(test_file),
+        "snapshots",
+        path.basename(test_file).replace(".py", ""),
+        test_name,
+        grouping_config_name.replace("-", "_").replace(":", "@"),
+        input_file.replace("-", "_").replace(".json", ".pysnap"),
+    )

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from os import path
-
 import pytest
 
 from sentry.eventstore.models import Event
@@ -13,6 +11,7 @@ from tests.sentry.grouping import (
     GROUPING_INPUTS_DIR,
     GroupingInput,
     dump_variant,
+    get_snapshot_path,
     with_grouping_inputs,
 )
 
@@ -94,12 +93,7 @@ def _assert_and_snapshot_results(
         output,
         # Manually set the snapshot path so that both of the tests above will file their snapshots
         # in the same spot
-        reference_file=path.join(
-            path.dirname(__file__),
-            "snapshots",
-            path.basename(__file__).replace(".py", ""),
-            "test_event_hash_variant",
-            config_name.replace("-", "_").replace(":", "@"),
-            input_file.replace("-", "_").replace(".json", ".pysnap"),
+        reference_file=get_snapshot_path(
+            __file__, input_file, "test_event_hash_variant", config_name
         ),
     )

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -1,62 +1,20 @@
 from __future__ import annotations
 
 from os import path
-from typing import Any
 
-import orjson
 import pytest
 
 from sentry.eventstore.models import Event
-from sentry.grouping.component import GroupingComponent
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
-from sentry.grouping.variants import BaseVariant
 from sentry.models.project import Project
 from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG
 from sentry.testutils.pytest.fixtures import InstaSnapshotter, django_db_all
-from tests.sentry.grouping import GROUPING_INPUTS_DIR, GroupingInput, with_grouping_inputs
-
-
-def to_json(value: Any) -> str:
-    return orjson.dumps(value, option=orjson.OPT_SORT_KEYS).decode()
-
-
-def dump_variant(
-    variant: BaseVariant, lines: list[str] | None = None, indent: int = 0
-) -> list[str]:
-    if lines is None:
-        lines = []
-
-    def _dump_component(component: GroupingComponent, indent: int) -> None:
-        if not component.hint and not component.values:
-            return
-        lines.append(
-            "%s%s%s%s"
-            % (
-                "  " * indent,
-                component.id,
-                component.contributes and "*" or "",
-                component.hint and " (%s)" % component.hint or "",
-            )
-        )
-        for value in component.values:
-            if isinstance(value, GroupingComponent):
-                _dump_component(value, indent + 1)
-            else:
-                lines.append("{}{}".format("  " * (indent + 1), to_json(value)))
-
-    lines.append("{}hash: {}".format("  " * indent, to_json(variant.get_hash())))
-
-    for key, value in sorted(variant.__dict__.items()):
-        if isinstance(value, GroupingComponent):
-            lines.append("{}{}:".format("  " * indent, key))
-            _dump_component(value, indent + 1)
-        elif key == "config":
-            # We do not want to dump the config
-            continue
-        else:
-            lines.append("{}{}: {}".format("  " * indent, key, to_json(value)))
-
-    return lines
+from tests.sentry.grouping import (
+    GROUPING_INPUTS_DIR,
+    GroupingInput,
+    dump_variant,
+    with_grouping_inputs,
+)
 
 
 @with_grouping_inputs("grouping_input", GROUPING_INPUTS_DIR)


### PR DESCRIPTION
This makes a few small changes to helpers used in variant (and soon to be grouphash metadata) tests:

- Move `dump_variant` and `to_json` from `test_variants.py` to `__init__.py` so they can be used by both types of tests.

- Add `get_snapshot_path` helper.

- Add an `include_non_contributing` parameter to `dump_variant`, defaulting to `True`. This keeps the current behavior for variants snapshots, but will let grouphash metadata snapshots only include variant values which contribute to grouping.

- Add a `pretty_print` parameter to `to_json`, defaulting to `False`. This similarly preserves the current behavior for variant snapshots, but will allow grouphash metadata snapshots to show hashing metadata in a more readable format. 