### PR TITLE
fix(reinvite-members): resending member invite does not modify member details

### DIFF
--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -46,7 +46,9 @@ ERR_NO_AUTH = "You cannot remove this member with an unauthenticated API request
 ERR_INSUFFICIENT_ROLE = "You cannot remove a member who has more access than you."
 ERR_INSUFFICIENT_SCOPE = "You are missing the member:admin scope."
 ERR_MEMBER_INVITE = "You cannot modify invitations sent by someone else."
-ERR_EDIT_WHEN_REINVITING = "You cannot modify other member details when resending an invitation."
+ERR_EDIT_WHEN_REINVITING = (
+    "You cannot modify member details when resending an invitation. Separate requests are required."
+)
 ERR_ONLY_OWNER = "You cannot remove the only remaining owner of the organization."
 ERR_UNINVITABLE = "You cannot send an invitation to a user who is already a full member."
 ERR_EXPIRED = "You cannot resend an expired invitation without regenerating the token."

--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import logging
-
 from django.db import router, transaction
 from django.db.models import Q
 from drf_spectacular.utils import extend_schema, inline_serializer
@@ -48,7 +46,7 @@ ERR_NO_AUTH = "You cannot remove this member with an unauthenticated API request
 ERR_INSUFFICIENT_ROLE = "You cannot remove a member who has more access than you."
 ERR_INSUFFICIENT_SCOPE = "You are missing the member:admin scope."
 ERR_MEMBER_INVITE = "You cannot modify invitations sent by someone else."
-ERR_MEMBER_REINVITE = "You can only reinvite members; you cannot modify other member details."
+ERR_EDIT_WHEN_REINVITING = "You cannot modify other member details when resending an invitation."
 ERR_ONLY_OWNER = "You cannot remove the only remaining owner of the organization."
 ERR_UNINVITABLE = "You cannot send an invitation to a user who is already a full member."
 ERR_EXPIRED = "You cannot resend an expired invitation without regenerating the token."
@@ -238,31 +236,14 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
         if is_member:
             if not enable_member_invite or not member.is_pending:
                 raise PermissionDenied
-            if not reinvite_request_only:
-                return Response({"detail": ERR_MEMBER_REINVITE}, status=403)
             if not is_invite_from_user:
                 return Response({"detail": ERR_MEMBER_INVITE}, status=403)
-
-        logger = logging.getLogger(__name__)
 
         # XXX(dcramer): if/when this expands beyond reinvite we need to check
         # access level
         if result.get("reinvite"):
-            logger.info(
-                "organization.member_reinvite",
-                extra={
-                    "organization_id": organization.id,
-                    "user_id": request.user.id,
-                    "member_id": member.id,
-                    "curr_role": member.role,
-                    "orgRole": result.get("orgRole"),
-                    "role": result.get("role"),
-                    "curr_teams": [t.slug for t in member.get_teams()],
-                    "teams": result.get("teams"),
-                    "curr_team_roles": [t for t in member.get_team_roles()],
-                    "teamRoles": result.get("teamRoles"),
-                },
-            )
+            if not reinvite_request_only:
+                return Response({"detail": ERR_EDIT_WHEN_REINVITING}, status=403)
             if member.is_pending:
                 if ratelimits.for_organization_member_invite(
                     organization=organization,
@@ -293,6 +274,25 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
             else:
                 # TODO(dcramer): proper error message
                 return Response({"detail": ERR_UNINVITABLE}, status=400)
+
+            self.create_audit_entry(
+                request=request,
+                organization=organization,
+                target_object=member.id,
+                target_user_id=member.user_id,
+                event=audit_log.get_event_id("MEMBER_REINVITE"),
+                data=member.get_audit_log_data(),
+            )
+
+            return Response(
+                serialize(
+                    member,
+                    request.user,
+                    OrganizationMemberWithRolesSerializer(
+                        allowed_roles=allowed_roles,
+                    ),
+                )
+            )
 
         assigned_org_role = result.get("orgRole") or result.get("role")
 

--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -570,6 +570,15 @@ default_manager.add(
     )
 )
 
