### PR TITLE
chore(deps): Bump sentry-sdk to 2.18.0

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -71,7 +71,7 @@ sentry-ophio==1.0.0
 sentry-protos>=0.1.33
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.9.2
-sentry-sdk[http2]>=2.17.0
+sentry-sdk[http2]>=2.18.0
 slack-sdk>=3.27.2
 snuba-sdk>=3.0.43
 simplejson>=3.17.6

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -189,7 +189,7 @@ sentry-ophio==1.0.0
 sentry-protos==0.1.33
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.2
-sentry-sdk==2.17.0
+sentry-sdk==2.18.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -130,7 +130,7 @@ sentry-ophio==1.0.0
 sentry-protos==0.1.33
 sentry-redis-tools==0.1.7
 sentry-relay==0.9.2
-sentry-sdk==2.17.0
+sentry-sdk==2.18.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0


### PR DESCRIPTION
Looking to get https://github.com/getsentry/sentry-python/pull/3723 to address instrumentation issues.