### PR TITLE
chore(dev): adjust sample rate of process profiles

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -71,7 +71,7 @@ SAMPLED_TASKS = {
     "sentry.tasks.summaries.weekly_reports.schedule_organizations": 1.0,
     "sentry.tasks.summaries.weekly_reports.prepare_organization_report": 0.1
     * settings.SENTRY_BACKEND_APM_SAMPLING,
-    "sentry.profiles.task.process_profile": 0.1 * settings.SENTRY_BACKEND_APM_SAMPLING,
+    "sentry.profiles.task.process_profile": 0.01 * settings.SENTRY_BACKEND_APM_SAMPLING,
     "sentry.tasks.derive_code_mappings.process_organizations": settings.SAMPLED_DEFAULT_RATE,
     "sentry.tasks.derive_code_mappings.derive_code_mappings": settings.SAMPLED_DEFAULT_RATE,
     "sentry.monitors.tasks.clock_pulse": 1.0,


### PR DESCRIPTION
this transaction is our second most sampled, and i don't think it needs to be this high. lowers by a factor of 10. relevant query: https://sentry.sentry.io/discover/homepage/?dataset=errors&field=count%28%29&field=transaction&name=All%20Errors&project=1&query=&queryDataset=error-events&sort=-count&statsPeriod=2d&yAxis=count%28%29