### PR TITLE
fix(dynamic-sampling): Prevent native form validation

### DIFF
--- a/static/app/views/settings/dynamicSampling/organizationSampleRateField.tsx
+++ b/static/app/views/settings/dynamicSampling/organizationSampleRateField.tsx
@@ -33,10 +33,7 @@ export function OrganizationSampleRateField({}) {
           title={t('You do not have permission to change the sample rate.')}
         >
           <PercentInput
-            width={100}
             type="number"
-            min={0}
-            max={100}
             disabled={!hasAccess}
             value={field.value}
             onChange={event => field.onChange(event.target.value)}

--- a/static/app/views/settings/dynamicSampling/organizationSampling.tsx
+++ b/static/app/views/settings/dynamicSampling/organizationSampling.tsx
@@ -67,7 +67,14 @@ export function OrganizationSampling() {
 
   return (
     <FormProvider formState={formState}>
-      <form onSubmit={event => event.preventDefault()}>
+      <OnRouteLeave
+        message={UNSAVED_CHANGES_MESSAGE}
+        when={locationChange =>
+          locationChange.currentLocation.pathname !==
+            locationChange.nextLocation.pathname && formState.hasChanged
+        }
+      />
+      <form onSubmit={event => event.preventDefault()} noValidate>
         <Panel>
           <PanelHeader>{t('General Settings')}</PanelHeader>
           <PanelBody>
@@ -75,13 +82,6 @@ export function OrganizationSampling() {
             <OrganizationSampleRateField />
           </PanelBody>
         </Panel>
-        <OnRouteLeave
-          message={UNSAVED_CHANGES_MESSAGE}
-          when={locationChange =>
-            locationChange.currentLocation.pathname !==
-              locationChange.nextLocation.pathname && formState.hasChanged
-          }
-        />
         <FormActions>
           <Button disabled={!formState.hasChanged || isPending} onClick={handleReset}>
             {t('Reset')}

--- a/static/app/views/settings/dynamicSampling/percentInput.tsx
+++ b/static/app/views/settings/dynamicSampling/percentInput.tsx
@@ -14,7 +14,7 @@ export function PercentInput(props: Props) {
         width: 160px;
       `}
     >
-      <InputGroup.Input type="number" {...props} />
+      <InputGroup.Input type="number" min={0} max={100} {...props} />
       <InputGroup.TrailingItems>
         <TrailingPercent>%</TrailingPercent>
       </InputGroup.TrailingItems>

--- a/static/app/views/settings/dynamicSampling/projectSampling.tsx
+++ b/static/app/views/settings/dynamicSampling/projectSampling.tsx
@@ -9,6 +9,7 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {OnRouteLeave} from 'sentry/utils/reactRouter6Compat/onRouteLeave';
 import {ProjectionPeriodControl} from 'sentry/views/settings/dynamicSampling/projectionPeriodControl';
 import {ProjectsEditTable} from 'sentry/views/settings/dynamicSampling/projectsEditTable';
 import {SamplingModeField} from 'sentry/views/settings/dynamicSampling/samplingModeField';
@@ -24,6 +25,9 @@ import {
 } from 'sentry/views/settings/dynamicSampling/utils/useSamplingProjectRates';
 
 const {useFormState, FormProvider} = projectSamplingForm;
+const UNSAVED_CHANGES_MESSAGE = t(
+  'You have unsaved changes, are you sure you want to leave?'
+);
 
 export function ProjectSampling() {
   const hasAccess = useHasDynamicSamplingWriteAccess();
@@ -79,7 +83,14 @@ export function ProjectSampling() {
 
   return (
     <FormProvider formState={formState}>
-      <form onSubmit={event => event.preventDefault()}>
+      <OnRouteLeave
+        message={UNSAVED_CHANGES_MESSAGE}
+        when={locationChange =>
+          locationChange.currentLocation.pathname !==
+            locationChange.nextLocation.pathname && formState.hasChanged
+        }
+      />
+      <form onSubmit={event => event.preventDefault()} noValidate>
         <Panel>
           <PanelHeader>{t('General Settings')}</PanelHeader>
           <PanelBody>

--- a/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
@@ -109,8 +109,6 @@ export function ProjectsEditTable({isLoading: isLoadingProp, sampleCounts}: Prop
               <PercentInput
                 type="number"
                 disabled
-                min={0}
-                max={100}
                 size="sm"
                 value={formatNumberWithDynamicDecimalPoints(projectedOrgRate, 2)}
               />

--- a/static/app/views/settings/dynamicSampling/projectsTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsTable.tsx
@@ -258,6 +258,7 @@ const TableRow = memo(function TableRow({
       <Cell>
         <FirstCellLine data-has-chevron={isExpandable}>
           <HiddenButton
+            type="button"
             disabled={!isExpandable}
             aria-label={isExpanded ? t('Collapse') : t('Expand')}
             onClick={() => setIsExpanded(value => !value)}
@@ -306,8 +307,6 @@ const TableRow = memo(function TableRow({
               type="number"
               disabled={!canEdit}
               onChange={handleChange}
-              min={0}
-              max={100}
               size="sm"
               value={sampleRate}
             />


### PR DESCRIPTION
Prevent native form validation.
Add route leave warning to manual sampling view.
Move repeated `min` and `max` prop values inside `PercentInput` component. 