### PR TITLE
feat(flags): add setup integration modal

### DIFF
--- a/static/app/components/events/featureFlags/eventFeatureFlagList.spec.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.spec.tsx
@@ -9,8 +9,10 @@ import {
 
 import {EventFeatureFlagList} from 'sentry/components/events/featureFlags/eventFeatureFlagList';
 import {
+  EMPTY_STATE_SECTION_PROPS,
   MOCK_DATA_SECTION_PROPS,
   MOCK_FLAGS,
+  NO_FLAG_CONTEXT_SECTION_PROPS,
 } from 'sentry/components/events/featureFlags/testUtils';
 
 // Needed to mock useVirtualizer lists.
@@ -191,5 +193,31 @@ describe('EventFeatureFlagList', function () {
         .getByText(webVitalsFlag.flag)
         .compareDocumentPosition(screen.getByText(enableReplay.flag))
     ).toBe(document.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it('renders empty state', function () {
+    render(<EventFeatureFlagList {...EMPTY_STATE_SECTION_PROPS} />);
+
+    const control = screen.queryByRole('button', {name: 'Sort Flags'});
+    expect(control).not.toBeInTheDocument();
+    const search = screen.queryByRole('button', {name: 'Open Feature Flag Search'});
+    expect(search).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Set Up Integration'})).toBeInTheDocument();
+    expect(
+      screen.queryByText('No feature flags were found for this event')
+    ).toBeInTheDocument();
+  });
+
+  it('renders nothing if event.contexts.flags is not set', function () {
+    render(<EventFeatureFlagList {...NO_FLAG_CONTEXT_SECTION_PROPS} />);
+
+    const control = screen.queryByRole('button', {name: 'Sort Flags'});
+    expect(control).not.toBeInTheDocument();
+    const search = screen.queryByRole('button', {name: 'Open Feature Flag Search'});
+    expect(search).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Set Up Integration'})
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Feature Flags')).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -247,9 +247,9 @@ export function EventFeatureFlagList({
             <KeyValueData.Card contentItems={columnTwo} />
           </CardContainer>
         ) : (
-          <EmptyStateWarning withIcon small>
+          <StyledEmptyStateWarning withIcon>
             {t('No feature flags were found for this event')}
-          </EmptyStateWarning>
+          </StyledEmptyStateWarning>
         )}
       </InterimSection>
     </ErrorBoundary>
@@ -263,4 +263,12 @@ const SuspectLabel = styled('div')`
 const ValueWrapper = styled('div')`
   display: flex;
   justify-content: space-between;
+`;
+
+const StyledEmptyStateWarning = styled(EmptyStateWarning)`
+  border: ${p => p.theme.border} solid 1px;
+  border-radius: ${p => p.theme.borderRadius};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 `;

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -237,7 +237,7 @@ export function EventFeatureFlagList({
             <KeyValueData.Card contentItems={columnTwo} />
           </CardContainer>
         ) : (
-          <EmptyStateWarning withIcon={false} small>
+          <EmptyStateWarning withIcon small>
             {t('No feature flags were found for this event')}
           </EmptyStateWarning>
         )}

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useMemo, useRef, useState} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {openModal} from 'sentry/actionCreators/modal';
@@ -96,6 +96,7 @@ export function EventFeatureFlagList({
   const hasFlags = Boolean(hasFlagContext && event?.contexts?.flags?.values.length);
 
   function handleClick() {
+    trackAnalytics('flags.setup_modal_opened', {organization});
     openModal(modalProps => <SetupIntegrationModal {...modalProps} />, {
       modalCss,
     });
@@ -164,6 +165,15 @@ export function EventFeatureFlagList({
     },
     [openDrawer, event, group, project, hydratedFlags, organization, sortBy, orderBy]
   );
+
+  useEffect(() => {
+    if (hasFlags) {
+      trackAnalytics('flags.table_rendered', {
+        organization,
+        numFlags: hydratedFlags.length,
+      });
+    }
+  }, [hasFlags, hydratedFlags.length, organization]);
 
   // TODO: for LD users, show a CTA in this section instead
   // if contexts.flags is not set, hide the section

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -95,7 +95,7 @@ export function EventFeatureFlagList({
   const hasFlagContext = !!event.contexts.flags;
   const hasFlags = Boolean(hasFlagContext && event?.contexts?.flags?.values.length);
 
-  function handleClick() {
+  function handleSetupButtonClick() {
     trackAnalytics('flags.setup_modal_opened', {organization});
     openModal(modalProps => <SetupIntegrationModal {...modalProps} />, {
       modalCss,
@@ -186,7 +186,11 @@ export function EventFeatureFlagList({
       {feedbackButton}
       {hasFlagContext && (
         <Fragment>
-          <Button aria-label={t('Set Up Integration')} size="xs" onClick={handleClick}>
+          <Button
+            aria-label={t('Set Up Integration')}
+            size="xs"
+            onClick={handleSetupButtonClick}
+          >
             {t('Set Up Integration')}
           </Button>
           {hasFlags && (

--- a/static/app/components/events/featureFlags/featureFlagSort.tsx
+++ b/static/app/components/events/featureFlags/featureFlagSort.tsx
@@ -31,6 +31,7 @@ export default function FeatureFlagSort({sortBy, orderBy, setOrderBy, setSortBy}
           aria-label={t('Sort Flags')}
           size="xs"
           icon={<IconSort />}
+          title={t('Sort Flags')}
         />
       )}
     >

--- a/static/app/components/events/featureFlags/setupIntegrationModal.tsx
+++ b/static/app/components/events/featureFlags/setupIntegrationModal.tsx
@@ -30,30 +30,30 @@ interface State {
   url: string | undefined;
 }
 
-async function useGenerateAuthToken(state: State) {
+function useGenerateAuthToken(state: State) {
   const api = useApi();
   const date = new Date().toISOString();
 
-  const newToken: any = await api.requestPromise(`/api-tokens/`, {
-    method: 'POST',
-    data: {
-      name: `${state.provider} Token ${date}`,
-      scopes: [
-        'project:read',
-        'project:write',
-        'project:admin',
-        'event:read',
-        'event:write',
-        'event:admin',
-        'org:read',
-        'org:write',
-        'org:admin',
-      ],
-    },
-  });
+  const createToken = async () =>
+    await api.requestPromise(`/api-tokens/`, {
+      method: 'POST',
+      data: {
+        name: `${state.provider} Token ${date}`,
+        scopes: [
+          'project:read',
+          'project:write',
+          'project:admin',
+          'event:read',
+          'event:write',
+          'event:admin',
+          'org:read',
+          'org:write',
+          'org:admin',
+        ],
+      },
+    });
 
-  const token = newToken.token;
-  return token;
+  return {createToken};
 }
 
 export function SetupIntegrationModal<T extends Data>({
@@ -67,7 +67,7 @@ export function SetupIntegrationModal<T extends Data>({
     url: undefined,
   });
   const {organization} = useLegacyStore(OrganizationStore);
-  const token = useGenerateAuthToken(state);
+  const {createToken} = useGenerateAuthToken(state);
 
   const handleSubmit = useCallback(() => {
     addSuccessMessage(t('Integration set up successfully'));
@@ -138,9 +138,9 @@ export function SetupIntegrationModal<T extends Data>({
             priority="default"
             title={!defined(state.provider) && t('You must select a provider first.')}
             onClick={async () => {
-              const newToken = await token;
+              const newToken = await createToken();
+              const encodedToken = encodeURI(newToken.token);
               const provider = state.provider.toLowerCase();
-              const encodedToken = encodeURI(newToken);
 
               setState(prevState => {
                 return {

--- a/static/app/components/events/featureFlags/setupIntegrationModal.tsx
+++ b/static/app/components/events/featureFlags/setupIntegrationModal.tsx
@@ -30,26 +30,21 @@ interface State {
   url: string | undefined;
 }
 
-function useGenerateAuthToken(state: State) {
+function useGenerateAuthToken({
+  state,
+  orgSlug,
+}: {
+  orgSlug: string | undefined;
+  state: State;
+}) {
   const api = useApi();
   const date = new Date().toISOString();
 
   const createToken = async () =>
-    await api.requestPromise(`/api-tokens/`, {
+    await api.requestPromise(`/organizations/${orgSlug}/org-auth-tokens/`, {
       method: 'POST',
       data: {
         name: `${state.provider} Token ${date}`,
-        scopes: [
-          'project:read',
-          'project:write',
-          'project:admin',
-          'event:read',
-          'event:write',
-          'event:admin',
-          'org:read',
-          'org:write',
-          'org:admin',
-        ],
       },
     });
 
@@ -67,7 +62,7 @@ export function SetupIntegrationModal<T extends Data>({
     url: undefined,
   });
   const {organization} = useLegacyStore(OrganizationStore);
-  const {createToken} = useGenerateAuthToken(state);
+  const {createToken} = useGenerateAuthToken({state, orgSlug: organization?.slug});
 
   const handleSubmit = useCallback(() => {
     addSuccessMessage(t('Integration set up successfully'));

--- a/static/app/components/events/featureFlags/setupIntegrationModal.tsx
+++ b/static/app/components/events/featureFlags/setupIntegrationModal.tsx
@@ -1,7 +1,6 @@
 import {Fragment, useCallback, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
-import type {Event} from '@sentry/types';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
@@ -20,19 +19,9 @@ import {defined} from 'sentry/utils';
 import useApi from 'sentry/utils/useApi';
 
 export type ChildrenProps<T> = {
-  Body: (props: {
-    children: React.ReactNode;
-    showSelfHostedMessage?: boolean;
-  }) => ReturnType<ModalRenderProps['Body']>;
-  Footer: (props: {
-    onBack?: () => void;
-    onNext?: () => void;
-    primaryDisabledReason?: string;
-    secondaryAction?: React.ReactNode;
-    submitEventData?: Event;
-  }) => ReturnType<ModalRenderProps['Footer']>;
+  Body: (props: {children: React.ReactNode}) => ReturnType<ModalRenderProps['Body']>;
+  Footer: () => ReturnType<ModalRenderProps['Footer']>;
   Header: (props: {children: React.ReactNode}) => ReturnType<ModalRenderProps['Header']>;
-  onFieldChange: <Field extends keyof T>(field: Field, value: T[Field]) => void;
   state: T;
 };
 

--- a/static/app/components/events/featureFlags/setupIntegrationModal.tsx
+++ b/static/app/components/events/featureFlags/setupIntegrationModal.tsx
@@ -1,0 +1,227 @@
+import {Fragment, useCallback, useState} from 'react';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+import type {Event} from '@sentry/types';
+
+import {addSuccessMessage} from 'sentry/actionCreators/indicator';
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import Alert from 'sentry/components/alert';
+import {Button, LinkButton} from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
+import SelectField from 'sentry/components/forms/fields/selectField';
+import type {Data} from 'sentry/components/forms/types';
+import TextCopyInput from 'sentry/components/textCopyInput';
+import {IconWarning} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import OrganizationStore from 'sentry/stores/organizationStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import {space} from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
+import useApi from 'sentry/utils/useApi';
+
+export type ChildrenProps<T> = {
+  Body: (props: {
+    children: React.ReactNode;
+    showSelfHostedMessage?: boolean;
+  }) => ReturnType<ModalRenderProps['Body']>;
+  Footer: (props: {
+    onBack?: () => void;
+    onNext?: () => void;
+    primaryDisabledReason?: string;
+    secondaryAction?: React.ReactNode;
+    submitEventData?: Event;
+  }) => ReturnType<ModalRenderProps['Footer']>;
+  Header: (props: {children: React.ReactNode}) => ReturnType<ModalRenderProps['Header']>;
+  onFieldChange: <Field extends keyof T>(field: Field, value: T[Field]) => void;
+  state: T;
+};
+
+interface State {
+  provider: string;
+  url: string | undefined;
+}
+
+async function useGenerateAuthToken(state: State) {
+  const api = useApi();
+  const date = new Date().toISOString();
+
+  const newToken: any = await api.requestPromise(`/api-tokens/`, {
+    method: 'POST',
+    data: {
+      name: `${state.provider} Token ${date}`,
+      scopes: [
+        'project:read',
+        'project:write',
+        'project:admin',
+        'event:read',
+        'event:write',
+        'event:admin',
+        'org:read',
+        'org:write',
+        'org:admin',
+      ],
+    },
+  });
+
+  const token = newToken.token;
+  return token;
+}
+
+export function SetupIntegrationModal<T extends Data>({
+  Header,
+  Body,
+  Footer,
+  closeModal,
+}: ModalRenderProps) {
+  const [state, setState] = useState<State>({
+    provider: 'LaunchDarkly',
+    url: undefined,
+  });
+  const {organization} = useLegacyStore(OrganizationStore);
+  const token = useGenerateAuthToken(state);
+
+  const handleSubmit = useCallback(() => {
+    addSuccessMessage(t('Integration set up successfully'));
+    closeModal();
+  }, [closeModal]);
+
+  const ModalHeader = useCallback(
+    ({children: headerChildren}: {children: React.ReactNode}) => {
+      return (
+        <Header closeButton>
+          <h3>{headerChildren}</h3>
+        </Header>
+      );
+    },
+    [Header]
+  );
+
+  const ModalFooter = useCallback(() => {
+    return (
+      <Footer>
+        <StyledButtonBar gap={1}>
+          <LinkButton priority="default" href="">
+            {t('Read Docs')}
+          </LinkButton>
+          <Button
+            priority="primary"
+            title={!defined(state.provider) && t('Required fields must be filled out.')}
+            onClick={() => handleSubmit()}
+            disabled={!defined(state.provider)}
+          >
+            {t('Done')}
+          </Button>
+        </StyledButtonBar>
+      </Footer>
+    );
+  }, [Footer, handleSubmit, state]);
+
+  const ModalBody = useCallback(
+    ({children: bodyChildren}: Parameters<ChildrenProps<T>['Body']>[0]) => {
+      return <Body>{bodyChildren}</Body>;
+    },
+    [Body]
+  );
+
+  const integrations = ['LaunchDarkly'];
+
+  return (
+    <Fragment>
+      <ModalHeader>{t('Set Up Feature Flag Integration')}</ModalHeader>
+      <ModalBody>
+        <SelectContainer>
+          <SelectField
+            label={t('Feature Flag Services')}
+            name="provider"
+            inline={false}
+            options={integrations.map(integration => ({
+              value: integration,
+              label: integration,
+            }))}
+            placeholder={t('Select a feature flag service')}
+            value={state.provider}
+            onChange={value => setState({...state, provider: value})}
+            flexibleControlStateSize
+            stacked
+            required
+          />
+          <WebhookButton
+            priority="default"
+            title={!defined(state.provider) && t('You must select a provider first.')}
+            onClick={async () => {
+              const newToken = await token;
+              const provider = state.provider.toLowerCase();
+              const encodedToken = encodeURI(newToken);
+
+              setState(prevState => {
+                return {
+                  ...prevState,
+                  url: `https://sentry.io/api/0/organizations/${organization?.slug}/flags/hooks/provider/${provider}/token/${encodedToken}/`,
+                };
+              });
+            }}
+            disabled={!defined(state.provider) || defined(state.url)}
+          >
+            {t('Create Webhook URL')}
+          </WebhookButton>
+        </SelectContainer>
+        <WebhookContainer>
+          {t('Webhook URL')}
+          <TextCopyInput
+            style={{padding: '20px'}}
+            disabled={!defined(state.url)}
+            placeholder={t('No webhook URL created yet')}
+            aria-label={t('Webhook URL')}
+            size="sm"
+          >
+            {state.url ?? ''}
+          </TextCopyInput>
+          <InfoContainer>
+            {t(
+              'The final step is to create a Webhook integration within your Feature flag service by utilizing the Webhook URL provided in the field above.'
+            )}
+            <Alert showIcon type="warning" icon={<IconWarning />}>
+              {t('You won’t be able to access this URL once this modal is closed.')}
+            </Alert>
+          </InfoContainer>
+        </WebhookContainer>
+      </ModalBody>
+      <ModalFooter />
+    </Fragment>
+  );
+}
+
+export const modalCss = css`
+  width: 100%;
+  max-width: 680px;
+`;
+
+const StyledButtonBar = styled(ButtonBar)`
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+`;
+
+const SelectContainer = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr max-content;
+  align-items: center;
+  gap: ${space(1)};
+`;
+
+const WebhookButton = styled(Button)`
+  margin-top: ${space(1)};
+`;
+
+const WebhookContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
+`;
+
+const InfoContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(2)};
+  margin-top: ${space(1)};
+`;

--- a/static/app/components/events/featureFlags/setupIntegrationModal.tsx
+++ b/static/app/components/events/featureFlags/setupIntegrationModal.tsx
@@ -16,6 +16,7 @@ import OrganizationStore from 'sentry/stores/organizationStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import useApi from 'sentry/utils/useApi';
 
 export type ChildrenProps<T> = {
@@ -147,6 +148,8 @@ export function SetupIntegrationModal<T extends Data>({
                   url: `https://sentry.io/api/0/organizations/${organization?.slug}/flags/hooks/provider/${provider}/token/${encodedToken}/`,
                 };
               });
