### PR TITLE
feat(insights): update module body hook to select screen rendering module

### DIFF
--- a/static/app/views/insights/mobile/screenRendering/screenRenderingLandingPage.tsx
+++ b/static/app/views/insights/mobile/screenRendering/screenRenderingLandingPage.tsx
@@ -29,7 +29,7 @@ export function ScreenRenderingModule() {
           headerActions={isProjectCrossPlatform && <PlatformSelector />}
         />
 
-        <ModuleBodyUpsellHook moduleName={ModuleName.APP_START}>
+        <ModuleBodyUpsellHook moduleName={ModuleName.SCREEN_RENDERING}>
           <Layout.Body>
             <Layout.Main fullWidth>
               <Container>

--- a/static/app/views/insights/mobile/screenRendering/screenRenderingSummaryPage.tsx
+++ b/static/app/views/insights/mobile/screenRendering/screenRenderingSummaryPage.tsx
@@ -26,7 +26,7 @@ function ScreenRenderingSummary() {
         module={ModuleName.SCREEN_RENDERING}
         breadcrumbs={[{label: SUMMARY_PAGE_TITLE}]}
       />
-      <ModuleBodyUpsellHook moduleName={ModuleName.APP_START}>
+      <ModuleBodyUpsellHook moduleName={ModuleName.SCREEN_RENDERING}>
         <Layout.Body>
           <Layout.Main fullWidth>
             <ModuleLayout.Layout>


### PR DESCRIPTION
This PR corresponds to https://github.com/getsentry/sentry/pull/80257

Now that we have copy for the screen rendering module (see above PR), we should set `moduleName` in the upsell hook to `screen rendering` so that screen rendering is selected on the module upsell screen.