### PR TITLE
chore(grouping): Remove unused `legacy_function_logic` grouping config option

### DIFF
--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -36,10 +36,6 @@ BASE_STRATEGY = create_strategy_configuration(
         # This turns on the automatic message trimming and parameter substitution
         # by the message strategy.
         "normalize_message": False,
-        # newstyle: enables the legacy function logic.  This is only used
-        # by the newstyle:2019-04-05 strategy.  Once this is no longer used
-        # this can go away entirely.
-        "legacy_function_logic": False,
         # newstyle: turns on some javascript fuzzing features.
         "javascript_fuzzing": False,
         # newstyle: platforms for which context line should be taken into


### PR DESCRIPTION
The docstring for the `legacy_function_logic` grouping config option states,

`This is only used by the newstyle:2019-04-05 strategy.  Once this is no longer used this can go away entirely.` 

The `newstyle:2019-04-05` strategy no longer exists, so this removes the now-unused `legacy_function_logic` option.