### PR TITLE
fix(releases): check project-level access for actions on existing releases

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -824,6 +824,7 @@ class OrganizationReleaseListTest(APITestCase, BaseMetricsTestCase):
     def test_disallow_archive_release_when_no_open_membership(self):
         # test legacy status value of None (=open)
         self.release.status = None
+        self.release.add_project(self.project)
         self.release.save()
 
         # disable Open Membership
@@ -842,17 +843,58 @@ class OrganizationReleaseListTest(APITestCase, BaseMetricsTestCase):
             kwargs={"organization_id_or_slug": self.organization.slug},
         )
 
+        # trying to archive the release
         response = self.client.post(
             url,
             format="json",
             data={
-                "version": "777",
-                "projects": [self.project.slug],
+                "version": self.release.version,
+                "projects": [],
                 "status": "archived",
             },
         )
         assert response.status_code == 400
-        assert b"Invalid project ids or slugs" in response.content
+        assert b"You do not have permission to one of the projects: bar" in response.content
+
+    def test_disallow_projects_update_for_release_when_no_open_membership(self):
+        team1 = self.create_team(organization=self.organization)
+        team2 = self.create_team(organization=self.organization)
+
+        project1 = self.create_project(teams=[team1], organization=self.organization)
+        project2 = self.create_project(teams=[team2], organization=self.organization)
+
+        # test legacy status value of None (=open)
+        self.release.status = None
+        self.release.add_project(project1)
+        self.release.save()
+
+        # disable Open Membership
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
+        # user has no access to projects of team1
+        user_team2 = self.create_user(is_superuser=False)
+        self.create_member(
+            user=user_team2, organization=self.organization, role="member", teams=[team2]
+        )
+        self.login_as(user_team2)
+
+        url = reverse(
+            "sentry-api-0-organization-releases",
+            kwargs={"organization_id_or_slug": self.organization.slug},
+        )
+
+        # trying to update projects of the release
+        response = self.client.post(
+            url,
+            format="json",
+            data={
+                "version": self.release.version,
+                "projects": [project2.slug],
+            },
+        )
+        assert response.status_code == 400
+        assert b"You do not have permission to one of the projects: bar" in response.content
 
 
 class OrganizationReleasesStatsTest(APITestCase):


### PR DESCRIPTION
Follow-up on https://github.com/getsentry/sentry/pull/78832

Here we check for project-level permissions if already existing release is about to be modified (archived or restored, updated the list of projects, etc.)