### PR TITLE
fix(issues): Move images loaded below stack trace

### DIFF
--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -281,6 +281,16 @@ export function EventDetailsContent({
           />
         </EntryErrorBoundary>
       )}
+      {defined(eventEntries[EntryType.DEBUGMETA]) && (
+        <EntryErrorBoundary type={EntryType.DEBUGMETA}>
+          <DebugMeta
+            event={event}
+            projectSlug={projectSlug}
+            groupId={group?.id}
+            data={eventEntries[EntryType.DEBUGMETA].data}
+          />
+        </EntryErrorBoundary>
+      )}
       {hasStreamlinedUI && (
         <ScreenshotDataSection event={event} projectSlug={project.slug} />
       )}
@@ -408,16 +418,6 @@ export function EventDetailsContent({
           project={project}
           group={group}
         />
-      )}
-      {defined(eventEntries[EntryType.DEBUGMETA]) && (
-        <EntryErrorBoundary type={EntryType.DEBUGMETA}>
-          <DebugMeta
-            event={event}
-            projectSlug={projectSlug}
-            groupId={group?.id}
-            data={eventEntries[EntryType.DEBUGMETA].data}
-          />
-        </EntryErrorBoundary>
       )}
       {defined(eventEntries[EntryType.REQUEST]) && (
         <EntryErrorBoundary type={EntryType.REQUEST}>

--- a/static/app/views/issueDetails/streamline/context.tsx
+++ b/static/app/views/issueDetails/streamline/context.tsx
@@ -42,6 +42,9 @@ export const enum SectionKey {
   TEMPLATE = 'template',
 
   BREADCRUMBS = 'breadcrumbs',
+  /**
+   * Also called images loaded
+   */
   DEBUGMETA = 'debugmeta',
   REQUEST = 'request',
 


### PR DESCRIPTION
moves from below breadcrumbs to above the screenshot if it exists

example issue https://demo.dev.getsentry.net:7999/issues/4735874009/