### PR TITLE
feat(explore): Sort traces by timestamp

### DIFF
--- a/static/app/views/explore/hooks/useTraces.tsx
+++ b/static/app/views/explore/hooks/useTraces.tsx
@@ -60,9 +60,17 @@ interface UseTracesOptions {
   enabled?: boolean;
   limit?: number;
   query?: string | string[];
+  sort?: 'timestamp' | '-timestamp';
 }
 
-export function useTraces({dataset, datetime, enabled, limit, query}: UseTracesOptions) {
+export function useTraces({
+  dataset,
+  datetime,
+  enabled,
+  limit,
+  query,
+  sort,
+}: UseTracesOptions) {
   const organization = useOrganization();
   const {projects} = useProjects();
   const {selection} = usePageFilters();
@@ -76,6 +84,7 @@ export function useTraces({dataset, datetime, enabled, limit, query}: UseTracesO
       ...normalizeDateTimeParams(datetime ?? selection.datetime),
       dataset,
       query,
+      sort, // only has an effect when `dataset` is `EAPSpans`
       per_page: limit,
       breakdownSlices: BREAKDOWN_SLICES,
     },

--- a/static/app/views/explore/tables/tracesTable/index.tsx
+++ b/static/app/views/explore/tables/tracesTable/index.tsx
@@ -49,6 +49,7 @@ export function TracesTable() {
     dataset,
     query,
     limit: DEFAULT_PER_PAGE,
+    sort: '-timestamp',
   });
 
   const showErrorState = useMemo(() => {


### PR DESCRIPTION
This enables the timestamp sorting on the traces tab in explore.