### PR TITLE
feat(issues): Update attachment screenshot modal, cards

### DIFF
--- a/static/app/components/events/attachmentViewers/jsonViewer.spec.tsx
+++ b/static/app/components/events/attachmentViewers/jsonViewer.spec.tsx
@@ -24,7 +24,7 @@ describe('JsonViewer', () => {
       <JsonViewer
         attachment={attachment}
         eventId={event.id}
-        orgId={organization.id}
+        orgSlug={organization.id}
         projectSlug={project.slug}
       />
     );
@@ -42,7 +42,7 @@ describe('JsonViewer', () => {
       <JsonViewer
         attachment={attachment}
         eventId={event.id}
-        orgId={organization.id}
+        orgSlug={organization.id}
         projectSlug={project.slug}
       />
     );
@@ -63,7 +63,7 @@ describe('JsonViewer', () => {
       <JsonViewer
         attachment={attachment}
         eventId={event.id}
-        orgId={organization.id}
+        orgSlug={organization.id}
         projectSlug={project.slug}
       />
     );

--- a/static/app/components/events/attachmentViewers/utils.tsx
+++ b/static/app/components/events/attachmentViewers/utils.tsx
@@ -4,16 +4,16 @@ import type {EventAttachment} from 'sentry/types/group';
 export type ViewerProps = {
   attachment: EventAttachment;
   eventId: Event['id'];
-  orgId: string;
+  orgSlug: string;
   projectSlug: string;
   className?: string;
 };
 
 export function getAttachmentUrl(props: ViewerProps, withPrefix?: boolean): string {
-  const {orgId, projectSlug, eventId, attachment} = props;
+  const {orgSlug, projectSlug, eventId, attachment} = props;
   return `${
     withPrefix ? '/api/0' : ''
-  }/projects/${orgId}/${projectSlug}/events/${eventId}/attachments/${
+  }/projects/${orgSlug}/${projectSlug}/events/${eventId}/attachments/${
     attachment.id
   }/?download`;
 }

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/index.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/index.tsx
@@ -101,7 +101,7 @@ function Screenshot({
           >
             <StyledImageVisualization
               attachment={screenshotAttachment}
-              orgId={orgSlug}
+              orgSlug={orgSlug}
               projectSlug={projectSlug}
               eventId={eventId}
               onLoad={() => setLoadingImage(false)}

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.spec.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.spec.tsx
@@ -3,69 +3,19 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import Modal, {
-  MAX_SCREENSHOTS_PER_PAGE,
-} from 'sentry/components/events/eventTagsAndScreenshot/screenshot/modal';
+import ScreenshotModal from 'sentry/components/events/eventTagsAndScreenshot/screenshot/modal';
 import GroupStore from 'sentry/stores/groupStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import type {EventAttachment} from 'sentry/types/group';
-import type {Project} from 'sentry/types/project';
 
 const stubEl = (props: {children?: React.ReactNode}) => <div>{props.children}</div>;
 
-function renderModal({
-  initialData: {organization, router},
-  eventAttachment,
-  projectSlug,
-  attachmentIndex,
-  attachments,
-  enablePagination,
-  groupId,
-}: {
-  eventAttachment: EventAttachment;
-  initialData: any;
-  projectSlug: Project['slug'];
-  attachmentIndex?: number;
-  attachments?: EventAttachment[];
-  enablePagination?: boolean;
-  groupId?: string;
-}) {
-  return render(
-    <Modal
-      Header={stubEl}
-      Footer={stubEl as ModalRenderProps['Footer']}
-      Body={stubEl as ModalRenderProps['Body']}
-      CloseButton={stubEl}
-      closeModal={() => undefined}
-      onDelete={jest.fn()}
-      onDownload={jest.fn()}
-      orgSlug={organization.slug}
-      projectSlug={projectSlug}
-      eventAttachment={eventAttachment}
-      downloadUrl=""
-      pageLinks={
-        '<http://localhost/api/0/issues/group-id/attachments/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1",' +
-        '<http://localhost/api/0/issues/group-id/attachments/?cursor=0:12:0>; rel="next"; results="true"; cursor="0:12:0"'
-      }
-      attachments={attachments}
-      attachmentIndex={attachmentIndex}
-      groupId={groupId}
-      enablePagination={enablePagination}
-    />,
-    {
-      router,
-      organization,
-    }
-  );
-}
+describe('ScreenshotModal', function () {
+  let initialData: ReturnType<typeof initializeOrg>;
+  const project = ProjectFixture();
 
-describe('Modals -> ScreenshotModal', function () {
-  let initialData;
-  let project;
-  let getAttachmentsMock;
   beforeEach(() => {
     initialData = initializeOrg({
       organization: OrganizationFixture(),
@@ -73,82 +23,23 @@ describe('Modals -> ScreenshotModal', function () {
         params: {groupId: 'group-id'},
         location: {query: {types: 'event.screenshot'}},
       },
-    } as Parameters<typeof initializeOrg>[0]);
-    project = ProjectFixture();
+    });
     ProjectsStore.loadInitialData([project]);
     GroupStore.init();
-
-    getAttachmentsMock = MockApiClient.addMockResponse({
-      url: '/issues/group-id/attachments/',
-      body: [EventAttachmentFixture()],
-      headers: {
-        link:
-          '<http://localhost/api/0/issues/group-id/attachments/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1",' +
-          '<http://localhost/api/0/issues/group-id/attachments/?cursor=0:12:0>; rel="next"; results="true"; cursor="0:12:0"',
-      },
-    });
   });
 
-  afterEach(() => {
-    MockApiClient.clearMockResponses();
-  });
   it('paginates single screenshots correctly', async function () {
     const eventAttachment = EventAttachmentFixture();
-    renderModal({
+    const attachments = [
       eventAttachment,
-      initialData,
-      projectSlug: project.slug,
-      attachmentIndex: 0,
-      attachments: [
-        eventAttachment,
-        EventAttachmentFixture({id: '2', event_id: 'new event id'}),
-        EventAttachmentFixture({id: '3'}),
-        EventAttachmentFixture({id: '4'}),
-        EventAttachmentFixture({id: '5'}),
-        EventAttachmentFixture({id: '6'}),
-      ],
-      enablePagination: true,
-      groupId: 'group-id',
-    });
-    expect(screen.getByRole('button', {name: 'Previous'})).toBeDisabled();
-    await userEvent.click(screen.getByRole('button', {name: 'Next'}));
-
-    expect(screen.getByText('new event id')).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Previous'})).toBeEnabled();
-  });
-
-  it('fetches a new batch of screenshots correctly', async function () {
-    const eventAttachment = EventAttachmentFixture();
-    const attachments = Array.from({length: MAX_SCREENSHOTS_PER_PAGE}, (_, index) =>
-      EventAttachmentFixture({id: `${index + 1}`})
-    ).concat(eventAttachment);
-
-    renderModal({
-      eventAttachment,
-      initialData,
-      projectSlug: project.slug,
-      attachmentIndex: MAX_SCREENSHOTS_PER_PAGE - 1,
-      attachments,
-      enablePagination: true,
-      groupId: 'group-id',
-    });
-    await userEvent.click(screen.getByRole('button', {name: 'Next'}));
-
-    await waitFor(() => {
-      expect(getAttachmentsMock).toHaveBeenCalledWith(
-        '/issues/group-id/attachments/',
-        expect.objectContaining({
-          query: expect.objectContaining({cursor: '0:12:0'}),
-        })
-      );
-    });
-  });
-
-  it('renders with previous and next buttons when passed attachments and index', async function () {
-    const eventAttachment = EventAttachmentFixture();
-    const attachments = [eventAttachment, EventAttachmentFixture({id: '2'})];
+      EventAttachmentFixture({id: '2', event_id: 'new event id'}),
+      EventAttachmentFixture({id: '3'}),
+      EventAttachmentFixture({id: '4'}),
+      EventAttachmentFixture({id: '5'}),
+      EventAttachmentFixture({id: '6'}),
+    ];
     render(
-      <Modal
+      <ScreenshotModal
         Header={stubEl}
         Footer={stubEl as ModalRenderProps['Footer']}
         Body={stubEl as ModalRenderProps['Body']}
@@ -156,14 +47,42 @@ describe('Modals -> ScreenshotModal', function () {
         closeModal={() => undefined}
         onDelete={jest.fn()}
         onDownload={jest.fn()}
-        orgSlug={initialData.organization.slug}
         projectSlug={project.slug}
         eventAttachment={eventAttachment}
         downloadUrl=""
-        attachments={attachments}
-        attachmentIndex={0}
         groupId="group-id"
-        enablePagination
+        attachments={attachments}
+      />,
+      {
+        router: initialData.router,
+        organization: initialData.organization,
+      }
+    );
+    expect(screen.getByRole('button', {name: 'Previous'})).toBeDisabled();
+    await userEvent.click(screen.getByRole('button', {name: 'Next'}));
+
+    expect(screen.getByText('new event id')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Previous'})).toBeEnabled();
+  });
+
+  it('renders with previous and next buttons when passed attachments', async function () {
+    const eventAttachment = EventAttachmentFixture();
+    const attachments = [eventAttachment, EventAttachmentFixture({id: '2'})];
+
+    render(
+      <ScreenshotModal
+        Header={stubEl}
+        Footer={stubEl as ModalRenderProps['Footer']}
+        Body={stubEl as ModalRenderProps['Body']}
+        CloseButton={stubEl}
+        closeModal={() => undefined}
+        onDelete={jest.fn()}
+        onDownload={jest.fn()}
+        projectSlug={project.slug}
+        eventAttachment={eventAttachment}
+        attachments={attachments}
+        downloadUrl=""
+        groupId="group-id"
       />,
       {
         router: initialData.router,
@@ -173,19 +92,16 @@ describe('Modals -> ScreenshotModal', function () {
 
     expect(screen.getByRole('button', {name: 'Previous'})).toBeDisabled();
     expect(screen.getByTestId('pagination-header-text')).toHaveTextContent('1 of 2');
+
     await userEvent.click(screen.getByRole('button', {name: 'Next'}));
     expect(screen.getByRole('button', {name: 'Next'})).toBeDisabled();
     expect(screen.getByTestId('pagination-header-text')).toHaveTextContent('2 of 2');
-
-    // This pagination doesn't use page links
-    expect(getAttachmentsMock).not.toHaveBeenCalled();
   });
 
   it('does not render pagination buttons when only one screenshot', function () {
     const eventAttachment = EventAttachmentFixture();
-    const attachments = [eventAttachment];
     render(
-      <Modal
+      <ScreenshotModal
         Header={stubEl}
         Footer={stubEl as ModalRenderProps['Footer']}
         Body={stubEl as ModalRenderProps['Body']}
@@ -193,20 +109,18 @@ describe('Modals -> ScreenshotModal', function () {
         closeModal={() => undefined}
         onDelete={jest.fn()}
         onDownload={jest.fn()}
-        orgSlug={initialData.organization.slug}
         projectSlug={project.slug}
         eventAttachment={eventAttachment}
         downloadUrl=""
-        attachments={attachments}
-        attachmentIndex={0}
         groupId="group-id"
-        enablePagination
       />,
       {
         router: initialData.router,
         organization: initialData.organization,
       }
     );
+
+    expect(screen.getByText(eventAttachment.name)).toBeInTheDocument();
 
     expect(screen.queryByRole('button', {name: 'Previous'})).not.toBeInTheDocument();
     expect(screen.queryByTestId('pagination-header-text')).not.toBeInTheDocument();

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.tsx
@@ -1,228 +1,160 @@
 import type {ComponentProps} from 'react';
-import {Fragment, useState} from 'react';
+import {Fragment, useCallback, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {Button, LinkButton} from 'sentry/components/button';
-import Buttonbar from 'sentry/components/buttonBar';
+import ButtonBar from 'sentry/components/buttonBar';
 import Confirm from 'sentry/components/confirm';
+import {Flex} from 'sentry/components/container/flex';
 import {DateTime} from 'sentry/components/dateTime';
-import {getRelativeTimeFromEventDateCreated} from 'sentry/components/events/contexts/utils';
-import Link from 'sentry/components/links/link';
-import NotAvailable from 'sentry/components/notAvailable';
-import type {CursorHandler} from 'sentry/components/pagination';
+import KeyValueData from 'sentry/components/keyValueData';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Event} from 'sentry/types/event';
-import type {EventAttachment, IssueAttachment} from 'sentry/types/group';
-import type {Organization} from 'sentry/types/organization';
+import type {EventAttachment} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {formatBytesBase2} from 'sentry/utils/bytes/formatBytesBase2';
-import getDynamicText from 'sentry/utils/getDynamicText';
-import parseLinkHeader from 'sentry/utils/parseLinkHeader';
-import useApi from 'sentry/utils/useApi';
-import {useLocation} from 'sentry/utils/useLocation';
+import {useHotkeys} from 'sentry/utils/useHotkeys';
+import useOrganization from 'sentry/utils/useOrganization';
 
 import ImageVisualization from './imageVisualization';
 import ScreenshotPagination from './screenshotPagination';
 
-export const MAX_SCREENSHOTS_PER_PAGE = 50;
+export const MAX_SCREENSHOTS_PER_PAGE = 20;
 
-type Props = ModalRenderProps & {
+interface ScreenshotModalProps extends ModalRenderProps {
   downloadUrl: string;
   eventAttachment: EventAttachment;
   onDelete: () => void;
   onDownload: () => void;
-  orgSlug: Organization['slug'];
   projectSlug: Project['slug'];
-  attachmentIndex?: number;
+  /**
+   * Enables pagination of screenshots.
+   */
   attachments?: EventAttachment[];
-  enablePagination?: boolean;
-  event?: Event;
+  /**
+   * Enables navigation to the issue details page.
+   */
   groupId?: string;
-  pageLinks?: string | null | undefined;
-};
+}
 
 export default function ScreenshotModal({
   eventAttachment,
-  orgSlug,
+  attachments = [],
   projectSlug,
   Header,
   Body,
   Footer,
-  event,
   onDelete,
   downloadUrl,
   onDownload,
-  pageLinks: initialPageLinks,
-  attachmentIndex,
-  attachments,
-  enablePagination,
   groupId,
-}: Props) {
-  const api = useApi();
-  const location = useLocation();
+}: ScreenshotModalProps) {
+  const organization = useOrganization();
 
   const [currentEventAttachment, setCurrentAttachment] =
     useState<EventAttachment>(eventAttachment);
-  const [currentAttachmentIndex, setCurrentAttachmentIndex] = useState<
-    number | undefined
-  >(attachmentIndex);
-  const [memoizedAttachments, setMemoizedAttachments] = useState<
-    IssueAttachment[] | undefined
-  >(attachments);
 
-  const [pageLinks, setPageLinks] = useState<string | null | undefined>(initialPageLinks);
-
-  const handleCursor: CursorHandler = (cursor, _pathname, query, delta) => {
-    if (defined(currentAttachmentIndex) && memoizedAttachments?.length) {
-      const newAttachmentIndex = currentAttachmentIndex + delta;
-      if (newAttachmentIndex === MAX_SCREENSHOTS_PER_PAGE || newAttachmentIndex === -1) {
-        api
-          .requestPromise(`/issues/${groupId}/attachments/`, {
-            method: 'GET',
-            includeAllArgs: true,
-            query: {
-              ...query,
-              per_page: MAX_SCREENSHOTS_PER_PAGE,
-              types: undefined,
-              screenshot: 1,
-              cursor,
-            },
-          })
-          .then(([data, _, resp]) => {
-            if (newAttachmentIndex === MAX_SCREENSHOTS_PER_PAGE) {
-              setCurrentAttachmentIndex(0);
-              setCurrentAttachment(data[0]);
-            } else {
-              setCurrentAttachmentIndex(MAX_SCREENSHOTS_PER_PAGE - 1);
-              setCurrentAttachment(data[MAX_SCREENSHOTS_PER_PAGE - 1]);
-            }
-            setMemoizedAttachments(data);
-            setPageLinks(resp?.getResponseHeader('Link'));
-          });
-        return;
+  const currentAttachmentIndex = attachments.findIndex(
+    attachment => attachment.id === currentEventAttachment.id
+  );
+  const paginateItems = useCallback(
+    (delta: number) => {
+      if (attachments.length) {
+        const newIndex = currentAttachmentIndex + delta;
+        if (newIndex >= 0 && newIndex < attachments.length) {
+          setCurrentAttachment(attachments[newIndex]);
+        }
       }
-      setCurrentAttachmentIndex(newAttachmentIndex);
-      setCurrentAttachment(memoizedAttachments[newAttachmentIndex]);
-    }
-  };
+    },
+    [attachments, currentAttachmentIndex]
+  );
 
-  const path = location.pathname;
-  const query = location.query;
+  useHotkeys(
+    [
+      {match: 'right', callback: () => paginateItems(1)},
+      {match: 'left', callback: () => paginateItems(-1)},
+    ],
+    [paginateItems]
+  );
+
   const {dateCreated, size, mimetype} = currentEventAttachment;
-  const links = pageLinks ? parseLinkHeader(pageLinks) : undefined;
 
-  // Pagination behaviour is different between the attachments tab with page links
-  // vs the issue details page where we have all of the screenshots fetched already
   let paginationProps: ComponentProps<typeof ScreenshotPagination> | null = null;
-  if (links) {
-    paginationProps = {
-      previousDisabled:
-        links?.previous?.results === false && currentAttachmentIndex === 0,
-      nextDisabled:
-        links?.next?.results === false &&
-        currentAttachmentIndex === MAX_SCREENSHOTS_PER_PAGE - 1,
-      onPrevious: () => {
-        handleCursor(links.previous?.cursor, path, query, -1);
-      },
-      onNext: () => {
-        handleCursor(links.next?.cursor, path, query, 1);
-      },
-    };
-  } else if (
-    memoizedAttachments &&
-    memoizedAttachments.length > 1 &&
-    defined(currentAttachmentIndex)
-  ) {
+  if (attachments.length > 1 && defined(currentAttachmentIndex)) {
     paginationProps = {
       previousDisabled: currentAttachmentIndex === 0,
-      nextDisabled: currentAttachmentIndex === memoizedAttachments.length - 1,
+      nextDisabled: currentAttachmentIndex === attachments.length - 1,
       onPrevious: () => {
-        setCurrentAttachment(memoizedAttachments[currentAttachmentIndex - 1]);
-        setCurrentAttachmentIndex(currentAttachmentIndex - 1);
+        paginateItems(-1);
       },
       onNext: () => {
-        setCurrentAttachment(memoizedAttachments[currentAttachmentIndex + 1]);
-        setCurrentAttachmentIndex(currentAttachmentIndex + 1);
+        paginateItems(1);
       },
       headerText: tct('[currentScreenshotIndex] of [totalScreenshotCount]', {
         currentScreenshotIndex: currentAttachmentIndex + 1,
-        totalScreenshotCount: memoizedAttachments.length,
+        totalScreenshotCount: attachments.length,
       }),
     };
   }
 
   return (
     <Fragment>
-      <StyledHeaderWrapper hasPagination={defined(paginationProps)}>
-        <Header closeButton>{t('Screenshot')}</Header>
-        {defined(paginationProps) && (
-          <Header>
-            <ScreenshotPagination {...paginationProps} />
-          </Header>
-        )}
-      </StyledHeaderWrapper>
+      <Header closeButton>
+        <h5>{t('Screenshot')}</h5>
+      </Header>
       <Body>
-        <StyledImageVisualization
-          attachment={currentEventAttachment}
-          orgId={orgSlug}
-          projectSlug={projectSlug}
-          eventId={currentEventAttachment.event_id}
-        />
-
-        <GeneralInfo>
-          {groupId && enablePagination && (
-            <Fragment>
-              <Label>{t('Event ID')}</Label>
-              <Value>
-                <Title
-                  to={`/organizations/${orgSlug}/issues/${groupId}/events/${currentEventAttachment.event_id}/`}
-                >
-                  {currentEventAttachment.event_id}
-                </Title>
-              </Value>
-            </Fragment>
-          )}
-          <Label coloredBg>{t('Date Created')}</Label>
-          <Value coloredBg>
-            {dateCreated ? (
-              <Fragment>
-                <DateTime
-                  date={getDynamicText({
-                    value: dateCreated,
-                    fixed: new Date(1508208080000),
-                  })}
-                />
-                {event &&
-                  getRelativeTimeFromEventDateCreated(
-                    event.dateCreated ? event.dateCreated : event.dateReceived,
-                    dateCreated,
-                    false
-                  )}
-              </Fragment>
-            ) : (
-              <NotAvailable />
-            )}
-          </Value>
-
-          <Label>{t('Size')}</Label>
-          <Value>{defined(size) ? formatBytesBase2(size) : <NotAvailable />}</Value>
-
-          <Label coloredBg>{t('MIME Type')}</Label>
-          <Value coloredBg>{mimetype ?? <NotAvailable />}</Value>
-        </GeneralInfo>
+        <Flex column gap={space(1.5)}>
+          {defined(paginationProps) && <ScreenshotPagination {...paginationProps} />}
+          <StyledImageVisualization
+            attachment={currentEventAttachment}
+            orgSlug={organization.slug}
+            projectSlug={projectSlug}
+            eventId={currentEventAttachment.event_id}
+          />
+          <KeyValueData.Card
+            title={eventAttachment.name}
+            contentItems={[
+              {
+                item: {
+                  key: 'event',
+                  subject: t('Event ID'),
+                  value: currentEventAttachment.event_id,
+                  action: groupId
+                    ? {
+                        link: `/organizations/${organization.slug}/issues/${groupId}/events/${currentEventAttachment.event_id}/`,
+                      }
+                    : undefined,
+                },
+              },
+              {
+                item: {
+                  key: 'date',
+                  subject: t('Date Created'),
+                  value: <DateTime date={dateCreated} />,
+                },
+              },
+              {
+                item: {key: 'size', subject: t('Size'), value: formatBytesBase2(size)},
+              },
+              {
+                item: {
+                  key: 'mimetype',
+                  subject: t('MIME Type'),
+                  value: mimetype,
+                },
+              },
+            ]}
+          />
+        </Flex>
       </Body>
       <Footer>
-        <Buttonbar gap={1}>
+        <ButtonBar gap={1}>
           <Confirm
             confirmText={t('Delete')}
-            header={t(
-              'Screenshots help identify what the user saw when the event happened'
-            )}
-            message={t('Are you sure you wish to delete this screenshot?')}
+            message={<h6>{t('Are you sure you want to delete this screenshot?')}</h6>}
             priority="danger"
             onConfirm={onDelete}
           >
@@ -231,62 +163,22 @@ export default function ScreenshotModal({
           <LinkButton onClick={onDownload} href={downloadUrl}>
             {t('Download')}
           </LinkButton>
-        </Buttonbar>
+        </ButtonBar>
       </Footer>
     </Fragment>
   );
 }
 
-const StyledHeaderWrapper = styled('div')<{hasPagination: boolean}>`
-  ${p =>
-    p.hasPagination &&
-    `
-  header {
-    margin-bottom: 0;
-  }
-
-  header:last-of-type {
-    margin-top: 0;
-    margin-bottom: ${space(3)};
-  }
-  `}
-`;
-
-const GeneralInfo = styled('div')`
-  display: grid;
-  grid-template-columns: max-content 1fr;
-  margin-bottom: ${space(3)};
-`;
-
-const Label = styled('div')<{coloredBg?: boolean}>`
-  color: ${p => p.theme.textColor};
-  padding: ${space(1)} ${space(1.5)} ${space(1)} ${space(1)};
-  ${p => p.coloredBg && `background-color: ${p.theme.backgroundSecondary};`}
-`;
-
-const Value = styled(Label)`
-  white-space: pre-wrap;
-  word-break: break-all;
-  color: ${p => p.theme.subText};
-  padding: ${space(1)};
-  font-family: ${p => p.theme.text.familyMono};
-  ${p => p.coloredBg && `background-color: ${p.theme.backgroundSecondary};`}
-`;
-
 const StyledImageVisualization = styled(ImageVisualization)`
+  border-bottom: 0;
   img {
-    border-radius: ${p => p.theme.borderRadius};
     max-height: calc(100vh - 300px);
   }
-`;
-
-const Title = styled(Link)`
-  ${p => p.theme.overflowEllipsis};
-  font-weight: ${p => p.theme.fontWeightNormal};
 `;
 
 export const modalCss = css`
   width: auto;
   height: 100%;
   max-width: 700px;
+  margin-top: 0 !important;
 `;

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/screenshotDataSection.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/screenshotDataSection.tsx
@@ -92,8 +92,6 @@ export function ScreenshotDataSection({
       modalProps => (
         <ScreenshotModal
           {...modalProps}
-          event={event}
-          orgSlug={organization.slug}
           projectSlug={projectSlug}
           eventAttachment={eventAttachment}
           downloadUrl={downloadUrl}
@@ -104,7 +102,6 @@ export function ScreenshotDataSection({
             })
           }
           attachments={screenshots}
-          attachmentIndex={screenshotInFocus}
         />
       ),
       {modalCss}

--- a/static/app/components/events/eventViewHierarchy.tsx
+++ b/static/app/components/events/eventViewHierarchy.tsx
@@ -45,7 +45,7 @@ function EventViewHierarchyContent({event, project}: Props) {
         ? getAttachmentUrl({
             attachment: hierarchyMeta,
             eventId: hierarchyMeta.event_id,
-            orgId: organization.slug,
+            orgSlug: organization.slug,
             projectSlug: project.slug,
           })
         : '',

--- a/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
@@ -36,7 +36,7 @@ export default function FeedbackScreenshot({
   const img = (
     <StyledImageVisualization
       attachment={screenshot}
-      orgId={organization.slug}
+      orgSlug={organization.slug}
       projectSlug={projectSlug}
       eventId={screenshot.event_id}
       onLoad={() => {

--- a/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.spec.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.spec.tsx
@@ -102,10 +102,9 @@ describe('GroupEventAttachments', function () {
       organization,
     });
     await userEvent.click(await screen.findByLabelText('Actions'));
-    expect(screen.getByText('Download').closest('a')).toHaveAttribute(
-      'href',
-      '/api/0/projects/org-slug/project-slug/events/12345678901234567890123456789012/attachments/1/?download=1'
-    );
+    expect(
+      await screen.findByRole('menuitemradio', {name: 'Download'})
+    ).toBeInTheDocument();
   });
 
   it('displays error message when request fails', async function () {

--- a/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.tsx
@@ -83,18 +83,16 @@ function GroupEventAttachments({project, groupId}: GroupEventAttachmentsProps) {
     if (attachments.length > 0) {
       return (
         <ScreenshotGrid>
-          {attachments.map((screenshot, index) => {
+          {attachments.map(screenshot => {
             return (
               <ScreenshotCard
-                key={`${index}-${screenshot.id}`}
+                key={screenshot.id}
                 eventAttachment={screenshot}
                 eventId={screenshot.event_id}
                 projectSlug={project.slug}
                 groupId={groupId}
                 onDelete={handleDelete}
-                pageLinks={getResponseHeader?.('Link')}
                 attachments={attachments}
-                attachmentIndex={index}
               />
             );
           })}
@@ -132,7 +130,7 @@ const ScreenshotGrid = styled('div')`
     grid-template-columns: repeat(3, minmax(100px, 1fr));
   }
 
-  @media (min-width: ${p => p.theme.breakpoints.large}) {
+  @media (min-width: ${p => p.theme.breakpoints.xlarge}) {
     grid-template-columns: repeat(4, minmax(100px, 1fr));
   }
 

--- a/static/app/views/issueDetails/groupEventAttachments/inlineEventAttachment.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/inlineEventAttachment.tsx
@@ -26,7 +26,7 @@ export function InlineEventAttachment({
   return (
     <AttachmentPreviewWrapper>
       <AttachmentComponent
-        orgId={organization.slug}
+        orgSlug={organization.slug}
         projectSlug={projectSlug}
         eventId={eventId}
         attachment={attachment}


### PR DESCRIPTION
- Removes broken pagination in screenshot modal. Currently, at the end of the page it crashes the page.
- Updates the screenshot card with newer dropdown and smaller header
- uses our newer lazy renderer to wrap images
- centers images within the card and loading state
- adds left/right keyboard shortcuts


screenshot table before
![image](https://github.com/user-attachments/assets/6b3b8ea1-a51f-4994-8919-b064104cde22)

screenshot table after
![image](https://github.com/user-attachments/assets/81387ecb-0706-4256-b230-8c596f58d3b6)


modal before
![image](https://github.com/user-attachments/assets/ad537bb6-cba7-4401-87cf-bb7dbf3dacf2)

modal after
![image](https://github.com/user-attachments/assets/5d476423-f79e-43b5-b1f7-807c4c745e9d)
