### PR TITLE
fix(settings): Fix project stats search

### DIFF
--- a/static/app/utils/project/sortProjects.tsx
+++ b/static/app/utils/project/sortProjects.tsx
@@ -10,6 +10,6 @@ function projectDisplayCompare(a: Project, b: Project): number {
 /**
  * Sort a list of projects by bookmarkedness, then by id
  */
-export function sortProjects(projects: Array<Project>): Array<Project> {
-  return projects.sort(projectDisplayCompare);
+export function sortProjects(projects: Readonly<Array<Project>>): Array<Project> {
+  return projects.toSorted(projectDisplayCompare);
 }

--- a/static/app/views/settings/organizationProjects/index.spec.tsx
+++ b/static/app/views/settings/organizationProjects/index.spec.tsx
@@ -1,6 +1,6 @@
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {browserHistory} from 'sentry/utils/browserHistory';
 import OrganizationProjectsContainer from 'sentry/views/settings/organizationProjects';
@@ -39,6 +39,18 @@ describe('OrganizationProjects', function () {
 
     expect(projectsGetMock).toHaveBeenCalledTimes(1);
     expect(statsGetMock).toHaveBeenCalledTimes(1);
+    expect(statsGetMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/stats/',
+      expect.objectContaining({
+        query: {
+          group: 'project',
+          projectID: [project.id],
+          // Time is frozen in tests
+          since: 1508121680,
+          stat: 'generated',
+        },
+      })
+    );
     expect(projectsPutMock).toHaveBeenCalledTimes(0);
 
     await userEvent.click(await screen.findByRole('button', {name: 'Bookmark Project'}));
@@ -50,21 +62,18 @@ describe('OrganizationProjects', function () {
   });
 
   it('should search organization projects', async function () {
-    jest.useFakeTimers();
     render(<OrganizationProjectsContainer />);
 
     expect(await screen.findByText('project-slug')).toBeInTheDocument();
 
     const searchBox = await screen.findByRole('textbox');
-    await userEvent.type(searchBox, 'random', {
-      advanceTimers: jest.advanceTimersByTime,
-    });
+    await userEvent.type(searchBox, 'random');
 
-    jest.runAllTimers();
-
-    expect(browserHistory.replace).toHaveBeenLastCalledWith({
-      pathname: '/mock-pathname/',
-      query: {query: 'random'},
+    await waitFor(() => {
+      expect(browserHistory.replace).toHaveBeenLastCalledWith({
+        pathname: '/mock-pathname/',
+        query: {query: 'random'},
+      });
     });
   });
 });

--- a/static/app/views/settings/organizationProjects/index.tsx
+++ b/static/app/views/settings/organizationProjects/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo, useState} from 'react';
+import {Fragment, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 
@@ -40,7 +40,7 @@ function OrganizationProjects() {
   const location = useLocation();
   const query = decodeScalar(location.query.query, '');
 
-  const [since] = useState(new Date().getTime() / 1000 - 3600 * 24);
+  const time = useRef(new Date().getTime());
   const {
     data: projectList,
     getResponseHeader,
@@ -66,7 +66,7 @@ function OrganizationProjects() {
       {
         query: {
           projectID: projectList?.map(p => p.id),
-          since,
+          since: time.current / 1000 - 3600 * 24,
           stat: 'generated',
           group: 'project',
         },


### PR DESCRIPTION
Fixes a few bugs on the org projects page:
- clear the cursor on search change
- filter stats down to projects on the current page instead of a similar but different page of projects
- sortProjects was modifying the array