### PR TITLE
feat(dashboards): Add timeseries support for EAP widgets

### DIFF
--- a/static/app/views/dashboards/datasetConfig/spans.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.spec.tsx
@@ -7,7 +7,7 @@ import {waitFor} from 'sentry-test/reactTestingLibrary';
 import type {Client} from 'sentry/api';
 import type {Organization} from 'sentry/types/organization';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
+import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES, FieldKind} from 'sentry/utils/fields';
 import {SpansConfig} from 'sentry/views/dashboards/datasetConfig/spans';
 import {WidgetType} from 'sentry/views/dashboards/types';
 
@@ -63,5 +63,28 @@ describe('SpansConfig', () => {
         })
       );
     });
+  });
+
+  it('returns the string tags as group by options', () => {
+    const mockTags = {
+      ['transaction']: {
+        name: 'transaction',
+        key: 'transaction',
+        kind: FieldKind.TAG,
+      },
+      ['platform']: {
+        name: 'platform',
+        key: 'platform',
+        kind: FieldKind.TAG,
+      },
+      ['span.duration']: {
+        name: 'span.duration',
+        key: 'span.duration',
+        kind: FieldKind.MEASUREMENT,
+      },
+    };
+    const groupByOptions = SpansConfig.getGroupByFieldOptions!(organization, mockTags);
+
+    expect(Object.keys(groupByOptions)).toEqual(['tag:transaction', 'tag:platform']);
   });
 });

--- a/static/app/views/dashboards/datasetConfig/spans.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.spec.tsx
@@ -1,13 +1,22 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {WidgetFixture} from 'sentry-fixture/widget';
 
+import {waitFor} from 'sentry-test/reactTestingLibrary';
+
+import type {Client} from 'sentry/api';
 import type {Organization} from 'sentry/types/organization';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
 import {SpansConfig} from 'sentry/views/dashboards/datasetConfig/spans';
+import {WidgetType} from 'sentry/views/dashboards/types';
 
 describe('SpansConfig', () => {
   let organization: Organization;
+  const api: Client = new MockApiClient();
 
   beforeEach(() => {
+    MockApiClient.clearMockResponses();
     organization = OrganizationFixture({
       features: ['performance-view'],
     });
@@ -21,5 +30,38 @@ describe('SpansConfig', () => {
       .map(func => func.split(':')[1]);
 
     expect(functionOptions).toEqual(ALLOWED_EXPLORE_VISUALIZE_AGGREGATES);
+  });
+
+  it('can make a series request with the expected dataset', async () => {
+    const eventsStatsMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: [],
+    });
+
+    const widget = WidgetFixture({
+      widgetType: WidgetType.SPANS,
+    });
+
+    // Trigger request
+    SpansConfig.getSeriesRequest!(
+      api,
+      widget,
+      0,
+      organization,
+      PageFiltersFixture(),
+      undefined,
+      'test-referrer',
+      undefined
+    );
+
+    expect(eventsStatsMock).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(eventsStatsMock).toHaveBeenCalledWith(
+        '/organizations/org-slug/events-stats/',
+        expect.objectContaining({
+          query: expect.objectContaining({dataset: DiscoverDatasets.SPANS_EAP}),
+        })
+      );
+    });
   });
 });

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -1,3 +1,4 @@
+import {doEventsRequest} from 'sentry/actionCreators/events';
 import type {Client} from 'sentry/api';
 import type {PageFilters} from 'sentry/types/core';
 import type {TagCollection} from 'sentry/types/group';
@@ -28,6 +29,7 @@ import {
   transformEventsResponseToSeries,
   transformEventsResponseToTable,
 } from 'sentry/views/dashboards/datasetConfig/errorsAndTransactions';
+import {getSeriesRequestData} from 'sentry/views/dashboards/datasetConfig/utils';
 import {DisplayType, type Widget, type WidgetQuery} from 'sentry/views/dashboards/types';
 import {eventViewFromWidget} from 'sentry/views/dashboards/utils';
 import SpansSearchBar from 'sentry/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar';
@@ -79,12 +81,12 @@ export const SpansConfig: DatasetConfig<
   getGroupByFieldOptions: getEventsTableFieldOptions,
   handleOrderByReset,
   supportedDisplayTypes: [
-    // DisplayType.AREA,
-    // DisplayType.BAR,
-    // DisplayType.BIG_NUMBER,
-    // DisplayType.LINE,
+    DisplayType.AREA,
+    DisplayType.BAR,
+    DisplayType.BIG_NUMBER,
+    DisplayType.LINE,
     DisplayType.TABLE,
-    // DisplayType.TOP_N,
+    DisplayType.TOP_N,
   ],
   getTableRequest: (
     api: Client,
@@ -108,7 +110,7 @@ export const SpansConfig: DatasetConfig<
       referrer
     );
   },
-  // getSeriesRequest: getErrorsSeriesRequest,
+  getSeriesRequest,
   transformTable: transformEventsResponseToTable,
   transformSeries: transformEventsResponseToSeries,
   filterTableOptions,
@@ -211,4 +213,25 @@ function getEventsRequest(
       },
     }
   );
+}
+
+function getSeriesRequest(
+  api: Client,
+  widget: Widget,
+  queryIndex: number,
+  organization: Organization,
+  pageFilters: PageFilters,
+  _onDemandControlContext?: OnDemandControlContext,
+  referrer?: string,
+  _mepSetting?: MEPState | null
+) {
+  const requestData = getSeriesRequestData(
+    widget,
+    queryIndex,
+    organization,
+    pageFilters,
+    DiscoverDatasets.SPANS_EAP,
+    referrer
+  );
+  return doEventsRequest<true>(api, requestData);
 }

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -30,7 +30,7 @@ import {
   transformEventsResponseToSeries,
   transformEventsResponseToTable,
 } from 'sentry/views/dashboards/datasetConfig/errorsAndTransactions';
-import {getSeriesRequestData} from 'sentry/views/dashboards/datasetConfig/utils';
+import {getSeriesRequestData} from 'sentry/views/dashboards/datasetConfig/utils/getSeriesRequestData';
 import {DisplayType, type Widget, type WidgetQuery} from 'sentry/views/dashboards/types';
 import {eventViewFromWidget} from 'sentry/views/dashboards/utils';
 import SpansSearchBar from 'sentry/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar';

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
@@ -103,7 +103,7 @@ export function SortBySelectors({
         title={disableSortReason}
         disabled={!disableSort || (disableSortDirection && disableSort)}
       >
-        {displayType === DisplayType.TABLE ? (
+        {displayType === DisplayType.TABLE || widgetType === WidgetType.SPANS ? (
           <SelectControl
             name="sortBy"
             aria-label={t('Sort by')}


### PR DESCRIPTION
Adds timeseries support for EAP widgets. This involves:

- Updating the helper of the config to conduct the events-stats request using the spans dataset (relies on #80159)
- Ensures that the correct primary options and aggregate options are displayed for timeseries charts
  - Pass down the right filtering helpers. i.e. y-axes are only functions, the parameters are only number tags; we already had this implemented for table aggregates
- Ensures the correct options are displayed in the sort field
  - Instead of allowing arbitrary selections, I allowed EAP widgets to use the "table" sorting, because in Explore we only show the fields that are selected. This maintains the same behaviour in dashboards

Contributes to #78264 