+
+              trackAnalytics('flags.webhook_url_generated', {organization});
             }}
             disabled={!defined(state.provider) || defined(state.url)}
           >

--- a/static/app/components/events/featureFlags/setupIntegrationModal.tsx
+++ b/static/app/components/events/featureFlags/setupIntegrationModal.tsx
@@ -167,7 +167,7 @@ export function SetupIntegrationModal<T extends Data>({
           </TextCopyInput>
           <InfoContainer>
             {t(
-              'The final step is to create a Webhook integration within your Feature flag service by utilizing the Webhook URL provided in the field above.'
+              'The final step is to create a Webhook integration within your feature flag service by utilizing the Webhook URL provided in the field above.'
             )}
             <Alert showIcon type="warning" icon={<IconWarning />}>
               {t('You won’t be able to access this URL once this modal is closed.')}

--- a/static/app/components/events/featureFlags/setupIntegrationModal.tsx
+++ b/static/app/components/events/featureFlags/setupIntegrationModal.tsx
@@ -89,7 +89,11 @@ export function SetupIntegrationModal<T extends Data>({
     return (
       <Footer>
         <StyledButtonBar gap={1}>
-          <LinkButton priority="default" href="">
+          <LinkButton
+            priority="default"
+            href="https://docs.sentry.io/product/issues/issue-details/#feature-flags"
+            external
+          >
             {t('Read Docs')}
           </LinkButton>
           <Button

--- a/static/app/components/events/featureFlags/testUtils.tsx
+++ b/static/app/components/events/featureFlags/testUtils.tsx
@@ -31,3 +31,21 @@ export const MOCK_DATA_SECTION_PROPS = {
   project: ProjectFixture(),
   group: GroupFixture(),
 };
+
+export const EMPTY_STATE_SECTION_PROPS = {
+  event: EventFixture({
+    id: 'abc123def456ghi789jkl',
+    contexts: {flags: {values: []}},
+  }),
+  project: ProjectFixture(),
+  group: GroupFixture(),
+};
+
+export const NO_FLAG_CONTEXT_SECTION_PROPS = {
+  event: EventFixture({
+    id: 'abc123def456ghi789jkl',
+    contexts: {other: {}},
+  }),
+  project: ProjectFixture(),
+  group: GroupFixture(),
+};

--- a/static/app/utils/analytics/featureFlagAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/featureFlagAnalyticsEvents.tsx
@@ -20,6 +20,6 @@ export const featureFlagEventMap: Record<FeatureFlagEventKey, string | null> = {
   'flags.sort-flags': 'Sorted Flags',
   'flags.event_and_suspect_flags_found': 'Number of Event and Suspect Flags',
   'flags.setup_modal_opened': 'Flag Setup Integration Modal Opened',
-  'flags.webhook_url_generated': 'Flag Webhook URL Generated in Modal',
+  'flags.webhook_url_generated': 'Flag Webhook URL Generated in Setup Integration Modal',
   'flags.table_rendered': 'Flag Table Rendered',
 };

--- a/static/app/utils/analytics/featureFlagAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/featureFlagAnalyticsEvents.tsx
@@ -4,8 +4,13 @@ export type FeatureFlagEventParameters = {
     numSuspectFlags: number;
     numTotalFlags: number;
   };
+  'flags.setup_modal_opened': {};
   'flags.sort-flags': {sortMethod: string};
+  'flags.table_rendered': {
+    numFlags: number;
+  };
   'flags.view-all-clicked': {};
+  'flags.webhook_url_generated': {};
 };
 
 export type FeatureFlagEventKey = keyof FeatureFlagEventParameters;
@@ -14,4 +19,7 @@ export const featureFlagEventMap: Record<FeatureFlagEventKey, string | null> = {
   'flags.view-all-clicked': 'Clicked View All Flags',
   'flags.sort-flags': 'Sorted Flags',
   'flags.event_and_suspect_flags_found': 'Number of Event and Suspect Flags',
+  'flags.setup_modal_opened': 'Flag Setup Integration Modal Opened',
+  'flags.webhook_url_generated': 'Flag Webhook URL Generated in Modal',
+  'flags.table_rendered': 'Flag Table Rendered',
 };


### PR DESCRIPTION
this PR adds a "set up integration" button on the feature flag table header actions. this button is visible only if we detect that `event.contexts.flags` is not undefined -- i.e. when an feature flag integration has already been set up.

## scenario A:  `event.contexts.flags` exists and is populated => we show "set up integration" button

<img width="804" alt="SCR-20241107-twid" src="https://github.com/user-attachments/assets/9fcdf520-06e3-43e4-bf73-bd4df230b132">

view all, search, sort, setup, & feedback buttons visible. (feedback button not visible in the screenshot because i was on `sentry` dev but it'll be visible in prod.)

## scenario B:  `event.contexts.flags` exists but is empty => we show empty state & "set up integration" button

<img width="892" alt="SCR-20241108-jhwl" src="https://github.com/user-attachments/assets/08910746-9d48-40cd-991e-d0e663ceeee1">


setup & give feedback buttons visible. (feedback button not visible in the screenshot because i was on `sentry` dev but it'll be visible in prod.)

## scenario C: LD user has not set up integration yet

TODO in the future: add CTA.
right now: we hide the FF section.

## scenario D: non LD-user has not set up integration yet

we hide the FF section.

## modal

when the "set up integration" button is clicked, we show a modal allowing the user to generate a webhook URL, which they can then paste into their provider website.

<img width="805" alt="SCR-20241107-twpz" src="https://github.com/user-attachments/assets/632b2ada-579a-46ab-aa02-30b95ef78eb0">

the copy field is disabled until the user creates the URL.

<img width="619" alt="SCR-20241107-txkn" src="https://github.com/user-attachments/assets/32596a73-1b80-4d99-b67c-0233391281fe">

when the URL is generated, the "create webhook URL" button is disabled.

notes:
- we default to LaunchDarkly since they're our only provider right now.
- when the modal is closed, old URLs still work, but they’re hidden and not shown again. (they can still be referenced in the org auth token page in org settings -- maybe we should make a note about this somewhere in the modal?)
- the token is named "{provider_name} Token {timestamp}" to keep them unique and user readable

## demo flow




https://github.com/user-attachments/assets/cefd742b-ed9a-4ca8-8fb3-fb4ccfbcc2e0




## TODO
- add CTA & feature flag for LD users 

## resources
- relates to https://github.com/getsentry/team-replay/issues/500
- [figma design](https://www.figma.com/design/oTVOd3RGUSZWYGwTpGjeGK/Specs%3A-Feature-Flag-List-in-Issue-Details?node-id=556-2484&node-type=canvas&t=ALPTsCZEhfhmwUHg-0)