### PR TITLE
ref(dynamic-sampling): refactor ds related utils

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -72,6 +72,7 @@ from sentry.dynamic_sampling.tasks.boost_low_volume_projects import (
     boost_low_volume_projects_of_org_with_query,
 )
 from sentry.dynamic_sampling.types import DynamicSamplingMode
+from sentry.dynamic_sampling.utils import has_custom_dynamic_sampling
 from sentry.hybridcloud.rpc import IDEMPOTENCY_KEY_LENGTH
 from sentry.integrations.utils.codecov import has_codecov_integration
 from sentry.lang.native.utils import (
@@ -375,13 +376,9 @@ class OrganizationSerializer(BaseOrganizationSerializer):
         return value
 
     def validate_targetSampleRate(self, value):
-        from sentry import features
-
         organization = self.context["organization"]
         request = self.context["request"]
-        has_dynamic_sampling_custom = features.has(
-            "organizations:dynamic-sampling-custom", organization, actor=request.user
-        )
+        has_dynamic_sampling_custom = has_custom_dynamic_sampling(organization, actor=request.user)
         if not has_dynamic_sampling_custom:
             raise serializers.ValidationError(
                 "Organization does not have the custom dynamic sample rate feature enabled."
@@ -398,13 +395,9 @@ class OrganizationSerializer(BaseOrganizationSerializer):
         return value
 
     def validate_samplingMode(self, value):
-        from sentry import features
-
         organization = self.context["organization"]
         request = self.context["request"]
-        has_dynamic_sampling_custom = features.has(
-            "organizations:dynamic-sampling-custom", organization, actor=request.user
-        )
+        has_dynamic_sampling_custom = has_custom_dynamic_sampling(organization, actor=request.user)
         if not has_dynamic_sampling_custom:
             raise serializers.ValidationError(
                 "Organization does not have the custom dynamic sample rate feature enabled."

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -38,6 +38,7 @@ from sentry.datascrubbing import validate_pii_config_update, validate_pii_select
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.dynamic_sampling import get_supported_biases_ids, get_user_biases
 from sentry.dynamic_sampling.types import DynamicSamplingMode
+from sentry.dynamic_sampling.utils import has_custom_dynamic_sampling, has_dynamic_sampling
 from sentry.grouping.enhancer import Enhancements
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.grouping.fingerprinting import FingerprintingRules, InvalidFingerprintingConfig
@@ -432,11 +433,9 @@ E.g. `['release', 'environment']`""",
         return validate_pii_selectors(value)
 
     def validate_targetSampleRate(self, value):
-        from sentry import features
-
         organization = self.context["project"].organization
         actor = self.context["request"].user
-        if not features.has("organizations:dynamic-sampling-custom", organization, actor=actor):
+        if not has_custom_dynamic_sampling(organization, actor=actor):
             raise serializers.ValidationError(
                 "Organization does not have the custom dynamic sample rate feature enabled."
             )
@@ -514,7 +513,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             data["hasAlertIntegrationInstalled"] = has_alert_integration(project)
 
         # Dynamic Sampling Logic
-        if features.has("organizations:dynamic-sampling", project.organization):
+        if has_dynamic_sampling(project.organization):
             ds_bias_serializer = DynamicSamplingBiasSerializer(
                 data=get_user_biases(project.get_option("sentry:dynamic_sampling_biases", None)),
                 many=True,
@@ -571,9 +570,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
 
         result = serializer.validated_data
 
-        if result.get("dynamicSamplingBiases") and not (
-            features.has("organizations:dynamic-sampling", project.organization)
-        ):
+        if result.get("dynamicSamplingBiases") and not (has_dynamic_sampling(project.organization)):
             return Response(
                 {"detail": "dynamicSamplingBiases is not a valid field"},
                 status=403,
@@ -927,7 +924,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         )
 
         data = serialize(project, request.user, DetailedProjectSerializer())
-        if not (features.has("organizations:dynamic-sampling", project.organization)):
+        if not has_dynamic_sampling(project.organization):
             data["dynamicSamplingBiases"] = None
         # If here because the case of when no dynamic sampling is enabled at all, you would want to kick
         # out both keys actually

--- a/src/sentry/dynamic_sampling/rules/base.py
+++ b/src/sentry/dynamic_sampling/rules/base.py
@@ -13,10 +13,7 @@ from sentry.dynamic_sampling.rules.utils import PolymorphicRule, RuleType, get_e
 from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_projects import (
     get_boost_low_volume_projects_sample_rate,
 )
-from sentry.dynamic_sampling.tasks.utils import (
-    has_custom_dynamic_sampling,
-    is_project_mode_sampling,
-)
+from sentry.dynamic_sampling.utils import has_custom_dynamic_sampling, is_project_mode_sampling
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -55,11 +55,10 @@ from sentry.dynamic_sampling.tasks.task_context import TaskContext
 from sentry.dynamic_sampling.tasks.utils import (
     dynamic_sampling_task,
     dynamic_sampling_task_with_context,
-    has_dynamic_sampling,
-    is_project_mode_sampling,
     sample_function,
 )
 from sentry.dynamic_sampling.types import DynamicSamplingMode
+from sentry.dynamic_sampling.utils import has_dynamic_sampling, is_project_mode_sampling
 from sentry.models.options import OrganizationOption
 from sentry.models.organization import Organization
 from sentry.models.project import Project

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -42,10 +42,9 @@ from sentry.dynamic_sampling.tasks.task_context import DynamicSamplingLogState, 
 from sentry.dynamic_sampling.tasks.utils import (
     dynamic_sampling_task,
     dynamic_sampling_task_with_context,
-    has_dynamic_sampling,
-    is_project_mode_sampling,
     sample_function,
 )
+from sentry.dynamic_sampling.utils import has_dynamic_sampling, is_project_mode_sampling
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.organization import Organization
 from sentry.sentry_metrics import indexer

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -21,9 +21,9 @@ from sentry.dynamic_sampling.tasks.task_context import TaskContext
 from sentry.dynamic_sampling.tasks.utils import (
     dynamic_sampling_task,
     dynamic_sampling_task_with_context,
-    has_dynamic_sampling,
     sample_function,
 )
+from sentry.dynamic_sampling.utils import has_dynamic_sampling
 from sentry.models.organization import Organization
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task

--- a/src/sentry/dynamic_sampling/tasks/utils.py
+++ b/src/sentry/dynamic_sampling/tasks/utils.py
@@ -3,11 +3,7 @@ from functools import wraps
 from random import random
 from typing import Concatenate, ParamSpec
 
-from sentry import features
-from sentry.constants import SAMPLING_MODE_DEFAULT
 from sentry.dynamic_sampling.tasks.task_context import TaskContext
-from sentry.dynamic_sampling.types import DynamicSamplingMode
-from sentry.models.organization import Organization
 from sentry.utils import metrics
 
 
@@ -17,29 +13,6 @@ def sample_function(function, _sample_rate: float = 1.0, **kwargs):
     """
     if _sample_rate >= 1.0 or 0.0 <= random() <= _sample_rate:
         function(**kwargs)
-
-
-def has_dynamic_sampling(organization: Organization | None) -> bool:
-    # If an organization can't be fetched, we will assume it has no dynamic sampling.
-    if organization is None:
-        return False
-
-    return features.has("organizations:dynamic-sampling", organization)
-
-
-def has_custom_dynamic_sampling(organization: Organization | None) -> bool:
-    return organization is not None and features.has(
-        "organizations:dynamic-sampling-custom", organization
-    )
-
-
-def is_project_mode_sampling(organization: Organization | None) -> bool:
-    return (
-        organization is not None
-        and has_custom_dynamic_sampling(organization)
-        and organization.get_option("sentry:sampling_mode", SAMPLING_MODE_DEFAULT)
-        == DynamicSamplingMode.PROJECT
-    )
 
 
 def _compute_task_name(function_name: str) -> str:

--- a/src/sentry/dynamic_sampling/utils.py
+++ b/src/sentry/dynamic_sampling/utils.py
@@ -1,4 +1,4 @@
-import typing
+from django.contrib.auth.models import AnonymousUser
 
 from sentry import features
 from sentry.constants import SAMPLING_MODE_DEFAULT
@@ -6,9 +6,6 @@ from sentry.dynamic_sampling.types import DynamicSamplingMode
 from sentry.models.organization import Organization
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
-
-if typing.TYPE_CHECKING:
-    from django.contrib.auth.models import AnonymousUser
 
 
 def has_dynamic_sampling(

--- a/src/sentry/dynamic_sampling/utils.py
+++ b/src/sentry/dynamic_sampling/utils.py
@@ -1,20 +1,30 @@
+import typing
+
 from sentry import features
 from sentry.constants import SAMPLING_MODE_DEFAULT
 from sentry.dynamic_sampling.types import DynamicSamplingMode
 from sentry.models.organization import Organization
+from sentry.users.models.user import User
+from sentry.users.services.user import RpcUser
+
+if typing.TYPE_CHECKING:
+    from django.contrib.auth.models import AnonymousUser
 
 
-def has_dynamic_sampling(organization: Organization | None) -> bool:
+def has_dynamic_sampling(
+    organization: Organization | None, actor: User | RpcUser | AnonymousUser | None = None
+) -> bool:
     # If an organization can't be fetched, we will assume it has no dynamic sampling.
-    if organization is None:
-        return False
-
-    return features.has("organizations:dynamic-sampling", organization)
-
-
-def has_custom_dynamic_sampling(organization: Organization | None, **kwargs) -> bool:
     return organization is not None and features.has(
-        "organizations:dynamic-sampling-custom", organization, **kwargs
+        "organizations:dynamic-sampling", organization, actor=actor
+    )
+
+
+def has_custom_dynamic_sampling(
+    organization: Organization | None, actor: User | RpcUser | AnonymousUser | None = None
+) -> bool:
+    return organization is not None and features.has(
+        "organizations:dynamic-sampling-custom", organization, actor=actor
     )
 
 

--- a/src/sentry/dynamic_sampling/utils.py
+++ b/src/sentry/dynamic_sampling/utils.py
@@ -1,0 +1,27 @@
+from sentry import features
+from sentry.constants import SAMPLING_MODE_DEFAULT
+from sentry.dynamic_sampling.types import DynamicSamplingMode
+from sentry.models.organization import Organization
+
+
+def has_dynamic_sampling(organization: Organization | None) -> bool:
+    # If an organization can't be fetched, we will assume it has no dynamic sampling.
+    if organization is None:
+        return False
+
+    return features.has("organizations:dynamic-sampling", organization)
+
+
+def has_custom_dynamic_sampling(organization: Organization | None, **kwargs) -> bool:
+    return organization is not None and features.has(
+        "organizations:dynamic-sampling-custom", organization, **kwargs
+    )
+
+
+def is_project_mode_sampling(organization: Organization | None) -> bool:
+    return (
+        organization is not None
+        and has_custom_dynamic_sampling(organization)
+        and organization.get_option("sentry:sampling_mode", SAMPLING_MODE_DEFAULT)
+        == DynamicSamplingMode.PROJECT
+    )

--- a/tests/sentry/dynamic_sampling/test_utils.py
+++ b/tests/sentry/dynamic_sampling/test_utils.py
@@ -1,6 +1,13 @@
 import pytest
 
 from sentry.dynamic_sampling.rules.utils import apply_dynamic_factor
+from sentry.dynamic_sampling.types import DynamicSamplingMode
+from sentry.dynamic_sampling.utils import (
+    has_custom_dynamic_sampling,
+    has_dynamic_sampling,
+    is_project_mode_sampling,
+)
+from sentry.testutils.cases import TestCase
 
 
 @pytest.mark.parametrize(
@@ -20,3 +27,55 @@ def test_apply_dynamic_factor_with_valid_params(base_sample_rate, x, expected):
 def test_apply_dynamic_factor_with_invalid_params(base_sample_rate, x):
     with pytest.raises(Exception):
         apply_dynamic_factor(base_sample_rate, x)
+
+
+class HasDynamicSamplingTestCase(TestCase):
+    def test_no_org(self):
+        assert not has_dynamic_sampling(None)
+
+    def test_positive(self):
+        org1 = self.create_organization("test-org")
+        with self.feature("organizations:dynamic-sampling"):
+            assert has_dynamic_sampling(org1)
+
+    def test_negative(self):
+        org1 = self.create_organization("test-org")
+        with self.feature({"organizations:dynamic-sampling": False}):
+            assert not has_dynamic_sampling(org1)
+
+
+class HasCustomDynamicSamplingTestCase(TestCase):
+    def test_no_org(self):
+        assert not has_dynamic_sampling(None)
+
+    def test_positive(self):
+        org1 = self.create_organization("test-org")
+        with self.feature("organizations:dynamic-sampling-custom"):
+            assert has_custom_dynamic_sampling(org1)
+
+    def test_negative(self):
+        org1 = self.create_organization("test-org")
+        with self.feature({"organizations:dynamic-sampling-custom": False}):
+            assert not has_custom_dynamic_sampling(org1)
+
+
+class IsProjectModeSamplingTestCase(TestCase):
+    def test_no_org(self):
+        assert not has_dynamic_sampling(None)
+
+    def test_no_custom_dynamic_samping(self):
+        org1 = self.create_organization("test-org")
+        with self.feature({"organizations:dynamic-sampling-custom": False}):
+            assert not is_project_mode_sampling(org1)
+
+    def test_positive(self):
+        org1 = self.create_organization("test-org")
+        org1.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT.value)
+        with self.feature("organizations:dynamic-sampling-custom"):
+            assert is_project_mode_sampling(org1)
+
+    def test_negative(self):
+        org1 = self.create_organization("test-org")
+        org1.update_option("sentry:sampling_mode", DynamicSamplingMode.ORGANIZATION.value)
+        with self.feature({"organizations:dynamic-sampling-custom": False}):
+            assert not is_project_mode_sampling(org1)


### PR DESCRIPTION
Extracting three utility functions from dynamic-sampling/tasks/utils to dynamic-sampling/utils.
Using `has_dynamic_sampling` and `has_custom_dynamic_sampling` instead of `features.has` where appropiate.

Preparation for https://github.com/getsentry/projects/issues/192