### PR TITLE
feat(dashboards): Add dataset source to serializer

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -63,6 +63,7 @@ class DashboardWidgetResponse(TypedDict):
     limit: int | None
     widgetType: str
     layout: dict[str, int]
+    datasetSource: str
 
 
 class DashboardPermissionsResponse(TypedDict):

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -63,7 +63,7 @@ class DashboardWidgetResponse(TypedDict):
     limit: int | None
     widgetType: str
     layout: dict[str, int]
-    datasetSource: str
+    datasetSource: str | None
 
 
 class DashboardPermissionsResponse(TypedDict):

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -6,7 +6,7 @@ from typing import TypedDict
 
 from django.db.models import Max
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import extend_schema_field
+from drf_spectacular.utils import extend_schema_field, extend_schema_serializer
 from rest_framework import serializers
 
 from sentry import features, options
@@ -279,6 +279,7 @@ class ThresholdMaxKeys(Enum):
     MAX_2 = "max2"
 
 
+@extend_schema_serializer(exclude_fields=["dataset_source"])
 class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
     # Is a string because output serializers also make it a string.
     id = serializers.CharField(required=False)

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -299,7 +299,9 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
     layout = LayoutField(required=False, allow_null=True)
     query_warnings: QueryWarning = {"queries": [], "columns": {}}
     dataset_source = serializers.ChoiceField(
-        choices=DatasetSourcesTypes.as_text_choices(), required=False, allow_null=True
+        choices=DatasetSourcesTypes.as_text_choices(),
+        required=False,
+        help_text="A widgets's unique id.",
     )
 
     def validate_display_type(self, display_type):

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -23,6 +23,7 @@ from sentry.models.dashboard_widget import (
     DashboardWidgetQuery,
     DashboardWidgetQueryOnDemand,
     DashboardWidgetTypes,
+    DatasetSourcesTypes,
 )
 from sentry.relay.config.metric_extraction import get_current_widget_specs, widget_exceeds_max_specs
 from sentry.search.events.builder.discover import UnresolvedQuery
@@ -42,6 +43,7 @@ AGGREGATE_BASE = r".*(\w+)\((.*)?\)"
 EQUATION_PREFIX = "equation|"
 
 OnDemandExtractionState = DashboardWidgetQueryOnDemand.OnDemandExtractionState
+DATASET_SOURCE_MAP = {source[1]: source[0] for source in DatasetSourcesTypes.as_choices()}
 
 
 class QueryWarning(TypedDict):
@@ -296,6 +298,9 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
     limit = serializers.IntegerField(min_value=1, max_value=10, required=False, allow_null=True)
     layout = LayoutField(required=False, allow_null=True)
     query_warnings: QueryWarning = {"queries": [], "columns": {}}
+    dataset_source = serializers.ChoiceField(
+        choices=DatasetSourcesTypes.as_text_choices(), required=False, allow_null=True
+    )
 
     def validate_display_type(self, display_type):
         return DashboardWidgetDisplayTypes.get_id_for_type_name(display_type)
@@ -452,6 +457,10 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
             DashboardWidgetTypes.TRANSACTION_LIKE,
         }:
             data["discover_widget_split"] = widget_type
+
+        dataset_source = data.get("dataset_source")
+        if dataset_source is not None:
+            data["dataset_source"] = DATASET_SOURCE_MAP[dataset_source]
 
         return data
 
@@ -644,6 +653,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
             order=order,
             limit=widget_data.get("limit", None),
             detail={"layout": widget_data.get("layout")},
+            dataset_source=widget_data.get("dataset_source", DatasetSourcesTypes.USER.value),
         )
 
         new_queries = []
@@ -705,6 +715,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
         )
         widget.order = order
         widget.limit = data.get("limit", widget.limit)
+        widget.dataset_source = data.get("dataset_source", widget.dataset_source)
         widget.detail = {"layout": data.get("layout", prev_layout)}
         widget.save()
 

--- a/src/sentry/apidocs/examples/dashboard_examples.py
+++ b/src/sentry/apidocs/examples/dashboard_examples.py
@@ -37,6 +37,7 @@ DASHBOARD_OBJECT = {
             "interval": "5m",
             "dateCreated": "2024-07-16T15:36:46.048343Z",
             "dashboardId": "1",
+            "datasetSource": "user",
             "queries": [
                 {
                     "id": "1",

--- a/src/sentry/models/dashboard_widget.py
+++ b/src/sentry/models/dashboard_widget.py
@@ -109,6 +109,10 @@ class DatasetSourcesTypes(Enum):
     def as_choices(cls):
         return tuple((source.value, source.name.lower()) for source in cls)
 
+    @classmethod
+    def as_text_choices(cls):
+        return tuple((source.name.lower(), source.value) for source in cls)
+
 
 # TODO: Can eventually be replaced solely with TRANSACTION_MULTI once no more dashboards use Discover.
 TransactionWidgetType = [DashboardWidgetTypes.DISCOVER, DashboardWidgetTypes.TRANSACTION_LIKE]

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -55,6 +55,7 @@ from snuba_sdk import Granularity, Limit, Offset
 from snuba_sdk.conditions import BooleanCondition, Condition, ConditionGroup
 
 from sentry import auth, eventstore
+from sentry.api.serializers.models.dashboard import DATASET_SOURCES
 from sentry.auth.authenticators.totp import TotpInterface
 from sentry.auth.provider import Provider
 from sentry.auth.providers.dummy import DummyProvider
@@ -2748,6 +2749,8 @@ class OrganizationDashboardWidgetTestCase(APITestCase):
             )
         if "layout" in data:
             assert data["layout"] == expected_widget.detail["layout"]
+        if "datasetSource" in data:
+            assert data["datasetSource"] == DATASET_SOURCES[expected_widget.dataset_source]
 
     def create_user_member_role(self):
         self.user = self.create_user(is_superuser=False)

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -681,6 +681,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
                             "conditions": "event.type:error",
                         }
                     ],
+                    "datasetSource": "user",
                 },
             ],
         }
@@ -1157,6 +1158,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
                             "conditions": "event.type:transaction",
                         },
                     ],
+                    "datasetSource": "user",
                 },
                 {"id": str(self.widget_2.id)},
             ],


### PR DESCRIPTION
Allows us to store a dataset source for a widget dataset decision. Lets us know when to show warnings like the forced widget warning if it is overridden by the user.