### PR TITLE
fix(flags): hide feature flag series legend if not under ff

### DIFF
--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -70,6 +70,7 @@ export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
     EventGraphSeries.EVENT
   );
   const eventView = useIssueDetailsEventView({group});
+  const hasFeatureFlagFeature = organization.features.includes('feature-flag-ui');
 
   const {
     data: groupStats = {},
@@ -168,20 +169,28 @@ export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
       seriesData.push(releaseSeries as BarChartSeries);
     }
 
-    if (flagSeries.markLine) {
+    if (flagSeries.markLine && hasFeatureFlagFeature) {
       seriesData.push(flagSeries as BarChartSeries);
     }
 
     return seriesData;
-  }, [visibleSeries, userSeries, eventSeries, releaseSeries, flagSeries, theme]);
+  }, [
+    visibleSeries,
+    userSeries,
+    eventSeries,
+    releaseSeries,
+    flagSeries,
+    theme,
+    hasFeatureFlagFeature,
+  ]);
 
   const bucketSize = eventSeries ? getBucketSize(series) : undefined;
 
   const [legendSelected, setLegendSelected] = useLocalStorageState(
     'issue-details-graph-legend',
     {
-      ['Releases']: true,
       ['Feature Flags']: true,
+      ['Releases']: true,
     }
   );
 
@@ -192,7 +201,7 @@ export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
     show: true,
     top: 4,
     right: 8,
-    data: ['Releases', 'Feature Flags'],
+    data: hasFeatureFlagFeature ? ['Feature Flags', 'Releases'] : ['Releases'],
     selected: legendSelected,
     zlevel: 10,
   });


### PR DESCRIPTION
we should show feature flags in the legend only if the org is under the `feature-flag-ui` flag. this was causing weird behavior with the flag series legend when the org didn't have the flag series enabled.

before: (demo org does not have this feature enabled)
<img width="971" alt="SCR-20241101-ofbz" src="https://github.com/user-attachments/assets/5324a1a7-42fc-45f7-a138-5e3d6c3c14b4">

after: legend only shows releases
<img width="1034" alt="SCR-20241101-oevv" src="https://github.com/user-attachments/assets/73fa9a92-6c4d-4794-b929-3ddc9cbf81e2">
