### PR TITLE
feat(ui): Deprecate domId function, swap for useId

### DIFF
--- a/static/app/components/activity/note/input.tsx
+++ b/static/app/components/activity/note/input.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useState} from 'react';
+import {useCallback, useId, useState} from 'react';
 import type {MentionsInputProps} from 'react-mentions';
 import {Mention, MentionsInput} from 'react-mentions';
 import type {Theme} from '@emotion/react';
@@ -12,7 +12,6 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import textStyles from 'sentry/styles/text';
 import type {NoteType} from 'sentry/types/alerts';
-import domId from 'sentry/utils/domId';
 import marked from 'sentry/utils/marked';
 import {useMembers} from 'sentry/utils/useMembers';
 import {useTeams} from 'sentry/utils/useTeams';
@@ -149,7 +148,7 @@ function NoteInput({
     [canSubmit, submitForm]
   );
 
-  const errorId = useMemo(() => domId('note-error-'), []);
+  const errorId = useId();
   const errorMessage =
     (errorJSON &&
       (typeof errorJSON.detail === 'string'

--- a/static/app/components/compactSelect/gridList/index.tsx
+++ b/static/app/components/compactSelect/gridList/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useContext, useMemo, useRef} from 'react';
+import {Fragment, useCallback, useContext, useId, useMemo, useRef} from 'react';
 import type {AriaGridListOptions} from '@react-aria/gridlist';
 import {useGridList} from '@react-aria/gridlist';
 import {mergeProps} from '@react-aria/utils';
@@ -6,7 +6,6 @@ import type {ListState} from '@react-stately/list';
 import type {CollectionChildren} from '@react-types/shared';
 
 import {t} from 'sentry/locale';
-import domId from 'sentry/utils/domId';
 import type {FormSize} from 'sentry/utils/theme';
 
 import {SelectContext} from '../control';
@@ -76,7 +75,7 @@ function GridList({
   ...props
 }: GridListProps) {
   const ref = useRef<HTMLUListElement>(null);
-  const labelId = domId('grid-label-');
+  const labelId = useId();
   const {gridProps} = useGridList(
     {...props, 'aria-labelledby': label ? labelId : props['aria-labelledby']},
     listState,

--- a/static/app/components/compactSelect/gridList/section.tsx
+++ b/static/app/components/compactSelect/gridList/section.tsx
@@ -1,9 +1,8 @@
-import {Fragment, useContext, useMemo} from 'react';
+import {Fragment, useContext, useId, useMemo} from 'react';
 import {useSeparator} from '@react-aria/separator';
 import type {ListState} from '@react-stately/list';
 import type {Node} from '@react-types/shared';
 
-import domId from 'sentry/utils/domId';
 import type {FormSize} from 'sentry/utils/theme';
 
 import {SelectFilterContext} from '../list';
@@ -31,7 +30,7 @@ interface GridListSectionProps {
  * inside). https://react-spectrum.adobe.com/react-aria/useGridList.html
  */
 export function GridListSection({node, listState, onToggle, size}: GridListSectionProps) {
-  const titleId = domId('grid-section-title-');
+  const titleId = useId();
   const {separatorProps} = useSeparator({elementType: 'li'});
 
   const showToggleAllButton =

--- a/static/app/components/compactSelect/index.tsx
+++ b/static/app/components/compactSelect/index.tsx
@@ -1,8 +1,7 @@
-import {useMemo} from 'react';
+import {useId, useMemo} from 'react';
 import {Item, Section} from '@react-stately/collections';
 
 import {t} from 'sentry/locale';
-import domId from 'sentry/utils/domId';
 
 import type {ControlProps} from './control';
 import {Control} from './control';
@@ -74,7 +73,7 @@ function CompactSelect<Value extends SelectKey>({
   triggerProps,
   ...controlProps
 }: SelectProps<Value>) {
-  const triggerId = useMemo(() => domId('select-trigger-'), []);
+  const triggerId = useId();
 
   // Combine list props into an object with two clearly separated types, one where
   // `multiple` is true and the other where it's not. Necessary to avoid TS errors.

--- a/static/app/components/compactSelect/list.tsx
+++ b/static/app/components/compactSelect/list.tsx
@@ -3,6 +3,7 @@ import {
   Fragment,
   useCallback,
   useContext,
+  useId,
   useLayoutEffect,
   useMemo,
 } from 'react';
@@ -13,7 +14,6 @@ import type {ListProps} from '@react-stately/list';
 import {useListState} from '@react-stately/list';
 
 import {defined} from 'sentry/utils';
-import domId from 'sentry/utils/domId';
 import type {FormSize} from 'sentry/utils/theme';
 
 import {SelectContext} from './control';
@@ -337,7 +337,7 @@ function List<Value extends SelectKey>({
     ]
   );
 
-  const listId = useMemo(() => domId('select-list-'), []);
+  const listId = useId();
 
   const sections = useMemo(
     () =>

--- a/static/app/components/compactSelect/utils.tsx
+++ b/static/app/components/compactSelect/utils.tsx
@@ -271,7 +271,8 @@ export function HiddenSectionToggle({
   const {focusProps} = useFocus({
     onFocus: () => {
       const visibleCounterpart = document.querySelector(
-        `#${listId} button[aria-hidden][data-key="${item.key}"]`
+        // Escape react useId to make valid CSS id selector
+        `#${CSS.escape(listId)} button[aria-hidden][data-key="${item.key}"]`
       );
 
       if (!visibleCounterpart) {
@@ -281,7 +282,7 @@ export function HiddenSectionToggle({
     },
     onBlur: () => {
       const visibleCounterpart = document.querySelector(
-        `#${listId} button[aria-hidden][data-key="${item.key}"]`
+        `#${CSS.escape(listId)} button[aria-hidden][data-key="${item.key}"]`
       );
 
       if (!visibleCounterpart) {

--- a/static/app/components/hovercard.tsx
+++ b/static/app/components/hovercard.tsx
@@ -116,7 +116,7 @@ function Hovercard({
   tipColor = 'backgroundElevated',
   ...hoverOverlayProps
 }: HovercardProps): React.ReactElement {
-  const {wrapTrigger, isOpen, ...hoverOverlayState} = useHoverOverlay('hovercard', {
+  const {wrapTrigger, isOpen, ...hoverOverlayState} = useHoverOverlay({
     offset,
     displayTimeout,
     isHoverable: true,

--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -1,4 +1,4 @@
-import {forwardRef as reactForwardRef, memo, useMemo, useRef, useState} from 'react';
+import {forwardRef as reactForwardRef, memo, useId, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 import {usePopper} from 'react-popper';
 import isPropValid from '@emotion/is-prop-valid';
@@ -10,7 +10,6 @@ import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import type {TooltipProps} from 'sentry/components/tooltip';
 import {Tooltip} from 'sentry/components/tooltip';
 import {space} from 'sentry/styles/space';
-import domId from 'sentry/utils/domId';
 import mergeRefs from 'sentry/utils/mergeRefs';
 import type {FormSize} from 'sentry/utils/theme';
 
@@ -130,8 +129,8 @@ function BaseMenuListItem({
   ...props
 }: Props) {
   const itemRef = useRef<HTMLLIElement>(null);
-  const labelId = useMemo(() => domId('menuitem-label-'), []);
-  const detailId = useMemo(() => domId('menuitem-details-'), []);
+  const labelId = useId();
+  const detailId = useId();
 
   return (
     <MenuItemWrap

--- a/static/app/components/overlayArrow.tsx
+++ b/static/app/components/overlayArrow.tsx
@@ -1,8 +1,7 @@
-import {forwardRef, useMemo} from 'react';
+import {forwardRef, useId} from 'react';
 import type {PopperProps} from 'react-popper';
 import styled from '@emotion/styled';
 
-import domId from 'sentry/utils/domId';
 import type {ColorOrAlias} from 'sentry/utils/theme';
 
 interface OverlayArrowProps extends React.ComponentPropsWithRef<'div'> {
@@ -42,8 +41,8 @@ function BaseOverlayArrow(
     `C ${w * 0.55} ${s / 2} ${w * 0.75} ${h - s / 2} ${w} ${h - s / 2}`,
   ].join('');
 
-  const strokeMaskId = useMemo(() => domId('stroke-mask'), []);
-  const fillMaskId = useMemo(() => domId('fill-mask'), []);
+  const strokeMaskId = useId();
+  const fillMaskId = useId();
 
   return (
     <Wrap ref={ref} placement={placement} size={size} {...props}>

--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -47,7 +47,7 @@ function Tooltip({
   const {container} = useContext(TooltipContext);
   const theme = useTheme();
   const {wrapTrigger, isOpen, overlayProps, placement, arrowData, arrowProps, reset} =
-    useHoverOverlay('tooltip', hoverOverlayProps);
+    useHoverOverlay(hoverOverlayProps);
 
   // Reset the visibility when the tooltip becomes disabled
   useEffect(() => {

--- a/static/app/utils/domId.tsx
+++ b/static/app/utils/domId.tsx
@@ -1,3 +1,6 @@
+/**
+ * @deprecated use `useId` from react instead
+ */
 function domId(prefix: string): string {
   return prefix + Math.random().toString(36).substring(2, 12);
 }

--- a/static/app/utils/useHoverOverlay.tsx
+++ b/static/app/utils/useHoverOverlay.tsx
@@ -3,6 +3,7 @@ import {
   isValidElement,
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -11,7 +12,6 @@ import type {PopperProps} from 'react-popper';
 import {usePopper} from 'react-popper';
 import {useTheme} from '@emotion/react';
 
-import domId from 'sentry/utils/domId';
 import type {ColorOrAlias} from 'sentry/utils/theme';
 
 function makeDefaultPopperModifiers(arrowElement: HTMLElement | null, offset: number) {
@@ -144,25 +144,22 @@ function maybeClearRefTimeout(ref: React.MutableRefObject<number | undefined>) {
 /**
  * A hook used to trigger a positioned overlay on hover.
  */
-function useHoverOverlay(
-  overlayType: string,
-  {
-    className,
-    delay,
-    displayTimeout,
-    isHoverable,
-    showUnderline,
-    underlineColor,
-    showOnlyOnOverflow,
-    skipWrapper,
-    forceVisible,
-    offset = 8,
-    position = 'top',
-    containerDisplayMode = 'inline-block',
-  }: UseHoverOverlayProps
-) {
+function useHoverOverlay({
+  className,
+  delay,
+  displayTimeout,
+  isHoverable,
+  showUnderline,
+  underlineColor,
+  showOnlyOnOverflow,
+  skipWrapper,
+  forceVisible,
+  offset = 8,
+  position = 'top',
+  containerDisplayMode = 'inline-block',
+}: UseHoverOverlayProps) {
   const theme = useTheme();
-  const describeById = useMemo(() => domId(`${overlayType}-`), [overlayType]);
+  const describeById = useId();
 
   const [isVisible, setIsVisible] = useState(forceVisible ?? false);
   const isOpen = forceVisible ?? isVisible;

--- a/static/app/views/issueDetails/streamline/note.tsx
+++ b/static/app/views/issueDetails/streamline/note.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useState} from 'react';
+import {useCallback, useId, useState} from 'react';
 import type {MentionsInputProps} from 'react-mentions';
 import {Mention, MentionsInput} from 'react-mentions';
 import type {Theme} from '@emotion/react';
@@ -13,7 +13,6 @@ import type {
 } from 'sentry/components/activity/note/types';
 import {t} from 'sentry/locale';
 import type {NoteType} from 'sentry/types/alerts';
-import domId from 'sentry/utils/domId';
 import {useMembers} from 'sentry/utils/useMembers';
 import {useTeams} from 'sentry/utils/useTeams';
 
@@ -121,7 +120,7 @@ function StreamlinedNoteInput({
     [canSubmit, handleSubmit]
   );
 
-  const errorId = useMemo(() => domId('note-error-'), []);
+  const errorId = useId();
   const errorMessage =
     (errorJSON &&
       (typeof errorJSON.detail === 'string'

--- a/static/app/views/replays/detail/memoryPanel/memoryChart.tsx
+++ b/static/app/views/replays/detail/memoryPanel/memoryChart.tsx
@@ -1,5 +1,5 @@
 import type {Dispatch, SetStateAction} from 'react';
-import {useMemo, useRef} from 'react';
+import {useId, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 
 import type {AreaChartProps, AreaChartSeries} from 'sentry/components/charts/areaChart';
@@ -14,7 +14,6 @@ import {space} from 'sentry/styles/space';
 import toArray from 'sentry/utils/array/toArray';
 import {formatBytesBase2} from 'sentry/utils/bytes/formatBytesBase2';
 import {getFormattedDate} from 'sentry/utils/dates';
-import domId from 'sentry/utils/domId';
 import formatDuration from 'sentry/utils/duration/formatDuration';
 import type {MemoryFrame} from 'sentry/utils/replays/types';
 
@@ -37,7 +36,7 @@ export default function MemoryChart({
   startTimestampMs,
 }: Props) {
   const theme = useTheme();
-  const idRef = useRef(domId('replay-memory-chart-'));
+  const chartId = useId();
 
   const chartOptions: Omit<AreaChartProps, 'series'> = useMemo(
     () => ({
@@ -52,7 +51,7 @@ export default function MemoryChart({
           appendToBody: true,
           trigger: 'axis',
           renderMode: 'html',
-          chartId: idRef.current,
+          chartId,
           formatter: values => {
             const firstValue = Array.isArray(values) ? values[0] : values;
             const seriesTooltips = toArray(values).map(
@@ -120,7 +119,7 @@ export default function MemoryChart({
         }
       },
     }),
-    [setCurrentHoverTime, setCurrentTime, startTimestampMs, theme]
+    [setCurrentHoverTime, setCurrentTime, startTimestampMs, theme, chartId]
   );
 
   const staticSeries = useMemo<AreaChartSeries[]>(
@@ -185,7 +184,7 @@ export default function MemoryChart({
   );
 
   return (
-    <div id={idRef.current}>
+    <div id={chartId}>
       <AreaChart series={series} {...chartOptions} />
     </div>
   );


### PR DESCRIPTION
react 18 has built in `useId` https://react.dev/reference/react/useId that should be used for described-by etc we're still using domId in some class components