### PR TITLE
feat(oauth): send feature flag to frontend

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -584,3 +584,11 @@ def register_temporary_features(manager: FeatureManager):
         FeatureHandlerStrategy.FLAGPOLE,
         api_expose=True,
     )
+
+    # Partner oauth
+    manager.add(
+        "organizations:scoped-partner-oauth",
+        OrganizationFeature,
+        FeatureHandlerStrategy.FLAGPOLE,
+        api_expose=False,
+    )

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -224,7 +224,10 @@ class _ClientConfig:
             yield "relocation:enabled"
         if features.has("system:multi-region"):
             yield "system:multi-region"
-        if features.has("system:scoped-partner-oauth"):
+        # TODO @athena: remove this feature flag after development is done
+        # this is a temporary hack to be able to used flagpole in a case where there's no organization
+        # availble on the frontend
+        if self.last_org and features.has("organizations:scoped-partner-oauth", self.last_org):
             yield "system:scoped-partner-oauth"
 
     @property

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -224,6 +224,8 @@ class _ClientConfig:
             yield "relocation:enabled"
         if features.has("system:multi-region"):
             yield "system:multi-region"
+        if features.has("system:scoped-partner-oauth"):
+            yield "system:scoped-partner-oauth"
 
     @property
     def needs_upgrade(self) -> bool:

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -227,7 +227,9 @@ class _ClientConfig:
         # TODO @athena: remove this feature flag after development is done
         # this is a temporary hack to be able to used flagpole in a case where there's no organization
         # availble on the frontend
-        if self.last_org and features.has("organizations:scoped-partner-oauth", self.last_org):
+        if self.last_org and features.has(
+            "organizations:scoped-partner-oauth", self.last_org, actor=self.user
+        ):
             yield "system:scoped-partner-oauth"
 
     @property


### PR DESCRIPTION
There's no org [where this feature flag is being checked](https://github.com/getsentry/getsentry/blob/master/static/getsentry/gsAdmin/views/instanceLevelOAuth/components/newInstanceLevelOAuthClient.tsx#L24) so enabling it through the config. This basically makes it available in the Config object on the frontend