### PR TITLE
feat(issues): Rearrange all events columns, sizes

### DIFF
--- a/static/app/views/issueDetails/allEventsTable.tsx
+++ b/static/app/views/issueDetails/allEventsTable.tsx
@@ -151,31 +151,31 @@ export const useEventColumns = (group: Group, organization: Organization): Colum
 
     const fields: string[] = [
       'id',
-      'transaction',
-      'title',
-      'trace',
       'timestamp',
+      'title',
+      'transaction',
       'release',
       'environment',
       'user.display',
       'device',
       'os',
       ...platformSpecificFields,
+      'trace',
       ...(isPerfIssue ? ['transaction.duration'] : []),
     ];
 
     const columnTitles: string[] = [
       t('Event ID'),
-      t('Transaction'),
-      t('Title'),
-      t('Trace'),
       t('Timestamp'),
+      t('Title'),
+      t('Transaction'),
       t('Release'),
       t('Environment'),
       t('User'),
       t('Device'),
       t('OS'),
       ...platformSpecificColumnTitles,
+      t('Trace'),
       ...(isPerfIssue ? [t('Total Duration')] : []),
       t('Minidump'),
     ];

--- a/static/app/views/issueDetails/streamline/eventList.tsx
+++ b/static/app/views/issueDetails/streamline/eventList.tsx
@@ -39,7 +39,33 @@ export function EventList({group}: EventListProps) {
   const routes = useRoutes();
   const [_error, setError] = useState('');
   const {fields, columnTitles} = useEventColumns(group, organization);
-  const eventView = useIssueDetailsEventView({group, queryProps: {fields}});
+  const eventView = useIssueDetailsEventView({
+    group,
+    queryProps: {
+      fields,
+      widths: fields.map(field => {
+        switch (field) {
+          case 'id':
+          case 'trace':
+          case 'replayId':
+            // Id columns can be smaller
+            return '100';
+          case 'environment':
+            // Big enough to fit "Environment"
+            return '115';
+          case 'timestamp':
+            return '220';
+          case 'url':
+            return '300';
+          case 'title':
+          case 'transaction':
+            return '200';
+          default:
+            return '150';
+        }
+      }),
+    },
+  });
 
   const grayText = css`
     color: ${theme.subText};


### PR DESCRIPTION
Re-sizes and re-arrange the columns in the all events table.

- put trace id much further at the end
- moved timestamp 2nd after the event id
- picked a few sizes based on column content

before
![image](https://github.com/user-attachments/assets/3d39b01d-cba3-4346-9b6e-5be7aa13df6a)


after
![image](https://github.com/user-attachments/assets/6e37eb3b-cf54-4ebe-ae31-83c769694a6d)

