### PR TITLE
ref(performance): Remove references to flag `search-query-builder-performance` in a few places

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pageSamplePerformanceTable.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import {Button, LinkButton} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
-import SearchBar from 'sentry/components/events/searchBar';
 import type {GridColumnHeader, GridColumnOrder} from 'sentry/components/gridEditable';
 import GridEditable, {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import SortLink from 'sentry/components/gridEditable/sortLink';
@@ -459,20 +458,12 @@ export function PageSamplePerformanceTable({transaction, search, limit = 9}: Pro
           </SegmentedControl.Item>
         </SegmentedControl>
         <StyledSearchBar>
-          {organization.features.includes('search-query-builder-performance') ? (
-            <TransactionSearchQueryBuilder
-              projects={projectIds}
-              initialQuery={query ?? ''}
-              searchSource={`${ModuleName.VITAL}-page-summary`}
-              onSearch={handleSearch}
-            />
-          ) : (
-            <SearchBar
-              query={query}
-              organization={organization}
-              onSearch={handleSearch}
-            />
-          )}
+          <TransactionSearchQueryBuilder
+            projects={projectIds}
+            initialQuery={query ?? ''}
+            searchSource={`${ModuleName.VITAL}-page-summary`}
+            onSearch={handleSearch}
+          />
         </StyledSearchBar>
       </SearchBarContainer>
       {datatype === Datatype.PAGELOADS && (

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.spec.tsx
@@ -54,7 +54,15 @@ describe('PageOverview', function () {
     });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/spans-aggregation/`,
-      body: {},
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/tags/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/recent-searches/`,
+      body: [],
     });
   });
 

--- a/static/app/views/insights/cache/components/samplePanel.tsx
+++ b/static/app/views/insights/cache/components/samplePanel.tsx
@@ -6,14 +6,12 @@ import * as qs from 'query-string';
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import {Button} from 'sentry/components/button';
 import {CompactSelect} from 'sentry/components/compactSelect';
-import SearchBar from 'sentry/components/events/searchBar';
 import Link from 'sentry/components/links/link';
 import {SpanSearchQueryBuilder} from 'sentry/components/performance/spanSearchQueryBuilder';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {DurationUnit, RateUnit, SizeUnit} from 'sentry/utils/discover/fields';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -58,7 +56,6 @@ import {
   SpanMetricsField,
   type SpanMetricsQueryFilters,
 } from 'sentry/views/insights/types';
