### PR TITLE
feat(issues): Hide stacktrace icon for streamline ui

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/stackTrace.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/stackTrace.tsx
@@ -9,6 +9,7 @@ import type {PlatformKey} from 'sentry/types/project';
 import {StackType, StackView} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
 import {isNativePlatform} from 'sentry/utils/platform';
+import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 import StackTraceContent from '../stackTrace/content';
 import {NativeContent} from '../stackTrace/nativeContent';
@@ -44,6 +45,7 @@ function StackTrace({
   frameSourceMapDebuggerData,
   stackType,
 }: Props) {
+  const hasStreamlinedUI = useHasStreamlinedUI();
   if (!defined(stacktrace)) {
     return null;
   }
@@ -90,6 +92,7 @@ function StackTrace({
         newestFirst={newestFirst}
         event={event}
         meta={meta}
+        hideIcon={hasStreamlinedUI}
       />
     );
   }
@@ -106,6 +109,7 @@ function StackTrace({
       threadId={threadId}
       frameSourceMapDebuggerData={frameSourceMapDebuggerData}
       hideSourceMapDebugger={stackType === StackType.MINIFIED}
+      hideIcon={hasStreamlinedUI}
     />
   );
 }

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -6,7 +6,6 @@ import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import type {FrameSourceMapDebuggerData} from 'sentry/components/events/interfaces/sourceMapsDebuggerModal';
 import Panel from 'sentry/components/panels/panel';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {Event, Frame} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
 import type {PlatformKey} from 'sentry/types/project';
@@ -302,7 +301,7 @@ function Content({
   const platformIcon = stackTracePlatformIcon(platform, data.frames ?? []);
 
   return (
-    <Wrapper hideIcon={hideIcon}>
+    <Wrapper>
       {hideIcon ? null : <StacktracePlatformIcon platform={platformIcon} />}
       <StackTraceContentPanel
         className={wrapperClassName}
@@ -319,12 +318,8 @@ function Content({
   );
 }
 
-const Wrapper = styled('div')<{hideIcon?: boolean}>`
+const Wrapper = styled('div')`
   position: relative;
-  margin-left: ${p => (p.hideIcon ? 0 : space(2))};
-  @media (max-width: ${p => p.theme.breakpoints.medium}) {
-    margin-left: 0;
-  }
 `;
 
 export const StackTraceContentPanel = styled(Panel)<{hideIcon?: boolean}>`

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -1,4 +1,5 @@
 import {cloneElement, Fragment, useState} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
@@ -12,7 +13,6 @@ import type {PlatformKey} from 'sentry/types/project';
 import type {StackTraceMechanism, StacktraceType} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
 import withOrganization from 'sentry/utils/withOrganization';
-import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 import type {DeprecatedLineProps} from '../../frame/deprecatedLine';
 import DeprecatedLine from '../../frame/deprecatedLine';
@@ -41,6 +41,7 @@ type Props = {
   hideIcon?: boolean;
   hideSourceMapDebugger?: boolean;
   isHoverPreviewed?: boolean;
+  isStackTracePreview?: boolean;
   lockAddress?: string;
   maxDepth?: number;
   mechanism?: StackTraceMechanism | null;
@@ -68,7 +69,6 @@ function Content({
   frameSourceMapDebuggerData,
   hideSourceMapDebugger,
 }: Props) {
-  const hasStreamlinedUI = useHasStreamlinedUI();
   const [showingAbsoluteAddresses, setShowingAbsoluteAddresses] = useState(false);
   const [showCompleteFunctionName, setShowCompleteFunctionName] = useState(false);
   const [toggleFrameMap, setToggleFrameMap] = useState(setInitialFrameMap());
@@ -302,11 +302,12 @@ function Content({
   const platformIcon = stackTracePlatformIcon(platform, data.frames ?? []);
 
   return (
-    <Wrapper hasIconMargin={!hideIcon && hasStreamlinedUI}>
-      {!hideIcon && <StacktracePlatformIcon platform={platformIcon} />}
+    <Wrapper hideIcon={hideIcon}>
+      {hideIcon ? null : <StacktracePlatformIcon platform={platformIcon} />}
       <StackTraceContentPanel
         className={wrapperClassName}
         data-test-id="stack-trace-content"
+        hideIcon={hideIcon}
       >
         <GuideAnchor target="stack_trace">
           <StyledList data-test-id="frames">
@@ -318,21 +319,26 @@ function Content({
   );
 }
 
-const Wrapper = styled('div')<{hasIconMargin: boolean}>`
+const Wrapper = styled('div')<{hideIcon?: boolean}>`
   position: relative;
-  margin-left: ${p => (p.hasIconMargin ? space(2) : 0)};
+  margin-left: ${p => (p.hideIcon ? 0 : space(2))};
   @media (max-width: ${p => p.theme.breakpoints.medium}) {
     margin-left: 0;
   }
 `;
 
-export const StackTraceContentPanel = styled(Panel)`
+export const StackTraceContentPanel = styled(Panel)<{hideIcon?: boolean}>`
   position: relative;
-  border-top-left-radius: 0;
-  @media (max-width: ${p => p.theme.breakpoints.medium}) {
-    border-top-left-radius: ${p => p.theme.borderRadius};
-  }
   overflow: hidden;
+
+  ${p =>
+    !p.hideIcon &&
+    css`
+      border-top-left-radius: 0;
+      @media (max-width: ${p.theme.breakpoints.medium}) {
+        border-top-left-radius: ${p.theme.borderRadius};
+      }
+    `}
 `;
 
 const StyledList = styled('ul')`

--- a/static/app/components/events/interfaces/crashContent/stackTrace/index.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/index.tsx
@@ -6,6 +6,7 @@ import type {PlatformKey} from 'sentry/types/project';
 import type {StacktraceType} from 'sentry/types/stacktrace';
 import {StackView} from 'sentry/types/stacktrace';
 import {isNativePlatform} from 'sentry/utils/platform';
+import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 import Content from './content';
 import {NativeContent} from './nativeContent';
@@ -38,6 +39,7 @@ export function StackTraceContent({
   threadId,
   lockAddress,
 }: Props) {
+  const hasStreamlinedUI = useHasStreamlinedUI();
   if (stackView === StackView.RAW) {
     return (
       <ErrorBoundary mini>
@@ -60,7 +62,7 @@ export function StackTraceContent({
           groupingCurrentLevel={groupingCurrentLevel}
           meta={meta}
           inlined={inlined}
-          hideIcon={inlined}
+          hideIcon={inlined || hasStreamlinedUI}
           maxDepth={maxDepth}
         />
       </ErrorBoundary>
@@ -77,7 +79,7 @@ export function StackTraceContent({
         event={event}
         newestFirst={newestFirst}
         meta={meta}
-        hideIcon={inlined}
+        hideIcon={inlined || hasStreamlinedUI}
         inlined={inlined}
         maxDepth={maxDepth}
         threadId={threadId}

--- a/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.tsx
@@ -279,6 +279,7 @@ export function NativeContent({
       <ContentPanel
         className={wrapperClassName}
         data-test-id="native-stack-trace-content"
+        hideIcon={hideIcon}
       >
         <Frames data-test-id="stack-trace">
           {!newestFirst ? convertedFrames : [...convertedFrames].reverse()}
@@ -292,9 +293,9 @@ const Wrapper = styled('div')`
   position: relative;
 `;
 
-const ContentPanel = styled(Panel)`
+const ContentPanel = styled(Panel)<{hideIcon?: boolean}>`
   position: relative;
-  border-top-left-radius: 0;
+  border-top-left-radius: ${p => (p.hideIcon ? p.theme.borderRadius : 0)};
   overflow: hidden;
 `;
 

--- a/static/app/components/events/interfaces/crashContent/stackTrace/platformIcon.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/platformIcon.tsx
@@ -1,18 +1,15 @@
 import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
 
-import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
-
 type Props = {
   platform: string;
 };
 
 function StacktracePlatformIcon({platform}: Props) {
-  const hasStreamlineUi = useHasStreamlinedUI();
   return (
     <StyledPlatformIcon
       platform={platform}
-      size={hasStreamlineUi ? '16px' : '20px'}
+      size="20px"
       radius={null}
       data-test-id={`platform-icon-${platform}`}
     />

--- a/static/app/components/groupPreviewTooltip/groupPreviewHovercard.tsx
+++ b/static/app/components/groupPreviewTooltip/groupPreviewHovercard.tsx
@@ -55,8 +55,7 @@ const StyledHovercardWithBodyClass = styled(HovercardWithBodyClass)`
   max-height: 300px;
   overflow-y: auto;
   overscroll-behavior: contain;
-  border-bottom-left-radius: ${p => p.theme.borderRadius};
-  border-bottom-right-radius: ${p => p.theme.borderRadius};
+  border-radius: ${p => p.theme.modalBorderRadius};
 `;
 
 const StyledHovercard = styled(Hovercard)<{hide?: boolean}>`

--- a/static/app/components/groupPreviewTooltip/stackTracePreview.tsx
+++ b/static/app/components/groupPreviewTooltip/stackTracePreview.tsx
@@ -80,7 +80,13 @@ export function StackTracePreviewContent({
   };
 
   if (isNativePlatform(platform)) {
-    return <NativeContent {...commonProps} groupingCurrentLevel={groupingCurrentLevel} />;
+    return (
+      <NativeContent
+        {...commonProps}
+        groupingCurrentLevel={groupingCurrentLevel}
+        hideIcon
+      />
+    );
   }
 
   return <StackTraceContent {...commonProps} hideIcon />;


### PR DESCRIPTION
Instead of indenting or overflowing, just hide the icon. Fixes some of the rounded corners on the stacktrace preview

before
![image](https://github.com/user-attachments/assets/919a56b3-269d-4de1-a66d-67dcb667cc8a)


after
![image](https://github.com/user-attachments/assets/6fe8fd8c-a523-4259-800d-8b5664bf5381)


stacktrace preview before
![image](https://github.com/user-attachments/assets/2ab6c927-0799-4b17-b83a-1abb75f352bc)


stacktrace preview after
![image](https://github.com/user-attachments/assets/a9a476ff-8318-432f-8a42-d08d9ff2d4c7)
