### PR TITLE
fix(new-trace): Rounding transaction durations with 2 dec. precision.

### DIFF
--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
@@ -398,6 +398,7 @@ function NewTraceDetailsSpanDetail(props: SpanDetailProps) {
                   baseDescription={t(
                     'Average total time for this span group across the project associated with its parent transaction, over the last 24 hours'
                   )}
+                  node={props.node}
                 />
               </Row>
               {span.exclusive_time ? (
@@ -416,6 +417,7 @@ function NewTraceDetailsSpanDetail(props: SpanDetailProps) {
                     baseDescription={t(
                       'Average self time for this span group across the project associated with its parent transaction, over the last 24 hours'
                     )}
+                    node={props.node}
                   />
                 </Row>
               ) : null}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/generalInfo.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/generalInfo.tsx
@@ -36,6 +36,7 @@ function SpanDuration({node}: {node: TraceTreeNode<TraceTree.Span>}) {
       baseDescription={t(
         'Average total time for this span group across the project associated with its parent transaction, over the last 24 hours'
       )}
+      node={node}
     />
   );
 }
@@ -56,6 +57,7 @@ function SpanSelfTime({node}: {node: TraceTreeNode<TraceTree.Span>}) {
       baseDescription={t(
         'Average self time for this span group across the project associated with its parent transaction, over the last 24 hours'
       )}
+      node={node}
     />
   ) : null;
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -200,6 +200,7 @@ const MIN_PCT_DURATION_DIFFERENCE = 10;
 type DurationProps = {
   baseline: number | undefined;
   duration: number;
+  node: TraceTreeNode<TraceTree.NodeValue>;
   baseDescription?: string;
   ratio?: number;
 };
@@ -209,8 +210,14 @@ function Duration(props: DurationProps) {
     return <DurationContainer>{t('unknown')}</DurationContainer>;
   }
 
+  // Since transactions have ms precision, we show 2 decimal places only if the duration is greater than 1 second.
+  const precision = isTransactionNode(props.node) ? (props.duration > 1 ? 2 : 0) : 2;
   if (props.baseline === undefined || props.baseline === 0) {
-    return <DurationContainer>{getDuration(props.duration, 2, true)}</DurationContainer>;
+    return (
+      <DurationContainer>
+        {getDuration(props.duration, precision, true)}
+      </DurationContainer>
+    );
   }
 
   const delta = props.duration - props.baseline;
@@ -245,7 +252,7 @@ function Duration(props: DurationProps) {
   return (
     <Fragment>
       <DurationContainer>
-        {getDuration(props.duration, 2, true)}{' '}
+        {getDuration(props.duration, precision, true)}{' '}
         {props.ratio ? `(${(props.ratio * 100).toFixed()}%)` : null}
       </DurationContainer>
       {deltaPct >= MIN_PCT_DURATION_DIFFERENCE ? (

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/generalInfo.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/generalInfo.tsx
@@ -70,6 +70,7 @@ function GeneralInfo({
           duration={durationInSeconds}
           baseline={avgDurationInSeconds}
           baseDescription={'Average duration for this transaction over the last 24 hours'}
+          node={node}
         />
       ),
     },

--- a/static/app/views/performance/newTraceDetails/traceRow/traceBar.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceBar.tsx
@@ -157,7 +157,17 @@ interface TraceBarProps {
 }
 
 export function TraceBar(props: TraceBarProps) {
-  const duration = props.node_space ? formatTraceDuration(props.node_space[1], 2) : null;
+  let duration: string | null = null;
+
+  if (props.node_space) {
+    // Since transactions have ms precision, we show 2 decimal places only if the duration is greater than 1 second.
+    const precision = isTransactionNode(props.node)
+      ? props.node_space[1] >= 1000
+        ? 2
+        : 0
+      : 2;
+    duration = formatTraceDuration(props.node_space[1], precision);
+  }
 
   const registerSpanBarRef = useCallback(
     (ref: HTMLDivElement | null) => {

--- a/static/app/views/performance/newTraceDetails/traceRow/traceBar.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceBar.tsx
@@ -157,9 +157,7 @@ interface TraceBarProps {
 }
 
 export function TraceBar(props: TraceBarProps) {
-  const duration = props.node_space
-    ? formatTraceDuration(props.node_space[1], isTransactionNode(props.node) ? 0 : 2)
-    : null;
+  const duration = props.node_space ? formatTraceDuration(props.node_space[1], 2) : null;
 
   const registerSpanBarRef = useCallback(
     (ref: HTMLDivElement | null) => {


### PR DESCRIPTION
<img width="1290" alt="Screenshot 2024-11-05 at 10 03 25 AM" src="https://github.com/user-attachments/assets/941b75d5-1694-43b7-a416-6e34bb550905">
