### PR TITLE
ref(contexts): Use newly added computed contexts

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -70,7 +70,7 @@ sentry-kafka-schemas>=0.1.118
 sentry-ophio==1.0.0
 sentry-protos>=0.1.34
 sentry-redis-tools>=0.1.7
-sentry-relay>=0.9.2
+sentry-relay>=0.9.3
 sentry-sdk[http2]>=2.18.0
 slack-sdk>=3.27.2
 snuba-sdk>=3.0.43

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -188,7 +188,7 @@ sentry-kafka-schemas==0.1.118
 sentry-ophio==1.0.0
 sentry-protos==0.1.34
 sentry-redis-tools==0.1.7
-sentry-relay==0.9.2
+sentry-relay==0.9.3
 sentry-sdk==2.18.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -129,7 +129,7 @@ sentry-kafka-schemas==0.1.118
 sentry-ophio==1.0.0
 sentry-protos==0.1.34
 sentry-redis-tools==0.1.7
-sentry-relay==0.9.2
+sentry-relay==0.9.3
 sentry-sdk==2.18.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6

--- a/src/sentry/interfaces/contexts.py
+++ b/src/sentry/interfaces/contexts.py
@@ -146,6 +146,28 @@ class ContextType:
             return value
 
 
+# NOTE:
+# If you are adding a new context to tag mapping which creates a tag out of an interpolation
+# of multiple context fields, you will most likely have to add the same mapping creation in Relay,
+# which should be added directly to the context payload itself, and you should reflect this here.
+#
+# Current examples of this include the `os`, `runtime` and `browser` fields of their respective context.
+#
+# Example:
+# Suppose you have a new context named "my_context" which has fields:
+# - "field_1"
+# - "field_2"
+#
+# And you want to create a tag named "field_3" which is equal to "{field_1}-{field_2}".
+#
+# If you do this here, on demand metrics will stop working because if a user filters by "field_3" and
+# we generate a metrics extraction specification for it, Relay won't know what "field_3" means, it will
+# only know "field_1" and "field_2" from the context.
+#
+# To solve this, you should materialize "field_3" during event normalization in Relay and directly express
+# the mapping in Sentry as "field_3" is equal to "field_3" (which was added by Relay during normalization).
+
+
 # TODO(dcramer): contexts need to document/describe expected (optional) fields
 @contexttype
 class DefaultContextType(ContextType):
@@ -168,20 +190,20 @@ class DeviceContextType(ContextType):
 @contexttype
 class RuntimeContextType(ContextType):
     type = "runtime"
-    context_to_tag_mapping = {"": "{name} {version}", "name": "{name}"}
+    context_to_tag_mapping = {"": "{runtime}", "name": "{name}"}
 
 
 @contexttype
 class BrowserContextType(ContextType):
     type = "browser"
-    context_to_tag_mapping = {"": "{name} {version}", "name": "{name}"}
+    context_to_tag_mapping = {"": "{browser}", "name": "{name}"}
     # viewport
 
 
 @contexttype
 class OsContextType(ContextType):
     type = "os"
-    context_to_tag_mapping = {"": "{name} {version}", "name": "{name}", "rooted": "{rooted}"}
+    context_to_tag_mapping = {"": "{os}", "name": "{name}", "rooted": "{rooted}"}
     # build, rooted
 
 

--- a/tests/sentry/event_manager/interfaces/snapshots/test_contexts/test_browser.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_contexts/test_browser.pysnap
@@ -1,0 +1,15 @@
+---
+source: tests/sentry/event_manager/interfaces/test_contexts.py
+---
+errors: null
+tags:
+- - browser
+  - Chrome 132.0.6834.0
+- - browser.name
+  - Chrome
+to_json:
+  browser:
+    browser: Chrome 132.0.6834.0
+    name: Chrome
+    type: browser
+    version: 132.0.6834.0

--- a/tests/sentry/event_manager/interfaces/snapshots/test_contexts/test_os.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_contexts/test_os.pysnap
@@ -1,6 +1,4 @@
 ---
-created: '2019-03-14T17:12:34.895867Z'
-creator: sentry
 source: tests/sentry/event_manager/interfaces/test_contexts.py
 ---
 errors: null
@@ -14,6 +12,7 @@ tags:
 to_json:
   os:
     name: Windows
+    os: Windows 95
     rooted: true
     type: os
     version: '95'

--- a/tests/sentry/event_manager/interfaces/snapshots/test_contexts/test_os_normalization.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_contexts/test_os_normalization.pysnap
@@ -1,6 +1,4 @@
 ---
