### PR TITLE
fix(issues): Add min interval to issues yAxis

### DIFF
--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -281,6 +281,7 @@ export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
           }}
           yAxis={{
             splitNumber: 2,
+            minInterval: 1,
             axisLabel: {
               formatter: (value: number) => {
                 return formatAbbreviatedNumber(value);


### PR DESCRIPTION
impossible to have 0.5 events

happens on low event counts
![image](https://github.com/user-attachments/assets/1a0dc866-4a58-46fa-b386-f51f4ab2e56a)
