### PR TITLE
chore(models): Prevent use of `DefaultFieldsModelExisting`

### DIFF
--- a/tests/sentry/backup/test_sanitize.py
+++ b/tests/sentry/backup/test_sanitize.py
@@ -24,7 +24,7 @@ from sentry.backup.sanitize import (
     sanitize,
 )
 from sentry.backup.scopes import RelocationScope
-from sentry.db.models.base import DefaultFieldsModelExisting
+from sentry.db.models.base import DefaultFieldsModel
 from sentry.db.models.fields.jsonfield import JSONField
 from sentry.db.models.fields.slug import SentrySlugField
 from sentry.db.models.fields.uuid import UUIDField
@@ -55,7 +55,7 @@ FAKE_DATE_ADDED = CURR_DATE - timedelta(days=7)
 FAKE_DATE_UPDATED = CURR_DATE - timedelta(days=6)
 
 
-class FakeSanitizableModel(DefaultFieldsModelExisting):
+class FakeSanitizableModel(DefaultFieldsModel):
     __relocation_scope__ = RelocationScope.Excluded
 
     email = models.EmailField(null=True, max_length=75)

--- a/tests/sentry/db/models/test_base.py
+++ b/tests/sentry/db/models/test_base.py
@@ -1,0 +1,63 @@
+from unittest import TestCase
+
+from sentry.data_secrecy.models import DataSecrecyWaiver
+from sentry.db.models import DefaultFieldsModelExisting
+from sentry.integrations.models import Integration, RepositoryProjectPathConfig
+from sentry.models.groupsearchview import GroupSearchView
+from sentry.models.importchunk import (
+    BaseImportChunk,
+    ControlImportChunk,
+    ControlImportChunkReplica,
+    RegionImportChunk,
+)
+from sentry.models.notificationsettingbase import NotificationSettingBase
+from sentry.models.notificationsettingoption import NotificationSettingOption
+from sentry.models.notificationsettingprovider import NotificationSettingProvider
+from sentry.models.projecttemplate import ProjectTemplate
+from sentry.models.relocation import (
+    Relocation,
+    RelocationFile,
+    RelocationValidation,
+    RelocationValidationAttempt,
+)
+from sentry.models.transaction_threshold import (
+    ProjectTransactionThreshold,
+    ProjectTransactionThresholdOverride,
+)
+from sentry.sentry_apps.models import SentryAppInstallationForProvider
+from sentry.uptime.models import ProjectUptimeSubscription, UptimeSubscription
+
+
+class PreventDefaultFieldsModelExistingUseTest(TestCase):
+    def all_subclasses(self, cls):
+        return set(cls.__subclasses__()).union(
+            [s for c in cls.__subclasses__() for s in self.all_subclasses(c)]
+        )
+
+    def test(self):
+        assert self.all_subclasses(DefaultFieldsModelExisting) == {
+            BaseImportChunk,
+            ControlImportChunk,
+            ControlImportChunkReplica,
+            DataSecrecyWaiver,
+            GroupSearchView,
+            Integration,
+            NotificationSettingBase,
+            NotificationSettingOption,
+            NotificationSettingProvider,
+            ProjectTemplate,
+            ProjectTransactionThreshold,
+            ProjectTransactionThresholdOverride,
+            ProjectUptimeSubscription,
+            RegionImportChunk,
+            Relocation,
+            RelocationFile,
+            RelocationValidation,
+            RelocationValidationAttempt,
+            RepositoryProjectPathConfig,
+            SentryAppInstallationForProvider,
+            UptimeSubscription,
+        }, (
+            "Don't use `DefaultFieldsModelExisting` for new models - Use `DefaultFieldsModel` "
+            "instead. If you're retrofitting an existing model, add it to the list in this test."
+        )


### PR DESCRIPTION
`DefaultFieldsModelExisting` only exists for retrofitting existing models to have `date_added` and `date_updated`. New models should use `DefaultFieldsModel`, which marks the fields as not nullable. This adds a test to enforce this.
