### PR TITLE
fix(segmented-control): Propagate disabled state to items

### DIFF
--- a/static/app/components/segmentedControl.tsx
+++ b/static/app/components/segmentedControl.tsx
@@ -93,7 +93,7 @@ export function SegmentedControl<Value extends string>({
             nextKey={option.nextKey}
             prevKey={option.prevKey}
             value={String(option.key)}
-            isDisabled={option.props.disabled}
+            isDisabled={option.props.disabled || disabled}
             state={state}
             size={size}
             priority={priority}


### PR DESCRIPTION
### Problem
Although the control is set to disabled, the items still appear selectable.

https://github.com/user-attachments/assets/b702bdb3-4ca1-4688-ac4c-b57aa053bc91

### Solution
Propagate the disabled state of the control to its items.

https://github.com/user-attachments/assets/e99e9d16-0124-43aa-86c3-56f276832a2f

