### PR TITLE
fix(profiling) add beta banner ending info

### DIFF
--- a/static/app/components/profiling/billing/alerts.tsx
+++ b/static/app/components/profiling/billing/alerts.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 
+import Alert from 'sentry/components/alert';
 import {Button} from 'sentry/components/button';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import {t} from 'sentry/locale';
@@ -26,3 +27,13 @@ export const ProfilingAM1OrMMXUpgrade = HookOrDefault({
     </Fragment>
   ),
 });
+
+export function ContinuousProfilingBetaBanner() {
+  return (
+    <Alert type="warning" showIcon>
+      {t(
+        'Continuous Profiling Beta is ending! We will begin to bill you for profiling usage after <date>.'
+      )}
+    </Alert>
+  );
+}

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -16,6 +16,7 @@ import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionT
 import Pagination from 'sentry/components/pagination';
 import {TransactionSearchQueryBuilder} from 'sentry/components/performance/transactionSearchQueryBuilder';
 import {
+  ContinuousProfilingBetaBanner,
   ProfilingAM1OrMMXUpgrade,
   ProfilingBetaAlertBanner,
   ProfilingUpgradeButton,
@@ -358,6 +359,9 @@ function ProfilingContent({location}: ProfilingContentProps) {
       >
         <Layout.Page>
           <ProfilingBetaAlertBanner organization={organization} />
+          {organization.features.includes('continuous-profiling-beta') ? (
+            <ContinuousProfilingBetaBanner />
+          ) : null}
           <ProfilingContentPageHeader tab={tab} onTabChange={onTabChange} />
           {tab === 'flamegraph' ? (
             <FlamegraphBody>


### PR DESCRIPTION
Adding a banner for orgs that have been sending us continuous profiles as part of the beta and explain what changes for them