### PR TITLE
feat(ds): Add feature validation to the batch sample rates endpoint

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_sampling_project_rates.py
+++ b/tests/sentry/api/endpoints/test_organization_sampling_project_rates.py
@@ -16,6 +16,9 @@ class OrganizationSamplingProjectRatesTest(APITestCase):
         self.organization.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
         self.login_as(user=self.user)
 
+    def test_without_ds(self):
+        self.get_error_response(self.organization.slug, status_code=404)
+
     def test_get(self):
         project1 = self.create_project(teams=[self.team])
         project2 = self.create_project(teams=[self.team])
@@ -62,4 +65,7 @@ class OrganizationSamplingProjectRatesTest(APITestCase):
             self.get_error_response(self.organization.slug, method="put", raw_data=data)
 
     def test_put_invalid_body(self):
-        self.get_error_response(self.organization.slug, method="put", raw_data={}, status_code=400)
+        with self.feature(self.features):
+            self.get_error_response(
+                self.organization.slug, method="put", raw_data={}, status_code=400
+            )


### PR DESCRIPTION
Without the feature flag and in automatic mode, the custom project rates will be
ignored and overwritten at a later point. To provide the user with more helpful
feedback, the endpoint now returns a 404 status code if custom DS is not
available for the plan, and a 403 if the user tries to update sample rates in
automatic mode.

