### PR TITLE
feat(insights): update `useModuleUrl` to always take you to a domain view

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -265,7 +265,7 @@ function Sidebar() {
     </Feature>
   );
 
-  const moduleURLBuilder = useModuleURLBuilder(true, false);
+  const moduleURLBuilder = useModuleURLBuilder(true);
 
   const queries = hasOrganization && (
     <Feature key="db" features="insights-entry-points" organization={organization}>

--- a/static/app/views/insights/common/utils/useModuleURL.tsx
+++ b/static/app/views/insights/common/utils/useModuleURL.tsx
@@ -16,6 +16,7 @@ import {
   type DomainView,
   useDomainViewFilters,
 } from 'sentry/views/insights/pages/useFilters';
+import {getModuleView} from 'sentry/views/insights/pages/utils';
 import {BASE_URL as QUEUE_BASE_URL} from 'sentry/views/insights/queues/settings';
 import {INSIGHTS_BASE_URL} from 'sentry/views/insights/settings';
 import {ModuleName} from 'sentry/views/insights/types';
@@ -42,22 +43,18 @@ export type RoutableModuleNames = Exclude<ModuleNameStrings, '' | 'other'>;
 export const useModuleURL = (
   moduleName: RoutableModuleNames,
   bare: boolean = false,
-  view?: DomainView
+  view?: DomainView // Todo - this should be required when a module belongs to multiple views
 ): string => {
-  const forceDomainView = Boolean(view);
-  const builder = useModuleURLBuilder(bare, true, forceDomainView);
+  const builder = useModuleURLBuilder(bare);
   return builder(moduleName, view);
 };
 
 type URLBuilder = (moduleName: RoutableModuleNames, domainView?: DomainView) => string;
 
-export function useModuleURLBuilder(
-  bare: boolean = false,
-  autoDetectDomainView: boolean = true,
-  forceDomainView?: boolean // TODO - eventually this param will be removed once we don't have modules in two spots
-): URLBuilder {
+export function useModuleURLBuilder(bare: boolean = false): URLBuilder {
   const organization = useOrganization({allowNull: true}); // Some parts of the app, like the main sidebar, render even if the organization isn't available (during loading, or at all).
-  const {isInDomainView, view: currentView} = useDomainViewFilters();
+  const hasDomainViewFeature = organization?.features.includes('insights-domain-view');
+  const {view: currentView} = useDomainViewFilters();
 
   if (!organization) {
     // If there isn't an organization, items that link to modules won't be visible, so this is a fallback just-in-case, and isn't trying too hard to be useful
@@ -66,9 +63,9 @@ export function useModuleURLBuilder(
 
   const {slug} = organization;
 
-  if ((autoDetectDomainView && isInDomainView) || forceDomainView) {
+  if (hasDomainViewFeature) {
     return function (moduleName: RoutableModuleNames, domainView?: DomainView) {
-      const view = domainView ?? currentView;
+      const view = domainView ?? currentView ?? getModuleView(moduleName as ModuleName);
       return bare
         ? `${DOMAIN_VIEW_BASE_URL}/${view}/${MODULE_BASE_URLS[moduleName]}`
         : normalizeUrl(
@@ -77,6 +74,7 @@ export function useModuleURLBuilder(
     };
   }
 
+  // TODO - delete this block once the domain view feature is fully rolled out
   return function (moduleName: RoutableModuleNames) {
     return bare
       ? `${INSIGHTS_BASE_URL}/${MODULE_BASE_URLS[moduleName]}`

--- a/static/app/views/insights/pages/ai/aiPageHeader.tsx
+++ b/static/app/views/insights/pages/ai/aiPageHeader.tsx
@@ -3,13 +3,13 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {
   AI_LANDING_SUB_PATH,
   AI_LANDING_TITLE,
+  MODULES,
 } from 'sentry/views/insights/pages/ai/settings';
 import {
   DomainViewHeader,
   type Props as HeaderProps,
 } from 'sentry/views/insights/pages/domainViewHeader';
 import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
-import {ModuleName} from 'sentry/views/insights/types';
 
 type Props = {
   headerTitle: HeaderProps['headerTitle'];
@@ -34,14 +34,12 @@ export function AiHeader({
     `/organizations/${slug}/${DOMAIN_VIEW_BASE_URL}/${AI_LANDING_SUB_PATH}/`
   );
 
-  const modules = [ModuleName.AI];
-
   return (
     <DomainViewHeader
       domainBaseUrl={aiBaseUrl}
       headerTitle={headerTitle}
       domainTitle={AI_LANDING_TITLE}
-      modules={modules}
+      modules={MODULES}
       selectedModule={module}
       additonalHeaderActions={headerActions}
       additionalBreadCrumbs={breadcrumbs}

--- a/static/app/views/insights/pages/ai/settings.ts
+++ b/static/app/views/insights/pages/ai/settings.ts
@@ -1,4 +1,7 @@
 import {t} from 'sentry/locale';
+import {ModuleName} from 'sentry/views/insights/types';
 
 export const AI_LANDING_SUB_PATH = 'ai';
 export const AI_LANDING_TITLE = t('AI');
+
+export const MODULES = [ModuleName.AI];

--- a/static/app/views/insights/pages/backend/backendPageHeader.tsx
+++ b/static/app/views/insights/pages/backend/backendPageHeader.tsx
@@ -3,13 +3,13 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {
   BACKEND_LANDING_SUB_PATH,
   BACKEND_LANDING_TITLE,
+  MODULES,
 } from 'sentry/views/insights/pages/backend/settings';
 import {
   DomainViewHeader,
   type Props as HeaderProps,
 } from 'sentry/views/insights/pages/domainViewHeader';
 import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
-import {ModuleName} from 'sentry/views/insights/types';
 
 type Props = {
   headerTitle: HeaderProps['headerTitle'];
@@ -34,7 +34,6 @@ export function BackendHeader({
   const backendBaseUrl = normalizeUrl(
     `/organizations/${slug}/${DOMAIN_VIEW_BASE_URL}/${BACKEND_LANDING_SUB_PATH}/`
   );
-  const modules = [ModuleName.DB, ModuleName.HTTP, ModuleName.CACHE, ModuleName.QUEUE];
 
   return (
     <DomainViewHeader
@@ -42,7 +41,7 @@ export function BackendHeader({
       domainTitle={BACKEND_LANDING_TITLE}
       headerTitle={headerTitle}
       additonalHeaderActions={headerActions}
-      modules={modules}
+      modules={MODULES}
       selectedModule={module}
       additionalBreadCrumbs={breadcrumbs}
       tabs={tabs}

--- a/static/app/views/insights/pages/backend/settings.ts
+++ b/static/app/views/insights/pages/backend/settings.ts
@@ -1,4 +1,12 @@
 import {t} from 'sentry/locale';
+import {ModuleName} from 'sentry/views/insights/types';
 
 export const BACKEND_LANDING_SUB_PATH = 'backend';
 export const BACKEND_LANDING_TITLE = t('Backend');
+
+export const MODULES = [
+  ModuleName.DB,
+  ModuleName.HTTP,
+  ModuleName.CACHE,
+  ModuleName.QUEUE,
+];

--- a/static/app/views/insights/pages/frontend/frontendPageHeader.tsx
+++ b/static/app/views/insights/pages/frontend/frontendPageHeader.tsx
@@ -7,9 +7,9 @@ import {
 import {
   FRONTEND_LANDING_SUB_PATH,
   FRONTEND_LANDING_TITLE,
+  MODULES,
 } from 'sentry/views/insights/pages/frontend/settings';
 import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
-import {ModuleName} from 'sentry/views/insights/types';
 
 type Props = {
   headerTitle: HeaderProps['headerTitle'];
@@ -35,13 +35,11 @@ export function FrontendHeader({
     `/organizations/${slug}/${DOMAIN_VIEW_BASE_URL}/${FRONTEND_LANDING_SUB_PATH}/`
   );
 
-  const modules = [ModuleName.VITAL, ModuleName.HTTP, ModuleName.RESOURCE];
-
   return (
     <DomainViewHeader
       domainBaseUrl={frontendBaseUrl}
       domainTitle={FRONTEND_LANDING_TITLE}
-      modules={modules}
+      modules={MODULES}
       selectedModule={module}
       additionalBreadCrumbs={breadcrumbs}
       additonalHeaderActions={headerActions}

--- a/static/app/views/insights/pages/frontend/settings.ts
+++ b/static/app/views/insights/pages/frontend/settings.ts
@@ -1,4 +1,5 @@
 import {t} from 'sentry/locale';
+import {ModuleName} from 'sentry/views/insights/types';
 
 export const FRONTEND_LANDING_SUB_PATH = 'frontend';
 export const FRONTEND_LANDING_TITLE = t('Frontend');
@@ -9,3 +10,5 @@ export const OVERVIEW_PAGE_ALLOWED_OPS = [
   'ui.render',
   'interaction',
 ];
+
+export const MODULES = [ModuleName.VITAL, ModuleName.HTTP, ModuleName.RESOURCE];

--- a/static/app/views/insights/pages/mobile/settings.ts
+++ b/static/app/views/insights/pages/mobile/settings.ts
@@ -1,4 +1,5 @@
 import {t} from 'sentry/locale';
+import {ModuleName} from 'sentry/views/insights/types';
 
 export const MOBILE_LANDING_SUB_PATH = 'mobile';
 export const MOBILE_LANDING_TITLE = t('Mobile');
@@ -12,4 +13,12 @@ export const OVERVIEW_PAGE_ALLOWED_OPS = [
   // navigation and pageload are seen in react-native
   'navigation',
   'pageload',
+];
+
+export const MODULES = [
+  ModuleName.APP_START,
+  ModuleName.SCREEN_LOAD,
+  ModuleName.SCREEN_RENDERING,
+  ModuleName.MOBILE_SCREENS,
+  ModuleName.MOBILE_UI,
 ];

--- a/static/app/views/insights/pages/settings.ts
+++ b/static/app/views/insights/pages/settings.ts
@@ -1,4 +1,17 @@
 import {t} from 'sentry/locale';
+import {MODULES as AI_MODULES} from 'sentry/views/insights/pages/ai/settings';
+import {MODULES as BACKEND_MODULES} from 'sentry/views/insights/pages/backend/settings';
+import {MODULES as FRONTEND_MODULES} from 'sentry/views/insights/pages/frontend/settings';
+import {MODULES as MOBILE_MODULES} from 'sentry/views/insights/pages/mobile/settings';
+import type {DomainView} from 'sentry/views/insights/pages/useFilters';
+import type {ModuleName} from 'sentry/views/insights/types';
 
 export const OVERVIEW_PAGE_TITLE = t('Overview');
 export const DOMAIN_VIEW_BASE_URL = 'performance';
+
+export const DOMAIN_VIEW_MODULES: Record<DomainView, ModuleName[]> = {
+  frontend: FRONTEND_MODULES,
+  backend: BACKEND_MODULES,
+  ai: AI_MODULES,
+  mobile: MOBILE_MODULES,
+};

--- a/static/app/views/insights/pages/utils.ts
+++ b/static/app/views/insights/pages/utils.ts
@@ -13,6 +13,9 @@ export const isModuleEnabled = (module: ModuleName, organization: Organization) 
 };
 
 export const getModuleView = (module: ModuleName): DomainView => {
+  if (DOMAIN_VIEW_MODULES.backend.includes(module)) {
+    return 'backend';
+  }
   if (DOMAIN_VIEW_MODULES.frontend.includes(module)) {
     return 'frontend';
   }

--- a/static/app/views/insights/pages/utils.ts
+++ b/static/app/views/insights/pages/utils.ts
@@ -1,7 +1,8 @@
-import type {ModuleName} from 'webpack-cli';
-
 import type {Organization} from 'sentry/types/organization';
+import {DOMAIN_VIEW_MODULES} from 'sentry/views/insights/pages/settings';
+import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import {MODULE_FEATURE_MAP} from 'sentry/views/insights/settings';
+import type {ModuleName} from 'sentry/views/insights/types';
 
 export const isModuleEnabled = (module: ModuleName, organization: Organization) => {
   const moduleFeatures: string[] | undefined = MODULE_FEATURE_MAP[module];
@@ -9,4 +10,17 @@ export const isModuleEnabled = (module: ModuleName, organization: Organization) 
     return false;
   }
   return moduleFeatures.every(feature => organization.features.includes(feature));
+};
+
+export const getModuleView = (module: ModuleName): DomainView => {
+  if (DOMAIN_VIEW_MODULES.frontend.includes(module)) {
+    return 'frontend';
+  }
+  if (DOMAIN_VIEW_MODULES.mobile.includes(module)) {
+    return 'mobile';
+  }
+  if (DOMAIN_VIEW_MODULES.ai.includes(module)) {
+    return 'ai';
+  }
+  return 'backend';
 };

--- a/static/app/views/performance/landing/widgets/widgets/performanceScoreWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/performanceScoreWidget.tsx
@@ -32,7 +32,7 @@ export function PerformanceScoreWidget(props: PerformanceWidgetProps) {
   const ringSegmentColors = theme.charts.getColorPalette(3);
   const ringBackgroundColors = ringSegmentColors.map(color => `${color}50`);
 
-  const moduleURL = useModuleURL('vital');
+  const moduleURL = useModuleURL('vital', false);
 
   return (
     <GenericPerformanceWidget

--- a/static/app/views/performance/landing/widgets/widgets/performanceScoreWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/performanceScoreWidget.tsx
@@ -32,7 +32,7 @@ export function PerformanceScoreWidget(props: PerformanceWidgetProps) {
   const ringSegmentColors = theme.charts.getColorPalette(3);
   const ringBackgroundColors = ringSegmentColors.map(color => `${color}50`);
 
-  const moduleURL = useModuleURL('vital', false);
+  const moduleURL = useModuleURL('vital');
 
   return (
     <GenericPerformanceWidget


### PR DESCRIPTION
Work for #77572 

Now that we are further along in diving performance by domains, we should ensure all url's to modules end up within a domain view (meaning under `/performance/frontend`, `/performance/backend`). This PR makes the necessary changes to do so

**useModuleUrlBuilder changes**
- The props `forceDomainView` is gone, all module urls should go to domain views now if the feature flag is on
- A prop `detectDomainView` is introduced, which controls whether the domain view should be determined from the url (in cases like the trace view where they might end up at a backend module from a frontend trace, we wouldn't want any auto detection)
- getModuleView is used to determine which domain applies to which module, as all but HTTP module only has one domain view, we can directly determine this. For this PR, http will always go to backend, in the future, we should determine wether we should go to backend or frontend based on the project.