### PR TITLE
fix(dashboards): Pass `BigNumberWidget` props through to `WidgetFrame`

### DIFF
--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidget.tsx
@@ -55,6 +55,11 @@ export function BigNumberWidget(props: Props) {
       title={props.title}
       description={props.description}
       actions={props.actions}
+      actionsDisabled={props.actionsDisabled}
+      actionsMessage={props.actionsMessage}
+      badgeProps={props.badgeProps}
+      onFullScreenViewClick={props.onFullScreenViewClick}
+      warnings={props.warnings}
       error={error}
       onRetry={props.onRetry}
     >


### PR DESCRIPTION
Some props weren't being passed. It would probably be better to unspat all props and pass them through, even though that's somewhat sloppy.
