### PR TITLE
ref(crons): Correct test_check_timeout large id usage

### DIFF
--- a/tests/sentry/monitors/clock_tasks/test_check_timeout.py
+++ b/tests/sentry/monitors/clock_tasks/test_check_timeout.py
@@ -42,6 +42,9 @@ class MonitorClockTasksCheckTimeoutTest(TestCase):
             },
         )
         monitor_environment = MonitorEnvironment.objects.create(
+            # XXX(epurkhiser): Arbitrarily large id to make sure we can
+            # correctly use the monitor_environment.id as the partition key
+            id=62702371781194950,
             monitor=monitor,
             environment_id=self.environment.id,
             last_checkin=ts,
@@ -51,9 +54,6 @@ class MonitorClockTasksCheckTimeoutTest(TestCase):
         )
         # Checkin will timeout in 30 minutes
         checkin = MonitorCheckIn.objects.create(
-            # XXX(epurkhiser): Arbitrarily large id to make sure we can
-            # correctly use the monitor_environment.id as the partition key
-            id=62702371781194950,
             monitor=monitor,
             monitor_environment=monitor_environment,
             project_id=project.id,


### PR DESCRIPTION
The large ID is meant to be set for the MonitorEnvironment not the
MonitorCheckIn like it was here.