### PR TITLE
feat(dashboards): Infinite duplicate dashboard names

### DIFF
--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -82,7 +82,7 @@ class Dashboard(Model):
     def incremental_title(cls, organization, name):
         """Given a dashboard name that already exists, returns a new unique name that does not exist, by appending the word "Copy" and an integer."""
         matching_dashboards = cls.objects.filter(
-            organization=organization, title__regex=rf"^{re.escape(name)} ?(Copy)? ?(\d+)?$"
+            organization=organization, title__regex=rf"^{re.escape(name)} ?(copy)? ?(\d+)?$"
         )
 
         if not matching_dashboards:
@@ -90,15 +90,15 @@ class Dashboard(Model):
 
         next_copy_number = 1
         for dashboard in matching_dashboards:
-            match = re.search(r" Copy ?(\d+)?", dashboard.title)
+            match = re.search(r" copy ?(\d+)?", dashboard.title)
             if match:
                 copy_number = int(match.group(1) or 1)
                 next_copy_number = max(next_copy_number, copy_number + 1)
 
         if next_copy_number == 1:
-            return f"{name} Copy"
+            return f"{name} copy"
 
-        return f"{name} Copy {next_copy_number}"
+        return f"{name} copy {next_copy_number}"
 
 
 @region_silo_model

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -87,14 +87,14 @@ class Dashboard(Model):
         base_name = re.sub(r" ?copy ?(\d+)?$", "", name)
         matching_dashboards = cls.objects.filter(
             organization=organization, title__regex=rf"^{re.escape(base_name)} ?(copy)? ?(\d+)?$"
-        )
+        ).values("title")
 
         if not matching_dashboards:
             return name
 
         next_copy_number = 0
         for dashboard in matching_dashboards:
-            match = re.search(r" copy ?(\d+)?", dashboard.title)
+            match = re.search(r" copy ?(\d+)?", dashboard["title"])
             if match:
                 copy_number = int(match.group(1) or 0)
                 next_copy_number = max(next_copy_number, copy_number + 1)

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -80,7 +80,9 @@ class Dashboard(Model):
 
     @classmethod
     def incremental_title(cls, organization, name):
