### PR TITLE
fix(insights): correct feature flags used in domain views

### DIFF
--- a/static/app/components/nav/config.tsx
+++ b/static/app/components/nav/config.tsx
@@ -101,7 +101,7 @@ export function createNavConfig({organization}: {organization: Organization}): N
   const perfDomainViews: NavSidebarItem = {
     label: t('Perf.'),
     icon: <IconLightning />,
-    feature: {features: 'insights-domain-view'},
+    feature: {features: ['insights-domain-view', 'performance-view']},
     submenu: [
       {
         label: FRONTEND_LANDING_TITLE,

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -606,7 +606,10 @@ function Sidebar() {
   );
 
   const performanceDomains = hasOrganization && (
-    <Feature features="insights-domain-view" organization={organization}>
+    <Feature
+      features={['insights-domain-view', 'performance-view']}
+      organization={organization}
+    >
       <SidebarAccordion
         {...sidebarItemProps}
         icon={<IconGraph />}

--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -6,7 +6,6 @@ import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidg
 import * as Layout from 'sentry/components/layouts/thirds';
 import {TabList, Tabs} from 'sentry/components/tabs';
 import {t} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
@@ -14,7 +13,6 @@ import {
   useModuleURLBuilder,
 } from 'sentry/views/insights/common/utils/useModuleURL';
 import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
-import {isModuleEnabled} from 'sentry/views/insights/pages/utils';
 import {MODULE_TITLES} from 'sentry/views/insights/settings';
 import type {ModuleName} from 'sentry/views/insights/types';
 
@@ -69,7 +67,7 @@ export function DomainViewHeader({
     ...additionalBreadCrumbs,
   ];
 
-  const filteredModules = filterEnabledModules(modules, organization);
+  const showModuleTabs = organization.features.includes('insights-entry-points');
 
   const defaultHandleTabChange = (key: ModuleName | typeof OVERVIEW_PAGE_TITLE) => {
     if (key === selectedModule || (key === OVERVIEW_PAGE_TITLE && !module)) {
@@ -96,11 +94,16 @@ export function DomainViewHeader({
       key: OVERVIEW_PAGE_TITLE,
       label: OVERVIEW_PAGE_TITLE,
     },
-    ...filteredModules.map(moduleName => ({
-      key: moduleName,
-      label: MODULE_TITLES[moduleName],
-    })),
   ];
+
+  if (showModuleTabs) {
+    tabList.push(
+      ...modules.map(moduleName => ({
+        key: moduleName,
+        label: MODULE_TITLES[moduleName],
+      }))
+    );
+  }
 
   return (
     <Fragment>
@@ -130,10 +133,3 @@ export function DomainViewHeader({
     </Fragment>
   );
 }
-
-const filterEnabledModules = (modules: ModuleName[], organization: Organization) => {
-  if (!organization.features.includes('insights-entry-points')) {
-    return [];
-  }
-  return modules.filter(module => isModuleEnabled(module, organization));
-};

--- a/static/app/views/insights/pages/mobile/mobilePageHeader.tsx
+++ b/static/app/views/insights/pages/mobile/mobilePageHeader.tsx
@@ -36,15 +36,15 @@ export function MobileHeader({
   );
 
   const hasMobileScreens = isModuleEnabled(ModuleName.MOBILE_SCREENS, organization);
+  const hasMobileUi = isModuleEnabled(ModuleName.MOBILE_UI, organization);
 
   const modules = hasMobileScreens
     ? [ModuleName.MOBILE_SCREENS]
-    : [
-        ModuleName.APP_START,
-        ModuleName.SCREEN_LOAD,
-        ModuleName.SCREEN_RENDERING,
-        ModuleName.MOBILE_UI,
-      ];
+    : [ModuleName.APP_START, ModuleName.SCREEN_LOAD, ModuleName.SCREEN_RENDERING];
+
+  if (!hasMobileScreens && hasMobileUi) {
+    modules.push(ModuleName.MOBILE_UI);
+  }
 
   return (
     <DomainViewHeader


### PR DESCRIPTION
There is a couple things I overlooked when doing the features for domain views, this PR corrects them. Here are the corrections

**SIDEBAR** 
To see the domain view section in the sidebar, you need access to both the `performance-view` and `insights-domain-view-flag`, `performance-view` was missed but its needed because we need to retain the same gating because domain views includes performance views.

**DOMAIN VIEW HEADERS**
- To view the module tabs within the headers, the only flag they need is `insights-entry-points`. Once they click the module tab, if the feature specific to the module is not enabled, the appropriate upsell page will be displayed, otherwise the module is displayed. (this logic already exists). What I did before was check if the module itself is enabled to render the tabs, but that would mean the upsell page was never displayed.
- If there is a module that shouldn't be displayed, even with `insights-entry-points` enabled (such as the screen loads module), the appropriate logic is added to the header (such as in `mobilePageHeader.tsx`)