### PR TITLE
fix(alerts): do not return special condition if flag not enabled

### DIFF
--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -31,6 +31,10 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
         can_create_tickets = features.has(
             "organizations:integrations-ticket-rules", project.organization
         )
+        has_user_frequency_condition_with_conditions_alert = features.has(
+            "organizations:event-unique-user-frequency-condition-with-conditions",
+            project.organization,
+        )
 
         # TODO: conditions need to be based on actions
         for rule_type, rule_cls in rules:
@@ -71,6 +75,11 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
                 continue
 
             if rule_type.startswith("condition/"):
+                if (
+                    node.id
+                    == "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyConditionWithConditions"
+                ) and not has_user_frequency_condition_with_conditions_alert:
+                    continue
                 condition_list.append(context)
             elif rule_type.startswith("filter/"):
                 filter_list.append(context)

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -537,6 +537,7 @@ class EventUniqueUserFrequencyCondition(BaseEventFrequencyCondition):
 
 class EventUniqueUserFrequencyConditionWithConditions(EventUniqueUserFrequencyCondition):
     id = "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyConditionWithConditions"
+    label = "The issue is seen by more than {value} users in {interval} with conditions"
 
     def query_hook(
         self, event: GroupEvent, start: datetime, end: datetime, environment_id: int


### PR DESCRIPTION
it seems for some projects, we use this endpoint to populate the frontend for alerts, and for others it seems hardcoded on the frontend, so i did not notice this during my internal testing, but so we need to check the flag before turning this condition in the configuration endpoint.