### PR TITLE
fix: Explicitly ask for the non-subdomain origin when loading the toolbar login-sucess popup

### DIFF
--- a/src/sentry/templates/sentry/toolbar/iframe.html
+++ b/src/sentry/templates/sentry/toolbar/iframe.html
@@ -36,8 +36,12 @@ Required context variables:
         }
 
         function requestAuthn(delay_ms) {
+          const origin = window.location.origin.endsWith('.sentry.io')
+            ? 'https://sentry.io'
+            : window.location.origin;
+
           window.open(
-            `/toolbar/${organizationSlug}/${projectIdOrSlug}/login-success/?delay=${delay_ms ?? '0'}`,
+            `${origin}/toolbar/${organizationSlug}/${projectIdOrSlug}/login-success/?delay=${delay_ms ?? '0'}`,
             'sentry-toolbar-auth-popup',
             'popup=true,innerWidth=800,innerHeight=550,noopener=false'
           );

--- a/src/sentry/templates/sentry/toolbar/login-success.html
+++ b/src/sentry/templates/sentry/toolbar/login-success.html
@@ -25,16 +25,12 @@
         });
 
         if (window.opener) {
-          const origin = window.location.origin.endsWith('.sentry.io')
-            ? 'https://sentry.io'
-            : window.location.origin;
-
           window.opener.postMessage({
             source: 'sentry-toolbar',
             message: 'did-login',
             cookie,
             token,
-          }, origin);
+          }, window.location.origin);
 
           if (delay && typeof delay === 'number') {
             setTimeout(() => {


### PR DESCRIPTION
The context is that redirects with `?redirect=` don't work depending on the origin of the url you're asking for...

- using a non-subdomain origin (ie: `sentry.io`) for web or api requests will redirect to the subdomain version. ✅ 
- using a non-subdomain origin with a `?redirect=` will take me to the correct page... sending me to the subdomain'd origin ✅ 
- but using a subdomain origin (ie: `sentry.sentry.io`) with `?redirect=` will not take me to the correct page ❌ 

Therefore, within the toolbar there are some constraints:
- I will to use the non-subdomain origin for requests that are going to endup as redirects, this makes sure the redirect works (see this PR)
  - The popup will endup at login-success.html, and on the subdomain'd origin. It will need to know the origin that the iframe is using.
- the iframe must use the sub-domain origin. If not then ajax requests will redirect to the sub-domain origin and result in a cors error.

Therefore:
- with the iframe on the sub-domain origin, cors works
- Also, with the iframe on the sub-domain origin, login-success will be on a matching origin and we don't need to do anything special in there anymore (this pr removes the special stuff)
- Finally, when we open the popup we should use the non-subdomain origin, this allows the redirect to work. This PR adds that special check into iframe.html.
