### PR TITLE
feat(issues): Add environment and release icon summary

### DIFF
--- a/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
@@ -99,4 +99,10 @@ describe('HighlightsIconSummary', function () {
     await userEvent.hover(screen.getByText('x86'));
     expect(await screen.findByText('Device Architecture')).toBeInTheDocument();
   });
+
+  it('renders release and environment tags', function () {
+    render(<HighlightsIconSummary event={event} />);
+    expect(screen.getByText('1.8')).toBeInTheDocument();
+    expect(screen.getByText('production')).toBeInTheDocument();
+  });
 });

--- a/static/app/components/events/highlights/highlightsIconSummary.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.tsx
@@ -10,6 +10,9 @@ import {
 } from 'sentry/components/events/contexts/utils';
 import {ScrollCarousel} from 'sentry/components/scrollCarousel';
 import {Tooltip} from 'sentry/components/tooltip';
+import Version from 'sentry/components/version';
+import {IconReleases, IconWindow} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import {isMobilePlatform, isNativePlatform} from 'sentry/utils/platform';
@@ -48,10 +51,13 @@ export function HighlightsIconSummary({event}: HighlightsIconSummaryProps) {
       return hasData;
     });
 
+  const releaseTag = event.tags?.find(tag => tag.key === 'release');
+  const environmentTag = event.tags?.find(tag => tag.key === 'environment');
+
   return items.length ? (
     <Fragment>
       <IconBar>
-        <ScrollCarousel gap={4}>
+        <ScrollCarousel gap={3}>
           {items.map((item, index) => (
             <Flex key={index} gap={space(1)} align="center">
               <IconWrapper>{item.icon}</IconWrapper>
@@ -65,6 +71,33 @@ export function HighlightsIconSummary({event}: HighlightsIconSummaryProps) {
               </IconDescription>
             </Flex>
           ))}
+          {releaseTag && (
+            <Flex key="release" gap={space(1)} align="flex-end">
+              <IconWrapper>
+                <IconReleases size="sm" color="subText" />
+              </IconWrapper>
+              <IconDescription>
+                {releaseTag && (
+                  <StyledVersion
+                    truncate
+                    tooltipRawVersion
+                    version={releaseTag.value}
+                    projectId={event.projectID}
+                  />
+                )}
+              </IconDescription>
+            </Flex>
+          )}
+          {environmentTag && (
+            <Flex key="environment" gap={space(1)} align="flex-end">
+              <IconWrapper>
+                <IconWindow size="sm" color="subText" />
+              </IconWrapper>
+              <IconDescription>
+                <Tooltip title={t('Environment')}>{environmentTag.value}</Tooltip>
+              </IconDescription>
+            </Flex>
+          )}
         </ScrollCarousel>
       </IconBar>
       <SectionDivider style={{marginTop: space(1)}} />
@@ -91,4 +124,12 @@ const IconWrapper = styled('div')`
 const IconSubtitle = styled(Tooltip)`
   display: block;
   color: ${p => p.theme.subText};
+`;
+
+const StyledVersion = styled(Version)`
+  font-size: ${p => p.theme.fontSizeMedium};
+  color: ${p => p.theme.textColor};
+  &:hover {
+    color: ${p => p.theme.textColor};
+  }
 `;


### PR DESCRIPTION
Adds the release and environment to the icon summary. Uses icons that we've previously used for these sections

![image](https://github.com/user-attachments/assets/5a9d76d3-50d6-4195-8a13-32886ad779b2)
