### PR TITLE
chore(grouping): Remove unused `silent` parameter in grouping config helper

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -136,7 +136,7 @@ class BackgroundGroupingConfigLoader(GroupingConfigLoader):
 
 
 @sentry_sdk.tracing.trace
-def get_grouping_config_dict_for_project(project, silent=True) -> GroupingConfig:
+def get_grouping_config_dict_for_project(project) -> GroupingConfig:
     """Fetches all the information necessary for grouping from the project
     settings.  The return value of this is persisted with the event on
     ingestion so that the grouping algorithm can be re-run later.


### PR DESCRIPTION
This removes the optional `silent` parameter from `get_grouping_config_dict_for_project`, which isn't used anywhere in the function (and hasn't been since https://github.com/getsentry/sentry/pull/12995 was merged five years ago).