### PR TITLE
fix(celery): fix recursion guard in holds_bad_pickle_object

### DIFF
--- a/src/sentry/celery.py
+++ b/src/sentry/celery.py
@@ -36,12 +36,12 @@ def holds_bad_pickle_object(value, memo=None):
 
     if isinstance(value, (tuple, list)):
         for item in value:
-            bad_object = holds_bad_pickle_object(item)
+            bad_object = holds_bad_pickle_object(item, memo)
             if bad_object is not None:
                 return bad_object
     elif isinstance(value, dict):
         for item in value.values():
-            bad_object = holds_bad_pickle_object(item)
+            bad_object = holds_bad_pickle_object(item, memo)
             if bad_object is not None:
                 return bad_object
 


### PR DESCRIPTION
`holds_bad_pickle_object` is only called during tests so this isn't a big deal, but the function's recursion guard (preventing an object with a reference cycle from looping forever) wasn't working, as the dict holding the already-seen IDs wasn't being passed to the recursive invocations.