### PR TITLE
feat(issue summary + issue-details): Move resources section to sidebar

### DIFF
--- a/static/app/views/issueDetails/streamline/resources.tsx
+++ b/static/app/views/issueDetails/streamline/resources.tsx
@@ -27,7 +27,8 @@ export default function Resources({configResources, eventPlatform, group}: Props
       {group.issueCategory !== IssueCategory.ERROR && configResources.description}
       <LinkSection>
         {links.map(({link, text}) => (
-          <LinkButton
+          <StyledLinkButton
+            priority="link"
             onClick={() =>
               trackAnalytics('issue_details.resources_link_clicked', {
                 organization,
@@ -40,7 +41,7 @@ export default function Resources({configResources, eventPlatform, group}: Props
             external
           >
             {text}
-          </LinkButton>
+          </StyledLinkButton>
         ))}
       </LinkSection>
     </div>
@@ -49,6 +50,12 @@ export default function Resources({configResources, eventPlatform, group}: Props
 
 const LinkSection = styled('div')`
   display: flex;
+  flex-direction: column;
   gap: ${space(1)};
   margin-top: ${space(1)};
+`;
+
+const StyledLinkButton = styled(LinkButton)`
+  text-decoration: underline;
+  align-self: flex-start;
 `;

--- a/static/app/views/issueDetails/streamline/resourcesSection.tsx
+++ b/static/app/views/issueDetails/streamline/resourcesSection.tsx
@@ -1,0 +1,35 @@
+import {Fragment} from 'react';
+
+import {t} from 'sentry/locale';
+import type {Event} from 'sentry/types/event';
+import type {Group} from 'sentry/types/group';
+import type {Project} from 'sentry/types/project';
+import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
+import Resources from 'sentry/views/issueDetails/streamline/resources';
+import {SidebarSectionTitle} from 'sentry/views/issueDetails/streamline/sidebar';
+
+export default function ResourcesSection({
+  group,
+  project,
+  event,
+}: {
+  event: Event | undefined;
+  group: Group;
+  project: Project;
+}) {
+  const config = getConfigForIssueType(group, project);
+
+  if (config.resources) {
+    return (
+      <Fragment>
+        <SidebarSectionTitle>{t('Resources')}</SidebarSectionTitle>
+        <Resources
+          eventPlatform={event?.platform}
+          group={group}
+          configResources={config.resources}
+        />
+      </Fragment>
+    );
+  }
+  return null;
+}

--- a/static/app/views/issueDetails/streamline/sidebar.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar.tsx
@@ -15,6 +15,7 @@ import {useUser} from 'sentry/utils/useUser';
 import StreamlinedActivitySection from 'sentry/views/issueDetails/streamline/activitySection';
 import FirstLastSeenSection from 'sentry/views/issueDetails/streamline/firstLastSeenSection';
 import PeopleSection from 'sentry/views/issueDetails/streamline/peopleSection';
+import ResourcesSection from 'sentry/views/issueDetails/streamline/resourcesSection';
 import {MergedIssuesSidebarSection} from 'sentry/views/issueDetails/streamline/sidebar/mergedSidebarSection';
 import {SimilarIssuesSidebarSection} from 'sentry/views/issueDetails/streamline/sidebar/similarIssuesSidebarSection';
 import SolutionsSection from 'sentry/views/issueDetails/streamline/solutionsSection';
@@ -46,11 +47,16 @@ export default function StreamlinedSidebar({group, event, project}: Props) {
 
   return (
     <Side>
-      {((organization.features.includes('ai-summary') &&
-        issueTypeConfig.issueSummary.enabled) ||
-        issueTypeConfig.resources) && (
+      {organization.features.includes('ai-summary') &&
+        issueTypeConfig.issueSummary.enabled && (
+          <Fragment>
+            <SolutionsSection group={group} project={project} event={event} />
+            <StyledBreak />
+          </Fragment>
+        )}
+      {issueTypeConfig.resources && (
         <Fragment>
-          <SolutionsSection group={group} project={project} event={event} />
+          <ResourcesSection group={group} project={project} event={event} />
           <StyledBreak />
         </Fragment>
       )}


### PR DESCRIPTION
Building toward the new design for the Solution Center / Issue Summary / Autofix, this PR moves the traditional Resources section into its own part of the streamlined sidebar instead of being inside the Solutions Center. The Solutions Center is only shown when the Issue Summary is available (in a future PR, this will become the Sentry AI drawer).

<img width="456" alt="Screenshot 2024-11-08 at 3 38 35 PM" src="https://github.com/user-attachments/assets/bcac2497-8995-4599-890f-69001bab00b3">
