### PR TITLE
ref(quick-start): Remove requisites for integrations

### DIFF
--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -270,7 +270,7 @@ export function getOnboardingTasks({
         'Triage and resolve issues faster by integrating Sentry with messaging platforms like Slack, Discord, and MS Teams.'
       ),
       skippable: true,
-      requisites: [OnboardingTaskKey.FIRST_PROJECT, OnboardingTaskKey.FIRST_EVENT],
+      requisites: [],
       actionType: 'app',
       location: `/settings/${organization.slug}/integrations/?category=chat`,
       display: hasQuickStartUpdatesFeature(organization),
@@ -282,7 +282,7 @@ export function getOnboardingTasks({
         'Resolve bugs faster with commit data and stack trace linking to your source code in GitHub, Gitlab, and more.'
       ),
       skippable: true,
-      requisites: [OnboardingTaskKey.FIRST_PROJECT, OnboardingTaskKey.FIRST_EVENT],
+      requisites: [],
       actionType: 'app',
       location: {
         pathname: `/settings/${organization.slug}/integrations/`,


### PR DESCRIPTION
We do not need this... Integrations can be added to an org