### PR TITLE
feat(profiling) Add context menu to flamechart page

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphContextMenu.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphContextMenu.tsx
@@ -167,7 +167,7 @@ export function FlamegraphContextMenu(props: FlamegraphContextMenuProps) {
               })}
               icon={<IconCopy size="xs" />}
             >
-              {t('Copy function name')}
+              {t('Copy Function Name')}
             </ProfilingContextMenuItemButton>
             <ProfilingContextMenuItemButton
               {...props.contextMenu.getMenuItemProps({
@@ -179,7 +179,7 @@ export function FlamegraphContextMenu(props: FlamegraphContextMenuProps) {
               })}
               icon={<IconCopy size="xs" />}
             >
-              {t('Copy source location')}
+              {t('Copy Source Location')}
             </ProfilingContextMenuItemButton>
             <ProfilingContextMenuItemButton
               disabled={!sourceCodeLink.isSuccess || !sourceCodeLink.data?.sourceUrl}
@@ -414,7 +414,7 @@ export function ContinuousFlamegraphContextMenu(props: FlamegraphContextMenuProp
               })}
               icon={<IconCopy size="xs" />}
             >
-              {t('Copy function name')}
+              {t('Copy Function Name')}
             </ProfilingContextMenuItemButton>
             <ProfilingContextMenuItemButton
               {...props.contextMenu.getMenuItemProps({
@@ -426,7 +426,7 @@ export function ContinuousFlamegraphContextMenu(props: FlamegraphContextMenuProp
               })}
               icon={<IconCopy size="xs" />}
             >
-              {t('Copy source location')}
+              {t('Copy Source Location')}
             </ProfilingContextMenuItemButton>
             <ProfilingContextMenuItemButton
               disabled={!sourceCodeLink.isSuccess || !sourceCodeLink.data?.sourceUrl}

--- a/static/app/components/profiling/flamegraph/flamegraphSpansContextMenu.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphSpansContextMenu.tsx
@@ -1,0 +1,113 @@
+import {Fragment} from 'react';
+
+import {
+  ProfilingContextMenu,
+  ProfilingContextMenuGroup,
+  ProfilingContextMenuHeading,
+  ProfilingContextMenuItemButton,
+  ProfilingContextMenuLayer,
+} from 'sentry/components/profiling/profilingContextMenu';
+import {IconCopy, IconOpen} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import type {useContextMenu} from 'sentry/utils/profiling/hooks/useContextMenu';
+import type {SpanChartNode} from 'sentry/utils/profiling/spanChart';
+
+function getNodeType(node: SpanChartNode | null) {
+  if (!node) {
+    return '';
+  }
+  if (node.node.span.op === 'transaction') {
+    return t('Transaction');
+  }
+  return t('Span');
+}
+
+export interface SpansContextMenuProps {
+  contextMenu: ReturnType<typeof useContextMenu>;
+  hoveredNode: SpanChartNode | null;
+  onCopyDescription: () => void;
+  onCopyEventId: () => void;
+  onCopyOperation: () => void;
+  onOpenInTraceView: () => void;
+}
+
+export function SpansContextMenu(props: SpansContextMenuProps) {
+  const title = getNodeType(props.hoveredNode);
+
+  return props.contextMenu.open ? (
+    <Fragment>
+      <ProfilingContextMenuLayer onClick={() => props.contextMenu.setOpen(false)} />
+      <ProfilingContextMenu
+        {...props.contextMenu.getMenuProps()}
+        style={{
+          position: 'absolute',
+          left: props.contextMenu.position?.left ?? -9999,
+          top: props.contextMenu.position?.top ?? -9999,
+          maxHeight: props.contextMenu.containerCoordinates?.height ?? 'auto',
+        }}
+      >
+        <ProfilingContextMenuHeading>{title}</ProfilingContextMenuHeading>
+        {props.hoveredNode ? (
+          <ProfilingContextMenuGroup>
+            <ProfilingContextMenuItemButton
+              {...props.contextMenu.getMenuItemProps({
+                onClick: () => {
+                  props.onOpenInTraceView();
+                  // This is a button, so close the context menu.
+                  props.contextMenu.setOpen(false);
+                },
+              })}
+              icon={<IconOpen size="xs" />}
+            >
+              {tct('Open in Trace View', {type: title})}
+            </ProfilingContextMenuItemButton>
+            <ProfilingContextMenuItemButton
+              disabled={
+                !props.hoveredNode.node.span.event_id &&
+                !props.hoveredNode.node.span.span_id
+              }
+              {...props.contextMenu.getMenuItemProps({
+                onClick: () => {
+                  props.onCopyEventId();
+                  // This is a button, so close the context menu.
+                  props.contextMenu.setOpen(false);
+                },
+              })}
+              icon={<IconCopy size="xs" />}
+            >
+              {tct('Copy Event ID', {type: title})}
+            </ProfilingContextMenuItemButton>
+            <ProfilingContextMenuItemButton
+              disabled={!props.hoveredNode.node.span.description}
+              {...props.contextMenu.getMenuItemProps({
+                onClick: () => {
+                  props.onCopyDescription();
+                  // This is a button, so close the context menu.
+                  props.contextMenu.setOpen(false);
+                },
+              })}
+              icon={<IconCopy size="xs" />}
+            >
+              {tct('Copy [type] Description', {type: title})}
+            </ProfilingContextMenuItemButton>
+            <ProfilingContextMenuItemButton
+              disabled={!props.hoveredNode.node.span.op}
+              {...props.contextMenu.getMenuItemProps({
+                onClick: () => {
+                  props.onCopyOperation();
+                  // This is a button, so close the context menu.
+                  props.contextMenu.setOpen(false);
+                },
+              })}
+              icon={<IconCopy size="xs" />}
+            >
+              {tct('Copy [type] Operation', {
+                type: title,
+              })}
+            </ProfilingContextMenuItemButton>
+          </ProfilingContextMenuGroup>
+        ) : null}
+      </ProfilingContextMenu>
+    </Fragment>
+  ) : null;
+}

--- a/static/app/utils/profiling/spanTree.tsx
+++ b/static/app/utils/profiling/spanTree.tsx
@@ -97,6 +97,7 @@ class SpanTree {
       span_id: transaction.contexts?.trace?.span_id ?? undefined,
       event_id: transaction.eventID,
       parent_span_id: undefined,
+      trace_id: transaction.contexts?.trace?.trace_id ?? undefined,
       op: 'transaction',
     });
 

--- a/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
@@ -26,6 +26,7 @@ export const enum TraceViewSources {
   TRACES = 'traces',
   METRICS = 'metrics',
   DISCOVER = 'discover',
+  PROFILING_FLAMEGRAPH = 'profiling_flamegraph',
   REQUESTS_MODULE = 'requests_module',
   QUERIES_MODULE = 'queries_module',
   ASSETS_MODULE = 'assets_module',


### PR DESCRIPTION
Unlike the flamegraph, the transaction view had no way of clicking into the nodes and being able to either copy or go to the trace view. I've added 3 copy actions (id, op and description) as well as open in trace view action.

![CleanShot 2024-10-30 at 22 33 37@2x](https://github.com/user-attachments/assets/fcb97c7c-a537-4445-a39e-970697e514b0)
