### PR TITLE
fix(traces): Trace meta needs include_all_accessible as well

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -1708,6 +1708,28 @@ class OrganizationEventsTraceMetaEndpoint(OrganizationEventsV2EndpointBase):
     }
     snuba_methods = ["GET"]
 
+    def get_projects(
+        self,
+        request: HttpRequest,
+        organization: Organization | RpcOrganization,
+        force_global_perms: bool = False,
+        include_all_accessible: bool = False,
+        project_ids: set[int] | None = None,
+        project_slugs: set[str] | None = None,
+    ) -> list[Project]:
+        """The trace endpoint always wants to get all projects regardless of what's passed into the API
+
+        This is because a trace can span any number of projects in an organization. But we still want to
+        use the get_projects function to check for any permissions. So we'll just pass project_ids=-1 everytime
+        which is what would be sent if we wanted all projects"""
+        return super().get_projects(
+            request,
+            organization,
+            project_ids={-1},
+            project_slugs=None,
+            include_all_accessible=True,
+        )
+
     def get(self, request: Request, organization: Organization, trace_id: str) -> HttpResponse:
         if not self.has_feature(organization, request):
             return Response(status=404)

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -1700,6 +1700,21 @@ class OrganizationEventsTraceMetaEndpointTest(OrganizationEventsTraceEndpointBas
         assert data["errors"] == 0
         assert data["performance_issues"] == 2
 
+    def test_no_team(self):
+        self.load_trace()
+        self.team.delete()
+        with self.feature(self.FEATURES):
+            response = self.client.get(
+                self.url,
+                format="json",
+            )
+        assert response.status_code == 200, response.content
+        data = response.data
+        assert data["projects"] == 4
+        assert data["transactions"] == 8
+        assert data["errors"] == 0
+        assert data["performance_issues"] == 2
+
     def test_with_errors(self):
         self.load_trace()
         self.load_errors(self.gen1_project, self.gen1_span_ids[0])


### PR DESCRIPTION
- Without this team permissions mattered which meant the trace meta was 404ing for some users uneccesarily