### PR TITLE
feat(workflow-engine): Implement apis for listing all detectors for a project, and creating new detectors

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -346,6 +346,7 @@ from sentry.users.api.endpoints.user_role_details import UserUserRoleDetailsEndp
 from sentry.users.api.endpoints.user_roles import UserUserRolesEndpoint
 from sentry.users.api.endpoints.userroles_details import UserRoleDetailsEndpoint
 from sentry.users.api.endpoints.userroles_index import UserRolesEndpoint
+from sentry.workflow_engine.endpoints import urls as workflow_urls
 
 from .endpoints.accept_organization_invite import AcceptOrganizationInvite
 from .endpoints.accept_project_transfer import AcceptProjectTransferEndpoint
@@ -2846,6 +2847,7 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         ProjectUptimeAlertIndexEndpoint.as_view(),
         name="sentry-api-0-project-uptime-alert-index",
     ),
+    *workflow_urls.urlpatterns,
 ]
 
 TEAM_URLS = [

--- a/src/sentry/workflow_engine/endpoints/project_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/project_detector_index.py
@@ -1,0 +1,71 @@
+from rest_framework import status
+from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
+
+from sentry.api.bases import ProjectAlertRulePermission, ProjectEndpoint
+from sentry.api.serializers import serialize
+from sentry.issues import grouptype
+from sentry.workflow_engine.models import Detector
+
+
+class ProjectDetectorIndexEndpoint(ProjectEndpoint):
+    # TODO: We probably need a specific permission for detectors. Possibly specific detectors have different perms
+    # too?
+    permission_classes = (ProjectAlertRulePermission,)
+
+    def _get_validator(self, request, project, group_type_slug):
+        detector_type = grouptype.registry.get_by_slug(group_type_slug)
+        if detector_type is None:
+            raise ValidationError({"groupType": ["Unknown group type"]})
+
+        if detector_type.detector_validator is None:
+            raise ValidationError({"groupType": ["Group type not compatible with detectors"]})
+
+        return detector_type.detector_validator(
+            context={
+                "project": project,
+                "organization": project.organization,
+                "request": request,
+                "access": request.access,
+            },
+            data=request.data,
+        )
+
+    def get(self, request, project):
+        """
+        List a Project's Detectors
+        `````````````````````````
+        Return a list of detectors for a given project.
+        """
+        queryset = Detector.objects.filter(
+            organization_id=project.organization_id,
+        ).order_by("id")
+
+        return self.paginate(
+            request=request,
+            queryset=queryset,
+            order_by="id",
+            on_results=lambda x: serialize(x, request.user),
+        )
+
+    def post(self, request, project):
+        """
+        Create a Detector
+        ````````````````
+        Create a new detector for a project.
+
+        :param string name: The name of the detector
+        :param string group_type: The type of detector to create
+        :param object data_source: Configuration for the data source
+        :param array data_conditions: List of conditions to trigger the detector
+        """
+        group_type = request.data.get("group_type")
+        if not group_type:
+            raise ValidationError({"groupType": ["This field is required."]})
+
+        validator = self._get_validator(request, project, group_type)
+        if not validator.is_valid():
+            return Response(validator.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        detector = validator.save()
+        return Response(serialize(detector, request.user), status=status.HTTP_201_CREATED)

--- a/src/sentry/workflow_engine/endpoints/urls.py
+++ b/src/sentry/workflow_engine/endpoints/urls.py
@@ -1,0 +1,11 @@
+from django.urls import re_path
+
+from .project_detector_index import ProjectDetectorIndexEndpoint
+
+urlpatterns = [
+    re_path(
+        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/detectors/$",
+        ProjectDetectorIndexEndpoint.as_view(),
+        name="sentry-api-0-project-detector-index",
+    ),
+]

--- a/src/sentry/workflow_engine/endpoints/urls.py
+++ b/src/sentry/workflow_engine/endpoints/urls.py
@@ -4,7 +4,7 @@ from .project_detector_index import ProjectDetectorIndexEndpoint
 
 urlpatterns = [
     re_path(
-        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/detectors/$",
+        r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/detectors/$",
         ProjectDetectorIndexEndpoint.as_view(),
         name="sentry-api-0-project-detector-index",
     ),

--- a/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
@@ -1,0 +1,186 @@
+from unittest import mock
+
+from sentry.api.serializers import serialize
+from sentry.incidents.grouptype import MetricAlertFire
+from sentry.models.environment import Environment
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.models import (
+    QuerySubscription,
+    QuerySubscriptionDataSourceHandler,
+    SnubaQuery,
+    SnubaQueryEventType,
+)
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import region_silo_test
+from sentry.workflow_engine.models import DataCondition, DataConditionGroup, DataSource, Detector
+from sentry.workflow_engine.registry import data_source_type_registry
+from sentry.workflow_engine.types import DetectorPriorityLevel
+
+
+class ProjectDetectorIndexBaseTest(APITestCase):
+    endpoint = "sentry-api-0-project-detector-index"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.environment = Environment.objects.create(
+            organization_id=self.organization.id, name="production"
+        )
+
+
+@region_silo_test
+class ProjectDetectorIndexGetTest(ProjectDetectorIndexBaseTest):
+    def test_simple(self):
+        detector = Detector.objects.create(
+            organization_id=self.organization.id,
+            name="Test Detector",
+            type=MetricAlertFire.slug,
+        )
+        detector_2 = Detector.objects.create(
+            organization_id=self.organization.id,
+            name="Test Detector 2",
+            type=MetricAlertFire.slug,
+        )
+        response = self.get_success_response(self.organization.slug, self.project.slug)
+        assert response.data == serialize([detector, detector_2])
+
+    def test_empty_result(self):
+        response = self.get_success_response(self.organization.slug, self.project.slug)
+        assert len(response.data) == 0
+
+
+@region_silo_test
+class ProjectDetectorIndexPostTest(ProjectDetectorIndexBaseTest):
+    method = "POST"
+
+    def setUp(self):
+        super().setUp()
+        self.valid_data = {
+            "name": "Test Detector",
+            "group_type": MetricAlertFire.slug,
+            "data_source": {
+                "query_type": SnubaQuery.Type.ERROR.value,
+                "dataset": Dataset.Events.name.lower(),
+                "query": "test query",
+                "aggregate": "count()",
+                "time_window": 60,
+                "environment": self.environment.name,
+                "event_types": [SnubaQueryEventType.EventType.ERROR.value],
+            },
+            "data_conditions": [
+                {
+                    "condition": "gt",
+                    "comparison": 100,
+                    "result": DetectorPriorityLevel.HIGH,
+                }
+            ],
+        }
+
+    def test_missing_group_type(self):
+        data = {**self.valid_data}
+        del data["group_type"]
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            **data,
+            status_code=400,
+        )
+        assert response.data == {"groupType": ["This field is required."]}
+
+    def test_invalid_group_type(self):
+        data = {**self.valid_data, "group_type": "invalid_type"}
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            **data,
+            status_code=400,
+        )
+        assert response.data == {"groupType": ["Unknown group type"]}
+
+    def test_incompatible_group_type(self):
+        with mock.patch("sentry.issues.grouptype.registry.get_by_slug") as mock_get:
+            mock_get.return_value = mock.Mock(detector_validator=None)
+            data = {**self.valid_data, "group_type": "incompatible_type"}
+            response = self.get_error_response(
+                self.organization.slug,
+                self.project.slug,
+                **data,
+                status_code=400,
+            )
+            assert response.data == {"groupType": ["Group type not compatible with detectors"]}
+
+    @mock.patch("sentry.workflow_engine.endpoints.validators.create_audit_entry")
+    def test_valid_creation(self, mock_audit):
+        with self.tasks():
+            response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                **self.valid_data,
+                status_code=201,
+            )
+
+        detector = Detector.objects.get(id=response.data["id"])
+        assert response.data == serialize([detector])[0]
+        assert detector.name == "Test Detector"
+        assert detector.type == MetricAlertFire.slug
+        assert detector.organization_id == self.organization.id
+
+        # Verify data source
+        data_source = DataSource.objects.get(detector=detector)
+        assert data_source.type == data_source_type_registry.get_key(
+            QuerySubscriptionDataSourceHandler
+        )
+        assert data_source.organization_id == self.organization.id
+
+        # Verify query subscription
+        query_sub = QuerySubscription.objects.get(id=data_source.query_id)
+        assert query_sub.project == self.project
+        assert query_sub.snuba_query
+        assert query_sub.snuba_query.type == SnubaQuery.Type.ERROR.value
+        assert query_sub.snuba_query.dataset == Dataset.Events.value
+        assert query_sub.snuba_query.query == "test query"
+        assert query_sub.snuba_query.aggregate == "count()"
+        assert query_sub.snuba_query.time_window == 3600
+        assert query_sub.snuba_query.environment == self.environment
+        assert query_sub.snuba_query.event_types == [SnubaQueryEventType.EventType.ERROR]
+
+        # Verify condition group and conditions
+        condition_group = detector.workflow_condition_group
+        assert condition_group
+        assert condition_group.logic_type == DataConditionGroup.Type.ANY
+        assert condition_group.organization_id == self.organization.id
+
+        conditions = list(DataCondition.objects.filter(condition_group=condition_group))
+        assert len(conditions) == 1
+        condition = conditions[0]
+        assert condition.condition == "gt"
+        assert condition.comparison == 100
+        assert condition.condition_result == DetectorPriorityLevel.HIGH
+
+        # Verify audit log
+        mock_audit.assert_called_once_with(
+            request=mock.ANY,
+            organization=self.organization,
+            target_object=detector.id,
+            event=mock.ANY,
+            data=detector.get_audit_log_data(),
+        )
+
+    def test_missing_required_field(self):
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            status_code=400,
+        )
+        assert response.data == {"groupType": ["This field is required."]}
+
+    def test_missing_name(self):
+        data = {**self.valid_data}
+        del data["name"]
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            **data,
+            status_code=400,
+        )
+        assert response.data == {"name": ["This field is required."]}


### PR DESCRIPTION
This implements a working api for fetching all detectors in a project, as well as using the serializers to be able to create new detectors.

Currently, the get api is just basic and doesn't allow any custom filtering or sorting. Those can be added in as needed.

The post api uses the group registry to fetch the appropriate validator. If no validator is specified for a group type then a detector can't be created for it.
