### PR TITLE
ref(grouping): Use underscores for variant types and keys

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -321,7 +321,7 @@ def get_grouping_variants_for_event(
             return {"checksum": ChecksumVariant(checksum)}
 
         rv: dict[str, BaseVariant] = {
-            "hashed-checksum": HashedChecksumVariant(hash_from_values(checksum), checksum),
+            "hashed_checksum": HashedChecksumVariant(hash_from_values(checksum), checksum),
         }
 
         # The legacy code path also supported arbitrary values here but
@@ -360,9 +360,9 @@ def get_grouping_variants_for_event(
 
         fingerprint = resolve_fingerprint_values(fingerprint, event.data)
         if (fingerprint_info or {}).get("matched_rule", {}).get("is_builtin") is True:
-            rv["built-in-fingerprint"] = BuiltInFingerprintVariant(fingerprint, fingerprint_info)
+            rv["built_in_fingerprint"] = BuiltInFingerprintVariant(fingerprint, fingerprint_info)
         else:
-            rv["custom-fingerprint"] = CustomFingerprintVariant(fingerprint, fingerprint_info)
+            rv["custom_fingerprint"] = CustomFingerprintVariant(fingerprint, fingerprint_info)
 
     # If only the default is referenced, we can use the variants as is
     elif defaults_referenced == 1 and len(fingerprint) == 1:

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -78,10 +78,10 @@ def _get_hash_basis(event: Event, project: Project, variants: dict[str, BaseVari
         # variants
         if "app" in variants and variants["app"].contributes
         else (
-            variants["hashed-checksum"]
+            variants["hashed_checksum"]
             # TODO: We won't need this 'if' once we stop returning both hashed and non-hashed
             # checksum contributing variants
-            if "hashed-checksum" in variants
+            if "hashed_checksum" in variants
             # Other than in the broken app/system and hashed/raw checksum cases, there should only
             # ever be a single contributing variant
             else [variant for variant in variants.values() if variant.contributes][0]

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -98,7 +98,7 @@ def _has_customized_fingerprint(event: Event, variants: dict[str, BaseVariant]) 
             return True
 
     # Fully customized fingerprint (from either us or the user)
-    fingerprint_variant = variants.get("custom-fingerprint") or variants.get("built-in-fingerprint")
+    fingerprint_variant = variants.get("custom_fingerprint") or variants.get("built_in_fingerprint")
 
     if fingerprint_variant:
         metrics.incr(

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -55,7 +55,7 @@ class ChecksumVariant(BaseVariant):
 
 
 class HashedChecksumVariant(ChecksumVariant):
-    type = "hashed-checksum"
+    type = "hashed_checksum"
     description = "hashed legacy checksum"
 
     def __init__(self, checksum: str, raw_checksum: str):
@@ -85,7 +85,7 @@ class PerformanceProblemVariant(BaseVariant):
         contains the event and the evidence.
     """
 
-    type = "performance-problem"
+    type = "performance_problem"
     description = "performance problem"
     contributes = True
 
@@ -157,7 +157,7 @@ def expose_fingerprint_dict(values, info=None):
 class CustomFingerprintVariant(BaseVariant):
     """A user-defined custom fingerprint."""
 
-    type = "custom-fingerprint"
+    type = "custom_fingerprint"
 
     def __init__(self, values, fingerprint_info=None):
         self.values = values
@@ -177,7 +177,7 @@ class CustomFingerprintVariant(BaseVariant):
 class BuiltInFingerprintVariant(CustomFingerprintVariant):
     """A built-in, Sentry defined fingerprint."""
 
-    type = "built-in-fingerprint"
+    type = "built_in_fingerprint"
 
     @property
     def description(self):
@@ -187,7 +187,7 @@ class BuiltInFingerprintVariant(CustomFingerprintVariant):
 class SaltedComponentVariant(ComponentVariant):
     """A salted version of a component."""
 
-    type = "salted-component"
+    type = "salted_component"
 
     def __init__(self, values, component, config, fingerprint_info=None):
         ComponentVariant.__init__(self, component, config)

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/built_in_fingerprint_chunkload_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:19:43.335885+00:00'
+created: '2024-11-08T22:03:15.369457+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -15,9 +15,9 @@ variants:
       contributes: false
       hint: custom fingerprint takes precedence
     type: component
-  built-in-fingerprint:
+  built_in_fingerprint:
     matched_rule: family:"javascript" type:"ChunkLoadError" -> "chunkloaderror"
-    type: built-in-fingerprint
+    type: built_in_fingerprint
     values:
     - chunkloaderror
   system:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_abs_path.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_abs_path.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:30.800129+00:00'
+created: '2024-11-08T22:03:15.648004+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -22,9 +22,9 @@ variants:
       contributes: false
       hint: custom fingerprint takes precedence
     type: component
-  custom-fingerprint:
+  custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" -> "{{ stack.abs_path }}"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - /foo/Application.cpp
   system:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_escape_chars.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_escape_chars.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:31.788940+00:00'
+created: '2024-11-08T22:03:16.573246+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -19,9 +19,9 @@ fingerprint:
 - '{{ message }}'
 title: '{[*?]}'
 variants:
-  custom-fingerprint:
+  custom_fingerprint:
     matched_rule: message:"\{\[\*\?\]\}" -> "escaped{{ message }}"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - escaped
     - '{[*?]}'

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:29.876535+00:00'
+created: '2024-11-08T22:03:15.088186+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -22,12 +22,12 @@ variants:
       contributes: false
       hint: custom fingerprint takes precedence
     type: component
-  custom-fingerprint:
+  custom_fingerprint:
     client_values:
     - my-route
     - '{{ default }}'
     matched_rule: type:"DatabaseUnavailable" -> "database-unavailable"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - database-unavailable
   system:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:32.297082+00:00'
+created: '2024-11-08T22:03:17.224512+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -24,12 +24,12 @@ variants:
       contributes: false
       hint: custom fingerprint takes precedence
     type: component
-  custom-fingerprint:
+  custom_fingerprint:
     client_values:
     - my-route
     - '{{ default }}'
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - database-unavailable
   system:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:28.545402+00:00'
+created: '2024-11-08T22:03:13.965272+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -27,7 +27,7 @@ variants:
     component:
       contributes: false
       hint: exception of system takes precedence
-    type: salted-component
+    type: salted_component
     values:
     - my-route
     - '{{ default }}'
@@ -38,7 +38,7 @@ variants:
     component:
       contributes: true
       hint: null
-    type: salted-component
+    type: salted_component
     values:
     - my-route
     - '{{ default }}'

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:28.751675+00:00'
+created: '2024-11-08T22:03:14.259249+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -24,12 +24,12 @@ variants:
       contributes: false
       hint: custom fingerprint takes precedence
     type: component
-  custom-fingerprint:
+  custom_fingerprint:
     client_values:
     - my-route
     - '{{ default }}'
     matched_rule: sdk:"sentry.java" type:"DatabaseUnavailable" -> "database-unavailable"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - database-unavailable
   system:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk_mismatch.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk_mismatch.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:31.555178+00:00'
+created: '2024-11-08T22:03:16.302941+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -27,7 +27,7 @@ variants:
     component:
       contributes: false
       hint: exception of system takes precedence
-    type: salted-component
+    type: salted_component
     values:
     - my-route
     - '{{ default }}'
@@ -38,7 +38,7 @@ variants:
     component:
       contributes: true
       hint: null
-    type: salted-component
+    type: salted_component
     values:
     - my-route
     - '{{ default }}'

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_value.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_value.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:32.087925+00:00'
+created: '2024-11-08T22:03:16.952667+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -24,9 +24,9 @@ variants:
       contributes: false
       hint: custom fingerprint takes precedence
     type: component
-  custom-fingerprint:
+  custom_fingerprint:
     matched_rule: value:"*went wrong*" -> "something-went-wrong{{ error.value }}"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - something-went-wrong
     - something went WRONG

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:28.227754+00:00'
+created: '2024-11-08T22:03:13.661245+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -27,10 +27,10 @@ variants:
       contributes: false
       hint: custom fingerprint takes precedence
     type: component
-  custom-fingerprint:
+  custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
       function }}"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - database-unavailable
     - main

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:31.887130+00:00'
+created: '2024-11-08T22:03:16.698987+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -19,9 +19,9 @@ fingerprint:
 - '{{ message }}'
 title: Hello my sweet Love
 variants:
-  custom-fingerprint:
+  custom_fingerprint:
     matched_rule: message:"*love*" -> "what-is-love{{ message }}"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - what-is-love
     - Hello my sweet Love

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message_on_value.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message_on_value.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:28.849683+00:00'
+created: '2024-11-08T22:03:14.418050+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -24,9 +24,9 @@ variants:
       contributes: false
       hint: custom fingerprint takes precedence
     type: component
-  custom-fingerprint:
+  custom_fingerprint:
     matched_rule: message:"*love*" -> "what-is-love{{ message }}"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - what-is-love
     - something has no love.

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:30.109890+00:00'
+created: '2024-11-08T22:03:15.258775+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -24,10 +24,10 @@ variants:
       contributes: false
       hint: custom fingerprint takes precedence
     type: component
-  custom-fingerprint:
+  custom_fingerprint:
     matched_rule: type:"SymCacheError" function:"symbolicator::actors::symcaches::*"
       -> "symcache-error"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - symcache-error
   system:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:29.262373+00:00'
+created: '2024-11-08T22:03:14.833107+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -24,9 +24,9 @@ variants:
       contributes: false
       hint: custom fingerprint takes precedence
     type: component
-  custom-fingerprint:
+  custom_fingerprint:
     matched_rule: function:"symbolicator::actors::symcaches::*" app:"true" -> "symcache-error"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - symcache-error
   system:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:32.422008+00:00'
+created: '2024-11-08T22:03:17.372603+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -27,10 +27,10 @@ variants:
       contributes: false
       hint: custom fingerprint takes precedence
     type: component
-  custom-fingerprint:
+  custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
       function }}"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - database-unavailable
     - <no-function>

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:32.190012+00:00'
+created: '2024-11-08T22:03:17.074388+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -27,7 +27,7 @@ variants:
     component:
       contributes: false
       hint: exception of system takes precedence
-    type: salted-component
+    type: salted_component
     values:
     - my-route
     - '{{ default }}'
@@ -38,7 +38,7 @@ variants:
     component:
       contributes: true
       hint: null
-    type: salted-component
+    type: salted_component
     values:
     - my-route
     - '{{ default }}'

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_package.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_package.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:28.644068+00:00'
+created: '2024-11-08T22:03:14.091914+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -22,9 +22,9 @@ variants:
       contributes: false
       hint: custom fingerprint takes precedence
     type: component
-  custom-fingerprint:
+  custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" -> "{{ package }}"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - <no-package>
   system:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_transaction.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_transaction.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:29.100447+00:00'
+created: '2024-11-08T22:03:14.660887+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -27,10 +27,10 @@ variants:
       contributes: false
       hint: custom fingerprint takes precedence
     type: component
-  custom-fingerprint:
+  custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
       transaction }}"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - database-unavailable
     - <no-transaction>

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_type_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_type_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:27.906317+00:00'
+created: '2024-11-08T22:03:13.370335+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -26,9 +26,9 @@ variants:
       contributes: false
       hint: custom fingerprint takes precedence
     type: component
-  custom-fingerprint:
+  custom_fingerprint:
     matched_rule: function:"main" -> "{{ type }}{{ module }}{{ function }}"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - <no-type>
     - <no-module>

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_log_info.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_log_info.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:31.694343+00:00'
+created: '2024-11-08T22:03:16.451923+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,9 +25,9 @@ fingerprint:
 - '{{ level }}'
 title: Love not found.
 variants:
-  custom-fingerprint:
+  custom_fingerprint:
     matched_rule: logger:"sentry.*" level:"ERROR" -> "log-{{ logger }}-{{ level }}"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - log-
     - sentry.example.love

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:28.968353+00:00'
+created: '2024-11-08T22:03:14.537139+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -17,9 +17,9 @@ fingerprint:
 - sdk-nextjs
 title: Es Dee Kay
 variants:
-  custom-fingerprint:
+  custom_fingerprint:
     matched_rule: sdk:"sentry.javascript.nextjs" -> "sdk-nextjs"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - sdk-nextjs
   default:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_tags.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_tags.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:31.414158+00:00'
+created: '2024-11-08T22:03:16.161628+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -19,9 +19,9 @@ fingerprint:
 - '{{ tags.barfoo }}'
 title: Hello my sweet Love
 variants:
-  custom-fingerprint:
+  custom_fingerprint:
     matched_rule: tags.foobar:"*stuff*" -> "foobar-matched-stuff-{{ tags.barfoo }}"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - foobar-matched-stuff-
     - amazing

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_override_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_override_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:28.357412+00:00'
+created: '2024-11-08T22:03:13.799217+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -17,11 +17,11 @@ fingerprint:
 - what-is-love
 title: Hello my sweet Love
 variants:
-  custom-fingerprint:
+  custom_fingerprint:
     client_values:
     - client-sent
     matched_rule: message:"*love*" -> "what-is-love"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - what-is-love
   default:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_package.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_package.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:30.956554+00:00'
+created: '2024-11-08T22:03:15.774925+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -22,9 +22,9 @@ variants:
       contributes: false
       hint: custom fingerprint takes precedence
     type: component
-  custom-fingerprint:
+  custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" -> "{{ package }}"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - foo.dylib
   system:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_python.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_python.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:28.104840+00:00'
+created: '2024-11-08T22:03:13.538456+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,9 +25,9 @@ variants:
       contributes: false
       hint: custom fingerprint takes precedence
     type: component
-  custom-fingerprint:
+  custom_fingerprint:
     matched_rule: type:"ReadTimeout" path:"**/requests/adapters.py" -> "timeout-in-requests"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - timeout-in-requests
   system:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_release.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_release.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:31.117234+00:00'
+created: '2024-11-08T22:03:15.904164+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -22,12 +22,12 @@ variants:
       contributes: false
       hint: custom fingerprint takes precedence
     type: component
-  custom-fingerprint:
+  custom_fingerprint:
     client_values:
     - my-route
     - '{{ default }}'
     matched_rule: release:"foo.bar@*" -> "foo.bar-release"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - foo.bar-release
   system:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_transaction.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_transaction.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:31.988821+00:00'
+created: '2024-11-08T22:03:16.826883+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -28,10 +28,10 @@ variants:
       contributes: false
       hint: custom fingerprint takes precedence
     type: component
-  custom-fingerprint:
+  custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
       transaction }}" title="DatabaseUnavailable ({{ transaction }})"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - database-unavailable
     - my-transaction

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_two_threads.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_two_threads.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:30.528301+00:00'
+created: '2024-11-08T22:03:15.510987+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -22,9 +22,9 @@ variants:
       contributes: false
       hint: custom fingerprint takes precedence
     type: component
-  custom-fingerprint:
+  custom_fingerprint:
     matched_rule: function:"main" -> "in-main"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - in-main
   system:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_type_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_type_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T22:32:31.280581+00:00'
+created: '2024-11-08T22:03:16.036167+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -27,10 +27,10 @@ variants:
       contributes: false
       hint: custom fingerprint takes precedence
     type: component
-  custom-fingerprint:
+  custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "{{ type
       }}{{ module }}"
-    type: custom-fingerprint
+    type: custom_fingerprint
     values:
     - DatabaseUnavailable
     - io.sentry.example.Application

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/checksum_no_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/checksum_no_regex_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-28T14:02:49.098955+00:00'
+created: '2024-11-08T19:38:50.201117+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -9,7 +9,7 @@ contributing variants:
   checksum*
     hash: "not a legit checksum"
     checksum: "not a legit checksum"
-  hashed-checksum*
+  hashed_checksum*
     hash: "de46d023e69b171b90ccf3ebca7aede4"
     checksum: "de46d023e69b171b90ccf3ebca7aede4"
     raw_checksum: "not a legit checksum"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/checksum_no_regex_match_long.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/checksum_no_regex_match_long.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:49.050340+00:00'
+created: '2024-11-08T19:38:50.016718+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: checksum
 ---
 contributing variants:
-  hashed-checksum*
+  hashed_checksum*
     hash: "2c2e85a6e73109222f131228ed06a7af"
     checksum: "2c2e85a6e73109222f131228ed06a7af"
     raw_checksum: "not a legit checksum and also too long a string"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/custom_fingerprint_client.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:49.810306+00:00'
+created: '2024-11-08T19:38:51.920957+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "f30afa00b85f5cac5ee0bce01b31f08d"
     info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
     values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:49.711711+00:00'
+created: '2024-11-08T19:38:51.829940+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/custom_fingerprint_server_rule.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:49.863964+00:00'
+created: '2024-11-08T19:38:52.048179+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:54.254098+00:00'
+created: '2024-11-08T19:39:01.703766+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/checksum_no_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/checksum_no_regex_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-28T14:02:39.366152+00:00'
+created: '2024-11-08T19:39:12.509223+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -9,7 +9,7 @@ contributing variants:
   checksum*
     hash: "not a legit checksum"
     checksum: "not a legit checksum"
-  hashed-checksum*
+  hashed_checksum*
     hash: "de46d023e69b171b90ccf3ebca7aede4"
     checksum: "de46d023e69b171b90ccf3ebca7aede4"
     raw_checksum: "not a legit checksum"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/checksum_no_regex_match_long.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/checksum_no_regex_match_long.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:39.311549+00:00'
+created: '2024-11-08T19:39:12.336490+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: checksum
 ---
 contributing variants:
-  hashed-checksum*
+  hashed_checksum*
     hash: "2c2e85a6e73109222f131228ed06a7af"
     checksum: "2c2e85a6e73109222f131228ed06a7af"
     raw_checksum: "not a legit checksum and also too long a string"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/custom_fingerprint_client.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:39.939582+00:00'
+created: '2024-11-08T19:39:13.721167+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "f30afa00b85f5cac5ee0bce01b31f08d"
     info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
     values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:39.892096+00:00'
+created: '2024-11-08T19:39:13.608994+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/custom_fingerprint_server_rule.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:39.989389+00:00'
+created: '2024-11-08T19:39:13.819005+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:44.671764+00:00'
+created: '2024-11-08T19:39:21.183635+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/checksum_no_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/checksum_no_regex_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-28T14:02:29.512254+00:00'
+created: '2024-11-08T19:39:33.277681+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -9,7 +9,7 @@ contributing variants:
   checksum*
     hash: "not a legit checksum"
     checksum: "not a legit checksum"
-  hashed-checksum*
+  hashed_checksum*
     hash: "de46d023e69b171b90ccf3ebca7aede4"
     checksum: "de46d023e69b171b90ccf3ebca7aede4"
     raw_checksum: "not a legit checksum"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/checksum_no_regex_match_long.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/checksum_no_regex_match_long.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:29.463789+00:00'
+created: '2024-11-08T19:39:33.181163+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: checksum
 ---
 contributing variants:
-  hashed-checksum*
+  hashed_checksum*
     hash: "2c2e85a6e73109222f131228ed06a7af"
     checksum: "2c2e85a6e73109222f131228ed06a7af"
     raw_checksum: "not a legit checksum and also too long a string"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/custom_fingerprint_client.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:30.046770+00:00'
+created: '2024-11-08T19:39:34.358029+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "f30afa00b85f5cac5ee0bce01b31f08d"
     info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
     values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:29.995654+00:00'
+created: '2024-11-08T19:39:34.297377+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/custom_fingerprint_server_rule.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:30.107810+00:00'
+created: '2024-11-08T19:39:34.466648+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:02:34.757521+00:00'
+created: '2024-11-08T19:39:42.079495+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T13:56:38.893371+00:00'
+created: '2024-11-08T19:39:50.761360+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  built-in-fingerprint*
+  built_in_fingerprint*
     hash: "5d731dcf8ecc4f042eeacf528d8d8da9"
     info: {"matched_rule":{"attributes":{},"fingerprint":["chunkloaderror"],"is_builtin":true,"matchers":[["family","javascript"],["type","ChunkLoadError"]],"text":"family:\"javascript\" type:\"ChunkLoadError\" -> \"chunkloaderror\""}}
     values: ["chunkloaderror"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T13:56:37.164322+00:00'
+created: '2024-11-08T19:39:50.661664+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  built-in-fingerprint*
+  built_in_fingerprint*
     hash: "5d731dcf8ecc4f042eeacf528d8d8da9"
     info: {"client_fingerprint":["{{ default }}","dogs are great"],"matched_rule":{"attributes":{},"fingerprint":["chunkloaderror"],"is_builtin":true,"matchers":[["family","javascript"],["type","ChunkLoadError"]],"text":"family:\"javascript\" type:\"ChunkLoadError\" -> \"chunkloaderror\""}}
     values: ["chunkloaderror"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/checksum_no_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/checksum_no_regex_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-28T13:56:44.160391+00:00'
+created: '2024-11-08T19:39:50.976769+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -9,7 +9,7 @@ contributing variants:
   checksum*
     hash: "not a legit checksum"
     checksum: "not a legit checksum"
-  hashed-checksum*
+  hashed_checksum*
     hash: "de46d023e69b171b90ccf3ebca7aede4"
     checksum: "de46d023e69b171b90ccf3ebca7aede4"
     raw_checksum: "not a legit checksum"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/checksum_no_regex_match_long.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/checksum_no_regex_match_long.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T13:56:42.371020+00:00'
+created: '2024-11-08T19:39:50.887328+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: checksum
 ---
 contributing variants:
-  hashed-checksum*
+  hashed_checksum*
     hash: "2c2e85a6e73109222f131228ed06a7af"
     checksum: "2c2e85a6e73109222f131228ed06a7af"
     raw_checksum: "not a legit checksum and also too long a string"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_client.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T13:57:05.708988+00:00'
+created: '2024-11-08T19:39:51.908843+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "f30afa00b85f5cac5ee0bce01b31f08d"
     info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
     values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T13:57:03.719704+00:00'
+created: '2024-11-08T19:39:51.815255+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T13:57:08.114402+00:00'
+created: '2024-11-08T19:39:52.075996+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2024-10-28T14:00:07.256402+00:00'
+created: '2024-11-08T19:40:01.146667+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
 hash_basis: fingerprint
 ---
 contributing variants:
-  custom-fingerprint*
+  custom_fingerprint*
     hash: "554e214208f0372603dc9fa6c1c0965f"
     info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
     values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/checksum_no_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/checksum_no_regex_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-24T16:39:05.705922+00:00'
+created: '2024-11-08T18:04:20.848101+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ checksum:
   hash: "not a legit checksum"
   checksum: "not a legit checksum"
 --------------------------------------------------------------------------
-hashed-checksum:
+hashed_checksum:
   hash: "de46d023e69b171b90ccf3ebca7aede4"
   checksum: "de46d023e69b171b90ccf3ebca7aede4"
   raw_checksum: "not a legit checksum"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/checksum_no_regex_match_long.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/checksum_no_regex_match_long.pysnap
@@ -1,9 +1,9 @@
 ---
-created: '2024-10-24T16:39:05.649697+00:00'
+created: '2024-11-08T18:04:20.645880+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
-hashed-checksum:
+hashed_checksum:
   hash: "2c2e85a6e73109222f131228ed06a7af"
   checksum: "2c2e85a6e73109222f131228ed06a7af"
   raw_checksum: "not a legit checksum and also too long a string"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:23:21.568140+00:00'
+created: '2024-11-08T18:04:22.531848+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -201,7 +201,7 @@ app:
         value (stacktrace and type take precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
   info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
   values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:26:47.033154+00:00'
+created: '2024-11-08T18:04:22.342258+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -201,7 +201,7 @@ app:
         value (stacktrace and type take precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:26:47.124257+00:00'
+created: '2024-11-08T18:04:22.646156+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -201,7 +201,7 @@ app:
         value (stacktrace and type take precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:26:51.228424+00:00'
+created: '2024-11-08T18:04:31.516329+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -201,7 +201,7 @@ app:
         value (stacktrace and type take precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/checksum_no_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/checksum_no_regex_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-24T16:39:30.105527+00:00'
+created: '2024-11-08T18:04:40.113591+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ checksum:
   hash: "not a legit checksum"
   checksum: "not a legit checksum"
 --------------------------------------------------------------------------
-hashed-checksum:
+hashed_checksum:
   hash: "de46d023e69b171b90ccf3ebca7aede4"
   checksum: "de46d023e69b171b90ccf3ebca7aede4"
   raw_checksum: "not a legit checksum"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/checksum_no_regex_match_long.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/checksum_no_regex_match_long.pysnap
@@ -1,9 +1,9 @@
 ---
-created: '2024-10-24T16:39:30.058498+00:00'
+created: '2024-11-08T18:04:39.458827+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
-hashed-checksum:
+hashed_checksum:
   hash: "2c2e85a6e73109222f131228ed06a7af"
   checksum: "2c2e85a6e73109222f131228ed06a7af"
   raw_checksum: "not a legit checksum and also too long a string"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:23:36.656187+00:00'
+created: '2024-11-08T18:04:41.360269+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
   info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
   values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:27:04.024202+00:00'
+created: '2024-11-08T18:04:41.229650+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:27:04.120102+00:00'
+created: '2024-11-08T18:04:41.463025+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:27:07.987767+00:00'
+created: '2024-11-08T18:04:49.033909+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/checksum_no_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/checksum_no_regex_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-24T16:39:17.694785+00:00'
+created: '2024-11-08T18:04:55.679976+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ checksum:
   hash: "not a legit checksum"
   checksum: "not a legit checksum"
 --------------------------------------------------------------------------
-hashed-checksum:
+hashed_checksum:
   hash: "de46d023e69b171b90ccf3ebca7aede4"
   checksum: "de46d023e69b171b90ccf3ebca7aede4"
   raw_checksum: "not a legit checksum"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/checksum_no_regex_match_long.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/checksum_no_regex_match_long.pysnap
@@ -1,9 +1,9 @@
 ---
-created: '2024-10-24T16:39:17.621191+00:00'
+created: '2024-11-08T18:04:55.536152+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
-hashed-checksum:
+hashed_checksum:
   hash: "2c2e85a6e73109222f131228ed06a7af"
   checksum: "2c2e85a6e73109222f131228ed06a7af"
   raw_checksum: "not a legit checksum and also too long a string"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:23:49.327010+00:00'
+created: '2024-11-08T18:04:56.469255+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
   info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
   values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:26:55.742395+00:00'
+created: '2024-11-08T18:04:56.395479+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:26:56.036770+00:00'
+created: '2024-11-08T18:04:56.559938+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:27:00.140364+00:00'
+created: '2024-11-08T18:05:07.898530+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-24T14:16:56.151196+00:00'
+created: '2024-11-08T18:05:13.933819+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -21,7 +21,7 @@ app:
         value*
           "ChunkLoadError: something something..."
 --------------------------------------------------------------------------
-built-in-fingerprint:
+built_in_fingerprint:
   hash: "5d731dcf8ecc4f042eeacf528d8d8da9"
   info: {"matched_rule":{"attributes":{},"fingerprint":["chunkloaderror"],"is_builtin":true,"matchers":[["family","javascript"],["type","ChunkLoadError"]],"text":"family:\"javascript\" type:\"ChunkLoadError\" -> \"chunkloaderror\""}}
   values: ["chunkloaderror"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-24T14:16:54.232771+00:00'
+created: '2024-11-08T18:05:13.851960+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -21,7 +21,7 @@ app:
         value*
           "ChunkLoadError: something else..."
 --------------------------------------------------------------------------
-built-in-fingerprint:
+built_in_fingerprint:
   hash: "5d731dcf8ecc4f042eeacf528d8d8da9"
   info: {"client_fingerprint":["{{ default }}","dogs are great"],"matched_rule":{"attributes":{},"fingerprint":["chunkloaderror"],"is_builtin":true,"matchers":[["family","javascript"],["type","ChunkLoadError"]],"text":"family:\"javascript\" type:\"ChunkLoadError\" -> \"chunkloaderror\""}}
   values: ["chunkloaderror"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/checksum_no_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/checksum_no_regex_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-24T16:32:32.133317+00:00'
+created: '2024-11-08T18:05:14.314410+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ checksum:
   hash: "not a legit checksum"
   checksum: "not a legit checksum"
 --------------------------------------------------------------------------
-hashed-checksum:
+hashed_checksum:
   hash: "de46d023e69b171b90ccf3ebca7aede4"
   checksum: "de46d023e69b171b90ccf3ebca7aede4"
   raw_checksum: "not a legit checksum"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/checksum_no_regex_match_long.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/checksum_no_regex_match_long.pysnap
@@ -1,9 +1,9 @@
 ---
-created: '2024-10-24T16:32:30.293261+00:00'
+created: '2024-11-08T18:05:14.214708+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
-hashed-checksum:
+hashed_checksum:
   hash: "2c2e85a6e73109222f131228ed06a7af"
   checksum: "2c2e85a6e73109222f131228ed06a7af"
   raw_checksum: "not a legit checksum and also too long a string"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-15T17:24:01.590598+00:00'
+created: '2024-11-08T18:05:15.262593+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
   info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]}
   values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:21:42.560447+00:00'
+created: '2024-11-08T18:05:15.190694+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"client_fingerprint":["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:21:47.347557+00:00'
+created: '2024-11-08T18:05:15.337844+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-16T19:24:31.061837+00:00'
+created: '2024-11-08T18:05:21.791163+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -167,7 +167,7 @@ app:
         value (ignored because stacktrace takes precedence)
           "SoftTimeLimitExceeded()"
 --------------------------------------------------------------------------
-custom-fingerprint:
+custom_fingerprint:
   hash: "554e214208f0372603dc9fa6c1c0965f"
   info: {"client_fingerprint":["{{ default }}","SoftTimeLimitExceeded","sentry.tasks.store.process_event"],"matched_rule":{"attributes":{},"fingerprint":["soft-timelimit-exceeded"],"matchers":[["type","SoftTimeLimitExceeded"]],"text":"type:\"SoftTimeLimitExceeded\" -> \"soft-timelimit-exceeded\""}}
   values: ["soft-timelimit-exceeded"]

--- a/tests/sentry/grouping/test_builtin_fingerprinting.py
+++ b/tests/sentry/grouping/test_builtin_fingerprinting.py
@@ -561,11 +561,11 @@ class BuiltInFingerprintingTest(TestCase):
             k: v.as_dict()
             for k, v in event.get_grouping_variants(force_config=GROUPING_CONFIG).items()
         }
-        assert "built-in-fingerprint" in variants
+        assert "built_in_fingerprint" in variants
 
-        assert variants["built-in-fingerprint"] == {
+        assert variants["built_in_fingerprint"] == {
             "hash": mock.ANY,  # ignore hash as it can change for unrelated reasons
-            "type": "built-in-fingerprint",
+            "type": "built_in_fingerprint",
             "description": "Sentry defined fingerprint",
             "values": ["chunkloaderror"],
             "client_values": ["my-route", "{{ default }}"],
@@ -711,7 +711,7 @@ class BuiltInFingerprintingTest(TestCase):
             ).items()
         }
 
-        assert "built-in-fingerprint" not in variants
+        assert "built_in_fingerprint" not in variants
         assert event_transaction_no_tx.data["fingerprint"] == ["my-route", "{{ default }}"]
 
     def test_hydration_rule_w_family_matcher(self):


### PR DESCRIPTION
In order to make usage in an upcoming `TypedDict` easier, this switches the strings we use as keys for our grouping variants from using dashes to using underscores. (It also changes said variants' `type` attributes, since they are meant to match the keys.) Because this is a somewhat noisy change, given the snapshot updates it causes, it's been split out into its own PR.

Note: These keys are never stored, so making the switch doesn't cause a data consistency problem - mostly we just pass them around the BE while we calculate event grouping. That said, we do pass them as part of the response from the grouping info endpoint. In order to preserve compatibility with the FE, this therefore switches the data back to using dashes just before it is returned from the endpoint. The fact that the `test_variant_keys_and_types_use_dashes_not_underscores` test [here](https://github.com/getsentry/sentry/blob/6abc34dcff03a54e68946843642e07c594d5ee7c/tests/sentry/api/endpoints/test_event_grouping_info.py#L151-L178) continues to pass with no changes proves that this conversion works.