### PR TITLE
fix(dashboards): Change widget legend series name delimiter

### DIFF
--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -397,7 +397,7 @@ describe('Modals -> WidgetViewerModal', function () {
           expect.objectContaining({
             option: expect.objectContaining({
               legend: expect.objectContaining({
-                selected: {[`Query Name:${mockWidget.id}`]: false},
+                selected: {[`Query Name;${mockWidget.id}`]: false},
               }),
             }),
           }),

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -370,13 +370,20 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
     const bucketSize = getBucketSize(timeseriesResults);
 
     const valueFormatter = (value: number, seriesName?: string) => {
-      const aggregateName = seriesName?.split(':').pop()?.trim();
+      const decodedSeriesName = seriesName
+        ? WidgetLegendNameEncoderDecoder.decodeSeriesNameForLegend(seriesName)
+        : seriesName;
+      const aggregateName = decodedSeriesName?.split(':').pop()?.trim();
       if (aggregateName) {
         return timeseriesResultsTypes
           ? tooltipFormatter(value, timeseriesResultsTypes[aggregateName])
           : tooltipFormatter(value, aggregateOutputType(aggregateName));
       }
       return tooltipFormatter(value, 'number');
+    };
+
+    const nameFormatter = (name: string) => {
+      return WidgetLegendNameEncoderDecoder.decodeSeriesNameForLegend(name);
     };
 
     const chartOptions = {
@@ -408,6 +415,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
 
           return getFormatter({
             valueFormatter,
+            nameFormatter,
             isGroupedByDate: true,
             bucketSize,
             addSecondsToTimeFormat: false,

--- a/static/app/views/dashboards/widgetLegendNameEncoderDecoder.tsx
+++ b/static/app/views/dashboards/widgetLegendNameEncoderDecoder.tsx
@@ -1,13 +1,15 @@
 import type {Series} from 'sentry/types/echarts';
 import type {Widget} from 'sentry/views/dashboards/types';
 
+const SERIES_NAME_DELIMITER = ';';
+
 class WidgetLegendNameEncoderDecoder {
   static encodeSeriesNameForLegend(seriesName: string, widgetId?: string) {
-    return `${seriesName}:${widgetId}`;
+    return `${seriesName}${SERIES_NAME_DELIMITER}${widgetId}`;
   }
 
   static decodeSeriesNameForLegend(encodedSeriesName: string) {
-    return encodedSeriesName.split(':')[0];
+    return encodedSeriesName.split(SERIES_NAME_DELIMITER)[0];
   }
 
   // change timeseries names to SeriesName:widgetID

--- a/static/app/views/dashboards/widgetLegendSelectionState.spec.tsx
+++ b/static/app/views/dashboards/widgetLegendSelectionState.spec.tsx
@@ -12,6 +12,7 @@ import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import WidgetLegendSelectionState from './widgetLegendSelectionState';
 
 const WIDGET_ID_DELIMITER = ':';
+const SERIES_NAME_DELIMITER = ';';
 
 describe('WidgetLegend functions util', () => {
   let legendFunctions: WidgetLegendSelectionState;
@@ -69,7 +70,7 @@ describe('WidgetLegend functions util', () => {
 
     it('set initial unselected legend options', () => {
       expect(legendFunctions.getWidgetSelectionState(widget)).toEqual({
-        'Releases:12345': false,
+        [`Releases${SERIES_NAME_DELIMITER}12345`]: false,
       });
     });
 
@@ -84,7 +85,10 @@ describe('WidgetLegend functions util', () => {
       location = {...location, query: {...location.query, unselectedSeries: []}};
 
       legendFunctions.setWidgetSelectionState(
-        {'Releases:12345': false, 'count():12345': true},
+        {
+          [`Releases${SERIES_NAME_DELIMITER}12345`]: false,
+          [`count()${SERIES_NAME_DELIMITER}12345`]: true,
+        },
         widget
       );
       expect(router.replace).toHaveBeenCalledWith({
@@ -124,13 +128,15 @@ describe('WidgetLegend functions util', () => {
 
     it('formats to query param format from selected', () => {
       expect(
-        legendFunctions.encodeLegendQueryParam(widget, {[`Releases:${widget.id}`]: false})
+        legendFunctions.encodeLegendQueryParam(widget, {
+          [`Releases${SERIES_NAME_DELIMITER}${widget.id}`]: false,
+        })
       ).toEqual(`${widget.id}${WIDGET_ID_DELIMITER}Releases`);
     });
 
     it('formats to selected format from query param', () => {
       expect(legendFunctions.decodeLegendQueryParam(widget)).toEqual({
-        [`Releases:${widget.id}`]: false,
+        [`Releases${SERIES_NAME_DELIMITER}${widget.id}`]: false,
       });
     });
   });

--- a/static/app/views/dashboards/widgetLegendSelectionState.tsx
+++ b/static/app/views/dashboards/widgetLegendSelectionState.tsx
@@ -16,8 +16,10 @@ type Props = {
 
 type LegendSelection = Record<string, boolean>;
 
-const SERIES_DELIMITER = ',';
+const SERIES_LIST_DELIMITER = ',';
 const WIDGET_ID_DELIMITER = ':';
+
+const SERIES_NAME_DELIMITER = ';';
 
 class WidgetLegendSelectionState {
   dashboard: DashboardDetails | null;
@@ -49,10 +51,10 @@ class WidgetLegendSelectionState {
 
       const thisWidgetWithReleasesWasSelected =
         Object.values(selected).filter(value => value === false).length !== 1 &&
-        Object.keys(selected).includes(`Releases:${widget.id}`);
+        Object.keys(selected).includes(`Releases${SERIES_NAME_DELIMITER}${widget.id}`);
 
       const thisWidgetWithoutReleasesWasSelected =
-        !Object.keys(selected).includes(`Releases:${widget.id}`) &&
+        !Object.keys(selected).includes(`Releases${SERIES_NAME_DELIMITER}${widget.id}`) &&
         Object.values(selected).filter(value => value === false).length === 1;
 
       if (thisWidgetWithReleasesWasSelected || thisWidgetWithoutReleasesWasSelected) {
@@ -164,7 +166,7 @@ class WidgetLegendSelectionState {
             WidgetLegendNameEncoderDecoder.decodeSeriesNameForLegend(series)
           )
         )
-        .join(SERIES_DELIMITER)
+        .join(SERIES_LIST_DELIMITER)
     );
   }
 
@@ -177,7 +179,7 @@ class WidgetLegendSelectionState {
     );
     if (widgetLegendString) {
       const [_, seriesNameString] = widgetLegendString.split(WIDGET_ID_DELIMITER);
-      const seriesNames = seriesNameString.split(SERIES_DELIMITER);
+      const seriesNames = seriesNameString.split(SERIES_LIST_DELIMITER);
       return seriesNames.reduce((acc, series) => {
         acc[
           decodeURIComponent(


### PR DESCRIPTION
Two things (kind of related)

- Originally the series name delimiter was `:` however apparently there are series names that have `:` in the name 🤩 so the widget legend was not working. I changed it to `;`. Also set this as a constant in the code so changing it requires a couple of line changes instead of searching through the file.  
- Also just realized the tooltip was showing the modified timeseries name that we use to control the legend hence I put a name formatter for the tooltip to account for that 

Sidenote: if there's any other bugs you notice let me know. Planning to EA on Monday