### PR TITLE
fix(profiling): change name displayed to profile hours

### DIFF
--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -337,6 +337,7 @@ class UsageStatsOrganization<
       dataCategoryApiName,
     } = this.props;
     const {total, accepted, invalid, rateLimited, filtered} = this.chartData.cardStats;
+    const dataCategoryNameLower = dataCategoryName.toLowerCase();
 
     const navigateToInboundFilterSettings = (event: ReactMouseEvent) => {
       event.preventDefault();
@@ -356,7 +357,7 @@ class UsageStatsOrganization<
         help: tct(
           'Accepted [dataCategory] were successfully processed by Sentry. For more information, read our [docsLink:docs].',
           {
-            dataCategory,
+            dataCategory: dataCategoryNameLower,
             docsLink: (
               <ExternalLink
                 href="https://docs.sentry.io/product/stats/#accepted"
@@ -380,7 +381,7 @@ class UsageStatsOrganization<
         help: tct(
           'Filtered [dataCategory] were blocked due to your [filterSettings: inbound data filter] rules. For more information, read our [docsLink:docs].',
           {
-            dataCategory,
+            dataCategory: dataCategoryNameLower,
             filterSettings: (
               <a href="#" onClick={event => navigateToInboundFilterSettings(event)} />
             ),
@@ -399,7 +400,7 @@ class UsageStatsOrganization<
         help: tct(
           'Rate Limited [dataCategory] were discarded due to rate limits or quota. For more information, read our [docsLink:docs].',
           {
-            dataCategory,
+            dataCategory: dataCategoryNameLower,
             docsLink: (
               <ExternalLink
                 href="https://docs.sentry.io/product/stats/#rate-limited"
@@ -415,7 +416,7 @@ class UsageStatsOrganization<
         help: tct(
           'Invalid [dataCategory] were sent by the SDK and were discarded because the data did not meet the basic schema requirements. For more information, read our [docsLink:docs].',
           {
-            dataCategory,
+            dataCategory: dataCategoryNameLower,
             docsLink: (
               <ExternalLink
                 href="https://docs.sentry.io/product/stats/#invalid"


### PR DESCRIPTION
changes name displayed in Stats page tooltip from `profileDuration` to `profile hours`

Before
![Screenshot 2024-11-12 at 3 07 37 PM](https://github.com/user-attachments/assets/26e88445-5a52-4fd3-a909-8ea8de0b43ff)

After
![Screenshot 2024-11-13 at 10 18 20 AM](https://github.com/user-attachments/assets/7a848bc5-05ea-4708-9bc2-3a6a42ff8860)
