### PR TITLE
chore(integrations): SourceCodeIssueIntegration metrics

### DIFF
--- a/src/sentry/integrations/bitbucket/issues.py
+++ b/src/sentry/integrations/bitbucket/issues.py
@@ -6,6 +6,9 @@ from typing import Any
 from django.urls import reverse
 
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
+from sentry.integrations.source_code_management.metrics import (
+    SourceCodeIssueIntegrationInteractionType,
+)
 from sentry.models.group import Group
 from sentry.shared_integrations.exceptions import ApiError, IntegrationFormError
 from sentry.silo.base import all_silo_function
@@ -119,24 +122,25 @@ class BitbucketIssuesSpec(SourceCodeIssueIntegration):
         ]
 
     def create_issue(self, data, **kwargs):
-        client = self.get_client()
-        if not data.get("repo"):
-            raise IntegrationFormError({"repo": ["Repository is required"]})
+        with self.record_event(SourceCodeIssueIntegrationInteractionType.CREATE_ISSUE).capture():
+            client = self.get_client()
+            if not data.get("repo"):
+                raise IntegrationFormError({"repo": ["Repository is required"]})
 
-        data["content"] = {"raw": data["description"]}
-        del data["description"]
+            data["content"] = {"raw": data["description"]}
+            del data["description"]
 
-        try:
-            issue = client.create_issue(data.get("repo"), data)
-        except ApiError as e:
-            self.raise_error(e)
+            try:
+                issue = client.create_issue(data.get("repo"), data)
+            except ApiError as e:
+                self.raise_error(e)
 
-        return {
-            "key": issue["id"],
-            "title": issue["title"],
-            "description": issue["content"]["html"],  # users content rendered as html
-            "repo": data.get("repo"),
-        }
+            return {
+                "key": issue["id"],
+                "title": issue["title"],
+                "description": issue["content"]["html"],  # users content rendered as html
+                "repo": data.get("repo"),
+            }
 
     def get_issue(self, issue_id, **kwargs):
         client = self.get_client()

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -11,6 +11,9 @@ from sentry.eventstore.models import Event, GroupEvent
 from sentry.integrations.mixins.issues import MAX_CHAR
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
+from sentry.integrations.source_code_management.metrics import (
+    SourceCodeIssueIntegrationInteractionType,
+)
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import Group
 from sentry.organizations.services.organization.service import organization_service
@@ -170,33 +173,34 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
         ]
 
     def create_issue(self, data: Mapping[str, Any], **kwargs: Any) -> Mapping[str, Any]:
-        client = self.get_client()
+        with self.record_event(SourceCodeIssueIntegrationInteractionType.CREATE_ISSUE).capture():
+            client = self.get_client()
 
-        repo = data.get("repo")
+            repo = data.get("repo")
 
-        if not repo:
-            raise IntegrationError("repo kwarg must be provided")
+            if not repo:
+                raise IntegrationError("repo kwarg must be provided")
 
-        try:
-            issue = client.create_issue(
-                repo=repo,
-                data={
-                    "title": data["title"],
-                    "body": data["description"],
-                    "assignee": data.get("assignee"),
-                    "labels": data.get("labels"),
-                },
-            )
-        except ApiError as e:
-            raise IntegrationError(self.message_from_error(e))
+            try:
+                issue = client.create_issue(
+                    repo=repo,
+                    data={
+                        "title": data["title"],
+                        "body": data["description"],
+                        "assignee": data.get("assignee"),
+                        "labels": data.get("labels"),
+                    },
+                )
+            except ApiError as e:
+                raise IntegrationError(self.message_from_error(e))
 
-        return {
-            "key": issue["number"],
-            "title": issue["title"],
-            "description": issue["body"],
-            "url": issue["html_url"],
-            "repo": repo,
-        }
+            return {
+                "key": issue["number"],
+                "title": issue["title"],
+                "description": issue["body"],
+                "url": issue["html_url"],
+                "repo": repo,
+            }
 
     def get_link_issue_config(self, group: Group, **kwargs: Any) -> list[dict[str, Any]]:
         params = kwargs.pop("params", {})

--- a/src/sentry/integrations/source_code_management/issues.py
+++ b/src/sentry/integrations/source_code_management/issues.py
@@ -5,40 +5,55 @@ from collections.abc import Mapping
 from typing import Any
 
 from sentry.integrations.mixins.issues import IssueBasicIntegration
