### PR TITLE
ref(onboardin) nudge people to start a transaction

### DIFF
--- a/static/app/utils/gettingStartedDocs/node.ts
+++ b/static/app/utils/gettingStartedDocs/node.ts
@@ -232,7 +232,7 @@ Sentry.profiler.startProfiler();
 ${
   params.isPerformanceSelected
     ? `
-// Starts a transaction that will be also be profiled
+// Starts a transaction that will also be profiled
 Sentry.startSpan({
   name: "My First Transaction",
 }, () => {

--- a/static/app/utils/gettingStartedDocs/node.ts
+++ b/static/app/utils/gettingStartedDocs/node.ts
@@ -229,8 +229,18 @@ Sentry.init({
 // Manually call startProfiler and stopProfiler
 // to profile the code in between
 Sentry.profiler.startProfiler();
-// this code will be profiled
-
+${
+  params.isPerformanceSelected
+    ? `
+// Starts a transaction that will be also be profiled
+Sentry.startSpan({
+  name: "My First Transaction",
+}, () => {
+  // the code executing inside the transaction will be wrapped in a span and profiled
+});
+`
+    : '// this code will be profiled'
+}
 // Calls to stopProfiling are optional - if you don't stop the profiler, it will keep profiling
 // your application until the process exits or stopProfiling is called.
 Sentry.profiler.stopProfiler();`


### PR DESCRIPTION
We already tell people to enable tracing, but we don't tell them to start a span, which in the case of continuous profiling can lead to a bit of a weird experience.

cc @shellmayr 