### PR TITLE
chore(sentryapp): add org id to installation verification response

### DIFF
--- a/src/sentry/sentry_apps/api/serializers/sentry_app_installation.py
+++ b/src/sentry/sentry_apps/api/serializers/sentry_app_installation.py
@@ -40,7 +40,7 @@ class SentryAppInstallationSerializer(Serializer):
         access = kwargs.get("access")
         data = {
             "app": {"uuid": attrs["sentry_app"].uuid, "slug": attrs["sentry_app"].slug},
-            "organization": {"slug": attrs["organization"].slug},
+            "organization": {"slug": attrs["organization"].slug, "id": attrs["organization"].id},
             "uuid": obj.uuid,
             "status": SentryAppInstallationStatus.as_str(obj.status),
         }

--- a/tests/sentry/sentry_apps/api/endpoints/test_organization_sentry_app_installation_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_organization_sentry_app_installation_details.py
@@ -69,7 +69,7 @@ class GetSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
         assert response.status_code == 200, response.content
         assert response.data == {
             "app": {"uuid": self.unpublished_app.uuid, "slug": self.unpublished_app.slug},
-            "organization": {"slug": self.org.slug},
+            "organization": {"slug": self.org.slug, "id": self.org.id},
             "uuid": self.installation2.uuid,
             "status": "pending",
         }
@@ -84,7 +84,7 @@ class GetSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
         assert response.status_code == 200, response.content
         assert response.data == {
             "app": {"uuid": self.unpublished_app.uuid, "slug": self.unpublished_app.slug},
-            "organization": {"slug": self.org.slug},
+            "organization": {"slug": self.org.slug, "id": self.org.id},
             "uuid": self.installation2.uuid,
             "code": self.orm_installation2.api_grant.code,
             "status": "pending",

--- a/tests/sentry/sentry_apps/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_organization_sentry_app_installations.py
@@ -50,7 +50,7 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
         assert response.data == [
             {
                 "app": {"slug": self.unpublished_app.slug, "uuid": self.unpublished_app.uuid},
-                "organization": {"slug": self.org.slug},
+                "organization": {"slug": self.org.slug, "id": self.org.id},
                 "uuid": self.installation2.uuid,
                 "code": self.installation2.api_grant.code,
                 "status": "installed",
@@ -62,7 +62,7 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
         assert response.data == [
             {
                 "app": {"slug": self.published_app.slug, "uuid": self.published_app.uuid},
-                "organization": {"slug": self.super_org.slug},
+                "organization": {"slug": self.super_org.slug, "id": self.super_org.id},
                 "uuid": self.installation.uuid,
                 "code": self.installation.api_grant.code,
                 "status": "installed",
@@ -94,7 +94,7 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
         assert response.data == [
             {
                 "app": {"slug": self.unpublished_app.slug, "uuid": self.unpublished_app.uuid},
-                "organization": {"slug": self.org.slug},
+                "organization": {"slug": self.org.slug, "id": self.org.id},
                 "uuid": self.installation2.uuid,
                 "code": self.installation2.api_grant.code,
                 "status": "installed",
@@ -115,7 +115,7 @@ class PostSentryAppInstallationsTest(SentryAppInstallationsTest):
         assert installation.api_grant is not None
         return {
             "app": {"slug": app.slug, "uuid": app.uuid},
-            "organization": {"slug": org.slug},
+            "organization": {"slug": org.slug, "id": org.id},
             "code": installation.api_grant.code,
         }
 

--- a/tests/sentry/sentry_apps/test_sentry_app_installation_notifier.py
+++ b/tests/sentry/sentry_apps/test_sentry_app_installation_notifier.py
@@ -57,7 +57,7 @@ class TestInstallationNotifier(TestCase):
             "data": {
                 "installation": {
                     "app": {"uuid": self.sentry_app.uuid, "slug": self.sentry_app.slug},
-                    "organization": {"slug": self.organization.slug},
+                    "organization": {"slug": self.organization.slug, "id": self.organization.id},
                     "uuid": self.install.uuid,
                     "code": self.install.api_grant.code,
                     "status": "installed",
@@ -90,7 +90,7 @@ class TestInstallationNotifier(TestCase):
             "data": {
                 "installation": {
                     "app": {"uuid": self.sentry_app.uuid, "slug": self.sentry_app.slug},
-                    "organization": {"slug": self.organization.slug},
+                    "organization": {"slug": self.organization.slug, "id": self.organization.id},
                     "uuid": self.install.uuid,
                     "code": self.install.api_grant.code,
                     "status": "installed",


### PR DESCRIPTION
we want to add the org id to the `SentryAppInstallationsEndpoint` response because org slug is mutable (see comment [here](https://github.com/getsentry/sentry/issues/78989#issuecomment-2465886004))