+from sentry.integrations.source_code_management.metrics import (
+    SourceCodeIssueIntegrationInteractionEvent,
+    SourceCodeIssueIntegrationInteractionType,
+)
 from sentry.integrations.source_code_management.repository import BaseRepositoryIntegration
 from sentry.models.group import Group
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 
 
 class SourceCodeIssueIntegration(IssueBasicIntegration, BaseRepositoryIntegration, ABC):
+    def record_event(self, event: SourceCodeIssueIntegrationInteractionType):
+        return SourceCodeIssueIntegrationInteractionEvent(
+            interaction_type=event,
+            provider_key=self.integration_name,
+            organization=self.organization,
+            org_integration=self.org_integration,
+        )
+
     def get_repository_choices(self, group: Group | None, params: Mapping[str, Any], **kwargs):
         """
         Returns the default repository and a set/subset of repositories of associated with the installation
         """
-        try:
-            repos = self.get_repositories()
-        except ApiError:
-            raise IntegrationError("Unable to retrieve repositories. Please try again later.")
-        else:
-            repo_choices = [(repo["identifier"], repo["name"]) for repo in repos]
+        with self.record_event(
+            SourceCodeIssueIntegrationInteractionType.GET_REPOSITORY_CHOICES
+        ).capture():
+            try:
+                repos = self.get_repositories()
+            except ApiError:
+                raise IntegrationError("Unable to retrieve repositories. Please try again later.")
+            else:
+                repo_choices = [(repo["identifier"], repo["name"]) for repo in repos]
 
-        defaults = self.get_project_defaults(group.project_id) if group else {}
-        repo = params.get("repo") or defaults.get("repo")
+            defaults = self.get_project_defaults(group.project_id) if group else {}
+            repo = params.get("repo") or defaults.get("repo")
 
-        try:
-            default_repo = repo or repo_choices[0][0]
-        except IndexError:
-            return "", repo_choices
+            try:
+                default_repo = repo or repo_choices[0][0]
+            except IndexError:
+                return "", repo_choices
 
-        # If a repo has been selected outside of the default list of
-        # repos, stick it onto the front of the list so that it can be
-        # selected.
-        try:
-            next(True for r in repo_choices if r[0] == default_repo)
-        except StopIteration:
-            repo_choices.insert(0, self.create_default_repo_choice(default_repo))
+            # If a repo has been selected outside of the default list of
+            # repos, stick it onto the front of the list so that it can be
+            # selected.
+            try:
+                next(True for r in repo_choices if r[0] == default_repo)
+            except StopIteration:
+                repo_choices.insert(0, self.create_default_repo_choice(default_repo))
 
-        return default_repo, repo_choices
+            return default_repo, repo_choices
 
     # TODO(saif): Make private and move all usages over to `get_defaults`
     def get_project_defaults(self, project_id):

