### PR TITLE
feat(autofix): Integrate setup and summary into Autofix drawer

### DIFF
--- a/static/app/components/events/autofix/autofixDrawer.spec.tsx
+++ b/static/app/components/events/autofix/autofixDrawer.spec.tsx
@@ -18,6 +18,25 @@ describe('AutofixDrawer', () => {
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
+
+    MockApiClient.addMockResponse({
+      url: `/issues/${mockGroup.id}/autofix/setup/`,
+      body: {
+        genAIConsent: {ok: true},
+        integration: {ok: true},
+        githubWriteIntegration: {ok: true},
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/summarize/`,
+      method: 'POST',
+      body: {
+        whatsWrong: 'Test whats wrong',
+        trace: 'Test trace',
+        possibleCause: 'Test possible cause',
+        headline: 'Test headline',
+      },
+    });
   });
 
   it('renders properly', () => {
@@ -32,11 +51,9 @@ describe('AutofixDrawer', () => {
 
     expect(screen.getByText(mockEvent.id)).toBeInTheDocument();
 
-    expect(screen.getByRole('heading', {name: 'Autofix'})).toBeInTheDocument();
+    expect(screen.getAllByRole('heading', {name: 'Autofix'})[0]).toBeInTheDocument();
 
-    expect(screen.getByText('Ready to start')).toBeInTheDocument();
-
-    const startButton = screen.getByRole('button', {name: 'Start'});
+    const startButton = screen.getByRole('button', {name: 'Start Autofix'});
     expect(startButton).toBeInTheDocument();
   });
 
@@ -54,7 +71,7 @@ describe('AutofixDrawer', () => {
 
     render(<AutofixDrawer event={mockEvent} group={mockGroup} project={mockProject} />);
 
-    const startButton = screen.getByRole('button', {name: 'Start'});
+    const startButton = screen.getByRole('button', {name: 'Start Autofix'});
     await userEvent.click(startButton);
 
     expect(
@@ -88,8 +105,7 @@ describe('AutofixDrawer', () => {
     await userEvent.click(startOverButton);
 
     await waitFor(() => {
-      expect(screen.getByText('Ready to start')).toBeInTheDocument();
-      expect(screen.getByRole('button', {name: 'Start'})).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Start Autofix'})).toBeInTheDocument();
     });
   });
 });

--- a/static/app/components/events/autofix/autofixDrawer.tsx
+++ b/static/app/components/events/autofix/autofixDrawer.tsx
@@ -2,6 +2,7 @@ import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import bannerImage from 'sentry-images/insights/module-upsells/insights-module-upsell.svg';
+import starImage from 'sentry-images/spot/banner-star.svg';
 
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import {Breadcrumbs as NavigationBreadcrumbs} from 'sentry/components/breadcrumbs';
@@ -10,8 +11,11 @@ import ButtonBar from 'sentry/components/buttonBar';
 import AutofixFeedback from 'sentry/components/events/autofix/autofixFeedback';
 import {AutofixSteps} from 'sentry/components/events/autofix/autofixSteps';
 import {useAiAutofix} from 'sentry/components/events/autofix/useAutofix';
+import {useAutofixSetup} from 'sentry/components/events/autofix/useAutofixSetup';
 import {DrawerBody, DrawerHeader} from 'sentry/components/globalDrawer/components';
+import {GroupSummaryBody, useGroupSummary} from 'sentry/components/group/groupSummary';
 import Input from 'sentry/components/input';
+import {IconSeer} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
@@ -20,6 +24,8 @@ import type {Project} from 'sentry/types/project';
 import {getShortEventId} from 'sentry/utils/events';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {MIN_NAV_HEIGHT} from 'sentry/views/issueDetails/streamline/eventTitle';
+
+import {AutofixSetupContent} from './autofixSetupModal';
 
 interface AutofixStartBoxProps {
   groupId: string;
@@ -38,41 +44,36 @@ function AutofixStartBox({onSend, groupId}: AutofixStartBoxProps) {
       <IllustrationContainer>
         <Illustration src={bannerImage} />
       </IllustrationContainer>
-      <Header>Ready to start</Header>
+      <Header>Autofix</Header>
       <br />
-      <p>
-        We'll begin by trying to figure out the root cause of the issue. If you have any
-        instructions or helpful context before we begin, you can optionally share that
-        below.
-      </p>
+      <p>Work together with Autofix to find the root cause and fix the issue.</p>
       <Row>
         <Input
           type="text"
           value={message}
           onChange={e => setMessage(e.target.value)}
-          placeholder={'(Optional) Share any extra context or instructions here...'}
+          placeholder={'(Optional) Share helpful context here...'}
         />
-        {message ? (
+        <ButtonWithStars>
+          <StarLarge1 src={starImage} />
+          <StarLarge2 src={starImage} />
+          <StarLarge3 src={starImage} />
           <Button
             priority="primary"
             onClick={send}
-            analyticsEventKey="autofix.give_instructions_clicked"
-            analyticsEventName="Autofix: Give Instructions Clicked"
+            analyticsEventKey={
+              message ? 'autofix.give_instructions_clicked' : 'autofix.start_fix_clicked'
+            }
+            analyticsEventName={
+              message
+                ? 'Autofix: Give Instructions Clicked'
+                : 'Autofix: Start Fix Clicked'
+            }
             analyticsParams={{group_id: groupId}}
           >
-            Start
+            {message ? 'Start' : 'Start Autofix'}
           </Button>
-        ) : (
-          <Button
-            priority="primary"
-            onClick={send}
-            analyticsEventKey="autofix.start_fix_clicked"
-            analyticsEventName="Autofix: Start Fix Clicked"
-            analyticsParams={{group_id: groupId}}
-          >
-            Start
-          </Button>
-        )}
+        </ButtonWithStars>
       </Row>
     </StartBox>
   );
@@ -86,9 +87,16 @@ interface AutofixDrawerProps {
 
 export function AutofixDrawer({group, project, event}: AutofixDrawerProps) {
   const {autofixData, triggerAutofix, reset} = useAiAutofix(group, event);
+  const {data: summaryData, isError} = useGroupSummary(group.id, group.issueCategory);
+  const {data: setupData, isPending: isSetupLoading} = useAutofixSetup({
+    groupId: group.id,
+  });
+
   useRouteAnalyticsParams({
     autofix_status: autofixData?.status ?? 'none',
   });
+
+  const isSetupComplete = setupData?.integration.ok && setupData?.genAIConsent.ok;
 
   return (
     <AutofixDrawerContainer>
@@ -128,7 +136,22 @@ export function AutofixDrawer({group, project, event}: AutofixDrawerProps) {
         )}
       </AutofixNavigator>
       <AutofixDrawerBody>
-        {!autofixData ? (
+        <HeaderText>
+          <IconSeer size="lg" />
+          {t('Sentry AI')}
+        </HeaderText>
+        <StyledCard>
+          <GroupSummaryBody data={summaryData} isError={isError} />
+        </StyledCard>
+        {!isSetupLoading && !isSetupComplete ? (
+          <SetupContainer>
+            <AutofixSetupContent
+              projectId={project.id}
+              groupId={group.id}
+              closeModal={() => {}} // Setup is inline, so no modal to close
+            />
+          </SetupContainer>
+        ) : !autofixData ? (
           <AutofixStartBox onSend={triggerAutofix} groupId={group.id} />
         ) : (
           <AutofixSteps
@@ -162,7 +185,6 @@ const StartBox = styled('div')`
   padding: ${space(2)};
   display: flex;
   flex-direction: column;
-  height: 100%;
   width: 100%;
 `;
 
@@ -224,4 +246,63 @@ const ShortId = styled('div')`
   font-family: ${p => p.theme.text.family};
   font-size: ${p => p.theme.fontSizeMedium};
   line-height: 1;
+`;
+
+const ButtonWithStars = styled('div')`
+  position: relative;
+  display: flex;
+  align-items: center;
+`;
+
+const StarLarge = styled('img')`
+  position: absolute;
+  width: 32px;
+  height: 32px;
+  z-index: 0;
+`;
+
+const StarLarge1 = styled(StarLarge)`
+  left: -10px;
+  bottom: -20px;
+  transform: rotate(90deg);
+`;
+
+const StarLarge2 = styled(StarLarge)`
+  right: -15px;
+  top: -20px;
+  transform: rotate(-30deg);
+`;
+
+const StarLarge3 = styled(StarLarge)`
+  right: -30px;
+  bottom: -15px;
+  transform: rotate(20deg);
+`;
+
+const SetupContainer = styled('div')`
+  padding: ${space(2)};
+
+  /* Override some modal-specific styles */
+  h3 {
+    font-size: ${p => p.theme.fontSizeLarge};
+    margin-bottom: ${space(2)};
+  }
+`;
+
+const StyledCard = styled('div')`
+  background: ${p => p.theme.backgroundElevated};
+  border-radius: ${p => p.theme.borderRadius};
+  border: 1px solid ${p => p.theme.border};
+  overflow: hidden;
+  box-shadow: ${p => p.theme.dropShadowMedium};
+  padding-bottom: ${space(1)};
+`;
+
+const HeaderText = styled('div')`
+  font-weight: bold;
+  font-size: ${p => p.theme.fontSizeLarge};
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
+  padding-bottom: ${space(2)};
 `;

--- a/static/app/components/events/autofix/autofixDrawer.tsx
+++ b/static/app/components/events/autofix/autofixDrawer.tsx
@@ -327,7 +327,7 @@ const StarTrail = styled('div')`
   width: 100%;
   display: flex;
   justify-content: center;
-  margin-bottom: ${space(4)};
+  margin-bottom: 5rem;
 `;
 
 const TrailStar = styled('img')<{index: number; offset: number; size: number}>`

--- a/static/app/components/events/autofix/autofixDrawer.tsx
+++ b/static/app/components/events/autofix/autofixDrawer.tsx
@@ -1,7 +1,6 @@
 import {useState} from 'react';
 import styled from '@emotion/styled';
 
-import bannerImage from 'sentry-images/insights/module-upsells/insights-module-upsell.svg';
 import starImage from 'sentry-images/spot/banner-star.svg';
 
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
@@ -41,9 +40,17 @@ function AutofixStartBox({onSend, groupId}: AutofixStartBoxProps) {
 
   return (
     <StartBox>
-      <IllustrationContainer>
-        <Illustration src={bannerImage} />
-      </IllustrationContainer>
+      <StarTrail>
+        {[...Array(8)].map((_, i) => (
+          <TrailStar
+            key={i}
+            src={starImage}
+            index={i}
+            size={28 - i * 2}
+            offset={(i % 2) * 30 - 15}
+          />
+        ))}
+      </StarTrail>
       <Header>Autofix</Header>
       <br />
       <p>Work together with Autofix to find the root cause and fix the issue.</p>
@@ -176,21 +183,16 @@ const Row = styled('div')`
   gap: ${space(1)};
 `;
 
-const IllustrationContainer = styled('div')`
-  padding: ${space(4)} 0 ${space(4)} 0;
-  display: flex;
-  justify-content: center;
-`;
-
-const Illustration = styled('img')`
-  height: 100%;
-`;
-
 const StartBox = styled('div')`
   padding: ${space(2)};
   display: flex;
   flex-direction: column;
-  width: 100%;
+  position: absolute;
+  bottom: 0;
+  left: ${space(2)};
+  right: ${space(2)};
+  background: ${p => p.theme.background};
+  z-index: -1;
 `;
 
 const AutofixDrawerContainer = styled('div')`
@@ -227,6 +229,8 @@ const AutofixDrawerBody = styled(DrawerBody)`
   * {
     direction: ltr;
   }
+  /* Add padding at the bottom to prevent content from being hidden behind StartBox */
+  padding-bottom: 280px;
 `;
 
 const Header = styled('h3')`
@@ -315,4 +319,22 @@ const HeaderText = styled('div')`
   align-items: center;
   gap: ${space(1)};
   padding-bottom: ${space(2)};
+`;
+
+const StarTrail = styled('div')`
+  position: relative;
+  height: 280px;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin-bottom: ${space(4)};
+`;
+
+const TrailStar = styled('img')<{index: number; offset: number; size: number}>`
+  position: absolute;
+  width: ${p => p.size}px;
+  height: ${p => p.size}px;
+  top: ${p => p.index * 50}px;
+  transform: translateX(${p => p.offset}px) rotate(${p => p.index * 40}deg);
+  opacity: ${p => Math.max(0.2, 1 - p.index * 0.1)};
 `;

--- a/static/app/components/events/autofix/autofixDrawer.tsx
+++ b/static/app/components/events/autofix/autofixDrawer.tsx
@@ -246,8 +246,6 @@ const AutofixDrawerBody = styled(DrawerBody)`
   * {
     direction: ltr;
   }
-  /* Add padding at the bottom to prevent content from being hidden behind StartBox */
-  padding-bottom: 280px;
 `;
 
 const Header = styled('h3')`

--- a/static/app/components/events/autofix/autofixDrawer.tsx
+++ b/static/app/components/events/autofix/autofixDrawer.tsx
@@ -256,27 +256,32 @@ const ButtonWithStars = styled('div')`
 
 const StarLarge = styled('img')`
   position: absolute;
-  width: 32px;
-  height: 32px;
   z-index: 0;
 `;
 
 const StarLarge1 = styled(StarLarge)`
-  left: -10px;
-  bottom: -20px;
+  left: 45px;
+  bottom: -15px;
   transform: rotate(90deg);
+
+  width: 16px;
+  height: 16px;
 `;
 
 const StarLarge2 = styled(StarLarge)`
-  right: -15px;
-  top: -20px;
+  left: -5px;
+  top: -15px;
   transform: rotate(-30deg);
+  width: 24px;
+  height: 24px;
 `;
 
 const StarLarge3 = styled(StarLarge)`
-  right: -30px;
-  bottom: -15px;
+  right: -25px;
+  bottom: 0px;
   transform: rotate(20deg);
+  width: 28px;
+  height: 28px;
 `;
 
 const SetupContainer = styled('div')`

--- a/static/app/components/events/autofix/autofixDrawer.tsx
+++ b/static/app/components/events/autofix/autofixDrawer.tsx
@@ -88,7 +88,11 @@ interface AutofixDrawerProps {
 export function AutofixDrawer({group, project, event}: AutofixDrawerProps) {
   const {autofixData, triggerAutofix, reset} = useAiAutofix(group, event);
   const {data: summaryData, isError} = useGroupSummary(group.id, group.issueCategory);
-  const {data: setupData, isPending: isSetupLoading} = useAutofixSetup({
+  const {
+    data: setupData,
+    isPending: isSetupLoading,
+    refetch: refetchSetup,
+  } = useAutofixSetup({
     groupId: group.id,
   });
 
@@ -148,7 +152,8 @@ export function AutofixDrawer({group, project, event}: AutofixDrawerProps) {
             <AutofixSetupContent
               projectId={project.id}
               groupId={group.id}
-              closeModal={() => {}} // Setup is inline, so no modal to close
+              closeModal={() => {}}
+              refetchSetup={refetchSetup}
             />
           </SetupContainer>
         ) : !autofixData ? (

--- a/static/app/components/events/autofix/autofixDrawer.tsx
+++ b/static/app/components/events/autofix/autofixDrawer.tsx
@@ -40,19 +40,17 @@ function AutofixStartBox({onSend, groupId}: AutofixStartBoxProps) {
 
   return (
     <StartBox>
-      <StarTrailContainer>
-        <StarTrail>
-          {[...Array(8)].map((_, i) => (
-            <TrailStar
-              key={i}
-              src={starImage}
-              index={i}
-              size={28 - i * 2}
-              offset={(i % 2) * 30 - 15}
-            />
-          ))}
-        </StarTrail>
-      </StarTrailContainer>
+      <StarTrail>
+        {[...Array(8)].map((_, i) => (
+          <TrailStar
+            key={i}
+            src={starImage}
+            index={i}
+            size={28 - i * 2}
+            offset={(i % 2) * 30 - 15}
+          />
+        ))}
+      </StarTrail>
       <ContentContainer>
         <Header>Autofix</Header>
         <br />
@@ -197,15 +195,6 @@ const StartBox = styled('div')`
   right: ${space(2)};
 `;
 
-const StarTrailContainer = styled('div')`
-  position: absolute;
-  bottom: 5rem;
-  left: 0;
-  right: 0;
-  z-index: -1;
-  pointer-events: none;
-`;
-
 const ContentContainer = styled('div')`
   position: relative;
   z-index: 1;
@@ -281,6 +270,7 @@ const ButtonWithStars = styled('div')`
 const StarLarge = styled('img')`
   position: absolute;
   z-index: 0;
+  filter: sepia(1) saturate(3) hue-rotate(290deg);
 `;
 
 const StarLarge1 = styled(StarLarge)`
@@ -341,7 +331,12 @@ const StarTrail = styled('div')`
   width: 100%;
   display: flex;
   justify-content: center;
-  position: relative;
+  position: absolute;
+  bottom: 5rem;
+  left: 0;
+  right: 0;
+  z-index: -1;
+  pointer-events: none;
 `;
 
 const TrailStar = styled('img')<{index: number; offset: number; size: number}>`
@@ -351,4 +346,5 @@ const TrailStar = styled('img')<{index: number; offset: number; size: number}>`
   top: ${p => p.index * 50}px;
   transform: translateX(${p => p.offset}px) rotate(${p => p.index * 40}deg);
   opacity: ${p => Math.max(0.2, 1 - p.index * 0.1)};
+  filter: sepia(1) saturate(3) hue-rotate(290deg);
 `;

--- a/static/app/components/events/autofix/autofixDrawer.tsx
+++ b/static/app/components/events/autofix/autofixDrawer.tsx
@@ -40,48 +40,54 @@ function AutofixStartBox({onSend, groupId}: AutofixStartBoxProps) {
 
   return (
     <StartBox>
-      <StarTrail>
-        {[...Array(8)].map((_, i) => (
-          <TrailStar
-            key={i}
-            src={starImage}
-            index={i}
-            size={28 - i * 2}
-            offset={(i % 2) * 30 - 15}
+      <StarTrailContainer>
+        <StarTrail>
+          {[...Array(8)].map((_, i) => (
+            <TrailStar
+              key={i}
+              src={starImage}
+              index={i}
+              size={28 - i * 2}
+              offset={(i % 2) * 30 - 15}
+            />
+          ))}
+        </StarTrail>
+      </StarTrailContainer>
+      <ContentContainer>
+        <Header>Autofix</Header>
+        <br />
+        <p>Work together with Autofix to find the root cause and fix the issue.</p>
+        <Row>
+          <Input
+            type="text"
+            value={message}
+            onChange={e => setMessage(e.target.value)}
+            placeholder={'(Optional) Share helpful context here...'}
           />
-        ))}
-      </StarTrail>
-      <Header>Autofix</Header>
-      <br />
-      <p>Work together with Autofix to find the root cause and fix the issue.</p>
-      <Row>
-        <Input
-          type="text"
-          value={message}
-          onChange={e => setMessage(e.target.value)}
-          placeholder={'(Optional) Share helpful context here...'}
-        />
-        <ButtonWithStars>
-          <StarLarge1 src={starImage} />
-          <StarLarge2 src={starImage} />
-          <StarLarge3 src={starImage} />
-          <Button
-            priority="primary"
-            onClick={send}
-            analyticsEventKey={
-              message ? 'autofix.give_instructions_clicked' : 'autofix.start_fix_clicked'
-            }
-            analyticsEventName={
-              message
-                ? 'Autofix: Give Instructions Clicked'
-                : 'Autofix: Start Fix Clicked'
-            }
-            analyticsParams={{group_id: groupId}}
-          >
-            {message ? 'Start' : 'Start Autofix'}
-          </Button>
-        </ButtonWithStars>
-      </Row>
+          <ButtonWithStars>
+            <StarLarge1 src={starImage} />
+            <StarLarge2 src={starImage} />
+            <StarLarge3 src={starImage} />
+            <Button
+              priority="primary"
+              onClick={send}
+              analyticsEventKey={
+                message
+                  ? 'autofix.give_instructions_clicked'
+                  : 'autofix.start_fix_clicked'
+              }
+              analyticsEventName={
+                message
+                  ? 'Autofix: Give Instructions Clicked'
+                  : 'Autofix: Start Fix Clicked'
+              }
+              analyticsParams={{group_id: groupId}}
+            >
+              {message ? 'Start' : 'Start Autofix'}
+            </Button>
+          </ButtonWithStars>
+        </Row>
+      </ContentContainer>
     </StartBox>
   );
 }
@@ -185,14 +191,25 @@ const Row = styled('div')`
 
 const StartBox = styled('div')`
   padding: ${space(2)};
-  display: flex;
-  flex-direction: column;
   position: absolute;
-  bottom: 0;
+  bottom: ${space(2)};
   left: ${space(2)};
   right: ${space(2)};
-  background: ${p => p.theme.background};
+`;
+
+const StarTrailContainer = styled('div')`
+  position: absolute;
+  bottom: 5rem;
+  left: 0;
+  right: 0;
   z-index: -1;
+  pointer-events: none;
+`;
+
+const ContentContainer = styled('div')`
+  position: relative;
+  z-index: 1;
+  margin-top: 80px;
 `;
 
 const AutofixDrawerContainer = styled('div')`
@@ -322,12 +339,11 @@ const HeaderText = styled('div')`
 `;
 
 const StarTrail = styled('div')`
-  position: relative;
-  height: 280px;
+  height: 400px;
   width: 100%;
   display: flex;
   justify-content: center;
-  margin-bottom: 5rem;
+  position: relative;
 `;
 
 const TrailStar = styled('img')<{index: number; offset: number; size: number}>`

--- a/static/app/components/events/autofix/autofixInsightCards.spec.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.spec.tsx
@@ -125,7 +125,7 @@ describe('AutofixInsightCards', () => {
   it('renders "No insights yet" message when there are no insights', () => {
     renderComponent({insights: []});
     expect(
-      screen.getByText(/Autofix will share important conclusions here/)
+      screen.getByText(/Autofix will share its discoveries here./)
     ).toBeInTheDocument();
   });
 

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -336,7 +336,7 @@ function AutofixInsightCards({
         <NoInsightsYet>
           <p>Autofix will share its discoveries here.</p>
           <p>
-            Autofix is like a new teammate with fresh eyes on your code.
+            Autofix is like an AI rubber ducky to help you debug your code.
             <br />
             Collaborate with it and share your own knowledge and opinions for the best
             results.

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -2,8 +2,6 @@ import {useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {AnimatePresence, type AnimationProps, motion} from 'framer-motion';
 
-import bannerImage from 'sentry-images/insights/module-upsells/insights-module-upsell.svg';
-
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {Button} from 'sentry/components/button';
 import {
@@ -334,15 +332,15 @@ function AutofixInsightCards({
             />
           )
         )
-      ) : !hasStepAbove && !hasStepBelow ? (
+      ) : stepIndex === 0 && !hasStepBelow ? (
         <NoInsightsYet>
+          <p>Autofix will share its discoveries here.</p>
           <p>
-            Autofix will share important conclusions here as it discovers them, building a
-            line of reasoning up to the root cause.
+            Autofix is like a new teammate with fresh eyes on your code.
+            <br />
+            Collaborate with it and share your own knowledge and opinions for the best
+            results.
           </p>
-          <IllustrationContainer>
-            <Illustration src={bannerImage} />
-          </IllustrationContainer>
         </NoInsightsYet>
       ) : null}
     </InsightsContainer>
@@ -502,14 +500,6 @@ const UserMessage = styled('div')`
   flex-shrink: 100;
 `;
 
-const IllustrationContainer = styled('div')`
-  padding-top: ${space(4)};
-`;
-
-const Illustration = styled('img')`
-  height: 100%;
-`;
-
 const NoInsightsYet = styled('div')`
   display: flex;
   justify-content: center;
@@ -517,6 +507,8 @@ const NoInsightsYet = styled('div')`
   padding-left: ${space(4)};
   padding-right: ${space(4)};
   text-align: center;
+  color: ${p => p.theme.subText};
+  padding-top: ${space(4)};
 `;
 
 const InsightsContainer = styled('div')``;

--- a/static/app/components/events/autofix/autofixSetupModal.tsx
+++ b/static/app/components/events/autofix/autofixSetupModal.tsx
@@ -145,12 +145,19 @@ function AutofixGithubIntegrationStep({
   canStartAutofix,
   closeModal,
   isLastStep,
+  refetchSetup,
 }: {
   autofixSetup: AutofixSetupResponse;
   canStartAutofix: boolean;
   closeModal: () => void;
   isLastStep?: boolean;
+  refetchSetup?: () => void;
 }) {
+  const handleClose = () => {
+    refetchSetup?.();
+    closeModal();
+  };
+
   const sortedRepos = useMemo(
     () =>
       autofixSetup.githubWriteIntegration.repos.toSorted((a, b) => {
@@ -186,7 +193,7 @@ function AutofixGithubIntegrationStep({
               priority="primary"
               size="sm"
               disabled={!canStartAutofix}
-              onClick={closeModal}
+              onClick={handleClose}
             >
               {t("Let's Go!")}
             </Button>
@@ -227,7 +234,7 @@ function AutofixGithubIntegrationStep({
               priority="primary"
               size="sm"
               disabled={!canStartAutofix}
-              onClick={closeModal}
+              onClick={handleClose}
             >
               {t('Skip & Enable Autofix')}
             </Button>
@@ -262,7 +269,7 @@ function AutofixGithubIntegrationStep({
             priority="primary"
             size="sm"
             disabled={!canStartAutofix}
-            onClick={closeModal}
+            onClick={handleClose}
           >
             {t('Skip & Enable Autofix')}
           </Button>
@@ -276,12 +283,14 @@ function AutofixSetupSteps({
   autofixSetup,
   closeModal,
   canStartAutofix,
+  refetchSetup,
 }: {
   autofixSetup: AutofixSetupResponse;
   canStartAutofix: boolean;
   closeModal: () => void;
   groupId: string;
   projectId: string;
+  refetchSetup?: () => void;
 }) {
   return (
     <GuidedSteps>
@@ -304,6 +313,7 @@ function AutofixSetupSteps({
           canStartAutofix={canStartAutofix}
           closeModal={closeModal}
           isLastStep
+          refetchSetup={refetchSetup}
         />
       </GuidedSteps.Step>
     </GuidedSteps>
@@ -314,10 +324,12 @@ export function AutofixSetupContent({
   projectId,
   groupId,
   closeModal,
+  refetchSetup,
 }: {
   closeModal: () => void;
   groupId: string;
   projectId: string;
+  refetchSetup?: () => void;
 }) {
   const organization = useOrganization();
   const {data, canStartAutofix, isPending, isError} = useAutofixSetup(
@@ -363,6 +375,7 @@ export function AutofixSetupContent({
         autofixSetup={data}
         canStartAutofix={canStartAutofix}
         closeModal={closeModal}
+        refetchSetup={refetchSetup}
       />
     </Fragment>
   );

--- a/static/app/components/events/autofix/autofixSetupModal.tsx
+++ b/static/app/components/events/autofix/autofixSetupModal.tsx
@@ -310,7 +310,7 @@ function AutofixSetupSteps({
   );
 }
 
-function AutofixSetupContent({
+export function AutofixSetupContent({
   projectId,
   groupId,
   closeModal,
@@ -350,13 +350,21 @@ function AutofixSetupContent({
   }
 
   return (
-    <AutofixSetupSteps
-      groupId={groupId}
-      projectId={projectId}
-      autofixSetup={data}
-      canStartAutofix={canStartAutofix}
-      closeModal={closeModal}
-    />
+    <Fragment>
+      <Header>Set up Autofix</Header>
+      <p>
+        Sentry's AI-enabled Autofix uses all of the contextual data surrounding this error
+        to work with you to find the root cause and create a fix.
+      </p>
+      <p>A few additional steps are needed before you can use Autofix.</p>
+      <AutofixSetupSteps
+        groupId={groupId}
+        projectId={projectId}
+        autofixSetup={data}
+        canStartAutofix={canStartAutofix}
+        closeModal={closeModal}
+      />
+    </Fragment>
   );
 }
 
@@ -391,6 +399,13 @@ export const AutofixSetupDone = styled('div')`
   flex-direction: column;
   padding: 40px;
   font-size: ${p => p.theme.fontSizeLarge};
+`;
+
+const Header = styled('p')`
+  font-size: ${p => p.theme.fontSizeLarge};
+  font-weight: ${p => p.theme.fontWeightBold};
+  margin-bottom: ${space(2)};
+  margin-top: ${space(2)};
 `;
 
 const RepoLinkUl = styled('ul')`

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -250,7 +250,7 @@ export function AutofixSteps({data, groupId, runId}: AutofixStepsProps) {
               <Step
                 step={step}
                 hasStepBelow={index + 1 < steps.length && !twoInsightStepsInARow}
-                hasStepAbove={index > 0}
+                hasStepAbove
                 groupId={groupId}
                 runId={runId}
                 repos={repos}

--- a/static/app/components/group/groupSummary.spec.tsx
+++ b/static/app/components/group/groupSummary.spec.tsx
@@ -96,9 +96,9 @@ describe('GroupSummary', function () {
     await userEvent.click(screen.getByText('TL;DR: Test headline'));
 
     // Verify expanded view shows the individual sections
-    expect(screen.getByText("What's wrong?")).toBeInTheDocument();
+    expect(screen.getByText("What's wrong")).toBeInTheDocument();
     expect(screen.getByText('Test whats wrong')).toBeInTheDocument();
-    expect(screen.getByText('Trace')).toBeInTheDocument();
+    expect(screen.getByText('In the trace')).toBeInTheDocument();
     expect(screen.getByText('Test trace')).toBeInTheDocument();
     expect(screen.getByText('Possible cause')).toBeInTheDocument();
     expect(screen.getByText('Test possible cause')).toBeInTheDocument();


### PR DESCRIPTION
Adds the issue summary and the Autofix set up into the Autofix drawer (the latter won't be seen by users yet since the banner is still set-up-gated).

In a future PR, I'll move the entry point to this drawer to the new Solutions Hub, remove the old entry points, integrate the Resources & Solutions doc links, and use the hide AI setting.

<img width="647" alt="Screenshot 2024-11-11 at 7 04 31 PM" src="https://github.com/user-attachments/assets/416de9d2-3625-4264-b40c-fe128727c802">
<img width="652" alt="Screenshot 2024-11-11 at 7 05 19 PM" src="https://github.com/user-attachments/assets/f51d0656-90f6-43f6-8f1c-9d630f9885f6">
<img width="627" alt="Screenshot 2024-11-11 at 7 52 39 PM" src="https://github.com/user-attachments/assets/116594f2-859a-43eb-91c4-44a36632ceff">



