### PR TITLE
feat(issue-details): Use detailed latency tooltip for event timestamp

### DIFF
--- a/static/app/views/issueDetails/streamline/eventTitle.tsx
+++ b/static/app/views/issueDetails/streamline/eventTitle.tsx
@@ -25,6 +25,7 @@ import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
 import {Divider} from 'sentry/views/issueDetails/divider';
+import EventCreatedTooltip from 'sentry/views/issueDetails/eventCreatedTooltip';
 import {
   type SectionConfig,
   SectionKey,
@@ -160,6 +161,8 @@ export const EventTitle = forwardRef<HTMLDivElement, EventNavigationProps>(
               />
             </EventIdInfo>
             <StyledTimeSince
+              tooltipBody={<EventCreatedTooltip event={event} />}
+              tooltipProps={{overlayStyle: {maxWidth: 300}}}
               date={event.dateCreated ?? event.dateReceived}
               css={grayText}
             />


### PR DESCRIPTION
We forgot to carry over the tooltip to the new UI.

**Before**
<img width="267" alt="image" src="https://github.com/user-attachments/assets/991ef620-588b-4cc8-84c9-a33955d06a89">

**After**
<img width="335" alt="image" src="https://github.com/user-attachments/assets/b086f5cb-0357-45f9-8753-4a061079cf0a">