### PR TITLE
feat(notifications): Unsubscribe user from issues when they leave team

### DIFF
--- a/src/sentry/api/endpoints/organization_member/team_details.py
+++ b/src/sentry/api/endpoints/organization_member/team_details.py
@@ -538,11 +538,13 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
         """
         Unsubscribe user from issues the team is subscribed to
         """
-        team_assigned_issues = GroupAssignee.objects.filter(team_id=team.id)
-        team_subscribed_isses = GroupSubscription.objects.filter(
-            team_id=team.id, reason=GroupSubscriptionReason.assigned
+        team_assigned_groups = GroupAssignee.objects.filter(team_id=team.id).values_list(
+            "group_id", flat=True
         )
-        issues_to_unsubscribe = set(team_assigned_issues) | set(team_subscribed_isses)
+        team_subscribed_groups = GroupSubscription.objects.filter(
+            team_id=team.id, reason=GroupSubscriptionReason.assigned
+        ).values_list("group_id", flat=True)
+        group_ids_to_unsubscribe = set(team_assigned_groups) | set(team_subscribed_groups)
         GroupSubscription.objects.filter(
-            group_id__in=[group.id for group in issues_to_unsubscribe], user_id=member.user_id
+            group_id__in=group_ids_to_unsubscribe, user_id=member.user_id
         ).delete()

--- a/src/sentry/api/endpoints/organization_member/team_details.py
+++ b/src/sentry/api/endpoints/organization_member/team_details.py
@@ -34,6 +34,7 @@ from sentry.models.organizationaccessrequest import OrganizationAccessRequest
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.team import Team
+from sentry.notifications.types import GroupSubscriptionReason
 from sentry.roles import organization_roles, team_roles
 from sentry.roles.manager import TeamRole
 from sentry.utils import metrics
@@ -538,7 +539,9 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
         Unsubscribe user from issues the team is subscribed to
         """
         team_assigned_issues = GroupAssignee.objects.filter(team_id=team.id)
-        team_subscribed_isses = GroupSubscription.objects.filter(team_id=team.id)
+        team_subscribed_isses = GroupSubscription.objects.filter(
+            team_id=team.id, reason=GroupSubscriptionReason.assigned
+        )
         issues_to_unsubscribe = set(team_assigned_issues) | set(team_subscribed_isses)
         GroupSubscription.objects.filter(
             group_id__in=[group.id for group in issues_to_unsubscribe], user_id=member.user_id

--- a/tests/sentry/api/endpoints/test_organization_member_team_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_team_details.py
@@ -768,6 +768,7 @@ class DeleteOrganizationMemberTeamTest(OrganizationMemberTeamTestBase):
         """
         self.login_as(self.member_on_team)
         rpc_user = user_service.get_user(user_id=self.member_on_team.user_id)
+        assert rpc_user
         user2 = self.create_user()
         self.create_member(user=user2, organization=self.org, role="member", teams=[self.team])
         group = self.create_group()

--- a/tests/sentry/api/endpoints/test_organization_member_team_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_team_details.py
@@ -768,14 +768,8 @@ class DeleteOrganizationMemberTeamTest(OrganizationMemberTeamTestBase):
         """
         self.login_as(self.member_on_team)
         rpc_user = user_service.get_user(user_id=self.member_on_team.user_id)
-        # one of the previous tests made it so this user is no longer a member of the team
-        self.create_member(
-            user=rpc_user, organization=self.organization, role="member", teams=[self.team]
-        )
         user2 = self.create_user()
-        self.create_member(
-            user=user2, organization=self.organization, role="member", teams=[self.team]
-        )
+        self.create_member(user=user2, organization=self.org, role="member", teams=[self.team])
         group = self.create_group()
         GroupAssignee.objects.create(group=group, team=self.team, project=self.project)
         for member in OrganizationMemberTeam.objects.filter(team=self.team):


### PR DESCRIPTION
Unsubscribe users from an issue that was assigned to a team when they leave that team. 

This appears to only affect legacy db rows because we now have a `team_id` column as of https://github.com/getsentry/sentry/pull/55879, but when @armenzg brought this up I saw that there were `user_ids` for each member of the team he'd left and no `team_id` data.