### PR TITLE
feat(rollback): Add new endpoint to retrieve rollback data

### DIFF
--- a/src/sentry/api/endpoints/organization_user_rollback.py
+++ b/src/sentry/api/endpoints/organization_user_rollback.py
@@ -41,8 +41,11 @@ class OrganizationRollbackUserEndpoint(OrganizationEndpoint):
         # Validate that the organization has rollbacks enabled
         if not organization.get_option("sentry:rollback_enabled", ROLLBACK_ENABLED_DEFAULT):
             return Response(
-                status=status.HTTP_403_FORBIDDEN,
-                data={"detail": "Rollbacks are disabled for this organization."},
+                status=status.HTTP_404_NOT_FOUND,
+                data={
+                    "detail": "Rollbacks are disabled for this organization.",
+                    "code": "disabled",
+                },
             )
 
         try:

--- a/src/sentry/api/endpoints/organization_user_rollback.py
+++ b/src/sentry/api/endpoints/organization_user_rollback.py
@@ -1,0 +1,65 @@
+from rest_framework import status
+from rest_framework.permissions import BasePermission
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.serializers.base import serialize
+from sentry.api.serializers.models.userrollback import UserRollbackSerializer
+from sentry.constants import ROLLBACK_ENABLED_DEFAULT
+from sentry.models.organization import Organization
+from sentry.models.rollbackorganization import RollbackOrganization
+from sentry.models.rollbackuser import RollbackUser
+
+
+class MemberPermission(BasePermission):
+    scope_map = {
+        "GET": ["member:read"],
+    }
+
+
+@region_silo_endpoint
+class OrganizationRollbackUserEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+    owner = ApiOwner.ISSUES
+    permission_classes = (MemberPermission,)
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        """
+        Retrieve an organiztion member's rollback
+        """
+        # Validate that the user/org has access to the feature
+        if not features.has("organizations:sentry-rollback-2024", organization, actor=request.user):
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        # Validate that the organization has rollbacks enabled
+        if not organization.get_option("sentry:rollback_enabled", ROLLBACK_ENABLED_DEFAULT):
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        try:
+            rollback_user = RollbackUser.objects.get(
+                user_id=request.user.id, organization=organization
+            )
+        except RollbackUser.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        try:
+            rollback_org = RollbackOrganization.objects.get(organization=organization)
+        except RollbackOrganization.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        return Response(
+            status=status.HTTP_200_OK,
+            data=serialize(
+                rollback_user,
+                rollback_org=rollback_org,
+                user=request.user,
+                serializer=UserRollbackSerializer(),
+            ),
+        )

--- a/src/sentry/api/endpoints/organization_user_rollback.py
+++ b/src/sentry/api/endpoints/organization_user_rollback.py
@@ -40,7 +40,10 @@ class OrganizationRollbackUserEndpoint(OrganizationEndpoint):
 
         # Validate that the organization has rollbacks enabled
         if not organization.get_option("sentry:rollback_enabled", ROLLBACK_ENABLED_DEFAULT):
