### PR TITLE
ref(profiling) remove autoscroll to 3/4 screen

### DIFF
--- a/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
@@ -81,25 +81,6 @@ export function AggregateFlamegraph(props: AggregateFlamegraphProps): ReactEleme
         },
       });
 
-      // Find p75 of the graphtree depth and set the view to 3/4 of that
-      const depths: number[] = [];
-      for (const frame of flamegraph.frames) {
-        if (frame.children.length > 0) {
-          continue;
-        }
-        depths.push(frame.depth);
-      }
-
-      if (depths.length > 0) {
-        depths.sort();
-        const d = depths[Math.floor(depths.length - 1 * 0.75)];
-        const depth = Math.max(d, 0);
-
-        newView.setConfigView(
-          newView.configView.withY(depth - (newView.configView.height * 3) / 4)
-        );
-      }
-
       return newView;
     },
 

--- a/static/app/components/profiling/flamegraph/differentialFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/differentialFlamegraph.tsx
@@ -68,25 +68,6 @@ export function DifferentialFlamegraph(props: DifferentialFlamegraphProps): Reac
         },
       });
 
-      // Find p75 of the graphtree depth and set the view to 3/4 of that
-      const depths: number[] = [];
-      for (const frame of props.differentialFlamegraph.frames) {
-        if (frame.children.length > 0) {
-          continue;
-        }
-        depths.push(frame.depth);
-      }
-
-      if (depths.length > 0) {
-        depths.sort();
-        const d = depths[Math.floor(depths.length - 1 * 0.75)];
-        const depth = Math.max(d, 0);
-
-        newView.setConfigView(
-          newView.configView.withY(depth - (newView.configView.height * 3) / 4)
-        );
-      }
-
       return newView;
     },
 

--- a/static/app/views/profiling/differentialFlamegraph.tsx
+++ b/static/app/views/profiling/differentialFlamegraph.tsx
@@ -127,25 +127,6 @@ function DifferentialFlamegraphView() {
         },
       });
 
-      // Find p75 of the graphtree depth and set the view to 3/4 of that
-      const depths: number[] = [];
-      for (const frame of differentialFlamegraph.differentialFlamegraph.frames) {
-        if (frame.children.length > 0) {
-          continue;
-        }
-        depths.push(frame.depth);
-      }
-
-      if (depths.length > 0) {
-        depths.sort();
-        const d = depths[Math.floor(depths.length - 1 * 0.75)];
-        const depth = Math.max(d, 0);
-
-        newView.setConfigView(
-          newView.configView.withY(depth - (newView.configView.height * 3) / 4)
-        );
-      }
-
       return newView;
     },
 


### PR DESCRIPTION
This doesnt work well in cases where the flamegraph has one deep stack. If we want to do this properly, we should look to either build on some heuristic of first app frame or above or look into computing a visual weight