### PR TITLE
ref(quick-start): Remove completion animation

### DIFF
--- a/static/app/components/onboardingWizard/useOnboardingTasks.tsx
+++ b/static/app/components/onboardingWizard/useOnboardingTasks.tsx
@@ -1,4 +1,4 @@
-import {findCompleteTasks} from 'sentry/components/onboardingWizard/utils';
+import {taskIsDone} from 'sentry/components/onboardingWizard/utils';
 import {
   type OnboardingTask,
   OnboardingTaskGroup,
@@ -6,6 +6,7 @@ import {
 } from 'sentry/types/onboarding';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
+
 // Refetch the data every second
 const DEFAULT_POLL_INTERVAL_MS = 1000;
 
@@ -56,7 +57,7 @@ export function useOnboardingTasks({
         return false;
       }
 
-      const serverCompletedTasks = (data as OnboardingTask[]).filter(findCompleteTasks);
+      const serverCompletedTasks = (data as OnboardingTask[]).filter(taskIsDone);
 
       // Stop polling if all tasks are complete
       return serverCompletedTasks.length === supportedTasks.length
@@ -72,7 +73,7 @@ export function useOnboardingTasks({
 
   return {
     allTasks: mergedTasks,
-    completeTasks: mergedTasks.filter(findCompleteTasks),
+    completeTasks: mergedTasks.filter(taskIsDone),
     gettingStartedTasks: mergedTasks.filter(
       task => task.group === OnboardingTaskGroup.GETTING_STARTED
     ),


### PR DESCRIPTION
**Problem**

In the Quick Start, we have an animation that moves tasks from the incomplete to the complete list. However, a timeout triggers a backend request to set the 'completionSeen' flag, leading to delays. This can make users think that Quick Start isn’t working properly.

**Solution**

To fix this, we should remove the timeout and backend request. We can explore new animation ideas separately and consider reintroducing them later.

closes https://github.com/getsentry/projects/issues/250
closes https://github.com/getsentry/projects/issues/248