### PR TITLE
feat(dashboards-eap): Add alpha flag to dataset option

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
@@ -2,6 +2,7 @@ import {useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';
+import FeatureBadge from 'sentry/components/badge/featureBadge';
 import {Button} from 'sentry/components/button';
 import type {RadioGroupProps} from 'sentry/components/forms/controls/radioGroup';
 import RadioGroup from 'sentry/components/forms/controls/radioGroup';
@@ -79,7 +80,7 @@ export function DataSetStep({
     ]);
   }
 
-  const datasetChoices = new Map<string, string>();
+  const datasetChoices = new Map<string, string | React.ReactNode>();
 
   if (hasDatasetSelectorFeature) {
     // TODO: Finalize description copy
@@ -92,7 +93,12 @@ export function DataSetStep({
   }
 
   if (organization.features.includes('dashboards-eap')) {
-    datasetChoices.set(DataSet.SPANS, t('Spans'));
+    datasetChoices.set(
+      DataSet.SPANS,
+      <FeatureBadgeAlignmentWrapper aria-label={t('Spans')}>
+        {t('Spans')} <FeatureBadge type="alpha" />
+      </FeatureBadgeAlignmentWrapper>
+    );
   }
 
   datasetChoices.set(DataSet.ISSUES, t('Issues (States, Assignment, Time, etc.)'));
@@ -145,5 +151,12 @@ const StyledCloseButton = styled(Button)`
   &:focus {
     background-color: transparent;
     opacity: 1;
+  }
+`;
+
+const FeatureBadgeAlignmentWrapper = styled('div')`
+  ${FeatureBadge} {
+    position: relative;
+    top: -1px;
   }
 `;


### PR DESCRIPTION
Adds the alpha flag to the Spans dataset option. The feature badge wasn't aligning properly so I added a small wrapper and shifted it up slightly to match.

<img width="659" alt="Screenshot 2024-11-04 at 12 18 09 PM" src="https://github.com/user-attachments/assets/473cae0a-c9b1-4bb7-b1f4-f3510e79dddf">
