### PR TITLE
Add ability to run task eagerly during testing

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -712,6 +712,8 @@ from kombu import Exchange, Queue
 BROKER_URL = "redis://127.0.0.1:6379"
 BROKER_TRANSPORT_OPTIONS: dict[str, int] = {}
 
+TASK_WORKER_ALWAYS_EAGER = False
+
 # Ensure workers run async by default
 # in Development you might want them to run in-process
 # though it would cause timeouts/recursions in some cases

--- a/src/sentry/taskworker/task.py
+++ b/src/sentry/taskworker/task.py
@@ -62,7 +62,12 @@ class Task:
         return self.apply_async(*args, **kwargs)
 
     def apply_async(self, *args, **kwargs):
-        self.__namespace.send_task(self, args, kwargs)
+        from django.conf import settings
+
+        if settings.TASK_WORKER_ALWAYS_EAGER:
+            self.__func(*args, **kwargs)
+        else:
+            self.__namespace.send_task(self, args, kwargs)
 
     def should_retry(self, state: RetryState, exc: Exception) -> bool:
         # No retry policy means no retries.

--- a/src/sentry/testutils/helpers/task_runner.py
+++ b/src/sentry/testutils/helpers/task_runner.py
@@ -14,14 +14,17 @@ __all__ = ("BurstTaskRunner", "TaskRunner")
 
 @contextlib.contextmanager
 def TaskRunner() -> Generator[None]:
-    prev = settings.CELERY_ALWAYS_EAGER
+    prev_celery_setting = settings.CELERY_ALWAYS_EAGER
+    prev_task_worker_setting = settings.TASK_WORKER_ALWAYS_EAGER
+    settings.TASK_WORKER_ALWAYS_EAGER = True
     settings.CELERY_ALWAYS_EAGER = True
     current_app.conf.CELERY_ALWAYS_EAGER = True
     try:
         yield
     finally:
-        current_app.conf.CELERY_ALWAYS_EAGER = prev
-        settings.CELERY_ALWAYS_EAGER = prev
+        current_app.conf.CELERY_ALWAYS_EAGER = prev_celery_setting
+        settings.CELERY_ALWAYS_EAGER = prev_celery_setting
+        settings.TASK_WORKER_ALWAYS_EAGER = prev_task_worker_setting
 
 
 class BurstTaskRunnerRetryError(Exception):

--- a/tests/sentry/taskworker/test_worker_task.py
+++ b/tests/sentry/taskworker/test_worker_task.py
@@ -1,0 +1,17 @@
+import pytest
+from django.conf import settings
+
+from sentry.taskdemo import broken, say_hello
+from sentry.testutils.cases import TestCase
+
+
+class TaskWorkerTest(TestCase):
+    def test_run_task_with_eager_restores_settings(self):
+        with self.tasks():
+            say_hello.delay("John")
+        assert not settings.TASK_WORKER_ALWAYS_EAGER
+
+    def test_run_task_with_excep(self):
+        with pytest.raises(ValueError):
+            with self.tasks():
+                broken.delay("boom")


### PR DESCRIPTION
### Overview

Piggyback off of existing existing test utilities to let us run taskworker tasks eagerly during tests