### PR TITLE
ref(utils): Refactor and fix types in `CircuitBreaker`

### DIFF
--- a/src/sentry/utils/circuit_breaker2.py
+++ b/src/sentry/utils/circuit_breaker2.py
@@ -366,21 +366,6 @@ class CircuitBreaker:
 
         return controlling_quota_by_state[_state]
 
-    @overload
-    def _get_remaining_error_quota(self, quota: None, window_end: int | None) -> None: ...
-
-    @overload
-    def _get_remaining_error_quota(self, quota: Quota, window_end: int | None) -> int: ...
-
-    @overload
-    def _get_remaining_error_quota(self, quota: None) -> None: ...
-
-    @overload
-    def _get_remaining_error_quota(self, quota: Quota) -> int: ...
-
-    @overload
-    def _get_remaining_error_quota(self) -> int | None: ...
-
     def _get_remaining_error_quota(
         self, quota: Quota | None = None, window_end: int | None = None
     ) -> int:

--- a/src/sentry/utils/circuit_breaker2.py
+++ b/src/sentry/utils/circuit_breaker2.py
@@ -345,6 +345,12 @@ class CircuitBreaker:
     @overload
     def _get_controlling_quota(self) -> Quota | None: ...
 
+    @overload
+    def _get_controlling_quota(self, state: CircuitBreakerState) -> Quota | None: ...
+
+    @overload
+    def _get_controlling_quota(self, state: None) -> Quota | None: ...
+
     def _get_controlling_quota(self, state: CircuitBreakerState | None = None) -> Quota | None:
         """
         Return the Quota corresponding to the given breaker state (or the current breaker state, if


### PR DESCRIPTION
This is a small refactor the `CircuitBreaker` class to enable an upcoming PR to typecheck successfully. The only internal behavior change is the return value of `_get_remaining_error_quota`, and there are no external behavior changes.

Included changes:

- Refactor `should_allow_request` to gather false cases, meaning we won't have to log the same metric twice.

- Add two extra overloads of `_get_controlling_quota`. (Not entirely clear why this was necessary, but the main `CircuitBreakerState | None` type on the `state` input somehow didn't count as allowing for a `CircuitBreakerState` to be passed in.)

- Rather than returning `None` from `_get_remaining_error_quota` when in broken state, return `-1`. This in turn allows the function typing to be much simpler (no overloads needed), since it now always returns an int.