### PR TITLE
ref(releases): remove references to project_id

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_release_file_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_file_details.py
@@ -160,9 +160,7 @@ class ReleaseFileDeleteTest(APITestCase):
 
         project = self.create_project(name="foo")
 
-        release = Release.objects.create(
-            project_id=project.id, organization_id=project.organization_id, version="1"
-        )
+        release = Release.objects.create(organization_id=project.organization_id, version="1")
         release.add_project(project)
 
         assert release.count_artifacts() == 0

--- a/tests/sentry/api/endpoints/test_organization_release_files.py
+++ b/tests/sentry/api/endpoints/test_organization_release_files.py
@@ -379,9 +379,7 @@ class ReleaseFileCreateTest(APITestCase):
     def test_duplicate_file(self):
         project = self.create_project(name="foo")
 
-        release = Release.objects.create(
-            project_id=project.id, organization_id=project.organization_id, version="1"
-        )
+        release = Release.objects.create(organization_id=project.organization_id, version="1")
         release.add_project(project)
 
         url = reverse(

--- a/tests/sentry/api/endpoints/test_project_release_file_details.py
+++ b/tests/sentry/api/endpoints/test_project_release_file_details.py
@@ -247,9 +247,7 @@ class ReleaseFileDeleteTest(APITestCase):
 
         project = self.create_project(name="foo")
 
-        release = Release.objects.create(
-            project_id=project.id, organization_id=project.organization_id, version="1"
-        )
+        release = Release.objects.create(organization_id=project.organization_id, version="1")
         release.add_project(project)
 
         assert release.count_artifacts() == 0

--- a/tests/sentry/api/endpoints/test_project_release_files.py
+++ b/tests/sentry/api/endpoints/test_project_release_files.py
@@ -422,9 +422,7 @@ class ReleaseFileCreateTest(APITestCase):
     def test_duplicate_file(self):
         project = self.create_project(name="foo")
 
-        release = Release.objects.create(
-            project_id=project.id, organization_id=project.organization_id, version="1"
-        )
+        release = Release.objects.create(organization_id=project.organization_id, version="1")
         release.add_project(project)
 
         url = reverse(


### PR DESCRIPTION
remove references in tests to release.project_id. this column is deprecated/not used and will be removed in https://github.com/getsentry/sentry/pull/80151