### PR TITLE
fix(dashboard): Only update permission if not none

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -585,7 +585,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
 
         self.update_dashboard_filters(self.instance, validated_data)
         if features.has(
-            "organizations:dashboard-permissions",
+            "organizations:dashboards-edit-access",
             self.context["organization"],
             actor=self.context["request"].user,
         ):
@@ -618,7 +618,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
 
         self.update_dashboard_filters(instance, validated_data)
         if features.has(
-            "organizations:dashboard-permissions",
+            "organizations:dashboards-edit-access",
             self.context["organization"],
             actor=self.context["request"].user,
         ):

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -590,7 +590,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
             actor=self.context["request"].user,
         ):
             if "permissions" in validated_data and validated_data["permissions"] is not None:
-                DashboardPermissions.objects.create(
+                self.instance.permissions, _ = DashboardPermissions.objects.update_or_create(
                     dashboard=self.instance, **validated_data["permissions"]
                 )
 
@@ -623,7 +623,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
             actor=self.context["request"].user,
         ):
             if "permissions" in validated_data and validated_data["permissions"] is not None:
-                DashboardPermissions.objects.update_or_create(
+                instance.permissions, _ = DashboardPermissions.objects.update_or_create(
                     dashboard=instance, defaults=validated_data["permissions"]
                 )
 

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -584,10 +584,15 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
             self.update_widgets(self.instance, validated_data["widgets"])
 
         self.update_dashboard_filters(self.instance, validated_data)
-        if "permissions" in validated_data:
-            DashboardPermissions.objects.create(
-                dashboard=self.instance, **validated_data["permissions"]
-            )
+        if features.has(
+            "organizations:dashboard-permissions",
+            self.context["organization"],
+            actor=self.context["request"].user,
+        ):
+            if "permissions" in validated_data and validated_data["permissions"] is not None:
+                DashboardPermissions.objects.create(
+                    dashboard=self.instance, **validated_data["permissions"]
+                )
 
         schedule_update_project_configs(self.instance)
 
@@ -612,10 +617,15 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
             self.update_widgets(instance, validated_data["widgets"])
 
         self.update_dashboard_filters(instance, validated_data)
-        if "permissions" in validated_data:
-            DashboardPermissions.objects.update_or_create(
-                dashboard=instance, defaults=validated_data["permissions"]
-            )
+        if features.has(
+            "organizations:dashboard-permissions",
+            self.context["organization"],
+            actor=self.context["request"].user,
+        ):
+            if "permissions" in validated_data and validated_data["permissions"] is not None:
+                DashboardPermissions.objects.update_or_create(
+                    dashboard=instance, defaults=validated_data["permissions"]
+                )
 
         schedule_update_project_configs(instance)
 

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -1871,9 +1871,10 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
             "title": "Dashboard",
             "permissions": {"isCreatorOnlyEditable": "False"},
         }
-        response = self.do_request(
-            "put", f"{self.url(self.dashboard.id)}?environment=mock_env", data=data
-        )
+        with self.feature({"organizations:dashboards-edit-access": True}):
+            response = self.do_request(
+                "put", f"{self.url(self.dashboard.id)}?environment=mock_env", data=data
+            )
         assert response.status_code == 200, response.data
         assert response.data["permissions"]["isCreatorOnlyEditable"] is False
 
@@ -1884,9 +1885,10 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
             "title": "Dashboard",
             "permissions": {"isCreatorOnlyEditable": "true"},
         }
-        response = self.do_request(
-            "put", f"{self.url(self.dashboard.id)}?environment=mock_env", data=data
-        )
+        with self.feature({"organizations:dashboards-edit-access": True}):
+            response = self.do_request(
+                "put", f"{self.url(self.dashboard.id)}?environment=mock_env", data=data
+            )
         assert response.status_code == 200, response.data
         assert response.data["permissions"]["isCreatorOnlyEditable"] is True
 
@@ -1902,9 +1904,10 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         }
 
         assert permission.is_creator_only_editable is False
-        response = self.do_request(
-            "put", f"{self.url(self.dashboard.id)}?environment=mock_env", data=data
-        )
+        with self.feature({"organizations:dashboards-edit-access": True}):
+            response = self.do_request(
+                "put", f"{self.url(self.dashboard.id)}?environment=mock_env", data=data
+            )
         assert response.status_code == 200, response.data
         assert response.data["permissions"]["isCreatorOnlyEditable"] is True
 
@@ -1918,9 +1921,10 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
             "title": "Dashboard",
             "permissions": {"isCreatorOnlyEditable": "something-invalid"},
         }
-        response = self.do_request(
-            "put", f"{self.url(self.dashboard.id)}?environment=mock_env", data=data
-        )
+        with self.feature({"organizations:dashboards-edit-access": True}):
+            response = self.do_request(
+                "put", f"{self.url(self.dashboard.id)}?environment=mock_env", data=data
+            )
         assert response.status_code == 400, response.data
         assert "isCreatorOnlyEditable" in response.data["permissions"]
 

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -1972,6 +1972,17 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
             response = self.do_request("put", self.url(self.dashboard.id))
         assert response.status_code == 200, response.content
 
+    def test_update_dashboard_permissions_with_none_does_not_create_permissions_object(self):
+        data = {
+            "title": "Dashboard",
+            "permissions": None,
+        }
+        with self.feature({"organizations:dashboards-edit-access": True}):
+            response = self.do_request("put", self.url(self.dashboard.id), data=data)
+        assert response.status_code == 200, response.data
+        assert response.data["permissions"] is None
+        assert not DashboardPermissions.objects.filter(dashboard=self.dashboard).exists()
+
 
 class OrganizationDashboardDetailsOnDemandTest(OrganizationDashboardDetailsTestCase):
     widget_type = DashboardWidgetTypes.DISCOVER


### PR DESCRIPTION
The dashboard request body can contain `permissions: null` which means that creating/updating fails.
Adds a feature flag, but also ignore when the permission is None.

Also adds a feature flag check.

Closes SENTRY-3HCC