### PR TITLE
ref(lpq): Delete queues, options, killswitches

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -711,6 +711,7 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
             attrs[item]["has_user_reports"] = item.id in projects_with_user_reports
             if not self._collapse(LATEST_DEPLOYS_KEY):
                 attrs[item]["deploys"] = deploys_by_project.get(item.id)
+            # TODO: remove this attribute and evenrything connected with it
             # check if the project is in LPQ for any platform
             # XXX(joshferge): determine if the frontend needs this flag at all
             # removing redis call as was causing problematic latency issues

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2946,9 +2946,7 @@ SYMBOLICATOR_POLL_TIMEOUT = 5
 # The `url` of the different Symbolicator pools.
 # We want to route different workloads to a different set of Symbolicator pools.
 # This can be as fine-grained as using a different pool for normal "native"
-# symbolication, `js` symbolication, `jvm` symbolication,
-# and `lpq` variants`of each of them.
-# (See `SENTRY_LPQ_OPTIONS` and related settings)
+# symbolication, `js` symbolication, and `jvm` symbolication.
 # The keys here should match the `SymbolicatorPools` enum
 # defined in `src/sentry/lang/native/symbolicator.py`.
 # If a specific setting does not exist, this will fall back to the `default` pool.
@@ -2960,9 +2958,6 @@ SYMBOLICATOR_POOL_URLS: dict[str, str] = {
     # "default": "...",
     # "js": "...",
     # "jvm": "...",
-    # "lpq": "...",
-    # "lpq_js": "...",
-    # "lpq_jvm": "...",
 }
 
 SENTRY_REQUEST_METRIC_ALLOWED_PATHS = (

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -917,28 +917,13 @@ CELERY_QUEUES_REGION = [
     Queue(
         "events.reprocessing.symbolicate_event", routing_key="events.reprocessing.symbolicate_event"
     ),
-    Queue(
-        "events.reprocessing.symbolicate_event_low_priority",
-        routing_key="events.reprocessing.symbolicate_event_low_priority",
-    ),
     Queue("events.save_event", routing_key="events.save_event"),
     Queue("events.save_event_highcpu", routing_key="events.save_event_highcpu"),
     Queue("events.save_event_transaction", routing_key="events.save_event_transaction"),
     Queue("events.save_event_attachments", routing_key="events.save_event_attachments"),
     Queue("events.symbolicate_event", routing_key="events.symbolicate_event"),
-    Queue(
-        "events.symbolicate_event_low_priority", routing_key="events.symbolicate_event_low_priority"
-    ),
     Queue("events.symbolicate_js_event", routing_key="events.symbolicate_js_event"),
-    Queue(
-        "events.symbolicate_js_event_low_priority",
-        routing_key="events.symbolicate_js_event_low_priority",
-    ),
     Queue("events.symbolicate_jvm_event", routing_key="events.symbolicate_jvm_event"),
-    Queue(
-        "events.symbolicate_jvm_event_low_priority",
-        routing_key="events.symbolicate_jvm_event_low_priority",
-    ),
     Queue("files.copy", routing_key="files.copy"),
     Queue("files.delete", routing_key="files.delete"),
     Queue(
@@ -1307,15 +1292,12 @@ PROCESSING_QUEUES = [
     "events.reprocessing.preprocess_event",
     "events.reprocessing.process_event",
     "events.reprocessing.symbolicate_event",
-    "events.reprocessing.symbolicate_event_low_priority",
     "events.save_event",
     "events.save_event_highcpu",
     "events.save_event_attachments",
     "events.save_event_transaction",
     "events.symbolicate_event",
-    "events.symbolicate_event_low_priority",
     "events.symbolicate_js_event",
-    "events.symbolicate_js_event_low_priority",
     "post_process_errors",
     "post_process_issue_platform",
     "post_process_transactions",

--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -130,28 +130,6 @@ ALL_KILLSWITCH_OPTIONS = {
             "platform": "The event platform as defined in the event payload's platform field, or 'none'",
         },
     ),
-    "store.symbolicate-event-lpq-never": KillswitchInfo(
-        description="""
-        Never allow a project's symbolication events to be demoted to symbolicator's low priority queue.
-
-        If a project is in both store.symbolicate-event-lpq-never and store.symbolicate-event-lpq-always,
-        store.symbolicate-event-lpq-never will always take precedence.
-        """,
-        fields={
-            "project_id": "A project ID to filter events by.",
-        },
-    ),
-    "store.symbolicate-event-lpq-always": KillswitchInfo(
-        description="""
-        Always push a project's symbolication events to symbolicator's low priority queue.
-
-        If a project is in both store.symbolicate-event-lpq-never and store.symbolicate-event-lpq-always,
-        store.symbolicate-event-lpq-never will always take precedence.
-        """,
-        fields={
-            "project_id": "A project ID to filter events by.",
-        },
-    ),
     "post_process.get-autoassign-owners": KillswitchInfo(
         description="""
         Prevent project from running ProjectOwnership._matching_ownership_rules.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1034,19 +1034,6 @@ register(
     "store.save-event-highcpu-platforms", type=Sequence, default=[], flags=FLAG_AUTOMATOR_MODIFIABLE
 )
 register(
-    "store.symbolicate-event-lpq-never", type=Sequence, default=[], flags=FLAG_AUTOMATOR_MODIFIABLE
-)
-register(
-    "store.symbolicate-event-lpq-always", type=Sequence, default=[], flags=FLAG_AUTOMATOR_MODIFIABLE
-)
-
-# Rate at which to send eligible projects to LPQ symbolicators. This is
-# intended to test gradually phasing out the LPQ.
-register(
-    "store.symbolicate-event-lpq-rate", type=Float, default=1.0, flags=FLAG_AUTOMATOR_MODIFIABLE
-)
-
-register(
     "post_process.get-autoassign-owners", type=Sequence, default=[], flags=FLAG_AUTOMATOR_MODIFIABLE
 )
 register(

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -230,7 +230,6 @@ def _do_symbolicate_event(
 # ============ Parameterized tasks below ============
 # We have different *tasks* and associated *queues* for the following permutations:
 # - Event Type (JS vs Native)
-# - Queue Type (LPQ vs normal)
 # - Reprocessing (currently not available for JS events)
 
 

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -449,7 +449,6 @@ def configure_sdk():
         "sync-options",
         "sync-options-control",
         "schedule-digests",
-        "check-symbolicator-lpq-project-eligibility",  # defined in getsentry
     ]
 
     enable_cache_spans = os.getenv("SENTRY_URL_PREFIX") == "sentry.my.sentry.io"

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -170,8 +170,6 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         # make sure options are not cached the first time to get predictable number of database queries
         with assume_test_silo_mode_of(ControlOption):
             sentry_options.delete("system.rate-limit")
-            sentry_options.delete("store.symbolicate-event-lpq-always")
-            sentry_options.delete("store.symbolicate-event-lpq-never")
 
         # TODO(dcramer): We need to pare this down. Lots of duplicate queries for membership data.
         # TODO(hybrid-cloud): put this back in


### PR DESCRIPTION
This is part of the effort to remove the LPQ functionality, which has been unused since Sep 19 (see https://github.com/getsentry/sentry-options-automator/pull/2324).

It deletes the low priority symbolication queues, options, and killswitches. It also deletes/updates some leftover comments.

Depends on INF-319 because the workers need to be deleted before the queues.