### PR TITLE
feat(auth): Add organization scope to oauth authorize endpoint

### DIFF
--- a/src/sentry/templates/sentry/oauth-authorize.html
+++ b/src/sentry/templates/sentry/oauth-authorize.html
@@ -11,16 +11,17 @@
     {% csrf_token %}
 
     <div>
-      <p><strong>{{ application.name }}</strong> is requesting access to your Sentry account ({{ user.username }}):</p>
+      <p><strong>{{ application.name }}</strong> is requesting access to your Sentry account linked to ({{ user.username }}):</p>
       <ul>
-        <li>Access to your account details, including your name and email address.</li>
+        <li>Your name</li>
+        <li>Your email address</li>
       </ul>
       <p>
         {% if organization_options|length == 0 %}
-          As well as the following access to your Sentry organizations:
+          {{ application.name }} will have the following permissions to your Sentry organizations:
         {% elif organization_options|length == 1 %}
         <!-- If user only has one org and application requires org level access, choose that org by default -->
-          As well as the following access to your Sentry organization <strong>{{organization_options.0.name}}</strong>:
+          {{ application.name }} will have the following permissions to your Sentry organization <strong>{{organization_options.0.name}}</strong>:
           <input type="hidden" name="selected_organization_id" value="{{ organization_options.0.id }}">
         {% endif %}
       </p>

--- a/src/sentry/templates/sentry/oauth-authorize.html
+++ b/src/sentry/templates/sentry/oauth-authorize.html
@@ -14,10 +14,31 @@
       <p><strong>{{ application.name }}</strong> is requesting access to your Sentry account ({{ user.username }}):</p>
       <ul>
         <li>Access to your account details, including your name and email address.</li>
+      </ul>
+      <p>
+        {% if organization_options|length == 0 %}
+          As well as the following access to your Sentry organizations:
+        {% elif organization_options|length == 1 %}
+        <!-- If user only has one org and application requires org level access, choose that org by default -->
+          As well as the following access to your Sentry organization <strong>{{organization_options.0.name}}</strong>:
+          <input type="hidden" name="selected_organization_id" value="{{ organization_options.0.id }}">
+        {% endif %}
+      </p>
+      <ul>
         {% for permission in permissions %}
           <li>{{ permission }}</li>
         {% endfor %}
       </ul>
+
+      {% if organization_options|length > 1 %}
+        <!-- If there are multiple organizations and application requires org level access, show the selector -->
+        <label for="organization">Select one of your sentry organizations to grant access to:</label>
+        <select name="selected_organization_id" id="organization_id">
+            {% for organization in organization_options %}
+                <option value="{{ organization.id }}">{{ organization.name }}</option>
+            {% endfor %}
+        </select>
+      {% endif %}
       {% if application.terms_url or application.privacy_url %}
         <p><small>
           {% if application.terms_url %}

--- a/src/sentry/templates/sentry/oauth-authorize.html
+++ b/src/sentry/templates/sentry/oauth-authorize.html
@@ -11,17 +11,18 @@
     {% csrf_token %}
 
     <div>
-      <p><strong>{{ application.name }}</strong> is requesting access to your Sentry account linked to ({{ user.username }}):</p>
+      <p><strong>{{ application.name }}</strong> is requesting access to your Sentry account linked to ({{ user.username }}). Granting this access will give {{ application.name }} access to your account details, including:</p>
       <ul>
         <li>Your name</li>
         <li>Your email address</li>
       </ul>
       <p>
-        {% if organization_options|length == 0 %}
-          {{ application.name }} will have the following permissions to your Sentry organizations:
+        {% if organization_options|length != 0 %}
+        <!-- If application needs user level access or it's org level access and user has multiple orgs -->
+          {{ application.name }} will also have the following permissions to your Sentry organizations:
         {% elif organization_options|length == 1 %}
         <!-- If user only has one org and application requires org level access, choose that org by default -->
