### PR TITLE
ref(insights): use getPerformanceBaseUrl everywhere

### DIFF
--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -29,6 +29,7 @@ import {isDemoWalkthrough} from 'sentry/utils/demoMode';
 import EventWaiter from 'sentry/utils/eventWaiter';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useApi from 'sentry/utils/useApi';
+import {getPerformanceBaseUrl} from 'sentry/views/performance/utils';
 
 function hasPlatformWithSourceMaps(projects: Project[] | undefined) {
   return projects !== undefined
@@ -136,7 +137,7 @@ export function getOnboardingTasks({
         skippable: false,
         requisites: [],
         actionType: 'app',
-        location: `/organizations/${organization.slug}/performance/`,
+        location: getPerformanceBaseUrl(organization.slug),
         display: true,
         group: OnboardingTaskGroup.GETTING_STARTED,
       },
@@ -332,7 +333,7 @@ export function getOnboardingTasks({
         // TODO: add analytics here for this specific action.
 
         if (!projects) {
-          navigateTo(`/organizations/${organization.slug}/performance/`, router);
+          navigateTo(getPerformanceBaseUrl(organization.slug), router);
           return;
         }
 
@@ -340,20 +341,20 @@ export function getOnboardingTasks({
           filterProjects(projects);
 
         if (projectsWithoutFirstTransactionEvent.length <= 0) {
-          navigateTo(`/organizations/${organization.slug}/performance/`, router);
+          navigateTo(getPerformanceBaseUrl(organization.slug), router);
           return;
         }
 
         if (projectsForOnboarding.length) {
           navigateTo(
-            `/organizations/${organization.slug}/performance/?project=${projectsForOnboarding[0].id}#performance-sidequest`,
+            `${getPerformanceBaseUrl(organization.slug)}/?project=${projectsForOnboarding[0].id}#performance-sidequest`,
             router
           );
           return;
         }
 
         navigateTo(
-          `/organizations/${organization.slug}/performance/?project=${projectsWithoutFirstTransactionEvent[0].id}#performance-sidequest`,
+          `${getPerformanceBaseUrl(organization.slug)}/?project=${projectsWithoutFirstTransactionEvent[0].id}#performance-sidequest`,
           router
         );
       },

--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -113,6 +113,8 @@ export function getOnboardingTasks({
   projects,
   onboardingContext,
 }: Options): OnboardingTaskDescriptor[] {
+  const performanceUrl = `${getPerformanceBaseUrl(organization.slug)}/`;
+
   if (isDemoWalkthrough()) {
     return [
       {
@@ -137,7 +139,7 @@ export function getOnboardingTasks({
         skippable: false,
         requisites: [],
         actionType: 'app',
-        location: getPerformanceBaseUrl(organization.slug),
+        location: performanceUrl,
         display: true,
         group: OnboardingTaskGroup.GETTING_STARTED,
       },
@@ -333,7 +335,7 @@ export function getOnboardingTasks({
         // TODO: add analytics here for this specific action.
 
         if (!projects) {
-          navigateTo(getPerformanceBaseUrl(organization.slug), router);
+          navigateTo(performanceUrl, router);
           return;
         }
 
@@ -341,20 +343,20 @@ export function getOnboardingTasks({
           filterProjects(projects);
 
         if (projectsWithoutFirstTransactionEvent.length <= 0) {
-          navigateTo(getPerformanceBaseUrl(organization.slug), router);
+          navigateTo(performanceUrl, router);
           return;
         }
 
         if (projectsForOnboarding.length) {
           navigateTo(
-            `${getPerformanceBaseUrl(organization.slug)}/?project=${projectsForOnboarding[0].id}#performance-sidequest`,
+            `${performanceUrl}?project=${projectsForOnboarding[0].id}#performance-sidequest`,
             router
           );
           return;
         }
 
         navigateTo(
-          `${getPerformanceBaseUrl(organization.slug)}/?project=${projectsWithoutFirstTransactionEvent[0].id}#performance-sidequest`,
+          `${performanceUrl}?project=${projectsWithoutFirstTransactionEvent[0].id}#performance-sidequest`,
           router
         );
       },

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -459,7 +459,7 @@ function Sidebar() {
             {hasNewNav ? 'Perf.' : t('Performance')}
           </GuideAnchor>
         }
-        to={getPerformanceBaseUrl(organization.slug)}
+        to={`${getPerformanceBaseUrl(organization.slug)}/`}
         id="performance"
       />
     </Feature>

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -77,6 +77,7 @@ import {
 } from 'sentry/views/insights/pages/settings';
 import {MODULE_TITLES} from 'sentry/views/insights/settings';
 import MetricsOnboardingSidebar from 'sentry/views/metrics/ddmOnboarding/sidebar';
+import {getPerformanceBaseUrl} from 'sentry/views/performance/utils';
 
 import {ProfilingOnboardingSidebar} from '../profiling/profilingOnboardingSidebar';
 
@@ -458,7 +459,7 @@ function Sidebar() {
             {hasNewNav ? 'Perf.' : t('Performance')}
           </GuideAnchor>
         }
-        to={`/organizations/${organization.slug}/performance/`}
+        to={getPerformanceBaseUrl(organization.slug)}
         id="performance"
       />
     </Feature>

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -33,6 +33,7 @@ import type {Project} from 'sentry/types/project';
 import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import HeaderTabs from 'sentry/views/organizationStats/header';
+import {getPerformanceBaseUrl} from 'sentry/views/performance/utils';
 
 import type {ChartDataTransform} from './usageChart';
 import {CHART_OPTIONS_DATACATEGORY} from './usageChart';
@@ -185,7 +186,7 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
     return {
       performance: {
         ...nextLocation,
-        pathname: `/organizations/${organization.slug}/performance/`,
+        pathname: getPerformanceBaseUrl(organization.slug),
       },
       projectDetail: {
         ...nextLocation,

--- a/static/app/views/performance/transactionSummary/pageLayout.tsx
+++ b/static/app/views/performance/transactionSummary/pageLayout.tsx
@@ -29,7 +29,11 @@ import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useRouter from 'sentry/utils/useRouter';
 import {aggregateWaterfallRouteWithQuery} from 'sentry/views/performance/transactionSummary/aggregateSpanWaterfall/utils';
 
-import {getSelectedProjectPlatforms, getTransactionName} from '../utils';
+import {
+  getPerformanceBaseUrl,
+  getSelectedProjectPlatforms,
+  getTransactionName,
+} from '../utils';
 
 import {anomaliesRouteWithQuery} from './transactionAnomalies/utils';
 import {eventsRouteWithQuery} from './transactionEvents/utils';
@@ -350,7 +354,7 @@ export function redirectToPerformanceHomepage(
   // If there is no transaction name, redirect to the Performance landing page
   browserHistory.replace(
     normalizeUrl({
-      pathname: `/organizations/${organization.slug}/performance/`,
+      pathname: getPerformanceBaseUrl(organization.slug),
       query: {
         ...location.query,
       },

--- a/static/app/views/performance/utils/index.tsx
+++ b/static/app/views/performance/utils/index.tsx
@@ -187,6 +187,7 @@ export function isSummaryViewFrontend(eventView: EventView, projects: Project[])
   );
 }
 
+// TODO - remove in favour of `getPerformanceBaseUrl`
 export function getPerformanceLandingUrl(organization: OrganizationSummary): string {
   return `${getPerformanceBaseUrl(organization.slug)}/`;
 }

--- a/static/app/views/performance/utils/index.tsx
+++ b/static/app/views/performance/utils/index.tsx
@@ -188,11 +188,11 @@ export function isSummaryViewFrontend(eventView: EventView, projects: Project[])
 }
 
 export function getPerformanceLandingUrl(organization: OrganizationSummary): string {
-  return `/organizations/${organization.slug}/performance/`;
+  return getPerformanceBaseUrl(organization.slug);
 }
 
 export function getPerformanceTrendsUrl(organization: OrganizationSummary): string {
-  return `/organizations/${organization.slug}/performance/trends/`;
+  return `${getPerformanceBaseUrl(organization.slug)}/trends/`;
 }
 
 export function getTransactionSearchQuery(location: Location, query: string = '') {

--- a/static/app/views/performance/utils/index.tsx
+++ b/static/app/views/performance/utils/index.tsx
@@ -188,7 +188,7 @@ export function isSummaryViewFrontend(eventView: EventView, projects: Project[])
 }
 
 export function getPerformanceLandingUrl(organization: OrganizationSummary): string {
-  return getPerformanceBaseUrl(organization.slug);
+  return `${getPerformanceBaseUrl(organization.slug)}/`;
 }
 
 export function getPerformanceTrendsUrl(organization: OrganizationSummary): string {

--- a/static/app/views/performance/vitalDetail/index.tsx
+++ b/static/app/views/performance/vitalDetail/index.tsx
@@ -26,6 +26,7 @@ import withProjects from 'sentry/utils/withProjects';
 import {generatePerformanceVitalDetailView} from '../data';
 import {
   addRoutePerformanceContext,
+  getPerformanceBaseUrl,
   getSelectedProjectPlatforms,
   getTransactionName,
 } from '../utils';
@@ -103,7 +104,7 @@ class VitalDetail extends Component<Props, State> {
     if (!eventView) {
       browserHistory.replace(
         normalizeUrl({
-          pathname: `/organizations/${organization.slug}/performance/`,
+          pathname: getPerformanceBaseUrl(organization.slug),
           query: {
             ...location.query,
           },

--- a/static/app/views/projectDetail/missingFeatureButtons/missingPerformanceButtons.tsx
+++ b/static/app/views/projectDetail/missingFeatureButtons/missingPerformanceButtons.tsx
@@ -8,6 +8,7 @@ import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useRouter from 'sentry/utils/useRouter';
 import {PERFORMANCE_TOUR_STEPS} from 'sentry/views/performance/onboarding';
+import {getPerformanceBaseUrl} from 'sentry/views/performance/utils';
 
 const DOCS_URL = 'https://docs.sentry.io/performance-monitoring/getting-started/';
 
@@ -48,7 +49,7 @@ function MissingPerformanceButtons({organization}: Props) {
             event.preventDefault();
             // TODO: add analytics here for this specific action.
             navigateTo(
-              `/organizations/${organization.slug}/performance/?project=:project#performance-sidequest`,
+              `${getPerformanceBaseUrl(organization.slug)}/?project=:project#performance-sidequest`,
               router
             );
           }}

--- a/static/app/views/projectsDashboard/projectCard.tsx
+++ b/static/app/views/projectsDashboard/projectCard.tsx
@@ -29,6 +29,7 @@ import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
+import {getPerformanceBaseUrl} from 'sentry/views/performance/utils';
 import MissingReleasesButtons from 'sentry/views/projectDetail/missingFeatureButtons/missingReleasesButtons';
 import {
   CRASH_FREE_DECIMAL_THRESHOLD,
@@ -157,7 +158,7 @@ class ProjectCard extends Component<Props> {
                       <em>|</em>
                       <TransactionsLink
                         data-test-id="project-transactions"
-                        to={`/organizations/${organization.slug}/performance/?project=${project.id}`}
+                        to={`${getPerformanceBaseUrl(organization.slug)}/?project=${project.id}`}
                       >
                         {t(
                           'Transactions: %s',


### PR DESCRIPTION
Rather then hardcoding urls to the performance landing page, we should grab them from a shared function. 
This won't change anything now, but eventually the original performance landing page is going away in favour of domain specific landing pages. 

Having a shared function will make it way easier to track down where this url is used and reroute to the url.