### PR TITLE
fix(alerts): Remove extra paren

### DIFF
--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -540,7 +540,6 @@ class TriggersChart extends PureComponent<Props, State> {
               });
             }}
           </OnDemandMetricRequest>
-          );
         </Fragment>
       );
     }


### PR DESCRIPTION
Doing some debugging, found this extra parens when rendering the chart

<img width="1028" alt="Screenshot 2024-11-05 at 3 37 41 PM" src="https://github.com/user-attachments/assets/7b8e06da-8fd5-4361-b0ec-3017fb3e8c6e">
