### PR TITLE
fix(profiling): Pass start/end timestamps for standalone profile chunks

### DIFF
--- a/src/sentry/profiles/flamegraph.py
+++ b/src/sentry/profiles/flamegraph.py
@@ -251,8 +251,8 @@ def get_chunks_from_spans_metadata(
     for row in data:
         intervals = [
             {
-                "start": str(int(datetime.fromisoformat(el["start"]).timestamp() * 10**9)),
-                "end": str(int(datetime.fromisoformat(el["end"]).timestamp() * 10**9)),
+                "start": str(int(datetime.fromisoformat(el["start"]).timestamp() * 1e9)),
+                "end": str(int(datetime.fromisoformat(el["end"]).timestamp() * 1e9)),
                 "active_thread_id": el["active_thread_id"],
             }
             for el in spans[row["profiler_id"]]
@@ -684,6 +684,10 @@ class FlamegraphExecutor:
                     "project_id": row["project_id"],
                     "profiler_id": row["profiler_id"],
                     "chunk_id": row["chunk_id"],
+                    "start": str(
+                        int(datetime.fromisoformat(row["start_timestamp"]).timestamp() * 1e9)
+                    ),
+                    "end": str(int(datetime.fromisoformat(row["end_timestamp"]).timestamp() * 1e9)),
                 }
                 for row in continuous_profile_results["data"]
             ]

--- a/tests/sentry/api/endpoints/test_organization_profiling_profiles.py
+++ b/tests/sentry/api/endpoints/test_organization_profiling_profiles.py
@@ -704,6 +704,8 @@ class OrganizationProfilingFlamegraphTest(ProfilesSnubaTestCase):
                             "project_id": self.project.id,
                             "profiler_id": profiler_id,
                             "chunk_id": chunk["chunk_id"],
+                            "start": str(int((start_timestamp - buffer).timestamp() * 1e9)),
+                            "end": str(int((finish_timestamp + buffer).timestamp() * 1e9)),
                         },
                     ],
                 },


### PR DESCRIPTION
We need to pass the start/end timestamps for a standalone chunk in order to link to it properly.