### PR TITLE
feat(devservices): Add sentry config

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -4,21 +4,21 @@ x-sentry-service-config:
   service_name: sentry
   dependencies:
     snuba:
-      description: snuba
+      description: Service that provides fast aggregation and query capabilities on top of Clickhouse
       remote:
         repo_name: snuba
         branch: master
         repo_link: git@github.com:getsentry/snuba.git
         mode: containerized
     relay:
-      description: relay
+      description: Service event forwarding and ingestion service
       remote:
         repo_name: relay
         branch: master
         repo_link: git@github.com:getsentry/relay.git
         mode: containerized
     postgres:
-      description: postgres
+      description: Database used to store Sentry data
   modes:
     default: [snuba, postgres, relay]
 

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -20,8 +20,7 @@ x-sentry-service-config:
     postgres:
       description: postgres
   modes:
-    default: [snuba, postgres]
-    ingest: [snuba, postgres, relay]
+    default: [snuba, postgres, relay]
 
 services:
   postgres:

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -1,0 +1,56 @@
+# Ignored by docker compose, used by devservices
+x-sentry-service-config:
+  version: 0.1
+  service_name: sentry
+  dependencies:
+    snuba:
+      description: snuba
+      remote:
+        repo_name: snuba
+        branch: master
+        repo_link: git@github.com:getsentry/snuba.git
+        mode: containerized
+    relay:
+      description: relay
+      remote:
+        repo_name: relay
+        branch: master
+        repo_link: git@github.com:getsentry/relay.git
+        mode: containerized
+    postgres:
+      description: postgres
+  modes:
+    default: [snuba, postgres]
+    ingest: [snuba, postgres, relay]
+
+services:
+  postgres:
+    image: ghcr.io/getsentry/image-mirror-library-postgres:14-alpine
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_DB: sentry
+    command:
+      [
+        postgres,
+        -c,
+        wal_level=logical,
+        -c,
+        max_replication_slots=1,
+        -c,
+        max_wal_senders=1,
+      ]
+    networks:
+      - devservices
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
+    extra_hosts:
+      - host.docker.internal:host-gateway
+
+networks:
+  devservices:
+    name: devservices
+
+volumes:
+  postgres-data:

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -326,6 +326,7 @@ def devserver(
             kafka_consumers.add("uptime-configs")
 
         if settings.SENTRY_USE_RELAY:
+            # TODO: Remove this once we have a better way to check if relay is running for new devservices
             if "relay-relay-1" not in containers:
                 daemons += [("relay", ["sentry", "devservices", "attach", "relay"])]
 

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -231,6 +231,9 @@ def devserver(
 
     daemons: MutableSequence[tuple[str, Sequence[str]]] = []
     kafka_consumers: set[str] = set()
+    containers: set[str] = set()
+    with get_docker_client() as docker:
+        containers = {c.name for c in docker.containers.list(filters={"status": "running"})}
 
     if experimental_spa:
         os.environ["SENTRY_UI_DEV_ONLY"] = "1"
@@ -323,7 +326,8 @@ def devserver(
             kafka_consumers.add("uptime-configs")
 
         if settings.SENTRY_USE_RELAY:
-            daemons += [("relay", ["sentry", "devservices", "attach", "relay"])]
+            if "relay-relay-1" not in containers:
+                daemons += [("relay", ["sentry", "devservices", "attach", "relay"])]
 
             kafka_consumers.add("ingest-events")
             kafka_consumers.add("ingest-attachments")
@@ -347,9 +351,7 @@ def devserver(
 
     # Create all topics if the Kafka eventstream is selected
     if kafka_consumers:
-        with get_docker_client() as docker:
-            containers = {c.name for c in docker.containers.list(filters={"status": "running"})}
-        if "sentry_kafka" not in containers:
+        if "sentry_kafka" not in containers and "shared-kafka-kafka-1" not in containers:
             raise click.ClickException(
                 f"""
 Devserver is configured to start some kafka consumers, but Kafka
@@ -368,7 +370,7 @@ or:
 and run `sentry devservices up kafka`.
 
 Alternatively, run without --workers.
-"""
+        """
             )
 
         from sentry.conf.types.kafka_definition import Topic


### PR DESCRIPTION
This adds devservices configs for usage with sentry. Instead of running relay as a part of devserver, we are opting to do it in a container which allows us to automatically import relay configs from the relay repo. This will help in reducing the duplication of configs across repos.