### PR TITLE
fix(dashboards): Fix missing line charts in widget viewer modal

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -1199,6 +1199,7 @@ export const modalCss = css`
 
 const Container = styled('div')<{height?: number | null}>`
   display: flex;
+  flex-direction: column;
   height: ${p => (p.height ? `${p.height}px` : 'auto')};
   position: relative;
   padding-bottom: ${space(3)};

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -554,7 +554,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
                               }
                             : {}),
                           legend,
-                          series: [...series, ...modifiedReleaseSeriesResults],
+                          series: [...series, ...(modifiedReleaseSeriesResults ?? [])],
                           onLegendSelectChanged,
                           forwardedRef,
                         }),

--- a/static/app/views/dashboards/widgetLegendNameEncoderDecoder.tsx
+++ b/static/app/views/dashboards/widgetLegendNameEncoderDecoder.tsx
@@ -12,6 +12,10 @@ class WidgetLegendNameEncoderDecoder {
 
   // change timeseries names to SeriesName:widgetID
   static modifyTimeseriesNames(widget: Widget, timeseriesResults?: Series[]) {
+    if (!timeseriesResults) {
+      return undefined;
+    }
+
     return timeseriesResults
       ? timeseriesResults.map(series => {
           return {


### PR DESCRIPTION
Compounding errors! As a result, line charts in the full screen view didn't show up.

- Allow modal charts to grow
    
    Flex-direction should be column so the item inside expands its height

- Return `undefined` if appropriate
    
    Returning `[]` prevents the modal from loading its own data
