### PR TITLE
feat(insights): update remaining domain view urls in transaction summary

### DIFF
--- a/static/app/components/profiling/profileEventsTable.tsx
+++ b/static/app/components/profiling/profileEventsTable.tsx
@@ -28,6 +28,10 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {QuickContextHoverWrapper} from 'sentry/views/discover/table/quickContext/quickContextWrapper';
 import {ContextType} from 'sentry/views/discover/table/quickContext/utils';
+import {
+  type DomainView,
+  useDomainViewFilters,
+} from 'sentry/views/insights/pages/useFilters';
 import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 
 import {ProfilingTransactionHovercard} from './profilingTransactionHovercard';
@@ -47,6 +51,7 @@ export function ProfileEventsTable<F extends FieldType>(
   const location = useLocation();
   const organization = useOrganization();
   const {projects} = useProjects();
+  const domainViewFilters = useDomainViewFilters();
 
   const generateSortLink = useCallback(
     (column: F) => () => {
@@ -81,7 +86,7 @@ export function ProfileEventsTable<F extends FieldType>(
         }),
         renderBodyCell: renderTableBody(
           props.data?.meta ?? ({fields: {}, units: {}} as EventsResults<F>['meta']),
-          {location, organization, projects}
+          {location, organization, projects, view: domainViewFilters?.view}
         ),
       }}
     />
@@ -92,6 +97,7 @@ type RenderBagger = {
   location: Location;
   organization: Organization;
   projects: Project[];
+  view?: DomainView;
 };
 
 function renderTableBody<F extends FieldType>(
@@ -176,6 +182,7 @@ function ProfileEventsCell<F extends FieldType>(props: ProfileEventsCellProps<F>
             dateSelection: dataSelection,
             timestamp,
             location: props.baggage.location,
+            view: props.baggage.view,
           })}
         >
           {getShortEventId(traceId)}

--- a/static/app/views/insights/common/components/tableCells/spanIdCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/spanIdCell.tsx
@@ -6,6 +6,7 @@ import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOrganization from 'sentry/utils/useOrganization';
 import {SPAN_ID_DISPLAY_LENGTH} from 'sentry/views/insights/http/settings';
+import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import type {ModuleName} from 'sentry/views/insights/types';
 
 interface Props {
@@ -30,6 +31,7 @@ export function SpanIdCell({
   location,
 }: Props) {
   const organization = useOrganization();
+  const domainViewFilters = useDomainViewFilters();
   const url = normalizeUrl(
     generateLinkToEventInTraceView({
       eventId: transactionId,
@@ -40,6 +42,7 @@ export function SpanIdCell({
       location,
       spanId,
       source,
+      view: domainViewFilters.view,
     })
   );
 

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -211,7 +211,7 @@ class EventsTable extends Component<Props, State> {
             view: this.props.domainViewFilters?.view,
           });
         } else {
-          target = generateTraceLink(transactionName)(
+          target = generateTraceLink(transactionName, this.props.domainViewFilters?.view)(
             organization,
             dataRow,
             locationWithTab

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/utils.tsx
@@ -23,16 +23,19 @@ export function spanDetailsRouteWithQuery({
   query,
   spanSlug,
   projectID,
+  view,
 }: {
   orgSlug: string;
   query: Query;
   spanSlug: SpanSlug;
   transaction: string;
   projectID?: string | string[];
+  view?: DomainView;
 }) {
   const pathname = generateSpanDetailsRoute({
     orgSlug,
     spanSlug,
+    view,
   });
 
   return {

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanMetricsTable.tsx
@@ -22,6 +22,10 @@ import {renderHeadCell} from 'sentry/views/insights/common/components/tableCells
 import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {
+  type DomainView,
+  useDomainViewFilters,
+} from 'sentry/views/insights/pages/useFilters';
+import {
   SpanMetricsField,
   type SpanMetricsQueryFilters,
 } from 'sentry/views/insights/types';
@@ -95,6 +99,7 @@ export default function SpanMetricsTable(props: Props) {
   const organization = useOrganization();
   const location = useLocation();
   const sort = useSpansTabTableSort();
+  const domainViewFilters = useDomainViewFilters();
 
   const query = useLocationQuery({
     fields: {
@@ -166,7 +171,8 @@ export default function SpanMetricsTable(props: Props) {
               location,
               organization,
               transactionName,
-              project
+              project,
+              domainViewFilters?.view
             ),
           }}
         />
@@ -180,7 +186,8 @@ function renderBodyCell(
   location: Location,
   organization: Organization,
   transactionName: string,
-  project?: Project
+  project?: Project,
+  view?: DomainView
 ) {
   return function (column: Column, dataRow: DataRow): React.ReactNode {
     if (column.key === SpanMetricsField.SPAN_OP) {
@@ -190,6 +197,7 @@ function renderBodyCell(
         query: location.query,
         spanSlug: {op: dataRow['span.op'], group: ''},
         projectID: project?.id,
+        view,
       });
 
       return (
@@ -210,6 +218,7 @@ function renderBodyCell(
         query: location.query,
         spanSlug: {op: dataRow['span.op'], group: dataRow['span.group']},
         projectID: project?.id,
+        view,
       });
 
       return (


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/79643
This PR updates the remaining urls in the transaction summary to go to the new domain views if applicable.