### PR TITLE
feat(issue-details): Use a time range for the graph tooltip

### DIFF
--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -608,7 +608,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
   }
 }
 
-const getBucketSize = (series: Series[] | undefined) => {
+export const getBucketSize = (series: Series[] | undefined) => {
   if (!series || series.length < 2) {
     return 0;
   }

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -28,7 +28,6 @@ import type {
   EChartDataZoomHandler,
   EChartEventHandler,
   ReactEchartsRef,
-  Series,
 } from 'sentry/types/echarts';
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
@@ -52,6 +51,7 @@ import {
 } from 'sentry/utils/discover/fields';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {eventViewFromWidget} from 'sentry/views/dashboards/utils';
+import {getBucketSize} from 'sentry/views/dashboards/widgetCard/utils';
 import WidgetLegendNameEncoderDecoder from 'sentry/views/dashboards/widgetLegendNameEncoderDecoder';
 
 import {getFormatter} from '../../../components/charts/components/tooltip';
@@ -607,14 +607,6 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
     );
   }
 }
-
-export const getBucketSize = (series: Series[] | undefined) => {
-  if (!series || series.length < 2) {
-    return 0;
-  }
-
-  return Number(series[0].data[1]?.name) - Number(series[0].data[0]?.name);
-};
 
 export default withTheme(WidgetCardChart);
 

--- a/static/app/views/dashboards/widgetCard/utils.tsx
+++ b/static/app/views/dashboards/widgetCard/utils.tsx
@@ -1,0 +1,9 @@
+import type {Series} from 'sentry/types/echarts';
+
+export const getBucketSize = (series: Series[] | undefined) => {
+  if (!series || series.length < 2) {
+    return 0;
+  }
+
+  return Number(series[0].data[1]?.name) - Number(series[0].data[0]?.name);
+};

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
@@ -79,7 +79,6 @@ describe('EventDetailsHeader', () => {
       screen.getByRole('button', {name: 'Toggle graph series - Users'})
     ).toBeInTheDocument();
     expect(screen.getByRole('figure')).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Open in Discover'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Close Sidebar'})).toBeInTheDocument();
   });
 

--- a/static/app/views/issueDetails/streamline/eventGraph.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.spec.tsx
@@ -113,13 +113,6 @@ describe('EventGraph', () => {
         },
       })
     );
-
-    const discoverButton = screen.getByLabelText('Open in Discover');
-    expect(discoverButton).toBeInTheDocument();
-    expect(discoverButton).toHaveAttribute(
-      'href',
-      expect.stringContaining(`/organizations/${organization.slug}/discover/results/`)
-    );
   });
 
   it('allows filtering by environment', async function () {

--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -3,7 +3,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';
-import {Button, type ButtonProps, LinkButton} from 'sentry/components/button';
+import {Button, type ButtonProps} from 'sentry/components/button';
 import {BarChart, type BarChartSeries} from 'sentry/components/charts/barChart';
 import Legend from 'sentry/components/charts/components/legend';
 import {defaultFormatAxisLabel} from 'sentry/components/charts/components/tooltip';
@@ -11,20 +11,18 @@ import {useChartZoom} from 'sentry/components/charts/useChartZoom';
 import {Flex} from 'sentry/components/container/flex';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import Placeholder from 'sentry/components/placeholder';
-import {IconTelescope} from 'sentry/icons';
 import {t, tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {SeriesDataUnit} from 'sentry/types/echarts';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {EventsStats, MultiSeriesEventsStats} from 'sentry/types/organization';
-import {DiscoverDatasets, SavedQueryDatasets} from 'sentry/utils/discover/types';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import {getBucketSize} from 'sentry/views/dashboards/widgetCard/chart';
 import useFlagSeries from 'sentry/views/issueDetails/streamline/useFlagSeries';
 import {
@@ -122,11 +120,6 @@ export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
     return createSeriesAndCount(groupStats['count_unique(user)']).series;
   }, [groupStats]);
 
-  const discoverUrl = eventView.getResultsViewUrlTarget(
-    organization.slug,
-    false,
-    hasDatasetSelector(organization) ? SavedQueryDatasets.ERRORS : undefined
-  );
   const chartZoomProps = useChartZoom({
     saveOnZoom: true,
   });
@@ -198,7 +191,7 @@ export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
     align: 'left',
     show: true,
     top: 4,
-    right: 95,
+    right: 8,
     data: ['Releases', 'Feature Flags'],
     selected: legendSelected,
     zlevel: 10,
@@ -314,14 +307,6 @@ export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
           }}
           {...chartZoomProps}
         />
