### PR TITLE
ref(dashboards): Lift `Toolbar` out of `WidgetCard`

### DIFF
--- a/static/app/views/dashboards/sortableWidget.tsx
+++ b/static/app/views/dashboards/sortableWidget.tsx
@@ -5,6 +5,7 @@ import PanelAlert from 'sentry/components/panels/panelAlert';
 import WidgetCard from 'sentry/views/dashboards/widgetCard';
 
 import {DashboardsMEPProvider} from './widgetCard/dashboardsMEPContext';
+import {Toolbar} from './widgetCard/toolbar';
 import type {DashboardFilters, Widget} from './types';
 import type WidgetLegendSelectionState from './widgetLegendSelectionState';
 
@@ -72,6 +73,14 @@ function SortableWidget(props: Props) {
     <GridWidgetWrapper>
       <DashboardsMEPProvider>
         <WidgetCard {...widgetProps} />
+        {props.isEditingDashboard && (
+          <Toolbar
+            onEdit={props.onEdit}
+            onDelete={props.onDelete}
+            onDuplicate={props.onDuplicate}
+            isMobile={props.isMobile}
+          />
+        )}
       </DashboardsMEPProvider>
     </GridWidgetWrapper>
   );

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -34,7 +34,6 @@ import withSentryRouter from 'sentry/utils/withSentryRouter';
 import {DASHBOARD_CHART_GROUP} from 'sentry/views/dashboards/dashboard';
 import {useDiscoverSplitAlert} from 'sentry/views/dashboards/discoverSplitAlert';
 import {MetricWidgetCard} from 'sentry/views/dashboards/metrics/widgetCard';
-import {Toolbar} from 'sentry/views/dashboards/widgetCard/toolbar';
 
 import type {DashboardFilters, Widget} from '../types';
 import {DisplayType, OnDemandExtractionState, WidgetType} from '../types';
@@ -285,14 +284,6 @@ function WidgetCard(props: Props) {
             </LazyRender>
           )}
         </WidgetFrame>
-        {props.isEditingDashboard && (
-          <Toolbar
-            onEdit={props.onEdit}
-            onDelete={props.onDelete}
-            onDuplicate={props.onDuplicate}
-            isMobile={props.isMobile}
-          />
-        )}
       </VisuallyCompleteWithData>
     </ErrorBoundary>
   );


### PR DESCRIPTION
Widget cards are used in a few places, but the toolbar is _only_ for sortable widgets. Therefore, the toolbar should live only in `SortableWidget`! 2EZ.

This'll help with some upcoming refactoring, too.
