### PR TITLE
chore(integrations): RepositoryIntegration metrics

### DIFF
--- a/src/sentry/integrations/source_code_management/metrics.py
+++ b/src/sentry/integrations/source_code_management/metrics.py
@@ -1,9 +1,15 @@
+from collections.abc import Mapping
 from enum import Enum
+from typing import Any
 
 from attr import dataclass
 
 from sentry.integrations.base import IntegrationDomain
+from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.services.integration import RpcOrganizationIntegration
 from sentry.integrations.utils.metrics import IntegrationEventLifecycleMetric
+from sentry.models.organization import Organization
+from sentry.organizations.services.organization import RpcOrganization
 
 
 class RepositoryIntegrationInteractionType(Enum):
@@ -28,6 +34,10 @@ class RepositoryIntegrationInteractionEvent(IntegrationEventLifecycleMetric):
     interaction_type: RepositoryIntegrationInteractionType
     provider_key: str
 
+    # Optional attributes to populate extras
+    organization: Organization | RpcOrganization | None = None
+    org_integration: OrganizationIntegration | RpcOrganizationIntegration | None = None
+
     def get_integration_domain(self) -> IntegrationDomain:
         return IntegrationDomain.SOURCE_CODE_MANAGEMENT
 
@@ -36,3 +46,9 @@ class RepositoryIntegrationInteractionEvent(IntegrationEventLifecycleMetric):
 
     def get_interaction_type(self) -> str:
         return str(self.interaction_type)
+
+    def get_extras(self) -> Mapping[str, Any]:
+        return {
+            "organization_id": (self.organization.id if self.organization else None),
+            "org_integration_id": (self.org_integration.id if self.org_integration else None),
+        }

--- a/src/sentry/integrations/source_code_management/metrics.py
+++ b/src/sentry/integrations/source_code_management/metrics.py
@@ -8,7 +8,7 @@ from sentry.integrations.utils.metrics import EventLifecycleMetric, EventLifecyc
 
 class RepositoryIntegrationInteractionType(Enum):
     """
-    A specific method used by a RepositoryIntegration (???)
+    A RepositoryIntegration feature.
     """
 
     GET_STACKTRACE_LINK = "GET_STACKTRACE_LINK"
@@ -22,7 +22,7 @@ class RepositoryIntegrationInteractionType(Enum):
 @dataclass
 class RepositoryIntegrationInteractionEvent(EventLifecycleMetric):
     """
-    An instance to be recorded of ... (???)
+    An instance to be recorded of a RepositoryIntegration feature call.
     """
 
     interaction_type: RepositoryIntegrationInteractionType

--- a/src/sentry/integrations/source_code_management/metrics.py
+++ b/src/sentry/integrations/source_code_management/metrics.py
@@ -1,0 +1,37 @@
+from enum import Enum
+
+from attr import dataclass
+
+from sentry.integrations.base import IntegrationDomain
+from sentry.integrations.utils.metrics import EventLifecycleMetric, EventLifecycleOutcome
+
+
+class RepositoryIntegrationInteractionType(Enum):
+    """
+    A specific method used by a RepositoryIntegration (???)
+    """
+
+    GET_STACKTRACE_LINK = "GET_STACKTRACE_LINK"
+    GET_CODEOWNER_FILE = "GET_CODEOWNER_FILE"
+    CHECK_FILE = "CHECK_FILE"
+
+    def __str__(self) -> str:
+        return self.value.lower()
+
+
+@dataclass
+class RepositoryIntegrationInteractionEvent(EventLifecycleMetric):
+    """
+    An instance to be recorded of ... (???)
+    """
+
+    interaction_type: RepositoryIntegrationInteractionType
+    provider_key: str
+
+    def get_key(self, outcome: EventLifecycleOutcome) -> str:
+        return self.get_standard_key(
+            domain=IntegrationDomain.SOURCE_CODE_MANAGEMENT,
+            integration_name=self.provider_key,
+            interaction_type=str(self.interaction_type),
+            outcome=outcome,
+        )

--- a/src/sentry/integrations/source_code_management/metrics.py
+++ b/src/sentry/integrations/source_code_management/metrics.py
@@ -3,7 +3,7 @@ from enum import Enum
 from attr import dataclass
 
 from sentry.integrations.base import IntegrationDomain
-from sentry.integrations.utils.metrics import EventLifecycleMetric, EventLifecycleOutcome
+from sentry.integrations.utils.metrics import IntegrationEventLifecycleMetric
 
 
 class RepositoryIntegrationInteractionType(Enum):
@@ -20,7 +20,7 @@ class RepositoryIntegrationInteractionType(Enum):
 
 
 @dataclass
-class RepositoryIntegrationInteractionEvent(EventLifecycleMetric):
+class RepositoryIntegrationInteractionEvent(IntegrationEventLifecycleMetric):
     """
     An instance to be recorded of a RepositoryIntegration feature call.
     """
@@ -28,10 +28,11 @@ class RepositoryIntegrationInteractionEvent(EventLifecycleMetric):
     interaction_type: RepositoryIntegrationInteractionType
     provider_key: str
 