--- a/src/sentry/integrations/source_code_management/issues.py
+++ b/src/sentry/integrations/source_code_management/issues.py
@@ -18,7 +18,7 @@ class SourceCodeIssueIntegration(IssueBasicIntegration, BaseRepositoryIntegratio
     def record_event(self, event: SourceCodeIssueIntegrationInteractionType):
         return SourceCodeIssueIntegrationInteractionEvent(
             interaction_type=event,
-            provider_key=self.integration_name,
+            provider_key=self.model.provider,
             organization=self.organization,
             org_integration=self.org_integration,
         )

--- a/src/sentry/integrations/source_code_management/metrics.py
+++ b/src/sentry/integrations/source_code_management/metrics.py
@@ -25,6 +25,17 @@ class RepositoryIntegrationInteractionType(Enum):
         return self.value.lower()
 
 
+class SourceCodeIssueIntegrationInteractionType(Enum):
+    """
+    A SourceCodeIssueIntegration feature.
+    """
+
+    GET_REPOSITORY_CHOICES = "GET_REPOSITORY_CHOICES"
+    CREATE_ISSUE = "CREATE_ISSUE"
+    SYNC_STATUS_OUTBOUND = "SYNC_STATUS_OUTBOUND"
+    SYNC_ASSIGNEE_OUTBOUND = "SYNC_ASSIGNEE_OUTBOUND"
+
+
 @dataclass
 class RepositoryIntegrationInteractionEvent(IntegrationEventLifecycleMetric):
     """
@@ -32,6 +43,35 @@ class RepositoryIntegrationInteractionEvent(IntegrationEventLifecycleMetric):
     """
 
     interaction_type: RepositoryIntegrationInteractionType
+    provider_key: str
+
+    # Optional attributes to populate extras
+    organization: Organization | RpcOrganization | None = None
+    org_integration: OrganizationIntegration | RpcOrganizationIntegration | None = None
+
+    def get_integration_domain(self) -> IntegrationDomain:
+        return IntegrationDomain.SOURCE_CODE_MANAGEMENT
+
+    def get_integration_name(self) -> str:
+        return self.provider_key
+
+    def get_interaction_type(self) -> str:
+        return str(self.interaction_type)
+
+    def get_extras(self) -> Mapping[str, Any]:
+        return {
+            "organization_id": (self.organization.id if self.organization else None),
+            "org_integration_id": (self.org_integration.id if self.org_integration else None),
+        }
+
+
+@dataclass
+class SourceCodeIssueIntegrationInteractionEvent(IntegrationEventLifecycleMetric):
+    """
+    An instance to be recorded of a SourceCodeIssueIntegration feature call.
+    """
+
+    interaction_type: SourceCodeIssueIntegrationInteractionType
     provider_key: str
 
     # Optional attributes to populate extras

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -11,6 +11,9 @@ from sentry.integrations.mixins import ResolveSyncAction
 from sentry.integrations.mixins.issues import IssueSyncIntegration
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
+from sentry.integrations.source_code_management.metrics import (
+    SourceCodeIssueIntegrationInteractionType,
+)
 from sentry.models.activity import Activity
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
 from sentry.silo.base import all_silo_function
@@ -168,35 +171,36 @@ class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration):
         """
         Creates the issue on the remote service and returns an issue ID.
         """
-        project_id = data.get("project")
-        if project_id is None:
-            raise ValueError("Azure DevOps expects project")
+        with self.record_event(SourceCodeIssueIntegrationInteractionType.CREATE_ISSUE).capture():
+            project_id = data.get("project")
+            if project_id is None:
+                raise ValueError("Azure DevOps expects project")
 
-        client = self.get_client()
+            client = self.get_client()
 
-        title = data["title"]
-        description = data["description"]
-        item_type = data["work_item_type"]
+            title = data["title"]
+            description = data["description"]
+            item_type = data["work_item_type"]
 
-        try:
-            created_item = client.create_work_item(
-                project=project_id,
-                item_type=item_type,
-                title=title,
-                # Descriptions cannot easily be seen. So, a comment will be added as well.
-                description=markdown(description),
-                comment=markdown(description),
-            )
-        except Exception as e:
-            self.raise_error(e)
+            try:
+                created_item = client.create_work_item(
+                    project=project_id,
+                    item_type=item_type,
+                    title=title,
+                    # Descriptions cannot easily be seen. So, a comment will be added as well.
+                    description=markdown(description),
+                    comment=markdown(description),
+                )
+            except Exception as e:
+                self.raise_error(e)
 
-        project_name = created_item["fields"]["System.AreaPath"]
-        return {
-            "key": str(created_item["id"]),
-            "title": title,
-            "description": description,
-            "metadata": {"display_name": "{}#{}".format(project_name, created_item["id"])},
-        }
+            project_name = created_item["fields"]["System.AreaPath"]
+            return {
+                "key": str(created_item["id"]),
+                "title": title,
+                "description": description,
+                "metadata": {"display_name": "{}#{}".format(project_name, created_item["id"])},
+            }
 
     def get_issue(self, issue_id: int, **kwargs: Any) -> Mapping[str, Any]:
         client = self.get_client()
@@ -219,100 +223,110 @@ class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration):
         assign: bool = True,
         **kwargs: Any,
     ) -> None:
-        client = self.get_client()
-        assignee = None
+        with self.record_event(
+            SourceCodeIssueIntegrationInteractionType.SYNC_ASSIGNEE_OUTBOUND
+        ).capture() as lifecycle:
+            client = self.get_client()
+            assignee = None
 
