### PR TITLE
fix(issues): Add back link to issue events

### DIFF
--- a/static/app/views/issueDetails/streamline/header.tsx
+++ b/static/app/views/issueDetails/streamline/header.tsx
@@ -104,7 +104,9 @@ export default function StreamlinedGroupHeader({
               {secondaryTitle ?? t('No error message')}
             </SecondaryTitle>
           </Flex>
-          <StatTitle>{t('Events')}</StatTitle>
+          <StatTitle>
+            <StatLink to={`${baseUrl}events/${location.search}`}>{t('Events')}</StatLink>
+          </StatTitle>
           <StatTitle>
             {userCount === 0 ? (
               t('Users')


### PR DESCRIPTION
If we have a link to users, events should be a link too

![image](https://github.com/user-attachments/assets/e79ace63-ce68-4340-9838-105ec1125d46)
