### PR TITLE
chore(testing): Switch flaky test project dsn for docker compose tests

### DIFF
--- a/.github/actions/test-setup-sentry-devservices/action.yml
+++ b/.github/actions/test-setup-sentry-devservices/action.yml
@@ -47,7 +47,7 @@ runs:
 
         ### pytest-sentry configuration ###
         if [ "$GITHUB_REPOSITORY" = "getsentry/sentry" ]; then
-          echo "PYTEST_SENTRY_DSN=https://6fd5cfea2d4d46b182ad214ac7810508@sentry.io/2423079" >> $GITHUB_ENV
+          echo "PYTEST_SENTRY_DSN=https://a748e1a557575821d36970353ef30c61@o1.ingest.us.sentry.io/4508264609415168" >> $GITHUB_ENV
           echo "PYTEST_SENTRY_TRACES_SAMPLE_RATE=0" >> $GITHUB_ENV
 
           # This records failures on master to sentry in order to detect flakey tests, as it's


### PR DESCRIPTION
Running docker compose tests were polluting the project where we collect flaky test information. Let's keep these separate