### PR TITLE
fix(sentry-app): Adds better validation for invalid token request bodies

### DIFF
--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_authorizations.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_authorizations.py
@@ -68,8 +68,8 @@ class SentryAppAuthorizationsEndpoint(SentryAppAuthorizationsBaseEndpoint):
 
                 token = Refresher(
                     install=installation,
-                    refresh_token=refresh_serializer.validated_data["refresh_token"],
-                    client_id=refresh_serializer.validated_data["client_id"],
+                    refresh_token=refresh_serializer.validated_data.get("refresh_token"),
+                    client_id=refresh_serializer.validated_data.get("client_id"),
                     user=promote_request_api_user(request),
                 ).run()
             else:

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_authorizations.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_authorizations.py
@@ -69,6 +69,16 @@ class TestSentryAppAuthorizations(APITestCase):
 
         assert expires_at == expected_expires_at
 
+    def test_exchange_for_token_missing_data(self):
+        response = self.get_error_response(code=None)
+
+        assert response.status_code == 400
+
+        # This is rejected by the base `SentryAppAuthorizationBaseEndpoint`
+        # class's authentication, so expect an unauthorized error.
+        response = self.get_error_response(client_id=None)
+        assert response.status_code == 401
+
     def test_incorrect_grant_type(self):
         self.get_error_response(grant_type="notit", status_code=403)
 
@@ -136,3 +146,23 @@ class TestSentryAppAuthorizations(APITestCase):
 
         new_token = ApiToken.objects.filter(refresh_token=response.data["refreshToken"])
         assert new_token.exists()
+
+    def test_refresh_token_exchange_with_missing_data(self):
+        response = self.get_success_response()
+
+        refresh_token = response.data["refreshToken"]
+
+        assert response.data["refreshToken"] is not None
+
+        response = self.get_error_response(
+            code=None, refresh_token=None, grant_type="refresh_token"
+        )
+
+        assert response.status_code == 400
+
+        # This is rejected by the base `SentryAppAuthorizationBaseEndpoint`
+        # class's authentication, so expect an unauthorized error.
+        response = self.get_error_response(
+            code=None, refresh_token=refresh_token, grant_type="refresh_token", client_id=None
+        )
+        assert response.status_code == 401


### PR DESCRIPTION
Fixes SENTRY-3HBC

Adds serializers for both token Authorization and Refresh flows.

This affects POST requests to the `/sentry-app-installations/<uuid>/authorization/` endpoint, providing explicit 400 status codes with invalid field information when a request body is misconfigured.

## Additional Context
Some fields in the request body (such as `client_id` and `secret`), are validated by a a separate Authentication flow prior to the defined serializer code, resulting in a 401 exception instead, hence the tests asserting for both cases.
