### PR TITLE
fix(dashboards): Reduce minimum width of widgets

### DIFF
--- a/static/app/views/dashboards/widgets/common/settings.tsx
+++ b/static/app/views/dashboards/widgets/common/settings.tsx
@@ -1,7 +1,7 @@
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
-export const MIN_WIDTH = 200;
+export const MIN_WIDTH = 110;
 export const MIN_HEIGHT = 96;
 
 export const Y_GUTTER = space(1.5);


### PR DESCRIPTION
In reality, in tight layouts, widget can be as small as 115px. I'm reducing the minimum width to 110, to give us some breathing room. This prevents awkward widget overlaps at small screen sizes.
