### PR TITLE
feat(issues): Display event details w/ tag drawer

### DIFF
--- a/static/app/views/issueDetails/groupTagValues.spec.tsx
+++ b/static/app/views/issueDetails/groupTagValues.spec.tsx
@@ -13,7 +13,7 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import {browserHistory} from 'sentry/utils/browserHistory';
-import GroupTagValues from 'sentry/views/issueDetails/groupTagValues';
+import {GroupTagValues} from 'sentry/views/issueDetails/groupTagValues';
 
 const group = GroupFixture();
 const tags = TagsFixture();

--- a/static/app/views/issueDetails/groupTagValues.tsx
+++ b/static/app/views/issueDetails/groupTagValues.tsx
@@ -32,6 +32,10 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
+import GroupEventDetails, {
+  type GroupEventDetailsProps,
+} from 'sentry/views/issueDetails/groupEventDetails/groupEventDetails';
+import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 type RouteParams = {
   groupId: string;
@@ -97,7 +101,7 @@ function useTagQueries({
   };
 }
 
-function GroupTagValues({baseUrl, project, group, environments}: Props) {
+export function GroupTagValues({baseUrl, project, group, environments}: Props) {
   const organization = useOrganization();
   const location = useLocation();
   const {orgId, tagKey = ''} = useParams<RouteParams>();
@@ -314,7 +318,16 @@ function GroupTagValues({baseUrl, project, group, environments}: Props) {
   );
 }
 
-export default GroupTagValues;
+function GroupTagValuesRoute(props: GroupEventDetailsProps & {baseUrl: string}) {
+  const hasStreamlinedUI = useHasStreamlinedUI();
+
+  // TODO(streamlined-ui): Point the router directly to group event details
+  if (hasStreamlinedUI) {
+    return <GroupEventDetails {...props} />;
+  }
+
+  return <GroupTagValues {...props} />;
+}
 
 const TitleWrapper = styled('div')`
   display: flex;
@@ -390,3 +403,5 @@ const RightAlignColumn = styled(Column)`
 const StyledPagination = styled(Pagination)`
   margin: 0;
 `;
+
+export default GroupTagValuesRoute;

--- a/static/app/views/issueDetails/groupTags/groupTagsTab.spec.tsx
+++ b/static/app/views/issueDetails/groupTags/groupTagsTab.spec.tsx
@@ -4,7 +4,7 @@ import {TagsFixture} from 'sentry-fixture/tags';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import GroupTagsTab from './groupTagsTab';
+import {GroupTagsTab} from './groupTagsTab';
 
 describe('GroupTagsTab', function () {
   const {routerProps, router, organization} = initializeOrg();

--- a/static/app/views/issueDetails/groupTags/groupTagsTab.tsx
+++ b/static/app/views/issueDetails/groupTags/groupTagsTab.tsx
@@ -19,7 +19,11 @@ import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
 import {percent} from 'sentry/utils';
 import {useLocation} from 'sentry/utils/useLocation';
+import GroupEventDetails, {
+  type GroupEventDetailsProps,
+} from 'sentry/views/issueDetails/groupEventDetails/groupEventDetails';
 import {useGroupTags} from 'sentry/views/issueDetails/groupTags/useGroupTags';
+import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 type GroupTagsProps = {
   baseUrl: string;
@@ -38,7 +42,7 @@ type SimpleTag = {
   totalValues: number;
 };
 
-function GroupTagsTab({group, baseUrl, environments}: GroupTagsProps) {
+export function GroupTagsTab({group, baseUrl, environments}: GroupTagsProps) {
   const location = useLocation();
 
   const {
@@ -132,6 +136,21 @@ function GroupTagsTab({group, baseUrl, environments}: GroupTagsProps) {
   );
 }
 
+function GroupTagsRoute(
+  props: GroupEventDetailsProps & {baseUrl: string; environments: string[]}
+) {
+  const hasStreamlinedUI = useHasStreamlinedUI();
+
+  // TODO(streamlined-ui): Point the router to group event details
+  if (hasStreamlinedUI) {
+    return <GroupEventDetails {...props} />;
+  }
+
+  return <GroupTagsTab {...props} />;
+}
+
+export default GroupTagsRoute;
+
 const Container = styled('div')`
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
@@ -205,5 +224,3 @@ const TagBarCount = styled('div')`
   padding-right: ${space(1)};
   font-variant-numeric: tabular-nums;
 `;
-
-export default GroupTagsTab;


### PR DESCRIPTION
For streamline event details we want to display the event details when the tag drawer is open.
