### PR TITLE
fix(insights): Queries module handle no span system

### DIFF
--- a/static/app/views/insights/database/components/databasePageFilters.tsx
+++ b/static/app/views/insights/database/components/databasePageFilters.tsx
@@ -12,8 +12,8 @@ import {SupportedDatabaseSystem} from 'sentry/views/insights/database/utils/cons
 import {ModuleName} from 'sentry/views/insights/types';
 
 type Props = {
-  system: string;
   databaseCommand?: string;
+  system?: string;
   table?: string;
 };
 
@@ -30,7 +30,7 @@ export function DatabasePageFilters(props: Props) {
         <ActionSelector
           moduleName={ModuleName.DB}
           value={databaseCommand ?? ''}
-          filters={{'span.system': system}}
+          filters={system ? {'span.system': system} : undefined}
         />
         <DomainSelector
           moduleName={ModuleName.DB}

--- a/static/app/views/insights/database/components/databaseSystemSelector.tsx
+++ b/static/app/views/insights/database/components/databaseSystemSelector.tsx
@@ -17,6 +17,8 @@ export function DatabaseSystemSelector() {
   const {selectedSystem, setSelectedSystem, options, isLoading, isError} =
     useSystemSelectorOptions();
 
+  const system = selectedSystem ?? systemQueryParam;
+
   return (
     <CompactSelect
       onChange={option => {
@@ -36,7 +38,7 @@ export function DatabaseSystemSelector() {
       triggerProps={{prefix: t('System')}}
       loading={isLoading}
       disabled={isError || isLoading || options.length <= 1}
-      value={systemQueryParam ?? selectedSystem}
+      value={system}
     />
   );
 }

--- a/static/app/views/insights/database/components/databaseSystemSelector.tsx
+++ b/static/app/views/insights/database/components/databaseSystemSelector.tsx
@@ -17,7 +17,7 @@ export function DatabaseSystemSelector() {
   const {selectedSystem, setSelectedSystem, options, isLoading, isError} =
     useSystemSelectorOptions();
 
-  const system = selectedSystem ?? systemQueryParam;
+  const system = systemQueryParam ?? selectedSystem;
 
   return (
     <CompactSelect

--- a/static/app/views/insights/database/components/tables/queriesTable.tsx
+++ b/static/app/views/insights/database/components/tables/queriesTable.tsx
@@ -80,7 +80,7 @@ interface Props {
     pageLinks?: string;
   };
   sort: ValidSort;
-  system: string;
+  system?: string;
 }
 
 export function QueriesTable({response, sort, system}: Props) {
@@ -145,7 +145,7 @@ function renderBodyCell(
   meta: EventsMetaType | undefined,
   location: Location,
   organization: Organization,
-  system: string
+  system?: string
 ) {
   if (column.key === 'span.description') {
     return (

--- a/static/app/views/insights/database/components/useSystemSelectorOptions.tsx
+++ b/static/app/views/insights/database/components/useSystemSelectorOptions.tsx
@@ -14,9 +14,9 @@ import {
 import {SpanMetricsField} from 'sentry/views/insights/types';
 
 export function useSystemSelectorOptions() {
-  const [selectedSystem, setSelectedSystem] = useLocalStorageState<string>(
+  const [selectedSystem, setSelectedSystem] = useLocalStorageState<string | undefined>(
     'insights-db-system-selector',
-    ''
+    undefined
   );
 
   const {data, isPending, isError} = useSpanMetrics(


### PR DESCRIPTION
Depending on the SDK, spans may not have the system tag properly set and `useSystemSelectorOptions` returns an empty string for an empty state. This results in the query to fetch data failing, since `span.system: ` as a query param is invalid, and it should be set to `undefined` instead.