### PR TITLE
ref: remove calls to iso_format(...) in tests/sentry/api

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_profiling_profiles.py
+++ b/tests/sentry/api/endpoints/test_organization_profiling_profiles.py
@@ -11,7 +11,7 @@ from sentry.profiles.flamegraph import FlamegraphExecutor
 from sentry.profiles.utils import proxy_profiling_service
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import APITestCase, ProfilesSnubaTestCase
-from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
+from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.utils.samples import load_data
 from sentry.utils.snuba import bulk_snuba_queries, raw_snql_query
 
@@ -605,8 +605,7 @@ class OrganizationProfilingFlamegraphTest(ProfilesSnubaTestCase):
         transaction = {
             "project.id": self.project.id,
             "profile.id": profile_id,
-            "timestamp": iso_format(datetime.fromtimestamp(profile_transaction["timestamp"]))
-            + "+00:00",
+            "timestamp": datetime.fromtimestamp(profile_transaction["timestamp"]).isoformat(),
             "profiler.id": None,
             "thread.id": None,
             "precise.start_ts": datetime.fromtimestamp(
@@ -726,8 +725,7 @@ class OrganizationProfilingFlamegraphTest(ProfilesSnubaTestCase):
             "id": profile_transaction_id,
             "project.id": self.project.id,
             "profile.id": profile_id,
-            "timestamp": iso_format(datetime.fromtimestamp(profile_transaction["timestamp"]))
-            + "+00:00",
+            "timestamp": datetime.fromtimestamp(profile_transaction["timestamp"]).isoformat(),
             "profiler.id": None,
             "thread.id": None,
             "precise.start_ts": datetime.fromtimestamp(
@@ -753,8 +751,7 @@ class OrganizationProfilingFlamegraphTest(ProfilesSnubaTestCase):
             "id": profiler_transaction_id,
             "project.id": self.project.id,
             "profile.id": None,
-            "timestamp": iso_format(datetime.fromtimestamp(profile_transaction["timestamp"]))
-            + "+00:00",
+            "timestamp": datetime.fromtimestamp(profile_transaction["timestamp"]).isoformat(),
             "profiler.id": profiler_id,
             "thread.id": thread_id,
             "precise.start_ts": datetime.fromtimestamp(

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 
 from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
 from sentry.testutils.cases import MetricsAPIBaseTestCase
-from sentry.testutils.helpers.datetime import freeze_time, iso_format
+from sentry.testutils.helpers.datetime import freeze_time
 from sentry.utils.samples import load_data
 
 pytestmark = [pytest.mark.sentry_metrics]
@@ -262,8 +262,8 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
                 {
                     "parent_span_id": "a" * 16,
                     "span_id": "e" * 16,
-                    "start_timestamp": iso_format(self.now - timedelta(days=2)),
-                    "timestamp": iso_format(self.now - timedelta(days=2)),
+                    "start_timestamp": (self.now - timedelta(days=2)).isoformat(),
+                    "timestamp": (self.now - timedelta(days=2)).isoformat(),
                     "op": "django.middleware",
                     "description": "middleware span",
                     "exclusive_time": 60.0,
@@ -284,8 +284,8 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
                 {
                     "parent_span_id": "a" * 16,
                     "span_id": "e" * 16,
-                    "start_timestamp": iso_format(self.now - timedelta(hours=1)),
-                    "timestamp": iso_format(self.now - timedelta(hours=1)),
+                    "start_timestamp": (self.now - timedelta(hours=1)).isoformat(),
+                    "timestamp": (self.now - timedelta(hours=1)).isoformat(),
                     "op": "django.middleware",
                     "description": "middleware span",
                     "exclusive_time": 100.0,
@@ -293,8 +293,8 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
                 {
                     "parent_span_id": "a" * 16,
                     "span_id": "f" * 16,
-                    "start_timestamp": iso_format(self.now - timedelta(hours=1)),
-                    "timestamp": iso_format(self.now - timedelta(hours=1)),
+                    "start_timestamp": (self.now - timedelta(hours=1)).isoformat(),
+                    "timestamp": (self.now - timedelta(hours=1)).isoformat(),
                     "op": "db",
                     "description": "db",
                     "exclusive_time": 10000.0,

--- a/tests/sentry/api/endpoints/test_organization_user_reports.py
+++ b/tests/sentry/api/endpoints/test_organization_user_reports.py
@@ -6,7 +6,6 @@ from sentry.ingest.userreport import save_userreport
 from sentry.models.group import GroupStatus
 from sentry.models.userreport import UserReport
 from sentry.testutils.cases import APITestCase, SnubaTestCase
-from sentry.testutils.helpers.datetime import iso_format
 
 
 class OrganizationUserReportListTest(APITestCase, SnubaTestCase):
@@ -169,7 +168,7 @@ class OrganizationUserReportListTest(APITestCase, SnubaTestCase):
         old_event = self.store_event(
             data={
                 "event_id": "f" * 32,
-                "timestamp": iso_format(datetime.now(UTC) - timedelta(days=retention_days + 1)),
+                "timestamp": (datetime.now(UTC) - timedelta(days=retention_days + 1)).isoformat(),
                 "environment": self.environment.name,
             },
             project_id=self.project_1.id,

--- a/tests/sentry/api/endpoints/test_project_users.py
+++ b/tests/sentry/api/endpoints/test_project_users.py
@@ -4,7 +4,6 @@ from unittest import mock
 from django.utils import timezone
 
 from sentry.testutils.cases import APITestCase, SnubaTestCase
-from sentry.testutils.helpers.datetime import iso_format
 from sentry.utils.eventuser import EventUser
 
 
@@ -18,7 +17,7 @@ class EventUserProjectUsersTest(APITestCase, SnubaTestCase):
             organization=self.organization, date_added=(timezone.now() - timedelta(hours=2))
         )
 
-        timestamp = iso_format(timezone.now() - timedelta(hours=1))
+        timestamp = (timezone.now() - timedelta(hours=1)).isoformat()
         self.event1 = self.store_event(
             project_id=self.project.id,
             data={

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -35,7 +35,6 @@ from sentry.incidents.models.alert_rule import AlertRule
 from sentry.incidents.models.incident import Incident
 from sentry.models.rule import Rule
 from sentry.testutils.cases import APITestCase, SnubaTestCase, TestCase
-from sentry.testutils.helpers.datetime import iso_format
 from sentry.testutils.silo import control_silo_test
 from sentry.users.models.user import User
 from sentry.utils.cursors import Cursor
@@ -925,7 +924,7 @@ class CallbackPaginatorTest(APITestCase, SnubaTestCase):
                 project_id=self.project.id,
                 data={
                     "event_id": str(i) * 32,
-                    "timestamp": iso_format(self.now - timedelta(minutes=2)),
+                    "timestamp": (self.now - timedelta(minutes=2)).isoformat(),
                 },
             )
 


### PR DESCRIPTION
I guess I have to teach my autofixer about addition / subtraction

<!-- Describe your PR here. -->