### PR TITLE
fix(autofix): Change color to fix dark mode

### DIFF
--- a/static/app/components/events/autofix/autofixMessageBox.tsx
+++ b/static/app/components/events/autofix/autofixMessageBox.tsx
@@ -481,7 +481,7 @@ const Container = styled('div')`
   bottom: 0;
   left: 0;
   right: 0;
-  background: white;
+  background: ${p => p.theme.backgroundElevated};
   z-index: 100;
   border-top: 1px solid ${p => p.theme.border};
   box-shadow: ${p => p.theme.dropShadowHeavy};


### PR DESCRIPTION
The message box was hardcoded as white. Change it to use a background color from the theme so it adapts to dark mode.