### PR TITLE
fix: Use the main sentry.io domian for postMessage

### DIFF
--- a/src/sentry/templates/sentry/toolbar/login-success.html
+++ b/src/sentry/templates/sentry/toolbar/login-success.html
@@ -32,7 +32,7 @@
             source: 'sentry-toolbar',
             message: 'did-login',
             cookie: cookie,
-          }, window.location.origin);
+          }, origin);
 
           if (delay && typeof delay === 'number') {
             setTimeout(() => {


### PR DESCRIPTION
I messed up in https://github.com/getsentry/sentry/pull/79242 and didn't use the new variable!

