### PR TITLE
feat(wizard): use cors header on dispatch in wizard view

### DIFF
--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -149,6 +149,10 @@ class SetupWizardView(BaseView):
     def options(self, request, *args, **kwargs):
         return super().options(request, *args, **kwargs)
 
+    @allow_cors_options
+    def dispatch(self, request, *args, **kwargs):
+        return super().dispatch(request, *args, **kwargs)
+
 
 def serialize_org_mapping(mapping: OrganizationMapping):
     status = OrganizationStatus(mapping.status)


### PR DESCRIPTION
The CORS headers returned from the OPTIONS requests sent to the view seem to disappear somewhere and not reach the browser - this PR attempts to add them in the dispatch step, like it is done in the Endpoint class. 