### PR TITLE
chore(grouping): Remove unused `collect_tag_data`

### DIFF
--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -301,25 +301,6 @@ def repair_group_environment_data(caches, project, events):
         )
 
 
-def collect_tag_data(events):
-    results: dict[tuple[int, str], dict[str, dict[str, tuple[int, datetime, datetime]]]] = {}
-
-    for event in events:
-        environment = get_environment_name(event)
-        tags = results.setdefault((event.group_id, environment), {})
-
-        for key, value in event.tags:
-            values = tags.setdefault(key, {})
-
-            if value in values:
-                times_seen, first_seen, last_seen = values[value]
-                values[value] = (times_seen + 1, event.datetime, last_seen)
-            else:
-                values[value] = (1, event.datetime, event.datetime)
-
-    return results
-
-
 def get_environment_name(event) -> str:
     return Environment.get_name_or_default(event.get_tag("environment"))
 


### PR DESCRIPTION
This removes the unmerge `collect_tag_data` helper, whose last usage was removed in https://github.com/getsentry/sentry/pull/15033.