### PR TITLE
feat(issues): Hide "comment" button until focused

### DIFF
--- a/static/app/views/issueDetails/streamline/activitySection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/activitySection.spec.tsx
@@ -65,7 +65,14 @@ describe('StreamlinedActivitySection', function () {
 
     const commentInput = screen.getByRole('textbox', {name: 'Add a comment'});
     expect(commentInput).toBeInTheDocument();
-    const submitButton = screen.getByRole('button', {name: 'Submit comment'});
+    expect(
+      screen.queryByRole('button', {name: 'Submit comment'})
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(commentInput);
+
+    // Button appears after input is focused
+    const submitButton = await screen.findByRole('button', {name: 'Submit comment'});
     expect(submitButton).toBeInTheDocument();
 
     expect(submitButton).toBeDisabled();

--- a/static/app/views/issueDetails/streamline/activitySection.tsx
+++ b/static/app/views/issueDetails/streamline/activitySection.tsx
@@ -102,7 +102,7 @@ export default function StreamlinedActivitySection({group}: {group: Group}) {
     minHeight: 140,
     group,
     projectSlugs,
-    placeholder: t('Add a comment...'),
+    placeholder: t('Add a comment\u2026'),
   };
 
   const mutators = useMutateActivity({

--- a/static/app/views/issueDetails/streamline/note.tsx
+++ b/static/app/views/issueDetails/streamline/note.tsx
@@ -64,6 +64,7 @@ function StreamlinedNoteInput({
 
   const [memberMentions, setMemberMentions] = useState<Mentioned[]>([]);
   const [teamMentions, setTeamMentions] = useState<Mentioned[]>([]);
+  const [isSubmitHidden, setIsSubmitHidden] = useState(true);
 
   const canSubmit = value.trim() !== '';
 
@@ -86,8 +87,17 @@ function StreamlinedNoteInput({
     [existingItem, onUpdate, cleanMarkdown, finalizedMentions, onCreate]
   );
 
+  const displaySubmitButton = useCallback(() => {
+    setIsSubmitHidden(false);
+  }, []);
+
   const handleSubmit = useCallback(
-    (e: React.MouseEvent<HTMLFormElement>) => {
+    (
+      e:
+        | React.FormEvent<HTMLFormElement>
+        | React.KeyboardEvent<HTMLTextAreaElement>
+        | React.KeyboardEvent<HTMLInputElement>
+    ) => {
       e.preventDefault();
       submitForm();
     },
@@ -106,7 +116,7 @@ function StreamlinedNoteInput({
     []
   );
 
-  const handleChange: MentionsInputProps['onChange'] = useCallback(
+  const handleChange = useCallback<NonNullable<MentionsInputProps['onChange']>>(
     e => {
       setValue(e.target.value);
       onChange?.(e, {updating: existingItem});
@@ -114,7 +124,7 @@ function StreamlinedNoteInput({
     [existingItem, onChange]
   );
 
-  const handleKeyDown: MentionsInputProps['onKeyDown'] = useCallback(
+  const handleKeyDown = useCallback<NonNullable<MentionsInputProps['onKeyDown']>>(
     e => {
       if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && canSubmit) {
         handleSubmit(e);
@@ -142,6 +152,7 @@ function StreamlinedNoteInput({
         placeholder={placeholder}
         onChange={handleChange}
         onKeyDown={handleKeyDown}
+        onFocus={displaySubmitButton}
         value={value}
         required
       >
@@ -161,15 +172,17 @@ function StreamlinedNoteInput({
           appendSpaceOnAdd
         />
       </MentionsInput>
-      <Button
-        priority="primary"
-        size="xs"
-        disabled={!canSubmit}
-        aria-label={t('Submit comment')}
-        type="submit"
-      >
-        {t('Comment')}
-      </Button>
+      {!isSubmitHidden && (
+        <Button
+          priority="primary"
+          size="xs"
+          disabled={!canSubmit}
+          aria-label={t('Submit comment')}
+          type="submit"
+        >
+          {t('Comment')}
+        </Button>
+      )}
     </NoteInputForm>
   );
 }

--- a/static/app/views/issueDetails/streamline/note.tsx
+++ b/static/app/views/issueDetails/streamline/note.tsx
@@ -64,7 +64,7 @@ function StreamlinedNoteInput({
 
   const [memberMentions, setMemberMentions] = useState<Mentioned[]>([]);
   const [teamMentions, setTeamMentions] = useState<Mentioned[]>([]);
-  const [isSubmitHidden, setIsSubmitHidden] = useState(true);
+  const [isSubmitVisible, setIsSubmitVisible] = useState(false);
 
   const canSubmit = value.trim() !== '';
 
@@ -88,7 +88,7 @@ function StreamlinedNoteInput({
   );
 
   const displaySubmitButton = useCallback(() => {
-    setIsSubmitHidden(false);
+    setIsSubmitVisible(true);
   }, []);
 
   const handleSubmit = useCallback(
@@ -172,7 +172,7 @@ function StreamlinedNoteInput({
           appendSpaceOnAdd
         />
       </MentionsInput>
-      {!isSubmitHidden && (
+      {isSubmitVisible && (
         <Button
           priority="primary"
           size="xs"

--- a/static/app/views/issueDetails/streamline/sidebar.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar.spec.tsx
@@ -107,7 +107,7 @@ describe('StreamlinedSidebar', function () {
     expect(mockExternalIssues).toHaveBeenCalled();
 
     expect(screen.getByRole('heading', {name: 'Activity'})).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('Add a comment...')).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: /Add a comment/})).toBeInTheDocument();
     expect(screen.getByText(activityContent)).toBeInTheDocument();
 
     expect(screen.getByRole('heading', {name: 'Similar Issues'})).toBeInTheDocument();


### PR DESCRIPTION
- Hides the comment submit button until the comment box has been focused
- fixes some implict any and replaces '...' with the thing that translate can use

before clicking on input
![image](https://github.com/user-attachments/assets/5fafa5f3-1ea5-43d6-b7ce-3f4c5d5d1197)

after clicking on input - the button will stay visible until its unmounted
![image](https://github.com/user-attachments/assets/506cab90-6d63-40ec-9a80-d0e30e38af57)
