### PR TITLE
fix(slack): add filtering for users affected by env if the rule has an env

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -218,9 +218,9 @@ def get_context(group: Group, rules: list[Rule] | None = None) -> str:
     state = None
     event_count = None
     if NotificationContextField.STATE in context:
-        state = SUPPORTED_CONTEXT_DATA[NotificationContextField.STATE](group)
+        state = SUPPORTED_CONTEXT_DATA[NotificationContextField.STATE](group, rules)
     if NotificationContextField.EVENTS in context:
-        event_count = SUPPORTED_CONTEXT_DATA[NotificationContextField.EVENTS](group)
+        event_count = SUPPORTED_CONTEXT_DATA[NotificationContextField.EVENTS](group, rules)
 
     if (state and state == "New") or (event_count and int(event_count) <= 1):
         if NotificationContextField.EVENTS in context:

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -93,13 +93,13 @@ def get_group_users_count(group: Group, rules: list[Rule] | None = None) -> int:
 # NOTE: if this starts getting large and functions get complicated,
 # pull things out into their own functions
 SUPPORTED_CONTEXT_DATA: dict[NotificationContextField, Callable] = {
-    NotificationContextField.EVENTS: lambda group: get_group_global_count(group),
+    NotificationContextField.EVENTS: lambda group, rules: get_group_global_count(group),
     NotificationContextField.USERS_AFFECTED: get_group_users_count,
-    NotificationContextField.STATE: lambda group: SUBSTATUS_TO_STR.get(group.substatus, "")
+    NotificationContextField.STATE: lambda group, rules: SUBSTATUS_TO_STR.get(group.substatus, "")
     .replace("_", " ")
     .title(),
-    NotificationContextField.FIRST_SEEN: lambda group: time_since(group.first_seen),
-    NotificationContextField.APPROX_START_TIME: lambda group: datetime.fromtimestamp(
+    NotificationContextField.FIRST_SEEN: lambda group, rules: time_since(group.first_seen),
+    NotificationContextField.APPROX_START_TIME: lambda group, rules: datetime.fromtimestamp(
         get_approx_start_time(group=group)
     ).strftime(
         "%Y-%m-%d %H:%M:%S"
@@ -232,10 +232,7 @@ def get_context(group: Group, rules: list[Rule] | None = None) -> str:
 
     for c in context:
         if c in SUPPORTED_CONTEXT_DATA:
-            if c == NotificationContextField.USERS_AFFECTED:
-                v = SUPPORTED_CONTEXT_DATA[c](group, rules)
-            else:
-                v = SUPPORTED_CONTEXT_DATA[c](group)
+            v = SUPPORTED_CONTEXT_DATA[c](group, rules)
             if v:
                 context_text += f"{c}: *{v}*   "
 

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime
 from typing import Any, TypedDict
 
@@ -38,6 +38,7 @@ from sentry.integrations.types import ExternalProviders
 from sentry.issues.endpoints.group_details import get_group_global_count
 from sentry.issues.grouptype import (
     GroupCategory,
+    NotificationContextField,
     PerformanceP95EndpointRegressionGroupType,
     ProfileFunctionRegressionType,
 )
@@ -60,7 +61,6 @@ from sentry.snuba.referrer import Referrer
 from sentry.types.actor import Actor
 from sentry.types.group import SUBSTATUS_TO_STR
 from sentry.users.services.user.model import RpcUser
-from sentry.utils import metrics
 
 STATUSES = {"resolved": "resolved", "ignored": "ignored", "unresolved": "re-opened"}
 SUPPORTED_COMMIT_PROVIDERS = (
@@ -77,14 +77,29 @@ MAX_BLOCK_TEXT_LENGTH = 256
 USER_FEEDBACK_MAX_BLOCK_TEXT_LENGTH = 1500
 
 
+def get_group_users_count(group: Group, rules: list[Rule] | None = None) -> int:
+    environment_ids: list[int] | None = None
+    if rules:
+        environment_ids = [rule.environment_id for rule in rules if rule.environment_id is not None]
+        if not environment_ids:
+            environment_ids = None
+
+    return group.count_users_seen(
+        referrer=Referrer.TAGSTORE_GET_GROUPS_USER_COUNTS_SLACK_ISSUE_NOTIFICATION.value,
+        environment_ids=environment_ids,
+    )
+
+
 # NOTE: if this starts getting large and functions get complicated,
 # pull things out into their own functions
-SUPPORTED_CONTEXT_DATA = {
-    "Events": lambda group: get_group_global_count(group),
-    "Users Affected": lambda group: get_group_users_count(group),
-    "State": lambda group: SUBSTATUS_TO_STR.get(group.substatus, "").replace("_", " ").title(),
-    "First Seen": lambda group: time_since(group.first_seen),
-    "Approx. Start Time": lambda group: datetime.fromtimestamp(
+SUPPORTED_CONTEXT_DATA: dict[NotificationContextField, Callable] = {
+    NotificationContextField.EVENTS: lambda group: get_group_global_count(group),
+    NotificationContextField.USERS_AFFECTED: get_group_users_count,
+    NotificationContextField.STATE: lambda group: SUBSTATUS_TO_STR.get(group.substatus, "")
+    .replace("_", " ")
+    .title(),
+    NotificationContextField.FIRST_SEEN: lambda group: time_since(group.first_seen),
+    NotificationContextField.APPROX_START_TIME: lambda group: datetime.fromtimestamp(
         get_approx_start_time(group=group)
     ).strftime(
         "%Y-%m-%d %H:%M:%S"
@@ -98,13 +113,6 @@ REGRESSION_PERFORMANCE_ISSUE_TYPES = [
 ]
 
 logger = logging.getLogger(__name__)
-
-
-def get_group_users_count(group: Group) -> int:
-    metrics.incr("slack.get_group_users_count", tags={"group_id": group.id}, sample_rate=1.0)
-    return group.count_users_seen(
-        referrer=Referrer.TAGSTORE_GET_GROUPS_USER_COUNTS_SLACK_ISSUE_NOTIFICATION.value
-    )
 
 
 def build_assigned_text(identity: RpcIdentity, assignee: str) -> str | None:
@@ -198,7 +206,7 @@ def get_tags(
     return fields
 
 
-def get_context(group: Group) -> str:
+def get_context(group: Group, rules: list[Rule] | None = None) -> str:
     context_text = ""
 
     context = group.issue_type.notification_config.context.copy()
@@ -209,22 +217,25 @@ def get_context(group: Group) -> str:
 
     state = None
     event_count = None
-    if "State" in context:
-        state = SUPPORTED_CONTEXT_DATA["State"](group)
-    if "Events" in context:
-        event_count = SUPPORTED_CONTEXT_DATA["Events"](group)
+    if NotificationContextField.STATE in context:
+        state = SUPPORTED_CONTEXT_DATA[NotificationContextField.STATE](group)
+    if NotificationContextField.EVENTS in context:
+        event_count = SUPPORTED_CONTEXT_DATA[NotificationContextField.EVENTS](group)
 
     if (state and state == "New") or (event_count and int(event_count) <= 1):
-        if "Events" in context:
-            context.remove("Events")
+        if NotificationContextField.EVENTS in context:
+            context.remove(NotificationContextField.EVENTS)
 
         # avoid hitting Snuba for user count if we don't need it
-        if "Users Affected" in context:
-            context.remove("Users Affected")
+        if NotificationContextField.USERS_AFFECTED in context:
+            context.remove(NotificationContextField.USERS_AFFECTED)
 
     for c in context:
         if c in SUPPORTED_CONTEXT_DATA:
-            v = SUPPORTED_CONTEXT_DATA[c](group)
+            if c == NotificationContextField.USERS_AFFECTED:
+                v = SUPPORTED_CONTEXT_DATA[c](group, rules)
+            else:
+                v = SUPPORTED_CONTEXT_DATA[c](group)
             if v:
                 context_text += f"{c}: *{v}*   "
 
@@ -609,7 +620,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             blocks.append(self.get_tags_block(tags, block_id))
 
         # add event count, user count, substate, first seen
-        context = get_context(self.group)
+        context = get_context(self.group, self.rules)
         if context:
             blocks.append(self.get_context_block(context))
 

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -4,7 +4,7 @@ import importlib
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import timedelta
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import TYPE_CHECKING, Any
 
 import sentry_sdk
@@ -125,11 +125,24 @@ class NoiseConfig:
         return int(self.expiry_time.total_seconds())
 
 
+class NotificationContextField(StrEnum):
+    EVENTS = "Events"
+    USERS_AFFECTED = "Users Affected"
+    STATE = "State"
+    FIRST_SEEN = "First Seen"
+    APPROX_START_TIME = "Approx. Start Time"
+
+
 @dataclass(frozen=True)
 class NotificationConfig:
     text_code_formatted: bool = True  # TODO(cathy): user feedback wants it formatted as text
     context: list[str] = field(
-        default_factory=lambda: ["Events", "Users Affected", "State", "First Seen"]
+        default_factory=lambda: [
+            NotificationContextField.EVENTS,
+            NotificationContextField.USERS_AFFECTED,
+            NotificationContextField.STATE,
+            NotificationContextField.FIRST_SEEN,
+        ]
     )  # see SUPPORTED_CONTEXT_DATA for all possible values, order matters!
     actions: list[str] = field(default_factory=lambda: ["archive", "resolve", "assign"])
     extra_action: dict[str, str] = field(
@@ -396,7 +409,7 @@ class PerformanceDurationRegressionGroupType(GroupType):
     enable_auto_resolve = False
     enable_escalation_detection = False
     default_priority = PriorityLevel.LOW
-    notification_config = NotificationConfig(context=["Approx. Start Time"])
+    notification_config = NotificationConfig(context=[NotificationContextField.APPROX_START_TIME])
 
 
 @dataclass(frozen=True)
@@ -409,7 +422,7 @@ class PerformanceP95EndpointRegressionGroupType(GroupType):
     enable_escalation_detection = False
     default_priority = PriorityLevel.MEDIUM
     released = True
-    notification_config = NotificationConfig(context=["Approx. Start Time"])
+    notification_config = NotificationConfig(context=[NotificationContextField.APPROX_START_TIME])
 
 
 # experimental
@@ -509,7 +522,7 @@ class ProfileFunctionRegressionExperimentalType(GroupType):
     category = GroupCategory.PERFORMANCE.value
     enable_auto_resolve = False
     default_priority = PriorityLevel.LOW
-    notification_config = NotificationConfig(context=["Approx. Start Time"])
+    notification_config = NotificationConfig(context=[NotificationContextField.APPROX_START_TIME])
 
 
 @dataclass(frozen=True)
@@ -521,7 +534,7 @@ class ProfileFunctionRegressionType(GroupType):
     enable_auto_resolve = False
     released = True
     default_priority = PriorityLevel.MEDIUM
-    notification_config = NotificationConfig(context=["Approx. Start Time"])
+    notification_config = NotificationConfig(context=[NotificationContextField.APPROX_START_TIME])
 
 
 @dataclass(frozen=True)

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -904,11 +904,15 @@ class Group(Model):
     def get_email_subject(self):
         return f"{self.qualified_short_id} - {self.title}"
 
-    def count_users_seen(self, referrer=Referrer.TAGSTORE_GET_GROUPS_USER_COUNTS.value):
+    def count_users_seen(
+        self,
+        referrer=Referrer.TAGSTORE_GET_GROUPS_USER_COUNTS.value,
+        environment_ids: list[int] | None = None,
+    ):
         return tagstore.backend.get_groups_user_counts(
             [self.project_id],
             [self.id],
-            environment_ids=None,
+            environment_ids=environment_ids,
             start=self.first_seen,
             tenant_ids={"organization_id": self.project.organization_id},
             referrer=referrer,

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -51,7 +51,6 @@ from sentry.notifications.utils.actions import MessageAction
 from sentry.ownership.grammar import Matcher, Owner, Rule, dump_schema
 from sentry.seer.anomaly_detection.types import StoreDataResponse
 from sentry.silo.base import SiloMode
-from sentry.snuba.referrer import Referrer
 from sentry.testutils.cases import PerformanceIssueTestCase, TestCase
 from sentry.testutils.factories import EventType
 from sentry.testutils.helpers import with_feature
@@ -1601,38 +1600,50 @@ class SlackNotificationConfigTest(TestCase, PerformanceIssueTestCase, Occurrence
             == f"Events: *3*   State: *Ongoing*   First Seen: *{time_since(group.first_seen)}*"
         )
 
-    @patch("sentry.models.Group.count_users_seen")
-    def test_get_context_users_affected(self, mock_count_users):
-        users_affected = 5
-        environment_id = 3
-        mock_count_users.return_value = users_affected
-
+    def test_get_context_users_affected(self):
+        env = self.create_environment(project=self.project)
+        env2 = self.create_environment(project=self.project)
         rule = IssueAlertRule.objects.create(project=self.project, label="my rule")
-        event = self.store_event(
-            data={},
-            project_id=self.project.id,
-            assert_no_errors=False,
-        )
+
+        event = [
+            self.store_event(
+                data={
+                    "user": {"id": i},
+                    "environment": env.name,
+                },
+                project_id=self.project.id,
+                assert_no_errors=False,
+            )
+            for i in range(5)
+        ][0]
+        [
+            self.store_event(
+                data={
+                    "user": {"id": i},
+                    "environment": env2.name,
+                },
+                project_id=self.project.id,
+                assert_no_errors=False,
+            )
+            for i in range(5, 7)
+        ]
+
         group = event.group
         assert group
         group.update(type=1, substatus=GroupSubStatus.ONGOING, times_seen=3)
 
         context = get_context(group, [rule])
-        mock_count_users.assert_called_with(
-            referrer=Referrer.TAGSTORE_GET_GROUPS_USER_COUNTS_SLACK_ISSUE_NOTIFICATION.value,
-            environment_ids=None,
-        )
         assert (
             context
-            == f"Events: *3*   Users Affected: *5*   State: *Ongoing*   First Seen: *{time_since(group.first_seen)}*"
+            == f"Events: *3*   Users Affected: *7*   State: *Ongoing*   First Seen: *{time_since(group.first_seen)}*"
         )
 
         # filter users affected by env
-        rule.update(environment_id=environment_id)
-        get_context(group, [rule])
-        mock_count_users.assert_called_with(
-            referrer=Referrer.TAGSTORE_GET_GROUPS_USER_COUNTS_SLACK_ISSUE_NOTIFICATION.value,
-            environment_ids=[environment_id],
+        rule.update(environment_id=env.id)
+        context = get_context(group, [rule])
+        assert (
+            context
+            == f"Events: *3*   Users Affected: *5*   State: *Ongoing*   First Seen: *{time_since(group.first_seen)}*"
         )
 
     def test_get_tags(self):


### PR DESCRIPTION
Currently, we always fetch `Users Affected` across all environments, even if the rule has a non-null `environment_id`, which means the rule fires only if the event happened in a specific environment.

There is already a function in which we can pass `environment_ids` to Snuba to get the count of users affected for specific envs, but we've been passing `None` by default. We can change this to pass the `environment_id` of the rule(s) that fired the issue alert (this is somehow an array).

I also added an enum for the different kinds of context fields that can appear in a Slack notification (`NotificationContextField`), so we can use that instead of strings.