### PR TITLE
fix(dashboards): Increase size of Widget Frame description tooltip icon

### DIFF
--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -90,7 +90,7 @@ export function WidgetFrame(props: WidgetFrameProps) {
                   aria-label={t('Widget description')}
                   borderless
                   size="xs"
-                  icon={<IconInfo />}
+                  icon={<IconInfo size="sm" />}
                 />
               </Tooltip>
             )}

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -253,6 +253,8 @@ const WidgetTooltipDescription = styled('div')`
 // We're using a button here to preserve tab accessibility
 const WidgetTooltipButton = styled(Button)`
   pointer-events: none;
+  padding-top: 0;
+  padding-bottom: 0;
 `;
 
 const VisualizationWrapper = styled('div')`


### PR DESCRIPTION
- Remove unnecessary icon button padding
- Increase icon size

**e.g.,**
<img width="267" alt="Screenshot 2024-11-05 at 2 09 12 PM" src="https://github.com/user-attachments/assets/3a2b4111-5ff1-436a-a8d6-fa1d7502f2e1">
