### PR TITLE
fix(auth): avoid redirect loop for customer domains

### DIFF
--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -364,12 +364,6 @@ class BaseView(View, OrganizationMixin):
             if response:
                 return response
 
-        if self.is_auth_required(request, *args, **kwargs):
-            return self.handle_auth_required(request, *args, **kwargs)
-
-        if self.is_sudo_required(request):
-            return self.handle_sudo_required(request, *args, **kwargs)
-
         if (
             is_using_customer_domain(request)
             and "organization_slug" in inspect.signature(self.convert_args).parameters
@@ -377,6 +371,12 @@ class BaseView(View, OrganizationMixin):
         ):
             # In customer domain contexts, we will need to pre-populate the organization_slug keyword argument.
             kwargs["organization_slug"] = organization_slug
+
+        if self.is_auth_required(request, *args, **kwargs):
+            return self.handle_auth_required(request, *args, **kwargs)
+
+        if self.is_sudo_required(request):
+            return self.handle_sudo_required(request, *args, **kwargs)
 
         args, kwargs = self.convert_args(request, *args, **kwargs)
 

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -184,12 +184,11 @@ class AuthLoginTest(TestCase, HybridCloudTestMixin):
         self.client.get(self.path)
 
         project_path = reverse("project-details", kwargs={"project_slug": "project"})
-
         resp = self.client.get(project_path, HTTP_HOST=f"{org.slug}.testserver")
-        # redirect to login page
+
         assert resp.status_code == 302
-        # loads auth org login page by parsing customer domain
-        assert resp.url == reverse("sentry-auth-organization", args=[org.slug])
+        # redirect to auth org login page by parsing customer domain
+        assert getattr(resp, "url", None) == reverse("sentry-auth-organization", args=[org.slug])
 
     def test_registration_disabled(self):
         with self.feature({"auth:register": False}), self.allow_registration():

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -188,7 +188,12 @@ class AuthLoginTest(TestCase, HybridCloudTestMixin):
 
         assert resp.status_code == 302
         # redirect to auth org login page by parsing customer domain
-        assert getattr(resp, "url", None) == reverse("sentry-auth-organization", args=[org.slug])
+        redirect_url = getattr(resp, "url", None)
+        assert redirect_url == reverse("sentry-auth-organization", args=[org.slug])
+
+        # get redirect
+        resp = self.client.get(redirect_url, HTTP_HOST=f"{org.slug}.testserver")
+        assert resp.status_code == 200
 
     def test_registration_disabled(self):
         with self.feature({"auth:register": False}), self.allow_registration():


### PR DESCRIPTION
`is_auth_required` checks for `organization_slug` in `kwargs` to redirect to the organization login page if the user isn't logged in. This is easily parsed when we don't have customer domains but we need to manually add it to kwargs when customer domains is on. The parsing for this was done below the `is_auth_required` function, so we just need to move it above.

Before


https://github.com/user-attachments/assets/cd19f497-6c13-4cc4-acc3-925f2385e9e4



After


https://github.com/user-attachments/assets/af049e3b-e5cd-4aa9-9f62-353eb63b2d00

