### PR TITLE
ref(grouping): Add `GroupingComponent` subclasses

### DIFF
--- a/src/sentry/grouping/__init__.py
+++ b/src/sentry/grouping/__init__.py
@@ -87,7 +87,7 @@ removes a component (and its children) entirely from the grouping output.
 Here an example of how components can be used::
 
     function_name = 'lambda$1234'
-    threads = GroupingComponent(
+    threads = BaseGroupingComponent(
         id="function",
         values=[function_name],
         contributes=False,

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, TypedDict
 import sentry_sdk
 
 from sentry import options
-from sentry.grouping.component import GroupingComponent
+from sentry.grouping.component import BaseGroupingComponent
 from sentry.grouping.enhancer import LATEST_VERSION, Enhancements
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.grouping.strategies.base import DEFAULT_GROUPING_ENHANCEMENTS_BASE, GroupingContext
@@ -264,10 +264,10 @@ def apply_server_fingerprinting(event, config, allow_custom_title=True):
 
 def _get_calculated_grouping_variants_for_event(
     event: Event, context: GroupingContext
-) -> dict[str, GroupingComponent]:
+) -> dict[str, BaseGroupingComponent]:
     winning_strategy: str | None = None
     precedence_hint: str | None = None
-    per_variant_components: dict[str, list[GroupingComponent]] = {}
+    per_variant_components: dict[str, list[BaseGroupingComponent]] = {}
 
     for strategy in context.config.iter_strategies():
         # Defined in src/sentry/grouping/strategies/base.py
@@ -292,7 +292,7 @@ def _get_calculated_grouping_variants_for_event(
 
     rv = {}
     for variant, components in per_variant_components.items():
-        component = GroupingComponent(id=variant, values=components)
+        component = BaseGroupingComponent(id=variant, values=components)
         if not component.contributes and precedence_hint:
             component.update(hint=precedence_hint)
         rv[variant] = component

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator, Iterator, Sequence
-from typing import Any
+from typing import Any, TypeVar
 
 from sentry.grouping.utils import hash_from_values
 
@@ -171,3 +171,6 @@ class BaseGroupingComponent:
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.id!r}, hint={self.hint!r}, contributes={self.contributes!r}, values={self.values!r})"
+
+
+GroupingComponent = TypeVar("GroupingComponent", bound=BaseGroupingComponent)

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -35,23 +35,23 @@ class GroupingComponent:
     into components to make a hash for grouping purposes.
     """
 
-    id: str
+    id: str = "default"
     hint: str | None
     contributes: bool | None
     values: Sequence[str | GroupingComponent]
 
     def __init__(
         self,
-        id: str,
+        id: str | None = None,
         hint: str | None = None,
         contributes: bool | None = None,
         values: Sequence[str | GroupingComponent] | None = None,
         variant_provider: bool = False,
     ):
-        self.id = id
+        self.id = id or self.id
 
         # Default values
-        self.hint = DEFAULT_HINTS.get(id)
+        self.hint = DEFAULT_HINTS.get(self.id)
         self.contributes = contributes
         self.variant_provider = variant_provider
         self.values: Sequence[str | GroupingComponent] = []

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -170,4 +170,4 @@ class GroupingComponent:
         return rv
 
     def __repr__(self) -> str:
-        return f"GroupingComponent({self.id!r}, hint={self.hint!r}, contributes={self.contributes!r}, values={self.values!r})"
+        return f"{self.__class__.__name__}({self.id!r}, hint={self.hint!r}, contributes={self.contributes!r}, values={self.values!r})"

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -23,7 +23,7 @@ KNOWN_MAJOR_COMPONENT_NAMES = {
 }
 
 
-def _calculate_contributes(values: Sequence[str | GroupingComponent]) -> bool:
+def _calculate_contributes(values: Sequence[str | int | GroupingComponent]) -> bool:
     for value in values or ():
         if not isinstance(value, GroupingComponent) or value.contributes:
             return True
@@ -38,14 +38,14 @@ class GroupingComponent:
     id: str = "default"
     hint: str | None
     contributes: bool | None
-    values: Sequence[str | GroupingComponent]
+    values: Sequence[str | int | GroupingComponent]
 
     def __init__(
         self,
         id: str | None = None,
         hint: str | None = None,
         contributes: bool | None = None,
-        values: Sequence[str | GroupingComponent] | None = None,
+        values: Sequence[str | int | GroupingComponent] | None = None,
         variant_provider: bool = False,
     ):
         self.id = id or self.id
@@ -54,7 +54,7 @@ class GroupingComponent:
         self.hint = DEFAULT_HINTS.get(self.id)
         self.contributes = contributes
         self.variant_provider = variant_provider
-        self.values: Sequence[str | GroupingComponent] = []
+        self.values: Sequence[str | int | GroupingComponent] = []
 
         self.update(
             hint=hint,
@@ -89,13 +89,13 @@ class GroupingComponent:
 
     def get_subcomponent(
         self, id: str, only_contributing: bool = False
-    ) -> str | GroupingComponent | None:
+    ) -> str | int | GroupingComponent | None:
         """Looks up a subcomponent by the id and returns the first or `None`."""
         return next(self.iter_subcomponents(id=id, only_contributing=only_contributing), None)
 
     def iter_subcomponents(
         self, id: str, recursive: bool = False, only_contributing: bool = False
-    ) -> Iterator[str | GroupingComponent | None]:
+    ) -> Iterator[str | int | GroupingComponent | None]:
         """Finds all subcomponents matching an id, optionally recursively."""
         for value in self.values:
             if isinstance(value, GroupingComponent):
@@ -113,7 +113,7 @@ class GroupingComponent:
         self,
         hint: str | None = None,
         contributes: bool | None = None,
-        values: Sequence[str | GroupingComponent] | None = None,
+        values: Sequence[str | int | GroupingComponent] | None = None,
     ) -> None:
         """Updates an already existing component with new values."""
         if hint is not None:
@@ -132,7 +132,7 @@ class GroupingComponent:
         rv.values = list(self.values)
         return rv
 
-    def iter_values(self) -> Generator[str | GroupingComponent]:
+    def iter_values(self) -> Generator[str | int | GroupingComponent]:
         """Recursively walks the component and flattens it into a list of
         values.
         """

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -35,6 +35,11 @@ class GroupingComponent:
     into components to make a hash for grouping purposes.
     """
 
