### PR TITLE
feat(issues): Lazy load trace waterfall components

### DIFF
--- a/static/app/components/events/eventEntry.tsx
+++ b/static/app/components/events/eventEntry.tsx
@@ -1,4 +1,7 @@
+import {lazy} from 'react';
+
 import ErrorBoundary from 'sentry/components/errorBoundary';
+import LazyLoad from 'sentry/components/lazyLoad';
 import {t} from 'sentry/locale';
 import type {Entry, Event, EventTransaction} from 'sentry/types/event';
 import {EntryType} from 'sentry/types/event';
@@ -15,12 +18,17 @@ import {DebugMeta} from './interfaces/debugMeta';
 import {Exception} from './interfaces/exception';
 import {Generic} from './interfaces/generic';
 import {Message} from './interfaces/message';
-import {SpanEvidenceSection} from './interfaces/performance/spanEvidence';
 import {Request} from './interfaces/request';
 import {Spans} from './interfaces/spans';
 import {StackTrace} from './interfaces/stackTrace';
 import {Template} from './interfaces/template';
 import {Threads} from './interfaces/threads';
+
+const LazySpanEvidenceSection = lazy(() =>
+  import('sentry/components/events/interfaces/performance/spanEvidence').then(m => ({
+    default: m.SpanEvidenceSection,
+  }))
+);
 
 type Props = {
   entry: Entry;
@@ -127,7 +135,8 @@ function EventEntryContent({
       }
       if (group?.issueCategory === IssueCategory.PERFORMANCE) {
         return (
-          <SpanEvidenceSection
+          <LazyLoad
+            LazyComponent={LazySpanEvidenceSection}
             event={event as EventTransaction}
             organization={organization as Organization}
             projectSlug={projectSlug}

--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -1,132 +1,25 @@
-import {Fragment, useMemo} from 'react';
+import {lazy} from 'react';
 import styled from '@emotion/styled';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
-import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
+import LazyLoad from 'sentry/components/lazyLoad';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import {type Group, IssueCategory} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
-import EventView from 'sentry/utils/discover/eventView';
-import {useLocation} from 'sentry/utils/useLocation';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 import {TraceDataSection} from 'sentry/views/issueDetails/traceDataSection';
-import {TraceViewWaterfall} from 'sentry/views/performance/newTraceDetails';
-import {useTrace} from 'sentry/views/performance/newTraceDetails/traceApi/useTrace';
-import {useTraceMeta} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceMeta';
-import {useTraceRootEvent} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
-import {useTraceTree} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceTree';
-import {
-  loadTraceViewPreferences,
-  type TracePreferencesState,
-} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
-import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
 
-const DEFAULT_ISSUE_DETAILS_TRACE_VIEW_PREFERENCES: TracePreferencesState = {
-  drawer: {
-    minimized: true,
-    sizes: {
-      'drawer left': 0.33,
-      'drawer right': 0.33,
-      'drawer bottom': 0.4,
-    },
-    layoutOptions: [],
-  },
-  missing_instrumentation: true,
-  autogroup: {
-    parent: true,
-    sibling: true,
-  },
-  layout: 'drawer bottom',
-  list: {
-    width: 0.5,
-  },
-};
+const LazyEventTraceWaterfall = lazy(
+  () => import('sentry/components/events/interfaces/performance/eventTraceWaterfall')
+);
 
-interface EventTraceViewInnerProps {
+interface EventTraceViewProps {
   event: Event;
-  organization: Organization;
-}
-
-function EventTraceViewInner({event, organization}: EventTraceViewInnerProps) {
-  // Assuming profile exists, should be checked in the parent component
-  const traceId = event.contexts.trace!.trace_id!;
-  const location = useLocation();
-
-  const trace = useTrace({
-    traceSlug: traceId ? traceId : undefined,
-    limit: 10000,
-  });
-  const meta = useTraceMeta([{traceSlug: traceId, timestamp: undefined}]);
-  const tree = useTraceTree({trace, meta, replay: null});
-
-  const hasNoTransactions = meta.data?.transactions === 0;
-  const shouldLoadTraceRoot = !trace.isPending && trace.data && !hasNoTransactions;
-
-  const rootEvent = useTraceRootEvent(shouldLoadTraceRoot ? trace.data! : null);
-
-  const preferences = useMemo(
-    () =>
-      loadTraceViewPreferences('issue-details-trace-view-preferences') ||
-      DEFAULT_ISSUE_DETAILS_TRACE_VIEW_PREFERENCES,
-    []
-  );
-
-  const traceEventView = useMemo(() => {
-    const statsPeriod = location.query.statsPeriod as string | undefined;
-    // Not currently expecting start/end timestamps to be applied to this view
-
-    return EventView.fromSavedQuery({
-      id: undefined,
-      name: `Events with Trace ID ${traceId}`,
-      fields: ['title', 'event.type', 'project', 'timestamp'],
-      orderby: '-timestamp',
-      query: `trace:${traceId}`,
-      projects: [ALL_ACCESS_PROJECTS],
-      version: 2,
-      range: statsPeriod,
-    });
-  }, [location.query.statsPeriod, traceId]);
-
-  const scrollToNode = useMemo(() => {
-    const firstTransactionEventId = trace.data?.transactions[0]?.event_id;
-    return {eventId: firstTransactionEventId};
-  }, [trace.data]);
-
-  if (trace.isPending || rootEvent.isPending || !rootEvent.data || hasNoTransactions) {
-    return null;
-  }
-
-  return (
-    <Fragment>
-      <TraceStateProvider
-        initialPreferences={preferences}
-        preferencesStorageKey="issue-details-view-preferences"
-      >
-        <TraceViewWaterfallWrapper>
-          <TraceViewWaterfall
-            tree={tree}
-            trace={trace}
-            replay={null}
-            rootEvent={rootEvent}
-            traceSlug={undefined}
-            organization={organization}
-            traceEventView={traceEventView}
-            meta={meta}
-            source="issues"
-            scrollToNode={scrollToNode}
-            isEmbedded
-          />
-        </TraceViewWaterfallWrapper>
-      </TraceStateProvider>
-    </Fragment>
-  );
-}
-
-interface EventTraceViewProps extends EventTraceViewInnerProps {
   group: Group;
+  organization: Organization;
 }
 
 export function EventTraceView({group, event, organization}: EventTraceViewProps) {
@@ -154,7 +47,11 @@ export function EventTraceView({group, event, organization}: EventTraceViewProps
             <TraceDataSection event={event} />
           </div>
           {hasTracePreviewFeature && (
-            <EventTraceViewInner event={event} organization={organization} />
+            <LazyLoad
+              LazyComponent={LazyEventTraceWaterfall}
+              event={event}
+              organization={organization}
+            />
           )}
         </TraceContentWrapper>
       </InterimSection>
@@ -166,10 +63,4 @@ const TraceContentWrapper = styled('div')`
   display: flex;
   flex-direction: column;
   gap: ${space(1)};
-`;
-
-const TraceViewWaterfallWrapper = styled('div')`
-  display: flex;
-  flex-direction: column;
-  height: 500px;
 `;

--- a/static/app/components/events/interfaces/performance/eventTraceWaterfall.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceWaterfall.tsx
@@ -1,0 +1,128 @@
+import {Fragment, useMemo} from 'react';
+import styled from '@emotion/styled';
+
+import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
+import type {Event} from 'sentry/types/event';
+import type {Organization} from 'sentry/types/organization';
+import EventView from 'sentry/utils/discover/eventView';
+import {useLocation} from 'sentry/utils/useLocation';
+import {TraceViewWaterfall} from 'sentry/views/performance/newTraceDetails';
+import {useTrace} from 'sentry/views/performance/newTraceDetails/traceApi/useTrace';
+import {useTraceMeta} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceMeta';
+import {useTraceRootEvent} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
+import {useTraceTree} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceTree';
+import {
+  loadTraceViewPreferences,
+  type TracePreferencesState,
+} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
+import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
+
+const DEFAULT_ISSUE_DETAILS_TRACE_VIEW_PREFERENCES: TracePreferencesState = {
+  drawer: {
+    minimized: true,
+    sizes: {
+      'drawer left': 0.33,
+      'drawer right': 0.33,
+      'drawer bottom': 0.4,
+    },
+    layoutOptions: [],
+  },
+  missing_instrumentation: true,
+  autogroup: {
+    parent: true,
+    sibling: true,
+  },
+  layout: 'drawer bottom',
+  list: {
+    width: 0.5,
+  },
+};
+
+interface EventTraceWaterfallProps {
+  event: Event;
+  organization: Organization;
+}
+
+export default function EventTraceWaterfall({
+  event,
+  organization,
+}: EventTraceWaterfallProps) {
+  // Assuming profile exists, should be checked in the parent component
+  const traceId = event.contexts.trace!.trace_id!;
+  const location = useLocation();
+
+  const trace = useTrace({
+    traceSlug: traceId ? traceId : undefined,
+    limit: 10000,
+  });
+  const meta = useTraceMeta([{traceSlug: traceId, timestamp: undefined}]);
+  const tree = useTraceTree({trace, meta, replay: null});
+
+  const hasNoTransactions = meta.data?.transactions === 0;
+  const shouldLoadTraceRoot = !trace.isPending && trace.data && !hasNoTransactions;
+
+  const rootEvent = useTraceRootEvent(shouldLoadTraceRoot ? trace.data! : null);
+
+  const preferences = useMemo(
+    () =>
+      loadTraceViewPreferences('issue-details-trace-view-preferences') ||
+      DEFAULT_ISSUE_DETAILS_TRACE_VIEW_PREFERENCES,
+    []
+  );
+
+  const traceEventView = useMemo(() => {
+    const statsPeriod = location.query.statsPeriod as string | undefined;
+    // Not currently expecting start/end timestamps to be applied to this view
+
+    return EventView.fromSavedQuery({
+      id: undefined,
+      name: `Events with Trace ID ${traceId}`,
+      fields: ['title', 'event.type', 'project', 'timestamp'],
+      orderby: '-timestamp',
+      query: `trace:${traceId}`,
+      projects: [ALL_ACCESS_PROJECTS],
+      version: 2,
+      range: statsPeriod,
+    });
+  }, [location.query.statsPeriod, traceId]);
+
+  const scrollToNode = useMemo(() => {
+    const firstTransactionEventId = trace.data?.transactions[0]?.event_id;
+    return {eventId: firstTransactionEventId};
+  }, [trace.data]);
+
+  if (trace.isPending || rootEvent.isPending || !rootEvent.data || hasNoTransactions) {
+    return null;
+  }
+
+  return (
+    <Fragment>
+      <TraceStateProvider
+        initialPreferences={preferences}
+        preferencesStorageKey="issue-details-view-preferences"
+      >
+        <TraceViewWaterfallWrapper>
+          <TraceViewWaterfall
+            tree={tree}
+            trace={trace}
+            replay={null}
+            rootEvent={rootEvent}
+            traceSlug={undefined}
+            organization={organization}
+            traceEventView={traceEventView}
+            meta={meta}
+            source="issues"
+            scrollToNode={scrollToNode}
+            isEmbedded
+          />
+        </TraceViewWaterfallWrapper>
+      </TraceStateProvider>
+    </Fragment>
+  );
+}
+
+const TraceViewWaterfallWrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+  height: 500px;
+`;

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -17,11 +17,8 @@ import EventHydrationDiff from 'sentry/components/events/eventHydrationDiff';
 import {EventProcessingErrors} from 'sentry/components/events/eventProcessingErrors';
 import EventReplay from 'sentry/components/events/eventReplay';
 import {EventSdk} from 'sentry/components/events/eventSdk';
-import AggregateSpanDiff from 'sentry/components/events/eventStatisticalDetector/aggregateSpanDiff';
 import EventBreakpointChart from 'sentry/components/events/eventStatisticalDetector/breakpointChart';
-import {EventAffectedTransactions} from 'sentry/components/events/eventStatisticalDetector/eventAffectedTransactions';
 import EventComparison from 'sentry/components/events/eventStatisticalDetector/eventComparison';
-import {EventDifferentialFlamegraph} from 'sentry/components/events/eventStatisticalDetector/eventDifferentialFlamegraph';
 import {EventFunctionComparisonList} from 'sentry/components/events/eventStatisticalDetector/eventFunctionComparisonList';
 import {EventRegressionSummary} from 'sentry/components/events/eventStatisticalDetector/eventRegressionSummary';
 import {EventFunctionBreakpointChart} from 'sentry/components/events/eventStatisticalDetector/functionBreakpointChart';
@@ -36,7 +33,6 @@ import HighlightsDataSection from 'sentry/components/events/highlights/highlight
 import {HighlightsIconSummary} from 'sentry/components/events/highlights/highlightsIconSummary';
 import {ActionableItems} from 'sentry/components/events/interfaces/crashContent/exception/actionableItems';
 import {actionableItemsEnabled} from 'sentry/components/events/interfaces/crashContent/exception/useActionableItems';
-import {CronTimelineSection} from 'sentry/components/events/interfaces/crons/cronTimelineSection';
 import {Csp} from 'sentry/components/events/interfaces/csp';
 import {DebugMeta} from 'sentry/components/events/interfaces/debugMeta';
 import {Exception} from 'sentry/components/events/interfaces/exception';
@@ -88,6 +84,28 @@ const LLMMonitoringSection = lazy(
 const LazySpanEvidenceSection = lazy(() =>
   import('sentry/components/events/interfaces/performance/spanEvidence').then(m => ({
     default: m.SpanEvidenceSection,
+  }))
+);
+const LazyCronTimelineSection = lazy(() =>
+  import('sentry/components/events/interfaces/crons/cronTimelineSection').then(m => ({
+    default: m.CronTimelineSection,
+  }))
+);
+const LazyEventDifferentialFlamegraph = lazy(() =>
+  import(
+    'sentry/components/events/eventStatisticalDetector/eventDifferentialFlamegraph'
+  ).then(m => ({
+    default: m.EventDifferentialFlamegraph,
+  }))
+);
+const LazyAggregateSpanDiff = lazy(
+  () => import('sentry/components/events/eventStatisticalDetector/aggregateSpanDiff')
+);
+const LazyEventAffectedTransactions = lazy(() =>
+  import(
+    'sentry/components/events/eventStatisticalDetector/eventAffectedTransactions'
+  ).then(m => ({
+    default: m.EventAffectedTransactions,
   }))
 );
 
@@ -230,7 +248,8 @@ export function EventDetailsContent({
         <UptimeDataSection event={event} project={project} group={group} />
       )}
       {group.issueCategory === IssueCategory.CRON && (
-        <CronTimelineSection
+        <LazyLoad
+          LazyComponent={LazyCronTimelineSection}
           event={event}
           organization={organization}
           project={project}
@@ -474,7 +493,7 @@ function PerformanceDurationRegressionIssueDetailsContent({
         <EventBreakpointChart event={event} />
       </ErrorBoundary>
       <ErrorBoundary mini>
-        <AggregateSpanDiff event={event} project={project} />
+        <LazyLoad LazyComponent={LazyAggregateSpanDiff} event={event} project={project} />
       </ErrorBoundary>
       <ErrorBoundary mini>
         <EventComparison event={event} project={project} />
@@ -499,7 +518,12 @@ function ProfilingDurationRegressionIssueDetailsContent({
             <EventFunctionBreakpointChart event={event} />
           </ErrorBoundary>
           <ErrorBoundary mini>
-            <EventAffectedTransactions event={event} group={group} project={project} />
+            <LazyLoad
+              LazyComponent={LazyEventAffectedTransactions}
+              event={event}
+              group={group}
+              project={project}
+            />
           </ErrorBoundary>
           <ErrorBoundary mini>
             <InterimSection
@@ -512,7 +536,7 @@ function ProfilingDurationRegressionIssueDetailsContent({
               frame with the largest increase in call stack population likely
               contributed to the cause for the duration regression.`)}
               </p>
-              <EventDifferentialFlamegraph event={event} />
+              <LazyLoad LazyComponent={LazyEventDifferentialFlamegraph} event={event} />
             </InterimSection>
           </ErrorBoundary>
           <ErrorBoundary mini>

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -44,7 +44,6 @@ import {Generic} from 'sentry/components/events/interfaces/generic';
 import {Message} from 'sentry/components/events/interfaces/message';
 import {AnrRootCause} from 'sentry/components/events/interfaces/performance/anrRootCause';
 import {EventTraceView} from 'sentry/components/events/interfaces/performance/eventTraceView';
-import {SpanEvidenceSection} from 'sentry/components/events/interfaces/performance/spanEvidence';
 import {Request} from 'sentry/components/events/interfaces/request';
 import {StackTrace} from 'sentry/components/events/interfaces/stackTrace';
 import {Template} from 'sentry/components/events/interfaces/template';
@@ -85,6 +84,11 @@ import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 const LLMMonitoringSection = lazy(
   () => import('sentry/components/events/interfaces/llm-monitoring/llmMonitoringSection')
+);
+const LazySpanEvidenceSection = lazy(() =>
+  import('sentry/components/events/interfaces/performance/spanEvidence').then(m => ({
+    default: m.SpanEvidenceSection,
+  }))
 );
 
 export interface EventDetailsContentProps {
@@ -301,7 +305,8 @@ export function EventDetailsContent({
         </QuickTraceQuery>
       )}
       {group.issueCategory === IssueCategory.PERFORMANCE && (
-        <SpanEvidenceSection
+        <LazyLoad
+          LazyComponent={LazySpanEvidenceSection}
           event={event as EventTransaction}
           organization={organization}
           projectSlug={project.slug}


### PR DESCRIPTION
We have both the old and new trace views directly bundled into issue details. Attempt to keep these split in their own chunks to avoid dragging in the entire app on page load.
