### PR TITLE
fix(issues): Add back search border, "..." translation

### DIFF
--- a/static/app/views/issueDetails/groupEvents.spec.tsx
+++ b/static/app/views/issueDetails/groupEvents.spec.tsx
@@ -157,7 +157,7 @@ describe('groupEvents', () => {
     });
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
-    const input = screen.getByPlaceholderText('Search events...');
+    const input = screen.getByPlaceholderText('Search events\u2026');
 
     await userEvent.click(input);
     await userEvent.keyboard('foo');
@@ -183,7 +183,7 @@ describe('groupEvents', () => {
     });
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
-    const input = screen.getByPlaceholderText('Search events...');
+    const input = screen.getByPlaceholderText('Search events\u2026');
 
     await userEvent.click(input);
 

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
@@ -69,7 +69,7 @@ describe('EventDetailsHeader', () => {
 
     expect(screen.getByRole('button', {name: 'All Envs'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: '14D'})).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('Filter events...')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Filter events\u2026')).toBeInTheDocument();
     expect(
       screen.getByRole('button', {
         name: 'Toggle graph series - Events',
@@ -105,7 +105,7 @@ describe('EventDetailsHeader', () => {
     render(<EventDetailsHeader {...defaultProps} />, {organization, router});
     expect(await screen.findByTestId('event-graph-loading')).not.toBeInTheDocument();
 
-    const search = screen.getByPlaceholderText('Filter events...');
+    const search = screen.getByPlaceholderText('Filter events\u2026');
     await userEvent.type(search, `${tagKey}:`);
     await userEvent.keyboard(`${tagValue}{enter}{enter}`);
     expect(mockUseNavigate).toHaveBeenCalledWith(expect.objectContaining(locationQuery), {

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -122,7 +122,7 @@ const EnvironmentFilter = styled(EnvironmentPageFilter)`
 `;
 
 const SearchFilter = styled(EventSearch)`
-  border: 0;
+  border-color: transparent;
   border-radius: 0;
   box-shadow: none;
 `;

--- a/static/app/views/issueDetails/streamline/eventSearch.tsx
+++ b/static/app/views/issueDetails/streamline/eventSearch.tsx
@@ -22,7 +22,10 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {ALL_EVENTS_EXCLUDED_TAGS} from 'sentry/views/issueDetails/groupEvents';
-import {useGroupTags} from 'sentry/views/issueDetails/groupTags/useGroupTags';
+import {
+  type GroupTag,
+  useGroupTags,
+} from 'sentry/views/issueDetails/groupTags/useGroupTags';
 import {
   mergeAndSortTagValues,
   useHasStreamlinedUI,
@@ -81,7 +84,7 @@ export function useEventQuery({group}: {group: Group}): string {
   return joinQuery(validQuery, false, true);
 }
 
-function useEventSearchFilterKeys(data) {
+function useEventSearchFilterKeys(data: GroupTag[]): TagCollection {
   const filterKeys = useMemo<TagCollection>(() => {
     const tags = [
       ...data.map(tag => ({...tag, kind: FieldKind.TAG})),
@@ -190,8 +193,8 @@ export function EventSearch({
       filterKeys={filterKeys}
       filterKeySections={filterKeySections}
       getTagValues={getTagValues}
-      placeholder={hasStreamlinedUI ? t('Filter events...') : t('Search events...')}
-      label={hasStreamlinedUI ? t('Filter events...') : t('Search events')}
+      placeholder={hasStreamlinedUI ? t('Filter events\u2026') : t('Search events\u2026')}
+      label={hasStreamlinedUI ? t('Filter events\u2026') : t('Search events')}
       searchSource="issue_events_tab"
       className={className}
       showUnsubmittedIndicator


### PR DESCRIPTION
- adds a transparent border to search to avoid size change on focus
- swap "..." for \u2026 which apparently translates better or something
- fixes an implicit any

before: border changes size on focus 

https://github.com/user-attachments/assets/a0e3e2ef-282a-4da4-a3ff-4e7b133b6f4e

