### PR TITLE
chore(issue-details): Clean up requests section formatting

### DIFF
--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -14,6 +14,7 @@ import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {useDetailedProject} from 'sentry/utils/useDetailedProject';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 const MAX_TREE_DEPTH = 4;
 const INVALID_BRANCH_REGEX = /\.{2,}/;
@@ -196,6 +197,7 @@ function TagTreeColumns({
 }
 
 function EventTagsTree(props: EventTagsTreeProps) {
+  const hasStreamlinedUI = useHasStreamlinedUI();
   const containerRef = useRef<HTMLDivElement>(null);
   const columnCount = useIssueDetailsColumnCount(containerRef);
   return (
@@ -204,6 +206,7 @@ function EventTagsTree(props: EventTagsTreeProps) {
         columnCount={columnCount}
         ref={containerRef}
         data-test-id="event-tags-tree"
+        style={hasStreamlinedUI ? {marginTop: 0} : undefined}
       >
         <TagTreeColumns columnCount={columnCount} {...props} />
       </TreeContainer>

--- a/static/app/components/events/interfaces/request/index.tsx
+++ b/static/app/components/events/interfaces/request/index.tsx
@@ -4,23 +4,30 @@ import styled from '@emotion/styled';
 import ClippedBox from 'sentry/components/clippedBox';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import ErrorBoundary from 'sentry/components/errorBoundary';
+import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import {GraphQlRequestBody} from 'sentry/components/events/interfaces/request/graphQlRequestBody';
 import {getCurlCommand, getFullUrl} from 'sentry/components/events/interfaces/utils';
+import KeyValueData, {
+  type KeyValueDataContentProps,
+} from 'sentry/components/keyValueData';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {SegmentedControl} from 'sentry/components/segmentedControl';
 import Truncate from 'sentry/components/truncate';
 import {IconOpen} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {EntryRequest, Event} from 'sentry/types/event';
 import {EntryType} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
 import {isUrl} from 'sentry/utils/string/isUrl';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
-import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
+import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
-import {RichHttpContentClippedBoxBodySection} from './richHttpContentClippedBoxBodySection';
+import {
+  getBodyContent,
+  RichHttpContentClippedBoxBodySection,
+} from './richHttpContentClippedBoxBodySection';
 import {RichHttpContentClippedBoxKeyValueList} from './richHttpContentClippedBoxKeyValueList';
 
 interface RequestProps {
@@ -35,12 +42,35 @@ interface RequestBodyProps extends RequestProps {
 type View = 'formatted' | 'curl';
 
 function RequestBodySection({data, event, meta}: RequestBodyProps) {
+  const hasStreamlinedUI = useHasStreamlinedUI();
+
   if (!defined(data.data)) {
     return null;
   }
 
   if (data.apiTarget === 'graphql' && typeof data.data.query === 'string') {
-    return <GraphQlRequestBody data={data.data} {...{event, meta}} />;
+    return hasStreamlinedUI ? (
+      <RequestCardPanel>
+        <KeyValueData.Title>{t('Body')}</KeyValueData.Title>
+        <GraphQlRequestBody data={data.data} {...{event, meta}} />
+      </RequestCardPanel>
+    ) : (
+      <GraphQlRequestBody data={data.data} {...{event, meta}} />
+    );
+  }
+
+  if (hasStreamlinedUI) {
+    const contentBody = getBodyContent({
+      data: data.data,
+      meta: meta?.data,
+      inferredContentType: data.inferredContentType,
+    });
+    return (
+      <RequestCardPanel>
+        <KeyValueData.Title>{t('Body')}</KeyValueData.Title>
+        {contentBody}
+      </RequestCardPanel>
+    );
   }
 
   return (
@@ -109,14 +139,53 @@ export function Request({data, event}: RequestProps) {
     </Fragment>
   );
 
+  if (hasStreamlinedUI) {
+    return (
+      <FoldSection
+        sectionKey={SectionKey.REQUEST}
+        title={t('HTTP Request')}
+        actions={actions}
+      >
+        <SummaryLine>{title}</SummaryLine>
+        {view === 'curl' ? (
+          <CodeSnippet language="bash">{getCurlCommand(data)}</CodeSnippet>
+        ) : (
+          <Fragment>
+            <RequestBodySection data={data} event={event} meta={meta} />
+            <RequestDataCard
+              title={t('Query String')}
+              data={data.query}
+              meta={meta?.query}
+            />
+            <RequestDataCard
+              title={t('Fragment')}
+              data={data.fragment}
+              meta={undefined}
+            />
+            <RequestDataCard
+              title={t('Cookies')}
+              data={data.cookies}
+              meta={meta?.cookies}
+            />
+            <RequestDataCard
+              title={t('Headers')}
+              data={data.headers}
+              meta={meta?.headers}
+            />
+            <RequestDataCard title={t('Environment')} data={data.env} meta={meta?.env} />
+          </Fragment>
+        )}
+      </FoldSection>
+    );
+  }
+
   return (
-    <InterimSection
+    <EventDataSection
       type={SectionKey.REQUEST}
-      title={hasStreamlinedUI ? t('HTTP Request') : title}
+      title={title}
       actions={actions}
       className="request"
     >
-      {hasStreamlinedUI && title}
       {view === 'curl' ? (
         <CodeSnippet language="bash">{getCurlCommand(data)}</CodeSnippet>
       ) : (
@@ -162,7 +231,45 @@ export function Request({data, event}: RequestProps) {
           )}
         </Fragment>
       )}
-    </InterimSection>
+    </EventDataSection>
+  );
+}
+
+function RequestDataCard({
+  title,
+  data,
+  meta,
+}: {
+  data: EntryRequest['data']['data'];
+  meta: Record<string, any> | undefined | null;
+  title: string;
+}) {
+  if (!defined(data)) {
+    return null;
+  }
+
+  const contentItems: KeyValueDataContentProps[] = [];
+
+  if (Array.isArray(data) && data.length > 0) {
+    data.forEach(([key, value], i: number) => {
+      const valueMeta = meta?.[i] ? meta[i]?.[1] : undefined;
+      contentItems.push({item: {key, subject: key, value}, meta: valueMeta});
+    });
+  } else if (typeof data === 'object') {
+    // Spread to flatten if it's a proxy
+    Object.entries({...data}).forEach(([key, value]) => {
+      const valueMeta = meta ? meta[key] : undefined;
+      contentItems.push({item: {key, subject: key, value}, meta: valueMeta});
+    });
+  }
+
+  return (
+    <ErrorBoundary
+      mini
+      message={tct('There was an error loading data: [title]', {title})}
+    >
+      <KeyValueData.Card title={title} contentItems={contentItems} truncateLength={5} />
+    </ErrorBoundary>
   );
 }
 
@@ -191,5 +298,16 @@ const StyledIconOpen = styled(IconOpen)`
 
   &:hover {
     color: ${p => p.theme.textColor};
+  }
+`;
+
+const SummaryLine = styled('div')`
+  margin-bottom: ${space(1)};
+`;
+
+const RequestCardPanel = styled(KeyValueData.CardPanel)`
+  display: block;
+  pre {
+    margin: 0;
   }
 `;

--- a/static/app/components/events/interfaces/request/richHttpContentClippedBoxBodySection.tsx
+++ b/static/app/components/events/interfaces/request/richHttpContentClippedBoxBodySection.tsx
@@ -15,6 +15,46 @@ type Props = {
   meta?: Record<any, any>;
 };
 
+export function getBodyContent({data, meta, inferredContentType}: Props) {
+  switch (inferredContentType) {
+    case 'application/json':
+      return (
+        <JsonEventData data-test-id="rich-http-content-body-context-data" data={data} />
+      );
+    case 'application/x-www-form-urlencoded':
+    case 'multipart/form-data': {
+      const transformedData = getTransformedData(data, meta).map(d => {
+        const [key, value] = d.data;
+        return {
+          key,
+          subject: key,
+          value,
+          meta: d.meta,
+        };
+      });
+
+      if (!transformedData.length) {
+        return null;
+      }
+
+      return (
+        <KeyValueList
+          data-test-id="rich-http-content-body-key-value-list"
+          data={transformedData}
+          isContextData
+        />
+      );
+    }
+
+    default:
+      return (
+        <pre data-test-id="rich-http-content-body-section-pre">
+          <StructuredEventData data={data} meta={meta} withAnnotatedText />
+        </pre>
+      );
+  }
+}
+
 export function RichHttpContentClippedBoxBodySection({
   data,
   meta,
@@ -24,47 +64,7 @@ export function RichHttpContentClippedBoxBodySection({
     return null;
   }
 
-  function getContent() {
-    switch (inferredContentType) {
-      case 'application/json':
-        return (
-          <JsonEventData data-test-id="rich-http-content-body-context-data" data={data} />
-        );
-      case 'application/x-www-form-urlencoded':
-      case 'multipart/form-data': {
-        const transformedData = getTransformedData(data, meta).map(d => {
-          const [key, value] = d.data;
-          return {
-            key,
-            subject: key,
-            value,
-            meta: d.meta,
-          };
-        });
-
-        if (!transformedData.length) {
-          return null;
-        }
-
-        return (
-          <KeyValueList
-            data-test-id="rich-http-content-body-key-value-list"
-            data={transformedData}
-            isContextData
-          />
-        );
-      }
-
-      default:
-        return (
-          <pre data-test-id="rich-http-content-body-section-pre">
-            <StructuredEventData data={data} meta={meta} withAnnotatedText />
-          </pre>
-        );
-    }
-  }
-
-  const content = getContent();
+  const content = getBodyContent({data, meta, inferredContentType});
 
   if (!content) {
     return null;

--- a/static/app/components/keyValueData/index.tsx
+++ b/static/app/components/keyValueData/index.tsx
@@ -307,8 +307,10 @@ const ActionButtonWrapper = styled('div')<{actionButtonAlwaysVisible?: boolean}>
 `;
 
 export const KeyValueData = {
+  Title,
   Content,
   Card,
+  CardPanel,
   Container,
 };
 


### PR DESCRIPTION
Opted to not make columns for the cards since there is usually quite a large size disparity between them, and it made the values feel constrained. The `Body` card could use some work as well for GraphQL formatting, but it matches the other cards more. Here is a [GraphQL issue](https://sentry-sdks.sentry.io/issues/5935306396/) for testing.

**Before**:
<img width="838" alt="image" src="https://github.com/user-attachments/assets/5cce9d72-5d23-4601-a83d-deb88155e87f">

**After**:
<img width="833" alt="image" src="https://github.com/user-attachments/assets/c5f05eb7-338b-4bcb-8e72-170e9fe1ef67">