### PR TITLE
ref(quick-start): Update 'track release' link

### DIFF
--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -469,7 +469,7 @@ export function getOnboardingTasks({
       skippable: true,
       requisites: [OnboardingTaskKey.FIRST_PROJECT, OnboardingTaskKey.FIRST_EVENT],
       actionType: 'app',
-      location: `/settings/${organization.slug}/projects/:projectId/release-tracking/`,
+      location: `/organizations/${organization.slug}/releases/`,
       display: true,
       group: OnboardingTaskGroup.GETTING_STARTED,
     },


### PR DESCRIPTION
when users click on "Track releases", they should go to the releases page

https://github.com/user-attachments/assets/5b9cca0d-7e74-4b35-881d-e58c853faaba


closes https://github.com/getsentry/projects/issues/334