### PR TITLE
ref: fix types for api.endpoints.chunk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,6 @@ module = [
     "sentry.api.endpoints.accept_organization_invite",
     "sentry.api.endpoints.auth_config",
     "sentry.api.endpoints.auth_login",
-    "sentry.api.endpoints.chunk",
     "sentry.api.endpoints.codeowners",
     "sentry.api.endpoints.codeowners.index",
     "sentry.api.endpoints.event_attachments",

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -134,9 +134,9 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
         logger.info("chunkupload.start")
 
         files = []
-        if request.data:
-            files = request.data.getlist("file")
-            files += [GzipChunk(chunk) for chunk in request.data.getlist("file_gzip")]
+        if request.FILES:
+            files = request.FILES.getlist("file")
+            files += [GzipChunk(chunk) for chunk in request.FILES.getlist("file_gzip")]
 
         if len(files) == 0:
             # No files uploaded is ok


### PR DESCRIPTION
request.data contains the whole post body and not necessarily files which could lead to type errors on form stuffing

<!-- Describe your PR here. -->