### PR TITLE
fix(auth): get scope from request

### DIFF
--- a/src/sentry/web/frontend/oauth_authorize.py
+++ b/src/sentry/web/frontend/oauth_authorize.py
@@ -127,17 +127,25 @@ class OAuthAuthorizeView(AuthLoginView):
                 err_response="client_id",
             )
 
-        # TODO (athena): Clean up this so scopes are always coming from the model
-        # This change is temporarily needed before we migrate existing applications
-        # to have the correct scopes
-        if application.requires_org_level_access:
-            scopes = application.scopes
+        scopes = request.GET.get("scope")
+        if scopes:
+            scopes = scopes.split(" ")
         else:
-            scopes = request.GET.get("scope")
-            if scopes:
-                scopes = scopes.split(" ")
-            else:
-                scopes = []
+            scopes = []
+        if application.requires_org_level_access:
+            # Applications that require org level access have a maximum scope limit set
+            # in admin that should not pass
+            max_scopes = application.scopes
+            for scope in scopes:
+                if scope not in max_scopes:
+                    return self.error(
+                        request=request,
+                        client_id=client_id,
+                        response_type=response_type,
+                        redirect_uri=redirect_uri,
+                        name="invalid_scope",
+                        state=state,
+                    )
 
         for scope in scopes:
             if scope not in settings.SENTRY_SCOPES:


### PR DESCRIPTION
In my [previous PR](https://github.com/getsentry/sentry/pull/79740) I assumed admin sets scopes for partner and we only use those for every auth. Talking to the partner and following oauth standards, it makes more sense if the partner asks for the scope they need in request params and admin sets the maximum scope a partner can ask for.