### PR TITLE
fix(dashboard): Create or update permission objects

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -179,7 +179,7 @@ class DashboardWidgetQuerySerializer(Serializer):
 class DashboardPermissionsSerializer(Serializer):
     def serialize(self, obj, attrs, user, **kwargs) -> DashboardPermissionsResponse:
         return {
-            "is_creator_only_editable": obj.is_creator_only_editable,
+            "isCreatorOnlyEditable": obj.is_creator_only_editable,
         }
 
 

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -17,6 +17,7 @@ from sentry.constants import ALL_ACCESS_PROJECTS
 from sentry.discover.arithmetic import ArithmeticError, categorize_columns
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.dashboard import Dashboard
+from sentry.models.dashboard_permissions import DashboardPermissions
 from sentry.models.dashboard_widget import (
     DashboardWidget,
     DashboardWidgetDisplayTypes,
@@ -583,6 +584,10 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
             self.update_widgets(self.instance, validated_data["widgets"])
 
         self.update_dashboard_filters(self.instance, validated_data)
+        if "permissions" in validated_data:
+            DashboardPermissions.objects.create(
+                dashboard=self.instance, **validated_data["permissions"]
+            )
 
         schedule_update_project_configs(self.instance)
 
@@ -607,6 +612,10 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
             self.update_widgets(instance, validated_data["widgets"])
 
         self.update_dashboard_filters(instance, validated_data)
+        if "permissions" in validated_data:
+            DashboardPermissions.objects.update_or_create(
+                dashboard=instance, defaults=validated_data["permissions"]
+            )
 
         schedule_update_project_configs(instance)
 

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -361,7 +361,7 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
         assert response.status_code == 200, response.content
 
         assert "permissions" in response.data
-        assert not response.data["permissions"]["is_creator_only_editable"]
+        assert not response.data["permissions"]["isCreatorOnlyEditable"]
 
     def test_dashboard_details_data_returns_Null_permissions(self):
         dashboard = Dashboard.objects.create(
@@ -1869,12 +1869,60 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         self.create_environment(project=mock_project, name="mock_env")
         data = {
             "title": "Dashboard",
-            "permissions": {"is_creator_only_editable": "False"},
+            "permissions": {"isCreatorOnlyEditable": "False"},
         }
         response = self.do_request(
             "put", f"{self.url(self.dashboard.id)}?environment=mock_env", data=data
         )
         assert response.status_code == 200, response.data
+        assert response.data["permissions"]["isCreatorOnlyEditable"] is False
+
+    def test_update_dashboard_permissions_to_true(self):
+        mock_project = self.create_project()
+        self.create_environment(project=mock_project, name="mock_env")
+        data = {
+            "title": "Dashboard",
+            "permissions": {"isCreatorOnlyEditable": "true"},
+        }
+        response = self.do_request(
+            "put", f"{self.url(self.dashboard.id)}?environment=mock_env", data=data
+        )
+        assert response.status_code == 200, response.data
+        assert response.data["permissions"]["isCreatorOnlyEditable"] is True
+
+    def test_update_dashboard_permissions_when_already_created(self):
+        mock_project = self.create_project()
+        permission = DashboardPermissions.objects.create(
+            is_creator_only_editable=False, dashboard=self.dashboard
+        )
+        self.create_environment(project=mock_project, name="mock_env")
+        data = {
+            "title": "Dashboard",
+            "permissions": {"isCreatorOnlyEditable": "true"},
+        }
+
+        assert permission.is_creator_only_editable is False
+        response = self.do_request(
+            "put", f"{self.url(self.dashboard.id)}?environment=mock_env", data=data
+        )
+        assert response.status_code == 200, response.data
+        assert response.data["permissions"]["isCreatorOnlyEditable"] is True
+
+        permission.refresh_from_db()
+        assert permission.is_creator_only_editable is True
+
+    def test_update_dashboard_permissions_with_invalid_value(self):
+        mock_project = self.create_project()
+        self.create_environment(project=mock_project, name="mock_env")
+        data = {
+            "title": "Dashboard",
+            "permissions": {"isCreatorOnlyEditable": "something-invalid"},
+        }
+        response = self.do_request(
+            "put", f"{self.url(self.dashboard.id)}?environment=mock_env", data=data
+        )
+        assert response.status_code == 400, response.data
+        assert "isCreatorOnlyEditable" in response.data["permissions"]
 
     def test_edit_dashboard_with_edit_permissions_not_granted(self):
         dashboard = Dashboard.objects.create(


### PR DESCRIPTION
Also changes the case of is_creator_only_editable in the model serializer to camel case to match.