### PR TITLE
fix(discover): Account for measurement units in events-meta

### DIFF
--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -1,11 +1,12 @@
 import re
+from collections.abc import Mapping
 
 import sentry_sdk
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import options, search
+from sentry import features, options, search
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
@@ -15,6 +16,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import GroupSerializer
 from sentry.api.utils import handle_query_errors
 from sentry.middleware import is_frontend_request
+from sentry.models.organization import Organization
 from sentry.snuba import spans_indexed, spans_metrics
 from sentry.snuba.query_sources import QuerySource
 from sentry.snuba.referrer import Referrer
@@ -27,6 +29,36 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
     }
     snuba_methods = ["GET"]
 
+    def get_features(self, organization: Organization, request: Request) -> Mapping[str, bool]:
+        feature_names = [
+            "organizations:dashboards-mep",
+            "organizations:mep-rollout-flag",
+            "organizations:performance-use-metrics",
+            "organizations:profiling",
+            "organizations:dynamic-sampling",
+            "organizations:use-metrics-layer",
+            "organizations:starfish-view",
+        ]
+        batch_features = features.batch_has(
+            feature_names,
+            organization=organization,
+            actor=request.user,
+        )
+
+        all_features = (
+            batch_features.get(f"organization:{organization.id}", {})
+            if batch_features is not None
+            else {}
+        )
+
+        for feature_name in feature_names:
+            if feature_name not in all_features:
+                all_features[feature_name] = features.has(
+                    feature_name, organization=organization, actor=request.user
+                )
+
+        return all_features
+
     def get(self, request: Request, organization) -> Response:
         try:
             snuba_params = self.get_snuba_params(request, organization)
@@ -35,12 +67,25 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
 
         dataset = self.get_dataset(request)
 
+        batch_features = self.get_features(organization, request)
+
+        use_metrics = (
+            (
+                batch_features.get("organizations:mep-rollout-flag", False)
+                and batch_features.get("organizations:dynamic-sampling", False)
+            )
+            or batch_features.get("organizations:performance-use-metrics", False)
+            or batch_features.get("organizations:dashboards-mep", False)
+        )
+
         with handle_query_errors():
             result = dataset.query(
                 selected_columns=["count()"],
                 snuba_params=snuba_params,
                 query=request.query_params.get("query"),
                 referrer=Referrer.API_ORGANIZATION_EVENTS_META.value,
+                has_metrics=use_metrics,
+                use_metrics_layer=batch_features.get("organizations:use-metrics-layer", False),
                 # TODO: @athena - add query_source when all datasets support it
                 # query_source=(
                 #     QuerySource.FRONTEND if is_frontend_request(request) else QuerySource.API

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -1,3 +1,5 @@
+from collections.abc import Mapping
+
 import sentry_sdk
 from django.core.exceptions import ValidationError
 from rest_framework import serializers
@@ -13,6 +15,7 @@ from sentry.api.utils import get_date_range_from_params
 from sentry.discover.arithmetic import categorize_columns
 from sentry.exceptions import InvalidParams, InvalidSearchQuery
 from sentry.models.environment import Environment
+from sentry.models.organization import Organization
 from sentry.search.events.builder.discover import DiscoverQueryBuilder
 from sentry.search.events.builder.errors import ErrorsQueryBuilder
 from sentry.search.events.types import QueryBuilderConfig
@@ -40,6 +43,7 @@ class DataExportQuerySerializer(serializers.Serializer):
 
     def validate(self, data):
         organization = self.context["organization"]
+        has_metrics = self.context["has_metrics"]
         query_info = data["query_info"]
 
         # Validate the project field, if provided
@@ -119,6 +123,7 @@ class DataExportQuerySerializer(serializers.Serializer):
                     config=QueryBuilderConfig(
                         auto_fields=True,
                         auto_aggregations=True,
+                        has_metrics=has_metrics,
                     ),
                 )
                 builder.get_snql_query()
@@ -134,6 +139,36 @@ class DataExportEndpoint(OrganizationEndpoint, EnvironmentMixin):
         "POST": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (OrganizationDataExportPermission,)
