### PR TITLE
fix(alert): display custom time in date dropdown

### DIFF
--- a/static/app/views/alerts/rules/metric/details/anomalyDetectionFeedbackBanner.tsx
+++ b/static/app/views/alerts/rules/metric/details/anomalyDetectionFeedbackBanner.tsx
@@ -7,6 +7,7 @@ import {Button} from 'sentry/components/button';
 import {feedbackClient} from 'sentry/components/featureFeedback/feedbackModal';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
+import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type {Incident} from 'sentry/views/alerts/types';
@@ -71,8 +72,12 @@ export default function AnomalyDetectionFeedbackBanner({
       type="info"
       trailingItems={
         <Fragment>
-          <StyledButton onClick={() => handleClick(true)}>{t('Yes')}</StyledButton>
-          <StyledButton onClick={() => handleClick(false)}>{t('No')}</StyledButton>
+          <StyledButton borderless onClick={() => handleClick(true)}>
+            {t('Yes')}
+          </StyledButton>
+          <StyledButton borderless onClick={() => handleClick(false)}>
+            {t('No')}
+          </StyledButton>
         </Fragment>
       }
       showIcon
@@ -84,9 +89,19 @@ export default function AnomalyDetectionFeedbackBanner({
 
 const StyledButton = styled(Button)`
   background-color: transparent;
+  color: ${p => p.theme.alert.info.color};
   border: 1px solid ${p => p.theme.alert.info.border};
+
+  &:hover,
+  &:focus,
+  &:active {
+    color: ${p => p.theme.alert.info.color};
+    border-color: ${p => p.theme.alert.info.borderHover};
+  }
 `;
 
 const StyledAlert = styled(Alert)`
   margin: 0;
+  padding-top: ${space(3)};
+  padding-bottom: ${space(3)};
 `;

--- a/static/app/views/alerts/rules/metric/details/body.tsx
+++ b/static/app/views/alerts/rules/metric/details/body.tsx
@@ -218,7 +218,11 @@ export default function MetricDetailsBody({
               relativeOptions={relativeOptions}
               showAbsolute={false}
               disallowArbitraryRelativeRanges
-              triggerLabel={relativeOptions[timePeriod.period ?? '']}
+              triggerLabel={
+                timePeriod.custom
+                  ? timePeriod.label
+                  : relativeOptions[timePeriod.period ?? '']
+              }
             />
             {selectedIncident && (
               <Tooltip


### PR DESCRIPTION
Fixes a few tiny issues with the anomaly detection alert UX.

- Date range dropdown now displays "Custom time" when an incident is selected, since the window uses a custom range
- Feedback banner padding and button styles have been normalized.



Closes [ALRT-367](https://getsentry.atlassian.net/browse/ALRT-367).

### BEFORE
<img width="1057" alt="Screenshot 2024-11-04 at 6 32 58 PM" src="https://github.com/user-attachments/assets/f40220e7-bc5a-4fc0-b27f-b7b2adcb1560">

### AFTER
<img width="1057" alt="Screenshot 2024-11-04 at 6 32 34 PM" src="https://github.com/user-attachments/assets/6bbf212e-b8ae-4b20-9c3a-554d43e592b7">



[ALRT-367]: https://getsentry.atlassian.net/browse/ALRT-367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