### PR TITLE
feat(metric-issues-poc): Create metric issue when alert actions are evaluated

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -186,6 +186,7 @@ def register_temporary_features(manager: FeatureManager):
     # Enable issue stream table layout changes
     manager.add("organizations:issue-stream-table-layout", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:large-debug-files", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
+    manager.add("organizations:metric-issue-poc", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable members to invite teammates to organizations
     manager.add("organizations:members-invite-teammates", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:mep-rollout-flag", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -42,6 +42,7 @@ from sentry.incidents.models.incident import (
     TriggerStatus,
 )
 from sentry.incidents.tasks import handle_trigger_action
+from sentry.incidents.utils.metric_issue_poc import create_or_update_metric_issue
 from sentry.incidents.utils.types import QuerySubscriptionUpdate
 from sentry.models.project import Project
 from sentry.seer.anomaly_detection.get_anomaly_data import get_anomaly_data_from_seer
@@ -779,6 +780,12 @@ class SubscriptionProcessor:
                     metric_value=metric_value,
                 ).delay,
                 router.db_for_write(AlertRule),
+            )
+
+        if features.has("organizations:metric-issue-poc", self.alert_rule.organization):
+            create_or_update_metric_issue(
+                incident=incident,
+                metric_value=metric_value,
             )
 
     def handle_incident_severity_update(self) -> None:

--- a/src/sentry/incidents/utils/metric_issue_poc.py
+++ b/src/sentry/incidents/utils/metric_issue_poc.py
@@ -1,0 +1,90 @@
+from collections.abc import Mapping
+from uuid import uuid4
+
+from sentry.incidents.models.incident import Incident, IncidentStatus
+from sentry.integrations.metric_alerts import get_incident_status_text
+from sentry.issues.grouptype import MetricIssuePOC
+from sentry.issues.issue_occurrence import IssueOccurrence
+from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
+from sentry.issues.status_change_message import StatusChangeMessage
+from sentry.models.group import GroupStatus
+from sentry.models.project import Project
+from sentry.types.group import PriorityLevel
+
+
+def _build_occurrence_from_incident(
+    project: Project,
+    incident: Incident,
+    event_data: Mapping[str, str | int],
+    metric_value: float,
+) -> IssueOccurrence:
+    initial_issue_priority = (
+        PriorityLevel.HIGH
+        if incident.status == IncidentStatus.CRITICAL.value
+        else PriorityLevel.MEDIUM
+    )
+    fingerprint = [str(incident.alert_rule.id)]
+    return IssueOccurrence(
+        id=uuid4().hex,
+        project_id=project.id,
+        event_id=event_data["event_id"],
+        fingerprint=fingerprint,
+        issue_title=incident.title,
+        subtitle=get_incident_status_text(incident.alert_rule, metric_value),
+        resource_id=None,
+        type=MetricIssuePOC,
+        detection_time=incident.date_started,
+        level="error",
+        culprit=None,
+        initial_issue_priority=initial_issue_priority,
+        # TODO(snigdha): Add more data here as needed
+        evidence_data={"metric_value": metric_value},
+        evidence_display=[],
+    )
+
+
+def create_or_update_metric_issue(
+    incident: Incident,
+    metric_value: float,
+) -> IssueOccurrence:
+
+    project = incident.alert_rule.projects.first()
+
+    # collect the data from the incident to treat as an event
+    event_data = {
+        "event_id": uuid4().hex,
+        "project_id": project.id,
+        "timestamp": incident.date_started.isoformat(),
+        "platform": project.platform or "",
+        "received": incident.date_started.isoformat(),
+    }
+
+    occurrence = _build_occurrence_from_incident(project, incident, event_data, metric_value)
+    produce_occurrence_to_kafka(
+        payload_type=PayloadType.OCCURRENCE,
+        occurrence=occurrence,
+        event_data=event_data,
+    )
+    update_group_status(incident, project, occurrence)
+
+    return occurrence
+
+
+def update_group_status(
+    incident: Incident, project: Project, occurrence: IssueOccurrence
+) -> StatusChangeMessage | None:
+    if incident.status != IncidentStatus.CLOSED.value:
+        return None
+
+    status_change_message = StatusChangeMessage(
+        fingerprint=occurrence.fingerprint,
+        project_id=project.id,
+        new_status=GroupStatus.RESOLVED,
+        new_substatus=None,
+    )
+    produce_occurrence_to_kafka(
+        payload_type=PayloadType.STATUS_CHANGE,
+        status_change=status_change_message,
+    )
+
+    return status_change_message

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -611,6 +611,17 @@ class UptimeDomainCheckFailure(GroupType):
     enable_escalation_detection = False
 
 
