### PR TITLE
feat: Add dns-prefetch for our region domains

### DIFF
--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -4,10 +4,8 @@
 {% load sentry_features %}
 {% load sentry_helpers %}
 {% load sentry_react %}
-
 {% load sentry_status %}
 {% get_sentry_version %}
-
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -26,10 +24,13 @@
   <meta property="{{ tag.property }}" content="{{ tag.content }}" />
   {% endfor %}
 
+  {% for domain in dns_prefetch %}
+  <link rel="dns-prefetch" href="{{ domain }}" />
+  {% endfor %}
+
   <link rel="mask-icon" sizes="any" href="{% absolute_asset_url "sentry" "images/logos/logo-sentry.svg" %}" color="#FB4226">
 
   <link href="{% frontend_app_asset_url "sentry" "entrypoints/sentry.css" %}" rel="stylesheet"/>
-
 
   <title>{% block title %}Sentry{% endblock %}</title>
 
@@ -69,7 +70,6 @@
 </head>
 
 
-
 <body class="{% block wrapperclass %}{% endblock %}">
   {% block body %}
   <div class="app">
@@ -80,8 +80,6 @@
     {% block alerts %}
     {% include "sentry/partial/alerts.html" %}
     {% endblock %}
-
-
 
     <div class="container">
       <div class="content">

--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -14,7 +14,11 @@ from rest_framework.request import Request
 from sentry import features, options
 from sentry.organizations.absolute_url import customer_domain_path, generate_organization_url
 from sentry.organizations.services.organization import organization_service
-from sentry.types.region import subdomain_is_region
+from sentry.types.region import (
+    find_all_multitenant_region_names,
+    get_region_by_name,
+    subdomain_is_region,
+)
 from sentry.users.services.user.model import RpcUser
 from sentry.utils.http import is_using_customer_domain, query_string
 from sentry.web.frontend.base import BaseView, ControlSiloOrganizationView
@@ -64,6 +68,16 @@ class ReactMixin:
     def meta_tags(self, request: Request, **kwargs):
         return {}
 
+    def dns_prefetch(self) -> list[str]:
+        regions = find_all_multitenant_region_names()
+        domains = []
+        if len(regions) < 2:
+            return domains
+        for region_name in regions:
+            region = get_region_by_name(region_name)
+            domains.append(region.address)
+        return domains
+
     def handle_react(self, request: Request, **kwargs) -> HttpResponse:
         context = {
             "CSRF_COOKIE_NAME": settings.CSRF_COOKIE_NAME,
@@ -71,6 +85,7 @@ class ReactMixin:
                 {"property": key, "content": value}
                 for key, value in self.meta_tags(request, **kwargs).items()
             ],
+            "dns_prefetch": self.dns_prefetch(),
             # Rendering the layout requires serializing the active organization.
             # Since we already have it here from the OrganizationMixin, we can
             # save some work and render it faster.


### PR DESCRIPTION
When the application is configured for multiple regions (like sentry.io) we should pre-fetch the DNS records for each region domain to save latency later.
