### PR TITLE
fix(traces): Sort traces by end timestamp instead of start timestamp

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -474,7 +474,7 @@ class TracesExecutor:
             #
             # To create the illusion that traces are sorted by most recent, apply
             # an additional sort here so the traces are sorted by most recent.
-            data.sort(key=lambda trace: trace["start"], reverse=self.sort == "-timestamp")
+            data.sort(key=lambda trace: trace["end"], reverse=self.sort == "-timestamp")
 
             if last_item is not None:
                 data.append(last_item)


### PR DESCRIPTION
We should sort traces by end timestamp here because we sort spans by end timestamp.