### PR TITLE
ref(setup-wizard): Add RouterProvider to Setup Wizard

### DIFF
--- a/static/app/views/setupWizard/index.tsx
+++ b/static/app/views/setupWizard/index.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {createBrowserRouter, RouterProvider} from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -93,12 +94,35 @@ type Props = {
   organizations?: (Organization & {region: string})[];
 };
 
+function SetupWizardContent({hash, organizations, enableProjectSelection}: Props) {
+  return enableProjectSelection ? (
+    <ProjectSelection hash={hash} organizations={organizations} />
+  ) : (
+    <WaitingForWizardToConnect hash={hash} organizations={organizations} />
+  );
+}
+
 function SetupWizard({
   hash = false,
   organizations,
   enableProjectSelection = false,
 }: Props) {
   const analyticsParams = useAnalyticsParams(organizations);
+
+  const [router] = useState(() =>
+    createBrowserRouter([
+      {
+        path: '*',
+        element: (
+          <SetupWizardContent
+            hash={hash}
+            organizations={organizations}
+            enableProjectSelection={enableProjectSelection}
+          />
+        ),
+      },
+    ])
+  );
 
   useEffect(() => {
     trackAnalytics('setup_wizard.viewed', analyticsParams);
@@ -107,11 +131,7 @@ function SetupWizard({
   return (
     <ThemeAndStyleProvider>
       <QueryClientProvider client={queryClient}>
-        {enableProjectSelection ? (
-          <ProjectSelection hash={hash} organizations={organizations} />
-        ) : (
-          <WaitingForWizardToConnect hash={hash} organizations={organizations} />
-        )}
+        <RouterProvider router={router} />
       </QueryClientProvider>
     </ThemeAndStyleProvider>
   );


### PR DESCRIPTION
I attempted to fix the automatic button analytics here: https://github.com/getsentry/getsentry/pull/15518

However, it needed to be reverted because it was causing issues in setup wizard, because this is rendered separate from the rest of the application and did not have a RouteProvider.

This adds a very simple RouteProvider (renders a single route) so that router hooks won't break inside this component.