### PR TITLE
ref(lpq): Delete LPQ from Symbolicator interface and symbolication tasks

### DIFF
--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -42,16 +42,11 @@ class SymbolicatorPlatform(Enum):
 @dataclass(frozen=True)
 class SymbolicatorTaskKind:
     """Bundles information about a symbolication task:
-    the platform, whether it's on the low priority queue, and
-    whether it's an existing event being reprocessed.
+    the platform and whether it's an existing event being reprocessed.
     """
 
     platform: SymbolicatorPlatform
-    is_low_priority: bool = False
     is_reprocessing: bool = False
-
-    def with_low_priority(self, is_low_priority: bool) -> SymbolicatorTaskKind:
-        return dataclasses.replace(self, is_low_priority=is_low_priority)
 
     def with_platform(self, platform: SymbolicatorPlatform) -> SymbolicatorTaskKind:
         return dataclasses.replace(self, platform=platform)
@@ -61,9 +56,19 @@ class SymbolicatorPools(Enum):
     default = "default"
     js = "js"
     jvm = "jvm"
-    lpq = "lpq"
-    lpq_js = "lpq_js"
-    lpq_jvm = "lpq_jvm"
+
+
+def pool_for_platform(platform: SymbolicatorPlatform) -> SymbolicatorPools:
+    """Returns the Symbolicator pool to use to symbolicate events for
+    the given platform.
+    """
+    match platform:
+        case SymbolicatorPlatform.native:
+            return SymbolicatorPools.default.value
+        case SymbolicatorPlatform.js:
+            return SymbolicatorPools.js.value
+        case SymbolicatorPlatform.jvm:
+            return SymbolicatorPools.jvm.value
 
 
 class Symbolicator:
@@ -75,21 +80,10 @@ class Symbolicator:
         event_id: str,
     ):
         URLS = settings.SYMBOLICATOR_POOL_URLS
