### PR TITLE
feat(issue-stream): Improve the way issue stream rows are linked

### DIFF
--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -167,7 +167,6 @@ const GroupExtra = styled('div')<{hasNewLayout: boolean}>`
   align-items: center;
   color: ${p => p.theme.textColor};
   font-size: ${p => p.theme.fontSizeSmall};
-  position: relative;
   min-width: 500px;
   white-space: nowrap;
   line-height: 1.2;
@@ -205,12 +204,14 @@ const CommentsLink = styled(Link)`
   align-items: center;
   grid-auto-flow: column;
   color: ${p => p.theme.textColor};
+  position: relative;
 `;
 
 const AnnotationNoMargin = styled(EventAnnotation)<{hasNewLayout: boolean}>`
   margin-left: 0;
   padding-left: 0;
   border-left: none;
+  position: relative;
 
   ${p =>
     !p.hasNewLayout &&
@@ -231,6 +232,7 @@ const AnnotationNoMargin = styled(EventAnnotation)<{hasNewLayout: boolean}>`
 
 const LoggerAnnotation = styled(AnnotationNoMargin)`
   color: ${p => p.theme.textColor};
+  position: relative;
 `;
 
 const Location = styled('div')`

--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -96,7 +96,12 @@ function EventOrGroupHeader({
 
     if (hasNewLayout) {
       return (
-        <NewTitleWithLink {...commonEleProps} to={to} onClick={onClick}>
+        <NewTitleWithLink
+          {...commonEleProps}
+          to={to}
+          onClick={onClick}
+          data-issue-title-link
+        >
           {getTitleChildren()}
         </NewTitleWithLink>
       );

--- a/static/app/components/group/issueReplayCount.tsx
+++ b/static/app/components/group/issueReplayCount.tsx
@@ -54,6 +54,7 @@ const ReplayCountLink = styled(Link)`
   color: ${p => p.theme.gray400};
   font-size: ${p => p.theme.fontSizeSmall};
   gap: 0 ${space(0.5)};
+  position: relative;
 
   &:hover {
     color: ${p => p.theme.linkHoverColor};

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -730,14 +730,23 @@ const Wrapper = styled(PanelItem)<{
   ${p =>
     p.hasNewLayout &&
     css`
-      cursor: pointer;
       padding: ${space(1)} 0;
       min-height: 66px;
 
-      /* Adds underline to issue title when active  */
-      &:hover {
-        [data-issue-title-primary] {
-          text-decoration: underline;
+      [data-issue-title-link] {
+        &::after {
+          content: '';
+          position: absolute;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+        }
+
+        &:hover {
+          [data-issue-title-primary] {
+            text-decoration: underline;
+          }
         }
       }
     `}
@@ -804,6 +813,7 @@ const GroupCheckBoxWrapper = styled('div')<{hasNewLayout: boolean}>`
   width: 32px;
   display: flex;
   align-items: center;
+  z-index: 1;
 `;
 
 const CheckboxLabel = styled('label')<{hasNewLayout: boolean}>`

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -764,9 +764,9 @@ const commonTheme = {
 
     // On mobile views issue list dropdowns overlap
     issuesList: {
-      stickyHeader: 1,
-      sortOptions: 2,
-      displayOptions: 3,
+      stickyHeader: 2,
+      sortOptions: 3,
+      displayOptions: 4,
     },
   },
 


### PR DESCRIPTION
Adds a pseudo-element that is absolutely positioned to take up the entire stream row so that clicking anywhere will hit the link. This way you can see the link show up on hover, and actions like cmd+click to open in a new tab will work like normal.