### PR TITLE
fix(alerts): better message for missing target ID

### DIFF
--- a/src/sentry/incidents/serializers/alert_rule_trigger.py
+++ b/src/sentry/incidents/serializers/alert_rule_trigger.py
@@ -86,6 +86,11 @@ class AlertRuleTriggerSerializer(CamelSnakeModelSerializer):
                 else:
                     action_instance = None
 
+                if not action_data.get("target_identifier", ""):
+                    raise serializers.ValidationError(
+                        "One or more of your actions is missing a target identifier."
+                    )
+
                 action_serializer = AlertRuleTriggerActionSerializer(
                     context={
                         "alert_rule": alert_rule_trigger.alert_rule,

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -929,6 +929,33 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             ]
         }
 
+    def test_critical_trigger_action_no_target_id(self):
+        rule_one_trigger_no_target_id = {
+            "aggregate": "count()",
+            "query": "",
+            "timeWindow": "300",
+            "projects": [self.project.slug],
+            "name": "OneTriggerOnlyCritical",
+            "owner": self.user.id,
+            "resolveThreshold": 200,
+            "thresholdType": 1,
+            "triggers": [
+                {
+                    "label": "critical",
+                    "alertThreshold": 100,
+                    "actions": [{"type": "email", "targetType": "team", "targetIdentifier": ""}],
+                }
+            ],
+        }
+
+        with self.feature("organizations:incidents"):
+            resp = self.get_error_response(
+                self.organization.slug, status_code=400, **rule_one_trigger_no_target_id
+            )
+        assert resp.data[0] == ErrorDetail(
+            string="One or more of your actions is missing a target identifier.", code="invalid"
+        )
+
     def test_invalid_projects(self):
         with self.feature("organizations:incidents"):
             resp = self.get_error_response(


### PR DESCRIPTION
`target_identifier` is required by the alert rule trigger action serializer. Previously, if this field was left blank, then the serializer would return the default "this field may not be blank" error message. Surface a more descriptive message to the user instead.

Fixes https://github.com/getsentry/team-core-product-foundations/issues/155