### PR TITLE
fix(flags): fix sort analytic

### DIFF
--- a/static/app/components/events/featureFlags/featureFlagSort.tsx
+++ b/static/app/components/events/featureFlags/featureFlagSort.tsx
@@ -43,6 +43,10 @@ export default function FeatureFlagSort({sortBy, orderBy, setOrderBy, setSortBy}
             setOrderBy(getDefaultOrderBy(selection.value));
           }
           setSortBy(selection.value);
+          trackAnalytics('flags.sort_flags', {
+            organization,
+            sortMethod: selection.value,
+          });
         }}
         options={SORT_BY_OPTIONS}
       />
@@ -51,7 +55,7 @@ export default function FeatureFlagSort({sortBy, orderBy, setOrderBy, setSortBy}
         value={orderBy}
         onChange={selection => {
           setOrderBy(selection.value);
-          trackAnalytics('flags.sort-flags', {
+          trackAnalytics('flags.sort_flags', {
             organization,
             sortMethod: selection.value,
           });

--- a/static/app/utils/analytics/featureFlagAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/featureFlagAnalyticsEvents.tsx
@@ -5,7 +5,7 @@ export type FeatureFlagEventParameters = {
     numTotalFlags: number;
   };
   'flags.setup_modal_opened': {};
-  'flags.sort-flags': {sortMethod: string};
+  'flags.sort_flags': {sortMethod: string};
   'flags.table_rendered': {
     numFlags: number;
   };
@@ -17,7 +17,7 @@ export type FeatureFlagEventKey = keyof FeatureFlagEventParameters;
 
 export const featureFlagEventMap: Record<FeatureFlagEventKey, string | null> = {
   'flags.view-all-clicked': 'Clicked View All Flags',
-  'flags.sort-flags': 'Sorted Flags',
+  'flags.sort_flags': 'Sorted Flags',
   'flags.event_and_suspect_flags_found': 'Number of Event and Suspect Flags',
   'flags.setup_modal_opened': 'Flag Setup Integration Modal Opened',
   'flags.webhook_url_generated': 'Flag Webhook URL Generated in Setup Integration Modal',


### PR DESCRIPTION
new flag analytic since we changed how sorting works.

options for `sortMethod` are now
- `eval`
- `alphabetical`
- `newest`
- `oldest`
- `a-z`
- `z-a`


<img width="220" alt="SCR-20241113-limo" src="https://github.com/user-attachments/assets/453e196b-420c-4f61-8e01-dba50f4c7ec5">
