### PR TITLE
fix(dashboards): Ensure release health widgets have the same meta

### DIFF
--- a/static/app/views/dashboards/datasetConfig/releases.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/releases.spec.tsx
@@ -81,6 +81,12 @@ describe('transformSessionsResponseToTable', function () {
         release: 'string',
         'session.status': 'string',
         'sum(session)': 'integer',
+        fields: {
+          'count_unique(user)': 'integer',
+          release: 'string',
+          'session.status': 'string',
+          'sum(session)': 'integer',
+        },
       },
     });
   });
@@ -163,6 +169,13 @@ describe('transformSessionsResponseToTable', function () {
         release: 'string',
         'session.status': 'string',
         'sum(session)': 'integer',
+        fields: {
+          'count_crashed(session)': 'integer',
+          'count_unique(user)': 'integer',
+          release: 'string',
+          'session.status': 'string',
+          'sum(session)': 'integer',
+        },
       },
     });
   });
@@ -236,6 +249,12 @@ describe('transformSessionsResponseToTable', function () {
         'count_unique(user)': 'integer',
         release: 'string',
         'session.status': 'string',
+        fields: {
+          'count_crashed(session)': 'integer',
+          'count_unique(user)': 'integer',
+          release: 'string',
+          'session.status': 'string',
+        },
       },
     });
   });

--- a/static/app/views/dashboards/datasetConfig/releases.tsx
+++ b/static/app/views/dashboards/datasetConfig/releases.tsx
@@ -290,6 +290,7 @@ export function transformSessionsResponseToTable(
 
   const singleRow = rows[0];
   const meta = {
+    ...changeObjectValuesToTypes(omit(singleRow, 'id')),
     fields: changeObjectValuesToTypes(omit(singleRow, 'id')),
   };
   return {meta, data: rows};

--- a/static/app/views/dashboards/datasetConfig/releases.tsx
+++ b/static/app/views/dashboards/datasetConfig/releases.tsx
@@ -290,7 +290,7 @@ export function transformSessionsResponseToTable(
 
   const singleRow = rows[0];
   const meta = {
-    ...changeObjectValuesToTypes(omit(singleRow, 'id')),
+    fields: changeObjectValuesToTypes(omit(singleRow, 'id')),
   };
   return {meta, data: rows};
 }

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -207,7 +207,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
 
     return tableResults.map((result, i) => {
       const tableMeta = {...result.meta};
-      const fields = Object.keys(tableMeta);
+      const fields = Object.keys(tableMeta?.fields ?? {});
 
       let field = fields[0];
       let selectedField = field;

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
@@ -553,6 +553,12 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
                 release: 'string',
                 'session.status': 'string',
                 'sum(session)': 'integer',
+                fields: {
+                  'count_unique(user)': 'integer',
+                  release: 'string',
+                  'session.status': 'string',
+                  'sum(session)': 'integer',
+                },
               },
               title: 'sessions',
             },
@@ -599,7 +605,10 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
           tableResults: [
             {
               data: [{'count_unique(user)': 51292.95404741901, id: '0'}],
-              meta: {'count_unique(user)': 'integer'},
+              meta: {
+                'count_unique(user)': 'integer',
+                fields: {'count_unique(user)': 'integer'},
+              },
               title: 'sessions',
             },
           ],


### PR DESCRIPTION
Other widgets have `{meta: {fields: [...]}}`, so when we converted the big number widgets it was expecting that field to index into or else it displayed No Data. Ensure there's a fields key for release health table responses