### PR TITLE
fix(profiling) change chart title for continuous profiling

### DIFF
--- a/static/app/views/profiling/landing/profilesChartWidget.tsx
+++ b/static/app/views/profiling/landing/profilesChartWidget.tsx
@@ -9,6 +9,7 @@ import type {PageFilters} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
 import {axisLabelFormatter, tooltipFormatter} from 'sentry/utils/discover/charts';
 import {useProfileEventsStats} from 'sentry/utils/profiling/hooks/useProfileEventsStats';
+import useOrganization from 'sentry/utils/useOrganization';
 
 import {
   ContentContainer,
@@ -39,6 +40,7 @@ export function ProfilesChartWidget({
   widgetHeight,
 }: ProfilesChartWidgetProps) {
   const theme = useTheme();
+  const organization = useOrganization();
 
   const profileStats = useProfileEventsStats({
     dataset: 'profiles',
@@ -116,7 +118,13 @@ export function ProfilesChartWidget({
   return (
     <WidgetContainer height={widgetHeight}>
       <HeaderContainer>
-        {header ?? <HeaderTitleLegend>{t('Profiles by Percentiles')}</HeaderTitleLegend>}
+        {header ?? (
+          <HeaderTitleLegend>
+            {organization.features.includes('continuous-profiling-compat')
+              ? t('Transactions by Percentiles')
+              : t('Profiles by Percentiles')}
+          </HeaderTitleLegend>
+        )}
       </HeaderContainer>
       <ContentContainer>
         <ChartZoom {...selection?.datetime}>


### PR DESCRIPTION
This is basically transactions, and since we are on transactions tab once the continuous profiling UI is released, the title should correctly reflect that.