### PR TITLE
feat(alerts): Adds a create alert button to explore chart

### DIFF
--- a/static/app/views/alerts/rules/metric/constants.tsx
+++ b/static/app/views/alerts/rules/metric/constants.tsx
@@ -187,7 +187,7 @@ export function createDefaultRule(
   };
 }
 
-function getAlertTimeWindow(period: string | undefined): TimeWindow | undefined {
+export function getAlertTimeWindow(period: string | undefined): TimeWindow | undefined {
   if (!period) {
     return undefined;
   }

--- a/static/app/views/alerts/rules/metric/create.tsx
+++ b/static/app/views/alerts/rules/metric/create.tsx
@@ -9,6 +9,7 @@ import {
   createDefaultRule,
   createRuleFromEventView,
   createRuleFromWizardTemplate,
+  getAlertTimeWindow,
 } from 'sentry/views/alerts/rules/metric/constants';
 import type {WizardRuleTemplate} from 'sentry/views/alerts/wizard/options';
 
@@ -69,6 +70,8 @@ function MetricRulesCreate(props: Props) {
   const defaultOwnerId = userTeamIds.find(id => projectTeamIds.has(id)) ?? null;
   defaultRule.owner = defaultOwnerId && `team:${defaultOwnerId}`;
   const environment = decodeScalar(location?.query?.environment) ?? null;
+  const interval = decodeScalar(location?.query?.interval) ?? undefined;
+  defaultRule.timeWindow = getAlertTimeWindow(interval) ?? defaultRule.timeWindow;
 
   return (
     <RuleForm

--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -232,7 +232,7 @@ export function ExploreCharts({query}: ExploreChartsProps) {
                     >
                       <DropdownMenu
                         triggerProps={{
-                          'aria-label': t('Chart Actions'),
+                          'aria-label': t('Create Alert'),
                           size: 'sm',
                           borderless: true,
                           showChevron: false,

--- a/static/app/views/insights/common/utils/getAlertsUrl.spec.tsx
+++ b/static/app/views/insights/common/utils/getAlertsUrl.spec.tsx
@@ -2,6 +2,7 @@ import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
+import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 
 describe('getAlertsUrl', function () {
@@ -20,6 +21,22 @@ describe('getAlertsUrl', function () {
     });
     expect(url).toEqual(
       '/organizations/orgSlug/alerts/new/metric/?aggregate=avg%28d%3Aspans%2Fduration%40millisecond%29&dataset=generic_metrics&eventTypes=transaction&project=project-slug&query=span.module%3Adb&statsPeriod=7d'
+    );
+  });
+  it('should return a url to an EAP alert rule', function () {
+    const aggregate = 'count(span.duration)';
+    const query = 'span.op:http.client';
+    const orgSlug = 'orgSlug';
+    const url = getAlertsUrl({
+      project,
+      aggregate,
+      query,
+      orgSlug,
+      pageFilters,
+      dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+    });
+    expect(url).toEqual(
+      '/organizations/orgSlug/alerts/new/metric/?aggregate=count%28span.duration%29&dataset=events_analytics_platform&eventTypes=transaction&project=project-slug&query=span.op%3Ahttp.client&statsPeriod=7d'
     );
   });
 });

--- a/static/app/views/insights/common/utils/getAlertsUrl.tsx
+++ b/static/app/views/insights/common/utils/getAlertsUrl.tsx
@@ -12,11 +12,15 @@ export function getAlertsUrl({
   orgSlug,
   pageFilters,
   name,
+  interval,
+  dataset = Dataset.GENERIC_METRICS,
 }: {
   aggregate: string;
   orgSlug: string;
   pageFilters: PageFilters;
   project: Project;
+  dataset?: Dataset;
+  interval?: string;
   name?: string;
   query?: string;
 }) {
@@ -24,13 +28,14 @@ export function getAlertsUrl({
   const environment = pageFilters.environments;
   const queryParams = {
     aggregate: aggregate,
-    dataset: Dataset.GENERIC_METRICS,
+    dataset,
     project: project.slug,
     eventTypes: 'transaction',
     query,
     statsPeriod,
     environment,
     name,
+    interval,
   };
   return normalizeUrl(
     `/organizations/${orgSlug}/alerts/new/metric/?${qs.stringify(queryParams)}`


### PR DESCRIPTION
Adds a button to create and Alert off of an explore chart, behind `alerts-eap` feature flag.
<img width="372" alt="image" src="https://github.com/user-attachments/assets/a716495e-dcab-4805-b528-ce6dba22cadd">
