### PR TITLE
feat(profiling): Add endpoint to determine if chunks exist

### DIFF
--- a/src/sentry/api/endpoints/organization_profiling_profiles.py
+++ b/src/sentry/api/endpoints/organization_profiling_profiles.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
+from snuba_sdk import Column, Condition, Limit, Op, Query, SnqlRequest, Storage
 
 from sentry import features
 from sentry.api.api_owners import ApiOwner
@@ -21,6 +22,9 @@ from sentry.profiles.flamegraph import (
 )
 from sentry.profiles.profile_chunks import get_chunk_ids
 from sentry.profiles.utils import proxy_profiling_service
+from sentry.snuba.dataset import Dataset, StorageKey
+from sentry.snuba.referrer import Referrer
+from sentry.utils.snuba import raw_snql_query
 
 
 class OrganizationProfilingBaseEndpoint(OrganizationEventsV2EndpointBase):
@@ -187,3 +191,41 @@ class OrganizationProfilingChunksFlamegraphEndpoint(OrganizationProfilingBaseEnd
             path=f"/organizations/{organization.id}/projects/{project_ids[0]}/chunks-flamegraph",
             json_data={"chunks_metadata": chunksMetadata},
         )
+
+
+@region_silo_endpoint
+class OrganizationProfilingHasChunksEndpoint(OrganizationProfilingBaseEndpoint):
+    def get(self, request: Request, organization: Organization) -> HttpResponse:
+        if not features.has("organizations:profiling", organization, actor=request.user):
+            return Response(status=404)
+
+        snuba_params = self.get_snuba_params(request, organization)
+
+        with handle_query_errors():
+            # We just need to query to see if any chunks exists in that time range.
+            query = Query(
+                match=Storage(StorageKey.ProfileChunks.value),
+                select=[Column("project_id")],
+                where=[
+                    Condition(Column("project_id"), Op.IN, snuba_params.project_ids),
+                    Condition(Column("end_timestamp"), Op.GTE, snuba_params.start),
+                    Condition(Column("start_timestamp"), Op.LT, snuba_params.end),
+                ],
+                limit=Limit(1),
+            )
+
+            referrer = Referrer.API_PROFILING_PROFILE_HAS_CHUNKS.value
+
+            request = SnqlRequest(
+                dataset=Dataset.Profiles.value,
+                app_id="default",
+                query=query,
+                tenant_ids={
+                    "referrer": referrer,
+                    "organization_id": organization.id,
+                },
+            )
+
+            data = raw_snql_query(request, referrer)["data"]
+
+        return Response({"chunks": len(data) > 0}, status=200)

--- a/src/sentry/api/endpoints/organization_profiling_profiles.py
+++ b/src/sentry/api/endpoints/organization_profiling_profiles.py
@@ -4,7 +4,9 @@ from rest_framework import serializers
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
-from snuba_sdk import Column, Condition, Limit, Op, Query, SnqlRequest, Storage
+from snuba_sdk import Column, Condition, Limit, Op, Query
+from snuba_sdk import Request as SnqlRequest
+from snuba_sdk import Storage
 
 from sentry import features
 from sentry.api.api_owners import ApiOwner
@@ -228,4 +230,4 @@ class OrganizationProfilingHasChunksEndpoint(OrganizationProfilingBaseEndpoint):
 
             data = raw_snql_query(request, referrer)["data"]
 
-        return Response({"chunks": len(data) > 0}, status=200)
+        return Response({"hasChunks": len(data) > 0}, status=200)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -523,6 +523,7 @@ from .endpoints.organization_profiling_profiles import (
     OrganizationProfilingChunksEndpoint,
     OrganizationProfilingChunksFlamegraphEndpoint,
     OrganizationProfilingFlamegraphEndpoint,
+    OrganizationProfilingHasChunksEndpoint,
 )
 from .endpoints.organization_projects import (
     OrganizationProjectsCountEndpoint,
@@ -2180,6 +2181,11 @@ ORGANIZATION_URLS = [
                     r"^chunks/$",
                     OrganizationProfilingChunksEndpoint.as_view(),
                     name="sentry-api-0-organization-profiling-chunks",
+                ),
+                re_path(
+                    r"^has-chunks/$",
+                    OrganizationProfilingHasChunksEndpoint.as_view(),
+                    name="sentry-api-0-organization-profiling-has-chunks",
                 ),
             ],
         ),

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -405,6 +405,7 @@ class Referrer(Enum):
     API_PROFILING_LANDING_TABLE = "api.profiling.landing-table"
     API_PROFILING_LANDING_FUNCTIONS_CARD = "api.profiling.landing-functions-card"
     API_PROFILING_PERFORMANCE_CHANGE_EXPLORER = "api.profiling.performance-change-explorer"
+    API_PROFILING_PROFILE_HAS_CHUNKS = "api.profiling.profile-has-chunks"
     API_PROFILING_PROFILE_SUMMARY_CHART = "api.profiling.profile-summary-chart"
     API_PROFILING_PROFILE_SUMMARY_TOTALS = "api.profiling.profile-summary-totals"
     API_PROFILING_PROFILE_SUMMARY_TABLE = "api.profiling.profile-summary-table"


### PR DESCRIPTION
We need a way to figure out when there are profile chunks being sent but no transactions in order to suggest to the user to switch to the flamegraph view.