### PR TITLE
chore(vscode): Turn on --reuse-db flag for vscode debugger

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -59,7 +59,7 @@
       "type": "python",
       "request": "launch",
       "module": "pytest",
-      "args": ["--verbosity", "2", "${file}"],
+      "args": ["--verbosity", "2", "${file}", "--reuse-db"],
       "django": true,
       "env": {
         "SENTRY_MODEL_MANIFEST_FILE_PATH": "./model-manifest.json"


### PR DESCRIPTION
turns on the --reuse-db flag for vscode python debugger by default
