### PR TITLE
ref: fix typing for sentry.snuba.discover in mypy 1.12.x

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -1393,8 +1393,7 @@ def find_histogram_min_max(
 
         max_fence_value = max(fences) if fences else None
 
-        candidates = [max_fence_value, max_value]
-        candidates = list(filter(lambda v: v is not None, candidates))
+        candidates = [cand for cand in (max_fence_value, max_value) if cand is not None]
         max_value = min(candidates) if candidates else None
         if max_value is not None and min_value is not None:
             # min_value may be either queried or provided by the user. max_value was queried.


### PR DESCRIPTION
not entirely sure why mypy 1.12.x doesn't want to narrow `list[Any | None]` to `list[Any]` but this fixes the checker either way and simplifies the code 🤷 

<!-- Describe your PR here. -->