### PR TITLE
fix(contexts): More audit updates for contexts

### DIFF
--- a/static/app/components/events/contexts/gpu/getGPUKnownDataDetails.spec.tsx
+++ b/static/app/components/events/contexts/gpu/getGPUKnownDataDetails.spec.tsx
@@ -23,11 +23,19 @@ describe('getGPUKnownDataDetails', function () {
     expect(allKnownData).toEqual([
       {subject: 'Name', value: ''},
       {subject: 'Version', value: 'Metal'},
+      {subject: 'GPU ID', value: 2400},
+      {subject: 'Vendor ID', value: '2400.0.0'},
       {subject: 'Vendor Name', value: 'Apple'},
       {subject: 'Memory', value: '4.0 GiB'},
-      {subject: 'NPOT Support', value: 'Full'},
-      {subject: 'Multi-Thread rendering', value: true},
       {subject: 'API Type', value: ''},
+      {subject: 'Multi-Thread Rendering', value: true},
+      {subject: 'NPOT Support', value: 'Full'},
+      {subject: 'Max Texture Size', value: 16384},
+      {subject: 'Approx. Shader Capability', value: 'OpenGL ES 3.0'},
+      {subject: 'Supports Draw Call Instancing', value: true},
+      {subject: 'Supports Ray Tracing', value: true},
+      {subject: 'Supports Compute Shaders', value: true},
+      {subject: 'Supports Geometry Shaders', value: true},
     ]);
   });
 });

--- a/static/app/components/events/contexts/gpu/getGPUKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/gpu/getGPUKnownDataDetails.tsx
@@ -22,40 +22,70 @@ export function getGPUKnownDataDetails({data, type}: Props): KnownDataDetails {
         subject: t('Version'),
         value: data.version,
       };
-    case GPUKnownDataType.MEMORY_SIZE:
+    case GPUKnownDataType.ID:
       return {
-        subject: t('Memory'),
-        value: data.memory_size ? formatMemory(data.memory_size) : undefined,
-      };
-    case GPUKnownDataType.NPOT_SUPPORT:
-      return {
-        subject: t('NPOT Support'),
-        value: data.npot_support,
-      };
-    case GPUKnownDataType.VENDOR_NAME:
-      return {
-        subject: t('Vendor Name'),
-        value: data.vendor_name,
-      };
-    case GPUKnownDataType.MULTI_THREAD_RENDERING:
-      return {
-        subject: t('Multi-Thread rendering'),
-        value: data.multi_threaded_rendering,
-      };
-    case GPUKnownDataType.API_TYPE:
-      return {
-        subject: t('API Type'),
-        value: data.api_type,
+        subject: t('GPU ID'),
+        value: data.id,
       };
     case GPUKnownDataType.VENDOR_ID:
       return {
         subject: t('Vendor ID'),
         value: data.vendor_id,
       };
-    case GPUKnownDataType.ID:
+    case GPUKnownDataType.VENDOR_NAME:
       return {
-        subject: t('GPU ID'),
-        value: data.id,
+        subject: t('Vendor Name'),
+        value: data.vendor_name,
+      };
+    case GPUKnownDataType.MEMORY_SIZE:
+      return {
+        subject: t('Memory'),
+        value: data.memory_size ? formatMemory(data.memory_size) : undefined,
+      };
+    case GPUKnownDataType.API_TYPE:
+      return {
+        subject: t('API Type'),
+        value: data.api_type,
+      };
+    case GPUKnownDataType.MULTI_THREAD_RENDERING:
+      return {
+        subject: t('Multi-Thread Rendering'),
+        value: data.multi_threaded_rendering,
+      };
+    case GPUKnownDataType.NPOT_SUPPORT:
+      return {
+        subject: t('NPOT Support'),
+        value: data.npot_support,
+      };
+    case GPUKnownDataType.MAX_TEXTURE_SIZE:
+      return {
+        subject: t('Max Texture Size'),
+        value: data.max_texture_size,
+      };
+    case GPUKnownDataType.GRAPHICS_SHADER_LEVEL:
+      return {
+        subject: t('Approx. Shader Capability'),
+        value: data.graphics_shader_level,
+      };
+    case GPUKnownDataType.SUPPORTS_DRAW_CALL_INSTANCING:
+      return {
+        subject: t('Supports Draw Call Instancing'),
+        value: data.supports_draw_call_instancing,
+      };
+    case GPUKnownDataType.SUPPORTS_RAY_TRACING:
+      return {
+        subject: t('Supports Ray Tracing'),
+        value: data.supports_ray_tracing,
+      };
+    case GPUKnownDataType.SUPPORTS_COMPUTE_SHADERS:
+      return {
+        subject: t('Supports Compute Shaders'),
+        value: data.supports_compute_shaders,
+      };
+    case GPUKnownDataType.SUPPORTS_GEOMETRY_SHADERS:
+      return {
+        subject: t('Supports Geometry Shaders'),
+        value: data.supports_geometry_shaders,
       };
     default:
       return undefined;

