### PR TITLE
build(ui): Support last 4 major safari versions 

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,16 +250,14 @@
     "production": [
       "last 10 Chrome versions",
       "last 10 Firefox versions",
-      "last 2 Edge major versions",
-      "last 2 Safari major versions",
+      "last 4 Safari major versions",
       "last 3 iOS major versions",
       "Firefox ESR"
     ],
     "development": [
       "last 10 Chrome versions",
       "last 10 Firefox versions",
-      "last 2 Edge major versions",
-      "last 2 Safari major versions",
+      "last 4 Safari major versions",
       "last 3 iOS major versions",
       "Firefox ESR"
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5180,9 +5180,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001283, caniuse-lite@^1.0.30001669:
-  version "1.0.30001669"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001669.tgz#fda8f1d29a8bfdc42de0c170d7f34a9cf19ed7a3"
-  integrity sha512-DlWzFDJqstqtIVx1zeSpIMLjunf5SmwOw0N2Ck/QSQdS8PLS4+9HrLaYei4w8BIAL7IB/UEDu889d8vhCTPA0w==
+  version "1.0.30001677"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001677.tgz"
+  integrity sha512-fmfjsOlJUpMWu+mAAtZZZHz7UEwsUxIIvu1TJfO1HqFQvB/B+ii0xr9B5HpbZY/mC4XZ8SvjHJqtAY6pDPQEog==
 
 cbor-web@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
the motivation here is with the recent release of safari 18 we no longer polyfill toSorted toReversed etc. Last 4 brings us back to safari 15 which didn't have these features. https://caniuse.com/?search=tosorted

 - drops the last 2 edge versions which is really just chromium these days. `edge 130, edge 129` isn't different from the last 10 chrome versions.
- updates the database.

brings our support to
```
❯ npx browserslist@latest
chrome 130
chrome 129
chrome 128
chrome 127
chrome 126
chrome 125
chrome 124
chrome 123
chrome 122
chrome 121
firefox 132
firefox 131
firefox 130
firefox 129
firefox 128
firefox 127
firefox 126
firefox 125
firefox 124
firefox 123
firefox 115
ios_saf 18.0
ios_saf 17.6-17.7
ios_saf 17.5
ios_saf 17.4
ios_saf 17.3
ios_saf 17.2
ios_saf 17.1
ios_saf 17.0
ios_saf 16.6-16.7
ios_saf 16.5
ios_saf 16.4
ios_saf 16.3
ios_saf 16.2
ios_saf 16.1
ios_saf 16.0
safari 18.0
safari 17.6
safari 17.5
safari 17.4
safari 17.3
safari 17.2
safari 17.1
safari 17.0
safari 16.6
safari 16.5
safari 16.4
safari 16.3
safari 16.2
safari 16.1
safari 16.0
safari 15.6
safari 15.5
safari 15.4
safari 15.2-15.3
safari 15.1
safari 15
```

previously
```
chrome 130
chrome 129
chrome 128
chrome 127
chrome 126
chrome 125
chrome 124
chrome 123
chrome 122
chrome 121
edge 130
edge 129
firefox 132
firefox 131
firefox 130
firefox 129
firefox 128
firefox 127
firefox 126
firefox 125
firefox 124
firefox 123
firefox 115
ios_saf 18.0
ios_saf 17.6-17.7
ios_saf 17.5
ios_saf 17.4
ios_saf 17.3
ios_saf 17.2
ios_saf 17.1
ios_saf 17.0
ios_saf 16.6-16.7
ios_saf 16.5
ios_saf 16.4
ios_saf 16.3
ios_saf 16.2
ios_saf 16.1
ios_saf 16.0
safari 18.0
safari 17.6
safari 17.5
safari 17.4
safari 17.3
safari 17.2
safari 17.1
safari 17.0
```

