### PR TITLE
feat(rollback): /rollback route should resolve to React app

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -455,6 +455,12 @@ urlpatterns += [
         react_page_view,
         name="stories",
     ),
+    # Rollback
+    re_path(
+        r"^rollback/",
+        react_page_view,
+        name="rollback",
+    ),
     # Legacy Redirects
     re_path(
         r"^docs/?$",


### PR DESCRIPTION
Added a client-side redirect here: https://github.com/getsentry/getsentry/pull/15557

But it never gets hit because `/rollback` isn't registered as a React route. 

We can't add a simple redirect here like we have for `/docs` because we want to go through the login flow if they are not authenticated.