### PR TITLE
fix(issue-details): Update resources section for streamlined experience

### DIFF
--- a/static/app/views/issueDetails/resourcesAndPossibleSolutions.tsx
+++ b/static/app/views/issueDetails/resourcesAndPossibleSolutions.tsx
@@ -18,7 +18,7 @@ import {getRegionDataFromOrganization} from 'sentry/utils/regions';
 import useOrganization from 'sentry/utils/useOrganization';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
-import {useIsSampleEvent} from 'sentry/views/issueDetails/utils';
+import {useHasStreamlinedUI, useIsSampleEvent} from 'sentry/views/issueDetails/utils';
 
 type Props = {
   event: Event;
@@ -51,6 +51,7 @@ export function ResourcesAndPossibleSolutions({event, project, group}: Props) {
   const config = getConfigForIssueType(group, project);
   const isSelfHostedErrorsOnly = ConfigStore.get('isSelfHostedErrorsOnly');
   const isSampleError = useIsSampleEvent();
+  const hasStreamlinedUI = useHasStreamlinedUI();
 
   const displayAiAutofix =
     ((organization.features.includes('autofix') &&
@@ -78,12 +79,12 @@ export function ResourcesAndPossibleSolutions({event, project, group}: Props) {
 
   return (
     <Wrapper
-      title={t('Resources and Possible Solutions')}
+      title={hasStreamlinedUI ? t('Autofix') : t('Resources and Possible Solutions')}
       configResources={!!config.resources}
       type={SectionKey.RESOURCES}
     >
       <Content>
-        {config.resources && (
+        {config.resources && !hasStreamlinedUI && (
           <Resources
             eventPlatform={event.platform}
             groupId={group.id}


### PR DESCRIPTION
this pr updates the resources section for the streamlined experience. now, the event details section will be called Autofix, since that is what we will show there. The resources are in the solutions center and will be hidden on the new experience from the details section. a bigger change to autofix will come in the future, but for now autofix will stay on event details.  