### PR TITLE
chore(alerts): remove notification-all-recipients flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -211,8 +211,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:more-slow-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     manager.add("organizations:navigation-sidebar-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:new-page-filter", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=True, api_expose=True)
-    # Notify all project members when fallthrough is disabled, instead of just the auto-assignee
-    manager.add("organizations:notification-all-recipients", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Drop obsoleted status changes in occurence consumer
     manager.add("organizations:occurence-consumer-prune-status-changes", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable User Feedback v1

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any
 
 from django.db.models import Q
 
-from sentry import features
 from sentry.eventstore.models import GroupEvent
 from sentry.integrations.types import ExternalProviders
 from sentry.integrations.utils.providers import get_provider_enum_from_string
@@ -207,7 +206,7 @@ def get_owners(
     Given a project and an event, decide which users and teams are the owners.
 
     If when checking owners, there is a rule match we only notify the last owner
-    (would-be auto-assignee) unless the organization passes the feature-flag
+    (would-be auto-assignee)
     """
 
     if event:
@@ -228,11 +227,7 @@ def get_owners(
 
     else:
         outcome = "match"
-        recipients = owners
-        # Used to suppress extra notifications to all matched owners, only notify the would-be auto-assignee
-        if not features.has("organizations:notification-all-recipients", project.organization):
-            recipients = recipients[-1:]
-
+        recipients = owners[-1:]
     return (recipients, outcome)
 
 

--- a/tests/sentry/digests/test_utilities.py
+++ b/tests/sentry/digests/test_utilities.py
@@ -183,14 +183,12 @@ class GetPersonalizedDigestsTestCase(TestCase, SnubaTestCase):
         digest = build_digest(self.project, sort_records(records))[0]
 
         expected_result = {
-            self.user1.id: set(self.team1_events),
             self.user2.id: set(self.team2_events),
             self.user3.id: set(self.team1_events + self.team2_events),
             self.user4.id: set(self.user4_events),
         }
 
-        with self.feature("organizations:notification-all-recipients"):
-            assert_get_personalized_digests(self.project, digest, expected_result)
+        assert_get_personalized_digests(self.project, digest, expected_result)
 
     def test_direct_email(self):
         """When the action type is not Issue Owners, then the target actor gets a digest."""
@@ -251,14 +249,13 @@ class GetPersonalizedDigestsTestCase(TestCase, SnubaTestCase):
         records = [event_to_record(event, (rule,)) for event in events + self.team1_events]
         digest = build_digest(self.project, sort_records(records))[0]
         expected_result = {
-            self.user1.id: set(events + self.team1_events),
+            self.user1.id: set(events),
             self.user2.id: set(events),
             self.user3.id: set(events + self.team1_events),
             self.user4.id: set(events),
             self.user5.id: set(events),
         }
-        with self.feature("organizations:notification-all-recipients"):
-            assert_get_personalized_digests(self.project, digest, expected_result)
+        assert_get_personalized_digests(self.project, digest, expected_result)
 
     def test_empty_records(self):
         assert build_digest(self.project, []) == DigestInfo({}, {}, {})

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -958,12 +958,6 @@ class MailAdapterNotifyIssueOwnersTest(BaseMailAdapterTest):
             fallthrough=True,
         )
 
-        with self.feature("organizations:notification-all-recipients"):
-            event_all_users = self.store_event(
-                data=make_event_data("foo.cbl"), project_id=project.id
-            )
-            self.assert_notify(event_all_users, [user.email, user2.email])
-
         event_team = self.store_event(data=make_event_data("foo.py"), project_id=project.id)
         self.assert_notify(event_team, [user.email, user2.email])
 
@@ -979,12 +973,6 @@ class MailAdapterNotifyIssueOwnersTest(BaseMailAdapterTest):
                 type="alerts",
                 value="never",
             )
-
-        with self.feature("organizations:notification-all-recipients"):
-            event_all_users = self.store_event(
-                data=make_event_data("foo.cbl"), project_id=project.id
-            )
-            self.assert_notify(event_all_users, [user.email])
 
     def test_notify_with_release_tag(self):
         owner = self.create_user(email="theboss@example.com", is_active=True)
@@ -1016,38 +1004,37 @@ class MailAdapterNotifyIssueOwnersTest(BaseMailAdapterTest):
                     type="alerts",
                     value="never",
                 )
-        with self.feature("organizations:notification-all-recipients"):
-            self.create_assert_delete_projectownership(
-                project,
-                [
-                    grammar.Rule(
-                        Matcher("tags.release", "*"),
-                        [Owner("user", user.email)],
-                    ),
-                    grammar.Rule(
-                        Matcher("tags.release", "1"),
-                        [Owner("user", user2.email)],
-                    ),
-                ],
-                {"release": "1"},
-                [user.email, user2.email],
-            )
+        self.create_assert_delete_projectownership(
+            project,
+            [
+                grammar.Rule(
+                    Matcher("tags.release", "*"),
+                    [Owner("user", user.email)],
+                ),
+                grammar.Rule(
+                    Matcher("tags.release", "1"),
+                    [Owner("user", user2.email)],
+                ),
+            ],
+            {"release": "1"},
+            [user2.email],
+        )
 
-            self.create_assert_delete_projectownership(
-                project,
-                [
-                    grammar.Rule(
-                        Matcher("tags.release", "*"),
-                        [Owner("user", user.email)],
-                    ),
-                    grammar.Rule(
-                        Matcher("tags.release", "2"),
-                        [Owner("team", team2.slug)],
-                    ),
-                ],
-                {"release": "2"},
-                [user.email, user3.email, user4.email, user5.email],
-            )
+        self.create_assert_delete_projectownership(
+            project,
+            [
+                grammar.Rule(
+                    Matcher("tags.release", "*"),
+                    [Owner("user", user.email)],
+                ),
+                grammar.Rule(
+                    Matcher("tags.release", "2"),
+                    [Owner("team", team2.slug)],
+                ),
+            ],
+            {"release": "2"},
+            [user3.email, user4.email, user5.email],
+        )
 
     def test_notify_with_dist_tag(self):
         owner = self.create_user(email="theboss@example.com", is_active=True)
@@ -1080,38 +1067,37 @@ class MailAdapterNotifyIssueOwnersTest(BaseMailAdapterTest):
                     value="never",
                 )
 
-        with self.feature("organizations:notification-all-recipients"):
-            self.create_assert_delete_projectownership(
-                project,
-                [
-                    grammar.Rule(
-                        Matcher("tags.dist", "*"),
-                        [Owner("user", user.email)],
-                    ),
-                    grammar.Rule(
-                        Matcher("tags.dist", "rc1"),
-                        [Owner("user", user2.email)],
-                    ),
-                ],
-                {"dist": "rc1", "release": "1"},
-                [user.email, user2.email],
-            )
+        self.create_assert_delete_projectownership(
+            project,
+            [
+                grammar.Rule(
+                    Matcher("tags.dist", "*"),
+                    [Owner("user", user.email)],
+                ),
+                grammar.Rule(
+                    Matcher("tags.dist", "rc1"),
+                    [Owner("user", user2.email)],
+                ),
+            ],
+            {"dist": "rc1", "release": "1"},
+            [user2.email],
+        )
 
-            self.create_assert_delete_projectownership(
-                project,
-                [
-                    grammar.Rule(
-                        Matcher("tags.dist", "*"),
-                        [Owner("user", user.email)],
-                    ),
-                    grammar.Rule(
-                        Matcher("tags.dist", "lenny"),
-                        [Owner("team", team2.slug)],
-                    ),
-                ],
-                {"dist": "lenny", "release": "1"},
-                [user.email, user3.email, user4.email, user5.email],
-            )
+        self.create_assert_delete_projectownership(
+            project,
+            [
+                grammar.Rule(
+                    Matcher("tags.dist", "*"),
+                    [Owner("user", user.email)],
+                ),
+                grammar.Rule(
+                    Matcher("tags.dist", "lenny"),
+                    [Owner("team", team2.slug)],
+                ),
+            ],
+            {"dist": "lenny", "release": "1"},
+            [user3.email, user4.email, user5.email],
+        )
 
     def test_dont_notify_with_dist_if_no_rule(self):
         owner = self.create_user(email="theboss@example.com", is_active=True)
@@ -1121,18 +1107,17 @@ class MailAdapterNotifyIssueOwnersTest(BaseMailAdapterTest):
         user = self.create_user(email="foo@example.com", is_active=True)
         self.create_member(user=user, organization=organization, teams=[team])
 
-        with self.feature("organizations:notification-all-recipients"):
-            self.create_assert_delete_projectownership(
-                project,
-                [
-                    grammar.Rule(
-                        Matcher("tags.abc", "hello"),
-                        [Owner("user", user.email)],
-                    ),
-                ],
-                {"dist": "hello", "release": "1"},
-                [],
-            )
+        self.create_assert_delete_projectownership(
+            project,
+            [
+                grammar.Rule(
+                    Matcher("tags.abc", "hello"),
+                    [Owner("user", user.email)],
+                ),
+            ],
+            {"dist": "hello", "release": "1"},
+            [],
+        )
 
     def test_notify_with_user_tag(self):
         owner = self.create_user(email="theboss@example.com", is_active=True)
@@ -1157,55 +1142,48 @@ class MailAdapterNotifyIssueOwnersTest(BaseMailAdapterTest):
                 user_by_extra,
             ]
         ]
-
-        with self.feature("organizations:notification-all-recipients"):
-            self.create_assert_delete_projectownership(
-                project,
-                [
-                    grammar.Rule(
-                        Matcher("tags.user.id", "unique_id"),
-                        [Owner("user", user_by_id.email)],
-                    ),
-                    grammar.Rule(
-                        Matcher("tags.user.username", "my_user"),
-                        [Owner("user", user_by_username.email)],
-                    ),
-                    grammar.Rule(
-                        Matcher("tags.user.email", "foo@example.com"),
-                        [Owner("user", user_by_email.email)],
-                    ),
-                    grammar.Rule(
-                        Matcher("tags.user.ip_address", "127.0.0.1"),
-                        [Owner("user", user_by_ip.email)],
-                    ),
-                    grammar.Rule(
-                        Matcher("tags.user.subscription", "basic"),
-                        [Owner("user", user_by_sub.email)],
-                    ),
-                    grammar.Rule(
-                        Matcher("tags.user.extra", "detail"),
-                        [Owner("user", user_by_extra.email)],
-                    ),
-                ],
-                {
-                    "user": {
-                        "id": "unique_id",
-                        "username": "my_user",
-                        "email": "foo@example.com",
-                        "ip_address": "127.0.0.1",
-                        "subscription": "basic",
-                        "extra": "detail",
-                    }
-                },
-                [
-                    user_by_id.email,
-                    user_by_username.email,
-                    user_by_email.email,
-                    user_by_ip.email,
-                    user_by_sub.email,
-                    user_by_extra.email,
-                ],
-            )
+        self.create_assert_delete_projectownership(
+            project,
+            [
+                grammar.Rule(
+                    Matcher("tags.user.id", "unique_id"),
+                    [Owner("user", user_by_id.email)],
+                ),
+                grammar.Rule(
+                    Matcher("tags.user.username", "my_user"),
+                    [Owner("user", user_by_username.email)],
+                ),
+                grammar.Rule(
+                    Matcher("tags.user.email", "foo@example.com"),
+                    [Owner("user", user_by_email.email)],
+                ),
+                grammar.Rule(
+                    Matcher("tags.user.ip_address", "127.0.0.1"),
+                    [Owner("user", user_by_ip.email)],
+                ),
+                grammar.Rule(
+                    Matcher("tags.user.subscription", "basic"),
+                    [Owner("user", user_by_sub.email)],
+                ),
+                grammar.Rule(
+                    Matcher("tags.user.extra", "detail"),
+                    [Owner("user", user_by_extra.email)],
+                ),
+            ],
+            {
+                "user": {
+                    "id": "unique_id",
+                    "username": "my_user",
+                    "email": "foo@example.com",
+                    "ip_address": "127.0.0.1",
+                    "subscription": "basic",
+                    "extra": "detail",
+                }
+            },
+            [
+                user_by_extra.email,
+            ],
+        )
 
     def test_notify_with_user_tag_edge_cases(self):
         owner = self.create_user(email="theboss@example.com", is_active=True)
@@ -1244,74 +1222,69 @@ class MailAdapterNotifyIssueOwnersTest(BaseMailAdapterTest):
 
             tags.user:*someemail* #sentry
         """
-        with self.feature("organizations:notification-all-recipients"):
-            dat = {"user": {"username": "someemail@example.com"}}
-            self.create_assert_delete_projectownership(
-                project,
-                [
-                    grammar.Rule(
-                        Matcher("tags.user.username", "someemail@example.com"),
-                        [Owner("user", user_username.email)],
-                    )
-                ],
-                dat,
-                [user_username.email],
-            )
+        dat = {"user": {"username": "someemail@example.com"}}
+        self.create_assert_delete_projectownership(
+            project,
+            [
+                grammar.Rule(
+                    Matcher("tags.user.username", "someemail@example.com"),
+                    [Owner("user", user_username.email)],
+                )
+            ],
+            dat,
+            [user_username.email],
+        )
 
-            self.create_assert_delete_projectownership(
-                project,
-                [
-                    grammar.Rule(
-                        Matcher("tags.user", "someemail@example.com"), [Owner("user", user.email)]
-                    )
-                ],
-                dat,
-                [],
-            )
+        self.create_assert_delete_projectownership(
+            project,
+            [
+                grammar.Rule(
+                    Matcher("tags.user", "someemail@example.com"), [Owner("user", user.email)]
+                )
+            ],
+            dat,
+            [],
+        )
 
-            self.create_assert_delete_projectownership(
-                project,
-                [grammar.Rule(Matcher("tags.user", "*"), [Owner("user", user_star.email)])],
-                dat,
-                [user_star.email],
-            )
+        self.create_assert_delete_projectownership(
+            project,
+            [grammar.Rule(Matcher("tags.user", "*"), [Owner("user", user_star.email)])],
+            dat,
+            [user_star.email],
+        )
 
-            self.create_assert_delete_projectownership(
-                project,
-                [
-                    grammar.Rule(
-                        Matcher("tags.user.username", "*"),
-                        [Owner("user", user_username_star.email)],
-                    )
-                ],
-                dat,
-                [user_username_star.email],
-            )
+        self.create_assert_delete_projectownership(
+            project,
+            [
+                grammar.Rule(
+                    Matcher("tags.user.username", "*"),
+                    [Owner("user", user_username_star.email)],
+                )
+            ],
+            dat,
+            [user_username_star.email],
+        )
 
-            self.create_assert_delete_projectownership(
-                project,
-                [grammar.Rule(Matcher("tags.user", "username"), [Owner("user", user.email)])],
-                dat,
-                [],
-            )
+        self.create_assert_delete_projectownership(
+            project,
+            [grammar.Rule(Matcher("tags.user", "username"), [Owner("user", user.email)])],
+            dat,
+            [],
+        )
 
-            self.create_assert_delete_projectownership(
-                project,
-                [grammar.Rule(Matcher("tags.user", "*someemail*"), [Owner("team", team.slug)])],
-                dat,
-                [u.email for u in [user, user_star, user_username, user_username_star]],
-            )
+        self.create_assert_delete_projectownership(
+            project,
+            [grammar.Rule(Matcher("tags.user", "*someemail*"), [Owner("team", team.slug)])],
+            dat,
+            [u.email for u in [user, user_star, user_username, user_username_star]],
+        )
 
-            self.create_assert_delete_projectownership(
-                project,
-                [
-                    grammar.Rule(
-                        Matcher("tags.user.email", "someemail*"), [Owner("team", team.slug)]
-                    )
-                ],
-                {"user": {"username": "someemail@example.com"}},
-                [],
-            )
+        self.create_assert_delete_projectownership(
+            project,
+            [grammar.Rule(Matcher("tags.user.email", "someemail*"), [Owner("team", team.slug)])],
+            {"user": {"username": "someemail@example.com"}},
+            [],
+        )
 
     def test_group_substatus_header(self):
         event = self.store_event(

--- a/tests/sentry/notifications/utils/test_participants.py
+++ b/tests/sentry/notifications/utils/test_participants.py
@@ -707,17 +707,6 @@ class GetOwnersCase(_ParticipantsTest):
         self.assert_recipients(expected=[], received=recipients)
         assert outcome == "empty"
 
-    # If matched, and all-recipients flag
-    def test_get_owners_match(self):
-        with self.feature("organizations:notification-all-recipients"):
-            self.create_ownership(self.project, [self.rule_1, self.rule_2, self.rule_3])
-            event = self.create_event(self.project)
-            recipients, outcome = get_owners(project=self.project, event=event)
-            self.assert_recipients(
-                expected=[self.team_1, self.team_2, self.user_1], received=recipients
-            )
-            assert outcome == "match"
-
     # If matched, and no all-recipients flag
     def test_get_owners_single_participant(self):
         self.create_ownership(self.project, [self.rule_1, self.rule_2, self.rule_3])


### PR DESCRIPTION
This feature is disabled in production. Remove all references to the flag as part of cleanup for ACI.