### PR TITLE
fix(status): Kickoff outbound status sync when updating group statuses

### DIFF
--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from sentry_sdk.tracing import NoOpSpan, Span, Transaction
 
+from sentry.integrations.tasks.kick_off_status_syncs import kick_off_status_syncs
 from sentry.issues.escalating import manage_issue_states
 from sentry.issues.status_change_message import StatusChangeMessageData
 from sentry.models.group import Group, GroupStatus
@@ -64,6 +65,9 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
             activity_type=ActivityType.SET_RESOLVED,
         )
         remove_group_from_inbox(group, action=GroupInboxRemoveAction.RESOLVED)
+        kick_off_status_syncs.apply_async(
+            kwargs={"project_id": group.project_id, "group_id": group.id}
+        )
 
     elif new_status == GroupStatus.IGNORED:
         # The IGNORED status supports 3 substatuses. For UNTIL_ESCALATING and
@@ -83,6 +87,9 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
             activity_type=ActivityType.SET_IGNORED,
         )
         remove_group_from_inbox(group, action=GroupInboxRemoveAction.IGNORED)
+        kick_off_status_syncs.apply_async(
+            kwargs={"project_id": group.project_id, "group_id": group.id}
+        )
     elif new_status == GroupStatus.UNRESOLVED and new_substatus == GroupSubStatus.ESCALATING:
         # Update the group status, priority, and add the group to the inbox
         manage_issue_states(group=group, group_inbox_reason=GroupInboxReason.ESCALATING)
@@ -118,6 +125,9 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
             from_substatus=group.substatus,
         )
         add_group_to_inbox(group, group_inbox_reason)
+        kick_off_status_syncs.apply_async(
+            kwargs={"project_id": group.project_id, "group_id": group.id}
+        )
     else:
         logger.error(
             "group.update_status.unsupported_status",

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -433,7 +433,6 @@ class GroupManager(BaseManager["Group"]):
         from_substatus: int | None = None,
     ) -> None:
         """For each groups, update status to `status` and create an Activity."""
-        from sentry.integrations.tasks.kick_off_status_syncs import kick_off_status_syncs
         from sentry.models.activity import Activity
 
         modified_groups_list = []
@@ -468,9 +467,6 @@ class GroupManager(BaseManager["Group"]):
                 send_notification=send_activity_notification,
             )
             record_group_history_from_activity_type(group, activity_type.value)
-            kick_off_status_syncs.apply_async(
-                kwargs={"project_id": group.project_id, "group_id": group.id}
-            )
 
             if group.id in updated_priority:
                 new_priority = updated_priority[group.id]

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -433,6 +433,7 @@ class GroupManager(BaseManager["Group"]):
         from_substatus: int | None = None,
     ) -> None:
         """For each groups, update status to `status` and create an Activity."""
+        from sentry.integrations.tasks.kick_off_status_syncs import kick_off_status_syncs
         from sentry.models.activity import Activity
 
         modified_groups_list = []
@@ -467,6 +468,9 @@ class GroupManager(BaseManager["Group"]):
                 send_notification=send_activity_notification,
             )
             record_group_history_from_activity_type(group, activity_type.value)
+            kick_off_status_syncs.apply_async(
+                kwargs={"project_id": group.project_id, "group_id": group.id}
+            )
 
             if group.id in updated_priority:
                 new_priority = updated_priority[group.id]

--- a/tests/sentry/issues/test_status_change_consumer.py
+++ b/tests/sentry/issues/test_status_change_consumer.py
@@ -76,7 +76,8 @@ class StatusChangeProcessMessageTest(IssueOccurrenceTestBase):
             assert not GroupInbox.objects.filter(group=self.group).exists()
 
     @django_db_all
-    def test_valid_payload_resolved(self) -> None:
+    @patch("sentry.integrations.tasks.kick_off_status_syncs.kick_off_status_syncs")
+    def test_valid_payload_resolved(self, mock_kick_off_status_syncs: MagicMock) -> None:
         message = get_test_message_status_change(self.project.id, fingerprint=["touch-id"])
         result = _process_message(message)
         assert result is not None
