### PR TITLE
feat(insights): add beta badge to ai pages

### DIFF
--- a/static/app/views/insights/llmMonitoring/views/llmMonitoringLandingPage.tsx
+++ b/static/app/views/insights/llmMonitoring/views/llmMonitoringLandingPage.tsx
@@ -73,6 +73,7 @@ export function LLMMonitoringPage() {
                 title={t('View analytics and information about your AI pipelines')}
                 docsUrl={MODULE_DOC_LINK}
               />
+              <FeatureBadge type={RELEASE_LEVEL} />
             </Fragment>
           }
           module={ModuleName.AI}

--- a/static/app/views/insights/pages/ai/aiOverviewPage.tsx
+++ b/static/app/views/insights/pages/ai/aiOverviewPage.tsx
@@ -1,6 +1,8 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
+import FeatureBadge from 'sentry/components/badge/featureBadge';
 import {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {NoAccess} from 'sentry/components/noAccess';
@@ -28,7 +30,10 @@ import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {ViewTrendsButton} from 'sentry/views/insights/common/components/viewTrendsButton';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {AiHeader} from 'sentry/views/insights/pages/ai/aiPageHeader';
-import {AI_LANDING_TITLE} from 'sentry/views/insights/pages/ai/settings';
+import {
+  AI_LANDING_TITLE,
+  AI_RELEASE_LEVEL,
+} from 'sentry/views/insights/pages/ai/settings';
 import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/domainOverviewPageProviders';
 import {generateGenericPerformanceEventView} from 'sentry/views/performance/data';
 import {TripleChartRow} from 'sentry/views/performance/landing/widgets/components/widgetChartRow';
@@ -135,7 +140,15 @@ function AiOverviewPage() {
       organization={organization}
       renderDisabled={NoAccess}
     >
-      <AiHeader headerTitle={AI_LANDING_TITLE} headerActions={<ViewTrendsButton />} />
+      <AiHeader
+        headerTitle={
+          <Fragment>
+            {AI_LANDING_TITLE}
+            <FeatureBadge type={AI_RELEASE_LEVEL} />
+          </Fragment>
+        }
+        headerActions={<ViewTrendsButton />}
+      />
       <Layout.Body>
         <Layout.Main fullWidth>
           <ModuleLayout.Layout>

--- a/static/app/views/insights/pages/ai/settings.ts
+++ b/static/app/views/insights/pages/ai/settings.ts
@@ -1,8 +1,10 @@
+import type {BadgeType} from 'sentry/components/badge/featureBadge';
 import {t} from 'sentry/locale';
 import {ModuleName} from 'sentry/views/insights/types';
 
 export const AI_LANDING_SUB_PATH = 'ai';
 export const AI_LANDING_TITLE = t('AI Performance');
 export const AI_SIDEBAR_LABEL = t('AI');
+export const AI_RELEASE_LEVEL: BadgeType = 'beta';
 
 export const MODULES = [ModuleName.AI];


### PR DESCRIPTION
All ai stuff is technically beta, so we should show a beta badge next to ai overview and llm monitoring.
<img width="420" alt="image" src="https://github.com/user-attachments/assets/99bf26cd-efbc-4612-a30d-a5a0e3b4aebc">