--- a/static/app/components/events/contexts/gpu/index.spec.tsx
+++ b/static/app/components/events/contexts/gpu/index.spec.tsx
@@ -9,14 +9,20 @@ import type {GPUData} from 'sentry/components/events/contexts/gpu/types';
 
 export const gpuMockData: GPUData = {
   name: '',
-  id: 0,
-  vendor_id: 0,
+  id: 2400,
+  vendor_id: '2400.0.0',
   vendor_name: 'Apple',
   memory_size: 4096,
   api_type: '',
   multi_threaded_rendering: true,
   version: 'Metal',
   npot_support: 'Full',
+  max_texture_size: 16384,
+  graphics_shader_level: 'OpenGL ES 3.0',
+  supports_draw_call_instancing: true,
+  supports_ray_tracing: true,
+  supports_compute_shaders: true,
+  supports_geometry_shaders: true,
 };
 
 export const gpuMetaMockData = {

--- a/static/app/components/events/contexts/gpu/index.tsx
+++ b/static/app/components/events/contexts/gpu/index.tsx
@@ -20,44 +20,23 @@ type Props = {
   meta?: Record<string, any>;
 };
 
-export const gpuKnownDataValues = [
-  GPUKnownDataType.NAME,
-  GPUKnownDataType.VERSION,
-  GPUKnownDataType.VENDOR_NAME,
-  GPUKnownDataType.MEMORY_SIZE,
-  GPUKnownDataType.NPOT_SUPPORT,
-  GPUKnownDataType.MULTI_THREAD_RENDERING,
-  GPUKnownDataType.API_TYPE,
-];
+export const gpuKnownDataValues = Object.values(GPUKnownDataType);
 
 const gpuIgnoredDataValues = [];
 
-function getGpuValues({data}: Pick<Props, 'data'>) {
-  const gpuValues = [...gpuKnownDataValues];
-  if (data.vendor_id > 0) {
-    gpuValues.unshift(GPUKnownDataType.VENDOR_ID);
-  }
-  if (data.id > 0) {
-    gpuValues.unshift(GPUKnownDataType.ID);
-  }
-  return gpuValues;
-}
-
 export function getKnownGpuContextData({data, meta}: Pick<Props, 'data' | 'meta'>) {
-  const gpuValues = getGpuValues({data});
   return getKnownData<GPUData, GPUKnownDataType>({
     data,
     meta,
-    knownDataTypes: gpuValues,
+    knownDataTypes: gpuKnownDataValues,
     onGetKnownDataDetails: v => getGPUKnownDataDetails(v),
   });
 }
 
 export function getUnknownGpuContextData({data, meta}: Pick<Props, 'data' | 'meta'>) {
-  const gpuValues = getGpuValues({data});
   return getUnknownData({
     allData: data,
-    knownKeys: [...gpuValues, ...gpuIgnoredDataValues],
+    knownKeys: [...gpuKnownDataValues, ...gpuIgnoredDataValues],
     meta,
   });
 }

--- a/static/app/components/events/contexts/gpu/types.tsx
+++ b/static/app/components/events/contexts/gpu/types.tsx
@@ -1,24 +1,37 @@
+// https://github.com/getsentry/relay/blob/24.10.0/relay-event-schema/src/protocol/contexts/gpu.rs#L21
+
 export enum GPUKnownDataType {
-  ID = 'id',
   NAME = 'name',
   VERSION = 'version',
-  VENDOR_NAME = 'vendor_name',
+  ID = 'id',
   VENDOR_ID = 'vendor_id',
+  VENDOR_NAME = 'vendor_name',
   MEMORY_SIZE = 'memory_size',
-  NPOT_SUPPORT = 'npot_support',
-  MULTI_THREAD_RENDERING = 'multi_threaded_rendering',
   API_TYPE = 'api_type',
+  MULTI_THREAD_RENDERING = 'multi_threaded_rendering',
+  NPOT_SUPPORT = 'npot_support',
+  MAX_TEXTURE_SIZE = 'max_texture_size',
+  GRAPHICS_SHADER_LEVEL = 'graphics_shader_level',
+  SUPPORTS_DRAW_CALL_INSTANCING = 'supports_draw_call_instancing',
+  SUPPORTS_RAY_TRACING = 'supports_ray_tracing',
+  SUPPORTS_COMPUTE_SHADERS = 'supports_compute_shaders',
+  SUPPORTS_GEOMETRY_SHADERS = 'supports_geometry_shaders',
 }
 
 export type GPUData = {
-  id: number;
-  vendor_id: number;
-  api_type?: string;
-  memory?: number;
-  memory_size?: number;
-  multi_threaded_rendering?: boolean;
-  name?: string;
-  npot_support?: string;
-  vendor_name?: string;
-  version?: string;
+  [GPUKnownDataType.ID]: number;
+  [GPUKnownDataType.VENDOR_ID]: string;
+  [GPUKnownDataType.NAME]?: string;
+  [GPUKnownDataType.VERSION]?: string;
+  [GPUKnownDataType.VENDOR_NAME]?: string;
+  [GPUKnownDataType.MEMORY_SIZE]?: number;
+  [GPUKnownDataType.API_TYPE]?: string;
+  [GPUKnownDataType.MULTI_THREAD_RENDERING]?: boolean;
+  [GPUKnownDataType.NPOT_SUPPORT]?: string;
+  [GPUKnownDataType.MAX_TEXTURE_SIZE]?: number;
+  [GPUKnownDataType.GRAPHICS_SHADER_LEVEL]?: string;
+  [GPUKnownDataType.SUPPORTS_DRAW_CALL_INSTANCING]?: boolean;
+  [GPUKnownDataType.SUPPORTS_RAY_TRACING]?: boolean;
+  [GPUKnownDataType.SUPPORTS_COMPUTE_SHADERS]?: boolean;
+  [GPUKnownDataType.SUPPORTS_GEOMETRY_SHADERS]?: boolean;
 };

--- a/static/app/components/events/contexts/trace/getTraceKnownDataDetails.spec.tsx
+++ b/static/app/components/events/contexts/trace/getTraceKnownDataDetails.spec.tsx
@@ -28,15 +28,27 @@ describe('getTraceKnownDataDetails', function () {
     }
 
     expect(allKnownData).toEqual([
-      {subject: 'Status', value: 'unknown'},
       {
         subject: 'Trace ID',
-        value: '61d2d7c5acf448ffa8e2f8f973e2cd36',
+        value: '12312012123120121231201212312012',
         action: {link: expect.anything()},
       },
-      {subject: 'Span ID', value: 'a5702f287954a9ef'},
-      {subject: 'Parent Span ID', value: 'b23703998ae619e7'},
-      {subject: 'Operation Name', value: 'something'},
+      {subject: 'Span ID', value: '0415201309082013'},
+      {subject: 'Parent Span ID', value: '123'},
+      {subject: 'Operation Name', value: 'http.server'},
+      {subject: 'Status', value: 'not_found'},
+      {subject: 'Exclusive Time (ms)', value: 1.035},
+      {subject: 'Client Sample Rate', value: 0.1},
+      {
+        subject: 'Dynamic Sampling Context',
+        value: {
+          trace_id: '12312012123120121231201212312012',
+          sample_rate: '1.0',
+          public_key: '93D0D1125146288EAEE2A9B3AF4F96CCBE3CB316',
+        },
+      },
+      {subject: 'Origin', value: 'auto.http.http_client_5'},
+      {subject: 'Data', value: {route: expect.anything()}},
     ]);
   });
 });

