### PR TITLE
feat: sentry mode

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -25,6 +25,7 @@ from sentry.conf.types.kafka_definition import ConsumerDefinition
 from sentry.conf.types.logging_config import LoggingConfig
 from sentry.conf.types.role_dict import RoleDict
 from sentry.conf.types.sdk_config import ServerSdkConfig
+from sentry.conf.types.sentry_config import SentryMode
 from sentry.utils import json  # NOQA (used in getsentry config)
 from sentry.utils.celery import crontab_with_minute_jitter, make_split_task_queues
 from sentry.utils.types import Type, type_from_value
@@ -1464,6 +1465,7 @@ if os.environ.get("OPENAPIGENERATE", False):
     }
 
 CRISPY_TEMPLATE_PACK = "bootstrap3"
+
 # Sentry and internal client configuration
 
 SENTRY_EARLY_FEATURES = {
@@ -2480,7 +2482,13 @@ SENTRY_MAX_AVATAR_SIZE = 5000000
 STATUS_PAGE_ID: str | None = None
 STATUS_PAGE_API_HOST = "statuspage.io"
 
-SENTRY_SELF_HOSTED = True
+# This supersedes SENTRY_SINGLE_TENANT and SENTRY_SELF_HOSTED.
+# An enum is better because there shouldn't be multiple "modes".
+SENTRY_MODE = SentryMode.SELF_HOSTED
+
+# For compatibility only. Prefer using SENTRY_MODE.
+SENTRY_SELF_HOSTED = SENTRY_MODE == SentryMode.SELF_HOSTED
+
 SENTRY_SELF_HOSTED_ERRORS_ONLY = False
 # only referenced in getsentry to provide the stable beacon version
 # updated with scripts/bump-version.sh

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -673,6 +673,10 @@ SILO_DEVSERVER = os.environ.get("SENTRY_SILO_DEVSERVER", False)
 # Which silo this instance runs as (CONTROL|REGION|MONOLITH|None) are the expected values
 SILO_MODE = os.environ.get("SENTRY_SILO_MODE", None)
 
+# This supersedes SENTRY_SINGLE_TENANT and SENTRY_SELF_HOSTED.
+# An enum is better because there shouldn't be multiple "modes".
+SENTRY_MODE = SentryMode.SELF_HOSTED if SILO_MODE is None else SentryMode.SAAS
+
 # If this instance is a region silo, which region is it running in?
 SENTRY_REGION = os.environ.get("SENTRY_REGION", None)
 
@@ -2481,10 +2485,6 @@ SENTRY_MAX_AVATAR_SIZE = 5000000
 # statuspage.io support
 STATUS_PAGE_ID: str | None = None
 STATUS_PAGE_API_HOST = "statuspage.io"
-
-# This supersedes SENTRY_SINGLE_TENANT and SENTRY_SELF_HOSTED.
-# An enum is better because there shouldn't be multiple "modes".
-SENTRY_MODE = SentryMode.SELF_HOSTED
 
 # For compatibility only. Prefer using SENTRY_MODE.
 SENTRY_SELF_HOSTED = SENTRY_MODE == SentryMode.SELF_HOSTED

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -675,7 +675,7 @@ SILO_MODE = os.environ.get("SENTRY_SILO_MODE", None)
 
 # This supersedes SENTRY_SINGLE_TENANT and SENTRY_SELF_HOSTED.
 # An enum is better because there shouldn't be multiple "modes".
-SENTRY_MODE = SentryMode.SELF_HOSTED if SILO_MODE is None else SentryMode.SAAS
+SENTRY_MODE = SentryMode.SELF_HOSTED
 
 # If this instance is a region silo, which region is it running in?
 SENTRY_REGION = os.environ.get("SENTRY_REGION", None)

--- a/src/sentry/conf/types/sentry_config.py
+++ b/src/sentry/conf/types/sentry_config.py
@@ -1,0 +1,3 @@
+from enum import StrEnum
+
+SentryMode = StrEnum("SentryMode", ("SELF_HOSTED", "SINGLE_TENANT", "SAAS"))

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -430,6 +430,9 @@ class _ClientConfig:
             "isOnPremise": is_self_hosted(),
             "isSelfHosted": is_self_hosted(),
             "isSelfHostedErrorsOnly": is_self_hosted_errors_only(),
+            # sentryMode intends to supersede isSelfHosted,
+            # so we can differentiate between "SELF_HOSTED", "SINGLE_TENANT", and "SAAS".
+            "sentryMode": settings.SENTRY_MODE.value.upper(),
             "shouldPreloadData": self.should_preload_data,
             "shouldShowBeaconConsentPrompt": not self.needs_upgrade
             and should_show_beacon_consent_prompt(),

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -432,7 +432,7 @@ class _ClientConfig:
             "isSelfHostedErrorsOnly": is_self_hosted_errors_only(),
             # sentryMode intends to supersede isSelfHosted,
             # so we can differentiate between "SELF_HOSTED", "SINGLE_TENANT", and "SAAS".
-            "sentryMode": settings.SENTRY_MODE.value.upper(),
+            "sentryMode": settings.SENTRY_MODE.name,
             "shouldPreloadData": self.should_preload_data,
             "shouldShowBeaconConsentPrompt": not self.needs_upgrade
             and should_show_beacon_consent_prompt(),

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -177,6 +177,9 @@ export interface Config {
     environment?: string;
     profilesSampleRate?: number;
   };
+  // sentryMode intends to supersede isSelfHosted,
+  // so we can differentiate between "SELF_HOSTED", "SINGLE_TENANT", and "SAAS".
+  sentryMode: 'SELF_HOSTED' | 'SINGLE_TENANT' | 'SAAS';
   shouldPreloadData: boolean;
   singleOrganization: boolean;
   superUserCookieDomain: string | null;

--- a/tests/js/fixtures/config.ts
+++ b/tests/js/fixtures/config.ts
@@ -26,6 +26,7 @@ export function ConfigFixture(params: Partial<Config> = {}): Config {
     isOnPremise: false,
     isSelfHosted: false,
     isSelfHostedErrorsOnly: false,
+    sentryMode: 'SAAS',
     lastOrganization: null,
     gravatarBaseUrl: 'https://gravatar.com',
     initialTrace: {

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -9,7 +9,6 @@ from django.test import override_settings
 
 from sentry import options
 from sentry.app import env
-from sentry.conf.types.sentry_config import SentryMode
 from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider
 from sentry.models.organization import Organization
@@ -81,10 +80,6 @@ def test_client_config_default():
     cfg = get_client_config()
     assert cfg["sentryMode"] == "SELF_HOSTED"
 
-    with override_settings(SENTRY_MODE=SentryMode.SINGLE_TENANT):
-        cfg = get_client_config()
-        assert cfg["sentryMode"] == "SINGLE_TENANT"
-
 
 @multiregion_client_config_test
 @pytest.mark.parametrize(
@@ -122,7 +117,6 @@ def test_client_config_in_silo_modes(request_factory: RequestFactory):
         with override_settings(SILO_MODE=silo_mode):
             result = dict(get_client_config(request))
             normalize(result)
-            assert result["sentryMode"] == "SAAS", silo_mode
             assert result == base_line
             cache.clear()
 

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -9,6 +9,7 @@ from django.test import override_settings
 
 from sentry import options
 from sentry.app import env
+from sentry.conf.types.sentry_config import SentryMode
 from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider
 from sentry.models.organization import Organization
@@ -74,6 +75,17 @@ multiregion_client_config_test = control_silo_test(
 )
 
 
+@no_silo_test
+@django_db_all
+def test_client_config_default():
+    cfg = get_client_config()
+    assert cfg["sentryMode"] == "SELF_HOSTED"
+
+    with override_settings(SENTRY_MODE=SentryMode.SINGLE_TENANT):
+        cfg = get_client_config()
+        assert cfg["sentryMode"] == "SINGLE_TENANT"
+
+
 @multiregion_client_config_test
 @pytest.mark.parametrize(
     "request_factory",
@@ -110,6 +122,7 @@ def test_client_config_in_silo_modes(request_factory: RequestFactory):
         with override_settings(SILO_MODE=silo_mode):
             result = dict(get_client_config(request))
             normalize(result)
+            assert result["sentryMode"] == "SAAS"
             assert result == base_line
             cache.clear()
 

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -122,7 +122,7 @@ def test_client_config_in_silo_modes(request_factory: RequestFactory):
         with override_settings(SILO_MODE=silo_mode):
             result = dict(get_client_config(request))
             normalize(result)
-            assert result["sentryMode"] == "SAAS"
+            assert result["sentryMode"] == "SAAS", silo_mode
             assert result == base_line
             cache.clear()
 


### PR DESCRIPTION
this adds a "sentry mode" ("SELF_HOSTED", "SINGLE_TENANT", "SAAS") we can branch on during the getsentry deletion effort, and additionally preemptively passes that to the frontend if we need it

(example usage: https://github.com/getsentry/sentry/pull/80325)

gs: https://github.com/getsentry/getsentry/pull/15670

