### PR TITLE
fix(new-trace): Updating mongo db span description format.

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
@@ -111,9 +111,9 @@ export function SpanDescription({
   const value =
     resolvedModule === ModuleName.DB ? (
       <Fragment>
-        <CodeSnippet language="sql" isRounded={false}>
+        <StyledCodeSnippet language="sql" isRounded={false}>
           {formattedDescription}
-        </CodeSnippet>
+        </StyledCodeSnippet>
         {span?.data?.['code.filepath'] ? (
           <StackTraceMiniFrame
             projectId={node.event?.projectID}
@@ -169,4 +169,10 @@ const ButtonGroup = styled('div')`
   gap: ${space(0.5)};
   flex-wrap: wrap;
   justify-content: flex-end;
+`;
+
+const StyledCodeSnippet = styled(CodeSnippet)`
+  code {
+    text-wrap: wrap;
+  }
 `;


### PR DESCRIPTION
Before:
<img width="635" alt="Screenshot 2024-10-24 at 6 23 58 PM" src="https://github.com/user-attachments/assets/d64b7669-119d-4a06-a857-22d2791637e3">

After:
<img width="594" alt="Screenshot 2024-10-24 at 6 24 27 PM" src="https://github.com/user-attachments/assets/f0e69c1b-c718-4a27-a762-f5f7147a24d0">
