### PR TITLE
fix(dashboards): remove legend query changes from add to dashboard modal

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -40,6 +40,7 @@ import {
 } from 'sentry/views/dashboards/widgetBuilder/utils';
 import WidgetCard from 'sentry/views/dashboards/widgetCard';
 import {DashboardsMEPProvider} from 'sentry/views/dashboards/widgetCard/dashboardsMEPContext';
+import WidgetLegendNameEncoderDecoder from 'sentry/views/dashboards/widgetLegendNameEncoderDecoder';
 import WidgetLegendSelectionState from 'sentry/views/dashboards/widgetLegendSelectionState';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 import {MetricsDataSwitcher} from 'sentry/views/performance/landing/metricsDataSwitcher';
@@ -234,6 +235,18 @@ function AddToDashboardModal({
     ].filter(Boolean) as SelectValue<string>[];
   }, [allowCreateNewDashboard, dashboards]);
 
+  const widgetLegendState = new WidgetLegendSelectionState({
+    location,
+    router,
+    organization,
+    dashboard: selectedDashboard,
+  });
+
+  const unselectedReleasesForCharts = {
+    [WidgetLegendNameEncoderDecoder.encodeSeriesNameForLegend('Releases', widget.id)]:
+      false,
+  };
+
   return (
     <OrganizationContext.Provider value={organization}>
       <Header closeButton>
@@ -290,13 +303,13 @@ function AddToDashboardModal({
                     widget={widget}
                     showStoredAlert
                     shouldResize={false}
-                    widgetLegendState={
-                      new WidgetLegendSelectionState({
-                        location,
-                        router,
-                        organization,
-                        dashboard: selectedDashboard,
-                      })
+                    widgetLegendState={widgetLegendState}
+                    onLegendSelectChanged={() => {}}
+                    legendOptions={
+                      organization.features.includes('dashboards-releases-on-charts') &&
+                      widgetLegendState.widgetRequiresLegendUnselection(widget)
+                        ? {selected: unselectedReleasesForCharts}
+                        : undefined
                     }
                   />
                 </MEPSettingProvider>


### PR DESCRIPTION
The add to dashboards modal chart was using and modifying the `unselectedSeries` parameter of the url query when it does not need to. Now we're passing in an empty function to handle legend selection changes to reinstate the default e-charts function for that and a default legend state.

![image](https://github.com/user-attachments/assets/80051e1d-c498-4f72-985c-aee37bca799d)