-        """Given a dashboard name that already exists, returns a new unique name that does not exist, by appending the word "copy" and an integer if necessary. If the name doesn't require an increment return it."""
+        """
+        Given a dashboard name that migh already exist, returns a new unique name that does not exist, by appending the word "copy" and an integer if necessary.
+        """
 
         base_name = re.sub(r" ?copy ?(\d+)?$", "", name)
         matching_dashboards = cls.objects.filter(

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -80,25 +80,27 @@ class Dashboard(Model):
 
     @classmethod
     def incremental_title(cls, organization, name):
-        """Given a dashboard name that already exists, returns a new unique name that does not exist, by appending the word "Copy" and an integer."""
+        """Given a dashboard name that already exists, returns a new unique name that does not exist, by appending the word "copy" and an integer if necessary. If the name doesn't require an increment return it."""
+
+        base_name = re.sub(r" ?copy ?(\d+)?$", "", name)
         matching_dashboards = cls.objects.filter(
-            organization=organization, title__regex=rf"^{re.escape(name)} ?(copy)? ?(\d+)?$"
+            organization=organization, title__regex=rf"^{re.escape(base_name)} ?(copy)? ?(\d+)?$"
         )
 
         if not matching_dashboards:
             return name
 
-        next_copy_number = 1
+        next_copy_number = 0
         for dashboard in matching_dashboards:
             match = re.search(r" copy ?(\d+)?", dashboard.title)
             if match:
-                copy_number = int(match.group(1) or 1)
+                copy_number = int(match.group(1) or 0)
                 next_copy_number = max(next_copy_number, copy_number + 1)
 
-        if next_copy_number == 1:
-            return f"{name} copy"
+        if next_copy_number == 0:
+            return f"{base_name} copy"
 
-        return f"{name} copy {next_copy_number}"
+        return f"{base_name} copy {next_copy_number}"
 
 
 @region_silo_model

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -79,7 +79,7 @@ class Dashboard(Model):
         return None
 
     @classmethod
-    def incremental_name(cls, organization, name):
+    def incremental_title(cls, organization, name):
         """Given a dashboard name that already exists, returns a new unique name that does not exist, by appending the word "Copy" and an integer."""
         matching_dashboards = cls.objects.filter(
             organization=organization, title__regex=rf"^{re.escape(name)} ?(Copy)? ?(\d+)?$"

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -77,6 +77,10 @@ class Dashboard(Model):
             return all_prebuilt_dashboards[dashboard_id]
         return None
 
+    @staticmethod
+    def incremental_name(organization, name):
+        return name
+
 
 @region_silo_model
 class DashboardTombstone(Model):

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -779,6 +779,58 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         assert response.status_code == 201, response.data
         assert response.data["title"] == f"{self.dashboard.title} copy 1"
 
+    def test_many_duplicate_dashboards(self):
+        title = "My Awesome Dashboard"
+
+        response = self.do_request(
+            "post",
+            self.url,
+            data={"title": title, "duplicate": True},
+        )
+
+        assert response.status_code == 201, response.data
+        assert response.data["title"] == "My Awesome Dashboard"
+
+        response = self.do_request(
+            "post",
+            self.url,
+            data={"title": title, "duplicate": True},
+        )
+
+        assert response.status_code == 201, response.data
+        assert response.data["title"] == "My Awesome Dashboard copy"
+
+        for i in range(1, 10):
+            response = self.do_request(
+                "post",
+                self.url,
+                data={"title": title, "duplicate": True},
+            )
+
+            assert response.status_code == 201, response.data
+            assert response.data["title"] == f"My Awesome Dashboard copy {i}"
+
+    def test_duplicate_a_duplicate(self):
+        title = "An Amazing Dashboard copy 3"
+
+        response = self.do_request(
+            "post",
+            self.url,
+            data={"title": title, "duplicate": True},
+        )
+
+        assert response.status_code == 201, response.data
+        assert response.data["title"] == "An Amazing Dashboard copy 3"
+
+        response = self.do_request(
+            "post",
+            self.url,
+            data={"title": title, "duplicate": True},
+        )
+
+        assert response.status_code == 201, response.data
+        assert response.data["title"] == "An Amazing Dashboard copy 4"
+
     def test_widget_preview_field_returns_empty_list_if_no_widgets(self):
         response = self.do_request("get", self.url, data={"query": "1"})
 

--- a/tests/sentry/models/test_dashboard.py
+++ b/tests/sentry/models/test_dashboard.py
@@ -9,31 +9,31 @@ class IncrementalNameTest(TestCase):
     def test_one_preexisting(self):
         self.create_dashboard(title="Stats", organization=self.organization)
 
-        assert Dashboard.incremental_title(self.organization, "Stats") == "Stats Copy"
+        assert Dashboard.incremental_title(self.organization, "Stats") == "Stats copy"
 
     def test_two_consecutive_preexisting(self):
         self.create_dashboard(title="Stats", organization=self.organization)
-        self.create_dashboard(title="Stats Copy", organization=self.organization)
+        self.create_dashboard(title="Stats copy", organization=self.organization)
 
-        assert Dashboard.incremental_title(self.organization, "Stats") == "Stats Copy 2"
+        assert Dashboard.incremental_title(self.organization, "Stats") == "Stats copy 2"
 
     def test_two_preexisting_non_starting(self):
-        self.create_dashboard(title="Stats Copy 4", organization=self.organization)
-        self.create_dashboard(title="Stats Copy 5", organization=self.organization)
+        self.create_dashboard(title="Stats copy 4", organization=self.organization)
+        self.create_dashboard(title="Stats copy 5", organization=self.organization)
 
-        assert Dashboard.incremental_title(self.organization, "Stats") == "Stats Copy 6"
+        assert Dashboard.incremental_title(self.organization, "Stats") == "Stats copy 6"
 
     def test_two_preexisting_non_starting_non_consecutive(self):
-        self.create_dashboard(title="Stats Copy 4", organization=self.organization)
-        self.create_dashboard(title="Stats Copy 17", organization=self.organization)
+        self.create_dashboard(title="Stats copy 4", organization=self.organization)
+        self.create_dashboard(title="Stats copy 17", organization=self.organization)
 
-        assert Dashboard.incremental_title(self.organization, "Stats") == "Stats Copy 18"
+        assert Dashboard.incremental_title(self.organization, "Stats") == "Stats copy 18"
 
     def test_similar_names(self):
         self.create_dashboard(title="Stats", organization=self.organization)
         self.create_dashboard(title="Statstististicks", organization=self.organization)
 
-        assert Dashboard.incremental_title(self.organization, "Stats") == "Stats Copy"
+        assert Dashboard.incremental_title(self.organization, "Stats") == "Stats copy"
 
     def test_similar_name_substring(self):
         self.create_dashboard(title="Statstististicks", organization=self.organization)
@@ -45,8 +45,8 @@ class IncrementalNameTest(TestCase):
         second_organization = self.create_organization()
 
         self.create_dashboard(title="My Stuff", organization=first_organization)
-        self.create_dashboard(title="My Stuff Copy", organization=first_organization)
-        self.create_dashboard(title="My Stuff Copy 2", organization=first_organization)
+        self.create_dashboard(title="My Stuff copy", organization=first_organization)
+        self.create_dashboard(title="My Stuff copy 2", organization=first_organization)
 
-        assert Dashboard.incremental_title(first_organization, "My Stuff") == "My Stuff Copy 3"
+        assert Dashboard.incremental_title(first_organization, "My Stuff") == "My Stuff copy 3"
         assert Dashboard.incremental_title(second_organization, "My Stuff") == "My Stuff"

--- a/tests/sentry/models/test_dashboard.py
+++ b/tests/sentry/models/test_dashboard.py
@@ -32,10 +32,10 @@ class IncrementalNameTest(TestCase):
     def test_copy_of_copy(self):
         self.create_dashboard(title="Stats copy 4", organization=self.organization)
 
-        assert Dashboard.incremental_title(self.organization, "Stats copy 4") == "Stats copy 4"
+        assert Dashboard.incremental_title(self.organization, "Stats copy 4") == "Stats copy 5"
 
     def test_name_with_copy_in_it(self):
-        assert Dashboard.incremental_title(self.organization, "Stats copy 4") == "Stats copy 5"
+        assert Dashboard.incremental_title(self.organization, "Stats copy 4") == "Stats copy 4"
 
     def test_similar_names(self):
         self.create_dashboard(title="Stats", organization=self.organization)

--- a/tests/sentry/models/test_dashboard.py
+++ b/tests/sentry/models/test_dashboard.py
@@ -3,31 +3,50 @@ from sentry.testutils.cases import TestCase
 
 
 class IncrementalNameTest(TestCase):
-    def setUp(self):
-        self.organization = self.create_organization
-
     def test_no_conflict(self):
         assert Dashboard.incremental_name(self.organization, "Stats") == "Stats"
 
     def test_one_preexisting(self):
-        self.create_dashboard(title="Stats")
+        self.create_dashboard(title="Stats", organization=self.organization)
 
         assert Dashboard.incremental_name(self.organization, "Stats") == "Stats Copy"
 
     def test_two_consecutive_preexisting(self):
-        self.create_dashboard(title="Stats")
-        self.create_dashboard(title="Stats Copy")
+        self.create_dashboard(title="Stats", organization=self.organization)
+        self.create_dashboard(title="Stats Copy", organization=self.organization)
 
         assert Dashboard.incremental_name(self.organization, "Stats") == "Stats Copy 2"
 
     def test_two_preexisting_non_starting(self):
-        self.create_dashboard(title="Stats Copy 4")
-        self.create_dashboard(title="Stats Copy 5")
+        self.create_dashboard(title="Stats Copy 4", organization=self.organization)
+        self.create_dashboard(title="Stats Copy 5", organization=self.organization)
 
         assert Dashboard.incremental_name(self.organization, "Stats") == "Stats Copy 6"
 
     def test_two_preexisting_non_starting_non_consecutive(self):
-        self.create_dashboard(title="Stats Copy 4")
-        self.create_dashboard(title="Stats Copy 17")
+        self.create_dashboard(title="Stats Copy 4", organization=self.organization)
+        self.create_dashboard(title="Stats Copy 17", organization=self.organization)
 
         assert Dashboard.incremental_name(self.organization, "Stats") == "Stats Copy 18"
+
+    def test_similar_names(self):
+        self.create_dashboard(title="Stats", organization=self.organization)
+        self.create_dashboard(title="Statstististicks", organization=self.organization)
+
+        assert Dashboard.incremental_name(self.organization, "Stats") == "Stats Copy"
+
+    def test_similar_name_substring(self):
+        self.create_dashboard(title="Statstististicks", organization=self.organization)
+
+        assert Dashboard.incremental_name(self.organization, "Stats") == "Stats"
+
+    def test_across_organizations(self):
+        first_organization = self.create_organization()
+        second_organization = self.create_organization()
+
+        self.create_dashboard(title="My Stuff", organization=first_organization)
+        self.create_dashboard(title="My Stuff Copy", organization=first_organization)
+        self.create_dashboard(title="My Stuff Copy 2", organization=first_organization)
+
+        assert Dashboard.incremental_name(first_organization, "My Stuff") == "My Stuff Copy 3"
+        assert Dashboard.incremental_name(second_organization, "My Stuff") == "My Stuff"

--- a/tests/sentry/models/test_dashboard.py
+++ b/tests/sentry/models/test_dashboard.py
@@ -1,0 +1,33 @@
+from sentry.models.dashboard import Dashboard
+from sentry.testutils.cases import TestCase
+
+
+class IncrementalNameTest(TestCase):
+    def setUp(self):
+        self.organization = self.create_organization
+
+    def test_no_conflict(self):
+        assert Dashboard.incremental_name(self.organization, "Stats") == "Stats"
+
+    def test_one_preexisting(self):
+        self.create_dashboard(title="Stats")
+
+        assert Dashboard.incremental_name(self.organization, "Stats") == "Stats Copy"
+
+    def test_two_consecutive_preexisting(self):
+        self.create_dashboard(title="Stats")
+        self.create_dashboard(title="Stats Copy")
+
+        assert Dashboard.incremental_name(self.organization, "Stats") == "Stats Copy 2"
+
+    def test_two_preexisting_non_starting(self):
+        self.create_dashboard(title="Stats Copy 4")
+        self.create_dashboard(title="Stats Copy 5")
+
+        assert Dashboard.incremental_name(self.organization, "Stats") == "Stats Copy 6"
+
+    def test_two_preexisting_non_starting_non_consecutive(self):
+        self.create_dashboard(title="Stats Copy 4")
+        self.create_dashboard(title="Stats Copy 17")
+
+        assert Dashboard.incremental_name(self.organization, "Stats") == "Stats Copy 18"

--- a/tests/sentry/models/test_dashboard.py
+++ b/tests/sentry/models/test_dashboard.py
@@ -4,41 +4,41 @@ from sentry.testutils.cases import TestCase
 
 class IncrementalNameTest(TestCase):
     def test_no_conflict(self):
-        assert Dashboard.incremental_name(self.organization, "Stats") == "Stats"
+        assert Dashboard.incremental_title(self.organization, "Stats") == "Stats"
 
     def test_one_preexisting(self):
         self.create_dashboard(title="Stats", organization=self.organization)
 
-        assert Dashboard.incremental_name(self.organization, "Stats") == "Stats Copy"
+        assert Dashboard.incremental_title(self.organization, "Stats") == "Stats Copy"
 
     def test_two_consecutive_preexisting(self):
         self.create_dashboard(title="Stats", organization=self.organization)
         self.create_dashboard(title="Stats Copy", organization=self.organization)
 
-        assert Dashboard.incremental_name(self.organization, "Stats") == "Stats Copy 2"
+        assert Dashboard.incremental_title(self.organization, "Stats") == "Stats Copy 2"
 
     def test_two_preexisting_non_starting(self):
         self.create_dashboard(title="Stats Copy 4", organization=self.organization)
         self.create_dashboard(title="Stats Copy 5", organization=self.organization)
 
-        assert Dashboard.incremental_name(self.organization, "Stats") == "Stats Copy 6"
+        assert Dashboard.incremental_title(self.organization, "Stats") == "Stats Copy 6"
 
     def test_two_preexisting_non_starting_non_consecutive(self):
         self.create_dashboard(title="Stats Copy 4", organization=self.organization)
         self.create_dashboard(title="Stats Copy 17", organization=self.organization)
 
-        assert Dashboard.incremental_name(self.organization, "Stats") == "Stats Copy 18"
+        assert Dashboard.incremental_title(self.organization, "Stats") == "Stats Copy 18"
 
     def test_similar_names(self):
         self.create_dashboard(title="Stats", organization=self.organization)
         self.create_dashboard(title="Statstististicks", organization=self.organization)
 
-        assert Dashboard.incremental_name(self.organization, "Stats") == "Stats Copy"
+        assert Dashboard.incremental_title(self.organization, "Stats") == "Stats Copy"
 
     def test_similar_name_substring(self):
         self.create_dashboard(title="Statstististicks", organization=self.organization)
 
-        assert Dashboard.incremental_name(self.organization, "Stats") == "Stats"
+        assert Dashboard.incremental_title(self.organization, "Stats") == "Stats"
 
     def test_across_organizations(self):
         first_organization = self.create_organization()
@@ -48,5 +48,5 @@ class IncrementalNameTest(TestCase):
         self.create_dashboard(title="My Stuff Copy", organization=first_organization)
         self.create_dashboard(title="My Stuff Copy 2", organization=first_organization)
 
-        assert Dashboard.incremental_name(first_organization, "My Stuff") == "My Stuff Copy 3"
-        assert Dashboard.incremental_name(second_organization, "My Stuff") == "My Stuff"
+        assert Dashboard.incremental_title(first_organization, "My Stuff") == "My Stuff Copy 3"
+        assert Dashboard.incremental_title(second_organization, "My Stuff") == "My Stuff"

--- a/tests/sentry/models/test_dashboard.py
+++ b/tests/sentry/models/test_dashboard.py
@@ -15,7 +15,7 @@ class IncrementalNameTest(TestCase):
         self.create_dashboard(title="Stats", organization=self.organization)
         self.create_dashboard(title="Stats copy", organization=self.organization)
 
-        assert Dashboard.incremental_title(self.organization, "Stats") == "Stats copy 2"
+        assert Dashboard.incremental_title(self.organization, "Stats") == "Stats copy 1"
 
     def test_two_preexisting_non_starting(self):
         self.create_dashboard(title="Stats copy 4", organization=self.organization)
@@ -28,6 +28,14 @@ class IncrementalNameTest(TestCase):
         self.create_dashboard(title="Stats copy 17", organization=self.organization)
 
         assert Dashboard.incremental_title(self.organization, "Stats") == "Stats copy 18"
+
+    def test_copy_of_copy(self):
+        self.create_dashboard(title="Stats copy 4", organization=self.organization)
+
+        assert Dashboard.incremental_title(self.organization, "Stats copy 4") == "Stats copy 4"
+
+    def test_name_with_copy_in_it(self):
+        assert Dashboard.incremental_title(self.organization, "Stats copy 4") == "Stats copy 5"
 
     def test_similar_names(self):
         self.create_dashboard(title="Stats", organization=self.organization)
@@ -46,7 +54,7 @@ class IncrementalNameTest(TestCase):
 
         self.create_dashboard(title="My Stuff", organization=first_organization)
         self.create_dashboard(title="My Stuff copy", organization=first_organization)
-        self.create_dashboard(title="My Stuff copy 2", organization=first_organization)
+        self.create_dashboard(title="My Stuff copy 1", organization=first_organization)
 
-        assert Dashboard.incremental_title(first_organization, "My Stuff") == "My Stuff copy 3"
+        assert Dashboard.incremental_title(first_organization, "My Stuff") == "My Stuff copy 2"
         assert Dashboard.incremental_title(second_organization, "My Stuff") == "My Stuff"


### PR DESCRIPTION
## tl;dr

Right now if you duplicate too many dashboards, or make too many of a dashboard template, you get an error. People don't like that. This PR makes it so you can make infinite duplicates, if you want.

## Changes

We've had a few complaints (and a few Sentry exceptions) from people who are clicking the "Duplicate" button on a dashboard and/or clicking the "Add Dashboard" button on the Dashboards page and seeing errors.

When people add copies of a dashboard we automatically increment the name. The sequence goes "My Dashboard", "My Dashboard copy", "My Dashboard copy 1", "My Dashboard copy 2", etc. We cap out at 9. Beyond 9 we show a little error toast. This is fine but isn't _awesome_. Also, a quirk of the endpoint code is that it recursively calls `self.post` and tries to insert a dashboard. For high copy numbers, this means 10 failed inserts in a row, which is not the most efficient.

This PR changes the approach. When a dashboard is created, it attempts an insert. If the insert fails due to `IntegrityError`, it calls `Dashboard.incremental_title` and fetches a "guaranteed" unique incremented title, and tries again.

The "guaranteed" unique title is done by fetching all matching dashboard names from the database, and finding the highest increment that way. This is subtly different from the current behaviour, because if someone deletes "My Dashboard copy 1" and duplicates "My Dashboard", they'll get "My Dashboard copy 3" if "My Dashboard copy 2" still exists. IMO this is better because that's closer to how many copies have been made.

## Performance

I checked the stats and the p99 for number of dashboards for an org is 16. The p100 is ~400 which is high but still pretty fast to find the right number. In the worst case this takes about 5ms. This scan only happens in case of a conflict, anyway, which is rare.

Closes https://github.com/getsentry/sentry/issues/77430

