### PR TITLE
perf(warmup): warmup  url resolver for all supported languages

### DIFF
--- a/tests/sentry/test_wsgi.py
+++ b/tests/sentry/test_wsgi.py
@@ -9,9 +9,11 @@ import sentry.wsgi
 assert "sentry.conf.urls" in sys.modules
 
 import django.urls.resolvers
+from django.conf import settings
 resolver = django.urls.resolvers.get_resolver()
 assert resolver._populated is True
-assert 'en' in resolver._reverse_dict
+for lang, _ in settings.LANGUAGES:
+    assert lang in resolver._reverse_dict
 """
 
 


### PR DESCRIPTION
Following up from https://github.com/getsentry/sentry/pull/80193

We still see slow latency caused when resolving urls. We were able to replicate with the below Github gist. Essentially we were running into a lock contention problem, as django stores a url resolver for each language we support, and when many threads try to initialize their resolver at once, it causes contention and latency. 

Fixes by warming up all languages' resolvers in the warmup endpoint. h/t @asottile-sentry for guidance and help replicating locally.

https://github.com/getsentry/sentry/pull/80193