### PR TITLE
fix(contexts): Audit and updates some more contexts

### DIFF
--- a/static/app/components/events/contexts/app/getAppKnownDataDetails.spec.tsx
+++ b/static/app/components/events/contexts/app/getAppKnownDataDetails.spec.tsx
@@ -30,11 +30,14 @@ describe('getAppKnownDataDetails', function () {
         subject: 'Device',
         value: '2421fae1ac9237a8131e74883e52b0f7034a143f',
       },
+      {subject: 'Build Type', value: 'test'},
       {subject: 'Build ID', value: 'io.sentry.sample.iOS-Swift'},
       {subject: 'Build Name', value: ''},
       {subject: 'Version', value: '7.1.3'},
       {subject: 'App Build', value: '1'},
       {subject: 'In Foreground', value: false},
+      {subject: 'Memory Usage', value: '12.0 MiB'},
+      {subject: 'View Names', value: ['app.view1', 'app.view2']},
     ]);
   });
 });

--- a/static/app/components/events/contexts/app/getAppKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/app/getAppKnownDataDetails.tsx
@@ -1,5 +1,6 @@
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
+import {formatBytesBase2} from 'sentry/utils/bytes/formatBytesBase2';
 
 import {getRelativeTimeFromEventDateCreated, type KnownDataDetails} from '../utils';
 
@@ -11,6 +12,14 @@ type Props = {
   event: Event;
   type: AppKnownDataType;
 };
