### PR TITLE
ref(alerts): Add metrics timer to Seer call

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -398,12 +398,15 @@ class SubscriptionProcessor:
             has_anomaly_detection
             and self.alert_rule.detection_type == AlertRuleDetectionType.DYNAMIC
         ):
-            potential_anomalies = get_anomaly_data_from_seer(
-                alert_rule=self.alert_rule,
-                subscription=self.subscription,
-                last_update=self.last_update.timestamp(),
-                aggregation_value=aggregation_value,
-            )
+            with metrics.timer(
+                "incidents.subscription_processor.process_update.get_anomaly_data_from_seer"
+            ):
+                potential_anomalies = get_anomaly_data_from_seer(
+                    alert_rule=self.alert_rule,
+                    subscription=self.subscription,
+                    last_update=self.last_update.timestamp(),
+                    aggregation_value=aggregation_value,
+                )
             if potential_anomalies is None:
                 logger.info(
                     "No potential anomalies found",


### PR DESCRIPTION
Add a timer so we can track the latency here as compared to the total latency of `process_update`.