### PR TITLE
fix(dashboards): Prevent widget modal crash when `query=` URL parameter is too high

### DIFF
--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -376,6 +376,17 @@ describe('Modals -> WidgetViewerModal', function () {
         expect(screen.getByText('Another Query Name')).toBeInTheDocument();
       });
 
+      it('renders the first query if the query index is invalid', async function () {
+        mockEvents();
+        initialData.router.location.query = {query: ['7']};
+
+        await renderModal({initialData, widget: mockWidget});
+        expect(screen.getByRole('button', {name: 'Open in Discover'})).toHaveAttribute(
+          'href',
+          '/organizations/org-slug/discover/results/?environment=prod&environment=dev&field=count%28%29&name=Test%20Widget&project=1&project=2&query=title%3A%2Forganizations%2F%3AorgId%2Fperformance%2Fsummary%2F&statsPeriod=24h&yAxis=count%28%29'
+        );
+      });
+
       it('renders the correct discover query link when there are multiple queries in a widget', async function () {
         mockEvents();
         initialData.router.location.query = {query: ['1']};

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -252,8 +252,11 @@ function WidgetViewerModal(props: Props) {
   const [totalResults, setTotalResults] = useState<string | undefined>();
 
   // Get query selection settings from location
-  const selectedQueryIndex =
+  let selectedQueryIndex =
     decodeInteger(location.query[WidgetViewerQueryField.QUERY]) ?? 0;
+  if (selectedQueryIndex > widget.queries.length) {
+    selectedQueryIndex = 0;
+  }
 
   // Get pagination settings from location
   const page = decodeInteger(location.query[WidgetViewerQueryField.PAGE]) ?? 0;

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -251,23 +251,6 @@ function WidgetViewerModal(props: Props) {
 
   const [totalResults, setTotalResults] = useState<string | undefined>();
 
-  // Get query selection settings from location
-  let selectedQueryIndex =
-    decodeInteger(location.query[WidgetViewerQueryField.QUERY]) ?? 0;
-  if (selectedQueryIndex > widget.queries.length) {
-    selectedQueryIndex = 0;
-    navigate(
-      {
-        pathname: location.pathname,
-        query: {
-          ...location.query,
-          [WidgetViewerQueryField.QUERY]: 0,
-        },
-      },
-      {replace: true}
-    );
-  }
-
   // Get pagination settings from location
   const page = decodeInteger(location.query[WidgetViewerQueryField.PAGE]) ?? 0;
   const cursor = decodeScalar(location.query[WidgetViewerQueryField.CURSOR]);
@@ -281,6 +264,15 @@ function WidgetViewerModal(props: Props) {
   const sortedQueries = cloneDeep(
     sort ? widget.queries.map(query => ({...query, orderby: sort})) : widget.queries
   );
+
+  // The table under the widget visualization can only show one query, but widgets might have multiple. Choose the query based on a URL parameter.
+  // Note that the URL parameter might be incorrect or invalid, in which case we drop down to the first query
+  let selectedQueryIndex =
+    decodeInteger(location.query[WidgetViewerQueryField.QUERY]) ?? 0;
+
+  if (defined(widget) && !defined(sortedQueries[selectedQueryIndex])) {
+    selectedQueryIndex = 0;
+  }
 
   // Top N widget charts (including widgets with limits) results rely on the sorting of the query
   // Set the orderby of the widget chart to match the location query params

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -256,6 +256,16 @@ function WidgetViewerModal(props: Props) {
     decodeInteger(location.query[WidgetViewerQueryField.QUERY]) ?? 0;
   if (selectedQueryIndex > widget.queries.length) {
     selectedQueryIndex = 0;
+    navigate(
+      {
+        pathname: location.pathname,
+        query: {
+          ...location.query,
+          [WidgetViewerQueryField.QUERY]: 0,
+        },
+      },
+      {replace: true}
+    );
   }
 
   // Get pagination settings from location

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -284,11 +284,13 @@ class DashboardDetail extends Component<Props, State> {
           onEdit: () => {
             const widgetIndex = dashboard.widgets.indexOf(widget);
             if (dashboardId) {
+              const query = omit(location.query, Object.values(WidgetViewerQueryField));
+
               router.push(
                 normalizeUrl({
                   pathname: `/organizations/${organization.slug}/dashboard/${dashboardId}/widget/${widgetIndex}/edit/`,
                   query: {
-                    ...location.query,
+                    ...query,
                     source: DashboardWidgetSource.DASHBOARDS,
                   },
                 })


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/80162
