### PR TITLE
fix(issue-stream): Use correct first/last seen dates

### DIFF
--- a/static/app/components/stream/group.spec.tsx
+++ b/static/app/components/stream/group.spec.tsx
@@ -39,8 +39,13 @@ describe('StreamGroup', function () {
         reason: 0,
         reason_details: null,
       },
-      firstSeen: '2017-10-10T02:41:20.000Z',
-      lastSeen: '2017-10-16T02:41:20.000Z',
+      lifetime: {
+        firstSeen: '2017-10-10T02:41:20.000Z',
+        lastSeen: '2017-10-16T02:41:20.000Z',
+        count: '2',
+        userCount: 1,
+        stats: {},
+      },
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/projects/',

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -131,9 +131,9 @@ function GroupCheckbox({
   );
 }
 
-function GroupTimestamp({date, label}: {date: string | null; label: string}) {
+function GroupTimestamp({date, label}: {date: string | null | undefined; label: string}) {
   if (!date) {
-    return <Placeholder height="18px" width="40px" />;
+    return <Placeholder height="18px" width="60px" />;
   }
 
   return (
@@ -641,12 +641,12 @@ function BaseGroupRow({
         <Fragment>
           {withColumns.includes('firstSeen') && (
             <TimestampWrapper breakpoint={COLUMN_BREAKPOINTS.AGE}>
-              <GroupTimestamp date={group.firstSeen} label={t('First Seen')} />
+              <GroupTimestamp date={group.lifetime?.firstSeen} label={t('First Seen')} />
             </TimestampWrapper>
           )}
           {withColumns.includes('lastSeen') && (
             <TimestampWrapper breakpoint={COLUMN_BREAKPOINTS.SEEN}>
-              <GroupTimestamp date={group.lastSeen} label={t('Last Seen')} />
+              <GroupTimestamp date={group.lifetime?.lastSeen} label={t('Last Seen')} />
             </TimestampWrapper>
           )}
           {withColumns.includes('event') &&


### PR DESCRIPTION
On the issue stream, group.firstSeen and group.lastSeen is always within the selected time range. We should be looking at `lifetime` for the actual first/last seen.