### PR TITLE
fix(issue-views): Fix logger link redirecting incorrectly

### DIFF
--- a/static/app/views/issueList/customViewsHeader.tsx
+++ b/static/app/views/issueList/customViewsHeader.tsx
@@ -337,6 +337,14 @@ function CustomViewsIssueListHeaderTabsContent({
     if (query) {
       if (!tabListState?.selectionManager.isSelected(TEMPORARY_TAB_KEY)) {
         tabListState?.setSelectedKey(TEMPORARY_TAB_KEY);
+        setTempTab({
+          id: TEMPORARY_TAB_KEY,
+          key: TEMPORARY_TAB_KEY,
+          label: t('Unsaved'),
+          query: query,
+          querySort: sort ?? IssueSortOptions.DATE,
+          isCommitted: true,
+        });
         navigate(
           normalizeUrl({
             ...location,
@@ -361,6 +369,7 @@ function CustomViewsIssueListHeaderTabsContent({
     queryParamsWithPageFilters,
     draggableTabs,
     organization,
+    tempTab,
   ]);
 
   // Update local tabs when new views are received from mutation request

--- a/static/app/views/issueList/customViewsHeader.tsx
+++ b/static/app/views/issueList/customViewsHeader.tsx
@@ -369,7 +369,6 @@ function CustomViewsIssueListHeaderTabsContent({
     queryParamsWithPageFilters,
     draggableTabs,
     organization,
-    tempTab,
   ]);
 
   // Update local tabs when new views are received from mutation request


### PR DESCRIPTION
Fixes an issue where clicking on the logger entry in the event/group extra details on issue stream would trigger a weird redirect loop and end up at the first tab, rather than a new search with the logger as a filter. 

This was caused by a consequence of the issue-views component assuming that a temp tab could only be triggered by a fresh navigate to the issue stream, and never within the issue stream: 

