### PR TITLE
fix(insights): header not showing correct tabs ai/backend

### DIFF
--- a/static/app/views/insights/pages/ai/aiPageHeader.tsx
+++ b/static/app/views/insights/pages/ai/aiPageHeader.tsx
@@ -15,11 +15,19 @@ type Props = {
   headerTitle: HeaderProps['headerTitle'];
   breadcrumbs?: HeaderProps['additionalBreadCrumbs'];
   headerActions?: HeaderProps['additonalHeaderActions'];
+  hideDefaultTabs?: HeaderProps['hideDefaultTabs'];
   module?: HeaderProps['selectedModule'];
   tabs?: HeaderProps['tabs'];
 };
 
-export function AiHeader({module, headerTitle, headerActions, breadcrumbs, tabs}: Props) {
+export function AiHeader({
+  module,
+  headerTitle,
+  headerActions,
+  breadcrumbs,
+  tabs,
+  hideDefaultTabs,
+}: Props) {
   const {slug} = useOrganization();
 
   const aiBaseUrl = normalizeUrl(
@@ -38,6 +46,7 @@ export function AiHeader({module, headerTitle, headerActions, breadcrumbs, tabs}
       additonalHeaderActions={headerActions}
       additionalBreadCrumbs={breadcrumbs}
       tabs={tabs}
+      hideDefaultTabs={hideDefaultTabs}
     />
   );
 }

--- a/static/app/views/insights/pages/ai/aiPageHeader.tsx
+++ b/static/app/views/insights/pages/ai/aiPageHeader.tsx
@@ -16,9 +16,10 @@ type Props = {
   breadcrumbs?: HeaderProps['additionalBreadCrumbs'];
   headerActions?: HeaderProps['additonalHeaderActions'];
   module?: HeaderProps['selectedModule'];
+  tabs?: HeaderProps['tabs'];
 };
 
-export function AiHeader({module, headerTitle, headerActions, breadcrumbs}: Props) {
+export function AiHeader({module, headerTitle, headerActions, breadcrumbs, tabs}: Props) {
   const {slug} = useOrganization();
 
   const aiBaseUrl = normalizeUrl(
@@ -36,6 +37,7 @@ export function AiHeader({module, headerTitle, headerActions, breadcrumbs}: Prop
       selectedModule={module}
       additonalHeaderActions={headerActions}
       additionalBreadCrumbs={breadcrumbs}
+      tabs={tabs}
     />
   );
 }

--- a/static/app/views/insights/pages/backend/backendPageHeader.tsx
+++ b/static/app/views/insights/pages/backend/backendPageHeader.tsx
@@ -16,10 +16,17 @@ type Props = {
   breadcrumbs?: HeaderProps['additionalBreadCrumbs'];
   headerActions?: HeaderProps['additonalHeaderActions'];
   module?: HeaderProps['selectedModule'];
+  tabs?: HeaderProps['tabs'];
 };
 
 // TODO - add props to append to breadcrumbs and change title
-export function BackendHeader({module, headerActions, headerTitle, breadcrumbs}: Props) {
+export function BackendHeader({
+  module,
+  headerActions,
+  headerTitle,
+  breadcrumbs,
+  tabs,
+}: Props) {
   const {slug} = useOrganization();
 
   const backendBaseUrl = normalizeUrl(
@@ -36,6 +43,7 @@ export function BackendHeader({module, headerActions, headerTitle, breadcrumbs}:
       modules={modules}
       selectedModule={module}
       additionalBreadCrumbs={breadcrumbs}
+      tabs={tabs}
     />
   );
 }

--- a/static/app/views/insights/pages/backend/backendPageHeader.tsx
+++ b/static/app/views/insights/pages/backend/backendPageHeader.tsx
@@ -15,6 +15,7 @@ type Props = {
   headerTitle: HeaderProps['headerTitle'];
   breadcrumbs?: HeaderProps['additionalBreadCrumbs'];
   headerActions?: HeaderProps['additonalHeaderActions'];
+  hideDefaultTabs?: HeaderProps['hideDefaultTabs'];
   module?: HeaderProps['selectedModule'];
   tabs?: HeaderProps['tabs'];
 };
@@ -26,6 +27,7 @@ export function BackendHeader({
   headerTitle,
   breadcrumbs,
   tabs,
+  hideDefaultTabs,
 }: Props) {
   const {slug} = useOrganization();
 
@@ -44,6 +46,7 @@ export function BackendHeader({
       selectedModule={module}
       additionalBreadCrumbs={breadcrumbs}
       tabs={tabs}
+      hideDefaultTabs={hideDefaultTabs}
     />
   );
 }


### PR DESCRIPTION
Forgot to forward some props in https://github.com/getsentry/sentry/pull/79056

Ensures correct tabs show up in backend/ai
<img width="836" alt="image" src="https://github.com/user-attachments/assets/16bd0fc3-6343-4cfe-9100-c959f3fcd164">
