### PR TITLE
feat(insights): Add insights query date range footer hook

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -199,6 +199,7 @@ export type ComponentHooks = {
   'component:first-party-integration-alert': () => React.ComponentType<FirstPartyIntegrationAlertProps>;
   'component:header-date-range': () => React.ComponentType<DateRangeProps>;
   'component:header-selector-items': () => React.ComponentType<SelectorItemsProps>;
+  'component:insights-date-range-query-limit-footer': () => React.ComponentType<{}>;
   'component:insights-upsell-page': () => React.ComponentType<InsightsUpsellHook>;
   'component:member-list-header': () => React.ComponentType<MemberListHeaderProps>;
   'component:monitor-status-toggle': () => React.ComponentType<StatusToggleButtonProps>;

--- a/static/app/views/insights/common/components/modulePageFilterBar.tsx
+++ b/static/app/views/insights/common/components/modulePageFilterBar.tsx
@@ -2,6 +2,7 @@ import {type ComponentProps, Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 import moment from 'moment-timezone';
 
+import HookOrDefault from 'sentry/components/hookOrDefault';
 import {
   DatePageFilter,
   type DatePageFilterProps,
@@ -85,6 +86,7 @@ export function ModulePageFilterBar({moduleName, onProjectChange, extraFilters}:
       const dateDifferenceMs = getDateDifferenceMs(value);
       return dateDifferenceMs > QUERY_DATE_RANGE_LIMIT_MS;
     };
+    dateFilterProps.menuFooter = <UpsellFooterHook />;
   }
 
   return (
@@ -140,3 +142,8 @@ const memoizedDateDifference = () => {
     return difference;
   };
 };
+
+export const UpsellFooterHook = HookOrDefault({
+  hookName: 'component:insights-date-range-query-limit-footer',
+  defaultComponent: ({}) => undefined,
+});


### PR DESCRIPTION
adds the footer to the date range selector when the user has a date range query limit enabled.

See https://github.com/getsentry/getsentry/pull/15635 for screenshot and more details.