+@dataclass(frozen=True)
+class MetricIssuePOC(GroupType):
+    type_id = 8002
+    slug = "metric_issue_poc"
+    description = "Metric Issue POC"
+    category = GroupCategory.METRIC_ALERT
+    default_priority = PriorityLevel.HIGH
+    enable_auto_resolve = False
+    enable_escalation_detection = False
+
+
 def should_create_group(
     grouptype: type[GroupType],
     client: RedisCluster | StrictRedis,

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -616,7 +616,7 @@ class MetricIssuePOC(GroupType):
     type_id = 8002
     slug = "metric_issue_poc"
     description = "Metric Issue POC"
-    category = GroupCategory.METRIC_ALERT
+    category = GroupCategory.METRIC_ALERT.value
     default_priority = PriorityLevel.HIGH
     enable_auto_resolve = False
     enable_escalation_detection = False

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -51,6 +51,7 @@ from sentry.incidents.subscription_processor import (
     update_alert_rule_stats,
 )
 from sentry.incidents.utils.types import AlertRuleActivationConditionType
+from sentry.issues.grouptype import MetricIssuePOC
 from sentry.models.project import Project
 from sentry.seer.anomaly_detection.get_anomaly_data import get_anomaly_data_from_seer
 from sentry.seer.anomaly_detection.types import (
@@ -69,6 +70,7 @@ from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers.alert_rule import TemporaryAlertRuleTriggerActionRegistry
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
+from sentry.types.group import PriorityLevel
 from sentry.utils import json
 
 EMPTY = object()
@@ -948,7 +950,8 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         )
         assert result is None
 
-    def test_alert(self):
+    @patch("sentry.incidents.utils.metric_issue_poc.create_or_update_metric_issue")
+    def test_alert(self, create_metric_issue_mock):
         # Verify that an alert rule that only expects a single update to be over the
         # alert threshold triggers correctly
         rule = self.rule
@@ -967,6 +970,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             [self.action],
             [(trigger.alert_threshold + 1, IncidentStatus.CRITICAL, uuid)],
         )
+        create_metric_issue_mock.assert_not_called()
 
     def test_activated_alert(self):
         # Verify that an alert rule that only expects a single update to be over the
@@ -1096,7 +1100,8 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         self.assert_trigger_does_not_exist(trigger)
         self.assert_action_handler_called_with_actions(None, [])
 
-    def test_resolve(self):
+    @patch("sentry.incidents.utils.metric_issue_poc.create_or_update_metric_issue")
+    def test_resolve(self, create_metric_issue_mock):
         # Verify that an alert rule that only expects a single update to be under the
         # resolve threshold triggers correctly
         rule = self.rule
@@ -1118,6 +1123,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         self.assert_actions_resolved_for_incident(
             incident, [self.action], [(rule.resolve_threshold - 1, IncidentStatus.CLOSED, mock.ANY)]
         )
+        create_metric_issue_mock.assert_not_called()
 
     def test_resolve_multiple_threshold_periods(self):
         # Verify that a rule that expects two consecutive updates to be under the
@@ -2871,6 +2877,81 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
 
         assert mock.call_count == 1
         assert mock.call_args[0][0] == self.sub
