### PR TITLE
fix(oauth): Show error if user has no org

### DIFF
--- a/src/sentry/web/frontend/oauth_authorize.py
+++ b/src/sentry/web/frontend/oauth_authorize.py
@@ -211,6 +211,14 @@ class OAuthAuthorizeView(AuthLoginView):
 
         if application.requires_org_level_access:
             organization_options = user_service.get_organizations(user_id=request.user.id)
+            if not organization_options:
+                return self.respond(
+                    "sentry/oauth-error.html",
+                    {
+                        "error": "This authorization flow is only available for users who are members of an organization."
+                    },
+                    status=400,
+                )
         else:
             # If application is not org level we should not show organizations to choose from at all
             organization_options = []


### PR DESCRIPTION
This flow is org scoped oauth so the user entering this flow must be a member of at least one organization. Before this would break the UI but now we show a proper error.

<img width="580" alt="Screenshot 2024-11-01 at 11 23 14 AM" src="https://github.com/user-attachments/assets/572f2e99-4aff-4f48-906a-062f49917ccf">
