### PR TITLE
feat(insights): update headers from module to trace view

### DIFF
--- a/static/app/views/insights/common/components/samplesTable/spanSamplesTable.tsx
+++ b/static/app/views/insights/common/components/samplesTable/spanSamplesTable.tsx
@@ -21,6 +21,7 @@ import {
   TextAlignRight,
 } from 'sentry/views/insights/common/components/textAlign';
 import type {SpanSample} from 'sentry/views/insights/common/queries/useSpanSamples';
+import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {type ModuleName, SpanMetricsField} from 'sentry/views/insights/types';
 
 const {HTTP_RESPONSE_CONTENT_LENGTH, SPAN_DESCRIPTION} = SpanMetricsField;
@@ -93,6 +94,7 @@ export function SpanSamplesTable({
 }: Props) {
   const location = useLocation();
   const organization = useOrganization();
+  const {view} = useDomainViewFilters();
 
   function renderHeadCell(column: GridColumnHeader): React.ReactNode {
     if (
@@ -130,6 +132,7 @@ export function SpanSamplesTable({
             },
             spanId: row.span_id,
             source,
+            view,
           })}
         >
           {row['transaction.id'].slice(0, 8)}
@@ -161,6 +164,7 @@ export function SpanSamplesTable({
             },
             spanId: row.span_id,
             source,
+            view,
           })}
         >
           {row.span_id}

--- a/static/app/views/insights/common/components/tableCells/spanIdCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/spanIdCell.tsx
@@ -6,6 +6,7 @@ import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOrganization from 'sentry/utils/useOrganization';
 import {SPAN_ID_DISPLAY_LENGTH} from 'sentry/views/insights/http/settings';
+import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import type {ModuleName} from 'sentry/views/insights/types';
 
 interface Props {
@@ -30,6 +31,7 @@ export function SpanIdCell({
   location,
 }: Props) {
   const organization = useOrganization();
+  const {view} = useDomainViewFilters();
   const url = normalizeUrl(
     generateLinkToEventInTraceView({
       eventId: transactionId,
@@ -40,6 +42,7 @@ export function SpanIdCell({
       location,
       spanId,
       source,
+      view,
     })
   );
 

--- a/static/app/views/insights/common/utils/useModuleURL.tsx
+++ b/static/app/views/insights/common/utils/useModuleURL.tsx
@@ -49,7 +49,10 @@ export const useModuleURL = (
   return builder(moduleName, view);
 };
 
-type URLBuilder = (moduleName: RoutableModuleNames, domainView?: DomainView) => string;
+export type URLBuilder = (
+  moduleName: RoutableModuleNames,
+  domainView?: DomainView
+) => string;
 
 export function useModuleURLBuilder(
   bare: boolean = false,

--- a/static/app/views/insights/pages/types.ts
+++ b/static/app/views/insights/pages/types.ts
@@ -1,0 +1,12 @@
+import {AI_LANDING_TITLE} from 'sentry/views/insights/pages/ai/settings';
+import {BACKEND_LANDING_TITLE} from 'sentry/views/insights/pages/backend/settings';
+import {FRONTEND_LANDING_TITLE} from 'sentry/views/insights/pages/frontend/settings';
+import {MOBILE_LANDING_TITLE} from 'sentry/views/insights/pages/mobile/settings';
+import type {DomainView} from 'sentry/views/insights/pages/useFilters';
+
+export const DOMAIN_VIEW_TITLES: Record<DomainView, string> = {
+  ai: AI_LANDING_TITLE,
+  backend: BACKEND_LANDING_TITLE,
+  frontend: FRONTEND_LANDING_TITLE,
+  mobile: MOBILE_LANDING_TITLE,
+};


### PR DESCRIPTION
Work for #77572 

This Pr makes the following changes.
1. When you click into the trace view from a module (typically from the span samples panel) and user is within a performance domain view (frontend, backend, ai, mobile), the headers are correctly reflected.
(There is likely some outstanding urls, but I can go through this after this PR)
<img width="1037" alt="image" src="https://github.com/user-attachments/assets/71eaef61-2930-4a2f-9811-4f6098c4e5be">

2. Updates the trace view header to build urls from `ModuleURLBuilder` instead of hardcoding them.