### PR TITLE
feat: add preconnect option for static origin

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -524,6 +524,9 @@ STATIC_URL = "/_static/{version}/"
 # as we configure webpack to include file content based hash in the filename
 STATIC_FRONTEND_APP_URL = "/_static/dist/"
 
+# URL origin from where the static files are served.
+STATIC_ORIGIN = None
+
 # The webpack output directory
 STATICFILES_DIRS = [
     os.path.join(STATIC_ROOT, "sentry", "dist"),

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -28,6 +28,10 @@
   <link rel="dns-prefetch" href="{{ domain }}" />
   {% endfor %}
 
+  {% for preconnect in preconnect %}
+  <link rel="preconnect" href="{{ preconnect }}" />
+  {% endfor %}
+
   <link rel="mask-icon" sizes="any" href="{% absolute_asset_url "sentry" "images/logos/logo-sentry.svg" %}" color="#FB4226">
 
   <link href="{% frontend_app_asset_url "sentry" "entrypoints/sentry.css" %}" rel="stylesheet"/>

--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -71,12 +71,7 @@ class ReactMixin:
 
     def preconnect(self) -> list[str]:
         preconnects = []
-        if (
-            # In dev (and possibly other configs), STATIC_HOST is not set, not checking for it would result in
-            # preconnects to the server we are already receiving the response from.
-            getattr(settings, "STATIC_ORIGIN", None)
-            is not None
-        ):
+        if settings.STATIC_ORIGIN is not None:
             preconnects.append(settings.STATIC_ORIGIN)
         return preconnects
 

--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -69,6 +69,17 @@ class ReactMixin:
     def meta_tags(self, request: Request, **kwargs):
         return {}
 
+    def preconnect(self) -> list[str]:
+        preconnects = []
+        if (
+            # In dev (and possibly other configs), STATIC_HOST is not set, not checking for it would result in
+            # preconnects to the server we are already receiving the response from.
+            getattr(settings, "STATIC_ORIGIN", None)
+            is not None
+        ):
+            preconnects.append(settings.STATIC_ORIGIN)
+        return preconnects
+
     def dns_prefetch(self) -> list[str]:
         regions = find_all_multitenant_region_names()
         domains = []
@@ -87,6 +98,7 @@ class ReactMixin:
                 for key, value in self.meta_tags(request, **kwargs).items()
             ],
             "dns_prefetch": self.dns_prefetch(),
+            "preconnect": self.preconnect(),
             # Rendering the layout requires serializing the active organization.
             # Since we already have it here from the OrganizationMixin, we can
             # save some work and render it faster.

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -438,3 +438,17 @@ class ReactPageViewTest(TestCase):
             assert '<link rel="dns-prefetch" href="http://us.testserver"' in response_body.decode(
                 "utf-8"
             )
+
+    def test_preconnect(self):
+        user = self.create_user("bar@example.com")
+        org = self.create_organization(owner=user)
+        self.login_as(user)
+
+        with self.settings(STATIC_ORIGIN="https://s1.sentry-cdn.com"):
+            response = self.client.get("/issues/", HTTP_HOST=f"{org.slug}.testserver")
+            assert response.status_code == 200
+            response_body = response.content
+            assert (
+                '<link rel="preconnect" href="https://s1.sentry-cdn.com"'
+                in response_body.decode("utf-8")
+            )


### PR DESCRIPTION
We serve static assets from a different origin (CDN) than what we receive the html response from, which means we pay the price of establishing a new connection at a later point in time, which delays the time it takes to fetch the static assets. This change adds a preconnect options, similar to the change done in https://github.com/getsentry/sentry/pull/79784 in an attempt to establish that connection sooner

I opted to add a STATIC_ORIGIN setting as opposed to trying to parse it out of STATIC_URL (which also contains the resource path). This means we'll need to add a config option before this is enabled.. An alternative could be to always assume https://, but I didnt want to assume anything 😅

