### PR TITLE
feat(insights): create banner on performance page that it's moving

### DIFF
--- a/static/app/utils/performance/contexts/pageAlert.tsx
+++ b/static/app/utils/performance/contexts/pageAlert.tsx
@@ -11,6 +11,7 @@ type PageAlertType = keyof Theme['alert'];
 export enum DismissId {
   RESOURCE_SIZE_ALERT = 0,
   CACHE_SDK_UPDATE_ALERT = 1,
+  PERFORMANCE_MOVING_ALERT = 2,
 }
 
 export type PageAlertOptions = {

--- a/static/app/utils/performance/contexts/pageAlert.tsx
+++ b/static/app/utils/performance/contexts/pageAlert.tsx
@@ -11,7 +11,6 @@ type PageAlertType = keyof Theme['alert'];
 export enum DismissId {
   RESOURCE_SIZE_ALERT = 0,
   CACHE_SDK_UPDATE_ALERT = 1,
-  PERFORMANCE_MOVING_ALERT = 2,
 }
 
 export type PageAlertOptions = {

--- a/static/app/views/performance/content.tsx
+++ b/static/app/views/performance/content.tsx
@@ -18,6 +18,7 @@ import {
   canUseMetricsData,
   METRIC_SEARCH_SETTING_PARAM,
 } from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
+import {PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
 import {PerformanceEventViewProvider} from 'sentry/utils/performance/contexts/performanceEventViewContext';
 import useRouteAnalyticsEventNames from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
@@ -172,36 +173,38 @@ function PerformanceContent({selection, location, demoMode, router}: Props) {
   return (
     <SentryDocumentTitle title={t('Performance')} orgSlug={organization.slug}>
       <PerformanceEventViewProvider value={{eventView}}>
-        <PageFiltersContainer
-          defaultSelection={{
-            datetime: {
-              start: null,
-              end: null,
-              utc: false,
-              period: getDefaultStatsPeriod(organization),
-            },
-          }}
-        >
-          <PerformanceLanding
-            router={router}
-            eventView={eventView}
-            setError={setError}
-            handleSearch={handleSearch}
-            handleTrendsClick={() =>
-              handleTrendsClick({
-                location,
-                organization,
-                projectPlatforms: getSelectedProjectPlatforms(location, projects),
-              })
-            }
-            onboardingProject={onboardingProject}
-            organization={organization}
-            location={location}
-            projects={projects}
-            selection={selection}
-            withStaticFilters={withStaticFilters}
-          />
-        </PageFiltersContainer>
+        <PageAlertProvider>
+          <PageFiltersContainer
+            defaultSelection={{
+              datetime: {
+                start: null,
+                end: null,
+                utc: false,
+                period: getDefaultStatsPeriod(organization),
+              },
+            }}
+          >
+            <PerformanceLanding
+              router={router}
+              eventView={eventView}
+              setError={setError}
+              handleSearch={handleSearch}
+              handleTrendsClick={() =>
+                handleTrendsClick({
+                  location,
+                  organization,
+                  projectPlatforms: getSelectedProjectPlatforms(location, projects),
+                })
+              }
+              onboardingProject={onboardingProject}
+              organization={organization}
+              location={location}
+              projects={projects}
+              selection={selection}
+              withStaticFilters={withStaticFilters}
+            />
+          </PageFiltersContainer>
+        </PageAlertProvider>
       </PerformanceEventViewProvider>
     </SentryDocumentTitle>
   );

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -1,5 +1,5 @@
 import type {FC} from 'react';
-import {Fragment, useEffect, useRef} from 'react';
+import {Fragment, useEffect, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
@@ -7,6 +7,7 @@ import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
+import Link from 'sentry/components/links/link';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
@@ -32,13 +33,17 @@ import {
   MEPConsumer,
   MEPSettingProvider,
 } from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
-import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
+import {PageAlert, usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useTeams} from 'sentry/utils/useTeams';
+import {AI_SIDEBAR_LABEL} from 'sentry/views/insights/pages/ai/settings';
+import {BACKEND_SIDEBAR_LABEL} from 'sentry/views/insights/pages/backend/settings';
+import {FRONTEND_SIDEBAR_LABEL} from 'sentry/views/insights/pages/frontend/settings';
+import {MOBILE_SIDEBAR_LABEL} from 'sentry/views/insights/pages/mobile/settings';
 
 import Onboarding from '../onboarding';
 import {MetricsEventsDropdown} from '../transactionSummary/transactionOverview/metricEvents/metricsEventsDropdown';
-import {getTransactionSearchQuery} from '../utils';
+import {getPerformanceBaseUrl, getTransactionSearchQuery} from '../utils';
 
 import {AllTransactionsView} from './views/allTransactionsView';
 import {BackendView} from './views/backendView';
@@ -87,8 +92,31 @@ export function PerformanceLanding(props: Props) {
     handleTrendsClick,
     onboardingProject,
   } = props;
-
+  const {setPageInfo, pageAlert} = usePageAlert();
   const {teams, initiallyLoaded} = useTeams({provideUserTeams: true});
+  const {slug} = organization;
+  const hasDomainViews = organization.features.includes('insights-domain-vew');
+
+  const performanceMovingAlert = useMemo(() => {
+    if (!slug) {
+      return undefined;
+    }
+    return (
+      <Fragment>
+        {t(
+          `To make it easier to see what's relevant for you, Sentry's Performance landing page is now being split into separate `
+        )}
+        <Link to={getPerformanceBaseUrl(slug, 'frontend')}>{FRONTEND_SIDEBAR_LABEL}</Link>
+        {`, `}
+        <Link to={getPerformanceBaseUrl(slug, 'backend')}>{BACKEND_SIDEBAR_LABEL}</Link>
+        {`, `}
+        <Link to={getPerformanceBaseUrl(slug, 'mobile')}>{MOBILE_SIDEBAR_LABEL}</Link>
+        {t(', and ')}
+        <Link to={getPerformanceBaseUrl(slug, 'ai')}>{AI_SIDEBAR_LABEL}</Link>
+        {t(' performance pages. They can all be found in the Insights tab.')}
+      </Fragment>
+    );
+  }, [slug]);
 
   const hasMounted = useRef(false);
   const paramLandingDisplay = getLandingDisplayFromParam(location);
@@ -98,6 +126,14 @@ export function PerformanceLanding(props: Props) {
   );
   const landingDisplay = paramLandingDisplay ?? defaultLandingDisplayForProjects;
   const showOnboarding = onboardingProject !== undefined;
+
+  if (
+    hasDomainViews &&
+    performanceMovingAlert &&
+    pageAlert?.message !== performanceMovingAlert
+  ) {
+    setPageInfo(performanceMovingAlert);
+  }
 
   useEffect(() => {
     if (hasMounted.current) {
@@ -162,135 +198,133 @@ export function PerformanceLanding(props: Props) {
 
   return (
     <Layout.Page data-test-id="performance-landing-v3">
-      <PageAlertProvider>
-        <Tabs
-          value={landingDisplay.field}
-          onChange={field =>
-            handleLandingDisplayChange(field, location, projects, organization, eventView)
-          }
-        >
-          <Layout.Header>
-            <Layout.HeaderContent>
-              <Layout.Title>
-                {t('Performance')}
-                <PageHeadingQuestionTooltip
-                  docsUrl="https://docs.sentry.io/product/performance/"
-                  title={t(
-                    'Your main view for transaction data with graphs that visualize transactions or trends, as well as a table where you can drill down on individual transactions.'
-                  )}
-                />
-              </Layout.Title>
-            </Layout.HeaderContent>
-            <Layout.HeaderActions>
-              {!showOnboarding && (
-                <ButtonBar gap={1}>
-                  <Button
-                    size="sm"
-                    priority="primary"
-                    data-test-id="landing-header-trends"
-                    onClick={() => handleTrendsClick()}
-                  >
-                    {t('View Trends')}
-                  </Button>
-                  <FeedbackWidgetButton />
-                </ButtonBar>
-              )}
-            </Layout.HeaderActions>
+      <Tabs
+        value={landingDisplay.field}
+        onChange={field =>
+          handleLandingDisplayChange(field, location, projects, organization, eventView)
+        }
+      >
+        <Layout.Header>
+          <Layout.HeaderContent>
+            <Layout.Title>
+              {t('Performance')}
+              <PageHeadingQuestionTooltip
+                docsUrl="https://docs.sentry.io/product/performance/"
+                title={t(
+                  'Your main view for transaction data with graphs that visualize transactions or trends, as well as a table where you can drill down on individual transactions.'
+                )}
+              />
+            </Layout.Title>
+          </Layout.HeaderContent>
+          <Layout.HeaderActions>
+            {!showOnboarding && (
+              <ButtonBar gap={1}>
+                <Button
+                  size="sm"
+                  priority="primary"
+                  data-test-id="landing-header-trends"
+                  onClick={() => handleTrendsClick()}
+                >
+                  {t('View Trends')}
+                </Button>
+                <FeedbackWidgetButton />
+              </ButtonBar>
+            )}
+          </Layout.HeaderActions>
 
-            <TabList hideBorder>
-              {LANDING_DISPLAYS.map(({label, field}) => (
-                <TabList.Item key={field}>{label}</TabList.Item>
-              ))}
-            </TabList>
-          </Layout.Header>
+          <TabList hideBorder>
+            {LANDING_DISPLAYS.map(({label, field}) => (
+              <TabList.Item key={field}>{label}</TabList.Item>
+            ))}
+          </TabList>
+        </Layout.Header>
 
-          <Layout.Body data-test-id="performance-landing-body">
-            <Layout.Main fullWidth>
-              <TabPanels>
-                <TabPanels.Item key={landingDisplay.field}>
-                  <MetricsCardinalityProvider
-                    sendOutcomeAnalytics
+        <Layout.Body data-test-id="performance-landing-body">
+          <Layout.Main fullWidth>
+            <TabPanels>
+              <TabPanels.Item key={landingDisplay.field}>
+                <MetricsCardinalityProvider
+                  sendOutcomeAnalytics
+                  organization={organization}
+                  location={location}
+                >
+                  <MetricsDataSwitcher
                     organization={organization}
+                    eventView={eventView}
                     location={location}
                   >
-                    <MetricsDataSwitcher
-                      organization={organization}
-                      eventView={eventView}
-                      location={location}
-                    >
-                      {metricsDataSide => {
-                        return (
-                          <MEPSettingProvider
+                    {metricsDataSide => {
+                      return (
+                        <MEPSettingProvider
+                          location={location}
+                          forceTransactions={metricsDataSide.forceTransactionsOnly}
+                        >
+                          <MetricsDataSwitcherAlert
+                            organization={organization}
+                            eventView={eventView}
+                            projects={projects}
                             location={location}
-                            forceTransactions={metricsDataSide.forceTransactionsOnly}
-                          >
-                            <MetricsDataSwitcherAlert
-                              organization={organization}
-                              eventView={eventView}
-                              projects={projects}
-                              location={location}
-                              router={props.router}
-                              {...metricsDataSide}
-                            />
-                            <PageAlert />
-                            {showOnboarding ? (
-                              <Fragment>
+                            router={props.router}
+                            {...metricsDataSide}
+                          />
+                          <PageAlert />
+                          {showOnboarding ? (
+                            <Fragment>
+                              {pageFilters}
+                              <Onboarding
+                                organization={organization}
+                                project={onboardingProject}
+                              />
+                            </Fragment>
+                          ) : (
+                            <Fragment>
+                              <SearchFilterContainer>
                                 {pageFilters}
-                                <Onboarding
+                                <MEPConsumer>
+                                  {({metricSettingState}) => (
+                                    // TODO replace `handleSearch prop` with transaction name search once
+                                    // transaction name search becomes the default search bar
+                                    <TransactionNameSearchBar
+                                      organization={organization}
+                                      eventView={eventView}
+                                      onSearch={(query: string) => {
+                                        handleSearch(
+                                          query,
+                                          metricSettingState ?? undefined
+                                        );
+                                      }}
+                                      query={getFreeTextFromQuery(derivedQuery)}
+                                    />
+                                  )}
+                                </MEPConsumer>
+                                <MetricsEventsDropdown />
+                              </SearchFilterContainer>
+                              {initiallyLoaded ? (
+                                <TeamKeyTransactionManager.Provider
                                   organization={organization}
-                                  project={onboardingProject}
-                                />
-                              </Fragment>
-                            ) : (
-                              <Fragment>
-                                <SearchFilterContainer>
-                                  {pageFilters}
-                                  <MEPConsumer>
-                                    {({metricSettingState}) => (
-                                      // TODO replace `handleSearch prop` with transaction name search once
-                                      // transaction name search becomes the default search bar
-                                      <TransactionNameSearchBar
-                                        organization={organization}
-                                        eventView={eventView}
-                                        onSearch={(query: string) => {
-                                          handleSearch(
-                                            query,
-                                            metricSettingState ?? undefined
-                                          );
-                                        }}
-                                        query={getFreeTextFromQuery(derivedQuery)}
-                                      />
-                                    )}
-                                  </MEPConsumer>
-                                  <MetricsEventsDropdown />
-                                </SearchFilterContainer>
-                                {initiallyLoaded ? (
-                                  <TeamKeyTransactionManager.Provider
-                                    organization={organization}
-                                    teams={teams}
-                                    selectedTeams={['myteams']}
-                                    selectedProjects={eventView.project.map(String)}
-                                  >
-                                    <GenericQueryBatcher>
-                                      <ViewComponent {...props} />
-                                    </GenericQueryBatcher>
-                                  </TeamKeyTransactionManager.Provider>
-                                ) : (
-                                  <LoadingIndicator />
-                                )}
-                              </Fragment>
-                            )}
-                          </MEPSettingProvider>
-                        );
-                      }}
-                    </MetricsDataSwitcher>
-                  </MetricsCardinalityProvider>
-                </TabPanels.Item>
-              </TabPanels>
-            </Layout.Main>
-          </Layout.Body>
-        </Tabs>
-      </PageAlertProvider>
+                                  teams={teams}
+                                  selectedTeams={['myteams']}
+                                  selectedProjects={eventView.project.map(String)}
+                                >
+                                  <GenericQueryBatcher>
+                                    <ViewComponent {...props} />
+                                  </GenericQueryBatcher>
+                                </TeamKeyTransactionManager.Provider>
+                              ) : (
+                                <LoadingIndicator />
+                              )}
+                            </Fragment>
+                          )}
+                        </MEPSettingProvider>
+                      );
+                    }}
+                  </MetricsDataSwitcher>
+                </MetricsCardinalityProvider>
+              </TabPanels.Item>
+            </TabPanels>
+          </Layout.Main>
+        </Layout.Body>
+      </Tabs>
     </Layout.Page>
   );
 }

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -95,7 +95,7 @@ export function PerformanceLanding(props: Props) {
   const {setPageInfo, pageAlert} = usePageAlert();
   const {teams, initiallyLoaded} = useTeams({provideUserTeams: true});
   const {slug} = organization;
-  const hasDomainViews = organization.features.includes('insights-domain-vew');
+  const hasDomainViews = organization.features.includes('insights-domain-view');
 
   const performanceMovingAlert = useMemo(() => {
     if (!slug) {


### PR DESCRIPTION
Adds a banner that tells customers that performance landing page is moving to new domain views.

An additional change I made to get this to work is move the `PageAlertProvider` up one component, so that I can set the alert via `usePageAlert` directly within the performance landing page component.

<img width="1281" alt="image" src="https://github.com/user-attachments/assets/aa0fa7c2-e13a-4491-bd57-60cee6f9006c">
