### PR TITLE
fix(issue-details): Hide specific event tab

### DIFF
--- a/static/app/views/issueDetails/streamline/eventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.tsx
@@ -184,10 +184,7 @@ export function IssueEventNavigation({event, group, query}: IssueEventNavigation
                       <TabList.Item
                         to={eventPath}
                         key={label}
-                        hidden={
-                          label === EventNavOptions.CUSTOM &&
-                          selectedOption !== EventNavOptions.CUSTOM
-                        }
+                        hidden={label === EventNavOptions.CUSTOM}
                         textValue={EventNavLabels[label]}
                       >
                         {EventNavLabels[label]}


### PR DESCRIPTION
this pr hides the specific event tab. now the tabs will act more as quick action buttons, so you can quickly jump to the recommend/first/last event, without always needing to show a tab for specific event. this will also help because now with the new location or prev/next events, if you click away from the recommended event, those buttons shift. 