-          {{ application.name }} will have the following permissions to your Sentry organization <strong>{{organization_options.0.name}}</strong>:
+          {{ application.name }} will also have the following permissions to your Sentry organization <strong>{{organization_options.0.name}}</strong>:
           <input type="hidden" name="selected_organization_id" value="{{ organization_options.0.id }}">
         {% endif %}
       </p>

--- a/src/sentry/users/services/user/impl.py
+++ b/src/sentry/users/services/user/impl.py
@@ -144,12 +144,9 @@ class DatabaseBackedUserService(UserService):
         org_ids = OrganizationMemberMapping.objects.filter(user_id=user_id).values_list(
             "organization_id", flat=True
         )
-        print("*****org ids", org_ids)
         org_query = OrganizationMapping.objects.filter(organization_id__in=org_ids)
-        print("*****org query", org_query)
         if only_visible:
             org_query = org_query.filter(status=OrganizationStatus.ACTIVE)
-
         return [serialize_organization_mapping(o) for o in org_query]
 
     def get_member_region_names(self, *, user_id: int) -> list[str]:

--- a/src/sentry/users/services/user/impl.py
+++ b/src/sentry/users/services/user/impl.py
@@ -144,9 +144,12 @@ class DatabaseBackedUserService(UserService):
         org_ids = OrganizationMemberMapping.objects.filter(user_id=user_id).values_list(
             "organization_id", flat=True
         )
+        print("*****org ids", org_ids)
         org_query = OrganizationMapping.objects.filter(organization_id__in=org_ids)
+        print("*****org query", org_query)
         if only_visible:
             org_query = org_query.filter(status=OrganizationStatus.ACTIVE)
+
         return [serialize_organization_mapping(o) for o in org_query]
 
     def get_member_region_names(self, *, user_id: int) -> list[str]:

--- a/src/sentry/web/frontend/oauth_authorize.py
+++ b/src/sentry/web/frontend/oauth_authorize.py
@@ -12,6 +12,7 @@ from sentry.models.apiapplication import ApiApplication, ApiApplicationStatus
 from sentry.models.apiauthorization import ApiAuthorization
 from sentry.models.apigrant import ApiGrant
 from sentry.models.apitoken import ApiToken
+from sentry.users.services.user.service import user_service
 from sentry.utils import metrics
 from sentry.web.frontend.auth_login import AuthLoginView
 
@@ -77,14 +78,12 @@ class OAuthAuthorizeView(AuthLoginView):
         response_type = request.GET.get("response_type")
         client_id = request.GET.get("client_id")
         redirect_uri = request.GET.get("redirect_uri")
-        scopes = request.GET.get("scope")
         state = request.GET.get("state")
         force_prompt = request.GET.get("force_prompt")
 
         if not client_id:
             return self.error(
                 request=request,
-                client_id=client_id,
                 response_type=response_type,
                 redirect_uri=redirect_uri,
                 name="unauthorized_client",
@@ -127,20 +126,28 @@ class OAuthAuthorizeView(AuthLoginView):
                 err_response="client_id",
             )
 
-        if scopes:
-            scopes = scopes.split(" ")
-            for scope in scopes:
-                if scope not in settings.SENTRY_SCOPES:
-                    return self.error(
-                        request=request,
-                        client_id=client_id,
-                        response_type=response_type,
-                        redirect_uri=redirect_uri,
-                        name="invalid_scope",
-                        state=state,
-                    )
+        # TODO (athena): Clean up this so scopes are always coming from the model
+        # This change is temporarily needed before we migrate existing applications
+        # to have the correct scopes
+        if application.requires_org_level_access:
+            scopes = application.scopes
         else:
