### PR TITLE
fix(profiling): Format all_examples in functions stats response

### DIFF
--- a/src/sentry/search/events/builder/profile_functions.py
+++ b/src/sentry/search/events/builder/profile_functions.py
@@ -45,8 +45,15 @@ class ProfileFunctionsQueryBuilderMixin:
 
     def process_profiling_function_columns(self, row: SnubaRow):
         if "all_examples()" in row:
+            key = "all_examples()"
+        elif "all_examples" in row:
+            key = "all_examples"
+        else:
+            key = None
+
+        if key is not None:
             parsed_examples = []
-            for example in row["all_examples()"]:
+            for example in row[key]:
                 profile_id, thread_id, start, end = example
 
                 # This is shaped like the `ExampleMetaData` in vroom
@@ -66,7 +73,7 @@ class ProfileFunctionsQueryBuilderMixin:
                         }
                     )
 
-            row["all_examples()"] = parsed_examples
+            row[key] = parsed_examples
 
 
 class ProfileFunctionsQueryBuilder(ProfileFunctionsQueryBuilderMixin, BaseQueryBuilder):
@@ -108,10 +115,12 @@ class ProfileFunctionsTimeseriesQueryBuilder(
         return custom_time_processor(self.interval, Function("toUInt32", [Column("timestamp")]))
 
     def process_results(self, results: Any) -> EventsResponse:
-        processed: EventsResponse = super().process_results(results)
-        for row in processed["data"]:
+        # Not sure why exactly but calling `super().process_results(results)`
+        # on the timeseries data mutates the data in such a way that breaks
+        # the zerofill later
+        for row in results["data"]:
             self.process_profiling_function_columns(row)
-        return processed
+        return results
 
 
 class ProfileTopFunctionsTimeseriesQueryBuilder(ProfileFunctionsTimeseriesQueryBuilder):

--- a/src/sentry/search/events/builder/profile_functions.py
+++ b/src/sentry/search/events/builder/profile_functions.py
@@ -44,6 +44,9 @@ class ProfileFunctionsQueryBuilderMixin:
         return resolved
 
     def process_profiling_function_columns(self, row: SnubaRow):
+        # We need to check both the aliased and non aliased names
+        # as not all use cases enable `transform_alias_to_input_format`
+        # and the events-stats endpoint does not actually apply it.
         if "all_examples()" in row:
             key = "all_examples()"
         elif "all_examples" in row:
@@ -115,9 +118,9 @@ class ProfileFunctionsTimeseriesQueryBuilder(
         return custom_time_processor(self.interval, Function("toUInt32", [Column("timestamp")]))
 
     def process_results(self, results: Any) -> EventsResponse:
-        # Not sure why exactly but calling `super().process_results(results)`
-        # on the timeseries data mutates the data in such a way that breaks
-        # the zerofill later
+        # Calling `super().process_results(results)` on the timeseries data
+        # mutates the data in such a way that breaks the zerofill later such
+        # as applying `transform_alias_to_input_format` setting.  So skip it.
         for row in results["data"]:
             self.process_profiling_function_columns(row)
         return results

--- a/src/sentry/snuba/functions.py
+++ b/src/sentry/snuba/functions.py
@@ -105,6 +105,7 @@ def timeseries_query(
     )
     results = builder.run_query(referrer=referrer, query_source=query_source)
     results = builder.strip_alias_prefix(results)
+    results = builder.process_results(results)
 
     return SnubaTSResult(
         {


### PR DESCRIPTION
The result of calling `all_examples()` in the stats endpoint needs to be formatted into the expected format for easier reuse on the frontend.