### PR TITLE
ref: IconLock doesnt have an isSolid state

### DIFF
--- a/static/app/icons/iconLock.tsx
+++ b/static/app/icons/iconLock.tsx
@@ -4,7 +4,6 @@ import type {SVGIconProps} from './svgIcon';
 import {SvgIcon} from './svgIcon';
 
 interface Props extends SVGIconProps {
-  isSolid?: boolean;
   locked?: boolean;
 }
 

--- a/static/app/icons/icons.stories.tsx
+++ b/static/app/icons/icons.stories.tsx
@@ -407,17 +407,17 @@ const SECTIONS: TSection[] = [
         id: 'lock',
         groups: ['action', 'status'],
         keywords: ['secure'],
-        additionalProps: ['isSolid'],
+        additionalProps: ['locked'],
         name: 'Lock',
         defaultProps: {
-          isSolid: false,
+          locked: false,
         },
       },
       {
-        id: 'lock-isSolid',
+        id: 'lock-locked',
         name: 'Lock',
         defaultProps: {
-          isSolid: true,
+          locked: true,
         },
       },
       {


### PR DESCRIPTION
**Before**
before we were looking at the `isSolid` variant, which is not a thing.
![SCR-20241029-mwtr](https://github.com/user-attachments/assets/21295eb8-30d1-4990-9482-f9c2d07f1526)

**After**
after we see the `locked` variant instead.
![SCR-20241029-mxdx](https://github.com/user-attachments/assets/7f056447-89e0-4328-b720-acb3a27e565e)
