### PR TITLE
fix(insights): domain views not showing setup project screen

### DIFF
--- a/static/app/views/insights/pages/ai/aiOverviewPage.tsx
+++ b/static/app/views/insights/pages/ai/aiOverviewPage.tsx
@@ -7,15 +7,12 @@ import {NoAccess} from 'sentry/components/noAccess';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
 import * as TeamKeyTransactionManager from 'sentry/components/performance/teamKeyTransactionsManager';
-import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {
   canUseMetricsData,
-  MEPSettingProvider,
   useMEPSettingContext,
 } from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {PageAlert, usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
@@ -32,7 +29,7 @@ import {ViewTrendsButton} from 'sentry/views/insights/common/components/viewTren
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {AiHeader} from 'sentry/views/insights/pages/ai/aiPageHeader';
 import {AI_LANDING_TITLE} from 'sentry/views/insights/pages/ai/settings';
-import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
+import {DomainOverviewPageWithProviders} from 'sentry/views/insights/pages/DomainOverviewPageWithProviders';
 import {generateGenericPerformanceEventView} from 'sentry/views/performance/data';
 import {TripleChartRow} from 'sentry/views/performance/landing/widgets/components/widgetChartRow';
 import {filterAllowedChartsMetrics} from 'sentry/views/performance/landing/widgets/utils';
@@ -199,20 +196,12 @@ function AiOverviewPage() {
 }
 
 function AiOverviewPageWithProviders() {
-  const organization = useOrganization();
-  const location = useLocation();
-
   return (
-    <PageFiltersContainer>
-      <SentryDocumentTitle title={OVERVIEW_PAGE_TITLE} orgSlug={organization.slug}>
-        <MEPSettingProvider location={location}>
-          <AiOverviewPage />
-        </MEPSettingProvider>
-      </SentryDocumentTitle>
-    </PageFiltersContainer>
+    <DomainOverviewPageWithProviders>
+      <AiOverviewPage />
+    </DomainOverviewPageWithProviders>
   );
 }
-
 const StyledTransactionNameSearchBar = styled(TransactionNameSearchBar)`
   flex: 2;
 `;

--- a/static/app/views/insights/pages/ai/aiOverviewPage.tsx
+++ b/static/app/views/insights/pages/ai/aiOverviewPage.tsx
@@ -29,7 +29,7 @@ import {ViewTrendsButton} from 'sentry/views/insights/common/components/viewTren
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {AiHeader} from 'sentry/views/insights/pages/ai/aiPageHeader';
 import {AI_LANDING_TITLE} from 'sentry/views/insights/pages/ai/settings';
-import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/DomainOverviewPageWithProviders';
+import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/domainOverviewPageProviders';
 import {generateGenericPerformanceEventView} from 'sentry/views/performance/data';
 import {TripleChartRow} from 'sentry/views/performance/landing/widgets/components/widgetChartRow';
 import {filterAllowedChartsMetrics} from 'sentry/views/performance/landing/widgets/utils';

--- a/static/app/views/insights/pages/ai/aiOverviewPage.tsx
+++ b/static/app/views/insights/pages/ai/aiOverviewPage.tsx
@@ -29,7 +29,7 @@ import {ViewTrendsButton} from 'sentry/views/insights/common/components/viewTren
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {AiHeader} from 'sentry/views/insights/pages/ai/aiPageHeader';
 import {AI_LANDING_TITLE} from 'sentry/views/insights/pages/ai/settings';
-import {DomainOverviewPageWithProviders} from 'sentry/views/insights/pages/DomainOverviewPageWithProviders';
+import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/DomainOverviewPageWithProviders';
 import {generateGenericPerformanceEventView} from 'sentry/views/performance/data';
 import {TripleChartRow} from 'sentry/views/performance/landing/widgets/components/widgetChartRow';
 import {filterAllowedChartsMetrics} from 'sentry/views/performance/landing/widgets/utils';
@@ -197,9 +197,9 @@ function AiOverviewPage() {
 
 function AiOverviewPageWithProviders() {
   return (
-    <DomainOverviewPageWithProviders>
+    <DomainOverviewPageProviders>
       <AiOverviewPage />
-    </DomainOverviewPageWithProviders>
+    </DomainOverviewPageProviders>
   );
 }
 const StyledTransactionNameSearchBar = styled(TransactionNameSearchBar)`

--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -7,15 +7,12 @@ import {NoAccess} from 'sentry/components/noAccess';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
 import * as TeamKeyTransactionManager from 'sentry/components/performance/teamKeyTransactionsManager';
-import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {
   canUseMetricsData,
-  MEPSettingProvider,
   useMEPSettingContext,
 } from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {PageAlert, usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
@@ -32,7 +29,7 @@ import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnbo
 import {ViewTrendsButton} from 'sentry/views/insights/common/viewTrendsButton';
 import {BackendHeader} from 'sentry/views/insights/pages/backend/backendPageHeader';
 import {BACKEND_LANDING_TITLE} from 'sentry/views/insights/pages/backend/settings';
-import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
+import {DomainOverviewPageWithProviders} from 'sentry/views/insights/pages/DomainOverviewPageWithProviders';
 import {generateBackendPerformanceEventView} from 'sentry/views/performance/data';
 import {
   DoubleChartRow,
@@ -230,17 +227,10 @@ function BackendOverviewPage() {
 }
 
 function BackendOverviewPageWithProviders() {
-  const organization = useOrganization();
-  const location = useLocation();
-
   return (
-    <PageFiltersContainer>
-      <SentryDocumentTitle title={OVERVIEW_PAGE_TITLE} orgSlug={organization.slug}>
-        <MEPSettingProvider location={location}>
-          <BackendOverviewPage />
-        </MEPSettingProvider>
-      </SentryDocumentTitle>
-    </PageFiltersContainer>
+    <DomainOverviewPageWithProviders>
+      <BackendOverviewPage />
+    </DomainOverviewPageWithProviders>
   );
 }
 

--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -29,7 +29,7 @@ import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnbo
 import {ViewTrendsButton} from 'sentry/views/insights/common/viewTrendsButton';
 import {BackendHeader} from 'sentry/views/insights/pages/backend/backendPageHeader';
 import {BACKEND_LANDING_TITLE} from 'sentry/views/insights/pages/backend/settings';
-import {DomainOverviewPageWithProviders} from 'sentry/views/insights/pages/DomainOverviewPageWithProviders';
+import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/DomainOverviewPageWithProviders';
 import {generateBackendPerformanceEventView} from 'sentry/views/performance/data';
 import {
   DoubleChartRow,
@@ -228,9 +228,9 @@ function BackendOverviewPage() {
 
 function BackendOverviewPageWithProviders() {
   return (
-    <DomainOverviewPageWithProviders>
+    <DomainOverviewPageProviders>
       <BackendOverviewPage />
-    </DomainOverviewPageWithProviders>
+    </DomainOverviewPageProviders>
   );
 }
 

--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -29,7 +29,7 @@ import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnbo
 import {ViewTrendsButton} from 'sentry/views/insights/common/viewTrendsButton';
 import {BackendHeader} from 'sentry/views/insights/pages/backend/backendPageHeader';
 import {BACKEND_LANDING_TITLE} from 'sentry/views/insights/pages/backend/settings';
-import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/DomainOverviewPageWithProviders';
+import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/domainOverviewPageProviders';
 import {generateBackendPerformanceEventView} from 'sentry/views/performance/data';
 import {
   DoubleChartRow,

--- a/static/app/views/insights/pages/domainOverviewPageProviders.tsx
+++ b/static/app/views/insights/pages/domainOverviewPageProviders.tsx
@@ -6,7 +6,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
 
-export function DomainOverviewPageWithProviders({children}: {children: React.ReactNode}) {
+export function DomainOverviewPageProviders({children}: {children: React.ReactNode}) {
   const organization = useOrganization();
   const location = useLocation();
 

--- a/static/app/views/insights/pages/domainOverviewPageWithProviders.tsx
+++ b/static/app/views/insights/pages/domainOverviewPageWithProviders.tsx
@@ -1,0 +1,22 @@
+import NoProjectMessage from 'sentry/components/noProjectMessage';
+import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
+
+export function DomainOverviewPageWithProviders({children}: {children: React.ReactNode}) {
+  const organization = useOrganization();
+  const location = useLocation();
+
+  return (
+    <NoProjectMessage organization={organization}>
+      <PageFiltersContainer>
+        <SentryDocumentTitle title={OVERVIEW_PAGE_TITLE} orgSlug={organization.slug}>
+          <MEPSettingProvider location={location}>{children}</MEPSettingProvider>
+        </SentryDocumentTitle>
+      </PageFiltersContainer>
+    </NoProjectMessage>
+  );
+}

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -27,7 +27,7 @@ import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLay
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {ViewTrendsButton} from 'sentry/views/insights/common/components/viewTrendsButton';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
-import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/DomainOverviewPageWithProviders';
+import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/domainOverviewPageProviders';
 import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
 import {
   FRONTEND_LANDING_TITLE,

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -7,15 +7,12 @@ import {NoAccess} from 'sentry/components/noAccess';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
 import * as TeamKeyTransactionManager from 'sentry/components/performance/teamKeyTransactionsManager';
-import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {
   canUseMetricsData,
-  MEPSettingProvider,
   useMEPSettingContext,
 } from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {PageAlert, usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
@@ -30,12 +27,12 @@ import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLay
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {ViewTrendsButton} from 'sentry/views/insights/common/components/viewTrendsButton';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
+import {DomainOverviewPageWithProviders} from 'sentry/views/insights/pages/DomainOverviewPageWithProviders';
 import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
 import {
   FRONTEND_LANDING_TITLE,
   OVERVIEW_PAGE_ALLOWED_OPS,
 } from 'sentry/views/insights/pages/frontend/settings';
-import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
 import {generateFrontendOtherPerformanceEventView} from 'sentry/views/performance/data';
 import {
   DoubleChartRow,
@@ -230,17 +227,10 @@ function FrontendOverviewPage() {
 }
 
 function FrontendOverviewPageWithProviders() {
-  const organization = useOrganization();
-  const location = useLocation();
-
   return (
-    <PageFiltersContainer>
-      <SentryDocumentTitle title={OVERVIEW_PAGE_TITLE} orgSlug={organization.slug}>
-        <MEPSettingProvider location={location}>
-          <FrontendOverviewPage />
-        </MEPSettingProvider>
-      </SentryDocumentTitle>
-    </PageFiltersContainer>
+    <DomainOverviewPageWithProviders>
+      <FrontendOverviewPage />
+    </DomainOverviewPageWithProviders>
   );
 }
 

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -27,7 +27,7 @@ import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLay
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {ViewTrendsButton} from 'sentry/views/insights/common/components/viewTrendsButton';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
-import {DomainOverviewPageWithProviders} from 'sentry/views/insights/pages/DomainOverviewPageWithProviders';
+import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/DomainOverviewPageWithProviders';
 import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
 import {
   FRONTEND_LANDING_TITLE,
@@ -228,9 +228,9 @@ function FrontendOverviewPage() {
 
 function FrontendOverviewPageWithProviders() {
   return (
-    <DomainOverviewPageWithProviders>
+    <DomainOverviewPageProviders>
       <FrontendOverviewPage />
-    </DomainOverviewPageWithProviders>
+    </DomainOverviewPageProviders>
   );
 }
 

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -6,15 +6,12 @@ import {NoAccess} from 'sentry/components/noAccess';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
 import * as TeamKeyTransactionManager from 'sentry/components/performance/teamKeyTransactionsManager';
-import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {
   canUseMetricsData,
-  MEPSettingProvider,
   useMEPSettingContext,
 } from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {PageAlert, usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
@@ -29,12 +26,12 @@ import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLay
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {ViewTrendsButton} from 'sentry/views/insights/common/viewTrendsButton';
+import {DomainOverviewPageWithProviders} from 'sentry/views/insights/pages/DomainOverviewPageWithProviders';
 import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
 import {
   MOBILE_LANDING_TITLE,
   OVERVIEW_PAGE_ALLOWED_OPS,
 } from 'sentry/views/insights/pages/mobile/settings';
-import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
 import {
   generateGenericPerformanceEventView,
   generateMobilePerformanceEventView,
@@ -256,17 +253,10 @@ function MobileOverviewPage() {
 }
 
 function MobileOverviewPageWithProviders() {
-  const organization = useOrganization();
-  const location = useLocation();
-
   return (
-    <PageFiltersContainer>
-      <SentryDocumentTitle title={OVERVIEW_PAGE_TITLE} orgSlug={organization.slug}>
-        <MEPSettingProvider location={location}>
-          <MobileOverviewPage />
-        </MEPSettingProvider>
-      </SentryDocumentTitle>
-    </PageFiltersContainer>
+    <DomainOverviewPageWithProviders>
+      <MobileOverviewPage />
+    </DomainOverviewPageWithProviders>
   );
 }
 

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -26,7 +26,7 @@ import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLay
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {ViewTrendsButton} from 'sentry/views/insights/common/viewTrendsButton';
-import {DomainOverviewPageWithProviders} from 'sentry/views/insights/pages/DomainOverviewPageWithProviders';
+import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/DomainOverviewPageWithProviders';
 import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
 import {
   MOBILE_LANDING_TITLE,
@@ -254,9 +254,9 @@ function MobileOverviewPage() {
 
 function MobileOverviewPageWithProviders() {
   return (
-    <DomainOverviewPageWithProviders>
+    <DomainOverviewPageProviders>
       <MobileOverviewPage />
-    </DomainOverviewPageWithProviders>
+    </DomainOverviewPageProviders>
   );
 }
 

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -26,7 +26,7 @@ import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLay
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {ViewTrendsButton} from 'sentry/views/insights/common/viewTrendsButton';
-import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/DomainOverviewPageWithProviders';
+import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/domainOverviewPageProviders';
 import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
 import {
   MOBILE_LANDING_TITLE,


### PR DESCRIPTION
Work for #77572 

Adds the setup project screen to domain views and moved providers into a shared component (as they are all the same between domains).
<img width="1460" alt="image" src="https://github.com/user-attachments/assets/b62aba40-37bc-46d4-a75d-8bf7a63a7a4a">
