### PR TITLE
ref(crons): Remove TickVolumeAnomolyResult from check_missing

### DIFF
--- a/src/sentry/monitors/clock_tasks/check_missed.py
+++ b/src/sentry/monitors/clock_tasks/check_missed.py
@@ -17,7 +17,6 @@ from sentry.monitors.models import (
     MonitorType,
 )
 from sentry.monitors.schedule import get_prev_schedule
-from sentry.monitors.types import TickVolumeAnomolyResult
 from sentry.utils import metrics
 
 from .producer import MONITORS_CLOCK_TASKS_CODEC, produce_task
@@ -48,7 +47,7 @@ IGNORE_MONITORS = ~Q(
 )
 
 
-def dispatch_check_missing(ts: datetime, volume_anomaly_result: TickVolumeAnomolyResult):
+def dispatch_check_missing(ts: datetime):
     """
     Given a clock tick timestamp determine which monitor environments are past
     their next_checkin_latest, indicating they haven't checked-in when they
@@ -79,7 +78,6 @@ def dispatch_check_missing(ts: datetime, volume_anomaly_result: TickVolumeAnomol
             "type": "mark_missing",
             "ts": ts.timestamp(),
             "monitor_environment_id": monitor_environment["id"],
-            "volume_anomaly_result": volume_anomaly_result.value,
         }
         # XXX(epurkhiser): Partitioning by monitor_environment.id is important
         # here as these task messages will be consumed in a multi-consumer

--- a/src/sentry/monitors/consumers/clock_tick_consumer.py
+++ b/src/sentry/monitors/consumers/clock_tick_consumer.py
@@ -16,7 +16,6 @@ from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.monitors.clock_tasks.check_missed import dispatch_check_missing
 from sentry.monitors.clock_tasks.check_timeout import dispatch_check_timeout
 from sentry.monitors.system_incidents import record_clock_tick_volume_metric
-from sentry.monitors.types import TickVolumeAnomolyResult
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +36,7 @@ def process_clock_tick(message: Message[KafkaPayload | FilteredPayload]):
         extra={"reference_datetime": str(ts)},
     )
 
-    dispatch_check_missing(ts, TickVolumeAnomolyResult.NORMAL)
+    dispatch_check_missing(ts)
     dispatch_check_timeout(ts)
 
 

--- a/tests/sentry/monitors/consumers/test_clock_tick_consumer.py
+++ b/tests/sentry/monitors/consumers/test_clock_tick_consumer.py
@@ -25,7 +25,6 @@ from sentry.monitors.models import (
     MonitorType,
     ScheduleType,
 )
-from sentry.monitors.types import TickVolumeAnomolyResult
 from sentry.testutils.cases import TestCase
 
 partition = Partition(Topic("test"), 0)
@@ -64,10 +63,7 @@ def test_simple(
     assert mock_dispatch_check_timeout.mock_calls[0] == mock.call(ts)
 
     assert mock_dispatch_check_missing.call_count == 1
-    assert mock_dispatch_check_missing.mock_calls[0] == mock.call(
-        ts,
-        TickVolumeAnomolyResult.NORMAL,
-    )
+    assert mock_dispatch_check_missing.mock_calls[0] == mock.call(ts)
 
 
 class MonitorsClockTickEndToEndTest(TestCase):


### PR DESCRIPTION
We'll no longer be using this here. I will make a follow up PR to `sentry-kafka-schemas` to remove the schema property (https://github.com/getsentry/sentry-kafka-schemas/pull/350)

Part of GH-79328