### PR TITLE
fix(tags): hide user avatar on user tag values page

### DIFF
--- a/static/app/components/avatar/styles.tsx
+++ b/static/app/components/avatar/styles.tsx
@@ -10,6 +10,7 @@ export const imageStyle = (props: ImageStyleProps) => css`
   top: 0px;
   left: 0px;
   border-radius: ${props.round ? '50%' : '3px'};
+  user-select: none;
   ${props.suggested &&
   css`
     filter: grayscale(100%);


### PR DESCRIPTION
When users go to copy the email address in the tag values, an arrant character will be added when they copy. For example if the value is :

(J) josh.ferge@gmail.com

when they copy the users email, they will get `Jjosh.ferge@gmail.com` added into their clipboard. This PR addresses by simply removing the little circle avatar from the tag values page. Since this will always be just a character, i feel like its not really adding much, so I think it's okay to remove.

before and after:

![Screenshot 2024-10-23 at 10 22 33 AM](https://github.com/user-attachments/assets/3de3103b-65ae-4850-ad1a-95301959f94a)
![Screenshot 2024-10-23 at 10 22 16 AM](https://github.com/user-attachments/assets/9c9cf67f-e2c3-47af-8142-04d60fc47d04)

Fixes https://github.com/getsentry/sentry/issues/79419