### PR TITLE
feat(ds): Add the OrganizationSamplingProjectRatesEndpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_sampling_project_rates.py
+++ b/src/sentry/api/endpoints/organization_sampling_project_rates.py
@@ -1,3 +1,8 @@
+from collections.abc import Mapping
+from typing import Any
+
+from django.db import transaction
+from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -5,14 +10,38 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint, OrganizationPermission
+from sentry.api.paginator import OffsetPaginator
+from sentry.api.serializers import Serializer, serialize
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.project import Project
 
 OPTION_KEY = "sentry:target_sample_rate"
 
 
+class GetSerializer(Serializer):
+    """TODO"""
+
+    def get_attrs(self, item_list, user, **kwargs) -> Mapping[Project, float]:
+        return ProjectOption.objects.get_value_bulk(item_list, OPTION_KEY)
+
+    def serialize(self, obj: Project, attrs: float, user, **kwargs) -> Mapping[str, Any]:
+        return {"id": obj.id, "sampleRate": attrs}
+
+
+class PutSerializer(serializers.Serializer):
+    """TODO"""
+
+    id = serializers.IntegerField(required=True)
+    sampleRate = serializers.FloatField(required=True, min_value=0, max_value=1)
+
+    def validate(self, data, **kwargs) -> Mapping[str, Any]:
+        return data
+
+
 @region_silo_endpoint
 class OrganizationSamplingProjectRatesEndpoint(OrganizationEndpoint):
+    """TODO"""
+
     owner = ApiOwner.TELEMETRY_EXPERIENCE
 
     publish_status = {
@@ -23,25 +52,40 @@ class OrganizationSamplingProjectRatesEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationPermission,)
 
     def get(self, request: Request, organization) -> Response:
-        # TODO: Implement pagination
-        projects = organization.projects
-        options = ProjectOption.objects.get_value_bulk(projects, OPTION_KEY)
-        result = {str(project.id): value for project, value in options.items()}
-        return Response({"projects": result})
+        """TODO"""
+
+        # NOTE: This fetches all projects in the organization. We do not filter
+        # to projects the org member has access to as the sample rate and
+        # project ID do not constitute sensitive information.
+        queryset = Project.objects.filter(
+            organization=organization,
+            status=Project.ACTIVE,
+        )
+
+        return self.paginate(
+            request=request,
+            queryset=queryset,
+            order_by="id",
+            paginator_cls=OffsetPaginator,
+            on_results=lambda x: serialize(x, request.user, GetSerializer()),
+        )
 
     def put(self, request: Request, organization) -> Response:
-        options = request.data.get("projects")
+        """TODO"""
 
-        # TODO: Validate payload against schema
-        if not isinstance(options, dict):
+        if not isinstance(request.DATA, list):
             raise ValueError("projects must be a dictionary")
-        for sample_rate in options.values():
-            if not isinstance(sample_rate, (int, float)) or sample_rate < 0 or sample_rate > 1:
-                raise ValueError("all sample_rates must be a number between 0 and 1")
 
-        projects = Project.objects.get_many_from_cache(list(options.keys()))
+        serializer = PutSerializer(request.DATA, many=True)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
 
-        for project in projects:
-            project.set_option(OPTION_KEY, options[str(project.id)])
+        project_ids = [d["id"] for d in serializer.data]
+        projects = self.get_projects(request, organization, project_ids=project_ids)
+
+        rate_by_project = {d["id"]: d["sampleRate"] for d in serializer.data}
+        with transaction.atomic():
+            for project in projects:
+                project.set_option(OPTION_KEY, rate_by_project[project.id])
 
         return Response(status=204)

--- a/src/sentry/api/endpoints/organization_sampling_project_rates.py
+++ b/src/sentry/api/endpoints/organization_sampling_project_rates.py
@@ -44,7 +44,7 @@ class PutSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class OrganizationSamplingProjectRatesEndpoint(OrganizationEndpoint):
-    """TODO"""
+    """Bulk endpoint for managing project sampling rates."""
 
     owner = ApiOwner.TELEMETRY_EXPERIENCE
 
@@ -56,7 +56,17 @@ class OrganizationSamplingProjectRatesEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationPermission,)
 
     def get(self, request: Request, organization) -> Response:
-        """TODO"""
+        """
+        List Sampling Rates for Projects
+        ````````````````````````````````
+
+        Return a list of sampling rates for projects in the organization by
+        project ID.
+
+        :pparam string organization_id_or_slug: the id or slug of the
+            organization.
+        :auth: required
+        """
 
         # NOTE: This fetches all projects in the organization. We do not filter
         # to projects the org member has access to as the sample rate and
@@ -75,7 +85,16 @@ class OrganizationSamplingProjectRatesEndpoint(OrganizationEndpoint):
         )
 
     def put(self, request: Request, organization) -> Response:
-        """TODO"""
+        """
+        Update Sampling Rates of Projects
+        `````````````````````````````````
+
+        Bulk update the sample rate of projects in a single request.
+
+        :pparam string organization_id_or_slug: the id or slug of the
+            organization.
+        :auth: required
+        """
 
         serializer = PutSerializer(data=request.data, many=True)
         if not serializer.is_valid():

