### PR TITLE
fix(issues): Prevent undefined replay id request

### DIFF
--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -159,7 +159,7 @@ function HighlightsData({
   const tagReplayId = tagReplayItem?.value ?? EMPTY_HIGHLIGHT_DEFAULT;
 
   // if the id doesn't exist for either tag or context, it's rendered as '--'
-  const replayId =
+  const replayId: string | undefined =
     contextReplayId !== EMPTY_HIGHLIGHT_DEFAULT
       ? contextReplayId
       : tagReplayId !== EMPTY_HIGHLIGHT_DEFAULT

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -21,7 +21,7 @@ type Options = {
   /**
    * The replayId
    */
-  replayId: string;
+  replayId: string | undefined;
 
   /**
    * Default: 50
@@ -91,6 +91,7 @@ function useReplayData({
   } = useApiQuery<{data: unknown}>([`/organizations/${orgSlug}/replays/${replayId}/`], {
     staleTime: Infinity,
     retry: false,
+    enabled: Boolean(replayId),
   });
   const replayRecord = useMemo(
     () => (replayData?.data ? mapResponseToReplayRecord(replayData.data) : undefined),
@@ -125,7 +126,11 @@ function useReplayData({
     isFetching: isFetchingAttachments,
     error: fetchAttachmentsError,
   } = useFetchParallelPages({
-    enabled: !fetchReplayError && Boolean(projectSlug) && Boolean(replayRecord),
+    enabled:
+      !fetchReplayError &&
+      Boolean(replayId) &&
+      Boolean(projectSlug) &&
+      Boolean(replayRecord),
     hits: replayRecord?.count_segments ?? 0,
     getQueryKey: getAttachmentsQueryKey,
     perPage: segmentsPerPage,


### PR DESCRIPTION
`replayId` had type `any` which was allowing it to be passed as undefined to useReplayData which would attempt to fetch an undefined replay.

![image](https://github.com/user-attachments/assets/a5a74689-094d-4a56-aeb6-b7583f69ebc3)
