### PR TITLE
feat(crons): Pass volume_anomaly_result through to mark_missing tasks

### DIFF
--- a/src/sentry/monitors/consumers/clock_tick_consumer.py
+++ b/src/sentry/monitors/consumers/clock_tick_consumer.py
@@ -39,7 +39,7 @@ def process_clock_tick(message: Message[KafkaPayload | FilteredPayload]):
         extra={"reference_datetime": str(ts), "volume_anomaly_result": volume_anomaly_result.value},
     )
 
-    dispatch_check_missing(ts)
+    dispatch_check_missing(ts, volume_anomaly_result)
 
     # When the tick is anomalys we are unable to mark timeouts, since it is
     # possible that a OK check-in was sent completing an earlier in-progress

--- a/tests/sentry/monitors/consumers/test_clock_tick_consumer.py
+++ b/tests/sentry/monitors/consumers/test_clock_tick_consumer.py
@@ -61,7 +61,10 @@ def test_simple(mock_dispatch_check_timeout, mock_dispatch_check_missing):
     assert mock_dispatch_check_timeout.mock_calls[0] == mock.call(ts)
 
     assert mock_dispatch_check_missing.call_count == 1
-    assert mock_dispatch_check_missing.mock_calls[0] == mock.call(ts)
+    assert mock_dispatch_check_missing.mock_calls[0] == mock.call(
+        ts,
+        TickVolumeAnomolyResult.NORMAL,
+    )
 
 
 @mock.patch("sentry.monitors.consumers.clock_tick_consumer.dispatch_check_missing")
@@ -87,7 +90,10 @@ def test_simple_abnormal(mock_dispatch_mark_unknown, mock_dispatch_check_missing
     assert mock_dispatch_mark_unknown.mock_calls[0] == mock.call(ts)
 
     assert mock_dispatch_check_missing.call_count == 1
-    assert mock_dispatch_check_missing.mock_calls[0] == mock.call(ts)
+    assert mock_dispatch_check_missing.mock_calls[0] == mock.call(
+        ts,
+        TickVolumeAnomolyResult.ABNORMAL,
+    )
 
 
 class MonitorsClockTickEndToEndTest(TestCase):


### PR DESCRIPTION
When marking a miss we will need to know the TickVolumeAnomolyResult to determine if a miss is created as `MISS` or `UNKNOWN`.

Part of GH-79328