### PR TITLE
feat(context): Implement `cloud_resource` known context

### DIFF
--- a/static/app/components/events/contexts/cloudResource.spec.tsx
+++ b/static/app/components/events/contexts/cloudResource.spec.tsx
@@ -1,0 +1,94 @@
+import type {CloudResourceContext} from '@sentry/types';
+import {EventFixture} from 'sentry-fixture/event';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {getCloudResourceContextData} from 'sentry/components/events/contexts/cloudResource';
+import ContextCard from 'sentry/components/events/contexts/contextCard';
+
+const MOCK_CLOUD_RESOURCE: CloudResourceContext = {
+  'cloud.provider': 'aws',
+  'cloud.platform': 'aws_ec2',
+  'cloud.account.id': '499517922981',
+  'cloud.region': 'us-east-1',
+  'cloud.availability_zone': 'us-east-1e',
+  'host.id': 'i-07d3301208fe0a55a',
+  'host.type': 't2.large',
+  // Extra data is still valid and preserved
+  extra_data: 'something',
+  unknown_key: 123,
+};
+
+const MOCK_REDACTION = {
+  ['host.id']: {
+    '': {
+      chunks: [
+        {
+          remark: 'x',
+          rule_id: 'project:0',
+          text: '',
+          type: 'redaction',
+        },
+      ],
+      len: 19,
+      rem: [['project:0', 'x', 0, 0]],
+    },
+  },
+};
+
+describe('CloudResourceContext', function () {
+  it('returns formatted data correctly', function () {
+    expect(getCloudResourceContextData({data: MOCK_CLOUD_RESOURCE})).toEqual([
+      {
+        key: 'cloud.provider',
+        subject: 'Provider',
+        value: 'Amazon Web Services',
+      },
+      {key: 'cloud.platform', subject: 'Platform', value: 'aws_ec2'},
+      {
+        key: 'cloud.account.id',
+        subject: 'Account ID',
+        value: '499517922981',
+      },
+      {key: 'cloud.region', subject: 'Region', value: 'us-east-1'},
+      {
+        key: 'cloud.availability_zone',
+        subject: 'Availability Zone',
+        value: 'us-east-1e',
+      },
+      {key: 'host.id', subject: 'Host ID', value: 'i-07d3301208fe0a55a'},
+      {key: 'host.type', subject: 'Host Type', value: 't2.large'},
+      {
+        key: 'extra_data',
+        subject: 'extra_data',
+        value: 'something',
+      },
+      {
+        key: 'unknown_key',
+        subject: 'unknown_key',
+        value: 123,
+      },
+    ]);
+  });
+
+  it('renders with meta annotations correctly', function () {
+    const event = EventFixture({
+      _meta: {contexts: {cloud_resource: MOCK_REDACTION}},
+    });
+
+    render(
+      <ContextCard
+        event={event}
+        type={'cloud_resource'}
+        alias={'cloud_resource'}
+        value={{...MOCK_CLOUD_RESOURCE, ['host.id']: ''}}
+      />
+    );
+
+    expect(screen.getByText('Cloud Resource')).toBeInTheDocument();
+    expect(screen.getByText('Provider')).toBeInTheDocument();
+    expect(screen.getByText('Amazon Web Services')).toBeInTheDocument();
+    expect(screen.getByText('Host ID')).toBeInTheDocument();
+    expect(screen.getByText(/redacted/)).toBeInTheDocument();
+  });
+});

