### PR TITLE
feat(profiling) add continuous profiling docs

### DIFF
--- a/static/app/gettingStartedDocs/node/awslambda.spec.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.spec.tsx
@@ -1,3 +1,5 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -69,6 +71,43 @@ describe('awslambda onboarding docs', function () {
     ).toBeInTheDocument();
     expect(
       screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
+    ).toBeInTheDocument();
+  });
+
+  it('continuous profiling', () => {
+    const organization = OrganizationFixture({
+      features: ['continuous-profiling'],
+    });
+
+    renderWithOnboardingLayout(
+      docs,
+      {
+        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
+      },
+      {
+        organization,
+      }
+    );
+
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(
+          /const { nodeProfilingIntegration } = require\("@sentry\/profiling-node"\)/
+        )
+      )
+    ).toBeInTheDocument();
+
+    // Profiles sample rate should not be set for continuous profiling
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
+    ).not.toBeInTheDocument();
+
+    // Should have start and stop profiling calls
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.startProfiling/))
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiling/))
     ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/awslambda.spec.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.spec.tsx
@@ -81,9 +81,7 @@ describe('awslambda onboarding docs', function () {
 
     renderWithOnboardingLayout(
       docs,
-      {
-        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
-      },
+      {},
       {
         organization,
       }

--- a/static/app/gettingStartedDocs/node/azurefunctions.spec.tsx
+++ b/static/app/gettingStartedDocs/node/azurefunctions.spec.tsx
@@ -80,9 +80,7 @@ describe('express onboarding docs', function () {
 
     renderWithOnboardingLayout(
       docs,
-      {
-        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
-      },
+      {},
       {
         organization,
       }

--- a/static/app/gettingStartedDocs/node/azurefunctions.spec.tsx
+++ b/static/app/gettingStartedDocs/node/azurefunctions.spec.tsx
@@ -1,3 +1,5 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -68,6 +70,43 @@ describe('express onboarding docs', function () {
     ).toBeInTheDocument();
     expect(
       screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
+    ).toBeInTheDocument();
+  });
+
+  it('continuous profiling', () => {
+    const organization = OrganizationFixture({
+      features: ['continuous-profiling'],
+    });
+
+    renderWithOnboardingLayout(
+      docs,
+      {
+        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
+      },
+      {
+        organization,
+      }
+    );
+
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(
+          /const { nodeProfilingIntegration } = require\("@sentry\/profiling-node"\)/
+        )
+      )
+    ).toBeInTheDocument();
+
+    // Profiles sample rate should not be set for continuous profiling
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
+    ).not.toBeInTheDocument();
+
+    // Should have start and stop profiling calls
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.startProfiling/))
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiling/))
     ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/connect.spec.tsx
+++ b/static/app/gettingStartedDocs/node/connect.spec.tsx
@@ -88,9 +88,7 @@ describe('connect onboarding docs', function () {
 
     renderWithOnboardingLayout(
       docs,
-      {
-        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
-      },
+      {},
       {
         organization,
       }

--- a/static/app/gettingStartedDocs/node/connect.spec.tsx
+++ b/static/app/gettingStartedDocs/node/connect.spec.tsx
@@ -1,3 +1,5 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -76,6 +78,43 @@ describe('connect onboarding docs', function () {
     ).toBeInTheDocument();
     expect(
       screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
+    ).toBeInTheDocument();
+  });
+
+  it('continuous profiling', () => {
+    const organization = OrganizationFixture({
+      features: ['continuous-profiling'],
+    });
+
+    renderWithOnboardingLayout(
+      docs,
+      {
+        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
+      },
+      {
+        organization,
+      }
+    );
+
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(
+          /const { nodeProfilingIntegration } = require\("@sentry\/profiling-node"\)/
+        )
+      )
+    ).toBeInTheDocument();
+
+    // Profiles sample rate should not be set for continuous profiling
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
+    ).not.toBeInTheDocument();
+
+    // Should have start and stop profiling calls
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.startProfiling/))
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiling/))
     ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/express.spec.tsx
+++ b/static/app/gettingStartedDocs/node/express.spec.tsx
@@ -1,3 +1,5 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -77,6 +79,42 @@ describe('express onboarding docs', function () {
     ).toBeInTheDocument();
     expect(
       screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
+    ).toBeInTheDocument();
+  });
+  it('continuous profiling', () => {
+    const organization = OrganizationFixture({
+      features: ['continuous-profiling'],
+    });
+
+    renderWithOnboardingLayout(
+      docs,
+      {
+        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
+      },
+      {
+        organization,
+      }
+    );
+
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(
+          /const { nodeProfilingIntegration } = require\("@sentry\/profiling-node"\)/
+        )
+      )
+    ).toBeInTheDocument();
+
+    // Profiles sample rate should not be set for continuous profiling
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
+    ).not.toBeInTheDocument();
+
+    // Should have start and stop profiling calls
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.startProfiling/))
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiling/))
     ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/express.spec.tsx
