### PR TITLE
feat(oauth): add organization to ApiToken

### DIFF
--- a/src/sentry/models/apitoken.py
+++ b/src/sentry/models/apitoken.py
@@ -266,6 +266,7 @@ class ApiToken(ReplicatedControlModel, HasApiScopes):
                 application=grant.application,
                 user=grant.user,
                 scope_list=grant.get_scopes(),
+                scoping_organization_id=grant.organization_id,
             )
 
             # remove the ApiGrant from the database to prevent reuse of the same

--- a/src/sentry/web/frontend/oauth_token.py
+++ b/src/sentry/web/frontend/oauth_token.py
@@ -174,6 +174,8 @@ class OAuthTokenView(View):
         }
         if id_token:
             token_information["id_token"] = id_token
+        if token.scoping_organization_id:
+            token_information["organization_id"] = str(token.scoping_organization_id)
         return HttpResponse(
             json.dumps(token_information),
             content_type="application/json",


### PR DESCRIPTION
When grant is scoped to a specific organization, APIToken should also be specific to the same organization.

For more context this is step 3 in tech spec: https://www.notion.so/sentry/Partner-OAuth-Flow-371b6bd1d16c447ea666e533c32e503e?pvs=4#c5d5e6f210784207b0b979a721857533