### PR TITLE
fix(insights): screen rendering analytic event name incorrect

### DIFF
--- a/static/app/views/insights/mobile/screenRendering/screenRenderingLandingPage.tsx
+++ b/static/app/views/insights/mobile/screenRendering/screenRenderingLandingPage.tsx
@@ -57,7 +57,7 @@ function PageWithProviders() {
     <ModulePageProviders
       moduleName="screen_load"
       features={MODULE_FEATURE_MAP[ModuleName.SCREEN_RENDERING]}
-      analyticEventName="insight.page_loads.screen_load"
+      analyticEventName="insight.page_loads.screen_rendering"
     >
       <ScreenRenderingModule />
     </ModulePageProviders>


### PR DESCRIPTION
Copy paste error, we were setting the `analyticEventName` to `screen_load` in the screen rendering module.