### PR TITLE
feat(backpressure): add processing-store-transactions option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2014,6 +2014,11 @@ register(
     default=0.8,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "backpressure.high_watermarks.processing-store-transactions",
+    default=0.8,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Killswitch for monitor check-ins
 register("crons.organization.disable-check-in", type=Sequence, default=[])


### PR DESCRIPTION
This adds the `backpressure.high_watermarks.processing-store-transactions`, which currently isn't used by anything but will be used by backpressure after transactions have been split out into their own processing store.