### PR TITLE
feat(issues): Persist issues graph when changing query

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -35,7 +35,7 @@
     // Type checking specific options
     "alwaysStrict": false,
     "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noUnusedLocals": true,

--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -35,7 +35,7 @@
     // Type checking specific options
     "alwaysStrict": false,
     "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": true,
+    "noImplicitAny": false,
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noUnusedLocals": true,

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
@@ -145,14 +145,6 @@ function GroupEventDetails(props: GroupEventDetailsProps) {
 
   const renderContent = () => {
     if (loadingEvent) {
-      if (hasStreamlinedUI) {
-        return (
-          <Fragment>
-            <EventDetailsHeader event={event} group={group} />
-            <LoadingIndicator />;
-          </Fragment>
-        );
-      }
       return <LoadingIndicator />;
     }
 
@@ -209,6 +201,9 @@ function GroupEventDetails(props: GroupEventDetailsProps) {
                     project={project}
                   />
                 )}
+                {hasStreamlinedUI ? (
+                  <EventDetailsHeader event={event} group={group} />
+                ) : null}
                 {renderContent()}
               </MainLayoutComponent>
               {hasStreamlinedUI ? (

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
@@ -28,6 +28,7 @@ import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageStat
 import GroupEventDetailsContent from 'sentry/views/issueDetails/groupEventDetails/groupEventDetailsContent';
 import GroupEventHeader from 'sentry/views/issueDetails/groupEventHeader';
 import GroupSidebar from 'sentry/views/issueDetails/groupSidebar';
+import {EventDetailsHeader} from 'sentry/views/issueDetails/streamline/eventDetailsHeader';
 import StreamlinedSidebar from 'sentry/views/issueDetails/streamline/sidebar';
 
 import ReprocessingProgress from '../reprocessingProgress';
@@ -144,6 +145,14 @@ function GroupEventDetails(props: GroupEventDetailsProps) {
 
   const renderContent = () => {
     if (loadingEvent) {
+      if (hasStreamlinedUI) {
+        return (
+          <Fragment>
+            <EventDetailsHeader event={event} group={group} />
+            <LoadingIndicator />;
+          </Fragment>
+        );
+      }
       return <LoadingIndicator />;
     }
 

--- a/static/app/views/issueDetails/streamline/eventDetails.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetails.tsx
@@ -18,7 +18,6 @@ import {
   useEventDetails,
   useEventDetailsReducer,
 } from 'sentry/views/issueDetails/streamline/context';
-import {EventDetailsHeader} from 'sentry/views/issueDetails/streamline/eventDetailsHeader';
 import {EventList} from 'sentry/views/issueDetails/streamline/eventList';
 import {EventNavigation} from 'sentry/views/issueDetails/streamline/eventNavigation';
 import {useEventQuery} from 'sentry/views/issueDetails/streamline/eventSearch';
@@ -38,7 +37,6 @@ export function EventDetails({
 
   return (
     <EventDetailsContext.Provider value={{...eventDetails, dispatch}}>
-      <EventDetailsHeader event={event} group={group} />
       {/* TODO(issues): We should use the router for this */}
       {currentTab === Tab.EVENTS && (
         <PageErrorBoundary mini message={t('There was an error loading the event list')}>

--- a/static/app/views/issueDetails/streamline/eventDetails.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetails.tsx
@@ -2,22 +2,13 @@ import {useLayoutEffect, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import Feature from 'sentry/components/acl/feature';
-import Alert from 'sentry/components/alert';
 import ErrorBoundary from 'sentry/components/errorBoundary';
-import {GroupSummary} from 'sentry/components/group/groupSummary';
-import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
-import type {MultiSeriesEventsStats} from 'sentry/types/organization';
 import {useIsStuck} from 'sentry/utils/useIsStuck';
-import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
-import {useNavigate} from 'sentry/utils/useNavigate';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import {
   EventDetailsContent,
   type EventDetailsContentProps,
@@ -27,18 +18,11 @@ import {
   useEventDetails,
   useEventDetailsReducer,
 } from 'sentry/views/issueDetails/streamline/context';
-import {EventGraph} from 'sentry/views/issueDetails/streamline/eventGraph';
+import {EventDetailsHeader} from 'sentry/views/issueDetails/streamline/eventDetailsHeader';
 import {EventList} from 'sentry/views/issueDetails/streamline/eventList';
 import {EventNavigation} from 'sentry/views/issueDetails/streamline/eventNavigation';
-import {
-  EventSearch,
-  useEventQuery,
-} from 'sentry/views/issueDetails/streamline/eventSearch';
+import {useEventQuery} from 'sentry/views/issueDetails/streamline/eventSearch';
 import {IssueContent} from 'sentry/views/issueDetails/streamline/issueContent';
-import {
-  useIssueDetailsDiscoverQuery,
-  useIssueDetailsEventView,
-} from 'sentry/views/issueDetails/streamline/useIssueDetailsDiscoverQuery';
 import {Tab} from 'sentry/views/issueDetails/types';
 import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
 
@@ -47,70 +31,14 @@ export function EventDetails({
   event,
   project,
 }: Required<EventDetailsContentProps>) {
-  const location = useLocation();
-  const navigate = useNavigate();
-  const {selection} = usePageFilters();
-  const {environments} = selection;
   const {eventDetails, dispatch} = useEventDetailsReducer();
-
   const searchQuery = useEventQuery({group});
-  const eventView = useIssueDetailsEventView({group});
-  const {currentTab} = useGroupDetailsRoute();
 
-  const {
-    data: groupStats,
-    isPending: isLoadingStats,
-    error,
-  } = useIssueDetailsDiscoverQuery<MultiSeriesEventsStats>({
-    params: {
-      route: 'events-stats',
-      eventView,
-      referrer: 'issue_details.streamline_graph',
-    },
-  });
+  const {currentTab} = useGroupDetailsRoute();
 
   return (
     <EventDetailsContext.Provider value={{...eventDetails, dispatch}}>
-      <Feature features={['organizations:ai-summary']}>
-        <GroupSummary groupId={group.id} groupCategory={group.issueCategory} />
-      </Feature>
-      <PageErrorBoundary mini message={t('There was an error loading the event filter')}>
-        <FilterContainer>
-          <EnvironmentPageFilter />
-          <SearchFilter
-            group={group}
-            handleSearch={query => {
-              navigate({...location, query: {...location.query, query}}, {replace: true});
-            }}
-            environments={environments}
-            query={searchQuery}
-            queryBuilderProps={{
-              disallowFreeText: true,
-            }}
-          />
-          <DatePageFilter />
-        </FilterContainer>
-      </PageErrorBoundary>
-      {error ? (
-        <div>
-          <GraphAlert type="error" showIcon>
-            {error.message}
-          </GraphAlert>
-        </div>
-      ) : (
-        <PageErrorBoundary mini message={t('There was an error loading the event graph')}>
-          {!isLoadingStats && groupStats && (
-            <ExtraContent>
-              <EventGraph
-                event={event}
-                group={group}
-                groupStats={groupStats}
-                searchQuery={searchQuery}
-              />
-            </ExtraContent>
-          )}
-        </PageErrorBoundary>
-      )}
+      <EventDetailsHeader event={event} group={group} />
       {/* TODO(issues): We should use the router for this */}
       {currentTab === Tab.EVENTS && (
         <PageErrorBoundary mini message={t('There was an error loading the event list')}>
@@ -183,16 +111,6 @@ function StickyEventNav({
   );
 }
 
-const SearchFilter = styled(EventSearch)`
-  border-radius: ${p => p.theme.borderRadius};
-`;
-
-const FilterContainer = styled('div')`
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: ${space(1.5)};
-`;
-
 const FloatingEventNavigation = styled(EventNavigation)`
   position: sticky;
   top: 0;
@@ -220,11 +138,6 @@ const GroupContent = styled(ExtraContent)`
 
 const ContentPadding = styled('div')`
   padding: ${space(1)} ${space(1.5)};
-`;
-
-const GraphAlert = styled(Alert)`
-  margin: 0;
-  border: 1px solid ${p => p.theme.translucentBorder};
 `;
 
 const PageErrorBoundary = styled(ErrorBoundary)`

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
@@ -9,11 +9,16 @@ import {TagsFixture} from 'sentry-fixture/tags';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import ProjectsStore from 'sentry/stores/projectsStore';
+
 import {EventDetailsHeader} from './eventDetailsHeader';
 
 describe('EventDetailsHeader', () => {
   const organization = OrganizationFixture();
-  const project = ProjectFixture();
+  const project = ProjectFixture({
+    environments: ['production', 'staging', 'development'],
+  });
   const group = GroupFixture();
   const event = EventFixture({id: 'event-id'});
   const persistantQuery = `issue:${group.shortId}`;
@@ -28,6 +33,16 @@ describe('EventDetailsHeader', () => {
       body: TagsFixture(),
       method: 'GET',
     });
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(
+      {
+        projects: [],
+        environments: [],
+        datetime: {start: null, end: null, period: '14d', utc: null},
+      },
+      new Set(['environments'])
+    );
+    ProjectsStore.loadInitialData([project]);
     mockEventStats = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events-stats/`,
       body: {'count()': EventsStatsFixture(), 'count_unique(user)': EventsStatsFixture()},

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -56,7 +56,7 @@ export function EventDetailsHeader({
       </PageErrorBoundary>
       <PageErrorBoundary mini message={t('There was an error loading the event graph')}>
         <ExtraContent>
-          <EventGraph event={event} group={group} searchQuery={searchQuery} />
+          <EventGraph event={event} group={group} />
         </ExtraContent>
       </PageErrorBoundary>
     </Fragment>

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -1,0 +1,85 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import Feature from 'sentry/components/acl/feature';
+import ErrorBoundary from 'sentry/components/errorBoundary';
+import {GroupSummary} from 'sentry/components/group/groupSummary';
+import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
+import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Event} from 'sentry/types/event';
+import type {Group} from 'sentry/types/group';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {
+  EventSearch,
+  useEventQuery,
+} from 'sentry/views/issueDetails/streamline/eventSearch';
+import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
+
+import {EventGraph} from './eventGraph';
+
+export function EventDetailsHeader({
+  group,
+  event,
+}: {
+  event: Event | undefined;
+  group: Group;
+}) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const environments = useEnvironmentsFromUrl();
+  const searchQuery = useEventQuery({group});
+
+  return (
+    <Fragment>
+      <Feature features={['organizations:ai-summary']}>
+        <GroupSummary groupId={group.id} groupCategory={group.issueCategory} />
+      </Feature>
+      <PageErrorBoundary mini message={t('There was an error loading the event filter')}>
+        <FilterContainer>
+          <EnvironmentPageFilter />
+          <SearchFilter
+            group={group}
+            handleSearch={query => {
+              navigate({...location, query: {...location.query, query}}, {replace: true});
+            }}
+            environments={environments}
+            query={searchQuery}
+            queryBuilderProps={{
+              disallowFreeText: true,
+            }}
+          />
+          <DatePageFilter />
+        </FilterContainer>
+      </PageErrorBoundary>
+      <PageErrorBoundary mini message={t('There was an error loading the event graph')}>
+        <ExtraContent>
+          <EventGraph event={event} group={group} searchQuery={searchQuery} />
+        </ExtraContent>
+      </PageErrorBoundary>
+    </Fragment>
+  );
+}
+
+const SearchFilter = styled(EventSearch)`
+  border-radius: ${p => p.theme.borderRadius};
+`;
+
+const FilterContainer = styled('div')`
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: ${space(1.5)};
+`;
+
+const PageErrorBoundary = styled(ErrorBoundary)`
+  margin: 0;
+  border: 1px solid ${p => p.theme.translucentBorder};
+`;
+
+const ExtraContent = styled('div')`
+  border: 1px solid ${p => p.theme.translucentBorder};
+  background: ${p => p.theme.background};
+  border-radius: ${p => p.theme.borderRadius};
+`;

--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -196,16 +196,7 @@ export function EventGraph({group, event}: EventGraphProps) {
           </Callout>
         </SummaryContainer>
         <LoadingChartContainer>
-          <Placeholder
-            style={{
-              position: 'absolute',
-              width: 'initial',
-              top: space(1),
-              left: space(1),
-              right: space(1),
-              bottom: space(1),
-            }}
-          />
+          <Placeholder height="96px" />
         </LoadingChartContainer>
       </GraphWrapper>
     );
@@ -334,12 +325,6 @@ const ChartContainer = styled('div')`
 const LoadingChartContainer = styled('div')`
   position: relative;
   padding: ${space(1)} ${space(1)};
-  display: flex;
-  align-items: center;
-  flex-direction: column;
-  & > div {
-    flex-grow: 1;
-  }
 `;
 
 const OpenInDiscoverButton = styled('div')`

--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -34,7 +34,6 @@ export const enum EventGraphSeries {
 interface EventGraphProps {
   event: Event | undefined;
   group: Group;
-  searchQuery: string;
 }
 
 function createSeriesAndCount(stats: EventsStats) {
@@ -56,13 +55,13 @@ function createSeriesAndCount(stats: EventsStats) {
   );
 }
 
-export function EventGraph({group, searchQuery, event}: EventGraphProps) {
+export function EventGraph({group, event}: EventGraphProps) {
   const theme = useTheme();
   const organization = useOrganization();
   const [visibleSeries, setVisibleSeries] = useState<EventGraphSeries>(
     EventGraphSeries.EVENT
   );
-  const eventView = useIssueDetailsEventView({group, queryProps: {query: searchQuery}});
+  const eventView = useIssueDetailsEventView({group});
 
   const {
     data: groupStats = {},

--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -2,11 +2,13 @@ import {useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import Alert from 'sentry/components/alert';
 import {LinkButton} from 'sentry/components/button';
 import {BarChart, type BarChartSeries} from 'sentry/components/charts/barChart';
 import Legend from 'sentry/components/charts/components/legend';
 import {useChartZoom} from 'sentry/components/charts/useChartZoom';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
+import Placeholder from 'sentry/components/placeholder';
 import {IconTelescope} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -19,16 +21,19 @@ import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import useOrganization from 'sentry/utils/useOrganization';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import useFlagSeries from 'sentry/views/issueDetails/streamline/flagSeries';
-import {useIssueDetailsEventView} from 'sentry/views/issueDetails/streamline/useIssueDetailsDiscoverQuery';
+import {
+  useIssueDetailsDiscoverQuery,
+  useIssueDetailsEventView,
+} from 'sentry/views/issueDetails/streamline/useIssueDetailsDiscoverQuery';
 
 export const enum EventGraphSeries {
   EVENT = 'event',
   USER = 'user',
 }
+
 interface EventGraphProps {
-  event: Event;
+  event: Event | undefined;
   group: Group;
-  groupStats: MultiSeriesEventsStats;
   searchQuery: string;
 }
 
@@ -51,26 +56,40 @@ function createSeriesAndCount(stats: EventsStats) {
   );
 }
 
-export function EventGraph({group, groupStats, searchQuery, event}: EventGraphProps) {
+export function EventGraph({group, searchQuery, event}: EventGraphProps) {
   const theme = useTheme();
   const organization = useOrganization();
   const [visibleSeries, setVisibleSeries] = useState<EventGraphSeries>(
     EventGraphSeries.EVENT
   );
+  const eventView = useIssueDetailsEventView({group, queryProps: {query: searchQuery}});
+
+  const {
+    data: groupStats = {},
+    isPending: isLoadingStats,
+    error,
+  } = useIssueDetailsDiscoverQuery<MultiSeriesEventsStats>({
+    params: {
+      route: 'events-stats',
+      eventView,
+      referrer: 'issue_details.streamline_graph',
+    },
+  });
 
   const [isGraphHovered, setIsGraphHovered] = useState(false);
-  const eventStats = groupStats['count()'];
-  const {series: eventSeries, count: eventCount} = useMemo(
-    () => createSeriesAndCount(eventStats),
-    [eventStats]
-  );
-  const userStats = groupStats['count_unique(user)'];
-  const {series: userSeries, count: userCount} = useMemo(
-    () => createSeriesAndCount(userStats),
-    [userStats]
-  );
+  const {series: eventSeries, count: eventCount} = useMemo(() => {
+    if (!groupStats['count()']) {
+      return {series: [], count: 0};
+    }
+    return createSeriesAndCount(groupStats['count()']);
+  }, [groupStats]);
+  const {series: userSeries, count: userCount} = useMemo(() => {
+    if (!groupStats['count_unique(user)']) {
+      return {series: [], count: 0};
+    }
+    return createSeriesAndCount(groupStats['count_unique(user)']);
+  }, [groupStats]);
 
-  const eventView = useIssueDetailsEventView({group, queryProps: {query: searchQuery}});
   const discoverUrl = eventView.getResultsViewUrlTarget(
     organization.slug,
     false,
@@ -92,7 +111,7 @@ export function EventGraph({group, groupStats, searchQuery, event}: EventGraphPr
   const series = useMemo((): BarChartSeries[] => {
     const seriesData: BarChartSeries[] = [];
 
-    if (eventStats && visibleSeries === EventGraphSeries.USER) {
+    if (visibleSeries === EventGraphSeries.USER) {
       seriesData.push({
         seriesName: t('Users'),
         itemStyle: {
@@ -102,9 +121,10 @@ export function EventGraph({group, groupStats, searchQuery, event}: EventGraphPr
         },
         stack: 'stats',
         data: userSeries,
+        animation: false,
       });
     }
-    if (eventStats && visibleSeries === EventGraphSeries.EVENT) {
+    if (visibleSeries === EventGraphSeries.EVENT) {
       seriesData.push({
         seriesName: t('Events'),
         itemStyle: {
@@ -114,6 +134,7 @@ export function EventGraph({group, groupStats, searchQuery, event}: EventGraphPr
         },
         stack: 'stats',
         data: eventSeries,
+        animation: false,
       });
     }
 
@@ -122,7 +143,7 @@ export function EventGraph({group, groupStats, searchQuery, event}: EventGraphPr
     }
 
     return seriesData;
-  }, [eventStats, visibleSeries, userSeries, eventSeries, flagSeries, theme]);
+  }, [visibleSeries, userSeries, eventSeries, flagSeries, theme]);
 
   const [legendSelected, setLegendSelected] = useState({
     ['Feature Flags']: true,
@@ -151,6 +172,45 @@ export function EventGraph({group, groupStats, searchQuery, event}: EventGraphPr
       },
     []
   );
+
+  if (error) {
+    return (
+      <GraphAlert type="error" showIcon>
+        {error.message}
+      </GraphAlert>
+    );
+  }
+
+  if (isLoadingStats) {
+    return (
+      <GraphWrapper>
+        <SummaryContainer>
+          <Callout isActive={visibleSeries === EventGraphSeries.EVENT} disabled>
+            <InteractionStateLayer hidden={visibleSeries === EventGraphSeries.EVENT} />
+            <Label>{tn('Event', 'Events', eventCount)}</Label>
+            <Count>-</Count>
+          </Callout>
+          <Callout isActive={visibleSeries === EventGraphSeries.USER} disabled>
+            <InteractionStateLayer hidden={visibleSeries === EventGraphSeries.USER} />
+            <Label>{t('Users')}</Label>
+            <Count>-</Count>
+          </Callout>
+        </SummaryContainer>
+        <LoadingChartContainer>
+          <Placeholder
+            style={{
+              position: 'absolute',
+              width: 'initial',
+              top: space(1),
+              left: space(1),
+              right: space(1),
+              bottom: space(1),
+            }}
+          />
+        </LoadingChartContainer>
+      </GraphWrapper>
+    );
+  }
 
   return (
     <GraphWrapper>
@@ -268,12 +328,28 @@ const Count = styled('div')`
 `;
 
 const ChartContainer = styled('div')`
-  padding: ${space(0.75)} ${space(1)} ${space(0.75)} 0;
   position: relative;
+  padding: ${space(0.75)} ${space(1)} ${space(0.75)} 0;
+`;
+
+const LoadingChartContainer = styled('div')`
+  position: relative;
+  padding: ${space(1)} ${space(1)};
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  & > div {
+    flex-grow: 1;
+  }
 `;
 
 const OpenInDiscoverButton = styled('div')`
   position: absolute;
   top: ${space(1)};
   right: ${space(1)};
+`;
+
+const GraphAlert = styled(Alert)`
+  margin: 0;
+  border: 1px solid ${p => p.theme.translucentBorder};
 `;

--- a/static/app/views/issueDetails/streamline/eventList.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventList.spec.tsx
@@ -7,13 +7,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {TagsFixture} from 'sentry-fixture/tags';
 
-import {
-  render,
-  renderHook,
-  screen,
-  userEvent,
-  waitFor,
-} from 'sentry-test/reactTestingLibrary';
+import {render, renderHook, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
@@ -21,9 +15,6 @@ import {useEventColumns} from 'sentry/views/issueDetails/allEventsTable';
 import {EventDetails} from 'sentry/views/issueDetails/streamline/eventDetails';
 import {MOCK_EVENTS_TABLE_DATA} from 'sentry/views/performance/transactionSummary/transactionEvents/testUtils';
 
-jest.mock('sentry/components/events/suspectCommits');
-jest.mock('sentry/views/issueDetails/groupEventDetails/groupEventDetailsContent');
-jest.mock('sentry/views/issueDetails/streamline/issueContent');
 jest.mock('screenfull', () => ({
   enabled: true,
   isFullscreen: false,
@@ -146,7 +137,9 @@ describe('EventList', () => {
     expect(screen.getByRole('button', {name: 'Next Page'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Close'})).toBeInTheDocument();
     expect(
-      screen.getByText(`Showing 0-${MOCK_EVENTS_TABLE_DATA.length} of ${totalCount}`)
+      await screen.findByText(
+        `Showing 0-${MOCK_EVENTS_TABLE_DATA.length} of ${totalCount}`
+      )
     ).toBeInTheDocument();
 
     // Returns minidump column, but we omit it as a custom column
@@ -154,24 +147,6 @@ describe('EventList', () => {
     for (const title of columns) {
       expect(screen.getByRole('columnheader', {name: title})).toBeInTheDocument();
     }
-  });
-
-  it('allows filtering by environment', async function () {
-    renderAllEvents();
-
-    await userEvent.click(screen.getByRole('button', {name: 'All Envs'}));
-    await userEvent.click(screen.getByRole('row', {name: 'production'}));
-
-    const expectedArgs = [
-      '/organizations/org-slug/events/',
-      expect.objectContaining({
-        query: expect.objectContaining({
-          environment: ['production'],
-        }),
-      }),
-    ];
-    expect(mockEventList).toHaveBeenCalledWith(...expectedArgs);
-    expect(mockEventListMeta).toHaveBeenCalledWith(...expectedArgs);
   });
 
   it('updates query from location param change', async function () {
@@ -203,24 +178,6 @@ describe('EventList', () => {
     await waitFor(() => {
       expect(mockEventList).toHaveBeenCalledWith(...expectedArgs);
     });
-    expect(mockEventListMeta).toHaveBeenCalledWith(...expectedArgs);
-  });
-
-  it('allows filtering by date', async function () {
-    renderAllEvents();
-
-    await userEvent.click(screen.getByRole('button', {name: '14D'}));
-    await userEvent.click(screen.getByRole('option', {name: 'Last 7 days'}));
-
-    const expectedArgs = [
-      '/organizations/org-slug/events/',
-      expect.objectContaining({
-        query: expect.objectContaining({
-          statsPeriod: '7d',
-        }),
-      }),
-    ];
-    expect(mockEventList).toHaveBeenCalledWith(...expectedArgs);
     expect(mockEventListMeta).toHaveBeenCalledWith(...expectedArgs);
   });
 });

--- a/static/app/views/issueDetails/streamline/flagSeries.tsx
+++ b/static/app/views/issueDetails/streamline/flagSeries.tsx
@@ -32,7 +32,7 @@ type FlagSeriesDatapoint = {
 };
 
 interface FlagSeriesProps {
-  event: Event;
+  event: Event | undefined;
   query: Record<string, any>;
 }
 
@@ -117,7 +117,7 @@ export default function useFlagSeries({query = {}, event}: FlagSeriesProps) {
           '</div>',
           '<div class="tooltip-footer">',
           time,
-          event.dateCreated &&
+          event?.dateCreated &&
             ` (${moment(time).from(event.dateCreated, true)} ${t('before this event')})`,
           '</div>',
           '<div class="tooltip-arrow"></div>',

--- a/static/app/views/issueDetails/streamline/useIssueDetailsDiscoverQuery.tsx
+++ b/static/app/views/issueDetails/streamline/useIssueDetailsDiscoverQuery.tsx
@@ -1,5 +1,3 @@
-import {useMemo} from 'react';
-
 import {getInterval} from 'sentry/components/charts/utils';
 import type {Group} from 'sentry/types/group';
 import type {NewQuery, SavedQuery} from 'sentry/types/organization';
@@ -29,8 +27,7 @@ export function useIssueDetailsEventView({
   const interval = getInterval(pageFilters.datetime, 'low');
   const config = getConfigForIssueType(group, group.project);
 
-  const {query: propQuery = '', ...overrideQueryProps} = queryProps ?? {};
-  const query = [`issue:${group.shortId}`, searchQuery, propQuery]
+  const query = [`issue:${group.shortId}`, searchQuery]
     .filter(s => s.length > 0)
     .join(' ');
 
@@ -47,8 +44,8 @@ export function useIssueDetailsEventView({
     yAxis: ['count()', 'count_unique(user)'],
     fields: ['title', 'release', 'environment', 'user.display', 'timestamp'],
     name: group.title || group.type,
+    ...queryProps,
     query,
-    ...overrideQueryProps,
   };
   return EventView.fromSavedQuery(discoverQuery);
 }

--- a/static/app/views/issueDetails/streamline/useIssueDetailsDiscoverQuery.tsx
+++ b/static/app/views/issueDetails/streamline/useIssueDetailsDiscoverQuery.tsx
@@ -74,6 +74,8 @@ export function useIssueDetailsDiscoverQuery<T>({
       interval: eventView.interval,
       yAxis: eventView.yAxis,
       partial: 1,
+      // Cursor on issue details can be used for other pagination
+      cursor: undefined,
     }),
     options,
     referrer,

--- a/static/app/views/issueDetails/streamline/useIssueDetailsDiscoverQuery.tsx
+++ b/static/app/views/issueDetails/streamline/useIssueDetailsDiscoverQuery.tsx
@@ -1,3 +1,5 @@
+import {useMemo} from 'react';
+
 import {getInterval} from 'sentry/components/charts/utils';
 import type {Group} from 'sentry/types/group';
 import type {NewQuery, SavedQuery} from 'sentry/types/organization';


### PR DESCRIPTION
header (graph, search, ai) no longer disappears on loading or error state.
Ai is going to move again so just ignore that.

disable the graph animation for now, flickering quite a bit on page route change