### PR TITLE
chore(functions): Switch suspect functions table to use all_examples

### DIFF
--- a/static/app/components/profiling/suspectFunctions/functionsTable.spec.tsx
+++ b/static/app/components/profiling/suspectFunctions/functionsTable.spec.tsx
@@ -55,9 +55,9 @@ describe('FunctionsTable', function () {
   it('renders one function', function () {
     const func = {
       'count()': 10,
-      'examples()': [
-        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      'all_examples()': [
+        {profile_id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'},
+        {profile_id: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'},
       ],
       function: 'foo',
       'p75()': 10000000,
@@ -97,9 +97,9 @@ describe('FunctionsTable', function () {
   it('renders empty name', function () {
     const func = {
       'count()': 10,
-      'examples()': [
-        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      'all_examples()': [
+        {profile_id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'},
+        {profile_id: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'},
       ],
       function: '',
       'p75()': 10000000,
@@ -130,9 +130,9 @@ describe('FunctionsTable', function () {
   it('renders empty package', function () {
     const func = {
       'count()': 10,
-      'examples()': [
-        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      'all_examples()': [
+        {profile_id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'},
+        {profile_id: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'},
       ],
       function: 'foo',
       'p75()': 10000000,

--- a/static/app/components/profiling/suspectFunctions/functionsTable.tsx
+++ b/static/app/components/profiling/suspectFunctions/functionsTable.tsx
@@ -11,8 +11,12 @@ import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {Container, NumberContainer} from 'sentry/utils/discover/styles';
 import {getShortEventId} from 'sentry/utils/events';
+import {
+  isContinuousProfileReference,
+  isTransactionProfileReference,
+} from 'sentry/utils/profiling/guards/profile';
 import type {EventsResults, Sort} from 'sentry/utils/profiling/hooks/types';
-import {generateProfileFlamechartRouteWithQuery} from 'sentry/utils/profiling/routes';
+import {generateProfileRouteFromProfileReference} from 'sentry/utils/profiling/routes';
 import {renderTableHead} from 'sentry/utils/profiling/tableRenderer';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -26,7 +30,7 @@ interface FunctionsTableProps {
   sort: Sort<any>;
 }
 
-function FunctionsTable(props: FunctionsTableProps) {
+export function FunctionsTable(props: FunctionsTableProps) {
   const location = useLocation();
   const organization = useOrganization();
 
@@ -36,28 +40,26 @@ function FunctionsTable(props: FunctionsTableProps) {
       return [];
     }
     return props.functions.map(func => {
-      const profileIds = (func['examples()'] as unknown as string[]) || [];
+      const examples = func['all_examples()'] as Profiling.ProfileReference[];
 
       return {
         ...func,
-        'examples()': profileIds.map(profileId => {
+        'all_examples()': examples.map(example => {
           return {
-            value: getShortEventId(profileId),
+            value: getShortEventId(getTargetId(example)),
             onClick: () =>
               trackAnalytics('profiling_views.go_to_flamegraph', {
                 organization,
                 source: `${props.analyticsPageSource}.suspect_functions_table`,
               }),
-            target: generateProfileFlamechartRouteWithQuery({
+            target: generateProfileRouteFromProfileReference({
               orgSlug: organization.slug,
               projectSlug: project.slug,
-              profileId,
-              query: {
-                // specify the frame to focus, the flamegraph will switch
-                // to the appropriate thread when these are specified
-                frameName: func.function as string,
-                framePackage: func.package as string,
-              },
+              reference: example,
+              // specify the frame to focus, the flamegraph will switch
+              // to the appropriate thread when these are specified
+              frameName: func.function as string,
+              framePackage: func.package as string,
             }),
           };
         }),
@@ -156,7 +158,7 @@ function ProfilingFunctionsTableCell({
           <PerformanceDuration nanoseconds={value} abbreviation />
         </NumberContainer>
       );
-    case 'examples()':
+    case 'all_examples()':
       return <ArrayLinks items={value} />;
     case 'function':
     case 'package':
@@ -167,13 +169,16 @@ function ProfilingFunctionsTableCell({
   }
 }
 
-type TableColumnKey =
-  | 'function'
-  | 'package'
-  | 'count()'
-  | 'p75()'
-  | 'sum()'
-  | 'examples()';
+export const functionsFields = [
+  'package',
+  'function',
+  'count()',
+  'p75()',
+  'sum()',
+  'all_examples()',
+] as const;
+
+export type TableColumnKey = (typeof functionsFields)[number];
 
 type TableDataRow = Record<TableColumnKey, any>;
 
@@ -185,7 +190,7 @@ const COLUMN_ORDER: TableColumnKey[] = [
   'count()',
   'p75()',
   'sum()',
-  'examples()',
+  'all_examples()',
 ];
 
 const COLUMNS: Record<TableColumnKey, TableColumn> = {
@@ -214,11 +219,19 @@ const COLUMNS: Record<TableColumnKey, TableColumn> = {
     name: t('Occurrences'),
     width: COL_WIDTH_UNDEFINED,
   },
-  'examples()': {
-    key: 'examples()',
+  'all_examples()': {
+    key: 'all_examples()',
     name: t('Example Profiles'),
     width: COL_WIDTH_UNDEFINED,
   },
 };
 
-export {FunctionsTable};
+function getTargetId(reference: Profiling.ProfileReference): string {
+  if (isTransactionProfileReference(reference)) {
+    return reference.profile_id;
+  }
+  if (isContinuousProfileReference(reference)) {
+    return reference.profiler_id;
+  }
+  return reference;
+}

--- a/static/app/components/profiling/suspectFunctions/functionsTable.tsx
+++ b/static/app/components/profiling/suspectFunctions/functionsTable.tsx
@@ -39,8 +39,9 @@ export function FunctionsTable(props: FunctionsTableProps) {
     if (!project) {
       return [];
     }
+
     return props.functions.map(func => {
-      const examples = func['all_examples()'] as Profiling.ProfileReference[];
+      const examples = func['all_examples()'];
 
       return {
         ...func,
@@ -226,7 +227,7 @@ const COLUMNS: Record<TableColumnKey, TableColumn> = {
   },
 };
 
-function getTargetId(reference: Profiling.ProfileReference): string {
+function getTargetId(reference): string {
   if (isTransactionProfileReference(reference)) {
     return reference.profile_id;
   }

--- a/static/app/components/profiling/suspectFunctions/suspectFunctionsTable.tsx
+++ b/static/app/components/profiling/suspectFunctions/suspectFunctionsTable.tsx
@@ -3,7 +3,11 @@ import styled from '@emotion/styled';
 
 import {CompactSelect} from 'sentry/components/compactSelect';
 import Pagination from 'sentry/components/pagination';
-import {FunctionsTable} from 'sentry/components/profiling/suspectFunctions/functionsTable';
+import type {TableColumnKey as FunctionsField} from 'sentry/components/profiling/suspectFunctions/functionsTable';
+import {
+  functionsFields,
+  FunctionsTable,
+} from 'sentry/components/profiling/suspectFunctions/functionsTable';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Project} from 'sentry/types/project';
@@ -114,17 +118,6 @@ export function SuspectFunctionsTable({
     </Fragment>
   );
 }
-
-const functionsFields = [
-  'package',
-  'function',
-  'count()',
-  'p75()',
-  'sum()',
-  'examples()',
-] as const;
-
-type FunctionsField = (typeof functionsFields)[number];
 
 const TableHeader = styled('div')`
   display: flex;

--- a/static/app/types/profiling.d.ts
+++ b/static/app/types/profiling.d.ts
@@ -244,19 +244,29 @@ declare namespace Profiling {
     profiles: ReadonlyArray<ProfileInput>;
   };
 
-  type TransactionProfileReference = {
-    project_id?: number;
+  type BaseTransactionProfileReference = {
     profile_id: string;
   };
 
-  type ContinuousProfileReference = {
+  type BaseContinuousProfileReference = {
+    end: number;
     profiler_id: string;
     start: number;
-    end: number;
     thread_id: string;
-    project_id?: number;
-    transaction_id?: string | undefined;
-    chunk_id?: string;
+  };
+
+  type BaseProfileReference =
+    | BaseTransactionProfileReference
+    | BaseContinuousProfileReference;
+
+  type TransactionProfileReference = BaseTransactionProfileReference & {
+    project_id: number;
+  };
+
+  type ContinuousProfileReference = BaseContinuousProfileReference & {
+    project_id: number;
+    transaction_id: string | undefined;
+    chunk_id: string;
   };
 
   type ProfileReference =

--- a/static/app/types/profiling.d.ts
+++ b/static/app/types/profiling.d.ts
@@ -245,18 +245,18 @@ declare namespace Profiling {
   };
 
   type TransactionProfileReference = {
-    project_id: number;
+    project_id?: number;
     profile_id: string;
   };
 
   type ContinuousProfileReference = {
-    project_id: number;
     profiler_id: string;
-    transaction_id: string | undefined;
     start: number;
-    chunk_id: string;
     end: number;
     thread_id: string;
+    project_id?: number;
+    transaction_id?: string | undefined;
+    chunk_id?: string;
   };
 
   type ProfileReference =

--- a/static/app/utils/profiling/guards/profile.tsx
+++ b/static/app/utils/profiling/guards/profile.tsx
@@ -50,13 +50,13 @@ export function isSentryContinuousProfileChunk(
 }
 
 export function isContinuousProfileReference(
-  ref: Profiling.ProfileReference
-): ref is Profiling.ContinuousProfileReference {
+  ref: Profiling.BaseProfileReference
+): ref is Profiling.BaseContinuousProfileReference {
   return typeof ref !== 'string' && 'profiler_id' in ref;
 }
 
 export function isTransactionProfileReference(
-  ref: Profiling.ProfileReference
-): ref is Profiling.TransactionProfileReference {
+  ref: Profiling.BaseProfileReference
+): ref is Profiling.BaseTransactionProfileReference {
   return typeof ref !== 'string' && 'profile_id' in ref;
 }

--- a/static/app/utils/profiling/hooks/types.tsx
+++ b/static/app/utils/profiling/hooks/types.tsx
@@ -3,8 +3,19 @@ import type {FieldValueType} from 'sentry/utils/fields';
 
 export type Unit = keyof typeof DURATION_UNITS | keyof typeof SIZE_UNITS | null;
 
-export type EventsResultsDataRow<F extends string> = {
-  [K in F]: string[] | string | number | null;
+type BaseReference =
+  | Profiling.BaseTransactionProfileReference
+  | Profiling.BaseContinuousProfileReference;
+
+type SpecialColumns = {
+  'all_examples()': BaseReference[];
+};
+
+export type EventsResultsDataRow<F extends string> = Pick<
+  SpecialColumns,
+  Extract<keyof SpecialColumns, F>
+> & {
+  [K in Exclude<F, keyof SpecialColumns>]: string[] | string | number | null;
 };
 
 export type EventsResultsMeta<F extends string> = {

--- a/static/app/utils/profiling/routes.tsx
+++ b/static/app/utils/profiling/routes.tsx
@@ -227,7 +227,7 @@ export function generateProfileRouteFromProfileReference({
   framePackage: string | undefined;
   orgSlug: Organization['slug'];
   projectSlug: Project['slug'];
-  reference: Profiling.ProfileReference;
+  reference: Profiling.BaseProfileReference | Profiling.ProfileReference;
   query?: Location['query'];
 }): LocationDescriptor {
   if (typeof reference === 'string') {
@@ -242,6 +242,8 @@ export function generateProfileRouteFromProfileReference({
   }
 
   if (isContinuousProfileReference(reference)) {
+    const eventId = 'transaction_id' in reference ? reference.transaction_id : undefined;
+
     return generateContinuousProfileFlamechartRouteWithQuery({
       orgSlug,
       projectSlug,
@@ -254,7 +256,7 @@ export function generateProfileRouteFromProfileReference({
         ...query,
         frameName,
         framePackage,
-        eventId: reference.transaction_id,
+        eventId,
         tid: reference.thread_id as unknown as string,
       }),
     });

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -263,8 +263,7 @@ describe('Performance > TransactionSummary', function () {
       match: [
         (_url, options) => {
           return (
-            options.query?.field?.includes('count()') &&
-            !options.query?.field?.includes('p95()')
+            options.query?.field?.length === 1 && options.query?.field[0] === 'count()'
           );
         },
       ],
@@ -429,10 +428,6 @@ describe('Performance > TransactionSummary', function () {
       ],
     });
     MockApiClient.addMockResponse({
-      url: `/projects/org-slug/project-slug/profiling/functions/`,
-      body: {functions: []},
-    });
-    MockApiClient.addMockResponse({
       method: 'GET',
       url: `/organizations/org-slug/metrics-compatibility/`,
       body: {
@@ -451,6 +446,29 @@ describe('Performance > TransactionSummary', function () {
           metrics_unparam: 0,
         },
       },
+    });
+
+    // Events Mock slowest functions
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        meta: {
+          fields: {
+            function: 'string',
+            package: 'string',
+            'p75()': 'duration',
+            'count()': 'integer',
+            'sum()': 'duration',
+            'all_examples()': 'string',
+          },
+        },
+        data: [],
+      },
+      match: [
+        (_url, options) => {
+          return options.query?.field?.indexOf('all_examples()') !== -1;
+        },
+      ],
     });
 
     jest.spyOn(MEPSetting, 'get').mockImplementation(() => MEPState.AUTO);


### PR DESCRIPTION
This switches the call to examples() to all_examples() in the SuspectFunctionsTable.