### PR TITLE
feat(testing): Bump clickhouse version for dc tests

### DIFF
--- a/devservices/docker-compose-testing.yml
+++ b/devservices/docker-compose-testing.yml
@@ -107,7 +107,7 @@ services:
   clickhouse:
     <<: *restart_policy
     container_name: sentry_clickhouse
-    image: 'ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:23.3.19.33.altinitystable'
+    image: 'ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:23.8.11.29.altinitystable'
     ulimits:
       nofile:
         soft: 262144


### PR DESCRIPTION
This is the wrong version, I think there's a replay test failing because of it now

