### PR TITLE
feat(explore): Use root duration

### DIFF
--- a/static/app/views/explore/hooks/useTraceSpans.spec.tsx
+++ b/static/app/views/explore/hooks/useTraceSpans.spec.tsx
@@ -9,9 +9,9 @@ import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import type {Organization} from 'sentry/types/organization';
 import {QueryClientProvider} from 'sentry/utils/queryClient';
+import type {TraceResult} from 'sentry/views/explore/hooks/useTraces';
+import type {SpanResults} from 'sentry/views/explore/hooks/useTraceSpans';
 import {OrganizationContext} from 'sentry/views/organizationContext';
-import type {TraceResult} from 'sentry/views/traces/hooks/useTraces';
-import type {SpanResults} from 'sentry/views/traces/hooks/useTraceSpans';
 
 import {useTraceSpans} from './useTraceSpans';
 
@@ -19,6 +19,7 @@ function createTraceResult(trace?: Partial<TraceResult>): TraceResult {
   return {
     breakdowns: [],
     duration: 333,
+    rootDuration: 333,
     end: 456,
     matchingSpans: 1,
     name: 'name',

--- a/static/app/views/explore/hooks/useTraces.spec.tsx
+++ b/static/app/views/explore/hooks/useTraces.spec.tsx
@@ -17,6 +17,7 @@ function createTraceResult(trace?: Partial<TraceResult>): TraceResult {
   return {
     breakdowns: [],
     duration: 333,
+    rootDuration: 333,
     end: 456,
     matchingSpans: 1,
     name: 'name',

--- a/static/app/views/explore/hooks/useTraces.tsx
+++ b/static/app/views/explore/hooks/useTraces.tsx
@@ -42,6 +42,7 @@ export interface TraceResult {
   numOccurrences: number;
   numSpans: number;
   project: string | null;
+  rootDuration: number | null;
   slices: number;
   start: number;
   trace: string;

--- a/static/app/views/explore/tables/tracesTable/index.tsx
+++ b/static/app/views/explore/tables/tracesTable/index.tsx
@@ -84,7 +84,7 @@ export function TracesTable() {
             {t('Timeline')}
           </StyledPanelHeader>
           <StyledPanelHeader align="right" lightText>
-            {t('Duration')}
+            {t('Root Duration')}
           </StyledPanelHeader>
           <StyledPanelHeader align="right" lightText>
             {t('Timestamp')}
@@ -264,7 +264,11 @@ function TraceRow({
         />
       </BreakdownPanelItem>
       <StyledPanelItem align="right">
-        <PerformanceDuration milliseconds={trace.duration} abbreviation />
+        {defined(trace.rootDuration) ? (
+          <PerformanceDuration milliseconds={trace.rootDuration} abbreviation />
+        ) : (
+          <EmptyValueContainer />
+        )}
       </StyledPanelItem>
       <StyledPanelItem align="right">
         <SpanTimeRenderer timestamp={trace.end} tooltipShowSeconds />


### PR DESCRIPTION
This switches to using the root duration instead of the full trace duration in the traces table.