### PR TITLE
feat(issue-details): Add provider specific icon to activities

### DIFF
--- a/static/app/views/issueDetails/streamline/activitySection.tsx
+++ b/static/app/views/issueDetails/streamline/activitySection.tsx
@@ -51,7 +51,9 @@ function TimelineItem({
   );
 
   const iconMapping = groupActivityTypeIconMapping[item.type];
-  const Icon = iconMapping?.Component ?? null;
+  const Icon = iconMapping?.componentFunction
+    ? iconMapping.componentFunction(item.data)
+    : iconMapping?.Component ?? null;
 
   return (
     <ActivityTimelineItem

--- a/static/app/views/issueDetails/streamline/groupActivityIcons.tsx
+++ b/static/app/views/issueDetails/streamline/groupActivityIcons.tsx
@@ -1,5 +1,7 @@
 import {
   IconAdd,
+  IconAsana,
+  IconBitbucket,
   IconChat,
   IconCheckmark,
   IconClose,
@@ -7,7 +9,10 @@ import {
   IconDelete,
   IconFire,
   IconFlag,
+  IconGithub,
+  IconGitlab,
   IconGraph,
+  IconJira,
   IconLock,
   IconMute,
   IconNext,
@@ -23,6 +28,7 @@ import {GroupActivityType} from 'sentry/types/group';
 interface IconWithDefaultProps {
   Component: React.ComponentType<any> | null;
   defaultProps: {locked?: boolean; type?: string};
+  componentFunction?: (props: any) => React.ComponentType<any>;
   propsFunction?: (props: any) => any;
 }
 
@@ -50,7 +56,27 @@ export const groupActivityTypeIconMapping: Record<
   [GroupActivityType.SET_PUBLIC]: {Component: IconLock, defaultProps: {}},
   [GroupActivityType.SET_PRIVATE]: {Component: IconLock, defaultProps: {locked: true}},
   [GroupActivityType.SET_REGRESSION]: {Component: IconFire, defaultProps: {}},
-  [GroupActivityType.CREATE_ISSUE]: {Component: IconAdd, defaultProps: {}},
+  [GroupActivityType.CREATE_ISSUE]: {
+    Component: IconAdd,
+    componentFunction: data => {
+      const provider = data.provider;
+      switch (provider.toLowerCase()) {
+        case 'github':
+          return IconGithub;
+        case 'gitlab':
+          return IconGitlab;
+        case 'bitbucket':
+          return IconBitbucket;
+        case 'jira ':
+          return IconJira;
+        case 'asana':
+          return IconAsana;
+        default:
+          return IconAdd;
+      }
+    },
+    defaultProps: {},
+  },
   [GroupActivityType.UNMERGE_SOURCE]: {Component: IconPrevious, defaultProps: {}},
   [GroupActivityType.UNMERGE_DESTINATION]: {Component: IconPrevious, defaultProps: {}},
   [GroupActivityType.FIRST_SEEN]: {Component: IconFlag, defaultProps: {}},

--- a/static/app/views/issueDetails/streamline/groupActivityIcons.tsx
+++ b/static/app/views/issueDetails/streamline/groupActivityIcons.tsx
@@ -60,16 +60,16 @@ export const groupActivityTypeIconMapping: Record<
     Component: IconAdd,
     componentFunction: data => {
       const provider = data.provider;
-      switch (provider.toLowerCase()) {
-        case 'github':
+      switch (provider) {
+        case 'GitHub':
           return IconGithub;
-        case 'gitlab':
+        case 'GitLab':
           return IconGitlab;
-        case 'bitbucket':
+        case 'Bitbucket':
           return IconBitbucket;
-        case 'jira ':
+        case 'Jira':
           return IconJira;
-        case 'asana':
+        case 'Asana':
           return IconAsana;
         default:
           return IconAdd;


### PR DESCRIPTION
this pr adds the provider's icon to the Create Issue activity for some providers . default behavior will stay the same

<img width="311" alt="Screenshot 2024-11-05 at 9 46 35 AM" src="https://github.com/user-attachments/assets/0c881e1a-a584-484f-87a6-93e2682375fb">
