### PR TITLE
feat(insights): register query limit flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -437,6 +437,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:insights-initial-modules", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enable access to newer Insights modules (Caches, Queues, LLMs, Mobile UI)
     manager.add("organizations:insights-addon-modules", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
+    # Make insights modules restrict queries to 14 days
+    manager.add("organizations:insights-query-limit", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Make Insights modules use EAP instead of metrics
     manager.add("organizations:insights-use-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable access to insights metrics alerts


### PR DESCRIPTION
We have plans to enable insights for AM3 team plans, however we are limiting the query to 14 days. This PR register a new flag to be backed by a feature flag handler to enable this. We can't use flagpole unfortunately because this feature is plan dependant, and will be long lived.

Corresponds to https://github.com/getsentry/getsentry/pull/15470