### PR TITLE
fix(events): Remove old rate hack

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -52,12 +52,6 @@ def get_query_columns(columns, rollup):
     column_map = {
         "user_count": "count_unique(user)",
         "event_count": "count()",
-        "epm()": "epm(%d)" % rollup,
-        "eps()": "eps(%d)" % rollup,
-        "tpm()": "tpm(%d)" % rollup,
-        "tps()": "tps(%d)" % rollup,
-        "sps()": "sps(%d)" % rollup,
-        "spm()": "spm(%d)" % rollup,
     }
 
     return [column_map.get(column, column) for column in columns]

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -175,6 +175,7 @@ class TimeseriesQueryBuilder(UnresolvedQuery):
         config = config if config is not None else QueryBuilderConfig()
         config.auto_fields = False
         config.equation_config = {"auto_add": True, "aggregates_only": True}
+        self.interval = interval
         super().__init__(
             dataset,
             params,
@@ -185,7 +186,6 @@ class TimeseriesQueryBuilder(UnresolvedQuery):
             config=config,
         )
 
-        self.interval = interval
         self.granularity = Granularity(interval)
 
         self.limit = None if limit is None else Limit(limit)

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -648,18 +648,16 @@ class DiscoverDatasetConfig(DatasetConfig):
                 ),
                 SnQLFunction(
                     "eps",
-                    snql_aggregate=lambda args, alias: Function(
-                        "divide", [Function("count", []), args["interval"]], alias
+                    snql_aggregate=lambda args, alias: function_aliases.resolve_eps(
+                        args, alias, self.builder
                     ),
                     optional_args=[IntervalDefault("interval", 1, None)],
                     default_result_type="rate",
                 ),
                 SnQLFunction(
                     "epm",
-                    snql_aggregate=lambda args, alias: Function(
-                        "divide",
-                        [Function("count", []), Function("divide", [args["interval"], 60])],
-                        alias,
+                    snql_aggregate=lambda args, alias: function_aliases.resolve_epm(
+                        args, alias, self.builder
                     ),
                     optional_args=[IntervalDefault("interval", 1, None)],
                     default_result_type="rate",

--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -2070,6 +2070,8 @@ class MetricsDatasetConfig(DatasetConfig):
         alias: str | None = None,
         extra_condition: Function | None = None,
     ) -> SelectType:
+        if hasattr(self.builder, "interval"):
+            args["interval"] = self.builder.interval
         return self._resolve_rate(60, args, alias, extra_condition)
 
     def _resolve_spm(
@@ -2078,6 +2080,8 @@ class MetricsDatasetConfig(DatasetConfig):
         alias: str | None = None,
         extra_condition: Function | None = None,
     ) -> SelectType:
+        if hasattr(self.builder, "interval"):
+            args["interval"] = self.builder.interval
         return self._resolve_rate(60, args, alias, extra_condition, "span.self_time")
 
     def _resolve_eps(
@@ -2086,6 +2090,8 @@ class MetricsDatasetConfig(DatasetConfig):
         alias: str | None = None,
         extra_condition: Function | None = None,
     ) -> SelectType:
+        if hasattr(self.builder, "interval"):
+            args["interval"] = self.builder.interval
         return self._resolve_rate(None, args, alias, extra_condition)
 
     def _resolve_rate(

--- a/src/sentry/search/events/datasets/metrics_layer.py
+++ b/src/sentry/search/events/datasets/metrics_layer.py
@@ -393,7 +393,11 @@ class MetricsLayerDatasetConfig(MetricsDatasetConfig):
                         "rate",
                         [
                             Column(TransactionMRI.DURATION.value),
-                            args["interval"],
+                            (
+                                self.builder.interval
+                                if hasattr(self.builder, "interval")
+                                else args["interval"]
+                            ),
                             60,
                         ],
                         alias,
@@ -407,7 +411,11 @@ class MetricsLayerDatasetConfig(MetricsDatasetConfig):
                         "rate",
                         [
                             Column(SpanMRI.SELF_TIME.value),
-                            args["interval"],
+                            (
+                                self.builder.interval
+                                if hasattr(self.builder, "interval")
+                                else args["interval"]
+                            ),
                             60,
                         ],
                         alias,
@@ -421,7 +429,11 @@ class MetricsLayerDatasetConfig(MetricsDatasetConfig):
                         "rate",
                         [
                             Column(TransactionMRI.DURATION.value),
-                            args["interval"],
+                            (
+                                self.builder.interval
+                                if hasattr(self.builder, "interval")
+                                else args["interval"]
+                            ),
                             1,
                         ],
                         alias,

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -207,18 +207,16 @@ class SpansIndexedDatasetConfig(DatasetConfig):
                 ),
                 SnQLFunction(
                     "eps",
-                    snql_aggregate=lambda args, alias: Function(
-                        "divide", [Function("count", []), args["interval"]], alias
+                    snql_aggregate=lambda args, alias: function_aliases.resolve_eps(
+                        args, alias, self.builder
                     ),
                     optional_args=[IntervalDefault("interval", 1, None)],
                     default_result_type="rate",
                 ),
                 SnQLFunction(
                     "epm",
-                    snql_aggregate=lambda args, alias: Function(
-                        "divide",
-                        [Function("count", []), Function("divide", [args["interval"], 60])],
-                        alias,
+                    snql_aggregate=lambda args, alias: function_aliases.resolve_epm(
+                        args, alias, self.builder
                     ),
                     optional_args=[IntervalDefault("interval", 1, None)],
                     default_result_type="rate",
@@ -611,20 +609,17 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
             for function in [
                 SnQLFunction(
                     "eps",
-                    snql_aggregate=lambda args, alias: Function(
-                        "divide", [Function("count", []), args["interval"]], alias
+                    snql_aggregate=lambda args, alias: function_aliases.resolve_eps(
+                        args, alias, self.builder
                     ),
                     optional_args=[IntervalDefault("interval", 1, None)],
                     default_result_type="rate",
                 ),
                 SnQLFunction(
                     "epm",
-                    snql_aggregate=lambda args, alias: Function(
-                        "divide",
-                        [Function("count", []), Function("divide", [args["interval"], 60])],
-                        alias,
+                    snql_aggregate=lambda args, alias: function_aliases.resolve_epm(
+                        args, alias, self.builder
                     ),
-                    optional_args=[IntervalDefault("interval", 1, None)],
                     default_result_type="rate",
                 ),
                 SnQLFunction(

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -1027,18 +1027,22 @@ class SpansMetricsDatasetConfig(DatasetConfig):
 
     def _resolve_epm(
         self,
-        args: Mapping[str, str | Column | SelectType | int | float],
+        args: dict[str, str | Column | SelectType | int | float],
         alias: str | None = None,
         extra_condition: Function | None = None,
     ) -> SelectType:
+        if hasattr(self.builder, "interval"):
+            args["interval"] = self.builder.interval
         return self._resolve_rate(60, args, alias, extra_condition)
 
     def _resolve_eps(
         self,
-        args: Mapping[str, str | Column | SelectType | int | float],
+        args: dict[str, str | Column | SelectType | int | float],
         alias: str | None = None,
         extra_condition: Function | None = None,
     ) -> SelectType:
+        if hasattr(self.builder, "interval"):
+            args["interval"] = self.builder.interval
         return self._resolve_rate(None, args, alias, extra_condition)
 
     def _resolve_rate(

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -753,6 +753,36 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
             [{"count": 0.02}],
         ]
 
+    def test_eps_equation(self):
+        response = self.do_request(
+            data={
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(hours=2),
+                "interval": "1h",
+                "yAxis": ["equation|eps() * 2"],
+            },
+        )
+
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 2
+        assert pytest.approx(0.000556, abs=0.0001) == response.data["data"][0][1][0]["count"]
+        assert pytest.approx(0.001112, abs=0.0001) == response.data["data"][1][1][0]["count"]
+
+    def test_epm_equation(self):
+        response = self.do_request(
+            data={
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(hours=2),
+                "interval": "1h",
+                "yAxis": ["equation|epm() * 2"],
+            },
+        )
+
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 2
+        assert pytest.approx(0.03334, abs=0.01) == response.data["data"][0][1][0]["count"]
+        assert pytest.approx(0.06667, abs=0.01) == response.data["data"][1][1][0]["count"]
+
     def test_equation_mixed_multi_yaxis(self):
         response = self.do_request(
             data={

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -2062,8 +2062,8 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
 
         assert response.status_code == 200, response.content
         assert response.data["meta"] == {
-            "fields": {"time": "date", "epm_900": "rate"},
-            "units": {"time": None, "epm_900": None},
+            "fields": {"time": "date", "epm": "rate"},
+            "units": {"time": None, "epm": None},
             "isMetricsData": True,
             "isMetricsExtractedData": False,
             "tips": {},


### PR DESCRIPTION
- Rates used to depend on a hack at the endpoint level where interval was passed as an argument for generating charts, this updates all the rate functions to just grab interval from the builder
- This also fixes a bug where equations on rates wouldn't work since the rate function wouldn't have the rate passed in since its hidden inside an equation