### PR TITLE
ref(issue-details): Some styling fixes around the event header

### DIFF
--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -14,7 +14,6 @@ import marked, {singleLineRenderer} from 'sentry/utils/marked';
 import {type ApiQueryKey, useApiQuery} from 'sentry/utils/queryClient';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 interface GroupSummaryProps {
   groupCategory: IssueCategory;
@@ -87,15 +86,13 @@ export function GroupSummary({groupId, groupCategory}: GroupSummaryProps) {
 
   const openForm = useFeedbackForm();
 
-  const isStreamlined = useHasStreamlinedUI();
-
   if (!isSummaryEnabled(hasGenAIConsent, groupCategory)) {
     // TODO: Render a banner for needing genai consent
     return null;
   }
 
   return (
-    <Wrapper isStreamlined={isStreamlined}>
+    <Wrapper>
       <StyledTitleRow onClick={() => setExpanded(!data ? false : !expanded)}>
         <CollapsedRow>
           <IconContainer>
@@ -182,8 +179,8 @@ const SummaryPreview = styled('span')`
   color: ${p => p.theme.subText};
 `;
 
-const Wrapper = styled(Panel)<{isStreamlined: boolean}>`
-  margin-bottom: ${p => (p.isStreamlined ? 0 : space(1))};
+const Wrapper = styled(Panel)`
+  margin-bottom: ${space(1)};
   padding: ${space(0.5)};
 `;
 

--- a/static/app/views/issueDetails/streamline/eventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.tsx
@@ -191,6 +191,7 @@ export function IssueEventNavigation({event, group, query}: IssueEventNavigation
                 </DropdownCountWrapper>
               ),
               textValue: TabName[Tab.REPLAYS],
+              disabled: replaysCount === 0,
               to: {
                 ...location,
                 pathname: `${baseUrl}${TabPaths[Tab.REPLAYS]}`,
@@ -207,6 +208,7 @@ export function IssueEventNavigation({event, group, query}: IssueEventNavigation
                 </DropdownCountWrapper>
               ),
               textValue: TabName[Tab.ATTACHMENTS],
+              disabled: attachments.attachments.length === 0 && !hasManyAttachments,
               to: {
                 ...location,
                 pathname: `${baseUrl}${TabPaths[Tab.ATTACHMENTS]}`,
@@ -220,6 +222,7 @@ export function IssueEventNavigation({event, group, query}: IssueEventNavigation
                 </DropdownCountWrapper>
               ),
               textValue: TabName[Tab.USER_FEEDBACK],
+              disabled: group.userReportCount === 0,
               to: {
                 ...location,
                 pathname: `${baseUrl}${TabPaths[Tab.USER_FEEDBACK]}`,
@@ -341,7 +344,7 @@ const LargeDropdownButtonWrapper = styled('div')`
 const NavigationDropdownButton = styled(DropdownButton)`
   font-size: ${p => p.theme.fontSizeLarge};
   font-weight: ${p => p.theme.fontWeightBold};
-  padding-right: ${space(0.25)};
+  padding-right: ${space(0.5)};
 `;
 
 const LargeInThisIssueText = styled('div')`
@@ -355,12 +358,11 @@ const EventNavigationWrapper = styled('div')`
   flex-direction: column;
   justify-content: space-between;
   font-size: ${p => p.theme.fontSizeSmall};
-  padding: ${space(1)} 0 ${space(0.5)} ${space(0.25)};
+  padding: 0 0 ${space(0.5)} ${space(0.25)};
 
   @media (min-width: ${p => p.theme.breakpoints.xsmall}) {
     flex-direction: row;
     align-items: center;
-    padding: ${space(1)} 0 ${space(0.5)} ${space(0.25)};
   }
 `;
 

--- a/static/app/views/issueDetails/streamline/eventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.tsx
@@ -173,7 +173,7 @@ export function IssueEventNavigation({event, group, query}: IssueEventNavigation
             {
               key: Tab.DETAILS,
               label: (
-                <DropdownCountWrapper>
+                <DropdownCountWrapper isCurrentTab={currentTab === Tab.DETAILS}>
                   {TabName[Tab.DETAILS]} <ItemCount value={group.count} />
                 </DropdownCountWrapper>
               ),
@@ -186,12 +186,11 @@ export function IssueEventNavigation({event, group, query}: IssueEventNavigation
             {
               key: Tab.REPLAYS,
               label: (
-                <DropdownCountWrapper>
+                <DropdownCountWrapper isCurrentTab={currentTab === Tab.REPLAYS}>
                   {TabName[Tab.REPLAYS]} <ItemCount value={replaysCount} />
                 </DropdownCountWrapper>
               ),
               textValue: TabName[Tab.REPLAYS],
-              disabled: replaysCount === 0,
               to: {
                 ...location,
                 pathname: `${baseUrl}${TabPaths[Tab.REPLAYS]}`,
@@ -200,7 +199,7 @@ export function IssueEventNavigation({event, group, query}: IssueEventNavigation
             {
               key: Tab.ATTACHMENTS,
               label: (
-                <DropdownCountWrapper>
+                <DropdownCountWrapper isCurrentTab={currentTab === Tab.ATTACHMENTS}>
                   {TabName[Tab.ATTACHMENTS]}
                   <CustomItemCount>
                     {hasManyAttachments ? '50+' : attachments.attachments.length}
@@ -208,7 +207,6 @@ export function IssueEventNavigation({event, group, query}: IssueEventNavigation
                 </DropdownCountWrapper>
               ),
               textValue: TabName[Tab.ATTACHMENTS],
-              disabled: attachments.attachments.length === 0 && !hasManyAttachments,
               to: {
                 ...location,
                 pathname: `${baseUrl}${TabPaths[Tab.ATTACHMENTS]}`,
@@ -217,12 +215,11 @@ export function IssueEventNavigation({event, group, query}: IssueEventNavigation
             {
               key: Tab.USER_FEEDBACK,
               label: (
-                <DropdownCountWrapper>
+                <DropdownCountWrapper isCurrentTab={currentTab === Tab.USER_FEEDBACK}>
                   {TabName[Tab.USER_FEEDBACK]} <ItemCount value={group.userReportCount} />
                 </DropdownCountWrapper>
               ),
               textValue: TabName[Tab.USER_FEEDBACK],
-              disabled: group.userReportCount === 0,
               to: {
                 ...location,
                 pathname: `${baseUrl}${TabPaths[Tab.USER_FEEDBACK]}`,
@@ -382,11 +379,13 @@ const Navigation = styled('div')`
   border-right: 1px solid ${p => p.theme.gray100};
 `;
 
-const DropdownCountWrapper = styled('div')`
+const DropdownCountWrapper = styled('div')<{isCurrentTab: boolean}>`
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: ${space(3)};
+  font-weight: ${p =>
+    p.isCurrentTab ? p.theme.fontWeightBold : p.theme.fontWeightNormal};
 `;
 
 const ItemCount = styled(Count)`

--- a/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
+++ b/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
@@ -1,11 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import Feature from 'sentry/components/acl/feature';
-import ErrorBoundary from 'sentry/components/errorBoundary';
-import {GroupSummary} from 'sentry/components/group/groupSummary';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
@@ -51,14 +47,6 @@ export function GroupDetailsLayout({
         <div>
           <EventDetailsHeader event={event} group={group} />
           <GroupContent>
-            <PageErrorBoundary
-              mini
-              message={t('There was an error loading the issue summary')}
-            >
-              <Feature features={['organizations:ai-summary']}>
-                <GroupSummary groupId={group.id} groupCategory={group.issueCategory} />
-              </Feature>
-            </PageErrorBoundary>
             <div>
               <IssueEventNavigation event={event} group={group} query={searchQuery} />
               {children}
@@ -87,19 +75,13 @@ const StyledLayoutBody = styled(Layout.Body)<{
 const GroupContent = styled(Layout.Main)`
   background: ${p => p.theme.backgroundSecondary};
   min-height: 100vh;
-  padding: ${space(1.5)};
+  padding: 10px ${space(1.5)} ${space(1.5)};
   display: flex;
   flex-direction: column;
-  gap: ${space(1.5)};
   @media (min-width: ${p => p.theme.breakpoints.large}) {
     border-right: 1px solid ${p => p.theme.translucentBorder};
   }
   @media (max-width: ${p => p.theme.breakpoints.large}) {
     border-bottom-width: 1px solid ${p => p.theme.translucentBorder};
   }
-`;
-
-const PageErrorBoundary = styled(ErrorBoundary)`
-  margin: 0;
-  border: 1px solid ${p => p.theme.translucentBorder};
 `;

--- a/static/app/views/issueDetails/streamline/sidebar.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar.tsx
@@ -1,10 +1,13 @@
 import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
+import Feature from 'sentry/components/acl/feature';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {StreamlinedExternalIssueList} from 'sentry/components/group/externalIssuesList/streamlinedExternalIssueList';
+import {GroupSummary} from 'sentry/components/group/groupSummary';
 import * as Layout from 'sentry/components/layouts/thirds';
 import * as SidebarSection from 'sentry/components/sidebarSection';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group, TeamParticipant, UserParticipant} from 'sentry/types/group';
@@ -41,6 +44,11 @@ export default function StreamlinedSidebar({group, event, project}: Props) {
 
   return (
     <Side>
+      <ErrorBoundary mini message={t('There was an error loading the issue summary')}>
+        <Feature features={['organizations:ai-summary']}>
+          <GroupSummary groupId={group.id} groupCategory={group.issueCategory} />
+        </Feature>
+      </ErrorBoundary>
       <FirstLastSeenSection group={group} />
       <StyledBreak />
       {event && (


### PR DESCRIPTION
Fixes the margins around the select header by moving AI summary to the sidebar. It doesn't look great, but we can redo that in another PR.

<img width="997" alt="image" src="https://github.com/user-attachments/assets/8ddf01c5-1cdb-41ac-89f1-fb8a1f6065a6">

Also bolding the currently selected tab to make it more apparent which is on.

<img width="190" alt="image" src="https://github.com/user-attachments/assets/90ace205-7a86-4efa-994a-62ddfc456497">