### PR TITLE
feat(insights): update web vitals and resource module routes to exclude browser

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1945,6 +1945,14 @@ function buildRoutes() {
         from="browser/resources"
         to={`/${INSIGHTS_BASE_URL}/${MODULE_BASE_URLS[ModuleName.RESOURCE]}/`}
       />
+      <Redirect
+        from="browser/assets"
+        to={`/${INSIGHTS_BASE_URL}/${MODULE_BASE_URLS[ModuleName.RESOURCE]}/`}
+      />
+      <Redirect
+        from="browser/pageloads"
+        to={`/${INSIGHTS_BASE_URL}/${MODULE_BASE_URLS[ModuleName.VITAL]}/`}
+      />
       <Route
         path=":eventSlug/"
         component={make(() => import('sentry/views/performance/transactionDetails'))}

--- a/static/app/views/insights/browser/resources/settings.ts
+++ b/static/app/views/insights/browser/resources/settings.ts
@@ -5,7 +5,7 @@ import {ResourceSpanOps} from 'sentry/views/insights/browser/resources/types';
 export const MODULE_TITLE = t('Assets');
 export const DATA_TYPE = t('Asset');
 export const DATA_TYPE_PLURAL = t('Assets');
-export const BASE_URL = 'browser/assets'; // Name of the data shown (singular)
+export const BASE_URL = 'assets'; // Name of the data shown (singular)
 export const MODULE_DESCRIPTION = t(
   'Find large and slow-to-load resources used by your application and understand their impact on page performance.'
 );

--- a/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.spec.tsx
@@ -147,7 +147,7 @@ describe('PagePerformanceTable', function () {
     expect(screen.getByRole('cell', {name: '/insights/browser/'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: '/insights/browser/'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/insights/browser/pageloads/overview/?project=11276&transaction=%2Finsights%2Fbrowser%2F'
+      '/organizations/org-slug/insights/pageloads/overview/?project=11276&transaction=%2Finsights%2Fbrowser%2F'
     );
 
     expect(screen.getByRole('cell', {name: 'frontend'})).toBeInTheDocument();

--- a/static/app/views/insights/browser/webVitals/settings.ts
+++ b/static/app/views/insights/browser/webVitals/settings.ts
@@ -1,7 +1,7 @@
 import {t} from 'sentry/locale';
 
 export const MODULE_TITLE = t('Web Vitals');
-export const BASE_URL = 'browser/pageloads';
+export const BASE_URL = 'pageloads';
 export const DATA_TYPE = t('Web Vitals');
 export const DATA_TYPE_PLURAL = t('Web Vitals');
 

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -959,7 +959,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
     );
     expect(await screen.findByRole('button', {name: 'View All'})).toHaveAttribute(
       'href',
-      '/insights/browser/assets/'
+      '/insights/assets/'
     );
     expect(eventsMock).toHaveBeenCalledTimes(1);
     expect(eventsMock).toHaveBeenNthCalledWith(


### PR DESCRIPTION
Work for https://github.com/getsentry/sentry/issues/77572
Similiar to https://github.com/getsentry/sentry/pull/79906

Domain views automatically have /frontend in the url, so we should remove /browser from the front of any module base urls.

This prevents module urls such as `/performance/frontend/browser/pageloads`.

This PR applies to the resource module and web vitals module
