### PR TITLE
ref(flags): consolidate sort into one dropdown

### DIFF
--- a/static/app/components/events/featureFlags/eventFeatureFlagList.spec.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.spec.tsx
@@ -81,7 +81,7 @@ describe('EventFeatureFlagList', function () {
     expect(drawerControl).toHaveFocus();
   });
 
-  it('renders a sort group dropdown with Evaluation Order as the default', async function () {
+  it('renders a sort dropdown with Evaluation Order as the default', async function () {
     render(<EventFeatureFlagList {...MOCK_DATA_SECTION_PROPS} />);
 
     const control = screen.getByRole('button', {name: 'Sort Flags'});

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.spec.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.spec.tsx
@@ -81,33 +81,32 @@ describe('EventFeatureFlagList', function () {
     expect(drawerControl).toHaveFocus();
   });
 
-  it('renders a flag granular sort dropdown with Newest as the default', async function () {
-    render(<EventFeatureFlagList {...MOCK_DATA_SECTION_PROPS} />);
-
-    const control = screen.getByRole('button', {name: 'Newest'});
-    expect(control).toBeInTheDocument();
-    await userEvent.click(control);
-    expect(screen.getByRole('option', {name: 'Oldest'})).toBeInTheDocument();
-  });
-
   it('renders a sort group dropdown with Evaluation Order as the default', async function () {
     render(<EventFeatureFlagList {...MOCK_DATA_SECTION_PROPS} />);
 
-    const control = screen.getByRole('button', {name: 'Evaluation Order'});
+    const control = screen.getByRole('button', {name: 'Sort Flags'});
     expect(control).toBeInTheDocument();
     await userEvent.click(control);
     expect(screen.getByRole('option', {name: 'Evaluation Order'})).toBeInTheDocument();
     expect(screen.getByRole('option', {name: 'Alphabetical'})).toBeInTheDocument();
   });
 
-  it('renders a sort group dropdown which affects the granular sort dropdown', async function () {
+  it('renders a sort dropdown which affects the granular sort dropdown', async function () {
     render(<EventFeatureFlagList {...MOCK_DATA_SECTION_PROPS} />);
 
-    const control = screen.getByRole('button', {name: 'Evaluation Order'});
+    const control = screen.getByRole('button', {name: 'Sort Flags'});
     expect(control).toBeInTheDocument();
     await userEvent.click(control);
     await userEvent.click(screen.getByRole('option', {name: 'Alphabetical'}));
-    expect(screen.getByRole('button', {name: 'A-Z'})).toBeInTheDocument();
+    await userEvent.click(control);
+    expect(screen.getByRole('option', {name: 'Alphabetical'})).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(screen.getByRole('option', {name: 'A-Z'})).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
   });
 
   it('allows sort dropdown to affect displayed flags', async function () {
@@ -124,10 +123,10 @@ describe('EventFeatureFlagList', function () {
     ).toBe(document.DOCUMENT_POSITION_PRECEDING);
 
     const sortControl = screen.getByRole('button', {
-      name: 'Newest',
+      name: 'Sort Flags',
     });
     await userEvent.click(sortControl);
-    await userEvent.click(screen.getByRole('option', {name: 'Oldest'}));
+    await userEvent.click(screen.getByRole('option', {name: 'Oldest First'}));
 
     // expect enableReplay to be following webVitalsFlag
     expect(
@@ -136,10 +135,7 @@ describe('EventFeatureFlagList', function () {
         .compareDocumentPosition(screen.getByText(enableReplay.flag))
     ).toBe(document.DOCUMENT_POSITION_FOLLOWING);
 
-    const sortGroupControl = screen.getByRole('button', {
-      name: 'Evaluation Order',
-    });
-    await userEvent.click(sortGroupControl);
+    await userEvent.click(sortControl);
     await userEvent.click(screen.getByRole('option', {name: 'Alphabetical'}));
 
     // expect enableReplay to be preceding webVitalsFlag, A-Z sort by default

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.spec.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.spec.tsx
@@ -109,6 +109,43 @@ describe('EventFeatureFlagList', function () {
     );
   });
 
+  it('renders a sort dropdown which disables the appropriate options', async function () {
+    render(<EventFeatureFlagList {...MOCK_DATA_SECTION_PROPS} />);
+
+    const control = screen.getByRole('button', {name: 'Sort Flags'});
+    expect(control).toBeInTheDocument();
+    await userEvent.click(control);
+    await userEvent.click(screen.getByRole('option', {name: 'Alphabetical'}));
+    await userEvent.click(control);
+    expect(screen.getByRole('option', {name: 'Alphabetical'})).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(screen.getByRole('option', {name: 'Newest First'})).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+    expect(screen.getByRole('option', {name: 'Oldest First'})).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+
+    await userEvent.click(screen.getByRole('option', {name: 'Evaluation Order'}));
+    await userEvent.click(control);
+    expect(screen.getByRole('option', {name: 'Evaluation Order'})).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(screen.getByRole('option', {name: 'Z-A'})).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+    expect(screen.getByRole('option', {name: 'A-Z'})).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
+
   it('allows sort dropdown to affect displayed flags', async function () {
     render(<EventFeatureFlagList {...MOCK_DATA_SECTION_PROPS} />);
 

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -13,7 +13,7 @@ import {
   getSelectionType,
   ORDER_BY_OPTIONS,
   OrderBy,
-  SORT_GROUP_OPTIONS,
+  SORT_BY_OPTIONS,
   SortBy,
   sortedFlags,
 } from 'sentry/components/events/featureFlags/featureFlagDrawer';
@@ -196,7 +196,7 @@ export function EventFeatureFlagList({
             }
             setSortBy(selection.value);
           }}
-          options={SORT_GROUP_OPTIONS}
+          options={SORT_BY_OPTIONS}
         />
         <CompositeSelect.Region
           label={t('Order By')}

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -3,23 +3,21 @@ import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
-import {CompositeSelect} from 'sentry/components/compactSelect/composite';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {
   CardContainer,
   FeatureFlagDrawer,
+} from 'sentry/components/events/featureFlags/featureFlagDrawer';
+import FeatureFlagSort from 'sentry/components/events/featureFlags/featureFlagSort';
+import {
   FlagControlOptions,
-  getDefaultOrderBy,
-  getSelectionType,
-  ORDER_BY_OPTIONS,
   OrderBy,
-  SORT_BY_OPTIONS,
   SortBy,
   sortedFlags,
-} from 'sentry/components/events/featureFlags/featureFlagDrawer';
+} from 'sentry/components/events/featureFlags/utils';
 import useDrawer from 'sentry/components/globalDrawer';
 import KeyValueData from 'sentry/components/keyValueData';
-import {IconMegaphone, IconSearch, IconSort} from 'sentry/icons';
+import {IconMegaphone, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Event, FeatureFlag} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
@@ -177,43 +175,12 @@ export function EventFeatureFlagList({
         title={t('Open Search')}
         onClick={() => onViewAllFlags(FlagControlOptions.SEARCH)}
       />
-      <CompositeSelect
-        trigger={triggerProps => (
-          <Button
-            {...triggerProps}
-            aria-label={t('Sort Flags')}
-            size="xs"
-            icon={<IconSort />}
-          />
-        )}
-      >
-        <CompositeSelect.Region
-          label={t('Sort By')}
-          value={sortBy}
-          onChange={selection => {
-            if (selection.value !== sortBy) {
-              setOrderBy(getDefaultOrderBy(selection.value));
-            }
-            setSortBy(selection.value);
-          }}
-          options={SORT_BY_OPTIONS}
-        />
-        <CompositeSelect.Region
-          label={t('Order By')}
-          value={orderBy}
-          onChange={selection => {
-            setOrderBy(selection.value);
-            trackAnalytics('flags.sort-flags', {
-              organization,
-              sortMethod: selection.value,
-            });
-          }}
-          options={ORDER_BY_OPTIONS.map(o => {
-            const selectionType = getSelectionType(o.value);
-            return selectionType !== sortBy ? {...o, disabled: true} : o;
-          })}
-        />
-      </CompositeSelect>
+      <FeatureFlagSort
+        orderBy={orderBy}
+        sortBy={sortBy}
+        setSortBy={setSortBy}
+        setOrderBy={setOrderBy}
+      />
     </ButtonBar>
   );
 

--- a/static/app/components/events/featureFlags/featureFlagDrawer.spec.tsx
+++ b/static/app/components/events/featureFlags/featureFlagDrawer.spec.tsx
@@ -112,4 +112,71 @@ describe('FeatureFlagDrawer', function () {
         .compareDocumentPosition(drawerScreen.getByText(enableReplay.flag))
     ).toBe(document.DOCUMENT_POSITION_FOLLOWING);
   });
+
+  it('renders a sort dropdown with Evaluation Order as the default', async function () {
+    const drawerScreen = await renderFlagDrawer();
+
+    const control = drawerScreen.getByRole('button', {name: 'Sort Flags'});
+    expect(control).toBeInTheDocument();
+    await userEvent.click(control);
+    expect(
+      drawerScreen.getByRole('option', {name: 'Evaluation Order'})
+    ).toBeInTheDocument();
+    expect(drawerScreen.getByRole('option', {name: 'Alphabetical'})).toBeInTheDocument();
+  });
+
+  it('renders a sort dropdown which affects the granular sort dropdown', async function () {
+    const drawerScreen = await renderFlagDrawer();
+
+    const control = drawerScreen.getByRole('button', {name: 'Sort Flags'});
+    expect(control).toBeInTheDocument();
+    await userEvent.click(control);
+    await userEvent.click(drawerScreen.getByRole('option', {name: 'Alphabetical'}));
+    await userEvent.click(control);
+    expect(drawerScreen.getByRole('option', {name: 'Alphabetical'})).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(drawerScreen.getByRole('option', {name: 'A-Z'})).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+  });
+
+  it('renders a sort dropdown which disables the appropriate options', async function () {
+    const drawerScreen = await renderFlagDrawer();
+
+    const control = drawerScreen.getByRole('button', {name: 'Sort Flags'});
+    expect(control).toBeInTheDocument();
+    await userEvent.click(control);
+    await userEvent.click(drawerScreen.getByRole('option', {name: 'Alphabetical'}));
+    await userEvent.click(control);
+    expect(drawerScreen.getByRole('option', {name: 'Alphabetical'})).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(drawerScreen.getByRole('option', {name: 'Newest First'})).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+    expect(drawerScreen.getByRole('option', {name: 'Oldest First'})).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+
+    await userEvent.click(drawerScreen.getByRole('option', {name: 'Evaluation Order'}));
+    await userEvent.click(control);
+    expect(drawerScreen.getByRole('option', {name: 'Evaluation Order'})).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(drawerScreen.getByRole('option', {name: 'Z-A'})).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+    expect(drawerScreen.getByRole('option', {name: 'A-Z'})).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
 });

--- a/static/app/components/events/featureFlags/featureFlagDrawer.spec.tsx
+++ b/static/app/components/events/featureFlags/featureFlagDrawer.spec.tsx
@@ -50,10 +50,7 @@ describe('FeatureFlagDrawer', function () {
     // Header & Controls
     expect(drawerScreen.getByText('Feature Flags', {selector: 'h3'})).toBeInTheDocument();
     expect(drawerScreen.getByRole('textbox', {name: 'Search Flags'})).toBeInTheDocument();
-    expect(drawerScreen.getByRole('button', {name: 'Newest'})).toBeInTheDocument();
-    expect(
-      drawerScreen.getByRole('button', {name: 'Evaluation Order'})
-    ).toBeInTheDocument();
+    expect(drawerScreen.getByRole('button', {name: 'Sort Flags'})).toBeInTheDocument();
 
     // Contents
     for (const {flag, result} of MOCK_FLAGS) {
@@ -91,10 +88,10 @@ describe('FeatureFlagDrawer', function () {
     ).toBe(document.DOCUMENT_POSITION_FOLLOWING);
 
     const sortControl = drawerScreen.getByRole('button', {
-      name: 'Newest',
+      name: 'Sort Flags',
     });
     await userEvent.click(sortControl);
-    await userEvent.click(drawerScreen.getByRole('option', {name: 'Oldest'}));
+    await userEvent.click(drawerScreen.getByRole('option', {name: 'Oldest First'}));
 
     // expect webVitalsFlag to be preceding enableReplay
     expect(
@@ -103,10 +100,7 @@ describe('FeatureFlagDrawer', function () {
         .compareDocumentPosition(drawerScreen.getByText(webVitalsFlag.flag))
     ).toBe(document.DOCUMENT_POSITION_PRECEDING);
 
-    const sortGroupControl = drawerScreen.getByRole('button', {
-      name: 'Evaluation Order',
-    });
-    await userEvent.click(sortGroupControl);
+    await userEvent.click(sortControl);
     await userEvent.click(drawerScreen.getByRole('option', {name: 'Alphabetical'}));
     await userEvent.click(sortControl);
     await userEvent.click(drawerScreen.getByRole('option', {name: 'Z-A'}));

--- a/static/app/components/events/featureFlags/featureFlagDrawer.tsx
+++ b/static/app/components/events/featureFlags/featureFlagDrawer.tsx
@@ -83,7 +83,7 @@ export const getDefaultOrderBy = (sortBy: SortBy) => {
   return sortBy === SortBy.EVAL_ORDER ? OrderBy.NEWEST : OrderBy.A_TO_Z;
 };
 
-export const SORT_GROUP_OPTIONS = [
+export const SORT_BY_OPTIONS = [
   {
     label: getSortByLabel(SortBy.EVAL_ORDER),
     value: SortBy.EVAL_ORDER,
@@ -207,7 +207,7 @@ export function FeatureFlagDrawer({
             }
             setSortBy(selection.value);
           }}
-          options={SORT_GROUP_OPTIONS}
+          options={SORT_BY_OPTIONS}
         />
         <CompositeSelect.Region
           label={t('Order By')}

--- a/static/app/components/events/featureFlags/featureFlagDrawer.tsx
+++ b/static/app/components/events/featureFlags/featureFlagDrawer.tsx
@@ -2,9 +2,7 @@ import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
-import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
-import {CompositeSelect} from 'sentry/components/compactSelect/composite';
 import {
   CrumbContainer,
   EventDrawerBody,
@@ -16,132 +14,25 @@ import {
   SearchInput,
   ShortId,
 } from 'sentry/components/events/eventDrawer';
+import FeatureFlagSort from 'sentry/components/events/featureFlags/featureFlagSort';
+import {
+  FlagControlOptions,
+  type OrderBy,
+  type SortBy,
+  sortedFlags,
+} from 'sentry/components/events/featureFlags/utils';
 import useFocusControl from 'sentry/components/events/useFocusControl';
 import {InputGroup} from 'sentry/components/inputGroup';
 import KeyValueData, {
   type KeyValueDataContentProps,
 } from 'sentry/components/keyValueData';
-import {IconSearch, IconSort} from 'sentry/icons';
+import {IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
-import {trackAnalytics} from 'sentry/utils/analytics';
 import {getShortEventId} from 'sentry/utils/events';
-import useOrganization from 'sentry/utils/useOrganization';
-
-export enum OrderBy {
-  NEWEST = 'newest',
-  OLDEST = 'oldest',
-  A_TO_Z = 'a-z',
-  Z_TO_A = 'z-a',
-}
-
-export enum SortBy {
-  EVAL_ORDER = 'eval',
-  ALPHABETICAL = 'alphabetical',
-}
-
-export const getSelectionType = (selection: string) => {
-  switch (selection) {
-    case OrderBy.A_TO_Z:
-    case OrderBy.Z_TO_A:
-      return 'alphabetical';
-    case OrderBy.OLDEST:
-    case OrderBy.NEWEST:
-    default:
-      return 'eval';
-  }
-};
-
-const getOrderByLabel = (sort: string) => {
-  switch (sort) {
-    case OrderBy.A_TO_Z:
-      return t('A-Z');
-    case OrderBy.Z_TO_A:
-      return t('Z-A');
-    case OrderBy.OLDEST:
-      return t('Oldest First');
-    case OrderBy.NEWEST:
-    default:
-      return t('Newest First');
-  }
-};
-
-const getSortByLabel = (sort: string) => {
-  switch (sort) {
-    case SortBy.ALPHABETICAL:
-      return t('Alphabetical');
-    case SortBy.EVAL_ORDER:
-    default:
-      return t('Evaluation Order');
-  }
-};
-
-export const getDefaultOrderBy = (sortBy: SortBy) => {
-  return sortBy === SortBy.EVAL_ORDER ? OrderBy.NEWEST : OrderBy.A_TO_Z;
-};
-
-export const SORT_BY_OPTIONS = [
-  {
-    label: getSortByLabel(SortBy.EVAL_ORDER),
-    value: SortBy.EVAL_ORDER,
-  },
-  {
-    label: getSortByLabel(SortBy.ALPHABETICAL),
-    value: SortBy.ALPHABETICAL,
-  },
-];
-
-export const ORDER_BY_OPTIONS = [
-  {
-    label: getOrderByLabel(OrderBy.NEWEST),
-    value: OrderBy.NEWEST,
-  },
-  {
-    label: getOrderByLabel(OrderBy.OLDEST),
-    value: OrderBy.OLDEST,
-  },
-  {
-    label: getOrderByLabel(OrderBy.A_TO_Z),
-    value: OrderBy.A_TO_Z,
-  },
-  {
-    label: getOrderByLabel(OrderBy.Z_TO_A),
-    value: OrderBy.Z_TO_A,
-  },
-];
-
-export const enum FlagControlOptions {
-  SEARCH = 'search',
-  SORT = 'sort',
-}
-
-export const handleSortAlphabetical = (flags: KeyValueDataContentProps[]) => {
-  return [...flags].sort((a, b) => {
-    return a.item.key.localeCompare(b.item.key);
-  });
-};
-
-export const sortedFlags = ({
-  flags,
-  sort,
-}: {
-  flags: KeyValueDataContentProps[];
-  sort: OrderBy;
-}): KeyValueDataContentProps[] => {
-  switch (sort) {
-    case OrderBy.A_TO_Z:
-      return handleSortAlphabetical(flags);
-    case OrderBy.Z_TO_A:
-      return [...handleSortAlphabetical(flags)].reverse();
-    case OrderBy.OLDEST:
-      return [...flags].reverse();
-    default:
-      return flags;
-  }
-};
 
 interface FlagDrawerProps {
   event: Event;
@@ -165,7 +56,6 @@ export function FeatureFlagDrawer({
   const [sortBy, setSortBy] = useState<SortBy>(initialSortBy);
   const [orderBy, setOrderBy] = useState<OrderBy>(initialOrderBy);
   const [search, setSearch] = useState('');
-  const organization = useOrganization();
   const {getFocusProps} = useFocusControl(initialFocusControl);
 
   const searchResults = sortedFlags({flags: hydratedFlags, sort: orderBy}).filter(f =>
@@ -188,43 +78,12 @@ export function FeatureFlagDrawer({
           <IconSearch size="xs" />
         </InputGroup.TrailingItems>
       </InputGroup>
-      <CompositeSelect
-        trigger={triggerProps => (
-          <Button
-            {...triggerProps}
-            aria-label={t('Sort Flags')}
-            size="xs"
-            icon={<IconSort />}
-          />
-        )}
-      >
-        <CompositeSelect.Region
-          label={t('Sort By')}
-          value={sortBy}
-          onChange={selection => {
-            if (selection.value !== sortBy) {
-              setOrderBy(getDefaultOrderBy(selection.value));
-            }
-            setSortBy(selection.value);
-          }}
-          options={SORT_BY_OPTIONS}
-        />
-        <CompositeSelect.Region
-          label={t('Order By')}
-          value={orderBy}
-          onChange={selection => {
-            setOrderBy(selection.value);
-            trackAnalytics('flags.sort-flags', {
-              organization,
-              sortMethod: selection.value,
-            });
-          }}
-          options={ORDER_BY_OPTIONS.map(o => {
-            const selectionType = getSelectionType(o.value);
-            return selectionType !== sortBy ? {...o, disabled: true} : o;
-          })}
-        />
-      </CompositeSelect>
+      <FeatureFlagSort
+        orderBy={orderBy}
+        sortBy={sortBy}
+        setSortBy={setSortBy}
+        setOrderBy={setOrderBy}
+      />
     </ButtonBar>
   );
 

--- a/static/app/components/events/featureFlags/featureFlagSort.tsx
+++ b/static/app/components/events/featureFlags/featureFlagSort.tsx
@@ -1,0 +1,65 @@
+import {Button} from 'sentry/components/button';
+import {CompositeSelect} from 'sentry/components/compactSelect/composite';
+import {
+  getDefaultOrderBy,
+  getSelectionType,
+  ORDER_BY_OPTIONS,
+  type OrderBy,
+  SORT_BY_OPTIONS,
+  type SortBy,
+} from 'sentry/components/events/featureFlags/utils';
+import {IconSort} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import useOrganization from 'sentry/utils/useOrganization';
+
+interface Props {
+  orderBy: OrderBy;
+  setOrderBy: (value: React.SetStateAction<OrderBy>) => void;
+  setSortBy: (value: React.SetStateAction<SortBy>) => void;
+  sortBy: SortBy;
+}
+
+export default function FeatureFlagSort({sortBy, orderBy, setOrderBy, setSortBy}: Props) {
+  const organization = useOrganization();
+
+  return (
+    <CompositeSelect
+      trigger={triggerProps => (
+        <Button
+          {...triggerProps}
+          aria-label={t('Sort Flags')}
+          size="xs"
+          icon={<IconSort />}
+        />
+      )}
+    >
+      <CompositeSelect.Region
+        label={t('Sort By')}
+        value={sortBy}
+        onChange={selection => {
+          if (selection.value !== sortBy) {
+            setOrderBy(getDefaultOrderBy(selection.value));
+          }
+          setSortBy(selection.value);
+        }}
+        options={SORT_BY_OPTIONS}
+      />
+      <CompositeSelect.Region
+        label={t('Order By')}
+        value={orderBy}
+        onChange={selection => {
+          setOrderBy(selection.value);
+          trackAnalytics('flags.sort-flags', {
+            organization,
+            sortMethod: selection.value,
+          });
+        }}
+        options={ORDER_BY_OPTIONS.map(o => {
+          const selectionType = getSelectionType(o.value);
+          return selectionType !== sortBy ? {...o, disabled: true} : o;
+        })}
+      />
+    </CompositeSelect>
+  );
+}

--- a/static/app/components/events/featureFlags/utils.tsx
+++ b/static/app/components/events/featureFlags/utils.tsx
@@ -1,0 +1,114 @@
+import type {KeyValueDataContentProps} from 'sentry/components/keyValueData';
+import {t} from 'sentry/locale';
+
+export enum OrderBy {
+  NEWEST = 'newest',
+  OLDEST = 'oldest',
+  A_TO_Z = 'a-z',
+  Z_TO_A = 'z-a',
+}
+
+export enum SortBy {
+  EVAL_ORDER = 'eval',
+  ALPHABETICAL = 'alphabetical',
+}
+
+export const getSelectionType = (selection: string) => {
+  switch (selection) {
+    case OrderBy.A_TO_Z:
+    case OrderBy.Z_TO_A:
+      return 'alphabetical';
+    case OrderBy.OLDEST:
+    case OrderBy.NEWEST:
+    default:
+      return 'eval';
+  }
+};
+
+const getOrderByLabel = (sort: string) => {
+  switch (sort) {
+    case OrderBy.A_TO_Z:
+      return t('A-Z');
+    case OrderBy.Z_TO_A:
+      return t('Z-A');
+    case OrderBy.OLDEST:
+      return t('Oldest First');
+    case OrderBy.NEWEST:
+    default:
+      return t('Newest First');
+  }
+};
+
+const getSortByLabel = (sort: string) => {
+  switch (sort) {
+    case SortBy.ALPHABETICAL:
+      return t('Alphabetical');
+    case SortBy.EVAL_ORDER:
+    default:
+      return t('Evaluation Order');
+  }
+};
+
+export const getDefaultOrderBy = (sortBy: SortBy) => {
+  return sortBy === SortBy.EVAL_ORDER ? OrderBy.NEWEST : OrderBy.A_TO_Z;
+};
+
+export const SORT_BY_OPTIONS = [
+  {
+    label: getSortByLabel(SortBy.EVAL_ORDER),
+    value: SortBy.EVAL_ORDER,
+  },
+  {
+    label: getSortByLabel(SortBy.ALPHABETICAL),
+    value: SortBy.ALPHABETICAL,
+  },
+];
+
+export const ORDER_BY_OPTIONS = [
+  {
+    label: getOrderByLabel(OrderBy.NEWEST),
+    value: OrderBy.NEWEST,
+  },
+  {
+    label: getOrderByLabel(OrderBy.OLDEST),
+    value: OrderBy.OLDEST,
+  },
+  {
+    label: getOrderByLabel(OrderBy.A_TO_Z),
+    value: OrderBy.A_TO_Z,
+  },
+  {
+    label: getOrderByLabel(OrderBy.Z_TO_A),
+    value: OrderBy.Z_TO_A,
+  },
+];
+
+export const enum FlagControlOptions {
+  SEARCH = 'search',
+  SORT = 'sort',
+}
+
+export const handleSortAlphabetical = (flags: KeyValueDataContentProps[]) => {
+  return [...flags].sort((a, b) => {
+    return a.item.key.localeCompare(b.item.key);
+  });
+};
+
+export const sortedFlags = ({
+  flags,
+  sort,
+}: {
+  flags: KeyValueDataContentProps[];
+  sort: OrderBy;
+}): KeyValueDataContentProps[] => {
+  switch (sort) {
+    case OrderBy.A_TO_Z:
+      return handleSortAlphabetical(flags);
+    case OrderBy.Z_TO_A:
+      return [...handleSortAlphabetical(flags)].reverse();
+    case OrderBy.OLDEST:
+      return [...flags].reverse();
+    default:
+      return flags;
+  }
+};

--- a/static/app/components/events/useFocusControl.tsx
+++ b/static/app/components/events/useFocusControl.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useState} from 'react';
 
 import type {BreadcrumbControlOptions} from 'sentry/components/events/breadcrumbs/breadcrumbsDrawer';
-import type {FlagControlOptions} from 'sentry/components/events/featureFlags/featureFlagDrawer';
+import type {FlagControlOptions} from 'sentry/components/events/featureFlags/utils';
 
 type FocusControlOption = BreadcrumbControlOptions | FlagControlOptions;
 


### PR DESCRIPTION
- update the feature flag section sort dropdown to consolidate the two dropdowns into one `CompositeSelect`. based on [figma](https://www.figma.com/design/oTVOd3RGUSZWYGwTpGjeGK/Specs%3A-Feature-Flag-List-in-Issue-Details?node-id=556-3776&node-type=frame&t=Hu03MiscDBvUMtK6-0)
- update test coverage

the design:

<img width="465" alt="SCR-20241107-krhc" src="https://github.com/user-attachments/assets/e1099bb9-7405-49eb-ab11-090b228d4565">


in the drawer:

https://github.com/user-attachments/assets/b016c16d-e039-48e3-8b0c-e50b735a7807

in the issue details section:

https://github.com/user-attachments/assets/ad58610f-8524-4b43-a299-2b87fca334a2