+
+    def get_features(self, organization: Organization, request: Request) -> Mapping[str, bool]:
+        feature_names = [
+            "organizations:dashboards-mep",
+            "organizations:mep-rollout-flag",
+            "organizations:performance-use-metrics",
+            "organizations:profiling",
+            "organizations:dynamic-sampling",
+            "organizations:use-metrics-layer",
+            "organizations:starfish-view",
+        ]
+        batch_features = features.batch_has(
+            feature_names,
+            organization=organization,
+            actor=request.user,
+        )
+
+        all_features = (
+            batch_features.get(f"organization:{organization.id}", {})
+            if batch_features is not None
+            else {}
+        )
+
+        for feature_name in feature_names:
+            if feature_name not in all_features:
+                all_features[feature_name] = features.has(
+                    feature_name, organization=organization, actor=request.user
+                )
+
+        return all_features
 
     def post(self, request: Request, organization) -> Response:
         """
@@ -152,6 +187,17 @@ class DataExportEndpoint(OrganizationEndpoint, EnvironmentMixin):
             return Response(error, status=400)
         limit = request.data.get("limit")
 
+        batch_features = self.get_features(organization, request)
+
+        use_metrics = (
+            (
+                batch_features.get("organizations:mep-rollout-flag", False)
+                and batch_features.get("organizations:dynamic-sampling", False)
+            )
+            or batch_features.get("organizations:performance-use-metrics", False)
+            or batch_features.get("organizations:dashboards-mep", False)
+        )
+
         # Validate the data export payload
         serializer = DataExportQuerySerializer(
             data=request.data,
@@ -161,6 +207,7 @@ class DataExportEndpoint(OrganizationEndpoint, EnvironmentMixin):
                     request=request, organization=organization, project_ids=project_query
                 ),
                 "get_projects": lambda: self.get_projects(request, organization),
+                "has_metrics": use_metrics,
             },
         )
         if not serializer.is_valid():

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -1,5 +1,3 @@
-from collections.abc import Mapping
-
 import sentry_sdk
 from django.core.exceptions import ValidationError
 from rest_framework import serializers
@@ -140,7 +138,7 @@ class DataExportEndpoint(OrganizationEndpoint, EnvironmentMixin):
     }
     permission_classes = (OrganizationDataExportPermission,)
 
-    def get_features(self, organization: Organization, request: Request) -> Mapping[str, bool]:
+    def get_features(self, organization: Organization, request: Request) -> dict[str, bool | None]:
         feature_names = [
             "organizations:dashboards-mep",
             "organizations:mep-rollout-flag",

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -5,14 +5,10 @@ from django.urls import reverse
 from rest_framework.exceptions import ParseError
 
 from sentry.issues.grouptype import ProfileFileIOGroupType
-from sentry.testutils.cases import (
-    APITestCase,
-    MetricsEnhancedPerformanceTestCase,
-    SnubaTestCase,
-    load_data,
-)
+from sentry.testutils.cases import APITestCase, MetricsEnhancedPerformanceTestCase, SnubaTestCase
 from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.datetime import before_now
+from sentry.utils.samples import load_data
 from tests.sentry.issues.test_utils import SearchIssueTestMixin
 
 pytestmark = pytest.mark.sentry_metrics

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -5,7 +5,12 @@ from django.urls import reverse
 from rest_framework.exceptions import ParseError
 
 from sentry.issues.grouptype import ProfileFileIOGroupType
-from sentry.testutils.cases import APITestCase, SnubaTestCase
+from sentry.testutils.cases import (
+    APITestCase,
+    MetricsEnhancedPerformanceTestCase,
+    SnubaTestCase,
+    load_data,
+)
 from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.datetime import before_now
 from tests.sentry.issues.test_utils import SearchIssueTestMixin
@@ -13,7 +18,9 @@ from tests.sentry.issues.test_utils import SearchIssueTestMixin
 pytestmark = pytest.mark.sentry_metrics
 
 
-class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase, SearchIssueTestMixin):
+class OrganizationEventsMetaEndpoint(
+    APITestCase, MetricsEnhancedPerformanceTestCase, SearchIssueTestMixin
+):
     def setUp(self):
         super().setUp()
         self.min_ago = before_now(minutes=1)
@@ -67,6 +74,44 @@ class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase, SearchIssueTest
 
         assert response.status_code == 200, response.content
         assert response.data["count"] == 1
+
+    def test_custom_measurements_query_uses_units(self):
+        self.store_transaction_metric(
+            33,
+            metric="measurements.custom",
+            internal_metric="d:transactions/measurements.custom@second",
+            entity="metrics_distributions",
+            tags={"transaction": "foo_transaction"},
+            timestamp=self.min_ago,
+        )
+        data = load_data("transaction", timestamp=self.min_ago)
+        data["measurements"] = {
+            "custom": {"value": 0.199, "unit": "second"},
+        }
+        self.store_event(data, self.project.id)
+        data = load_data("transaction", timestamp=self.min_ago)
+        data["measurements"] = {
+            "custom": {"value": 0.201, "unit": "second"},
+        }
+        self.store_event(data, self.project.id)
+        url = reverse(
+            "sentry-api-0-organization-events-meta",
+            kwargs={"organization_id_or_slug": self.project.organization.slug},
+        )
+        features = {
+            "organizations:discover-basic": True,
+            "organizations:performance-use-metrics": True,
+        }
+        for dataset in ["discover", "transactions"]:
+            query = {
+                "field": ["measurements.custom"],
+                "query": "measurements.custom:>200",
+                "dataset": dataset,
+            }
+            with self.feature(features):
+                response = self.client.get(url, query, format="json")
+            assert response.status_code == 200, response.content
+            assert response.data["count"] == 1
 
     def test_invalid_query(self):
         with self.feature(self.features):


### PR DESCRIPTION
We make a metrics query to check for custom measurement units. We
weren't doing that for events-meta and data export. This fixes https://github.com/getsentry/sentry/issues/80068