### PR TITLE
ref: capture stacktraces in codecov errors

### DIFF
--- a/tests/sentry/api/endpoints/test_project_stacktrace_coverage.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_coverage.py
@@ -155,6 +155,6 @@ class ProjectStacktraceLinkTestCodecov(BaseProjectStacktraceLink):
             (
                 "sentry.integrations.utils.codecov",
                 logging.ERROR,
-                "Codecov HTTP error: 500. Continuing execution.",
+                "Codecov HTTP error: 500",
             )
         ]


### PR DESCRIPTION
SENTRY-2B9D looks like a programming error but it's impossible to see where it comes from due to the incorrect logger.error calls

<!-- Describe your PR here. -->