### PR TITLE
feat(issue summary): Remove impact from issue summary, support bullets

### DIFF
--- a/static/app/components/group/groupSummary.spec.tsx
+++ b/static/app/components/group/groupSummary.spec.tsx
@@ -91,7 +91,7 @@ describe('GroupSummary', function () {
     expect(await screen.findByText('Test headline')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText('Test headline'));
-    expect(screen.getByText('Test impact')).toBeInTheDocument();
+    expect(screen.getByText('Test summary')).toBeInTheDocument();
   });
 
   it('does not render the summary if no consent', async function () {
@@ -136,7 +136,6 @@ describe('GroupSummary', function () {
 
     expect(screen.queryByText('Test headline')).not.toBeInTheDocument();
     expect(screen.queryByText('Test summary')).not.toBeInTheDocument();
-    expect(screen.queryByText('Impact: Test impact')).not.toBeInTheDocument();
   });
 
   it('does not render the summary if the issue is not in the error category', function () {
@@ -177,6 +176,5 @@ describe('GroupSummary', function () {
 
     expect(screen.queryByText('Test headline')).not.toBeInTheDocument();
     expect(screen.queryByText('Test summary')).not.toBeInTheDocument();
-    expect(screen.queryByText('Impact: Test impact')).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -236,7 +236,6 @@ const Content = styled('div')`
 `;
 
 const ButtonContainer = styled('div')`
-  margin-top: ${space(1.5)};
   align-items: center;
   display: flex;
 `;

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -108,7 +108,9 @@ export function GroupSummary({groupId, groupCategory}: GroupSummaryProps) {
               <HeadlinePreview>{data.headline}</HeadlinePreview>
               <SummaryPreview
                 dangerouslySetInnerHTML={{
-                  __html: singleLineRenderer(`Details: ${data.summary}`),
+                  __html: singleLineRenderer(
+                    `Details: ${data.summary.replaceAll('\n', ' ').replaceAll('-', '')}`
+                  ),
                 }}
               />
             </Fragment>
@@ -126,16 +128,9 @@ export function GroupSummary({groupId, groupCategory}: GroupSummaryProps) {
             <Content>
               <SummaryContent
                 dangerouslySetInnerHTML={{
-                  __html: marked(`**Details:** ${data.summary}`),
+                  __html: marked(data.summary),
                 }}
               />
-              <ImpactContent>
-                <SummaryContent
-                  dangerouslySetInnerHTML={{
-                    __html: marked(`**Impact:** ${data.impact}`),
-                  }}
-                />
-              </ImpactContent>
             </Content>
           )}
           {openForm && !isPending && (
@@ -232,11 +227,6 @@ const SummaryContent = styled('div')`
   code {
     word-break: break-all;
   }
-`;
-
-const ImpactContent = styled('div')`
-  display: flex;
-  flex-direction: column;
 `;
 
 const Content = styled('div')`


### PR DESCRIPTION
Removes the impact section and tweaks the formatting to let a bulleted summary render nicely.
<img width="772" alt="Screenshot 2024-10-24 at 10 12 35 AM" src="https://github.com/user-attachments/assets/f09dcfac-1037-4c02-9b59-ed4a2573d935">
