### PR TITLE
feat(profiling): add support for stack trace rules

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -112,6 +112,7 @@ def keep_profiling_rules(config: str) -> str:
     if config is None or config == "":
         return ""
     for rule in config.splitlines():
+        rule = rule.strip()
         if rule == "" or rule.startswith("#"):  # ignore comment lines
             continue
         *matchers, action = rule.split()

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2849,3 +2849,22 @@ register(
     default=1_000_000,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# option used to enable/disable applying
+# stack trace rules in profiles
+register(
+    "profiling.stack_trace_rules.enabled",
+    default=False,
+    type=Bool,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+# list of project IDs for which we'll apply
+# stack trace rules to the profiles in case
+# there are any rules defined
+register(
+    "profiling.stack_trace_rules.allowed_project_ids",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/profiles/utils.py
+++ b/src/sentry/profiles/utils.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping, MutableMapping
 from datetime import datetime
 from types import TracebackType
 from typing import Any, Self
@@ -14,9 +15,13 @@ from urllib3.response import HTTPResponse as VroomResponse
 
 from sentry.api.event_search import SearchFilter, parse_search_query
 from sentry.exceptions import InvalidSearchQuery
+from sentry.grouping.enhancer import Enhancements, keep_profiling_rules
 from sentry.net.http import connection_from_url
 from sentry.utils import json, metrics
 from sentry.utils.sdk import set_measurement
+
+Profile = MutableMapping[str, Any]
+CallTrees = Mapping[str, list[Any]]
 
 
 class RetrySkipTimeout(urllib3.Retry):
@@ -171,3 +176,24 @@ def parse_profile_filters(query: str) -> dict[str, str]:
         profile_filters[term.key.name] = term.value.value
 
     return profile_filters
+
+
+def apply_stack_trace_rules_to_profile(profile: Profile, rules_config: str) -> None:
+    profiling_rules = keep_profiling_rules(rules_config)
+    if profiling_rules == "":
+        return
+    enhancements = Enhancements.from_config_string(profiling_rules)
+    if "version" in profile:
+        enhancements.apply_modifications_to_frame(
+            profile["profile"]["frames"], profile["platform"], {}
+        )
+    elif profile["platform"] == "android":
+        # set the fields that Enhancements expect
+        # with the right names.
+        for method in profile["profile"]["methods"]:
+            method["function"] = method.get("name", "")
+            method["abs_path"] = method.get("source_file", "")
+            method["module"] = method.get("class_name", "")
+        enhancements.apply_modifications_to_frame(
+            profile["profile"]["methods"], profile["platform"], {}
+        )

--- a/src/sentry/profiles/utils.py
+++ b/src/sentry/profiles/utils.py
@@ -178,6 +178,19 @@ def parse_profile_filters(query: str) -> dict[str, str]:
     return profile_filters
 
 
+# This support applying a subset of stack trace rules to the profile (matchers and actions).
+#
+# Matchers allowed:
+#
+#     stack.abs_path
+#     stack.module
+#     stack.function
+#     stack.package
+#
+# Actions allowed:
+#
+#     +app
+#     -app
 def apply_stack_trace_rules_to_profile(profile: Profile, rules_config: str) -> None:
     profiling_rules = keep_profiling_rules(rules_config)
     if profiling_rules == "":
@@ -188,8 +201,10 @@ def apply_stack_trace_rules_to_profile(profile: Profile, rules_config: str) -> N
             profile["profile"]["frames"], profile["platform"], {}
         )
     elif profile["platform"] == "android":
-        # set the fields that Enhancements expect
+        # Set the fields that Enhancements expect
         # with the right names.
+        # Sample format already has the right fields,
+        # for android we need to create aliases.
         for method in profile["profile"]["methods"]:
             method["function"] = method.get("name", "")
             method["abs_path"] = method.get("source_file", "")

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from sentry.models.project import Project
     from sentry.models.projectkey import ProjectKey
     from sentry.monitors.models import Monitor
-    from sentry.profiles.task import Profile
+    from sentry.profiles.utils import Profile
 
 
 @unique

--- a/tests/sentry/profiles/test_task.py
+++ b/tests/sentry/profiles/test_task.py
@@ -19,7 +19,6 @@ from sentry.models.projectkey import ProjectKey, UseCase
 from sentry.models.release import Release
 from sentry.models.releasefile import ReleaseFile
 from sentry.profiles.task import (
-    Profile,
     _calculate_profile_duration_ms,
     _deobfuscate,
     _deobfuscate_using_symbolicator,
@@ -30,6 +29,7 @@ from sentry.profiles.task import (
     get_metrics_dsn,
     process_profile_task,
 )
+from sentry.profiles.utils import Profile
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.factories import Factories, get_fixture_path
 from sentry.testutils.pytest.fixtures import django_db_all

--- a/tests/sentry/profiles/test_utils.py
+++ b/tests/sentry/profiles/test_utils.py
@@ -1,0 +1,122 @@
+from typing import Any
+
+from sentry.profiles.utils import apply_stack_trace_rules_to_profile
+
+
+def test_apply_stack_trace_rules_to_profile_sample_format():
+    profile: dict[str, Any] = {
+        "version": 1,
+        "platform": "python",
+        "profile": {
+            "frames": [
+                {
+                    "function": "functionA",
+                    "abs_path": "/env/lib/python3.11/site-packages/urllib3/connection.py",
+                    "module": "urllib3.connection",
+                    "in_app": True,
+                },
+                {
+                    "function": "<module>",
+                    "abs_path": "/Documents/dev/python_concurrency/multiple_requests.py",
+                    "module": "__main__",
+                    "in_app": False,
+                },
+                {
+                    "function": "system_function",
+                    "abs_path": "/Python.framework/Versions/3.11/lib/python3.11/socket.py",
+                    "module": "socket",
+                    "in_app": True,
+                },
+            ],
+        },
+    }
+
+    expected_frames = [
+        {
+            "function": "functionA",
+            "abs_path": "/env/lib/python3.11/site-packages/urllib3/connection.py",
+            "module": "urllib3.connection",
+            "in_app": False,
+            "data": {"orig_in_app": 1},
+        },
+        {
+            "function": "<module>",
+            "abs_path": "/Documents/dev/python_concurrency/multiple_requests.py",
+            "module": "__main__",
+            "in_app": True,
+            "data": {"orig_in_app": 0},
+        },
+        {
+            "function": "system_function",
+            "abs_path": "/Python.framework/Versions/3.11/lib/python3.11/socket.py",
+            "module": "socket",
+            "in_app": False,
+            "data": {"orig_in_app": 1},
+        },
+    ]
+
+    profiling_rules = """
+        stack.module:urllib3.connection -app
+        stack.abs_path:/Documents/dev/python_concurrency/multiple_requests.py +app
+        stack.function:system_function -app
+        """
+    apply_stack_trace_rules_to_profile(profile, profiling_rules)
+    assert profile["profile"]["frames"] == expected_frames
+
+
+def test_apply_stack_trace_rules_to_profile_android():
+    profile: dict[str, Any] = {
+        "platform": "android",
+        "profile": {
+            "methods": [
+                {
+                    "class_name": "com.example.android.myorg.MainFragment",
+                    "name": "deleteAll",
+                    "signature": "(com.example.android.myorg.MainFragment)",
+                    "source_file": "MainFragment.java",
+                    "in_app": False,
+                },
+                {
+                    "class_name": "java.io.BufferedInputStream",
+                    "name": "read1",
+                    "signature": "(byte[], int, int): int",
+                    "source_file": "BufferedInputStream.java",
+                    "in_app": True,
+                },
+            ]
+        },
+    }
+
+    expected_methods = [
+        {
+            "class_name": "com.example.android.myorg.MainFragment",
+            "name": "deleteAll",
+            "signature": "(com.example.android.myorg.MainFragment)",
+            "source_file": "MainFragment.java",
+            "in_app": True,
+            "function": "deleteAll",
+            "abs_path": "MainFragment.java",
+            "module": "com.example.android.myorg.MainFragment",
+            "data": {"orig_in_app": 0},
+        },
+        {
+            "class_name": "java.io.BufferedInputStream",
+            "name": "read1",
+            "signature": "(byte[], int, int): int",
+            "source_file": "BufferedInputStream.java",
+            "in_app": False,
+            "function": "read1",
+            "abs_path": "BufferedInputStream.java",
+            "module": "java.io.BufferedInputStream",
+            "data": {"orig_in_app": 1},
+        },
+    ]
+
+    profiling_rules = """
+    stack.module:java.io.BufferedInputStream -app
+    stack.function:deleteAll +app
+    """
+
+    apply_stack_trace_rules_to_profile(profile, profiling_rules)
+
+    assert profile["profile"]["methods"] == expected_methods


### PR DESCRIPTION
This adds support for applying a subset of stack trace rules (when available) to the profiles.

The list of rules supported can be referenced in this previous PR: https://github.com/getsentry/sentry/pull/79957