### PR TITLE
feat(workflow_engine): Implement basic evaluation method with de-duping for stateful detectors

### DIFF
--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -15,7 +15,7 @@ from sentry.backup.scopes import RelocationScope
 from sentry.db.models import DefaultFieldsModel, FlexibleForeignKey, region_silo_model
 from sentry.issues import grouptype
 from sentry.models.owner_base import OwnerModel
-from sentry.utils import redis
+from sentry.utils import metrics, redis
 from sentry.utils.iterators import chunked
 from sentry.workflow_engine.models import DataPacket
 from sentry.workflow_engine.models.detector_state import DetectorState
@@ -196,6 +196,54 @@ class StatefulDetectorHandler(DetectorHandler[T], abc.ABC):
                 counter_updates=counter_updates[gk],
             )
         return results
+
+    def evaluate(self, data_packet: DataPacket[T]) -> list[DetectorEvaluationResult]:
+        """
+        Evaluates a given data packet and returns a list of `DetectorEvaluationResult`.
+        There will be one result for each group key result in the packet, unless the
+        evaluation is skipped due to various rules.
+        """
+        dedupe_value = self.get_dedupe_value(data_packet)
+        group_values = self.get_group_key_values(data_packet)
+        all_state_data = self.get_state_data(group_values.keys())
+        results = []
+        for group_key, group_value in group_values.items():
+            result = self.evaluate_group_key_value(
+                group_key, group_value, all_state_data[group_key], dedupe_value
+            )
+            if result:
+                results.append(result)
+        return results
+
+    def evaluate_group_key_value(
+        self, group_key: str, value: int, state_data: DetectorStateData, dedupe_value: int
+    ) -> DetectorEvaluationResult | None:
+        """
+        Evaluates a value associated with a given `group_key` and returns a `DetectorEvaluationResult` with the results
+        and any state changes that need to be made.
+
+        Checks that we haven't already processed this datapacket for this group_key, and skips evaluation if we have.
+        """
+        if dedupe_value <= state_data.dedupe_value:
+            # TODO: Does it actually make more sense to just do this at the data packet level rather than the group
+            # key level?
+            metrics.incr("workflow_engine.detector.skipping_already_processed_update")
+            return
+
+        return DetectorEvaluationResult(
+            False,
+            DetectorPriorityLevel.OK,
+            {},
+            DetectorStateData(
+                group_key=group_key,
+                active=False,
+                status=DetectorPriorityLevel.OK,
+                dedupe_value=dedupe_value,
+                # TODO: We'll increment and change these later, but for now they don't change so just pass an empty dict
+                # so we no-op
+                counter_updates={},
+            ),
+        )
 
     def build_dedupe_value_key(self, group_key: str | None) -> str:
         if group_key is None:

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -205,7 +205,7 @@ class StatefulDetectorHandler(DetectorHandler[T], abc.ABC):
         """
         dedupe_value = self.get_dedupe_value(data_packet)
         group_values = self.get_group_key_values(data_packet)
-        all_state_data = self.get_state_data(group_values.keys())
+        all_state_data = self.get_state_data(list(group_values.keys()))
         results = []
         for group_key, group_value in group_values.items():
             result = self.evaluate_group_key_value(
@@ -228,7 +228,7 @@ class StatefulDetectorHandler(DetectorHandler[T], abc.ABC):
             # TODO: Does it actually make more sense to just do this at the data packet level rather than the group
             # key level?
             metrics.incr("workflow_engine.detector.skipping_already_processed_update")
-            return
+            return None
 
         return DetectorEvaluationResult(
             False,

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -216,7 +216,7 @@ class StatefulDetectorHandler(DetectorHandler[T], abc.ABC):
         return results
 
     def evaluate_group_key_value(
-        self, group_key: str, value: int, state_data: DetectorStateData, dedupe_value: int
+        self, group_key: str | None, value: int, state_data: DetectorStateData, dedupe_value: int
     ) -> DetectorEvaluationResult | None:
         """
         Evaluates a value associated with a given `group_key` and returns a `DetectorEvaluationResult` with the results

