### PR TITLE
chore(grouping): Enable PHP and Go for embeddings backfill

### DIFF
--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -13,12 +13,21 @@ logger = logging.getLogger(__name__)
 MAX_FRAME_COUNT = 30
 MAX_EXCEPTION_COUNT = 30
 FULLY_MINIFIED_STACKTRACE_MAX_FRAME_COUNT = 20
-SEER_ELIGIBLE_PLATFORMS_EVENTS = frozenset(["python", "javascript", "node", "ruby"])
+SEER_ELIGIBLE_PLATFORMS_EVENTS = frozenset(["python", "javascript", "node", "ruby", "php", "go"])
 SEER_ELIGIBLE_PLATFORMS = frozenset(
     [
         "bun",
         "deno",
         "django",
+        "go",
+        "go-echo",
+        "go-fasthttp",
+        "go-fiber",
+        "go-gin",
+        "go-http",
+        "go-iris",
+        "go-martini",
+        "go-negroni",
         "javascript",
         "javascript-angular",
         "javascript-angularjs",
@@ -63,6 +72,12 @@ SEER_ELIGIBLE_PLATFORMS = frozenset(
         "node-profiling-onboarding-2-configure-performance",
         "node-profiling-onboarding-3-configure-profiling",
         "node-serverlesscloud",
+        "PHP",
+        "php",
+        "php-laravel",
+        "php-monolog",
+        "php-symfony",
+        "php-symfony2",
         "python",
         "python-aiohttp",
         "python-asgi",


### PR DESCRIPTION
The list of platforms was determined with the following query:

```sql
SELECT
  sp.platform as platform_group,
FROM
  getsentry.sentry_projectoptions AS pr_opt
  INNER JOIN getsentry.sentry_project AS sp ON pr_opt.project_id = sp.id
WHERE
  sp.platform LIKE 'go%'
  OR sp.platform LIKE '%PHP%'
  OR sp.platform LIKE '%php%'
GROUP BY
  platform_group
ORDER BY
  platform_group;
```

- PHP
- go
- go-echo
- go-fasthttp
- go-fiber
- go-gin
- go-http
- go-iris
- go-martini
- go-negroni
- php
- php-laravel
- php-monolog
- php-symfony
- php-symfony2
