### PR TITLE
fix(insights): Remove "Beta" badge

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -74,7 +74,6 @@ import {
 import {
   DOMAIN_VIEW_BASE_TITLE,
   DOMAIN_VIEW_BASE_URL,
-  DOMAIN_VIEW_RELEASE_LEVEL,
 } from 'sentry/views/insights/pages/settings';
 import {MODULE_TITLES} from 'sentry/views/insights/settings';
 import MetricsOnboardingSidebar from 'sentry/views/metrics/ddmOnboarding/sidebar';
@@ -623,8 +622,6 @@ function Sidebar() {
         id="insights-domains"
         initiallyExpanded
         exact={!shouldAccordionFloat}
-        isAlpha={DOMAIN_VIEW_RELEASE_LEVEL === 'alpha'}
-        isBeta={DOMAIN_VIEW_RELEASE_LEVEL === 'beta'}
       >
         <SidebarItem
           {...sidebarItemProps}

--- a/static/app/views/insights/pages/settings.ts
+++ b/static/app/views/insights/pages/settings.ts
@@ -1,4 +1,3 @@
-import type {BadgeType} from 'sentry/components/badge/featureBadge';
 import {t} from 'sentry/locale';
 import {MODULES as AI_MODULES} from 'sentry/views/insights/pages/ai/settings';
 import {MODULES as BACKEND_MODULES} from 'sentry/views/insights/pages/backend/settings';
@@ -8,7 +7,6 @@ import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import type {ModuleName} from 'sentry/views/insights/types';
 
 export const OVERVIEW_PAGE_TITLE = t('Overview');
-export const DOMAIN_VIEW_RELEASE_LEVEL: BadgeType = 'beta';
 export const DOMAIN_VIEW_BASE_URL = 'insights';
 export const DOMAIN_VIEW_BASE_TITLE = t('Insights');
 


### PR DESCRIPTION
GA preparation.

**e.g.,**
<img width="232" alt="Screenshot 2024-11-12 at 10 18 38 AM" src="https://github.com/user-attachments/assets/da6ebbc3-914c-4ae9-a5bd-fbd4efe0a118">