-        <OpenInDiscoverButton
-          size="xs"
-          icon={<IconTelescope />}
-          to={discoverUrl}
-          aria-label={t('Open in Discover')}
-        >
-          {t('Discover')}
-        </OpenInDiscoverButton>
       </ChartContainer>
     </GraphWrapper>
   );
@@ -399,12 +384,6 @@ const ChartContainer = styled('div')`
 const LoadingChartContainer = styled('div')`
   position: relative;
   padding: ${space(1)} ${space(1)};
-`;
-
-const OpenInDiscoverButton = styled(LinkButton)`
-  position: absolute;
-  top: ${space(1)};
-  right: ${space(1)};
 `;
 
 const GraphAlert = styled(Alert)`

--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -6,6 +6,7 @@ import Alert from 'sentry/components/alert';
 import {Button, type ButtonProps, LinkButton} from 'sentry/components/button';
 import {BarChart, type BarChartSeries} from 'sentry/components/charts/barChart';
 import Legend from 'sentry/components/charts/components/legend';
+import {defaultFormatAxisLabel} from 'sentry/components/charts/components/tooltip';
 import {useChartZoom} from 'sentry/components/charts/useChartZoom';
 import {Flex} from 'sentry/components/container/flex';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
@@ -24,6 +25,7 @@ import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
+import {getBucketSize} from 'sentry/views/dashboards/widgetCard/chart';
 import useFlagSeries from 'sentry/views/issueDetails/streamline/useFlagSeries';
 import {
   useIssueDetailsDiscoverQuery,
@@ -180,6 +182,8 @@ export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
     return seriesData;
   }, [visibleSeries, userSeries, eventSeries, releaseSeries, flagSeries, theme]);
 
