### PR TITLE
doc(inbound-filters): Disclaimer about obfuscated exceptions

### DIFF
--- a/static/app/views/settings/project/projectFilters/index.spec.tsx
+++ b/static/app/views/settings/project/projectFilters/index.spec.tsx
@@ -279,7 +279,7 @@ describe('ProjectFilters', function () {
 
     expect(
       await screen.findByText(
-        "Minidumps, errors in the minified production build of React, and Internet Explorer's i18n errors cannot be filtered by message."
+        "Minidumps, obfuscated or minified exceptions (ProGuard, errors in the minified production build of React), and Internet Explorer's i18n errors cannot be filtered by message."
       )
     ).toBeInTheDocument();
   });

--- a/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -375,7 +375,7 @@ function CustomFilters({project, disabled}: {disabled: boolean; project: Project
           {hasFeature && project.options?.['filters:error_messages'] && (
             <PanelAlert type="warning" data-test-id="error-message-disclaimer">
               {t(
-                "Minidumps, errors in the minified production build of React, and Internet Explorer's i18n errors cannot be filtered by message."
+                "Minidumps, obfuscated or minified exceptions (ProGuard, errors in the minified production build of React), and Internet Explorer's i18n errors cannot be filtered by message."
               )}
             </PanelAlert>
           )}


### PR DESCRIPTION
Exception names are obfuscated by ProGuard, so Relay cannot filter them.