### PR TITLE
feat(activity): Adds a comment button in streamlined view

### DIFF
--- a/static/app/components/feedback/useMutateActivity.tsx
+++ b/static/app/components/feedback/useMutateActivity.tsx
@@ -5,12 +5,13 @@ import type {Group, GroupActivity} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import type {MutateOptions} from 'sentry/utils/queryClient';
 import {fetchMutation, useMutation} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 
 type TPayload = {activity: GroupActivity[]; note?: NoteType; noteId?: string};
 type TMethod = 'PUT' | 'POST' | 'DELETE';
 export type TData = GroupActivity;
-export type TError = unknown;
+export type TError = RequestError;
 export type TVariables = [TPayload, TMethod];
 export type TContext = unknown;
 

--- a/static/app/views/issueDetails/streamline/activitySection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/activitySection.spec.tsx
@@ -42,6 +42,62 @@ describe('StreamlinedActivitySection', function () {
 
   GroupStore.add([group]);
 
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders the input with a comment button', async function () {
+    const comment = 'nice work friends';
+    const postMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/1337/comments/',
+      method: 'POST',
+      body: {
+        id: 'note-2',
+        user: UserFixture({id: '2'}),
+        type: 'note',
+        data: {text: comment},
+        dateCreated: '2024-10-31T00:00:00.000000Z',
+      },
+    });
+
+    render(<StreamlinedActivitySection group={group} />);
+
+    const commentInput = screen.getByRole('textbox', {name: 'Add a comment'});
+    expect(commentInput).toBeInTheDocument();
+    const submitButton = screen.getByRole('button', {name: 'Submit comment'});
+    expect(submitButton).toBeInTheDocument();
+
+    expect(submitButton).toBeDisabled();
+    await userEvent.type(commentInput, comment);
+    expect(submitButton).toBeEnabled();
+
+    await userEvent.click(submitButton);
+    expect(postMock).toHaveBeenCalled();
+  });
+
+  it('allows submitting the comment field with hotkeys', async function () {
+    const comment = 'nice work friends';
+    const postMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/1337/comments/',
+      method: 'POST',
+      body: {
+        id: 'note-3',
+        user: UserFixture({id: '2'}),
+        type: 'note',
+        data: {text: comment},
+        dateCreated: '2024-10-31T00:00:00.000000Z',
+      },
+    });
+
+    render(<StreamlinedActivitySection group={group} />);
+
+    const commentInput = screen.getByRole('textbox', {name: 'Add a comment'});
+    await userEvent.type(commentInput, comment);
+    await userEvent.keyboard('{Meta>}{Enter}{/Meta}');
+    expect(postMock).toHaveBeenCalled();
+  });
+
   it('renders note and allows for delete', async function () {
     const deleteMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/1337/comments/note-1/',

--- a/static/app/views/issueDetails/streamline/activitySection.tsx
+++ b/static/app/views/issueDetails/streamline/activitySection.tsx
@@ -11,7 +11,7 @@ import Timeline from 'sentry/components/timeline';
 import TimeSince from 'sentry/components/timeSince';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconEllipsis} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import GroupStore from 'sentry/stores/groupStore';
 import {space} from 'sentry/styles/space';
 import textStyles from 'sentry/styles/text';
@@ -136,8 +136,11 @@ export default function StreamlinedActivitySection({group}: {group: Group}) {
   const handleCreate = useCallback(
     (n: NoteType, _me: User) => {
       mutators.handleCreate(n, group.activity, {
-        onError: () => {
-          addErrorMessage(t('Unable to post comment'));
+        onError: err => {
+          const errMessage = err.responseJSON?.detail
+            ? tct('Error: [msg]', {msg: err.responseJSON?.detail as string})
+            : t('Unable to post comment');
+          addErrorMessage(errMessage);
         },
         onSuccess: data => {
           GroupStore.addActivity(group.id, data);

--- a/static/app/views/issueDetails/streamline/note.tsx
+++ b/static/app/views/issueDetails/streamline/note.tsx
@@ -12,7 +12,6 @@ import type {
   Mentioned,
 } from 'sentry/components/activity/note/types';
 import {Button} from 'sentry/components/button';
-import {Flex} from 'sentry/components/container/flex';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {NoteType} from 'sentry/types/alerts';
@@ -132,45 +131,46 @@ function StreamlinedNoteInput({
         : errorJSON.detail?.message || t('Unable to post comment'))) ||
     null;
   return (
-    <Flex column gap={space(0.75)} align="end">
-      <NoteInputForm data-test-id="note-input-form" noValidate onSubmit={handleSubmit}>
-        <MentionsInput
-          aria-label={t('Add a comment')}
-          aria-errormessage={errorMessage ? errorId : undefined}
-          style={mentionStyle({theme, minHeight: 14, streamlined: true})}
-          placeholder={placeholder}
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
-          value={value}
-          required
-        >
-          <Mention
-            trigger="@"
-            data={suggestMembers}
-            onAdd={handleAddMember}
-            displayTransform={(_id, display) => `@${display}`}
-            markup="**[sentry.strip:member]__display__**"
-            appendSpaceOnAdd
-          />
-          <Mention
-            trigger="#"
-            data={suggestTeams}
-            onAdd={handleAddTeam}
-            markup="**[sentry.strip:team]__display__**"
-            appendSpaceOnAdd
-          />
-        </MentionsInput>
-      </NoteInputForm>
+    <NoteInputForm data-test-id="note-input-form" noValidate onSubmit={handleSubmit}>
+      <MentionsInput
+        aria-label={t('Add a comment')}
+        aria-errormessage={errorMessage ? errorId : undefined}
+        style={{
+          ...mentionStyle({theme, minHeight: 14, streamlined: true}),
+          width: '100%',
+        }}
+        placeholder={placeholder}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        value={value}
+        required
+      >
+        <Mention
+          trigger="@"
+          data={suggestMembers}
+          onAdd={handleAddMember}
+          displayTransform={(_id, display) => `@${display}`}
+          markup="**[sentry.strip:member]__display__**"
+          appendSpaceOnAdd
+        />
+        <Mention
+          trigger="#"
+          data={suggestTeams}
+          onAdd={handleAddTeam}
+          markup="**[sentry.strip:team]__display__**"
+          appendSpaceOnAdd
+        />
+      </MentionsInput>
       <Button
         priority="primary"
         size="xs"
         disabled={!canSubmit}
-        onClick={submitForm}
         aria-label={t('Submit comment')}
+        type="submit"
       >
         {t('Comment')}
       </Button>
-    </Flex>
+    </NoteInputForm>
   );
 }
 
@@ -216,6 +216,10 @@ const getNoteInputErrorStyles = (p: {theme: Theme; error?: string}) => {
 };
 
 const NoteInputForm = styled('form')<{error?: string}>`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(0.75)};
+  align-items: flex-end;
   width: 100%;
   transition: padding 0.2s ease-in-out;
 

--- a/static/app/views/issueDetails/streamline/note.tsx
+++ b/static/app/views/issueDetails/streamline/note.tsx
@@ -11,7 +11,10 @@ import type {
   MentionChangeEvent,
   Mentioned,
 } from 'sentry/components/activity/note/types';
+import {Button} from 'sentry/components/button';
+import {Flex} from 'sentry/components/container/flex';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {NoteType} from 'sentry/types/alerts';
 import domId from 'sentry/utils/domId';
 import {useMembers} from 'sentry/utils/useMembers';
@@ -129,33 +132,45 @@ function StreamlinedNoteInput({
         : errorJSON.detail?.message || t('Unable to post comment'))) ||
     null;
   return (
-    <NoteInputForm data-test-id="note-input-form" noValidate onSubmit={handleSubmit}>
-      <MentionsInput
-        aria-errormessage={errorMessage ? errorId : undefined}
-        style={mentionStyle({theme, minHeight: 14, streamlined: true})}
-        placeholder={placeholder}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        value={value}
-        required
+    <Flex column gap={space(0.75)} align="end">
+      <NoteInputForm data-test-id="note-input-form" noValidate onSubmit={handleSubmit}>
+        <MentionsInput
+          aria-label={t('Add a comment')}
+          aria-errormessage={errorMessage ? errorId : undefined}
+          style={mentionStyle({theme, minHeight: 14, streamlined: true})}
+          placeholder={placeholder}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          value={value}
+          required
+        >
+          <Mention
+            trigger="@"
+            data={suggestMembers}
+            onAdd={handleAddMember}
+            displayTransform={(_id, display) => `@${display}`}
+            markup="**[sentry.strip:member]__display__**"
+            appendSpaceOnAdd
+          />
+          <Mention
+            trigger="#"
+            data={suggestTeams}
+            onAdd={handleAddTeam}
+            markup="**[sentry.strip:team]__display__**"
+            appendSpaceOnAdd
+          />
+        </MentionsInput>
+      </NoteInputForm>
+      <Button
+        priority="primary"
+        size="xs"
+        disabled={!canSubmit}
+        onClick={submitForm}
+        aria-label={t('Submit comment')}
       >
-        <Mention
-          trigger="@"
-          data={suggestMembers}
-          onAdd={handleAddMember}
-          displayTransform={(_id, display) => `@${display}`}
-          markup="**[sentry.strip:member]__display__**"
-          appendSpaceOnAdd
-        />
-        <Mention
-          trigger="#"
-          data={suggestTeams}
-          onAdd={handleAddTeam}
-          markup="**[sentry.strip:team]__display__**"
-          appendSpaceOnAdd
-        />
-      </MentionsInput>
-    </NoteInputForm>
+        {t('Comment')}
+      </Button>
+    </Flex>
   );
 }
 
@@ -201,6 +216,7 @@ const getNoteInputErrorStyles = (p: {theme: Theme; error?: string}) => {
 };
 
 const NoteInputForm = styled('form')<{error?: string}>`
+  width: 100%;
   transition: padding 0.2s ease-in-out;
 
   ${p => getNoteInputErrorStyles(p)};


### PR DESCRIPTION
Adds a comment button for more clarity about how to submit comments. The previous 'cmd+enter' will still work.

Also added tests for that hotkey, and the state of the button.

<img width="357" alt="image" src="https://github.com/user-attachments/assets/6dbc7738-f9be-459d-8e41-cdabec05c33e">
<img width="343" alt="image" src="https://github.com/user-attachments/assets/23078dbf-5e0f-4543-855b-6e455b723a95">
