### PR TITLE
fix(eap): Correctly map eap columns to sentry prefixed keys

### DIFF
--- a/src/sentry/search/events/builder/spans_indexed.py
+++ b/src/sentry/search/events/builder/spans_indexed.py
@@ -83,33 +83,7 @@ class SpansEAPQueryBuilder(SpansIndexedQueryBuilderMixin, BaseQueryBuilder):
             # attr field is less permissive than tags, we can't have - in them
             or "-" in field
         ):
-            # Temporary until at least after 22 Dec 2024 when old data rotates out, otherwise we should just call super
-            # here and return default_field without any extra work
-            default_field = super().resolve_field(raw_field, alias)
-            if (
-                isinstance(default_field, Column)
-                and default_field.subscriptable == "attr_str"
-                or isinstance(default_field, AliasedExpression)
-                and default_field.exp.subscriptable == "attr_str"
-            ):
-                key = (
-                    default_field.key
-                    if isinstance(default_field, Column)
-                    else default_field.exp.key
-                )
-                unprefixed_field = Column(f"attr_str[{key}]")
-                prefixed_field = Column(f"attr_str[sentry.{key}]")
-                return Function(
-                    "if",
-                    [
-                        Function("mapContains", [Column("attr_str"), key]),
-                        unprefixed_field,
-                        prefixed_field,
-                    ],
-                    raw_field if alias else None,
-                )
-            else:
-                return default_field
+            return super().resolve_field(raw_field, alias)
 
         if field_type not in ["number", "string"]:
             raise InvalidSearchQuery(
@@ -117,33 +91,19 @@ class SpansEAPQueryBuilder(SpansIndexedQueryBuilderMixin, BaseQueryBuilder):
             )
 
         if field_type == "string":
-            attr_type = "attr_str"
             field_col = Column(f"attr_str[{field}]")
         else:
-            attr_type = "attr_num"
             field_col = Column(f"attr_num[{field}]")
 
         if alias:
             field_alias = f"tags_{field}@{field_type}"
+
             self.typed_tag_to_alias_map[raw_field] = field_alias
             self.alias_to_typed_tag_map[field_alias] = raw_field
-        else:
-            field_alias = None
 
-        # Temporary until at least after 22 Dec 2024 when old data rotates out
-        unprefixed_field = field_col
-        prefixed_field = Column(f"{attr_type}[sentry.{field}]")
-        col = Function(
-            "if",
-            [
-                Function("mapContains", [Column(attr_type), field]),
-                unprefixed_field,
-                prefixed_field,
-            ],
-            field_alias,
-        )
+            field_col = AliasedExpression(field_col, field_alias)
 
-        return col
+        return field_col
 
 
 class TimeseriesSpanIndexedQueryBuilder(SpansIndexedQueryBuilderMixin, TimeseriesQueryBuilder):

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -411,7 +411,7 @@ class SpansIndexedDatasetConfig(DatasetConfig):
 
     def _resolve_bounded_sample(
         self,
-        args: Mapping[str, str | Column | SelectType | int | float],
+        args: Mapping[str, str | SelectType | int | float],
         alias: str,
     ) -> SelectType:
         base_condition = Function(
@@ -447,7 +447,7 @@ class SpansIndexedDatasetConfig(DatasetConfig):
 
     def _resolve_rounded_time(
         self,
-        args: Mapping[str, str | Column | SelectType | int | float],
+        args: Mapping[str, str | SelectType | int | float],
         alias: str,
     ) -> SelectType:
         start, end = self.builder.start, self.builder.end
@@ -473,7 +473,7 @@ class SpansIndexedDatasetConfig(DatasetConfig):
 
     def _resolve_percentile(
         self,
-        args: Mapping[str, str | Column | SelectType | int | float],
+        args: Mapping[str, str | SelectType | int | float],
         alias: str,
         fixed_percentile: float | None = None,
     ) -> SelectType:
@@ -493,7 +493,7 @@ class SpansIndexedDatasetConfig(DatasetConfig):
 
     def _resolve_random_samples(
         self,
-        args: Mapping[str, str | Column | SelectType | int | float],
+        args: Mapping[str, str | SelectType | int | float],
         alias: str,
     ) -> SelectType:
         offset = 0 if self.builder.offset is None else self.builder.offset.offset
@@ -567,9 +567,9 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
 
     def _resolve_aggregate_if(
         self, aggregate: str
-    ) -> Callable[[Mapping[str, str | Column | SelectType | int | float], str | None], SelectType]:
+    ) -> Callable[[Mapping[str, str | SelectType | int | float], str | None], SelectType]:
         def resolve_aggregate_if(
-            args: Mapping[str, str | Column | SelectType | int | float],
+            args: Mapping[str, str | SelectType | int | float],
             alias: str | None = None,
         ) -> SelectType:
             attr = extract_attr(args["column"])