+  const bucketSize = eventSeries ? getBucketSize(series) : undefined;
+
   const [legendSelected, setLegendSelected] = useLocalStorageState(
     'issue-details-graph-legend',
     {
@@ -278,6 +282,27 @@ export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
             right: 8,
             top: 20,
             bottom: 0,
+          }}
+          tooltip={{
+            formatAxisLabel: (
+              value,
+              isTimestamp,
+              utc,
+              showTimeInTooltip,
+              addSecondsToTimeFormat,
+              _bucketSize,
+              _seriesParamsOrParam
+            ) =>
+              String(
+                defaultFormatAxisLabel(
+                  value,
+                  isTimestamp,
+                  utc,
+                  showTimeInTooltip,
+                  addSecondsToTimeFormat,
+                  bucketSize
+                )
+              ),
           }}
           yAxis={{
             splitNumber: 2,

--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -23,7 +23,7 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {getBucketSize} from 'sentry/views/dashboards/widgetCard/chart';
+import {getBucketSize} from 'sentry/views/dashboards/widgetCard/utils';
 import useFlagSeries from 'sentry/views/issueDetails/streamline/useFlagSeries';
 import {
   useIssueDetailsDiscoverQuery,

--- a/static/app/views/issueDetails/streamline/eventNavigation.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.spec.tsx
@@ -9,6 +9,7 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 
 import * as useMedia from 'sentry/utils/useMedia';
 import {SectionKey, useEventDetails} from 'sentry/views/issueDetails/streamline/context';
+import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
 
 import {IssueEventNavigation} from './eventNavigation';
 
@@ -47,12 +48,44 @@ describe('EventNavigation', () => {
       dispatch: jest.fn(),
     });
     MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/tags/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/${group.id}/attachments/`,
       body: [],
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/replay-count/',
       body: {},
+    });
+  });
+
+  describe('all events buttons', () => {
+    it('renders the all events controls', () => {
+      const allEventsRouter = RouterFixture({
+        params: {groupId: group.id},
+        routes: [{path: TabPaths[Tab.EVENTS]}],
+        location: LocationFixture({
+          pathname: `/organizations/${organization.slug}/issues/${group.id}/events/`,
+        }),
+      });
+
+      render(<IssueEventNavigation {...defaultProps} />, {router: allEventsRouter});
+
+      const discoverButton = screen.getByLabelText('Open in Discover');
+      expect(discoverButton).toBeInTheDocument();
+      expect(discoverButton).toHaveAttribute(
+        'href',
+        expect.stringContaining(`/organizations/${organization.slug}/discover/results/`)
+      );
+
+      const closeButton = screen.getByRole('button', {name: 'Return to event details'});
+      expect(closeButton).toBeInTheDocument();
+      expect(closeButton).toHaveAttribute(
+        'href',
+        expect.stringContaining(`/organizations/${organization.slug}/issues/${group.id}/`)
+      );
     });
   });
 

--- a/static/app/views/issueDetails/streamline/eventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.tsx
@@ -3,17 +3,19 @@ import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
 import Count from 'sentry/components/count';
 import DropdownButton from 'sentry/components/dropdownButton';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {TabList, Tabs} from 'sentry/components/tabs';
 import {Tooltip} from 'sentry/components/tooltip';
-import {IconChevron} from 'sentry/icons';
+import {IconChevron, IconTelescope} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
+import {SavedQueryDatasets} from 'sentry/utils/discover/types';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {keepPreviousData, useApiQuery} from 'sentry/utils/queryClient';
 import useReplayCountForIssues from 'sentry/utils/replayCount/useReplayCountForIssues';
@@ -22,7 +24,9 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
+import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import {useGroupEventAttachments} from 'sentry/views/issueDetails/groupEventAttachments/useGroupEventAttachments';
+import {useIssueDetailsEventView} from 'sentry/views/issueDetails/streamline/useIssueDetailsDiscoverQuery';
 import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
 import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
 import {
@@ -69,6 +73,13 @@ export function IssueEventNavigation({event, group, query}: IssueEventNavigation
   const isSmallScreen = useMedia(`(max-width: ${theme.breakpoints.small})`);
   const [shouldPreload, setShouldPreload] = useState({next: false, previous: false});
   const environments = useEnvironmentsFromUrl();
+  const eventView = useIssueDetailsEventView({group});
+
+  const discoverUrl = eventView.getResultsViewUrlTarget(
+    organization.slug,
+    false,
+    hasDatasetSelector(organization) ? SavedQueryDatasets.ERRORS : undefined
+  );
 
   // Reset shouldPreload when the groupId changes
   useEffect(() => {
@@ -321,10 +332,25 @@ export function IssueEventNavigation({event, group, query}: IssueEventNavigation
               {t('All Events')}
             </LinkButton>
           )}
+
           {currentTab === Tab.EVENTS && (
-            <LinkButton to={{pathname: `${baseUrl}${TabPaths[Tab.DETAILS]}`}} size="xs">
-              {t('Close')}
-            </LinkButton>
+            <ButtonBar gap={1}>
+              <LinkButton
+                to={discoverUrl}
+                aria-label={t('Open in Discover')}
+                size="xs"
+                icon={<IconTelescope />}
+              >
+                {t('Discover')}
+              </LinkButton>
+              <LinkButton
+                to={{pathname: `${baseUrl}${TabPaths[Tab.DETAILS]}`}}
+                aria-label={t('Return to event details')}
+                size="xs"
+              >
+                {t('Close')}
+              </LinkButton>
+            </ButtonBar>
           )}
         </NavigationWrapper>
       ) : null}


### PR DESCRIPTION
A bit verbose, but the bar chart tooltips are calculated off of the item rather than the axis, so I needed to compute the bucketSize manually. It works though!

<img width="387" alt="image" src="https://github.com/user-attachments/assets/c0262913-0e12-444f-acc7-280576529894">


Also moves the discover button out of the graph, and into all events:

<img width="263" alt="image" src="https://github.com/user-attachments/assets/d6e8f25c-eec7-4410-86a8-79a61741ca9a">
