### PR TITLE
fix(issue-stream): Fix layout for regression issues

### DIFF
--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -604,37 +604,40 @@ function BaseGroupRow({
       </GroupSummary>
       {hasGuideAnchor && issueStreamAnchor}
 
-      {withChart &&
-      !displayReprocessingLayout &&
-      issueTypeConfig.stats.enabled &&
-      hasNewLayout ? (
-        <NarrowChartWrapper breakpoint={COLUMN_BREAKPOINTS.TREND}>
-          <GroupStatusChart
-            hideZeros
-            loading={!defined(groupStats)}
-            stats={groupStats}
-            secondaryStats={groupSecondaryStats}
-            showSecondaryPoints={showSecondaryPoints}
-            groupStatus={getBadgeProperties(group.status, group.substatus)?.status}
-            showMarkLine
-          />
-        </NarrowChartWrapper>
-      ) : (
-        <ChartWrapper
-          narrowGroups={narrowGroups}
-          margin={withColumns.includes('firstSeen')}
-        >
-          <GroupStatusChart
-            hideZeros
-            loading={!defined(groupStats)}
-            stats={groupStats}
-            secondaryStats={groupSecondaryStats}
-            showSecondaryPoints={showSecondaryPoints}
-            groupStatus={getBadgeProperties(group.status, group.substatus)?.status}
-            showMarkLine
-          />
-        </ChartWrapper>
-      )}
+      {withChart && !displayReprocessingLayout ? (
+        hasNewLayout ? (
+          <NarrowChartWrapper breakpoint={COLUMN_BREAKPOINTS.TREND}>
+            {issueTypeConfig.stats.enabled ? (
+              <GroupStatusChart
+                hideZeros
+                loading={!defined(groupStats)}
+                stats={groupStats}
+                secondaryStats={groupSecondaryStats}
+                showSecondaryPoints={showSecondaryPoints}
+                groupStatus={getBadgeProperties(group.status, group.substatus)?.status}
+                showMarkLine
+              />
+            ) : null}
+          </NarrowChartWrapper>
+        ) : (
+          <ChartWrapper
+            narrowGroups={narrowGroups}
+            margin={withColumns.includes('firstSeen')}
+          >
+            {issueTypeConfig.stats.enabled ? (
+              <GroupStatusChart
+                hideZeros
+                loading={!defined(groupStats)}
+                stats={groupStats}
+                secondaryStats={groupSecondaryStats}
+                showSecondaryPoints={showSecondaryPoints}
+                groupStatus={getBadgeProperties(group.status, group.substatus)?.status}
+                showMarkLine
+              />
+            ) : null}
+          </ChartWrapper>
+        )
+      ) : null}
       {displayReprocessingLayout ? (
         renderReprocessingColumns()
       ) : (
@@ -649,28 +652,34 @@ function BaseGroupRow({
               <GroupTimestamp date={group.lifetime?.lastSeen} label={t('Last Seen')} />
             </TimestampWrapper>
           )}
-          {withColumns.includes('event') &&
-          issueTypeConfig.stats.enabled &&
-          hasNewLayout ? (
-            <NarrowEventsOrUsersCountsWrapper breakpoint={COLUMN_BREAKPOINTS.EVENTS}>
-              <InnerCountsWrapper>{groupCount}</InnerCountsWrapper>
-            </NarrowEventsOrUsersCountsWrapper>
-          ) : (
-            <EventCountsWrapper
-              leftMargin={withColumns.includes('lastSeen') ? undefined : '0px'}
-            >
-              {groupCount}
-            </EventCountsWrapper>
-          )}
-          {withColumns.includes('users') &&
-          issueTypeConfig.stats.enabled &&
-          hasNewLayout ? (
-            <NarrowEventsOrUsersCountsWrapper breakpoint={COLUMN_BREAKPOINTS.USERS}>
-              <InnerCountsWrapper>{groupUsersCount}</InnerCountsWrapper>
-            </NarrowEventsOrUsersCountsWrapper>
-          ) : (
-            <EventCountsWrapper>{groupUsersCount}</EventCountsWrapper>
-          )}
+          {withColumns.includes('event') ? (
+            hasNewLayout ? (
+              <NarrowEventsOrUsersCountsWrapper breakpoint={COLUMN_BREAKPOINTS.EVENTS}>
+                {issueTypeConfig.stats.enabled ? (
+                  <InnerCountsWrapper>{groupCount}</InnerCountsWrapper>
+                ) : null}
+              </NarrowEventsOrUsersCountsWrapper>
+            ) : (
+              <EventCountsWrapper
+                leftMargin={withColumns.includes('lastSeen') ? undefined : '0px'}
+              >
+                {issueTypeConfig.stats.enabled ? groupCount : null}
+              </EventCountsWrapper>
+            )
+          ) : null}
+          {withColumns.includes('users') ? (
+            hasNewLayout ? (
+              <NarrowEventsOrUsersCountsWrapper breakpoint={COLUMN_BREAKPOINTS.USERS}>
+                {issueTypeConfig.stats.enabled ? (
+                  <InnerCountsWrapper>{groupUsersCount}</InnerCountsWrapper>
+                ) : null}
+              </NarrowEventsOrUsersCountsWrapper>
+            ) : (
+              <EventCountsWrapper>
+                {issueTypeConfig.stats.enabled ? groupUsersCount : null}
+              </EventCountsWrapper>
+            )
+          ) : null}
           {withColumns.includes('priority') ? (
             hasNewLayout ? (
               <NarrowPriorityWrapper breakpoint={COLUMN_BREAKPOINTS.PRIORITY}>


### PR DESCRIPTION
Previously, we weren't rendering anything for the events/users/trend column for regression issues. This regressed (hah) at some point while we were making changes to the stream layout. 

Before:

![CleanShot 2024-10-23 at 14 22 06](https://github.com/user-attachments/assets/b478263e-93ae-45df-af34-adeeef4ba683)

After:

![CleanShot 2024-10-23 at 14 21 10](https://github.com/user-attachments/assets/ee09e031-92d8-4675-b63a-3f68b070c462)
