### PR TITLE
ref: record if transactions ever have plugin tags

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -268,13 +268,13 @@ def has_pending_commit_resolution(group: Group) -> bool:
 
 
 @overload
-def get_max_crashreports(model: Project | Organization) -> int:
-    ...
+def get_max_crashreports(model: Project | Organization) -> int: ...
 
 
 @overload
-def get_max_crashreports(model: Project | Organization, *, allow_none: Literal[True]) -> int | None:
-    ...
+def get_max_crashreports(
+    model: Project | Organization, *, allow_none: Literal[True]
+) -> int | None: ...
 
 
 def get_max_crashreports(model: Project | Organization, *, allow_none: bool = False) -> int | None:

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -554,7 +554,7 @@ class EventManager:
             except ProjectKey.DoesNotExist:
                 pass
 
-        _derive_plugin_tags_many(jobs, projects, True)
+        _derive_plugin_tags_many(jobs, projects, is_transaction=True)
         _derive_interface_tags_many(jobs)
 
         # Load attachments first, but persist them at the very last after

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -268,13 +268,13 @@ def has_pending_commit_resolution(group: Group) -> bool:
 
 
 @overload
-def get_max_crashreports(model: Project | Organization) -> int: ...
+def get_max_crashreports(model: Project | Organization) -> int:
+    ...
 
 
 @overload
-def get_max_crashreports(
-    model: Project | Organization, *, allow_none: Literal[True]
-) -> int | None: ...
+def get_max_crashreports(model: Project | Organization, *, allow_none: Literal[True]) -> int | None:
+    ...
 
 
 def get_max_crashreports(model: Project | Organization, *, allow_none: bool = False) -> int | None:
@@ -554,7 +554,7 @@ class EventManager:
             except ProjectKey.DoesNotExist:
                 pass
 
-        _derive_plugin_tags_many(jobs, projects)
+        _derive_plugin_tags_many(jobs, projects, True)
         _derive_interface_tags_many(jobs)
 
         # Load attachments first, but persist them at the very last after
@@ -829,14 +829,21 @@ def _get_event_user_many(jobs: Sequence[Job], projects: ProjectsMapping) -> None
 
 
 @sentry_sdk.tracing.trace
-def _derive_plugin_tags_many(jobs: Sequence[Job], projects: ProjectsMapping) -> None:
+def _derive_plugin_tags_many(
+    jobs: Sequence[Job], projects: ProjectsMapping, is_transaction: bool = False
+) -> None:
     # XXX: We ought to inline or remove this one for sure
     plugins_for_projects = {p.id: plugins.for_project(p, version=None) for p in projects.values()}
 
     for job in jobs:
         for plugin in plugins_for_projects[job["project_id"]]:
             added_tags = safe_execute(plugin.get_tags, job["event"])
+
             if added_tags:
+                # XXX: Temporarily record if any transactions actually have added tags, in order to
+                # determine whether this can be safely removed. This metric should be removed once validated.
+                if is_transaction:
+                    metrics.incr("save_transaction_events.has_added_tags")
                 data = job["data"]
                 # plugins should not override user provided tags
                 for key, value in added_tags:


### PR DESCRIPTION
it does not seem right that plugin code is allowed to run in the ingest transactions consumer, i believe it should be post process only

this is just a validation step to verify if this is actually doing anything anyway so we can determine if it is safe to remove later
