### PR TITLE
feat(explore): Add pagination to explore traces

### DIFF
--- a/static/app/views/explore/hooks/useTraces.tsx
+++ b/static/app/views/explore/hooks/useTraces.tsx
@@ -55,6 +55,7 @@ interface TraceResults {
 }
 
 interface UseTracesOptions {
+  cursor?: string;
   dataset?: DiscoverDatasets;
   datetime?: PageFilters['datetime'];
   enabled?: boolean;
@@ -64,6 +65,7 @@ interface UseTracesOptions {
 }
 
 export function useTraces({
+  cursor,
   dataset,
   datetime,
   enabled,
@@ -86,6 +88,7 @@ export function useTraces({
       query,
       sort, // only has an effect when `dataset` is `EAPSpans`
       per_page: limit,
+      cursor,
       breakdownSlices: BREAKDOWN_SLICES,
     },
   };

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -25,6 +25,35 @@ enum Tab {
   TRACE = 'trace',
 }
 
+function useTab(): [Tab, (tab: Tab) => void] {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const tab = useMemo(() => {
+    const rawTab = decodeScalar(location.query.table);
+    if (rawTab === 'trace') {
+      return Tab.TRACE;
+    }
+    return Tab.SPAN;
+  }, [location.query.table]);
+
+  const setTab = useCallback(
+    (newTab: Tab) => {
+      navigate({
+        ...location,
+        query: {
+          ...location.query,
+          table: newTab,
+          cursor: undefined,
+        },
+      });
+    },
+    [location, navigate]
+  );
+
+  return [tab, setTab];
+}
+
 interface ExploreTablesProps {}
 
 export function ExploreTables({}: ExploreTablesProps) {
@@ -43,15 +72,7 @@ function ExploreAggregatesTable() {
 }
 
 function ExploreSamplesTable() {
-  const location = useLocation();
-  const navigate = useNavigate();
-  const tab = useMemo(() => {
-    const rawTab = decodeScalar(location.query.table);
-    if (rawTab === 'trace') {
-      return Tab.TRACE;
-    }
-    return Tab.SPAN;
-  }, [location.query.table]);
+  const [tab, setTab] = useTab();
 
   const [fields, setFields] = useSampleFields();
   const numberTags = useSpanTags('number');
@@ -71,20 +92,6 @@ function ExploreSamplesTable() {
       {closeEvents: 'escape-key'}
     );
   }, [fields, setFields, stringTags, numberTags]);
-
-  const setTab = useCallback(
-    newTab => {
-      navigate({
-        ...location,
-        query: {
-          ...location.query,
-          table: newTab,
-          cursor: undefined,
-        },
-      });
-    },
-    [location, navigate]
-  );
 
   return (
     <Fragment>


### PR DESCRIPTION
This adds pagination buttons to the traces list in explore. Note the traces are not perfectly chronologically sorted.