### PR TITLE
ref(replay): Use types/enums in VideoReplayerWithInteractions

### DIFF
--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -1,4 +1,8 @@
-import {EventType, type eventWithTime as TEventWithTime} from '@sentry-internal/rrweb';
+import {
+  EventType,
+  type eventWithTime as TEventWithTime,
+  MouseInteractions,
+} from '@sentry-internal/rrweb';
 
 export type {serializedNodeWithId} from '@sentry-internal/rrweb-snapshot';
 export type {fullSnapshotEvent, incrementalSnapshotEvent} from '@sentry-internal/rrweb';
@@ -136,7 +140,7 @@ export function isTouchStartFrame(frame: RecordingFrame) {
   return (
     frame.type === EventType.IncrementalSnapshot &&
     'type' in frame.data &&
-    frame.data.type === 7
+    frame.data.type === MouseInteractions.TouchStart
   );
 }
 
@@ -144,7 +148,7 @@ export function isTouchEndFrame(frame: RecordingFrame) {
   return (
     frame.type === EventType.IncrementalSnapshot &&
     'type' in frame.data &&
-    frame.data.type === 9
+    frame.data.type === MouseInteractions.TouchEnd
   );
 }
 

--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -132,6 +132,26 @@ export function isRecordingFrame(
   return 'type' in attachment && 'timestamp' in attachment;
 }
 
+export function isTouchStartFrame(frame: RecordingFrame) {
+  return (
+    frame.type === EventType.IncrementalSnapshot &&
+    'type' in frame.data &&
+    frame.data.type === 7
+  );
+}
+
+export function isTouchEndFrame(frame: RecordingFrame) {
+  return (
+    frame.type === EventType.IncrementalSnapshot &&
+    'type' in frame.data &&
+    frame.data.type === 9
+  );
+}
+
+export function isMetaFrame(frame: RecordingFrame) {
+  return frame.type === EventType.Meta;
+}
+
 export function isBreadcrumbFrameEvent(
   attachment: Record<string, any>
 ): attachment is BreadcrumbFrameEvent {


### PR DESCRIPTION
Removed some magic numbers in favor of `EventType` and `NodeType` imports... and prefer `RecordingFrame` over the rrweb `eventWithTime` too.