### PR TITLE
ref: fix typing for generate_controlsilo_urls in mypy 1.12.x

### DIFF
--- a/src/sentry/management/commands/generate_controlsilo_urls.py
+++ b/src/sentry/management/commands/generate_controlsilo_urls.py
@@ -162,7 +162,7 @@ export default patterns;
             if isinstance(pat, URLPattern):
                 try:
                     if not pat.name:
-                        name = pat.name
+                        name: str | None = pat.name
                     elif namespace:
                         name = f"{namespace}:{pat.name}"
                     else:


### PR DESCRIPTION
mypy now narrows truthiness of a nullable string to `Literal[''] | None` and then infers that as the basis type for `name` here -- the annotation convinces mypy otherwise

<!-- Describe your PR here. -->