### PR TITLE
feat(insights): add buisness icon to module tab if module is not enabled

### DIFF
--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -1,10 +1,13 @@
 import {Fragment} from 'react';
+import styled from '@emotion/styled';
 
 import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
 import ButtonBar from 'sentry/components/buttonBar';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {TabList, Tabs} from 'sentry/components/tabs';
+import {IconBusiness} from 'sentry/icons';
+import {space} from 'sentry/styles/space';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useModuleTitles} from 'sentry/views/insights/common/utils/useModuleTitle';
@@ -16,6 +19,7 @@ import {
   DOMAIN_VIEW_BASE_TITLE,
   OVERVIEW_PAGE_TITLE,
 } from 'sentry/views/insights/pages/settings';
+import {isModuleEnabled} from 'sentry/views/insights/pages/utils';
 import type {ModuleName} from 'sentry/views/insights/types';
 
 export type Props = {
@@ -32,7 +36,7 @@ export type Props = {
 
 type Tab = {
   key: string;
-  label: string;
+  label: React.ReactNode;
 };
 
 export function DomainViewHeader({
@@ -105,7 +109,7 @@ export function DomainViewHeader({
     tabList.push(
       ...modules.map(moduleName => ({
         key: moduleName,
-        label: moduleTitles[moduleName],
+        label: <TabLabel moduleName={moduleName} />,
       }))
     );
   }
@@ -138,3 +142,25 @@ export function DomainViewHeader({
     </Fragment>
   );
 }
+
+function TabLabel({moduleName}: {moduleName: ModuleName}) {
+  const moduleTitles = useModuleTitles();
+  const organization = useOrganization();
+  const showBuisnessIcon = !isModuleEnabled(moduleName, organization);
+  if (showBuisnessIcon) {
+    return (
+      <TabWithIconContainer>
+        {moduleTitles[moduleName]}
+        <IconBusiness />
+      </TabWithIconContainer>
+    );
+  }
+  return <Fragment>{moduleTitles[moduleName]}</Fragment>;
+}
+
+const TabWithIconContainer = styled('div')`
+  display: inline-flex;
+  align-items: center;
+  text-align: left;
+  gap: ${space(0.5)};
+`;

--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -146,8 +146,8 @@ export function DomainViewHeader({
 function TabLabel({moduleName}: {moduleName: ModuleName}) {
   const moduleTitles = useModuleTitles();
   const organization = useOrganization();
-  const showBuisnessIcon = !isModuleEnabled(moduleName, organization);
-  if (showBuisnessIcon) {
+  const showBusinessIcon = !isModuleEnabled(moduleName, organization);
+  if (showBusinessIcon) {
     return (
       <TabWithIconContainer>
         {moduleTitles[moduleName]}


### PR DESCRIPTION
Work for #77572 

Adds buisness icon when a module is not enabled.
<img width="1283" alt="image" src="https://github.com/user-attachments/assets/40b8aa8b-8835-42aa-8767-74b9a31a7686">

This might technically be better done in getsentry because there is a scenario where you might see the buisness icon in self hosted, when the `insights-entry-points` flag is true, but `insights-initial-modules`/`insights-addon-modules` is false`, but there would be no reason to have flags set like this anyways.