### PR TITLE
fix(dynamic-sampling): adjust task time limits

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -83,8 +83,8 @@ logger = logging.getLogger(__name__)
     queue="dynamicsampling",
     default_retry_delay=5,
     max_retries=5,
-    soft_time_limit=2 * 60 * 60,
-    time_limit=2 * 60 * 60 + 5,
+    soft_time_limit=5 * 60,  # 5 minutes
+    time_limit=5 * 60 + 5,
     silo_mode=SiloMode.REGION,
 )
 @dynamic_sampling_task_with_context(max_task_execution=MAX_TASK_SECONDS)

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -92,8 +92,8 @@ class ProjectTransactionsTotals(TypedDict, total=True):
     queue="dynamicsampling",
     default_retry_delay=5,
     max_retries=5,
-    soft_time_limit=2 * 60 * 60,
-    time_limit=2 * 60 * 60 + 5,
+    soft_time_limit=6 * 60,  # 6 minutes
+    time_limit=6 * 60 + 5,
     silo_mode=SiloMode.REGION,
 )
 @dynamic_sampling_task_with_context(max_task_execution=MAX_TASK_SECONDS)
@@ -150,8 +150,8 @@ def boost_low_volume_transactions(context: TaskContext) -> None:
     queue="dynamicsampling",
     default_retry_delay=5,
     max_retries=5,
-    soft_time_limit=25 * 60,
-    time_limit=2 * 60 + 5,
+    soft_time_limit=4 * 60,  # 4 minutes
+    time_limit=4 * 60 + 5,
     silo_mode=SiloMode.REGION,
 )
 @dynamic_sampling_task

--- a/src/sentry/dynamic_sampling/tasks/custom_rule_notifications.py
+++ b/src/sentry/dynamic_sampling/tasks/custom_rule_notifications.py
@@ -30,8 +30,8 @@ MIN_SAMPLES_FOR_NOTIFICATION = 10
     queue="dynamicsampling",
     default_retry_delay=5,
     max_retries=5,
-    soft_time_limit=2 * 60 * 60,  # 2hours
-    time_limit=2 * 60 * 60 + 5,
+    soft_time_limit=1 * 60,  # 1 minute
+    time_limit=1 * 60 + 5,
     silo_mode=SiloMode.REGION,
 )
 @dynamic_sampling_task_with_context(max_task_execution=MAX_TASK_SECONDS)
@@ -180,8 +180,8 @@ def create_discover_link(rule: CustomDynamicSamplingRule, projects: list[int]) -
     queue="dynamicsampling",
     default_retry_delay=5,
     max_retries=5,
-    soft_time_limit=2 * 60 * 60,  # 2hours
-    time_limit=2 * 60 * 60 + 5,
+    soft_time_limit=3 * 60,  # 3 minutes
+    time_limit=3 * 60 + 5,
     silo_mode=SiloMode.REGION,
 )
 @dynamic_sampling_task

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -164,7 +164,7 @@ def recalibrate_org(org_id: OrganizationId, total: int, indexed: int) -> None:
     queue="dynamicsampling",
     default_retry_delay=5,
     max_retries=5,
-    soft_time_limit=25 * 60,
+    soft_time_limit=2 * 60,
     time_limit=2 * 60 + 5,
     silo_mode=SiloMode.REGION,
 )

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -45,8 +45,8 @@ from sentry.tasks.base import instrumented_task
     queue="dynamicsampling",
     default_retry_delay=5,
     max_retries=5,
-    soft_time_limit=2 * 60 * 60,  # 2hours
-    time_limit=2 * 60 * 60 + 5,
+    soft_time_limit=1 * 60,  # 1 minute
+    time_limit=1 * 60 + 5,
     silo_mode=SiloMode.REGION,
 )
 @dynamic_sampling_task_with_context(max_task_execution=MAX_TASK_SECONDS)
@@ -85,8 +85,8 @@ def recalibrate_orgs(context: TaskContext) -> None:
     queue="dynamicsampling",
     default_retry_delay=5,
     max_retries=5,
-    soft_time_limit=25 * 60,
-    time_limit=2 * 60 + 5,
+    soft_time_limit=6 * 60,  # 6 minutes
+    time_limit=6 * 60 + 5,
     silo_mode=SiloMode.REGION,
 )
 @dynamic_sampling_task

--- a/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
+++ b/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
@@ -29,8 +29,8 @@ from sentry.tasks.base import instrumented_task
     queue="dynamicsampling",
     default_retry_delay=5,
     max_retries=5,
-    soft_time_limit=2 * 60 * 60,  # 2 hours
-    time_limit=2 * 60 * 60 + 5,
+    soft_time_limit=3 * 60,  # 3 minutes
+    time_limit=3 * 60 + 5,
     silo_mode=SiloMode.REGION,
 )
 @dynamic_sampling_task_with_context(max_task_execution=MAX_TASK_SECONDS)


### PR DESCRIPTION
Adjust task time limits with values taken from previous runtime profiles

Make sure that `time_limit` is always `soft_time_limit + 5`

Closes https://github.com/getsentry/projects/issues/371