### PR TITLE
feat(perf): make N+1 DB Query count user-configurable

### DIFF
--- a/src/sentry/api/endpoints/project_performance_issue_settings.py
+++ b/src/sentry/api/endpoints/project_performance_issue_settings.py
@@ -55,6 +55,7 @@ class InternalProjectOptions(Enum):
 
 class ConfigurableThresholds(Enum):
     N_PLUS_ONE_DB_DURATION = "n_plus_one_db_duration_threshold"
+    N_PLUS_ONE_DB_COUNT = "n_plus_one_db_count"
     UNCOMPRESSED_ASSET_DURATION = "uncompressed_asset_duration_threshold"
     UNCOMPRESSED_ASSET_SIZE = "uncompressed_asset_size_threshold"
     LARGE_HTTP_PAYLOAD_SIZE = "large_http_payload_size_threshold"
@@ -86,6 +87,7 @@ internal_only_project_settings_to_group_map: dict[str, type[GroupType]] = {
 
 configurable_thresholds_to_internal_settings_map: dict[str, str] = {
     ConfigurableThresholds.N_PLUS_ONE_DB_DURATION.value: InternalProjectOptions.N_PLUS_ONE_DB.value,
+    ConfigurableThresholds.N_PLUS_ONE_DB_COUNT.value: InternalProjectOptions.N_PLUS_ONE_DB.value,
     ConfigurableThresholds.UNCOMPRESSED_ASSET_DURATION.value: InternalProjectOptions.UNCOMPRESSED_ASSET.value,
     ConfigurableThresholds.UNCOMPRESSED_ASSET_SIZE.value: InternalProjectOptions.UNCOMPRESSED_ASSET.value,
     ConfigurableThresholds.LARGE_HTTP_PAYLOAD_SIZE.value: InternalProjectOptions.LARGE_HTTP_PAYLOAD.value,
@@ -104,6 +106,7 @@ class ProjectPerformanceIssueSettingsSerializer(serializers.Serializer):
     n_plus_one_db_duration_threshold = serializers.IntegerField(
         required=False, min_value=50, max_value=TEN_SECONDS
     )
+    n_plus_one_db_count = serializers.IntegerField(required=False, min_value=5, max_value=100)
     slow_db_query_duration_threshold = serializers.IntegerField(
         required=False, min_value=100, max_value=TEN_SECONDS
     )

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -59,6 +59,8 @@ export const allowedSizeValues: number[] = [
   10000000,
 ]; // 50kb to 10MB in bytes
 
+export const allowedCountValues: number[] = [5, 10, 20, 50, 100];
+
 export const projectDetectorSettingsId = 'detector-threshold-settings';
 
 type ProjectPerformanceSettings = {[key: string]: number | boolean};
@@ -82,6 +84,7 @@ enum DetectorConfigAdmin {
 export enum DetectorConfigCustomer {
   SLOW_DB_DURATION = 'slow_db_query_duration_threshold',
   N_PLUS_DB_DURATION = 'n_plus_one_db_duration_threshold',
+  N_PLUS_DB_COUNT = 'n_plus_one_db_count',
   N_PLUS_API_CALLS_DURATION = 'n_plus_one_api_calls_total_duration_threshold',
   RENDER_BLOCKING_ASSET_RATIO = 'render_blocking_fcp_ratio',
   LARGE_HTT_PAYLOAD_SIZE = 'large_http_payload_size_threshold',
@@ -511,6 +514,10 @@ class ProjectPerformance extends DeprecatedAsyncView<Props, State> {
       return fps ? `${Math.floor(fps / 5) * 5}fps` : '';
     };
 
+    const formatCount = (value: number | ''): string => {
+      return '' + value;
+    };
+
     const issueType = safeGetQsParam('issueType');
 
     return [
@@ -532,6 +539,24 @@ class ProjectPerformance extends DeprecatedAsyncView<Props, State> {
             tickValues: [0, allowedDurationValues.length - 1],
             showTickLabels: true,
             formatLabel: formatDuration,
+            flexibleControlStateSize: true,
+            disabledReason,
+          },
+          {
+            name: DetectorConfigCustomer.N_PLUS_DB_COUNT,
+            type: 'range',
+            label: t('Minimum Query Count'),
+            defaultValue: 5,
+            help: t(
+              'Setting the value to 5 means that an eligible event will be detected as an N+1 DB Query Issue only if the number of repeated queries exceeds 5'
+            ),
+            allowedValues: allowedCountValues,
+            disabled: !(
+              hasAccess && performanceSettings[DetectorConfigAdmin.N_PLUS_DB_ENABLED]
+            ),
+            tickValues: [0, allowedCountValues.length - 1],
+            showTickLabels: true,
+            formatLabel: formatCount,
             flexibleControlStateSize: true,
             disabledReason,
           },

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -59,8 +59,6 @@ export const allowedSizeValues: number[] = [
   10000000,
 ]; // 50kb to 10MB in bytes
 
-export const allowedCountValues: number[] = [5, 10, 20, 50, 100];
-
 export const projectDetectorSettingsId = 'detector-threshold-settings';
 
 type ProjectPerformanceSettings = {[key: string]: number | boolean};
@@ -84,7 +82,6 @@ enum DetectorConfigAdmin {
 export enum DetectorConfigCustomer {
   SLOW_DB_DURATION = 'slow_db_query_duration_threshold',
   N_PLUS_DB_DURATION = 'n_plus_one_db_duration_threshold',
-  N_PLUS_DB_COUNT = 'n_plus_one_db_count',
   N_PLUS_API_CALLS_DURATION = 'n_plus_one_api_calls_total_duration_threshold',
   RENDER_BLOCKING_ASSET_RATIO = 'render_blocking_fcp_ratio',
   LARGE_HTT_PAYLOAD_SIZE = 'large_http_payload_size_threshold',
@@ -514,10 +511,6 @@ class ProjectPerformance extends DeprecatedAsyncView<Props, State> {
       return fps ? `${Math.floor(fps / 5) * 5}fps` : '';
     };
 
-    const formatCount = (value: number | ''): string => {
-      return '' + value;
-    };
-
     const issueType = safeGetQsParam('issueType');
 
     return [
@@ -539,24 +532,6 @@ class ProjectPerformance extends DeprecatedAsyncView<Props, State> {
             tickValues: [0, allowedDurationValues.length - 1],
             showTickLabels: true,
             formatLabel: formatDuration,
-            flexibleControlStateSize: true,
-            disabledReason,
-          },
-          {
-            name: DetectorConfigCustomer.N_PLUS_DB_COUNT,
-            type: 'range',
-            label: t('Minimum Query Count'),
-            defaultValue: 5,
-            help: t(
-              'Setting the value to 5 means that an eligible event will be detected as an N+1 DB Query Issue only if the number of repeated queries exceeds 5'
-            ),
-            allowedValues: allowedCountValues,
-            disabled: !(
-              hasAccess && performanceSettings[DetectorConfigAdmin.N_PLUS_DB_ENABLED]
-            ),
-            tickValues: [0, allowedCountValues.length - 1],
-            showTickLabels: true,
-            formatLabel: formatCount,
             flexibleControlStateSize: true,
             disabledReason,
           },

--- a/tests/sentry/api/endpoints/test_project_performance_issue_settings.py
+++ b/tests/sentry/api/endpoints/test_project_performance_issue_settings.py
@@ -72,6 +72,7 @@ class ProjectPerformanceIssueSettingsTest(APITestCase):
             {
                 "performance.issues.slow_db_query.duration_threshold": 1000,
                 "performance.issues.n_plus_one_db.duration_threshold": 100,
+                "performance.issues.n_plus_one_db.count_threshold": 10,
                 "performance.issues.render_blocking_assets.fcp_ratio_threshold": 0.80,
                 "performance.issues.large_http_payload.size_threshold": 2000,
                 "performance.issues.db_on_main_thread.total_spans_duration_threshold": 33,
@@ -90,6 +91,7 @@ class ProjectPerformanceIssueSettingsTest(APITestCase):
             # System and project defaults
             assert response.data["slow_db_query_duration_threshold"] == 1000
             assert response.data["n_plus_one_db_duration_threshold"] == 100
+            assert response.data["n_plus_one_db_count"] == 10
             assert response.data["render_blocking_fcp_ratio"] == 0.8
             assert response.data["large_http_payload_size_threshold"] == 2000
             assert response.data["db_on_main_thread_duration_threshold"] == 33
@@ -102,6 +104,7 @@ class ProjectPerformanceIssueSettingsTest(APITestCase):
 
             get_value.return_value = {
                 "n_plus_one_db_duration_threshold": 10000,
+                "n_plus_one_db_count": 50,
                 "slow_db_query_duration_threshold": 5000,
                 "render_blocking_fcp_ratio": 0.8,
                 "uncompressed_asset_duration_threshold": 500,
@@ -121,6 +124,7 @@ class ProjectPerformanceIssueSettingsTest(APITestCase):
             # Updated project settings
             assert response.data["slow_db_query_duration_threshold"] == 5000
             assert response.data["n_plus_one_db_duration_threshold"] == 10000
+            assert response.data["n_plus_one_db_count"] == 50
             assert response.data["render_blocking_fcp_ratio"] == 0.8
             assert response.data["uncompressed_asset_duration_threshold"] == 500
             assert response.data["uncompressed_asset_size_threshold"] == 300000


### PR DESCRIPTION
The N+1 DB Query performance issue has a threshold of 5 identical queries before triggering. In #76835, we decided to make this user configurable.

Make the N+1 DB performance issue Minimum Query Count user-configurable via API. A second PR will add a setting to control this from the frontend.