### PR TITLE
fix(DropdownMenu): Use navigate instead of click event

### DIFF
--- a/static/app/components/dropdownMenu/index.spec.tsx
+++ b/static/app/components/dropdownMenu/index.spec.tsx
@@ -290,4 +290,37 @@ describe('DropdownMenu', function () {
     });
     expect(onAction).toHaveBeenCalledTimes(1);
   });
+
+  it('navigates to link on meta key', async function () {
+    const onAction = jest.fn();
+    const router = RouterFixture();
+    const user = userEvent.setup();
+
+    const errorFn = jest.fn();
+    jest.spyOn(console, 'error').mockImplementation(errorFn);
+
+    render(
+      <DropdownMenu
+        items={[
+          {key: 'item1', label: 'Item One', to: '/test'},
+          {key: 'item2', label: 'Item Two', to: '/test2', onAction},
+        ]}
+        triggerLabel="Menu"
+      />,
+      {router}
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Menu'}));
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard('[MetaLeft>]'); // Press meta key without releasing
+    await user.keyboard('{Enter}');
+    await user.keyboard('[/MetaLeft]'); // Release meta key
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+    // JSDOM throws an error on navigation to random urls
+    expect(errorFn).toHaveBeenCalledTimes(1);
+
+    // eslint-disable-next-line no-console
+    jest.mocked(console.error).mockRestore();
+  });
 });

--- a/static/app/components/dropdownMenu/index.spec.tsx
+++ b/static/app/components/dropdownMenu/index.spec.tsx
@@ -296,8 +296,7 @@ describe('DropdownMenu', function () {
     const router = RouterFixture();
     const user = userEvent.setup();
 
-    const errorFn = jest.fn();
-    jest.spyOn(console, 'error').mockImplementation(errorFn);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     render(
       <DropdownMenu
@@ -318,9 +317,9 @@ describe('DropdownMenu', function () {
 
     expect(onAction).toHaveBeenCalledTimes(1);
     // JSDOM throws an error on navigation to random urls
-    expect(errorFn).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
 
     // eslint-disable-next-line no-console
-    jest.mocked(console.error).mockRestore();
+    errorSpy.mockRestore();
   });
 });

--- a/static/app/components/dropdownMenu/index.spec.tsx
+++ b/static/app/components/dropdownMenu/index.spec.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -263,5 +264,30 @@ describe('DropdownMenu', function () {
     await waitFor(() => {
       expect(screen.queryByRole('menuitemradio')).not.toBeInTheDocument();
     });
+  });
+
+  it('navigates to link on enter', async function () {
+    const onAction = jest.fn();
+    const router = RouterFixture();
+    render(
+      <DropdownMenu
+        items={[
+          {key: 'item1', label: 'Item One', to: '/test'},
+          {key: 'item2', label: 'Item Two', to: '/test2', onAction},
+        ]}
+        triggerLabel="Menu"
+      />,
+      {router}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Menu'}));
+    await userEvent.keyboard('{ArrowDown}');
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => {
+      expect(router.push).toHaveBeenCalledWith(
+        expect.objectContaining({pathname: '/test2'})
+      );
+    });
+    expect(onAction).toHaveBeenCalledTimes(1);
   });
 });

--- a/static/app/components/dropdownMenu/item.tsx
+++ b/static/app/components/dropdownMenu/item.tsx
@@ -8,7 +8,9 @@ import type {LocationDescriptor} from 'history';
 
 import Link from 'sentry/components/links/link';
 import type {MenuListItemProps} from 'sentry/components/menuListItem';
-import MenuListItem from 'sentry/components/menuListItem';
+import MenuListItem, {
+  InnerWrap as MenuListItemInnerWrap,
+} from 'sentry/components/menuListItem';
 import {IconChevron} from 'sentry/icons';
 import mergeRefs from 'sentry/utils/mergeRefs';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -166,6 +168,18 @@ function BaseDropdownMenuItem(
   const {keyboardProps} = useKeyboard({
     onKeyDown: e => {
       if (e.key === 'Enter' && to) {
+        // If the user is holding down the meta key, we want to dispatch a mouse event
+        if (e.metaKey || e.ctrlKey) {
+          const mouseEvent = new MouseEvent('click', {
+            ctrlKey: e.ctrlKey,
+            metaKey: e.metaKey,
+          });
+          ref.current
+            ?.querySelector(`${MenuListItemInnerWrap}`)
+            ?.dispatchEvent(mouseEvent);
+          return;
+        }
+
         navigate(to);
         return;
       }

--- a/static/app/components/dropdownMenu/item.tsx
+++ b/static/app/components/dropdownMenu/item.tsx
@@ -8,11 +8,10 @@ import type {LocationDescriptor} from 'history';
 
 import Link from 'sentry/components/links/link';
 import type {MenuListItemProps} from 'sentry/components/menuListItem';
-import MenuListItem, {
-  InnerWrap as MenuListItemInnerWrap,
-} from 'sentry/components/menuListItem';
+import MenuListItem from 'sentry/components/menuListItem';
 import {IconChevron} from 'sentry/icons';
 import mergeRefs from 'sentry/utils/mergeRefs';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import usePrevious from 'sentry/utils/usePrevious';
 
 import {DropdownMenuContext} from './list';
@@ -119,6 +118,7 @@ function BaseDropdownMenuItem(
     node.value ?? {};
   const {size} = node.props;
   const {rootOverlayState} = useContext(DropdownMenuContext);
+  const navigate = useNavigate();
 
   const actionHandler = () => {
     if (to) {
@@ -166,11 +166,7 @@ function BaseDropdownMenuItem(
   const {keyboardProps} = useKeyboard({
     onKeyDown: e => {
       if (e.key === 'Enter' && to) {
-        const mouseEvent = new MouseEvent('click', {
-          ctrlKey: e.ctrlKey,
-          metaKey: e.metaKey,
-        });
-        ref.current?.querySelector(`${MenuListItemInnerWrap}`)?.dispatchEvent(mouseEvent);
+        navigate(to);
         return;
       }
 

--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -317,7 +317,7 @@ function getTextColor({
   }
 }
 
-export const InnerWrap = styled('div', {
+const InnerWrap = styled('div', {
   shouldForwardProp: prop =>
     typeof prop === 'string' &&
     isPropValid(prop) &&

--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -317,7 +317,7 @@ function getTextColor({
   }
 }
 
-const InnerWrap = styled('div', {
+export const InnerWrap = styled('div', {
   shouldForwardProp: prop =>
     typeof prop === 'string' &&
     isPropValid(prop) &&


### PR DESCRIPTION
fixes a bug where using "enter" did a full page reload when navigating to the new page

using the enter key on a dropdown with "to" should:
- not do a full page refresh when navigating
- allow cmd+enter to open the link in a new tab