### PR TITLE
fix(alerts): add guard for `on-demand-metrics-ui` flag

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -1192,7 +1192,9 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
         />
       );
     }
-    const isOnDemand = isOnDemandMetricAlert(dataset, aggregate, query);
+    const isOnDemand =
+      organization.features.includes('on-demand-metrics-ui') &&
+      isOnDemandMetricAlert(dataset, aggregate, query);
 
     let formattedAggregate = aggregate;
     if (alertType === 'custom_metrics') {


### PR DESCRIPTION
Unclear at the moment if this is the ideal solution!

Locally, moving this `isOnDemand` check behind a feature flag seems to fix the **New Alert Rule** preview charts for Performance metrics with specific queries (`has:http.url` is one that is consistently broken).

Closes [ALRT-369](https://getsentry.atlassian.net/browse/ALRT-369).

[ALRT-369]: https://getsentry.atlassian.net/browse/ALRT-369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