+    id: str
+    hint: str | None
+    contributes: bool | None
+    values: Sequence[str | GroupingComponent]
+
     def __init__(
         self,
         id: str,

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -15,7 +15,7 @@ from sentry_ophio.enhancers import Component as RustComponent
 from sentry_ophio.enhancers import Enhancements as RustEnhancements
 
 from sentry import projectoptions
-from sentry.grouping.component import GroupingComponent
+from sentry.grouping.component import BaseGroupingComponent
 from sentry.stacktraces.functions import set_in_app
 from sentry.utils.safe import get_path, set_path
 
@@ -179,7 +179,7 @@ class Enhancements:
         for py_component, rust_component in zip(components, rust_components):
             py_component.update(contributes=rust_component.contributes, hint=rust_component.hint)
 
-        component = GroupingComponent(
+        component = BaseGroupingComponent(
             id="stacktrace",
             values=components,
             hint=rust_results.hint,

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -15,7 +15,7 @@ from sentry_ophio.enhancers import Component as RustComponent
 from sentry_ophio.enhancers import Enhancements as RustEnhancements
 
 from sentry import projectoptions
-from sentry.grouping.component import BaseGroupingComponent
+from sentry.grouping.component import StacktraceGroupingComponent
 from sentry.stacktraces.functions import set_in_app
 from sentry.utils.safe import get_path, set_path
 
@@ -179,8 +179,7 @@ class Enhancements:
         for py_component, rust_component in zip(components, rust_components):
             py_component.update(contributes=rust_component.contributes, hint=rust_component.hint)
 
-        component = BaseGroupingComponent(
-            id="stacktrace",
+        component = StacktraceGroupingComponent(
             values=components,
             hint=rust_results.hint,
             contributes=rust_results.contributes,

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -4,7 +4,7 @@ from typing import Any, Generic, Protocol, TypeVar
 
 from sentry import projectoptions
 from sentry.eventstore.models import Event
-from sentry.grouping.component import GroupingComponent
+from sentry.grouping.component import BaseGroupingComponent, GroupingComponent
 from sentry.grouping.enhancer import Enhancements
 from sentry.interfaces.base import Interface
 
@@ -117,7 +117,7 @@ class GroupingContext:
 
     def get_single_grouping_component(
         self, interface: Interface, *, event: Event, **kwargs: Any
-    ) -> GroupingComponent:
+    ) -> BaseGroupingComponent:
         """Invokes a delegate grouping strategy.  If no such delegate is
         configured a fallback grouping component is returned.
         """
@@ -193,7 +193,7 @@ class Strategy(Generic[ConcreteInterface]):
 
     def get_grouping_component(
         self, event: Event, context: GroupingContext, variant: str | None = None
-    ) -> None | GroupingComponent | ReturnedVariants:
+    ) -> None | BaseGroupingComponent | ReturnedVariants:
         """Given a specific variant this calculates the grouping component."""
         args = []
         iface = event.interfaces.get(self.interface)

--- a/src/sentry/grouping/strategies/legacy.py
+++ b/src/sentry/grouping/strategies/legacy.py
@@ -3,7 +3,7 @@ import re
 from typing import Any
 
 from sentry.eventstore.models import Event
-from sentry.grouping.component import GroupingComponent
+from sentry.grouping.component import BaseGroupingComponent
 from sentry.grouping.strategies.base import (
     GroupingContext,
     ReturnedVariants,
@@ -164,17 +164,17 @@ def single_exception_legacy(
     interface: SingleException, event: Event, context: GroupingContext, **meta: Any
 ) -> ReturnedVariants:
 
-    type_component = GroupingComponent(
+    type_component = BaseGroupingComponent(
         id="type",
         values=[interface.type] if interface.type else [],
         contributes=False,
     )
-    value_component = GroupingComponent(
+    value_component = BaseGroupingComponent(
         id="value",
         values=[interface.value] if interface.value else [],
         contributes=False,
     )
-    stacktrace_component = GroupingComponent(id="stacktrace")
+    stacktrace_component = BaseGroupingComponent(id="stacktrace")
 
     if interface.stacktrace is not None:
         stacktrace_component = context.get_single_grouping_component(
@@ -195,7 +195,7 @@ def single_exception_legacy(
             value_component.update(contributes=True)
 
     return {
-        context["variant"]: GroupingComponent(
+        context["variant"]: BaseGroupingComponent(
             id="exception", values=[stacktrace_component, type_component, value_component]
         )
     }
@@ -231,7 +231,7 @@ def chained_exception_legacy(
             if stacktrace_component is None or not stacktrace_component.contributes:
                 value.update(contributes=False, hint="exception has no stacktrace")
 
-    return {context["variant"]: GroupingComponent(id="chained-exception", values=values)}
+    return {context["variant"]: BaseGroupingComponent(id="chained-exception", values=values)}
 
 
 @chained_exception_legacy.variant_processor
@@ -262,7 +262,7 @@ def frame_legacy(
     # Safari throws [native code] frames in for calls like ``forEach``
     # whereas Chrome ignores these. Let's remove it from the hashing algo
     # so that they're more likely to group together
-    filename_component = GroupingComponent(id="filename")
+    filename_component = BaseGroupingComponent(id="filename")
     if interface.filename == "<anonymous>":
         filename_component.update(
             contributes=False, values=[interface.filename], hint="anonymous filename discarded"
@@ -293,12 +293,12 @@ def frame_legacy(
     # if we have a module we use that for grouping.  This will always
     # take precedence over the filename, even if the module is
     # considered unhashable.
-    module_component = GroupingComponent(id="module")
+    module_component = BaseGroupingComponent(id="module")
     if interface.module:
         if is_unhashable_module_legacy(interface, platform):
             module_component.update(
                 values=[
-                    GroupingComponent(
+                    BaseGroupingComponent(
                         id="salt", values=["<module>"], hint="normalized generated module name"
                     )
                 ],
@@ -313,7 +313,7 @@ def frame_legacy(
             )
 
     # Context line when available is the primary contributor
-    context_line_component = GroupingComponent(id="context-line")
+    context_line_component = BaseGroupingComponent(id="context-line")
     if interface.context_line is not None:
         if len(interface.context_line) > 120:
             context_line_component.update(hint="discarded because line too long")
@@ -322,9 +322,9 @@ def frame_legacy(
         else:
             context_line_component.update(values=[interface.context_line])
 
-    symbol_component = GroupingComponent(id="symbol")
-    function_component = GroupingComponent(id="function")
-    lineno_component = GroupingComponent(id="lineno")
+    symbol_component = BaseGroupingComponent(id="symbol")
+    function_component = BaseGroupingComponent(id="function")
+    lineno_component = BaseGroupingComponent(id="lineno")
 
     # The context line grouping information is the most reliable one.
     # If we did not manage to find some information there, we want to
@@ -347,7 +347,7 @@ def frame_legacy(
             if is_unhashable_function_legacy(func):
                 function_component.update(
                     values=[
-                        GroupingComponent(
+                        BaseGroupingComponent(
                             id="salt", values=["<function>"], hint="normalized lambda function name"
                         )
                     ]
@@ -380,7 +380,7 @@ def frame_legacy(
             )
 
     return {
-        context["variant"]: GroupingComponent(
+        context["variant"]: BaseGroupingComponent(
             id="frame",
             values=[
                 module_component,
@@ -461,7 +461,7 @@ def threads_legacy(
     thread_count = len(interface.values)
     if thread_count != 1:
         return {
-            context["variant"]: GroupingComponent(
+            context["variant"]: BaseGroupingComponent(
                 id="threads",
                 contributes=False,
                 hint="ignored because contains %d threads" % thread_count,
@@ -471,13 +471,13 @@ def threads_legacy(
     stacktrace = interface.values[0].get("stacktrace")
     if not stacktrace:
         return {
-            context["variant"]: GroupingComponent(
+            context["variant"]: BaseGroupingComponent(
                 id="threads", contributes=False, hint="thread has no stacktrace"
             )
         }
 
     return {
-        context["variant"]: GroupingComponent(
+        context["variant"]: BaseGroupingComponent(
             id="threads",
             values=[context.get_single_grouping_component(stacktrace, event=event, **meta)],
         )

--- a/src/sentry/grouping/strategies/legacy.py
+++ b/src/sentry/grouping/strategies/legacy.py
@@ -3,7 +3,22 @@ import re
 from typing import Any
 
 from sentry.eventstore.models import Event
-from sentry.grouping.component import BaseGroupingComponent
+from sentry.grouping.component import (
+    ChainedExceptionGroupingComponent,
+    ContextLineGroupingComponent,
+    ErrorTypeGroupingComponent,
+    ErrorValueGroupingComponent,
+    ExceptionGroupingComponent,
+    FilenameGroupingComponent,
+    FrameGroupingComponent,
+    FunctionGroupingComponent,
+    LineNumberGroupingComponent,
+    ModuleGroupingComponent,
+    SaltGroupingComponent,
+    StacktraceGroupingComponent,
+    SymbolGroupingComponent,
+    ThreadsGroupingComponent,
+)
 from sentry.grouping.strategies.base import (
     GroupingContext,
     ReturnedVariants,
@@ -164,17 +179,15 @@ def single_exception_legacy(
     interface: SingleException, event: Event, context: GroupingContext, **meta: Any
 ) -> ReturnedVariants:
 
-    type_component = BaseGroupingComponent(
-        id="type",
+    type_component = ErrorTypeGroupingComponent(
         values=[interface.type] if interface.type else [],
         contributes=False,
     )
-    value_component = BaseGroupingComponent(
-        id="value",
+    value_component = ErrorValueGroupingComponent(
         values=[interface.value] if interface.value else [],
         contributes=False,
     )
-    stacktrace_component = BaseGroupingComponent(id="stacktrace")
+    stacktrace_component = StacktraceGroupingComponent()
 
     if interface.stacktrace is not None:
         stacktrace_component = context.get_single_grouping_component(
@@ -195,8 +208,8 @@ def single_exception_legacy(
             value_component.update(contributes=True)
 
     return {
-        context["variant"]: BaseGroupingComponent(
-            id="exception", values=[stacktrace_component, type_component, value_component]
+        context["variant"]: ExceptionGroupingComponent(
+            values=[stacktrace_component, type_component, value_component]
         )
     }
 
@@ -231,7 +244,7 @@ def chained_exception_legacy(
             if stacktrace_component is None or not stacktrace_component.contributes:
                 value.update(contributes=False, hint="exception has no stacktrace")
 
-    return {context["variant"]: BaseGroupingComponent(id="chained-exception", values=values)}
+    return {context["variant"]: ChainedExceptionGroupingComponent(values=values)}
 
 
 @chained_exception_legacy.variant_processor
@@ -262,7 +275,7 @@ def frame_legacy(
     # Safari throws [native code] frames in for calls like ``forEach``
     # whereas Chrome ignores these. Let's remove it from the hashing algo
     # so that they're more likely to group together
-    filename_component = BaseGroupingComponent(id="filename")
+    filename_component = FilenameGroupingComponent()
     if interface.filename == "<anonymous>":
         filename_component.update(
             contributes=False, values=[interface.filename], hint="anonymous filename discarded"
@@ -293,13 +306,13 @@ def frame_legacy(
     # if we have a module we use that for grouping.  This will always
     # take precedence over the filename, even if the module is
     # considered unhashable.
-    module_component = BaseGroupingComponent(id="module")
+    module_component = ModuleGroupingComponent()
     if interface.module:
         if is_unhashable_module_legacy(interface, platform):
             module_component.update(
                 values=[
-                    BaseGroupingComponent(
-                        id="salt", values=["<module>"], hint="normalized generated module name"
+                    SaltGroupingComponent(
+                        values=["<module>"], hint="normalized generated module name"
                     )
                 ],
                 hint="ignored module",
@@ -313,7 +326,7 @@ def frame_legacy(
             )
 
     # Context line when available is the primary contributor
-    context_line_component = BaseGroupingComponent(id="context-line")
+    context_line_component = ContextLineGroupingComponent()
     if interface.context_line is not None:
         if len(interface.context_line) > 120:
             context_line_component.update(hint="discarded because line too long")
@@ -322,9 +335,9 @@ def frame_legacy(
         else:
             context_line_component.update(values=[interface.context_line])
 
-    symbol_component = BaseGroupingComponent(id="symbol")
-    function_component = BaseGroupingComponent(id="function")
-    lineno_component = BaseGroupingComponent(id="lineno")
+    symbol_component = SymbolGroupingComponent()
+    function_component = FunctionGroupingComponent()
+    lineno_component = LineNumberGroupingComponent()
 
     # The context line grouping information is the most reliable one.
     # If we did not manage to find some information there, we want to
@@ -347,8 +360,8 @@ def frame_legacy(
             if is_unhashable_function_legacy(func):
                 function_component.update(
                     values=[
-                        BaseGroupingComponent(
-                            id="salt", values=["<function>"], hint="normalized lambda function name"
+                        SaltGroupingComponent(
+                            values=["<function>"], hint="normalized lambda function name"
                         )
                     ]
                 )
@@ -380,8 +393,7 @@ def frame_legacy(
             )
 
     return {
-        context["variant"]: BaseGroupingComponent(
-            id="frame",
+        context["variant"]: FrameGroupingComponent(
             values=[
                 module_component,
                 filename_component,
@@ -461,8 +473,7 @@ def threads_legacy(
     thread_count = len(interface.values)
     if thread_count != 1:
         return {
-            context["variant"]: BaseGroupingComponent(
-                id="threads",
+            context["variant"]: ThreadsGroupingComponent(
                 contributes=False,
                 hint="ignored because contains %d threads" % thread_count,
             )
@@ -471,14 +482,13 @@ def threads_legacy(
     stacktrace = interface.values[0].get("stacktrace")
     if not stacktrace:
         return {
-            context["variant"]: BaseGroupingComponent(
-                id="threads", contributes=False, hint="thread has no stacktrace"
+            context["variant"]: ThreadsGroupingComponent(
+                contributes=False, hint="thread has no stacktrace"
             )
         }
 
     return {
-        context["variant"]: BaseGroupingComponent(
-            id="threads",
+        context["variant"]: ThreadsGroupingComponent(
             values=[context.get_single_grouping_component(stacktrace, event=event, **meta)],
         )
     }

--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -4,7 +4,7 @@ from typing import Any
 from sentry import analytics
 from sentry.eventstore.models import Event
 from sentry.features.rollout import in_rollout_group
-from sentry.grouping.component import BaseGroupingComponent
+from sentry.grouping.component import MessageGroupingComponent
 from sentry.grouping.parameterization import Parameterizer, UniqueIdExperiment
 from sentry.grouping.strategies.base import (
     GroupingContext,
@@ -108,17 +108,10 @@ def message_v1(
         raw = interface.message or interface.formatted or ""
         normalized = normalize_message_for_grouping(raw, event)
         hint = "stripped event-specific values" if raw != normalized else None
-        return {
-            context["variant"]: BaseGroupingComponent(
-                id="message",
-                values=[normalized],
-                hint=hint,
-            )
-        }
+        return {context["variant"]: MessageGroupingComponent(values=[normalized], hint=hint)}
     else:
         return {
-            context["variant"]: BaseGroupingComponent(
-                id="message",
+            context["variant"]: MessageGroupingComponent(
                 values=[interface.message or interface.formatted or ""],
             )
         }

--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -4,7 +4,7 @@ from typing import Any
 from sentry import analytics
 from sentry.eventstore.models import Event
 from sentry.features.rollout import in_rollout_group
-from sentry.grouping.component import GroupingComponent
+from sentry.grouping.component import BaseGroupingComponent
 from sentry.grouping.parameterization import Parameterizer, UniqueIdExperiment
 from sentry.grouping.strategies.base import (
     GroupingContext,
@@ -109,7 +109,7 @@ def message_v1(
         normalized = normalize_message_for_grouping(raw, event)
         hint = "stripped event-specific values" if raw != normalized else None
         return {
-            context["variant"]: GroupingComponent(
+            context["variant"]: BaseGroupingComponent(
                 id="message",
                 values=[normalized],
                 hint=hint,
@@ -117,7 +117,7 @@ def message_v1(
         }
     else:
         return {
-            context["variant"]: GroupingComponent(
+            context["variant"]: BaseGroupingComponent(
                 id="message",
                 values=[interface.message or interface.formatted or ""],
             )

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -7,7 +7,7 @@ from collections.abc import Generator
 from typing import Any
 
 from sentry.eventstore.models import Event
-from sentry.grouping.component import GroupingComponent
+from sentry.grouping.component import BaseGroupingComponent
 from sentry.grouping.strategies.base import (
     GroupingContext,
     ReturnedVariants,
@@ -116,17 +116,17 @@ def get_filename_component(
     filename: str | None,
     platform: str | None,
     allow_file_origin: bool = False,
-) -> GroupingComponent:
+) -> BaseGroupingComponent:
     """Attempt to normalize filenames by detecting special filenames and by
     using the basename only.
     """
     if filename is None:
-        return GroupingComponent(id="filename")
+        return BaseGroupingComponent(id="filename")
 
     # Only use the platform independent basename for grouping and
     # lowercase it
     filename = _basename_re.split(filename)[-1].lower()
-    filename_component = GroupingComponent(
+    filename_component = BaseGroupingComponent(
         id="filename",
         values=[filename],
     )
@@ -151,14 +151,14 @@ def get_module_component(
     module: str | None,
     platform: str | None,
     context: GroupingContext,
-) -> GroupingComponent:
+) -> BaseGroupingComponent:
     """Given an absolute path, module and platform returns the module component
     with some necessary cleaning performed.
     """
     if module is None:
-        return GroupingComponent(id="module")
+        return BaseGroupingComponent(id="module")
 
-    module_component = GroupingComponent(
+    module_component = BaseGroupingComponent(
         id="module",
         values=[module],
     )
@@ -200,7 +200,7 @@ def get_function_component(
     platform: str | None,
     sourcemap_used: bool = False,
     context_line_available: bool = False,
-) -> GroupingComponent:
+) -> BaseGroupingComponent:
     """
     Attempt to normalize functions by removing common platform outliers.
 
@@ -230,9 +230,9 @@ def get_function_component(
             func = trim_function_name(func, platform)
 
     if not func:
-        return GroupingComponent(id="function")
+        return BaseGroupingComponent(id="function")
 
-    function_component = GroupingComponent(
+    function_component = BaseGroupingComponent(
         id="function",
         values=[func],
     )
@@ -332,7 +332,7 @@ def frame(
     if context_line_component is not None:
         values.append(context_line_component)
 
-    rv = GroupingComponent(id="frame", values=values)
+    rv = BaseGroupingComponent(id="frame", values=values)
 
     # if we are in javascript fuzzing mode we want to disregard some
     # frames consistently.  These force common bad stacktraces together
@@ -368,7 +368,7 @@ def frame(
 
 def get_contextline_component(
     frame: Frame, platform: str | None, function: str, context: GroupingContext
-) -> GroupingComponent:
+) -> BaseGroupingComponent:
     """Returns a contextline component.  The caller's responsibility is to
     make sure context lines are only used for platforms where we trust the
     quality of the sourcecode.  It does however protect against some bad
@@ -376,9 +376,9 @@ def get_contextline_component(
     """
     line = " ".join((frame.context_line or "").expandtabs(2).split())
     if not line:
-        return GroupingComponent(id="context-line")
+        return BaseGroupingComponent(id="context-line")
 
-    component = GroupingComponent(
+    component = BaseGroupingComponent(
         id="context-line",
         values=[line],
     )
@@ -498,7 +498,7 @@ def stacktrace_variant_processor(
 def single_exception(
     interface: SingleException, event: Event, context: GroupingContext, **meta: Any
 ) -> ReturnedVariants:
-    type_component = GroupingComponent(
+    type_component = BaseGroupingComponent(
         id="type",
         values=[interface.type] if interface.type else [],
     )
@@ -522,7 +522,7 @@ def single_exception(
                 contributes=False, hint="ignored because exception is synthetic"
             )
         if interface.mechanism.meta and "ns_error" in interface.mechanism.meta:
-            ns_error_component = GroupingComponent(
+            ns_error_component = BaseGroupingComponent(
                 id="ns-error",
                 values=[
                     interface.mechanism.meta["ns_error"].get("domain"),
@@ -538,7 +538,7 @@ def single_exception(
             )
     else:
         stacktrace_variants = {
-            "app": GroupingComponent(id="stacktrace"),
+            "app": BaseGroupingComponent(id="stacktrace"),
         }
 
     rv = {}
@@ -553,7 +553,7 @@ def single_exception(
             values.append(ns_error_component)
 
         if context["with_exception_value_fallback"]:
-            value_component = GroupingComponent(
+            value_component = BaseGroupingComponent(
                 id="value",
             )
 
@@ -587,7 +587,7 @@ def single_exception(
 
             values.append(value_component)
 
-        rv[variant] = GroupingComponent(id="exception", values=values)
+        rv[variant] = BaseGroupingComponent(id="exception", values=values)
 
     return rv
 
@@ -628,7 +628,7 @@ def chained_exception(
         return exception_components[id(exceptions[0])]
 
     # Case 2: produce a component for each chained exception
-    by_name: dict[str, list[GroupingComponent]] = {}
+    by_name: dict[str, list[BaseGroupingComponent]] = {}
 
     for exception in exceptions:
         for name, component in exception_components[id(exception)].items():
@@ -637,7 +637,7 @@ def chained_exception(
     rv = {}
 
     for name, component_list in by_name.items():
-        rv[name] = GroupingComponent(
+        rv[name] = BaseGroupingComponent(
             id="chained-exception",
             values=component_list,
         )
@@ -777,7 +777,7 @@ def threads(
         return thread_variants
 
     return {
-        "app": GroupingComponent(
+        "app": BaseGroupingComponent(
             id="threads",
             contributes=False,
             hint=(
@@ -798,7 +798,7 @@ def _filtered_threads(
     stacktrace = threads[0].get("stacktrace")
     if not stacktrace:
         return {
-            "app": GroupingComponent(
+            "app": BaseGroupingComponent(
                 id="threads", contributes=False, hint="thread has no stacktrace"
             )
         }
@@ -808,7 +808,7 @@ def _filtered_threads(
     for name, stacktrace_component in context.get_grouping_component(
         stacktrace, event=event, **meta
     ).items():
-        rv[name] = GroupingComponent(id="threads", values=[stacktrace_component])
+        rv[name] = BaseGroupingComponent(id="threads", values=[stacktrace_component])
 
     return rv
 

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -7,7 +7,20 @@ from collections.abc import Generator
 from typing import Any
 
 from sentry.eventstore.models import Event
-from sentry.grouping.component import BaseGroupingComponent
+from sentry.grouping.component import (
+    ChainedExceptionGroupingComponent,
+    ContextLineGroupingComponent,
+    ErrorTypeGroupingComponent,
+    ErrorValueGroupingComponent,
+    ExceptionGroupingComponent,
+    FilenameGroupingComponent,
+    FrameGroupingComponent,
+    FunctionGroupingComponent,
+    ModuleGroupingComponent,
+    NSErrorGroupingComponent,
+    StacktraceGroupingComponent,
+    ThreadsGroupingComponent,
+)
 from sentry.grouping.strategies.base import (
     GroupingContext,
     ReturnedVariants,
@@ -116,20 +129,17 @@ def get_filename_component(
     filename: str | None,
     platform: str | None,
     allow_file_origin: bool = False,
-) -> BaseGroupingComponent:
+) -> FilenameGroupingComponent:
     """Attempt to normalize filenames by detecting special filenames and by
     using the basename only.
     """
     if filename is None:
-        return BaseGroupingComponent(id="filename")
+        return FilenameGroupingComponent()
 
     # Only use the platform independent basename for grouping and
     # lowercase it
     filename = _basename_re.split(filename)[-1].lower()
-    filename_component = BaseGroupingComponent(
-        id="filename",
-        values=[filename],
-    )
+    filename_component = FilenameGroupingComponent(values=[filename])
 
     if has_url_origin(abs_path, allow_file_origin=allow_file_origin):
         filename_component.update(contributes=False, hint="ignored because frame points to a URL")
@@ -151,17 +161,14 @@ def get_module_component(
     module: str | None,
     platform: str | None,
     context: GroupingContext,
-) -> BaseGroupingComponent:
+) -> ModuleGroupingComponent:
     """Given an absolute path, module and platform returns the module component
     with some necessary cleaning performed.
     """
     if module is None:
-        return BaseGroupingComponent(id="module")
+        return ModuleGroupingComponent()
 
-    module_component = BaseGroupingComponent(
-        id="module",
-        values=[module],
-    )
+    module_component = ModuleGroupingComponent(values=[module])
 
     if platform == "javascript" and "/" in module and abs_path and abs_path.endswith(module):
         module_component.update(contributes=False, hint="ignored bad javascript module")
@@ -200,7 +207,7 @@ def get_function_component(
     platform: str | None,
     sourcemap_used: bool = False,
     context_line_available: bool = False,
-) -> BaseGroupingComponent:
+) -> FunctionGroupingComponent:
     """
     Attempt to normalize functions by removing common platform outliers.
 
@@ -230,12 +237,9 @@ def get_function_component(
             func = trim_function_name(func, platform)
 
     if not func:
-        return BaseGroupingComponent(id="function")
+        return FunctionGroupingComponent()
 
-    function_component = BaseGroupingComponent(
-        id="function",
-        values=[func],
-    )
+    function_component = FunctionGroupingComponent(values=[func])
 
     if platform == "ruby":
         if func.startswith("block "):
@@ -332,7 +336,7 @@ def frame(
     if context_line_component is not None:
         values.append(context_line_component)
 
-    rv = BaseGroupingComponent(id="frame", values=values)
+    rv = FrameGroupingComponent(values=values)
 
     # if we are in javascript fuzzing mode we want to disregard some
     # frames consistently.  These force common bad stacktraces together
@@ -368,7 +372,7 @@ def frame(
 
 def get_contextline_component(
     frame: Frame, platform: str | None, function: str, context: GroupingContext
-) -> BaseGroupingComponent:
+) -> ContextLineGroupingComponent:
     """Returns a contextline component.  The caller's responsibility is to
     make sure context lines are only used for platforms where we trust the
     quality of the sourcecode.  It does however protect against some bad
@@ -376,12 +380,9 @@ def get_contextline_component(
     """
     line = " ".join((frame.context_line or "").expandtabs(2).split())
     if not line:
-        return BaseGroupingComponent(id="context-line")
+        return ContextLineGroupingComponent()
 
-    component = BaseGroupingComponent(
-        id="context-line",
-        values=[line],
-    )
+    component = ContextLineGroupingComponent(values=[line])
     if line:
         if len(frame.context_line) > 120:
             component.update(hint="discarded because line too long", contributes=False)
@@ -498,8 +499,7 @@ def stacktrace_variant_processor(
 def single_exception(
     interface: SingleException, event: Event, context: GroupingContext, **meta: Any
 ) -> ReturnedVariants:
-    type_component = BaseGroupingComponent(
-        id="type",
+    type_component = ErrorTypeGroupingComponent(
         values=[interface.type] if interface.type else [],
     )
     system_type_component = type_component.shallow_copy()
@@ -522,8 +522,7 @@ def single_exception(
                 contributes=False, hint="ignored because exception is synthetic"
             )
         if interface.mechanism.meta and "ns_error" in interface.mechanism.meta:
-            ns_error_component = BaseGroupingComponent(
-                id="ns-error",
+            ns_error_component = NSErrorGroupingComponent(
                 values=[
                     interface.mechanism.meta["ns_error"].get("domain"),
                     interface.mechanism.meta["ns_error"].get("code"),
@@ -538,7 +537,7 @@ def single_exception(
             )
     else:
         stacktrace_variants = {
-            "app": BaseGroupingComponent(id="stacktrace"),
+            "app": StacktraceGroupingComponent(),
         }
 
     rv = {}
@@ -553,9 +552,7 @@ def single_exception(
             values.append(ns_error_component)
 
         if context["with_exception_value_fallback"]:
-            value_component = BaseGroupingComponent(
-                id="value",
-            )
+            value_component = ErrorValueGroupingComponent()
 
             raw = interface.value
             if raw is not None:
@@ -587,7 +584,7 @@ def single_exception(
 
             values.append(value_component)
 
-        rv[variant] = BaseGroupingComponent(id="exception", values=values)
+        rv[variant] = ExceptionGroupingComponent(values=values)
 
     return rv
 
@@ -628,7 +625,7 @@ def chained_exception(
         return exception_components[id(exceptions[0])]
 
     # Case 2: produce a component for each chained exception
-    by_name: dict[str, list[BaseGroupingComponent]] = {}
+    by_name: dict[str, list[ExceptionGroupingComponent]] = {}
 
     for exception in exceptions:
         for name, component in exception_components[id(exception)].items():
@@ -637,10 +634,7 @@ def chained_exception(
     rv = {}
 
     for name, component_list in by_name.items():
-        rv[name] = BaseGroupingComponent(
-            id="chained-exception",
-            values=component_list,
-        )
+        rv[name] = ChainedExceptionGroupingComponent(values=component_list)
 
     return rv
 
@@ -777,8 +771,7 @@ def threads(
         return thread_variants
 
     return {
-        "app": BaseGroupingComponent(
-            id="threads",
+        "app": ThreadsGroupingComponent(
             contributes=False,
             hint=(
                 "ignored because does not contain exactly one crashing, "
@@ -797,18 +790,14 @@ def _filtered_threads(
 
     stacktrace = threads[0].get("stacktrace")
     if not stacktrace:
-        return {
-            "app": BaseGroupingComponent(
-                id="threads", contributes=False, hint="thread has no stacktrace"
-            )
-        }
+        return {"app": ThreadsGroupingComponent(contributes=False, hint="thread has no stacktrace")}
 
     rv = {}
 
     for name, stacktrace_component in context.get_grouping_component(
         stacktrace, event=event, **meta
     ).items():
-        rv[name] = BaseGroupingComponent(id="threads", values=[stacktrace_component])
+        rv[name] = ThreadsGroupingComponent(values=[stacktrace_component])
 
     return rv
 

--- a/src/sentry/grouping/strategies/security.py
+++ b/src/sentry/grouping/strategies/security.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from sentry.eventstore.models import Event
-from sentry.grouping.component import GroupingComponent
+from sentry.grouping.component import BaseGroupingComponent
 from sentry.grouping.strategies.base import (
     GroupingContext,
     ReturnedVariants,
@@ -15,11 +15,11 @@ def _security_v1(
     reported_id: str, obj: SecurityReport, context: GroupingContext, **meta: Any
 ) -> ReturnedVariants:
     return {
-        context["variant"]: GroupingComponent(
+        context["variant"]: BaseGroupingComponent(
             id=reported_id,
             values=[
-                GroupingComponent(id="salt", values=[reported_id]),
-                GroupingComponent(id="hostname", values=[obj.hostname]),
+                BaseGroupingComponent(id="salt", values=[reported_id]),
+                BaseGroupingComponent(id="hostname", values=[obj.hostname]),
             ],
         )
     }
@@ -52,8 +52,8 @@ def hpkp_v1(
 @strategy(ids=["csp:v1"], interface=Csp, score=1003)
 @produces_variants(["default"])
 def csp_v1(interface: Csp, event: Event, context: GroupingContext, **meta: Any) -> ReturnedVariants:
-    violation_component = GroupingComponent(id="violation")
-    uri_component = GroupingComponent(id="uri")
+    violation_component = BaseGroupingComponent(id="violation")
+    uri_component = BaseGroupingComponent(id="uri")
 
     if interface.local_script_violation_type:
         violation_component.update(values=["'%s'" % interface.local_script_violation_type])
@@ -67,10 +67,10 @@ def csp_v1(interface: Csp, event: Event, context: GroupingContext, **meta: Any) 
         uri_component.update(values=[interface.normalized_blocked_uri])
 
     return {
-        context["variant"]: GroupingComponent(
+        context["variant"]: BaseGroupingComponent(
             id="csp",
             values=[
-                GroupingComponent(id="salt", values=[interface.effective_directive]),
+                BaseGroupingComponent(id="salt", values=[interface.effective_directive]),
                 violation_component,
                 uri_component,
             ],

--- a/src/sentry/grouping/strategies/template.py
+++ b/src/sentry/grouping/strategies/template.py
@@ -1,7 +1,11 @@
 from typing import Any
 
 from sentry.eventstore.models import Event
-from sentry.grouping.component import BaseGroupingComponent
+from sentry.grouping.component import (
+    ContextLineGroupingComponent,
+    FilenameGroupingComponent,
+    TemplateGroupingComponent,
+)
 from sentry.grouping.strategies.base import (
     GroupingContext,
     ReturnedVariants,
@@ -16,16 +20,16 @@ from sentry.interfaces.template import Template
 def template_v1(
     interface: Template, event: Event, context: GroupingContext, **meta: Any
 ) -> ReturnedVariants:
-    filename_component = BaseGroupingComponent(id="filename")
+    filename_component = FilenameGroupingComponent()
     if interface.filename is not None:
         filename_component.update(values=[interface.filename])
 
-    context_line_component = BaseGroupingComponent(id="context-line")
+    context_line_component = ContextLineGroupingComponent()
     if interface.context_line is not None:
         context_line_component.update(values=[interface.context_line])
 
     return {
-        context["variant"]: BaseGroupingComponent(
-            id="template", values=[filename_component, context_line_component]
+        context["variant"]: TemplateGroupingComponent(
+            values=[filename_component, context_line_component]
         )
     }

--- a/src/sentry/grouping/strategies/template.py
+++ b/src/sentry/grouping/strategies/template.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from sentry.eventstore.models import Event
-from sentry.grouping.component import GroupingComponent
+from sentry.grouping.component import BaseGroupingComponent
 from sentry.grouping.strategies.base import (
     GroupingContext,
     ReturnedVariants,
@@ -16,16 +16,16 @@ from sentry.interfaces.template import Template
 def template_v1(
     interface: Template, event: Event, context: GroupingContext, **meta: Any
 ) -> ReturnedVariants:
-    filename_component = GroupingComponent(id="filename")
+    filename_component = BaseGroupingComponent(id="filename")
     if interface.filename is not None:
         filename_component.update(values=[interface.filename])
 
-    context_line_component = GroupingComponent(id="context-line")
+    context_line_component = BaseGroupingComponent(id="context-line")
     if interface.context_line is not None:
         context_line_component.update(values=[interface.context_line])
 
     return {
-        context["variant"]: GroupingComponent(
+        context["variant"]: BaseGroupingComponent(
             id="template", values=[filename_component, context_line_component]
         )
     }

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -105,7 +105,7 @@ class PerformanceProblemVariant(BaseVariant):
 
 class ComponentVariant(BaseVariant):
     """A component variant is a variant that produces a hash from the
-    `GroupingComponent` it encloses.
+    `BaseGroupingComponent` it encloses.
     """
 
     type = "component"

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -18,7 +18,7 @@ from sentry.grouping.api import (
     get_default_grouping_config_dict,
     load_grouping_config,
 )
-from sentry.grouping.component import GroupingComponent
+from sentry.grouping.component import BaseGroupingComponent
 from sentry.grouping.enhancer import Enhancements
 from sentry.grouping.fingerprinting import FingerprintingRules
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
@@ -181,7 +181,7 @@ def dump_variant(
     if lines is None:
         lines = []
 
-    def _dump_component(component: GroupingComponent, indent: int) -> None:
+    def _dump_component(component: BaseGroupingComponent, indent: int) -> None:
         if not component.hint and not component.values:
             return
         if component.contributes or include_non_contributing:
@@ -195,7 +195,7 @@ def dump_variant(
                 )
             )
             for value in component.values:
-                if isinstance(value, GroupingComponent):
+                if isinstance(value, BaseGroupingComponent):
                     _dump_component(value, indent + 1)
                 else:
                     lines.append("{}{}".format("  " * (indent + 1), to_json(value)))
@@ -203,7 +203,7 @@ def dump_variant(
     lines.append("{}hash: {}".format("  " * indent, to_json(variant.get_hash())))
 
     for key, value in sorted(variant.__dict__.items()):
-        if isinstance(value, GroupingComponent):
+        if isinstance(value, BaseGroupingComponent):
             lines.append("{}{}:".format("  " * indent, key))
             _dump_component(value, indent + 1)
         elif key in ["config", "hash"]:

--- a/tests/sentry/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/grouping/test_grouphash_metadata.py
@@ -7,7 +7,7 @@ import pytest
 
 from sentry.eventstore.models import Event
 from sentry.grouping.api import get_default_grouping_config_dict
-from sentry.grouping.component import GroupingComponent
+from sentry.grouping.component import BaseGroupingComponent
 from sentry.grouping.ingest.grouphash_metadata import _get_hash_basis
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
 from sentry.grouping.variants import ComponentVariant
@@ -106,10 +106,10 @@ def test_unknown_hash_basis(
 
     unknown_variants = {
         "dogs": ComponentVariant(
-            GroupingComponent(
+            BaseGroupingComponent(
                 id="not_a_known_component_type",
                 contributes=True,
-                values=[GroupingComponent(id="dogs_are_great", contributes=True)],
+                values=[BaseGroupingComponent(id="dogs_are_great", contributes=True)],
             ),
             get_default_grouping_config_dict(),
         )


### PR DESCRIPTION
This adds a full taxonomy of `GroupingCompontent` subclasses, partially just as a form of documentation (we create this deeply nested `variants` structure when grouping, and it's helpful to understand what kind of data is in each part), and partially so that it's easier to write helpers dealing with different kinds of components and not have to constantly be checking for the presence of this or that attribute.

In order to support the subclassing, as few other changes have been made:

- Rename `GroupindComponent` to `BaseGroupingComponent`.
- Add class-level type declarations to `BaseGroupingComponent`.
- Allow `id` to be a class attribute (no longer require it to be passed to `__init__`).
- Use the class name (rather than hardcoded `GroupingComponent`) in `__repr__`.
- Add `int` to the `values` list type. (This is more of a bug fix, though it's also a necessary for the typing of `NSErrorGroupingComponent`. In fact, `values` has always been able to contain ints, but the incoming data isn't super strictly typed, so typechecking has passed even with this missing.)