### PR TITLE
feat(insights): update view trends header and link for domain views

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1701,6 +1701,10 @@ function buildRoutes() {
           path="trace/:traceSlug/"
           component={make(() => import('sentry/views/performance/traceDetails'))}
         />
+        <Route
+          path="trends/"
+          component={make(() => import('sentry/views/performance/trends'))}
+        />
         <Route path={`${MODULE_BASE_URLS[ModuleName.HTTP]}/`}>
           <IndexRoute
             component={make(
@@ -1761,6 +1765,10 @@ function buildRoutes() {
           path="trace/:traceSlug/"
           component={make(() => import('sentry/views/performance/traceDetails'))}
         />
+        <Route
+          path="trends/"
+          component={make(() => import('sentry/views/performance/trends'))}
+        />
         <Route path={`${MODULE_BASE_URLS[ModuleName.DB]}/`}>
           <IndexRoute
             component={make(
@@ -1818,6 +1826,10 @@ function buildRoutes() {
         <Route
           path="trace/:traceSlug/"
           component={make(() => import('sentry/views/performance/traceDetails'))}
+        />
+        <Route
+          path="trends/"
+          component={make(() => import('sentry/views/performance/trends'))}
         />
         <Route path={`${MODULE_BASE_URLS[ModuleName.MOBILE_SCREENS]}/`}>
           <IndexRoute
@@ -1910,6 +1922,10 @@ function buildRoutes() {
         <Route
           path="trace/:traceSlug/"
           component={make(() => import('sentry/views/performance/traceDetails'))}
+        />
+        <Route
+          path="trends/"
+          component={make(() => import('sentry/views/performance/trends'))}
         />
         <Route path={`${MODULE_BASE_URLS[ModuleName.AI]}/`}>
           <IndexRoute

--- a/static/app/views/insights/common/components/viewTrendsButton.tsx
+++ b/static/app/views/insights/common/components/viewTrendsButton.tsx
@@ -3,15 +3,17 @@ import {t} from 'sentry/locale';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {trendsTargetRoute} from 'sentry/views/performance/utils';
 
 export function ViewTrendsButton() {
   const location = useLocation();
   const organization = useOrganization();
   const navigate = useNavigate();
+  const {view} = useDomainViewFilters();
 
   const handleTrendsClick = () => {
-    const target = trendsTargetRoute({organization, location});
+    const target = trendsTargetRoute({organization, location, view});
     navigate(target);
   };
   return (

--- a/static/app/views/performance/trends/content.tsx
+++ b/static/app/views/performance/trends/content.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import type {Location} from 'history';
 
 import {Alert} from 'sentry/components/alert';
-import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {CompactSelect} from 'sentry/components/compactSelect';
 import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -26,9 +25,10 @@ import {generateAggregateFields} from 'sentry/utils/discover/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import withPageFilters from 'sentry/utils/withPageFilters';
+import {TrendsHeader} from 'sentry/views/performance/trends/trendsHeader';
 import getSelectedQueryKey from 'sentry/views/performance/trends/utils/getSelectedQueryKey';
 
-import {getPerformanceLandingUrl, getTransactionSearchQuery} from '../utils';
+import {getTransactionSearchQuery} from '../utils';
 
 import ChangedTransactions from './changedTransactions';
 import type {TrendFunctionField, TrendView} from './types';
@@ -166,26 +166,6 @@ class TrendsContent extends Component<Props, State> {
     return '';
   }
 
-  getPerformanceLink() {
-    const {location} = this.props;
-
-    const newQuery = {
-      ...location.query,
-    };
-    const query = decodeScalar(location.query.query, '');
-    const conditions = new MutableSearch(query);
-
-    // This stops errors from occurring when navigating to other views since we are appending aggregates to the trends view
-    conditions.removeFilter('tpm()');
-    conditions.removeFilter('confidence()');
-    conditions.removeFilter('transaction.duration');
-    newQuery.query = conditions.formatString();
-    return {
-      pathname: getPerformanceLandingUrl(this.props.organization),
-      query: newQuery,
-    };
-  }
-
   render() {
     const {organization, eventView, location, projects} = this.props;
     const {previousTrendFunction} = this.state;
@@ -235,22 +215,7 @@ class TrendsContent extends Component<Props, State> {
           datetime: defaultTrendsSelectionDate,
         }}
       >
-        <Layout.Header>
-          <Layout.HeaderContent>
-            <Breadcrumbs
-              crumbs={[
-                {
-                  label: 'Performance',
-                  to: this.getPerformanceLink(),
-                },
-                {
-                  label: 'Trends',
-                },
-              ]}
-            />
-            <Layout.Title>{t('Trends')}</Layout.Title>
-          </Layout.HeaderContent>
-        </Layout.Header>
+        <TrendsHeader />
         <Layout.Body>
           <Layout.Main fullWidth>
             <DefaultTrends location={location} eventView={eventView} projects={projects}>

--- a/static/app/views/performance/trends/index.spec.tsx
+++ b/static/app/views/performance/trends/index.spec.tsx
@@ -19,6 +19,7 @@ import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import {WebVital} from 'sentry/utils/fields';
+import {useLocation} from 'sentry/utils/useLocation';
 import TrendsIndex from 'sentry/views/performance/trends/';
 import {defaultTrendsSelectionDate} from 'sentry/views/performance/trends/content';
 import {
@@ -30,6 +31,9 @@ import {
 const trendsViewQuery = {
   query: `tpm():>0.01 transaction.duration:>0 transaction.duration:<${DEFAULT_MAX_DURATION}`,
 };
+jest.mock('sentry/utils/useLocation');
+
+const mockUseLocation = jest.mocked(useLocation);
 
 jest.mock('moment-timezone', () => {
   const moment = jest.requireActual('moment-timezone');
@@ -133,6 +137,16 @@ function initializeTrendsData(
 
   const newQuery = {...(includeDefaultQuery ? trendsViewQuery : {}), ...query};
 
+  mockUseLocation.mockReturnValue({
+    pathname: '/organizations/org-slug/performance/trends/',
+    action: 'PUSH',
+    hash: '',
+    key: '',
+    query: newQuery,
+    search: '',
+    state: undefined,
+  });
+
   const initialData = initializeOrg({
     organization,
     router: {
@@ -152,6 +166,16 @@ function initializeTrendsData(
 describe('Performance > Trends', function () {
   let trendsStatsMock: jest.Mock;
   beforeEach(function () {
+    mockUseLocation.mockReturnValue({
+      pathname: '/organizations/org-slug/performance/trends/',
+      action: 'PUSH',
+      hash: '',
+      key: '',
+      query: {},
+      search: '',
+      state: undefined,
+    });
+
     browserHistory.push = jest.fn();
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/projects/',

--- a/static/app/views/performance/trends/trendsHeader.tsx
+++ b/static/app/views/performance/trends/trendsHeader.tsx
@@ -1,0 +1,79 @@
+import {Breadcrumbs} from 'sentry/components/breadcrumbs';
+import * as Layout from 'sentry/components/layouts/thirds';
+import {t} from 'sentry/locale';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {AiHeader} from 'sentry/views/insights/pages/ai/aiPageHeader';
+import {BackendHeader} from 'sentry/views/insights/pages/backend/backendPageHeader';
+import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
+import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
+import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
+import {getPerformanceLandingUrl} from 'sentry/views/performance/utils';
+
+export function TrendsHeader() {
+  const location = useLocation();
+  const organization = useOrganization();
+  const {view, isInDomainView} = useDomainViewFilters();
+
+  const headerTitle = t('Trends');
+
+  const getPerformanceLink = () => {
+    const newQuery = {
+      ...location.query,
+    };
+    const query = decodeScalar(location.query.query, '');
+    const conditions = new MutableSearch(query);
+
+    // This stops errors from occurring when navigating to other views since we are appending aggregates to the trends view
+    conditions.removeFilter('tpm()');
+    conditions.removeFilter('confidence()');
+    conditions.removeFilter('transaction.duration');
+    newQuery.query = conditions.formatString();
+    return {
+      pathname: getPerformanceLandingUrl(organization),
+      query: newQuery,
+    };
+  };
+
+  if (!isInDomainView) {
+    return (
+      <Layout.Header>
+        <Layout.HeaderContent>
+          <Breadcrumbs
+            crumbs={[
+              {
+                label: t('Performance'),
+                to: getPerformanceLink(),
+              },
+              {
+                label: headerTitle,
+              },
+            ]}
+          />
+          <Layout.Title>{headerTitle}</Layout.Title>
+        </Layout.HeaderContent>
+      </Layout.Header>
+    );
+  }
+
+  const headerProps = {
+    headerTitle,
+    breadcrumbs: [{label: headerTitle, to: undefined}],
+  };
+
+  if (view === 'ai') {
+    return <AiHeader {...headerProps} />;
+  }
+
+  if (view === 'frontend') {
+    return <FrontendHeader {...headerProps} />;
+  }
+
+  if (view === 'mobile') {
+    return <MobileHeader {...headerProps} />;
+  }
+
+  return <BackendHeader {...headerProps} />;
+}

--- a/static/app/views/performance/utils/index.tsx
+++ b/static/app/views/performance/utils/index.tsx
@@ -192,8 +192,11 @@ export function getPerformanceLandingUrl(organization: OrganizationSummary): str
   return `${getPerformanceBaseUrl(organization.slug)}/`;
 }
 
-export function getPerformanceTrendsUrl(organization: OrganizationSummary): string {
-  return `${getPerformanceBaseUrl(organization.slug)}/trends/`;
+export function getPerformanceTrendsUrl(
+  organization: OrganizationSummary,
+  view?: DomainView
+): string {
+  return `${getPerformanceBaseUrl(organization.slug, view)}/trends/`;
 }
 
 export function getTransactionSearchQuery(location: Location, query: string = '') {
@@ -225,11 +228,13 @@ export function trendsTargetRoute({
   organization,
   initialConditions,
   additionalQuery,
+  view,
 }: {
   location: Location;
   organization: Organization;
   additionalQuery?: {[x: string]: string};
   initialConditions?: MutableSearch;
+  view?: DomainView;
 }) {
   const newQuery = {
     ...location.query,
@@ -264,7 +269,7 @@ export function trendsTargetRoute({
   }
   newQuery.query = modifiedConditions.formatString();
 
-  return {pathname: getPerformanceTrendsUrl(organization), query: {...newQuery}};
+  return {pathname: getPerformanceTrendsUrl(organization, view), query: {...newQuery}};
 }
 
 export function removeTracingKeysFromSearch(


### PR DESCRIPTION
Work for #77572 

When you click the `view trends` button at the top right of the domain overview page, it takes you to the trends page.
The PR makes the following changes.
1. When in a domain view, clicking that button now takes you to `/insights/<view>/trends/`, I had to add a new route per view to make this work.

2. The breadcrumbs on the trends page now accurately reflects the location. This logic is done in a new component `TrendsHeader.tsx` as the trends content component is a class based component so it would be trickier to use the domain view filter hooks.
<img width="1285" alt="image" src="https://github.com/user-attachments/assets/272fa7fe-4598-410f-b08f-476053ca35d4">

