### PR TITLE
feat(issue-views): Surface org-wide saved searches in add view

### DIFF
--- a/static/app/views/issueList/addViewPage.tsx
+++ b/static/app/views/issueList/addViewPage.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import bannerStar from 'sentry-images/spot/banner-star.svg';
 
 import {usePrompt} from 'sentry/actionCreators/prompts';
-import Badge from 'sentry/components/badge/badge';
 import {Button, LinkButton} from 'sentry/components/button';
 import {openConfirmModal} from 'sentry/components/confirm';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
@@ -23,8 +22,7 @@ import {NewTabContext} from 'sentry/views/issueList/utils/newTabContext';
 type SearchSuggestion = {
   label: string;
   query: string;
-  isOrganizationSavedSearch?: boolean;
-  isPersonalSavedSearch?: boolean;
+  scope?: 'personal' | 'organization';
 };
 
 interface SearchSuggestionListProps {
@@ -79,16 +77,16 @@ function AddViewPage({
   );
 
   const savedSearchSuggestions: SearchSuggestion[] = [
-    ...personalSavedSearches.map(search => ({
+    ...(personalSavedSearches.map(search => ({
       label: search.name,
       query: search.query,
-      isPersonalSavedSearch: true,
-    })),
-    ...organizationSavedSearches.map(search => ({
+      scope: 'personal',
+    })) as SearchSuggestion[]),
+    ...(organizationSavedSearches.map(search => ({
       label: search.name,
       query: search.query,
-      isOrganizationSavedSearch: true,
-    })),
+      scope: 'organization',
+    })) as SearchSuggestion[]),
   ];
 
   return (
@@ -256,11 +254,13 @@ function SearchSuggestionList({
             <OverflowEllipsisTextContainer>
               {suggestion.label}
             </OverflowEllipsisTextContainer>
-            {suggestion.isPersonalSavedSearch ? (
-              <Badge type="internal">{t('Personal')}</Badge>
-            ) : (
-              <div />
-            )}
+            <ScopeTagContainer>
+              {suggestion.scope === 'personal' ? (
+                <Scope>{t('Private')}</Scope>
+              ) : suggestion.scope === 'organization' ? (
+                <Scope>{t('Public')}</Scope>
+              ) : null}
+            </ScopeTagContainer>
             <QueryWrapper>
               <FormattedQuery query={suggestion.query} />
               <ActionsWrapper className="data-actions-wrapper">
@@ -297,6 +297,14 @@ function SearchSuggestionList({
 }
 
 export default AddViewPage;
+
+const Scope = styled('div')`
+  color: ${p => p.theme.subText};
+`;
+
+const ScopeTagContainer = styled('div')`
+  display: flex;
+`;
 
 const Suggestions = styled('section')`
   width: 100%;

--- a/static/app/views/issueList/issueListTable.tsx
+++ b/static/app/views/issueList/issueListTable.tsx
@@ -27,13 +27,14 @@ interface IssueListTableProps {
   onDelete: () => void;
   onSelectStatsPeriod: (period: string) => void;
   onSortChange: (sort: string) => void;
+  organizationSavedSearches: SavedSearch[];
   pageLinks: string;
   paginationAnalyticsEvent: (direction: string) => void;
   paginationCaption: React.ReactNode;
+  personalSavedSearches: SavedSearch[];
   query: string;
   queryCount: number;
   refetchGroups: (fetchAllCounts?: boolean) => void;
-  savedSearches: SavedSearch[];
   selectedProjectIds: number[];
   selection: PageFilters;
   sort: string;
@@ -61,12 +62,16 @@ function IssueListTable({
   pageLinks,
   onCursor,
   paginationAnalyticsEvent,
-  savedSearches,
+  personalSavedSearches,
+  organizationSavedSearches,
 }: IssueListTableProps) {
   const {newViewActive} = useContext(NewTabContext);
 
   return newViewActive ? (
-    <AddViewPage savedSearches={savedSearches} />
+    <AddViewPage
+      personalSavedSearches={personalSavedSearches}
+      organizationSavedSearches={organizationSavedSearches}
+    />
   ) : (
     <Fragment>
       <Panel>

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -1260,8 +1260,11 @@ class IssueListOverview extends Component<Props, State> {
                 pageLinks={pageLinks}
                 onCursor={this.onCursorChange}
                 paginationAnalyticsEvent={this.paginationAnalyticsEvent}
-                savedSearches={this.props.savedSearches?.filter(
+                personalSavedSearches={this.props.savedSearches?.filter(
                   search => search.visibility === 'owner'
+                )}
+                organizationSavedSearches={this.props.savedSearches?.filter(
+                  search => search.visibility === 'organization'
                 )}
               />
             </StyledMain>


### PR DESCRIPTION
This PR udpates the saved searches section in the add view page to include org-wide saved searches along with personal saved searches. Previously, only personal saved searches were shown.  

Personal saved searches are hoisted to the top of the list and are denoted with a "Personal" badge:

<img width="603" alt="image" src="https://github.com/user-attachments/assets/fd08f1dc-a8b2-45f3-bcd6-dcee78bfe245">

(Designs are not finalized) 
