### PR TITLE
fix(grouping): Remove redundant salt wrapper components in legacy grouping

### DIFF
--- a/src/sentry/grouping/strategies/legacy.py
+++ b/src/sentry/grouping/strategies/legacy.py
@@ -296,14 +296,7 @@ def frame_legacy(
     module_component = GroupingComponent(id="module")
     if interface.module:
         if is_unhashable_module_legacy(interface, platform):
-            module_component.update(
-                values=[
-                    GroupingComponent(
-                        id="salt", values=["<module>"], hint="normalized generated module name"
-                    )
-                ],
-                hint="ignored module",
-            )
+            module_component.update(values=["<module>"], hint="normalized generated module name")
         else:
             module_name, module_hint = remove_module_outliers_legacy(interface.module, platform)
             module_component.update(values=[module_name], hint=module_hint)
@@ -346,11 +339,7 @@ def frame_legacy(
         elif func:
             if is_unhashable_function_legacy(func):
                 function_component.update(
-                    values=[
-                        GroupingComponent(
-                            id="salt", values=["<function>"], hint="normalized lambda function name"
-                        )
-                    ]
+                    values=["<function>"], hint="normalized lambda function name"
                 )
             else:
                 function, function_hint = remove_function_outliers_legacy(func)

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/frame_ignores_java8_lambda_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/frame_ignores_java8_lambda_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-28T14:02:51.878887+00:00'
+created: '2024-11-13T17:36:33.087509+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -14,6 +14,5 @@ contributing variants:
           frame*
             module*
               "foo.bar.Baz"
-            function*
-              salt* (normalized lambda function name)
-                "<function>"
+            function* (normalized lambda function name)
+              "<function>"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/frame_ignores_java8_lambda_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/frame_ignores_java8_lambda_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-28T14:02:51.939165+00:00'
+created: '2024-11-13T17:36:33.190334+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -12,8 +12,7 @@ contributing variants:
       system*
         stacktrace*
           frame*
-            module* (ignored module)
-              salt* (normalized generated module name)
-                "<module>"
+            module* (normalized generated module name)
+              "<module>"
             function*
               "call"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/frame_ignores_module_if_page_url_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/frame_ignores_module_if_page_url_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-10-28T14:02:52.122282+00:00'
+created: '2024-11-13T17:36:33.547311+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -12,8 +12,7 @@ contributing variants:
       system*
         stacktrace*
           frame*
-            module* (ignored module)
-              salt* (normalized generated module name)
-                "<module>"
+            module* (normalized generated module name)
+              "<module>"
             function*
               "a"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_ignores_java8_lambda_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_ignores_java8_lambda_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:26.823824Z'
+created: '2024-11-13T17:26:12.765496+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,9 +11,8 @@ app:
         frame* (frame considered in-app because no frame is in-app)
           module*
             "foo.bar.Baz"
-          function*
-            salt* (normalized lambda function name)
-              "<function>"
+          function* (normalized lambda function name)
+            "<function>"
 --------------------------------------------------------------------------
 system:
   hash: "aee9aaca552e7fd593d085ca5a2260cf"
@@ -23,6 +22,5 @@ system:
         frame*
           module*
             "foo.bar.Baz"
-          function*
-            salt* (normalized lambda function name)
-              "<function>"
+          function* (normalized lambda function name)
+            "<function>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_ignores_java8_lambda_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_ignores_java8_lambda_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:26.836720Z'
+created: '2024-11-13T17:23:54.995527+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,9 +9,8 @@ app:
     app (stacktrace of system takes precedence)
       stacktrace (ignored because hash matches system variant)
         frame* (frame considered in-app because no frame is in-app)
-          module* (ignored module)
-            salt* (normalized generated module name)
-              "<module>"
+          module* (normalized generated module name)
+            "<module>"
           function*
             "call"
 --------------------------------------------------------------------------
@@ -21,8 +20,7 @@ system:
     system*
       stacktrace*
         frame*
-          module* (ignored module)
-            salt* (normalized generated module name)
-              "<module>"
+          module* (normalized generated module name)
+            "<module>"
           function*
             "call"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_ignores_module_if_page_url_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_ignores_module_if_page_url_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:26.918697Z'
+created: '2024-11-13T17:23:55.422554+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,9 +9,8 @@ app:
     app (stacktrace of system takes precedence)
       stacktrace (ignored because hash matches system variant)
         frame* (frame considered in-app because no frame is in-app)
-          module* (ignored module)
-            salt* (normalized generated module name)
-              "<module>"
+          module* (normalized generated module name)
+            "<module>"
           filename (module takes precedence)
             "foo.py"
           function*
@@ -23,9 +22,8 @@ system:
     system*
       stacktrace*
         frame*
-          module* (ignored module)
-            salt* (normalized generated module name)
-              "<module>"
+          module* (normalized generated module name)
+            "<module>"
           filename (module takes precedence)
             "foo.py"
           function*


### PR DESCRIPTION
In our grouping algorithm, we sometimes include in the hash a constant value (a "salt") alongside the dynamic values generated from the event. (For example, when grouping ExpectCT and Expect-Staple security reports, we include `expect-ct` or `expect-staple` alongside the hostname of the server which violated the rule, so that the two types of violations hash into separate groups even when the hostname is the same.)

However, in two places in the legacy grouping algorithm, we're using a salt grouping component not to add an extra value into the hashing but just as an extra wrapper around either an anonymous module name or an anonymous function name. This doesn't change the eventual hash value, but it does violate the thus far unenforced (but soon to be enforced) type signature of both the module and function grouping components, which are meant only to hold actual values, not wrapper components. This fixes the type mismatch by removing the salt component wrappers and placing the module and function name values directly in the module and function grouping components.

Notes:

- We can see that this doesn't change the hash value (and therefore wouldn't result in a grouping change, even if someone were still on legacy grouping), because the hash values in the affected snapshots don't change.
- In the case of the module, this change also entailed removing the spot where the `ignored module` hint used to live. I was going to incorporate it into the remaining hint until I realized that in fact it's been a lie all along - we don't ignore the module! So instead I just got rid of it. (You can see that the module is used because it has a `*` next to it in the snapshots, meaning it contributes to grouping.)