--- a/static/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
@@ -15,7 +15,7 @@ type Props = {
   event: Event;
   location: Location;
   organization: Organization;
-  type: TraceKnownDataType;
+  type: TraceKnownDataType | 'transaction_name';
 };
 
 export function getTraceKnownDataDetails({
@@ -69,7 +69,38 @@ export function getTraceKnownDataDetails({
       };
     }
 
-    case TraceKnownDataType.TRANSACTION_NAME: {
+    case TraceKnownDataType.EXCLUSIVE_TIME: {
+      return {
+        subject: t('Exclusive Time (ms)'),
+        value: data.exclusive_time,
+      };
+    }
+    case TraceKnownDataType.CLIENT_SAMPLE_RATE: {
+      return {
+        subject: t('Client Sample Rate'),
+        value: data.client_sample_rate,
+      };
+    }
+    case TraceKnownDataType.DYNAMIC_SAMPLING_CONTEXT: {
+      return {
+        subject: t('Dynamic Sampling Context'),
+        value: data.dynamic_sampling_context,
+      };
+    }
+    case TraceKnownDataType.ORIGIN: {
+      return {
+        subject: t('Origin'),
+        value: data.origin,
+      };
+    }
+    case TraceKnownDataType.DATA: {
+      return {
+        subject: t('Data'),
+        value: data.data,
+      };
+    }
+
+    case 'transaction_name': {
       const eventTag = event?.tags.find(tag => {
         return tag.key === 'transaction';
       });

--- a/static/app/components/events/contexts/trace/index.spec.tsx
+++ b/static/app/components/events/contexts/trace/index.spec.tsx
@@ -12,12 +12,25 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import {TraceEventContext} from 'sentry/components/events/contexts/trace';
 
 export const traceMockData = {
-  trace_id: '61d2d7c5acf448ffa8e2f8f973e2cd36',
-  span_id: 'a5702f287954a9ef',
-  parent_span_id: 'b23703998ae619e7',
-  op: 'something',
-  status: 'unknown',
-  type: 'trace',
+  trace_id: '12312012123120121231201212312012',
+  span_id: '0415201309082013',
+  parent_span_id: '123',
+  description: '<OrganizationContext>',
+  op: 'http.server',
+  status: 'not_found',
+  exclusive_time: 1.035,
+  client_sample_rate: 0.1,
+  dynamic_sampling_context: {
+    trace_id: '12312012123120121231201212312012',
+    sample_rate: '1.0',
+    public_key: '93D0D1125146288EAEE2A9B3AF4F96CCBE3CB316',
+  },
+  origin: 'auto.http.http_client_5',
+  data: {
+    route: {
+      name: 'HomeRoute',
+    },
+  },
 };
 
 export const traceContextMetaMockData = {

--- a/static/app/components/events/contexts/trace/index.tsx
+++ b/static/app/components/events/contexts/trace/index.tsx
@@ -19,12 +19,9 @@ import type {TraceKnownData} from './types';
 import {TraceKnownDataType} from './types';
 
 export const traceKnownDataValues = [
-  TraceKnownDataType.STATUS,
-  TraceKnownDataType.TRACE_ID,
-  TraceKnownDataType.SPAN_ID,
-  TraceKnownDataType.PARENT_SPAN_ID,
-  TraceKnownDataType.TRANSACTION_NAME,
-  TraceKnownDataType.OP_NAME,
+  ...Object.values(TraceKnownDataType),
+  // Manually added key to link to transactions
+  'transaction_name',
 ];
 
 const traceIgnoredDataValues = [];

--- a/static/app/components/events/contexts/trace/types.tsx
+++ b/static/app/components/events/contexts/trace/types.tsx
@@ -4,13 +4,22 @@ export enum TraceKnownDataType {
   PARENT_SPAN_ID = 'parent_span_id',
   OP_NAME = 'op',
   STATUS = 'status',
-  TRANSACTION_NAME = 'transaction_name',
+  EXCLUSIVE_TIME = 'exclusive_time',
+  CLIENT_SAMPLE_RATE = 'client_sample_rate',
+  DYNAMIC_SAMPLING_CONTEXT = 'dynamic_sampling_context',
+  ORIGIN = 'origin',
+  DATA = 'data',
 }
 
 export type TraceKnownData = {
-  op?: string;
-  parent_span_id?: string;
-  span_id?: string;
-  status?: string;
-  trace_id?: string;
+  [TraceKnownDataType.TRACE_ID]?: string;
+  [TraceKnownDataType.SPAN_ID]?: string;
+  [TraceKnownDataType.PARENT_SPAN_ID]?: string;
+  [TraceKnownDataType.OP_NAME]?: string;
+  [TraceKnownDataType.STATUS]?: string;
+  [TraceKnownDataType.EXCLUSIVE_TIME]?: number;
+  [TraceKnownDataType.CLIENT_SAMPLE_RATE]?: number;
+  [TraceKnownDataType.DYNAMIC_SAMPLING_CONTEXT]?: Record<string, string>;
+  [TraceKnownDataType.ORIGIN]?: string;
+  [TraceKnownDataType.DATA]?: Record<string, any>;
 };


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/80334 - Docs Link: https://develop.sentry.dev/sdk/data-model/event-payloads/contexts/#gpu-context

Audits the rest of the context items from the docs side. Fixes up `gpu` and `trace`.  Next I'll be working on the adding a few more known contexts from https://github.com/getsentry/sentry/pull/80378