### PR TITLE
:mag: nit: don't show audit log toast if user doesn't have permissions

### DIFF
--- a/static/app/views/settings/organizationAuditLog/index.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.tsx
@@ -38,9 +38,7 @@ function OrganizationAuditLog({location}: Props) {
   const organization = useOrganization();
   const api = useApi();
 
-  const hasPermission = !(
-    organization.access.includes('org:write') || isActiveSuperuser()
-  );
+  const hasPermission = organization.access.includes('org:write') || isActiveSuperuser();
 
   const handleCursor: CursorHandler = resultsCursor => {
     setState(prevState => ({

--- a/static/app/views/settings/organizationAuditLog/index.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.tsx
@@ -86,7 +86,9 @@ function OrganizationAuditLog({location}: Props) {
         ...prevState,
         isLoading: false,
       }));
-      addErrorMessage('Unable to load audit logs.');
+      if (err.status !== 403) {
+        addErrorMessage('Unable to load audit logs.');
+      }
     }
   }, [api, organization.slug, state.currentCursor, state.eventType]);
 

--- a/static/app/views/settings/organizationAuditLog/index.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.tsx
@@ -38,6 +38,10 @@ function OrganizationAuditLog({location}: Props) {
   const organization = useOrganization();
   const api = useApi();
 
+  const hasPermission = !(
+    organization.access.includes('org:write') || isActiveSuperuser()
+  );
+
   const handleCursor: CursorHandler = resultsCursor => {
     setState(prevState => ({
       ...prevState,
@@ -52,6 +56,10 @@ function OrganizationAuditLog({location}: Props) {
   }, [location.query]);
 
   const fetchAuditLogData = useCallback(async () => {
+    if (!hasPermission) {
+      return;
+    }
+
     setState(prevState => ({...prevState, isLoading: true}));
 
     try {
@@ -90,7 +98,7 @@ function OrganizationAuditLog({location}: Props) {
         addErrorMessage('Unable to load audit logs.');
       }
     }
-  }, [api, organization.slug, state.currentCursor, state.eventType]);
+  }, [api, organization.slug, state.currentCursor, state.eventType, hasPermission]);
 
   useEffect(() => {
     fetchAuditLogData();
@@ -109,7 +117,7 @@ function OrganizationAuditLog({location}: Props) {
 
   return (
     <Fragment>
-      {organization.access.includes('org:write') || isActiveSuperuser() ? (
+      {hasPermission ? (
         <AuditLogList
           entries={state.entryList}
           pageLinks={state.entryListPageLinks}


### PR DESCRIPTION
if the user doesn't have permissions, lets not show the error toast

before:
![image](https://github.com/user-attachments/assets/c53d56d4-3503-4a15-8764-c533dbef80ad)

after:
![image](https://github.com/user-attachments/assets/c7a2e59d-f01c-43f0-9267-f3376c22b29f)
