### PR TITLE
fix(wizard): add cors headers to setup wizard view

### DIFF
--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -10,6 +10,7 @@ from django.http import Http404, HttpRequest, HttpResponse, HttpResponseBadReque
 from django.http.response import HttpResponseBase
 from django.shortcuts import get_object_or_404
 
+from sentry.api.base import allow_cors_options
 from sentry.api.endpoints.setup_wizard import SETUP_WIZARD_CACHE_KEY, SETUP_WIZARD_CACHE_TIMEOUT
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.project import STATUS_LABELS
@@ -57,6 +58,7 @@ class SetupWizardView(BaseView):
             return self.redirect(add_params_to_url(settings.SENTRY_SIGNUP_URL, params))
         return super().handle_auth_required(request, *args, **kwargs)
 
+    @allow_cors_options
     def get(self, request: HttpRequest, wizard_hash) -> HttpResponseBase:
         """
         This opens a page where with an active session fill stuff into the cache
@@ -114,6 +116,7 @@ class SetupWizardView(BaseView):
         context["enableProjectSelection"] = True
         return render_to_response("sentry/setup-wizard.html", context, request)
 
+    @allow_cors_options
     def post(self, request: HttpRequest, wizard_hash=None) -> HttpResponse:
         """
         This updates the cache content for a specific hash

--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -10,7 +10,7 @@ from django.http import Http404, HttpRequest, HttpResponse, HttpResponseBadReque
 from django.http.response import HttpResponseBase
 from django.shortcuts import get_object_or_404
 
-from sentry.api.base import allow_cors_options
+from sentry.api.base import allow_cors_options, apply_cors_headers
 from sentry.api.endpoints.setup_wizard import SETUP_WIZARD_CACHE_KEY, SETUP_WIZARD_CACHE_TIMEOUT
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.project import STATUS_LABELS
@@ -114,7 +114,8 @@ class SetupWizardView(BaseView):
                     return render_to_response("sentry/setup-wizard.html", context, request)
 
         context["enableProjectSelection"] = True
-        return render_to_response("sentry/setup-wizard.html", context, request)
+        response = render_to_response("sentry/setup-wizard.html", context, request)
+        return apply_cors_headers(request, response, allowed_methods=self._allowed_methods())
 
     @allow_cors_options
     def post(self, request: HttpRequest, wizard_hash=None) -> HttpResponse:

--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -10,7 +10,7 @@ from django.http import Http404, HttpRequest, HttpResponse, HttpResponseBadReque
 from django.http.response import HttpResponseBase
 from django.shortcuts import get_object_or_404
 
-from sentry.api.base import allow_cors_options, apply_cors_headers
+from sentry.api.base import allow_cors_options
 from sentry.api.endpoints.setup_wizard import SETUP_WIZARD_CACHE_KEY, SETUP_WIZARD_CACHE_TIMEOUT
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.project import STATUS_LABELS
@@ -110,11 +110,9 @@ class SetupWizardView(BaseView):
                         mapping=target_org_mapping, project=target_project, user=request.user
                     )
                     default_cache.set(cache_key, cache_data, SETUP_WIZARD_CACHE_TIMEOUT)
-
                     context["enableProjectSelection"] = False
 
-        response = render_to_response("sentry/setup-wizard.html", context, request)
-        return apply_cors_headers(request, response, allowed_methods=self._allowed_methods())
+        return render_to_response("sentry/setup-wizard.html", context, request)
 
     @allow_cors_options
     def post(self, request: HttpRequest, wizard_hash=None) -> HttpResponse:

--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -92,6 +92,7 @@ class SetupWizardView(BaseView):
             org_mappings_map[mapping.organization_id] = serialized_mapping
 
         context["organizations"] = list(org_mappings_map.values())
+        context["enableProjectSelection"] = True
 
         # If org_slug and project_slug are provided, we will use them to select the project
         # If the project is not found or the slugs are not provided, we will show the project selection
@@ -111,9 +112,7 @@ class SetupWizardView(BaseView):
                     default_cache.set(cache_key, cache_data, SETUP_WIZARD_CACHE_TIMEOUT)
 
                     context["enableProjectSelection"] = False
-                    return render_to_response("sentry/setup-wizard.html", context, request)
 
-        context["enableProjectSelection"] = True
         response = render_to_response("sentry/setup-wizard.html", context, request)
         return apply_cors_headers(request, response, allowed_methods=self._allowed_methods())
 

