### PR TITLE
feat(issue-details): Enable sorting in all events table

### DIFF
--- a/static/app/views/issueDetails/streamline/eventList.tsx
+++ b/static/app/views/issueDetails/streamline/eventList.tsx
@@ -18,6 +18,7 @@ import {type Group, IssueType} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {parseCursor} from 'sentry/utils/cursor';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
+import {decodeSorts} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useRoutes} from 'sentry/utils/useRoutes';
@@ -67,6 +68,10 @@ export function EventList({group}: EventListProps) {
     },
   });
 
+  eventView.sorts = decodeSorts(location.query.sort).filter(sort =>
+    fields.includes(sort.field)
+  );
+
   const grayText = css`
     color: ${theme.subText};
     font-weight: ${theme.fontWeightNormal};
@@ -93,7 +98,6 @@ export function EventList({group}: EventListProps) {
         columnTitles={columnTitles}
         referrer={referrer}
         hidePagination
-        disableSort
         renderTableHeader={({
           pageLinks,
           pageEventsCount,

--- a/static/app/views/issueDetails/streamline/eventList.tsx
+++ b/static/app/views/issueDetails/streamline/eventList.tsx
@@ -93,6 +93,7 @@ export function EventList({group}: EventListProps) {
         columnTitles={columnTitles}
         referrer={referrer}
         hidePagination
+        disableSort
         renderTableHeader={({
           pageLinks,
           pageEventsCount,

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -94,7 +94,6 @@ type Props = {
   transactionName: string;
   columnTitles?: string[];
   customColumns?: ('attachments' | 'minidump')[];
-  disableSort?: boolean;
   domainViewFilters?: DomainViewFilters;
   excludedTags?: string[];
   hidePagination?: boolean;
@@ -364,7 +363,6 @@ class EventsTable extends Component<Props, State> {
     const currentSort = eventView.sortForField(field, tableMeta);
     // EventId, TraceId, and ReplayId are technically sortable but we don't want to sort them here since sorting by a uuid value doesn't make sense
     const canSort =
-      !this.props.disableSort &&
       field.field !== 'id' &&
       field.field !== 'trace' &&
       field.field !== 'replayId' &&

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -94,6 +94,7 @@ type Props = {
   transactionName: string;
   columnTitles?: string[];
   customColumns?: ('attachments' | 'minidump')[];
+  disableSort?: boolean;
   domainViewFilters?: DomainViewFilters;
   excludedTags?: string[];
   hidePagination?: boolean;
@@ -363,6 +364,7 @@ class EventsTable extends Component<Props, State> {
     const currentSort = eventView.sortForField(field, tableMeta);
     // EventId, TraceId, and ReplayId are technically sortable but we don't want to sort them here since sorting by a uuid value doesn't make sense
     const canSort =
+      !this.props.disableSort &&
       field.field !== 'id' &&
       field.field !== 'trace' &&
       field.field !== 'replayId' &&


### PR DESCRIPTION
this pr enables sorting in all events, you can click the column to "sort" right now, which does change the query, but we didn't do anything with it. 