### PR TITLE
fix(grouping): Fix assertion in `get_hashes` test

### DIFF
--- a/tests/sentry/eventstore/test_models.py
+++ b/tests/sentry/eventstore/test_models.py
@@ -428,7 +428,7 @@ class EventTest(TestCase, PerformanceIssueTestCase):
         variants = event.get_grouping_variants()
 
         assert hashes == expected_hash_values
-        assert expected_variants == expected_variants
+        assert variants == expected_variants
 
         # Since the `variants` dictionaries are equal, it suffices to only check the values in one
         assert "default" in variants


### PR DESCRIPTION
This fixes a bug in one of the `Event.get_hashes` tests, wherein we've been comparing the expected value to itself rather than to the calculated value.