### PR TITLE
fix(issues): Fix links with attachment filters

### DIFF
--- a/static/app/components/events/eventAttachments.spec.tsx
+++ b/static/app/components/events/eventAttachments.spec.tsx
@@ -55,7 +55,7 @@ describe('EventAttachments', function () {
 
     expect(screen.getByRole('link', {name: 'View crashes'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/issues/1/attachments/?types=event.minidump&types=event.applecrashreport'
+      '/organizations/org-slug/issues/1/attachments/?attachmentFilter=onlyCrash'
     );
 
     expect(screen.getByRole('link', {name: 'configure limit'})).toHaveAttribute(

--- a/static/app/components/events/eventAttachmentsCrashReportsNotice.tsx
+++ b/static/app/components/events/eventAttachmentsCrashReportsNotice.tsx
@@ -2,7 +2,7 @@ import {Alert} from 'sentry/components/alert';
 import Link from 'sentry/components/links/link';
 import {tct} from 'sentry/locale';
 import {useLocation} from 'sentry/utils/useLocation';
-import {crashReportTypes} from 'sentry/views/issueDetails/groupEventAttachments/groupEventAttachmentsFilter';
+import {EventAttachmentFilter} from 'sentry/views/issueDetails/groupEventAttachments/groupEventAttachmentsFilter';
 
 type Props = {
   groupId: string;
@@ -15,7 +15,7 @@ function EventAttachmentsCrashReportsNotice({orgSlug, projectSlug, groupId}: Pro
   const settingsUrl = `/settings/${orgSlug}/projects/${projectSlug}/security-and-privacy/`;
   const attachmentsUrl = {
     pathname: `/organizations/${orgSlug}/issues/${groupId}/attachments/`,
-    query: {...location.query, types: crashReportTypes},
+    query: {...location.query, attachmentFilter: EventAttachmentFilter.CRASH_REPORTS},
   };
 
   return (

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/screenshotDataSection.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/screenshotDataSection.tsx
@@ -18,7 +18,7 @@ import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {SCREENSHOT_TYPE} from 'sentry/views/issueDetails/groupEventAttachments/groupEventAttachmentsFilter';
+import {EventAttachmentFilter} from 'sentry/views/issueDetails/groupEventAttachments/groupEventAttachmentsFilter';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
@@ -113,7 +113,7 @@ export function ScreenshotDataSection({
 
   const linkPath = {
     pathname: `${location.pathname}${TabPaths[Tab.ATTACHMENTS]}`,
-    query: {...location.query, types: SCREENSHOT_TYPE},
+    query: {...location.query, attachmentFilter: EventAttachmentFilter.SCREENSHOT},
   };
   const title = tn('Screenshot', 'Screenshots', screenshots.length);
 

--- a/static/app/views/issueDetails/groupEventAttachments/groupEventAttachmentsFilter.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/groupEventAttachmentsFilter.tsx
@@ -7,9 +7,6 @@ import {isMobilePlatform} from 'sentry/utils/platform';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 
-const crashReportTypes = ['event.minidump', 'event.applecrashreport'];
-const SCREENSHOT_TYPE = 'event.screenshot';
-
 export const enum EventAttachmentFilter {
   ALL = 'all',
   CRASH_REPORTS = 'onlyCrash',
@@ -72,5 +69,4 @@ const FilterWrapper = styled('div')`
   justify-content: flex-end;
 `;
 
-export {crashReportTypes, SCREENSHOT_TYPE};
 export default GroupEventAttachmentsFilter;


### PR DESCRIPTION
Attachment filters no longer use "types" with an array of types which was overly complicated compared to a string of the current filter.