-    def get_key(self, outcome: EventLifecycleOutcome) -> str:
-        return self.get_standard_key(
-            domain=IntegrationDomain.SOURCE_CODE_MANAGEMENT,
-            integration_name=self.provider_key,
-            interaction_type=str(self.interaction_type),
-            outcome=outcome,
-        )
+    def get_integration_domain(self) -> IntegrationDomain:
+        return IntegrationDomain.SOURCE_CODE_MANAGEMENT
+
+    def get_integration_name(self) -> str:
+        return self.provider_key
+
+    def get_interaction_type(self) -> str:
+        return str(self.interaction_type)

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -9,11 +9,14 @@ import sentry_sdk
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.integrations.base import IntegrationInstallation
 from sentry.integrations.services.repository import RpcRepository
+from sentry.integrations.source_code_management.metrics import (
+    RepositoryIntegrationInteractionEvent,
+    RepositoryIntegrationInteractionType,
+)
 from sentry.models.repository import Repository
 from sentry.shared_integrations.client.base import BaseApiResponseX
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.users.models.identity import Identity
-from sentry.utils import metrics
 
 REPOSITORY_INTEGRATION_CHECK_FILE_METRIC = "repository_integration.check_file.{result}"
 REPOSITORY_INTEGRATION_GET_FILE_METRIC = "repository_integration.get_file.{result}"
@@ -94,6 +97,9 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
         """
         return []
 
+    def record_event(self, event: RepositoryIntegrationInteractionType):
+        return RepositoryIntegrationInteractionEvent(event, self.integration_name)
+
     def check_file(self, repo: Repository, filepath: str, branch: str | None = None) -> str | None:
         """
         Calls the client's `check_file` method to see if the file exists.
@@ -107,34 +113,31 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
         filepath: file from the stacktrace (string)
         branch: commitsha or default_branch (string)
         """
-        filepath = filepath.lstrip("/")
-        try:
-            client = self.get_client()
-        except (Identity.DoesNotExist, IntegrationError):
-            sentry_sdk.capture_exception()
-            return None
-        try:
-            response = client.check_file(repo, filepath, branch)
-            metrics.incr(
-                REPOSITORY_INTEGRATION_CHECK_FILE_METRIC.format(result="success"),
-                tags={"integration": self.integration_name},
-            )
-            if not response:
-                return None
-        except IdentityNotValid:
-            return None
-        except ApiError as e:
-            if e.code != 404:
-                metrics.incr(
-                    REPOSITORY_INTEGRATION_CHECK_FILE_METRIC.format(result="failure"),
-                    tags={"integration": self.integration_name},
-                )
+        with self.record_event(
+            RepositoryIntegrationInteractionType.CHECK_FILE
+        ).capture() as lifecycle:
+            filepath = filepath.lstrip("/")
+            try:
+                client = self.get_client()
+            except (Identity.DoesNotExist, IntegrationError):
                 sentry_sdk.capture_exception()
-                raise
+                return None
+            try:
+                response = client.check_file(repo, filepath, branch)
+                if not response:
+                    return None
+            except IdentityNotValid:
+                lifecycle.record_failure(IdentityNotValid)
+                return None
+            except ApiError as e:
+                if e.code != 404:
+                    sentry_sdk.capture_exception()
+                    raise
 
-            return None
+                lifecycle.record_failure(ApiError)
+                return None
 
-        return self.format_source_url(repo, filepath, branch)
+            return self.format_source_url(repo, filepath, branch)
 
     def get_stacktrace_link(
         self, repo: Repository, filepath: str, default: str, version: str | None
@@ -149,18 +152,19 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
         If no file was found return `None`, and re-raise for non-"Not Found"
         errors, like 403 "Account Suspended".
         """
-        scope = sentry_sdk.Scope.get_isolation_scope()
-        scope.set_tag("stacktrace_link.tried_version", False)
-        if version:
-            scope.set_tag("stacktrace_link.tried_version", True)
-            source_url = self.check_file(repo, filepath, version)
-            if source_url:
-                scope.set_tag("stacktrace_link.used_version", True)
-                return source_url
-        scope.set_tag("stacktrace_link.used_version", False)
-        source_url = self.check_file(repo, filepath, default)
+        with self.record_event(RepositoryIntegrationInteractionType.GET_STACKTRACE_LINK).capture():
+            scope = sentry_sdk.Scope.get_isolation_scope()
+            scope.set_tag("stacktrace_link.tried_version", False)
+            if version:
+                scope.set_tag("stacktrace_link.tried_version", True)
+                source_url = self.check_file(repo, filepath, version)
+                if source_url:
+                    scope.set_tag("stacktrace_link.used_version", True)
+                    return source_url
+            scope.set_tag("stacktrace_link.used_version", False)
+            source_url = self.check_file(repo, filepath, default)
 
