### PR TITLE
fix(discover): Don't append event type col w/ dataset selector

### DIFF
--- a/static/app/views/discover/table/index.tsx
+++ b/static/app/views/discover/table/index.tsx
@@ -164,7 +164,9 @@ class Table extends PureComponent<TableProps, TableState> {
 
       // We need to include the event.type field because we want to
       // route to issue details for error and default event types.
-      apiPayload.field.push('event.type');
+      if (!hasDatasetSelector(organization)) {
+        apiPayload.field.push('event.type');
+      }
     }
 
     // To generate the target url for TRACE ID and EVENT ID links we always include a timestamp,

--- a/static/app/views/discover/table/tableView.spec.tsx
+++ b/static/app/views/discover/table/tableView.spec.tsx
@@ -351,7 +351,6 @@ describe('TableView > CellActions', function () {
         transaction: 'string',
         timestamp: 'date',
         project: 'string',
-        'event.type': 'string',
       },
       data: [
         {
@@ -360,7 +359,6 @@ describe('TableView > CellActions', function () {
           transaction: '/organizations/',
           timestamp: '2019-05-23T22:12:48+00:00',
           project: 'project-slug',
-          'event.type': '',
         },
       ],
     };


### PR DESCRIPTION
event.type gets interpreted as a tag and really slows down transaction queries.
We also use selected dataset to determine if the link should go to trace view or
issue details page.