### PR TITLE
perf(warmup): set active language so resolver warms up correctly

### DIFF
--- a/src/sentry/api/endpoints/warmup.py
+++ b/src/sentry/api/endpoints/warmup.py
@@ -1,3 +1,4 @@
+from django.urls import reverse
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -17,4 +18,10 @@ class WarmupEndpoint(Endpoint):
     rate_limits = RateLimitConfig(group="INTERNAL")
 
     def get(self, request: Request) -> Response:
+        # our settings.LANGUAGE_CODE is 'en-us', but during requests it always
+        # resolves to 'en', as 'en-us' is not a by default supported language.
+        # call reverse here in the endpoint so we warm up the resolver
+        # for the en language after the locale middleware has activated it
+        reverse("sentry-warmup")
+
         return Response(200)

--- a/src/sentry/wsgi.py
+++ b/src/sentry/wsgi.py
@@ -3,6 +3,7 @@ import os.path
 import sys
 
 from django.urls import reverse
+from django.utils.translation import activate, get_supported_language_variant
 
 # Add the project to the python path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir))
@@ -19,6 +20,12 @@ from django.core.handlers.wsgi import WSGIHandler
 
 # Run WSGI handler for the application
 application = WSGIHandler()
+
+# our settings.LANGUAGE_CODE is 'en-us', but during requests it always
+# resolves to 'en', as 'en-us' is not a by default supported language.
+# activate the supported language variant, so the resolver warms up for
+# what serves most requests
+activate(get_supported_language_variant(settings.LANGUAGE_CODE))
 
 # trigger a warmup of the application
 application(

--- a/src/sentry/wsgi.py
+++ b/src/sentry/wsgi.py
@@ -3,7 +3,6 @@ import os.path
 import sys
 
 from django.urls import reverse
-from django.utils.translation import activate, get_supported_language_variant
 
 # Add the project to the python path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir))
@@ -20,12 +19,6 @@ from django.core.handlers.wsgi import WSGIHandler
 
 # Run WSGI handler for the application
 application = WSGIHandler()
-
-# our settings.LANGUAGE_CODE is 'en-us', but during requests it always
-# resolves to 'en', as 'en-us' is not a by default supported language.
-# activate the supported language variant, so the resolver warms up for
-# what serves most requests
-activate(get_supported_language_variant(settings.LANGUAGE_CODE))
 
 # trigger a warmup of the application
 application(

--- a/tests/sentry/test_wsgi.py
+++ b/tests/sentry/test_wsgi.py
@@ -11,6 +11,7 @@ assert "sentry.conf.urls" in sys.modules
 import django.urls.resolvers
 resolver = django.urls.resolvers.get_resolver()
 assert resolver._populated is True
+assert 'en' in resolver._reverse_dict
 """
 
 


### PR DESCRIPTION
### Problem

We are still seeing [slow requests](https://sentry.sentry.io/profiling/profile/sentry/d9c9828c87dc49efb0d744cc8cc318e7/flamegraph/?colorCoding=by%20system%20vs%20application%20frame&fov=0%2C20%2C7183052800%2C7&query=&sorting=call%20order&tid=132925328709312&view=top%20down) where we spend a long time on populating the URL resolver for internal RPC calls.

### Solution

Our django default language is `en-us`. However, when serving requests, the LocaleMiddleware will set the requests active language to `en`, as `en-us` is not an actual language variant we support. (This seems to be true of all of django's default I18N setups, which is strange to me, but a las).

The warmup request was populating the url resolver for `en-us`, which is not actually used. We fix this by activating the language to be `en` before making the warmup request. Adds an assertion to verify this.


