### PR TITLE
ref(devtools): Return current transaction name and search term

### DIFF
--- a/static/app/components/devtoolbar/hooks/useCurrentTransactionName.test.tsx
+++ b/static/app/components/devtoolbar/hooks/useCurrentTransactionName.test.tsx
@@ -1,0 +1,32 @@
+// case: transactionName includes non parameterized id eg.  /issues/4489703641/ or /releases/frontend@e99590b53cf9817aa9086b5b464fd9eb4c895453/
+
+import {toSearchTerm} from 'sentry/components/devtoolbar/hooks/useCurrentTransactionName';
+
+// case: transactionName includes :id eg. //alerts/rules/details/:ruleId/
+
+// '/pokemon/[pokemonName]';
+
+describe('getSearchTerm', () => {
+  it.each([
+    {
+      transactionName: '//alerts/rules/details/:ruleId/',
+      searchTerm: '/alerts/rules/details/*/',
+    },
+    {transactionName: '/pokemon/[pokemonName]', searchTerm: '/pokemon/*/'},
+    {transactionName: '/replays/<id>/details/', searchTerm: '/replays/*/details/'},
+    {
+      transactionName: '/param/{id}/param2/key:value/',
+      searchTerm: '/param/*/param2/key:value/',
+    },
+    {transactionName: '/issues/4489703641/', searchTerm: '/issues/*/'},
+    {
+      transactionName: '/all/:id1/:id2/param',
+      searchTerm: '/all/*/*/param/',
+    },
+  ])(
+    'should get the correct search term from the transaction name',
+    ({transactionName, searchTerm}) => {
+      expect(toSearchTerm(transactionName)).toStrictEqual(searchTerm);
+    }
+  );
+});

