### PR TITLE
chore(insights): Remove MongoDB feature flag from frontend

### DIFF
--- a/static/app/views/insights/database/components/databasePageFilters.tsx
+++ b/static/app/views/insights/database/components/databasePageFilters.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import useOrganization from 'sentry/utils/useOrganization';
 import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ActionSelector} from 'sentry/views/insights/common/views/spans/selectors/actionSelector';
 import {DomainSelector} from 'sentry/views/insights/common/views/spans/selectors/domainSelector';
@@ -19,8 +18,6 @@ type Props = {
 };
 
 export function DatabasePageFilters(props: Props) {
-  const organization = useOrganization();
-
   const {system, databaseCommand, table} = props;
 
   const additionalQuery = useMemo(() => [`span.system:${system}`], [system]);
@@ -29,9 +26,7 @@ export function DatabasePageFilters(props: Props) {
     <PageFilterWrapper>
       <ModulePageFilterBar moduleName={ModuleName.DB} />
       <PageFilterBar condensed>
-        {organization.features.includes('performance-queries-mongodb-extraction') && (
-          <DatabaseSystemSelector />
-        )}
+        <DatabaseSystemSelector />
         <ActionSelector
           moduleName={ModuleName.DB}
           value={databaseCommand ?? ''}


### PR DESCRIPTION
MongoDB query support is rolled out to 100% GA now, we can remove the usage of this flag from the frontend