### PR TITLE
chore(issues): Reserve the rollback slug and rollback.sentry.io

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -168,6 +168,7 @@ RESERVED_ORGANIZATION_SLUGS = frozenset(
         "register",
         "remote",
         "resources",
+        "rollback",
         "sa1",
         "sales",
         "security",


### PR DESCRIPTION
Confirmed this slug is also not currently reserved: https://redash.getsentry.net/queries/7626/source