### PR TITLE
ref(grouping): Add `create_or_update_grouphash_metadata` helper

### DIFF
--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from sentry.models.grouphash import GroupHash
+from sentry.models.grouphashmetadata import GroupHashMetadata
+
+
+def create_or_update_grouphash_metadata(
+    grouphash: GroupHash,
+    created: bool,
+    grouping_config: str,
+) -> None:
+    # TODO: Do we want to expand this to backfill metadata for existing grouphashes? If we do,
+    # we'll have to override the metadata creation date for them.
+
+    if created:
+        GroupHashMetadata.objects.create(
+            grouphash=grouphash,
+            latest_grouping_config=grouping_config,
+        )
+    elif grouphash.metadata and grouphash.metadata.latest_grouping_config != grouping_config:
+        # Keep track of the most recent config which computed this hash, so that once a
+        # config is deprecated, we can clear out the GroupHash records which are no longer
+        # being produced
+        grouphash.metadata.update(latest_grouping_config=grouping_config)

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -21,9 +21,9 @@ from sentry.grouping.api import (
     load_grouping_config,
 )
 from sentry.grouping.ingest.config import is_in_transition
+from sentry.grouping.ingest.grouphash_metadata import create_or_update_grouphash_metadata
 from sentry.grouping.variants import BaseVariant
 from sentry.models.grouphash import GroupHash
-from sentry.models.grouphashmetadata import GroupHashMetadata
 from sentry.models.project import Project
 from sentry.utils import metrics
 from sentry.utils.metrics import MutableTags
@@ -223,23 +223,10 @@ def get_or_create_grouphashes(
     for hash_value in hashes:
         grouphash, created = GroupHash.objects.get_or_create(project=project, hash=hash_value)
 
-        # TODO: Do we want to expand this to backfill metadata for existing grouphashes? If we do,
-        # we'll have to override the metadata creation date for them.
         if options.get("grouping.grouphash_metadata.ingestion_writes_enabled") and features.has(
             "organizations:grouphash-metadata-creation", project.organization
         ):
-            if created:
-                GroupHashMetadata.objects.create(
-                    grouphash=grouphash,
-                    latest_grouping_config=grouping_config,
-                )
-            elif (
-                grouphash.metadata and grouphash.metadata.latest_grouping_config != grouping_config
-            ):
-                # Keep track of the most recent config which computed this hash, so that once a
-                # config is deprecated, we can clear out the GroupHash records which are no longer
-                # being produced
-                grouphash.metadata.update(latest_grouping_config=grouping_config)
+            create_or_update_grouphash_metadata(grouphash, created, grouping_config)
 
         grouphashes.append(grouphash)
 


### PR DESCRIPTION
This moves the grouphash-metadata-related code from `get_or_create_grouphashes` into a new helper function, `create_or_update_grouphash_metadata`, in its own module, in anticipation of a bunch more related code being added shortly.