### PR TITLE
fix(group-inbox): Update GroupInbox when using issue platform to update statuses

### DIFF
--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -11,7 +11,12 @@ from sentry.issues.escalating import manage_issue_states
 from sentry.issues.status_change_message import StatusChangeMessageData
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphash import GroupHash
-from sentry.models.groupinbox import GroupInboxReason
+from sentry.models.groupinbox import (
+    GroupInboxReason,
+    GroupInboxRemoveAction,
+    add_group_to_inbox,
+    remove_group_from_inbox,
+)
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.types.activity import ActivityType
@@ -58,6 +63,8 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
             substatus=new_substatus,
             activity_type=ActivityType.SET_RESOLVED,
         )
+        remove_group_from_inbox(group, action=GroupInboxRemoveAction.RESOLVED)
+
     elif new_status == GroupStatus.IGNORED:
         # The IGNORED status supports 3 substatuses. For UNTIL_ESCALATING and
         # UNTIL_CONDITION_MET, we expect the caller to monitor the conditions/escalating
@@ -75,13 +82,19 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
             substatus=new_substatus,
             activity_type=ActivityType.SET_IGNORED,
         )
+        remove_group_from_inbox(group, action=GroupInboxRemoveAction.IGNORED)
     elif new_status == GroupStatus.UNRESOLVED and new_substatus == GroupSubStatus.ESCALATING:
+        # Update the group status, priority, and add the group to the inbox
         manage_issue_states(group=group, group_inbox_reason=GroupInboxReason.ESCALATING)
     elif new_status == GroupStatus.UNRESOLVED:
         activity_type = None
+        group_inbox_reason = None
         if new_substatus == GroupSubStatus.REGRESSED:
             activity_type = ActivityType.SET_REGRESSION
+            group_inbox_reason = GroupInboxReason.REGRESSION
+
         elif new_substatus == GroupSubStatus.ONGOING:
+            group_inbox_reason = GroupInboxReason.ONGOING
             if group.substatus == GroupSubStatus.ESCALATING:
                 # If the group was previously escalating, update the priority via AUTO_SET_ONGOING
                 activity_type = ActivityType.AUTO_SET_ONGOING
@@ -104,6 +117,7 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
             activity_type=activity_type,
             from_substatus=group.substatus,
         )
+        add_group_to_inbox(group, group_inbox_reason)
     else:
         logger.error(
             "group.update_status.unsupported_status",


### PR DESCRIPTION
Currently, updating a group's status via the issue platform doesn't add/remove the group from GroupInbox. Since we use GroupInbox to populate issues in the `is:for_review` query, we're seeing resolved groups in the stream that should be otherwise hidden. [Example](https://sentry.sentry.io/issues/?project=1&query=is%3Afor_review%20%21issue.category%3Aerror%20issue%3ASENTRY-3H3K&referrer=issue-list&sort=date&statsPeriod=90d&viewId=54006)

Fixing this behavior in this PR to make sure the GroupInbox is updated with each status change.  