### PR TITLE
ref(ds): Change sample rate of DS batch tasks to 100%

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -112,7 +112,13 @@ def boost_low_volume_projects(context: TaskContext) -> None:
             for org_id, projects in fetch_projects_with_total_root_transaction_count_and_rates(
                 context, org_ids=orgs, measure=measure
             ).items():
-                boost_low_volume_projects_of_org.delay(org_id, projects)
+                boost_low_volume_projects_of_org.apply_async(
+                    kwargs={
+                        "org_id": org_id,
+                        "projects_with_tx_count_and_rates": projects,
+                    },
+                    headers={"sentry-propagate-traces": False},
+                )
 
 
 @metrics.wraps("dynamic_sampling.partition_by_measure")

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -140,7 +140,10 @@ def boost_low_volume_transactions(context: TaskContext) -> None:
         for project_transactions in transactions_zip(
             totals_it, big_transactions_it, small_transactions_it
         ):
-            boost_low_volume_transactions_of_project.delay(project_transactions)
+            boost_low_volume_transactions_of_project.apply_async(
+                kwargs={"project_transactions": project_transactions},
+                headers={"sentry-propagate-traces": False},
+            )
 
 
 @instrumented_task(

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -76,10 +76,8 @@ SAMPLED_TASKS = {
     "sentry.tasks.derive_code_mappings.derive_code_mappings": settings.SAMPLED_DEFAULT_RATE,
     "sentry.monitors.tasks.clock_pulse": 1.0,
     "sentry.tasks.auto_enable_codecov": settings.SAMPLED_DEFAULT_RATE,
-    "sentry.dynamic_sampling.tasks.boost_low_volume_projects": 0.2
-    * settings.SENTRY_BACKEND_APM_SAMPLING,
-    "sentry.dynamic_sampling.tasks.boost_low_volume_transactions": 0.2
-    * settings.SENTRY_BACKEND_APM_SAMPLING,
+    "sentry.dynamic_sampling.tasks.boost_low_volume_projects": 1.0,
+    "sentry.dynamic_sampling.tasks.boost_low_volume_transactions": 1.0,
     "sentry.dynamic_sampling.tasks.recalibrate_orgs": 0.2 * settings.SENTRY_BACKEND_APM_SAMPLING,
     "sentry.dynamic_sampling.tasks.sliding_window_org": 0.2 * settings.SENTRY_BACKEND_APM_SAMPLING,
     "sentry.dynamic_sampling.tasks.custom_rule_notifications": 0.2


### PR DESCRIPTION
Changes the sample rate of the batched dynamic sampling tasks to 100%, since
they run only once every 10 minutes. Additionalloy, this disables trace
propagation to the spawned sub-task to prevent extremely large traces.

