### PR TITLE
fix(releases): Resolve in next version for semver

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -277,8 +277,9 @@ def update_groups(
                 or Release.objects.filter(
                     projects=projects[0], organization_id=projects[0].organization_id
                 )
-                .extra(select={"sort": "COALESCE(date_released, date_added)"})
-                .order_by("-sort")
+                .filter_to_semver()
+                .annotate_prerelease_column()
+                .order_by(*[f"-{col}" for col in Release.SEMVER_COLS])
                 .first()
             )
 

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -707,9 +707,14 @@ def update_groups(
 
 def get_latest_release(project: Project) -> Release | None:
     release = None
-    follows_semver = follows_semver_versioning_scheme(
-        org_id=project.organization_id, project_id=project.id
-    )
+
+    # XXX: Remove block once released
+    follows_semver = False
+    if features.has("organizations:releases-resolve-next-release-semver-fix", project.organization):
+        follows_semver = follows_semver_versioning_scheme(
+            org_id=project.organization_id, project_id=project.id
+        )
+
     releases = Release.objects.filter(projects=project, organization_id=project.organization_id)
     if follows_semver:
         release = (

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -272,16 +272,7 @@ def update_groups(
                     status=400,
                 )
             # may not be a release yet
-            release = (
-                status_details.get("inNextRelease")
-                or Release.objects.filter(
-                    projects=projects[0], organization_id=projects[0].organization_id
-                )
-                .filter_to_semver()
-                .annotate_prerelease_column()
-                .order_by(*[f"-{col}" for col in Release.SEMVER_COLS])
-                .first()
-            )
+            release = status_details.get("inNextRelease") or get_latest_release(projects[0])
 
             activity_type = ActivityType.SET_RESOLVED_IN_RELEASE.value
             activity_data = {
@@ -712,6 +703,28 @@ def update_groups(
         )
 
     return Response(result)
+
+
+def get_latest_release(project: Project) -> Release | None:
+    release = None
+    follows_semver = follows_semver_versioning_scheme(
+        org_id=project.organization_id, project_id=project.id
+    )
+    releases = Release.objects.filter(projects=project, organization_id=project.organization_id)
+    if follows_semver:
+        release = (
+            releases.filter_to_semver()
+            .annotate_prerelease_column()
+            .order_by(*[f"-{col}" for col in Release.SEMVER_COLS])
+            .first()
+        )
+    else:
+        release = (
+            releases.extra(select={"sort": "COALESCE(date_released, date_added)"})
+            .order_by("-sort")
+            .first()
+        )
+    return release
 
 
 def handle_is_subscribed(

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -349,6 +349,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:relay-cardinality-limiter", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable the release details performance section
     manager.add("organizations:release-comparison-performance", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Fixes the next release resolution for semver releases
+    manager.add("organizations:releases-resolve-next-release-semver-fix", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # enable new release set_commits functionality
     manager.add("organizations:set-commits-updated", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable new release UI

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -335,6 +335,7 @@ class GroupUpdateTest(APITestCase):
         assert GroupResolution.objects.all().count() == 0
 
         url = f"/api/0/issues/{group.id}/"
+
         response = self.client.put(url, data={"status": "resolvedInNextRelease"})
         assert response.status_code == 200, response.content
 
@@ -347,7 +348,6 @@ class GroupUpdateTest(APITestCase):
         assert group_resolution.group == group
         assert group_resolution.type == GroupResolution.Type.in_next_release
         assert group_resolution.status == GroupResolution.Status.pending
-        # This is what should be the result
         assert group_resolution.release.version == most_recent_version.version
 
     def test_resolved_in_next_release_semver(self):
@@ -357,7 +357,7 @@ class GroupUpdateTest(APITestCase):
         project.flags.has_releases = True
         project.save()
         Release.get_or_create(version="com.foo.bar@1.0+0", project=project)
-        most_recent_version = Release.get_or_create(version="com.foo.bar@2.0+0", project=project)
+        greatest_version = Release.get_or_create(version="com.foo.bar@2.0+0", project=project)
         # It should not be picked up based on creation date
         Release.get_or_create(version="com.foo.bar@1.0+1", project=project)
         group = self.create_group(project=project)
@@ -378,8 +378,7 @@ class GroupUpdateTest(APITestCase):
         assert group_resolution.group == group
         assert group_resolution.type == GroupResolution.Type.in_next_release
         assert group_resolution.status == GroupResolution.Status.pending
-        # This is what should be the result
-        assert group_resolution.release.version == most_recent_version.version
+        assert group_resolution.release.version == greatest_version.version
 
     def test_resolved_in_next_release_no_release(self):
         self.login_as(user=self.user)

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -322,7 +322,7 @@ class GroupUpdateTest(APITestCase):
             user_id=self.user.id, group=group, is_active=True
         ).exists()
 
-    def test_resolved_in_next_release(self):
+    def test_resolved_in_next_release_non_semver(self):
         self.login_as(user=self.user)
 
         project = self.create_project()
@@ -330,16 +330,56 @@ class GroupUpdateTest(APITestCase):
         project.save()
         group = self.create_group(project=project)
         Release.get_or_create(version="abcd", project=project)
+        most_recent_version = Release.get_or_create(version="def", project=project)
+        assert group.status == GroupStatus.UNRESOLVED
+        assert GroupResolution.objects.all().count() == 0
 
         url = f"/api/0/issues/{group.id}/"
-
         response = self.client.put(url, data={"status": "resolvedInNextRelease"})
         assert response.status_code == 200, response.content
 
+        # Refetch from DB to ensure the latest state is fetched
         group = Group.objects.get(id=group.id, project=group.project.id)
         assert group.status == GroupStatus.RESOLVED
 
-        assert GroupResolution.objects.filter(group=group).exists()
+        group_resolution = GroupResolution.objects.filter(group=group).first()
+        assert group_resolution is not None
+        assert group_resolution.group == group
+        assert group_resolution.type == GroupResolution.Type.in_next_release
+        assert group_resolution.status == GroupResolution.Status.pending
+        # This is what should be the result
+        assert group_resolution.release.version == most_recent_version.version
+
+    def test_resolved_in_next_release_semver(self):
+        self.login_as(user=self.user)
+
+        project = self.create_project()
+        project.flags.has_releases = True
+        project.save()
+        Release.get_or_create(version="com.foo.bar@1.0+0", project=project)
+        most_recent_version = Release.get_or_create(version="com.foo.bar@2.0+0", project=project)
+        # It should not be picked up based on creation date
+        Release.get_or_create(version="com.foo.bar@1.0+1", project=project)
+        group = self.create_group(project=project)
+        assert group.status == GroupStatus.UNRESOLVED
+        assert GroupResolution.objects.all().count() == 0
+
+        url = f"/api/0/issues/{group.id}/"
+        data = {"status": "resolvedInNextRelease"}
+        response = self.client.put(url, data=data)
+        assert response.status_code == 200, response.content == {}
+
+        # Refetch from DB to ensure the latest state is fetched
+        group = Group.objects.get(id=group.id, project=project.id)
+        assert group.status == GroupStatus.RESOLVED
+
+        group_resolution = GroupResolution.objects.filter(group=group).first()
+        assert group_resolution is not None
+        assert group_resolution.group == group
+        assert group_resolution.type == GroupResolution.Type.in_next_release
+        assert group_resolution.status == GroupResolution.Status.pending
+        # This is what should be the result
+        assert group_resolution.release.version == most_recent_version.version
 
     def test_resolved_in_next_release_no_release(self):
         self.login_as(user=self.user)

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -350,6 +350,37 @@ class GroupUpdateTest(APITestCase):
         assert group_resolution.status == GroupResolution.Status.pending
         assert group_resolution.release.version == most_recent_version.version
 
+    # XXX: Remove this test once the feature flag is removed
+    def test_resolved_in_next_release_semver_without_feature_flag(self):
+        self.login_as(user=self.user)
+
+        project = self.create_project()
+        project.flags.has_releases = True
+        project.save()
+        Release.get_or_create(version="com.foo.bar@1.0+0", project=project)
+        Release.get_or_create(version="com.foo.bar@2.0+0", project=project)
+        wrong_release = Release.get_or_create(version="com.foo.bar@1.0+1", project=project)
+        group = self.create_group(project=project)
+        assert group.status == GroupStatus.UNRESOLVED
+        assert GroupResolution.objects.all().count() == 0
+
+        url = f"/api/0/issues/{group.id}/"
+        data = {"status": "resolvedInNextRelease"}
+        response = self.client.put(url, data=data)
+        assert response.status_code == 200, response.content == {}
+
+        # Refetch from DB to ensure the latest state is fetched
+        group = Group.objects.get(id=group.id, project=project.id)
+        assert group.status == GroupStatus.RESOLVED
+
+        group_resolution = GroupResolution.objects.filter(group=group).first()
+        assert group_resolution is not None
+        assert group_resolution.group == group
+        assert group_resolution.type == GroupResolution.Type.in_next_release
+        assert group_resolution.status == GroupResolution.Status.pending
+        assert group_resolution.release.version == wrong_release.version
+
+    @with_feature("organizations:releases-resolve-next-release-semver-fix")
     def test_resolved_in_next_release_semver(self):
         self.login_as(user=self.user)
 


### PR DESCRIPTION
The previous code aimed to pick the latest releases based on creation rather than taking into consideration the semver versioning.

Fixes #69937