### PR TITLE
ref(quick-start): Move releases to be above 'link sentry to source...'

### DIFF
--- a/static/app/components/onboardingWizard/newSidebar.tsx
+++ b/static/app/components/onboardingWizard/newSidebar.tsx
@@ -40,8 +40,8 @@ const orderedGettingStartedTasks = [
   OnboardingTaskKey.INVITE_MEMBER,
   OnboardingTaskKey.ALERT_RULE,
   OnboardingTaskKey.SOURCEMAPS,
-  OnboardingTaskKey.LINK_SENTRY_TO_SOURCE_CODE,
   OnboardingTaskKey.RELEASE_TRACKING,
+  OnboardingTaskKey.LINK_SENTRY_TO_SOURCE_CODE,
 ];
 
 const orderedBeyondBasicsTasks = [


### PR DESCRIPTION
this new order makes more sense as setting up a source code management does not automatically send releases 