### PR TITLE
feat(crons): Support dispatching `mark_unknown`

### DIFF
--- a/tests/sentry/monitors/consumers/test_clock_tasks_consumer.py
+++ b/tests/sentry/monitors/consumers/test_clock_tasks_consumer.py
@@ -68,3 +68,23 @@ def test_dispatch_mark_timeout(mock_mark_checkin_timeout):
 
     assert mock_mark_checkin_timeout.call_count == 1
     assert mock_mark_checkin_timeout.mock_calls[0] == mock.call(1, ts)
+
+
+@mock.patch("sentry.monitors.consumers.clock_tasks_consumer.mark_checkin_unknown")
+def test_dispatch_mark_unknown(mock_mark_checkin_unknown):
+    ts = timezone.now().replace(second=0, microsecond=0)
+
+    consumer = create_consumer()
+    send_task(
+        consumer,
+        ts,
+        {
+            "type": "mark_unknown",
+            "ts": ts.timestamp(),
+            "monitor_environment_id": 1,
+            "checkin_id": 1,
+        },
+    )
+
+    assert mock_mark_checkin_unknown.call_count == 1
+    assert mock_mark_checkin_unknown.mock_calls[0] == mock.call(1, ts)


### PR DESCRIPTION
This causes clock ticks with the "volume_anomaly_result" set as abnormal
to dispatch a mark_unknown task instead of a check_timeouts task.

This is needed since when we detect an anomalous tick we're unable to
know if we lost customer data during that tick, meaning all in-progress
check-ins that were waiting for closing check-ins must now be
invalidated with a status of unknown.

Part of GH-79328
Requires https://github.com/getsentry/sentry/pull/79735