### PR TITLE
feat(insights): update overview page tab title for domain view

### DIFF
--- a/static/app/views/insights/pages/ai/aiPageHeader.tsx
+++ b/static/app/views/insights/pages/ai/aiPageHeader.tsx
@@ -3,6 +3,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {
   AI_LANDING_SUB_PATH,
   AI_LANDING_TITLE,
+  AI_OVERVIEW_PAGE_TITLE,
 } from 'sentry/views/insights/pages/ai/settings';
 import {
   DomainViewHeader,
@@ -39,6 +40,7 @@ export function AiHeader({
   return (
     <DomainViewHeader
       domainBaseUrl={aiBaseUrl}
+      domainOverviewPageTitle={AI_OVERVIEW_PAGE_TITLE}
       headerTitle={headerTitle}
       domainTitle={AI_LANDING_TITLE}
       modules={modules}

--- a/static/app/views/insights/pages/ai/settings.ts
+++ b/static/app/views/insights/pages/ai/settings.ts
@@ -2,3 +2,4 @@ import {t} from 'sentry/locale';
 
 export const AI_LANDING_SUB_PATH = 'ai';
 export const AI_LANDING_TITLE = t('AI');
+export const AI_OVERVIEW_PAGE_TITLE = t('AI Performance');

--- a/static/app/views/insights/pages/backend/backendPageHeader.tsx
+++ b/static/app/views/insights/pages/backend/backendPageHeader.tsx
@@ -3,6 +3,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {
   BACKEND_LANDING_SUB_PATH,
   BACKEND_LANDING_TITLE,
+  BACKEND_OVERVIEW_PAGE_TITLE,
 } from 'sentry/views/insights/pages/backend/settings';
 import {
   DomainViewHeader,
@@ -39,6 +40,7 @@ export function BackendHeader({
   return (
     <DomainViewHeader
       domainBaseUrl={backendBaseUrl}
+      domainOverviewPageTitle={BACKEND_OVERVIEW_PAGE_TITLE}
       domainTitle={BACKEND_LANDING_TITLE}
       headerTitle={headerTitle}
       additonalHeaderActions={headerActions}

--- a/static/app/views/insights/pages/backend/settings.ts
+++ b/static/app/views/insights/pages/backend/settings.ts
@@ -2,3 +2,4 @@ import {t} from 'sentry/locale';
 
 export const BACKEND_LANDING_SUB_PATH = 'backend';
 export const BACKEND_LANDING_TITLE = t('Backend');
+export const BACKEND_OVERVIEW_PAGE_TITLE = t('Backend Performance');

--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -13,11 +13,11 @@ import {
   type RoutableModuleNames,
   useModuleURLBuilder,
 } from 'sentry/views/insights/common/utils/useModuleURL';
-import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
 import type {ModuleName} from 'sentry/views/insights/types';
 
 export type Props = {
   domainBaseUrl: string;
+  domainOverviewPageTitle: string;
   domainTitle: string;
   headerTitle: React.ReactNode;
   modules: ModuleName[];
@@ -37,6 +37,7 @@ export function DomainViewHeader({
   modules,
   headerTitle,
   domainTitle,
+  domainOverviewPageTitle,
   selectedModule,
   hideDefaultTabs,
   additonalHeaderActions,
@@ -61,7 +62,7 @@ export function DomainViewHeader({
       preservePageFilters: true,
     },
     {
-      label: selectedModule ? moduleTitles[selectedModule] : OVERVIEW_PAGE_TITLE,
+      label: selectedModule ? moduleTitles[selectedModule] : domainOverviewPageTitle,
       to: selectedModule
         ? `${moduleURLBuilder(selectedModule as RoutableModuleNames)}/`
         : domainBaseUrl,
@@ -72,14 +73,14 @@ export function DomainViewHeader({
 
   const showModuleTabs = organization.features.includes('insights-entry-points');
 
-  const defaultHandleTabChange = (key: ModuleName | typeof OVERVIEW_PAGE_TITLE) => {
-    if (key === selectedModule || (key === OVERVIEW_PAGE_TITLE && !module)) {
+  const defaultHandleTabChange = (key: ModuleName | typeof domainOverviewPageTitle) => {
+    if (key === selectedModule || (key === domainOverviewPageTitle && !module)) {
       return;
     }
     if (!key) {
       return;
     }
-    if (key === OVERVIEW_PAGE_TITLE) {
+    if (key === domainOverviewPageTitle) {
       navigate(domainBaseUrl);
       return;
     }
@@ -87,15 +88,17 @@ export function DomainViewHeader({
   };
 
   const tabValue =
-    hideDefaultTabs && tabs?.value ? tabs.value : selectedModule ?? OVERVIEW_PAGE_TITLE;
+    hideDefaultTabs && tabs?.value
+      ? tabs.value
+      : selectedModule ?? domainOverviewPageTitle;
 
   const handleTabChange =
     hideDefaultTabs && tabs ? tabs.onTabChange : defaultHandleTabChange;
 
   const tabList: Tab[] = [
     {
-      key: OVERVIEW_PAGE_TITLE,
-      label: OVERVIEW_PAGE_TITLE,
+      key: domainOverviewPageTitle,
+      label: domainOverviewPageTitle,
     },
   ];
 

--- a/static/app/views/insights/pages/frontend/frontendPageHeader.tsx
+++ b/static/app/views/insights/pages/frontend/frontendPageHeader.tsx
@@ -7,6 +7,7 @@ import {
 import {
   FRONTEND_LANDING_SUB_PATH,
   FRONTEND_LANDING_TITLE,
+  FRONTEND_OVERVIEW_PAGE_TITLE,
 } from 'sentry/views/insights/pages/frontend/settings';
 import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
 import {ModuleName} from 'sentry/views/insights/types';
@@ -41,6 +42,7 @@ export function FrontendHeader({
     <DomainViewHeader
       domainBaseUrl={frontendBaseUrl}
       domainTitle={FRONTEND_LANDING_TITLE}
+      domainOverviewPageTitle={FRONTEND_OVERVIEW_PAGE_TITLE}
       modules={modules}
       selectedModule={module}
       additionalBreadCrumbs={breadcrumbs}

--- a/static/app/views/insights/pages/frontend/settings.ts
+++ b/static/app/views/insights/pages/frontend/settings.ts
@@ -2,6 +2,7 @@ import {t} from 'sentry/locale';
 
 export const FRONTEND_LANDING_SUB_PATH = 'frontend';
 export const FRONTEND_LANDING_TITLE = t('Frontend');
+export const FRONTEND_OVERVIEW_PAGE_TITLE = t('Frontend Performance');
 
 export const OVERVIEW_PAGE_ALLOWED_OPS = [
   'pageload',

--- a/static/app/views/insights/pages/mobile/mobilePageHeader.tsx
+++ b/static/app/views/insights/pages/mobile/mobilePageHeader.tsx
@@ -7,6 +7,7 @@ import {
 import {
   MOBILE_LANDING_SUB_PATH,
   MOBILE_LANDING_TITLE,
+  MOBILE_OVERVIEW_PAGE_TITLE,
 } from 'sentry/views/insights/pages/mobile/settings';
 import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
 import {isModuleEnabled} from 'sentry/views/insights/pages/utils';
@@ -50,6 +51,7 @@ export function MobileHeader({
     <DomainViewHeader
       domainBaseUrl={mobileBaseUrl}
       domainTitle={MOBILE_LANDING_TITLE}
+      domainOverviewPageTitle={MOBILE_OVERVIEW_PAGE_TITLE}
       headerTitle={headerTitle}
       modules={modules}
       selectedModule={module}

--- a/static/app/views/insights/pages/mobile/settings.ts
+++ b/static/app/views/insights/pages/mobile/settings.ts
@@ -2,6 +2,7 @@ import {t} from 'sentry/locale';
 
 export const MOBILE_LANDING_SUB_PATH = 'mobile';
 export const MOBILE_LANDING_TITLE = t('Mobile');
+export const MOBILE_OVERVIEW_PAGE_TITLE = t('Mobile Performance');
 
 export const OVERVIEW_PAGE_ALLOWED_OPS = [
   'ui.action.swipe',


### PR DESCRIPTION
Work for #77572 

Rather then "overview", we say "frontend performance" in the domain view tabs
<img width="867" alt="image" src="https://github.com/user-attachments/assets/dcb5cf80-b898-41d7-ac7e-c76bf2db78d8">