+
+    @with_feature("organizations:metric-issue-poc")
+    @mock.patch("sentry.incidents.utils.metric_issue_poc.produce_occurrence_to_kafka")
+    def test_alert_creates_metric_issue(self, mock_produce_occurrence_to_kafka):
+        rule = self.rule
+        trigger = self.trigger
+        processor = self.send_update(rule, trigger.alert_threshold + 1)
+
+        self.assert_trigger_counts(processor, self.trigger, 0, 0)
+        incident = self.assert_active_incident(rule)
+        assert incident.date_started == (
+            timezone.now().replace(microsecond=0) - timedelta(seconds=rule.snuba_query.time_window)
+        )
+        self.assert_trigger_exists_with_status(incident, self.trigger, TriggerStatus.ACTIVE)
+        latest_activity = self.latest_activity(incident)
+        uuid = str(latest_activity.notification_uuid)
+        self.assert_actions_fired_for_incident(
+            incident,
+            [self.action],
+            [(trigger.alert_threshold + 1, IncidentStatus.CRITICAL, uuid)],
+        )
+
+        # Verify that a metric issue is created when an alert fires
+        mock_produce_occurrence_to_kafka.assert_called_once()
+        occurrence = mock_produce_occurrence_to_kafka.call_args.kwargs["occurrence"]
+        assert occurrence.type == MetricIssuePOC
+        assert occurrence.issue_title == incident.title
+        assert occurrence.initial_issue_priority == PriorityLevel.HIGH
+        assert occurrence.evidence_data["metric_value"] == trigger.alert_threshold + 1
+
+    @with_feature("organizations:metric-issue-poc")
+    @mock.patch("sentry.incidents.utils.metric_issue_poc.produce_occurrence_to_kafka")
+    def test_resolved_alert_updates_metric_issue(self, mock_produce_occurrence_to_kafka):
+        from sentry.models.group import GroupStatus
+
+        # Trigger an incident at critical status
+        rule = self.rule
+        trigger = self.trigger
+        processor = self.send_update(rule, trigger.alert_threshold + 1, timedelta(minutes=-2))
+        self.assert_trigger_counts(processor, self.trigger, 0, 0)
+        incident = self.assert_active_incident(rule)
+        self.assert_trigger_exists_with_status(incident, self.trigger, TriggerStatus.ACTIVE)
+        self.assert_actions_fired_for_incident(
+            incident,
+            [self.action],
+            [(trigger.alert_threshold + 1, IncidentStatus.CRITICAL, mock.ANY)],
+        )
+
+        # Check that a metric issue is created
+        assert mock_produce_occurrence_to_kafka.call_count == 1
+        occurrence = mock_produce_occurrence_to_kafka.call_args.kwargs["occurrence"]
+        assert occurrence.type == MetricIssuePOC
+        assert occurrence.initial_issue_priority == PriorityLevel.HIGH
+        assert occurrence.evidence_data["metric_value"] == trigger.alert_threshold + 1
+        mock_produce_occurrence_to_kafka.reset_mock()
+
+        # Resolve the incident
+        processor = self.send_update(rule, rule.resolve_threshold - 1, timedelta(minutes=-1))
+        self.assert_trigger_counts(processor, self.trigger, 0, 0)
+        self.assert_no_active_incident(rule)
+        self.assert_trigger_exists_with_status(incident, self.trigger, TriggerStatus.RESOLVED)
+        self.assert_actions_resolved_for_incident(
+            incident, [self.action], [(rule.resolve_threshold - 1, IncidentStatus.CLOSED, mock.ANY)]
+        )
+
+        # Verify that the metric issue is updated
+        assert mock_produce_occurrence_to_kafka.call_count == 2
+        occurrence = mock_produce_occurrence_to_kafka.call_args_list[0][1]["occurrence"]
+        assert occurrence.type == MetricIssuePOC
+        assert occurrence.initial_issue_priority == PriorityLevel.MEDIUM
+        assert occurrence.evidence_data["metric_value"] == rule.resolve_threshold - 1
+
+        status_change = mock_produce_occurrence_to_kafka.call_args_list[1][1]["status_change"]
+        assert status_change.new_status == GroupStatus.RESOLVED
+        assert occurrence.fingerprint == status_change.fingerprint
 
 
 class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetricsTestCase):

