### PR TITLE
feat(issues): Preload next/previous event

### DIFF
--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -212,7 +212,8 @@ function useEventApiQuery({
     groupId,
     eventId: eventIdUrl,
     environments,
-    recommendedEventQuery,
+    recommendedEventQuery:
+      eventIdUrl === 'recommended' ? recommendedEventQuery : undefined,
   });
 
   const isLatestOrRecommendedEvent =

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -8,7 +8,6 @@ import {
 } from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
-import omit from 'lodash/omit';
 import * as qs from 'query-string';
 
 import FloatingFeedbackWidget from 'sentry/components/feedback/widget/floatingFeedbackWidget';
@@ -40,7 +39,6 @@ import {
 } from 'sentry/utils/events';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {getAnalyicsDataForProject} from 'sentry/utils/projects';
-import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {setApiQueryData, useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import useDisableRouteAnalytics from 'sentry/utils/routeAnalytics/useDisableRouteAnalytics';
@@ -50,6 +48,7 @@ import useApi from 'sentry/utils/useApi';
 import {useDetailedProject} from 'sentry/utils/useDetailedProject';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useMemoWithPrevious} from 'sentry/utils/useMemoWithPrevious';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import useProjects from 'sentry/utils/useProjects';
@@ -66,7 +65,7 @@ import {Tab} from 'sentry/views/issueDetails/types';
 import {makeFetchGroupQueryKey, useGroup} from 'sentry/views/issueDetails/useGroup';
 import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
 import {
-  getGroupEventDetailsQueryData,
+  getGroupEventQueryKey,
   getGroupReprocessingStatus,
   markEventSeen,
   ReprocessingStatus,
@@ -202,53 +201,47 @@ function useEventApiQuery({
 }) {
   const organization = useOrganization();
   const location = useLocation<{query?: string}>();
-  const {currentTab: tab} = useGroupDetailsRoute();
   const defaultIssueEvent = useDefaultIssueEvent();
   const eventIdUrl = eventId ?? defaultIssueEvent;
   const recommendedEventQuery =
     typeof location.query.query === 'string' ? location.query.query : undefined;
-  const hasStreamlinedUI = useHasStreamlinedUI();
+  const navigate = useNavigate();
 
-  const queryKey: ApiQueryKey = [
-    `/organizations/${organization.slug}/issues/${groupId}/events/${eventIdUrl}/`,
-    {
-      query: getGroupEventDetailsQueryData({
-        environments,
-        query: recommendedEventQuery,
-      }),
-    },
-  ];
-
-  const isOnDetailsTab = tab === Tab.DETAILS;
+  const queryKey = getGroupEventQueryKey({
+    orgSlug: organization.slug,
+    groupId,
+    eventId: eventIdUrl,
+    environments,
+    recommendedEventQuery,
+  });
 
   const isLatestOrRecommendedEvent =
     eventIdUrl === 'latest' || eventIdUrl === 'recommended';
-  const latestOrRecommendedEvent = useApiQuery<Event>(queryKey, {
+  const eventQuery = useApiQuery<Event>(queryKey, {
     // Latest/recommended event will change over time, so only cache for 30 seconds
-    staleTime: 30000,
-    gcTime: 30000,
-    enabled: isLatestOrRecommendedEvent && (hasStreamlinedUI || isOnDetailsTab),
-    retry: false,
-  });
-  const otherEventQuery = useApiQuery<Event>(queryKey, {
     // Oldest/specific events will never change
-    staleTime: Infinity,
-    enabled: !isLatestOrRecommendedEvent && (hasStreamlinedUI || isOnDetailsTab),
+    staleTime: isLatestOrRecommendedEvent ? 30000 : Infinity,
     retry: false,
   });
 
   useEffect(() => {
-    if (latestOrRecommendedEvent.isError) {
+    if (isLatestOrRecommendedEvent && eventQuery.isError && location.query.query) {
       // If we get an error from the helpful event endpoint, it probably means
       // the query failed validation. We should remove the query to try again.
-      browserHistory.replace({
-        ...window.location,
-        query: omit(qs.parse(window.location.search), 'query'),
-      });
+      navigate(
+        {
+          ...location,
+          query: {
+            ...location.query,
+            query: undefined,
+          },
+        },
+        {replace: true}
+      );
     }
-  }, [latestOrRecommendedEvent.isError]);
+  }, [isLatestOrRecommendedEvent, eventQuery.isError, navigate, location]);
 
-  return isLatestOrRecommendedEvent ? latestOrRecommendedEvent : otherEventQuery;
+  return eventQuery;
 }
 
 /**

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -201,11 +201,11 @@ function useEventApiQuery({
 }) {
   const organization = useOrganization();
   const location = useLocation<{query?: string}>();
+  const navigate = useNavigate();
   const defaultIssueEvent = useDefaultIssueEvent();
   const eventIdUrl = eventId ?? defaultIssueEvent;
   const recommendedEventQuery =
     typeof location.query.query === 'string' ? location.query.query : undefined;
-  const navigate = useNavigate();
 
   const isLatestOrRecommendedEvent =
     eventIdUrl === 'latest' || eventIdUrl === 'recommended';

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -207,17 +207,17 @@ function useEventApiQuery({
     typeof location.query.query === 'string' ? location.query.query : undefined;
   const navigate = useNavigate();
 
+  const isLatestOrRecommendedEvent =
+    eventIdUrl === 'latest' || eventIdUrl === 'recommended';
+
   const queryKey = getGroupEventQueryKey({
     orgSlug: organization.slug,
     groupId,
     eventId: eventIdUrl,
     environments,
-    recommendedEventQuery:
-      eventIdUrl === 'recommended' ? recommendedEventQuery : undefined,
+    recommendedEventQuery: isLatestOrRecommendedEvent ? recommendedEventQuery : undefined,
   });
 
-  const isLatestOrRecommendedEvent =
-    eventIdUrl === 'latest' || eventIdUrl === 'recommended';
   const eventQuery = useApiQuery<Event>(queryKey, {
     // Latest/recommended event will change over time, so only cache for 30 seconds
     // Oldest/specific events will never change

--- a/static/app/views/issueDetails/streamline/eventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.tsx
@@ -116,6 +116,7 @@ export function IssueEventNavigation({event, group, query}: IssueEventNavigation
       notifyOnChangeProps: [],
     }
   );
+
   const {getReplayCountForIssue} = useReplayCountForIssues({
     statsPeriod: '90d',
   });

--- a/static/app/views/issueDetails/streamline/eventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
 import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -13,6 +13,7 @@ import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
@@ -20,7 +21,11 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
 import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
-import {useDefaultIssueEvent} from 'sentry/views/issueDetails/utils';
+import {
+  getGroupEventQueryKey,
+  useDefaultIssueEvent,
+  useEnvironmentsFromUrl,
+} from 'sentry/views/issueDetails/utils';
 
 const enum EventNavOptions {
   RECOMMENDED = 'recommended',
@@ -58,6 +63,55 @@ export function IssueEventNavigation({event, group, query}: IssueEventNavigation
   const params = useParams<{eventId?: string}>();
   const defaultIssueEvent = useDefaultIssueEvent();
   const isSmallScreen = useMedia(`(max-width: ${theme.breakpoints.small})`);
+  const [shouldPreload, setShouldPreload] = useState({next: false, previous: false});
+  const environments = useEnvironmentsFromUrl();
+
+  // Reset shouldPreload when the groupId changes
+  useEffect(() => {
+    setShouldPreload({next: false, previous: false});
+  }, [group.id]);
+
+  const handleHoverPagination = useCallback(
+    (direction: 'next' | 'previous', isEnabled: boolean) => () => {
+      if (isEnabled) {
+        setShouldPreload(prev => ({...prev, [direction]: true}));
+      }
+    },
+    []
+  );
+
+  // Prefetch next
+  useApiQuery(
+    getGroupEventQueryKey({
+      orgSlug: organization.slug,
+      groupId: group.id,
+      // Will be defined when enabled
+      eventId: event?.nextEventID!,
+      environments,
+    }),
+    {
+      enabled: shouldPreload.next && defined(event?.nextEventID),
+      staleTime: Infinity,
+      // Ignore state changes from the query
+      notifyOnChangeProps: [],
+    }
+  );
+  // Prefetch previous
+  useApiQuery(
+    getGroupEventQueryKey({
+      orgSlug: organization.slug,
+      groupId: group.id,
+      // Will be defined when enabled
+      eventId: event?.previousEventID!,
+      environments,
+    }),
+    {
+      enabled: shouldPreload.previous && defined(event?.previousEventID),
+      staleTime: Infinity,
+      // Ignore state changes from the query
+      notifyOnChangeProps: [],
+    }
+  );
 
   const selectedOption = useMemo(() => {
     if (query?.trim()) {
@@ -153,6 +207,14 @@ export function IssueEventNavigation({event, group, query}: IssueEventNavigation
                       query: {...location.query, referrer: 'previous-event'},
                     }}
                     css={grayText}
+                    onMouseEnter={handleHoverPagination(
+                      'previous',
+                      defined(event.previousEventID)
+                    )}
+                    onClick={() => {
+                      // Assume they will continue to paginate
+                      setShouldPreload({next: true, previous: true});
+                    }}
                   />
                 </Tooltip>
                 <Tooltip title={t('Next Event')} skipWrapper>
@@ -167,6 +229,14 @@ export function IssueEventNavigation({event, group, query}: IssueEventNavigation
                       query: {...location.query, referrer: 'next-event'},
                     }}
                     css={grayText}
+                    onMouseEnter={handleHoverPagination(
+                      'next',
+                      defined(event.nextEventID)
+                    )}
+                    onClick={() => {
+                      // Assume they will continue to paginate
+                      setShouldPreload({next: true, previous: true});
+                    }}
                   />
                 </Tooltip>
               </Navigation>

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -10,6 +10,7 @@ import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {Event} from 'sentry/types/event';
 import type {Group, GroupActivity, TagValue} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
+import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';
 import {useUser} from 'sentry/utils/useUser';
@@ -191,22 +192,47 @@ export function useEnvironmentsFromUrl(): string[] {
 export function getGroupEventDetailsQueryData({
   environments,
   query,
-  stacktraceOnly,
 }: {
+  query: string | undefined;
   environments?: string[];
-  query?: string;
-  stacktraceOnly?: boolean;
-} = {}): Record<string, string | string[]> {
-  const defaultParams = {
-    collapse: stacktraceOnly ? ['stacktraceOnly'] : ['fullRelease'],
-    ...(query ? {query} : {}),
+}): Record<string, string | string[]> {
+  const params: Record<string, string | string[]> = {
+    collapse: ['fullRelease'],
   };
 
-  if (!environments || environments.length === 0) {
-    return defaultParams;
+  if (query) {
+    params.query = query;
   }
 
-  return {...defaultParams, environment: environments};
+  if (environments && environments.length > 0) {
+    params.environment = environments;
+  }
+
+  return params;
+}
+
+export function getGroupEventQueryKey({
+  orgSlug,
+  groupId,
+  eventId,
+  environments,
+  recommendedEventQuery,
+}: {
+  environments: string[];
+  eventId: string;
+  groupId: string;
+  orgSlug: string;
+  recommendedEventQuery?: string;
+}): ApiQueryKey {
+  return [
+    `/organizations/${orgSlug}/issues/${groupId}/events/${eventId}/`,
+    {
+      query: getGroupEventDetailsQueryData({
+        environments,
+        query: recommendedEventQuery,
+      }),
+    },
+  ];
 }
 
 export function useHasStreamlinedUI() {


### PR DESCRIPTION
Prefetch next/previous event after hovering or clicking on event navigation. New ui only for now, however some changes will affect both views.
