### PR TITLE
chore(integrations): register integration domains in initializer

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_integrations_index.py
+++ b/src/sentry/integrations/api/endpoints/organization_integrations_index.py
@@ -21,7 +21,8 @@ from sentry.integrations.api.bases.organization_integrations import (
     OrganizationIntegrationBaseEndpoint,
 )
 from sentry.integrations.api.serializers.models.integration import OrganizationIntegrationResponse
-from sentry.integrations.base import INTEGRATION_TYPE_TO_PROVIDER, IntegrationDomain
+from sentry.integrations.base import IntegrationDomain
+from sentry.integrations.manager import default_manager as integrations
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.organizations.services.organization.model import (
@@ -117,7 +118,8 @@ class OrganizationIntegrationsEndpoint(OrganizationIntegrationBaseEndpoint):
             except ValueError:
                 return Response({"detail": "Invalid integration type"}, status=400)
             provider_slugs = [
-                provider for provider in INTEGRATION_TYPE_TO_PROVIDER.get(integration_domain, [])
+                provider
+                for provider in integrations.get_integrations_for_domain(integration_domain)
             ]
             queryset = queryset.filter(integration__provider__in=provider_slugs)
 

--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -174,6 +174,7 @@ class BitbucketIntegration(RepositoryIntegration, BitbucketIssuesSpec):
 class BitbucketIntegrationProvider(IntegrationProvider):
     key = "bitbucket"
     name = "Bitbucket"
+    domain = IntegrationDomain.SOURCE_CODE_MANAGEMENT
     metadata = metadata
     scopes = scopes
     integration_cls = BitbucketIntegration

--- a/src/sentry/integrations/bitbucket_server/integration.py
+++ b/src/sentry/integrations/bitbucket_server/integration.py
@@ -330,6 +330,7 @@ class BitbucketServerIntegration(RepositoryIntegration):
 class BitbucketServerIntegrationProvider(IntegrationProvider):
     key = "bitbucket_server"
     name = "Bitbucket Server"
+    domain = IntegrationDomain.SOURCE_CODE_MANAGEMENT
     metadata = metadata
     integration_cls = BitbucketServerIntegration
     needs_default_identity = True

--- a/src/sentry/integrations/discord/integration.py
+++ b/src/sentry/integrations/discord/integration.py
@@ -10,6 +10,7 @@ from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.integrations.base import (
     FeatureDescription,
+    IntegrationDomain,
     IntegrationFeatures,
     IntegrationInstallation,
     IntegrationMetadata,
@@ -114,6 +115,7 @@ class DiscordIntegration(IntegrationInstallation):
 class DiscordIntegrationProvider(IntegrationProvider):
     key = "discord"
     name = "Discord"
+    domain = IntegrationDomain.MESSAGING
     metadata = metadata
     integration_cls = DiscordIntegration
     features = frozenset([IntegrationFeatures.CHAT_UNFURL, IntegrationFeatures.ALERT_RULE])

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -311,6 +311,7 @@ class GitHubIntegration(RepositoryIntegration, GitHubIssuesSpec, CommitContextIn
 class GitHubIntegrationProvider(IntegrationProvider):
     key = "github"
     name = "GitHub"
+    domain = IntegrationDomain.SOURCE_CODE_MANAGEMENT
     metadata = metadata
     integration_cls = GitHubIntegration
     features = frozenset(

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -13,6 +13,7 @@ from sentry.identity.github_enterprise import get_user_info
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.integrations.base import (
     FeatureDescription,
+    IntegrationDomain,
     IntegrationFeatureNotImplementedError,
     IntegrationFeatures,
     IntegrationMetadata,
@@ -318,6 +319,7 @@ class InstallationConfigView(PipelineView):
 class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
     key = "github_enterprise"
     name = "GitHub Enterprise"
+    domain = IntegrationDomain.SOURCE_CODE_MANAGEMENT
     metadata = metadata
     integration_cls = GitHubEnterpriseIntegration
     features = frozenset(

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -13,6 +13,7 @@ from sentry.identity.gitlab.provider import GitlabIdentityProvider
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.integrations.base import (
     FeatureDescription,
+    IntegrationDomain,
     IntegrationFeatures,
     IntegrationMetadata,
     IntegrationProvider,
@@ -313,6 +314,7 @@ class InstallationGuideView(PipelineView):
 class GitlabIntegrationProvider(IntegrationProvider):
     key = "gitlab"
     name = "GitLab"
+    domain = IntegrationDomain.SOURCE_CODE_MANAGEMENT
     metadata = metadata
     integration_cls = GitlabIntegration
 

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -16,6 +16,7 @@ from sentry import features
 from sentry.eventstore.models import GroupEvent
 from sentry.integrations.base import (
     FeatureDescription,
+    IntegrationDomain,
     IntegrationFeatures,
     IntegrationMetadata,
     IntegrationProvider,
@@ -995,6 +996,7 @@ class JiraIntegration(IssueSyncIntegration):
 class JiraIntegrationProvider(IntegrationProvider):
     key = "jira"
     name = "Jira"
+    domain = IntegrationDomain.PROJECT_MANAGEMENT
     metadata = metadata
     integration_cls = JiraIntegration
 

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -20,6 +20,7 @@ from rest_framework.request import Request
 from sentry import features
 from sentry.integrations.base import (
     FeatureDescription,
+    IntegrationDomain,
     IntegrationFeatures,
     IntegrationMetadata,
     IntegrationProvider,
@@ -1167,6 +1168,7 @@ class JiraServerIntegration(IssueSyncIntegration):
 class JiraServerIntegrationProvider(IntegrationProvider):
     key = "jira_server"
     name = "Jira Server"
+    domain = IntegrationDomain.PROJECT_MANAGEMENT
     metadata = metadata
     integration_cls = JiraServerIntegration
 

--- a/src/sentry/integrations/manager.py
+++ b/src/sentry/integrations/manager.py
@@ -43,8 +43,9 @@ class IntegrationManager:
 
     def register(self, cls: type[IntegrationProvider]) -> None:
         self.__values[cls.key] = cls
-        self.__domain_integrations[cls.domain].append(cls.key)
-        self.__integration_domains[cls.key] = cls.domain
+        if cls.domain:
+            self.__domain_integrations[cls.domain].append(cls.key)
+            self.__integration_domains[cls.key] = cls.domain
 
     def unregister(self, cls: type[IntegrationProvider]) -> None:
         try:

--- a/src/sentry/integrations/msteams/integration.py
+++ b/src/sentry/integrations/msteams/integration.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 from sentry import options
 from sentry.integrations.base import (
     FeatureDescription,
+    IntegrationDomain,
     IntegrationFeatures,
     IntegrationInstallation,
     IntegrationMetadata,
@@ -79,6 +80,7 @@ class MsTeamsIntegration(IntegrationInstallation):
 class MsTeamsIntegrationProvider(IntegrationProvider):
     key = "msteams"
     name = "Microsoft Teams"
+    domain = IntegrationDomain.MESSAGING
     can_add = False
     metadata = metadata
     integration_cls = MsTeamsIntegration

--- a/src/sentry/integrations/opsgenie/integration.py
+++ b/src/sentry/integrations/opsgenie/integration.py
@@ -13,6 +13,7 @@ from rest_framework.serializers import ValidationError
 from sentry.constants import ObjectStatus
 from sentry.integrations.base import (
     FeatureDescription,
+    IntegrationDomain,
     IntegrationFeatures,
     IntegrationInstallation,
     IntegrationMetadata,
@@ -229,6 +230,7 @@ class OpsgenieIntegration(IntegrationInstallation):
 class OpsgenieIntegrationProvider(IntegrationProvider):
     key = "opsgenie"
     name = "Opsgenie"
+    domain = IntegrationDomain.ON_CALL_SCHEDULING
     metadata = metadata
     integration_cls = OpsgenieIntegration
     features = frozenset([IntegrationFeatures.INCIDENT_MANAGEMENT, IntegrationFeatures.ALERT_RULE])

--- a/src/sentry/integrations/pagerduty/integration.py
+++ b/src/sentry/integrations/pagerduty/integration.py
@@ -12,6 +12,7 @@ from rest_framework.request import Request
 from sentry import options
 from sentry.integrations.base import (
     FeatureDescription,
+    IntegrationDomain,
     IntegrationFeatures,
     IntegrationInstallation,
     IntegrationMetadata,
@@ -166,6 +167,7 @@ class PagerDutyIntegration(IntegrationInstallation):
 class PagerDutyIntegrationProvider(IntegrationProvider):
     key = "pagerduty"
     name = "PagerDuty"
+    domain = IntegrationDomain.ON_CALL_SCHEDULING
     metadata = metadata
     features = frozenset([IntegrationFeatures.ALERT_RULE, IntegrationFeatures.INCIDENT_MANAGEMENT])
     integration_cls = PagerDutyIntegration

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -13,6 +13,7 @@ from slack_sdk.errors import SlackApiError
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.integrations.base import (
     FeatureDescription,
+    IntegrationDomain,
     IntegrationFeatures,
     IntegrationInstallation,
     IntegrationMetadata,
@@ -88,6 +89,7 @@ class SlackIntegration(SlackNotifyBasicMixin, IntegrationInstallation):
 class SlackIntegrationProvider(IntegrationProvider):
     key = "slack"
     name = "Slack"
+    domain = IntegrationDomain.MESSAGING
     metadata = metadata
     features = frozenset([IntegrationFeatures.CHAT_UNFURL, IntegrationFeatures.ALERT_RULE])
     integration_cls = SlackIntegration

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -20,6 +20,7 @@ from sentry.identity.services.identity.model import RpcIdentity
 from sentry.identity.vsts.provider import get_user_info
 from sentry.integrations.base import (
     FeatureDescription,
+    IntegrationDomain,
     IntegrationFeatures,
     IntegrationMetadata,
     IntegrationProvider,
@@ -381,6 +382,7 @@ class VstsIntegration(RepositoryIntegration, VstsIssuesSpec):
 class VstsIntegrationProvider(IntegrationProvider):
     key = "vsts"
     name = "Azure DevOps"
+    domain = IntegrationDomain.SOURCE_CODE_MANAGEMENT
     metadata = metadata
     api_version = "4.1"
     oauth_redirect_url = "/extensions/vsts/setup/"


### PR DESCRIPTION
Instead of hardcoding the integration domains and their keys, we can specify the `domain` inside each respective `IntegrationProvider`. When the provider gets registered in `initializer.py`, we can dynamically construct the mapping of domains to keys, and vice versa.

`domain` is optional as there are some integrations that we haven't classified yet. If/when we emit metrics, we can classify these under "unknown".