### PR TITLE
fix(tests): Fix outdated assertion

### DIFF
--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -140,7 +140,12 @@ class TestJavascriptIntegration(RelayStoreHelper):
 
         event = self.post_and_retrieve_event(data)
         contexts = event.interfaces["contexts"].to_json()
-        assert contexts.get("os") == {"name": "Windows", "version": "8", "type": "os"}
+        assert contexts.get("os") == {
+            "os": "Windows 8",
+            "name": "Windows",
+            "version": "8",
+            "type": "os",
+        }
         assert contexts.get("device") is None
 
     @requires_symbolicator
@@ -165,8 +170,18 @@ class TestJavascriptIntegration(RelayStoreHelper):
         event = self.post_and_retrieve_event(data)
 
         contexts = event.interfaces["contexts"].to_json()
-        assert contexts.get("os") == {"name": "Android", "type": "os", "version": "4.3"}
-        assert contexts.get("browser") == {"name": "Android", "type": "browser", "version": "4.3"}
+        assert contexts.get("os") == {
+            "os": "Android 4.3",
+            "name": "Android",
+            "type": "os",
+            "version": "4.3",
+        }
+        assert contexts.get("browser") == {
+            "browser": "Android 4.3",
+            "name": "Android",
+            "type": "browser",
+            "version": "4.3",
+        }
         assert contexts.get("device") == {
             "family": "Samsung SCH-R530U",
             "type": "device",

--- a/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_debug_id_resolving.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_debug_id_resolving.pysnap
@@ -8,6 +8,7 @@ contexts:
   os:
     build: ''
     name: Windows
+    os: Windows 10.0.14393
     type: os
     version: 10.0.14393
 debug_meta:


### PR DESCRIPTION
This PR fixes outdated test assertions which failed because of https://github.com/getsentry/relay/pull/4239.