### PR TITLE
ref(crons): Acocunt for math edge cases in _evaluate_tick_decision

### DIFF
--- a/src/sentry/monitors/clock_dispatch.py
+++ b/src/sentry/monitors/clock_dispatch.py
@@ -142,8 +142,8 @@ def _evaluate_tick_decision(tick: datetime):
     if past_minute_volume is None:
         return
 
-    # Can't make any decisions if we don't have historic data
-    if len(historic_volume) == 0:
+    # We need AT LEAST two data points to calculate standard deviation
+    if len(historic_volume) < 2:
         return
 
     # Record some statistics about the past_minute_volume volume in comparison
@@ -157,7 +157,10 @@ def _evaluate_tick_decision(tick: datetime):
     # Calculate the z-score of our past minutes volume in comparison to the
     # historic volume data. The z-score is measured in terms of standard
     # deviations from the mean
-    z_score = (past_minute_volume - historic_mean) / historic_stdev
+    if historic_stdev != 0.0:
+        z_score = (past_minute_volume - historic_mean) / historic_stdev
+    else:
+        z_score = 0.0
 
     # Percentage deviation from the mean for our past minutes volume
     pct_deviation = (abs(past_minute_volume - historic_mean) / historic_mean) * 100


### PR DESCRIPTION
Fixes [SENTRY-3H3S](https://sentry.sentry.io/issues/6017716797/).

When we didn't have enough data we weren't able to calculate a standard deviation