### PR TITLE
fix(dashboard): Cleanup DashboardProject instances on delete

### DIFF
--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -20,8 +20,8 @@ from sentry.models.dashboard_widget import DashboardWidgetTypes
 class DashboardProject(Model):
     __relocation_scope__ = RelocationScope.Excluded
 
-    project = FlexibleForeignKey("sentry.Project")
-    dashboard = FlexibleForeignKey("sentry.Dashboard")
+    project = FlexibleForeignKey("sentry.Project", on_delete=models.CASCADE)
+    dashboard = FlexibleForeignKey("sentry.Dashboard", on_delete=models.CASCADE)
 
     class Meta:
         app_label = "sentry"


### PR DESCRIPTION
Currently we leave a number of dashboard to project relationships hanging when projects are deleted. Add this clause so deleting projects removes them properly from the dashboard filters.

This appeared because we were grabbing projects off the dashboard instances to run the widget queries, but if a project has been deleted, resolving the project could fail just to evaluate the filters.
