### PR TITLE
feat(issue-details): Add resources from config to solutions center

### DIFF
--- a/static/app/views/issueDetails/streamline/resources.tsx
+++ b/static/app/views/issueDetails/streamline/resources.tsx
@@ -6,13 +6,8 @@ import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import {IssueCategory} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import type {IssueTypeConfig} from 'sentry/utils/issueTypeConfig/types';
+import type {IssueTypeConfig, ResourceLink} from 'sentry/utils/issueTypeConfig/types';
 import useOrganization from 'sentry/utils/useOrganization';
-
-export type ResourceLink = {
-  link: string;
-  text: string;
-};
 
 type Props = {
   configResources: NonNullable<IssueTypeConfig['resources']>;
@@ -22,7 +17,7 @@ type Props = {
 
 export default function Resources({configResources, eventPlatform, group}: Props) {
   const organization = useOrganization();
-  const links = [
+  const links: ResourceLink[] = [
     ...configResources.links,
     ...(configResources.linksByPlatform[eventPlatform ?? ''] ?? []),
   ];

--- a/static/app/views/issueDetails/streamline/resources.tsx
+++ b/static/app/views/issueDetails/streamline/resources.tsx
@@ -55,5 +55,5 @@ export default function Resources({configResources, eventPlatform, group}: Props
 const LinkSection = styled('div')`
   display: flex;
   gap: ${space(1)};
-  margin-top: ${space(2)};
+  margin-top: ${space(1)};
 `;

--- a/static/app/views/issueDetails/streamline/resources.tsx
+++ b/static/app/views/issueDetails/streamline/resources.tsx
@@ -1,0 +1,59 @@
+import styled from '@emotion/styled';
+
+import {LinkButton} from 'sentry/components/button';
+import {space} from 'sentry/styles/space';
+import type {Event} from 'sentry/types/event';
+import type {Group} from 'sentry/types/group';
+import {IssueCategory} from 'sentry/types/group';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import type {IssueTypeConfig} from 'sentry/utils/issueTypeConfig/types';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export type ResourceLink = {
+  link: string;
+  text: string;
+};
+
+type Props = {
+  configResources: NonNullable<IssueTypeConfig['resources']>;
+  eventPlatform: Event['platform'];
+  group: Group;
+};
+
+export default function Resources({configResources, eventPlatform, group}: Props) {
+  const organization = useOrganization();
+  const links = [
+    ...configResources.links,
+    ...(configResources.linksByPlatform[eventPlatform ?? ''] ?? []),
+  ];
+
+  return (
+    <div>
+      {group.issueCategory !== IssueCategory.ERROR && configResources.description}
+      <LinkSection>
+        {links.map(({link, text}) => (
+          <LinkButton
+            onClick={() =>
+              trackAnalytics('issue_details.resources_link_clicked', {
+                organization,
+                resource: text,
+                group_id: group.id,
+              })
+            }
+            key={link}
+            href={link}
+            external
+          >
+            {text}
+          </LinkButton>
+        ))}
+      </LinkSection>
+    </div>
+  );
+}
+
+const LinkSection = styled('div')`
+  display: flex;
+  gap: ${space(1)};
+  margin-top: ${space(2)};
+`;

--- a/static/app/views/issueDetails/streamline/solutionsDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/solutionsDrawer.tsx
@@ -13,8 +13,10 @@ import type {Group} from 'sentry/types/group';
 import {IssueCategory} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {getShortEventId} from 'sentry/utils/events';
+import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import marked from 'sentry/utils/marked';
 import {MIN_NAV_HEIGHT} from 'sentry/views/issueDetails/streamline/eventTitle';
+import Resources from 'sentry/views/issueDetails/streamline/resources';
 
 interface SolutionsDrawerProps {
   group: Group;
@@ -24,6 +26,7 @@ interface SolutionsDrawerProps {
 
 export function SolutionsDrawer({group, project, event}: SolutionsDrawerProps) {
   const {data, hasGenAIConsent} = useGroupSummary(group.id, group.issueCategory);
+  const config = getConfigForIssueType(group, project);
 
   return (
     <SolutionsDrawerContainer>
@@ -58,6 +61,13 @@ export function SolutionsDrawer({group, project, event}: SolutionsDrawerProps) {
               }}
             />
           </GroupSummaryWrapper>
+        )}
+        {config.resources && (
+          <Resources
+            eventPlatform={event?.platform}
+            group={group}
+            configResources={config.resources}
+          />
         )}
       </Content>
     </SolutionsDrawerContainer>


### PR DESCRIPTION
this pr adds resources from the config into the solutions center in the streamlined experience. not removing them from the existing section, since once we move autofix over, we can just hide the section for the new experience. \\
![Screenshot 2024-11-01 at 9 58 43 AM](https://github.com/user-attachments/assets/e2e6d0b0-0a98-440a-b0d8-a17909dcd17a)
