### PR TITLE
fix(quick-start): Fix task pending indicator

### DIFF
--- a/static/app/components/onboardingWizard/newSidebar.tsx
+++ b/static/app/components/onboardingWizard/newSidebar.tsx
@@ -184,9 +184,7 @@ function Task({task, status, hidePanel, showWaitingIndicator}: TaskProps) {
           )}
           {status === 'pending' && (
             <Tooltip
-              title={t(
-                'You’ve invited members, and their acceptance is pending. Keep an eye out for updates!'
-              )}
+              title={task.pendingTitle ?? t('Task in progress\u2026')}
               containerDisplayMode="flex"
               css={css`
                 justify-content: center;

--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -311,7 +311,7 @@ export function getOnboardingTasks({
       actionType: 'app',
       location: `/organizations/${organization.slug}/projects/new/`,
       display: true,
-      pendingTitle: t('Waiting for error'),
+      pendingTitle: t('Awaiting an error for this project.'),
       SupplementComponent: ({task}: OnboardingSupplementComponentProps) => {
         if (!hasQuickStartUpdatesFeature(organization)) {
           return null;

--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -250,6 +250,9 @@ export function getOnboardingTasks({
       action: () => openInviteMembersModal({source: 'onboarding_widget'}),
       display: true,
       group: OnboardingTaskGroup.GETTING_STARTED,
+      pendingTitle: t(
+        'You’ve invited members, and their acceptance is pending. Keep an eye out for updates!'
+      ),
     },
     {
       task: OnboardingTaskKey.FIRST_INTEGRATION,
@@ -308,6 +311,7 @@ export function getOnboardingTasks({
       actionType: 'app',
       location: `/organizations/${organization.slug}/projects/new/`,
       display: true,
+      pendingTitle: t('Waiting for error'),
       SupplementComponent: ({task}: OnboardingSupplementComponentProps) => {
         if (!hasQuickStartUpdatesFeature(organization)) {
           return null;

--- a/static/app/types/onboarding.tsx
+++ b/static/app/types/onboarding.tsx
@@ -78,6 +78,7 @@ interface OnboardingTaskDescriptorBase {
    * The group that this task belongs to, e.g. basic and level up
    */
   group?: OnboardingTaskGroup;
+  pendingTitle?: string;
   /**
    * Joins with this task id for server-side onboarding state.
    * This allows you to create alias for exising onboarding tasks or create multiple


### PR DESCRIPTION
The title for the "Invite your team' task was being shown for other pending indicators. This PR fixes it 

**Preview**

https://github.com/user-attachments/assets/c32fe76f-00d4-4ab3-8e3d-a8a938dff7ce