-        pool = SymbolicatorPools.default.value
-        if task_kind.is_low_priority:
-            if task_kind.platform == SymbolicatorPlatform.js:
-                pool = SymbolicatorPools.lpq_js.value
-            elif task_kind.platform == SymbolicatorPlatform.jvm:
-                pool = SymbolicatorPools.lpq_jvm.value
-            else:
-                pool = SymbolicatorPools.lpq.value
-        elif task_kind.platform == SymbolicatorPlatform.js:
-            pool = SymbolicatorPools.js.value
-        elif task_kind.platform == SymbolicatorPlatform.jvm:
-            pool = SymbolicatorPools.jvm.value
+        pool = pool_for_platform(task_kind.platform)
 
         base_url = (
-            URLS.get(pool)
+            URLS.get(pool.value)
             or URLS.get(SymbolicatorPools.default.value)
             or options.get("symbolicator.options")["url"]
         )

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -64,11 +64,11 @@ def pool_for_platform(platform: SymbolicatorPlatform) -> SymbolicatorPools:
     """
     match platform:
         case SymbolicatorPlatform.native:
-            return SymbolicatorPools.default.value
+            return SymbolicatorPools.default
         case SymbolicatorPlatform.js:
-            return SymbolicatorPools.js.value
+            return SymbolicatorPools.js
         case SymbolicatorPlatform.jvm:
-            return SymbolicatorPools.jvm.value
+            return SymbolicatorPools.jvm
 
 
 class Symbolicator:

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -355,7 +355,5 @@ symbolicate_jvm_event = make_task_fn(
 symbolicate_event_from_reprocessing = make_task_fn(
     name="sentry.tasks.store.symbolicate_event_from_reprocessing",
     queue="events.reprocessing.symbolicate_event",
-    task_kind=SymbolicatorTaskKind(
-        platform=SymbolicatorPlatform.native, is_low_priority=False, is_reprocessing=True
-    ),
+    task_kind=SymbolicatorTaskKind(platform=SymbolicatorPlatform.native, is_reprocessing=True),
 )

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -8,14 +8,12 @@ from django.conf import settings
 
 from sentry.eventstore import processing
 from sentry.eventstore.processing.base import Event
-from sentry.features.rollout import in_random_rollout
 from sentry.killswitches import killswitch_matches_context
 from sentry.lang.javascript.processing import process_js_stacktraces
 from sentry.lang.native.processing import get_native_symbolication_function
 from sentry.lang.native.symbolicator import Symbolicator, SymbolicatorPlatform, SymbolicatorTaskKind
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.processing import realtime_metrics
 from sentry.silo.base import SiloMode
 from sentry.stacktraces.processing import StacktraceInfo, find_stacktraces_in_data
 from sentry.tasks import store
@@ -339,47 +337,19 @@ def make_task_fn(name: str, queue: str, task_kind: SymbolicatorTaskKind) -> Symb
 symbolicate_event = make_task_fn(
     name="sentry.tasks.store.symbolicate_event",
     queue="events.symbolicate_event",
-    task_kind=SymbolicatorTaskKind(
-        platform=SymbolicatorPlatform.native, is_low_priority=False, is_reprocessing=False
-    ),
+    task_kind=SymbolicatorTaskKind(platform=SymbolicatorPlatform.native, is_reprocessing=False),
 )
 symbolicate_js_event = make_task_fn(
     name="sentry.tasks.symbolicate_js_event",
     queue="events.symbolicate_js_event",
-    task_kind=SymbolicatorTaskKind(
-        platform=SymbolicatorPlatform.js, is_low_priority=False, is_reprocessing=False
-    ),
+    task_kind=SymbolicatorTaskKind(platform=SymbolicatorPlatform.js, is_reprocessing=False),
 )
 symbolicate_jvm_event = make_task_fn(
     name="sentry.tasks.symbolicate_jvm_event",
     queue="events.symbolicate_jvm_event",
-    task_kind=SymbolicatorTaskKind(
-        platform=SymbolicatorPlatform.jvm, is_low_priority=False, is_reprocessing=False
-    ),
+    task_kind=SymbolicatorTaskKind(platform=SymbolicatorPlatform.jvm, is_reprocessing=False),
 )
 
-# LPQ variants:
-symbolicate_event_low_priority = make_task_fn(
-    name="sentry.tasks.store.symbolicate_event_low_priority",
-    queue="events.symbolicate_event_low_priority",
-    task_kind=SymbolicatorTaskKind(
-        platform=SymbolicatorPlatform.native, is_low_priority=True, is_reprocessing=False
-    ),
-)
-symbolicate_js_event_low_priority = make_task_fn(
-    name="sentry.tasks.symbolicate_js_event_low_priority",
-    queue="events.symbolicate_js_event_low_priority",
-    task_kind=SymbolicatorTaskKind(
-        platform=SymbolicatorPlatform.js, is_low_priority=True, is_reprocessing=False
-    ),
-)
-symbolicate_jvm_event_low_priority = make_task_fn(
-    name="sentry.tasks.symbolicate_jvm_event_low_priority",
-    queue="events.symbolicate_jvm_event_low_priority",
-    task_kind=SymbolicatorTaskKind(
-        platform=SymbolicatorPlatform.jvm, is_low_priority=True, is_reprocessing=False
-    ),
-)
 
 # Reprocessing variants, only for "native" events:
 symbolicate_event_from_reprocessing = make_task_fn(
@@ -387,12 +357,5 @@ symbolicate_event_from_reprocessing = make_task_fn(
     queue="events.reprocessing.symbolicate_event",
     task_kind=SymbolicatorTaskKind(
         platform=SymbolicatorPlatform.native, is_low_priority=False, is_reprocessing=True
-    ),
-)
-symbolicate_event_from_reprocessing_low_priority = make_task_fn(
-    name="sentry.tasks.store.symbolicate_event_from_reprocessing_low_priority",
-    queue="events.reprocessing.symbolicate_event_low_priority",
-    task_kind=SymbolicatorTaskKind(
-        platform=SymbolicatorPlatform.native, is_low_priority=True, is_reprocessing=True
     ),
 )

--- a/tests/sentry/tasks/test_symbolication.py
+++ b/tests/sentry/tasks/test_symbolication.py
@@ -28,12 +28,6 @@ def mock_symbolicate_event():
 
 
 @pytest.fixture
-def mock_symbolicate_event_low_priority():
-    with mock.patch("sentry.tasks.symbolication.symbolicate_event_low_priority") as m:
-        yield m
-
-
-@pytest.fixture
 def mock_get_symbolication_function_for_platform():
     with mock.patch("sentry.tasks.symbolication.get_symbolication_function_for_platform") as m:
         yield m


### PR DESCRIPTION
This is part of the effort to remove the LPQ functionality, which has been unused since Sep 19 (see https://github.com/getsentry/sentry-options-automator/pull/2324).

This removes the notion of being on the LPQ from symbolication tasks and deletes the task definitions that were previously using it.

As a drive-by, this also factors platform -> pool selection into its own function.