### PR TITLE
ref(crons): Drop non-bulk volume update functions

### DIFF
--- a/src/sentry/monitors/clock_dispatch.py
+++ b/src/sentry/monitors/clock_dispatch.py
@@ -85,27 +85,7 @@ def _make_reference_ts(ts: datetime):
     return int(ts.replace(second=0, microsecond=0).timestamp())
 
 
-def update_check_in_volume(ts: datetime):
-    """
-    Increment a counter for this particular timestamp trimmed down to the
-    minute.
-
-    This counter will be used as historical data to help incidate if we may
-    have had some data-loss (due to an incident) and would want to tick our
-    clock in a mode where misses and time-outs are created as "unknown".
-    """
-    redis_client = redis.redis_clusters.get(settings.SENTRY_MONITORS_REDIS_CLUSTER)
-
-    reference_ts = _make_reference_ts(ts)
-    key = MONITOR_VOLUME_HISTORY.format(reference_ts)
-
-    pipeline = redis_client.pipeline()
-    pipeline.incr(key, amount=1)
-    pipeline.expire(key, MONITOR_VOLUME_RETENTION)
-    pipeline.execute()
-
-
-def bulk_update_check_in_volume(ts_list: Sequence[datetime]):
+def update_check_in_volume(ts_list: Sequence[datetime]):
     """
     Increment counters for a list of check-in timestamps. Each timestamp will be
     trimmed to the minute and groupped appropriately

--- a/tests/sentry/monitors/consumers/test_monitor_consumer.py
+++ b/tests/sentry/monitors/consumers/test_monitor_consumer.py
@@ -1045,8 +1045,8 @@ class MonitorConsumerTest(TestCase):
             logger.exception.assert_called_with("Failed to trigger monitor tasks")
             try_monitor_clock_tick.side_effect = None
 
-    @mock.patch("sentry.monitors.consumers.monitor_consumer.bulk_update_check_in_volume")
-    def test_parallel_monitor_update_check_in_volume(self, bulk_update_check_in_volume):
+    @mock.patch("sentry.monitors.consumers.monitor_consumer.update_check_in_volume")
+    def test_parallel_monitor_update_check_in_volume(self, update_check_in_volume):
         factory = StoreMonitorCheckInStrategyFactory(mode="parallel", max_batch_size=4)
         commit = mock.Mock()
         consumer = factory.create_with_partitions(commit, {self.partition: 0})
@@ -1065,8 +1065,8 @@ class MonitorConsumerTest(TestCase):
         # yet be processed itself)
         self.send_checkin(monitor.slug, consumer=consumer, ts=now + timedelta(minutes=2))
 
-        assert bulk_update_check_in_volume.call_count == 1
-        assert list(bulk_update_check_in_volume.call_args_list[0][0][0]) == [
+        assert update_check_in_volume.call_count == 1
+        assert list(update_check_in_volume.call_args_list[0][0][0]) == [
             now,
             now + timedelta(seconds=10),
             now + timedelta(seconds=30),


### PR DESCRIPTION
Just always use the bulk update version