### PR TITLE
feat(code-mappings): Enable csharp for automatic code mappings, add tests

### DIFF
--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -19,7 +19,7 @@ BACKSLASH = "\\"  # This is the Python representation of a single backslash
 # Read this to learn about file extensions for different languages
 # https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
 # We only care about the ones that would show up in stacktraces after symbolication
-EXTENSIONS = ["js", "jsx", "tsx", "ts", "mjs", "py", "rb", "rake", "php", "go"]
+EXTENSIONS = ["js", "jsx", "tsx", "ts", "mjs", "py", "rb", "rake", "php", "go", "cs"]
 
 # List of file paths prefixes that should become stack trace roots
 FILE_PATH_PREFIX_LENGTH = {

--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -21,7 +21,7 @@ from sentry.tasks.base import instrumented_task
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.utils.safe import get_path
 
-SUPPORTED_LANGUAGES = ["javascript", "python", "node", "ruby", "php", "go"]
+SUPPORTED_LANGUAGES = ["javascript", "python", "node", "ruby", "php", "go", "csharp"]
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Enables automatic code mappings for issues with csharp as a platform. I examined a bunch of real csharp stacktraces to make sure that csharp stacktrace file paths to confirm that there wasn't anything significantly different than the file paths found in the currently supported platforms. 

Last time we did this for php and go, we rolled it out under a feature flag. Happy to do that for csharp as well if anyone has concerns, but I think this should be reasonably safe, especially with the safety check I put in several months back. 