### PR TITLE
fix(issue-stream): Improve issue title spacing and overflow

### DIFF
--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -84,20 +84,26 @@ function EventOrGroupHeader({
       );
     }
 
+    const to = createIssueLink({
+      organization,
+      data,
+      eventId,
+      referrer: source,
+      streamIndex: index,
+      location,
+      query,
+    });
+
+    if (hasNewLayout) {
+      return (
+        <NewTitleWithLink {...commonEleProps} to={to} onClick={onClick}>
+          {getTitleChildren()}
+        </NewTitleWithLink>
+      );
+    }
+
     return (
-      <TitleWithLink
-        {...commonEleProps}
-        to={createIssueLink({
-          organization,
-          data,
-          eventId,
-          referrer: source,
-          streamIndex: index,
-          location,
-          query,
-        })}
-        onClick={onClick}
-      >
+      <TitleWithLink {...commonEleProps} to={to} onClick={onClick}>
         {getTitleChildren()}
       </TitleWithLink>
     );
@@ -107,7 +113,7 @@ function EventOrGroupHeader({
 
   return (
     <div data-test-id="event-issue-header">
-      <Title>{getTitle()}</Title>
+      <Title extraMargin={hasNewLayout}>{getTitle()}</Title>
       {eventLocation && !hasNewLayout ? <Location>{eventLocation}</Location> : null}
       {!hasNewLayout ? (
         <StyledEventMessage
@@ -129,8 +135,8 @@ const truncateStyles = css`
   white-space: nowrap;
 `;
 
-const Title = styled('div')`
-  margin-bottom: ${space(0.25)};
+const Title = styled('div')<{extraMargin: boolean}>`
+  margin-bottom: ${p => (p.extraMargin ? space(0.75) : space(0.25))};
   font-size: ${p => p.theme.fontSizeLarge};
   & em {
     font-size: ${p => p.theme.fontSizeMedium};
@@ -178,8 +184,18 @@ const TitleWithLink = styled(GlobalSelectionLink)`
   display: inline-flex;
   align-items: center;
 `;
+
+const NewTitleWithLink = styled(GlobalSelectionLink)`
+  ${p => p.theme.overflowEllipsis};
+  color: ${p => p.theme.textColor};
+
+  &:hover {
+    color: ${p => p.theme.textColor};
+  }
+`;
+
 const TitleWithoutLink = styled('span')`
-  display: inline-flex;
+  ${p => p.theme.overflowEllipsis};
 `;
 
 export default withOrganization(EventOrGroupHeader);

--- a/static/app/components/eventOrGroupTitle.tsx
+++ b/static/app/components/eventOrGroupTitle.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {BaseGroup, GroupTombstoneHelper} from 'sentry/types/group';
 import {getMessage, getTitle, isTombstone} from 'sentry/utils/events';
@@ -32,8 +33,33 @@ function EventOrGroupTitle({
 
   const secondaryTitle = hasNewLayout ? getMessage(data) : subtitle;
 
+  if (hasNewLayout) {
+    return (
+      <span className={className}>
+        {!isTombstone(data) && withStackTracePreview ? (
+          <GroupPreviewTooltip
+            groupId={groupID ? groupID : id}
+            issueCategory={data.issueCategory}
+            groupingCurrentLevel={data.metadata?.current_level}
+            query={query}
+          >
+            <Title data-issue-title-primary>{titleLabel}</Title>
+          </GroupPreviewTooltip>
+        ) : (
+          titleLabel
+        )}
+        {secondaryTitle && (
+          <Fragment>
+            <Spacer width={space(1)} />
+            <Message title={secondaryTitle}>{secondaryTitle}</Message>
+          </Fragment>
+        )}
+      </span>
+    );
+  }
+
   return (
-    <Wrapper className={className} hasNewLayout={hasNewLayout}>
+    <Wrapper className={className}>
       {!isTombstone(data) && withStackTracePreview ? (
         <GroupPreviewTooltip
           groupId={groupID ? groupID : id}
@@ -41,23 +67,15 @@ function EventOrGroupTitle({
           groupingCurrentLevel={data.metadata?.current_level}
           query={query}
         >
-          {hasNewLayout ? (
-            <Title data-issue-title-primary>{titleLabel}</Title>
-          ) : (
-            titleLabel
-          )}
+          {titleLabel}
         </GroupPreviewTooltip>
       ) : (
         titleLabel
       )}
       {secondaryTitle && (
         <Fragment>
-          <Spacer />
-          {hasNewLayout ? (
-            <Message title={secondaryTitle}>{secondaryTitle}</Message>
-          ) : (
-            <Subtitle title={secondaryTitle}>{secondaryTitle}</Subtitle>
-          )}
+          <Spacer width="10px" />
+          <Subtitle title={secondaryTitle}>{secondaryTitle}</Subtitle>
           <br />
         </Fragment>
       )}
@@ -72,8 +90,8 @@ export default EventOrGroupTitle;
  * into 2 separate text nodes on the HTML AST. This allows the
  * title to be highlighted without spilling over to the subtitle.
  */
-function Spacer() {
-  return <span style={{display: 'inline-block', width: 10}}>&nbsp;</span>;
+function Spacer({width}: {width: string}) {
+  return <span style={{display: 'inline-block', width}}>&nbsp;</span>;
 }
 
 const Subtitle = styled('em')`
@@ -85,24 +103,17 @@ const Subtitle = styled('em')`
 `;
 
 const Message = styled('span')`
-  ${p => p.theme.overflowEllipsis};
-  display: inline-block;
-  height: 100%;
-  color: ${p => p.theme.textColor};
   font-weight: ${p => p.theme.fontWeightNormal};
   font-size: ${p => p.theme.fontSizeMedium};
 `;
 
 const Title = styled('span')`
-  ${p => p.theme.overflowEllipsis};
-  display: inline-block;
-  color: ${p => p.theme.textColor};
   font-size: ${p => p.theme.fontSizeMedium};
 `;
 
-const Wrapper = styled('span')<{hasNewLayout: boolean}>`
+const Wrapper = styled('span')`
   display: inline-grid;
   grid-template-columns: auto max-content 1fr max-content;
 
-  align-items: ${p => (p.hasNewLayout ? 'normal' : 'baseline')};
+  align-items: baseline;
 `;

--- a/static/app/components/groupPreviewTooltip/groupPreviewHovercard.tsx
+++ b/static/app/components/groupPreviewTooltip/groupPreviewHovercard.tsx
@@ -37,6 +37,7 @@ export function GroupPreviewHovercard({
       tipColor="background"
       hide={shouldNotPreview || hide}
       body={<div onClick={handleStackTracePreviewClick}>{body}</div>}
+      containerDisplayMode="inline"
       {...props}
     >
       {children}

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -820,7 +820,7 @@ const CheckboxLabel = styled('label')<{hasNewLayout: boolean}>`
   ${p =>
     p.hasNewLayout &&
     css`
-      padding-top: 14px;
+      padding-top: ${space(2)};
     `}
 `;
 


### PR DESCRIPTION
Some small changes to the layout to fix a few issues:

- Decreases space between title and message
- Fixes layout issue on old issue details header
- Long error type names now show an ellipsis when overflowing