### PR TITLE
chore(login-banners): Remove banner choice from html

### DIFF
--- a/src/sentry/templates/sentry/partial/alerts.html
+++ b/src/sentry/templates/sentry/partial/alerts.html
@@ -77,11 +77,7 @@
 {% elif show_login_banner %}
   <div class="alert-banner">
     <div class="alert-message">
-      {% if banner_choice == 0 %}
       Join our Live Demo: Intro to Sentry & Codecov on Nov. 7. &nbsp<a target="_blank" href="https://sentry.io/resources/intro-to-codecov-sentry-workshop/">RSVP</a>
-      {% elif banner_choice == 1 %}
-      Join our Live Demo: Intro to Sentry & Codecov on Nov. 7. &nbsp<a target="_blank" href="https://sentry.io/resources/intro-to-codecov-sentry-workshop/">RSVP</a>
-      {% endif %}
     </div>
   </div>
 {% endif %}


### PR DESCRIPTION
The plan is to only use one banner for now, so we can remove banner choice. A separate PR will remove `banner_choice` from the context