### PR TITLE
feat(rollback) Add endpoints to retrieve and modify rollback settings

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -269,6 +269,9 @@ from sentry.replays.endpoints.project_replay_recording_segment_index import (
 )
 from sentry.replays.endpoints.project_replay_video_details import ProjectReplayVideoDetailsEndpoint
 from sentry.replays.endpoints.project_replay_viewed_by import ProjectReplayViewedByEndpoint
+from sentry.rollback.endpoints.organization_rollback_settings import (
+    OrganizationRollbackSettingsEndpoint,
+)
 from sentry.rules.history.endpoints.project_rule_group_history import (
     ProjectRuleGroupHistoryIndexEndpoint,
 )
@@ -1757,6 +1760,11 @@ ORGANIZATION_URLS = [
         r"^(?P<organization_id_or_slug>[^\/]+)/group-search-views/$",
         OrganizationGroupSearchViewsEndpoint.as_view(),
         name="sentry-api-0-organization-group-search-views",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/rollback-settings/$",
+        OrganizationRollbackSettingsEndpoint.as_view(),
+        name="sentry-api-0-organization-rollback-settings",
     ),
     # Pinned and saved search
     re_path(

--- a/src/sentry/rollback/endpoints/organization_rollback_settings.py
+++ b/src/sentry/rollback/endpoints/organization_rollback_settings.py
@@ -1,0 +1,77 @@
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import audit_log
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.models.organization import Organization
+
+
+@region_silo_endpoint
+class OrganizationRollbackSettingsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PRIVATE,
+    }
+    scope_map = {
+        "GET": ["org:read", "org:admin"],
+        "PUT": ["org:admin"],
+    }
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        rollback_enabled = organization.get_option("sentry:rollback_enabled")
+        rollback_sharing_enabled = organization.get_option("sentry:rollback_sharing_enabled")
+
+        if rollback_enabled is None and rollback_sharing_enabled is None:
+            organization.update_option("sentry:rollback_enabled", True)
+            organization.update_option("sentry:rollback_sharing_enabled", True)
+            rollback_enabled, rollback_sharing_enabled = True, True
+
+        return Response(
+            status=200,
+            data={
+                "rollbackEnabled": rollback_enabled,
+                "rollbackSharingEnabled": rollback_sharing_enabled,
+            },
+        )
+
+    def put(self, request: Request, organization: Organization) -> Response:
+        rollback_enabled = request.data.get("rollbackEnabled")
+        rollback_sharing_enabled = request.data.get("rollbackSharingEnabled")
+
+        if rollback_enabled is None and rollback_sharing_enabled is None:
+            return Response(
+                {"detail": "Must specify at least one setting"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if (rollback_enabled is not None and not isinstance(rollback_enabled, bool)) or (
+            rollback_sharing_enabled is not None and not isinstance(rollback_sharing_enabled, bool)
+        ):
+            return Response(
+                {"detail": "Settings values must be a boolean"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if rollback_enabled is not None:
+            organization.update_option(key="sentry:rollback_enabled", value=rollback_enabled)
+
+        if rollback_sharing_enabled is not None:
+            organization.update_option(
+                key="sentry:rollback_sharing_enabled", value=rollback_sharing_enabled
+            )
+
+        self.create_audit_entry(
+            request=request,
+            organization=organization,
+            target_object=organization.id,
+            event=audit_log.get_event_id("ORG_EDIT"),
+            data={
+                "rollbackEnabled": rollback_enabled,
+                "rollbackSharingEnabled": rollback_sharing_enabled,
+            },
+        )
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/tests/sentry/rollback/endpoints/test_organization_rollback_settings.py
+++ b/tests/sentry/rollback/endpoints/test_organization_rollback_settings.py
@@ -1,0 +1,113 @@
+from django.urls import reverse
+
+from sentry.testutils.cases import APITestCase
+
+
+class OrganizationRollbackSettingsGetEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-organization-rollback-settings"
+    method = "get"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+
+        self.url = reverse(
+            self.endpoint,
+            kwargs={"organization_id_or_slug": self.organization.slug},
+        )
+
+    def test_get_settings_defaults(self):
+        response = self.get_success_response(self.organization.slug)
+
+        assert response.status_code == 200
+        assert response.data == {
+            "rollbackEnabled": True,
+            "rollbackSharingEnabled": True,
+        }
+
+    def test_get_settings_overrides(self):
+        self.organization.update_option("sentry:rollback_enabled", True)
+        self.organization.update_option("sentry:rollback_sharing_enabled", False)
+
+        response = self.get_success_response(self.organization.slug)
+
+        assert response.status_code == 200
+        assert response.data == {
+            "rollbackEnabled": True,
+            "rollbackSharingEnabled": False,
+        }
+
+
+class OrganizationRollbackSettingsPutEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-organization-rollback-settings"
+    method = "put"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+
+        self.url = reverse(
+            self.endpoint,
+            kwargs={"organization_id_or_slug": self.organization.slug},
+        )
+
+    def test_put_settings(self):
+        response = self.client.put(
+            self.url,
+            {
+                "rollbackEnabled": True,
+                "rollbackSharingEnabled": True,
+            },
+        )
+
+        assert response.status_code == 204
+
+        assert self.organization.get_option("sentry:rollback_enabled") is True
+        assert self.organization.get_option("sentry:rollback_sharing_enabled") is True
+
+    def test_put_settings_partial(self):
+        self.organization.update_option("sentry:rollback_enabled", True)
+        self.organization.update_option("sentry:rollback_sharing_enabled", True)
+
+        response = self.client.put(
+            self.url,
+            {
+                "rollbackEnabled": True,
+                "rollbackSharingEnabled": False,
+            },
+        )
+
+        assert response.status_code == 204
+        assert self.organization.get_option("sentry:rollback_enabled") is True
+        assert self.organization.get_option("sentry:rollback_sharing_enabled") is False
+
+    def test_error_put_settings_no_params(self):
+        response = self.client.put(
+            self.url,
+            data={},
+        )
+
+        assert response.status_code == 400
+        assert response.data == {"detail": "Must specify at least one setting"}
+
+    def test_error_put_settings_requires_admin(self):
+        self.user = self.create_user(is_superuser=False)
+        self.login_as(user=self.user)
+
+        response = self.client.put(
+            self.url,
+            {
+                "rollbackEnabled": True,
+            },
+        )
+
+        assert response.status_code == 403
+
+    def test_error_put_settings_invalid_types(self):
+        response = self.client.put(
+            self.url,
+            {"rollbackEnabled": "potato", "rollbackSharingEnabled": "potato"},
+        )
+
+        assert response.status_code == 400
+        assert response.data == {"detail": "Settings values must be a boolean"}


### PR DESCRIPTION
Create two new endpoints:

* `GET` `organization/<org_id_or_slug>/rollback-settings` - Returns the two rollback settings, `rollback_enabled` and `rollback_sharing_enabled`. 

* `PUT` `organization/<org_id_or_slug>/rollback-settings` - Updates one or both of the two rollback settings. 

