### PR TITLE
fix(issues): Hide archive options in extended  menu

### DIFF
--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -435,7 +435,8 @@ export function Actions(props: Props) {
           size: 'sm',
         }}
         items={[
-          ...(isIgnored
+          // We don't hide the archive button for streamlined UI
+          ...(isIgnored || hasStreamlinedUI
             ? []
             : [
                 {


### PR DESCRIPTION
fixes archive from appearing in two places. previously we would display archive in the ... menu on smaller screens

![image](https://github.com/user-attachments/assets/e2402875-df76-48e1-816e-934052fc3e95)
