### PR TITLE
chore(issue-details): Turn off releases in event graph by default

### DIFF
--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -195,7 +195,7 @@ export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
     'issue-details-graph-legend',
     {
       ['Feature Flags']: true,
-      ['Releases']: true,
+      ['Releases']: false,
     }
   );
 


### PR DESCRIPTION
this pr updates the event graph to have releases off by default 