### PR TITLE
feat(issue-details): Add release data to streamline graph

### DIFF
--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
@@ -38,6 +38,10 @@ describe('EventDetailsHeader', () => {
       body: TagsFixture(),
       method: 'GET',
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/stats/`,
+      body: [],
+    });
     PageFiltersStore.init();
     PageFiltersStore.onInitializeUrlState(
       {

--- a/static/app/views/issueDetails/streamline/eventGraph.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.spec.tsx
@@ -34,6 +34,10 @@ describe('EventGraph', () => {
       body: TagsFixture(),
       method: 'GET',
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/stats/`,
+      body: [],
+    });
     PageFiltersStore.init();
     PageFiltersStore.onInitializeUrlState(
       {

--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -164,14 +164,14 @@ export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
 
   const legend = Legend({
     theme: theme,
-    icon: 'path://M 10 10 H 500 V 9000 H 10 L 10 10',
     orient: 'horizontal',
     align: 'left',
     show: true,
-    top: 8,
+    top: 4,
     right: 95,
     data: ['Releases', 'Feature Flags'],
     selected: legendSelected,
+    zlevel: 10,
   });
 
   const onLegendSelectChanged = useMemo(
@@ -250,7 +250,7 @@ export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
           grid={{
             left: 8,
             right: 8,
-            top: 12,
+            top: 20,
             bottom: 0,
           }}
           yAxis={{

--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -27,6 +27,7 @@ import {
   useIssueDetailsDiscoverQuery,
   useIssueDetailsEventView,
 } from 'sentry/views/issueDetails/streamline/useIssueDetailsDiscoverQuery';
+import {useReleaseMarkLineSeries} from 'sentry/views/issueDetails/streamline/useReleaseMarkLineSeries';
 
 export const enum EventGraphSeries {
   EVENT = 'event',
@@ -101,6 +102,7 @@ export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
     saveOnZoom: true,
   });
 
+  const releaseSeries = useReleaseMarkLineSeries({group});
   const flagSeries = useFlagSeries({
     query: {
       start: eventView.start,
@@ -141,16 +143,21 @@ export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
       });
     }
 
+    if (releaseSeries.markLine) {
+      seriesData.push(releaseSeries as BarChartSeries);
+    }
+
     if (flagSeries.markLine) {
       seriesData.push(flagSeries as BarChartSeries);
     }
 
     return seriesData;
-  }, [visibleSeries, userSeries, eventSeries, flagSeries, theme]);
+  }, [visibleSeries, userSeries, eventSeries, releaseSeries, flagSeries, theme]);
 
   const [legendSelected, setLegendSelected] = useLocalStorageState(
     'issue-details-graph-legend',
     {
+      ['Releases']: true,
       ['Feature Flags']: true,
     }
   );
@@ -163,7 +170,7 @@ export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
     show: true,
     top: 8,
     right: 95,
-    data: ['Feature Flags'],
+    data: ['Releases', 'Feature Flags'],
     selected: legendSelected,
   });
 