--- a/tests/sentry/workflow_engine/models/test_detector.py
+++ b/tests/sentry/workflow_engine/models/test_detector.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.cases import TestCase
@@ -16,14 +17,11 @@ from sentry.workflow_engine.types import DetectorPriorityLevel
 class MockDetectorStateHandler(StatefulDetectorHandler[dict]):
     counter_names = ["test1", "test2"]
 
-    def evaluate(self, data_packet: DataPacket[dict]) -> list[DetectorEvaluationResult]:
-        return []
-
     def get_dedupe_value(self, data_packet: DataPacket[dict]) -> int:
-        return 0
+        return data_packet.get("dedupe", 0)
 
     def get_group_key_values(self, data_packet: DataPacket[dict]) -> dict[str, int]:
-        return {}
+        return data_packet.get("group_vals", {})
 
 
 class TestKeyBuilders(unittest.TestCase):
@@ -174,3 +172,100 @@ class TestCommitStateUpdateData(StatefulDetectorHandlerTestMixin):
         assert redis.get(dedupe_key) == "150"
         assert not redis.exists(counter_key_1)
         assert redis.get(counter_key_2) == "20"
+
+
+class TestEvaluate(StatefulDetectorHandlerTestMixin):
+    def test(self):
+        handler = self.build_handler()
+        assert handler.evaluate({"dedupe": 1}) == []
+        assert handler.evaluate({"dedupe": 2, "group_vals": {"val1": 0}}) == [
+            DetectorEvaluationResult(
+                is_active=False,
+                priority=DetectorPriorityLevel.OK,
+                data={},
+                state_update_data=DetectorStateData(
+                    group_key="val1",
+                    active=False,
+                    status=DetectorPriorityLevel.OK,
+                    dedupe_value=2,
+                    counter_updates={},
+                ),
+            )
+        ]
+
+    def test_dedupe(self):
+        handler = self.build_handler()
+        result = handler.evaluate({"dedupe": 2, "group_vals": {"val1": 0}})
+        assert result == [
+            DetectorEvaluationResult(
+                is_active=False,
+                priority=DetectorPriorityLevel.OK,
+                data={},
+                state_update_data=DetectorStateData(
+                    group_key="val1",
+                    active=False,
+                    status=DetectorPriorityLevel.OK,
+                    dedupe_value=2,
+                    counter_updates={},
+                ),
+            )
+        ]
+        handler.commit_state_update_data([r.state_update_data for r in result])
+        with mock.patch("sentry.workflow_engine.models.detector.metrics") as mock_metrics:
+            assert handler.evaluate({"dedupe": 2, "group_vals": {"val1": 0}}) == []
+            assert not mock_metrics.incr.assert_called_once_with(
+                "workflow_engine.detector.skipping_already_processed_update"
+            )
+
+
+class TestEvaluateGroupKeyValue(StatefulDetectorHandlerTestMixin):
+
+    def test_dedupe(self):
+        handler = self.build_handler()
+        with mock.patch("sentry.workflow_engine.models.detector.metrics") as mock_metrics:
+            expected_result = DetectorEvaluationResult(
+                False,
+                DetectorPriorityLevel.OK,
+                {},
+                DetectorStateData(
+                    "group_key",
+                    False,
+                    DetectorPriorityLevel.OK,
+                    100,
+                    {},
+                ),
+            )
+            assert (
+                handler.evaluate_group_key_value(
+                    expected_result.state_update_data.group_key,
+                    1,
+                    DetectorStateData(
+                        "group_key",
+                        False,
+                        DetectorPriorityLevel.OK,
+                        99,
+                        {},
+                    ),
+                    dedupe_value=100,
+                )
+                == expected_result
+            )
+            assert not mock_metrics.incr.called
+            assert (
+                handler.evaluate_group_key_value(
+                    expected_result.state_update_data.group_key,
+                    1,
+                    DetectorStateData(
+                        "group_key",
+                        False,
+                        DetectorPriorityLevel.OK,
+                        100,
+                        {},
+                    ),
+                    dedupe_value=100,
+                )
+                is None
+            )
+            assert not mock_metrics.incr.assert_called_once_with(
+                "workflow_engine.detector.skipping_already_processed_update"
+            )


### PR DESCRIPTION
This implements a barebone evaluate method for stateful detectors. All it does is load up the state for the packet being evaluated and performs the de-dupe check. For completeness it returns results that aren't meaningful yet.

<!-- Describe your PR here. -->