### PR TITLE
ref(quick-start): Remove event waiter component in the new experience

### DIFF
--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -197,10 +197,22 @@ export function getOnboardingTasks({
       location: getOnboardingInstructionsUrl({projects, organization}),
       display: true,
       SupplementComponent: withApi(
-        ({api, task, onCompleteTask}: FirstEventWaiterProps) =>
-          !!projects?.length &&
-          task.requisiteTasks.length === 0 &&
-          !task.completionSeen ? (
+        ({api, task, onCompleteTask}: FirstEventWaiterProps) => {
+          if (hasQuickStartUpdatesFeature(organization)) {
+            if (!projects?.length || task.requisiteTasks.length > 0 || taskIsDone(task)) {
+              return null;
+            }
+            return (
+              <EventWaitingIndicator
+                text={t('Waiting for error')}
+                hasQuickStartUpdatesFeature
+              />
+            );
+          }
+
+          return !!projects?.length &&
+            task.requisiteTasks.length === 0 &&
+            !task.completionSeen ? (
             <EventWaiter
               api={api}
               organization={organization}
@@ -208,14 +220,10 @@ export function getOnboardingTasks({
               eventType="error"
               onIssueReceived={() => !taskIsDone(task) && onCompleteTask()}
             >
-              {() => (
-                <EventWaitingIndicator
-                  text={t('Waiting for error')}
-                  hasQuickStartUpdatesFeature={hasQuickStartUpdatesFeature(organization)}
-                />
-              )}
+              {() => <EventWaitingIndicator text={t('Waiting for error')} />}
             </EventWaiter>
-          ) : null
+          ) : null;
+        }
       ),
       group: OnboardingTaskGroup.GETTING_STARTED,
     },
@@ -330,10 +338,17 @@ export function getOnboardingTasks({
       },
       display: true,
       SupplementComponent: withApi(
-        ({api, task, onCompleteTask}: FirstEventWaiterProps) =>
-          !!projects?.length &&
-          task.requisiteTasks.length === 0 &&
-          !task.completionSeen ? (
+        ({api, task, onCompleteTask}: FirstEventWaiterProps) => {
+          if (hasQuickStartUpdatesFeature(organization)) {
+            if (!projects?.length || task.requisiteTasks.length > 0 || taskIsDone(task)) {
+              return null;
+            }
+            return <EventWaitingIndicator hasQuickStartUpdatesFeature />;
+          }
+
+          return !!projects?.length &&
+            task.requisiteTasks.length === 0 &&
+            !task.completionSeen ? (
             <EventWaiter
               api={api}
               organization={organization}
@@ -341,13 +356,10 @@ export function getOnboardingTasks({
               eventType="transaction"
               onIssueReceived={() => !taskIsDone(task) && onCompleteTask()}
             >
-              {() => (
-                <EventWaitingIndicator
-                  hasQuickStartUpdatesFeature={hasQuickStartUpdatesFeature(organization)}
-                />
-              )}
+              {() => <EventWaitingIndicator />}
             </EventWaiter>
-          ) : null
+          ) : null;
+        }
       ),
     },
     {
@@ -387,10 +399,23 @@ export function getOnboardingTasks({
       },
       display: organization.features?.includes('session-replay'),
       SupplementComponent: withApi(
-        ({api, task, onCompleteTask}: FirstEventWaiterProps) =>
-          !!projects?.length &&
-          task.requisiteTasks.length === 0 &&
-          !task.completionSeen ? (
+        ({api, task, onCompleteTask}: FirstEventWaiterProps) => {
+          if (hasQuickStartUpdatesFeature(organization)) {
+            if (!projects?.length || task.requisiteTasks.length > 0 || taskIsDone(task)) {
+              return null;
+            }
+
+            return (
+              <EventWaitingIndicator
+                text={t('Waiting for user session')}
+                hasQuickStartUpdatesFeature
+              />
+            );
+          }
+
+          return !!projects?.length &&
+            task.requisiteTasks.length === 0 &&
+            !task.completionSeen ? (
             <EventWaiter
               api={api}
               organization={organization}
@@ -398,14 +423,10 @@ export function getOnboardingTasks({
               eventType="replay"
               onIssueReceived={() => !taskIsDone(task) && onCompleteTask()}
             >
-              {() => (
-                <EventWaitingIndicator
-                  hasQuickStartUpdatesFeature={hasQuickStartUpdatesFeature(organization)}
-                  text={t('Waiting for user session')}
-                />
-              )}
+              {() => <EventWaitingIndicator text={t('Waiting for user session')} />}
             </EventWaiter>
-          ) : null
+          ) : null;
+        }
       ),
     },
     {
@@ -513,7 +534,7 @@ const EventWaitingIndicator = styled(
     text,
     ...p
   }: React.HTMLAttributes<HTMLDivElement> & {
-    hasQuickStartUpdatesFeature: boolean;
+    hasQuickStartUpdatesFeature?: boolean;
     text?: string;
   }) => {
     if (quickStartUpdatesFeature) {


### PR DESCRIPTION
In the current quick start, we make multiple calls to the projects endpoint—for the first event, the first error, and for the first replay. We can simplify this process by simply checking if the response from the onboarding tasks indicates that these tasks have been completed.

**Before**

https://github.com/user-attachments/assets/31d5dcd7-2b51-4856-8936-68539380cb82



**After**

https://github.com/user-attachments/assets/12ddf703-463a-4ff1-afb1-5a98f98eb206
