### PR TITLE
ref(warmup): remove language url resolving

### DIFF
--- a/src/sentry/api/endpoints/warmup.py
+++ b/src/sentry/api/endpoints/warmup.py
@@ -1,6 +1,3 @@
-from django.conf import settings
-from django.urls import reverse
-from django.utils.translation import override
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -20,11 +17,4 @@ class WarmupEndpoint(Endpoint):
     rate_limits = RateLimitConfig(group="INTERNAL")
 
     def get(self, request: Request) -> Response:
-        # for each possible language we support, warm up the url resolver
-        # this fixes an issue we were seeing where many languages trying
-        # to resolve at once would cause lock contention
-        for lang, _ in settings.LANGUAGES:
-            with override(lang):
-                reverse("sentry-warmup")
-
         return Response(200)

--- a/tests/sentry/test_wsgi.py
+++ b/tests/sentry/test_wsgi.py
@@ -12,8 +12,6 @@ import django.urls.resolvers
 from django.conf import settings
 resolver = django.urls.resolvers.get_resolver()
 assert resolver._populated is True
-for lang, _ in settings.LANGUAGES:
-    assert lang in resolver._reverse_dict
 """
 
 


### PR DESCRIPTION
This didn't seem to fix the issue, so let's remove it. opting for https://github.com/getsentry/sentry/pull/80371 instead.