### PR TITLE
feat(dashboards): Add EAP tags

### DIFF
--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -23,7 +23,6 @@ import {
   handleOrderByReset,
 } from 'sentry/views/dashboards/datasetConfig/base';
 import {
-  filterAggregateParams,
   getCustomEventsFieldRenderer,
   getTableSortOptions,
   transformEventsResponseToSeries,
@@ -112,7 +111,6 @@ export const SpansConfig: DatasetConfig<
   // getSeriesRequest: getErrorsSeriesRequest,
   transformTable: transformEventsResponseToTable,
   transformSeries: transformEventsResponseToSeries,
-  filterAggregateParams,
   filterTableOptions,
 };
 

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -52,7 +52,7 @@ const EAP_AGGREGATIONS = ALLOWED_EXPLORE_VISUALIZE_AGGREGATES.reduce((acc, aggre
     parameters: [
       {
         kind: 'column',
-        columnTypes: ['number'],
+        columnTypes: ['number', 'string'], // Need to keep the string type for unknown values before tags are resolved
         defaultValue: 'span.duration',
         required: true,
       },
@@ -112,6 +112,7 @@ export const SpansConfig: DatasetConfig<
   transformTable: transformEventsResponseToTable,
   transformSeries: transformEventsResponseToSeries,
   filterTableOptions,
+  filterAggregateParams,
 };
 
 function getEventsTableFieldOptions(
@@ -152,6 +153,19 @@ function filterTableOptions(option: FieldValueOption) {
   // the parameter fields for aggregate functions
   if ('dataType' in option.value.meta) {
     return option.value.meta.dataType !== 'number';
+  }
+  return true;
+}
+
+function filterAggregateParams(option: FieldValueOption) {
+  // Allow for unknown values to be used for aggregate functions
+  // This supports showing the tag value even if it's not in the current
+  // set of tags.
+  if ('unknown' in option.value.meta && option.value.meta.unknown) {
+    return true;
+  }
+  if ('dataType' in option.value.meta) {
+    return option.value.meta.dataType === 'number';
   }
   return true;
 }

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/visualizationStep.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/visualizationStep.spec.tsx
@@ -87,6 +87,10 @@ function mockRequests(orgSlug: Organization['slug']) {
     method: 'GET',
     body: [],
   });
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/spans/fields/`,
+    body: [],
+  });
 
   return {eventsMock};
 }

--- a/static/app/views/dashboards/widgetBuilder/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/index.tsx
@@ -2,7 +2,9 @@ import Feature from 'sentry/components/acl/feature';
 import {Alert} from 'sentry/components/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import useOrganization from 'sentry/utils/useOrganization';
+import {SpanTagsProvider} from 'sentry/views/explore/contexts/spanTagsContext';
 
 import WidgetLegendSelectionState from '../widgetLegendSelectionState';
 
@@ -24,18 +26,20 @@ function WidgetBuilderContainer(props: WidgetBuilderProps) {
         </Layout.Page>
       )}
     >
-      <WidgetBuilder
-        {...props}
-        organization={organization}
-        widgetLegendState={
-          new WidgetLegendSelectionState({
-            location: props.location,
-            organization,
-            dashboard: props.dashboard,
-            router: props.router,
-          })
-        }
-      />
+      <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP}>
+        <WidgetBuilder
+          {...props}
+          organization={organization}
+          widgetLegendState={
+            new WidgetLegendSelectionState({
+              location: props.location,
+              organization,
+              dashboard: props.dashboard,
+              router: props.router,
+            })
+          }
+        />
+      </SpanTagsProvider>
     </Feature>
   );
 }

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
@@ -265,6 +265,10 @@ describe('WidgetBuilder', function () {
       url: '/organizations/org-slug/releases/',
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/spans/fields/`,
+      body: [],
+    });
 
     TagStore.reset();
   });
