### PR TITLE
feat(dashboards): Add EAP search bar for filtering step

### DIFF
--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -30,7 +30,7 @@ import {
 } from 'sentry/views/dashboards/datasetConfig/errorsAndTransactions';
 import {DisplayType, type Widget, type WidgetQuery} from 'sentry/views/dashboards/types';
 import {eventViewFromWidget} from 'sentry/views/dashboards/utils';
-import {EventsSearchBar} from 'sentry/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar';
+import SpansSearchBar from 'sentry/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar';
 import type {FieldValueOption} from 'sentry/views/discover/table/queryField';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 import {generateFieldOptions} from 'sentry/views/discover/utils';
@@ -68,7 +68,7 @@ export const SpansConfig: DatasetConfig<
   defaultWidgetQuery: DEFAULT_WIDGET_QUERY,
   enableEquations: false,
   getCustomFieldRenderer: getCustomEventsFieldRenderer,
-  SearchBar: EventsSearchBar, // TODO: Replace with a custom EAP search bar
+  SearchBar: SpansSearchBar,
   filterSeriesSortOptions: () => () => true,
   filterYAxisAggregateParams: () => () => true,
   filterYAxisOptions: () => () => true,

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
@@ -1,0 +1,133 @@
+import type {ComponentProps} from 'react';
+import {WidgetQueryFixture} from 'sentry-fixture/widgetQuery';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import type {TagValue} from 'sentry/types/group';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import SpansSearchBar from 'sentry/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar';
+import {SpanTagsProvider} from 'sentry/views/explore/contexts/spanTagsContext';
+
+// The endpoint seems to just return these fields, but the original TagValue type
+// has extra fields related to user information that we don't seem to need.
+interface MockedTagValue
+  extends Pick<TagValue, 'key' | 'value' | 'name' | 'count' | 'firstSeen' | 'lastSeen'> {}
+
+function renderWithProvider({
+  widgetQuery,
+  onSearch,
+}: ComponentProps<typeof SpansSearchBar>) {
+  return render(
+    <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP}>
+      <SpansSearchBar widgetQuery={widgetQuery} onSearch={onSearch} />
+    </SpanTagsProvider>
+  );
+}
+
+function mockSpanTags({
+  type,
+  mockedTags,
+}: {
+  mockedTags: {key: string; name: string}[];
+  type: 'string' | 'number';
+}) {
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/spans/fields/`,
+    body: mockedTags,
+    match: [
+      function (_url: string, options: Record<string, any>) {
+        return options.query.type === type;
+      },
+    ],
+  });
+}
+
+function mockSpanTagValues({
+  type,
+  tagKey,
+  mockedValues,
+}: {
+  mockedValues: MockedTagValue[];
+  tagKey: string;
+  type: 'string' | 'number';
+}) {
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/spans/fields/${tagKey}/values/`,
+    body: mockedValues,
+    match: [
+      function (_url: string, options: Record<string, any>) {
+        return options.query.type === type;
+      },
+    ],
+  });
+}
+
+describe('SpansSearchBar', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/recent-searches/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/recent-searches/`,
+      body: [],
+      method: 'POST',
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/spans/fields/`,
+      body: [],
+    });
+
+    mockSpanTags({type: 'string', mockedTags: []});
+    mockSpanTagValues({type: 'string', tagKey: 'span.op', mockedValues: []});
+
+    mockSpanTags({type: 'number', mockedTags: []});
+    mockSpanTagValues({type: 'number', tagKey: 'span.op', mockedValues: []});
+  });
+
+  it('renders the initial query conditions', async () => {
+    mockSpanTags({type: 'string', mockedTags: [{key: 'span.op', name: 'span.op'}]});
+    mockSpanTagValues({
+      type: 'string',
+      tagKey: 'span.op',
+      mockedValues: [
+        {
+          key: 'span.op',
+          value: 'function',
+          name: 'function',
+          count: 1,
+          firstSeen: '2024-01-01',
+          lastSeen: '2024-01-01',
+        },
+      ],
+    });
+
+    renderWithProvider({
+      widgetQuery: WidgetQueryFixture({conditions: 'span.op:function'}),
+      onSearch: jest.fn(),
+    });
+
+    await screen.findByLabelText('span.op:function');
+  });
+
+  it('calls onSearch with the correct query', async () => {
+    const onSearch = jest.fn();
+
+    renderWithProvider({widgetQuery: WidgetQueryFixture({conditions: ''}), onSearch});
+
+    const searchInput = await screen.findByRole('combobox', {
+      name: 'Add a search term',
+    });
+    await userEvent.type(searchInput, 'span.op:function');
+
+    // It takes two enters. One to enter the search term, and one to submit the search.
+    await userEvent.keyboard('{enter}');
+    await userEvent.keyboard('{enter}');
+
+    await waitFor(() => {
+      expect(onSearch).toHaveBeenCalledWith('span.op:function', expect.anything());
+    });
+  });
+});

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.tsx
@@ -7,7 +7,10 @@ import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
  * A search bar for exploring tags and values for spans in Dashboards.
  * This assumes that the dataset used is the EAP spans dataset.
  */
-function SpansSearchBar({widgetQuery, onSearch}: WidgetBuilderSearchBarProps) {
+function SpansSearchBar({
+  widgetQuery,
+  onSearch,
+}: Pick<WidgetBuilderSearchBarProps, 'widgetQuery' | 'onSearch'>) {
   const {
     selection: {projects},
   } = usePageFilters();

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.tsx
@@ -1,0 +1,28 @@
+import {EAPSpanSearchQueryBuilder} from 'sentry/components/performance/spanSearchQueryBuilder';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import type {WidgetBuilderSearchBarProps} from 'sentry/views/dashboards/datasetConfig/base';
+import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+
+/**
+ * A search bar for exploring tags and values for spans in Dashboards.
+ * This assumes that the dataset used is the EAP spans dataset.
+ */
+function SpansSearchBar({widgetQuery, onSearch}: WidgetBuilderSearchBarProps) {
+  const {
+    selection: {projects},
+  } = usePageFilters();
+  const numberTags = useSpanTags('number');
+  const stringTags = useSpanTags('string');
+  return (
+    <EAPSpanSearchQueryBuilder
+      initialQuery={widgetQuery.conditions}
+      onSearch={onSearch}
+      numberTags={numberTags}
+      stringTags={stringTags}
+      searchSource="explore"
+      projects={projects}
+    />
+  );
+}
+
+export default SpansSearchBar;

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.tsx
@@ -22,7 +22,7 @@ function SpansSearchBar({
       onSearch={onSearch}
       numberTags={numberTags}
       stringTags={stringTags}
-      searchSource="explore"
+      searchSource="dashboards"
       projects={projects}
     />
   );


### PR DESCRIPTION
Use the explore search bar for the spans dataset. The behaviour we should see is that the recent searches in explore appear in the recent searches for dashboards, as well as the autocomplete with EAP tags should also have the respective values.

When submitting the search (be sure to actually hit enter to submit it), it should trigger a request with the expected filter passed along.

[#78264](https://github.com/getsentry/sentry/issues/78264)