### PR TITLE
fix(insights): span summary breadcrumbs link incorrect

### DIFF
--- a/static/app/views/performance/breadcrumb.tsx
+++ b/static/app/views/performance/breadcrumb.tsx
@@ -6,6 +6,7 @@ import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {SpanSlug} from 'sentry/utils/performance/suspectSpans/types';
 import {decodeScalar} from 'sentry/utils/queryString';
+import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 
 import Tab from './transactionSummary/tabs';
 import {eventsRouteWithQuery} from './transactionSummary/transactionEvents/utils';
@@ -87,6 +88,7 @@ export const getTabCrumbs = ({
   eventSlug,
   traceSlug,
   tab,
+  view,
 }: {
   location: Location;
   organization: Organization;
@@ -98,6 +100,7 @@ export const getTabCrumbs = ({
     name: string;
     project: string;
   };
+  view?: DomainView;
   vitalName?: string;
 }) => {
   const crumbs: Crumb[] = [];
@@ -119,6 +122,7 @@ export const getTabCrumbs = ({
       transaction: transaction.name,
       projectID: transaction.project,
       query: location.query,
+      view,
     };
 
     switch (tab) {

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -295,6 +295,7 @@ function TransactionHeader({
           name: transactionName,
           project: projectId,
         },
+        view,
       }),
     };
     if (view === FRONTEND_LANDING_SUB_PATH) {

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/content.tsx
@@ -73,6 +73,7 @@ export default function SpanSummary(props: Props) {
       transaction: {name: transactionName, project: project?.id ?? ''},
       tab: Tab.SPANS,
       spanSlug,
+      view,
     }),
     hideDefaultTabs: true,
   };


### PR DESCRIPTION
When clicking on `spans` in the span summary page breadcrumbs (see screenshot) and while in a domain view, we would would take you back the original performance span summary. 

This PR updates it to correctly take you to `/performance/<view>/summary/spans` vs `/performance/summary/spans` as it did before
<img width="630" alt="image" src="https://github.com/user-attachments/assets/3eba0fc5-5723-45c0-839f-bd215f377200">
