### PR TITLE
fix(grouping): Make built-in fingerprinting SDK test more general

### DIFF
--- a/tests/sentry/grouping/test_builtin_fingerprinting.py
+++ b/tests/sentry/grouping/test_builtin_fingerprinting.py
@@ -590,9 +590,9 @@ class BuiltInFingerprintingTest(TestCase):
 
     def test_built_in_chunkload_rules_wrong_sdk(self):
         """
-        Built-in ChunkLoadError rule should also apply event if SDK is not sentry.javascript.nextjs.
+        Built-in ChunkLoadError rule should also apply regardless of the SDK value.
         """
-        self.chunkload_error_trace["sdk"]["name"] = "sentry.javascript.react"
+        self.chunkload_error_trace["sdk"]["name"] = "not.a.real.SDK"
 
         event = self._get_event_for_trace(stacktrace=self.chunkload_error_trace)
 


### PR DESCRIPTION
When we worked on how we group `ChunkLoadError`s, we talked about them as if they were something unique to nextjs, but that's not actually true. They're errors thrown by Webpack, which is used by nextjs but also used by other frameworks and also used just on its own. We therefore should really be testing that our grouping works for all SDKs, not just non-nextjs SDKs. This fixes the relevant test to reflect that.