### PR TITLE
fix(issues): Add project id to partition key for occurrences

### DIFF
--- a/src/sentry/issues/producer.py
+++ b/src/sentry/issues/producer.py
@@ -66,9 +66,9 @@ def produce_occurrence_to_kafka(
 
     partition_key = None
     if occurrence and occurrence.fingerprint:
-        partition_key = occurrence.fingerprint[0].encode()
+        partition_key = f"{occurrence.fingerprint[0]}-{occurrence.project_id}".encode()
     elif status_change and status_change.fingerprint:
-        partition_key = status_change.fingerprint[0].encode()
+        partition_key = f"{status_change.fingerprint[0]}-{status_change.project_id}".encode()
     payload = KafkaPayload(partition_key, json.dumps(payload_data).encode("utf-8"), [])
     if settings.SENTRY_EVENTSTREAM != "sentry.eventstream.kafka.KafkaEventStream":
         # If we're not running Kafka then we're just in dev.

--- a/tests/sentry/issues/test_producer.py
+++ b/tests/sentry/issues/test_producer.py
@@ -105,7 +105,7 @@ class TestProduceOccurrenceToKafka(TestCase, OccurrenceTestMixin):
         mock_produce.assert_called_once_with(
             ArroyoTopic(name="ingest-occurrences"),
             KafkaPayload(
-                occurrence.fingerprint[0].encode(),
+                f"{occurrence.fingerprint[0]}-{occurrence.project_id}".encode(),
                 json.dumps({"mock_data": "great"}).encode("utf-8"),
                 [],
             ),
@@ -402,7 +402,7 @@ class TestProduceOccurrenceForStatusChange(TestCase, OccurrenceTestMixin):
         mock_produce.assert_called_once_with(
             ArroyoTopic(name="ingest-occurrences"),
             KafkaPayload(
-                status_change.fingerprint[0].encode(),
+                f"{status_change.fingerprint[0]}-{status_change.project_id}".encode(),
                 json.dumps({"mock_data": "great"}).encode("utf-8"),
                 [],
             ),


### PR DESCRIPTION
this pr adds the project id to the partition key for occurrences. for some issue types, there is only 1 fingerprint so we want to spread those issues across partitions 