### PR TITLE
ref(dashboards): Lift up widget card loading logic

### DIFF
--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -95,6 +95,7 @@ export function WidgetCardChartContainer({
     <WidgetCardDataLoader
       widget={widget}
       dashboardFilters={dashboardFilters}
+      selection={selection}
       onDataFetched={onDataFetched}
       onWidgetSplitDecision={onWidgetSplitDecision}
       tableItemLimit={tableItemLimit}

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -129,44 +129,6 @@ export function WidgetCardChartContainer({
         const modifiedTimeseriesResults =
           WidgetLegendNameEncoderDecoder.modifyTimeseriesNames(widget, timeseriesResults);
 
-        if (widget.widgetType === WidgetType.RELEASE) {
-          return (
-            <Fragment>
-              {typeof renderErrorMessage === 'function'
-                ? renderErrorMessage(errorMessage)
-                : null}
-              <WidgetCardChart
-                timeseriesResults={modifiedTimeseriesResults}
-                tableResults={tableResults}
-                errorMessage={errorMessage}
-                loading={loading}
-                location={location}
-                widget={widget}
-                selection={selection}
-                organization={organization}
-                isMobile={isMobile}
-                windowWidth={windowWidth}
-                expandNumbers={expandNumbers}
-                onZoom={onZoom}
-                showSlider={showSlider}
-                noPadding={noPadding}
-                chartZoomOptions={chartZoomOptions}
-                chartGroup={chartGroup}
-                shouldResize={shouldResize}
-                onLegendSelectChanged={
-                  onLegendSelectChanged ? onLegendSelectChanged : keepLegendState
-                }
-                legendOptions={
-                  legendOptions
-                    ? legendOptions
-                    : {selected: widgetLegendState.getWidgetSelectionState(widget)}
-                }
-                widgetLegendState={widgetLegendState}
-              />
-            </Fragment>
-          );
-        }
-
         return (
           <Fragment>
             {typeof renderErrorMessage === 'function'

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -21,9 +21,7 @@ import type WidgetLegendSelectionState from '../widgetLegendSelectionState';
 import type {AugmentedEChartDataZoomHandler} from './chart';
 import WidgetCardChart from './chart';
 import {IssueWidgetCard} from './issueWidgetCard';
-import IssueWidgetQueries from './issueWidgetQueries';
-import ReleaseWidgetQueries from './releaseWidgetQueries';
-import WidgetQueries from './widgetQueries';
+import {WidgetCardDataLoader} from './widgetCardDataLoader';
 
 type Props = {
   api: Client;
@@ -61,7 +59,6 @@ type Props = {
 };
 
 export function WidgetCardChartContainer({
-  api,
   organization,
   selection,
   widget,
@@ -85,18 +82,31 @@ export function WidgetCardChartContainer({
 }: Props) {
   const location = useLocation();
 
-  if (widget.widgetType === WidgetType.ISSUE) {
-    return (
-      <IssueWidgetQueries
-        api={api}
-        organization={organization}
-        widget={widget}
-        selection={selection}
-        limit={tableItemLimit}
-        onDataFetched={onDataFetched}
-        dashboardFilters={dashboardFilters}
-      >
-        {({tableResults, errorMessage, loading}) => {
+  function keepLegendState({
+    selected,
+  }: {
+    selected: Record<string, boolean>;
+    type: 'legendselectchanged';
+  }) {
+    widgetLegendState.setWidgetSelectionState(selected, widget);
+  }
+
+  return (
+    <WidgetCardDataLoader
+      widget={widget}
+      dashboardFilters={dashboardFilters}
+      onDataFetched={onDataFetched}
+      onWidgetSplitDecision={onWidgetSplitDecision}
+      tableItemLimit={tableItemLimit}
+    >
+      {({
+        tableResults,
+        timeseriesResults,
+        errorMessage,
+        loading,
+        timeseriesResultsTypes,
+      }) => {
+        if (widget.widgetType === WidgetType.ISSUE) {
           return (
             <Fragment>
               {typeof renderErrorMessage === 'function'
@@ -113,40 +123,13 @@ export function WidgetCardChartContainer({
               />
             </Fragment>
           );
-        }}
-      </IssueWidgetQueries>
-    );
-  }
+        }
 
-  function keepLegendState({
-    selected,
-  }: {
-    selected: Record<string, boolean>;
-    type: 'legendselectchanged';
-  }) {
-    widgetLegendState.setWidgetSelectionState(selected, widget);
-  }
+        // Bind timeseries to widget for ability to control each widget's legend individually
+        const modifiedTimeseriesResults =
+          WidgetLegendNameEncoderDecoder.modifyTimeseriesNames(widget, timeseriesResults);
 
-  if (widget.widgetType === WidgetType.RELEASE) {
-    return (
-      <ReleaseWidgetQueries
-        api={api}
-        organization={organization}
-        widget={widget}
-        selection={selection}
-        limit={widget.limit ?? tableItemLimit}
-        onDataFetched={onDataFetched}
-        dashboardFilters={dashboardFilters}
-      >
-        {({tableResults, timeseriesResults, errorMessage, loading}) => {
-          // Bind timeseries to widget for ability to control each widget's legend individually
-          // NOTE: e-charts legends control all charts that have the same series name so attaching
-          // widget id will differentiate the charts allowing them to be controlled individually
-          const modifiedTimeseriesResults =
-            WidgetLegendNameEncoderDecoder.modifyTimeseriesNames(
-              widget,
-              timeseriesResults
-            );
+        if (widget.widgetType === WidgetType.RELEASE) {
           return (
             <Fragment>
               {typeof renderErrorMessage === 'function'
@@ -182,32 +165,8 @@ export function WidgetCardChartContainer({
               />
             </Fragment>
           );
-        }}
-      </ReleaseWidgetQueries>
-    );
-  }
+        }
 
-  return (
-    <WidgetQueries
-      api={api}
-      organization={organization}
-      widget={widget}
-      selection={selection}
-      limit={tableItemLimit}
-      onDataFetched={onDataFetched}
-      dashboardFilters={dashboardFilters}
-      onWidgetSplitDecision={onWidgetSplitDecision}
-    >
-      {({
-        tableResults,
-        timeseriesResults,
-        errorMessage,
-        loading,
-        timeseriesResultsTypes,
-      }) => {
-        // Bind timeseries to widget for ability to control each widget's legend individually
-        const modifiedTimeseriesResults =
-          WidgetLegendNameEncoderDecoder.modifyTimeseriesNames(widget, timeseriesResults);
         return (
           <Fragment>
             {typeof renderErrorMessage === 'function'
@@ -224,7 +183,14 @@ export function WidgetCardChartContainer({
               organization={organization}
               isMobile={isMobile}
               windowWidth={windowWidth}
+              expandNumbers={expandNumbers}
               onZoom={onZoom}
+              showSlider={showSlider}
+              timeseriesResultsTypes={timeseriesResultsTypes}
+              noPadding={noPadding}
+              chartZoomOptions={chartZoomOptions}
+              chartGroup={chartGroup}
+              shouldResize={shouldResize}
               onLegendSelectChanged={
                 onLegendSelectChanged ? onLegendSelectChanged : keepLegendState
               }
@@ -233,19 +199,12 @@ export function WidgetCardChartContainer({
                   ? legendOptions
                   : {selected: widgetLegendState.getWidgetSelectionState(widget)}
               }
-              expandNumbers={expandNumbers}
-              showSlider={showSlider}
-              noPadding={noPadding}
-              chartZoomOptions={chartZoomOptions}
-              timeseriesResultsTypes={timeseriesResultsTypes}
-              chartGroup={chartGroup}
-              shouldResize={shouldResize}
               widgetLegendState={widgetLegendState}
             />
           </Fragment>
         );
       }}
-    </WidgetQueries>
+    </WidgetCardDataLoader>
   );
 }
 

--- a/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
@@ -1,0 +1,125 @@
+import {Fragment} from 'react';
+
+import type {Series} from 'sentry/types/echarts';
+import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
+import type {AggregationOutputType} from 'sentry/utils/discover/fields';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+
+import type {DashboardFilters, Widget} from '../types';
+import {WidgetType} from '../types';
+
+import IssueWidgetQueries from './issueWidgetQueries';
+import ReleaseWidgetQueries from './releaseWidgetQueries';
+import WidgetQueries from './widgetQueries';
+
+type Results = {
+  loading: boolean;
+  errorMessage?: string;
+  pageLinks?: string;
+  tableResults?: TableDataWithTitle[];
+  timeseriesResults?: Series[];
+  timeseriesResultsTypes?: Record<string, AggregationOutputType>;
+  totalIssuesCount?: string;
+};
+
+type Props = {
+  children: (props: Results) => React.ReactNode;
+  widget: Widget;
+  dashboardFilters?: DashboardFilters;
+  onDataFetched?: (
+    results: Pick<
+      Results,
+      | 'pageLinks'
+      | 'tableResults'
+      | 'timeseriesResults'
+      | 'timeseriesResultsTypes'
+      | 'totalIssuesCount'
+    >
+  ) => void;
+  onWidgetSplitDecision?: (splitDecision: WidgetType) => void;
+  tableItemLimit?: number;
+};
+
+export function WidgetCardDataLoader({
+  children,
+  widget,
+  dashboardFilters,
+  tableItemLimit,
+  onDataFetched,
+  onWidgetSplitDecision,
+}: Props) {
+  const api = useApi();
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+
+  if (widget.widgetType === WidgetType.ISSUE) {
+    return (
+      <IssueWidgetQueries
+        api={api}
+        organization={organization}
+        widget={widget}
+        selection={selection}
+        limit={tableItemLimit}
+        onDataFetched={onDataFetched}
+        dashboardFilters={dashboardFilters}
+      >
+        {({tableResults, errorMessage, loading}) => (
+          <Fragment>{children({tableResults, errorMessage, loading})}</Fragment>
+        )}
+      </IssueWidgetQueries>
+    );
+  }
+
+  if (widget.widgetType === WidgetType.RELEASE) {
+    return (
+      <ReleaseWidgetQueries
+        api={api}
+        organization={organization}
+        widget={widget}
+        selection={selection}
+        limit={widget.limit ?? tableItemLimit}
+        onDataFetched={onDataFetched}
+        dashboardFilters={dashboardFilters}
+      >
+        {({tableResults, timeseriesResults, errorMessage, loading}) => (
+          <Fragment>
+            {children({tableResults, timeseriesResults, errorMessage, loading})}
+          </Fragment>
+        )}
+      </ReleaseWidgetQueries>
+    );
+  }
+
+  return (
+    <WidgetQueries
+      api={api}
+      organization={organization}
+      widget={widget}
+      selection={selection}
+      limit={tableItemLimit}
+      onDataFetched={onDataFetched}
+      dashboardFilters={dashboardFilters}
+      onWidgetSplitDecision={onWidgetSplitDecision}
+    >
+      {({
+        tableResults,
+        timeseriesResults,
+        errorMessage,
+        loading,
+        timeseriesResultsTypes,
+      }) => (
+        <Fragment>
+          {children({
+            tableResults,
+            timeseriesResults,
+            errorMessage,
+            loading,
+            timeseriesResultsTypes,
+          })}
+        </Fragment>
+      )}
+    </WidgetQueries>
+  );
+}

--- a/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
@@ -1,11 +1,11 @@
 import {Fragment} from 'react';
 
+import type {PageFilters} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {AggregationOutputType} from 'sentry/utils/discover/fields';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
 
 import type {DashboardFilters, Widget} from '../types';
 import {WidgetType} from '../types';
@@ -26,6 +26,7 @@ type Results = {
 
 type Props = {
   children: (props: Results) => React.ReactNode;
+  selection: PageFilters;
   widget: Widget;
   dashboardFilters?: DashboardFilters;
   onDataFetched?: (
@@ -45,6 +46,7 @@ type Props = {
 export function WidgetCardDataLoader({
   children,
   widget,
+  selection,
   dashboardFilters,
   tableItemLimit,
   onDataFetched,
@@ -52,7 +54,6 @@ export function WidgetCardDataLoader({
 }: Props) {
   const api = useApi();
   const organization = useOrganization();
-  const {selection} = usePageFilters();
 
   if (widget.widgetType === WidgetType.ISSUE) {
     return (


### PR DESCRIPTION
Before:

- `WidgetCard` renders `WidgetCardChartContainer`
- `WidgetCardChartContainer` chooses an `XQueries` data loader per component, and renders a `WidgetCardChart` inside

After:

- `WidgetCard` renders `WidgetCardChartContainer`
- `WidgetCardChartContainer` renders a `WidgetCardDataLoader` which returns the data as render props
- `WidgetCardChartContainer` passes the render props to a `WidgetCardChart`

The "after" is better because the data loading logic is now separate, which means I can use it outside this context. This will allow me to load data _higher in the component hierarchy_, which is a prerequisite to using standard dashboard widgets
