### PR TITLE
fix(dashboards): Simplify default EAP query

### DIFF
--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -41,12 +41,12 @@ import {generateFieldOptions} from 'sentry/views/discover/utils';
 
 const DEFAULT_WIDGET_QUERY: WidgetQuery = {
   name: '',
-  fields: ['span.op', 'avg(span.duration)'],
-  columns: ['span.op'],
+  fields: ['count(span.duration)'],
+  columns: [],
   fieldAliases: [],
-  aggregates: ['avg(span.duration)'],
+  aggregates: ['count(span.duration)'],
   conditions: '',
-  orderby: '-avg(span.duration)',
+  orderby: '',
 };
 
 const EAP_AGGREGATIONS = ALLOWED_EXPLORE_VISUALIZE_AGGREGATES.reduce((acc, aggregate) => {


### PR DESCRIPTION
The grouping by span.op was unnecessary and lead to a slow initial query. Simply showing count(span.duration) is the default that's shown in Explore as well.