### PR TITLE
feat(quick-start): Add useOnboardingTasks hook

### DIFF
--- a/static/app/components/onboardingWizard/newSidebar.tsx
+++ b/static/app/components/onboardingWizard/newSidebar.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import partition from 'lodash/partition';
@@ -8,8 +8,8 @@ import {updateOnboardingTask} from 'sentry/actionCreators/onboardingTasks';
 import {Button} from 'sentry/components/button';
 import {Chevron} from 'sentry/components/chevron';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
-import type {OnboardingContextProps} from 'sentry/components/onboarding/onboardingContext';
 import SkipConfirm from 'sentry/components/onboardingWizard/skipConfirm';
+import type {useOnboardingTasks} from 'sentry/components/onboardingWizard/useOnboardingTasks';
 import {findCompleteTasks, taskIsDone} from 'sentry/components/onboardingWizard/utils';
 import ProgressRing from 'sentry/components/progressRing';
 import SidebarPanel from 'sentry/components/sidebar/sidebarPanel';
@@ -19,20 +19,12 @@ import {IconCheckmark, IconClose} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import DemoWalkthroughStore from 'sentry/stores/demoWalkthroughStore';
 import {space} from 'sentry/styles/space';
-import {
-  type OnboardingTask,
-  OnboardingTaskGroup,
-  OnboardingTaskKey,
-} from 'sentry/types/onboarding';
-import type {Organization} from 'sentry/types/organization';
-import type {Project} from 'sentry/types/project';
+import {type OnboardingTask, OnboardingTaskKey} from 'sentry/types/onboarding';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isDemoWalkthrough} from 'sentry/utils/demoMode';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
-
-import {getMergedTasks} from './taskConfig';
 
 /**
  * How long (in ms) to delay before beginning to mark tasks complete
@@ -60,30 +52,6 @@ const orderedBeyondBasicsTasks = [
   OnboardingTaskKey.FIRST_TRANSACTION,
   OnboardingTaskKey.SECOND_PLATFORM,
 ];
-
-export function useOnboardingTasks(
-  organization: Organization,
-  projects: Project[],
-  onboardingContext: OnboardingContextProps
-) {
-  return useMemo(() => {
-    const all = getMergedTasks({
-      organization,
-      projects,
-      onboardingContext,
-    }).filter(task => task.display);
-    return {
-      allTasks: all,
-      gettingStartedTasks: all.filter(
-        task => task.group === OnboardingTaskGroup.GETTING_STARTED
-      ),
-      beyondBasicsTasks: all.filter(
-        task => task.group !== OnboardingTaskGroup.GETTING_STARTED
-      ),
-      completeTasks: all.filter(findCompleteTasks),
-    };
-  }, [organization, projects, onboardingContext]);
-}
 
 function groupTasksByCompletion(tasks: OnboardingTask[]) {
   const [completedTasks, incompletedTasks] = partition(tasks, task =>

--- a/static/app/components/onboardingWizard/useOnboardingTasks.tsx
+++ b/static/app/components/onboardingWizard/useOnboardingTasks.tsx
@@ -73,10 +73,10 @@ export function useOnboardingTasks({
   return {
     allTasks: supportedTasks,
     completeTasks: mergedTasks.filter(findCompleteTasks),
-    gettingStartedTasks: supportedTasks.filter(
+    gettingStartedTasks: mergedTasks.filter(
       task => task.group === OnboardingTaskGroup.GETTING_STARTED
     ),
-    beyondBasicsTasks: supportedTasks.filter(
+    beyondBasicsTasks: mergedTasks.filter(
       task => task.group !== OnboardingTaskGroup.GETTING_STARTED
     ),
   };

--- a/static/app/components/onboardingWizard/useOnboardingTasks.tsx
+++ b/static/app/components/onboardingWizard/useOnboardingTasks.tsx
@@ -71,7 +71,7 @@ export function useOnboardingTasks({
   });
 
   return {
-    allTasks: supportedTasks,
+    allTasks: mergedTasks,
     completeTasks: mergedTasks.filter(findCompleteTasks),
     gettingStartedTasks: mergedTasks.filter(
       task => task.group === OnboardingTaskGroup.GETTING_STARTED

--- a/static/app/components/onboardingWizard/useOnboardingTasks.tsx
+++ b/static/app/components/onboardingWizard/useOnboardingTasks.tsx
@@ -1,0 +1,83 @@
+import {findCompleteTasks} from 'sentry/components/onboardingWizard/utils';
+import {
+  type OnboardingTask,
+  OnboardingTaskGroup,
+  type OnboardingTaskStatus,
+} from 'sentry/types/onboarding';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+// Refetch the data every second
+const DEFAULT_POLL_INTERVAL_MS = 1000;
+
+// Merge supported onboarding tasks with their completion status from the server.
+function mergeTasks({
+  supportedTasks,
+  serverTasks,
+}: {
+  serverTasks: OnboardingTaskStatus[];
+  supportedTasks: OnboardingTask[];
+}): OnboardingTask[] {
+  return supportedTasks.map(
+    supportedTask =>
+      ({
+        ...supportedTask,
+        ...serverTasks.find(
+          serverTask =>
+            serverTask.task === supportedTask.task ||
+            serverTask.task === supportedTask.serverTask
+        ),
+        requisiteTasks: [],
+      }) as OnboardingTask
+  );
+}
+
+// This hook polls the onboarding tasks endpoint every second until all supported tasks are complete and
+// returns the task groups: "allTasks", "gettingStartedTasks", "beyondBasicsTasks", and "completeTasks".
+export function useOnboardingTasks({
+  supportedTasks,
+}: {
+  supportedTasks: OnboardingTask[];
+}): {
+  allTasks: OnboardingTask[];
+  beyondBasicsTasks: OnboardingTask[];
+  completeTasks: OnboardingTask[];
+  gettingStartedTasks: OnboardingTask[];
+} {
+  const organization = useOrganization();
+
+  const {data: serverTasks = {onboardingTasks: []}} = useApiQuery<{
+    onboardingTasks: OnboardingTaskStatus[];
+  }>([`/organizations/${organization.slug}/onboarding-tasks/`], {
+    staleTime: 0,
+    enabled: supportedTasks.length > 0,
+    refetchInterval: query => {
+      const data = query.state.data?.[0]?.onboardingTasks;
+      if (!data) {
+        return false;
+      }
+
+      const serverCompletedTasks = (data as OnboardingTask[]).filter(findCompleteTasks);
+
+      // Stop polling if all tasks are complete
+      return serverCompletedTasks.length === supportedTasks.length
+        ? false
+        : DEFAULT_POLL_INTERVAL_MS;
+    },
+  });
+
+  const mergedTasks = mergeTasks({
+    supportedTasks,
+    serverTasks: serverTasks.onboardingTasks,
+  });
+
+  return {
+    allTasks: supportedTasks,
+    completeTasks: mergedTasks.filter(findCompleteTasks),
+    gettingStartedTasks: supportedTasks.filter(
+      task => task.group === OnboardingTaskGroup.GETTING_STARTED
+    ),
+    beyondBasicsTasks: supportedTasks.filter(
+      task => task.group !== OnboardingTaskGroup.GETTING_STARTED
+    ),
+  };
+}

--- a/static/app/components/sidebar/newOnboardingStatus.tsx
+++ b/static/app/components/sidebar/newOnboardingStatus.tsx
@@ -4,10 +4,9 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {OnboardingContext} from 'sentry/components/onboarding/onboardingContext';
-import {
-  NewOnboardingSidebar,
-  useOnboardingTasks,
-} from 'sentry/components/onboardingWizard/newSidebar';
+import {NewOnboardingSidebar} from 'sentry/components/onboardingWizard/newSidebar';
+import {getMergedTasks} from 'sentry/components/onboardingWizard/taskConfig';
+import {useOnboardingTasks} from 'sentry/components/onboardingWizard/useOnboardingTasks';
 import ProgressRing, {
   RingBackground,
   RingBar,
@@ -42,8 +41,14 @@ export function NewOnboardingStatus({
   const isActive = currentPanel === SidebarPanelKey.ONBOARDING_WIZARD;
   const walkthrough = isDemoWalkthrough();
 
+  const supportedTasks = getMergedTasks({
+    organization,
+    projects,
+    onboardingContext,
+  }).filter(task => task.display);
+
   const {allTasks, gettingStartedTasks, beyondBasicsTasks, completeTasks} =
-    useOnboardingTasks(organization, projects, onboardingContext);
+    useOnboardingTasks({supportedTasks});
 
   const handleToggle = useCallback(() => {
     if (!walkthrough && !isActive === true) {


### PR DESCRIPTION
This PR introduces a new hook, `useOnboardingTasks`, which fetches data from the `onboarding-tasks/` endpoint and continues to fetch until all supported tasks are completed.

In a follow-up, we can remove the project polling currently implemented in tasks such as "Capture your first error". See [here](https://github.com/getsentry/sentry/blob/a0970b65d3e821177837a209d3fad1cad4729b5f/static/app/components/onboardingWizard/taskConfig.tsx#L199-L219)