@@ -93,7 +94,12 @@ class StatusChangeProcessMessageTest(IssueOccurrenceTestBase):
             group_inbox_reason=None,
         )
 
-    def test_valid_payload_archived_forever(self) -> None:
+        mock_kick_off_status_syncs.apply_async.assert_called_once_with(
+            kwargs={"project_id": self.project.id, "group_id": self.group.id}
+        )
+
+    @patch("sentry.integrations.tasks.kick_off_status_syncs.kick_off_status_syncs")
+    def test_valid_payload_archived_forever(self, mock_kick_off_status_syncs: MagicMock) -> None:
         message = get_test_message_status_change(
             self.project.id,
             fingerprint=self.fingerprint,
@@ -115,7 +121,14 @@ class StatusChangeProcessMessageTest(IssueOccurrenceTestBase):
             group_inbox_reason=None,
         )
 
-    def test_valid_payload_unresolved_escalating(self) -> None:
+        mock_kick_off_status_syncs.apply_async.assert_called_once_with(
+            kwargs={"project_id": self.project.id, "group_id": self.group.id}
+        )
+
+    @patch("sentry.integrations.tasks.kick_off_status_syncs.kick_off_status_syncs")
+    def test_valid_payload_unresolved_escalating(
+        self, mock_kick_off_status_syncs: MagicMock
+    ) -> None:
         self.group.update(
             status=GroupStatus.IGNORED,
             substatus=GroupSubStatus.UNTIL_ESCALATING,
@@ -141,6 +154,10 @@ class StatusChangeProcessMessageTest(IssueOccurrenceTestBase):
             ActivityType.SET_ESCALATING,
             PriorityLevel.HIGH,
             group_inbox_reason=GroupInboxReason.ESCALATING,
+        )
+
+        mock_kick_off_status_syncs.apply_async.assert_called_once_with(
+            kwargs={"project_id": self.project.id, "group_id": self.group.id}
         )
 
     def test_valid_payload_auto_ongoing(self) -> None:

--- a/tests/sentry/issues/test_status_change_consumer.py
+++ b/tests/sentry/issues/test_status_change_consumer.py
@@ -76,7 +76,7 @@ class StatusChangeProcessMessageTest(IssueOccurrenceTestBase):
             assert not GroupInbox.objects.filter(group=self.group).exists()
 
     @django_db_all
-    @patch("sentry.integrations.tasks.kick_off_status_syncs.kick_off_status_syncs")
+    @patch("sentry.issues.status_change_consumer.kick_off_status_syncs")
     def test_valid_payload_resolved(self, mock_kick_off_status_syncs: MagicMock) -> None:
         message = get_test_message_status_change(self.project.id, fingerprint=["touch-id"])
         result = _process_message(message)
@@ -98,7 +98,7 @@ class StatusChangeProcessMessageTest(IssueOccurrenceTestBase):
             kwargs={"project_id": self.project.id, "group_id": self.group.id}
         )
 
-    @patch("sentry.integrations.tasks.kick_off_status_syncs.kick_off_status_syncs")
+    @patch("sentry.issues.status_change_consumer.kick_off_status_syncs")
     def test_valid_payload_archived_forever(self, mock_kick_off_status_syncs: MagicMock) -> None:
         message = get_test_message_status_change(
             self.project.id,


### PR DESCRIPTION
The sentry codebase has multiple paths to update a group's status and substatus and update other tables such as GroupActivity and GroupHistory as groups transition between various states. `manage_issue_states`, which is used to update a group's status as it escalates, is missing a call to kickoff outbound status syncs which would update the status in external integrations such as Jira. This sync should also be triggered when status changes are made via the issue platform (https://github.com/getsentry/sentry/issues/79851). 

