### PR TITLE
fix(insights): 'last 7 days' option disabled with query limit

### DIFF
--- a/static/app/views/insights/common/components/modulePageFilterBar.tsx
+++ b/static/app/views/insights/common/components/modulePageFilterBar.tsx
@@ -35,9 +35,8 @@ export function ModulePageFilterBar({moduleName, onProjectChange, extraFilters}:
   const hasDataWithAllProjects = useHasFirstSpan(moduleName, allProjects);
   const [showTooltip, setShowTooltip] = useState(false);
 
-  const hasDateRangeQueryLimit = organization.features.includes(
-    'insights-query-date-range-limit'
-  );
+  const hasDateRangeQueryLimit =
+    true || organization.features.includes('insights-query-date-range-limit');
 
   const handleClickAnywhereOnPage = () => {
     setShowTooltip(false);
@@ -79,7 +78,7 @@ export function ModulePageFilterBar({moduleName, onProjectChange, extraFilters}:
 
     dateFilterProps.maxPickableDays = QUERY_DATE_RANGE_LIMIT;
     dateFilterProps.isOptionDisabled = ({value}) => {
-      if (['absolute', '1h', '24h', '7d'].includes(value)) {
+      if (!['14d', '30d', '90d'].includes(value)) {
         return false;
       }
       return true;

--- a/static/app/views/insights/common/components/modulePageFilterBar.tsx
+++ b/static/app/views/insights/common/components/modulePageFilterBar.tsx
@@ -35,8 +35,9 @@ export function ModulePageFilterBar({moduleName, onProjectChange, extraFilters}:
   const hasDataWithAllProjects = useHasFirstSpan(moduleName, allProjects);
   const [showTooltip, setShowTooltip] = useState(false);
 
-  const hasDateRangeQueryLimit =
-    true || organization.features.includes('insights-query-date-range-limit');
+  const hasDateRangeQueryLimit = organization.features.includes(
+    'insights-query-date-range-limit'
+  );
 
   const handleClickAnywhereOnPage = () => {
     setShowTooltip(false);

--- a/static/app/views/insights/common/components/modulePageFilterBar.tsx
+++ b/static/app/views/insights/common/components/modulePageFilterBar.tsx
@@ -65,14 +65,18 @@ export function ModulePageFilterBar({moduleName, onProjectChange, extraFilters}:
 
   const dateFilterProps: DatePageFilterProps = {};
   if (hasDateRangeQueryLimit) {
-    dateFilterProps.relativeOptions = {
-      '1h': t('Last 1 hour'),
-      '24h': t('Last 24 hours'),
-      '7d': t('Last 7 days'),
-      '14d': <DisabledDateOption value={t('Last 14 days')} />,
-      '30d': <DisabledDateOption value={t('Last 30 days')} />,
-      '90d': <DisabledDateOption value={t('Last 90 days')} />,
+    dateFilterProps.relativeOptions = ({arbitraryOptions}) => {
+      return {
+        ...arbitraryOptions,
+        '1h': t('Last 1 hour'),
+        '24h': t('Last 24 hours'),
+        '7d': t('Last 7 days'),
+        '14d': <DisabledDateOption value={t('Last 14 days')} />,
+        '30d': <DisabledDateOption value={t('Last 30 days')} />,
+        '90d': <DisabledDateOption value={t('Last 90 days')} />,
+      };
     };
+
     dateFilterProps.maxPickableDays = QUERY_DATE_RANGE_LIMIT;
     dateFilterProps.isOptionDisabled = ({value}) => {
       if (['absolute', '1h', '24h', '7d'].includes(value)) {

--- a/static/app/views/insights/common/components/modulePageFilterBar.tsx
+++ b/static/app/views/insights/common/components/modulePageFilterBar.tsx
@@ -26,6 +26,7 @@ type Props = {
 };
 
 const CHANGE_PROJECT_TEXT = t('Make sure you have the correct project selected.');
+const DISABLED_OPTIONS = ['14d', '30d', '90d'];
 
 export function ModulePageFilterBar({moduleName, onProjectChange, extraFilters}: Props) {
   const {projects: allProjects} = useProjects();
@@ -35,8 +36,9 @@ export function ModulePageFilterBar({moduleName, onProjectChange, extraFilters}:
   const hasDataWithAllProjects = useHasFirstSpan(moduleName, allProjects);
   const [showTooltip, setShowTooltip] = useState(false);
 
-  const hasDateRangeQueryLimit =
-    true || organization.features.includes('insights-query-date-range-limit');
+  const hasDateRangeQueryLimit = organization.features.includes(
+    'insights-query-date-range-limit'
+  );
 
   const handleClickAnywhereOnPage = () => {
     setShowTooltip(false);
@@ -78,7 +80,7 @@ export function ModulePageFilterBar({moduleName, onProjectChange, extraFilters}:
 
     dateFilterProps.maxPickableDays = QUERY_DATE_RANGE_LIMIT;
     dateFilterProps.isOptionDisabled = ({value}) => {
-      if (!['14d', '30d', '90d'].includes(value)) {
+      if (!DISABLED_OPTIONS.includes(value)) {
         return false;
       }
       return true;

--- a/static/app/views/insights/common/components/modulePageFilterBar.tsx
+++ b/static/app/views/insights/common/components/modulePageFilterBar.tsx
@@ -1,6 +1,5 @@
 import {type ComponentProps, Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
-import moment from 'moment-timezone';
 
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import {
@@ -10,11 +9,10 @@ import {
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
-import {parseStatsPeriod} from 'sentry/components/timeRangeSelector/utils';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconBusiness} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {DAY, SECOND} from 'sentry/utils/formatters';
+import {SECOND} from 'sentry/utils/formatters';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {useHasFirstSpan} from 'sentry/views/insights/common/queries/useHasFirstSpan';
@@ -28,7 +26,6 @@ type Props = {
 };
 
 const CHANGE_PROJECT_TEXT = t('Make sure you have the correct project selected.');
-const QUERY_DATE_RANGE_LIMIT_MS = QUERY_DATE_RANGE_LIMIT * DAY;
 
 export function ModulePageFilterBar({moduleName, onProjectChange, extraFilters}: Props) {
   const {projects: allProjects} = useProjects();
@@ -38,11 +35,8 @@ export function ModulePageFilterBar({moduleName, onProjectChange, extraFilters}:
   const hasDataWithAllProjects = useHasFirstSpan(moduleName, allProjects);
   const [showTooltip, setShowTooltip] = useState(false);
 
-  const getDateDifferenceMs = memoizedDateDifference();
-
-  const hasDateRangeQueryLimit = organization.features.includes(
-    'insights-query-date-range-limit'
-  );
+  const hasDateRangeQueryLimit =
+    true || organization.features.includes('insights-query-date-range-limit');
 
   const handleClickAnywhereOnPage = () => {
     setShowTooltip(false);
@@ -80,11 +74,10 @@ export function ModulePageFilterBar({moduleName, onProjectChange, extraFilters}:
     };
     dateFilterProps.maxPickableDays = QUERY_DATE_RANGE_LIMIT;
     dateFilterProps.isOptionDisabled = ({value}) => {
-      if (value === 'absolute') {
+      if (['absolute', '1h', '24h', '7d'].includes(value)) {
         return false;
       }
-      const dateDifferenceMs = getDateDifferenceMs(value);
-      return dateDifferenceMs > QUERY_DATE_RANGE_LIMIT_MS;
+      return true;
     };
     dateFilterProps.menuFooter = <UpsellFooterHook />;
   }
@@ -128,20 +121,6 @@ const DisabledDateOptionContainer = styled('div')`
 const StyledIconBuisness = styled(IconBusiness)`
   margin-left: auto;
 `;
-
-// There's only a couple options, so might as well memoize this and not repeat it many times
-const memoizedDateDifference = () => {
-  const cache = {};
-  return (value: string) => {
-    if (value in cache) {
-      return cache[value];
-    }
-    const {start, end} = parseStatsPeriod(value);
-    const difference = moment(end).diff(moment(start));
-    cache[value] = difference;
-    return difference;
-  };
-};
 
 export const UpsellFooterHook = HookOrDefault({
   hookName: 'component:insights-date-range-query-limit-footer',


### PR DESCRIPTION
Somehow this stopped working, and the "last 7 day option" was greyed out and disabled, despite checking if `dateDifferenceMs > QUERY_DATE_RANGE_LIMIT_MS` before. (it shouldn't be disabled, we should allow 7 days of querying when the user is on am3 team plan) 

`dateDifferenceMs` was return a value greater the 7 days, even when you pass in `7d` to it.

To make this less fragile, we can just hardcode what options are disabled. I think the previous approach might have been too fancy for what's needed.

This PR also fixes a bug where arbitrary options results in "Invalid Period"

<img width="334" alt="image" src="https://github.com/user-attachments/assets/6c619903-7ea1-4617-9c50-1e58d37530bc">
