### PR TITLE
feat(dynamic-sampling): Org assist UX

### DIFF
--- a/static/app/views/settings/dynamicSampling/percentInput.tsx
+++ b/static/app/views/settings/dynamicSampling/percentInput.tsx
@@ -1,4 +1,5 @@
 import type React from 'react';
+import {forwardRef} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -7,20 +8,22 @@ import {space} from 'sentry/styles/space';
 
 interface Props extends React.ComponentProps<typeof InputGroup.Input> {}
 
-export function PercentInput(props: Props) {
-  return (
-    <InputGroup
-      css={css`
-        width: 160px;
-      `}
-    >
-      <InputGroup.Input type="number" min={0} max={100} {...props} />
-      <InputGroup.TrailingItems>
-        <TrailingPercent>%</TrailingPercent>
-      </InputGroup.TrailingItems>
-    </InputGroup>
-  );
-}
+export const PercentInput = forwardRef<HTMLInputElement, Props>(
+  function PercentInput(props, ref) {
+    return (
+      <InputGroup
+        css={css`
+          width: 160px;
+        `}
+      >
+        <InputGroup.Input ref={ref} type="number" min={0} max={100} {...props} />
+        <InputGroup.TrailingItems>
+          <TrailingPercent>%</TrailingPercent>
+        </InputGroup.TrailingItems>
+      </InputGroup>
+    );
+  }
+);
 
 const TrailingPercent = styled('strong')`
   padding: 0 ${space(0.25)};

--- a/static/app/views/settings/dynamicSampling/projectSampling.tsx
+++ b/static/app/views/settings/dynamicSampling/projectSampling.tsx
@@ -1,7 +1,11 @@
 import {useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
-import {addLoadingMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'sentry/actionCreators/indicator';
 import {Button} from 'sentry/components/button';
 import LoadingError from 'sentry/components/loadingError';
 import Panel from 'sentry/components/panels/panel';
@@ -73,10 +77,11 @@ export function ProjectSampling() {
     updateSamplingProjectRates.mutate(ratesArray, {
       onSuccess: () => {
         formState.save();
+        setEditMode('single');
         addSuccessMessage(t('Changes applied'));
       },
       onError: () => {
-        addLoadingMessage(t('Unable to save changes. Please try again.'));
+        addErrorMessage(t('Unable to save changes. Please try again.'));
       },
     });
   };

--- a/static/app/views/settings/dynamicSampling/projectSampling.tsx
+++ b/static/app/views/settings/dynamicSampling/projectSampling.tsx
@@ -32,6 +32,7 @@ const UNSAVED_CHANGES_MESSAGE = t(
 export function ProjectSampling() {
   const hasAccess = useHasDynamicSamplingWriteAccess();
   const [period, setPeriod] = useState<ProjectionSamplePeriod>('24h');
+  const [editMode, setEditMode] = useState<'single' | 'bulk'>('single');
 
   const sampleRatesQuery = useGetSamplingProjectRates();
   const sampleCountsQuery = useProjectSampleCounts({period});
@@ -55,6 +56,11 @@ export function ProjectSampling() {
     initialValues: initialValues,
     enableReInitialize: true,
   });
+
+  const handleReset = () => {
+    formState.reset();
+    setEditMode('single');
+  };
 
   const handleSubmit = () => {
     const ratesArray = Object.entries(formState.fields.projectRates.value).map(
@@ -115,12 +121,14 @@ export function ProjectSampling() {
           <LoadingError onRetry={sampleCountsQuery.refetch} />
         ) : (
           <ProjectsEditTable
+            editMode={editMode}
+            onEditModeChange={setEditMode}
             isLoading={sampleRatesQuery.isPending || sampleCountsQuery.isPending}
             sampleCounts={sampleCountsQuery.data}
           />
         )}
         <FormActions>
-          <Button disabled={isFormActionDisabled} onClick={formState.reset}>
+          <Button disabled={isFormActionDisabled} onClick={handleReset}>
             {t('Reset')}
           </Button>
           <Button

--- a/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
@@ -3,6 +3,8 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import partition from 'lodash/partition';
 
+import {Button} from 'sentry/components/button';
+import FieldGroup from 'sentry/components/forms/fieldGroup';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
 import {t} from 'sentry/locale';
@@ -18,20 +20,28 @@ import {scaleSampleRates} from 'sentry/views/settings/dynamicSampling/utils/scal
 import type {ProjectSampleCount} from 'sentry/views/settings/dynamicSampling/utils/useProjectSampleCounts';
 
 interface Props {
+  editMode: 'single' | 'bulk';
   isLoading: boolean;
+  onEditModeChange: (mode: 'single' | 'bulk') => void;
   sampleCounts: ProjectSampleCount[];
 }
 
 const {useFormField} = projectSamplingForm;
 const EMPTY_ARRAY = [];
 
-export function ProjectsEditTable({isLoading: isLoadingProp, sampleCounts}: Props) {
+export function ProjectsEditTable({
+  isLoading: isLoadingProp,
+  sampleCounts,
+  editMode,
+  onEditModeChange,
+}: Props) {
   const {projects, fetching} = useProjects();
   const hasAccess = useHasDynamicSamplingWriteAccess();
   const {value, initialValue, error, onChange} = useFormField('projectRates');
+  const [isBulkEditEnabled, setIsBulkEditEnabled] = useState(false);
 
   const [orgRate, setOrgRate] = useState<string>('');
-  const [editMode, setEditMode] = useState<'single' | 'bulk'>('single');
+
   const projectRateSnapshotRef = useRef<Record<string, string>>({});
 
   const dataByProjectId = useMemo(
@@ -52,9 +62,9 @@ export function ProjectsEditTable({isLoading: isLoadingProp, sampleCounts}: Prop
         ...prev,
         [projectId]: newRate,
       }));
-      setEditMode('single');
+      onEditModeChange('single');
     },
-    [onChange]
+    [onChange, onEditModeChange]
   );
 
   const handleOrgChange = useCallback(
@@ -63,6 +73,7 @@ export function ProjectsEditTable({isLoading: isLoadingProp, sampleCounts}: Prop
       if (editMode === 'single') {
         projectRateSnapshotRef.current = value;
       }
+      const cappedOrgRate = Math.min(100, Math.max(0, Number(newRate))) ?? 100;
 
       const scalingItems = Object.entries(projectRateSnapshotRef.current)
         .map(([projectId, rate]) => ({
@@ -75,7 +86,7 @@ export function ProjectsEditTable({isLoading: isLoadingProp, sampleCounts}: Prop
 
       const {scaledItems} = scaleSampleRates({
         items: scalingItems,
-        sampleRate: Number(newRate) / 100,
+        sampleRate: cappedOrgRate / 100,
       });
 
       const newProjectValues = scaledItems.reduce((acc, item) => {
@@ -87,9 +98,9 @@ export function ProjectsEditTable({isLoading: isLoadingProp, sampleCounts}: Prop
       });
 
       setOrgRate(newRate);
-      setEditMode('bulk');
+      onEditModeChange('bulk');
     },
-    [dataByProjectId, editMode, onChange, value]
+    [dataByProjectId, editMode, onChange, onEditModeChange, value]
   );
 
   const items = useMemo(
@@ -126,6 +137,15 @@ export function ProjectsEditTable({isLoading: isLoadingProp, sampleCounts}: Prop
     return formatNumberWithDynamicDecimalPoints(totalSampledSpans / totalSpans, 2);
   }, [editMode, items, orgRate, value]);
 
+  const initialOrgRate = useMemo(() => {
+    const totalSpans = items.reduce((acc, item) => acc + item.count, 0);
+    const totalSampledSpans = items.reduce(
+      (acc, item) => acc + item.count * Number(initialValue[item.project.id] ?? 100),
+      0
+    );
+    return formatNumberWithDynamicDecimalPoints(totalSampledSpans / totalSpans, 2);
+  }, [initialValue, items]);
+
   const breakdownSampleRates = useMemo(
     () =>
       Object.entries(value).reduce(
@@ -151,23 +171,52 @@ export function ProjectsEditTable({isLoading: isLoadingProp, sampleCounts}: Prop
           />
         ) : (
           <Fragment>
-            <SamplingBreakdown
-              sampleCounts={sampleCounts}
-              sampleRates={breakdownSampleRates}
-            />
-            <Divider />
-            <ProjectedOrgRateWrapper>
-              {t('Projected Organization Rate')}
-              <div>
+            <BreakdownWrapper>
+              <SamplingBreakdown
+                sampleCounts={sampleCounts}
+                sampleRates={breakdownSampleRates}
+              />
+            </BreakdownWrapper>
+            <FieldGroup
+              label={t('Projected Organization Rate')}
+              help={t(
+                'An estimate of the organization-wide sample rate, based on the span volume in the selected time frame.'
+              )}
+              flexibleControlStateSize
+              alignRight
+            >
+              <InputWrapper>
                 <PercentInput
                   type="number"
-                  disabled={!hasAccess}
+                  disabled={!hasAccess || !isBulkEditEnabled}
                   size="sm"
                   onChange={handleOrgChange}
                   value={projectedOrgRate}
                 />
-              </div>
-            </ProjectedOrgRateWrapper>
+                <FlexRow>
+                  <PreviousValue>
+                    {initialOrgRate !== projectedOrgRate ? (
+                      t('previous: %f%%', initialOrgRate)
+                    ) : (
+                      // Placeholder char to prevent the line from collapsing
+                      <Fragment>&#x200b;</Fragment>
+                    )}
+                  </PreviousValue>
+                  {hasAccess && !isBulkEditEnabled && (
+                    <BulkEditButton
+                      size="zero"
+                      title={t(
+                        'Scale all your project rates up and down by adjusting the organization-wide target'
+                      )}
+                      priority="link"
+                      onClick={() => setIsBulkEditEnabled(true)}
+                    >
+                      {t('bulk edit')}
+                    </BulkEditButton>
+                  )}
+                </FlexRow>
+              </InputWrapper>
+            </FieldGroup>
           </Fragment>
         )}
       </BreakdownPanel>
@@ -186,20 +235,33 @@ export function ProjectsEditTable({isLoading: isLoadingProp, sampleCounts}: Prop
 
 const BreakdownPanel = styled(Panel)`
   margin-bottom: ${space(3)};
