### PR TITLE
feat(autofix): Add unit test gen

### DIFF
--- a/static/app/components/events/autofix/autofixMessageBox.spec.tsx
+++ b/static/app/components/events/autofix/autofixMessageBox.spec.tsx
@@ -316,4 +316,40 @@ describe('AutofixMessageBox', () => {
       within(screen.getByRole('dialog')).getByText('Allow Autofix to Make Pull Requests')
     ).toBeInTheDocument();
   });
+
+  it('shows segmented control with "Add tests" option for changes step', () => {
+    render(<AutofixMessageBox {...changesStepProps} />);
+
+    expect(screen.getByRole('radio', {name: 'Give feedback'})).toBeInTheDocument();
+    expect(screen.getByRole('radio', {name: 'Add tests'})).toBeInTheDocument();
+    expect(screen.getByRole('radio', {name: 'Approve changes'})).toBeInTheDocument();
+  });
+
+  it('shows "Add Tests" button and static message when "Add tests" is selected', async () => {
+    render(<AutofixMessageBox {...changesStepProps} />);
+
+    await userEvent.click(screen.getByRole('radio', {name: 'Add tests'}));
+
+    expect(
+      screen.getByText('Write unit tests to make sure the issue is fixed?')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Add Tests'})).toBeInTheDocument();
+  });
+
+  it('sends correct message when "Add Tests" is clicked without onSend prop', async () => {
+    MockApiClient.addMockResponse({
+      method: 'POST',
+      url: '/issues/123/autofix/update/',
+      body: {},
+    });
+
+    render(<AutofixMessageBox {...changesStepProps} />);
+
+    await userEvent.click(screen.getByRole('radio', {name: 'Add tests'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Add Tests'}));
+
+    await waitFor(() => {
+      expect(addSuccessMessage).toHaveBeenCalledWith('Thanks for the input.');
+    });
+  });
 });

--- a/static/app/components/events/autofix/autofixMessageBox.tsx
+++ b/static/app/components/events/autofix/autofixMessageBox.tsx
@@ -259,9 +259,9 @@ function AutofixMessageBox({
     'suggested_root_cause' | 'custom_root_cause'
   >('suggested_root_cause');
 
-  const [changesMode, setChangesMode] = useState<'give_feedback' | 'create_prs'>(
-    'give_feedback'
-  );
+  const [changesMode, setChangesMode] = useState<
+    'give_feedback' | 'add_tests' | 'create_prs'
+  >('give_feedback');
 
   const changes =
     isChangesStep && step?.type === AutofixStepType.CHANGES ? step.changes : [];
@@ -294,12 +294,18 @@ function AutofixMessageBox({
       return;
     }
 
-    if (message.trim() !== '' || allowEmptyMessage) {
+    let text = message;
+    if (isChangesStep && changesMode === 'add_tests') {
+      text =
+        'Please write a unit test that reproduces the issue to make sure it is fixed.';
+    }
+
+    if (text.trim() !== '' || allowEmptyMessage) {
       if (onSend != null) {
-        onSend(message);
+        onSend(text);
       } else {
         send({
-          message: message,
+          message: text,
         });
       }
       setMessage('');
@@ -377,6 +383,9 @@ function AutofixMessageBox({
                   <SegmentedControl.Item key="give_feedback">
                     {t('Give feedback')}
                   </SegmentedControl.Item>
+                  <SegmentedControl.Item key="add_tests">
+                    {t('Add tests')}
+                  </SegmentedControl.Item>
                   <SegmentedControl.Item key="create_prs">
                     {t('Approve changes')}
                   </SegmentedControl.Item>
@@ -429,6 +438,20 @@ function AutofixMessageBox({
               </InputArea>
             </form>
           )}
+        {isChangesStep && changesMode === 'add_tests' && !prsMade && (
+          <form onSubmit={handleSend}>
+            <InputArea>
+              <Fragment>
+                <StaticMessage>
+                  Write unit tests to make sure the issue is fixed?
+                </StaticMessage>
+                <Button type="submit" priority="primary">
+                  Add Tests
+                </Button>
+              </Fragment>
+            </InputArea>
+          </form>
+        )}
         {isChangesStep && changesMode === 'create_prs' && !prsMade && (
           <InputArea>
             <Fragment>

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -74,6 +74,13 @@ export function Step({
         <AnimatePresence initial={false}>
           <AnimationWrapper key="content" {...animationProps}>
             <Fragment>
+              {hasErroredStepBefore && hasStepAbove && (
+                <StepMessage>
+                  Autofix encountered an error.
+                  <br />
+                  Restarting step from scratch...
+                </StepMessage>
+              )}
               {step.type === AutofixStepType.DEFAULT && (
                 <AutofixInsightCards
                   insights={step.insights}
@@ -97,13 +104,6 @@ export function Step({
               )}
               {step.type === AutofixStepType.CHANGES && (
                 <AutofixChanges step={step} groupId={groupId} runId={runId} />
-              )}
-              {hasErroredStepBefore && hasStepBelow && (
-                <StepMessage>
-                  Autofix encountered an error.
-                  <br />
-                  Restarting step from scratch...
-                </StepMessage>
               )}
             </Fragment>
           </AnimationWrapper>
@@ -188,7 +188,9 @@ export function AutofixSteps({data, groupId, runId}: AutofixStepsProps) {
       return count;
     }, 0);
 
-    const hasNewSteps = currentStepsLength > prevStepsLengthRef.current;
+    const hasNewSteps =
+      currentStepsLength > prevStepsLengthRef.current &&
+      steps[currentStepsLength - 1].type !== AutofixStepType.DEFAULT;
     const hasNewInsights = currentInsightsCount > prevInsightsCountRef.current;
 
     if (hasNewSteps || hasNewInsights) {


### PR DESCRIPTION
Adds an option to the end of the coding step to add tests to the fix. Under the hood, this just prompts the model using our existing feedback mechanism. But it seems to work fine!

This PR also tacks on bug fixes for the "New insight" popup and for the error message positioning.

<img width="615" alt="Screenshot 2024-11-07 at 8 05 00 AM" src="https://github.com/user-attachments/assets/ba21635f-10bc-42dc-bf12-38f5fb1cedb7">


