### PR TITLE
feat(dynamic-sampling): Move nav entry

### DIFF
--- a/static/app/views/settings/organization/navigationConfiguration.tsx
+++ b/static/app/views/settings/organization/navigationConfiguration.tsx
@@ -114,12 +114,8 @@ const organizationNavigation: NavigationSection[] = [
         path: `${organizationSettingsPathPrefix}/dynamic-sampling/`,
         title: t('Dynamic Sampling'),
         description: t('Manage your sampling rate'),
-        show: ({organization, isSelfHosted}) =>
-          !!(
-            organization &&
-            hasDynamicSamplingCustomFeature(organization) &&
-            isSelfHosted
-          ),
+        show: ({organization}) =>
+          !!organization && hasDynamicSamplingCustomFeature(organization),
       },
     ],
   },


### PR DESCRIPTION
Move `Dynamic Sampling` nav entry from `Usage & Billing` into `Organization`.

Relates to https://github.com/getsentry/getsentry/pull/15530