### PR TITLE
feat(crons): Implement `make_clock_tick_decision`

### DIFF
--- a/src/sentry/monitors/types.py
+++ b/src/sentry/monitors/types.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from enum import StrEnum
 from typing import Literal, NotRequired, TypedDict, Union
 
 from django.utils.functional import cached_property
@@ -129,23 +128,3 @@ class IntervalSchedule:
 
 
 ScheduleConfig = Union[CrontabSchedule, IntervalSchedule]
-
-
-class TickVolumeAnomolyResult(StrEnum):
-    """
-    This enum represents the result of comparing the minute we ticked past
-    with it's historic volume data. This is used to determine if we may have
-    consumed an anomalous number of check-ins, indicating there is an upstream
-    incident and we care not able to reliably report misses and time-outs.
-
-    A NORMAL result means we've considered the volume to be within the expected
-    volume for that minute. A ANOMALY value indicates there was a drop in
-    volume significant enough to consider it abnormal.
-    """
-
-    NORMAL = "normal"
-    ABNORMAL = "abnormal"
-
-    @classmethod
-    def from_str(cls, st: str) -> TickVolumeAnomolyResult:
-        return cls[st.upper()]

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2010,12 +2010,41 @@ register(
 # Killswitch for monitor check-ins
 register("crons.organization.disable-check-in", type=Sequence, default=[])
 
-# Enables anomaly detection based on the volume of check-ins being processed
+# Enables system incident anomaly detection based on the volume of check-ins
+# being processed
 register(
     "crons.tick_volume_anomaly_detection",
     default=False,
     flags=FLAG_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# The threshold that the tick metric must surpass for a tick to be determined
+# as anomalous. This value should be negative, since we will only determine an
+# incident based on a decrease in volume.
+#
+# See the `monitors.system_incidents` module for more details
+register(
+    "crons.system_incidents.pct_deviation_anomaly_threshold",
+    default=-10,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+# The threshold that the tick metric must surpass to transition to an incident
+# state. This should be a fairly high value to avoid false positive incidents.
+register(
+    "crons.system_incidents.pct_deviation_incident_threshold",
+    default=-30,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+# This is the number of previous ticks we will consider the tick metrics and
+# tick decisions for to determine a decision about the tick being evaluated.
+register(
+    "crons.system_incidents.tick_decision_window",
+    default=5,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 
 # Sets the timeout for webhooks
 register(


### PR DESCRIPTION
This function returns a DecisionResult which encapsulates the TickAnomalyDecision and AnomalyTransition values for a particular clock tick.

In the future this logic will be run at each clock tick and the result will later be used to decide if we can process issue occurrences in the incident_occurrences consumer for a specific clock tick.

Part of GH-79328