### PR TITLE
ref(dashboards): Remove `draggableProps`

### DIFF
--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -1,5 +1,4 @@
 import {Fragment, useState} from 'react';
-import type {useSortable} from '@dnd-kit/sortable';
 import styled from '@emotion/styled';
 import type {LegendComponentOption} from 'echarts';
 import type {Location} from 'history';
@@ -64,8 +63,6 @@ export const SESSION_DURATION_ALERT = (
   </PanelAlert>
 );
 
-type DraggableProps = Pick<ReturnType<typeof useSortable>, 'attributes' | 'listeners'>;
-
 type Props = WithRouterProps & {
   api: Client;
   isEditingDashboard: boolean;
@@ -76,7 +73,6 @@ type Props = WithRouterProps & {
   widgetLegendState: WidgetLegendSelectionState;
   widgetLimitReached: boolean;
   dashboardFilters?: DashboardFilters;
-  draggableProps?: DraggableProps;
   hideToolbar?: boolean;
   index?: string;
   isEditingWidget?: boolean;
@@ -320,7 +316,6 @@ function WidgetCard(props: Props) {
                   onEdit={props.onEdit}
                   onDelete={props.onDelete}
                   onDuplicate={props.onDuplicate}
-                  draggableProps={props.draggableProps}
                   hideToolbar={props.hideToolbar}
                   isMobile={props.isMobile}
                 />

--- a/static/app/views/dashboards/widgetCard/toolbar.tsx
+++ b/static/app/views/dashboards/widgetCard/toolbar.tsx
@@ -1,4 +1,3 @@
-import type {useSortable} from '@dnd-kit/sortable';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
@@ -8,10 +7,7 @@ import {space} from 'sentry/styles/space';
 
 import {DRAG_HANDLE_CLASS} from '../dashboard';
 
-type DraggableProps = Pick<ReturnType<typeof useSortable>, 'attributes' | 'listeners'>;
-
 type ToolbarProps = {
-  draggableProps?: DraggableProps;
   hideToolbar?: boolean;
   isMobile?: boolean;
   onDelete?: () => void;
@@ -25,7 +21,6 @@ export function Toolbar({
   onEdit,
   onDelete,
   onDuplicate,
-  draggableProps,
 }: ToolbarProps) {
   return (
     <ToolbarPanel>
@@ -37,8 +32,6 @@ export function Toolbar({
             icon={<IconGrabbable />}
             borderless
             className={DRAG_HANDLE_CLASS}
-            {...draggableProps?.listeners}
-            {...draggableProps?.attributes}
           />
         )}
         {onEdit && (


### PR DESCRIPTION
These are no longer used, I think, as of https://github.com/getsentry/sentry/pull/40967 since dashboards are now using React Grid Layout, rather than DnD Kit.
