### PR TITLE
fix(flags): guard against ill-formatted flags context

### DIFF
--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -95,7 +95,14 @@ export function EventFeatureFlagList({
   const hydratedFlags = useMemo(() => {
     // Transform the flags array into something readable by the key-value component
     // Reverse the flags to show newest at the top by default
-    const flags: FeatureFlag[] = event.contexts?.flags?.values.toReversed() ?? [];
+    const rawFlags: FeatureFlag[] = event.contexts?.flags?.values.toReversed() ?? [];
+
+    // Filter out ill-formatted flags, which come from wrongly-configured SDKs or user-provided context.
+    const flags = rawFlags.filter(
+      f => f && typeof f === 'object' && 'flag' in f && 'result' in f,
+      rawFlags
+    );
+
     return flags.map(f => {
       return {
         item: {

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -99,8 +99,7 @@ export function EventFeatureFlagList({
 
     // Filter out ill-formatted flags, which come from SDK developer error or user-provided contexts.
     const flags = rawFlags.filter(
-      f => f && typeof f === 'object' && 'flag' in f && 'result' in f,
-      rawFlags
+      f => f && typeof f === 'object' && 'flag' in f && 'result' in f
     );
 
     return flags.map(f => {

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -97,7 +97,7 @@ export function EventFeatureFlagList({
     // Reverse the flags to show newest at the top by default
     const rawFlags: FeatureFlag[] = event.contexts?.flags?.values.toReversed() ?? [];
 
-    // Filter out ill-formatted flags, which come from wrongly-configured SDKs or user-provided context.
+    // Filter out ill-formatted flags, which come from SDK developer error or user-provided contexts.
     const flags = rawFlags.filter(
       f => f && typeof f === 'object' && 'flag' in f && 'result' in f,
       rawFlags


### PR DESCRIPTION
Fixes [JAVASCRIPT-2WKR](https://sentry.sentry.io/issues/6048218651/)

Prevents issue details from erroring from a null-access on event flags data. This guards against 2 cases:
1. All contexts can technically be user-provided, so `values` could contain anything if a user set it.
2. When testing the new JS SDK, I found out that having a low `normalizeDepth` could cause the flags to be serialized as a string `"Object"`. Should be fixed by https://github.com/getsentry/sentry-javascript/pull/14207/commits/6eab55fae6c0f10a678a2f3a0e68a8212183ab1c but it may happen in the future due to developer error 