### PR TITLE
feat(dynamic-sampling): add endpoint to retrieve project span counts

### DIFF
--- a/src/sentry/api/endpoints/organization_sampling_project_span_counts.py
+++ b/src/sentry/api/endpoints/organization_sampling_project_span_counts.py
@@ -1,0 +1,69 @@
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases import OrganizationEndpoint, OrganizationPermission
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.utils import get_date_range_from_params
+from sentry.constants import ObjectStatus
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.sentry_metrics.querying.data import (
+    MetricsAPIQueryResultsTransformer,
+    MQLQuery,
+    run_queries,
+)
+from sentry.sentry_metrics.querying.types import QueryOrder, QueryType
+from sentry.snuba.referrer import Referrer
+from sentry.utils.dates import parse_stats_period
+
+
+@region_silo_endpoint
+class OrganizationSamplingProjectSpanCountsEndpoint(OrganizationEndpoint):
+    """Endpoint for retrieving project span counts in all orgs."""
+
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
+
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+
+    permission_classes = (OrganizationPermission,)
+
+    def _check_feature(self, request: Request, organization: Organization):
+        if not features.has(
+            "organizations:dynamic-sampling-custom", organization, actor=request.user
+        ):
+            raise ResourceDoesNotExist
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        # TODO(shellmayr): add docstring
+        self._check_feature(request, organization)
+
+        start, end = get_date_range_from_params(request.GET)
+        projects = Project.objects.filter(organization=organization, status=ObjectStatus.ACTIVE)
+        mql = "sum(c:spans/count_per_root_project@none) by (project,target_project_id)"
+        query = MQLQuery(mql=mql, order=QueryOrder.DESC)
+        results = run_queries(
+            mql_queries=[query],
+            start=start,
+            end=end,
+            interval=self._interval_from_request(request),
+            organization=organization,
+            projects=projects,
+            environments=self.get_environments(request, organization),
+            referrer=Referrer.DYNAMIC_SAMPLING_SETTINGS_GET_SPAN_COUNTS.value,
+            query_type=QueryType.TOTALS,
+        ).apply_transformer(MetricsAPIQueryResultsTransformer())
+
+        return Response(status=200, data=results)
+
+    def _interval_from_request(self, request: Request) -> int:
+        """
+        Extracts the interval of the query from the request payload.
+        """
+        interval = parse_stats_period(request.GET.get("interval", "1h"))
+        return int(3600 if interval is None else interval.total_seconds())

--- a/src/sentry/api/endpoints/organization_sampling_project_span_counts.py
+++ b/src/sentry/api/endpoints/organization_sampling_project_span_counts.py
@@ -1,6 +1,3 @@
-from collections.abc import Sequence
-from typing import cast
-
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -39,11 +36,11 @@ class OrganizationSamplingProjectSpanCountsEndpoint(OrganizationEndpoint):
         self._check_feature(request, organization)
 
         start, end = get_date_range_from_params(request.GET)
-        projects = cast(
-            Sequence[Project],
-            list(
-                Project.objects.filter(organization=organization, status=ObjectStatus.ACTIVE).all()
-            ),
+        # We are purposely not filtering on team membership, as all users should be able to see the span counts
+        # in order to show the dynamic sampling settings page with all valid data. Please do not remove this
+        # without consulting the owner of the endpoint
+        projects = list(
+            Project.objects.filter(organization=organization, status=ObjectStatus.ACTIVE)
         )
         mql = f"sum({SpanMRI.COUNT_PER_ROOT_PROJECT.value}) by (project,target_project_id)"
         query = MQLQuery(mql=mql, order=QueryOrder.DESC)

--- a/src/sentry/api/endpoints/organization_sampling_project_span_counts.py
+++ b/src/sentry/api/endpoints/organization_sampling_project_span_counts.py
@@ -41,7 +41,9 @@ class OrganizationSamplingProjectSpanCountsEndpoint(OrganizationEndpoint):
         start, end = get_date_range_from_params(request.GET)
         projects = cast(
             Sequence[Project],
-            Project.objects.filter(organization=organization, status=ObjectStatus.ACTIVE).all(),
+            list(
+                Project.objects.filter(organization=organization, status=ObjectStatus.ACTIVE).all()
+            ),
         )
         mql = f"sum({SpanMRI.COUNT_PER_ROOT_PROJECT.value}) by (project,target_project_id)"
         query = MQLQuery(mql=mql, order=QueryOrder.DESC)

--- a/src/sentry/api/endpoints/organization_sampling_project_span_counts.py
+++ b/src/sentry/api/endpoints/organization_sampling_project_span_counts.py
@@ -36,7 +36,6 @@ class OrganizationSamplingProjectSpanCountsEndpoint(OrganizationEndpoint):
     }
 
     def get(self, request: Request, organization: Organization) -> Response:
