### PR TITLE
fix(anomaly detection): do anomaly detection on aggregation values of 0

### DIFF
--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -34,7 +34,7 @@ def get_anomaly_data_from_seer(
     aggregation_value: float | None,
 ) -> list[TimeSeriesPoint] | None:
     snuba_query = alert_rule.snuba_query
-    if not snuba_query or not aggregation_value:
+    if not snuba_query or aggregation_value is None:
         return None
 
     # XXX: we know we have these things because the serializer makes sure we do, but mypy insists


### PR DESCRIPTION
This was exiting early if `aggregation_value` was 0.