@@ -2599,10 +2603,6 @@ describe('WidgetBuilder', function () {
 
   describe('Spans Dataset', () => {
     it('queries for span tags and returns the correct data', async () => {
-      MockApiClient.addMockResponse({
-        url: `/organizations/org-slug/spans/fields/`,
-        body: [],
-      });
       MockApiClient.addMockResponse({
         url: `/organizations/org-slug/spans/fields/`,
         body: [

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
@@ -2598,7 +2598,7 @@ describe('WidgetBuilder', function () {
   });
 
   describe('Spans Dataset', () => {
-    it.only('queries for span tags and returns the correct data', async () => {
+    it('queries for span tags and returns the correct data', async () => {
       MockApiClient.addMockResponse({
         url: `/organizations/org-slug/spans/fields/`,
         body: [],

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
@@ -2596,4 +2596,84 @@ describe('WidgetBuilder', function () {
       );
     });
   });
+
+  describe('Spans Dataset', () => {
+    it.only('queries for span tags and returns the correct data', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/org-slug/spans/fields/`,
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/org-slug/spans/fields/`,
+        body: [
+          {
+            key: 'plan',
+            name: 'Plan',
+          },
+        ],
+        match: [
+          function (_url: string, options: Record<string, any>) {
+            return options.query.type === 'string';
+          },
+        ],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/org-slug/spans/fields/`,
+        body: [
+          {
+            key: 'lcp.size',
+            name: 'Lcp.Size',
+          },
+          {
+            key: 'something.else',
+            name: 'Something.Else',
+          },
+        ],
+        match: [
+          function (_url: string, options: Record<string, any>) {
+            return options.query.type === 'number';
+          },
+        ],
+      });
+
+      const dashboard = mockDashboard({
+        widgets: [
+          WidgetFixture({
+            widgetType: WidgetType.SPANS,
+            displayType: DisplayType.TABLE,
+            queries: [
+              {
+                name: 'Test Widget',
+                fields: ['count(tags[lcp.size,number])'],
+                columns: [],
+                aggregates: ['count(tags[lcp.size,number])'],
+                conditions: '',
+                orderby: '',
+              },
+            ],
+          }),
+        ],
+      });
+      renderTestComponent({
+        dashboard,
+        orgFeatures: [...defaultOrgFeatures],
+        params: {
+          widgetIndex: '0',
+        },
+      });
+
+      // Click the argument to the count() function
+      expect(await screen.findByText('lcp.size')).toBeInTheDocument();
+      await userEvent.click(screen.getByText('lcp.size'));
+
+      // The option now appears in the aggregate property dropdown
+      expect(screen.queryAllByText('lcp.size')).toHaveLength(2);
+      expect(screen.getByText('something.else')).toBeInTheDocument();
+
+      // Click count() to verify the string tag is in the dropdown
+      expect(screen.queryByText('plan')).not.toBeInTheDocument();
+      await userEvent.click(screen.getByText(`count(…)`));
+      expect(screen.getByText('plan')).toBeInTheDocument();
+    });
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -35,8 +35,6 @@ import {
   generateFieldAsString,
   getColumnsAndAggregates,
   getColumnsAndAggregatesAsStrings,
-  isAggregateField,
-  parseFunction,
 } from 'sentry/utils/discover/fields';
 import {DatasetSource} from 'sentry/utils/discover/types';
 import {isEmptyObject} from 'sentry/utils/object/isEmptyObject';
@@ -312,38 +310,7 @@ function WidgetBuilder({
   const numericSpanTags = useSpanTags('number');
   const stringSpanTags = useSpanTags('string');
   if (state.dataSet === DataSet.SPANS) {
-    const numericTagRegex = /tags\[(?<tagName>.+),number\]/;
-
-    // Inject tags that were set on the widget, but may not have been returned
-    // by the API yet or at all to avoid a blank field while no tag options match
-    const injectedTags = state.queries[0].fields?.reduce((acc, field) => {
-      if (isAggregateField(field)) {
-        const parsedFunction = parseFunction(field);
-        if (parsedFunction?.arguments[0]) {
-          const numericTagKey = parsedFunction.arguments[0];
-          return {
-            ...acc,
-            [numericTagKey]: {
-              key: numericTagKey,
-              name: numericTagKey,
-              kind: 'measurement',
-            },
-          };
-        }
-      }
-
-      return {
-        ...acc,
-        [field]: {
-          key: field,
-          name: field,
-          kind: numericTagRegex.test(field) ? 'measurement' : 'tag',
-        },
-      };
-    }, {});
-
-    // Inject the tags first so the API tags override the injected ones
-    tags = {...injectedTags, ...numericSpanTags, ...stringSpanTags};
+    tags = {...numericSpanTags, ...stringSpanTags};
   }
 
   useEffect(() => {

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilderDataset.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilderDataset.spec.tsx
@@ -276,6 +276,10 @@ describe('WidgetBuilder', function () {
       url: '/organizations/org-slug/releases/',
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/spans/fields/`,
+      body: [],
+    });
 
     TagStore.reset();
   });

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilderSortBy.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilderSortBy.spec.tsx
@@ -231,6 +231,10 @@ describe('WidgetBuilder', function () {
       url: '/organizations/org-slug/releases/',
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/spans/fields/`,
+      body: [],
+    });
 
     TagStore.reset();
   });


### PR DESCRIPTION
**Background context:**
EAP has two kinds of tags, string and numeric tags, which are used differently. String tags are used for groupings (i.e. the primary options you see in the dropdown for selecting) and numeric tags are used for the arguments to an aggregate function.

Wrap the widget builder in the span tags provider and consume the tags in the dataset config. Since we don't have a way to conditionally apply the provider well, I decided to override the tags in the root component so we pass around the correct ones to children. It would be a good improvement to only request this data for span widgets and if this tags massaging didn't have to leak out of the config, but I won't tackle that in this PR.

I've also had to write some code to allow for tags to render in the builder even if the tags endpoints haven't returned yet, or if a tag is not in the response. To do so required me to allow `string` types in aggregate parameters and filter for numbers or unknown strings. Strings are explicitly expected. If it's neither of these scenarios, I went with the liberal "show it" approach during this testing phase.

#78264 