### PR TITLE
ref(replay): add flutter onboarding to sidebar

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/utils/replayOnboarding.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/replayOnboarding.tsx
@@ -8,7 +8,7 @@ import {tct} from 'sentry/locale';
 
 export const getReplayMobileConfigureDescription = ({link}: {link: string}) =>
   tct(
-    'The SDK aggressively redacts all text and images. We plan to add fine controls for redacting, but currently, we just allow either on or off. Learn more about configuring Session Replay by reading the [link:configuration docs].',
+    'The SDK aggressively redacts all text and images by default. You can easily configure the unmasking or masking behavior. Learn more about configuring Session Replay by reading the [link:configuration docs].',
     {
       link: <ExternalLink href={link} />,
     }

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -464,6 +464,7 @@ export const replayMobilePlatforms: PlatformKey[] = [
   'android',
   'apple-ios',
   'react-native',
+  'flutter',
 ];
 
 // These are all the platforms that can set up replay.

--- a/static/app/gettingStartedDocs/flutter/flutter.tsx
+++ b/static/app/gettingStartedDocs/flutter/flutter.tsx
@@ -10,8 +10,13 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {MobileBetaBanner} from 'sentry/components/onboarding/gettingStartedDoc/utils';
 import exampleSnippets from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsExampleSnippets';
 import {metricTagsExplanation} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
+import {
+  getReplayMobileConfigureDescription,
+  getReplayVerifyStep,
+} from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
 import {feedbackOnboardingCrashApiDart} from 'sentry/gettingStartedDocs/dart/dart';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
@@ -108,6 +113,21 @@ Future<void> main() async {
     appRunner: initApp, // Init your App.
   );
 };`;
+
+const getInstallReplaySnippet = () => `
+await SentryFlutter.init(
+  (options) {
+    ...
+    options.experimental.replay.sessionSampleRate = 1.0;
+    options.experimental.replay.onErrorSampleRate = 1.0;
+  },
+  appRunner: () => runApp(MyApp()),
+);
+`;
+
+const getConfigureReplaySnippet = () => `
+options.experimental.replay.maskAllText = true;
+options.experimental.replay.maskAllImages = true;`;
 
 const metricsOnboarding: OnboardingConfig = {
   install: (params: DocsParams) => [
@@ -347,11 +367,84 @@ const onboarding: OnboardingConfig = {
   ],
 };
 
+const replayOnboarding: OnboardingConfig = {
+  introduction: () => (
+    <MobileBetaBanner link="https://docs.sentry.io/platforms/flutter/session-replay/" />
+  ),
+  install: (params: Params) => [
+    {
+      type: StepType.INSTALL,
+      description: tct(
+        'Make sure your Sentry Flutter SDK version is at least 8.9.0, which is required for Session Replay. You can update your [code:pubspec.yaml] to the matching version:',
+        {code: <code />}
+      ),
+      configurations: [
+        {
+          code: [
+            {
+              label: 'YAML',
+              value: 'yaml',
+              language: 'yaml',
+              code: getInstallSnippet(params),
+            },
+          ],
+        },
+        {
+          description: t(
+            'To set up the integration, add the following to your Sentry initialization:'
+          ),
+        },
+        {
+          code: [
+            {
+              label: 'Dart',
+              value: 'dart',
+              language: 'dart',
+              code: getInstallReplaySnippet(),
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  configure: () => [
+    {
+      type: StepType.CONFIGURE,
+      description: getReplayMobileConfigureDescription({
+        link: 'https://docs.sentry.io/platforms/flutter/session-replay/#privacy',
+      }),
+      configurations: [
+        {
+          description: t(
+            'The following code is the default configuration, which masks and blocks everything.'
+          ),
+          code: [
+            {
+              label: 'Dart',
+              value: 'dart',
+              language: 'dart',
+              code: getConfigureReplaySnippet(),
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  verify: getReplayVerifyStep({
+    replayOnErrorSampleRateName:
+      'options\u200b.experimental\u200b.sessionReplay\u200b.onErrorSampleRate',
+    replaySessionSampleRateName:
+      'options\u200b.experimental\u200b.sessionReplay\u200b.sessionSampleRate',
+  }),
+  nextSteps: () => [],
+};
+
 const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: feedbackOnboardingCrashApiDart,
   crashReportOnboarding: feedbackOnboardingCrashApiDart,
   customMetricsOnboarding: metricsOnboarding,
+  replayOnboarding,
 };
 
 export default docs;

--- a/static/app/utils/replays/projectSupportsReplay.spec.tsx
+++ b/static/app/utils/replays/projectSupportsReplay.spec.tsx
@@ -58,13 +58,12 @@ describe('projectSupportsReplay & projectCanLinkToReplay', () => {
     }
   );
 
-  it.each([
-    'apple-macos' as PlatformKey,
-    'flutter' as PlatformKey,
-    'unity' as PlatformKey,
-  ])('should FAIL for Desktop framework %s', platform => {
-    const project = mockProjectFixture(platform);
-    expect(projectSupportsReplay(project)).toBeFalsy();
-    expect(projectCanLinkToReplay(organization, project)).toBeFalsy();
-  });
+  it.each(['apple-macos' as PlatformKey, 'unreal' as PlatformKey])(
+    'should FAIL for Desktop framework %s',
+    platform => {
+      const project = mockProjectFixture(platform);
+      expect(projectSupportsReplay(project)).toBeFalsy();
+      expect(projectCanLinkToReplay(organization, project)).toBeFalsy();
+    }
+  );
 });


### PR DESCRIPTION
add flutter onboarding to the sidebar. mirrors the docs here: https://docs.sentry.io/platforms/flutter/session-replay/

closes https://github.com/getsentry/sentry/issues/80234

before:

<img width="1132" alt="SCR-20241105-kuew" src="https://github.com/user-attachments/assets/76099fd6-2e1d-47a5-bb49-bf98bd561a01">


after:


<img width="880" alt="SCR-20241105-ktnn" src="https://github.com/user-attachments/assets/71732ab4-ec02-42c2-b4c9-364d9411b165">
