### PR TITLE
fix(trace-explorer): Reorder project avatars correctly

### DIFF
--- a/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
+++ b/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
@@ -71,8 +71,9 @@ export function ProjectsRenderer({
 }: ProjectsRendererProps) {
   const organization = useOrganization();
   const {projects} = useProjects({slugs: projectSlugs, orgId: organization.slug});
-  const projectAvatars =
-    projects.length > 0 ? projects : projectSlugs.map(slug => ({slug}));
+  const projectAvatars = projectSlugs.map(slug => {
+    return projects.find(project => project.slug === slug) ?? {slug};
+  });
   const numProjects = projectAvatars.length;
   const numVisibleProjects =
     maxVisibleProjects - numProjects >= 0 ? numProjects : maxVisibleProjects - 1;

--- a/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
+++ b/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
@@ -71,6 +71,7 @@ export function ProjectsRenderer({
 }: ProjectsRendererProps) {
   const organization = useOrganization();
   const {projects} = useProjects({slugs: projectSlugs, orgId: organization.slug});
+  // ensure that projectAvatars is in the same order as the projectSlugs prop
   const projectAvatars = projectSlugs.map(slug => {
     return projects.find(project => project.slug === slug) ?? {slug};
   });

--- a/static/app/views/traces/fieldRenderers.tsx
+++ b/static/app/views/traces/fieldRenderers.tsx
@@ -71,8 +71,9 @@ export function ProjectsRenderer({
   return (
     <Projects orgId={organization.slug} slugs={projectSlugs}>
       {({projects}) => {
-        const projectAvatars =
-          projects.length > 0 ? projects : projectSlugs.map(slug => ({slug}));
+        const projectAvatars = projectSlugs.map(slug => {
+          return projects.find(project => project.slug === slug) ?? {slug};
+        });
         const numProjects = projectAvatars.length;
         const numVisibleProjects =
           maxVisibleProjects - numProjects >= 0 ? numProjects : maxVisibleProjects - 1;

--- a/static/app/views/traces/fieldRenderers.tsx
+++ b/static/app/views/traces/fieldRenderers.tsx
@@ -71,6 +71,7 @@ export function ProjectsRenderer({
   return (
     <Projects orgId={organization.slug} slugs={projectSlugs}>
       {({projects}) => {
+        // ensure that projectAvatars is in the same order as the projectSlugs prop
         const projectAvatars = projectSlugs.map(slug => {
           return projects.find(project => project.slug === slug) ?? {slug};
         });


### PR DESCRIPTION
The useProjects hook returns the projects in a different order than was passed in. This resorts it so that it is in the same order as we originally wanted.