### PR TITLE
feat(billing): Removes invite-member feature flag validation

### DIFF
--- a/src/sentry/api/endpoints/organization_member/index.py
+++ b/src/sentry/api/endpoints/organization_member/index.py
@@ -314,11 +314,6 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
         """
         Add or invite a member to an organization.
         """
-        if not features.has("organizations:invite-members", organization, actor=request.user):
-            return Response(
-                {"organization": "Your organization is not allowed to invite members"}, status=403
-            )
-
         allowed_roles = get_allowed_org_roles(request, organization, creating_org_invite=True)
         assigned_org_role = request.data.get("orgRole") or request.data.get("role")
 

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -550,12 +550,12 @@ class OrganizationMemberPermissionRoleTest(OrganizationMemberListTestBase, Hybri
     def test_member_invites(self):
         self.invite_all_helper("member")
 
-    def test_respects_feature_flag(self):
+    def test_ignores_feature_flag(self):
         user = self.create_user("baz@example.com")
 
         with Feature({"organizations:invite-members": False}):
             data = {"email": user.email, "role": "member", "teams": [self.team.slug]}
-            self.get_error_response(self.organization.slug, **data, status_code=403)
+            self.get_success_response(self.organization.slug, **data, status_code=201)
 
     def test_no_team_invites(self):
         data = {"email": "eric@localhost", "role": "owner", "teams": []}


### PR DESCRIPTION
This PR is the backend change to allow Developer orgs to invite Billing members.

Removes the check for the "organizations:invite-members" feature flag on the endpoint. This change removes the need to add the feature flag to all Developer orgs.