### PR TITLE
fix(dashboards): Add padding around big number actions in Project Details

### DIFF
--- a/static/app/views/projectDetail/projectScoreCards/actionWrapper.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/actionWrapper.tsx
@@ -1,0 +1,7 @@
+import styled from '@emotion/styled';
+
+import {space} from 'sentry/styles/space';
+
+export const ActionWrapper = styled('div')`
+  padding: ${space(2)};
+`;

--- a/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
@@ -13,6 +13,8 @@ import {getTermHelp, PerformanceTerm} from 'sentry/views/performance/data';
 
 import MissingPerformanceButtons from '../missingFeatureButtons/missingPerformanceButtons';
 
+import {ActionWrapper} from './actionWrapper';
+
 type Props = {
   isProjectStabilized: boolean;
   organization: Organization;
@@ -114,7 +116,9 @@ function ProjectApdexScoreCard(props: Props) {
   if (!hasTransactions || !organization.features.includes('performance-view')) {
     return (
       <WidgetFrame title={cardTitle} description={cardHelp}>
-        <MissingPerformanceButtons organization={organization} />
+        <ActionWrapper>
+          <MissingPerformanceButtons organization={organization} />
+        </ActionWrapper>
       </WidgetFrame>
     );
   }

--- a/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
@@ -21,6 +21,8 @@ import {
 
 import MissingReleasesButtons from '../missingFeatureButtons/missingReleasesButtons';
 
+import {ActionWrapper} from './actionWrapper';
+
 type Props = {
   field:
     | SessionFieldWithOperation.CRASH_FREE_RATE_SESSIONS
@@ -135,11 +137,13 @@ function ProjectStabilityScoreCard(props: Props) {
   if (hasSessions === false) {
     return (
       <WidgetFrame title={cardTitle} description={cardHelp}>
-        <MissingReleasesButtons
-          organization={organization}
-          health
-          platform={props.project?.platform}
-        />
+        <ActionWrapper>
+          <MissingReleasesButtons
+            organization={organization}
+            health
+            platform={props.project?.platform}
+          />
+        </ActionWrapper>
       </WidgetFrame>
     );
   }

--- a/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.tsx
@@ -11,6 +11,8 @@ import {WidgetFrame} from 'sentry/views/dashboards/widgets/common/widgetFrame';
 
 import MissingReleasesButtons from '../missingFeatureButtons/missingReleasesButtons';
 
+import {ActionWrapper} from './actionWrapper';
+
 const API_LIMIT = 1000;
 
 type Release = {date: string; version: string};
@@ -147,7 +149,9 @@ function ProjectVelocityScoreCard(props: Props) {
   if (!isLoading && noReleaseEver) {
     return (
       <WidgetFrame title={cardTitle} description={cardHelp}>
-        <MissingReleasesButtons organization={organization} />
+        <ActionWrapper>
+          <MissingReleasesButtons organization={organization} />
+        </ActionWrapper>
       </WidgetFrame>
     );
   }


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/getsentry/sentry/pull/79676. Adds a container around widget actions.

**Before:**
<img width="471" alt="Screenshot 2024-10-30 at 12 58 53 PM" src="https://github.com/user-attachments/assets/484220db-300c-4072-9288-7e22f29d8816">

**After:**
<img width="467" alt="Screenshot 2024-10-30 at 1 00 06 PM" src="https://github.com/user-attachments/assets/cdf898ef-52c8-4d93-a8f9-6ab1069c94d8">
