### PR TITLE
feat(issue-details): Add first/last seen back to streamlined sidebar

### DIFF
--- a/static/app/components/group/externalIssuesList/streamlinedExternalIssueList.tsx
+++ b/static/app/components/group/externalIssuesList/streamlinedExternalIssueList.tsx
@@ -145,6 +145,7 @@ const IssueActionWrapper = styled('div')`
 
 const StyledSectionTitle = styled(SidebarSection.Title)`
   margin-top: ${space(0.25)};
+  color: ${p => p.theme.headingColor};
 `;
 
 const LinkedIssue = styled(LinkButton)`

--- a/static/app/views/issueDetails/streamline/activitySection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/activitySection.spec.tsx
@@ -1,6 +1,5 @@
 import {GroupFixture} from 'sentry-fixture/group';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {ReleaseFixture} from 'sentry-fixture/release';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {
@@ -25,9 +24,6 @@ describe('StreamlinedActivitySection', function () {
   ProjectsStore.loadInitialData([project]);
   GroupStore.init();
 
-  const firstRelease = ReleaseFixture({id: '1'});
-  const lastRelease = ReleaseFixture({id: '2'});
-
   const group = GroupFixture({
     id: '1337',
     activity: [
@@ -49,12 +45,6 @@ describe('StreamlinedActivitySection', function () {
     const deleteMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/1337/comments/note-1/',
       method: 'DELETE',
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${group.id}/first-last-release/`,
-      method: 'GET',
-      body: {firstRelease, lastRelease},
     });
 
     render(<StreamlinedActivitySection group={group} />);
@@ -90,12 +80,6 @@ describe('StreamlinedActivitySection', function () {
         },
       ],
       project,
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${updatedActivityGroup.id}/first-last-release/`,
-      method: 'GET',
-      body: {firstRelease, lastRelease},
     });
 
     render(<StreamlinedActivitySection group={updatedActivityGroup} />);

--- a/static/app/views/issueDetails/streamline/firstLastSeenSection.tsx
+++ b/static/app/views/issueDetails/streamline/firstLastSeenSection.tsx
@@ -1,0 +1,97 @@
+import styled from '@emotion/styled';
+
+import TimeSince from 'sentry/components/timeSince';
+import Version from 'sentry/components/version';
+import {tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Group} from 'sentry/types/group';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+import type {GroupRelease} from 'sentry/views/issueDetails/streamline/activitySection';
+
+export default function FirstLastSeenSection({group}: {group: Group}) {
+  const organization = useOrganization();
+
+  const {data: groupReleaseData} = useApiQuery<GroupRelease>(
+    [`/organizations/${organization.slug}/issues/${group.id}/first-last-release/`],
+    {
+      staleTime: 30000,
+      gcTime: 30000,
+    }
+  );
+
+  return (
+    <FirstLastSeen>
+      <div>
+        <Title>
+          {tct('Last seen [timeSince]', {
+            timeSince: <StyledTimeSince date={group.lastSeen} />,
+          })}
+        </Title>
+        {groupReleaseData?.firstRelease && (
+          <SubtitleWrapper>
+            {tct('in release [release]', {
+              release: (
+                <ReleaseWrapper>
+                  <Version
+                    version={groupReleaseData.firstRelease.version}
+                    projectId={group.project.id}
+                    tooltipRawVersion
+                  />
+                </ReleaseWrapper>
+              ),
+            })}
+          </SubtitleWrapper>
+        )}
+      </div>
+      <div>
+        <Title>
+          {tct('First seen [timeSince]', {
+            timeSince: <StyledTimeSince date={group.firstSeen} />,
+          })}
+        </Title>
+        {groupReleaseData?.lastRelease && (
+          <SubtitleWrapper>
+            {tct('in release [release]', {
+              release: (
+                <ReleaseWrapper>
+                  <Version
+                    version={groupReleaseData.lastRelease.version}
+                    projectId={group.project.id}
+                    tooltipRawVersion
+                  />
+                </ReleaseWrapper>
+              ),
+            })}
+          </SubtitleWrapper>
+        )}
+      </div>
+    </FirstLastSeen>
+  );
+}
+
+const ReleaseWrapper = styled('span')`
+  a {
+    color: ${p => p.theme.gray300};
+    text-decoration: underline;
+    text-decoration-style: dotted;
+  }
+`;
+const Title = styled('span')`
+  font-weight: ${p => p.theme.fontWeightBold};
+`;
+
+const SubtitleWrapper = styled('div')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.subText};
+`;
+
+const FirstLastSeen = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(0.75)};
+`;
+
+const StyledTimeSince = styled(TimeSince)`
+  font-weight: normal;
+`;

--- a/static/app/views/issueDetails/streamline/firstLastSeenSection.tsx
+++ b/static/app/views/issueDetails/streamline/firstLastSeenSection.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 import TimeSince from 'sentry/components/timeSince';
 import Version from 'sentry/components/version';
-import {tct} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -25,7 +25,11 @@ export default function FirstLastSeenSection({group}: {group: Group}) {
       <div>
         <Title>
           {tct('Last seen [timeSince]', {
-            timeSince: <StyledTimeSince date={group.lastSeen} />,
+            timeSince: group.lastSeen ? (
+              <StyledTimeSince date={group.lastSeen} />
+            ) : (
+              <NoTimeSince>{t('N/A')}</NoTimeSince>
+            ),
           })}
         </Title>
         {groupReleaseData?.firstRelease && (
@@ -47,7 +51,11 @@ export default function FirstLastSeenSection({group}: {group: Group}) {
       <div>
         <Title>
           {tct('First seen [timeSince]', {
-            timeSince: <StyledTimeSince date={group.firstSeen} />,
+            timeSince: group.firstSeen ? (
+              <StyledTimeSince date={group.firstSeen} />
+            ) : (
+              <NoTimeSince>{t('N/A')}</NoTimeSince>
+            ),
           })}
         </Title>
         {groupReleaseData?.lastRelease && (
@@ -93,5 +101,9 @@ const FirstLastSeen = styled('div')`
 `;
 
 const StyledTimeSince = styled(TimeSince)`
+  font-weight: normal;
+`;
+
+const NoTimeSince = styled('span')`
   font-weight: normal;
 `;

--- a/static/app/views/issueDetails/streamline/firstLastSeenSection.tsx
+++ b/static/app/views/issueDetails/streamline/firstLastSeenSection.tsx
@@ -77,7 +77,7 @@ const ReleaseWrapper = styled('span')`
     text-decoration-style: dotted;
   }
 `;
-const Title = styled('span')`
+const Title = styled('div')`
   font-weight: ${p => p.theme.fontWeightBold};
 `;
 

--- a/static/app/views/issueDetails/streamline/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/streamline/groupActivityItem.tsx
@@ -21,15 +21,13 @@ import type {Organization, Team} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import type {User} from 'sentry/types/user';
 import {isSemverRelease} from 'sentry/utils/versions/isSemverRelease';
-import type {GroupRelease} from 'sentry/views/issueDetails/streamline/activitySection';
 
 export default function getGroupActivityItem(
   activity: GroupActivity,
   organization: Organization,
   projectId: Project['id'],
   author: React.ReactNode,
-  teams: Team[],
-  groupReleaseData?: GroupRelease
+  teams: Team[]
 ) {
   const issuesLink = `/organizations/${organization.slug}/issues/`;
 
@@ -593,26 +591,6 @@ export default function getGroupActivityItem(
       }
       case GroupActivityType.FIRST_SEEN:
         if (activity.data.priority) {
-          const firstRelease = groupReleaseData?.firstRelease;
-
-          if (firstRelease) {
-            return {
-              title: t('First Seen'),
-              message: tct('in [firstRelease]. Marked as [priority] priority', {
-                priority: activity.data.priority,
-                firstRelease: (
-                  <ReleaseWrapper>
-                    <Version
-                      version={firstRelease.version}
-                      projectId={projectId}
-                      tooltipRawVersion
-                    />
-                  </ReleaseWrapper>
-                ),
-              }),
-            };
-          }
-
           return {
             title: t('First Seen'),
             message: tct('Marked as [priority] priority', {
@@ -622,28 +600,6 @@ export default function getGroupActivityItem(
         }
         return {
           title: t('First Seen'),
-          message: null,
-        };
-      case GroupActivityType.LAST_SEEN:
-        const lastRelease = groupReleaseData?.lastRelease;
-        if (lastRelease) {
-          return {
-            title: t('Last Seen'),
-            message: tct('in [lastRelease]', {
-              lastRelease: (
-                <ReleaseWrapper>
-                  <Version
-                    version={lastRelease.version}
-                    projectId={projectId}
-                    tooltipRawVersion
-                  />
-                </ReleaseWrapper>
-              ),
-            }),
-          };
-        }
-        return {
-          title: t('Last Seen'),
           message: null,
         };
       case GroupActivityType.ASSIGNED: {

--- a/static/app/views/issueDetails/streamline/sidebar.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar.tsx
@@ -23,9 +23,9 @@ export default function StreamlinedSidebar({group, event, project}: Props) {
       {event && (
         <ErrorBoundary mini>
           <StreamlinedExternalIssueList group={group} event={event} project={project} />
+          <StyledBreak />
         </ErrorBoundary>
       )}
-      <StyledBreak />
       <StreamlinedActivitySection group={group} />
     </div>
   );

--- a/static/app/views/issueDetails/streamline/sidebar.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar.tsx
@@ -7,6 +7,7 @@ import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import StreamlinedActivitySection from 'sentry/views/issueDetails/streamline/activitySection';
+import FirstLastSeenSection from 'sentry/views/issueDetails/streamline/firstLastSeenSection';
 
 type Props = {
   group: Group;
@@ -17,19 +18,21 @@ type Props = {
 export default function StreamlinedSidebar({group, event, project}: Props) {
   return (
     <div>
+      <FirstLastSeenSection group={group} />
+      <StyledBreak />
+      <StreamlinedActivitySection group={group} />
+      <StyledBreak />
       {event && (
         <ErrorBoundary mini>
           <StreamlinedExternalIssueList group={group} event={event} project={project} />
         </ErrorBoundary>
       )}
-      <StyledBreak />
-      <StreamlinedActivitySection group={group} />
     </div>
   );
 }
 
 const StyledBreak = styled('hr')`
-  margin-top: ${space(2)};
-  margin-bottom: ${space(2)};
+  margin-top: ${space(1.5)};
+  margin-bottom: ${space(1.5)};
   border-color: ${p => p.theme.border};
 `;

--- a/static/app/views/issueDetails/streamline/sidebar.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar.tsx
@@ -20,13 +20,13 @@ export default function StreamlinedSidebar({group, event, project}: Props) {
     <div>
       <FirstLastSeenSection group={group} />
       <StyledBreak />
-      <StreamlinedActivitySection group={group} />
-      <StyledBreak />
       {event && (
         <ErrorBoundary mini>
           <StreamlinedExternalIssueList group={group} event={event} project={project} />
         </ErrorBoundary>
       )}
+      <StyledBreak />
+      <StreamlinedActivitySection group={group} />
     </div>
   );
 }


### PR DESCRIPTION
this pr adds back first/last seen to the streamlined sidebar. it also removes last seen from activity, because it has its own section. 