### PR TITLE
feat: Add metric for events to symbolicate

### DIFF
--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -155,6 +155,12 @@ def _do_preprocess_event(
     # one after the other, so we handle mixed stacktraces.
     stacktraces = find_stacktraces_in_data(data)
     symbolicate_platforms = get_symbolication_platforms(data, stacktraces)
+    metrics.incr(
+        "events.to-symbolicate",
+        tags={platform.value: True for platform in symbolicate_platforms},
+        skip_internal=False,
+    )
+
     should_symbolicate = len(symbolicate_platforms) > 0
     if should_symbolicate:
         first_platform = symbolicate_platforms.pop(0)


### PR DESCRIPTION
This metric is tagged with the platforms for which the event needs to be symbolicated. That will give us insight into how many events even contain multiple symbolicable platforms and in which combinations.