### PR TITLE
ref(hydration error): Refactor and shrink padding in the hydration error modal

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
+++ b/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
@@ -44,7 +44,7 @@ export default function ReplayComparisonModal({
             <Tooltip
               isHoverable
               title={tct(
-                'This modal helps with debugging hydration errors by diffing the dom before and after the app hydrated. [boldBefore:Before] refers to the html rendered on the server. [boldAfter:After] refers to the html rendered on the client. Read more about [link:resolving hydration errors]',
+                'This modal helps with debugging hydration errors by diffing the DOM before and after the app hydrated. [boldBefore:Before] refers to the HTML rendered on the server. [boldAfter:After] refers to the HTML rendered on the client. Read more about [link:resolving hydration errors]',
                 {
                   boldBefore: <Before />,
                   boldAfter: <After />,

--- a/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
+++ b/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
@@ -4,7 +4,10 @@ import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import Alert from 'sentry/components/alert';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import {useGlobalModal} from 'sentry/components/globalModal/useGlobalModal';
+import ExternalLink from 'sentry/components/links/externalLink';
 import ReplayDiffChooser from 'sentry/components/replays/diff/replayDiffChooser';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconInfo} from 'sentry/icons/iconInfo';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
@@ -36,7 +39,24 @@ export default function ReplayComparisonModal({
     <OrganizationContext.Provider value={organization}>
       <Header closeButton>
         <ModalHeader>
-          <h4>{t('Hydration Error')}</h4>
+          <Title>
+            {t('Hydration Error')}
+            <Tooltip
+              isHoverable
+              title={tct(
+                'This modal helps with debugging hydration errors by diffing the dom before and after the app hydrated. [boldBefore:Before] refers to the html rendered on the server. [boldAfter:After] refers to the html rendered on the client. Read more about [link:resolving hydration errors]',
+                {
+                  boldBefore: <Before />,
+                  boldAfter: <After />,
+                  link: (
+                    <ExternalLink href="https://sentry.io/answers/hydration-error-nextjs/" />
+                  ),
+                }
+              )}
+            >
+              <IconInfo />
+            </Tooltip>
+          </Title>
           {focusTrap ? (
             <FeedbackWidgetButton
               optionOverrides={{
@@ -52,33 +72,19 @@ export default function ReplayComparisonModal({
         </ModalHeader>
       </Header>
       <Body>
-        <Grid>
-          <StyledParagraph>
-            {tct(
-              'This modal helps with debugging hydration errors by diffing the dom before and after the app hydrated. [boldBefore:Before] refers to the html rendered on the server. [boldAfter:After] refers to the html rendered on the client. This feature is actively being developed; please share any questions or feedback to the discussion linked above.',
-              {
-                boldBefore: <Before />,
-                boldAfter: <After />,
-              }
+        {isSameTimestamp ? (
+          <Alert type="warning" showIcon>
+            {t(
+              "Cannot display diff for this hydration error. Sentry wasn't able to identify the correct event."
             )}
-          </StyledParagraph>
+          </Alert>
+        ) : null}
 
-          {isSameTimestamp ? (
-            <Alert type="warning" showIcon>
-              {t(
-                "Cannot display diff for this hydration error. Sentry wasn't able to identify the correct event."
-              )}
-            </Alert>
-          ) : (
-            <div />
-          )}
-
-          <ReplayDiffChooser
-            replay={replay}
-            leftOffsetMs={leftOffsetMs}
-            rightOffsetMs={rightOffsetMs}
-          />
-        </Grid>
+        <ReplayDiffChooser
+          replay={replay}
+          leftOffsetMs={leftOffsetMs}
+          rightOffsetMs={rightOffsetMs}
+        />
       </Body>
     </OrganizationContext.Provider>
   );
@@ -91,22 +97,17 @@ const ModalHeader = styled('div')`
   flex-direction: row;
 `;
 
-const Grid = styled('div')`
-  height: 100%;
-  display: grid;
-  grid-template-rows: max-content max-content 1fr;
-  align-items: start;
+const Title = styled('h4')`
+  display: flex;
+  gap: ${space(1)};
 `;
 
-const StyledParagraph = styled('p')`
-  padding-top: ${space(0.5)};
-  margin-bottom: ${space(1)};
-`;
-
-const Before = styled('strong')`
+export const Before = styled('span')`
   color: ${p => p.theme.red300};
+  font-weight: bold;
 `;
 
-const After = styled('strong')`
+export const After = styled('span')`
   color: ${p => p.theme.green300};
+  font-weight: bold;
 `;

--- a/static/app/components/replays/diff/replayDiffChooser.tsx
+++ b/static/app/components/replays/diff/replayDiffChooser.tsx
@@ -1,13 +1,11 @@
 import styled from '@emotion/styled';
 
-import Alert from 'sentry/components/alert';
 import FeatureBadge from 'sentry/components/badge/featureBadge';
-import ExternalLink from 'sentry/components/links/externalLink';
 import {ReplaySideBySideImageDiff} from 'sentry/components/replays/diff/replaySideBySideImageDiff';
 import {ReplaySliderDiff} from 'sentry/components/replays/diff/replaySliderDiff';
 import {ReplayTextDiff} from 'sentry/components/replays/diff/replayTextDiff';
 import {TabList, TabPanels, TabStateProvider} from 'sentry/components/tabs';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
@@ -57,18 +55,6 @@ export default function ReplayDiffChooser({
             />
           </TabPanels.Item>
           <TabPanels.Item key={DiffType.HTML}>
-            <StyledAlert type="info" showIcon>
-              {tct(
-                `The HTML Diff is currently in beta and has known issues (e.g. the ‘before’ is sometimes empty). We are exploring different options to replace this view, please see [link: this ticket] for more details and share your feedback.`,
-                {
-                  link: (
-                    <ExternalLink
-                      href={'https://github.com/getsentry/sentry/issues/80092'}
-                    />
-                  ),
-                }
-              )}
-            </StyledAlert>
             <ReplayTextDiff
               leftOffsetMs={leftOffsetMs}
               replay={replay}
@@ -88,14 +74,11 @@ export default function ReplayDiffChooser({
   );
 }
 
-const StyledAlert = styled(Alert)`
-  margin: ${space(1)} 0 0;
-`;
-
 const Grid = styled('div')`
   display: grid;
   grid-template-rows: max-content 1fr;
   height: 100%;
+  gap: ${space(1)};
 `;
 
 const StyledTabPanels = styled(TabPanels)`

--- a/static/app/components/replays/diff/replaySideBySideImageDiff.tsx
+++ b/static/app/components/replays/diff/replaySideBySideImageDiff.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/container/flex';
+import {After, Before, DiffHeader} from 'sentry/components/replays/diff/utils';
 import ReplayPlayer from 'sentry/components/replays/player/replayPlayer';
 import ReplayPlayerMeasurer from 'sentry/components/replays/player/replayPlayerMeasurer';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {ReplayPlayerEventsContextProvider} from 'sentry/utils/replays/playback/providers/replayPlayerEventsContext';
 import {ReplayPlayerPluginsContextProvider} from 'sentry/utils/replays/playback/providers/replayPlayerPluginsContext';
@@ -20,12 +20,8 @@ export function ReplaySideBySideImageDiff({leftOffsetMs, replay, rightOffsetMs}:
   return (
     <Flex column>
       <DiffHeader>
-        <Before flex="1" align="center">
-          {t('Before')}
-        </Before>
-        <After flex="1" align="center">
-          {t('After')}
-        </After>
+        <Before />
+        <After />
       </DiffHeader>
 
       <ReplayGrid>
@@ -52,36 +48,9 @@ export function ReplaySideBySideImageDiff({leftOffsetMs, replay, rightOffsetMs}:
   );
 }
 
-const DiffHeader = styled('div')`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  flex: 1;
-  font-weight: ${p => p.theme.fontWeightBold};
-  line-height: 1.2;
-
-  div {
-    height: 28px; /* div with and without buttons inside are the same height */
-  }
-
-  div:last-child {
-    padding-left: ${space(2)};
-  }
-
-  padding: 10px 0;
-`;
-
 const ReplayGrid = styled('div')`
   display: grid;
   grid-template-columns: 1fr 1fr;
-`;
-
-export const Before = styled(Flex)`
-  color: ${p => p.theme.red300};
-`;
-
-export const After = styled(Flex)`
-  color: ${p => p.theme.green300};
 `;
 
 const Border = styled('span')`

--- a/static/app/components/replays/diff/replaySliderDiff.tsx
+++ b/static/app/components/replays/diff/replaySliderDiff.tsx
@@ -2,10 +2,9 @@ import {Fragment, useCallback, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceContainer';
+import {After, Before, DiffHeader} from 'sentry/components/replays/diff/utils';
 import ReplayPlayer from 'sentry/components/replays/player/replayPlayer';
 import ReplayPlayerMeasurer from 'sentry/components/replays/player/replayPlayerMeasurer';
-import {Tooltip} from 'sentry/components/tooltip';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import toPixels from 'sentry/utils/number/toPixels';
@@ -36,18 +35,10 @@ export function ReplaySliderDiff({
 
   return (
     <Fragment>
-      <Header>
-        <Tooltip title={t('How the initial server-rendered page looked.')}>
-          <Before>{t('Before')}</Before>
-        </Tooltip>
-        <Tooltip
-          title={t(
-            'How React re-rendered the page on your browser, after detecting a hydration error.'
-          )}
-        >
-          <After>{t('After')}</After>
-        </Tooltip>
-      </Header>
+      <DiffHeader>
+        <Before />
+        <After />
+      </DiffHeader>
       <WithPadding>
         <Positioned style={{minHeight}} ref={positionedRef}>
           {viewDimensions.width ? (
@@ -152,7 +143,6 @@ function DiffSides({
 }
 
 const WithPadding = styled(NegativeSpaceContainer)`
-  padding-block: ${space(1.5)};
   overflow: visible;
   height: 100%;
 `;
@@ -220,23 +210,6 @@ const Divider = styled('div')`
     bottom: 0;
     transform: translate(calc(var(--handle-size) / -2 + var(--line-width) / 2), 100%);
   }
-`;
-
-const Header = styled('div')`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 14px 0;
-`;
-
-const Before = styled('div')`
-  color: ${p => p.theme.red300};
-  font-weight: bold;
-`;
-
-const After = styled('div')`
-  color: ${p => p.theme.green300};
-  font-weight: bold;
 `;
 
 const StyledNegativeSpaceContainer = styled(NegativeSpaceContainer)`

--- a/static/app/components/replays/diff/replayTextDiff.tsx
+++ b/static/app/components/replays/diff/replayTextDiff.tsx
@@ -33,10 +33,10 @@ export function ReplayTextDiff({replay, leftOffsetMs, rightOffsetMs}: Props) {
     <Container>
       <StyledAlert type="info" showIcon>
         {tct(
-          `The HTML Diff is currently in beta and has known issues (e.g. the ‘before’ is sometimes empty). We are exploring different options to replace this view, please see [link: this ticket] for more details and share your feedback.`,
+          `The HTML Diff is currently in beta and has known issues (e.g. the 'Before' is sometimes empty). We are exploring different options to replace this view. Please see [link: this ticket] for more details and share your feedback.`,
           {
             link: (
-              <ExternalLink href={'https://github.com/getsentry/sentry/issues/80092'} />
+              <ExternalLink href="https://github.com/getsentry/sentry/issues/80092" />
             ),
           }
         )}

--- a/static/app/components/replays/diff/replayTextDiff.tsx
+++ b/static/app/components/replays/diff/replayTextDiff.tsx
@@ -1,11 +1,13 @@
-import {Fragment, useMemo} from 'react';
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
 import beautify from 'js-beautify';
 
+import Alert from 'sentry/components/alert';
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
-import {After, Before} from 'sentry/components/replays/diff/replaySideBySideImageDiff';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {After, Before, DiffHeader} from 'sentry/components/replays/diff/utils';
 import SplitDiff from 'sentry/components/splitDiff';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useExtractPageHtml from 'sentry/utils/replays/hooks/useExtractPageHtml';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
@@ -28,10 +30,19 @@ export function ReplayTextDiff({replay, leftOffsetMs, rightOffsetMs}: Props) {
   );
 
   return (
-    <Fragment>
+    <Container>
+      <StyledAlert type="info" showIcon>
+        {tct(
+          `The HTML Diff is currently in beta and has known issues (e.g. the ‘before’ is sometimes empty). We are exploring different options to replace this view, please see [link: this ticket] for more details and share your feedback.`,
+          {
+            link: (
+              <ExternalLink href={'https://github.com/getsentry/sentry/issues/80092'} />
+            ),
+          }
+        )}
+      </StyledAlert>
       <DiffHeader>
-        <Before flex="1" align="center">
-          {t('Before')}
+        <Before>
           <CopyToClipboardButton
             text={leftBody ?? ''}
             size="xs"
@@ -40,8 +51,7 @@ export function ReplayTextDiff({replay, leftOffsetMs, rightOffsetMs}: Props) {
             aria-label={t('Copy Before')}
           />
         </Before>
-        <After flex="1" align="center">
-          {t('After')}
+        <After>
           <CopyToClipboardButton
             text={rightBody ?? ''}
             size="xs"
@@ -54,31 +64,25 @@ export function ReplayTextDiff({replay, leftOffsetMs, rightOffsetMs}: Props) {
       <SplitDiffScrollWrapper>
         <SplitDiff base={leftBody ?? ''} target={rightBody ?? ''} type="words" />
       </SplitDiffScrollWrapper>
-    </Fragment>
+    </Container>
   );
 }
+
+const Container = styled('div')`
+  height: 0;
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
+`;
+
+const StyledAlert = styled(Alert)`
+  margin: 0;
+`;
 
 const SplitDiffScrollWrapper = styled('div')`
   overflow: auto;
   height: 0;
   display: flex;
   flex-grow: 1;
-`;
-
-const DiffHeader = styled('div')`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  font-weight: ${p => p.theme.fontWeightBold};
-  line-height: 1.2;
-
-  div {
-    height: 28px; /* div with and without buttons inside are the same height */
-  }
-
-  div:last-child {
-    padding-left: ${space(2)};
-  }
-
-  padding: 10px 0;
 `;

--- a/static/app/components/replays/diff/utils.tsx
+++ b/static/app/components/replays/diff/utils.tsx
@@ -1,0 +1,54 @@
+import styled from '@emotion/styled';
+
+import {Tooltip} from 'sentry/components/tooltip';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+export const DiffHeader = styled('div')`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: ${space(1)};
+  font-weight: ${p => p.theme.fontWeightBold};
+  line-height: 1.2;
+  justify-content: space-between;
+
+  & > *:first-child {
+    color: ${p => p.theme.red300};
+  }
+
+  & > *:last-child {
+    color: ${p => p.theme.green300};
+  }
+`;
+
+const Label = styled('div')`
+  display: flex;
+  align-items: center;
+  font-weight: bold;
+`;
+
+export function Before({children}: {children?: React.ReactNode}) {
+  return (
+    <Tooltip title={t('How the initial server-rendered page looked.')}>
+      <Label>
+        {t('Before')}
+        {children}
+      </Label>
+    </Tooltip>
+  );
+}
+export function After({children}: {children?: React.ReactNode}) {
+  return (
+    <Tooltip
+      title={t(
+        'How React re-rendered the page on your browser, after detecting a hydration error.'
+      )}
+    >
+      <Label>
+        {t('After')}
+        {children}
+      </Label>
+    </Tooltip>
+  );
+}

--- a/static/app/components/tabs/tabList.tsx
+++ b/static/app/components/tabs/tabList.tsx
@@ -251,7 +251,7 @@ function BaseTabList({
 const collectionFactory = (nodes: Iterable<Node<any>>) => new ListCollection(nodes);
 
 /**
- * To be used as a direct child of the`<Tabs />` component. See example usage
+ * To be used as a direct child of the `<Tabs />` component. See example usage
  * in tabs.stories.js
  */
 export function TabList({items, variant, ...props}: TabListProps) {

--- a/static/app/components/tabs/tabList.tsx
+++ b/static/app/components/tabs/tabList.tsx
@@ -251,7 +251,7 @@ function BaseTabList({
 const collectionFactory = (nodes: Iterable<Node<any>>) => new ListCollection(nodes);
 
 /**
- * To be used as a direct child of the <Tabs /> component. See example usage
+ * To be used as a direct child of the`<Tabs />` component. See example usage
  * in tabs.stories.js
  */
 export function TabList({items, variant, ...props}: TabListProps) {


### PR DESCRIPTION
This PR tidies up the hydration error diff modal and related components:
- we're shrinking padding, so there's more space for content
- i've moved a big descriptive paragraph into a tooltip. i believe people understand what's going on, at least after the first interaction
- more consistent use of tooltips related to the `Before` & `After` labels
- more consistent wrapper html in the 'Chooser' component where the tabs live, and it's children
- the 'give feedback' button is getsentry specific. so it's not visible in the screenshots from my dev machine, but it hasn't changed.

| Area | Before | After |
| --- | --- | --- |
| Issue Details | <img width="667" alt="SCR-20241113-oexa" src="https://github.com/user-attachments/assets/51a85eb7-bf27-4216-a605-5ef567259820"> | <img width="671" alt="SCR-20241113-oeyi" src="https://github.com/user-attachments/assets/acf8839a-5e4e-4207-a3a3-30ee809fd7e3">
| Slider Diff | <img width="1236" alt="before" src="https://github.com/user-attachments/assets/0bd16a90-d7c3-4f0d-be46-f7565f860a08"> | <img width="1236" alt="after-slider" src="https://github.com/user-attachments/assets/aebfe9ac-a018-42ef-a42a-2a4a0b967fc8">
| Side-By-Side |  | <img width="1236" alt="after-side-by-side" src="https://github.com/user-attachments/assets/bb11a056-b077-4c86-943b-b554e3f4ca62">
| HTML Diff | | <img width="1236" alt="after-html" src="https://github.com/user-attachments/assets/164af4f9-043d-4702-8ac4-78811e85767a">

