### PR TITLE
feat(metrics): Add indexed reserved tag

### DIFF
--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -200,6 +200,7 @@ SHARED_TAG_STRINGS = {
     "cardinality.window": PREFIX + 278,
     "cardinality.limit": PREFIX + 279,
     "cardinality.scope": PREFIX + 280,
+    "indexed": PREFIX + 281,
     # GENERAL/MISC (don't have a category)
     "": PREFIX + 1000,
 }


### PR DESCRIPTION
This PR adds the `indexed` reserved tag which was will be emitted by Relay when this PR (https://github.com/getsentry/relay/pull/4158) is deployed.

Part of: https://github.com/getsentry/relay/issues/3696