### PR TITLE
fix(query-builder): Fix enter in empty search box not updating query

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -413,7 +413,7 @@ function SearchQueryBuilderComboboxInner<T extends SelectOptionOrSectionWithKey<
             onExit?.();
             return;
           case 'Enter':
-            if (state.selectionManager.focusedKey) {
+            if (isOpen && state.selectionManager.focusedKey) {
               return;
             }
             state.close();

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -139,8 +139,10 @@ function useHighlightFirstOptionOnSectionChange({
   selectedSection,
   sections,
   hiddenOptions,
+  isOpen,
 }: {
   hiddenOptions: Set<SelectKey>;
+  isOpen: boolean;
   sections: Section[];
   selectedSection: Key | null;
   state: ComboBoxState<SelectOptionOrSectionWithKey<string>>;
@@ -156,6 +158,10 @@ function useHighlightFirstOptionOnSectionChange({
   const previousSection = usePrevious(selectedSection);
 
   useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
     if (selectedSection === previousSection) {
       return;
     }
@@ -163,7 +169,13 @@ function useHighlightFirstOptionOnSectionChange({
     if (firstItem) {
       state.selectionManager.setFocusedKey(firstItem.key);
     }
-  }, [displayedListItems, previousSection, selectedSection, state.selectionManager]);
+  }, [
+    displayedListItems,
+    isOpen,
+    previousSection,
+    selectedSection,
+    state.selectionManager,
+  ]);
 }
 
 function FilterKeyMenuContent<T extends SelectOptionOrSectionWithKey<string>>({
@@ -272,6 +284,7 @@ export function FilterKeyListBox<T extends SelectOptionOrSectionWithKey<string>>
     selectedSection,
     hiddenOptions: hiddenOptionsWithRecentsAdded,
     sections,
+    isOpen,
   });
 
   const fullWidth = !query;


### PR DESCRIPTION
A bit difficult to reproduce, but sometimes the menu thinks there is a focused key even when the menu is closed. This adds a couple checks to ensure that pressing enter will always cause onSearch to fire:

- Checks `isOpen` when enter is pressed so that it won't choose a focused item when the menu is not opened
- Prevents the menu from focusing items when the menu is not open