### PR TITLE
chore(sentry apps): Update codeowners after sentry app consolidation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -348,7 +348,7 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 
 
 ## Integrations
-/src/sentry/api/endpoints/sentry_app/                                @getsentry/product-owners-settings-integrations
+/src/sentry/sentry_apps/                                             @getsentry/product-owners-settings-integrations @getsentry/ecosystem
 /src/sentry/api/endpoints/project_rule*.py                           @getsentry/alerts-notifications
 /src/sentry/api/serializers/models/rule.py                           @getsentry/alerts-notifications
 
@@ -374,8 +374,8 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 
 
 # To find matching files -> find . -name "*sentry_app*.py"
-*sentry_app*.py                                                      @getsentry/product-owners-settings-integrations
-*sentryapp*.py                                                       @getsentry/product-owners-settings-integrations
+*sentry_app*.py                                                      @getsentry/product-owners-settings-integrations @getsentry/ecosystem
+*sentryapp*.py                                                       @getsentry/product-owners-settings-integrations @getsentry/ecosystem
 *doc_integration*.py                                                 @getsentry/ecosystem
 *docintegration*.py                                                  @getsentry/ecosystem
 
@@ -613,7 +613,7 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /src/sentry/api/endpoints/organization_missing_org_members.py           @getsentry/ecosystem
 /src/sentry/tasks/invite_missing_org_members.py                         @getsentry/ecosystem
 /static/app/components/modals/inviteMissingMembersModal/                @getsentry/ecosystem
-/src/sentry/tasks/integrations/github/pr_comment.py                     @getsentry/ecosystem
+/src/sentry/integrations/github/tasks/pr_comment.py                     @getsentry/ecosystem
 ## End of Ecosystem
 
 ## Core Product Foundations

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -349,6 +349,7 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 
 ## Integrations
 /src/sentry/sentry_apps/                                             @getsentry/product-owners-settings-integrations @getsentry/ecosystem
+/tests/sentry/sentry_apps                                            @getsentry/product-owners-settings-integrations @getsentry/ecosystem
 /src/sentry/api/endpoints/project_rule*.py                           @getsentry/alerts-notifications
 /src/sentry/api/serializers/models/rule.py                           @getsentry/alerts-notifications
 


### PR DESCRIPTION
Everything has been shuffled around so let's update codeowners to reflect that.
Mainly updates sentry apps paths and adds ecosystem to be codeowners for sentry apps.

issue ref(#73857)