### PR TITLE
fix(dashboards): Improve typography of `WidgetCard` error panel

### DIFF
--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
@@ -130,7 +130,7 @@ export default storyBook(BigNumberWidget, story => {
           <JSXProperty name="maximumValue" value={1000000} /> will show &gt;1m.
         </p>
         <SideBySide>
-          <NormalWidget>
+          <SmallWidget>
             <BigNumberWidget
               title="Count"
               data={[
@@ -145,7 +145,7 @@ export default storyBook(BigNumberWidget, story => {
                 },
               }}
             />
-          </NormalWidget>
+          </SmallWidget>
         </SideBySide>
       </Fragment>
     );
@@ -161,25 +161,25 @@ export default storyBook(BigNumberWidget, story => {
         </p>
 
         <SideBySide>
-          <NormalWidget>
+          <SmallWidget>
             <BigNumberWidget title="Loading Count" isLoading />
-          </NormalWidget>
-          <NormalWidget>
+          </SmallWidget>
+          <SmallWidget>
             <BigNumberWidget title="Missing Count" data={[{}]} />
-          </NormalWidget>
-          <NormalWidget>
+          </SmallWidget>
+          <SmallWidget>
             <BigNumberWidget
               title="Count Error"
               error={new Error('Something went wrong!')}
             />
-          </NormalWidget>
-          <NormalWidget>
+          </SmallWidget>
+          <SmallWidget>
             <BigNumberWidget
               title="Data Error"
               error={new Error('Something went wrong!')}
               onRetry={() => {}}
             />
-          </NormalWidget>
+          </SmallWidget>
         </SideBySide>
       </Fragment>
     );
@@ -203,7 +203,7 @@ export default storyBook(BigNumberWidget, story => {
         </p>
 
         <SideBySide>
-          <NormalWidget>
+          <SmallWidget>
             <BigNumberWidget
               title="eps()"
               data={[
@@ -225,9 +225,9 @@ export default storyBook(BigNumberWidget, story => {
                 },
               }}
             />
-          </NormalWidget>
+          </SmallWidget>
 
-          <NormalWidget>
+          <SmallWidget>
             <BigNumberWidget
               title="http_rate(500)"
               data={[
@@ -247,8 +247,8 @@ export default storyBook(BigNumberWidget, story => {
                 },
               }}
             />
-          </NormalWidget>
-          <NormalWidget>
+          </SmallWidget>
+          <SmallWidget>
             <BigNumberWidget
               title="http_rate(200)"
               data={[
@@ -268,7 +268,7 @@ export default storyBook(BigNumberWidget, story => {
                 },
               }}
             />
-          </NormalWidget>
+          </SmallWidget>
         </SideBySide>
       </Fragment>
     );
@@ -301,7 +301,7 @@ export default storyBook(BigNumberWidget, story => {
         </p>
 
         <SideBySide>
-          <NormalWidget>
+          <SmallWidget>
             <BigNumberWidget
               title="eps()"
               data={[
@@ -313,9 +313,9 @@ export default storyBook(BigNumberWidget, story => {
               thresholds={thresholds}
               preferredPolarity="+"
             />
-          </NormalWidget>
+          </SmallWidget>
 
-          <NormalWidget>
+          <SmallWidget>
             <BigNumberWidget
               title="eps()"
               data={[
@@ -327,9 +327,9 @@ export default storyBook(BigNumberWidget, story => {
               thresholds={thresholds}
               preferredPolarity="-"
             />
-          </NormalWidget>
+          </SmallWidget>
 
-          <NormalWidget>
+          <SmallWidget>
             <BigNumberWidget
               title="eps()"
               data={[
@@ -341,7 +341,7 @@ export default storyBook(BigNumberWidget, story => {
               thresholds={thresholds}
               preferredPolarity="+"
             />
-          </NormalWidget>
+          </SmallWidget>
         </SideBySide>
 
         <p>
@@ -350,7 +350,7 @@ export default storyBook(BigNumberWidget, story => {
         </p>
 
         <SideBySide>
-          <NormalWidget>
+          <SmallWidget>
             <BigNumberWidget
               title="eps()"
               data={[
@@ -362,9 +362,9 @@ export default storyBook(BigNumberWidget, story => {
               thresholds={thresholds}
               preferredPolarity="-"
             />
-          </NormalWidget>
+          </SmallWidget>
 
-          <NormalWidget>
+          <SmallWidget>
             <BigNumberWidget
               title="eps()"
               data={[
@@ -376,9 +376,9 @@ export default storyBook(BigNumberWidget, story => {
               thresholds={thresholds}
               preferredPolarity="-"
             />
-          </NormalWidget>
+          </SmallWidget>
 
-          <NormalWidget>
+          <SmallWidget>
             <BigNumberWidget
               title="eps()"
               data={[
@@ -390,7 +390,7 @@ export default storyBook(BigNumberWidget, story => {
               thresholds={thresholds}
               preferredPolarity="-"
             />
-          </NormalWidget>
+          </SmallWidget>
         </SideBySide>
       </Fragment>
     );
@@ -402,6 +402,6 @@ const SmallSizingWindow = styled(SizingWindow)`
   height: 200px;
 `;
 
-const NormalWidget = styled('div')`
+const SmallWidget = styled('div')`
   width: 250px;
 `;

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.stories.tsx
@@ -181,6 +181,18 @@ export default storyBook(BigNumberWidget, story => {
             />
           </SmallWidget>
         </SideBySide>
+
+        <p>The contents of the error adjust slightly as the widget gets bigger.</p>
+
+        <SideBySide>
+          <MediumWidget>
+            <BigNumberWidget
+              title="Data Error"
+              error={new Error('Something went wrong!')}
+              onRetry={() => {}}
+            />
+          </MediumWidget>
+        </SideBySide>
       </Fragment>
     );
   });
@@ -404,4 +416,8 @@ const SmallSizingWindow = styled(SizingWindow)`
 
 const SmallWidget = styled('div')`
   width: 250px;
+`;
+
+const MediumWidget = styled('div')`
+  width: 420px;
 `;

--- a/static/app/views/dashboards/widgets/common/errorPanel.tsx
+++ b/static/app/views/dashboards/widgets/common/errorPanel.tsx
@@ -13,16 +13,15 @@ export function ErrorPanel({error}: ErrorPanelProps) {
   return (
     <Panel>
       <NonShrinkingWarningIcon color={DEEMPHASIS_COLOR_NAME} size="md" />
-      <span>{error?.toString()}</span>
+      <ErrorText>{error?.toString()}</ErrorText>
     </Panel>
   );
 }
 
-const NonShrinkingWarningIcon = styled(IconWarning)`
-  flex-shrink: 0;
-`;
-
 const Panel = styled('div')<{height?: string}>`
+  container-type: size;
+  container-name: error-panel;
+
   position: absolute;
   inset: 0;
 
@@ -34,5 +33,16 @@ const Panel = styled('div')<{height?: string}>`
   overflow: hidden;
 
   color: ${p => p.theme[DEEMPHASIS_COLOR_NAME]};
-  font-size: ${p => p.theme.fontSizeLarge};
+`;
+
+const NonShrinkingWarningIcon = styled(IconWarning)`
+  flex-shrink: 0;
+`;
+
+const ErrorText = styled('span')`
+  font-size: ${p => p.theme.fontSizeSmall};
+
+  @container error-panel (min-width: 360px) {
+    font-size: ${p => p.theme.fontSizeMedium};
+  }
 `;


### PR DESCRIPTION
Reduce the font-size so it fits into small cards, and use a container query to increase the font size at higher sizes. I'll fix the icon behaviour in another PR later.

**e.g.,**
<img width="454" alt="Screenshot 2024-10-23 at 11 11 19 AM" src="https://github.com/user-attachments/assets/ed7af05e-f3f6-4c0d-a27c-3694576b70e8">
