### PR TITLE
chore(anomaly detection): add alpha stickers

### DIFF
--- a/static/app/views/alerts/rules/metric/details/sidebar.tsx
+++ b/static/app/views/alerts/rules/metric/details/sidebar.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {OnDemandWarningIcon} from 'sentry/components/alerts/onDemandMetricAlert';
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
 import AlertBadge from 'sentry/components/badge/alertBadge';
+import FeatureBadge from 'sentry/components/badge/featureBadge';
 import {Button} from 'sentry/components/button';
 import {SectionHeading} from 'sentry/components/charts/styles';
 import {DateTime} from 'sentry/components/dateTime';
@@ -94,7 +95,7 @@ function TriggerDescription({
         }
       )
     : rule.detectionType === AlertRuleComparisonType.DYNAMIC
-      ? 'Dynamic threshold is reached'
+      ? 'Anomaly detection threshold is reached'
       : tct('[metric] is [condition] in [timeWindow]', {
           metric: metricName,
           condition: `${thresholdTypeText} ${threshold}`,
@@ -110,7 +111,16 @@ function TriggerDescription({
       <TriggerStep>
         <TriggerTitleText>{t('When')}</TriggerTitleText>
         <TriggerActions>
-          <TriggerText>{thresholdText}</TriggerText>
+          <TriggerText>
+            {thresholdText}
+            {rule.detectionType === AlertRuleComparisonType.DYNAMIC ? (
+              <FeatureBadge
+                type="alpha"
+                title="Anomaly detection is in alpha and may produce inaccurate results"
+                tooltipProps={{isHoverable: true}}
+              />
+            ) : null}
+          </TriggerText>
         </TriggerActions>
       </TriggerStep>
       <TriggerStep>

--- a/static/app/views/alerts/rules/metric/thresholdTypeForm.tsx
+++ b/static/app/views/alerts/rules/metric/thresholdTypeForm.tsx
@@ -101,7 +101,11 @@ function ThresholdTypeForm({
       AlertRuleComparisonType.DYNAMIC,
       <ComparisonContainer key="Dynamic">
         {t('Anomaly: whenever values are outside of expected bounds')}
-        <FeatureBadge type="beta" tooltipProps={{isHoverable: true}} />
+        <FeatureBadge
+          type="alpha"
+          title="Anomaly detection is in alpha and may produce inaccurate results"
+          tooltipProps={{isHoverable: true}}
+        />
       </ComparisonContainer>,
     ] as RadioOption);
   }


### PR DESCRIPTION
Replace the beta sticker on the alert creation sticker with an alpha sticker, and add an alpha sticker to the alert rule details page.

<img width="328" alt="Screenshot 2024-11-04 at 4 28 58 PM" src="https://github.com/user-attachments/assets/b20c8197-bf26-495d-aee8-ace3c2fc1ebd">
