### PR TITLE
feat(insights): initially expanded insight domain views in sidebar

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -621,7 +621,7 @@ function Sidebar() {
         icon={<IconGraph />}
         label={DOMAIN_VIEW_BASE_TITLE}
         id="insights-domains"
-        initiallyExpanded={false}
+        initiallyExpanded
         exact={!shouldAccordionFloat}
         isAlpha={DOMAIN_VIEW_RELEASE_LEVEL === 'alpha'}
         isBeta={DOMAIN_VIEW_RELEASE_LEVEL === 'beta'}


### PR DESCRIPTION
Work for #77572 

Expand domain views in the sidebar by default