-        if user and assign is True:
-            sentry_emails = [email.lower() for email in user.emails]
-            continuation_token = None
-            while True:
-                vsts_users = client.get_users(self.model.name, continuation_token)
-                continuation_token = vsts_users.headers.get("X-MS-ContinuationToken")
-                for vsts_user in vsts_users["value"]:
-                    vsts_email = vsts_user.get("mailAddress")
-                    if vsts_email and vsts_email.lower() in sentry_emails:
-                        assignee = vsts_user["mailAddress"]
+            if user and assign is True:
+                sentry_emails = [email.lower() for email in user.emails]
+                continuation_token = None
+                while True:
+                    vsts_users = client.get_users(self.model.name, continuation_token)
+                    continuation_token = vsts_users.headers.get("X-MS-ContinuationToken")
+                    for vsts_user in vsts_users["value"]:
+                        vsts_email = vsts_user.get("mailAddress")
+                        if vsts_email and vsts_email.lower() in sentry_emails:
+                            assignee = vsts_user["mailAddress"]
+                            break
+
+                    if not continuation_token:
                         break
 
-                if not continuation_token:
-                    break
+                if assignee is None:
+                    # TODO(lb): Email people when this happens
+                    self.logger.info(
+                        "vsts.assignee-not-found",
+                        extra={
+                            "integration_id": external_issue.integration_id,
+                            "user_id": user.id,
+                            "issue_key": external_issue.key,
+                        },
+                    )
+                    lifecycle.record_halt()
+                    return
 
-            if assignee is None:
-                # TODO(lb): Email people when this happens
+            try:
+                client.update_work_item(external_issue.key, assigned_to=assignee)
+            except (ApiUnauthorized, ApiError):
                 self.logger.info(
-                    "vsts.assignee-not-found",
+                    "vsts.failed-to-assign",
                     extra={
                         "integration_id": external_issue.integration_id,
-                        "user_id": user.id,
+                        "user_id": user.id if user else None,
                         "issue_key": external_issue.key,
                     },
                 )
-                return
-
-        try:
-            client.update_work_item(external_issue.key, assigned_to=assignee)
-        except (ApiUnauthorized, ApiError):
-            self.logger.info(
-                "vsts.failed-to-assign",
-                extra={
-                    "integration_id": external_issue.integration_id,
-                    "user_id": user.id if user else None,
-                    "issue_key": external_issue.key,
-                },
-            )
+                lifecycle.record_halt()
 
     def sync_status_outbound(
         self, external_issue: "ExternalIssue", is_resolved: bool, project_id: int, **kwargs: Any
     ) -> None:
-        client = self.get_client()
-        work_item = client.get_work_item(external_issue.key)
-        # For some reason, vsts doesn't include the project id
-        # in the work item response.
-        # TODO(jess): figure out if there's a better way to do this
-        vsts_project_name = work_item["fields"]["System.TeamProject"]
+        with self.record_event(
+            SourceCodeIssueIntegrationInteractionType.SYNC_STATUS_OUTBOUND
+        ).capture() as lifecycle:
+            client = self.get_client()
+            work_item = client.get_work_item(external_issue.key)
+            # For some reason, vsts doesn't include the project id
+            # in the work item response.
+            # TODO(jess): figure out if there's a better way to do this
+            vsts_project_name = work_item["fields"]["System.TeamProject"]
 
-        vsts_projects = client.get_projects()
+            vsts_projects = client.get_projects()
 
-        vsts_project_id = None
-        for p in vsts_projects:
-            if p["name"] == vsts_project_name:
-                vsts_project_id = p["id"]
-                break
+            vsts_project_id = None
+            for p in vsts_projects:
+                if p["name"] == vsts_project_name:
+                    vsts_project_id = p["id"]
+                    break
 
