### PR TITLE
ref(dashboards): Move padding out of `WidgetFrame`

### DIFF
--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -638,7 +638,6 @@ const BigNumberResizeWrapper = styled('div')`
   flex-grow: 1;
   overflow: hidden;
   position: relative;
-  margin: ${space(1)} ${space(3)} ${space(3)} ${space(3)};
 `;
 
 const BigNumber = styled('div')`

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.tsx
@@ -15,7 +15,7 @@ import type {
   Thresholds,
 } from 'sentry/views/dashboards/widgets/common/types';
 
-import {DEFAULT_FIELD} from '../common/settings';
+import {DEFAULT_FIELD, X_GUTTER, Y_GUTTER} from '../common/settings';
 
 import {ThresholdsIndicator} from './thresholdsIndicator';
 
@@ -144,7 +144,7 @@ function Wrapper({children}) {
 
 const AutoResizeParent = styled('div')`
   position: absolute;
-  inset: 0;
+  inset: ${Y_GUTTER} ${X_GUTTER} ${Y_GUTTER} ${X_GUTTER};
 
   color: ${p => p.theme.headingColor};
 

--- a/static/app/views/dashboards/widgets/common/settings.tsx
+++ b/static/app/views/dashboards/widgets/common/settings.tsx
@@ -1,7 +1,11 @@
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 
 export const MIN_WIDTH = 200;
 export const MIN_HEIGHT = 96;
+
+export const Y_GUTTER = space(1.5);
+export const X_GUTTER = space(2);
 
 export const DEFAULT_FIELD = 'unknown'; // Numeric data might, in theory, have a missing field. In this case we need a fallback to provide to the field rendering pipeline. `'unknown'` will results in rendering as a string
 

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -11,7 +11,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 import {ErrorPanel} from './errorPanel';
-import {MIN_HEIGHT, MIN_WIDTH} from './settings';
+import {MIN_HEIGHT, MIN_WIDTH, X_GUTTER, Y_GUTTER} from './settings';
 import {TooltipIconTrigger} from './tooltipIconTrigger';
 import type {StateProps} from './types';
 import {WarningsList} from './warningsList';
@@ -174,7 +174,7 @@ const Frame = styled('div')`
   width: 100%;
   min-width: ${MIN_WIDTH}px;
 
-  padding: ${space(1.5)} ${space(2)};
+  padding: ${Y_GUTTER} ${X_GUTTER};
 
   border-radius: ${p => p.theme.panelBorderRadius};
   border: ${p => p.theme.border};

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -174,8 +174,6 @@ const Frame = styled('div')`
   width: 100%;
   min-width: ${MIN_WIDTH}px;
 
-  padding: ${Y_GUTTER} ${X_GUTTER};
-
   border-radius: ${p => p.theme.panelBorderRadius};
   border: ${p => p.theme.border};
   border: 1px ${p => 'solid ' + p.theme.border};
@@ -198,13 +196,14 @@ const Frame = styled('div')`
   }
 `;
 
-const HEADER_HEIGHT = 26;
+const HEADER_HEIGHT = '26px';
 
 const Header = styled('div')`
   display: flex;
   align-items: center;
-  height: ${HEADER_HEIGHT}px;
+  height: calc(${HEADER_HEIGHT} + ${Y_GUTTER});
   gap: ${space(0.75)};
+  padding: ${X_GUTTER} ${Y_GUTTER} 0 ${X_GUTTER};
 `;
 
 const TitleText = styled(HeaderTitle)`


### PR DESCRIPTION
Right now `WidgetFrame` adds padding around the visualization. Handy for consistency, but for _table_ visualizations, we want _no padding_. I don't want to add a `noPadding` prop, that feels gross. Instead, I'm removing the mandatory padding from the frame, and frame users will be in charge of the padding. Gutters are specified in settings, which will encourage correct padding, and standard widgets will obviously use it.

No visual changes as a result.
