### PR TITLE
fix(ui) Fix domains in prefetch-dns tags

### DIFF
--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -12,6 +12,7 @@ from django.urls import resolve
 from rest_framework.request import Request
 
 from sentry import features, options
+from sentry.api.utils import generate_region_url
 from sentry.organizations.absolute_url import customer_domain_path, generate_organization_url
 from sentry.organizations.services.organization import organization_service
 from sentry.types.region import (
@@ -75,7 +76,7 @@ class ReactMixin:
             return domains
         for region_name in regions:
             region = get_region_by_name(region_name)
-            domains.append(region.address)
+            domains.append(generate_region_url(region.name))
         return domains
 
     def handle_react(self, request: Request, **kwargs) -> HttpResponse:

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -435,6 +435,6 @@ class ReactPageViewTest(TestCase):
             response = self.client.get("/issues/", HTTP_HOST=f"{org.slug}.testserver")
             assert response.status_code == 200
             response_body = response.content
-            assert '<link rel="dns-prefetch" href="https://us.testserver"' in response_body.decode(
+            assert '<link rel="dns-prefetch" href="http://us.testserver"' in response_body.decode(
                 "utf-8"
             )


### PR DESCRIPTION
I forgot that `region.address` is not a public DNS name.

Refs #79784
