### PR TITLE
chore(issues): Update `usesIssuePlatform` for performance issues

### DIFF
--- a/static/app/utils/issueTypeConfig/performanceConfig.tsx
+++ b/static/app/utils/issueTypeConfig/performanceConfig.tsx
@@ -30,7 +30,7 @@ const performanceConfig: IssueCategoryConfigMapping = {
     userFeedback: {enabled: false},
     // Performance issues render a custom SpanEvidence component
     evidence: null,
-    usesIssuePlatform: false,
+    usesIssuePlatform: true,
   },
   [IssueType.PERFORMANCE_CONSECUTIVE_DB_QUERIES]: {
     resources: {

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -28,7 +28,7 @@ import IssueListCacheStore from 'sentry/stores/IssueListCacheStore';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group, GroupStatusResolution, MarkReviewed} from 'sentry/types/group';
-import {GroupStatus, GroupSubstatus, IssueCategory} from 'sentry/types/group';
+import {GroupStatus, GroupSubstatus} from 'sentry/types/group';
 import type {Organization, SavedQueryVersions} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -115,9 +115,6 @@ export function Actions(props: Props) {
   const getDiscoverUrl = () => {
     const {title, type, shortId} = group;
 
-    const groupIsOccurrenceBacked =
-      group.issueCategory === IssueCategory.PERFORMANCE && !!event?.occurrence;
-
     const discoverQuery = {
       id: undefined,
       name: title || type,
@@ -127,10 +124,7 @@ export function Actions(props: Props) {
       projects: [Number(project.id)],
       version: 2 as SavedQueryVersions,
       range: '90d',
-      dataset:
-        config.usesIssuePlatform || groupIsOccurrenceBacked
-          ? DiscoverDatasets.ISSUE_PLATFORM
-          : undefined,
+      dataset: config.usesIssuePlatform ? DiscoverDatasets.ISSUE_PLATFORM : undefined,
     };
 
     const discoverView = EventView.fromSavedQuery(discoverQuery);

--- a/static/app/views/issueDetails/allEventsTable.tsx
+++ b/static/app/views/issueDetails/allEventsTable.tsx
@@ -59,10 +59,7 @@ function AllEventsTable(props: Props) {
   const groupIsOccurrenceBacked = !!data?.occurrence;
 
   const eventView: EventView = EventView.fromLocation(props.location);
-  if (
-    config.usesIssuePlatform ||
-    (group.issueCategory === IssueCategory.PERFORMANCE && groupIsOccurrenceBacked)
-  ) {
+  if (config.usesIssuePlatform) {
     eventView.dataset = DiscoverDatasets.ISSUE_PLATFORM;
   }
   eventView.fields = fields.map(fieldName => ({field: fieldName}));


### PR DESCRIPTION
When the migration from transaction backing to occurrence backing is complete, this was likely missed because of the shim code. Resolves that, and as a bonus, fixes the graphs on the new issue details pages:

**Before**
<img width="1179" alt="image" src="https://github.com/user-attachments/assets/e3977ad2-3c73-42ef-8412-50d175aa14dd">

**After**
<img width="1196" alt="image" src="https://github.com/user-attachments/assets/0e65f5f4-a0ec-4f13-a86d-701b2214a246">
