### PR TITLE
fix(context): Display expected OS fields nicely

### DIFF
--- a/static/app/components/events/contexts/operatingSystem/getOperatingSystemKnownDataDetails.spec.tsx
+++ b/static/app/components/events/contexts/operatingSystem/getOperatingSystemKnownDataDetails.spec.tsx
@@ -1,5 +1,5 @@
-import {operatingSystemKnownDataValues} from 'sentry/components/events/contexts/operatingSystem';
 import {getOperatingSystemKnownDataDetails} from 'sentry/components/events/contexts/operatingSystem/getOperatingSystemKnownDataDetails';
+import {OperatingSystemKnownDataType} from 'sentry/components/events/contexts/operatingSystem/types';
 
 import {operatingSystemMockData} from './index.spec';
 
@@ -7,9 +7,9 @@ describe('getOperatingSystemKnownDataDetails', function () {
   it('returns values and according to the parameters', function () {
     const allKnownData: ReturnType<typeof getOperatingSystemKnownDataDetails>[] = [];
 
-    for (const type of Object.keys(operatingSystemKnownDataValues)) {
+    for (const type of Object.keys(OperatingSystemKnownDataType)) {
       const operatingSystemKnownDataDetails = getOperatingSystemKnownDataDetails({
-        type: operatingSystemKnownDataValues[type],
+        type: OperatingSystemKnownDataType[type],
         data: operatingSystemMockData,
       });
 
@@ -21,10 +21,14 @@ describe('getOperatingSystemKnownDataDetails', function () {
     }
 
     expect(allKnownData).toEqual([
-      {subject: 'Name', value: 'Mac OS X 10.14.0'},
-      {subject: 'Version', value: ''},
-      {subject: 'Kernel Version', value: ''},
-      {subject: 'Rooted', value: null},
+      {subject: 'Name', value: 'Linux'},
+      {subject: 'Version', value: '6.1.82'},
+      {subject: 'Build', value: '20C69'},
+      {subject: 'Kernel Version', value: '99.168.amzn2023.x86_64'},
+      {subject: 'Rooted', value: 'yes'},
+      {subject: 'Theme', value: 'dark'},
+      {subject: 'Raw Description', value: ''},
+      {subject: 'Distro', value: 'Amazon Linux 2023.4.20240401'},
     ]);
   });
 });

--- a/static/app/components/events/contexts/operatingSystem/getOperatingSystemKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/operatingSystem/getOperatingSystemKnownDataDetails.tsx
@@ -23,7 +23,12 @@ export function getOperatingSystemKnownDataDetails({
     case OperatingSystemKnownDataType.VERSION:
       return {
         subject: t('Version'),
-        value: `${data.version}${data.build ? `(${data.build})` : ''}`,
+        value: data.version,
+      };
+    case OperatingSystemKnownDataType.BUILD:
+      return {
+        subject: t('Build'),
+        value: data.build,
       };
     case OperatingSystemKnownDataType.KERNEL_VERSION:
       return {
@@ -34,6 +39,23 @@ export function getOperatingSystemKnownDataDetails({
       return {
         subject: t('Rooted'),
         value: defined(data.rooted) ? (data.rooted ? t('yes') : t('no')) : null,
+      };
+    case OperatingSystemKnownDataType.THEME:
+      return {
+        subject: t('Theme'),
+        value: data.theme,
+      };
+    case OperatingSystemKnownDataType.RAW_DESCRIPTION:
+      return {
+        subject: t('Raw Description'),
+        value: data.raw_description,
+      };
+    case OperatingSystemKnownDataType.DISTRIBUTION:
+      return {
+        subject: t('Distro'),
+        value: data.distribution?.pretty_name
+          ? data.distribution?.pretty_name
+          : `${data.distribution?.name}${data.distribution?.version ? `(${data.distribution.version})` : ''}`,
       };
     default:
       return undefined;

--- a/static/app/components/events/contexts/operatingSystem/index.spec.tsx
+++ b/static/app/components/events/contexts/operatingSystem/index.spec.tsx
@@ -7,11 +7,18 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import {OperatingSystemEventContext} from 'sentry/components/events/contexts/operatingSystem';
 
 export const operatingSystemMockData = {
-  name: 'Mac OS X 10.14.0',
-  version: '',
+  name: 'Linux',
+  version: '6.1.82',
+  build: '20C69',
+  kernel_version: '99.168.amzn2023.x86_64',
+  rooted: true,
+  theme: 'dark',
   raw_description: '',
-  build: '',
-  kernel_version: '',
+  distribution: {
+    name: 'amzn',
+    version: '2023',
+    pretty_name: 'Amazon Linux 2023.4.20240401',
+  },
 };
 
 export const operatingSystemMetaMockData = {
@@ -47,7 +54,7 @@ describe('operating system event context', function () {
       },
     });
 
-    expect(screen.getByText('raw_description')).toBeInTheDocument(); // subject
+    expect(screen.getByText('Raw Description')).toBeInTheDocument(); // subject
     await userEvent.hover(screen.getByText(/redacted/));
     expect(
       await screen.findByText(

--- a/static/app/components/events/contexts/operatingSystem/index.tsx
+++ b/static/app/components/events/contexts/operatingSystem/index.tsx
@@ -12,22 +12,13 @@ import {
 
 import {getOperatingSystemKnownDataDetails} from './getOperatingSystemKnownDataDetails';
 import type {OperatingSystemKnownData} from './types';
-import {OperatingSystemIgnoredDataType, OperatingSystemKnownDataType} from './types';
+import {OperatingSystemKnownDataType} from './types';
 
 type Props = {
   data: OperatingSystemKnownData;
   event: Event;
   meta?: Record<string, any>;
 };
-
-export const operatingSystemKnownDataValues = [
-  OperatingSystemKnownDataType.NAME,
-  OperatingSystemKnownDataType.VERSION,
-  OperatingSystemKnownDataType.KERNEL_VERSION,
-  OperatingSystemKnownDataType.ROOTED,
-];
-
-const operatingSystemIgnoredDataValues = [OperatingSystemIgnoredDataType.BUILD];
 
 export function getKnownOperatingSystemContextData({
   data,
@@ -36,7 +27,7 @@ export function getKnownOperatingSystemContextData({
   return getKnownData<OperatingSystemKnownData, OperatingSystemKnownDataType>({
     data,
     meta,
-    knownDataTypes: operatingSystemKnownDataValues,
+    knownDataTypes: Object.values(OperatingSystemKnownDataType),
     onGetKnownDataDetails: v => getOperatingSystemKnownDataDetails(v),
   });
 }
@@ -47,7 +38,7 @@ export function getUnknownOperatingSystemContextData({
 }: Pick<Props, 'data' | 'meta'>) {
   return getUnknownData({
     allData: data,
-    knownKeys: [...operatingSystemKnownDataValues, ...operatingSystemIgnoredDataValues],
+    knownKeys: Object.values(OperatingSystemKnownDataType),
     meta,
   });
 }

--- a/static/app/components/events/contexts/operatingSystem/types.tsx
+++ b/static/app/components/events/contexts/operatingSystem/types.tsx
@@ -1,19 +1,27 @@
+// https://develop.sentry.dev/sdk/data-model/event-payloads/contexts/#os-context
 export enum OperatingSystemKnownDataType {
   NAME = 'name',
   VERSION = 'version',
+  BUILD = 'build',
   KERNEL_VERSION = 'kernel_version',
   ROOTED = 'rooted',
-}
-
-export enum OperatingSystemIgnoredDataType {
-  BUILD = 'build',
+  THEME = 'theme',
+  RAW_DESCRIPTION = 'raw_description',
+  DISTRIBUTION = 'distribution',
 }
 
 export type OperatingSystemKnownData = {
-  build: string;
-  kernel_version: string;
-  name: string;
-  rooted?: boolean;
   type?: string;
-  version?: string;
+  [OperatingSystemKnownDataType.NAME]?: string;
+  [OperatingSystemKnownDataType.VERSION]?: string;
+  [OperatingSystemKnownDataType.BUILD]?: string;
+  [OperatingSystemKnownDataType.KERNEL_VERSION]?: string;
+  [OperatingSystemKnownDataType.ROOTED]?: boolean;
+  [OperatingSystemKnownDataType.THEME]?: string;
+  [OperatingSystemKnownDataType.RAW_DESCRIPTION]?: string;
+  [OperatingSystemKnownDataType.DISTRIBUTION]?: {
+    name?: string;
+    pretty_name?: string;
+    version?: string;
+  };
 };


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry/issues/80313, more inline with docs for OS. Also looked into the server vs. client OS thing and it seems that we're not consistent about using `client_os` even for frontend SDKs so we can't reliable label anything one way or the other :/

Might look at some of the other context items to make sure they're inline with docs, but likely in other PRs