### PR TITLE
getsentry: move robots.txt

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -25,6 +25,7 @@ from sentry.conf.types.kafka_definition import ConsumerDefinition
 from sentry.conf.types.logging_config import LoggingConfig
 from sentry.conf.types.role_dict import RoleDict
 from sentry.conf.types.sdk_config import ServerSdkConfig
+from sentry.conf.types.sentry_config import SentryMode
 from sentry.utils import json  # NOQA (used in getsentry config)
 from sentry.utils.celery import crontab_with_minute_jitter, make_split_task_queues
 from sentry.utils.types import Type, type_from_value
@@ -1474,6 +1475,7 @@ if os.environ.get("OPENAPIGENERATE", False):
     }
 
 CRISPY_TEMPLATE_PACK = "bootstrap3"
+
 # Sentry and internal client configuration
 
 SENTRY_EARLY_FEATURES = {
@@ -2490,7 +2492,13 @@ SENTRY_MAX_AVATAR_SIZE = 5000000
 STATUS_PAGE_ID: str | None = None
 STATUS_PAGE_API_HOST = "statuspage.io"
 
-SENTRY_SELF_HOSTED = True
+# This supersedes SENTRY_SINGLE_TENANT and SENTRY_SELF_HOSTED.
+# An enum is better because there shouldn't be multiple "modes".
+SENTRY_MODE = SentryMode.SELF_HOSTED
+
+# For compatibility only. Prefer using SENTRY_MODE.
+SENTRY_SELF_HOSTED = SENTRY_MODE == SentryMode.SELF_HOSTED
+
 SENTRY_SELF_HOSTED_ERRORS_ONLY = False
 # only referenced in getsentry to provide the stable beacon version
 # updated with scripts/bump-version.sh

--- a/src/sentry/conf/types/sentry_config.py
+++ b/src/sentry/conf/types/sentry_config.py
@@ -1,0 +1,3 @@
+from enum import Enum
+
+SentryMode = Enum("SentryMode", ("SELF_HOSTED", "SINGLE_TENANT", "SAAS"))

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -1,9 +1,9 @@
+from django.conf import settings
 from django.http import HttpResponse
 from django.views.decorators.cache import cache_control
 from django.views.generic.base import View as BaseView
 from rest_framework.request import Request
 
-from sentry.conf.server import SENTRY_MODE
 from sentry.conf.types.sentry_config import SentryMode
 from sentry.models.project import Project
 from sentry.silo.base import SiloMode
@@ -38,10 +38,9 @@ class ClientConfigView(BaseView):
 
 @cache_control(max_age=3600, public=True)
 def robots_txt(request):
-    breakpoint()
     if (
-        SENTRY_MODE == SentryMode.SELF_HOSTED
-        or SENTRY_MODE == SentryMode.SINGLE_TENANT
+        settings.SENTRY_MODE == SentryMode.SELF_HOSTED
+        or settings.SENTRY_MODE == SentryMode.SINGLE_TENANT
         or request.subdomain
     ):
         return HttpResponse(ROBOTS_DISALLOW_ALL, content_type="text/plain")

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -3,12 +3,32 @@ from django.views.decorators.cache import cache_control
 from django.views.generic.base import View as BaseView
 from rest_framework.request import Request
 
+from sentry.conf.server import SENTRY_MODE
+from sentry.conf.types.sentry_config import SentryMode
 from sentry.models.project import Project
 from sentry.silo.base import SiloMode
 from sentry.utils import json
 from sentry.utils.http import get_origins
 from sentry.web.client_config import get_client_config
 from sentry.web.helpers import render_to_response
+
+# Paths to pages should not be added here, otherwise crawlers will
+# not be able to access the metadata with the 'none' directive
+# and the URL of these pages may still appear in search results
+ROBOTS = """User-agent: *
+Disallow: /api/
+Allow: /api/*/store/
+Allow: /
+
+Sitemap: https://sentry.io/sitemap-index.xml
+"""
+
+# For customer domains, like acme.us.sentry.io,
+# we want to disallow honest crawlers from accessing any page on a customer domain.
+# This should prevent a customer domain from showing up in search engine results.
+ROBOTS_DISALLOW_ALL = """User-agent: *
+Disallow: /
+"""
 
 
 class ClientConfigView(BaseView):
@@ -18,7 +38,15 @@ class ClientConfigView(BaseView):
 
 @cache_control(max_age=3600, public=True)
 def robots_txt(request):
-    return HttpResponse("User-agent: *\nDisallow: /\n", content_type="text/plain")
+    breakpoint()
+    if (
+        SENTRY_MODE == SentryMode.SELF_HOSTED
+        or SENTRY_MODE == SentryMode.SINGLE_TENANT
+        or request.subdomain
+    ):
+        return HttpResponse(ROBOTS_DISALLOW_ALL, content_type="text/plain")
+
+    return HttpResponse(ROBOTS, content_type="text/plain")
 
 
 @cache_control(max_age=60)

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from sentry import options
 from sentry.api.utils import generate_region_url
 from sentry.auth import superuser
+from sentry.conf.types.sentry_config import SentryMode
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.deletions.tasks.scheduled import run_deletion
 from sentry.models.apitoken import ApiToken
@@ -81,6 +82,24 @@ class RobotsTxtTest(TestCase):
         resp = self.client.get(self.path)
         assert resp.status_code == 200
         assert resp["Content-Type"] == "text/plain"
+        assert (
+            resp.content
+            == b"""User-agent: *
+Disallow: /
+"""
+        )
+
+    def test_robots_saas(self):
+        with override_settings(SENTRY_MODE=SentryMode.SAAS):
+            resp = self.client.get(self.path)
+            assert resp.status_code == 200
+            assert resp["Content-Type"] == "text/plain"
+            assert (
+                resp.content
+                == b"""User-agent: *
+Disallow: /
+"""
+            )
 
 
 @region_silo_test(regions=create_test_regions("us", "eu"), include_monolith_run=True)

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -97,7 +97,11 @@ Disallow: /
             assert (
                 resp.content
                 == b"""User-agent: *
-Disallow: /
+Disallow: /api/
+Allow: /api/*/store/
+Allow: /
+
+Sitemap: https://sentry.io/sitemap-index.xml
 """
             )
 


### PR DESCRIPTION
sentry.sentry.io (and all saas subdomains), self hosted, and single tenants should be disallow all
sentry.io should have the sitemap

i'm gonna separate SENTRY_MODE after i figure out how to send that to frontend btw

getsentry: https://github.com/getsentry/getsentry/pull/15644