--- a/static/app/components/events/contexts/cloudResource.tsx
+++ b/static/app/components/events/contexts/cloudResource.tsx
@@ -1,0 +1,99 @@
+import {t} from 'sentry/locale';
+import type {KeyValueListData} from 'sentry/types/group';
+
+// https://github.com/getsentry/relay/blob/24.10.0/relay-event-schema/src/protocol/contexts/cloud_resource.rs
+const enum CloudResourceContextKeys {
+  CLOUD_ACCOUNT_ID = 'cloud.account.id',
+  CLOUD_PROVIDER = 'cloud.provider',
+  CLOUD_PLATFORM = 'cloud.platform',
+  CLOUD_REGION = 'cloud.region',
+  CLOUD_AVAILABILITY_ZONE = 'cloud.availability_zone',
+  HOST_ID = 'host.id',
+  HOST_TYPE = 'host.type',
+}
+
+export interface CloudResourceContext {
+  // Any custom keys users may set
+  [key: string]: any;
+  ['cloud.account.id']?: string;
+  ['cloud.availability_zone']?: string;
+  ['cloud.platform']?: string;
+  ['cloud.provider']?: string;
+  ['cloud.region']?: string;
+  ['host.id']?: string;
+  ['host.type']?: string;
+}
+
+const CLOUD_PROVIDERS = {
+  alibaba_cloud: t('Alibaba Cloud'),
+  aws: t('Amazon Web Services'),
+  azure: t('Microsoft Azure'),
+  gcp: t('Google Cloud Platform'),
+  ibm_cloud: t('IBM Cloud'),
+  tencent_cloud: t('Tencent Cloud'),
+};
+
+export function getCloudResourceContextData({
+  data = {},
+  meta,
+}: {
+  data: CloudResourceContext;
+  meta?: Record<keyof CloudResourceContext, any>;
+}): KeyValueListData {
+  return Object.keys(data).map(ctxKey => {
+    switch (ctxKey) {
+      case CloudResourceContextKeys.CLOUD_ACCOUNT_ID:
+        return {
+          key: ctxKey,
+          subject: t('Account ID'),
+          value: data[CloudResourceContextKeys.CLOUD_ACCOUNT_ID],
+        };
+      case CloudResourceContextKeys.CLOUD_PROVIDER:
+        const provider = data[CloudResourceContextKeys.CLOUD_PROVIDER];
+        return {
+          key: ctxKey,
+          subject: t('Provider'),
+          value:
+            provider && CLOUD_PROVIDERS[provider] ? CLOUD_PROVIDERS[provider] : provider,
+        };
+      case CloudResourceContextKeys.CLOUD_PLATFORM:
+        return {
+          key: ctxKey,
+          subject: t('Platform'),
+          value: data[CloudResourceContextKeys.CLOUD_PLATFORM],
+        };
+      case CloudResourceContextKeys.CLOUD_REGION:
+        return {
+          key: ctxKey,
+          subject: t('Region'),
+          value: data[CloudResourceContextKeys.CLOUD_REGION],
+        };
+      case CloudResourceContextKeys.CLOUD_AVAILABILITY_ZONE:
+        return {
+          key: ctxKey,
+          subject: t('Availability Zone'),
+          value: data[CloudResourceContextKeys.CLOUD_AVAILABILITY_ZONE],
+        };
+      case CloudResourceContextKeys.HOST_ID:
+        return {
+          key: ctxKey,
+          subject: t('Host ID'),
+          value: data[CloudResourceContextKeys.HOST_ID],
+        };
+
+      case CloudResourceContextKeys.HOST_TYPE:
+        return {
+          key: ctxKey,
+          subject: t('Host Type'),
+          value: data[CloudResourceContextKeys.HOST_TYPE],
+        };
+      default:
+        return {
+          key: ctxKey,
+          subject: ctxKey,
+          value: data[ctxKey],
+          meta: meta?.[ctxKey]?.[''],
+        };
+    }
+  });
+}

--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -6,6 +6,7 @@ import logoUnknown from 'sentry-logos/logo-unknown.svg';
 
 import UserAvatar from 'sentry/components/avatar/userAvatar';
 import {DeviceName} from 'sentry/components/deviceName';
+import {getCloudResourceContextData} from 'sentry/components/events/contexts/cloudResource';
 import {
   ContextIcon,
   type ContextIconProps,
@@ -344,6 +345,8 @@ export function getContextTitle({
       return t('Trace Details');
     case 'otel':
       return 'OpenTelemetry';
+    case 'cloud_resource':
+      return t('Cloud Resource');
     case 'unity':
       return 'Unity';
     case 'memory_info': // Current value for memory info
@@ -542,6 +545,8 @@ export function getFormattedContextData({
         ...getKnownReplayContextData({data: contextValue, meta, organization}),
         ...getUnknownReplayContextData({data: contextValue, meta}),
       ];
+    case 'cloud_resource':
+      return getCloudResourceContextData({data: contextValue, meta});
     default:
       return getDefaultContextData(contextValue);
   }

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -1,3 +1,5 @@
+import type {CloudResourceContext} from '@sentry/types';
+
 import type {
   AggregateSpanType,
   MetricsSummary,
@@ -644,6 +646,7 @@ export type EventContexts = {
   'ThreadPool Info'?: ThreadPoolInfoContext;
   browser?: BrowserContext;
   client_os?: OSContext;
+  cloud_resource?: CloudResourceContext;
   device?: DeviceContext;
   feedback?: Record<string, any>;
   flags?: Flags;


### PR DESCRIPTION
Continuing work on contexts, bringing the [Cloud Resource context](https://develop.sentry.dev/sdk/data-model/event-payloads/contexts/#cloud-resource-context) to the app with specialty formatting.  I chose not to follow he `getKnown` `getUnknown` setup that the current ctx items have, since that was for the deprecated chunk ux, and it can be soooo much simpler now. I'm going to continue this pattern for the rest of the new context as well ('culture', 'missing_instrumentation', etc.)