### PR TITLE
feat(issue-details): Update Downtime data section

### DIFF
--- a/static/app/components/events/interfaces/uptime/uptimeDataSection.tsx
+++ b/static/app/components/events/interfaces/uptime/uptimeDataSection.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import {LinkButton} from 'sentry/components/button';
 import {DateTime} from 'sentry/components/dateTime';
 import Duration from 'sentry/components/duration';
-import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconSettings} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -14,6 +13,8 @@ import {type Group, GroupActivityType, GroupStatus} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOrganization from 'sentry/utils/useOrganization';
+import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
+import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 
 interface Props {
   event: Event;
@@ -66,10 +67,11 @@ export function UptimeDataSection({group, event, project}: Props) {
   const alertRuleId = event.tags.find(tag => tag.key === 'uptime_rule')?.value;
 
   return (
-    <EventDataSection
+    <InterimSection
       title={t('Downtime Information')}
-      type="downtime"
+      type={SectionKey.DOWNTIME}
       help={t('Information about the detected downtime')}
+      preventCollapse
       actions={
         alertRuleId !== undefined && (
           <LinkButton
@@ -91,7 +93,7 @@ export function UptimeDataSection({group, event, project}: Props) {
         : tct('Domain has been down for [duration]', {
             duration,
           })}
-    </EventDataSection>
+    </InterimSection>
   );
 }
 

--- a/static/app/views/issueDetails/streamline/context.tsx
+++ b/static/app/views/issueDetails/streamline/context.tsx
@@ -17,6 +17,7 @@ export const enum SectionKey {
   LLM_MONITORING = 'llm-monitoring',
 
   UPTIME = 'uptime', // Only Uptime issues
+  DOWNTIME = 'downtime',
   CRON_TIMELINE = 'cron-timeline', // Only Cron issues
 
   HIGHLIGHTS = 'highlights',

--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -138,7 +138,7 @@ export const FoldSection = forwardRef<HTMLElement, FoldSectionProps>(function Fo
           />
           <TitleWithActions>
             <TitleWrapper>{title}</TitleWrapper>
-            {!preventCollapse && !isCollapsed && (
+            {!isCollapsed && (
               <div
                 onClick={e => e.stopPropagation()}
                 onMouseEnter={() => setIsLayerEnabled(false)}

--- a/static/app/views/issueDetails/streamline/interimSection.tsx
+++ b/static/app/views/issueDetails/streamline/interimSection.tsx
@@ -18,9 +18,9 @@ import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
  */
 export const InterimSection = forwardRef<
   HTMLElement,
-  EventDataSectionProps & Pick<FoldSectionProps, 'initialCollapse'>
+  EventDataSectionProps & Pick<FoldSectionProps, 'initialCollapse' | 'preventCollapse'>
 >(function InterimSection(
-  {children, title, type, actions = null, initialCollapse, ...props},
+  {children, title, type, actions = null, initialCollapse, preventCollapse, ...props},
   ref
 ) {
   const hasStreamlinedUI = useHasStreamlinedUI();
@@ -32,6 +32,7 @@ export const InterimSection = forwardRef<
       actions={actions}
       ref={ref}
       initialCollapse={initialCollapse}
+      preventCollapse={preventCollapse}
     >
       {children}
     </FoldSection>


### PR DESCRIPTION
Updates the downtime section for uptime issues. Since it was a single line and feels very important, I opted not to make it collapsible.

**Before**
<img width="1169" alt="image" src="https://github.com/user-attachments/assets/bed5b12a-116d-48f2-8506-f7b46e14e9df">


**After**
<img width="1170" alt="image" src="https://github.com/user-attachments/assets/4ebc5706-6a76-42a8-91ea-a7b25a6d9053">
