### PR TITLE
ref(replay): Only show timeline gaps larger than 1.1s

### DIFF
--- a/static/app/components/replays/breadcrumbs/timelineGaps.tsx
+++ b/static/app/components/replays/breadcrumbs/timelineGaps.tsx
@@ -19,9 +19,9 @@ export default function TimelineGaps({durationMs, startTimestampMs, videoEvents}
 
   let start = startTimestampMs;
 
-  // create gap in timeline when there is a gap between video events larger than 1s
+  // create gap in timeline when there is a gap between video events larger than 1.1s
   for (const video of videoEvents) {
-    if (video.timestamp - start > 1000) {
+    if (video.timestamp - start > 1100) {
       ranges.push({
         left: toPercent((start - startTimestampMs) / durationMs),
         width: toPercent((video.timestamp - start) / durationMs),

--- a/static/app/components/replays/breadcrumbs/timelineGaps.tsx
+++ b/static/app/components/replays/breadcrumbs/timelineGaps.tsx
@@ -3,8 +3,10 @@ import styled from '@emotion/styled';
 
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import toPercent from 'sentry/utils/number/toPercent';
 import type {VideoEvent} from 'sentry/utils/replays/types';
+import useOrganization from 'sentry/utils/useOrganization';
 
 interface Props {
   durationMs: number;
@@ -35,6 +37,11 @@ export default function TimelineGaps({durationMs, startTimestampMs, videoEvents}
       width: toPercent(durationMs / durationMs),
     });
   }
+
+  trackAnalytics('replay.number_of_timeline_gaps', {
+    gaps: ranges.length,
+    organization: useOrganization(),
+  });
 
   // TODO: Fix tooltip position to follow mouse (it currently goes off the timeline when zoomed too much)
   return (

--- a/static/app/components/replays/breadcrumbs/timelineGaps.tsx
+++ b/static/app/components/replays/breadcrumbs/timelineGaps.tsx
@@ -17,9 +17,9 @@ export default function TimelineGaps({durationMs, startTimestampMs, videoEvents}
 
   let start = startTimestampMs;
 
-  // create gap in timeline when there is a gap between video events
+  // create gap in timeline when there is a gap between video events larger than 1s
   for (const video of videoEvents) {
-    if (start < video.timestamp) {
+    if (video.timestamp - start > 1000) {
       ranges.push({
         left: toPercent((start - startTimestampMs) / durationMs),
         width: toPercent((video.timestamp - start) / durationMs),

--- a/static/app/utils/analytics/replayAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/replayAnalyticsEvents.tsx
@@ -60,6 +60,11 @@ export type ReplayEventParameters = {
     frame: string;
   };
 
+  'replay.gaps_detected': {
+    gaps: number;
+    max_gap: number;
+    replay_duration: number;
+  };
   'replay.hydration-error.issue-details-opened': {};
   'replay.hydration-modal.slider-interaction': {};
   'replay.hydration-modal.tab-change': {
@@ -85,11 +90,6 @@ export type ReplayEventParameters = {
     user_email: string;
   };
   'replay.list-view-setup-sidebar': {};
-  'replay.number_of_timeline_gaps': {
-    gaps: number;
-    max_gap: number;
-    replay_duration: number;
-  };
   'replay.play-pause': {
     context: string;
     mobile: boolean;
@@ -153,7 +153,7 @@ export const replayEventMap: Record<ReplayEventKey, string | null> = {
   'replay.list-sorted': 'Sorted Replay List',
   'replay.list-time-spent': 'Time Spent Viewing Replay List',
   'replay.list-view-setup-sidebar': 'Views Set Up Replays Sidebar',
-  'replay.number_of_timeline_gaps': 'Number of Gaps in Replay Timeline',
+  'replay.gaps_detected': 'Number of Gaps in Replay Timeline',
   'replay.play-pause': 'Played/Paused Replay',
   'replay.rage-click-sdk-banner.dismissed': 'Replay Rage Click SDK Banner Dismissed',
   'replay.rage-click-sdk-banner.rendered': 'Replay Rage Click SDK Banner Rendered',

--- a/static/app/utils/analytics/replayAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/replayAnalyticsEvents.tsx
@@ -85,6 +85,9 @@ export type ReplayEventParameters = {
     user_email: string;
   };
   'replay.list-view-setup-sidebar': {};
+  'replay.number_of_timeline_gaps': {
+    gaps: number;
+  };
   'replay.play-pause': {
     context: string;
     mobile: boolean;
@@ -148,6 +151,7 @@ export const replayEventMap: Record<ReplayEventKey, string | null> = {
   'replay.list-sorted': 'Sorted Replay List',
   'replay.list-time-spent': 'Time Spent Viewing Replay List',
   'replay.list-view-setup-sidebar': 'Views Set Up Replays Sidebar',
+  'replay.number_of_timeline_gaps': 'Number of Gaps in Replay Timeline',
   'replay.play-pause': 'Played/Paused Replay',
   'replay.rage-click-sdk-banner.dismissed': 'Replay Rage Click SDK Banner Dismissed',
   'replay.rage-click-sdk-banner.rendered': 'Replay Rage Click SDK Banner Rendered',

--- a/static/app/utils/analytics/replayAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/replayAnalyticsEvents.tsx
@@ -87,6 +87,8 @@ export type ReplayEventParameters = {
   'replay.list-view-setup-sidebar': {};
   'replay.number_of_timeline_gaps': {
     gaps: number;
+    max_gap: number;
+    replay_duration: number;
   };
   'replay.play-pause': {
     context: string;


### PR DESCRIPTION
Only gaps larger than 1.1s will be shown. Also adds analytics to see how many timeline gaps there are within a replay

Before:
<img width="1501" alt="image" src="https://github.com/user-attachments/assets/2995cd5b-9c78-4604-8a12-a0a1a546fe72">

After:
<img width="1501" alt="image" src="https://github.com/user-attachments/assets/33d36944-0911-402f-af03-0b3a51923c5b">

