### PR TITLE
chore(tests): skip failing test (TestMockData::test_main_skip_default_setup)

### DIFF
--- a/tests/sentry/utils/mockdata/test_core.py
+++ b/tests/sentry/utils/mockdata/test_core.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sentry.models.broadcast import Broadcast
 from sentry.models.environment import Environment
 from sentry.models.organizationmapping import OrganizationMapping
@@ -51,6 +53,7 @@ def test_create_member() -> None:
 
 @no_silo_test  # mockdata.main works only in monolith mode
 class TestMockData(SnubaTestCase, TestCase):
+    @pytest.mark.skip(reason="Skipping for now (10/29) while we investigate")
     def test_main_skip_default_setup(self) -> None:
         self.create_user(is_superuser=True)
 


### PR DESCRIPTION
test is failing on master :C . Let's skip for now until we figure out what team owns this test and what's up with it 