### PR TITLE
chore(dashboards): Remove unused getColoredWidgetIndicator function

### DIFF
--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -20,7 +20,6 @@ import {
   SIX_HOURS,
   TWENTY_FOUR_HOURS,
 } from 'sentry/components/charts/utils';
-import CircleIndicator from 'sentry/components/circleIndicator';
 import {normalizeDateTimeString} from 'sentry/components/organizations/pageFilters/parse';
 import {parseSearch, Token} from 'sentry/components/searchSyntax/parser';
 import {t} from 'sentry/locale';
@@ -29,7 +28,6 @@ import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import {getUtcDateString} from 'sentry/utils/dates';
-import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {DURATION_UNITS} from 'sentry/utils/discover/fieldRenderers';
 import {
@@ -53,7 +51,6 @@ import {getMetricDisplayType, getMetricsUrl} from 'sentry/utils/metrics';
 import {parseField} from 'sentry/utils/metrics/mri';
 import type {MetricsWidget} from 'sentry/utils/metrics/types';
 import {decodeList, decodeScalar} from 'sentry/utils/queryString';
-import theme from 'sentry/utils/theme';
 import type {
   DashboardDetails,
   DashboardFilters,
@@ -67,9 +64,7 @@ import {
   WidgetType,
 } from 'sentry/views/dashboards/types';
 
-import {ThresholdsHoverWrapper} from './widgetBuilder/buildSteps/thresholdsStep/thresholdsHoverWrapper';
 import type {ThresholdsConfig} from './widgetBuilder/buildSteps/thresholdsStep/thresholdsStep';
-import {ThresholdMaxKeys} from './widgetBuilder/buildSteps/thresholdsStep/thresholdsStep';
 
 export type ValidationError = {
   [key: string]: string | string[] | ValidationError[] | ValidationError;
@@ -146,53 +141,6 @@ export function normalizeUnit(value: number, unit: string, dataType: string): nu
         ? DURATION_UNITS[unit]
         : 1;
   return value * multiplier;
-}
-
-export function getColoredWidgetIndicator(
-  thresholds: ThresholdsConfig,
-  tableData: TableDataWithTitle[]
-): React.ReactNode {
-  const tableMeta = {...tableData[0].meta};
-  const fields = Object.keys(tableMeta);
-  const field = fields[0];
-  const dataType = tableMeta[field];
-  const dataUnit = tableMeta.units?.[field];
-  const dataRow = tableData[0].data[0];
-
-  if (!dataRow) {
-    return null;
-  }
-
-  const data = Number(dataRow[field]);
-  const normalizedData = dataUnit ? normalizeUnit(data, dataUnit, dataType) : data;
-
-  const {max_values} = thresholds;
-
-  let color = theme.red300;
-
-  const yellowMax = max_values[ThresholdMaxKeys.MAX_2];
-  const normalizedYellowMax =
-    thresholds.unit && yellowMax
-      ? normalizeUnit(yellowMax, thresholds.unit, dataType)
-      : yellowMax;
-  if (normalizedYellowMax && normalizedData <= normalizedYellowMax) {
-    color = theme.yellow300;
-  }
-
-  const greenMax = max_values[ThresholdMaxKeys.MAX_1];
-  const normalizedGreenMax =
-    thresholds.unit && greenMax
-      ? normalizeUnit(greenMax, thresholds.unit, dataType)
-      : greenMax;
-  if (normalizedGreenMax && normalizedData <= normalizedGreenMax) {
-    color = theme.green300;
-  }
-
-  return (
-    <ThresholdsHoverWrapper thresholds={thresholds} type={dataType}>
-      <CircleIndicator color={color} size={12} />
-    </ThresholdsHoverWrapper>
-  );
 }
 
 function coerceStringToArray(value?: string | string[] | null) {


### PR DESCRIPTION
Noticed this was unused when making my last PR. Removing it to reduce overhead if we come back to fix how we access table meta values.

This is unused now because the new big number widget maintains this behaviour internally