### PR TITLE
chore(sentry apps): Adjust logs when we dont have a url

### DIFF
--- a/src/sentry/sentry_apps/external_requests/select_requester.py
+++ b/src/sentry/sentry_apps/external_requests/select_requester.py
@@ -50,18 +50,24 @@ class SelectRequester:
 
             response = json.loads(body)
         except Exception as e:
-            logger.info(
-                "select-requester.error",
-                extra={
-                    "sentry_app_slug": self.sentry_app.slug,
-                    "install_uuid": self.install.uuid,
-                    "project_slug": self.project_slug,
-                    "error_message": str(e),
-                    "uri": self.uri,
-                    "dependent_data": self.dependent_data,
-                    "webhook_url": self.sentry_app.webhook_url,
-                },
-            )
+            extra = {
+                "sentry_app_slug": self.sentry_app.slug,
+                "install_uuid": self.install.uuid,
+                "project_slug": self.project_slug,
+                "error_message": str(e),
+                "url": url or "",
+            }
+
+            if not url:
+                extra.update(
+                    {
+                        "uri": self.uri,
+                        "dependent_data": self.dependent_data,
+                        "webhook_url": self.sentry_app.webhook_url,
+                    }
+                )
+
+            logger.info("select-requester.error", extra)
             raise APIError from e
 
         if not self._validate_response(response):

--- a/src/sentry/sentry_apps/external_requests/select_requester.py
+++ b/src/sentry/sentry_apps/external_requests/select_requester.py
@@ -55,7 +55,6 @@ class SelectRequester:
                 "install_uuid": self.install.uuid,
                 "project_slug": self.project_slug,
                 "error_message": str(e),
-                "url": url or "",
             }
 
             if not url:
@@ -66,8 +65,12 @@ class SelectRequester:
                         "webhook_url": self.sentry_app.webhook_url,
                     }
                 )
+                message = "select-requester.missing-url"
+            else:
+                extra.update({"url": url})
+                message = "select-requester.request-failed"
 
-            logger.info("select-requester.error", extra)
+            logger.info(message, extra=extra)
             raise APIError from e
 
         if not self._validate_response(response):

--- a/src/sentry/sentry_apps/external_requests/select_requester.py
+++ b/src/sentry/sentry_apps/external_requests/select_requester.py
@@ -57,7 +57,9 @@ class SelectRequester:
                     "install_uuid": self.install.uuid,
                     "project_slug": self.project_slug,
                     "error_message": str(e),
-                    "url": url,
+                    "uri": self.uri,
+                    "dependent_data": self.dependent_data,
+                    "webhook_url": self.sentry_app.webhook_url,
                 },
             )
             raise APIError from e


### PR DESCRIPTION
From: https://sentry.sentry.io/issues/6013836656/?project=1
It looks like there's some cases where `build_url` fails so we get a url error in the logging part. In that case we should capture the url parameters to see what was missing.