### PR TITLE
feat(workflow-engine): App basic serializers for workflow engine apis

### DIFF
--- a/src/sentry/workflow_engine/apps.py
+++ b/src/sentry/workflow_engine/apps.py
@@ -5,4 +5,4 @@ class Config(AppConfig):
     name = "sentry.workflow_engine"
 
     def ready(self):
-        pass
+        from sentry.workflow_engine.endpoints import serializers  # NOQA

--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -1,0 +1,111 @@
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from sentry.api.serializers import Serializer, register, serialize
+from sentry.workflow_engine.models import (
+    DataCondition,
+    DataConditionGroup,
+    DataSource,
+    DataSourceDetector,
+    Detector,
+)
+
+
+@register(DataSource)
+class DataSourceSerializer(Serializer):
+    def serialize(self, obj: DataSource, attrs: Mapping[str, Any], user, **kwargs):
+        return {
+            "id": str(obj.id),
+            "organizationId": str(obj.organization_id),
+            "type": obj.type,
+            "queryId": str(obj.query_id),
+        }
+
+
+@register(DataCondition)
+class DataConditionSerializer(Serializer):
+    def serialize(self, obj: DataCondition, *args, **kwargs):
+        return {
+            "id": str(obj.id),
+            "condition": obj.condition,
+            "comparison": obj.comparison,
+            "result": obj.condition_result,
+        }
+
+
+@register(DataConditionGroup)
+class DataConditionGroupSerializer(Serializer):
+    def get_attrs(self, item_list: Sequence[DataConditionGroup], user, **kwargs):
+        attrs: Mapping[DataConditionGroup, Any] = defaultdict(dict)
+        conditions = defaultdict(list)
+
+        condition_list = list(DataCondition.objects.filter(condition_group__in=item_list))
+
+        for condition, serialized in zip(condition_list, serialize(condition_list, user=user)):
+            conditions[condition.condition_group_id].append(serialized)
+
+        for item in item_list:
+            attrs[item]["conditions"] = conditions.get(item.id, [])
+
+        return attrs
+
+    def serialize(self, obj: DataConditionGroup, attrs: Mapping[str, Any], user, **kwargs):
+        return {
+            "id": str(obj.id),
+            "organizationId": str(obj.organization_id),
+            "logicType": obj.logic_type,
+            "conditions": attrs.get("conditions"),
+        }
+
+
+@register(Detector)
+class DetectorSerializer(Serializer):
+    def get_attrs(self, item_list: Sequence[Detector], user, **kwargs):
+        attrs: Mapping[Detector, Any] = defaultdict(dict)
+
+        dsd_list = list(
+            DataSourceDetector.objects.filter(detector__in=item_list).select_related("data_source")
+        )
+        data_sources = {dsd.data_source for dsd in dsd_list}
+        serialized_data_sources = {
+            ds.id: serialized
+            for ds, serialized in zip(data_sources, serialize(data_sources, user=user))
+        }
+        ds_map = defaultdict(list)
+        for dsd in dsd_list:
+            ds_map[dsd.detector_id].append(serialized_data_sources[dsd.data_source_id])
+
+        condition_groups = list(
+            DataConditionGroup.objects.filter(
+                id__in=[
+                    d.workflow_condition_group_id
+                    for d in item_list
+                    if d.workflow_condition_group_id
+                ]
+            )
+        )
+        condition_group_map = {
+            str(group.id): serialized
+            for group, serialized in zip(condition_groups, serialize(condition_groups, user=user))
+        }
+
+        for item in item_list:
+            attrs[item]["data_sources"] = ds_map.get(item.id)
+            attrs[item]["condition_group"] = condition_group_map.get(
+                str(item.workflow_condition_group_id)
+            )
+
+        return attrs
+
+    def serialize(self, obj: Detector, attrs: Mapping[str, Any], user, **kwargs):
+        return {
+            "id": str(obj.id),
+            "organizationId": str(obj.organization_id),
+            "name": obj.name,
+            "type": obj.type,
+            "dateCreated": obj.date_added,
+            "dateUpdated": obj.date_updated,
+            "dataSources": attrs.get("data_sources"),
+            "conditionGroup": attrs.get("condition_group"),
+        }

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -1,0 +1,161 @@
+from sentry.api.serializers import serialize
+from sentry.incidents.grouptype import MetricAlertFire
+from sentry.testutils.cases import TestCase
+from sentry.workflow_engine.models import DataCondition, DataConditionGroup, DataSource, Detector
+from sentry.workflow_engine.types import DetectorPriorityLevel
+
+
+class TestDetectorSerializer(TestCase):
+    def test_serialize_simple(self):
+        detector = Detector.objects.create(
+            organization_id=self.organization.id,
+            name="Test Detector",
+            type=MetricAlertFire.slug,
+        )
+
+        result = serialize(detector)
+
+        assert result == {
+            "id": str(detector.id),
+            "organizationId": str(self.organization.id),
+            "name": "Test Detector",
+            "type": MetricAlertFire.slug,
+            "dateCreated": detector.date_added,
+            "dateUpdated": detector.date_updated,
+            "dataSources": None,
+            "conditionGroup": None,
+        }
+
+    def test_serialize_full(self):
+        condition_group = DataConditionGroup.objects.create(
+            organization_id=self.organization.id,
+            logic_type=DataConditionGroup.Type.ANY,
+        )
+        condition = DataCondition.objects.create(
+            condition_group=condition_group,
+            condition="gt",
+            comparison=100,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+        detector = Detector.objects.create(
+            organization_id=self.organization.id,
+            name="Test Detector",
+            type=MetricAlertFire.slug,
+            workflow_condition_group=condition_group,
+        )
+        data_source = DataSource.objects.create(
+            organization_id=self.organization.id,
+            type=DataSource.Type.SNUBA_QUERY_SUBSCRIPTION,
+            query_id=1,
+        )
+        data_source.detectors.set([detector])
+
+        result = serialize(detector)
+
+        assert result == {
+            "id": str(detector.id),
+            "organizationId": str(self.organization.id),
+            "name": "Test Detector",
+            "type": MetricAlertFire.slug,
+            "dateCreated": detector.date_added,
+            "dateUpdated": detector.date_updated,
+            "dataSources": [
+                {
+                    "id": str(data_source.id),
+                    "organizationId": str(self.organization.id),
+                    "type": 1,
+                    "queryId": "1",
+                }
+            ],
+            "conditionGroup": {
+                "id": str(condition_group.id),
+                "organizationId": str(self.organization.id),
+                "logicType": DataConditionGroup.Type.ANY,
+                "conditions": [
+                    {
+                        "id": str(condition.id),
+                        "condition": "gt",
+                        "comparison": 100,
+                        "result": DetectorPriorityLevel.HIGH,
+                    }
+                ],
+            },
+        }
+
+    def test_serialize_bulk(self):
+        detectors = [
+            Detector.objects.create(
+                organization_id=self.organization.id,
+                name=f"Test Detector {i}",
+                type=MetricAlertFire.slug,
+            )
+            for i in range(2)
+        ]
+
+        result = serialize(detectors)
+
+        assert len(result) == 2
+        assert all(d["name"] in ["Test Detector 0", "Test Detector 1"] for d in result)
+
+
+class TestDataSourceSerializer(TestCase):
+    def test_serialize(self):
+        data_source = DataSource.objects.create(
+            organization_id=self.organization.id,
+            type=DataSource.Type.SNUBA_QUERY_SUBSCRIPTION,
+            query_id=1,
+        )
+
+        result = serialize(data_source)
+
+        assert result == {
+            "id": str(data_source.id),
+            "organizationId": str(self.organization.id),
+            "type": DataSource.Type.SNUBA_QUERY_SUBSCRIPTION,
+            "queryId": "1",
+        }
+
+
+class TestDataConditionGroupSerializer(TestCase):
+    def test_serialize_simple(self):
+        condition_group = DataConditionGroup.objects.create(
+            organization_id=self.organization.id,
+            logic_type=DataConditionGroup.Type.ANY,
+        )
+
+        result = serialize(condition_group)
+
+        assert result == {
+            "id": str(condition_group.id),
+            "organizationId": str(self.organization.id),
+            "logicType": DataConditionGroup.Type.ANY,
+            "conditions": [],
+        }
+
+    def test_serialize_with_conditions(self):
+        condition_group = DataConditionGroup.objects.create(
+            organization_id=self.organization.id,
+            logic_type=DataConditionGroup.Type.ANY,
+        )
+        condition = DataCondition.objects.create(
+            condition_group=condition_group,
+            condition="gt",
+            comparison=100,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+
+        result = serialize(condition_group)
+
+        assert result == {
+            "id": str(condition_group.id),
+            "organizationId": str(self.organization.id),
+            "logicType": DataConditionGroup.Type.ANY,
+            "conditions": [
+                {
+                    "id": str(condition.id),
+                    "condition": "gt",
+                    "comparison": 100,
+                    "result": DetectorPriorityLevel.HIGH,
+                }
+            ],
+        }


### PR DESCRIPTION
This implements serializers for returning responses from workflow engine apis. Datasource should return the extra data about its specific query type, I'll implement that separately

<!-- Describe your PR here. -->