-import {useSpanFieldSupportedTags} from 'sentry/views/performance/utils/useSpanFieldSupportedTags';
 
 // This is similar to http sample table, its difficult to use the generic span samples sidebar as we require a bunch of custom things.
 export function CacheSamplePanel() {
@@ -66,9 +63,6 @@ export function CacheSamplePanel() {
   const location = useLocation();
   const organization = useOrganization();
   const {selection} = usePageFilters();
-  const {data: supportedTags} = useSpanFieldSupportedTags({
-    excludedTags: [SpanIndexedField.CACHE_HIT],
-  });
 
   const query = useLocationQuery({
     fields: {
@@ -393,26 +387,13 @@ export function CacheSamplePanel() {
           </ModuleLayout.Half>
 
           <ModuleLayout.Full>
-            {organization.features.includes('search-query-builder-performance') ? (
-              <SpanSearchQueryBuilder
-                searchSource={`${ModuleName.CACHE}-sample-panel`}
-                initialQuery={query.spanSearchQuery}
-                onSearch={handleSearch}
-                placeholder={t('Search for span attributes')}
-                projects={selection.projects}
-              />
-            ) : (
-              <SearchBar
-                searchSource={`${ModuleName.CACHE}-sample-panel`}
-                query={query.spanSearchQuery}
-                onSearch={handleSearch}
-                placeholder={t('Search for span attributes')}
-                organization={organization}
-                supportedTags={supportedTags}
-                dataset={DiscoverDatasets.SPANS_INDEXED}
-                projectIds={selection.projects}
-              />
-            )}
+            <SpanSearchQueryBuilder
+              searchSource={`${ModuleName.CACHE}-sample-panel`}
+              initialQuery={query.spanSearchQuery}
+              onSearch={handleSearch}
+              placeholder={t('Search for span attributes')}
+              projects={selection.projects}
+            />
           </ModuleLayout.Full>
 
           <Fragment>

--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
@@ -5,14 +5,12 @@ import omit from 'lodash/omit';
 import * as qs from 'query-string';
 
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
-import SearchBar from 'sentry/components/events/searchBar';
 import {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import Link from 'sentry/components/links/link';
 import {SpanSearchQueryBuilder} from 'sentry/components/performance/spanSearchQueryBuilder';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
 import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
 import {decodeScalar} from 'sentry/utils/queryString';
@@ -35,7 +33,6 @@ import {
   SpanMetricsField,
   type SubregionCode,
 } from 'sentry/views/insights/types';
-import {useSpanFieldSupportedTags} from 'sentry/views/performance/utils/useSpanFieldSupportedTags';
 
 const {HTTP_RESPONSE_CONTENT_LENGTH, SPAN_DESCRIPTION} = SpanMetricsField;
 
@@ -85,7 +82,6 @@ export function SampleList({
   const {projects} = useProjects();
 
   const spanSearchQuery = decodeScalar(location.query.spanSearchQuery);
-  const {data: supportedTags} = useSpanFieldSupportedTags();
 
   const project = useMemo(
     () => projects.find(p => p.id === String(location.query.project)),
@@ -225,26 +221,13 @@ export function SampleList({
         />
 
         <StyledSearchBar>
-          {organization.features.includes('search-query-builder-performance') ? (
-            <SpanSearchQueryBuilder
-              projects={selection.projects}
-              initialQuery={spanSearchQuery ?? ''}
-              onSearch={handleSearch}
-              placeholder={t('Search for span attributes')}
-              searchSource={`${moduleName}-sample-panel`}
-            />
-          ) : (
-            <SearchBar
-              searchSource={`${moduleName}-sample-panel`}
-              query={spanSearchQuery}
-              onSearch={handleSearch}
-              placeholder={t('Search for span attributes')}
-              organization={organization}
-              supportedTags={supportedTags}
-              dataset={DiscoverDatasets.SPANS_INDEXED}
-              projectIds={selection.projects}
-            />
-          )}
+          <SpanSearchQueryBuilder
+            projects={selection.projects}
+            initialQuery={spanSearchQuery ?? ''}
+            onSearch={handleSearch}
+            placeholder={t('Search for span attributes')}
+            searchSource={`${moduleName}-sample-panel`}
+          />
         </StyledSearchBar>
 
         <SampleTable

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
@@ -102,21 +102,6 @@ describe('DatabaseSpanSummaryPage', function () {
       },
     });
 
-    const spanFieldTagsMock = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/spans/fields/`,
-      method: 'GET',
-      body: [
-        {
-          key: 'api_key',
-          name: 'Api Key',
-        },
-        {
-          key: 'bytes.size',
-          name: 'Bytes.Size',
-        },
-      ],
-    });
-
     const transactionListMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       method: 'GET',
@@ -275,20 +260,6 @@ describe('DatabaseSpanSummaryPage', function () {
       })
     );
 
-    // Supported span fields for panel search bar
-    expect(spanFieldTagsMock).toHaveBeenNthCalledWith(
-      1,
-      `/organizations/${organization.slug}/spans/fields/`,
-      expect.objectContaining({
-        method: 'GET',
-        query: {
-          project: [],
-          environment: [],
-          statsPeriod: '1h',
-        },
-      })
-    );
-
     // Transactions table
     expect(transactionListMock).toHaveBeenNthCalledWith(
       1,
@@ -321,7 +292,6 @@ describe('DatabaseSpanSummaryPage', function () {
     expect(spanDescriptionRequestMock).toHaveBeenCalledTimes(1);
     expect(eventsRequestMock).toHaveBeenCalledTimes(1);
     expect(eventsStatsRequestMock).toHaveBeenCalledTimes(2);
-    expect(spanFieldTagsMock).toHaveBeenCalledTimes(1);
     expect(transactionListMock).toHaveBeenCalledTimes(1);
 
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));

--- a/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
@@ -88,6 +88,11 @@ describe('HTTPSamplesPanel', () => {
         },
       },
     });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
+      body: [],
+    });
   });
 
   afterAll(() => {

--- a/static/app/views/insights/http/components/httpSamplesPanel.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.tsx
@@ -5,7 +5,6 @@ import * as qs from 'query-string';
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import {Button} from 'sentry/components/button';
 import {CompactSelect} from 'sentry/components/compactSelect';
-import SearchBar from 'sentry/components/events/searchBar';
 import Link from 'sentry/components/links/link';
 import {SpanSearchQueryBuilder} from 'sentry/components/performance/spanSearchQueryBuilder';
 import {SegmentedControl} from 'sentry/components/segmentedControl';
@@ -13,7 +12,6 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {DurationUnit, RateUnit} from 'sentry/utils/discover/fields';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
 import {decodeList, decodeScalar} from 'sentry/utils/queryString';
 import {
@@ -65,7 +63,6 @@ import {
   type SpanMetricsQueryFilters,
 } from 'sentry/views/insights/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceMetadataHeader';
-import {useSpanFieldSupportedTags} from 'sentry/views/performance/utils/useSpanFieldSupportedTags';
 
 export function HTTPSamplesPanel() {
   const navigate = useNavigate();
@@ -88,7 +85,6 @@ export function HTTPSamplesPanel() {
 
   const {projects} = useProjects();
   const {selection} = usePageFilters();
-  const {data: supportedTags} = useSpanFieldSupportedTags();
 
   const project = projects.find(p => query.project === p.id);
 
@@ -481,26 +477,13 @@ export function HTTPSamplesPanel() {
           )}
 
           <ModuleLayout.Full>
-            {organization.features.includes('search-query-builder-performance') ? (
-              <SpanSearchQueryBuilder
-                projects={selection.projects}
-                initialQuery={query.spanSearchQuery}
-                onSearch={handleSearch}
-                placeholder={t('Search for span attributes')}
-                searchSource={`${ModuleName.HTTP}-sample-panel`}
-              />
-            ) : (
-              <SearchBar
-                searchSource={`${ModuleName.HTTP}-sample-panel`}
-                query={query.spanSearchQuery}
-                onSearch={handleSearch}
-                placeholder={t('Search for span attributes')}
-                organization={organization}
-                supportedTags={supportedTags}
-                dataset={DiscoverDatasets.SPANS_INDEXED}
-                projectIds={selection.projects}
-              />
-            )}
+            <SpanSearchQueryBuilder
+              projects={selection.projects}
+              initialQuery={query.spanSearchQuery}
+              onSearch={handleSearch}
+              placeholder={t('Search for span attributes')}
+              searchSource={`${ModuleName.HTTP}-sample-panel`}
+            />
           </ModuleLayout.Full>
 
           {query.panel === 'duration' && (

--- a/static/app/views/insights/mobile/common/components/spanSamplesPanelContainer.tsx
+++ b/static/app/views/insights/mobile/common/components/spanSamplesPanelContainer.tsx
@@ -2,7 +2,6 @@ import {Fragment, useCallback, useState} from 'react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 
-import SearchBar from 'sentry/components/events/searchBar';
 import {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import Link from 'sentry/components/links/link';
 import {SpanSearchQueryBuilder} from 'sentry/components/performance/spanSearchQueryBuilder';
@@ -10,7 +9,6 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DurationUnit} from 'sentry/utils/discover/fields';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -32,7 +30,6 @@ import {
   SpanMetricsField,
   type SpanMetricsQueryFilters,
 } from 'sentry/views/insights/types';
-import {useSpanFieldSupportedTags} from 'sentry/views/performance/utils/useSpanFieldSupportedTags';
 
 import {TraceViewSources} from '../../../../performance/newTraceDetails/traceMetadataHeader';
 
@@ -70,7 +67,6 @@ export function SpanSamplesContainer({
 
   const organization = useOrganization();
   const {selection} = usePageFilters();
-  const {data: supportedTags} = useSpanFieldSupportedTags();
 
   const searchQuery =
     searchQueryKey !== undefined
@@ -202,26 +198,13 @@ export function SpanSamplesContainer({
       />
 
       <StyledSearchBar>
-        {organization.features.includes('search-query-builder-performance') ? (
-          <SpanSearchQueryBuilder
-            searchSource={`${moduleName}-sample-panel`}
-            initialQuery={searchQuery ?? ''}
-            onSearch={handleSearch}
-            placeholder={t('Search for span attributes')}
-            projects={selection.projects}
-          />
-        ) : (
-          <SearchBar
-            searchSource={`${moduleName}-sample-panel`}
-            query={searchQuery}
-            onSearch={handleSearch}
-            placeholder={t('Search for span attributes')}
-            organization={organization}
-            supportedTags={supportedTags}
-            dataset={DiscoverDatasets.SPANS_INDEXED}
-            projectIds={selection.projects}
-          />
-        )}
+        <SpanSearchQueryBuilder
+          searchSource={`${moduleName}-sample-panel`}
+          initialQuery={searchQuery ?? ''}
+          onSearch={handleSearch}
+          placeholder={t('Search for span attributes')}
+          projects={selection.projects}
+        />
       </StyledSearchBar>
 
       <SampleTable

--- a/static/app/views/insights/queues/components/messageSpanSamplesPanel.spec.tsx
+++ b/static/app/views/insights/queues/components/messageSpanSamplesPanel.spec.tsx
@@ -128,6 +128,11 @@ describe('messageSpanSamplesPanel', () => {
         },
       ],
     });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/recent-searches/`,
+      body: [],
+    });
   });
 
   afterAll(() => {

--- a/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
+++ b/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
@@ -5,14 +5,12 @@ import * as qs from 'query-string';
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import {Button} from 'sentry/components/button';
 import {CompactSelect, type SelectOption} from 'sentry/components/compactSelect';
-import SearchBar from 'sentry/components/events/searchBar';
 import Link from 'sentry/components/links/link';
 import {SpanSearchQueryBuilder} from 'sentry/components/performance/spanSearchQueryBuilder';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {DurationUnit, SizeUnit} from 'sentry/utils/discover/fields';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -51,7 +49,6 @@ import {
   SpanIndexedField,
   type SpanMetricsResponse,
 } from 'sentry/views/insights/types';
-import {useSpanFieldSupportedTags} from 'sentry/views/performance/utils/useSpanFieldSupportedTags';
 import {Subtitle} from 'sentry/views/profiling/landing/styles';
 
 export function MessageSpanSamplesPanel() {
@@ -70,12 +67,6 @@ export function MessageSpanSamplesPanel() {
   });
   const {projects} = useProjects();
   const {selection} = usePageFilters();
-  const {data: supportedTags} = useSpanFieldSupportedTags({
-    excludedTags: [
-      SpanIndexedField.TRACE_STATUS,
-      SpanIndexedField.MESSAGING_MESSAGE_RETRY_COUNT,
-    ],
-  });
 
   const project = projects.find(p => query.project === p.id);
 
@@ -366,26 +357,13 @@ export function MessageSpanSamplesPanel() {
           </ModuleLayout.Full>
 
           <ModuleLayout.Full>
-            {organization.features.includes('search-query-builder-performance') ? (
-              <SpanSearchQueryBuilder
-                searchSource={`${ModuleName.QUEUE}-sample-panel`}
-                initialQuery={query.spanSearchQuery}
-                onSearch={handleSearch}
-                placeholder={t('Search for span attributes')}
-                projects={selection.projects}
-              />
-            ) : (
-              <SearchBar
-                searchSource={`${ModuleName.QUEUE}-sample-panel`}
-                query={query.spanSearchQuery}
-                onSearch={handleSearch}
-                placeholder={t('Search for span attributes')}
-                organization={organization}
-                supportedTags={supportedTags}
-                dataset={DiscoverDatasets.SPANS_INDEXED}
-                projectIds={selection.projects}
-              />
-            )}
+            <SpanSearchQueryBuilder
+              searchSource={`${ModuleName.QUEUE}-sample-panel`}
+              initialQuery={query.spanSearchQuery}
+              onSearch={handleSearch}
+              placeholder={t('Search for span attributes')}
+              projects={selection.projects}
+            />
           </ModuleLayout.Full>
 
           <ModuleLayout.Full>

--- a/static/app/views/insights/queues/views/destinationSummaryPage.spec.tsx
+++ b/static/app/views/insights/queues/views/destinationSummaryPage.spec.tsx
@@ -56,7 +56,6 @@ describe('destinationSummaryPage', () => {
 
   let eventsMock: jest.Mock;
   let eventsStatsMock: jest.Mock;
-  let spanFieldTagsMock: jest.Mock;
 
   beforeEach(() => {
     eventsMock = MockApiClient.addMockResponse({
@@ -70,21 +69,6 @@ describe('destinationSummaryPage', () => {
       method: 'GET',
       body: {data: []},
     });
-
-    spanFieldTagsMock = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/spans/fields/`,
-      method: 'GET',
-      body: [
-        {
-          key: 'api_key',
-          name: 'Api Key',
-        },
-        {
-          key: 'bytes.size',
-          name: 'Bytes.Size',
-        },
-      ],
-    });
   });
 
   it('renders', async () => {
@@ -95,16 +79,5 @@ describe('destinationSummaryPage', () => {
     screen.getByText('Published vs Processed');
     expect(eventsStatsMock).toHaveBeenCalled();
     expect(eventsMock).toHaveBeenCalled();
-    expect(spanFieldTagsMock).toHaveBeenCalledWith(
-      `/organizations/${organization.slug}/spans/fields/`,
-      expect.objectContaining({
-        method: 'GET',
-        query: {
-          project: [],
-          environment: [],
-          statsPeriod: '1h',
-        },
-      })
-    );
   });
 });

--- a/static/app/views/performance/transactionEvents.spec.tsx
+++ b/static/app/views/performance/transactionEvents.spec.tsx
@@ -146,6 +146,14 @@ describe('Performance > TransactionSummary', function () {
       url: '/organizations/org-slug/replay-count/',
       body: {},
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/tags/',
+      body: [],
+    });
   });
 
   afterEach(function () {
@@ -172,7 +180,7 @@ describe('Performance > TransactionSummary', function () {
     expect(screen.getByRole('heading', {name: '/performance'})).toBeInTheDocument();
 
     expect(
-      await screen.findByRole('textbox', {name: 'Search events'})
+      await screen.findByPlaceholderText('Search for events, users, tags, and more')
     ).toBeInTheDocument();
 
     expect(await screen.findByRole('button', {name: 'Next'})).toBeInTheDocument();

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
@@ -153,6 +153,14 @@ describe('Performance Transaction Events Content', function () {
       url: '/organizations/org-slug/events-has-measurements/',
       body: {measurements: false},
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/recent-searches/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/tags/`,
+      body: [],
+    });
     initialData = initializeData();
     eventView = EventView.fromNewQueryWithLocation(
       {

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -5,7 +5,6 @@ import omit from 'lodash/omit';
 
 import {LinkButton} from 'sentry/components/button';
 import {CompactSelect} from 'sentry/components/compactSelect';
-import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
@@ -225,22 +224,12 @@ function Search(props: Props) {
         <DatePageFilter />
       </PageFilterBar>
       <StyledSearchBarWrapper>
-        {organization.features.includes('search-query-builder-performance') ? (
-          <TransactionSearchQueryBuilder
-            projects={projectIds}
-            initialQuery={query}
-            onSearch={handleSearch}
-            searchSource="transaction_events"
-          />
-        ) : (
-          <SearchBar
-            organization={organization}
-            projectIds={eventView.project}
-            query={query}
-            fields={eventView.fields}
-            onSearch={handleSearch}
-          />
-        )}
+        <TransactionSearchQueryBuilder
+          projects={projectIds}
+          initialQuery={query}
+          onSearch={handleSearch}
+          searchSource="transaction_events"
+        />
       </StyledSearchBarWrapper>
       <CompactSelect
         triggerProps={{prefix: t('Percentile')}}

--- a/static/app/views/performance/transactionSummary/transactionEvents/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/index.spec.tsx
@@ -123,6 +123,14 @@ const setupMockApiResponeses = () => {
     url: '/organizations/org-slug/replay-count/',
     body: {},
   });
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/recent-searches/`,
+    body: [],
+  });
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/tags/`,
+    body: [],
+  });
 };
 
 const initializeData = (settings?: InitializeDataSettings) => {


### PR DESCRIPTION
Has been GA for a while, would love to delete these flags and rip out all the old code.

Not a full sweep, just going down the list and making minimal fixes to tests to keep them passing:

- SamplePanel
- PageSamplePerformanceTable
- DatabaseSpanSummaryPage
- SpanSamplesPanel
- MessageSpanSamplesPanel
- TransactionSummary