-        # TODO(shellmayr): add docstring
         self._check_feature(request, organization)
 
         start, end = get_date_range_from_params(request.GET)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -21,6 +21,9 @@ from sentry.api.endpoints.organization_plugins_index import OrganizationPluginsE
 from sentry.api.endpoints.organization_projects_experiment import (
     OrganizationProjectsExperimentEndpoint,
 )
+from sentry.api.endpoints.organization_sampling_project_span_counts import (
+    OrganizationSamplingProjectSpanCountsEndpoint,
+)
 from sentry.api.endpoints.organization_spans_aggregation import OrganizationSpansAggregationEndpoint
 from sentry.api.endpoints.organization_stats_summary import OrganizationStatsSummaryEndpoint
 from sentry.api.endpoints.organization_unsubscribe import (
@@ -1416,6 +1419,11 @@ ORGANIZATION_URLS = [
         r"^(?P<organization_id_or_slug>[^\/]+)/sampling/project-rates/$",
         OrganizationSamplingProjectRatesEndpoint.as_view(),
         name="sentry-api-0-organization-sampling-project-rates",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/sampling/project-span-counts/$",
+        OrganizationSamplingProjectSpanCountsEndpoint.as_view(),
+        name="sentry-api-0-organization-sampling-span-counts",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/sdk-updates/$",

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1421,9 +1421,9 @@ ORGANIZATION_URLS = [
         name="sentry-api-0-organization-sampling-project-rates",
     ),
     re_path(
-        r"^(?P<organization_id_or_slug>[^\/]+)/sampling/project-span-counts/$",
+        r"^(?P<organization_id_or_slug>[^\/]+)/sampling/project-root-counts/$",
         OrganizationSamplingProjectSpanCountsEndpoint.as_view(),
-        name="sentry-api-0-organization-sampling-span-counts",
+        name="sentry-api-0-organization-sampling-root-counts",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/sdk-updates/$",

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -690,6 +690,7 @@ class Referrer(Enum):
     DYNAMIC_SAMPLING_TASKS_CUSTOM_RULE_NOTIFICATIONS = (
         "dynamic_sampling.tasks.custom_rule_notifications"
     )
+    DYNAMIC_SAMPLING_SETTINGS_GET_SPAN_COUNTS = "dynamic_sampling.settings.get_project_span_counts"
     ESCALATING_GROUPS = "sentry.issues.escalating"
     EVENTSTORE_GET_EVENT_BY_ID_NODESTORE = "eventstore.backend.get_event_by_id_nodestore"
     EVENTSTORE_GET_EVENTS = "eventstore.get_events"

--- a/tests/sentry/api/endpoints/test_organization_sampling_project_span_counts.py
+++ b/tests/sentry/api/endpoints/test_organization_sampling_project_span_counts.py
@@ -1,23 +1,58 @@
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
+import pytest
 from django.urls import reverse
 
-from sentry.testutils.cases import APITestCase
+from sentry.snuba.metrics import SpanMRI
+from sentry.testutils.cases import MetricsEnhancedPerformanceTestCase
+from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import region_silo_test
 
+pytestmark = [pytest.mark.sentry_metrics]
 
+
+@freeze_time(MetricsEnhancedPerformanceTestCase.MOCK_DATETIME)
 @region_silo_test
-class OrganizationSamplingProjectSpanCountsTest(APITestCase):
+class OrganizationSamplingProjectSpanCountsTest(MetricsEnhancedPerformanceTestCase):
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)
         self.org = self.create_organization(owner=self.user)
-        self.project = self.create_project(organization=self.org)
+        self.project_1 = self.create_project(organization=self.org, name="project_1")
+        self.project_2 = self.create_project(organization=self.org, name="project_2")
+        self.project_3 = self.create_project(organization=self.org, name="project_3")
         self.url = reverse(
             "sentry-api-0-organization-sampling-span-counts",
             kwargs={"organization_id_or_slug": self.org.slug},
         )
+
+        metric_data = (
+            (self.project_1.id, self.project_2.id, 12),
+            (self.project_1.id, self.project_3.id, 13),
+            (self.project_2.id, self.project_1.id, 21),
+        )
+
+        hour_ago = self.MOCK_DATETIME - timedelta(hours=1)
+        day_ago = self.MOCK_DATETIME - timedelta(days=5)
+
+        for project_source_id, target_project_id, span_count in metric_data:
+            self.store_metric(
+                org_id=self.org.id,
+                value=span_count,
+                project_id=int(project_source_id),
+                mri=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
+                tags={"target_project_id": str(target_project_id)},
+                timestamp=hour_ago.timestamp(),
+            )
+            self.store_metric(
+                org_id=self.org.id,
+                value=span_count,
+                project_id=int(project_source_id),
+                mri=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
+                tags={"target_project_id": str(target_project_id)},
+                timestamp=day_ago.timestamp(),
+            )
 
     def test_feature_flag_required(self):
         response = self.client.get(self.url)
@@ -67,3 +102,56 @@ class OrganizationSamplingProjectSpanCountsTest(APITestCase):
         )
 
         assert response.status_code == 404
+
+    def test_get_span_counts_with_ingested_data_24h(self):
+        """Test span counts endpoint with actual ingested metrics data"""
+        with self.feature("organizations:dynamic-sampling-custom"):
+            response = self.client.get(
+                self.url,
+                data={"statsPeriod": "24h"},
+            )
+
+        assert response.status_code == 200
+        data = response.data["data"][0]
+        data = sorted(data, key=lambda x: x["by"]["target_project_id"])
+
+        assert data[0]["by"]["project"] == self.project_2.name
+        assert data[0]["by"]["target_project_id"] == str(self.project_1.id)
+        assert data[0]["totals"] == 21.0
+
+        assert data[1]["by"]["project"] == self.project_1.name
+        assert data[1]["by"]["target_project_id"] == str(self.project_2.id)
+        assert data[1]["totals"] == 12.0
+
+        assert data[2]["by"]["project"] == self.project_1.name
+        assert data[2]["by"]["target_project_id"] == str(self.project_3.id)
+        assert data[2]["totals"] == 13.0
+
+        assert response.data["end"] == MetricsEnhancedPerformanceTestCase.MOCK_DATETIME
+        assert (response.data["end"] - response.data["start"]) == timedelta(days=1)
+
+    def test_get_span_counts_with_ingested_data_30d(self):
+        with self.feature("organizations:dynamic-sampling-custom"):
+            response = self.client.get(
+                self.url,
+                data={"statsPeriod": "30d"},
+            )
+
+        assert response.status_code == 200
+        data = response.data["data"][0]
+        data = sorted(data, key=lambda x: x["by"]["target_project_id"])
+
+        assert data[0]["by"]["project"] == self.project_2.name
+        assert data[0]["by"]["target_project_id"] == str(self.project_1.id)
+        assert data[0]["totals"] == 21.0 * 2
+
+        assert data[1]["by"]["project"] == self.project_1.name
+        assert data[1]["by"]["target_project_id"] == str(self.project_2.id)
+        assert data[1]["totals"] == 12.0 * 2
+
+        assert data[2]["by"]["project"] == self.project_1.name
+        assert data[2]["by"]["target_project_id"] == str(self.project_3.id)
+        assert data[2]["totals"] == 13.0 * 2
+
+        assert response.data["end"] == MetricsEnhancedPerformanceTestCase.MOCK_DATETIME
+        assert (response.data["end"] - response.data["start"]) == timedelta(days=30)

--- a/tests/sentry/api/endpoints/test_organization_sampling_project_span_counts.py
+++ b/tests/sentry/api/endpoints/test_organization_sampling_project_span_counts.py
@@ -1,0 +1,69 @@
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from django.urls import reverse
+
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test
+class OrganizationSamplingProjectSpanCountsTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.org = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.org)
+        self.url = reverse(
+            "sentry-api-0-organization-sampling-span-counts",
+            kwargs={"organization_id_or_slug": self.org.slug},
+        )
+
+    def test_feature_flag_required(self):
+        response = self.client.get(self.url)
+        assert response.status_code == 404
+
+    @patch("sentry.api.endpoints.organization_sampling_project_span_counts.run_queries")
+    def test_get_span_counts(self, mock_run_queries):
+        self.create_project(organization=self.org)
+        mock_run_queries.return_value.apply_transformer.return_value = {
+            "groups": [
+                {
+                    "by": {"project": "1", "target_project_id": "2"},
+                    "totals": {"sum(c:spans/count_per_root_project@none)": 123},
+                }
+            ]
+        }
+
+        with self.feature("organizations:dynamic-sampling-custom"):
+            response = self.client.get(
+                self.url,
+                format="json",
+                data={
+                    "start": (datetime.now() - timedelta(hours=1)).isoformat(),
+                    "end": datetime.now().isoformat(),
+                    "interval": "1h",
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.data == {
+            "groups": [
+                {
+                    "by": {"project": "1", "target_project_id": "2"},
+                    "totals": {"sum(c:spans/count_per_root_project@none)": 123},
+                }
+            ]
+        }
+
+    def test_missing_feature_flag(self):
+        response = self.client.get(
+            self.url,
+            format="json",
+            data={
+                "start": (datetime.now() - timedelta(hours=1)).isoformat(),
+                "end": datetime.now().isoformat(),
+            },
+        )
+
+        assert response.status_code == 404

--- a/tests/sentry/api/endpoints/test_organization_sampling_project_span_counts.py
+++ b/tests/sentry/api/endpoints/test_organization_sampling_project_span_counts.py
@@ -21,6 +21,7 @@ class OrganizationSamplingProjectSpanCountsTest(MetricsEnhancedPerformanceTestCa
         self.project_1 = self.create_project(organization=self.org, name="project_1")
         self.project_2 = self.create_project(organization=self.org, name="project_2")
         self.project_3 = self.create_project(organization=self.org, name="project_3")
+        self.project_4 = self.create_project(organization=self.org, name="project_4")
         self.url = reverse(
             "sentry-api-0-organization-sampling-span-counts",
             kwargs={"organization_id_or_slug": self.org.slug},
@@ -33,7 +34,8 @@ class OrganizationSamplingProjectSpanCountsTest(MetricsEnhancedPerformanceTestCa
         )
 
         hour_ago = self.MOCK_DATETIME - timedelta(hours=1)
-        day_ago = self.MOCK_DATETIME - timedelta(days=5)
+        days_ago = self.MOCK_DATETIME - timedelta(days=5)
+        fifty_days_ago = self.MOCK_DATETIME - timedelta(days=50)
 
         for project_source_id, target_project_id, span_count in metric_data:
             self.store_metric(
@@ -50,7 +52,15 @@ class OrganizationSamplingProjectSpanCountsTest(MetricsEnhancedPerformanceTestCa
                 project_id=int(project_source_id),
                 mri=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
                 tags={"target_project_id": str(target_project_id)},
-                timestamp=int(day_ago.timestamp()),
+                timestamp=int(days_ago.timestamp()),
+            )
+            self.store_metric(
+                org_id=self.org.id,
+                value=span_count,
+                project_id=int(project_source_id),
+                mri=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
+                tags={"target_project_id": str(target_project_id)},
+                timestamp=int(fifty_days_ago.timestamp()),
             )
 
     def test_feature_flag_required(self):

--- a/tests/sentry/api/endpoints/test_organization_sampling_project_span_counts.py
+++ b/tests/sentry/api/endpoints/test_organization_sampling_project_span_counts.py
@@ -1,5 +1,4 @@
-from datetime import datetime, timedelta
-from unittest.mock import patch
+from datetime import timedelta
 
 import pytest
 from django.urls import reverse
@@ -58,50 +57,17 @@ class OrganizationSamplingProjectSpanCountsTest(MetricsEnhancedPerformanceTestCa
         response = self.client.get(self.url)
         assert response.status_code == 404
 
-    @patch("sentry.api.endpoints.organization_sampling_project_span_counts.run_queries")
-    def test_get_span_counts(self, mock_run_queries):
-        self.create_project(organization=self.org)
-        mock_run_queries.return_value.apply_transformer.return_value = {
-            "groups": [
-                {
-                    "by": {"project": "1", "target_project_id": "2"},
-                    "totals": {"sum(c:spans/count_per_root_project@none)": 123},
-                }
-            ]
-        }
+    def test_get_span_counts_without_permission(self):
+        user = self.create_user()
+        self.login_as(user)
 
         with self.feature("organizations:dynamic-sampling-custom"):
             response = self.client.get(
                 self.url,
-                format="json",
-                data={
-                    "start": (datetime.now() - timedelta(hours=1)).isoformat(),
-                    "end": datetime.now().isoformat(),
-                    "interval": "1h",
-                },
+                data={"statsPeriod": "24h"},
             )
 
-        assert response.status_code == 200
-        assert response.data == {
-            "groups": [
-                {
-                    "by": {"project": "1", "target_project_id": "2"},
-                    "totals": {"sum(c:spans/count_per_root_project@none)": 123},
-                }
-            ]
-        }
-
-    def test_missing_feature_flag(self):
-        response = self.client.get(
-            self.url,
-            format="json",
-            data={
-                "start": (datetime.now() - timedelta(hours=1)).isoformat(),
-                "end": datetime.now().isoformat(),
-            },
-        )
-
-        assert response.status_code == 404
+        assert response.status_code == 403
 
     def test_get_span_counts_with_ingested_data_24h(self):
         """Test span counts endpoint with actual ingested metrics data"""

--- a/tests/sentry/api/endpoints/test_organization_sampling_project_span_counts.py
+++ b/tests/sentry/api/endpoints/test_organization_sampling_project_span_counts.py
@@ -23,7 +23,7 @@ class OrganizationSamplingProjectSpanCountsTest(MetricsEnhancedPerformanceTestCa
         self.project_3 = self.create_project(organization=self.org, name="project_3")
         self.project_4 = self.create_project(organization=self.org, name="project_4")
         self.url = reverse(
-            "sentry-api-0-organization-sampling-span-counts",
+            "sentry-api-0-organization-sampling-root-counts",
             kwargs={"organization_id_or_slug": self.org.slug},
         )
 

--- a/tests/sentry/api/endpoints/test_organization_sampling_project_span_counts.py
+++ b/tests/sentry/api/endpoints/test_organization_sampling_project_span_counts.py
@@ -42,7 +42,7 @@ class OrganizationSamplingProjectSpanCountsTest(MetricsEnhancedPerformanceTestCa
                 project_id=int(project_source_id),
                 mri=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
                 tags={"target_project_id": str(target_project_id)},
-                timestamp=hour_ago.timestamp(),
+                timestamp=int(hour_ago.timestamp()),
             )
             self.store_metric(
                 org_id=self.org.id,
@@ -50,7 +50,7 @@ class OrganizationSamplingProjectSpanCountsTest(MetricsEnhancedPerformanceTestCa
                 project_id=int(project_source_id),
                 mri=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
                 tags={"target_project_id": str(target_project_id)},
-                timestamp=day_ago.timestamp(),
+                timestamp=int(day_ago.timestamp()),
             )
 
     def test_feature_flag_required(self):
@@ -78,23 +78,23 @@ class OrganizationSamplingProjectSpanCountsTest(MetricsEnhancedPerformanceTestCa
             )
 
         assert response.status_code == 200
-        data = response.data["data"][0]
-        data = sorted(data, key=lambda x: x["by"]["target_project_id"])
+        data = response.data  # type: ignore[attr-defined]
+        span_counts = sorted(data["data"][0], key=lambda x: x["by"]["target_project_id"])
 
-        assert data[0]["by"]["project"] == self.project_2.name
-        assert data[0]["by"]["target_project_id"] == str(self.project_1.id)
-        assert data[0]["totals"] == 21.0
+        assert span_counts[0]["by"]["project"] == self.project_2.name
+        assert span_counts[0]["by"]["target_project_id"] == str(self.project_1.id)
+        assert span_counts[0]["totals"] == 21.0
 
-        assert data[1]["by"]["project"] == self.project_1.name
-        assert data[1]["by"]["target_project_id"] == str(self.project_2.id)
-        assert data[1]["totals"] == 12.0
+        assert span_counts[1]["by"]["project"] == self.project_1.name
+        assert span_counts[1]["by"]["target_project_id"] == str(self.project_2.id)
+        assert span_counts[1]["totals"] == 12.0
 
-        assert data[2]["by"]["project"] == self.project_1.name
-        assert data[2]["by"]["target_project_id"] == str(self.project_3.id)
-        assert data[2]["totals"] == 13.0
+        assert span_counts[2]["by"]["project"] == self.project_1.name
+        assert span_counts[2]["by"]["target_project_id"] == str(self.project_3.id)
+        assert span_counts[2]["totals"] == 13.0
 
-        assert response.data["end"] == MetricsEnhancedPerformanceTestCase.MOCK_DATETIME
-        assert (response.data["end"] - response.data["start"]) == timedelta(days=1)
+        assert data["end"] == MetricsEnhancedPerformanceTestCase.MOCK_DATETIME
+        assert (data["end"] - data["start"]) == timedelta(days=1)
 
     def test_get_span_counts_with_ingested_data_30d(self):
         with self.feature("organizations:dynamic-sampling-custom"):
@@ -104,20 +104,20 @@ class OrganizationSamplingProjectSpanCountsTest(MetricsEnhancedPerformanceTestCa
             )
 
         assert response.status_code == 200
-        data = response.data["data"][0]
-        data = sorted(data, key=lambda x: x["by"]["target_project_id"])
+        data = response.data  # type: ignore[attr-defined]
+        span_counts = sorted(data["data"][0], key=lambda x: x["by"]["target_project_id"])
 
-        assert data[0]["by"]["project"] == self.project_2.name
-        assert data[0]["by"]["target_project_id"] == str(self.project_1.id)
-        assert data[0]["totals"] == 21.0 * 2
+        assert span_counts[0]["by"]["project"] == self.project_2.name
+        assert span_counts[0]["by"]["target_project_id"] == str(self.project_1.id)
+        assert span_counts[0]["totals"] == 21.0 * 2
 
-        assert data[1]["by"]["project"] == self.project_1.name
-        assert data[1]["by"]["target_project_id"] == str(self.project_2.id)
-        assert data[1]["totals"] == 12.0 * 2
+        assert span_counts[1]["by"]["project"] == self.project_1.name
+        assert span_counts[1]["by"]["target_project_id"] == str(self.project_2.id)
+        assert span_counts[1]["totals"] == 12.0 * 2
 
-        assert data[2]["by"]["project"] == self.project_1.name
-        assert data[2]["by"]["target_project_id"] == str(self.project_3.id)
-        assert data[2]["totals"] == 13.0 * 2
+        assert span_counts[2]["by"]["project"] == self.project_1.name
+        assert span_counts[2]["by"]["target_project_id"] == str(self.project_3.id)
+        assert span_counts[2]["totals"] == 13.0 * 2
 
-        assert response.data["end"] == MetricsEnhancedPerformanceTestCase.MOCK_DATETIME
-        assert (response.data["end"] - response.data["start"]) == timedelta(days=30)
+        assert data["end"] == MetricsEnhancedPerformanceTestCase.MOCK_DATETIME
+        assert (data["end"] - data["start"]) == timedelta(days=30)


### PR DESCRIPTION
- Expose the span counts in all projects of an org via a new endpoint at /{organization}/sampling/project-span-counts/
- API response format is the same as in the metrics/query API
- Allows all members of an org with org:read permissions or higher to access the project ids, project names, and span counts of all projects in the org, even if there is no open membership

Contributes to https://github.com/getsentry/projects/issues/353