### PR TITLE
chore: Bump sentry-protos to 0.1.33

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -68,7 +68,7 @@ rfc3986-validator>=0.1.1
 sentry-arroyo>=2.16.5
 sentry-kafka-schemas>=0.1.116
 sentry-ophio==1.0.0
-sentry-protos>=0.1.32
+sentry-protos>=0.1.33
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.9.2
 sentry-sdk[http2]>=2.17.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -186,7 +186,7 @@ sentry-forked-django-stubs==5.1.1.post1
 sentry-forked-djangorestframework-stubs==3.15.1.post2
 sentry-kafka-schemas==0.1.116
 sentry-ophio==1.0.0
-sentry-protos==0.1.32
+sentry-protos==0.1.33
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.2
 sentry-sdk==2.17.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -127,7 +127,7 @@ s3transfer==0.10.0
 sentry-arroyo==2.16.5
 sentry-kafka-schemas==0.1.116
 sentry-ophio==1.0.0
-sentry-protos==0.1.32
+sentry-protos==0.1.33
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.2
 sentry-sdk==2.17.0


### PR DESCRIPTION
This expands the messages for taskworkers.