-created: '2022-04-19T12:13:12.606509Z'
-creator: sentry
 source: tests/sentry/event_manager/interfaces/test_contexts.py
 ---
 errors: null
@@ -13,6 +11,7 @@ to_json:
   os:
     build: '7601'
     name: Windows
+    os: Windows 7
     raw_description: Microsoft Windows 6.1.7601 S
     type: os
     version: '7'

--- a/tests/sentry/event_manager/interfaces/snapshots/test_contexts/test_runtime.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_contexts/test_runtime.pysnap
@@ -1,6 +1,4 @@
 ---
-created: '2019-03-14T17:12:34.943424Z'
-creator: sentry
 source: tests/sentry/event_manager/interfaces/test_contexts.py
 ---
 errors: null
@@ -13,5 +11,6 @@ to_json:
   runtime:
     build: BLAH
     name: Java
+    runtime: Java 1.2.3
     type: runtime
     version: 1.2.3

--- a/tests/sentry/event_manager/interfaces/snapshots/test_contexts/test_runtime_normalization.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_contexts/test_runtime_normalization.pysnap
@@ -1,6 +1,4 @@
 ---
-created: '2019-03-14T17:12:34.953209Z'
-creator: sentry
 source: tests/sentry/event_manager/interfaces/test_contexts.py
 ---
 errors: null
@@ -14,5 +12,6 @@ to_json:
     build: '461808'
     name: .NET Framework
     raw_description: .NET Framework 4.0.30319.42000
+    runtime: .NET Framework 4.7.2
     type: runtime
     version: 4.7.2

--- a/tests/sentry/event_manager/interfaces/test_contexts.py
+++ b/tests/sentry/event_manager/interfaces/test_contexts.py
@@ -24,7 +24,9 @@ def make_ctx_snapshot(insta_snapshot):
 
 
 def test_os(make_ctx_snapshot):
-    make_ctx_snapshot({"os": {"name": "Windows", "version": "95", "rooted": True}})
+    make_ctx_snapshot(
+        {"os": {"os": "Windows 95", "name": "Windows", "version": "95", "rooted": True}}
+    )
 
 
 def test_null_values(make_ctx_snapshot):
@@ -44,12 +46,20 @@ def test_os_normalization(make_ctx_snapshot):
 
 
 def test_runtime(make_ctx_snapshot, insta_snapshot):
-    make_ctx_snapshot({"runtime": {"name": "Java", "version": "1.2.3", "build": "BLAH"}})
+    make_ctx_snapshot(
+        {"runtime": {"runtime": "Java 1.2.3", "name": "Java", "version": "1.2.3", "build": "BLAH"}}
+    )
 
 
 def test_runtime_normalization(make_ctx_snapshot):
     make_ctx_snapshot(
         {"runtime": {"raw_description": ".NET Framework 4.0.30319.42000", "build": "461808"}}
+    )
+
+
+def test_browser(make_ctx_snapshot, insta_snapshot):
+    make_ctx_snapshot(
+        {"browser": {"browser": "Chrome 132.0.6834.0", "name": "Chrome", "version": "132.0.6834.0"}}
     )
 
 

--- a/tests/sentry/event_manager/interfaces/test_contexts.py
+++ b/tests/sentry/event_manager/interfaces/test_contexts.py
@@ -45,7 +45,7 @@ def test_os_normalization(make_ctx_snapshot):
     make_ctx_snapshot({"os": {"raw_description": "Microsoft Windows 6.1.7601 S"}})
 
 
-def test_runtime(make_ctx_snapshot, insta_snapshot):
+def test_runtime(make_ctx_snapshot):
     make_ctx_snapshot(
         {"runtime": {"runtime": "Java 1.2.3", "name": "Java", "version": "1.2.3", "build": "BLAH"}}
     )
@@ -57,7 +57,7 @@ def test_runtime_normalization(make_ctx_snapshot):
     )
 
 
-def test_browser(make_ctx_snapshot, insta_snapshot):
+def test_browser(make_ctx_snapshot):
     make_ctx_snapshot(
         {"browser": {"browser": "Chrome 132.0.6834.0", "name": "Chrome", "version": "132.0.6834.0"}}
     )


### PR DESCRIPTION
This PR uses the new computed contexts fields that were added in Relay in https://github.com/getsentry/relay/pull/4239.

Needs: https://github.com/getsentry/relay/pull/4239