### PR TITLE
ref(grouping): Refactor and split hashed `ChecksumVariant` into separate class

### DIFF
--- a/src/sentry/grouping/__init__.py
+++ b/src/sentry/grouping/__init__.py
@@ -41,6 +41,10 @@ Variants
     in the past were able to provide a grouping hash (the checksum) which was
     used for grouping exclusively.
 
+`HashedChecksumVariant`:
+    A ChecksumVariant with a hash value which has been normalized by running the
+    provided checksum through a hashing function.
+
 `FallbackVariant`:
     This variant produces always the same hash.  It's used if nothing else works.
 

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -26,6 +26,7 @@ from sentry.grouping.variants import (
     ComponentVariant,
     CustomFingerprintVariant,
     FallbackVariant,
+    HashedChecksumVariant,
     SaltedComponentVariant,
 )
 from sentry.models.grouphash import GroupHash
@@ -320,7 +321,7 @@ def get_grouping_variants_for_event(
             return {"checksum": ChecksumVariant(checksum)}
 
         rv: dict[str, BaseVariant] = {
-            "hashed-checksum": ChecksumVariant(hash_from_values(checksum), hashed=True),
+            "hashed-checksum": HashedChecksumVariant(hash_from_values(checksum), checksum),
         }
 
         # The legacy code path also supported arbitrary values here but

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -42,22 +42,28 @@ class ChecksumVariant(BaseVariant):
     """A checksum variant returns a single hardcoded hash."""
 
     type = "checksum"
+    description = "legacy checksum"
 
-    def __init__(self, checksum: str, hashed: bool = False):
+    def __init__(self, checksum: str):
         self.checksum = checksum
-        self.hashed = hashed
-
-    @property
-    def description(self) -> str:
-        if self.hashed:
-            return "hashed legacy checksum"
-        return "legacy checksum"
 
     def get_hash(self) -> str | None:
         return self.checksum
 
     def _get_metadata_as_dict(self):
         return {"checksum": self.checksum}
+
+
+class HashedChecksumVariant(ChecksumVariant):
+    type = "hashed-checksum"
+    description = "hashed legacy checksum"
+
+    def __init__(self, checksum: str, raw_checksum: str):
+        self.checksum = checksum
+        self.raw_checksum = raw_checksum
+
+    def _get_metadata_as_dict(self):
+        return {"checksum": self.checksum, "raw_checksum": self.raw_checksum}
 
 
 class FallbackVariant(BaseVariant):

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -43,8 +43,8 @@ class ChecksumVariant(BaseVariant):
 
     type = "checksum"
 
-    def __init__(self, hash: str, hashed: bool = False):
-        self.hash = hash
+    def __init__(self, checksum: str, hashed: bool = False):
+        self.checksum = checksum
         self.hashed = hashed
 
     @property
@@ -54,7 +54,7 @@ class ChecksumVariant(BaseVariant):
         return "legacy checksum"
 
     def get_hash(self) -> str | None:
-        return self.hash
+        return self.checksum
 
 
 class FallbackVariant(BaseVariant):

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -43,12 +43,12 @@ class ChecksumVariant(BaseVariant):
 
     type = "checksum"
 
-    def __init__(self, hash, hashed=False):
+    def __init__(self, hash: str, hashed: bool = False):
         self.hash = hash
         self.hashed = hashed
 
     @property
-    def description(self):
+    def description(self) -> str:
         if self.hashed:
             return "hashed legacy checksum"
         return "legacy checksum"

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -56,6 +56,9 @@ class ChecksumVariant(BaseVariant):
     def get_hash(self) -> str | None:
         return self.checksum
 
+    def _get_metadata_as_dict(self):
+        return {"checksum": self.checksum}
+
 
 class FallbackVariant(BaseVariant):
     type = "fallback"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/checksum_no_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/checksum_no_regex_match.pysnap
@@ -1,12 +1,13 @@
 ---
-created: '2024-10-23T23:31:04.165771+00:00'
+created: '2024-10-24T16:39:05.705922+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 checksum:
   hash: "not a legit checksum"
-  hashed: false
+  checksum: "not a legit checksum"
 --------------------------------------------------------------------------
 hashed-checksum:
   hash: "de46d023e69b171b90ccf3ebca7aede4"
-  hashed: true
+  checksum: "de46d023e69b171b90ccf3ebca7aede4"
+  raw_checksum: "not a legit checksum"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/checksum_no_regex_match_long.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/checksum_no_regex_match_long.pysnap
@@ -1,8 +1,9 @@
 ---
-created: '2024-10-23T23:31:04.119227+00:00'
+created: '2024-10-24T16:39:05.649697+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 hashed-checksum:
   hash: "2c2e85a6e73109222f131228ed06a7af"
-  hashed: true
+  checksum: "2c2e85a6e73109222f131228ed06a7af"
+  raw_checksum: "not a legit checksum and also too long a string"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/checksum_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/checksum_regex_match.pysnap
@@ -1,8 +1,8 @@
 ---
-created: '2024-10-23T23:31:04.207745+00:00'
+created: '2024-10-24T16:39:05.782674+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 checksum:
   hash: "11212012123120120415201309082013"
-  hashed: false
+  checksum: "11212012123120120415201309082013"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/checksum_no_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/checksum_no_regex_match.pysnap
@@ -1,12 +1,13 @@
 ---
-created: '2024-10-23T23:31:04.025726+00:00'
+created: '2024-10-24T16:39:30.105527+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 checksum:
   hash: "not a legit checksum"
-  hashed: false
+  checksum: "not a legit checksum"
 --------------------------------------------------------------------------
 hashed-checksum:
   hash: "de46d023e69b171b90ccf3ebca7aede4"
-  hashed: true
+  checksum: "de46d023e69b171b90ccf3ebca7aede4"
+  raw_checksum: "not a legit checksum"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/checksum_no_regex_match_long.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/checksum_no_regex_match_long.pysnap
@@ -1,8 +1,9 @@
 ---
-created: '2024-10-23T23:31:03.978728+00:00'
+created: '2024-10-24T16:39:30.058498+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 hashed-checksum:
   hash: "2c2e85a6e73109222f131228ed06a7af"
-  hashed: true
+  checksum: "2c2e85a6e73109222f131228ed06a7af"
+  raw_checksum: "not a legit checksum and also too long a string"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/checksum_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/checksum_regex_match.pysnap
@@ -1,8 +1,8 @@
 ---
-created: '2024-10-23T23:31:04.074740+00:00'
+created: '2024-10-24T16:39:30.173047+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 checksum:
   hash: "11212012123120120415201309082013"
-  hashed: false
+  checksum: "11212012123120120415201309082013"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/checksum_no_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/checksum_no_regex_match.pysnap
@@ -1,12 +1,13 @@
 ---
-created: '2024-10-23T23:31:03.885053+00:00'
+created: '2024-10-24T16:39:17.694785+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 checksum:
   hash: "not a legit checksum"
-  hashed: false
+  checksum: "not a legit checksum"
 --------------------------------------------------------------------------
 hashed-checksum:
   hash: "de46d023e69b171b90ccf3ebca7aede4"
-  hashed: true
+  checksum: "de46d023e69b171b90ccf3ebca7aede4"
+  raw_checksum: "not a legit checksum"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/checksum_no_regex_match_long.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/checksum_no_regex_match_long.pysnap
@@ -1,8 +1,9 @@
 ---
-created: '2024-10-23T23:31:03.843495+00:00'
+created: '2024-10-24T16:39:17.621191+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 hashed-checksum:
   hash: "2c2e85a6e73109222f131228ed06a7af"
-  hashed: true
+  checksum: "2c2e85a6e73109222f131228ed06a7af"
+  raw_checksum: "not a legit checksum and also too long a string"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/checksum_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/checksum_regex_match.pysnap
@@ -1,8 +1,8 @@
 ---
-created: '2024-10-23T23:31:03.932140+00:00'
+created: '2024-10-24T16:39:17.764556+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 checksum:
   hash: "11212012123120120415201309082013"
-  hashed: false
+  checksum: "11212012123120120415201309082013"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/checksum_no_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/checksum_no_regex_match.pysnap
@@ -1,12 +1,13 @@
 ---
-created: '2024-10-23T23:31:02.204971+00:00'
+created: '2024-10-24T16:32:32.133317+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 checksum:
   hash: "not a legit checksum"
-  hashed: false
+  checksum: "not a legit checksum"
 --------------------------------------------------------------------------
 hashed-checksum:
   hash: "de46d023e69b171b90ccf3ebca7aede4"
-  hashed: true
+  checksum: "de46d023e69b171b90ccf3ebca7aede4"
+  raw_checksum: "not a legit checksum"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/checksum_no_regex_match_long.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/checksum_no_regex_match_long.pysnap
@@ -1,8 +1,9 @@
 ---
-created: '2024-10-23T23:31:00.433039+00:00'
+created: '2024-10-24T16:32:30.293261+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 hashed-checksum:
   hash: "2c2e85a6e73109222f131228ed06a7af"
-  hashed: true
+  checksum: "2c2e85a6e73109222f131228ed06a7af"
+  raw_checksum: "not a legit checksum and also too long a string"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/checksum_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/checksum_regex_match.pysnap
@@ -1,8 +1,8 @@
 ---
-created: '2024-10-23T23:31:03.762694+00:00'
+created: '2024-10-24T16:32:34.163485+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 checksum:
   hash: "11212012123120120415201309082013"
-  hashed: false
+  checksum: "11212012123120120415201309082013"


### PR DESCRIPTION
This makes a few changes to the checksum grouping variant, or order to make it easier to gather metadata about it.

- Split `ChecksumVariant`, which can represent a hashed or unhashed checksum, into `ChecksumVariant` (unhashed) and `HashedChecksumVariant` (hashed).

- Switch the `description` attribute from the instance to the class, since it's now static.

- Remove the `hashed` attribute since a) it's not checked anywhere and b) it's now implied by the identity of the class.

- Rename the `hash` attribute to `checksum`, since it's not always an actually-usable hash. (This doesn't break any downstream grouping code because said code relies on the `get_hash` function rather than the `hash` attribute.) Add it to the variant metadata dict, since it's no longer included automatically by dint of being called 'hash`.

- Add a `raw_checksum` attribute to `HashedChecksumVariant` and include it in the variant metadata dict, to make it available for grouphash metadata.

- Add types.