### PR TITLE
feat(dashboards): Remove suspect commit from popover

### DIFF
--- a/static/app/views/discover/table/quickContext/issueContext.spec.tsx
+++ b/static/app/views/discover/table/quickContext/issueContext.spec.tsx
@@ -1,9 +1,8 @@
 import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RepositoryFixture} from 'sentry-fixture/repository';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {GroupStatus} from 'sentry/types/group';
 import type {EventData} from 'sentry/utils/discover/eventView';
@@ -36,29 +35,9 @@ const renderIssueContext = (dataRow: EventData = defaultRow) => {
 describe('Quick Context Content Issue Column', function () {
   beforeEach(() => {
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/users/',
-      body: [],
-    });
-
-    MockApiClient.addMockResponse({
-      url: '/projects/org-slug/cool-team/events/6b43e285de834ec5b5fe30d62d549b20/committers/',
-      body: [],
-    });
-
-    MockApiClient.addMockResponse({
-      url: '/issues/3512441874/events/oldest/',
-      method: 'GET',
-      body: [],
-    });
-
-    MockApiClient.addMockResponse({
-      url: '/issues/3512441874/',
+      url: '/organizations/org-slug/issues/3512441874/',
       method: 'GET',
       body: mockedGroup,
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/projects/`,
-      body: [ProjectFixture()],
     });
   });
 
@@ -77,7 +56,7 @@ describe('Quick Context Content Issue Column', function () {
   it('Renders resolved issue status context', async () => {
     const group = {...mockedGroup, status: GroupStatus.RESOLVED};
     MockApiClient.addMockResponse({
-      url: '/issues/3512441874/',
+      url: '/organizations/org-slug/issues/3512441874/',
       method: 'GET',
       body: group,
     });
@@ -91,7 +70,7 @@ describe('Quick Context Content Issue Column', function () {
   it('Renders unresolved issue status context', async () => {
     const group = {...mockedGroup, status: GroupStatus.UNRESOLVED};
     MockApiClient.addMockResponse({
-      url: '/issues/3512441874/',
+      url: '/organizations/org-slug/issues/3512441874/',
       method: 'GET',
       body: group,
     });
@@ -124,94 +103,5 @@ describe('Quick Context Content Issue Column', function () {
 
     expect(await screen.findByText(/Title/i)).toBeInTheDocument();
     expect(screen.getByText(/typeError: error description/i)).toBeInTheDocument();
-  });
-
-  describe('Suspect commits', () => {
-    const maiseyCommitter = {
-      author: {name: 'Maisey the Dog', id: '1231'},
-      commits: [
-        {
-          message: 'feat(simulator): Add option for multiple squirrels (#1121)',
-          id: 'ab2709293d0c9000829084ac7b1c9221fb18437c',
-          dateCreated: '2012-09-08T04:15:12',
-          repository: RepositoryFixture(),
-        },
-      ],
-    };
-    const charlieCommitter = {
-      author: {name: 'Charlie Bear', id: '1121'},
-      commits: [
-        {
-          message:
-            'ref(simulator): Split leaderboard calculations into separate functions (#1231)',
-          id: 'fe29668b24cea6faad8afb8f6d9417f402ef9c18',
-          dateCreated: '2012-04-15T09:09:12',
-          repository: RepositoryFixture(),
-        },
-      ],
-    };
-
-    beforeEach(() => {
-      MockApiClient.addMockResponse({
-        url: '/issues/3512441874/events/oldest/',
-        method: 'GET',
-        body: {
-          eventID: '6b43e285de834ec5b5fe30d62d549b20',
-        },
-      });
-    });
-
-    afterEach(() => {
-      MockApiClient.clearMockResponses();
-    });
-
-    it('Renders a single suspect commit', async () => {
-      MockApiClient.addMockResponse({
-        method: 'GET',
-        url: '/projects/org-slug/cool-team/events/6b43e285de834ec5b5fe30d62d549b20/committers/',
-        body: {
-          committers: [maiseyCommitter],
-        },
-      });
-      renderIssueContext();
-
-      // Make sure the title renders in the singular, since there's only one commit
-      expect(await screen.findByText(/Suspect Commit/i)).toBeInTheDocument();
-      expect(screen.queryByText(/Suspect Commits/i)).not.toBeInTheDocument();
-
-      // Ensure all commit data is present
-      expect(screen.getByText(/MD/i)).toBeInTheDocument();
-      expect(screen.getByTestId('quick-context-commit-row')).toHaveTextContent(
-        /View commit ab27092 by Maisey the Dog/
-      );
-    });
-
-    it('Renders multiple suspect commits', async () => {
-      MockApiClient.addMockResponse({
-        method: 'GET',
-        url: '/projects/org-slug/cool-team/events/6b43e285de834ec5b5fe30d62d549b20/committers/',
-        body: {
-          committers: [maiseyCommitter, charlieCommitter],
-        },
-      });
-      renderIssueContext();
-
-      // Make sure the title renders in the plural
-      expect(await screen.findByText(/Suspect Commits \(2\)/i)).toBeInTheDocument();
-
-      // When there's more than one commit, any past the first start out hidden
-      const expandButton = await screen.findByTestId('expand-commit-list');
-      await userEvent.click(expandButton);
-
-      // Check that they're both there
-      expect(screen.getByText(/MD/i)).toBeInTheDocument();
-      expect(screen.getByText(/CB/i)).toBeInTheDocument();
-      expect(screen.getAllByTestId('quick-context-commit-row')[0]).toHaveTextContent(
-        /View commit ab27092 by Maisey the Dog/
-      );
-      expect(screen.getAllByTestId('quick-context-commit-row')[1]).toHaveTextContent(
-        /View commit fe29668 by Charlie Bear/
-      );
-    });
   });
 });

--- a/static/app/views/discover/table/quickContext/issueContext.tsx
+++ b/static/app/views/discover/table/quickContext/issueContext.tsx
@@ -3,21 +3,16 @@ import styled from '@emotion/styled';
 
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
 import Count from 'sentry/components/count';
-import {QuickContextCommitRow} from 'sentry/components/discover/quickContextCommitRow';
-import {SuspectCommitHeader} from 'sentry/components/events/styles';
-import {StyledPanel, SuspectCommits} from 'sentry/components/events/suspectCommits';
 import {getAssignedToDisplayName} from 'sentry/components/group/assignedTo';
-import Panel from 'sentry/components/panels/panel';
 import {IconWrapper} from 'sentry/components/sidebarSection';
-import * as SidebarSection from 'sentry/components/sidebarSection';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconCheckmark, IconMute, IconNot, IconUser} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {makeFetchGroupQueryKey} from 'sentry/views/issueDetails/useGroup';
 
 import {NoContext} from './quickContextWrapper';
 import {
@@ -29,7 +24,7 @@ import {
   Wrapper,
 } from './styles';
 import type {BaseContextProps} from './utils';
-import {ContextType, tenSecondInMs} from './utils';
+import {ContextType} from './utils';
 
 function IssueContext(props: BaseContextProps) {
   const {dataRow, organization} = props;
@@ -46,29 +41,16 @@ function IssueContext(props: BaseContextProps) {
     isError: issueError,
     data: issue,
   } = useApiQuery<Group>(
-    [
-      `/issues/${dataRow['issue.id']}/`,
-      {
-        query: {
-          collapse: 'release',
-          expand: 'inbox',
-        },
-      },
-    ],
+    makeFetchGroupQueryKey({
+      groupId: dataRow['issue.id'],
+      organizationSlug: organization.slug,
+      // The link to issue details doesn't seem to currently pass selected environments
+      environments: [],
+    }),
     {
-      staleTime: tenSecondInMs,
+      staleTime: 30_000,
     }
   );
-
-  // NOTE: Suspect commits are generated from the first event of an issue.
-  // Therefore, all events for an issue have the same suspect commits.
-  const {
-    isPending: eventLoading,
-    isError: eventError,
-    data: event,
-  } = useApiQuery<Event>([`/issues/${dataRow['issue.id']}/events/oldest/`], {
-    staleTime: tenSecondInMs,
-  });
 
   const title = issue?.title;
   const renderTitle = () =>
@@ -154,22 +136,8 @@ function IssueContext(props: BaseContextProps) {
       </IssueContextContainer>
     );
 
-  const renderSuspectCommits = () =>
-    event?.eventID &&
-    issue && (
-      <SuspectCommitsContainer data-test-id="quick-context-suspect-commits-container">
-        <SuspectCommits
-          projectSlug={issue.project.slug}
-          eventId={event.eventID}
-          commitRow={QuickContextCommitRow}
-        />
-      </SuspectCommitsContainer>
-    );
-
-  const isLoading = issueLoading || eventLoading;
-  const isError = issueError || eventError;
-  if (isLoading || isError) {
-    return <NoContext isLoading={isLoading} />;
+  if (issueLoading || issueError) {
+    return <NoContext isLoading={issueLoading} />;
   }
 
   return (
@@ -177,25 +145,9 @@ function IssueContext(props: BaseContextProps) {
       {renderTitle()}
       {renderStatusAndCounts()}
       {renderAssignee()}
-      {renderSuspectCommits()}
     </Wrapper>
   );
 }
-
-const SuspectCommitsContainer = styled(ContextContainer)`
-  ${SidebarSection.Wrap}, ${Panel}, h6 {
-    margin: 0;
-  }
-
-  ${StyledPanel} {
-    border: none;
-    box-shadow: none;
-  }
-
-  ${SuspectCommitHeader} {
-    margin: ${space(2)} 0 ${space(0.75)};
-  }
-`;
 
 const IssueTitleBody = styled(ContextBody)`
   margin: 0;

--- a/static/app/views/discover/table/quickContext/quickContextHovercard.spec.tsx
+++ b/static/app/views/discover/table/quickContext/quickContextHovercard.spec.tsx
@@ -2,7 +2,6 @@ import {EventFixture} from 'sentry-fixture/event';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ReleaseFixture} from 'sentry-fixture/release';
 
-import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import ConfigStore from 'sentry/stores/configStore';
@@ -10,8 +9,6 @@ import {EventOrGroupType} from 'sentry/types/event';
 import {ReleaseStatus} from 'sentry/types/release';
 import type {EventData} from 'sentry/utils/discover/eventView';
 import type EventView from 'sentry/utils/discover/eventView';
-import {QueryClientProvider} from 'sentry/utils/queryClient';
-import {useLocation} from 'sentry/utils/useLocation';
 
 import {QuickContextHoverWrapper} from './quickContextWrapper';
 import {defaultRow, mockedCommit, mockedUser1, mockedUser2} from './testUtils';
@@ -24,35 +21,22 @@ const renderQuickContextContent = (
 ) => {
   const organization = OrganizationFixture();
   render(
-    <QueryClientProvider client={makeTestQueryClient()}>
-      <QuickContextHoverWrapper
-        dataRow={dataRow}
-        contextType={contextType}
-        organization={organization}
-        eventView={eventView}
-      >
-        Text from Child
-      </QuickContextHoverWrapper>
-    </QueryClientProvider>,
+    <QuickContextHoverWrapper
+      dataRow={dataRow}
+      contextType={contextType}
+      organization={organization}
+      eventView={eventView}
+    >
+      Text from Child
+    </QuickContextHoverWrapper>,
     {organization}
   );
 };
 
-jest.mock('sentry/utils/useLocation');
-
 describe('Quick Context', function () {
   describe('Quick Context default behaviour', function () {
-    beforeEach(() => {
-      MockApiClient.addMockResponse({
-        url: '/issues/3512441874/events/oldest/',
-        method: 'GET',
-        body: [],
-      });
-    });
-
     afterEach(() => {
       MockApiClient.clearMockResponses();
-      jest.mocked(useLocation).mockReset();
     });
 
     it('Renders child', async () => {
@@ -66,14 +50,8 @@ describe('Quick Context', function () {
         url: '/organizations/org-slug/users/',
         body: [],
       });
-
       MockApiClient.addMockResponse({
-        url: '/projects/org-slug/cool-team/events/6b43e285de834ec5b5fe30d62d549b20/committers/',
-        body: [],
-      });
-
-      MockApiClient.addMockResponse({
-        url: '/issues/3512441874/',
+        url: '/organizations/org-slug/issues/3512441874/',
         method: 'GET',
         body: {},
       });
@@ -89,14 +67,8 @@ describe('Quick Context', function () {
         url: '/organizations/org-slug/users/',
         body: [],
       });
-
       MockApiClient.addMockResponse({
-        url: '/projects/org-slug/cool-team/events/6b43e285de834ec5b5fe30d62d549b20/committers/',
-        body: [],
-      });
-
-      MockApiClient.addMockResponse({
-        url: '/issues/3512441874/',
+        url: '/organizations/org-slug/issues/3512441874/',
         statusCode: 400,
       });
 
@@ -113,7 +85,7 @@ describe('Quick Context', function () {
 
     it('Renders issue context header with copy button', async () => {
       MockApiClient.addMockResponse({
-        url: '/issues/3512441874/',
+        url: '/organizations/org-slug/issues/3512441874/',
         method: 'GET',
         body: {},
       });


### PR DESCRIPTION
Removes suspect commits from the hovercard on dashboards and discover. Not super useful. 

Use `makeFetchGroupQueryKey` to enable caching by using the same query key that will load if the user navigates to issue details.

suspect commits with one of our beta flags turned on
![image](https://github.com/user-attachments/assets/7bf3f202-ed6f-4ea9-98f5-6e5513ac3c82)
