### PR TITLE
ref(crons): Prefer passing `ret_type` in croniter constructor

### DIFF
--- a/src/sentry/monitors/schedule.py
+++ b/src/sentry/monitors/schedule.py
@@ -38,8 +38,12 @@ def get_next_schedule(
     # of granularity we're able to support
 
     if schedule.type == "crontab":
-        iterator = croniter(schedule.crontab, reference_ts)
-        return iterator.get_next(datetime).replace(second=0, microsecond=0)
+        iterator = croniter(
+            expr_format=schedule.crontab,
+            start_time=reference_ts,
+            ret_type=datetime,
+        )
+        return iterator.get_next().replace(second=0, microsecond=0)
 
     if schedule.type == "interval":
         rule = rrule.rrule(
@@ -77,11 +81,12 @@ def get_prev_schedule(
     >>> 05:30
     """
     if schedule.type == "crontab":
-        return (
-            croniter(schedule.crontab, reference_ts)
-            .get_prev(datetime)
-            .replace(second=0, microsecond=0)
+        iterator = croniter(
+            expr_format=schedule.crontab,
+            start_time=reference_ts,
+            ret_type=datetime,
         )
+        return iterator.get_prev().replace(second=0, microsecond=0)
 
     if schedule.type == "interval":
         rule = rrule.rrule(


### PR DESCRIPTION
It was kind of confusing what passing `datetime` into `get_next` did
before. Now that I've read a lot more of the croniter code, I think this
makes more sense.