### PR TITLE
ref(dashboards): Remove `Toolbar` `hideToolbar` prop

### DIFF
--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -74,7 +74,6 @@ type Props = WithRouterProps & {
   widgetLegendState: WidgetLegendSelectionState;
   widgetLimitReached: boolean;
   dashboardFilters?: DashboardFilters;
-  hideToolbar?: boolean;
   index?: string;
   isEditingWidget?: boolean;
   isMobile?: boolean;
@@ -307,7 +306,6 @@ function WidgetCard(props: Props) {
               onEdit={props.onEdit}
               onDelete={props.onDelete}
               onDuplicate={props.onDuplicate}
-              hideToolbar={props.hideToolbar}
               isMobile={props.isMobile}
             />
           )}

--- a/static/app/views/dashboards/widgetCard/toolbar.tsx
+++ b/static/app/views/dashboards/widgetCard/toolbar.tsx
@@ -8,23 +8,16 @@ import {space} from 'sentry/styles/space';
 import {DRAG_HANDLE_CLASS} from '../dashboard';
 
 type ToolbarProps = {
-  hideToolbar?: boolean;
   isMobile?: boolean;
   onDelete?: () => void;
   onDuplicate?: () => void;
   onEdit?: () => void;
 };
 
-export function Toolbar({
-  hideToolbar,
-  isMobile,
-  onEdit,
-  onDelete,
-  onDuplicate,
-}: ToolbarProps) {
+export function Toolbar({isMobile, onEdit, onDelete, onDuplicate}: ToolbarProps) {
   return (
     <ToolbarPanel>
-      <IconContainer style={{visibility: hideToolbar ? 'hidden' : 'visible'}}>
+      <IconContainer>
         {!isMobile && (
           <GrabbableButton
             size="xs"


### PR DESCRIPTION
As far as I can tell it's not used. No parent component ever passes it, and there's no reason I can figure out why it exists. The entire toolbar is completely removed from the DOM if not currently editing a dashboard.

You tell me, though!
