### PR TITLE
feat(devservices): Restrict container access to localhost

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -43,7 +43,7 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
     ports:
-      - 5432:5432
+      - 127.0.0.1:5432:5432
     extra_hosts:
       - host.docker.internal:host-gateway
 


### PR DESCRIPTION
We should be exposing ports only to localhost as a security measure.

