### PR TITLE
feat(issues): Remove child props from group tags

### DIFF
--- a/static/app/views/issueDetails/groupTagValues.spec.tsx
+++ b/static/app/views/issueDetails/groupTagValues.spec.tsx
@@ -1,4 +1,5 @@
 import {GroupFixture} from 'sentry-fixture/group';
+import {ProjectFixture} from 'sentry-fixture/project';
 import {TagsFixture} from 'sentry-fixture/tags';
 import {TagValuesFixture} from 'sentry-fixture/tagvalues';
 
@@ -8,30 +9,39 @@ import {
   screen,
   userEvent,
   waitFor,
-  waitForElementToBeRemoved,
   within,
 } from 'sentry-test/reactTestingLibrary';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import {GroupTagValues} from 'sentry/views/issueDetails/groupTagValues';
 
-const group = GroupFixture();
-const tags = TagsFixture();
-
-function init(tagKey: string) {
-  return initializeOrg({
-    router: {
-      location: {
-        query: {},
-        pathname: '/organizations/:orgId/issues/:groupId/tags/:tagKey/',
-      },
-      params: {orgId: 'org-slug', groupId: group.id, tagKey},
-    },
-  });
-}
-
 describe('GroupTagValues', () => {
+  const group = GroupFixture();
+  const tags = TagsFixture();
+  const project = ProjectFixture();
+
+  function init(tagKey: string, environment?: string[] | string) {
+    return initializeOrg({
+      router: {
+        location: {
+          query: {
+            environment,
+          },
+          pathname: '/organizations/:orgId/issues/:groupId/tags/:tagKey/',
+        },
+        params: {orgId: 'org-slug', groupId: group.id, tagKey},
+      },
+    });
+  }
+
   beforeEach(() => {
+    ProjectsStore.init();
+    ProjectsStore.loadInitialData([project]);
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/`,
+      body: group,
+    });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/1/tags/user/',
       body: tags.find(({key}) => key === 'user'),
@@ -43,27 +53,16 @@ describe('GroupTagValues', () => {
   });
 
   it('renders a list of tag values', async () => {
-    const {router, routerProps, project} = init('user');
+    const {router} = init('user');
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/1/tags/user/values/',
       body: TagValuesFixture(),
     });
-    render(
-      <GroupTagValues
-        environments={[]}
-        group={group}
-        project={project}
-        baseUrl=""
-        {...routerProps}
-      />,
-      {router}
-    );
-
-    await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
+    render(<GroupTagValues />, {router});
 
     // Special case for user tag - column title changes to Affected Users
-    expect(screen.getByText('Affected Users')).toBeInTheDocument();
+    expect(await screen.findByText('Affected Users')).toBeInTheDocument();
 
     // Affected user column
     expect(screen.getByText('David Cramer')).toBeInTheDocument();
@@ -74,7 +73,7 @@ describe('GroupTagValues', () => {
   });
 
   it('can page through tag values', async () => {
-    const {router, routerProps, project} = init('user');
+    const {router} = init('user');
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/1/tags/user/values/',
@@ -85,20 +84,9 @@ describe('GroupTagValues', () => {
           '<https://sentry.io/api/0/organizations/sentry/user-feedback/?statsPeriod=14d&cursor=0:100:0>; rel="next"; results="true"; cursor="0:100:0"',
       },
     });
-    render(
-      <GroupTagValues
-        environments={[]}
-        group={group}
-        project={project}
-        baseUrl=""
-        {...routerProps}
-      />,
-      {router}
-    );
+    render(<GroupTagValues />, {router});
 
-    await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
-
-    expect(screen.getByRole('button', {name: 'Previous'})).toBeDisabled();
+    expect(await screen.findByRole('button', {name: 'Previous'})).toBeDisabled();
     expect(screen.getByRole('button', {name: 'Next'})).toBeEnabled();
 
     // Clicking next button loads page with query param ?cursor=0:100:0
@@ -111,24 +99,15 @@ describe('GroupTagValues', () => {
   });
 
   it('navigates to issue details events tab with correct query params', async () => {
-    const {routerProps, router, project} = init('user');
+    const {router} = init('user');
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/1/tags/user/values/',
       body: TagValuesFixture(),
     });
-    render(
-      <GroupTagValues
-        environments={[]}
-        group={group}
-        project={project}
-        baseUrl=""
-        {...routerProps}
-      />,
-      {
-        router,
-      }
-    );
+    render(<GroupTagValues />, {
+      router,
+    });
 
     await userEvent.click(await screen.findByRole('button', {name: 'More'}));
     await userEvent.click(
@@ -144,23 +123,14 @@ describe('GroupTagValues', () => {
   });
 
   it('renders an error message if tag values request fails', async () => {
-    const {router, routerProps, project} = init('user');
+    const {router} = init('user', 'staging');
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/1/tags/user/values/',
       statusCode: 500,
     });
 
-    render(
-      <GroupTagValues
-        environments={['staging']}
-        group={group}
-        project={project}
-        baseUrl=""
-        {...routerProps}
-      />,
-      {router}
-    );
+    render(<GroupTagValues />, {router});
 
     expect(
       await screen.findByText('There was an error loading tag details')
@@ -168,23 +138,14 @@ describe('GroupTagValues', () => {
   });
 
   it('renders an error message if no tag values are returned because of environment selection', async () => {
-    const {router, routerProps, project} = init('user');
+    const {router} = init('user', 'staging');
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/1/tags/user/values/',
       body: [],
     });
 
-    render(
-      <GroupTagValues
-        environments={['staging']}
-        group={group}
-        project={project}
-        baseUrl=""
-        {...routerProps}
-      />,
-      {router}
-    );
+    render(<GroupTagValues />, {router});
 
     expect(
       await screen.findByText(

--- a/static/app/views/issueDetails/groupTags/groupTagsTab.tsx
+++ b/static/app/views/issueDetails/groupTags/groupTagsTab.tsx
@@ -16,20 +16,19 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import Version from 'sentry/components/version';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Group} from 'sentry/types/group';
 import {percent} from 'sentry/utils';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useParams} from 'sentry/utils/useParams';
 import GroupEventDetails, {
   type GroupEventDetailsProps,
 } from 'sentry/views/issueDetails/groupEventDetails/groupEventDetails';
 import {useGroupTags} from 'sentry/views/issueDetails/groupTags/useGroupTags';
-import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
-
-type GroupTagsProps = {
-  baseUrl: string;
-  environments: string[];
-  group: Group;
-};
+import {useGroup} from 'sentry/views/issueDetails/useGroup';
+import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
+import {
+  useEnvironmentsFromUrl,
+  useHasStreamlinedUI,
+} from 'sentry/views/issueDetails/utils';
 
 type SimpleTag = {
   key: string;
@@ -42,8 +41,18 @@ type SimpleTag = {
   totalValues: number;
 };
 
-export function GroupTagsTab({group, baseUrl, environments}: GroupTagsProps) {
+export function GroupTagsTab() {
   const location = useLocation();
+  const environments = useEnvironmentsFromUrl();
+  const {baseUrl} = useGroupDetailsRoute();
+  const params = useParams<{groupId: string}>();
+
+  const {
+    data: group,
+    isPending: isGroupPending,
+    isError: isGroupError,
+    refetch: refetchGroup,
+  } = useGroup({groupId: params.groupId});
 
   const {
     data = [],
@@ -51,21 +60,24 @@ export function GroupTagsTab({group, baseUrl, environments}: GroupTagsProps) {
     isError,
     refetch,
   } = useGroupTags({
-    groupId: group.id,
+    groupId: group?.id,
     environment: environments,
   });
 
   const alphabeticalTags = data.sort((a, b) => a.key.localeCompare(b.key));
 
-  if (isPending) {
+  if (isPending || isGroupPending) {
     return <LoadingIndicator />;
   }
 
-  if (isError) {
+  if (isError || isGroupError) {
     return (
       <LoadingError
         message={t('There was an error loading issue tags.')}
-        onRetry={refetch}
+        onRetry={() => {
+          refetch();
+          refetchGroup();
+        }}
       />
     );
   }
@@ -136,9 +148,7 @@ export function GroupTagsTab({group, baseUrl, environments}: GroupTagsProps) {
   );
 }
 
-function GroupTagsRoute(
-  props: GroupEventDetailsProps & {baseUrl: string; environments: string[]}
-) {
+function GroupTagsRoute(props: GroupEventDetailsProps) {
   const hasStreamlinedUI = useHasStreamlinedUI();
 
   // TODO(streamlined-ui): Point the router to group event details
@@ -146,7 +156,7 @@ function GroupTagsRoute(
     return <GroupEventDetails {...props} />;
   }
 
-  return <GroupTagsTab {...props} />;
+  return <GroupTagsTab />;
 }
 
 export default GroupTagsRoute;


### PR DESCRIPTION
The goal is to remove cloneElement and passing untyped props from groupDetails down to child routes.

https://github.com/getsentry/sentry/blob/f4a29f737fe9e46716468934b68dadb3605f03b9/static/app/views/issueDetails/groupDetails.tsx#L651-L661