### PR TITLE
feat(dashboards): Update EAP aggregations

### DIFF
--- a/static/app/views/dashboards/datasetConfig/spans.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.spec.tsx
@@ -1,0 +1,25 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import type {Organization} from 'sentry/types/organization';
+import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
+import {SpansConfig} from 'sentry/views/dashboards/datasetConfig/spans';
+
+describe('SpansConfig', () => {
+  let organization: Organization;
+
+  beforeEach(() => {
+    organization = OrganizationFixture({
+      features: ['performance-view'],
+    });
+  });
+
+  it('returns all of the EAP aggregations as primary options', () => {
+    const functionOptions = Object.keys(
+      SpansConfig.getTableFieldOptions(organization, {})
+    )
+      .filter(func => func.startsWith('function'))
+      .map(func => func.split(':')[1]);
+
+    expect(functionOptions).toEqual(ALLOWED_EXPLORE_VISUALIZE_AGGREGATES);
+  });
+});

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -39,18 +39,18 @@ import {generateFieldOptions} from 'sentry/views/discover/utils';
 
 const DEFAULT_WIDGET_QUERY: WidgetQuery = {
   name: '',
-  fields: ['span.op', 'count()'],
+  fields: ['span.op', 'count(span.op)'],
   columns: ['span.op'],
   fieldAliases: [],
-  aggregates: ['count()'],
+  aggregates: ['count(span.op)'],
   conditions: '',
-  orderby: '-count()',
+  orderby: '-count(span.op)',
 };
 
 const EAP_AGGREGATIONS = ALLOWED_EXPLORE_VISUALIZE_AGGREGATES.reduce((acc, aggregate) => {
   acc[aggregate] = {
     isSortable: true,
-    outputType: 'number',
+    outputType: null,
     parameters: [
       {
         kind: 'column',

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -9,14 +9,16 @@ import type {
 import toArray from 'sentry/utils/array/toArray';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
-import {getAggregations} from 'sentry/utils/discover/fields';
 import {
   type DiscoverQueryExtras,
   type DiscoverQueryRequestParams,
   doDiscoverQuery,
 } from 'sentry/utils/discover/genericDiscoverQuery';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {TRACE_FIELD_DEFINITIONS} from 'sentry/utils/fields';
+import {
+  ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
+  TRACE_FIELD_DEFINITIONS,
+} from 'sentry/utils/fields';
 import type {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import type {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
 import {
@@ -45,12 +47,28 @@ const DEFAULT_WIDGET_QUERY: WidgetQuery = {
   orderby: '-count()',
 };
 
+const EAP_AGGREGATIONS = ALLOWED_EXPLORE_VISUALIZE_AGGREGATES.reduce((acc, aggregate) => {
+  acc[aggregate] = {
+    isSortable: true,
+    outputType: 'number',
+    parameters: [
+      {
+        kind: 'column',
+        columnTypes: ['string', 'integer', 'number', 'duration', 'date', 'boolean'],
+        defaultValue: 'user',
+        required: true,
+      },
+    ],
+  };
+  return acc;
+}, {});
+
 export const SpansConfig: DatasetConfig<
   EventsStats | MultiSeriesEventsStats,
   TableData | EventsTableData
 > = {
   defaultWidgetQuery: DEFAULT_WIDGET_QUERY,
-  enableEquations: false, // TODO: Should EAP support equations?
+  enableEquations: false,
   getCustomFieldRenderer: getCustomEventsFieldRenderer,
   SearchBar: EventsSearchBar, // TODO: Replace with a custom EAP search bar
   filterSeriesSortOptions: () => () => true,
@@ -108,8 +126,7 @@ function getEventsTableFieldOptions(
     organization,
     tagKeys: Object.values(tags ?? {}).map(({key}) => key),
     fieldKeys: Object.keys(TRACE_FIELD_DEFINITIONS),
-    // TODO: Use EAP specific aggregations
-    aggregations: getAggregations(DiscoverDatasets.TRANSACTIONS),
+    aggregations: EAP_AGGREGATIONS,
   });
 }
 

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -521,7 +521,7 @@ export function generateFieldOptions({
   functions.forEach(func => {
     const ellipsis = aggregations[func].parameters.length ? '\u2026' : '';
     const parameters = aggregations[func].parameters.map(param => {
-      const overrides = AGGREGATIONS[func].getFieldOverrides;
+      const overrides = aggregations[func].getFieldOverrides;
       if (typeof overrides === 'undefined') {
         return param;
       }
@@ -606,7 +606,7 @@ export function generateFieldOptions({
     tagKeys.sort();
     tagKeys.forEach(tag => {
       const tagValue =
-        fieldKeys.includes(tag) || AGGREGATIONS.hasOwnProperty(tag)
+        fieldKeys.includes(tag) || aggregations.hasOwnProperty(tag)
           ? `tags[${tag}]`
           : tag;
       fieldOptions[`tag:${tag}`] = {


### PR DESCRIPTION
Adds the aggregations available in Explore to dashboards. This is a hardcoded list where all of the aggregates accept any of the fields (which explains why I have such a broad parameter type).

Note: Some of the fields aren't actually compatible with EAP yet (e.g. `span.action`) but I will update the tags in a future PR to expose the correct ones that are supported.

[#78264](https://github.com/getsentry/sentry/issues/78264)