### PR TITLE
feat(onboarding-tasks): Add endpoint to get onboarding tasks

### DIFF
--- a/src/sentry/api/endpoints/organization_onboarding_tasks.py
+++ b/src/sentry/api/endpoints/organization_onboarding_tasks.py
@@ -68,7 +68,6 @@ class OrganizationOnboardingTaskEndpoint(OrganizationEndpoint):
         return Response(status=204)
 
     def get(self, request: Request, organization) -> Response:
-
         tasks_to_serialize = list(
             onboarding_tasks.fetch_onboarding_tasks(organization, request.user)
         )

--- a/src/sentry/api/endpoints/organization_onboarding_tasks.py
+++ b/src/sentry/api/endpoints/organization_onboarding_tasks.py
@@ -7,17 +7,19 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.serializers import serialize
 from sentry.models.organizationonboardingtask import OnboardingTaskStatus
 
 
 class OnboardingTaskPermission(OrganizationPermission):
-    scope_map = {"POST": ["org:read"]}
+    scope_map = {"POST": ["org:read"], "GET": ["org:read"]}
 
 
 @region_silo_endpoint
 class OrganizationOnboardingTaskEndpoint(OrganizationEndpoint):
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.TELEMETRY_EXPERIENCE
     permission_classes = (OnboardingTaskPermission,)
@@ -64,3 +66,12 @@ class OrganizationOnboardingTaskEndpoint(OrganizationEndpoint):
             onboarding_tasks.try_mark_onboarding_complete(organization.id)
 
         return Response(status=204)
+
+    def get(self, request: Request, organization) -> Response:
+
+        tasks_to_serialize = list(
+            onboarding_tasks.fetch_onboarding_tasks(organization, request.user)
+        )
+        serialized_tasks = serialize(tasks_to_serialize, request.user)
+
+        return Response({"onboardingTasks": serialized_tasks}, status=200)

--- a/tests/sentry/api/endpoints/test_organization_onboarding_tasks.py
+++ b/tests/sentry/api/endpoints/test_organization_onboarding_tasks.py
@@ -95,3 +95,22 @@ class OrganizationOnboardingTaskEndpointTest(APITestCase):
         assert not OrganizationOnboardingTask.objects.filter(
             organization=self.org, task=OnboardingTask.FIRST_PROJECT
         ).exists()
+
+    def test_get_tasks(self):
+        # create a task
+        self.client.post(self.path, {"task": "create_project", "status": "complete"})
+
+        # get tasks
+        response = self.client.get(self.path)
+        assert response.status_code == 200, response.content
+
+        # Verify that the response contains the 'onboardingTasks' key
+        assert "onboardingTasks" in response.data
+        tasks = response.data["onboardingTasks"]
+
+        # Verify that the 'create_project' task is in the list of onboarding tasks
+        create_project_task = next(
+            (task for task in tasks if task["task"] == "create_project"), None
+        )
+        assert create_project_task is not None
+        assert create_project_task["status"] == "complete"


### PR DESCRIPTION
**Problem**
Users completing tasks in the Quick Start may experience a strange situation where, after completing a task (e.g., sending a release), they still see the "Track releases" task as incomplete. This happens because there is no polling mechanism for the organization's data, where we retrieve the `onboardingTasks` property with the updated task statuses. The UI only reflects changes after a page refresh, which re-fetches the organization endpoint.

**Solution**
Since polling the organization endpoint is heavy (so I have heard many times), I am adding a dedicated `get` function to fetch only the onboarding tasks. This will allow us to safely poll for updates in the Quick Start sidebar, ensuring tasks are marked as complete without needing a full page refresh or re-fetch of the entire organization data.

Contributes to https://github.com/getsentry/projects/issues/248