### PR TITLE
fix(alerts): allow team admins to create alert rules

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -204,7 +204,8 @@ class OrganizationDataExportPermission(OrganizationPermission):
 class OrganizationAlertRulePermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin", "alerts:read"],
-        # grant org:write permission, but raise permission denied if the user isn't a team admin (doesn't have project:write)
+        # grant org:read permission, but raise permission denied if the members aren't allowed
+        # to create alerts and the user isn't a team admin
         "POST": ["org:read", "org:write", "org:admin", "alerts:write"],
         "PUT": ["org:write", "org:admin", "alerts:write"],
         "DELETE": ["org:write", "org:admin", "alerts:write"],

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -204,7 +204,8 @@ class OrganizationDataExportPermission(OrganizationPermission):
 class OrganizationAlertRulePermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin", "alerts:read"],
-        "POST": ["org:write", "org:admin", "alerts:write"],
+        # grant org:write permission, but raise permission denied if the user isn't a team admin (doesn't have project:write)
+        "POST": ["org:read", "org:write", "org:admin", "alerts:write"],
         "PUT": ["org:write", "org:admin", "alerts:write"],
         "DELETE": ["org:write", "org:admin", "alerts:write"],
     }

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -438,7 +438,9 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint, AlertRuleIndexMix
 
     def has_create_alert_permission(self, request: Request, organization: Organization) -> None:
         """
-        Determine if the requesting user has access to alert creation.
+        Determine if the requesting user has access to alert creation. If the request does not have the "alerts:write"
+        permission, then we must verify that the user is a team admin with "alerts:write" access to the project(s)
+        in their request.
         """
         #
         if request.access.has_scope("alerts:write"):
@@ -642,5 +644,5 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint, AlertRuleIndexMix
         }
         ```
         """
-
+        self.has_create_alert_permission(request, organization)
         return self.create_metric_alert(request, organization)

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -627,13 +627,11 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint, AlertRuleIndexMix
         """
         # projects where the user has project membership
         projects = self.get_projects(request, organization)
-        # team admins and regular org members don't have project:write on an org level
-        if not request.access.has_scope("project:write") and not request.access.has_scope(
-            "alerts:write"
-        ):
-            # team admins will have project:write scoped to their projects, members will not
+        # if sentry:alerts_member_write is false, then team admins and regular org members don't have alerts:write on an org level
+        if not request.access.has_scope("alerts:write"):
+            # team admins will have alerts:write scoped to their projects, members will not
             team_admin_has_access = all(
-                [request.access.has_project_scope(project, "project:write") for project in projects]
+                [request.access.has_project_scope(project, "alerts:write") for project in projects]
             )
             # all() returns True for empty list, so include a check for it
             if not team_admin_has_access or not projects:

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -436,7 +436,7 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint, AlertRuleIndexMix
     }
     permission_classes = (OrganizationAlertRulePermission,)
 
-    def has_create_alert_permission(self, request: Request, organization: Organization) -> None:
+    def check_can_create_alert(self, request: Request, organization: Organization) -> None:
         """
         Determine if the requesting user has access to alert creation. If the request does not have the "alerts:write"
         permission, then we must verify that the user is a team admin with "alerts:write" access to the project(s)
@@ -644,5 +644,5 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint, AlertRuleIndexMix
         }
         ```
         """
-        self.has_create_alert_permission(request, organization)
+        self.check_can_create_alert(request, organization)
         return self.create_metric_alert(request, organization)

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -989,6 +989,19 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         resp = self.get_response(self.organization.slug, **self.alert_rule_dict)
         assert resp.status_code == 403
 
+    def test_team_admin_create(self):
+        team_admin_user = self.create_user()
+        self.create_member(
+            team_roles=[(self.team, "admin")],
+            user=team_admin_user,
+            role="member",
+            organization=self.organization,
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+        self.login_as(team_admin_user)
+        resp = self.get_success_response(self.organization.slug, **self.alert_rule_dict)
+        assert resp.status_code == 201
+
     def test_member_create(self):
         member_user = self.create_user()
         self.create_member(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -999,7 +999,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         )
         self.organization.update_option("sentry:alerts_member_write", False)
         self.login_as(team_admin_user)
-        resp = self.get_success_response(self.organization.slug, **self.alert_rule_dict)
+        with self.feature("organizations:incidents"):
+            resp = self.get_success_response(self.organization.slug, **self.alert_rule_dict)
         assert resp.status_code == 201
 
     def test_member_create(self):

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -997,11 +997,22 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             role="member",
             organization=self.organization,
         )
+
+        member_user = self.create_user()
+        self.create_member(
+            user=member_user, organization=self.organization, role="member", teams=[self.team]
+        )
+
         self.organization.update_option("sentry:alerts_member_write", False)
         self.login_as(team_admin_user)
         with self.feature("organizations:incidents"):
             resp = self.get_success_response(self.organization.slug, **self.alert_rule_dict)
         assert resp.status_code == 201
+
+        # verify that a regular team member cannot create an alert
+        self.login_as(member_user)
+        resp = self.get_response(self.organization.slug, **self.alert_rule_dict)
+        assert resp.status_code == 403
 
     def test_member_create(self):
         member_user = self.create_user()


### PR DESCRIPTION
Fix a permission issue where team admins were unable to create alerts. The fix involves granting org:read access to the endpoint and then confirming in the convert_args that the user is a team admin for the project in the request. Also add a test to confirm this behavior.

Fixes https://github.com/getsentry/sentry/issues/75612