### PR TITLE
fix(dashboards): Fix error rendering in Dashboards

### DIFF
--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -167,7 +167,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
 
       return (
         <TableWrapper key={`table:${result.title}`}>
-          <SimpleTableChart
+          <StyledSimpleTableChart
             eventView={eventView}
             fieldAliases={fieldAliases}
             location={location}
@@ -671,13 +671,16 @@ const ChartWrapper = styled('div')<{autoHeightResize: boolean; noPadding?: boole
 `;
 
 const TableWrapper = styled('div')`
-  margin-top: ${space(1.5)};
   width: 100%;
   flex-grow: 0;
   flex-shrink: 0;
   border-bottom-left-radius: ${p => p.theme.borderRadius};
   border-bottom-right-radius: ${p => p.theme.borderRadius};
   overflow: auto;
+`;
+
+const StyledSimpleTableChart = styled(SimpleTableChart)`
+  margin-top: ${space(1.5)};
 `;
 
 const StyledErrorPanel = styled(ErrorPanel)`

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -671,16 +671,15 @@ const ChartWrapper = styled('div')<{autoHeightResize: boolean; noPadding?: boole
 `;
 
 const TableWrapper = styled('div')`
-  width: 100%;
-  flex-grow: 0;
-  flex-shrink: 0;
+  margin-top: ${space(1.5)};
+  min-height: 0;
   border-bottom-left-radius: ${p => p.theme.borderRadius};
   border-bottom-right-radius: ${p => p.theme.borderRadius};
-  overflow: auto;
 `;
 
 const StyledSimpleTableChart = styled(SimpleTableChart)`
-  margin-top: ${space(1.5)};
+  overflow: auto;
+  height: 100%;
 `;
 
 const StyledErrorPanel = styled(ErrorPanel)`

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -257,6 +257,7 @@ const WidgetTooltipButton = styled(Button)`
 
 const VisualizationWrapper = styled('div')`
   display: flex;
+  flex-direction: column;
   flex-grow: 1;
   min-height: 0;
   position: relative;


### PR DESCRIPTION
Lost during recent refactors. The container of the visualization _must_ have a column flex direction so that when the visualization has multiple elements (an error and a panel, for example) they are laid out correct. The margin fix is closely related, it's needed to prevent overflow.

**Before:**
<img width="479" alt="Screenshot 2024-10-25 at 3 44 23 PM" src="https://github.com/user-attachments/assets/65b08f9b-107d-402d-ac8f-0ca182706dd1">

**After:**
<img width="467" alt="Screenshot 2024-10-25 at 3 47 47 PM" src="https://github.com/user-attachments/assets/4a6e316f-ff73-49a5-8440-7694fbc96131">
