### PR TITLE
fix(symbolicator): Remove `accept_invalid_certs` for NVIDIA's certificates

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2724,13 +2724,6 @@ SENTRY_BUILTIN_SOURCES = {
         "filters": {"filetypes": ["pe", "pdb"]},
         "url": "https://driver-symbols.nvidia.com/",
         "is_public": True,
-        # This tells Symbolicator to accept invalid SSL certs
-        # when connecting to this source. Currently Symbolicator can't deal
-        # with this source's certs because the `openssl` version we use
-        # lacks support for Authority Information Access (AIA),
-        # so we ignore the certs for now.
-        # TODO: Remove this once we can support AIA.
-        "accept_invalid_certs": True,
     },
     "chromium": {
         "type": "http",


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/79588
