### PR TITLE
feat(performance): Swap DropdownLink in trends

### DIFF
--- a/static/app/views/performance/trends/changedTransactions.tsx
+++ b/static/app/views/performance/trends/changedTransactions.tsx
@@ -4,17 +4,15 @@ import type {Location} from 'history';
 
 import type {Client} from 'sentry/api';
 import Feature from 'sentry/components/acl/feature';
-import {Button} from 'sentry/components/button';
 import {HeaderTitleLegend} from 'sentry/components/charts/styles';
 import Count from 'sentry/components/count';
-import DropdownLink from 'sentry/components/dropdownLink';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import Duration from 'sentry/components/duration';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import {RadioLineItem} from 'sentry/components/forms/controls/radioGroup';
 import IdBadge from 'sentry/components/idBadge';
 import Link from 'sentry/components/links/link';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import MenuItem from 'sentry/components/menuItem';
 import type {CursorHandler} from 'sentry/components/pagination';
 import Pagination from 'sentry/components/pagination';
 import Panel from 'sentry/components/panels/panel';
@@ -482,57 +480,54 @@ function TrendsListItem(props: TrendsListItemProps) {
             </Fragment>
           </Tooltip>
         </ItemTransactionPercentage>
-        <DropdownLink
-          caret={false}
-          anchorRight
-          title={
-            <StyledButton
-              size="xs"
-              icon={<IconEllipsis data-test-id="trends-item-action" />}
-              aria-label={t('Actions')}
-            />
-          }
-        >
-          {!organization.features.includes('performance-new-trends') && (
-            <Fragment>
-              <MenuItem
-                onClick={() =>
-                  handleFilterDuration(
-                    location,
-                    organization,
-                    longestPeriodValue,
-                    FilterSymbols.LESS_THAN_EQUALS,
-                    trendChangeType,
-                    projects,
-                    trendView.project
-                  )
-                }
-              >
-                <MenuAction>{t('Show \u2264 %s', longestDuration)}</MenuAction>
-              </MenuItem>
-              <MenuItem
-                onClick={() =>
-                  handleFilterDuration(
-                    location,
-                    organization,
-                    longestPeriodValue,
-                    FilterSymbols.GREATER_THAN_EQUALS,
-                    trendChangeType,
-                    projects,
-                    trendView.project
-                  )
-                }
-              >
-                <MenuAction>{t('Show \u2265 %s', longestDuration)}</MenuAction>
-              </MenuItem>
-            </Fragment>
-          )}
-          <MenuItem
-            onClick={() => handleFilterTransaction(location, transaction.transaction)}
-          >
-            <MenuAction>{t('Hide from list')}</MenuAction>
-          </MenuItem>
-        </DropdownLink>
+        <DropdownMenu
+          triggerProps={{
+            size: 'xs',
+            icon: <IconEllipsis data-test-id="trends-item-action" />,
+            'aria-label': t('Actions'),
+            showChevron: false,
+          }}
+          items={[
+            ...(organization.features.includes('performance-new-trends')
+              ? []
+              : [
+                  {
+                    key: 'shortestDuration',
+                    label: t('Show \u2264 %s', longestDuration),
+                    onAction: () =>
+                      handleFilterDuration(
+                        location,
+                        organization,
+                        longestPeriodValue,
+                        FilterSymbols.LESS_THAN_EQUALS,
+                        trendChangeType,
+                        projects,
+                        trendView.project
+                      ),
+                  },
+                  {
+                    key: 'longestDuration',
+                    label: t('Show \u2265 %s', longestDuration),
+                    onAction: () =>
+                      handleFilterDuration(
+                        location,
+                        organization,
+                        longestPeriodValue,
+                        FilterSymbols.GREATER_THAN_EQUALS,
+                        trendChangeType,
+                        projects,
+                        trendView.project
+                      ),
+                  },
+                ]),
+            {
+              key: 'hide',
+              label: t('Hide from list'),
+              onAction: () => handleFilterTransaction(location, transaction.transaction),
+            },
+          ]}
+          position="bottom-end"
+        />
         <ItemTransactionDurationChange>
           {project && (
             <Tooltip title={transaction.project}>
@@ -672,10 +667,6 @@ const ChartContainer = styled('div')`
 const StyledHeaderTitleLegend = styled(HeaderTitleLegend)`
   border-radius: ${p => p.theme.borderRadius};
   margin: ${space(2)} ${space(3)};
-`;
-
-const StyledButton = styled(Button)`
-  vertical-align: middle;
 `;
 
 const MenuAction = styled('div')<{['data-test-id']?: string}>`

--- a/static/app/views/performance/trends/changedTransactions.tsx
+++ b/static/app/views/performance/trends/changedTransactions.tsx
@@ -483,7 +483,7 @@ function TrendsListItem(props: TrendsListItemProps) {
         <DropdownMenu
           triggerProps={{
             size: 'xs',
-            icon: <IconEllipsis data-test-id="trends-item-action" />,
+            icon: <IconEllipsis />,
             'aria-label': t('Actions'),
             showChevron: false,
           }}

--- a/static/app/views/performance/trends/index.spec.tsx
+++ b/static/app/views/performance/trends/index.spec.tsx
@@ -421,10 +421,15 @@ describe('Performance > Trends', function () {
     expect(transactions).toHaveLength(2);
     const firstTransaction = transactions[0];
 
-    const menuActions = within(firstTransaction).getAllByTestId('menu-action');
-    expect(menuActions).toHaveLength(3);
+    await userEvent.click(
+      within(firstTransaction).getByRole('button', {name: 'Actions'})
+    );
+    await waitFor(() => {
+      const menuActions = within(firstTransaction).getAllByRole('menuitemradio');
+      expect(menuActions).toHaveLength(3);
+    });
 
-    const menuAction = menuActions[2];
+    const menuAction = within(firstTransaction).getAllByRole('menuitemradio')[2];
     await clickEl(menuAction);
 
     expect(browserHistory.push).toHaveBeenCalledWith({
@@ -480,10 +485,15 @@ describe('Performance > Trends', function () {
     expect(transactions).toHaveLength(2);
     const firstTransaction = transactions[0];
 
-    const menuActions = within(firstTransaction).getAllByTestId('menu-action');
-    expect(menuActions).toHaveLength(3);
+    await userEvent.click(
+      within(firstTransaction).getByRole('button', {name: 'Actions'})
+    );
+    await waitFor(() => {
+      const menuActions = within(firstTransaction).getAllByRole('menuitemradio');
+      expect(menuActions).toHaveLength(3);
+    });
 
-    const menuAction = menuActions[0];
+    const menuAction = within(firstTransaction).getAllByRole('menuitemradio')[0];
     await clickEl(menuAction);
 
     expect(browserHistory.push).toHaveBeenCalledWith({
@@ -511,10 +521,15 @@ describe('Performance > Trends', function () {
     expect(transactions).toHaveLength(2);
     const firstTransaction = transactions[0];
 
-    const menuActions = within(firstTransaction).getAllByTestId('menu-action');
-    expect(menuActions).toHaveLength(3);
+    await userEvent.click(
+      within(firstTransaction).getByRole('button', {name: 'Actions'})
+    );
+    await waitFor(() => {
+      const menuActions = within(firstTransaction).getAllByRole('menuitemradio');
+      expect(menuActions).toHaveLength(3);
+    });
 
-    const menuAction = menuActions[1];
+    const menuAction = within(firstTransaction).getAllByRole('menuitemradio')[1];
     await clickEl(menuAction);
 
     expect(browserHistory.push).toHaveBeenCalledWith({


### PR DESCRIPTION
It seems broken currently and this new version is just as broken but no longer uses DropdownLink. It seems like the page isn't refreshed on query change and the search bar does not update.

before
![image](https://github.com/user-attachments/assets/5c6271b2-cdfd-436b-9157-35904706725f)


after
![image](https://github.com/user-attachments/assets/f94313c2-a9c7-4879-a69c-4f8bd181c494)
