### PR TITLE
feat(symbolication): Introduce "unsupported dsym" error

### DIFF
--- a/src/sentry/api/helpers/actionable_items_helper.py
+++ b/src/sentry/api/helpers/actionable_items_helper.py
@@ -40,6 +40,7 @@ priority_ranking = {
     EventError.NATIVE_MISSING_DSYM: ActionPriority.LOW,
     EventError.NATIVE_INTERNAL_FAILURE: ActionPriority.LOW,
     EventError.NATIVE_SYMBOLICATOR_FAILED: ActionPriority.LOW,
+    EventError.NATIVE_UNSUPPORTED_DSYM: ActionPriority.LOW,
     EventError.NATIVE_MISSING_OPTIONALLY_BUNDLED_DSYM: ActionPriority.LOW,
     EventError.PAST_TIMESTAMP: ActionPriority.LOW,
     EventError.PROGUARD_MISSING_LINENO: ActionPriority.LOW,

--- a/src/sentry/lang/native/error.py
+++ b/src/sentry/lang/native/error.py
@@ -15,6 +15,12 @@ USER_FIXABLE_ERRORS = (
     EventError.NATIVE_MISSING_DSYM,
     EventError.NATIVE_MISSING_OPTIONALLY_BUNDLED_DSYM,
     EventError.NATIVE_BAD_DSYM,
+    # We tried to use a debug file for a purpose it doesn't support.
+    # Currently this only happens when trying to symbolicate a
+    # CLR (.NET) event with a Windows PDB file. The tracking issue
+    # for supporting this is
+    # https://github.com/getsentry/team-ingest/issues/550.
+    EventError.NATIVE_UNSUPPORTED_DSYM,
     EventError.NATIVE_MISSING_SYMBOL,
     EventError.FETCH_GENERIC_ERROR,
     # Emitted for e.g. broken minidumps

--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -99,6 +99,8 @@ def _merge_frame(new_frame, symbolicated, platform="native"):
 def _handle_image_status(status, image, os, data):
     if status in ("found", "unused"):
         return
+    elif status == "unsupported":
+        error = SymbolicationFailed(type=EventError.NATIVE_UNSUPPORTED_DSYM)
     elif status == "missing":
         package = image.get("code_file")
         if not package:

--- a/src/sentry/models/eventerror.py
+++ b/src/sentry/models/eventerror.py
@@ -48,6 +48,7 @@ class EventError:
     NATIVE_SIMULATOR_FRAME = "native_simulator_frame"
     NATIVE_UNKNOWN_IMAGE = "native_unknown_image"
     NATIVE_SYMBOLICATOR_FAILED = "native_symbolicator_failed"
+    NATIVE_UNSUPPORTED_DSYM = "native_unsupported_dsym"
 
     # Processing: Proguard
     PROGUARD_MISSING_MAPPING = "proguard_missing_mapping"


### PR DESCRIPTION
This is intended to improve the user experience for cases like https://github.com/getsentry/symbolicator/issues/1539 in which we attempt to symbolicate a CLR event with a Windows PDB file. It maps the "unsupported" frame status returned by Symbolicator (https://github.com/getsentry/symbolicator/pull/1541) to a new error variant. Properly displaying and explaining this error is left for a future PR.