### PR TITLE
fix(issues): Shrink message

### DIFF
--- a/static/app/components/events/interfaces/message.tsx
+++ b/static/app/components/events/interfaces/message.tsx
@@ -1,3 +1,5 @@
+import styled from '@emotion/styled';
+
 import {renderLinksInText} from 'sentry/components/events/interfaces/crashContent/exception/utils';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
@@ -59,10 +61,19 @@ export function Message({data, event}: Props) {
 
   return (
     <InterimSection title={t('Message')} type={SectionKey.MESSAGE}>
-      <pre className="plain">
-        {<AnnotatedText value={messageData} meta={meta?.data?.formatted?.['']} />}
-      </pre>
+      <PlainPre>
+        <AnnotatedText value={messageData} meta={meta?.data?.formatted?.['']} />
+      </PlainPre>
       {renderParams(data.params, meta)}
     </InterimSection>
   );
 }
+
+const PlainPre = styled('pre')`
+  background-color: inherit;
+  padding: 0;
+  border: 0;
+  margin-bottom: 0;
+  white-space: pre-wrap;
+  word-break: break-all;
+`;


### PR DESCRIPTION
we seem to still have other places that still use this class name. but migrating away from the global css is always nice.

`pre.plain` still being used in other places https://github.com/getsentry/sentry/blob/6caa046c5202ecf616d6d1af56c99f7f27823dbd/static/app/components/events/interfaces/crashContent/stackTrace/index.tsx#L44

can see the extra margin here
![image](https://github.com/user-attachments/assets/13521adb-9f6a-4e26-9258-392376f5ff25)
