### PR TITLE
feat(dashboards): Allow `ReactElement` as `WidgetFrame` description

### DIFF
--- a/static/app/views/dashboards/widgets/common/widgetFrame.stories.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.stories.tsx
@@ -1,9 +1,10 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import ExternalLink from 'sentry/components/links/externalLink';
 import JSXNode from 'sentry/components/stories/jsxNode';
 import SideBySide from 'sentry/components/stories/sideBySide';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import storyBook from 'sentry/stories/storyBook';
 import {WidgetFrame} from 'sentry/views/dashboards/widgets/common/widgetFrame';
 
@@ -29,6 +30,11 @@ export default storyBook(WidgetFrame, story => {
           The title is automatically wrapped in a tooltip if it does not fit.
         </p>
 
+        <p>
+          The description can be a React element, but don't go overboard. Stick to
+          strings, or <code>tct</code> output consisting of text and links.
+        </p>
+
         <SideBySide>
           <NormalWidget>
             <WidgetFrame
@@ -40,6 +46,18 @@ export default storyBook(WidgetFrame, story => {
             <WidgetFrame
               title="p95(measurements.lcp) / p95(measurements.inp)"
               description="This is a tough formula to reason about"
+            />
+          </NormalWidget>
+          <NormalWidget>
+            <WidgetFrame
+              title="p95(span.duration)"
+              description={tct('Learn more about this on our [documentation] website.', {
+                documentation: (
+                  <ExternalLink href="https://docs.sentry.io">
+                    {t('documentation')}
+                  </ExternalLink>
+                ),
+              })}
             />
           </NormalWidget>
         </SideBySide>

--- a/static/app/views/dashboards/widgets/common/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgets/common/widgetFrame.tsx
@@ -21,7 +21,7 @@ export interface WidgetFrameProps extends StateProps {
   actionsMessage?: string;
   badgeProps?: BadgeProps | BadgeProps[];
   children?: React.ReactNode;
-  description?: string;
+  description?: React.ReactElement | string;
   onFullScreenViewClick?: () => void;
   title?: string;
   warnings?: string[];


### PR DESCRIPTION
The most common use-case is translated strings, so that's what I documented.

**e.g.,**
<img width="274" alt="Screenshot 2024-11-08 at 4 39 23 PM" src="https://github.com/user-attachments/assets/4484427b-878c-4a85-b98c-a9684cc084b9">