--- a/tests/sentry/incidents/utils/test_metric_issue_poc.py
+++ b/tests/sentry/incidents/utils/test_metric_issue_poc.py
@@ -1,0 +1,76 @@
+from sentry.incidents.models.incident import IncidentStatus
+from sentry.incidents.utils.metric_issue_poc import create_or_update_metric_issue
+from sentry.issues.grouptype import MetricIssuePOC
+from sentry.issues.issue_occurrence import IssueOccurrence
+from sentry.models.group import Group, GroupStatus
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import apply_feature_flag_on_cls
+from sentry.testutils.pytest.fixtures import django_db_all
+from sentry.types.group import GroupSubStatus, PriorityLevel
+from tests.sentry.issues.test_occurrence_consumer import IssueOccurrenceTestBase
+
+
+@apply_feature_flag_on_cls("organizations:metric-issue-poc-ingest")
+class TestMetricIssuePOC(IssueOccurrenceTestBase, APITestCase):
+    def setUp(self):
+        self.organization = self.create_organization()
+        self.project = self.create_project(organization=self.organization)
+        self.alert_rule = self.create_alert_rule(
+            organization=self.organization,
+            projects=[self.project],
+            name="My Alert Rule",
+        )
+
+        self.incident = self.create_incident(
+            organization=self.organization,
+            projects=[self.project],
+            alert_rule=self.alert_rule,
+            title="My Incident",
+            status=IncidentStatus.CRITICAL.value,
+        )
+
+        self.event_data = {
+            "project_id": self.project.id,
+            "timestamp": self.incident.date_started.isoformat(),
+            "platform": self.project.platform or "",
+            "received": self.incident.date_started.isoformat(),
+        }
+
+    @django_db_all
+    def test_incident_creates_metric_issue(self):
+        occurrence = create_or_update_metric_issue(self.incident, 100.0)
+        occurrence.save()
+
+        self.event_data["event_id"] = occurrence.event_id
+        stored_occurrence = IssueOccurrence.fetch(occurrence.id, occurrence.project_id)
+        assert stored_occurrence
+        assert occurrence.event_id == stored_occurrence.event_id
+        assert occurrence.type == MetricIssuePOC
+        assert occurrence.initial_issue_priority == PriorityLevel.HIGH
+
+        assert Group.objects.filter(type=MetricIssuePOC.type_id).count() == 1
+        group = Group.objects.get(type=MetricIssuePOC.type_id)
+
+        assert group.status == GroupStatus.UNRESOLVED
+        assert group.substatus == GroupSubStatus.NEW
+        assert group.priority == PriorityLevel.HIGH
+
+    @django_db_all
+    def test_resolved_incident(self):
+        assert Group.objects.filter(type=MetricIssuePOC.type_id).count() == 0
+        self.incident.status = IncidentStatus.CLOSED.value
+        occurrence = create_or_update_metric_issue(self.incident, 0.0)
+        occurrence.save()
+        self.event_data["event_id"] = occurrence.event_id
+
+        stored_occurrence = IssueOccurrence.fetch(occurrence.id, occurrence.project_id)
+        assert stored_occurrence
+        assert stored_occurrence.type == MetricIssuePOC
+        assert stored_occurrence.initial_issue_priority == PriorityLevel.MEDIUM
+
+        assert Group.objects.filter(type=MetricIssuePOC.type_id).count() == 1
+        group = Group.objects.get(type=MetricIssuePOC.type_id)
+
+        assert group.status == GroupStatus.RESOLVED
+        assert group.substatus is None
+        assert group.priority == PriorityLevel.MEDIUM

--- a/tests/sentry/incidents/utils/test_metric_issue_poc.py
+++ b/tests/sentry/incidents/utils/test_metric_issue_poc.py
@@ -39,6 +39,7 @@ class TestMetricIssuePOC(IssueOccurrenceTestBase, APITestCase):
     @django_db_all
     def test_incident_creates_metric_issue(self):
         occurrence = create_or_update_metric_issue(self.incident, 100.0)
+        assert occurrence
         occurrence.save()
 
         self.event_data["event_id"] = occurrence.event_id
@@ -60,6 +61,7 @@ class TestMetricIssuePOC(IssueOccurrenceTestBase, APITestCase):
         assert Group.objects.filter(type=MetricIssuePOC.type_id).count() == 0
         self.incident.status = IncidentStatus.CLOSED.value
         occurrence = create_or_update_metric_issue(self.incident, 0.0)
+        assert occurrence
         occurrence.save()
         self.event_data["event_id"] = occurrence.event_id
 


### PR DESCRIPTION
This PR sets up a new issue type, metric issue poc, which we can safely clean up when we've completed the POC. Any groups with this group type will be deleted as well. 

For organizations that have the `organizations:metric-issue-poc` and `organizations:metric-issue-poc-ingest` flags enabled, we'll start to create metric issues for metric alerts. The issue fingerprints rely only on the alert id, and the current design expects a new occurrence for each status change. This is the first of many PRs in this series so I'll expect some of the implementation details to change as there's still work to do to support new activity types and the metric issues UI. 