### PR TITLE
fix(dashboards): Add custom field renderer

### DIFF
--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -12,6 +12,7 @@ import type {
 import toArray from 'sentry/utils/array/toArray';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
+import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {
   type DiscoverQueryExtras,
   type DiscoverQueryRequestParams,
@@ -115,6 +116,9 @@ export const SpansConfig: DatasetConfig<
   transformSeries: transformEventsResponseToSeries,
   filterTableOptions,
   filterAggregateParams,
+  getCustomFieldRenderer: (field, meta, _organization) => {
+    return getFieldRenderer(field, meta, false);
+  },
 };
 
 function getPrimaryFieldOptions(


### PR DESCRIPTION
Tables weren't rendering aggregates properly because the metadata for the response comes back with fields in the original format they were sent, i.e. for avg(span.duration) instead of aliasing to avg_span_duration like we used to do.

To get around this, we just need to pass a boolean telling our field renderer not to expect that aliased version.

I'm going to add a test for this, I just wanted it in in time for demos.

Before:
![Screenshot 2024-11-05 at 9 39 34 AM](https://github.com/user-attachments/assets/cd7959e8-0d13-45bd-8786-d327c79c381a)

After:
![Screenshot 2024-11-05 at 9 39 53 AM](https://github.com/user-attachments/assets/323be131-61ba-4cda-aee5-7c40636dc0bd)
