### PR TITLE
fix(issue-views): Display typed filters correctly in new issue view page

### DIFF
--- a/static/app/views/issueList/addViewPage.tsx
+++ b/static/app/views/issueList/addViewPage.tsx
@@ -15,9 +15,11 @@ import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {SavedSearch} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {getFieldDefinition} from 'sentry/utils/fields';
 import useOrganization from 'sentry/utils/useOrganization';
 import {OverflowEllipsisTextContainer} from 'sentry/views/insights/common/components/textAlign';
 import {NewTabContext} from 'sentry/views/issueList/utils/newTabContext';
+import {useIssueListFilterKeys} from 'sentry/views/issueList/utils/useIssueListFilterKeys';
 
 type SearchSuggestion = {
   label: string;
@@ -191,6 +193,8 @@ function SearchSuggestionList({
       ? 'Issue Views: Recommended View Saved'
       : 'Issue Views: Saved Search Saved';
 
+  const filterKeys = useIssueListFilterKeys();
+
   return (
     <Suggestions>
       <TitleWrapper>
@@ -262,7 +266,11 @@ function SearchSuggestionList({
               ) : null}
             </ScopeTagContainer>
             <QueryWrapper>
-              <FormattedQuery query={suggestion.query} />
+              <FormattedQuery
+                query={suggestion.query}
+                fieldDefinitionGetter={getFieldDefinition}
+                filterKeys={filterKeys}
+              />
               <ActionsWrapper className="data-actions-wrapper">
                 <StyledButton
                   size="zero"

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -18,7 +18,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {mergeAndSortTagValues} from 'sentry/views/issueDetails/utils';
 import {makeGetIssueTagValues} from 'sentry/views/issueList/utils/getIssueTagValues';
-import {useFetchIssueTags} from 'sentry/views/issueList/utils/useFetchIssueTags';
+import {useIssueListFilterKeys} from 'sentry/views/issueList/utils/useIssueListFilterKeys';
 
 const getFilterKeySections = (tags: TagCollection): FilterKeySection[] => {
   const allTags: Tag[] = Object.values(tags).filter(
@@ -71,18 +71,7 @@ function IssueListSearchBar({
 }: Props) {
   const api = useApi();
   const {selection: pageFilters} = usePageFilters();
-  const {tags: issueTags} = useFetchIssueTags({
-    org: organization,
-    projectIds: pageFilters.projects.map(id => id.toString()),
-    keepPreviousData: true,
-    start: pageFilters.datetime.start
-      ? getUtcDateString(pageFilters.datetime.start)
-      : undefined,
-    end: pageFilters.datetime.end
-      ? getUtcDateString(pageFilters.datetime.end)
-      : undefined,
-    statsPeriod: pageFilters.datetime.period,
-  });
+  const filterKeys = useIssueListFilterKeys();
 
   const tagValueLoader = useCallback(
     async (key: string, search: string) => {
@@ -141,15 +130,15 @@ function IssueListSearchBar({
   );
 
   const filterKeySections = useMemo(() => {
-    return getFilterKeySections(issueTags);
-  }, [issueTags]);
+    return getFilterKeySections(filterKeys);
+  }, [filterKeys]);
 
   return (
     <SearchQueryBuilder
       initialQuery={initialQuery}
       getTagValues={getTagValues}
       filterKeySections={filterKeySections}
-      filterKeys={issueTags}
+      filterKeys={filterKeys}
       recentSearches={SavedSearchType.ISSUE}
       disallowLogicalOperators
       showUnsubmittedIndicator

--- a/static/app/views/issueList/utils/useIssueListFilterKeys.tsx
+++ b/static/app/views/issueList/utils/useIssueListFilterKeys.tsx
@@ -1,0 +1,23 @@
+import {getUtcDateString} from 'sentry/utils/dates';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {useFetchIssueTags} from 'sentry/views/issueList/utils/useFetchIssueTags';
+
+export function useIssueListFilterKeys() {
+  const organization = useOrganization();
+  const {selection: pageFilters} = usePageFilters();
+  const {tags: issueTags} = useFetchIssueTags({
+    org: organization,
+    projectIds: pageFilters.projects.map(id => id.toString()),
+    keepPreviousData: true,
+    start: pageFilters.datetime.start
+      ? getUtcDateString(pageFilters.datetime.start)
+      : undefined,
+    end: pageFilters.datetime.end
+      ? getUtcDateString(pageFilters.datetime.end)
+      : undefined,
+    statsPeriod: pageFilters.datetime.period,
+  });
+
+  return issueTags;
+}


### PR DESCRIPTION
Typed filters, such as `firstSeen` (date), weren't rendering correctly because we weren't providing the set of filter keys to the FormattedQuery. This extracts the hook that calculates these filter keys and uses it in both the search bar and the new view page so it's using the same set in both places.

Before:

![CleanShot 2024-11-06 at 14 47 16@2x](https://github.com/user-attachments/assets/b0090b5b-baf9-47c0-af3e-5a4f914ba6ae)

After:

![CleanShot 2024-11-06 at 14 32 28@2x](https://github.com/user-attachments/assets/fac2d896-c33a-47cd-9794-05b74077df0b)
