### PR TITLE
chore(issue-details): Sort all events by timestamp

### DIFF
--- a/static/app/views/issueDetails/streamline/eventList.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventList.spec.tsx
@@ -120,6 +120,7 @@ describe('EventList', () => {
           query: persistantQuery,
           referrer: 'issue_details.streamline_list',
           statsPeriod: '14d',
+          sort: '-timestamp',
         },
       })
     );

--- a/static/app/views/issueDetails/streamline/eventList.tsx
+++ b/static/app/views/issueDetails/streamline/eventList.tsx
@@ -43,6 +43,7 @@ export function EventList({group}: EventListProps) {
     group,
     queryProps: {
       fields,
+      orderby: ['-timestamp'],
       widths: fields.map(field => {
         switch (field) {
           case 'id':

--- a/static/app/views/issueDetails/streamline/useIssueDetailsDiscoverQuery.tsx
+++ b/static/app/views/issueDetails/streamline/useIssueDetailsDiscoverQuery.tsx
@@ -44,7 +44,6 @@ export function useIssueDetailsEventView({
     yAxis: ['count()', 'count_unique(user)'],
     fields: ['title', 'release', 'environment', 'user.display', 'timestamp'],
     name: group.title || group.type,
-    orderby: ['-timestamp'],
     ...queryProps,
     query,
   };

--- a/static/app/views/issueDetails/streamline/useIssueDetailsDiscoverQuery.tsx
+++ b/static/app/views/issueDetails/streamline/useIssueDetailsDiscoverQuery.tsx
@@ -44,6 +44,7 @@ export function useIssueDetailsEventView({
     yAxis: ['count()', 'count_unique(user)'],
     fields: ['title', 'release', 'environment', 'user.display', 'timestamp'],
     name: group.title || group.type,
+    orderby: ['-timestamp'],
     ...queryProps,
     query,
   };


### PR DESCRIPTION
this pr sorts the all events table on streamlined issue details by timestamp, which is what the previous all events behavior was.