### PR TITLE
fix(admin): boolean form items should not be validated as required

### DIFF
--- a/static/app/views/admin/adminUserEdit.tsx
+++ b/static/app/views/admin/adminUserEdit.tsx
@@ -43,7 +43,6 @@ const userEditForm: JsonFormObject = {
     {
       name: 'isActive',
       type: 'boolean',
-      required: true,
       label: t('Active'),
       help: t(
         'Designates whether this user should be treated as active. Unselect this instead of deleting accounts.'
@@ -52,14 +51,12 @@ const userEditForm: JsonFormObject = {
     {
       name: 'isStaff',
       type: 'boolean',
-      required: true,
       label: t('Admin'),
       help: t('Designates whether this user can perform administrative functions.'),
     },
     {
       name: 'isSuperuser',
       type: 'boolean',
-      required: true,
       label: t('Superuser'),
       help: t(
         'Designates whether this user has all permissions without explicitly assigning them.'


### PR DESCRIPTION
boolean(switch) form items with required will be incorrectly validated as must be true

![bug](https://github.com/user-attachments/assets/28cc303d-aab7-4f2e-a203-79f807d0ab80)