-            return Response(status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                status=status.HTTP_403_FORBIDDEN,
+                data={"detail": "Rollbacks are disabled for this organization."},
+            )
 
         try:
             rollback_user = RollbackUser.objects.get(

--- a/src/sentry/api/serializers/models/userrollback.py
+++ b/src/sentry/api/serializers/models/userrollback.py
@@ -1,0 +1,41 @@
+from typing import TypedDict
+
+from sentry.api.serializers import Serializer
+
+
+class RollbackOrganizationSerializerResponse(TypedDict):
+    id: int
+    name: str
+    slug: str
+
+
+class RollbackUserSerializerResponse(TypedDict):
+    id: int
+    name: str
+
+
+class RollbackSerializerResponse(TypedDict):
+    organization: RollbackOrganizationSerializerResponse
+    user: RollbackUserSerializerResponse
+    data: dict  # JSON Blob
+
+
+class UserRollbackSerializer(Serializer):
+    def serialize(self, obj, attrs, user, **kwargs) -> RollbackSerializerResponse:
+        rollback_org = kwargs.get("rollback_org")
+
+        return {
+            "organization": {
+                "id": obj.organization.id,
+                "name": obj.organization.name,
+                "slug": obj.organization.slug,
+            },
+            "user": {
+                "id": obj.user_id,
+                "name": user.name,
+            },
+            "data": {
+                "user": obj.data,
+                "organization": rollback_org.data if rollback_org else None,
+            },
+        }

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -27,6 +27,7 @@ from sentry.api.endpoints.organization_unsubscribe import (
     OrganizationUnsubscribeIssue,
     OrganizationUnsubscribeProject,
 )
+from sentry.api.endpoints.organization_user_rollback import OrganizationRollbackUserEndpoint
 from sentry.api.endpoints.project_backfill_similar_issues_embeddings_records import (
     ProjectBackfillSimilarIssuesEmbeddingsRecords,
 )
@@ -1935,6 +1936,11 @@ ORGANIZATION_URLS = [
         r"^(?P<organization_id_or_slug>[^\/]+)/user-feedback/$",
         OrganizationUserReportsEndpoint.as_view(),
         name="sentry-api-0-organization-user-feedback",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/user-rollback/$",
+        OrganizationRollbackUserEndpoint.as_view(),
+        name="sentry-api-0-organization-user-rollback",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/user-teams/$",

--- a/tests/sentry/api/endpoints/test_organization_user_rollback.py
+++ b/tests/sentry/api/endpoints/test_organization_user_rollback.py
@@ -1,0 +1,75 @@
+from django.urls import reverse
+from rest_framework import status
+
+from sentry.models.rollbackorganization import RollbackOrganization
+from sentry.models.rollbackuser import RollbackUser
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test
+class OrganizationRollbackUserEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-organization-user-rollback"
+    method = "get"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+
+    def _get_path(self) -> str:
+        return reverse(self.endpoint)
+
+    @with_feature("organizations:sentry-rollback-2024")
+    def test_simple(self):
+        rollback_user = RollbackUser.objects.create(
+            user_id=self.user.id,
+            organization=self.organization,
+            data={"animal": "sea otter"},
+        )
+        rollback_org = RollbackOrganization.objects.create(
+            organization=self.organization,
+            data={"animal": "georgie"},
+        )
+
+        response = self.get_success_response(self.organization.slug)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {
+            "organization": {
+                "id": self.organization.id,
+                "name": self.organization.name,
+                "slug": self.organization.slug,
+            },
+            "user": {"id": self.user.id, "name": self.user.name},
+            "data": {"user": rollback_user.data, "organization": rollback_org.data},
+        }
+
+    @with_feature("organizations:sentry-rollback-2024")
+    def test_rollback_disabled(self):
+        self.organization.update_option("sentry:rollback_enabled", False)
+        response = self.get_error_response(self.organization.slug)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @with_feature("organizations:sentry-rollback-2024")
+    def test_rollback_user_not_found(self):
+        RollbackOrganization.objects.create(
+            organization=self.organization,
+            data={"animal": "georgie"},
+        )
+        response = self.get_error_response(self.organization.slug)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @with_feature("organizations:sentry-rollback-2024")
+    def test_rollback_org_not_found(self):
+        RollbackUser.objects.create(
+            user_id=self.user.id,
+            organization=self.organization,
+            data={"animal": "sea otter"},
+        )
+
+        response = self.get_error_response(self.organization.slug)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_rollback_feature_flag_off(self):
+        response = self.get_error_response(self.organization.slug)
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/tests/sentry/api/endpoints/test_organization_user_rollback.py
+++ b/tests/sentry/api/endpoints/test_organization_user_rollback.py
@@ -45,6 +45,24 @@ class OrganizationRollbackUserEndpointTest(APITestCase):
         }
 
     @with_feature("organizations:sentry-rollback-2024")
+    def test_user_not_in_org(self):
+        newUser = self.create_user("other@example.com")
+        newOrg = self.create_organization("otherorg")
+
+        RollbackUser.objects.create(
+            user_id=newUser.id,
+            organization=newOrg,
+            data={"animal": "sea otter"},
+        )
+        RollbackOrganization.objects.create(
+            organization=newOrg,
+            data={"animal": "georgie"},
+        )
+
+        response = self.get_error_response(self.organization.slug)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @with_feature("organizations:sentry-rollback-2024")
     def test_rollback_disabled(self):
         self.organization.update_option("sentry:rollback_enabled", False)
         response = self.get_error_response(self.organization.slug)


### PR DESCRIPTION
Adds the `organization/<org_slug_or_id>/user-rollbacks` endpoint. This retrieves the JSON blobs from the user and their org's rollback entry. Currently gated by the `organizations:sentry-rollback-2024` feature flag. 