### PR TITLE
fix(issues): Line up "in app" icons

### DIFF
--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -223,7 +223,7 @@ export class DeprecatedLine extends Component<Props, State> {
 
   renderExpander() {
     if (!this.isExpandable()) {
-      return null;
+      return <div style={{width: 20, height: 20}} />;
     }
 
     const {isExpanded} = this.state;


### PR DESCRIPTION
when the expand chevron is not displayed

before
<img width="759" alt="image" src="https://github.com/user-attachments/assets/321b3e91-3078-4d6b-ab60-15ef0a9f4903">

after
<img width="764" alt="image" src="https://github.com/user-attachments/assets/a76e3201-2fca-4a74-8e4b-28e8c57ed545">
