### PR TITLE
feat(issue-stream): Better adjust filter layout as screen size gets smaller

### DIFF
--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -12,6 +12,7 @@ type Props = {
   onSelect: (sort: string) => void;
   query: string;
   sort: string;
+  className?: string;
   showIcon?: boolean;
   triggerSize?: DropdownButtonProps['size'];
 };
@@ -35,6 +36,7 @@ export function getSortTooltip(key: IssueSortOptions) {
 }
 
 function IssueListSortOptions({
+  className,
   onSelect,
   sort,
   query,
@@ -53,6 +55,7 @@ function IssueListSortOptions({
 
   return (
     <CompactSelect
+      className={className}
       size="md"
       onChange={opt => onSelect(opt.value)}
       options={sortKeys.map(key => ({

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -1,3 +1,4 @@
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
@@ -19,18 +20,20 @@ interface Props {
 function IssueListFilters({query, sort, onSortChange, onSearch}: Props) {
   const organization = useOrganization();
 
+  const hasNewLayout = organization.features.includes('issue-stream-table-layout');
+
   return (
-    <SearchContainer>
+    <FiltersContainer hasNewLayout={hasNewLayout}>
       <StyledPageFilterBar>
         <ProjectPageFilter />
         <EnvironmentPageFilter />
         <DatePageFilter />
       </StyledPageFilterBar>
 
-      <IssueSearchWithSavedSearches {...{query, onSearch}} />
+      <Search {...{query, onSearch}} />
 
       {organization.features.includes('issue-stream-table-layout') && (
-        <IssueListSortOptions
+        <Sort
           query={query}
           sort={sort}
           onSelect={onSortChange}
@@ -38,33 +41,78 @@ function IssueListFilters({query, sort, onSortChange, onSearch}: Props) {
           showIcon={false}
         />
       )}
-    </SearchContainer>
+    </FiltersContainer>
   );
 }
 
-const SearchContainer = styled('div')`
-  display: flex;
-  flex-wrap: wrap;
-  column-gap: ${space(2)};
+const FiltersContainer = styled('div')<{hasNewLayout: boolean}>`
+  display: grid;
+  column-gap: ${space(1)};
   row-gap: ${space(1)};
-  width: 100%;
   margin-bottom: ${space(2)};
+  width: 100%;
 
-  @media (max-width: ${p => p.theme.breakpoints.small}) {
-    flex-direction: column;
-  }
+  ${p =>
+    p.hasNewLayout
+      ? css`
+          grid-template-columns: 100%;
+          grid-template-areas:
+            'page-filters'
+            'search'
+            'sort';
+
+          @media (min-width: ${p.theme.breakpoints.xsmall}) {
+            grid-template-columns: auto 1fr;
+            grid-template-areas:
+              'page-filters sort'
+              'search search';
+          }
+
+          @media (min-width: ${p.theme.breakpoints.large}) {
+            grid-template-columns: auto 1fr auto;
+            grid-template-areas: 'page-filters search sort';
+          }
+        `
+      : css`
+          grid-template-columns: 100%;
+          grid-template-areas:
+            'page-filters'
+            'search';
+
+          @media (min-width: ${p.theme.breakpoints.xsmall}) {
+            grid-template-columns: auto 1fr;
+            grid-template-areas:
+              'page-filters sort'
+              'search search';
+          }
+
+          @media (min-width: ${p.theme.breakpoints.large}) {
+            grid-template-columns: auto 1fr;
+            grid-template-areas: 'page-filters search';
+          }
+        `}
+`;
+
+const Search = styled(IssueSearchWithSavedSearches)`
+  grid-area: search;
 `;
 
 const StyledPageFilterBar = styled(PageFilterBar)`
+  grid-area: page-filters;
   display: flex;
   flex-basis: content;
   width: 100%;
   max-width: 43rem;
-  align-self: flex-start;
+  justify-self: start;
 
   > div > button {
     width: 100%;
   }
+`;
+
+const Sort = styled(IssueListSortOptions)`
+  grid-area: sort;
+  justify-self: end;
 `;
 
 export default IssueListFilters;

--- a/static/app/views/issueList/issueSearchWithSavedSearches.tsx
+++ b/static/app/views/issueList/issueSearchWithSavedSearches.tsx
@@ -13,9 +13,11 @@ import IssueListSearchBar from './searchBar';
 type IssueSearchWithSavedSearchesProps = {
   onSearch: (query: string) => void;
   query: string;
+  className?: string;
 };
 
 export function IssueSearchWithSavedSearches({
+  className,
   query,
   onSearch,
 }: IssueSearchWithSavedSearchesProps) {
@@ -36,7 +38,7 @@ export function IssueSearchWithSavedSearches({
   }
 
   return (
-    <SearchBarWithButtonContainer>
+    <SearchBarWithButtonContainer className={className}>
       {!organization.features.includes('issue-stream-custom-views') && (
         <StyledButton onClick={onSavedSearchesToggleClicked}>
           {selectedSavedSearch?.name ?? t('Custom Search')}


### PR DESCRIPTION
< 500px (wish I could put the sort to the right of page filters, but it doesn't fit):

![CleanShot 2024-10-22 at 15 56 29](https://github.com/user-attachments/assets/5a40a91a-7eb8-4fb8-a53b-7a2d8e144082)

< 1200px:

![CleanShot 2024-10-22 at 15 56 57](https://github.com/user-attachments/assets/63f4d660-0cee-4edc-a2d8-f59b6d7650d7)

And up:

![CleanShot 2024-10-22 at 15 57 10](https://github.com/user-attachments/assets/13e06f10-0589-42a3-9176-a998e21bf688)
