### PR TITLE
feat(autofix): Add support for showing a reason for not finding a root cause

### DIFF
--- a/static/app/components/events/autofix/autofixRootCause.spec.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.spec.tsx
@@ -42,15 +42,14 @@ describe('AutofixRootCause', function () {
         {...{
           ...defaultProps,
           causes: [],
+          terminationReason: 'The error comes from outside the codebase.',
         }}
       />
     );
 
     // Displays all root cause and code context info
     expect(
-      screen.getByText(
-        'No root cause found. Maybe help Autofix rethink by editing an insight above?'
-      )
+      screen.getByText('No root cause found. The error comes from outside the codebase.')
     ).toBeInTheDocument();
   });
 

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -42,6 +42,7 @@ type AutofixRootCauseProps = {
   repos: AutofixRepository[];
   rootCauseSelection: AutofixRootCauseSelection;
   runId: string;
+  terminationReason?: string;
 };
 
 const contentAnimationProps: AnimationProps = {
@@ -474,9 +475,7 @@ export function AutofixRootCause(props: AutofixRootCauseProps) {
         <AnimationWrapper key="card" {...cardAnimationProps}>
           <NoCausesPadding>
             <Alert type="warning">
-              {t(
-                'No root cause found. Maybe help Autofix rethink by editing an insight above?'
-              )}
+              {t('No root cause found.\n\n%s', props.terminationReason ?? '')}
             </Alert>
           </NoCausesPadding>
         </AnimationWrapper>

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -91,6 +91,7 @@ export function Step({
                   runId={runId}
                   causes={step.causes}
                   rootCauseSelection={step.selection}
+                  terminationReason={step.termination_reason}
                   repos={repos}
                 />
               )}

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -140,6 +140,7 @@ export interface AutofixRootCauseStep extends BaseStep {
   causes: AutofixRootCauseData[];
   selection: AutofixRootCauseSelection;
   type: AutofixStepType.ROOT_CAUSE_ANALYSIS;
+  termination_reason?: string;
 }
 
 export type AutofixCodebaseChange = {


### PR DESCRIPTION
When Autofix can't find a root cause, we can now show a reason why.
<img width="693" alt="Screenshot 2024-10-23 at 10 22 18 AM" src="https://github.com/user-attachments/assets/34ab0a2d-7f18-44b6-a1c7-d06f3a0e803e">