-        return source_url
+            return source_url
 
     def get_codeowner_file(
         self, repo: Repository, ref: str | None = None
@@ -177,26 +181,22 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
          * filepath - full path of the file i.e. CODEOWNERS, .github/CODEOWNERS, docs/CODEOWNERS
          * raw - the decoded raw contents of the codeowner file
         """
-        if self.codeowners_locations is None:
-            raise NotImplementedError("Implement self.codeowners_locations to use this method.")
+        with self.record_event(
+            RepositoryIntegrationInteractionType.GET_CODEOWNER_FILE
+        ).capture() as lifecycle:
+            if self.codeowners_locations is None:
+                raise NotImplementedError("Implement self.codeowners_locations to use this method.")
 
-        for filepath in self.codeowners_locations:
-            html_url = self.check_file(repo, filepath, ref)
-            if html_url:
-                try:
-                    contents = self.get_client().get_file(repo, filepath, ref, codeowners=True)
-                    metrics.incr(
-                        REPOSITORY_INTEGRATION_GET_FILE_METRIC.format(result="success"),
-                        tags={"integration": self.integration_name},
-                    )
-                except ApiError:
-                    metrics.incr(
-                        REPOSITORY_INTEGRATION_GET_FILE_METRIC.format(result="success"),
-                        tags={"integration": self.integration_name},
-                    )
-                    continue
-                return {"filepath": filepath, "html_url": html_url, "raw": contents}
-        return None
+            for filepath in self.codeowners_locations:
+                html_url = self.check_file(repo, filepath, ref)
+                if html_url:
+                    try:
+                        contents = self.get_client().get_file(repo, filepath, ref, codeowners=True)
+                    except ApiError:
+                        lifecycle.record_failure(ApiError)
+                        continue
+                    return {"filepath": filepath, "html_url": html_url, "raw": contents}
+            return None
 
 
 class RepositoryClient(ABC):

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -98,7 +98,12 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
         return []
 
     def record_event(self, event: RepositoryIntegrationInteractionType):
-        return RepositoryIntegrationInteractionEvent(event, self.integration_name)
+        return RepositoryIntegrationInteractionEvent(
+            interaction_type=event,
+            provider_key=self.integration_name,
+            organization=self.organization,
+            org_integration=self.org_integration,
+        )
 
     def check_file(self, repo: Repository, filepath: str, branch: str | None = None) -> str | None:
         """

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -23,6 +23,7 @@ from sentry.integrations.source_code_management.commit_context import (
     FileBlameInfo,
     SourceLineInfo,
 )
+from sentry.integrations.utils.metrics import EventLifecycleOutcome
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
 from sentry.shared_integrations.response.base import BaseApiResponse
@@ -137,8 +138,9 @@ class GitHubApiClientTest(TestCase):
         assert responses.calls[0].response.status_code == 404
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @responses.activate
-    def test_get_stacktrace_link(self, get_jwt):
+    def test_get_stacktrace_link(self, mock_record, get_jwt):
         path = "/src/sentry/integrations/github/client.py"
         version = "master"
         url = "https://api.github.com/repos/{}/contents/{}?ref={}".format(
@@ -156,6 +158,14 @@ class GitHubApiClientTest(TestCase):
             source_url
             == "https://github.com/Test-Organization/foo/blob/master/src/sentry/integrations/github/client.py"
         )
+        assert (
+            len(mock_record.mock_calls) == 4
+        )  # get_stacktrace_link calls check_file, which also has metrics
+        start1, start2, halt1, halt2 = mock_record.mock_calls
+        assert start1.args[0] == EventLifecycleOutcome.STARTED
+        assert start2.args[0] == EventLifecycleOutcome.STARTED  # check_file
+        assert halt1.args[0] == EventLifecycleOutcome.SUCCESS  # check_file
+        assert halt2.args[0] == EventLifecycleOutcome.SUCCESS
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
@@ -209,8 +219,9 @@ class GitHubApiClientTest(TestCase):
         return_value=GITHUB_CODEOWNERS["html_url"],
     )
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @responses.activate
-    def test_get_codeowner_file(self, mock_jwt, mock_check_file):
+    def test_get_codeowner_file(self, mock_record, mock_jwt, mock_check_file):
         self.config = self.create_code_mapping(
             repo=self.repo,
             project=self.project,
@@ -228,6 +239,11 @@ class GitHubApiClientTest(TestCase):
             responses.calls[0].request.headers["Content-Type"] == "application/raw; charset=utf-8"
         )
         assert result == GITHUB_CODEOWNERS
+        assert (
+            len(mock_record.mock_calls) == 2
+        )  # check_file is mocked in this test, so there will be no metrics logged for it
+        assert mock_record.mock_calls[0].args[0] == EventLifecycleOutcome.STARTED
+        assert mock_record.mock_calls[1].args[0] == EventLifecycleOutcome.SUCCESS
 
     @responses.activate
     def test_get_cached_repo_files_caching_functionality(self):


### PR DESCRIPTION
Add metrics to the following `RepositoryIntegration` methods: `get_stacktrace_link`, `check_file`, and `get_codeowner_file`.