### PR TITLE
ref(dynamic-sampling): Refine bulk update UX

### DIFF
--- a/static/app/views/settings/dynamicSampling/organizationSampling.tsx
+++ b/static/app/views/settings/dynamicSampling/organizationSampling.tsx
@@ -108,7 +108,7 @@ export function OrganizationSampling() {
         </HeadingRow>
         <p>
           {tct(
-            'This table gives you a preview of how your projects will be affected by the target sample rate. The [strong:projected rates are estimates] based on recent span volume and change continuously.',
+            'This table gives you a preview of how your projects will be affected by the target sample rate. The [strong:estimated rates] are based on recent span volume and change continuously.',
             {
               strong: <strong />,
             }

--- a/static/app/views/settings/dynamicSampling/projectionPeriodControl.tsx
+++ b/static/app/views/settings/dynamicSampling/projectionPeriodControl.tsx
@@ -11,7 +11,7 @@ interface Props {
 export function ProjectionPeriodControl({period, onChange}: Props) {
   return (
     <Tooltip
-      title={t('The time period for which the projected sample rates are calculated.')}
+      title={t('The time period for which the estimated sample rates are calculated.')}
     >
       <SegmentedControl
         label={t('Stats period')}

--- a/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
@@ -201,6 +201,12 @@ export function ProjectsEditTable({
                   size="sm"
                   onChange={handleOrgChange}
                   value={projectedOrgRate}
+                  onKeyDown={event => {
+                    if (event.key === 'Enter') {
+                      event.preventDefault();
+                      inputRef.current?.blur();
+                    }
+                  }}
                   onBlur={() => setIsBulkEditEnabled(false)}
                 />
                 <FlexRow>

--- a/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
@@ -188,10 +188,8 @@ export function ProjectsEditTable({
               />
             </BreakdownWrapper>
             <FieldGroup
-              label={t('Projected Organization Rate')}
-              help={t(
-                "An estimate of the combined sample rate for all projects. Adjusting this will proportionally update each project's rate below."
-              )}
+              label={t('Estimated Organization Rate')}
+              help={t('An estimate of the combined sample rate for all projects.')}
               flexibleControlStateSize
               alignRight
             >
@@ -203,6 +201,7 @@ export function ProjectsEditTable({
                   size="sm"
                   onChange={handleOrgChange}
                   value={projectedOrgRate}
+                  onBlur={() => setIsBulkEditEnabled(false)}
                 />
                 <FlexRow>
                   <PreviousValue>
@@ -214,9 +213,10 @@ export function ProjectsEditTable({
                   {hasAccess && !isBulkEditEnabled && (
                     <BulkEditButton
                       size="zero"
-                      title={t(
-                        'Adjusting your organization rate will automatically scale individual project rates to match.'
-                      )}
+                      tooltipProps={{
+                        position: 'bottom',
+                      }}
+                      title={t('Proportionally scale project rates')}
                       priority="link"
                       onClick={() => {
                         setIsBulkEditEnabled(true);
@@ -233,7 +233,7 @@ export function ProjectsEditTable({
       </BreakdownPanel>
 
       <ProjectsTable
-        canEdit
+        canEdit={!isBulkEditEnabled}
         onChange={handleProjectChange}
         emptyMessage={t('No active projects found in the selected period.')}
         isLoading={isLoading}

--- a/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
@@ -239,6 +239,7 @@ export function ProjectsEditTable({
       </BreakdownPanel>
 
       <ProjectsTable
+        rateHeader={t('Target Rate')}
         canEdit={!isBulkEditEnabled}
         onChange={handleProjectChange}
         emptyMessage={t('No active projects found in the selected period.')}

--- a/static/app/views/settings/dynamicSampling/projectsPreviewTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsPreviewTable.tsx
@@ -97,6 +97,7 @@ export function ProjectsPreviewTable({isLoading, sampleCounts}: Props) {
 
       <ProjectsTable
         stickyHeaders
+        rateHeader={t('Estimated Rate')}
         inputTooltip={t('To edit project sample rates, switch to manual sampling mode.')}
         emptyMessage={t('No active projects found in the selected period.')}
         isEmpty={!sampleCounts.length}

--- a/static/app/views/settings/dynamicSampling/projectsPreviewTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsPreviewTable.tsx
@@ -97,6 +97,7 @@ export function ProjectsPreviewTable({isLoading, sampleCounts}: Props) {
 
       <ProjectsTable
         stickyHeaders
+        inputTooltip={t('To edit project sample rates, switch to manual sampling mode.')}
         emptyMessage={t('No active projects found in the selected period.')}
         isEmpty={!sampleCounts.length}
         isLoading={isLoading}

--- a/static/app/views/settings/dynamicSampling/projectsTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsTable.tsx
@@ -29,6 +29,7 @@ interface Props extends Omit<React.ComponentProps<typeof StyledPanelTable>, 'hea
   items: ProjectItem[];
   canEdit?: boolean;
   inactiveItems?: ProjectItem[];
+  inputTooltip?: string;
   onChange?: (projectId: string, value: string) => void;
 }
 
@@ -37,6 +38,7 @@ const COLUMN_COUNT = 4;
 export function ProjectsTable({
   items,
   inactiveItems = [],
+  inputTooltip,
   canEdit,
   onChange,
   ...props
@@ -63,7 +65,7 @@ export function ProjectsTable({
           <IconArrow direction={tableSort === 'desc' ? 'down' : 'up'} size="xs" />
         </SortableHeader>,
         t('Stored Spans'),
-        canEdit ? t('Target Rate') : t('Projected Rate'),
+        canEdit ? t('Target Rate') : t('Estimated Rate'),
       ]}
     >
       {mainItems
@@ -81,6 +83,7 @@ export function ProjectsTable({
             key={item.project.id}
             canEdit={canEdit}
             onChange={onChange}
+            inputTooltip={inputTooltip}
             {...item}
           />
         ))}
@@ -219,6 +222,7 @@ const TableRow = memo(function TableRow({
   initialSampleRate,
   subProjects,
   error,
+  inputTooltip,
   onChange,
 }: {
   count: number;
@@ -229,6 +233,7 @@ const TableRow = memo(function TableRow({
   subProjects: SubProject[];
   canEdit?: boolean;
   error?: string;
+  inputTooltip?: string;
   onChange?: (projectId: string, value: string) => void;
 }) {
   const organization = useOrganization();
@@ -299,10 +304,7 @@ const TableRow = memo(function TableRow({
       </Cell>
       <Cell>
         <FirstCellLine>
-          <Tooltip
-            disabled={canEdit}
-            title={t('To edit project sample rates, switch to manual sampling mode.')}
-          >
+          <Tooltip disabled={!inputTooltip} title={inputTooltip}>
             <PercentInput
               type="number"
               disabled={!canEdit}

--- a/static/app/views/settings/dynamicSampling/projectsTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsTable.tsx
@@ -27,6 +27,7 @@ interface ProjectItem {
 
 interface Props extends Omit<React.ComponentProps<typeof StyledPanelTable>, 'headers'> {
   items: ProjectItem[];
+  rateHeader: React.ReactNode;
   canEdit?: boolean;
   inactiveItems?: ProjectItem[];
   inputTooltip?: string;
@@ -40,6 +41,7 @@ export function ProjectsTable({
   inactiveItems = [],
   inputTooltip,
   canEdit,
+  rateHeader,
   onChange,
   ...props
 }: Props) {
@@ -65,7 +67,7 @@ export function ProjectsTable({
           <IconArrow direction={tableSort === 'desc' ? 'down' : 'up'} size="xs" />
         </SortableHeader>,
         t('Stored Spans'),
-        canEdit ? t('Target Rate') : t('Estimated Rate'),
+        rateHeader,
       ]}
     >
       {mainItems


### PR DESCRIPTION
Disable project rate inputs while org assist / bulk mode is active.
Adjust copy `projected` -> `estimated`.

https://github.com/user-attachments/assets/1148a97a-62d4-440c-be50-60f091b48bc5

Part of https://github.com/getsentry/projects/issues/390

