### PR TITLE
ref(quick-start): Add missing bottom left illustration

### DIFF
--- a/static/app/components/onboardingWizard/newSidebar.tsx
+++ b/static/app/components/onboardingWizard/newSidebar.tsx
@@ -461,7 +461,6 @@ const TaskActions = styled('div')`
   gap: ${space(1)};
 `;
 
-// We modify the position of this image to be rendered on the bottom left of the sidebar
 const BottomLeft = styled('img')`
   width: 60%;
   transform: rotate(180deg);

--- a/static/app/components/onboardingWizard/newSidebar.tsx
+++ b/static/app/components/onboardingWizard/newSidebar.tsx
@@ -4,6 +4,8 @@ import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
 import partition from 'lodash/partition';
 
+import HighlightTopRight from 'sentry-images/pattern/highlight-top-right.svg';
+
 import {navigateTo} from 'sentry/actionCreators/navigation';
 import {updateOnboardingTask} from 'sentry/actionCreators/onboardingTasks';
 import {Button} from 'sentry/components/button';
@@ -341,6 +343,7 @@ export function NewOnboardingSidebar({
           />
         )}
       </Content>
+      <BottomLeft src={HighlightTopRight} />
     </Wrapper>
   );
 }
@@ -357,6 +360,7 @@ const Content = styled('div')`
   display: flex;
   flex-direction: column;
   gap: ${space(1)};
+  flex: 1;
 
   p {
     margin-bottom: ${space(1)};
@@ -455,4 +459,11 @@ const TaskActions = styled('div')`
   display: flex;
   flex-direction: column;
   gap: ${space(1)};
+`;
+
+// We modify the position of this image to be rendered on the bottom left of the sidebar
+const BottomLeft = styled('img')`
+  width: 60%;
+  transform: rotate(180deg);
+  margin-top: ${space(3)};
 `;


### PR DESCRIPTION
closes https://github.com/getsentry/projects/issues/330

<img width="680" alt="Screenshot 2024-10-29 at 10 42 16" src="https://github.com/user-attachments/assets/4a647819-2b6c-4d6a-8117-be06f2d6bc68">