--- a/tests/sentry/web/frontend/test_setup_wizard.py
+++ b/tests/sentry/web/frontend/test_setup_wizard.py
@@ -4,9 +4,7 @@ from django.urls import reverse
 from sentry.api.endpoints.setup_wizard import SETUP_WIZARD_CACHE_KEY
 from sentry.cache import default_cache
 from sentry.testutils.cases import PermissionTestCase
-from sentry.testutils.helpers import override_options
 from sentry.testutils.silo import control_silo_test
-from tests.sentry.api.test_base import _dummy_endpoint
 
 
 @control_silo_test
@@ -307,35 +305,3 @@ class SetupWizard(PermissionTestCase):
 
         assert resp.status_code == 302
         assert resp.headers["Location"] == "/auth/login/"
-
-    @override_options({"system.base-hostname": "example.com"})
-    def test_setup_wizard_cors(self):
-        request = self.make_request(method="GET")
-        request.META["HTTP_ORIGIN"] = "http://myslug.example.com"
-
-        response = _dummy_endpoint(request)
-        response.render()
-        assert response.status_code == 200, response.content
-
-        assert response["Access-Control-Allow-Origin"] == "http://myslug.example.com"
-        assert response["Access-Control-Allow-Headers"] == (
-            "X-Sentry-Auth, X-Requested-With, Origin, Accept, "
-            "Content-Type, Authentication, Authorization, Content-Encoding, "
-            "sentry-trace, baggage, X-CSRFToken"
-        )
-        assert response["Access-Control-Expose-Headers"] == (
-            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, "
-            "Endpoint, Retry-After, Link"
-        )
-        assert response["Access-Control-Allow-Methods"] == "GET, HEAD, OPTIONS"
-        assert "Access-Control-Allow-Credentials" in response
-
-        request = self.make_request(method="GET")
-        request.META["HTTP_ORIGIN"] = "http://myslug.examples.com"
-
-        response = _dummy_endpoint(request)
-        response.render()
-        assert response.status_code == 200, response.content
-
-        assert response["Access-Control-Allow-Origin"] == "http://myslug.examples.com"
-        assert "Access-Control-Allow-Credentials" not in response

--- a/tests/sentry/web/frontend/test_setup_wizard.py
+++ b/tests/sentry/web/frontend/test_setup_wizard.py
@@ -4,7 +4,9 @@ from django.urls import reverse
 from sentry.api.endpoints.setup_wizard import SETUP_WIZARD_CACHE_KEY
 from sentry.cache import default_cache
 from sentry.testutils.cases import PermissionTestCase
+from sentry.testutils.helpers import override_options
 from sentry.testutils.silo import control_silo_test
+from tests.sentry.api.test_base import _dummy_endpoint
 
 
 @control_silo_test
@@ -305,3 +307,35 @@ class SetupWizard(PermissionTestCase):
 
         assert resp.status_code == 302
         assert resp.headers["Location"] == "/auth/login/"
+
+    @override_options({"system.base-hostname": "example.com"})
+    def test_setup_wizard_cors(self):
+        request = self.make_request(method="GET")
+        request.META["HTTP_ORIGIN"] = "http://myslug.example.com"
+
+        response = _dummy_endpoint(request)
+        response.render()
+        assert response.status_code == 200, response.content
+
+        assert response["Access-Control-Allow-Origin"] == "http://myslug.example.com"
+        assert response["Access-Control-Allow-Headers"] == (
+            "X-Sentry-Auth, X-Requested-With, Origin, Accept, "
+            "Content-Type, Authentication, Authorization, Content-Encoding, "
+            "sentry-trace, baggage, X-CSRFToken"
+        )
+        assert response["Access-Control-Expose-Headers"] == (
+            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, "
+            "Endpoint, Retry-After, Link"
+        )
+        assert response["Access-Control-Allow-Methods"] == "GET, HEAD, OPTIONS"
+        assert "Access-Control-Allow-Credentials" in response
+
+        request = self.make_request(method="GET")
+        request.META["HTTP_ORIGIN"] = "http://myslug.examples.com"
+
+        response = _dummy_endpoint(request)
+        response.render()
+        assert response.status_code == 200, response.content
+
+        assert response["Access-Control-Allow-Origin"] == "http://myslug.examples.com"
+        assert "Access-Control-Allow-Credentials" not in response


### PR DESCRIPTION
When the user is not logged in and uses the wizard for node.js, they are redirected to our login page. After a successful auth process, the user is then redirected towards the wizard's project selector page on the org-slug sub-domain (e.g. sentry.sentry.io). When submitting the form on this page towards the API on http://sentry.io/settings/wizard/..., this request is blocked by the browser due to a CORS error. This PR attempts to remedy this by adding CORS headers to the django view of the project selector. 

Closes https://github.com/getsentry/sentry/issues/79807