### PR TITLE
chore(api): publish OrganizationintegrationDetails API

### DIFF
--- a/src/sentry/apidocs/examples/integration_examples.py
+++ b/src/sentry/apidocs/examples/integration_examples.py
@@ -56,6 +56,58 @@ class IntegrationExamples:
         )
     ]
 
+    GET_INTEGRATION = [
+        OpenApiExample(
+            "List All Available Integrations for Alphabet Soup Factory",
+            value={
+                "id": "24817",
+                "name": "Alphabet Soup Factory",
+                "icon": "https://avatars.slack-edge.com/alphabet-soup",
+                "domainName": "alphabet-soup.slack.com",
+                "accountType": None,
+                "scopes": [
+                    "channels:read",
+                    "chat:write",
+                    "chat:write.customize",
+                    "chat:write.public",
+                    "commands",
+                    "groups:read",
+                    "im:history",
+                    "im:read",
+                    "links:read",
+                    "links:write",
+                    "team:read",
+                    "users:read",
+                ],
+                "status": "active",
+                "provider": {
+                    "key": "slack",
+                    "slug": "slack",
+                    "name": "Slack",
+                    "canAdd": True,
+                    "canDisable": False,
+                    "features": ["alert-rule", "chat-unfurl"],
+                    "aspects": {
+                        "alerts": [
+                            {
+                                "type": "info",
+                                "text": "The Slack integration adds a new Alert Rule action to all projects. To enable automatic notifications sent to Slack you must create a rule using the slack workspace action in your project settings.",
+                            }
+                        ]
+                    },
+                },
+                "configOrganization": [],
+                "configData": {"installationType": "born_as_bot"},
+                "externalId": "7252394",
+                "organizationId": 6234528,
+                "organizationIntegrationStatus": "active",
+                "gracePeriodEnd": None,
+            },
+            status_codes=["200"],
+            response_only=True,
+        )
+    ]
+
     EXTERNAL_USER_CREATE = [
         OpenApiExample(
             "Create an external user",

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -48,6 +48,13 @@ class GlobalParams:
         type=str,
         location="path",
     )
+    INTEGRATION_ID = OpenApiParameter(
+        name="integration_id",
+        description="The ID of the integration installed on the organization.",
+        required=True,
+        type=str,
+        location="path",
+    )
     STATS_PERIOD = OpenApiParameter(
         name="statsPeriod",
         location="query",

--- a/src/sentry/integrations/api/endpoints/organization_integration_details.py
+++ b/src/sentry/integrations/api/endpoints/organization_integration_details.py
@@ -19,6 +19,7 @@ from sentry.api.serializers import serialize
 from sentry.apidocs.constants import RESPONSE_NO_CONTENT, RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.integration_examples import IntegrationExamples
 from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ObjectStatus
 from sentry.deletions.models.scheduleddeletion import ScheduledDeletion
 from sentry.integrations.api.bases.organization_integrations import (
@@ -57,7 +58,9 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
             GlobalParams.INTEGRATION_ID,
         ],
         responses={
-            200: OrganizationIntegrationResponse,
+            200: inline_sentry_response_serializer(
+                "OrganizationIntegrationResponse", OrganizationIntegrationResponse
+            ),
         },
         examples=IntegrationExamples.GET_INTEGRATION,
     )

--- a/src/sentry/integrations/api/endpoints/organization_integration_details.py
+++ b/src/sentry/integrations/api/endpoints/organization_integration_details.py
@@ -6,6 +6,7 @@ from django.db import router, transaction
 from django.http import Http404
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
+from drf_spectacular.utils import extend_schema
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -15,12 +16,18 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.serializers import serialize
+from sentry.apidocs.constants import RESPONSE_NO_CONTENT, RESPONSE_NOT_FOUND
+from sentry.apidocs.examples.integration_examples import IntegrationExamples
+from sentry.apidocs.parameters import GlobalParams
 from sentry.constants import ObjectStatus
 from sentry.deletions.models.scheduleddeletion import ScheduledDeletion
 from sentry.integrations.api.bases.organization_integrations import (
     OrganizationIntegrationBaseEndpoint,
 )
-from sentry.integrations.api.serializers.models.integration import OrganizationIntegrationSerializer
+from sentry.integrations.api.serializers.models.integration import (
+    OrganizationIntegrationResponse,
+    OrganizationIntegrationSerializer,
+)
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.organizations.services.organization import RpcUserOrganizationContext
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
@@ -34,14 +41,26 @@ class IntegrationSerializer(serializers.Serializer):
 
 
 @control_silo_endpoint
+@extend_schema(tags=["Integrations"])
 class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint):
     owner = ApiOwner.INTEGRATIONS
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
-        "POST": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PUBLIC,
+        "GET": ApiPublishStatus.PUBLIC,
+        "POST": ApiPublishStatus.PRIVATE,
     }
 
+    @extend_schema(
+        operation_id="Retrieve an Integration for an Organization",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.INTEGRATION_ID,
+        ],
+        responses={
+            200: OrganizationIntegrationResponse,
+        },
+        examples=IntegrationExamples.GET_INTEGRATION,
+    )
     @set_referrer_policy("strict-origin-when-cross-origin")
     @method_decorator(never_cache)
     def get(
@@ -61,6 +80,14 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
             )
         )
 
+    @extend_schema(
+        operation_id="Delete an Integration for an Organization",
+        parameters=[GlobalParams.ORG_ID_OR_SLUG, GlobalParams.INTEGRATION_ID],
+        responses={
+            204: RESPONSE_NO_CONTENT,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     @set_referrer_policy("strict-origin-when-cross-origin")
     @method_decorator(never_cache)
     def delete(


### PR DESCRIPTION
![image (5)](https://github.com/user-attachments/assets/ec74cd61-1f71-4490-bc73-d338932cc614)

I also marked the POST as private since we require the organization integration config to look a certain way for each integration, so we probably don't want users messing with it. It should probably be a PUT, but we can fix that another time.