### PR TITLE
docs(api): Remove instability warning from project stats API endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_stats.py
+++ b/src/sentry/api/endpoints/project_stats.py
@@ -22,9 +22,6 @@ class ProjectStatsEndpoint(ProjectEndpoint, EnvironmentMixin, StatsMixin):
         Retrieve Event Counts for a Project
         ```````````````````````````````````
 
-        .. caution::
-           This endpoint may change in the future without notice.
-
         Return a set of points representing a normalized timestamp and the
         number of events seen in the period.
 


### PR DESCRIPTION
We'd like to use this endpoint, but the instability warning gave us the impression we shouldn't rely on it. However, looking at the git history, it seems like the warning is unwarranted.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
