### PR TITLE
fix(trace) run autogrouping on subtree

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -1475,14 +1475,13 @@ export class TraceTree extends TraceTreeEventDispatcher {
         }
 
         if (options.preferences.missing_instrumentation) {
-          TraceTree.DetectMissingInstrumentation(this.root);
+          TraceTree.DetectMissingInstrumentation(root);
         }
-
         if (options.preferences.autogroup.sibling) {
-          TraceTree.AutogroupSiblingSpanNodes(this.root);
+          TraceTree.AutogroupSiblingSpanNodes(root);
         }
         if (options.preferences.autogroup.parent) {
-          TraceTree.AutogroupDirectChildrenSpanNodes(this.root);
+          TraceTree.AutogroupDirectChildrenSpanNodes(root);
         }
 
         if (index !== -1) {


### PR DESCRIPTION
This doesnt need to run on the entire tree and we can only run it on the subtree of spans we've created