+++ b/static/app/gettingStartedDocs/node/express.spec.tsx
@@ -88,9 +88,7 @@ describe('express onboarding docs', function () {
 
     renderWithOnboardingLayout(
       docs,
-      {
-        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
-      },
+      {},
       {
         organization,
       }

--- a/static/app/gettingStartedDocs/node/fastify.spec.tsx
+++ b/static/app/gettingStartedDocs/node/fastify.spec.tsx
@@ -1,3 +1,5 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -77,6 +79,43 @@ describe('fastify onboarding docs', function () {
     ).toBeInTheDocument();
     expect(
       screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
+    ).toBeInTheDocument();
+  });
+
+  it('continuous profiling', () => {
+    const organization = OrganizationFixture({
+      features: ['continuous-profiling'],
+    });
+
+    renderWithOnboardingLayout(
+      docs,
+      {
+        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
+      },
+      {
+        organization,
+      }
+    );
+
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(
+          /const { nodeProfilingIntegration } = require\("@sentry\/profiling-node"\)/
+        )
+      )
+    ).toBeInTheDocument();
+
+    // Profiles sample rate should not be set for continuous profiling
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
+    ).not.toBeInTheDocument();
+
+    // Should have start and stop profiling calls
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.startProfiling/))
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiling/))
     ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/fastify.spec.tsx
+++ b/static/app/gettingStartedDocs/node/fastify.spec.tsx
@@ -89,9 +89,7 @@ describe('fastify onboarding docs', function () {
 
     renderWithOnboardingLayout(
       docs,
-      {
-        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
-      },
+      {},
       {
         organization,
       }

--- a/static/app/gettingStartedDocs/node/gcpfunctions.spec.tsx
+++ b/static/app/gettingStartedDocs/node/gcpfunctions.spec.tsx
@@ -1,3 +1,5 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -71,6 +73,43 @@ describe('gcpfunctions onboarding docs', function () {
     ).toBeInTheDocument();
     expect(
       screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
+    ).toBeInTheDocument();
+  });
+
+  it('continuous profiling', () => {
+    const organization = OrganizationFixture({
+      features: ['continuous-profiling'],
+    });
+
+    renderWithOnboardingLayout(
+      docs,
+      {
+        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
+      },
+      {
+        organization,
+      }
+    );
+
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(
+          /const { nodeProfilingIntegration } = require\("@sentry\/profiling-node"\)/
+        )
+      )
+    ).toBeInTheDocument();
+
+    // Profiles sample rate should not be set for continuous profiling
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
+    ).not.toBeInTheDocument();
+
+    // Should have start and stop profiling calls
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.startProfiling/))
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiling/))
     ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/gcpfunctions.spec.tsx
+++ b/static/app/gettingStartedDocs/node/gcpfunctions.spec.tsx
@@ -83,9 +83,7 @@ describe('gcpfunctions onboarding docs', function () {
 
     renderWithOnboardingLayout(
       docs,
-      {
-        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
-      },
+      {},
       {
         organization,
       }

--- a/static/app/gettingStartedDocs/node/hapi.spec.tsx
+++ b/static/app/gettingStartedDocs/node/hapi.spec.tsx
@@ -89,9 +89,7 @@ describe('hapi onboarding docs', function () {
 
     renderWithOnboardingLayout(
       docs,
-      {
-        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
-      },
+      {},
       {
         organization,
       }

--- a/static/app/gettingStartedDocs/node/hapi.spec.tsx
+++ b/static/app/gettingStartedDocs/node/hapi.spec.tsx
@@ -1,3 +1,5 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -77,6 +79,43 @@ describe('hapi onboarding docs', function () {
     ).toBeInTheDocument();
     expect(
       screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
+    ).toBeInTheDocument();
+  });
+
+  it('continuous profiling', () => {
+    const organization = OrganizationFixture({
+      features: ['continuous-profiling'],
+    });
+
+    renderWithOnboardingLayout(
+      docs,
+      {
+        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
+      },
+      {
+        organization,
+      }
+    );
+
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(
+          /const { nodeProfilingIntegration } = require\("@sentry\/profiling-node"\)/
+        )
+      )
+    ).toBeInTheDocument();
+
+    // Profiles sample rate should not be set for continuous profiling
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
+    ).not.toBeInTheDocument();
+
+    // Should have start and stop profiling calls
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.startProfiling/))
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiling/))
     ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/koa.spec.tsx
+++ b/static/app/gettingStartedDocs/node/koa.spec.tsx
@@ -1,3 +1,5 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -77,6 +79,43 @@ describe('koa onboarding docs', function () {
     ).toBeInTheDocument();
     expect(
       screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
+    ).toBeInTheDocument();
+  });
+
+  it('continuous profiling', () => {
+    const organization = OrganizationFixture({
+      features: ['continuous-profiling'],
+    });
+
+    renderWithOnboardingLayout(
+      docs,
+      {
+        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
+      },
+      {
+        organization,
+      }
+    );
+
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(
+          /const { nodeProfilingIntegration } = require\("@sentry\/profiling-node"\)/
+        )
+      )
+    ).toBeInTheDocument();
+
+    // Profiles sample rate should not be set for continuous profiling
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
+    ).not.toBeInTheDocument();
+
+    // Should have start and stop profiling calls
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.startProfiling/))
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiling/))
     ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/koa.spec.tsx
