### PR TITLE
feat(ui): Re-enable eslint rules-of-hooks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
     jest: true,
   },
   rules: {
+    'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': [
       'error',
       {additionalHooks: '(useEffectAfterFirstRender|useMemoWithPrevious)'},

--- a/biome.json
+++ b/biome.json
@@ -19,7 +19,6 @@
       "correctness": {
         "noGlobalObjectCalls": "error",
         "noUnreachable": "error",
-        "useHookAtTopLevel": "error",
         "useIsNan": "error",
         "noUnusedPrivateClassMembers": "error",
         "noInvalidUseBeforeDeclaration": "error",

--- a/static/app/components/modals/inviteMembersModal/emailValue.tsx
+++ b/static/app/components/modals/inviteMembersModal/emailValue.tsx
@@ -10,10 +10,13 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 import type {InviteStatus} from './types';
 
-function renderEmailValue<Option extends OptionTypeBase>(
-  status: InviteStatus[string],
-  valueProps: MultiValueProps<Option>
-) {
+function EmailValue<Option extends OptionTypeBase>({
+  status,
+  valueProps,
+}: {
+  status: InviteStatus[string];
+  valueProps: MultiValueProps<Option>;
+}) {
   const organization = useOrganization();
   const {children, ...props} = valueProps;
   const error = status?.error;
@@ -58,4 +61,4 @@ SendingIndicator.defaultProps = {
   size: 14,
 };
 
-export default renderEmailValue;
+export default EmailValue;

--- a/static/app/components/modals/inviteMembersModal/inviteRowControl.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteRowControl.tsx
@@ -13,7 +13,7 @@ import {t} from 'sentry/locale';
 import type {SelectValue} from 'sentry/types/core';
 import type {OrgRole} from 'sentry/types/organization';
 
-import renderEmailValue from './renderEmailValue';
+import EmailValue from './emailValue';
 import type {InviteStatus} from './types';
 
 type SelectOption = SelectValue<string>;
@@ -33,13 +33,6 @@ type Props = {
   teams: string[];
   className?: string;
 };
-
-function ValueComponent(
-  props: MultiValueProps<SelectOption>,
-  inviteStatus: Props['inviteStatus']
-) {
-  return renderEmailValue(inviteStatus[props.data.value], props);
-}
 
 function mapToOptions(values: string[]): SelectOption[] {
   return values.map(value => ({value, label: value}));
@@ -100,7 +93,9 @@ function InviteRowControl({
         inputValue={inputValue}
         value={emails}
         components={{
-          MultiValue: props => ValueComponent(props, inviteStatus),
+          MultiValue: (props: any) => (
+            <EmailValue status={inviteStatus[props.data.value]} valueProps={props} />
+          ),
           DropdownIndicator: () => null,
         }}
         options={mapToOptions(emails)}

--- a/static/app/components/modals/inviteMembersModal/inviteRowControl.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteRowControl.tsx
@@ -93,7 +93,7 @@ function InviteRowControl({
         inputValue={inputValue}
         value={emails}
         components={{
-          MultiValue: (props: any) => (
+          MultiValue: (props: MultiValueProps<SelectOption>) => (
             <EmailValue status={inviteStatus[props.data.value]} valueProps={props} />
           ),
           DropdownIndicator: () => null,

--- a/static/app/components/modals/inviteMembersModal/inviteRowControlNew.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteRowControlNew.tsx
@@ -93,7 +93,7 @@ function InviteRowControl({roleDisabledUnallowed, roleOptions}: Props) {
           inputValue={inputValue}
           value={emails}
           components={{
-            MultiValue: (props: any) => (
+            MultiValue: (props: MultiValueProps<SelectOption>) => (
               <EmailValue status={inviteStatus[props.data.value]} valueProps={props} />
             ),
             DropdownIndicator: () => null,

--- a/static/app/components/modals/inviteMembersModal/inviteRowControlNew.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteRowControlNew.tsx
@@ -14,7 +14,7 @@ import {space} from 'sentry/styles/space';
 import type {SelectValue} from 'sentry/types/core';
 import type {OrgRole} from 'sentry/types/organization';
 
-import renderEmailValue from './renderEmailValue';
+import EmailValue from './emailValue';
 import type {InviteStatus} from './types';
 
 type SelectOption = SelectValue<string>;
@@ -23,13 +23,6 @@ type Props = {
   roleDisabledUnallowed: boolean;
   roleOptions: OrgRole[];
 };
-
-function ValueComponent(
-  props: MultiValueProps<SelectOption>,
-  inviteStatus: InviteStatus
-) {
-  return renderEmailValue(inviteStatus[props.data.value], props);
-}
 
 function mapToOptions(values: string[]): SelectOption[] {
   return values.map(value => ({value, label: value}));
@@ -100,7 +93,9 @@ function InviteRowControl({roleDisabledUnallowed, roleOptions}: Props) {
           inputValue={inputValue}
           value={emails}
           components={{
-            MultiValue: props => ValueComponent(props, inviteStatus),
+            MultiValue: (props: any) => (
+              <EmailValue status={inviteStatus[props.data.value]} valueProps={props} />
+            ),
             DropdownIndicator: () => null,
           }}
           options={mapToOptions(emails)}

--- a/static/app/utils/useLocation.tsx
+++ b/static/app/utils/useLocation.tsx
@@ -19,10 +19,10 @@ export function useLocation<Q extends Query = DefaultQuery>(): Location<Q> {
     return legacyRouterContext.location;
   }
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: react-router 6 migration
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const router6Location = useReactRouter6Location();
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: react-router 6 migration
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const location = useMemo(
     () => location6ToLocation3<Q>(router6Location),
     [router6Location]

--- a/static/app/utils/useNavigate.tsx
+++ b/static/app/utils/useNavigate.tsx
@@ -29,13 +29,13 @@ export function useNavigate(): ReactRouter3Navigate {
   const legacyRouterContext = useRouteContext();
 
   if (!legacyRouterContext) {
-    // biome-ignore lint/correctness/useHookAtTopLevel: react-router-6 migration
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const router6Navigate = useReactRouter6Navigate();
 
     // XXX(epurkhiser): Translate legacy LocationDescriptor to To in the
     // navigate helper.
 
-    // biome-ignore lint/correctness/useHookAtTopLevel: react-router-6 migration
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const navigate = useCallback<ReactRouter3Navigate>(
       (to: LocationDescriptor | number, options: NavigateOptions = {}) =>
         typeof to === 'number'
@@ -52,15 +52,15 @@ export function useNavigate(): ReactRouter3Navigate {
 
   const {router} = legacyRouterContext;
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: react-router-6 migration
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const hasMountedRef = useRef(false);
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: react-router-6 migration
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
     hasMountedRef.current = true;
   });
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: react-router-6 migration
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const navigate = useCallback<ReactRouter3Navigate>(
     (to: LocationDescriptor | number, options: NavigateOptions = {}) => {
       if (!hasMountedRef.current) {

--- a/static/app/utils/useParams.tsx
+++ b/static/app/utils/useParams.tsx
@@ -13,7 +13,7 @@ export function useParams<P = Record<string, string>>(): P {
   let contextParams: any;
 
   if (!legacyRouterContext) {
-    // biome-ignore lint/correctness/useHookAtTopLevel: react-router 6 migration
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     contextParams = useReactRouter6Params();
   } else {
     contextParams = legacyRouterContext.params;

--- a/static/app/utils/useRouter.tsx
+++ b/static/app/utils/useRouter.tsx
@@ -24,17 +24,17 @@ function useRouter(): InjectedRouter<any, any> {
     return legacyRouterContext.router;
   }
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: react-router 6 migration
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const navigate = useNavigate();
-  // biome-ignore lint/correctness/useHookAtTopLevel: react-router 6 migration
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const location = useLocation();
-  // biome-ignore lint/correctness/useHookAtTopLevel: react-router 6 migration
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const params = useParams();
-  // biome-ignore lint/correctness/useHookAtTopLevel: react-router 6 migration
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const routes = useRoutes();
 
   // XXX(epurkhiser): We emulate the react-router 3 `router` interface here
-  // biome-ignore lint/correctness/useHookAtTopLevel: react-router 6 migration
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const router = useMemo(
     () =>
       ({

--- a/static/app/utils/useRoutes.tsx
+++ b/static/app/utils/useRoutes.tsx
@@ -14,13 +14,13 @@ export function useRoutes(): PlainRoute<any>[] {
     return legacyRouterContext.routes;
   }
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: react-router-6 migration
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const matches = useMatches();
 
   // XXX(epurkhiser): This transforms react-router 6 style matches back to old
   // style react-router 3 rroute matches.
   //
-  // biome-ignore lint/correctness/useHookAtTopLevel: react-router-6 migration
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   return useMemo(
     () =>
       matches.map<PlainRoute>(match => {

--- a/static/app/views/insights/common/components/issues.tsx
+++ b/static/app/views/insights/common/components/issues.tsx
@@ -80,7 +80,7 @@ function IssueListHeader({issues}: {issues?: Group[]}) {
   );
 }
 
-function fetchIssues(
+function useInsightIssues(
   issueTypes: string[],
   message?: string
 ): {isLoading: boolean; issues?: Group[]} {
@@ -134,7 +134,7 @@ export default function InsightIssuesList({
   issueTypes: string[];
   message?: string;
 }) {
-  const {isLoading, issues} = fetchIssues(issueTypes, message);
+  const {isLoading, issues} = useInsightIssues(issueTypes, message);
 
   if (isLoading || issues?.length === 0) {
     return <Fragment />;

--- a/static/app/views/insights/common/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/insights/common/views/spans/spanTimeCharts.tsx
@@ -308,7 +308,7 @@ function ErrorChart({moduleName, filters}: ChartProps): JSX.Element {
 }
 
 /** This fucntion is just to generate mock data based on other time stamps we have found */
-const mockSeries = ({moduleName, filters, extraQuery}: ChartProps) => {
+const useMockSeries = ({moduleName, filters, extraQuery}: ChartProps) => {
   const pageFilters = usePageFilters();
   const eventView = getEventView(moduleName, pageFilters.selection, filters);
   if (extraQuery) {
@@ -359,7 +359,7 @@ const mockSeries = ({moduleName, filters, extraQuery}: ChartProps) => {
 };
 
 function BundleSizeChart(props: ChartProps) {
-  const {isPending, data} = mockSeries(props);
+  const {isPending, data} = useMockSeries(props);
   return (
     <Chart
       stacked

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/ancestry.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/ancestry.tsx
@@ -155,7 +155,7 @@ function SpanChildrenTraversalButton({
   );
 }
 
-export function getSpanAncestryAndGroupingItems({
+export function useSpanAncestryAndGroupingItems({
   node,
   onParentClick,
   location,

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/generalInfo.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/generalInfo.tsx
@@ -12,7 +12,7 @@ import type {TraceTree} from '../../../../traceModels/traceTree';
 import type {TraceTreeNode} from '../../../../traceModels/traceTreeNode';
 import {type SectionCardKeyValueList, TraceDrawerComponents} from '../../styles';
 
-import {getSpanAncestryAndGroupingItems} from './ancestry';
+import {useSpanAncestryAndGroupingItems} from './ancestry';
 
 type GeneralnfoProps = {
   location: Location;
@@ -134,7 +134,7 @@ export function GeneralInfo(props: GeneralnfoProps) {
     });
   }
 
-  const ancestryAndGroupingItems = getSpanAncestryAndGroupingItems({
+  const ancestryAndGroupingItems = useSpanAncestryAndGroupingItems({
     node: props.node,
     onParentClick: props.onParentClick,
     location: props.location,


### PR DESCRIPTION
biome supports `useHookAtTopLevel` and `useExhaustiveDependencies` but its missing functionality of eslint rules of hooks that can lead to hooks being used inside functions that are not named correctly

related https://github.com/biomejs/biome/issues/1984
