### PR TITLE
fix(profiling): Track sample stats for continuous profiles

### DIFF
--- a/static/app/utils/profiling/profile/continuousProfile.tsx
+++ b/static/app/utils/profiling/profile/continuousProfile.tsx
@@ -63,6 +63,9 @@ export class ContinuousProfile extends Profile {
   }
 
   appendSample(stack: Frame[], duration: number, end: number): void {
+    // Keep track of discarded samples and ones that may have negative weights
+    this.trackSampleStats(duration);
+
     // Ignore samples with 0 weight
     if (duration === 0) {
       return;


### PR DESCRIPTION
This ensures that the sample count for the thread selector is correct for continuous profiles.