### PR TITLE
fix(stacktrace): Fix formatting on native frames

### DIFF
--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -2,6 +2,7 @@ import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {CommitRow} from 'sentry/components/commitRow';
+import {Flex} from 'sentry/components/container/flex';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {StacktraceBanners} from 'sentry/components/events/interfaces/crashContent/exception/banners/stacktraceBanners';
 import {getLockReason} from 'sentry/components/events/interfaces/threads/threadSelector/lockReason';
@@ -374,7 +375,9 @@ export function Threads({data, event, projectSlug, groupingCurrentLevel, group}:
         title={tn('Stack Trace', 'Stack Traces', threads.length)}
         type={SectionKey.STACKTRACE}
       >
-        {threadComponent}
+        <Flex column gap={space(2)}>
+          {threadComponent}
+        </Flex>
       </InterimSection>
     ) : (
       threadComponent
@@ -400,7 +403,6 @@ const ThreadStateWrapper = styled('div')`
   flex-direction: row;
   align-items: center;
   gap: ${space(0.5)};
-  padding: ${space(1)} ${space(4)};
 `;
 
 const LockReason = styled(TextOverflow)`
@@ -419,6 +421,10 @@ const ThreadTraceWrapper = styled('div')`
   display: flex;
   flex-direction: column;
   gap: ${space(2)};
+  padding: ${space(1)} ${space(4)};
+  @media (max-width: ${p => p.theme.breakpoints.medium}) {
+    padding: ${space(1)} ${space(2)};
+  }
 `;
 
 const ThreadHeading = styled('h3')`

--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -367,27 +367,21 @@ export function Threads({data, event, projectSlug, groupingCurrentLevel, group}:
     </Fragment>
   );
 
-  // If there is only one thread, we expect the stacktrace to wrap itself in a section
-  return hasMoreThanOneThread && hasStreamlinedUI ? (
-    <InterimSection
-      title={tn('Stack Trace', 'Stack Traces', threads.length)}
-      type={SectionKey.STACKTRACE}
-    >
-      <ThreadTraceWrapper
-        style={{
-          // TODO(issues): Remove on streamline issues ui GA
-          padding:
-            !hasMoreThanOneThread || hasStreamlinedUI
-              ? undefined
-              : `${space(1)} ${space(4)}`,
-        }}
+  if (hasStreamlinedUI) {
+    // If there is only one thread, we expect the stacktrace to wrap itself in a section
+    return hasMoreThanOneThread ? (
+      <InterimSection
+        title={tn('Stack Trace', 'Stack Traces', threads.length)}
+        type={SectionKey.STACKTRACE}
       >
         {threadComponent}
-      </ThreadTraceWrapper>
-    </InterimSection>
-  ) : (
-    threadComponent
-  );
+      </InterimSection>
+    ) : (
+      threadComponent
+    );
+  }
+
+  return <ThreadTraceWrapper>{threadComponent}</ThreadTraceWrapper>;
 }
 
 const Grid = styled('div')`
@@ -406,6 +400,7 @@ const ThreadStateWrapper = styled('div')`
   flex-direction: row;
   align-items: center;
   gap: ${space(0.5)};
+  padding: ${space(1)} ${space(4)};
 `;
 
 const LockReason = styled(TextOverflow)`


### PR DESCRIPTION
Lots of conditional styles here that can't be caught in tests, got screenshots for the things I verified in this PR. Resolves https://github.com/getsentry/sentry/issues/79526. These screenshots are all with this patch applied.

**Current UI**

Single frame: 
<img width="1122" alt="image" src="https://github.com/user-attachments/assets/df8beaa1-52e7-46af-a66b-8d673e933985">

Single frame small width:
<img width="588" alt="image" src="https://github.com/user-attachments/assets/86b706a2-c761-48c5-8703-071e46b7bdb8">

Multiple frame:
<img width="1157" alt="image" src="https://github.com/user-attachments/assets/cdfdb516-652b-4270-92cf-cd924f11cc34">

Multiple frame small width:
<img width="580" alt="image" src="https://github.com/user-attachments/assets/64fc739b-5f36-4bb0-a7ff-14b631763627">


**New UI**

Single frame:
<img width="1166" alt="image" src="https://github.com/user-attachments/assets/0c7efca1-c730-4a37-9d99-050b3e2af827">

Single frame small width:
<img width="587" alt="image" src="https://github.com/user-attachments/assets/1fa6875d-21df-46af-afcd-8cd947372549">

Multiple frames:
<img width="1128" alt="image" src="https://github.com/user-attachments/assets/3382235d-4c07-4be7-a623-aea19ba790d3">

Multiple frames small width:
<img width="918" alt="image" src="https://github.com/user-attachments/assets/7b82fbe8-2449-477f-aa4c-7338d951c3e8">


