### PR TITLE
ref(insights): use shared constants

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -71,6 +71,10 @@ import {
   MOBILE_LANDING_SUB_PATH,
   MOBILE_SIDEBAR_LABEL,
 } from 'sentry/views/insights/pages/mobile/settings';
+import {
+  DOMAIN_VIEW_BASE_TITLE,
+  DOMAIN_VIEW_BASE_URL,
+} from 'sentry/views/insights/pages/settings';
 import {MODULE_TITLES} from 'sentry/views/insights/settings';
 import MetricsOnboardingSidebar from 'sentry/views/metrics/ddmOnboarding/sidebar';
 
@@ -613,7 +617,7 @@ function Sidebar() {
       <SidebarAccordion
         {...sidebarItemProps}
         icon={<IconGraph />}
-        label={t('Performance')}
+        label={DOMAIN_VIEW_BASE_TITLE}
         id="performance-domains"
         initiallyExpanded={false}
         exact={!shouldAccordionFloat}
@@ -621,28 +625,28 @@ function Sidebar() {
         <SidebarItem
           {...sidebarItemProps}
           label={FRONTEND_SIDEBAR_LABEL}
-          to={`/organizations/${organization.slug}/performance/${FRONTEND_LANDING_SUB_PATH}/`}
+          to={`/organizations/${organization.slug}/${DOMAIN_VIEW_BASE_URL}/${FRONTEND_LANDING_SUB_PATH}/`}
           id="performance-domains-web"
           icon={<SubitemDot collapsed />}
         />
         <SidebarItem
           {...sidebarItemProps}
           label={BACKEND_SIDEBAR_LABEL}
-          to={`/organizations/${organization.slug}/performance/${BACKEND_LANDING_SUB_PATH}/`}
+          to={`/organizations/${organization.slug}/${DOMAIN_VIEW_BASE_URL}/${BACKEND_LANDING_SUB_PATH}/`}
           id="performance-domains-platform"
           icon={<SubitemDot collapsed />}
         />
         <SidebarItem
           {...sidebarItemProps}
           label={MOBILE_SIDEBAR_LABEL}
-          to={`/organizations/${organization.slug}/performance/${MOBILE_LANDING_SUB_PATH}/`}
+          to={`/organizations/${organization.slug}/${DOMAIN_VIEW_BASE_URL}/${MOBILE_LANDING_SUB_PATH}/`}
           id="performance-domains-mobile"
           icon={<SubitemDot collapsed />}
         />
         <SidebarItem
           {...sidebarItemProps}
           label={AI_SIDEBAR_LABEL}
-          to={`/organizations/${organization.slug}/performance/${AI_LANDING_SUB_PATH}/`}
+          to={`/organizations/${organization.slug}/${DOMAIN_VIEW_BASE_URL}/${AI_LANDING_SUB_PATH}/`}
           id="performance-domains-ai"
           icon={<SubitemDot collapsed />}
         />

--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -5,7 +5,6 @@ import ButtonBar from 'sentry/components/buttonBar';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {TabList, Tabs} from 'sentry/components/tabs';
-import {t} from 'sentry/locale';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useModuleTitles} from 'sentry/views/insights/common/utils/useModuleTitle';
@@ -13,7 +12,10 @@ import {
   type RoutableModuleNames,
   useModuleURLBuilder,
 } from 'sentry/views/insights/common/utils/useModuleURL';
-import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
+import {
+  DOMAIN_VIEW_BASE_TITLE,
+  OVERVIEW_PAGE_TITLE,
+} from 'sentry/views/insights/pages/settings';
 import type {ModuleName} from 'sentry/views/insights/types';
 
 export type Props = {
@@ -51,7 +53,7 @@ export function DomainViewHeader({
 
   const baseCrumbs: Crumb[] = [
     {
-      label: t('Performance'),
+      label: DOMAIN_VIEW_BASE_TITLE,
       to: undefined, // There is no base /performance/ page
       preservePageFilters: true,
     },

--- a/static/app/views/insights/pages/useFilters.tsx
+++ b/static/app/views/insights/pages/useFilters.tsx
@@ -5,6 +5,7 @@ import {AI_LANDING_SUB_PATH} from 'sentry/views/insights/pages/ai/settings';
 import {BACKEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/backend/settings';
 import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
 import {MOBILE_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mobile/settings';
+import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
 
 export type DomainView =
   | typeof FRONTEND_LANDING_SUB_PATH
@@ -31,7 +32,7 @@ export type Filters = {
 export const useDomainViewFilters = () => {
   const location = useLocation();
   const pathSegments = location.pathname.split('/').filter(Boolean);
-  const indexOfPerformance = pathSegments.indexOf('performance');
+  const indexOfPerformance = pathSegments.indexOf(DOMAIN_VIEW_BASE_URL);
   const isInDomainView = indexOfPerformance !== -1;
 
   const view = pathSegments[indexOfPerformance + 1] as DomainViewFilters['view'];

--- a/static/app/views/performance/transactionSummary/utils.tsx
+++ b/static/app/views/performance/transactionSummary/utils.tsx
@@ -45,12 +45,7 @@ export function generateTransactionSummaryRoute({
   subPath?: string;
   view?: DomainView; // TODO - this should be mantatory once we release domain view
 }): string {
-  if (view) {
-    return normalizeUrl(
-      `/organizations/${orgSlug}/performance/${view}/summary/${subPath ? `${subPath}/` : ''}`
-    );
-  }
-  return `/organizations/${orgSlug}/performance/summary/${subPath ? `${subPath}/` : ''}`;
+  return `${getPerformanceBaseUrl(orgSlug, view)}/summary/${subPath ? `${subPath}/` : ''}`;
 }
 
 // normalizes search conditions by removing any redundant search conditions before presenting them in:

--- a/static/app/views/performance/utils/index.tsx
+++ b/static/app/views/performance/utils/index.tsx
@@ -27,6 +27,7 @@ import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
+import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 
 import {DEFAULT_MAX_DURATION} from '../trends/utils';
@@ -395,7 +396,7 @@ export function usePerformanceGeneralProjectSettings(projectId?: number) {
 
 export function getPerformanceBaseUrl(orgSlug: string, view?: DomainView) {
   if (view) {
-    return normalizeUrl(`/organizations/${orgSlug}/performance/${view}`);
+    return normalizeUrl(`/organizations/${orgSlug}/${DOMAIN_VIEW_BASE_URL}/${view}`);
   }
   return normalizeUrl(`/organizations/${orgSlug}/performance`);
 }


### PR DESCRIPTION
A couple places that I missed should be using shared constants/functions instead of hardcoded values.