### PR TITLE
fix(dashboards): Fix unable to plot top N chart if query data is missing

### DIFF
--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -502,19 +502,21 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
 
           // Create a list of series based on the order of the fields,
           const series = timeseriesResults
-            ? timeseriesResults.map((values, i: number) => {
-                let seriesName = '';
-                if (values.seriesName !== undefined) {
-                  seriesName = isEquation(values.seriesName)
-                    ? getEquation(values.seriesName)
-                    : values.seriesName;
-                }
-                return {
-                  ...values,
-                  seriesName,
-                  color: colors[i],
-                };
-              })
+            ? timeseriesResults
+                .map((values, i: number) => {
+                  let seriesName = '';
+                  if (values.seriesName !== undefined) {
+                    seriesName = isEquation(values.seriesName)
+                      ? getEquation(values.seriesName)
+                      : values.seriesName;
+                  }
+                  return {
+                    ...values,
+                    seriesName,
+                    color: colors[i],
+                  };
+                })
+                .filter(Boolean) // NOTE: `timeseriesResults` is a sparse array! We have to filter out the empty slots after the colors are assigned, since the colours are assigned based on sparse array index
             : [];
 
           const seriesStart = series[0]?.data[0]?.name;

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -324,7 +324,7 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
       })
     );
     const rawResultsClone = cloneDeep(this.state.rawResults) ?? [];
-    const transformedTimeseriesResults: Series[] = [];
+    const transformedTimeseriesResults: Series[] = []; // Watch out, this is a sparse array. `map` and `forEach` will skip the empty slots. Spreading the array with `...` will create an `undefined` for each slot.
     responses.forEach(([data], requestIndex) => {
       afterFetchSeriesData?.(data);
       rawResultsClone[requestIndex] = data;


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/80073

This was introduced in https://github.com/getsentry/sentry/pull/78675. The cause is a surprising JavaScript behaviour.

If you create a line chart widget with multiple queries and a "Group By" clause, when we fetch the results we pre-allocate an array for all the chart series we expect.

For example, two queries with top 3 results each creates 6 array slots. If, for some reason, one of the query results does not fill the slots (e.g., there are only two top series, or none because there's no data) this creates a [sparse array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Indexed_collections#sparse_arrays).

We need the pre-filled array because we assign colours based on series array index. If we don't pre-fill the array, the series colours will change as the queries load. Yuck.

Iterating over sparse arrays with `map` or `forEach` skips the empty slots, and there's no need to check for `undefined` values. The regression in #80073 is the array spread `[...series]` which converts each missing slot in the array into `undefined`. Suddenly, downstream functions might be an `undefined` where they didn't expect it.

The solution here is to filter out `undefined` values before plotting. At this point the colours are assigned, so there's no risk of changing series colours.

NOTE: Sparse arrays are dangerous since TypeScript does not acknowledge them. We should avoid them, but for now I just want to fix the bug.