-            scopes = []
+            scopes = request.GET.get("scope")
+            if scopes:
+                scopes = scopes.split(" ")
+            else:
+                scopes = []
+
+        for scope in scopes:
+            if scope not in settings.SENTRY_SCOPES:
+                return self.error(
+                    request=request,
+                    client_id=client_id,
+                    response_type=response_type,
+                    redirect_uri=redirect_uri,
+                    name="invalid_scope",
+                    state=state,
+                )
 
         payload = {
             "rt": response_type,
@@ -201,11 +208,18 @@ class OAuthAuthorizeView(AuthLoginView):
             if pending_scopes:
                 raise NotImplementedError(f"{pending_scopes} scopes did not have descriptions")
 
+        if application.requires_org_level_access:
+            organization_options = user_service.get_organizations(user_id=request.user.id)
+        else:
+            # If application is not org level we should not show organizations to choose from at all
+            organization_options = []
+
         context = {
             "user": request.user,
             "application": application,
             "scopes": scopes,
             "permissions": permissions,
+            "organization_options": organization_options,
         }
         return self.respond("sentry/oauth-authorize.html", context)
 
@@ -274,15 +288,25 @@ class OAuthAuthorizeView(AuthLoginView):
             raise NotImplementedError
 
     def approve(self, request: HttpRequest, application, **params):
+        # Some applications require org level access, so user who approves only gives
+        # access to that organization by selecting one. If None, means the application
+        # has user level access and will be able to have access to all the organizations of that user.
+        selected_organization_id = request.POST.get("selected_organization_id")
+
         try:
             with transaction.atomic(router.db_for_write(ApiAuthorization)):
                 ApiAuthorization.objects.create(
-                    application=application, user_id=request.user.id, scope_list=params["scopes"]
+                    application=application,
+                    user_id=request.user.id,
+                    scope_list=params["scopes"],
+                    organization_id=selected_organization_id,
                 )
         except IntegrityError:
             if params["scopes"]:
                 auth = ApiAuthorization.objects.get(
-                    application=application, user_id=request.user.id
+                    application=application,
+                    user_id=request.user.id,
+                    organization_id=selected_organization_id,
                 )
                 for scope in params["scopes"]:
                     if scope not in auth.scope_list:
@@ -303,6 +327,7 @@ class OAuthAuthorizeView(AuthLoginView):
                 application=application,
                 redirect_uri=params["redirect_uri"],
                 scope_list=params["scopes"],
+                organization_id=selected_organization_id,
             )
             logger.info(
                 "approve.grant",
@@ -323,6 +348,7 @@ class OAuthAuthorizeView(AuthLoginView):
                 user_id=request.user.id,
                 refresh_token=None,
                 scope_list=params["scopes"],
+                scoping_organization_id=selected_organization_id,
             )
 
             logger.info(

--- a/src/sentry/web/frontend/oauth_authorize.py
+++ b/src/sentry/web/frontend/oauth_authorize.py
@@ -84,6 +84,7 @@ class OAuthAuthorizeView(AuthLoginView):
         if not client_id:
             return self.error(
                 request=request,
+                client_id=client_id,
                 response_type=response_type,
                 redirect_uri=redirect_uri,
                 name="unauthorized_client",


### PR DESCRIPTION
Tech spec for more context: https://www.notion.so/sentry/Partner-OAuth-Flow-371b6bd1d16c447ea666e533c32e503e?pvs=4#2939e9377d3c4305b1314664410db603

In this PR I'm adding org selector to our application authorization endpoint. This endpoint is used by external applications to get things like grant code to then use with our APIs.

Before:
This view is only user level. Which means if user gives permission like "org:read" that's permission to all their orgs.
<img width="556" alt="Screenshot 2024-10-18 at 4 23 30 PM" src="https://github.com/user-attachments/assets/a47c98e2-37ce-4d7d-8b0d-f01994fb97b5">

After:
* Nothing changes for existing applications because none of the existing applications have `requires_org_level_access` so they all remain user level like above
* Future application that admin creates with `requires_org_level_access` shows this to the user who has only one org:
<img width="748" alt="Screenshot 2024-10-18 at 4 34 54 PM" src="https://github.com/user-attachments/assets/340dc070-aa6e-48e6-8d17-a9ee5473ae7a">

* Future application that admin creates with `requires_org_level_access` shows this to the user with multiple orgs

https://github.com/user-attachments/assets/a4cb067f-ac9f-424f-ae5a-43e6e06b8ffd




