### PR TITLE
feat(query-builder): Omit the clear action when empty

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -244,7 +244,7 @@ describe('SearchQueryBuilder', function () {
       await waitFor(() => expect(mockOnChange).toHaveBeenCalled());
 
       expect(
-        screen.queryByRole('button', {name: 'Clear search query'})
+        screen.getByRole('button', {name: 'Clear search query'})
       ).toBeInTheDocument();
     });
   });

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -221,6 +221,33 @@ describe('SearchQueryBuilder', function () {
         screen.queryByRole('button', {name: 'Clear search query'})
       ).not.toBeInTheDocument();
     });
+
+    it('is hidden if the prop is specified and text is empty', async function () {
+      const mockOnChange = jest.fn();
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          onChange={mockOnChange}
+          hideClearWhenEmpty
+        />
+      );
+      // Must await something to prevent act warnings
+      await act(tick);
+
+      expect(
+        screen.queryByRole('button', {name: 'Clear search query'})
+      ).not.toBeInTheDocument();
+      await userEvent.type(
+        screen.getByRole('combobox', {name: 'Add a search term'}),
+        'foo a:b{enter}'
+      );
+
+      await waitFor(() => expect(mockOnChange).toHaveBeenCalled());
+
+      expect(
+        screen.queryByRole('button', {name: 'Clear search query'})
+      ).toBeInTheDocument();
+    });
   });
 
   describe('disabled', function () {

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -231,8 +231,7 @@ describe('SearchQueryBuilder', function () {
           hideClearWhenEmpty
         />
       );
-      // Must await something to prevent act warnings
-      await act(tick);
+      await screen.findByRole('combobox', {name: 'Add a search term'});
 
       expect(
         screen.queryByRole('button', {name: 'Clear search query'})

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -224,13 +224,7 @@ describe('SearchQueryBuilder', function () {
 
     it('is hidden if the prop is specified and text is empty', async function () {
       const mockOnChange = jest.fn();
-      render(
-        <SearchQueryBuilder
-          {...defaultProps}
-          onChange={mockOnChange}
-          hideClearWhenEmpty
-        />
-      );
+      render(<SearchQueryBuilder {...defaultProps} onChange={mockOnChange} />);
       await screen.findByRole('combobox', {name: 'Add a search term'});
 
       expect(

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -83,6 +83,10 @@ export interface SearchQueryBuilderProps {
    */
   filterKeySections?: FilterKeySection[];
   /**
+   * When true, the clear query button will be hidden when the query is empty.
+   */
+  hideClearWhenEmpty?: boolean;
+  /**
    * Allows for customization of the invalid token messages.
    */
   invalidMessages?: SearchConfig['invalidMessages'];
@@ -143,31 +147,32 @@ function SearchIndicator({
   );
 }
 
-const ActionButtons = forwardRef<HTMLDivElement, {trailingItems?: React.ReactNode}>(
-  ({trailingItems = null}, ref) => {
-    const {dispatch, handleSearch, disabled} = useSearchQueryBuilder();
+const ActionButtons = forwardRef<
+  HTMLDivElement,
+  {hideClearWhenEmpty?: boolean; trailingItems?: React.ReactNode}
+>(({trailingItems = null, hideClearWhenEmpty = false}, ref) => {
+  const {dispatch, handleSearch, disabled, query} = useSearchQueryBuilder();
 
-    if (disabled) {
-      return null;
-    }
-
-    return (
-      <ButtonsWrapper ref={ref}>
-        {trailingItems}
-        <ActionButton
-          aria-label={t('Clear search query')}
-          size="zero"
-          icon={<IconClose />}
-          borderless
-          onClick={() => {
-            dispatch({type: 'CLEAR'});
-            handleSearch('');
-          }}
-        />
-      </ButtonsWrapper>
-    );
+  if (disabled || (hideClearWhenEmpty && query === '')) {
+    return null;
   }
-);
+
+  return (
+    <ButtonsWrapper ref={ref}>
+      {trailingItems}
+      <ActionButton
+        aria-label={t('Clear search query')}
+        size="zero"
+        icon={<IconClose />}
+        borderless
+        onClick={() => {
+          dispatch({type: 'CLEAR'});
+          handleSearch('');
+        }}
+      />
+    </ButtonsWrapper>
+  );
+});
 
 export function SearchQueryBuilder({
   className,
@@ -187,6 +192,7 @@ export function SearchQueryBuilder({
   onChange,
   onSearch,
   onBlur,
+  hideClearWhenEmpty = false,
   placeholder,
   queryInterface = QueryInterfaceType.TOKENIZED,
   recentSearches,
@@ -305,7 +311,11 @@ export function SearchQueryBuilder({
             <TokenizedQueryGrid label={label} actionBarWidth={actionBarWidth} />
           )}
           {size !== 'small' && (
-            <ActionButtons ref={actionBarRef} trailingItems={trailingItems} />
+            <ActionButtons
+              ref={actionBarRef}
+              trailingItems={trailingItems}
+              hideClearWhenEmpty={hideClearWhenEmpty}
+            />
           )}
         </PanelProvider>
       </Wrapper>

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -83,10 +83,6 @@ export interface SearchQueryBuilderProps {
    */
   filterKeySections?: FilterKeySection[];
   /**
-   * When true, the clear query button will be hidden when the query is empty.
-   */
-  hideClearWhenEmpty?: boolean;
-  /**
    * Allows for customization of the invalid token messages.
    */
   invalidMessages?: SearchConfig['invalidMessages'];
@@ -147,32 +143,33 @@ function SearchIndicator({
   );
 }
 
-const ActionButtons = forwardRef<
-  HTMLDivElement,
-  {hideClearWhenEmpty?: boolean; trailingItems?: React.ReactNode}
->(({trailingItems = null, hideClearWhenEmpty = false}, ref) => {
-  const {dispatch, handleSearch, disabled, query} = useSearchQueryBuilder();
+const ActionButtons = forwardRef<HTMLDivElement, {trailingItems?: React.ReactNode}>(
+  ({trailingItems = null}, ref) => {
+    const {dispatch, handleSearch, disabled, query} = useSearchQueryBuilder();
 
-  if (disabled || (hideClearWhenEmpty && query === '')) {
-    return null;
+    if (disabled) {
+      return null;
+    }
+
+    return (
+      <ButtonsWrapper ref={ref}>
+        {trailingItems}
+        {query === '' ? null : (
+          <ActionButton
+            aria-label={t('Clear search query')}
+            size="zero"
+            icon={<IconClose />}
+            borderless
+            onClick={() => {
+              dispatch({type: 'CLEAR'});
+              handleSearch('');
+            }}
+          />
+        )}
+      </ButtonsWrapper>
+    );
   }
-
-  return (
-    <ButtonsWrapper ref={ref}>
-      {trailingItems}
-      <ActionButton
-        aria-label={t('Clear search query')}
-        size="zero"
-        icon={<IconClose />}
-        borderless
-        onClick={() => {
-          dispatch({type: 'CLEAR'});
-          handleSearch('');
-        }}
-      />
-    </ButtonsWrapper>
-  );
-});
+);
 
 export function SearchQueryBuilder({
   className,
@@ -192,7 +189,6 @@ export function SearchQueryBuilder({
   onChange,
   onSearch,
   onBlur,
-  hideClearWhenEmpty = false,
   placeholder,
   queryInterface = QueryInterfaceType.TOKENIZED,
   recentSearches,
@@ -311,11 +307,7 @@ export function SearchQueryBuilder({
             <TokenizedQueryGrid label={label} actionBarWidth={actionBarWidth} />
           )}
           {size !== 'small' && (
-            <ActionButtons
-              ref={actionBarRef}
-              trailingItems={trailingItems}
-              hideClearWhenEmpty={hideClearWhenEmpty}
-            />
+            <ActionButtons ref={actionBarRef} trailingItems={trailingItems} />
           )}
         </PanelProvider>
       </Wrapper>

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -66,6 +66,7 @@ export function EventDetailsHeader({
             environments={environments}
             query={searchQuery}
             queryBuilderProps={{
+              hideClearWhenEmpty: true,
               disallowFreeText: true,
             }}
           />

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -66,7 +66,6 @@ export function EventDetailsHeader({
             environments={environments}
             query={searchQuery}
             queryBuilderProps={{
-              hideClearWhenEmpty: true,
               disallowFreeText: true,
             }}
           />


### PR DESCRIPTION
~Adds `hideClearWhenEmpty` as a prop to omit the action button to clear the query if nothing has been added to the query yet.~

Omits the action button when the query is empty.