--- a/static/app/components/devtoolbar/hooks/useCurrentTransactionName.test.tsx
+++ b/static/app/components/devtoolbar/hooks/useCurrentTransactionName.test.tsx
@@ -14,6 +14,10 @@ describe('getSearchTerm', () => {
     },
     {transactionName: '/issues/4489703641/', searchTerm: '/issues/*/'},
     {
+      transactionName: 'v1.3/tutorial/event/123',
+      searchTerm: '/v1.3/tutorial/event/*/',
+    },
+    {
       transactionName: '/all/:id1/:id2/param',
       searchTerm: '/all/*/*/param/',
     },

--- a/static/app/components/devtoolbar/hooks/useCurrentTransactionName.test.tsx
+++ b/static/app/components/devtoolbar/hooks/useCurrentTransactionName.test.tsx
@@ -1,10 +1,4 @@
-// case: transactionName includes non parameterized id eg.  /issues/4489703641/ or /releases/frontend@e99590b53cf9817aa9086b5b464fd9eb4c895453/
-
 import {toSearchTerm} from 'sentry/components/devtoolbar/hooks/useCurrentTransactionName';
-
-// case: transactionName includes :id eg. //alerts/rules/details/:ruleId/
-
-// '/pokemon/[pokemonName]';
 
 describe('getSearchTerm', () => {
   it.each([

--- a/static/app/components/devtoolbar/hooks/useCurrentTransactionName.test.tsx
+++ b/static/app/components/devtoolbar/hooks/useCurrentTransactionName.test.tsx
@@ -17,6 +17,22 @@ describe('getSearchTerm', () => {
       transactionName: '/all/:id1/:id2/param',
       searchTerm: '/all/*/*/param/',
     },
+    {
+      transactionName: '//settings/account/emails/',
+      searchTerm: '/settings/account/emails/',
+    },
+    {
+      transactionName: '//settings/account/api/auth-tokens/new-token/',
+      searchTerm: '/settings/account/api/auth-tokens/new-token/',
+    },
+    {
+      transactionName: '/about/ps5/',
+      searchTerm: '/about/ps5/',
+    },
+    {
+      transactionName: '/',
+      searchTerm: '/',
+    },
   ])(
     'should get the correct search term from the transaction name',
     ({transactionName, searchTerm}) => {

--- a/static/app/components/devtoolbar/hooks/useCurrentTransactionName.tsx
+++ b/static/app/components/devtoolbar/hooks/useCurrentTransactionName.tsx
@@ -76,18 +76,13 @@ export function toSearchTerm(transaction) {
   // finds dynamic parts of transaction name to change into search term
   let modifiedTransaction = transaction;
 
-  // /:param used by React, Vue, Angular, Express, Ruby on Rails, Phoenix, Solid
-  const colonRegex = /([\/])(([:]([^\/]*)))/g;
-  modifiedTransaction = modifiedTransaction.replaceAll(colonRegex, '/*');
-  // /[param] used by Next.js, Nuxt.js, Svelte
-  const bracketRegex = /([\/])([\[]([^\/]*)[\]])/g;
-  modifiedTransaction = modifiedTransaction.replaceAll(bracketRegex, '/*');
-  //  /{param} used by ASP.NET Core, Laravel, Symfony
-  const curlyRegex = /([\/])([{]([^\/]*)[}])/g;
-  modifiedTransaction = modifiedTransaction.replaceAll(curlyRegex, '/*');
-  // /<param> used by Flask, Django
-  const arrowRegex = /([\/])([<]([^\/]*)[>])/g;
-  modifiedTransaction = modifiedTransaction.replaceAll(arrowRegex, '/*');
+  // ([:]([^\/]*)) matches :param used by React, Vue, Angular, Express, Ruby on Rails, Phoenix, Solid
+  // ([\[]([^\/]*)[\]]) matches [param] used by Next.js, Nuxt.js, Svelte
+  // ([{]([^\/]*)[}]) matches {param} used by ASP.NET Core, Laravel, Symfony
+  // ([<]([^\/]*)[>]) matches <param> used by Flask, Django
+  const parameterizedRegex =
+    / ([\/]) (([:]([^\/]*)) | ([\[]([^\/]*)[\]]) | ([{]([^\/]*)[}]) | ([<]([^\/]*)[>])) /g;
+  modifiedTransaction = modifiedTransaction.replaceAll(parameterizedRegex, '/*');
 
   // transaction name could contain the resolved URL instead of the route pattern (ie actual id instead of :id)
   // match any param that starts with a number eg. /12353

--- a/static/app/components/devtoolbar/hooks/useCurrentTransactionName.tsx
+++ b/static/app/components/devtoolbar/hooks/useCurrentTransactionName.tsx
@@ -81,7 +81,7 @@ export function toSearchTerm(transaction) {
   // ([{]([^\/]*)[}]) matches {param} used by ASP.NET Core, Laravel, Symfony
   // ([<]([^\/]*)[>]) matches <param> used by Flask, Django
   const parameterizedRegex =
-    / ([\/]) (([:]([^\/]*)) | ([\[]([^\/]*)[\]]) | ([{]([^\/]*)[}]) | ([<]([^\/]*)[>])) /g;
+    /([\/])(([:]([^\/]*))|([\[]([^\/]*)[\]])|([{]([^\/]*)[}])|([<]([^\/]*)[>]))/g;
   modifiedTransaction = modifiedTransaction.replaceAll(parameterizedRegex, '/*');
 
   // transaction name could contain the resolved URL instead of the route pattern (ie actual id instead of :id)

--- a/static/app/components/devtoolbar/hooks/useCurrentTransactionName.tsx
+++ b/static/app/components/devtoolbar/hooks/useCurrentTransactionName.tsx
@@ -82,7 +82,7 @@ export function toSearchTerm(transaction) {
   const nonparameterizedRegex = /([\/])([0-9]+)/g;
   transaction = transaction.replaceAll(nonparameterizedRegex, '/*');
 
-  // Step 3: Join the array back into a string with '/'
+  // Join the array back into a string with '/'
   const searchTerm = `/${transaction}/`.replaceAll(/\/+/g, '/');
   return searchTerm;
 }

--- a/static/app/components/devtoolbar/hooks/useCurrentTransactionName.tsx
+++ b/static/app/components/devtoolbar/hooks/useCurrentTransactionName.tsx
@@ -1,8 +1,88 @@
-import * as Sentry from '@sentry/react';
+import type {Scope} from '@sentry/types';
+
+type V8Carrier = {
+  stack: {
+    getScope?: () => Scope;
+  };
+};
+
+type LegacyCarrier = {
+  /** pre-v8 way of accessing scope (v7 and earlier) */
+  hub?: {
+    getScope?: () => Scope;
+  };
+};
+
+type VersionedCarrier = {version: string} & Record<Exclude<string, 'version'>, V8Carrier>;
+
+type WindowWithSentry = Window & {
+  __SENTRY__?: LegacyCarrier & VersionedCarrier;
+};
 
 export default function useCurrentTransactionName() {
-  const scope = Sentry.getCurrentScope();
+  const scope = getScope();
   const scopeData = scope.getScopeData();
-  const transactionName = `/${scopeData.transactionName}/`.replaceAll('//', '/');
-  return transactionName;
+
+  const search = toSearchTerm(scopeData.transactionName);
+
+  return search;
+}
+
+function getScope() {
+  const sentryCarrier = (window as WindowWithSentry).__SENTRY__;
+  const sentryClient = sentryCarrier && getSentryScope(sentryCarrier);
+
+  if (!sentryClient) {
+    // TODO: find a way to get scope on v7 of the Sentry SDK
+    throw Error(
+      "Couldn't find a Sentry SDK client. Make sure you're using a Sentry SDK with version 7.x or 8.x"
+    );
+  }
+
+  return sentryClient;
+}
+
+/**
+ * Accesses the `window.__SENTRY__` carrier object and tries to get the Sentry client
+ * from it. This function supports all carrier object structures from v7 to all versions
+ * of v8.
+ */
+function getSentryScope(
+  sentryCarrier: LegacyCarrier & VersionedCarrier
+): Scope | undefined {
+  // 8.6.0+ way to get the scope
+  if (sentryCarrier.version) {
+    const versionedCarrier = sentryCarrier[sentryCarrier.version];
+    const scope =
+      typeof versionedCarrier?.stack?.getScope === 'function'
+        ? versionedCarrier?.stack?.getScope?.()
+        : undefined;
+    return scope;
+  }
+
+  // pre-8.6.0 (+v7) way to get the scope
+  if (sentryCarrier.hub) {
+    const hub = sentryCarrier.hub;
+    if (typeof hub.getScope === 'function') {
+      return hub.getScope();
+    }
+  }
+
+  return undefined;
+}
+
+export function toSearchTerm(transaction) {
+  // finds parameterized parts of transaction name: /:param, /[param], /{param}, /<param>,
+  const parameterizedRegex =
+    /([\/])(([:]([^\/]*))|([\[]([^\/]*)[\]])|([{]([^\/]*)[}])|([<]([^\/]*)[>]))/g;
+
+  transaction = transaction.replaceAll(parameterizedRegex, '/*');
+
+  // replaces nonparameterized urls with /*/ ie. /12345/
+  const nonparameterizedRegex = /([\/])([0-9]+)/g;
+  transaction = transaction.replaceAll(nonparameterizedRegex, '/*');
+
+  // Step 3: Join the array back into a string with '/'
+  const searchTerm = `/${transaction}/`.replaceAll(/\/+/g, '/');
+  return searchTerm;
 }

--- a/static/app/components/devtoolbar/hooks/useCurrentTransactionName.tsx
+++ b/static/app/components/devtoolbar/hooks/useCurrentTransactionName.tsx
@@ -34,6 +34,7 @@ function getScope() {
 
   if (!sentryScope) {
     // using console log for now, will change this when moving to dev tool bar repo
+    // eslint-disable-next-line no-console
     console.log(
       "Couldn't find a Sentry SDK scope. Make sure you're using a Sentry SDK with version 7.x or 8.x"
     );

--- a/static/app/components/devtoolbar/hooks/useCurrentTransactionName.tsx
+++ b/static/app/components/devtoolbar/hooks/useCurrentTransactionName.tsx
@@ -30,20 +30,19 @@ export default function useCurrentTransactionName() {
 
 function getScope() {
   const sentryCarrier = (window as WindowWithSentry).__SENTRY__;
-  const sentryClient = sentryCarrier && getSentryScope(sentryCarrier);
+  const sentryScope = sentryCarrier && getSentryScope(sentryCarrier);
 
-  if (!sentryClient) {
-    // TODO: find a way to get scope on v7 of the Sentry SDK
+  if (!sentryScope) {
     throw Error(
-      "Couldn't find a Sentry SDK client. Make sure you're using a Sentry SDK with version 7.x or 8.x"
+      "Couldn't find a Sentry SDK scope. Make sure you're using a Sentry SDK with version 7.x or 8.x"
     );
   }
 
-  return sentryClient;
+  return sentryScope;
 }
 
 /**
- * Accesses the `window.__SENTRY__` carrier object and tries to get the Sentry client
+ * Accesses the `window.__SENTRY__` carrier object and tries to get the Sentry scope
  * from it. This function supports all carrier object structures from v7 to all versions
  * of v8.
  */

--- a/static/app/components/devtoolbar/hooks/useCurrentTransactionName.tsx
+++ b/static/app/components/devtoolbar/hooks/useCurrentTransactionName.tsx
@@ -78,7 +78,7 @@ export function toSearchTerm(transaction) {
 
   transaction = transaction.replaceAll(parameterizedRegex, '/*');
 
-  // replaces nonparameterized urls with /*/ ie. /12345/
+  // finds nonparameterized parts of transaction: /12345/
   const nonparameterizedRegex = /([\/])([0-9]+)/g;
   transaction = transaction.replaceAll(nonparameterizedRegex, '/*');
 


### PR DESCRIPTION
This gets the current transaction name from an instance of the JS SDK, and turns it into an issue search-query.
We get the transaction name from the window's Sentry SDK instead of importing Sentry. The way to access the scope of the SDK changed in v8.6.0, so there's a new way and a legacy way to access the scope. This ensures that the toolbar will work with SDK v7+. 
We then change the transaction name into an issue searchable query. The transaction name could have an id, which could be in a generalized format. This PR replaces IDs that are only integers, and ids with the format `:id`, `<id>`, `{id}`, and `[id]` with `*` so the issue search doesn't only apply to pages with that specific id. In the future, we could expand the regex to replace UUIDs too.
If the scope is needed for other use cases, we could split that into a separate file, but for now it's easier transfer this into the dev toolbar repo if everything is in one file.

Before:
<img width="1485" alt="image" src="https://github.com/user-attachments/assets/474a4ae6-7c62-48b6-abc2-6ba4897b92ea">

After: 
<img width="1485" alt="image" src="https://github.com/user-attachments/assets/e37c66fc-09c3-4feb-95ed-e19d3dcd619b">


Closes https://github.com/getsentry/sentry-toolbar/issues/72