### PR TITLE
styles(explore): Show full text on hover for span description

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -311,7 +311,15 @@ export const FIELD_FORMATTERS: FieldFormatters = {
           </Container>
         );
       }
-      return <Container>{nullableValue(value)}</Container>;
+
+      const content =
+        value && typeof value === 'string' ? (
+          <span title={value}>{nullableValue(value)}</span>
+        ) : (
+          nullableValue(value)
+        );
+
+      return <Container>{content}</Container>;
     },
   },
   array: {


### PR DESCRIPTION
This adds a hover when hovering any string fields in order to see the full text.