--- a/src/sentry/api/endpoints/organization_sampling_project_rates.py
+++ b/src/sentry/api/endpoints/organization_sampling_project_rates.py
@@ -1,0 +1,47 @@
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases import OrganizationEndpoint, OrganizationPermission
+from sentry.models.options.project_option import ProjectOption
+from sentry.models.project import Project
+
+OPTION_KEY = "sentry:target_sample_rate"
+
+
+@region_silo_endpoint
+class OrganizationSamplingProjectRatesEndpoint(OrganizationEndpoint):
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
+
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PRIVATE,
+    }
+
+    permission_classes = (OrganizationPermission,)
+
+    def get(self, request: Request, organization) -> Response:
+        # TODO: Implement pagination
+        projects = organization.projects
+        options = ProjectOption.objects.get_value_bulk(projects, OPTION_KEY)
+        result = {str(project.id): value for project, value in options.items()}
+        return Response({"projects": result})
+
+    def put(self, request: Request, organization) -> Response:
+        options = request.data.get("projects")
+
+        # TODO: Validate payload against schema
+        if not isinstance(options, dict):
+            raise ValueError("projects must be a dictionary")
+        for sample_rate in options.values():
+            if not isinstance(sample_rate, (int, float)) or sample_rate < 0 or sample_rate > 1:
+                raise ValueError("all sample_rates must be a number between 0 and 1")
+
+        projects = Project.objects.get_many_from_cache(list(options.keys()))
+
+        for project in projects:
+            project.set_option(OPTION_KEY, options[str(project.id)])
+
+        return Response(status=204)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -545,6 +545,7 @@ from .endpoints.organization_releases import (
     OrganizationReleasesStatsEndpoint,
 )
 from .endpoints.organization_request_project_creation import OrganizationRequestProjectCreation
+from .endpoints.organization_sampling_project_rates import OrganizationSamplingProjectRatesEndpoint
 from .endpoints.organization_sdk_updates import (
     OrganizationSdksEndpoint,
     OrganizationSdkUpdatesEndpoint,
@@ -1408,6 +1409,11 @@ ORGANIZATION_URLS = [
         r"^(?P<organization_id_or_slug>[^\/]+)/config/repos/$",
         OrganizationConfigRepositoriesEndpoint.as_view(),
         name="sentry-api-0-organization-config-repositories",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/sampling/project-rates/$",
+        OrganizationSamplingProjectRatesEndpoint.as_view(),
+        name="sentry-api-0-organization-sampling-project-rates",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/sdk-updates/$",

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -1,3 +1,4 @@
+from sentry.constants import TARGET_SAMPLE_RATE_DEFAULT
 from sentry.projectoptions import register
 
 # This controls what sentry:option-epoch value is given to a project when it is created
@@ -186,4 +187,4 @@ register(
 )
 
 # Dynamic sampling rate in project-level "manual" configuration mode
-register(key="sentry:target_sample_rate", default=1.0)
+register(key="sentry:target_sample_rate", default=TARGET_SAMPLE_RATE_DEFAULT)

--- a/tests/sentry/api/endpoints/test_organization_sampling_project_rates.py
+++ b/tests/sentry/api/endpoints/test_organization_sampling_project_rates.py
@@ -1,0 +1,20 @@
+from sentry.testutils.cases import APITestCase
+
+
+class OrganizationSamplingProjectRatesTest(APITestCase):
+    endpoint = "sentry-api-0-organization-sampling-project-rates"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+
+    def test_get(self):
+        project1 = self.create_project(teams=[self.team])
+        project2 = self.create_project(teams=[self.team])
+        project2.update_option("sentry:target_sample_rate", 0.2)
+
+        response = self.get_success_response(self.organization.slug)
+        assert response.data == [
+            {"id": project1.id, "sampleRate": None},  # TODO: This must be 1.0
+            {"id": project2.id, "sampleRate": 0.2},
+        ]

--- a/tests/sentry/api/endpoints/test_organization_sampling_project_rates.py
+++ b/tests/sentry/api/endpoints/test_organization_sampling_project_rates.py
@@ -15,6 +15,28 @@ class OrganizationSamplingProjectRatesTest(APITestCase):
 
         response = self.get_success_response(self.organization.slug)
         assert response.data == [
-            {"id": project1.id, "sampleRate": None},  # TODO: This must be 1.0
+            {"id": project1.id, "sampleRate": 1.0},
             {"id": project2.id, "sampleRate": 0.2},
         ]
+
+    def test_put(self):
+        project1 = self.create_project(teams=[self.team])
+        project1.update_option("sentry:target_sample_rate", 0.2)
+        project2 = self.create_project(teams=[self.team])
+        project2.update_option("sentry:target_sample_rate", 0.2)
+
+        data = [
+            # we leave project 1 unchanged
+            {"id": project2.id, "sampleRate": 0.5},
+        ]
+
+        response = self.get_success_response(self.organization.slug, method="put", raw_data=data)
+        assert response.data == [
+            {"id": project2.id, "sampleRate": 0.5},
+        ]
+
+        assert project1.get_option("sentry:target_sample_rate") == 0.2
+        assert project2.get_option("sentry:target_sample_rate") == 0.5
+
+    def test_put_invalid_body(self):
+        self.get_error_response(self.organization.slug, method="put", raw_data={})


### PR DESCRIPTION
Adds a bulk endpoint to fetch and modify sample rates of projects in an organization. This is used in the org-level dynamic sampling settings screen in "Manual Mode", where users set sample rates of projects. 

The endpoint exposes the ID and sample rate of all projects in the organization in the following format:
```json
[
  {
    "id": 42,
    "sample_rate": 0.21
  },
  {
    "id": 4711,
    "sample_rate": 0.4711
  }
]
```

Similar to the projects index endpoint, there is **no check for teams** in `GET`. This is because `OrganizationEndpoint.get_projects` does play well with pagination. That is, all projects are returned. For `PUT`, all access checks are performed.

The endpoint is considered internal at this point, so there are no API doc examples.

Closes https://github.com/getsentry/projects/issues/296

