### PR TITLE
fix(dashboards): Remove threshold indicator from modal title

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -60,7 +60,6 @@ import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import {
   dashboardFiltersToString,
   eventViewFromWidget,
-  getColoredWidgetIndicator,
   getFieldsFromEquations,
   getNumEquations,
   getWidgetDiscoverUrl,
@@ -1022,9 +1021,6 @@ function WidgetViewerModal(props: Props) {
                     <WidgetHeader>
                       <WidgetTitleRow>
                         <h3>{widget.title}</h3>
-                        {widget.thresholds &&
-                          tableData &&
-                          getColoredWidgetIndicator(widget.thresholds, tableData)}
                       </WidgetTitleRow>
                       {widget.description && (
                         <Tooltip


### PR DESCRIPTION
The indicator lives next to the number now, we don't need both!

**e.g.,**
<img width="393" alt="Screenshot 2024-10-23 at 6 18 15 PM" src="https://github.com/user-attachments/assets/58d3861e-be03-4adf-a460-77c2fef95b37">
