### PR TITLE
chore(slack): add logging for slack options load filtering

### DIFF
--- a/src/sentry/integrations/slack/webhooks/options_load.py
+++ b/src/sentry/integrations/slack/webhooks/options_load.py
@@ -78,7 +78,7 @@ class SlackOptionsLoadEndpoint(Endpoint):
                 "project_id": group.project_id,
                 "teams": len(all_teams),
                 "filtered_teams": len(filtered_teams),
-                "members": len(all_members),
+                "members": len(list(all_members)),
                 "filtered_members": len(filtered_members),
             },
         )

--- a/src/sentry/integrations/slack/webhooks/options_load.py
+++ b/src/sentry/integrations/slack/webhooks/options_load.py
@@ -70,6 +70,18 @@ class SlackOptionsLoadEndpoint(Endpoint):
                 all_members,
             )
         )
+        _logger.info(
+            "slack.options_webhook_filter",
+            extra={
+                "substring": substring,
+                "group_id": group.id,
+                "project_id": group.project_id,
+                "teams": len(all_teams),
+                "filtered_teams": len(filtered_teams),
+                "members": len(all_members),
+                "filtered_members": len(filtered_members),
+            },
+        )
 
         option_groups: list[OptionGroup] = []
         if filtered_teams:


### PR DESCRIPTION
Debug why sometimes you can't assign via the Slack dropdown.