@@ -945,7 +945,7 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
 
     def _resolve_sum_weighted(
         self,
-        args: Mapping[str, str | Column | SelectType | int | float],
+        args: Mapping[str, str | SelectType | int | float],
         alias: str | None = None,
     ) -> SelectType:
         attr = extract_attr(args["column"])
@@ -988,7 +988,7 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
 
     def _resolve_count_weighted(
         self,
-        args: Mapping[str, str | Column | SelectType | int | float],
+        args: Mapping[str, str | SelectType | int | float],
         alias: str | None = None,
     ) -> SelectType:
         attr = extract_attr(args["column"])
@@ -1027,7 +1027,7 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
 
     def _resolve_percentile_weighted(
         self,
-        args: Mapping[str, str | Column | SelectType | int | float],
+        args: Mapping[str, str | SelectType | int | float],
         alias: str,
         fixed_percentile: float | None = None,
     ) -> SelectType:
@@ -1081,7 +1081,7 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
 
     def _resolve_margin_of_error(
         self,
-        args: Mapping[str, str | Column | SelectType | int | float],
+        args: Mapping[str, str | SelectType | int | float],
         alias: str | None = None,
     ) -> SelectType:
         """Calculates the Margin of error for a given value, but unfortunately basis the total count based on
@@ -1127,7 +1127,7 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
 
     def _resolve_finite_population_correction(
         self,
-        args: Mapping[str, str | Column | SelectType | int | float],
+        args: Mapping[str, str | SelectType | int | float],
         total_samples: SelectType,
         population_size: int | float,
     ) -> SelectType:
@@ -1152,7 +1152,7 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
 
     def _resolve_lower_limit(
         self,
-        args: Mapping[str, str | Column | SelectType | int | float],
+        args: Mapping[str, str | SelectType | int | float],
         alias: str,
     ) -> SelectType:
         """round(max(0, proportion_by_sample - margin_of_error) * total_population)"""
@@ -1198,7 +1198,7 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
 
     def _resolve_upper_limit(
         self,
-        args: Mapping[str, str | Column | SelectType | int | float],
+        args: Mapping[str, str | SelectType | int | float],
         alias: str,
     ) -> SelectType:
         """round(max(0, proportion_by_sample + margin_of_error) * total_population)"""
@@ -1236,31 +1236,36 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
 
 
 def extract_attr(
-    column: str | Column | SelectType | int | float,
+    column: str | SelectType | int | float,
 ) -> tuple[Column, str] | None:
     # This check exists to handle the temporay prefixing.
     # Once that's removed, this condition should become much simpler
 
-    if not isinstance(column, Function):
-        return None
+    if isinstance(column, Column):
+        if column.subscriptable not in {"attr_str", "attr_num"}:
+            return None
+        return Column(column.subscriptable), column.key
 
-    if column.function != "if":
-        return None
+    if isinstance(column, Function):
+        if column.function != "if":
+            return None
 
-    if len(column.parameters) != 3:
-        return None
+        if len(column.parameters) != 3:
+            return None
 
-    if (
-        not isinstance(column.parameters[0], Function)
-        or column.parameters[0].function != "mapContains"
-        or len(column.parameters[0].parameters) != 2
-    ):
-        return None
+        if (
+            not isinstance(column.parameters[0], Function)
+            or column.parameters[0].function != "mapContains"
+            or len(column.parameters[0].parameters) != 2
+        ):
+            return None
 
-    attr_col = column.parameters[0].parameters[0]
-    attr_name = column.parameters[0].parameters[1]
+        attr_col = column.parameters[0].parameters[0]
+        attr_name = column.parameters[0].parameters[1]
 
-    if not isinstance(attr_col, Column) or not isinstance(attr_name, str):
-        return None
+        if not isinstance(attr_col, Column) or not isinstance(attr_name, str):
+            return None
 
-    return attr_col, attr_name
+        return attr_col, attr_name
+
+    return None

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -1238,34 +1238,6 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
 def extract_attr(
     column: str | SelectType | int | float,
 ) -> tuple[Column, str] | None:
-    # This check exists to handle the temporay prefixing.
-    # Once that's removed, this condition should become much simpler
-
-    if isinstance(column, Column):
-        if column.subscriptable not in {"attr_str", "attr_num"}:
-            return None
+    if isinstance(column, Column) and column.subscriptable in {"attr_str", "attr_num"}:
         return Column(column.subscriptable), column.key
-
-    if isinstance(column, Function):
-        if column.function != "if":
-            return None
-
-        if len(column.parameters) != 3:
-            return None
-
-        if (
-            not isinstance(column.parameters[0], Function)
-            or column.parameters[0].function != "mapContains"
-            or len(column.parameters[0].parameters) != 2
-        ):
-            return None
-
-        attr_col = column.parameters[0].parameters[0]
-        attr_name = column.parameters[0].parameters[1]
-
-        if not isinstance(attr_col, Column) or not isinstance(attr_name, str):
-            return None
-
-        return attr_col, attr_name
-
     return None

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -181,7 +181,7 @@ SPAN_EAP_COLUMN_MAP = {
     "project": "project_id",
     "project.id": "project_id",
     "project_id": "project_id",
-    "span.action": "attr_str[action]",
+    "span.action": "attr_str[sentry.action]",
     # For some reason the decision was made to store description as name? its called description everywhere else though
     "span.description": "name",
     "description": "name",
@@ -191,12 +191,12 @@ SPAN_EAP_COLUMN_MAP = {
     # These sample columns are for debugging only and shouldn't be used
     "sampling_weight": "sampling_weight",
     "sampling_factor": "sampling_factor",
-    "span.domain": "attr_str[domain]",
-    "span.group": "attr_str[group]",
-    "span.op": "attr_str[op]",
-    "span.category": "attr_str[category]",
+    "span.domain": "attr_str[sentry.domain]",
+    "span.group": "attr_str[sentry.group]",
+    "span.op": "attr_str[sentry.op]",
+    "span.category": "attr_str[sentry.category]",
     "span.self_time": "exclusive_time_ms",
-    "span.status": "attr_str[status]",
+    "span.status": "attr_str[sentry.status]",
     "timestamp": "timestamp",
     "trace": "trace_id",
     "transaction": "segment_name",
@@ -205,19 +205,19 @@ SPAN_EAP_COLUMN_MAP = {
     # txn event id(32 char uuid). EAP will no longer be storing this.
     "transaction.id": "segment_id",
     "transaction.span_id": "segment_id",
-    "transaction.method": "attr_str[transaction.method]",
+    "transaction.method": "attr_str[sentry.transaction.method]",
     "is_transaction": "is_segment",
     "segment.id": "segment_id",
     # We should be able to delete origin.transaction and just use transaction
     "origin.transaction": "segment_name",
     # Copy paste, unsure if this is truth in production
-    "messaging.destination.name": "attr_str[messaging.destination.name]",
-    "messaging.message.id": "attr_str[messaging.message.id]",
-    "span.status_code": "attr_str[status_code]",
-    "replay.id": "attr_str[replay_id]",
-    "span.ai.pipeline.group": "attr_str[ai_pipeline_group]",
-    "trace.status": "attr_str[trace.status]",
-    "browser.name": "attr_str[browser.name]",
+    "messaging.destination.name": "attr_str[sentry.messaging.destination.name]",
+    "messaging.message.id": "attr_str[sentry.messaging.message.id]",
+    "span.status_code": "attr_str[sentry.status_code]",
+    "replay.id": "attr_str[sentry.replay_id]",
+    "span.ai.pipeline.group": "attr_str[sentry.ai_pipeline_group]",
+    "trace.status": "attr_str[sentry.trace.status]",
+    "browser.name": "attr_str[sentry.browser.name]",
     "ai.total_tokens.used": "attr_num[ai_total_tokens_used]",
     "ai.total_cost": "attr_num[ai_total_cost]",
 }
@@ -1437,7 +1437,8 @@ def resolve_column(dataset) -> Callable:
         elif dataset == Dataset.EventsAnalyticsPlatform:
             if isinstance(col, str) and col.startswith("sentry_tags["):
                 # Replace the first instance of sentry tags with attr str instead
-                return col.replace("sentry_tags", "attr_str", 1)
+                # And sentry tags are always prefixed with `sentry.`
+                return col.replace("sentry_tags[", "attr_str[sentry.", 1)
             if isinstance(col, str) and col.startswith("tags["):
                 # Replace the first instance of sentry tags with attr str instead
                 return col.replace("tags", "attr_str", 1)

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -142,6 +142,7 @@ SPAN_COLUMN_MAP = {
     "user.id": "sentry_tags[user.id]",
     "user.email": "sentry_tags[user.email]",
     "user.username": "sentry_tags[user.username]",
+    "user.ip": "sentry_tags[user.ip]",
     "profile.id": "profile_id",
     "cache.hit": "sentry_tags[cache.hit]",
     "transaction.method": "sentry_tags[transaction.method]",
@@ -220,6 +221,15 @@ SPAN_EAP_COLUMN_MAP = {
     "browser.name": "attr_str[sentry.browser.name]",
     "ai.total_tokens.used": "attr_num[ai_total_tokens_used]",
     "ai.total_cost": "attr_num[ai_total_cost]",
+    "sdk.name": "attr_str[sentry.sdk.name]",
+    "release": "attr_str[release]",
+    "user": "attr_str[sentry.user]",
+    "user.id": "attr_str[sentry.user.id]",
+    "user.email": "attr_str[sentry.user.email]",
+    "user.username": "attr_str[sentry.user.username]",
+    "user.ip": "attr_str[sentry.user.ip]",
+    "user.geo.subregion": "attr_str[sentry.user.geo.subregion]",
+    "user.geo.country_code": "attr_str[sentry.user.geo.country_code]",
 }
 
 METRICS_SUMMARIES_COLUMN_MAP = {

--- a/tests/sentry/search/events/builder/test_spans_indexed.py
+++ b/tests/sentry/search/events/builder/test_spans_indexed.py
@@ -8,6 +8,7 @@ from sentry.exceptions import InvalidSearchQuery
 from sentry.search.events.builder.spans_indexed import (
     SPAN_ID_FIELDS,
     SPAN_UUID_FIELDS,
+    SpansEAPQueryBuilder,
     SpansIndexedQueryBuilder,
 )
 from sentry.snuba.dataset import Dataset
@@ -509,3 +510,189 @@ def test_span_module_optimization_where_clause(params):
 
     condition = Condition(builder.resolve_field("sentry_tags[category]"), Op.EQ, "http")
     assert condition in builder.where
+
+
+@pytest.mark.parametrize(
+    ["attribute", "expected"],
+    [
+        pytest.param(
+            "id",
+            AliasedExpression(Column("span_id"), alias="id"),
+            id="id",
+        ),
+        pytest.param("span_id", Column("span_id"), id="span_id"),
+        pytest.param(
+            "parent_span",
+            AliasedExpression(Column("parent_span_id"), alias="parent_span"),
+            id="parent_span",
+        ),
+        pytest.param(
+            "organization.id",
+            AliasedExpression(Column("organization_id"), alias="organization.id"),
+            id="organization.id",
+        ),
+        pytest.param(
+            "project",
+            AliasedExpression(Column("project_id"), alias="project"),
+            id="project",
+        ),
+        pytest.param(
+            "project.id",
+            AliasedExpression(Column("project_id"), alias="project.id"),
+            id="project.id",
+        ),
+        pytest.param("project_id", Column("project_id"), id="project_id"),
+        pytest.param(
+            "span.action",
+            AliasedExpression(Column("attr_str[sentry.action]"), alias="span.action"),
+            id="span.action",
+        ),
+        pytest.param(
+            "span.description",
+            AliasedExpression(Column("name"), alias="span.description"),
+            id="span.description",
+        ),
+        pytest.param(
+            "description",
+            AliasedExpression(Column("name"), alias="description"),
+            id="description",
+        ),
+        pytest.param(
+            "message",
+            AliasedExpression(Column("name"), alias="message"),
+            id="message",
+        ),
+        pytest.param("sampling_weight", Column("sampling_weight"), id="sampling_weight"),
+        pytest.param("sampling_factor", Column("sampling_factor"), id="sampling_factor"),
+        pytest.param(
+            "span.domain",
+            AliasedExpression(Column("attr_str[sentry.domain]"), alias="span.domain"),
+            id="span.domain",
+        ),
+        pytest.param(
+            "span.group",
+            AliasedExpression(Column("attr_str[sentry.group]"), alias="span.group"),
+            id="span.group",
+        ),
+        pytest.param(
+            "span.op",
+            AliasedExpression(Column("attr_str[sentry.op]"), alias="span.op"),
+            id="span.op",
+        ),
+        pytest.param(
+            "span.category",
+            AliasedExpression(Column("attr_str[sentry.category]"), alias="span.category"),
+            id="span.category",
+        ),
+        pytest.param(
+            "span.self_time",
+            AliasedExpression(Column("exclusive_time_ms"), alias="span.self_time"),
+            id="span.self_time",
+        ),
+        pytest.param(
+            "span.status",
+            AliasedExpression(Column("attr_str[sentry.status]"), alias="span.status"),
+            id="span.status",
+        ),
+        pytest.param("timestamp", Column("timestamp"), id="timestamp"),
+        pytest.param(
+            "trace",
+            AliasedExpression(Column("trace_id"), alias="trace"),
+            id="trace",
+        ),
+        pytest.param(
+            "transaction",
+            AliasedExpression(Column("segment_name"), alias="transaction"),
+            id="transaction",
+        ),
+        pytest.param(
+            "transaction.span_id",
+            AliasedExpression(Column("segment_id"), alias="transaction.span_id"),
+            id="transaction.span_id",
+        ),
+        pytest.param(
+            "transaction.method",
+            AliasedExpression(
+                Column("attr_str[sentry.transaction.method]"), alias="transaction.method"
+            ),
+            id="transaction.method",
+        ),
+        pytest.param(
+            "is_transaction",
+            AliasedExpression(Column("is_segment"), alias="is_transaction"),
+            id="is_transaction",
+        ),
+        pytest.param(
+            "segment.id",
+            AliasedExpression(Column("segment_id"), alias="segment.id"),
+            id="segment.id",
+        ),
+        pytest.param(
+            "origin.transaction",
+            AliasedExpression(Column("segment_name"), alias="origin.transaction"),
+            id="origin.transaction",
+        ),
+        pytest.param(
+            "messaging.destination.name",
+            AliasedExpression(
+                Column("attr_str[sentry.messaging.destination.name]"),
+                alias="messaging.destination.name",
+            ),
+            id="messaging.destination.name",
+        ),
+        pytest.param(
+            "messaging.message.id",
+            AliasedExpression(
+                Column("attr_str[sentry.messaging.message.id]"), alias="messaging.message.id"
+            ),
+            id="messaging.message.id",
+        ),
+        pytest.param(
+            "span.status_code",
+            AliasedExpression(Column("attr_str[sentry.status_code]"), alias="span.status_code"),
+            id="span.status_code",
+        ),
+        pytest.param(
+            "replay.id",
+            AliasedExpression(Column("attr_str[sentry.replay_id]"), alias="replay.id"),
+            id="replay.id",
+        ),
+        pytest.param(
+            "span.ai.pipeline.group",
+            AliasedExpression(
+                Column("attr_str[sentry.ai_pipeline_group]"), alias="span.ai.pipeline.group"
+            ),
+            id="span.ai.pipeline.group",
+        ),
+        pytest.param(
+            "trace.status",
+            AliasedExpression(Column("attr_str[sentry.trace.status]"), alias="trace.status"),
+            id="trace.status",
+        ),
+        pytest.param(
+            "browser.name",
+            AliasedExpression(Column("attr_str[sentry.browser.name]"), alias="browser.name"),
+            id="browser.name",
+        ),
+        pytest.param(
+            "ai.total_tokens.used",
+            AliasedExpression(
+                Column("attr_num[ai_total_tokens_used]"), alias="ai.total_tokens.used"
+            ),
+            id="ai.total_tokens.used",
+        ),
+        pytest.param(
+            "ai.total_cost",
+            AliasedExpression(Column("attr_num[ai_total_cost]"), alias="ai.total_cost"),
+            id="ai.total_cost",
+        ),
+    ],
+)
+@django_db_all
+def test_eap_attributes(params, attribute, expected):
+    builder = SpansEAPQueryBuilder(
+        Dataset.EventsAnalyticsPlatform,
+        params,
+        selected_columns=[attribute],
+    )
+    assert expected in builder.columns


### PR DESCRIPTION
The old data is going to be deleted soon, so stop coalescing the prefixed and unprefixed versions together.