### PR TITLE
fix(dashboards): Add explanation tooltip for "Latest Release" in release selector

### DIFF
--- a/static/app/views/dashboards/releasesSelectControl.tsx
+++ b/static/app/views/dashboards/releasesSelectControl.tsx
@@ -25,6 +25,9 @@ const ALIASED_RELEASES = [
   {
     label: t('Latest Release(s)'),
     value: 'latest',
+    tooltip: t(
+      'The highest version number for Semantic Versioning or the most recent release for commit SHA.'
+    ),
   },
 ];
 


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/76326

**e.g.,**
<img width="488" alt="Screenshot 2024-11-05 at 2 26 01 PM" src="https://github.com/user-attachments/assets/1d1c0f8f-39ab-47e5-b28e-99249785bd67">
