### PR TITLE
chore(issue-views): Speed up animation of ellipsis menu fading in

### DIFF
--- a/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/draggableTabBar.tsx
@@ -478,7 +478,7 @@ export function DraggableTabBar({
                 // but enables the animation later on when switching tabs
                 initial={tabListState ? {opacity: 0} : false}
                 animate={{opacity: 1}}
-                transition={{delay: 0.1}}
+                transition={{delay: 0.1, duration: 0.1}}
               >
                 <DraggableTabMenuButton
                   hasUnsavedChanges={!!tab.unsavedChanges}


### PR DESCRIPTION
The duration for the tab select animation was decreased - this PR makes the duration for fade in animation for the ellipsis menu match that of the tab select animation. 