### PR TITLE
fix(autofix): Add null check for root cause code context

### DIFF
--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -224,7 +224,7 @@ function RootCauseContext({
           )}
         </ExpandableInsightContext>
       )}
-      {cause.code_context.length > 0 && (
+      {cause?.code_context && cause.code_context.length > 0 && (
         <ExpandableInsightContext
           icon={<IconCode size="sm" color="subText" />}
           title={'Relevant code'}


### PR DESCRIPTION
Fixes [issue](https://sentry.sentry.io/issues/6010162629/?project=11276&query=is:unresolved%20issue.priority:%5Bhigh,%20medium%5D&statsPeriod=7d&stream_index=0) where Autofix drawer crashes due to missing cause or missing code context.