### PR TITLE
fix(autofix): Prevent overflow for rethink input and diff editing overlays

### DIFF
--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -420,49 +420,57 @@ function DiffHunkContent({
             )}
             {editingGroup === index && (
               <EditOverlay ref={overlayRef}>
-                <OverlayTitle>{t('Editing %s', fileName)}</OverlayTitle>
-                <SectionTitle>{getDeletedLineTitle(index)}</SectionTitle>
-                {linesWithChanges
-                  .slice(index, lineGroups.find(g => g.start === index)?.end! + 1)
-                  .filter(l => l.line_type === DiffLineType.REMOVED).length > 0 ? (
-                  <RemovedLines>
-                    {linesWithChanges
-                      .slice(index, lineGroups.find(g => g.start === index)?.end! + 1)
-                      .filter(l => l.line_type === DiffLineType.REMOVED)
-                      .map((l, i) => (
-                        <RemovedLine key={i}>{l.value}</RemovedLine>
-                      ))}
-                  </RemovedLines>
-                ) : (
-                  <NoChangesMessage>{t('No lines are being deleted.')}</NoChangesMessage>
-                )}
-                <SectionTitle>{getNewLineTitle(index)}</SectionTitle>
-                <TextAreaWrapper>
-                  <StyledTextArea
-                    value={editedContent}
-                    onChange={handleTextAreaChange}
-                    rows={5}
-                    autosize
-                    placeholder={
-                      editedLines.length === 0 ? t('No lines are being added...') : ''
-                    }
-                  />
-                  <ClearButton
-                    size="xs"
-                    onClick={handleClearChanges}
-                    aria-label={t('Clear changes')}
-                    icon={<IconDelete size="xs" />}
-                    title={t('Clear all new lines')}
-                  />
-                </TextAreaWrapper>
-                <OverlayButtonGroup>
-                  <Button size="xs" onClick={handleCancelEdit}>
-                    {t('Cancel')}
-                  </Button>
-                  <Button size="xs" priority="primary" onClick={handleSaveEdit}>
-                    {t('Save')}
-                  </Button>
-                </OverlayButtonGroup>
+                <OverlayHeader>
+                  <OverlayTitle>{t('Editing %s', fileName)}</OverlayTitle>
+                </OverlayHeader>
+                <OverlayContent>
+                  <SectionTitle>{getDeletedLineTitle(index)}</SectionTitle>
+                  {linesWithChanges
+                    .slice(index, lineGroups.find(g => g.start === index)?.end! + 1)
+                    .filter(l => l.line_type === DiffLineType.REMOVED).length > 0 ? (
+                    <RemovedLines>
+                      {linesWithChanges
+                        .slice(index, lineGroups.find(g => g.start === index)?.end! + 1)
+                        .filter(l => l.line_type === DiffLineType.REMOVED)
+                        .map((l, i) => (
+                          <RemovedLine key={i}>{l.value}</RemovedLine>
+                        ))}
+                    </RemovedLines>
+                  ) : (
+                    <NoChangesMessage>
+                      {t('No lines are being deleted.')}
+                    </NoChangesMessage>
+                  )}
+                  <SectionTitle>{getNewLineTitle(index)}</SectionTitle>
+                  <TextAreaWrapper>
+                    <StyledTextArea
+                      value={editedContent}
+                      onChange={handleTextAreaChange}
+                      rows={5}
+                      autosize
+                      placeholder={
+                        editedLines.length === 0 ? t('No lines are being added...') : ''
+                      }
+                    />
+                    <ClearButton
+                      size="xs"
+                      onClick={handleClearChanges}
+                      aria-label={t('Clear changes')}
+                      icon={<IconDelete size="xs" />}
+                      title={t('Clear all new lines')}
+                    />
+                  </TextAreaWrapper>
+                </OverlayContent>
+                <OverlayFooter>
+                  <OverlayButtonGroup>
+                    <Button size="xs" onClick={handleCancelEdit}>
+                      {t('Cancel')}
+                    </Button>
+                    <Button size="xs" priority="primary" onClick={handleSaveEdit}>
+                      {t('Save')}
+                    </Button>
+                  </OverlayButtonGroup>
+                </OverlayFooter>
               </EditOverlay>
             )}
           </DiffContent>
@@ -685,22 +693,38 @@ const ActionButton = styled(Button)<{isHovered: boolean}>`
 
 const EditOverlay = styled('div')`
   position: fixed;
-  bottom: 200px;
+  bottom: 11rem;
   right: ${space(2)};
   left: calc(50% + ${space(2)});
   background: ${p => p.theme.backgroundElevated};
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
   box-shadow: ${p => p.theme.dropShadowHeavy};
-  padding: ${space(2)};
   z-index: 1;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 18rem);
+`;
+
+const OverlayHeader = styled('div')`
+  padding: ${space(2)} ${space(2)} 0;
+  border-bottom: 1px solid ${p => p.theme.border};
+`;
+
+const OverlayContent = styled('div')`
+  padding: 0 ${space(2)} ${space(2)} ${space(2)};
+  overflow-y: auto;
+`;
+
+const OverlayFooter = styled('div')`
+  padding: ${space(2)};
+  border-top: 1px solid ${p => p.theme.border};
 `;
 
 const OverlayButtonGroup = styled('div')`
   display: flex;
   justify-content: flex-end;
   gap: ${space(1)};
-  margin-top: ${space(1)};
   font-family: ${p => p.theme.text.family};
 `;
 

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -413,6 +413,9 @@ function ChainLink({
     };
   }, [showOverlay]);
 
+  // Determine if this is the first chain link (before first insight)
+  const isFirstLink = insightCardAboveIndex === null || insightCardAboveIndex < 0;
+
   return (
     <ArrowContainer>
       <IconArrow direction={'down'} className="arrow-icon" />
@@ -426,7 +429,7 @@ function ChainLink({
       />
 
       {showOverlay && (
-        <RethinkInput ref={overlayRef}>
+        <RethinkInput $isFirstLink={isFirstLink} ref={overlayRef}>
           <form
             onSubmit={e => {
               e.preventDefault();
@@ -560,11 +563,11 @@ const RethinkButton = styled(Button)`
   font-weight: normal;
   font-size: small;
   border: none;
-  color: ${p => p.theme.gray200};
+  color: ${p => p.theme.subText};
   transition: color 0.2s ease-in-out;
 `;
 
-const RethinkInput = styled('div')`
+const RethinkInput = styled('div')<{$isFirstLink: boolean}>`
   position: absolute;
   box-shadow: ${p => p.theme.dropShadowHeavy};
   border: 1px solid ${p => p.theme.border};
@@ -574,6 +577,7 @@ const RethinkInput = styled('div')`
   border-radius: ${p => p.theme.borderRadius};
   margin: 0 ${space(1.5)} 0 ${space(1.5)};
   z-index: 10000;
+  transform: translateY(${p => (p.$isFirstLink ? '25%' : '-25%')});
 
   .row-form {
     display: flex;


### PR DESCRIPTION
Adjusts positioning of rethink input boxes so they don't get clipped by the root cause and fix cards.
Adds scrolling to the diff editing overlay so you can see all the changes in the case of big diffs.

<img width="636" alt="Screenshot 2024-11-01 at 4 02 10 PM" src="https://github.com/user-attachments/assets/3b6a4bd0-62a5-470f-9da9-ea8f61367387">
<img width="600" alt="Screenshot 2024-11-01 at 4 30 03 PM" src="https://github.com/user-attachments/assets/3114e3e7-feb4-410a-a0e5-b00d7aed6f04">
