### PR TITLE
test(alerts): increase "edits query" timeout

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -625,7 +625,7 @@ describe('Incident Rules Form', () => {
           }),
         })
       );
-    }, 7500);
+    }, 10000);
 
     it('switches from percent change to count', async () => {
       createWrapper({

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -611,8 +611,9 @@ describe('Incident Rules Form', () => {
         ruleId: rule.id,
       });
 
-      await userEvent.type(screen.getByTestId('query-builder-input'), 'has:http.url');
-      await userEvent.type(screen.getByTestId('query-builder-input'), '{enter}');
+      const queryInput = await screen.findByTestId('query-builder-input');
+      await userEvent.type(queryInput, 'has:http.url');
+      await userEvent.type(queryInput, '{enter}');
 
       await userEvent.click(screen.getByLabelText('Save Rule'));
 
@@ -624,7 +625,7 @@ describe('Incident Rules Form', () => {
           }),
         })
       );
-    });
+    }, 7500);
 
     it('switches from percent change to count', async () => {
       createWrapper({


### PR DESCRIPTION
Updates timeout for `ruleForm.spec.tsx` edits query test from 5s to 7.5s, since it has multiple `userEvent.type` calls which can be slow.