### PR TITLE
feat(issues): Preserve previous suspect commit

### DIFF
--- a/static/app/components/events/suspectCommits.tsx
+++ b/static/app/components/events/suspectCommits.tsx
@@ -39,6 +39,7 @@ export function SuspectCommits({
   const {data} = useCommitters({
     eventId,
     projectSlug,
+    group,
   });
   const committers = data?.committers ?? [];
 

--- a/static/app/components/group/assignedTo.tsx
+++ b/static/app/components/group/assignedTo.tsx
@@ -196,6 +196,7 @@ function AssignedTo({
     {
       eventId: event?.id ?? '',
       projectSlug: project.slug,
+      group,
     },
     {
       notifyOnChangeProps: ['data'],

--- a/static/app/utils/useCommitters.tsx
+++ b/static/app/utils/useCommitters.tsx
@@ -1,12 +1,15 @@
+import type {Group} from 'sentry/types/group';
 import type {Committer} from 'sentry/types/integrations';
 import type {ApiQueryKey, UseApiQueryOptions} from 'sentry/utils/queryClient';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import usePrevious from 'sentry/utils/usePrevious';
 
 import useOrganization from './useOrganization';
 
 interface UseCommittersProps {
   eventId: string;
   projectSlug: string;
+  group?: Group;
 }
 
 interface CommittersResponse {
@@ -20,16 +23,20 @@ const makeCommittersQueryKey = (
 ): ApiQueryKey => [`/projects/${orgSlug}/${projectSlug}/events/${eventId}/committers/`];
 
 function useCommitters(
-  {eventId, projectSlug}: UseCommittersProps,
+  {eventId, projectSlug, group}: UseCommittersProps,
   options: Partial<UseApiQueryOptions<CommittersResponse>> = {}
 ) {
   const org = useOrganization();
+  const previousGroupId = usePrevious(group?.id);
   return useApiQuery<CommittersResponse>(
     makeCommittersQueryKey(org.slug, projectSlug, eventId),
     {
       staleTime: Infinity,
       retry: false,
       enabled: !!eventId,
+      placeholderData: previousData => {
+        return group?.id === previousGroupId ? previousData : undefined;
+      },
       ...options,
     }
   );

--- a/static/app/views/issueDetails/streamline/assigneeSelector.tsx
+++ b/static/app/views/issueDetails/streamline/assigneeSelector.tsx
@@ -38,6 +38,7 @@ export function GroupHeaderAssigneeSelector({
   const {data: committersResponse} = useCommitters({
     eventId: event?.id ?? '',
     projectSlug: project.slug,
+    group,
   });
 
   useEffect(() => {


### PR DESCRIPTION
When paginating events, suspect commits reload. The suspect commits are likely to be the same, so we can preserve the result until the new ones load in.
