### PR TITLE
ref(grouping): Add `VariantsByDescriptor` type

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -321,7 +321,7 @@ def get_grouping_variants_for_event(
             return {"checksum": ChecksumVariant(checksum)}
 
         rv: dict[str, BaseVariant] = {
-            "hashed-checksum": HashedChecksumVariant(hash_from_values(checksum), checksum),
+            "hashed_checksum": HashedChecksumVariant(hash_from_values(checksum), checksum),
         }
 
         # The legacy code path also supported arbitrary values here but
@@ -360,9 +360,9 @@ def get_grouping_variants_for_event(
 
         fingerprint = resolve_fingerprint_values(fingerprint, event.data)
         if (fingerprint_info or {}).get("matched_rule", {}).get("is_builtin") is True:
-            rv["built-in-fingerprint"] = BuiltInFingerprintVariant(fingerprint, fingerprint_info)
+            rv["built_in_fingerprint"] = BuiltInFingerprintVariant(fingerprint, fingerprint_info)
         else:
-            rv["custom-fingerprint"] = CustomFingerprintVariant(fingerprint, fingerprint_info)
+            rv["custom_fingerprint"] = CustomFingerprintVariant(fingerprint, fingerprint_info)
 
     # If only the default is referenced, we can use the variants as is
     elif defaults_referenced == 1 and len(fingerprint) == 1:

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -98,7 +98,7 @@ def _has_customized_fingerprint(event: Event, variants: dict[str, BaseVariant]) 
             return True
 
     # Fully customized fingerprint (from either us or the user)
-    fingerprint_variant = variants.get("custom-fingerprint") or variants.get("built-in-fingerprint")
+    fingerprint_variant = variants.get("custom_fingerprint") or variants.get("built_in_fingerprint")
 
     if fingerprint_variant:
         metrics.incr(

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TypedDict
+
 from sentry.grouping.utils import hash_from_values, is_default_fingerprint_var
 from sentry.types.misc import KeyedList
 
@@ -213,3 +215,14 @@ class SaltedComponentVariant(ComponentVariant):
         rv = ComponentVariant._get_metadata_as_dict(self)
         rv.update(expose_fingerprint_dict(self.values, self.info))
         return rv
+
+
+class VariantsByDescriptor(TypedDict, total=False):
+    system: ComponentVariant
+    app: ComponentVariant
+    custom_fingerprint: CustomFingerprintVariant
+    built_in_fingerprint: BuiltInFingerprintVariant
+    checksum: ChecksumVariant
+    hashed_checksum: HashedChecksumVariant
+    default: ComponentVariant
+    fallback: FallbackVariant

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -55,7 +55,7 @@ class ChecksumVariant(BaseVariant):
 
 
 class HashedChecksumVariant(ChecksumVariant):
-    type = "hashed-checksum"
+    type = "hashed_checksum"
     description = "hashed legacy checksum"
 
     def __init__(self, checksum: str, raw_checksum: str):
@@ -85,7 +85,7 @@ class PerformanceProblemVariant(BaseVariant):
         contains the event and the evidence.
     """
 
-    type = "performance-problem"
+    type = "performance_problem"
     description = "performance problem"
     contributes = True
 
@@ -157,7 +157,7 @@ def expose_fingerprint_dict(values, info=None):
 class CustomFingerprintVariant(BaseVariant):
     """A user-defined custom fingerprint."""
 
-    type = "custom-fingerprint"
+    type = "custom_fingerprint"
 
     def __init__(self, values, fingerprint_info=None):
         self.values = values
@@ -177,7 +177,7 @@ class CustomFingerprintVariant(BaseVariant):
 class BuiltInFingerprintVariant(CustomFingerprintVariant):
     """A built-in, Sentry defined fingerprint."""
 
-    type = "built-in-fingerprint"
+    type = "built_in_fingerprint"
 
     @property
     def description(self):
@@ -187,7 +187,7 @@ class BuiltInFingerprintVariant(CustomFingerprintVariant):
 class SaltedComponentVariant(ComponentVariant):
     """A salted version of a component."""
 
-    type = "salted-component"
+    type = "salted_component"
 
     def __init__(self, values, component, config, fingerprint_info=None):
         ComponentVariant.__init__(self, component, config)

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -53,8 +53,8 @@ export type VariantEvidence = {
 };
 
 type EventGroupVariantKey =
-  | 'built-in-fingerprint'
-  | 'custom-fingerprint'
+  | 'built_in_fingerprint'
+  | 'custom_fingerprint'
   | 'app'
   | 'default'
   | 'system';
@@ -62,11 +62,11 @@ type EventGroupVariantKey =
 export const enum EventGroupVariantType {
   CHECKSUM = 'checksum',
   FALLBACK = 'fallback',
-  CUSTOM_FINGERPRINT = 'custom-fingerprint',
-  BUILT_IN_FINGERPRINT = 'built-in-fingerprint',
+  CUSTOM_FINGERPRINT = 'custom_fingerprint',
+  BUILT_IN_FINGERPRINT = 'built_in_fingerprint',
   COMPONENT = 'component',
-  SALTED_COMPONENT = 'salted-component',
-  PERFORMANCE_PROBLEM = 'performance-problem',
+  SALTED_COMPONENT = 'salted_component',
+  PERFORMANCE_PROBLEM = 'performance_problem',
 }
 
 interface BaseVariant {

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/checksum_no_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/checksum_no_regex_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-28T14:02:49.098955+00:00'
+created: '2024-11-08T19:38:50.201117+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -9,7 +9,7 @@ contributing variants:
   checksum*
     hash: "not a legit checksum"
     checksum: "not a legit checksum"
-  hashed-checksum*
+  hashed_checksum*
     hash: "de46d023e69b171b90ccf3ebca7aede4"
     checksum: "de46d023e69b171b90ccf3ebca7aede4"
     raw_checksum: "not a legit checksum"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/checksum_no_regex_match_long.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/checksum_no_regex_match_long.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:49.050340+00:00'
+created: '2024-11-08T19:38:50.016718+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: checksum
 ---
 contributing variants:
-  hashed-checksum*
+  hashed_checksum*
     hash: "2c2e85a6e73109222f131228ed06a7af"
     checksum: "2c2e85a6e73109222f131228ed06a7af"
     raw_checksum: "not a legit checksum and also too long a string"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/custom_fingerprint_client.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:49.810306+00:00'
+created: '2024-11-08T19:38:51.920957+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "f30afa00b85f5cac5ee0bce01b31f08d"
     info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
     values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:49.711711+00:00'
+created: '2024-11-08T19:38:51.829940+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/custom_fingerprint_server_rule.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:49.863964+00:00'
+created: '2024-11-08T19:38:52.048179+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:54.254098+00:00'
+created: '2024-11-08T19:39:01.703766+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/checksum_no_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/checksum_no_regex_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-28T14:02:39.366152+00:00'
+created: '2024-11-08T19:39:12.509223+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -9,7 +9,7 @@ contributing variants:
   checksum*
     hash: "not a legit checksum"
     checksum: "not a legit checksum"
-  hashed-checksum*
+  hashed_checksum*
     hash: "de46d023e69b171b90ccf3ebca7aede4"
     checksum: "de46d023e69b171b90ccf3ebca7aede4"
     raw_checksum: "not a legit checksum"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/checksum_no_regex_match_long.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/checksum_no_regex_match_long.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:39.311549+00:00'
+created: '2024-11-08T19:39:12.336490+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: checksum
 ---
 contributing variants:
-  hashed-checksum*
+  hashed_checksum*
     hash: "2c2e85a6e73109222f131228ed06a7af"
     checksum: "2c2e85a6e73109222f131228ed06a7af"
     raw_checksum: "not a legit checksum and also too long a string"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/custom_fingerprint_client.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:39.939582+00:00'
+created: '2024-11-08T19:39:13.721167+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "f30afa00b85f5cac5ee0bce01b31f08d"
     info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
     values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:39.892096+00:00'
+created: '2024-11-08T19:39:13.608994+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/custom_fingerprint_server_rule.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:39.989389+00:00'
+created: '2024-11-08T19:39:13.819005+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:44.671764+00:00'
+created: '2024-11-08T19:39:21.183635+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/checksum_no_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/checksum_no_regex_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-28T14:02:29.512254+00:00'
+created: '2024-11-08T19:39:33.277681+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -9,7 +9,7 @@ contributing variants:
   checksum*
     hash: "not a legit checksum"
     checksum: "not a legit checksum"
-  hashed-checksum*
+  hashed_checksum*
     hash: "de46d023e69b171b90ccf3ebca7aede4"
     checksum: "de46d023e69b171b90ccf3ebca7aede4"
     raw_checksum: "not a legit checksum"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/checksum_no_regex_match_long.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/checksum_no_regex_match_long.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:29.463789+00:00'
+created: '2024-11-08T19:39:33.181163+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: checksum
 ---
 contributing variants:
-  hashed-checksum*
+  hashed_checksum*
     hash: "2c2e85a6e73109222f131228ed06a7af"
     checksum: "2c2e85a6e73109222f131228ed06a7af"
     raw_checksum: "not a legit checksum and also too long a string"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/custom_fingerprint_client.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:30.046770+00:00'
+created: '2024-11-08T19:39:34.358029+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "f30afa00b85f5cac5ee0bce01b31f08d"
     info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
     values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:29.995654+00:00'
+created: '2024-11-08T19:39:34.297377+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/custom_fingerprint_server_rule.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:30.107810+00:00'
+created: '2024-11-08T19:39:34.466648+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:34.757521+00:00'
+created: '2024-11-08T19:39:42.079495+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T13:56:38.893371+00:00'
+created: '2024-11-08T19:39:50.761360+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  built-in-fingerprint*
+  built_in_fingerprint*
     hash: "5d731dcf8ecc4f042eeacf528d8d8da9"
     info: {"matched_rule":{"attributes":{},"fingerprint":["chunkloaderror"],"is_builtin":true,"matchers":[["family","javascript"],["type","ChunkLoadError"]],"text":"family:\"javascript\" type:\"ChunkLoadError\" -> \"chunkloaderror\""}}
     values: ["chunkloaderror"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T13:56:37.164322+00:00'
+created: '2024-11-08T19:39:50.661664+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  built-in-fingerprint*
+  built_in_fingerprint*
     hash: "5d731dcf8ecc4f042eeacf528d8d8da9"
     info: {"client_fingerprint":["{{ default }}","dogs are great"],"matched_rule":{"attributes":{},"fingerprint":["chunkloaderror"],"is_builtin":true,"matchers":[["family","javascript"],["type","ChunkLoadError"]],"text":"family:\"javascript\" type:\"ChunkLoadError\" -> \"chunkloaderror\""}}
     values: ["chunkloaderror"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/checksum_no_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/checksum_no_regex_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-28T13:56:44.160391+00:00'
+created: '2024-11-08T19:39:50.976769+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -9,7 +9,7 @@ contributing variants:
   checksum*
     hash: "not a legit checksum"
     checksum: "not a legit checksum"
-  hashed-checksum*
+  hashed_checksum*
     hash: "de46d023e69b171b90ccf3ebca7aede4"
     checksum: "de46d023e69b171b90ccf3ebca7aede4"
     raw_checksum: "not a legit checksum"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/checksum_no_regex_match_long.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/checksum_no_regex_match_long.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T13:56:42.371020+00:00'
+created: '2024-11-08T19:39:50.887328+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: checksum
 ---
 contributing variants:
-  hashed-checksum*
+  hashed_checksum*
     hash: "2c2e85a6e73109222f131228ed06a7af"
     checksum: "2c2e85a6e73109222f131228ed06a7af"
     raw_checksum: "not a legit checksum and also too long a string"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_client.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T13:57:05.708988+00:00'
+created: '2024-11-08T19:39:51.908843+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "f30afa00b85f5cac5ee0bce01b31f08d"
     info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
     values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T13:57:03.719704+00:00'
+created: '2024-11-08T19:39:51.815255+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T13:57:08.114402+00:00'
+created: '2024-11-08T19:39:52.075996+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:00:07.256402+00:00'
+created: '2024-11-08T19:40:01.146667+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/checksum_no_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/checksum_no_regex_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-24T16:39:05.705922+00:00'
+created: '2024-11-08T18:04:20.848101+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ checksum:
   hash: "not a legit checksum"
   checksum: "not a legit checksum"
 --------------------------------------------------------------------------
-hashed-checksum:
+hashed_checksum:
   hash: "de46d023e69b171b90ccf3ebca7aede4"
   checksum: "de46d023e69b171b90ccf3ebca7aede4"
   raw_checksum: "not a legit checksum"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/checksum_no_regex_match_long.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/checksum_no_regex_match_long.pysnap
@@ -1,9 +1,9 @@
 ---
-created: '2024-10-24T16:39:05.649697+00:00'
+created: '2024-11-08T18:04:20.645880+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
-hashed-checksum:
+hashed_checksum:
   hash: "2c2e85a6e73109222f131228ed06a7af"
   checksum: "2c2e85a6e73109222f131228ed06a7af"
   raw_checksum: "not a legit checksum and also too long a string"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:23:21.568140+00:00'
+created: '2024-11-08T18:04:22.531848+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -201,7 +201,7 @@ app:
         value (stacktrace and type take precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
   info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
   values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:26:47.033154+00:00'
+created: '2024-11-08T18:04:22.342258+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -201,7 +201,7 @@ app:
         value (stacktrace and type take precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:26:47.124257+00:00'
+created: '2024-11-08T18:04:22.646156+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -201,7 +201,7 @@ app:
         value (stacktrace and type take precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:26:51.228424+00:00'
+created: '2024-11-08T18:04:31.516329+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -201,7 +201,7 @@ app:
         value (stacktrace and type take precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/checksum_no_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/checksum_no_regex_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-24T16:39:30.105527+00:00'
+created: '2024-11-08T18:04:40.113591+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ checksum:
   hash: "not a legit checksum"
   checksum: "not a legit checksum"
 --------------------------------------------------------------------------
-hashed-checksum:
+hashed_checksum:
   hash: "de46d023e69b171b90ccf3ebca7aede4"
   checksum: "de46d023e69b171b90ccf3ebca7aede4"
   raw_checksum: "not a legit checksum"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/checksum_no_regex_match_long.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/checksum_no_regex_match_long.pysnap
@@ -1,9 +1,9 @@
 ---
-created: '2024-10-24T16:39:30.058498+00:00'
+created: '2024-11-08T18:04:39.458827+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
-hashed-checksum:
+hashed_checksum:
   hash: "2c2e85a6e73109222f131228ed06a7af"
   checksum: "2c2e85a6e73109222f131228ed06a7af"
   raw_checksum: "not a legit checksum and also too long a string"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:23:36.656187+00:00'
+created: '2024-11-08T18:04:41.360269+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
   info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
   values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:27:04.024202+00:00'
+created: '2024-11-08T18:04:41.229650+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:27:04.120102+00:00'
+created: '2024-11-08T18:04:41.463025+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:27:07.987767+00:00'
+created: '2024-11-08T18:04:49.033909+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/checksum_no_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/checksum_no_regex_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-24T16:39:17.694785+00:00'
+created: '2024-11-08T18:04:55.679976+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ checksum:
   hash: "not a legit checksum"
   checksum: "not a legit checksum"
 --------------------------------------------------------------------------
-hashed-checksum:
+hashed_checksum:
   hash: "de46d023e69b171b90ccf3ebca7aede4"
   checksum: "de46d023e69b171b90ccf3ebca7aede4"
   raw_checksum: "not a legit checksum"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/checksum_no_regex_match_long.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/checksum_no_regex_match_long.pysnap
@@ -1,9 +1,9 @@
 ---
-created: '2024-10-24T16:39:17.621191+00:00'
+created: '2024-11-08T18:04:55.536152+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
-hashed-checksum:
+hashed_checksum:
   hash: "2c2e85a6e73109222f131228ed06a7af"
   checksum: "2c2e85a6e73109222f131228ed06a7af"
   raw_checksum: "not a legit checksum and also too long a string"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:23:49.327010+00:00'
+created: '2024-11-08T18:04:56.469255+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
   info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
   values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:26:55.742395+00:00'
+created: '2024-11-08T18:04:56.395479+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:26:56.036770+00:00'
+created: '2024-11-08T18:04:56.559938+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:27:00.140364+00:00'
+created: '2024-11-08T18:05:07.898530+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-24T14:16:56.151196+00:00'
+created: '2024-11-08T18:05:13.933819+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -21,7 +21,7 @@ app:
         value*
           "ChunkLoadError: something something..."
 --------------------------------------------------------------------------
-built-in-fingerprint:
+built_in_fingerprint:
   hash: "5d731dcf8ecc4f042eeacf528d8d8da9"
   info: {"matched_rule":{"attributes":{},"fingerprint":["chunkloaderror"],"is_builtin":true,"matchers":[["family","javascript"],["type","ChunkLoadError"]],"text":"family:\"javascript\" type:\"ChunkLoadError\" -> \"chunkloaderror\""}}
   values: ["chunkloaderror"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-24T14:16:54.232771+00:00'
+created: '2024-11-08T18:05:13.851960+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -21,7 +21,7 @@ app:
         value*
           "ChunkLoadError: something else..."
 --------------------------------------------------------------------------
-built-in-fingerprint:
+built_in_fingerprint:
   hash: "5d731dcf8ecc4f042eeacf528d8d8da9"
   info: {"client_fingerprint":["{{ default }}","dogs are great"],"matched_rule":{"attributes":{},"fingerprint":["chunkloaderror"],"is_builtin":true,"matchers":[["family","javascript"],["type","ChunkLoadError"]],"text":"family:\"javascript\" type:\"ChunkLoadError\" -> \"chunkloaderror\""}}
   values: ["chunkloaderror"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/checksum_no_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/checksum_no_regex_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-24T16:32:32.133317+00:00'
+created: '2024-11-08T18:05:14.314410+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ checksum:
   hash: "not a legit checksum"
   checksum: "not a legit checksum"
 --------------------------------------------------------------------------
-hashed-checksum:
+hashed_checksum:
   hash: "de46d023e69b171b90ccf3ebca7aede4"
   checksum: "de46d023e69b171b90ccf3ebca7aede4"
   raw_checksum: "not a legit checksum"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/checksum_no_regex_match_long.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/checksum_no_regex_match_long.pysnap
@@ -1,9 +1,9 @@
 ---
-created: '2024-10-24T16:32:30.293261+00:00'
+created: '2024-11-08T18:05:14.214708+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
-hashed-checksum:
+hashed_checksum:
   hash: "2c2e85a6e73109222f131228ed06a7af"
   checksum: "2c2e85a6e73109222f131228ed06a7af"
   raw_checksum: "not a legit checksum and also too long a string"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:24:01.590598+00:00'
+created: '2024-11-08T18:05:15.262593+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
   info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
   values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:21:42.560447+00:00'
+created: '2024-11-08T18:05:15.190694+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:21:47.347557+00:00'
+created: '2024-11-08T18:05:15.337844+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:24:31.061837+00:00'
+created: '2024-11-08T18:05:21.791163+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/test_builtin_fingerprinting.py
+++ b/tests/sentry/grouping/test_builtin_fingerprinting.py
@@ -561,11 +561,11 @@ class BuiltInFingerprintingTest(TestCase):
             k: v.as_dict()
             for k, v in event.get_grouping_variants(force_config=GROUPING_CONFIG).items()
         }
-        assert "built-in-fingerprint" in variants
+        assert "built_in_fingerprint" in variants
 
-        assert variants["built-in-fingerprint"] == {
+        assert variants["built_in_fingerprint"] == {
             "hash": mock.ANY,  # ignore hash as it can change for unrelated reasons
-            "type": "built-in-fingerprint",
+            "type": "built_in_fingerprint",
             "description": "Sentry defined fingerprint",
             "values": ["chunkloaderror"],
             "client_values": ["my-route", "{{ default }}"],
@@ -711,7 +711,7 @@ class BuiltInFingerprintingTest(TestCase):
             ).items()
         }
 
-        assert "built-in-fingerprint" not in variants
+        assert "built_in_fingerprint" not in variants
         assert event_transaction_no_tx.data["fingerprint"] == ["my-route", "{{ default }}"]
 
     def test_hydration_rule_w_family_matcher(self):


### PR DESCRIPTION
This adds a new type, `VariantsByDescriptor`, to describe the dictionary containing grouping variant data structures which will be used when gathering hashing metadata. 

In order to make it work easily in `TypedDict` form, the keys we use needed to be changed from using dashes to using underscores. (These values aren't stored anywhere - just used in memory as we're calculating grouping - so there's no data consistency problem created by changing them.) Because those changes add a bunch of noise, both in and of themselves and in the snapshot changes they cause, I split them off into their own PR.