### PR TITLE
fix(project-details): Use correct dataset for 'Number of Errors' chart

### DIFF
--- a/static/app/views/projectDetail/charts/projectBaseEventsChart.tsx
+++ b/static/app/views/projectDetail/charts/projectBaseEventsChart.tsx
@@ -28,6 +28,10 @@ type Props = Omit<
 };
 
 class ProjectBaseEventsChart extends Component<Props> {
+  defaultProps = {
+    dataset: DiscoverDatasets.METRICS_ENHANCED,
+  };
+
   componentDidMount() {
     this.fetchTotalCount();
   }
@@ -39,14 +43,15 @@ class ProjectBaseEventsChart extends Component<Props> {
   }
 
   async fetchTotalCount() {
-    const {api, organization, selection, onTotalValuesChange, query} = this.props;
+    const {api, organization, selection, onTotalValuesChange, query, dataset} =
+      this.props;
     const {projects, environments, datetime} = selection;
 
     try {
       const totals = await fetchTotalCount(api, organization.slug, {
         field: [],
         query,
-        dataset: DiscoverDatasets.METRICS_ENHANCED,
+        dataset,
         environment: environments,
         project: projects.map(proj => String(proj)),
         ...normalizeDateTimeParams(datetime),
@@ -69,6 +74,7 @@ class ProjectBaseEventsChart extends Component<Props> {
       field,
       title,
       help,
+      dataset,
       ...eventsChartProps
     } = this.props;
     const {projects, environments, datetime} = selection;
@@ -85,7 +91,7 @@ class ProjectBaseEventsChart extends Component<Props> {
           query={query}
           api={api}
           projects={projects}
-          dataset={DiscoverDatasets.METRICS_ENHANCED}
+          dataset={dataset}
           environments={environments}
           start={start}
           end={end}

--- a/static/app/views/projectDetail/projectCharts.tsx
+++ b/static/app/views/projectDetail/projectCharts.tsx
@@ -33,6 +33,7 @@ import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import withApi from 'sentry/utils/withApi';
@@ -406,6 +407,7 @@ class ProjectCharts extends Component<Props, State> {
                     interval={this.barChartInterval}
                     chartComponent={BarChart}
                     disableReleases
+                    dataset={DiscoverDatasets.ERRORS}
                   />
                 ) : (
                   <ProjectErrorsBasicChart


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/80516

[This PR](https://github.com/getsentry/sentry/pull/57657) changed project details charts to use the METRICS_ENHANCED dataset. However, the errors chart should be looking at the ERRORS dataset.

Looking at our Javascript project, we go from 2.3M to 76K which matches discover:

 Before:
![CleanShot 2024-11-11 at 11 43 23](https://github.com/user-attachments/assets/2c2cd75d-8edc-4a84-90dc-df443c90ad5b)

After:
![CleanShot 2024-11-11 at 11 44 20](https://github.com/user-attachments/assets/34d30005-7d1c-4c47-8901-ec0c6dd048be)