-  padding: ${space(2)};
 `;
 
-const ProjectedOrgRateWrapper = styled('label')`
+const BreakdownWrapper = styled('div')`
+  padding: ${space(2)};
+  border-bottom: 1px solid ${p => p.theme.innerBorder};
+`;
+
+const InputWrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(0.5)};
+`;
+
+const FlexRow = styled('div')`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  flex-wrap: wrap;
   gap: ${space(1)};
-  font-weight: ${p => p.theme.fontWeightNormal};
 `;
 
-const Divider = styled('hr')`
-  margin: ${space(2)} -${space(2)};
+const PreviousValue = styled('span')`
+  font-size: ${p => p.theme.fontSizeExtraSmall};
+  color: ${p => p.theme.subText};
+`;
+
+const BulkEditButton = styled(Button)`
+  font-size: ${p => p.theme.fontSizeExtraSmall};
+  padding: 0;
   border: none;
-  border-top: 1px solid ${p => p.theme.innerBorder};
 `;

--- a/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useMemo, useRef, useState} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import partition from 'lodash/partition';
@@ -39,6 +39,7 @@ export function ProjectsEditTable({
   const hasAccess = useHasDynamicSamplingWriteAccess();
   const {value, initialValue, error, onChange} = useFormField('projectRates');
   const [isBulkEditEnabled, setIsBulkEditEnabled] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const [orgRate, setOrgRate] = useState<string>('');
 
@@ -55,6 +56,12 @@ export function ProjectsEditTable({
       ),
     [sampleCounts]
   );
+
+  useEffect(() => {
+    if (isBulkEditEnabled) {
+      inputRef.current?.focus();
+    }
+  }, [isBulkEditEnabled]);
 
   const handleProjectChange = useCallback(
     (projectId: string, newRate: string) => {
@@ -180,7 +187,7 @@ export function ProjectsEditTable({
             <FieldGroup
               label={t('Projected Organization Rate')}
               help={t(
-                'An estimate of the organization-wide sample rate, based on the span volume in the selected time frame.'
+                "An estimate of the combined sample rate for all projects. Adjusting this will proportionally update each project's rate below."
               )}
               flexibleControlStateSize
               alignRight
@@ -188,6 +195,7 @@ export function ProjectsEditTable({
               <InputWrapper>
                 <PercentInput
                   type="number"
+                  ref={inputRef}
                   disabled={!hasAccess || !isBulkEditEnabled}
                   size="sm"
                   onChange={handleOrgChange}
@@ -206,12 +214,14 @@ export function ProjectsEditTable({
                     <BulkEditButton
                       size="zero"
                       title={t(
-                        'Scale all your project rates up and down by adjusting the organization-wide target'
+                        'Adjusting your organization rate will automatically scale individual project rates to match.'
                       )}
                       priority="link"
-                      onClick={() => setIsBulkEditEnabled(true)}
+                      onClick={() => {
+                        setIsBulkEditEnabled(true);
+                      }}
                     >
-                      {t('bulk edit')}
+                      {t('edit')}
                     </BulkEditButton>
                   )}
                 </FlexRow>


### PR DESCRIPTION
Render the org rate input as disabled initially.
Add a `bulk edit` button with a tooltip to explain the functionality.
On button click the org rate input is enabled.

https://github.com/user-attachments/assets/f07bf374-12aa-4cb7-b151-b63b61b83f45

Closes https://github.com/getsentry/projects/issues/191