### PR TITLE
ref(highlights): Use the hovercard for the release tag summary

### DIFF
--- a/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.spec.tsx
@@ -1,4 +1,6 @@
 import {EventFixture} from 'sentry-fixture/event';
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -14,6 +16,8 @@ jest.mock('sentry/components/events/contexts/contextIcon', () => ({
 }));
 
 describe('HighlightsIconSummary', function () {
+  const organization = OrganizationFixture();
+  const group = GroupFixture();
   const event = EventFixture({
     contexts: TEST_EVENT_CONTEXTS,
     tags: TEST_EVENT_TAGS,
@@ -100,9 +104,21 @@ describe('HighlightsIconSummary', function () {
     expect(await screen.findByText('Device Architecture')).toBeInTheDocument();
   });
 
-  it('renders release and environment tags', function () {
-    render(<HighlightsIconSummary event={event} />);
-    expect(screen.getByText('1.8')).toBeInTheDocument();
+  it('renders release and environment tags', async function () {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${group.project.slug}/releases/1.8/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/1.8/deploys/`,
+      body: [],
+    });
+    render(<HighlightsIconSummary event={event} group={group} />);
+    expect(await screen.findByText('1.8')).toBeInTheDocument();
     expect(screen.getByText('production')).toBeInTheDocument();
   });
 });

--- a/static/app/components/events/highlights/highlightsIconSummary.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.tsx
@@ -11,18 +11,23 @@ import {
 import {ScrollCarousel} from 'sentry/components/scrollCarousel';
 import {Tooltip} from 'sentry/components/tooltip';
 import Version from 'sentry/components/version';
+import VersionHoverCard from 'sentry/components/versionHoverCard';
 import {IconReleases, IconWindow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
+import type {Group} from 'sentry/types/group';
 import {isMobilePlatform, isNativePlatform} from 'sentry/utils/platform';
+import useOrganization from 'sentry/utils/useOrganization';
 import {SectionDivider} from 'sentry/views/issueDetails/streamline/foldSection';
 
 interface HighlightsIconSummaryProps {
   event: Event;
+  group?: Group;
 }
 
-export function HighlightsIconSummary({event}: HighlightsIconSummaryProps) {
+export function HighlightsIconSummary({event, group}: HighlightsIconSummaryProps) {
+  const organization = useOrganization();
   // Hide device for non-native platforms since it's mostly duplicate of the client_os or os context
   const shouldDisplayDevice =
     isMobilePlatform(event.platform) || isNativePlatform(event.platform);
@@ -77,13 +82,17 @@ export function HighlightsIconSummary({event}: HighlightsIconSummaryProps) {
                 <IconReleases size="sm" color="subText" />
               </IconWrapper>
               <IconDescription>
-                {releaseTag && (
-                  <StyledVersion
-                    truncate
-                    tooltipRawVersion
-                    version={releaseTag.value}
-                    projectId={event.projectID}
-                  />
+                {group && releaseTag && (
+                  <VersionHoverCard
+                    organization={organization}
+                    projectSlug={group.project.slug}
+                    releaseVersion={releaseTag.value}
+                  >
+                    <StyledVersion
+                      version={releaseTag.value}
+                      projectId={group.project.id}
+                    />
+                  </VersionHoverCard>
                 )}
               </IconDescription>
             </Flex>

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -143,7 +143,7 @@ export function EventDetailsContent({
 
   return (
     <Fragment>
-      {hasStreamlinedUI && <HighlightsIconSummary event={event} />}
+      {hasStreamlinedUI && <HighlightsIconSummary event={event} group={group} />}
       {hasActionableItems && !hasStreamlinedUI && (
         <ActionableItems event={event} project={project} isShare={false} />
       )}


### PR DESCRIPTION
In the icon summary, we can use the hovercard here as well.

<img width="441" alt="image" src="https://github.com/user-attachments/assets/980dc1d9-86a1-4a23-b5a8-2a4b8d199a4d">
