### PR TITLE
fix(alerts): Chart displays transformed timeseries data properly

### DIFF
--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -70,10 +70,6 @@ type DefaultProps = {
    */
   includePrevious: boolean;
   /**
-   * Transform the response data to be something ingestible by charts
-   */
-  includeTransformedData: boolean;
-  /**
    * Interval to group results in
    *
    * e.g. 1d, 1h, 1m, 1s
@@ -95,6 +91,10 @@ type DefaultProps = {
    * Absolute end date for query
    */
   end?: DateString;
+  /**
+   * Transform the response data to be something ingestible by charts
+   */
+  includeTransformedData?: boolean;
   /**
    * Relative time period for query.
    *

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -477,6 +477,7 @@ class TriggersChart extends PureComponent<Props, State> {
         query,
         queryExtras,
         sampleRate,
+        period,
         environment: environment ? [environment] : undefined,
         project: projects.map(({id}) => Number(id)),
         interval: `${timeWindow}m`,
@@ -485,8 +486,6 @@ class TriggersChart extends PureComponent<Props, State> {
         includePrevious: false,
         currentSeriesNames: [formattedAggregate || aggregate],
         partial: false,
-        includeTimeAggregation: false,
-        includeTransformedData: false,
         limit: 15,
         children: noop,
       };
@@ -497,15 +496,10 @@ class TriggersChart extends PureComponent<Props, State> {
             <OnDemandMetricRequest
               {...baseProps}
               api={this.historicalAPI}
-              period={period}
               dataLoadedCallback={onHistoricalDataLoaded}
             />
           ) : null}
-          <OnDemandMetricRequest
-            {...baseProps}
-            period={period}
-            dataLoadedCallback={onDataLoaded}
-          >
+          <OnDemandMetricRequest {...baseProps} dataLoadedCallback={onDataLoaded}>
             {({
               loading,
               errored,


### PR DESCRIPTION
**Context**:
Alerts wasn't able to display the response of `metrics-estimation-stats` requests, which resulted in a blank preview chart. It seems like a query that is on-demand compatible makes a request to `/api/0/organizations/<org_slug>/metrics-estimation-stats/`. This was returning data but it wasn't displaying it.

The `includeTransformedData` was accidentally sent to `false` in [this PR](https://github.com/getsentry/sentry/pull/78238/files#diff-beab3f251ab14752d3d75dcfc86718666d83e061412af0e7a58889510e56e9ddR484) (presumably to get typescript to work properly), but the default value for `includeTransformedData` is true. When it was set to `false` it stopped processing the response properly and returned an empty array, which explained the empty chart.

I made the prop optional so we don't need to be forced to set a value when there's default behaviour. It also looks like `includeTimeAggregations` was also not on the original component, so I also removed it in case it also causes unexpected behaviour 