-        integration_external_project = integration_service.get_integration_external_project(
-            organization_id=external_issue.organization_id,
-            integration_id=external_issue.integration_id,
-            external_id=vsts_project_id,
-        )
-        if integration_external_project is None:
-            self.logger.info(
-                "vsts.external-project-not-found",
-                extra={
-                    "integration_id": external_issue.integration_id,
-                    "is_resolved": is_resolved,
-                    "issue_key": external_issue.key,
-                },
+            integration_external_project = integration_service.get_integration_external_project(
+                organization_id=external_issue.organization_id,
+                integration_id=external_issue.integration_id,
+                external_id=vsts_project_id,
             )
-            return
+            if integration_external_project is None:
+                self.logger.info(
+                    "vsts.external-project-not-found",
+                    extra={
+                        "integration_id": external_issue.integration_id,
+                        "is_resolved": is_resolved,
+                        "issue_key": external_issue.key,
+                    },
+                )
+                lifecycle.record_halt()
+                return
 
-        status = (
-            integration_external_project.resolved_status
-            if is_resolved
-            else integration_external_project.unresolved_status
-        )
-
-        try:
-            client.update_work_item(external_issue.key, state=status)
-        except (ApiUnauthorized, ApiError) as error:
-            self.logger.info(
-                "vsts.failed-to-change-status",
-                extra={
-                    "integration_id": external_issue.integration_id,
-                    "is_resolved": is_resolved,
-                    "issue_key": external_issue.key,
-                    "exception": error,
-                },
+            status = (
+                integration_external_project.resolved_status
+                if is_resolved
+                else integration_external_project.unresolved_status
             )
+
+            try:
+                client.update_work_item(external_issue.key, state=status)
+            except (ApiUnauthorized, ApiError) as error:
+                self.logger.info(
+                    "vsts.failed-to-change-status",
+                    extra={
+                        "integration_id": external_issue.integration_id,
+                        "is_resolved": is_resolved,
+                        "issue_key": external_issue.key,
+                        "exception": error,
+                    },
+                )
+                lifecycle.record_halt()
 
     def get_resolve_sync_action(self, data: Mapping[str, Any]) -> ResolveSyncAction:
         done_states = self._get_done_statuses(data["project"])

--- a/tests/sentry/integrations/bitbucket/test_issues.py
+++ b/tests/sentry/integrations/bitbucket/test_issues.py
@@ -1,9 +1,14 @@
+from unittest import mock
+
 import orjson
+import pytest
 import responses
 
 from sentry.integrations.bitbucket.issues import ISSUE_TYPES, PRIORITIES
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.utils.metrics import EventLifecycleOutcome
+from sentry.shared_integrations.exceptions import IntegrationFormError
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.factories import EventType
 from sentry.testutils.helpers.datetime import before_now
@@ -277,7 +282,8 @@ class BitbucketIssueTest(APITestCase):
         ]
 
     @responses.activate
-    def test_create_issue(self):
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_create_issue(self, mock_record):
         repo = "myaccount/repo1"
         id = "112"
         title = "hello"
@@ -293,3 +299,28 @@ class BitbucketIssueTest(APITestCase):
             {"id": id, "title": title, "description": content, "repo": repo}
         )
         assert result == {"key": id, "title": title, "description": content, "repo": repo}
+        assert len(mock_record.mock_calls) == 2
+        start, halt = mock_record.mock_calls
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.SUCCESS
+
+    @responses.activate
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_create_issue_failure(self, mock_record):
+        """
+        This test is primarily used to verify that we omit failure metrics.
+        """
+        id = "112"
+        title = "hello"
+        content = {"html": "This is the description"}
+
+        installation = self.integration.get_installation(self.organization.id)
+        with pytest.raises(IntegrationFormError):
+            installation.create_issue(
+                {"id": id, "title": title, "description": content}  # omit repo
+            )
+
+        assert len(mock_record.mock_calls) == 2
+        start, halt = mock_record.mock_calls
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.FAILURE

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -1,9 +1,11 @@
 import datetime
 from functools import cached_property
 from typing import cast
+from unittest import mock
 from unittest.mock import patch
 
 import orjson
+import pytest
 import responses
 from django.test import RequestFactory
 from django.utils import timezone
@@ -13,7 +15,9 @@ from sentry.integrations.github import client
 from sentry.integrations.github.integration import GitHubIntegration
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.utils.metrics import EventLifecycleOutcome
 from sentry.issues.grouptype import FeedbackGroup
+from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.silo.util import PROXY_BASE_URL_HEADER, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
 from sentry.testutils.cases import IntegratedApiTestCase, PerformanceIssueTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -191,7 +195,8 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             self._check_proxying()
 
     @responses.activate