+++ b/static/app/gettingStartedDocs/node/koa.spec.tsx
@@ -89,9 +89,7 @@ describe('koa onboarding docs', function () {
 
     renderWithOnboardingLayout(
       docs,
-      {
-        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
-      },
+      {},
       {
         organization,
       }

--- a/static/app/gettingStartedDocs/node/nestjs.spec.tsx
+++ b/static/app/gettingStartedDocs/node/nestjs.spec.tsx
@@ -89,9 +89,7 @@ describe('Nest.js onboarding docs', function () {
 
     renderWithOnboardingLayout(
       docs,
-      {
-        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
-      },
+      {},
       {
         organization,
       }

--- a/static/app/gettingStartedDocs/node/nestjs.spec.tsx
+++ b/static/app/gettingStartedDocs/node/nestjs.spec.tsx
@@ -1,3 +1,5 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -77,6 +79,43 @@ describe('Nest.js onboarding docs', function () {
     ).toBeInTheDocument();
     expect(
       screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
+    ).toBeInTheDocument();
+  });
+
+  it('continuous profiling', () => {
+    const organization = OrganizationFixture({
+      features: ['continuous-profiling'],
+    });
+
+    renderWithOnboardingLayout(
+      docs,
+      {
+        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
+      },
+      {
+        organization,
+      }
+    );
+
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(
+          /import \{ nodeProfilingIntegration } from "@sentry\/profiling-node"/
+        )
+      )
+    ).toBeInTheDocument();
+
+    // Profiles sample rate should not be set for continuous profiling
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
+    ).not.toBeInTheDocument();
+
+    // Should have start and stop profiling calls
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.startProfiling/))
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiling/))
     ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/node.spec.tsx
+++ b/static/app/gettingStartedDocs/node/node.spec.tsx
@@ -81,9 +81,7 @@ describe('node onboarding docs', function () {
 
     renderWithOnboardingLayout(
       docs,
-      {
-        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
-      },
+      {},
       {
         organization,
       }

--- a/static/app/gettingStartedDocs/node/node.spec.tsx
+++ b/static/app/gettingStartedDocs/node/node.spec.tsx
@@ -1,3 +1,5 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
 import {screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -69,6 +71,43 @@ describe('node onboarding docs', function () {
     ).toBeInTheDocument();
     expect(
       screen.getByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
+    ).toBeInTheDocument();
+  });
+
+  it('continuous profiling', () => {
+    const organization = OrganizationFixture({
+      features: ['continuous-profiling'],
+    });
+
+    renderWithOnboardingLayout(
+      docs,
+      {
+        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
+      },
+      {
+        organization,
+      }
+    );
+
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(
+          /const { nodeProfilingIntegration } = require\("@sentry\/profiling-node"\)/
+        )
+      )
+    ).toBeInTheDocument();
+
+    // Profiles sample rate should not be set for continuous profiling
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
+    ).not.toBeInTheDocument();
+
+    // Should have start and stop profiling calls
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.startProfiling/))
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiling/))
     ).toBeInTheDocument();
   });
 });

--- a/static/app/utils/gettingStartedDocs/node.ts
+++ b/static/app/utils/gettingStartedDocs/node.ts
@@ -216,13 +216,26 @@ Sentry.init({
       tracesSampleRate: 1.0, //  Capture 100% of the transactions\n`
       : ''
   }${
-    params.isProfilingSelected
+    params.isProfilingSelected &&
+    params.profilingOptions?.defaultProfilingMode !== 'continuous'
       ? `
     // Set sampling rate for profiling - this is relative to tracesSampleRate
     profilesSampleRate: 1.0,`
       : ''
-  }});
-`;
+  }});${
+    params.isProfilingSelected &&
+    params.profilingOptions?.defaultProfilingMode === 'continuous'
+      ? `
+// Manually call startProfiling and stopProfiling
+// to profile the code in between
+Sentry.profiler.startProfiling()
+// this code will be profiled
+
+// Calls to stopProfiling are optional - if you don't stop the profiler, it will keep profiling
+// your application until the process exits or stopProfiling is called.
+Sentry.profiler.stopProfiling()`
+      : ''
+  }`;
 
 export function getProductIntegrations({
   productSelection,

--- a/tests/js/sentry-test/onboarding/renderWithOnboardingLayout.tsx
+++ b/tests/js/sentry-test/onboarding/renderWithOnboardingLayout.tsx
@@ -41,10 +41,8 @@ export function renderWithOnboardingLayout<
     selectedOptions = {},
   } = options;
 
-  const {organization: org} = renderOptions;
-
   const {organization, project, router} = initializeOrg({
-    organization: org,
+    organization: renderOptions.organization,
     router: {
       location: {
         query: selectedOptions,


### PR DESCRIPTION
Add continuous profiling docs for nodejs and its frameworks. For nextjs, remix and friends, we prompt users to rely on the wizard install, so I will create a PR there next