+default_manager.add(
+    AuditLogEvent(
+        event_id=204,
+        name="MEMBER_REINVITE",
+        api_name="member.reinvite",
+        template="reinvited member {email}",
+    )
+)
+
 default_manager.add(events.DataSecrecyWaivedAuditLogEvent())
 
 default_manager.add(

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -5,6 +5,7 @@ from django.db.models import F
 from django.test import override_settings
 from django.urls import reverse
 
+from sentry import audit_log
 from sentry.auth.authenticators.recovery_code import RecoveryCodeInterface
 from sentry.auth.authenticators.totp import TotpInterface
 from sentry.models.authprovider import AuthProvider
@@ -13,6 +14,7 @@ from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.roles import organization_roles
 from sentry.silo.base import SiloMode
+from sentry.testutils.asserts import assert_org_audit_log_exists
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.options import override_options
@@ -202,9 +204,15 @@ class UpdateOrganizationMemberTest(OrganizationMemberTestBase, HybridCloudTestMi
 
         self.organization.flags.disable_member_invite = False
         self.organization.save()
-        self.get_success_response(self.organization.slug, self.curr_invite.id, reinvite=1)
+        with outbox_runner():
+            self.get_success_response(self.organization.slug, self.curr_invite.id, reinvite=1)
         mock_send_invite_email.assert_called_once_with()
+        assert_org_audit_log_exists(
+            organization=self.organization,
+            event=audit_log.get_event_id("MEMBER_REINVITE"),
+        )
         mock_send_invite_email.reset_mock()
+
         response = self.get_error_response(
             self.organization.slug, self.other_invite.id, reinvite=1, status_code=403
         )
@@ -240,13 +248,13 @@ class UpdateOrganizationMemberTest(OrganizationMemberTestBase, HybridCloudTestMi
         )
         assert (
             response.data.get("detail")
-            == "You cannot modify other member details when resending an invitation."
+            == "You cannot modify member details when resending an invitation. Separate requests are required."
         )
         assert not mock_send_invite_email.mock_calls
 
     @patch("sentry.models.OrganizationMember.send_invite_email")
     @with_feature("organizations:members-invite-teammates")
-    def test_member_cannot_reinvite_members(self, mock_send_invite_email):
+    def test_member_cannot_reinvite_non_pending_members(self, mock_send_invite_email):
         self.login_as(self.curr_user)
 
         self.organization.flags.disable_member_invite = True
@@ -275,7 +283,7 @@ class UpdateOrganizationMemberTest(OrganizationMemberTestBase, HybridCloudTestMi
         )
         assert (
             response.data.get("detail")
-            == "You cannot modify other member details when resending an invitation."
+            == "You cannot modify member details when resending an invitation. Separate requests are required."
         )
         assert not mock_send_invite_email.mock_calls
 
@@ -299,8 +307,14 @@ class UpdateOrganizationMemberTest(OrganizationMemberTestBase, HybridCloudTestMi
                 "role": None,
             }
         ]
+        with outbox_runner():
+            self.get_success_response(self.organization.slug, member_om.id, reinvite=1)
 
-        self.get_success_response(self.organization.slug, member_om.id, reinvite=1)
+        assert_org_audit_log_exists(
+            organization=self.organization,
+            event=audit_log.get_event_id("MEMBER_REINVITE"),
+        )
+
         teams = list(map(lambda team: team.slug, member_om.teams.all()))
         roles = [t for t in member_om.get_team_roles()]
         assert member_om.role == "member"


### PR DESCRIPTION
fix for https://github.com/getsentry/sentry/issues/80063
member details should not be modified by resending an invitation. to make sure no details are changed, we now return early once the invitation has been re-sent.

also added:
- an additional check that the request is not attempting to update member details and resend an invitation at the same time, since we don't want to allow this behavior
- a new audit log event for `MEMBER_REINVITE`, since reinviting doesn't really fall under `MEMBER_EDIT`