+
+// https://github.com/getsentry/relay/blob/24.10.0/relay-event-schema/src/protocol/contexts/app.rs#L37
+function formatMemory(memoryInBytes: number) {
+  if (!Number.isInteger(memoryInBytes) || memoryInBytes <= 0) {
+    return null;
+  }
+  return formatBytesBase2(memoryInBytes);
+}
 
 export function getAppKnownDataDetails({data, event, type}: Props): KnownDataDetails {
   switch (type) {
@@ -61,6 +70,16 @@ export function getAppKnownDataDetails({data, event, type}: Props): KnownDataDet
       return {
         subject: t('In Foreground'),
         value: data.in_foreground,
+      };
+    case AppKnownDataType.MEMORY:
+      return {
+        subject: t('Memory Usage'),
+        value: data.app_memory ? formatMemory(data.app_memory) : undefined,
+      };
+    case AppKnownDataType.VIEW_NAMES:
+      return {
+        subject: t('View Names'),
+        value: data.view_names,
       };
     default:
       return undefined;

--- a/static/app/components/events/contexts/app/index.spec.tsx
+++ b/static/app/components/events/contexts/app/index.spec.tsx
@@ -17,6 +17,8 @@ export const appMockData: AppData = {
   app_id: '3145EA1A-0EAE-3F8C-969A-13A01394D3EA',
   type: 'app',
   in_foreground: false,
+  app_memory: 1048576 * 12,
+  view_names: ['app.view1', 'app.view2'],
 };
 
 export const appMetaMockData = {

--- a/static/app/components/events/contexts/app/index.tsx
+++ b/static/app/components/events/contexts/app/index.tsx
@@ -19,16 +19,7 @@ type Props = {
   meta?: Record<string, any>;
 };
 
-export const appKnownDataValues = [
-  AppKnownDataType.ID,
-  AppKnownDataType.START_TIME,
-  AppKnownDataType.DEVICE_HASH,
-  AppKnownDataType.IDENTIFIER,
-  AppKnownDataType.NAME,
-  AppKnownDataType.VERSION,
-  AppKnownDataType.BUILD,
-  AppKnownDataType.IN_FOREGROUND,
-];
+export const appKnownDataValues = Object.values(AppKnownDataType);
 
 const appIgnoredDataValues = [];
 

--- a/static/app/components/events/contexts/app/types.tsx
+++ b/static/app/components/events/contexts/app/types.tsx
@@ -8,17 +8,21 @@ export enum AppKnownDataType {
   VERSION = 'app_version',
   BUILD = 'app_build',
   IN_FOREGROUND = 'in_foreground',
+  MEMORY = 'app_memory',
+  VIEW_NAMES = 'view_names',
 }
 
 export type AppData = {
   type: string;
-  app_build?: string;
-  app_id?: string;
-  app_identifier?: string;
-  app_name?: string;
-  app_start_time?: string;
-  app_version?: string;
-  build_type?: string;
-  device_app_hash?: string;
-  in_foreground?: boolean;
+  [AppKnownDataType.BUILD]?: string;
+  [AppKnownDataType.ID]?: string;
+  [AppKnownDataType.IDENTIFIER]?: string;
+  [AppKnownDataType.NAME]?: string;
+  [AppKnownDataType.START_TIME]?: string;
+  [AppKnownDataType.VERSION]?: string;
+  [AppKnownDataType.TYPE]?: string;
+  [AppKnownDataType.DEVICE_HASH]?: string;
+  [AppKnownDataType.IN_FOREGROUND]?: boolean;
+  [AppKnownDataType.MEMORY]?: number;
+  [AppKnownDataType.VIEW_NAMES]?: string[];
 };

--- a/static/app/components/events/contexts/device/getDeviceKnownDataDetails.spec.tsx
+++ b/static/app/components/events/contexts/device/getDeviceKnownDataDetails.spec.tsx
@@ -29,6 +29,7 @@ describe('getDeviceKnownDataDetails', function () {
       {subject: 'Architecture', value: 'x86'},
       {subject: 'Battery Level', value: '100%'},
       {subject: 'Battery Status', value: undefined},
+      {subject: 'Battery Temperature (°C)', value: 45},
       expect.objectContaining({subject: 'Boot Time'}),
       {subject: 'Brand', value: 'google'},
       {subject: 'Charging', value: true},

--- a/static/app/components/events/contexts/device/getDeviceKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/device/getDeviceKnownDataDetails.tsx
@@ -71,6 +71,11 @@ export function getDeviceKnownDataDetails({data, event, type}: Props): KnownData
         subject: t('Battery Status'),
         value: data.battery_status,
       };
+    case DeviceContextKey.BATTERY_TEMPERATURE:
+      return {
+        subject: t('Battery Temperature (°C)'),
+        value: data.battery_temperature,
+      };
     case DeviceContextKey.ORIENTATION:
       return {
         subject: t('Orientation'),

--- a/static/app/components/events/contexts/device/index.spec.tsx
+++ b/static/app/components/events/contexts/device/index.spec.tsx
@@ -12,6 +12,7 @@ export const deviceMockData: DeviceContext = {
   orientation: 'portrait',
   family: 'Android',
   battery_level: 100,
+  battery_temperature: 45,
   screen_dpi: 480,
   memory_size: 1055186944,
   timezone: 'America/Los_Angeles',

--- a/static/app/components/events/contexts/runtime/getRuntimeKnownDataDetails.spec.tsx
+++ b/static/app/components/events/contexts/runtime/getRuntimeKnownDataDetails.spec.tsx
@@ -27,7 +27,15 @@ describe('getRuntimeKnownDataDetails', function () {
       },
       {
         subject: 'Version',
-        value: '1.7.13(2.7.18 (default, Apr 20 2020, 19:34:11) \n[GCC 8.3.0])',
+        value: '1.7.13',
+      },
+      {
+        subject: 'Build',
+        value: '2.7.18 (default, Apr 20 2020, 19:34:11) \n[GCC 8.3.0]',
+      },
+      {
+        subject: 'Raw Description',
+        value: '',
       },
     ]);
   });

--- a/static/app/components/events/contexts/runtime/getRuntimeKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/runtime/getRuntimeKnownDataDetails.tsx
@@ -16,10 +16,20 @@ export function getRuntimeKnownDataDetails({type, data}: Props): KnownDataDetail
         subject: t('Name'),
         value: data.name,
       };
+    case RuntimeKnownDataType.BUILD:
+      return {
+        subject: t('Build'),
+        value: data.build,
+      };
     case RuntimeKnownDataType.VERSION:
       return {
         subject: t('Version'),
-        value: `${data.version}${data.build ? `(${data.build})` : ''}`,
+        value: data.version,
+      };
+    case RuntimeKnownDataType.RAW_DESCRIPTION:
+      return {
+        subject: t('Raw Description'),
+        value: data.raw_description,
       };
     default:
       return undefined;

--- a/static/app/components/events/contexts/runtime/index.spec.tsx
+++ b/static/app/components/events/contexts/runtime/index.spec.tsx
@@ -8,6 +8,7 @@ import {RuntimeEventContext} from 'sentry/components/events/contexts/runtime';
 export const runtimeMockData = {
   version: '1.7.13',
   type: 'runtime',
+  raw_description: '',
   build: '2.7.18 (default, Apr 20 2020, 19:34:11) \n[GCC 8.3.0]',
   name: '',
 };

--- a/static/app/components/events/contexts/runtime/index.tsx
+++ b/static/app/components/events/contexts/runtime/index.tsx
@@ -12,7 +12,7 @@ import {
 
 import {getRuntimeKnownDataDetails} from './getRuntimeKnownDataDetails';
 import type {RuntimeData} from './types';
-import {RuntimeIgnoredDataType, RuntimeKnownDataType} from './types';
+import {RuntimeKnownDataType} from './types';
 
 type Props = {
   data: RuntimeData;
@@ -20,12 +20,7 @@ type Props = {
   meta?: Record<string, any>;
 };
 
-export const runtimeKnownDataValues = [
-  RuntimeKnownDataType.NAME,
-  RuntimeKnownDataType.VERSION,
-];
-
-const runtimeIgnoredDataValues = [RuntimeIgnoredDataType.BUILD];
+export const runtimeKnownDataValues = Object.values(RuntimeKnownDataType);
 
 export function getKnownRuntimeContextData({data, meta}: Pick<Props, 'data' | 'meta'>) {
   return getKnownData<RuntimeData, RuntimeKnownDataType>({
@@ -39,7 +34,7 @@ export function getKnownRuntimeContextData({data, meta}: Pick<Props, 'data' | 'm
 export function getUnknownRuntimeContextData({data, meta}: Pick<Props, 'data' | 'meta'>) {
   return getUnknownData({
     allData: data,
-    knownKeys: [...runtimeKnownDataValues, ...runtimeIgnoredDataValues],
+    knownKeys: runtimeKnownDataValues,
     meta,
   });
 }

--- a/static/app/components/events/contexts/runtime/types.tsx
+++ b/static/app/components/events/contexts/runtime/types.tsx
@@ -1,15 +1,14 @@
 export enum RuntimeKnownDataType {
   NAME = 'name',
   VERSION = 'version',
-}
-
-export enum RuntimeIgnoredDataType {
   BUILD = 'build',
+  RAW_DESCRIPTION = 'raw_description',
 }
 
 export type RuntimeData = {
-  name: string;
   type: string;
-  build?: string;
-  version?: string;
+  [RuntimeKnownDataType.NAME]: string;
+  [RuntimeKnownDataType.VERSION]?: string;
+  [RuntimeKnownDataType.BUILD]?: string;
+  [RuntimeKnownDataType.RAW_DESCRIPTION]?: string;
 };

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -404,6 +404,7 @@ export enum DeviceContextKey {
   ARCH = 'arch',
   BATTERY_LEVEL = 'battery_level',
   BATTERY_STATUS = 'battery_status',
+  BATTERY_TEMPERATURE = 'battery_temperature',
   BOOT_TIME = 'boot_time',
   BRAND = 'brand',
   CHARGING = 'charging',
@@ -450,6 +451,7 @@ export interface DeviceContext
   [DeviceContextKey.ARCH]?: string;
   [DeviceContextKey.BATTERY_LEVEL]?: number;
   [DeviceContextKey.BATTERY_STATUS]?: string;
+  [DeviceContextKey.BATTERY_TEMPERATURE]?: number;
   [DeviceContextKey.BOOT_TIME]?: string;
   [DeviceContextKey.BRAND]?: string;
   [DeviceContextKey.CHARGING]?: boolean;


### PR DESCRIPTION
After https://github.com/getsentry/sentry/pull/80324 I have been comparing relay's schema with our docs and with sentry and continue to find disparities. I will have a series of PRs fixing these up, and one last one afterward to update docs to [reflect relay's schema](https://github.com/getsentry/relay/tree/24.10.0/relay-event-schema/src/protocol/contexts).

In this PR I fix up `device`, `runtime` and `app` contexts to display more info (that they may already be sending!)