### PR TITLE
fix(new-trace): Use correct billing terminology

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceTypeWarnings/errorsOnlyWarnings.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTypeWarnings/errorsOnlyWarnings.tsx
@@ -14,6 +14,7 @@ import {browserHistory} from 'sentry/utils/browserHistory';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import useProjects from 'sentry/utils/useProjects';
+import {getDocsLinkForEventType} from 'sentry/views/settings/account/notifications/utils';
 
 import {traceAnalytics} from '../traceAnalytics';
 import type {TraceTree} from '../traceModels/traceTree';
@@ -139,6 +140,7 @@ type Subscription = {
   planDetails: {
     billingInterval: 'monthly' | 'annual';
   };
+  planTier: string;
   onDemandBudgets?: {
     enabled: boolean;
   };
@@ -191,7 +193,9 @@ function PerformanceQuotaExceededWarning(props: ErrorOnlyWarningsProps) {
 
   const title = tct("You've exceeded your [billingType]", {
     billingType: subscription?.onDemandBudgets?.enabled
-      ? t('pay-as-you-go budget')
+      ? subscription.planTier === 'am3'
+        ? t('pay-as-you-go budget')
+        : t('on-demand budget')
       : t('quota'),
   });
 
@@ -223,13 +227,15 @@ function PerformanceQuotaExceededWarning(props: ErrorOnlyWarningsProps) {
           props.tree.shape
         );
         browserHistory.push({
-          pathname: `/settings/billing/checkout/`,
+          pathname: `/settings/billing/checkout/?referrer=trace-view`,
           query: {
             skipBundles: true,
           },
         });
       }}
-      docsRoute="https://docs.sentry.io/pricing/quotas/"
+      docsRoute={getDocsLinkForEventType(
+        dataCategories && 'spans' in dataCategories ? 'span' : 'transaction'
+      )}
       primaryButtonText={ctaText}
     />
   );

--- a/static/app/views/performance/newTraceDetails/traceTypeWarnings/errorsOnlyWarnings.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTypeWarnings/errorsOnlyWarnings.tsx
@@ -193,9 +193,9 @@ function PerformanceQuotaExceededWarning(props: ErrorOnlyWarningsProps) {
 
   const title = tct("You've exceeded your [billingType]", {
     billingType: subscription?.onDemandBudgets?.enabled
-      ? subscription.planTier === 'am3'
-        ? t('pay-as-you-go budget')
-        : t('on-demand budget')
+      ? ['am1', 'am2'].includes(subscription.planTier)
+        ? t('on-demand budget')
+        : t('pay-as-you-go budget')
       : t('quota'),
   });
 


### PR DESCRIPTION
Zendesk ticket: https://sentry.zendesk.com/agent/tickets/136385

Customers on the latest plan use the term "pay-as-you-go budget" but on legacy plans we use the term "on-demand." Updated the trace view over-quota banner to reflect this + use the more specific docs links.