### PR TITLE
feat(insights): remove mobile from mobile module routes

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1592,6 +1592,14 @@ function buildRoutes() {
           )}
         />
       </Route>
+      <Redirect
+        from="mobile/app-startup/"
+        to={`/${INSIGHTS_BASE_URL}/${MODULE_BASE_URLS[ModuleName.APP_START]}/`}
+      />
+      <Redirect
+        from="mobile/screens/"
+        to={`/${INSIGHTS_BASE_URL}/${MODULE_BASE_URLS[ModuleName.SCREEN_LOAD]}/`}
+      />
       <Route path={`${MODULE_BASE_URLS[ModuleName.AI]}/`}>
         <IndexRoute
           component={make(

--- a/static/app/views/insights/mobile/appStarts/components/tables/spanOperationTable.spec.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/tables/spanOperationTable.spec.tsx
@@ -94,7 +94,7 @@ describe('SpanOpSelector', function () {
 
     expect(screen.getByRole('link', {name: 'Application Init'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/insights/mobile/app-startup/spans/?spanDescription=Application%20Init&spanGroup=7f4be68f08c0455f&spanOp=app.start.warm&transaction=foo-bar'
+      '/organizations/org-slug/insights/app-startup/spans/?spanDescription=Application%20Init&spanGroup=7f4be68f08c0455f&spanOp=app.start.warm&transaction=foo-bar'
     );
   });
 

--- a/static/app/views/insights/mobile/appStarts/settings.ts
+++ b/static/app/views/insights/mobile/appStarts/settings.ts
@@ -1,7 +1,7 @@
 import {t} from 'sentry/locale';
 
 export const MODULE_TITLE = t('App Starts');
-export const BASE_URL = 'mobile/app-startup';
+export const BASE_URL = 'app-startup';
 export const DATA_TYPE = t('App Start');
 export const DATA_TYPE_PLURAL = t('App Starts');
 

--- a/static/app/views/insights/mobile/screenload/settings.ts
+++ b/static/app/views/insights/mobile/screenload/settings.ts
@@ -1,7 +1,7 @@
 import {t} from 'sentry/locale';
 
 export const MODULE_TITLE = t('Screen Loads');
-export const BASE_URL = 'mobile/screens';
+export const BASE_URL = 'screens';
 export const DATA_TYPE = t('Screen Load');
 export const DATA_TYPE_PLURAL = t('Screen Loads');
 

--- a/static/app/views/insights/mobile/screens/settings.ts
+++ b/static/app/views/insights/mobile/screens/settings.ts
@@ -2,7 +2,7 @@ import {t} from 'sentry/locale';
 
 export const MODULE_TITLE = t('Mobile Screens');
 // TBD, existing screen load modules uses 'screens' already
-export const BASE_URL = 'mobile/mobile-screens';
+export const BASE_URL = 'mobile-screens';
 
 export const MODULE_DESCRIPTION = t("Improve your application's responsiveness.");
 

--- a/static/app/views/insights/mobile/ui/settings.ts
+++ b/static/app/views/insights/mobile/ui/settings.ts
@@ -1,7 +1,7 @@
 import {t} from 'sentry/locale';
 
 export const MODULE_TITLE = t('Mobile UI');
-export const BASE_URL = 'mobile/ui';
+export const BASE_URL = 'ui';
 
 export const MODULE_DESCRIPTION = t("Improve your application's responsiveness.");
 


### PR DESCRIPTION
Work for #77572 
Domain views automatically have `/mobile` in the url, so we should remove `/mobile` from the front of any module base urls. 

This prevents module urls such as `/performance/mobile/mobile/app-startup`

I only added redirects for app starts and screen loads, as the other mobile module's aren't released yet