--- a/static/app/views/issueDetails/streamline/flagSeries.tsx
+++ b/static/app/views/issueDetails/streamline/flagSeries.tsx
@@ -70,7 +70,7 @@ export default function useFlagSeries({query = {}, event, group}: FlagSeriesProp
   const markLine = MarkLine({
     animation: false,
     lineStyle: {
-      color: theme.purple300,
+      color: theme.blue300,
       opacity: 0.3,
       type: 'solid',
     },

--- a/static/app/views/issueDetails/streamline/flagSeries.tsx
+++ b/static/app/views/issueDetails/streamline/flagSeries.tsx
@@ -105,6 +105,7 @@ export default function useFlagSeries({query = {}, event, group}: FlagSeriesProp
   return {
     seriesName: t('Feature Flags'),
     data: [],
+    color: theme.blue200,
     markLine,
     type: 'line', // use this type so the bar chart doesn't shrink/grow
   };

--- a/static/app/views/issueDetails/streamline/groupDetailsLayout.spec.tsx
+++ b/static/app/views/issueDetails/streamline/groupDetailsLayout.spec.tsx
@@ -30,6 +30,10 @@ describe('GroupDetailsLayout', () => {
       body: {},
     });
     MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/stats/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/${group.id}/attachments/`,
       body: [],
     });

--- a/static/app/views/issueDetails/streamline/useReleaseMarkLineSeries.tsx
+++ b/static/app/views/issueDetails/streamline/useReleaseMarkLineSeries.tsx
@@ -102,6 +102,7 @@ export function useReleaseMarkLineSeries({group}: {group: Group}) {
     seriesName: t('Releases'),
     data: [],
     markLine,
+    color: theme.purple200,
     type: 'line',
   };
 }

--- a/static/app/views/issueDetails/streamline/useReleaseMarkLineSeries.tsx
+++ b/static/app/views/issueDetails/streamline/useReleaseMarkLineSeries.tsx
@@ -1,0 +1,107 @@
+import {useTheme} from '@emotion/react';
+
+import MarkLine from 'sentry/components/charts/components/markLine';
+import {t} from 'sentry/locale';
+import type {Group} from 'sentry/types/group';
+import {escape} from 'sentry/utils';
+import {getFormattedDate} from 'sentry/utils/dates';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+import {formatVersion} from 'sentry/utils/versions/formatVersion';
+import {useIssueDetailsEventView} from 'sentry/views/issueDetails/streamline/useIssueDetailsDiscoverQuery';
+
+interface ReleaseStat {
+  date: string;
+  version: string;
+}
+
+export function useReleaseMarkLineSeries({group}: {group: Group}) {
+  const navigate = useNavigate();
+  const theme = useTheme();
+  const eventView = useIssueDetailsEventView({group});
+  const organization = useOrganization();
+  const {
+    data: releases = [],
+    isPending: isLoadingReleases,
+    error: releasesError,
+  } = useApiQuery<ReleaseStat[]>(
+    [
+      `/organizations/${organization.slug}/releases/stats/`,
+      {
+        query: {
+          project: eventView.project,
+          environment: eventView.environment,
+          start: eventView.start,
+          end: eventView.end,
+          statsPeriod: eventView.statsPeriod,
+        },
+      },
+    ],
+    {
+      staleTime: 0,
+    }
+  );
+
+  if (isLoadingReleases || releasesError) {
+    return {
+      seriesName: t('Releases'),
+      markLine: {},
+      data: [],
+    };
+  }
+
+  const markLine = MarkLine({
+    animation: false,
+    lineStyle: {
+      color: theme.purple300,
+      opacity: 0.3,
+      type: 'solid',
+    },
+    label: {
+      show: false,
+    },
+    data: releases.map(release => ({
+      xAxis: +new Date(release.date),
+      name: formatVersion(release.version, true),
+      value: formatVersion(release.version, true),
+      onClick: () => {
+        navigate({
+          pathname: `/organizations/${
+            organization.slug
+          }/releases/${encodeURIComponent(release.version)}/`,
+        });
+      },
+      label: {
+        formatter: () => formatVersion(release.version, true),
+      },
+    })),
+    tooltip: {
+      trigger: 'item',
+      formatter: ({data}: any) => {
+        const time = getFormattedDate(data.value, 'MMM D, YYYY LT', {
+          local: !eventView.utc,
+        });
+        const version = escape(formatVersion(data.name, true));
+        return [
+          '<div class="tooltip-series">',
+          `<div><span class="tooltip-label"><strong>${t(
+            'Release'
+          )}</strong></span> ${version}</div>`,
+          '</div>',
+          '<div class="tooltip-footer">',
+          time,
+          '</div>',
+          '<div class="tooltip-arrow"></div>',
+        ].join('');
+      },
+    },
+  });
+
+  return {
+    seriesName: t('Releases'),
+    data: [],
+    markLine,
+    type: 'line',
+  };
+}


### PR DESCRIPTION
Allows both release and feature flag data to appear on the graph. Since discover already had releases as purple, I switched feature flags over to a blue series. I also removed the icon override to match what's on discover, and changed the margins a bit so it wasn't difficult to toggle the series

<img width="1140" alt="image" src="https://github.com/user-attachments/assets/afabd70d-0267-4165-ab17-1f1ccc273da0">
