### PR TITLE
ref(trace) increase precision of container width

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -1550,7 +1550,7 @@ export class VirtualizedViewManager {
       container.style.setProperty(
         '--list-column-width',
         // @ts-expect-error we set number value type on purpose
-        Math.round(options.list_width * 1000) / 1000
+        options.list_width
       );
       this.last_list_column_width = options.list_width;
     }
@@ -1558,7 +1558,7 @@ export class VirtualizedViewManager {
       container.style.setProperty(
         '--span-column-width',
         // @ts-expect-error we set number value type on purpose
-        Math.round(options.span_list_width * 1000) / 1000
+        options.span_list_width
       );
       this.last_span_column_width = options.span_list_width;
     }


### PR DESCRIPTION
Partially mitigate the rendering problem where too small of a precision affects the bar rendering. This is still and issue, and would require us to significantly refactor the rendering (and likely use canvas for rendering), but it does make it less likely to happen with this change