-    def test_create_issue(self):
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_create_issue(self, mock_record):
         responses.add(
             responses.POST,
             "https://api.github.com/repos/getsentry/sentry/issues",
@@ -216,6 +221,10 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             "url": "https://github.com/getsentry/sentry/issues/231",
             "repo": "getsentry/sentry",
         }
+        assert len(mock_record.mock_calls) == 2
+        start, halt = mock_record.mock_calls
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.SUCCESS
 
         if self.should_call_api_without_proxying():
             assert len(responses.calls) == 2
@@ -234,6 +243,25 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             }
         else:
             self._check_proxying()
+
+    @responses.activate
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_create_issue_failure(self, mock_record):
+        """
+        Test that metrics are being correctly emitted on failure.
+        """
+        form_data = {
+            "title": "rip",
+            "description": "Goodnight, sweet prince",
+        }
+
+        with pytest.raises(IntegrationError):
+            self.install.create_issue(form_data)
+
+        assert len(mock_record.mock_calls) == 2
+        start, halt = mock_record.mock_calls
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.FAILURE
 
     def test_performance_issues_content(self):
         """Test that a GitHub issue created from a performance issue has the expected title and description"""

--- a/tests/sentry/integrations/gitlab/test_issues.py
+++ b/tests/sentry/integrations/gitlab/test_issues.py
@@ -1,9 +1,12 @@
+from unittest import mock
+
 import pytest
 import responses
 
 from fixtures.gitlab import GitLabTestCase
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.utils.metrics import EventLifecycleOutcome
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils.factories import EventType
 from sentry.testutils.helpers.datetime import before_now
@@ -137,7 +140,8 @@ class GitlabIssuesTest(GitLabTestCase):
         ]
 
     @responses.activate
-    def test_create_issue(self):
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_create_issue(self, mock_record):
         issue_iid = "1"
         project_id = "10"
         project_name = "getsentry/sentry"
@@ -172,6 +176,29 @@ class GitlabIssuesTest(GitLabTestCase):
             "project": project_id,
             "metadata": {"display_name": key},
         }
+        assert len(mock_record.mock_calls) == 2
+        start, halt = mock_record.mock_calls
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.SUCCESS
+
+    @responses.activate
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_create_issue_failure(self, mock_record):
+        """
+        Test that metrics are being correctly emitted on failure.
+        """
+        form_data = {
+            "title": "rip",
+            "description": "Goodnight, sweet prince",
+        }
+
+        with pytest.raises(IntegrationError):
+            self.installation.create_issue(form_data)
+
+        assert len(mock_record.mock_calls) == 2
+        start, halt = mock_record.mock_calls
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.FAILURE
 
     @responses.activate
     def test_get_issue(self):

--- a/tests/sentry/integrations/test_issues.py
+++ b/tests/sentry/integrations/test_issues.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+import pytest
+
 from sentry.integrations.example.integration import AliasedIntegrationProvider, ExampleIntegration
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.organization_integration import OrganizationIntegration
@@ -10,6 +12,7 @@ from sentry.models.group import Group, GroupStatus
 from sentry.models.grouplink import GroupLink
 from sentry.models.groupresolution import GroupResolution
 from sentry.models.release import Release
+from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode
@@ -422,6 +425,21 @@ class IssueDefaultTest(TestCase):
             default_repo, repo_choice = self.installation.get_repository_choices(self.group, {})
             assert default_repo == ""
             assert repo_choice == []
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_get_repository_choices_error(self, mock_record):
+        with pytest.raises(IntegrationError):
+            with mock.patch.object(
+                self.installation,
+                "get_repositories",
+                return_value=[],
+                side_effect=ApiError("This sucks!"),
+            ):
+                self.installation.get_repository_choices(self.group, {})
+        assert len(mock_record.mock_calls) == 2
+        start, halt = mock_record.mock_calls
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.FAILURE
 
     def test_get_repository_choices_default_repo(self):
         assert self.installation.org_integration is not None


### PR DESCRIPTION
Add metrics for the following `SourceCodeIssueIntegration` metrics: `get_repository_choices`, `create_issue`, `sync_status_outbound`, and `sync_assignee_outbound`. Manually call halt for user errors in the last two methods.

PR has a lot of lines modified, but this is mostly due to indentations and tests.