### PR TITLE
ref: fix typing for digests.backends.redis in mypy 1.12.x

### DIFF
--- a/src/sentry/digests/backends/redis.py
+++ b/src/sentry/digests/backends/redis.py
@@ -220,12 +220,9 @@ class RedisBackend(Backend):
                     raise
 
             records = [
-                Record(
-                    key.decode(),
-                    self.codec.decode(value) if value is not None else None,
-                    float(timestamp),
-                )
+                Record(key.decode(), self.codec.decode(value), float(timestamp))
                 for key, value, timestamp in response
+                if value is not None
             ]
 
             # If the record value is `None`, this means the record data was


### PR DESCRIPTION
mypy notices that Record argument 2 cannot be None (before there was `Any | None` which is just `Any` so it "allowed it")

<!-- Describe your PR here. -->