### PR TITLE
chore(eap): Skip failing CI tests

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -1153,6 +1153,7 @@ class OrganizationTracesStatsEndpointTest(OrganizationTracesEndpointTestBase):
             ],
         }
 
+    @pytest.mark.skip(reason="failing in CI")
     def test_span_duration_filter(self):
         for q in [
             ["span.duration:>100"],
@@ -1166,6 +1167,7 @@ class OrganizationTracesStatsEndpointTest(OrganizationTracesEndpointTestBase):
             response = self.do_request(query)
             assert response.status_code == 200, response.data
 
+    @pytest.mark.skip(reason="failing in CI")
     def test_stats(self):
         project_1 = self.create_project()
         project_2 = self.create_project()

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
@@ -40,6 +40,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
 
     # These throughput tests should roughly match the ones in OrganizationEventsStatsEndpointTest
     @pytest.mark.querybuilder
+    @pytest.mark.skip(reason="failing in CI")
     def test_throughput_epm_hour_rollup(self):
         # Each of these denotes how many events to create in each hour
         event_counts = [6, 0, 6, 3, 0, 3]
@@ -75,6 +76,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             for test in zip(event_counts, rows):
                 assert test[1][1][0]["count"] == test[0] / (3600.0 / 60.0)
 
+    @pytest.mark.skip(reason="failing in CI")
     def test_throughput_epm_day_rollup(self):
         # Each of these denotes how many events to create in each minute
         event_counts = [6, 0, 6, 3, 0, 3]
@@ -108,6 +110,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
 
             assert data[0][1][0]["count"] == sum(event_counts) / (86400.0 / 60.0)
 
+    @pytest.mark.skip(reason="failing in CI")
     def test_throughput_epm_hour_rollup_offset_of_hour(self):
         # Each of these denotes how many events to create in each hour
         event_counts = [6, 0, 6, 3, 0, 3]
@@ -143,6 +146,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             for test in zip(event_counts, rows):
                 assert test[1][1][0]["count"] == test[0] / (3600.0 / 60.0)
 
+    @pytest.mark.skip(reason="failing in CI")
     def test_throughput_eps_minute_rollup(self):
         # Each of these denotes how many events to create in each minute
         event_counts = [6, 0, 6, 3, 0, 3]
@@ -178,6 +182,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             for test in zip(event_counts, rows):
                 assert test[1][1][0]["count"] == test[0] / 60.0
 
+    @pytest.mark.skip(reason="failing in CI")
     def test_top_events(self):
         # Each of these denotes how many events to create in each minute
         for transaction in ["foo", "bar"]:


### PR DESCRIPTION
Skip EAP tests that are breaking everyone's backend CI runs