### PR TITLE
ref: Remove unused form/button, prefer the 'request-authn' command instead

### DIFF
--- a/src/sentry/templates/sentry/toolbar/iframe.html
+++ b/src/sentry/templates/sentry/toolbar/iframe.html
@@ -16,10 +16,6 @@ Required context variables:
     <link rel="icon" type="image/png" href="{% absolute_asset_url "sentry" "images/favicon.png" %}">
   </head>
   <body>
-    <form id="login-form">
-      <button type="submit">Log in</button>
-    </form>
-
     {% script %}
     <script>
       (function() {
@@ -41,15 +37,6 @@ Required context variables:
             'sentry-toolbar-auth-popup',
             'popup=true,innerWidth=800,innerHeight=550,noopener=false'
           );
-        }
-
-        function setupLoginForm() {
-          log('setupLoginForm()');
-          const form = document.getElementById('login-form');
-          form.addEventListener('submit', submitEvent => {
-            submitEvent.preventDefault();
-            requestAuthn();
-          });
         }
 
         function sendStateMessage(state) {
@@ -171,7 +158,6 @@ Required context variables:
         log('Init', { referrer, state });
 
         setupMessageChannel();
-        setupLoginForm();
         listenForLoginSuccess();
         // enum of: logged-out, missing-project, invalid-domain, logged-in
         sendStateMessage(state === 'success' ? 'logged-in' : state);


### PR DESCRIPTION
Dead code is dead. See https://github.com/getsentry/sentry-toolbar/pull/87 the callsites, default behavior was not to show this html snippet.