### PR TITLE
fix(dashboard): Catch exceptions when initializing query builders

### DIFF
--- a/src/sentry/discover/dashboard_widget_split.py
+++ b/src/sentry/discover/dashboard_widget_split.py
@@ -192,12 +192,6 @@ def _get_and_save_split_decision_for_dashboard_widget(
             )
         return DashboardWidgetTypes.ERROR_EVENTS, False
 
-    # If either builder fails to initialize, the query was only compatible with the other dataset.
-    if errors_builder is None:
-        return DashboardWidgetTypes.TRANSACTION_LIKE, False
-    if transactions_builder is None:
-        return DashboardWidgetTypes.ERROR_EVENTS, False
-
     dataset_inferred_from_query = _dataset_split_decision_inferred_from_query(
         errors_builder, transactions_builder
     )

--- a/src/sentry/discover/dashboard_widget_split.py
+++ b/src/sentry/discover/dashboard_widget_split.py
@@ -146,7 +146,10 @@ def _get_and_save_split_decision_for_dashboard_widget(
     snuba_dataclass = _get_snuba_dataclass_for_dashboard_widget(widget, list(projects))
 
     selected_columns = _get_field_list(widget_query.fields or [])
-    equations = _get_equation_list(widget_query.fields or [])
+
+    # Empty equations are filtered out in the UI when making a query,
+    # do the same here to avoid unnecessary errors.
+    equations = [equation for equation in _get_equation_list(widget_query.fields or []) if equation]
     query = widget_query.conditions
 
     errors_builder = init_query_builder(

--- a/src/sentry/discover/dashboard_widget_split.py
+++ b/src/sentry/discover/dashboard_widget_split.py
@@ -24,6 +24,7 @@ from sentry.models.dashboard_widget import (
     DatasetSourcesTypes,
 )
 from sentry.models.project import Project
+from sentry.search.events.builder.base import BaseQueryBuilder
 from sentry.search.events.builder.discover import DiscoverQueryBuilder
 from sentry.search.events.builder.errors import ErrorsQueryBuilder
 from sentry.search.events.types import QueryBuilderConfig, SnubaParams
@@ -71,6 +72,39 @@ def _save_split_decision_for_widget(
     widget.save()
 
 
+def init_query_builder(
+    Builder: type[BaseQueryBuilder],
+    widget: DashboardWidget,
+    fallback_dataset: int,
+    builder_kwargs=None,
+    dry_run=False,
+):
+    try:
+        return Builder(
+            **(builder_kwargs or {}),
+        )
+    except (
+        snuba.UnqualifiedQueryError,
+        InvalidSearchQuery,
+        InvalidQueryError,
+        snuba.QueryExecutionError,
+    ) as e:
+        sentry_sdk.capture_exception(e)
+        if dry_run:
+            logger.info(
+                "Split decision for %s: %s (forced fallback)",
+                widget.id,
+                fallback_dataset,
+            )
+        else:
+            _save_split_decision_for_widget(
+                widget,
+                fallback_dataset,
+                DatasetSourcesTypes.FORCED,
+            )
+        return None
+
+
 @sentry_sdk.trace
 def _get_and_save_split_decision_for_dashboard_widget(
     widget_query: DashboardWidgetQuery, dry_run: bool
@@ -115,70 +149,54 @@ def _get_and_save_split_decision_for_dashboard_widget(
     equations = _get_equation_list(widget_query.fields or [])
     query = widget_query.conditions
 
-    try:
-        # Optimizing the query we're running a little - we're omitting the order by
-        # and setting limit = 1 since the only check happening with the data returned
-        # is if data exists.
-        try:
-            errors_builder = ErrorsQueryBuilder(
-                Dataset.Events,
-                params={},
-                snuba_params=snuba_dataclass,
-                query=query,
-                selected_columns=selected_columns,
-                equations=equations,
-                limit=1,
-                config=QueryBuilderConfig(
-                    auto_aggregations=True,
-                    equation_config={
-                        "auto_add": True,
-                    },
-                ),
-            )
-        except snuba.UnqualifiedQueryError as e:
-            sentry_sdk.capture_exception(e)
-            # Handle unqualified errors because the query may not be compatible,
-            # with the dataset. There's a chance we can still inspect the other
-            # dataset, so make an empty query builder
-            errors_builder = ErrorsQueryBuilder(
-                Dataset.Events,
-                params={},
-                snuba_params=snuba_dataclass,
-                query="",
-                selected_columns=[],
-                equations=[],
-                limit=1,
-            )
-
-        transactions_builder = DiscoverQueryBuilder(
-            Dataset.Transactions,
-            params={},
-            snuba_params=snuba_dataclass,
-            query=query,
-            selected_columns=selected_columns,
-            equations=equations,
-            limit=1,
-            config=QueryBuilderConfig(
+    errors_builder = init_query_builder(
+        ErrorsQueryBuilder,
+        widget,
+        DashboardWidgetTypes.TRANSACTION_LIKE,
+        builder_kwargs={
+            "dataset": Dataset.Events,
+            "params": {},
+            "snuba_params": snuba_dataclass,
+            "query": query,
+            "selected_columns": selected_columns,
+            "equations": equations,
+            "limit": 1,
+            "config": QueryBuilderConfig(
                 auto_aggregations=True,
                 equation_config={
                     "auto_add": True,
                 },
             ),
-        )
-    except (InvalidSearchQuery, InvalidQueryError) as e:
-        sentry_sdk.capture_exception(e)
-        if dry_run:
-            logger.info(
-                "Split decision for %s: %s (forced)",
-                widget.id,
-                DashboardWidgetTypes.ERROR_EVENTS,
-            )
-        else:
-            _save_split_decision_for_widget(
-                widget,
-                DashboardWidgetTypes.ERROR_EVENTS,
-                DatasetSourcesTypes.FORCED,
-            )
+        },
+        dry_run=dry_run,
+    )
+
+    transactions_builder = init_query_builder(
+        DiscoverQueryBuilder,
+        widget,
+        DashboardWidgetTypes.ERROR_EVENTS,
+        builder_kwargs={
+            "dataset": Dataset.Transactions,
+            "params": {},
+            "snuba_params": snuba_dataclass,
+            "query": query,
+            "selected_columns": selected_columns,
+            "equations": equations,
+            "limit": 1,
+            "config": QueryBuilderConfig(
+                auto_aggregations=True,
+                equation_config={
+                    "auto_add": True,
+                },
+            ),
+        },
+        dry_run=dry_run,
+    )
+
+    # If either builder fails to initialize, the query was only compatible with the other dataset.
+    if errors_builder is None:
+        return DashboardWidgetTypes.TRANSACTION_LIKE, False
+    if transactions_builder is None:
         return DashboardWidgetTypes.ERROR_EVENTS, False
 
     dataset_inferred_from_query = _dataset_split_decision_inferred_from_query(

--- a/src/sentry/discover/dashboard_widget_split.py
+++ b/src/sentry/discover/dashboard_widget_split.py
@@ -136,7 +136,7 @@ def _get_and_save_split_decision_for_dashboard_widget(
                 ),
             )
         except snuba.UnqualifiedQueryError as e:
-            sentry_sdk.capture_message(e)
+            sentry_sdk.capture_exception(e)
             # Handle unqualified errors because the query may not be compatible,
             # with the dataset. There's a chance we can still inspect the other
             # dataset, so make an empty query builder

--- a/tests/sentry/discover/test_dashboard_widget_split.py
+++ b/tests/sentry/discover/test_dashboard_widget_split.py
@@ -523,7 +523,7 @@ class DashboardWidgetDatasetSplitTestCase(BaseMetricsLayerTestCase, TestCase, Sn
                 == DashboardDatasetSourcesTypes.SPLIT_VERSION_2.value
             )
 
-    def test_dashboard_split_transaction_status(self):
+    def test_dashboard_split_transaction_status_error_events_dataset(self):
         transaction_widget = DashboardWidget.objects.create(
             dashboard=self.dashboard,
             order=0,
@@ -550,10 +550,42 @@ class DashboardWidgetDatasetSplitTestCase(BaseMetricsLayerTestCase, TestCase, Sn
             else transaction_widget.discover_widget_split == 101
         )
         if not self.dry_run:
-            assert (
-                transaction_widget.dataset_source
-                == DashboardDatasetSourcesTypes.SPLIT_VERSION_2.value
-            )
+            assert transaction_widget.dataset_source == DashboardDatasetSourcesTypes.FORCED.value
+
+    def test_unhandled_filter_sets_error_events_dataset(self):
+        error_widget = DashboardWidget.objects.create(
+            dashboard=self.dashboard,
+            order=0,
+            title="error widget",
+            display_type=DashboardWidgetDisplayTypes.LINE_CHART,
+            widget_type=DashboardWidgetTypes.DISCOVER,
+            interval="1d",
+            detail={"layout": {"x": 0, "y": 0, "w": 1, "h": 1, "minH": 2}},
+        )
+        error_widget_query = DashboardWidgetQuery.objects.create(
+            widget=error_widget,
+            fields=[
+                "equation|count() / total.count * 100",
+                "release",
+                "error_event",
+                "count()",
+                "total.count",
+            ],
+            columns=["release"],
+            aggregates=["equation|count() / total.count * 100", "count()", "total.count"],
+            conditions="error.unhandled:false",
+            order=0,
+        )
+
+        _get_and_save_split_decision_for_dashboard_widget(error_widget_query, self.dry_run)
+        error_widget.refresh_from_db()
+        assert (
+            error_widget.discover_widget_split is None
+            if self.dry_run
+            else error_widget.discover_widget_split == 100
+        )
+        if not self.dry_run:
+            assert error_widget.dataset_source == DashboardDatasetSourcesTypes.FORCED.value
 
 
 class DashboardWidgetDatasetSplitDryRunTestCase(DashboardWidgetDatasetSplitTestCase):

--- a/tests/sentry/discover/test_dashboard_widget_split.py
+++ b/tests/sentry/discover/test_dashboard_widget_split.py
@@ -587,6 +587,38 @@ class DashboardWidgetDatasetSplitTestCase(BaseMetricsLayerTestCase, TestCase, Sn
         if not self.dry_run:
             assert error_widget.dataset_source == DashboardDatasetSourcesTypes.FORCED.value
 
+    def test_empty_equation_is_filtered_out(self):
+        error_widget = DashboardWidget.objects.create(
+            dashboard=self.dashboard,
+            order=0,
+            title="error widget",
+            display_type=DashboardWidgetDisplayTypes.LINE_CHART,
+            widget_type=DashboardWidgetTypes.DISCOVER,
+            interval="1d",
+            detail={"layout": {"x": 0, "y": 0, "w": 1, "h": 1, "minH": 2}},
+        )
+        error_widget_query = DashboardWidgetQuery.objects.create(
+            widget=error_widget,
+            fields=[
+                "count()",
+                "equation|",
+            ],
+            columns=[],
+            aggregates=["count()", "equation|"],
+            conditions='message:"Testing"',
+            order=0,
+        )
+
+        _get_and_save_split_decision_for_dashboard_widget(error_widget_query, self.dry_run)
+        error_widget.refresh_from_db()
+        assert (
+            error_widget.discover_widget_split is None
+            if self.dry_run
+            else error_widget.discover_widget_split == 100
+        )
+        if not self.dry_run:
+            assert error_widget.dataset_source == DashboardDatasetSourcesTypes.SPLIT_VERSION_2.value
+
 
 class DashboardWidgetDatasetSplitDryRunTestCase(DashboardWidgetDatasetSplitTestCase):
     def setUp(self):

--- a/tests/sentry/discover/test_dataset_split.py
+++ b/tests/sentry/discover/test_dataset_split.py
@@ -577,6 +577,77 @@ class DiscoverSavedQueryDatasetSplitTestCase(TestCase, SnubaTestCase):
         saved_query = DiscoverSavedQuery.objects.get(id=errors_query.id)
         assert saved_query.dataset == 0 if self.dry_run else saved_query.dataset == 1
 
+    def test_dashboard_split_transaction_status_error_events_dataset(self):
+        transaction_query = DiscoverSavedQuery.objects.create(
+            organization_id=self.organization.id,
+            name="",
+            query={
+                "environment": [],
+                "fields": ["transaction", "p75(transaction.duration)", "total.count"],
+                "query": "event.type:transaction transaction.status:ok",
+                "range": "90d",
+            },
+            version=2,
+            dataset=0,
+            dataset_source=0,
+        )
+
+        _get_and_save_split_decision_for_query(transaction_query, self.dry_run)
+        transaction_query.refresh_from_db()
+        assert transaction_query.dataset == 0 if self.dry_run else transaction_query.dataset == 2
+        if not self.dry_run:
+            assert transaction_query.dataset_source == DatasetSourcesTypes.FORCED.value
+
+    def test_unhandled_filter_sets_error_events_dataset(self):
+        error_query = DiscoverSavedQuery.objects.create(
+            organization_id=self.organization.id,
+            name="",
+            query={
+                "environment": [],
+                "fields": [
+                    "equation|count() / total.count * 100",
+                    "release",
+                    "error_event",
+                    "count()",
+                    "total.count",
+                ],
+                "query": "error.unhandled:false",
+                "range": "90d",
+            },
+            version=2,
+            dataset=0,
+            dataset_source=0,
+        )
+
+        _get_and_save_split_decision_for_query(error_query, self.dry_run)
+        error_query.refresh_from_db()
+        assert error_query.dataset == 0 if self.dry_run else error_query.dataset == 1
+        if not self.dry_run:
+            assert error_query.dataset_source == DatasetSourcesTypes.FORCED.value
+
+    def test_empty_equation_is_filtered_out(self):
+        error_query = DiscoverSavedQuery.objects.create(
+            organization_id=self.organization.id,
+            name="",
+            query={
+                "fields": [
+                    "count()",
+                    "equation|",
+                ],
+                "query": 'message:"Testing"',
+                "range": "90d",
+            },
+            version=2,
+            dataset=0,
+            dataset_source=0,
+        )
+
+        _get_and_save_split_decision_for_query(error_query, self.dry_run)
+        error_query.refresh_from_db()
+        assert error_query.dataset == 0 if self.dry_run else error_query.dataset == 1
+        if not self.dry_run:
+            assert error_query.dataset_source == DatasetSourcesTypes.INFERRED.value
+
 
 class DiscoverSavedQueryDatasetSplitDryRunTestCase(DiscoverSavedQueryDatasetSplitTestCase):
     def setUp(self):


### PR DESCRIPTION
Sometimes we can error out on initializing datasets because we try to initialize both to inspect at the same time downstream. This change extracts the logic to initialize a query builder and catches predictable errors which indicate we should just set the opposite dataset (since, assuming it worked before, if it fails on one then it must be the other dataset).

Also fixes the case where empty equations were causing errors. In this case we don't want to flip it to the other dataset, these should just be ignored since that's what the UI does.