### PR TITLE
chore(ui): Disable biome on package.json

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -95,7 +95,8 @@
       "**/*.sourcemap.js",
       "**/*.min.js",
       "fixtures",
-      ".devenv"
+      ".devenv",
+      "package.json"
     ]
   },
   "css": {


### PR DESCRIPTION
yarn formats it and biome tries to format it back, the formatting of package.json really doesn't matter.

goal: `yarn lint` currently does not pass
