### PR TITLE
refactor(nav): stateful NavContextProvider

### DIFF
--- a/static/app/components/nav/config.tsx
+++ b/static/app/components/nav/config.tsx
@@ -14,28 +14,10 @@ import {
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import type {Organization} from 'sentry/types/organization';
-import {getDiscoverLandingUrl} from 'sentry/utils/discover/urls';
 import {MODULE_BASE_URLS} from 'sentry/views/insights/common/utils/useModuleURL';
-import {MODULE_SIDEBAR_TITLE as MODULE_TITLE_HTTP} from 'sentry/views/insights/http/settings';
-import {
-  AI_LANDING_SUB_PATH,
-  AI_LANDING_TITLE,
-} from 'sentry/views/insights/pages/ai/settings';
-import {
-  BACKEND_LANDING_SUB_PATH,
-  BACKEND_LANDING_TITLE,
-} from 'sentry/views/insights/pages/backend/settings';
-import {
-  FRONTEND_LANDING_SUB_PATH,
-  FRONTEND_LANDING_TITLE,
-} from 'sentry/views/insights/pages/frontend/settings';
-import {
-  MOBILE_LANDING_SUB_PATH,
-  MOBILE_LANDING_TITLE,
-} from 'sentry/views/insights/pages/mobile/settings';
+import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
 import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
-import {INSIGHTS_BASE_URL, MODULE_TITLES} from 'sentry/views/insights/settings';
-import {getSearchForIssueGroup, IssueGroup} from 'sentry/views/issueList/utils';
+import {INSIGHTS_BASE_URL} from 'sentry/views/insights/settings';
 
 /**
  * Global nav settings for all Sentry users.
@@ -45,55 +27,21 @@ import {getSearchForIssueGroup, IssueGroup} from 'sentry/views/issueList/utils';
  */
 export function createNavConfig({organization}: {organization: Organization}): NavConfig {
   const prefix = `organizations/${organization.slug}`;
-  const insightsPrefix = `${prefix}/${INSIGHTS_BASE_URL}`;
-  const hasPerfDomainViews = organization.features.includes('insights-domain-view');
+  const hasPerformanceDomainViews =
+    organization.features.includes('insights-domain-view');
 
-  const insights: NavSidebarItem = {
+  const legacyInsights: NavSidebarItem = {
     label: t('Insights'),
     icon: <IconGraph />,
+    id: 'insights',
+    to: `organizations/${organization.slug}/${INSIGHTS_BASE_URL}/${MODULE_BASE_URLS.http}/`,
     feature: {features: 'insights-entry-points'},
-    submenu: [
-      {
-        label: MODULE_TITLE_HTTP,
-        to: `/${insightsPrefix}/${MODULE_BASE_URLS.http}/`,
-      },
-      {label: MODULE_TITLES.db, to: `/${insightsPrefix}/${MODULE_BASE_URLS.db}/`},
-      {
-        label: MODULE_TITLES.resource,
-        to: `/${insightsPrefix}/${MODULE_BASE_URLS.resource}/`,
-      },
-      {
-        label: MODULE_TITLES.app_start,
-        to: `/${insightsPrefix}/${MODULE_BASE_URLS.app_start}/`,
-      },
-      {
-        label: MODULE_TITLES['mobile-screens'],
-        to: `/${insightsPrefix}/${MODULE_BASE_URLS['mobile-screens']}/`,
-        feature: {features: 'insights-mobile-screens-module'},
-      },
-      {
-        label: MODULE_TITLES.vital,
-        to: `/${insightsPrefix}/${MODULE_BASE_URLS.vital}/`,
-      },
-      {
-        label: MODULE_TITLES.cache,
-        to: `/${insightsPrefix}/${MODULE_BASE_URLS.cache}/`,
-      },
-      {
-        label: MODULE_TITLES.queue,
-        to: `/${insightsPrefix}/${MODULE_BASE_URLS.queue}/`,
-      },
-      {
-        label: MODULE_TITLES.ai,
-        to: `/${insightsPrefix}/${MODULE_BASE_URLS.ai}/`,
-        feature: {features: 'insights-entry-points'},
-      },
-    ],
   };
 
-  const perf: NavSidebarItem = {
+  const legacyPerformance: NavSidebarItem = {
     label: t('Perf.'),
-    to: '/performance/',
+    to: `/${prefix}/performance/`,
+    id: 'performance',
     icon: <IconLightning />,
     feature: {
       features: 'performance-view',
@@ -101,119 +49,61 @@ export function createNavConfig({organization}: {organization: Organization}): N
     },
   };
 
-  const perfDomainViews: NavSidebarItem = {
+  const performanceDomain: NavSidebarItem = {
     label: t('Perf.'),
     icon: <IconLightning />,
+    id: 'performance',
+    to: `/${prefix}/${DOMAIN_VIEW_BASE_URL}/${FRONTEND_LANDING_SUB_PATH}/`,
     feature: {features: ['insights-domain-view', 'performance-view']},
-    submenu: [
-      {
-        label: FRONTEND_LANDING_TITLE,
-        to: `/${prefix}/${DOMAIN_VIEW_BASE_URL}/${FRONTEND_LANDING_SUB_PATH}/`,
-      },
-      {
-        label: BACKEND_LANDING_TITLE,
-        to: `/${prefix}/${DOMAIN_VIEW_BASE_URL}/${BACKEND_LANDING_SUB_PATH}/`,
-      },
-      {
-        label: AI_LANDING_TITLE,
-        to: `/${prefix}/${DOMAIN_VIEW_BASE_URL}/${AI_LANDING_SUB_PATH}/`,
-      },
-      {
-        label: MOBILE_LANDING_TITLE,
-        to: `/${prefix}/${DOMAIN_VIEW_BASE_URL}/${MOBILE_LANDING_SUB_PATH}/`,
-      },
-    ],
   };
+
+  const performance = hasPerformanceDomainViews
+    ? [performanceDomain]
+    : [legacyInsights, legacyPerformance];
 
   return {
     main: [
       {
         label: t('Issues'),
         icon: <IconIssues />,
-        submenu: [
-          {
-            label: t('All'),
-            to: `/${prefix}/issues/?query=is:unresolved`,
-          },
-          {
-            label: t('Error & Outage'),
-            to: `/${prefix}/issues/${getSearchForIssueGroup(IssueGroup.ERROR_OUTAGE)}`,
-          },
-          {
-            label: t('Trend'),
-            to: `/${prefix}/issues/${getSearchForIssueGroup(IssueGroup.TREND)}`,
-          },
-          {
-            label: t('Craftsmanship'),
-            to: `/${prefix}/issues/${getSearchForIssueGroup(IssueGroup.CRAFTSMANSHIP)}`,
-          },
-          {
-            label: t('Security'),
-            to: `/${prefix}/issues/${getSearchForIssueGroup(IssueGroup.SECURITY)}`,
-          },
-          {label: t('Feedback'), to: `/${prefix}/feedback/`},
-        ],
+        id: 'issues',
+        to: `/${prefix}/issues/`,
       },
-      {label: t('Projects'), to: `/${prefix}/projects/`, icon: <IconProject />},
+      {
+        label: t('Projects'),
+        id: 'projects',
+        to: `/${prefix}/projects/`,
+        icon: <IconProject />,
+      },
       {
         label: t('Explore'),
         icon: <IconSearch />,
-        submenu: [
-          {
-            label: t('Traces'),
-            to: `/${prefix}/traces/`,
-            feature: {features: 'performance-trace-explorer'},
-          },
-          {
-            label: t('Metrics'),
-            to: `/${prefix}/metrics/`,
-            feature: {features: 'custom-metrics'},
-          },
-          {
-            label: t('Profiles'),
-            to: `/${prefix}/profiling/`,
-            feature: {
-              features: 'profiling',
-              hookName: 'feature-disabled:profiling-sidebar-item',
-              requireAll: false,
-            },
-          },
-          {
-            label: t('Replays'),
-            to: `/${prefix}/replays/`,
-            feature: {
-              features: 'session-replay-ui',
-              hookName: 'feature-disabled:replay-sidebar-item',
-            },
-          },
-          {
-            label: t('Discover'),
-            to: getDiscoverLandingUrl(organization),
-            feature: {
-              features: 'discover-basic',
-              hookName: 'feature-disabled:discover2-sidebar-item',
-            },
-          },
-          {label: t('Releases'), to: `/${prefix}/releases/`},
-          {label: t('Crons'), to: `/${prefix}/crons/`},
-        ],
+        id: 'explore',
+        to: `/${prefix}/traces/`,
       },
-      ...(hasPerfDomainViews ? [perfDomainViews, perf] : [insights, perf]),
+      ...performance,
       {
         label: t('Boards'),
         to: '/dashboards/',
         icon: <IconDashboard />,
+        id: 'boards',
         feature: {
           features: ['discover', 'discover-query', 'dashboards-basic', 'dashboards-edit'],
           hookName: 'feature-disabled:dashboards-sidebar-item',
           requireAll: false,
         },
       },
-      {label: t('Alerts'), to: `/${prefix}/alerts/rules/`, icon: <IconSiren />},
+      {
+        label: t('Alerts'),
+        id: 'alerts',
+        to: `/${prefix}/alerts/rules/`,
+        icon: <IconSiren />,
+      },
     ],
     footer: [
       {
         label: t('Help'),
+        id: 'help',
         icon: <IconQuestion />,
         dropdown: [
           {
@@ -242,6 +132,7 @@ export function createNavConfig({organization}: {organization: Organization}): N
       },
       {
         label: t('Settings'),
+        id: 'settings',
         to: `/settings/${organization.slug}/`,
         icon: <IconSettings />,
       },

--- a/static/app/components/nav/context.tsx
+++ b/static/app/components/nav/context.tsx
@@ -2,7 +2,7 @@ import {createContext, useContext, useEffect, useState} from 'react';
 
 import {createNavConfig} from 'sentry/components/nav/config';
 import type {NavConfig, NavMenuKey} from 'sentry/components/nav/utils';
-import {getActiveNavIds} from 'sentry/components/nav/utils';
+import {useActiveNavIds} from 'sentry/components/nav/utils';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface NavContext {
@@ -24,7 +24,7 @@ const NavContext = createContext<NavContext>({} as any);
 export function NavContextProvider({children}) {
   const organization = useOrganization();
   const config = createNavConfig({organization});
-  const defaultActiveIds = getActiveNavIds();
+  const defaultActiveIds = useActiveNavIds();
   const [activeMenuId, setActiveMenuId] = useState<NavMenuKey>(defaultActiveIds.menu);
   const [activeSubmenuId, setActiveSubmenuId] = useState<string | undefined>(
     defaultActiveIds.submenu

--- a/static/app/components/nav/index.spec.tsx
+++ b/static/app/components/nav/index.spec.tsx
@@ -5,9 +5,11 @@ import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {getAllByRole, render, screen} from 'sentry-test/reactTestingLibrary';
 
 import Nav from 'sentry/components/nav';
+import {NavContextProvider} from 'sentry/components/nav/context';
 
 const ALL_AVAILABLE_FEATURES = [
   'insights-entry-points',
+  'insights-domain-view',
   'discover',
   'discover-basic',
   'discover-query',
@@ -25,12 +27,17 @@ const ALL_AVAILABLE_FEATURES = [
 describe('Nav', function () {
   describe('default', function () {
     beforeEach(() => {
-      render(<Nav />, {
-        router: RouterFixture({
-          location: LocationFixture({pathname: '/organizations/org-slug/issues/'}),
-        }),
-        organization: OrganizationFixture({features: ALL_AVAILABLE_FEATURES}),
-      });
+      render(
+        <NavContextProvider>
+          <Nav />
+        </NavContextProvider>,
+        {
+          router: RouterFixture({
+            location: LocationFixture({pathname: '/organizations/org-slug/issues/'}),
+          }),
+          organization: OrganizationFixture({features: ALL_AVAILABLE_FEATURES}),
+        }
+      );
     });
     it('renders primary navigation', async function () {
       expect(
@@ -48,34 +55,32 @@ describe('Nav', function () {
         screen.getByRole('navigation', {name: 'Primary Navigation'}),
         'link'
       );
-      expect(links).toHaveLength(8);
+      expect(links).toHaveLength(7);
 
-      [
-        'Issues',
-        'Projects',
-        'Explore',
-        'Insights',
-        'Perf.',
-        'Boards',
-        'Alerts',
-        'Settings',
-      ].forEach((title, index) => {
-        expect(links[index]).toHaveAccessibleName(title);
-      });
+      ['Issues', 'Projects', 'Explore', 'Perf.', 'Boards', 'Alerts', 'Settings'].forEach(
+        (title, index) => {
+          expect(links[index]).toHaveAccessibleName(title);
+        }
+      );
     });
   });
 
   describe('issues', function () {
     beforeEach(() => {
-      render(<Nav />, {
-        router: RouterFixture({
-          location: LocationFixture({
-            pathname: '/organizations/org-slug/issues/',
-            search: '?query=is:unresolved',
+      render(
+        <NavContextProvider>
+          <Nav />
+        </NavContextProvider>,
+        {
+          router: RouterFixture({
+            location: LocationFixture({
+              pathname: '/organizations/org-slug/issues/',
+              search: '?query=is:unresolved',
+            }),
           }),
-        }),
-        organization: OrganizationFixture({features: ALL_AVAILABLE_FEATURES}),
-      });
+          organization: OrganizationFixture({features: ALL_AVAILABLE_FEATURES}),
+        }
+      );
     });
 
     it('renders secondary navigation', async function () {
@@ -99,12 +104,19 @@ describe('Nav', function () {
 
   describe('insights', function () {
     beforeEach(() => {
-      render(<Nav />, {
-        router: RouterFixture({
-          location: LocationFixture({pathname: '/organizations/org-slug/insights/http/'}),
-        }),
-        organization: OrganizationFixture({features: ALL_AVAILABLE_FEATURES}),
-      });
+      render(
+        <NavContextProvider>
+          <Nav />
+        </NavContextProvider>,
+        {
+          router: RouterFixture({
+            location: LocationFixture({
+              pathname: '/organizations/org-slug/insights/http/',
+            }),
+          }),
+          organization: OrganizationFixture({features: ALL_AVAILABLE_FEATURES}),
+        }
+      );
     });
 
     it('renders secondary navigation', async function () {
@@ -116,16 +128,12 @@ describe('Nav', function () {
     it('includes expected submenu items', function () {
       const container = screen.getByRole('navigation', {name: 'Secondary Navigation'});
       const links = getAllByRole(container, 'link');
-      expect(links).toHaveLength(8);
+      expect(links).toHaveLength(4);
       [
-        'Requests',
-        'Queries',
-        'Assets',
-        'App Starts',
-        'Web Vitals',
-        'Caches',
-        'Queues',
-        'LLM Monitoring',
+        'Frontend Performance',
+        'Backend Performance',
+        'AI Performance',
+        'Mobile Performance',
       ].forEach((title, index) => {
         expect(links[index]).toHaveAccessibleName(title);
       });
@@ -134,12 +142,17 @@ describe('Nav', function () {
 
   describe('explore', function () {
     beforeEach(() => {
-      render(<Nav />, {
-        router: RouterFixture({
-          location: LocationFixture({pathname: '/organizations/org-slug/traces/'}),
-        }),
-        organization: OrganizationFixture({features: ALL_AVAILABLE_FEATURES}),
-      });
+      render(
+        <NavContextProvider>
+          <Nav />
+        </NavContextProvider>,
+        {
+          router: RouterFixture({
+            location: LocationFixture({pathname: '/organizations/org-slug/traces/'}),
+          }),
+          organization: OrganizationFixture({features: ALL_AVAILABLE_FEATURES}),
+        }
+      );
     });
 
     it('renders secondary navigation', async function () {

--- a/static/app/components/nav/index.tsx
+++ b/static/app/components/nav/index.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 
-import {NavContextProvider} from 'sentry/components/nav/context';
 import MobileTopbar from 'sentry/components/nav/mobileTopbar';
 import Sidebar from 'sentry/components/nav/sidebar';
 import {useBreakpoints} from 'sentry/utils/metrics/useBreakpoints';
@@ -8,11 +7,7 @@ import {useBreakpoints} from 'sentry/utils/metrics/useBreakpoints';
 function Nav() {
   const screen = useBreakpoints();
 
-  return (
-    <NavContextProvider>
-      <NavContainer>{screen.medium ? <Sidebar /> : <MobileTopbar />}</NavContainer>
-    </NavContextProvider>
-  );
+  return <NavContainer>{screen.medium ? <Sidebar /> : <MobileTopbar />}</NavContainer>;
 }
 
 const NavContainer = styled('div')`

--- a/static/app/components/nav/submenus/explore.tsx
+++ b/static/app/components/nav/submenus/explore.tsx
@@ -1,0 +1,46 @@
+import Submenu, {SubmenuBody, SubmenuItem} from 'sentry/components/nav/submenu';
+import {t} from 'sentry/locale';
+import {getDiscoverLandingUrl} from 'sentry/utils/discover/urls';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export type PerformanceSubmenuKey =
+  | 'traces'
+  | 'metrics'
+  | 'profiling'
+  | 'discover'
+  | 'releases'
+  | 'crons'
+  | 'feedback';
+
+export default function PerformanceSubmenu() {
+  const organization = useOrganization();
+  const prefix = `organizations/${organization.slug}`;
+
+  return (
+    <Submenu>
+      <SubmenuBody>
+        <SubmenuItem id="traces" to={`/${prefix}/traces/`}>
+          {t('Traces')}
+        </SubmenuItem>
+        <SubmenuItem id="metrics" to={`/${prefix}/metrics/`}>
+          {t('Metrics')}
+        </SubmenuItem>
+        <SubmenuItem id="profiling" to={`/${prefix}/profiling/`}>
+          {t('Profiles')}
+        </SubmenuItem>
+        <SubmenuItem id="replays" to={`/${prefix}/replays/`}>
+          {t('Replays')}
+        </SubmenuItem>
+        <SubmenuItem id="discover" to={getDiscoverLandingUrl(organization)}>
+          {t('Discover')}
+        </SubmenuItem>
+        <SubmenuItem id="releases" to={`/${prefix}/releases/`}>
+          {t('Releases')}
+        </SubmenuItem>
+        <SubmenuItem id="crons" to={`/${prefix}/crons/`}>
+          {t('Crons')}
+        </SubmenuItem>
+      </SubmenuBody>
+    </Submenu>
+  );
+}

--- a/static/app/components/nav/submenus/index.tsx
+++ b/static/app/components/nav/submenus/index.tsx
@@ -1,0 +1,23 @@
+import {useNavContext} from 'sentry/components/nav/context';
+
+import ExploreSubmenu from './explore';
+import InsightsSubmenu from './insights';
+import IssuesSubmenu from './issues';
+import PerformanceSubmenu from './performance';
+
+export default function ActiveSubmenu() {
+  const {activeMenuId} = useNavContext();
+
+  switch (activeMenuId) {
+    case 'explore':
+      return <ExploreSubmenu />;
+    case 'insights':
+      return <InsightsSubmenu />;
+    case 'issues':
+      return <IssuesSubmenu />;
+    case 'performance':
+      return <PerformanceSubmenu />;
+    default:
+      return null;
+  }
+}

--- a/static/app/components/nav/submenus/insights.tsx
+++ b/static/app/components/nav/submenus/insights.tsx
@@ -1,0 +1,76 @@
+import Feature from 'sentry/components/acl/feature';
+import Submenu, {SubmenuBody, SubmenuItem} from 'sentry/components/nav/submenu';
+import useOrganization from 'sentry/utils/useOrganization';
+import {MODULE_BASE_URLS} from 'sentry/views/insights/common/utils/useModuleURL';
+import {MODULE_SIDEBAR_TITLE as MODULE_TITLE_HTTP} from 'sentry/views/insights/http/settings';
+import {INSIGHTS_BASE_URL, MODULE_TITLES} from 'sentry/views/insights/settings';
+
+export type InsightsSubmenuKey =
+  | 'all'
+  | 'error'
+  | 'trend'
+  | 'craftsmanship'
+  | 'security'
+  | 'feedback';
+
+export default function InsightsSubmenu() {
+  const {slug} = useOrganization();
+  const prefix = `organizations/${slug}/${INSIGHTS_BASE_URL}`;
+
+  return (
+    <Submenu>
+      <SubmenuBody>
+        <SubmenuItem
+          id={MODULE_BASE_URLS.http}
+          to={`/${prefix}/${MODULE_BASE_URLS.http}`}
+        >
+          {MODULE_TITLE_HTTP}
+        </SubmenuItem>
+        <SubmenuItem id={MODULE_BASE_URLS.db} to={`/${prefix}/${MODULE_BASE_URLS.db}`}>
+          {MODULE_TITLES.db}
+        </SubmenuItem>
+        <SubmenuItem
+          id={MODULE_BASE_URLS.resource}
+          to={`/${prefix}/${MODULE_BASE_URLS.resource}`}
+        >
+          {MODULE_TITLES.resource}
+        </SubmenuItem>
+        <SubmenuItem
+          id={MODULE_BASE_URLS.app_start}
+          to={`/${prefix}/${MODULE_BASE_URLS.app_start}`}
+        >
+          {MODULE_TITLES.app_start}
+        </SubmenuItem>
+        <SubmenuItem
+          id={MODULE_BASE_URLS.vital}
+          to={`/${prefix}/${MODULE_BASE_URLS.vital}`}
+        >
+          {MODULE_TITLES.vital}
+        </SubmenuItem>
+        <Feature features="insights-mobile-screens-module">
+          <SubmenuItem
+            id={MODULE_BASE_URLS['mobile-screens']}
+            to={`/${prefix}/${MODULE_BASE_URLS['mobile-screens']}/`}
+          >
+            {MODULE_TITLES['mobile-screens']}
+          </SubmenuItem>
+        </Feature>
+        <SubmenuItem
+          id={MODULE_BASE_URLS.cache}
+          to={`/${prefix}/${MODULE_BASE_URLS.cache}`}
+        >
+          {MODULE_TITLES.cache}
+        </SubmenuItem>
+        <SubmenuItem
+          id={MODULE_BASE_URLS.queue}
+          to={`/${prefix}/${MODULE_BASE_URLS.queue}`}
+        >
+          {MODULE_TITLES.queue}
+        </SubmenuItem>
+        <SubmenuItem id={MODULE_BASE_URLS.ai} to={`/${prefix}/${MODULE_BASE_URLS.ai}`}>
+          {MODULE_TITLES.ai}
+        </SubmenuItem>
+      </SubmenuBody>
+    </Submenu>
+  );
+}

--- a/static/app/components/nav/submenus/issues.tsx
+++ b/static/app/components/nav/submenus/issues.tsx
@@ -1,0 +1,67 @@
+import Submenu, {SubmenuBody, SubmenuItem} from 'sentry/components/nav/submenu';
+import {t} from 'sentry/locale';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export type IssuesSubmenuKey =
+  | 'all'
+  | 'error'
+  | 'trend'
+  | 'craftsmanship'
+  | 'security'
+  | 'feedback';
+
+export default function IssuesSubmenu() {
+  const organization = useOrganization();
+  const location = useLocation();
+  const prefix = `organizations/${organization.slug}`;
+  const defaultPathname = `/${prefix}/issues/`;
+
+  return (
+    <Submenu>
+      <SubmenuBody>
+        <SubmenuItem
+          id="all"
+          to={{...location, pathname: defaultPathname, state: {issueTaxonomy: 'all'}}}
+        >
+          {t('All')}
+        </SubmenuItem>
+        <SubmenuItem
+          id="error"
+          to={{...location, pathname: defaultPathname, state: {issueTaxonomy: 'error'}}}
+        >
+          {t('Error & Outage')}
+        </SubmenuItem>
+        <SubmenuItem
+          id="trend"
+          to={{...location, pathname: defaultPathname, state: {issueTaxonomy: 'trend'}}}
+        >
+          {t('Trend')}
+        </SubmenuItem>
+        <SubmenuItem
+          id="craftsmanship"
+          to={{
+            ...location,
+            pathname: defaultPathname,
+            state: {issueTaxonomy: 'craftsmanship'},
+          }}
+        >
+          {t('Craftsmanship')}
+        </SubmenuItem>
+        <SubmenuItem
+          id="security"
+          to={{
+            ...location,
+            pathname: defaultPathname,
+            state: {issueTaxonomy: 'security'},
+          }}
+        >
+          {t('Security')}
+        </SubmenuItem>
+        <SubmenuItem id="feedback" to={`/${prefix}/feedback/`}>
+          {t('Feedback')}
+        </SubmenuItem>
+      </SubmenuBody>
+    </Submenu>
+  );
+}

--- a/static/app/components/nav/submenus/performance.tsx
+++ b/static/app/components/nav/submenus/performance.tsx
@@ -1,0 +1,52 @@
+import Submenu, {SubmenuBody, SubmenuItem} from 'sentry/components/nav/submenu';
+import useOrganization from 'sentry/utils/useOrganization';
+import {
+  AI_LANDING_SUB_PATH,
+  AI_LANDING_TITLE,
+} from 'sentry/views/insights/pages/ai/settings';
+import {
+  BACKEND_LANDING_SUB_PATH,
+  BACKEND_LANDING_TITLE,
+} from 'sentry/views/insights/pages/backend/settings';
+import {
+  FRONTEND_LANDING_SUB_PATH,
+  FRONTEND_LANDING_TITLE,
+} from 'sentry/views/insights/pages/frontend/settings';
+import {
+  MOBILE_LANDING_SUB_PATH,
+  MOBILE_LANDING_TITLE,
+} from 'sentry/views/insights/pages/mobile/settings';
+import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
+
+export default function PerformanceSubmenu() {
+  const organization = useOrganization();
+  const prefix = `organizations/${organization.slug}/${DOMAIN_VIEW_BASE_URL}`;
+
+  return (
+    <Submenu>
+      <SubmenuBody>
+        <SubmenuItem
+          id={FRONTEND_LANDING_SUB_PATH}
+          to={`/${prefix}/${FRONTEND_LANDING_SUB_PATH}`}
+        >
+          {FRONTEND_LANDING_TITLE}
+        </SubmenuItem>
+        <SubmenuItem
+          id={BACKEND_LANDING_SUB_PATH}
+          to={`/${prefix}/${BACKEND_LANDING_SUB_PATH}`}
+        >
+          {BACKEND_LANDING_TITLE}
+        </SubmenuItem>
+        <SubmenuItem id={AI_LANDING_SUB_PATH} to={`/${prefix}/${AI_LANDING_SUB_PATH}`}>
+          {AI_LANDING_TITLE}
+        </SubmenuItem>
+        <SubmenuItem
+          id={MOBILE_LANDING_SUB_PATH}
+          to={`/${prefix}/${MOBILE_LANDING_SUB_PATH}`}
+        >
+          {MOBILE_LANDING_TITLE}
+        </SubmenuItem>
+      </SubmenuBody>
+    </Submenu>
+  );
+}

--- a/static/app/components/nav/utils.tsx
+++ b/static/app/components/nav/utils.tsx
@@ -2,10 +2,19 @@ import type {LocationDescriptor} from 'history';
 
 import type {FeatureProps} from 'sentry/components/acl/feature';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
-import {isItemActive} from 'sentry/components/sidebar/sidebarItem';
 import {SIDEBAR_NAVIGATION_SOURCE} from 'sentry/components/sidebar/utils';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import type {useLocation} from 'sentry/utils/useLocation';
+
+export type NavMenuKey =
+  | 'issues'
+  | 'projects'
+  | 'explore'
+  | 'insights'
+  | 'performance'
+  | 'boards'
+  | 'alerts'
+  | 'settings'
+  | 'help';
 
 // TODO(nate.moore): these should be derived from the route data, not hardcoded
 export function getActiveNavIds(): {menu: string; submenu?: string} {
@@ -91,13 +100,13 @@ export interface NavSidebarItem extends NavItem {
    */
   icon: React.ReactElement;
   /**
+   * A unique key for this menu
+   */
+  id: NavMenuKey;
+  /**
    * dropdown menu to display when this SidebarItem is clicked
    */
   dropdown?: MenuItemProps[];
-  /**
-   * Optionally, the submenu items to display when this SidebarItem is active
-   */
-  submenu?: NavSubmenuItem[] | NavItemLayout<NavSubmenuItem>;
   /**
    * The pathname (including `search` params) to navigate to when the item is clicked.
    * Defaults to the `to` property of the first `SubmenuItem` if excluded.
@@ -116,61 +125,6 @@ export interface NavSubmenuItem extends NavItem {
 }
 
 export type NavConfig = NavItemLayout<NavSidebarItem>;
-
-export type NavigationItemStatus = 'inactive' | 'active' | 'active-parent';
-
-/**
- * Determine if a given SidebarItem or SubmenuItem is active
- */
-export function isNavItemActive(
-  item: NavSidebarItem | NavSubmenuItem,
-  location: ReturnType<typeof useLocation>
-): boolean {
-  const to = resolveNavItemTo(item);
-  if (!to) {
-    return false;
-  }
-
-  /**
-   * Issue submenu is special cased because it is matched based on query params
-   * rather than the pathname.
-   */
-  if (location.pathname.includes('/issues/') && to.includes('/issues/')) {
-    const {label} = item;
-    const matches = hasMatchingQueryParam({to, label}, location);
-    const isDefault = label === 'All';
-    if (location.search) {
-      return matches || isDefault;
-    }
-    return isDefault;
-  }
-
-  const normalizedTo = normalizeUrl(to);
-  const normalizedCurrent = normalizeUrl(location.pathname);
-  // Shortcut for exact matches
-  if (normalizedTo === normalizedCurrent) {
-    return true;
-  }
-  // Fallback to legacy nav logic
-  return isItemActive({to, label: item.label});
-}
-
-export function isSubmenuItemActive(
-  item: NavSidebarItem,
-  location: ReturnType<typeof useLocation>
-): boolean {
-  if (!item.submenu) {
-    return false;
-  }
-  if (isNonEmptyArray(item.submenu)) {
-    return item.submenu.some(subitem => isNavItemActive(subitem, location));
-  }
-  return (
-    item.submenu.main.some(subitem => isNavItemActive(subitem, location)) ||
-    item.submenu.footer?.some(subitem => isNavItemActive(subitem, location)) ||
-    false
-  );
-}
 
 /**
  * Creates a `LocationDescriptor` from a URL string that may contain search params
@@ -199,65 +153,4 @@ export function makeLinkPropsFromTo(to: string): {
 
 export function isNonEmptyArray(item: unknown): item is any[] {
   return Array.isArray(item) && item.length > 0;
-}
-
-/**
- * SidebarItem `to` can be derived from the first submenu item if necessary
- */
-export function resolveNavItemTo(
-  item: NavSidebarItem | NavSubmenuItem
-): string | undefined {
-  if (item.to) {
-    return item.to;
-  }
-  if (isSidebarItem(item) && item.dropdown) {
-    return undefined;
-  }
-  if (isSidebarItem(item) && isNonEmptyArray(item.submenu)) {
-    return item.submenu[0].to;
-  }
-  return undefined;
-}
-
-/**
- * Unique logic for query param matches.
- *
- * `location` might have additional query params,
- * but it considered active if it contains *all* of the params in `item`.
- */
-function hasMatchingQueryParam(
-  item: Required<Pick<NavSidebarItem | NavSubmenuItem, 'to' | 'label'>>,
-  location: ReturnType<typeof useLocation>
-): boolean {
-  if (location.search.length === 0) {
-    return false;
-  }
-  if (item.to.includes('?')) {
-    const search = new URLSearchParams(location.search);
-    const itemSearch = new URLSearchParams(item.to.split('?').at(-1));
-    const itemQuery = itemSearch.get('query');
-    const query = search.get('query');
-    /**
-     * The "Issues / All" tab is a special case!
-     * It is considered active if no other queries are.
-     */
-    if (item?.label === 'All') {
-      return !query && !itemQuery;
-    }
-    if (itemQuery && query) {
-      let match = false;
-      for (const key of itemQuery?.split(' ')) {
-        match = query.includes(key);
-        if (!match) {
-          continue;
-        }
-      }
-      return match;
-    }
-  }
-  return false;
-}
-
-function isSidebarItem(item: NavSidebarItem | NavSubmenuItem): item is NavSidebarItem {
-  return Object.hasOwn(item, 'icon');
 }

--- a/static/app/components/nav/utils.tsx
+++ b/static/app/components/nav/utils.tsx
@@ -7,6 +7,59 @@ import {SIDEBAR_NAVIGATION_SOURCE} from 'sentry/components/sidebar/utils';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import type {useLocation} from 'sentry/utils/useLocation';
 
+// TODO(nate.moore): these should be derived from the route data, not hardcoded
+export function getActiveNavIds(): {menu: string; submenu?: string} {
+  const {pathname} = window.location;
+
+  if (pathname.includes('/issues/')) {
+    const after = pathname.split('/issues/').at(-1)?.trim();
+    return {menu: 'issues', submenu: after ? undefined : 'all'};
+  }
+  if (pathname.includes('/feedback/')) {
+    return {menu: 'issues', submenu: 'feedback'};
+  }
+  if (pathname.includes('/projects/')) {
+    return {menu: 'projects'};
+  }
+  if (pathname.includes('/insights/')) {
+    const domain = pathname.split('/').at(-1);
+    return {menu: 'performance', submenu: domain};
+  }
+  if (pathname.includes('/dashboard/')) {
+    return {menu: 'boards'};
+  }
+  if (pathname.includes('/settings/')) {
+    return {menu: 'settings'};
+  }
+  if (pathname.includes('/alerts/')) {
+    return {menu: 'alerts'};
+  }
+
+  if (pathname.includes('/traces/')) {
+    return {menu: 'explore', submenu: 'insights'};
+  }
+  if (pathname.includes('/metrics/')) {
+    return {menu: 'explore', submenu: 'metrics'};
+  }
+  if (pathname.includes('/profiling/')) {
+    return {menu: 'explore', submenu: 'profiling'};
+  }
+  if (pathname.includes('/replays/')) {
+    return {menu: 'explore', submenu: 'replays'};
+  }
+  if (pathname.includes('/discover/')) {
+    return {menu: 'explore', submenu: 'discover'};
+  }
+  if (pathname.includes('/releases/')) {
+    return {menu: 'explore', submenu: 'releases'};
+  }
+  if (pathname.includes('/crons/')) {
+    return {menu: 'explore', submenu: 'crons'};
+  }
+
+  return {menu: 'issues', submenu: 'all'};
+}
+
 /**
  * NavItem is the base class for both SidebarItem and SubmenuItem
  */

--- a/static/app/components/nav/utils.tsx
+++ b/static/app/components/nav/utils.tsx
@@ -4,6 +4,7 @@ import type {FeatureProps} from 'sentry/components/acl/feature';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {SIDEBAR_NAVIGATION_SOURCE} from 'sentry/components/sidebar/utils';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useLocation} from 'sentry/utils/useLocation';
 
 export type NavMenuKey =
   | 'issues'
@@ -17,8 +18,8 @@ export type NavMenuKey =
   | 'help';
 
 // TODO(nate.moore): these should be derived from the route data, not hardcoded
-export function getActiveNavIds(): {menu: string; submenu?: string} {
-  const {pathname} = window.location;
+export function useActiveNavIds(): {menu: NavMenuKey; submenu?: string} {
+  const {pathname} = useLocation();
 
   if (pathname.includes('/issues/')) {
     const after = pathname.split('/issues/').at(-1)?.trim();

--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import Footer from 'sentry/components/footer';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import Nav from 'sentry/components/nav';
+import {NavContextProvider} from 'sentry/components/nav/context';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import Sidebar from 'sentry/components/sidebar';
 import type {Organization} from 'sentry/types/organization';
@@ -56,14 +57,16 @@ interface LayoutProps extends Props {
 function AppLayout({children, organization}: LayoutProps) {
   return (
     <AppContainer className="app">
-      <Nav />
-      {/* The `#main` selector is used to make the app content `inert` when an overlay is active */}
-      <BodyContainer id="main">
-        {organization && <OrganizationHeader organization={organization} />}
-        {organization && <DevToolInit />}
-        <Body>{children}</Body>
-        <Footer />
-      </BodyContainer>
+      <NavContextProvider>
+        <Nav />
+        {/* The `#main` selector is used to make the app content `inert` when an overlay is active */}
+        <BodyContainer id="main">
+          {organization && <OrganizationHeader organization={organization} />}
+          {organization && <DevToolInit />}
+          <Body>{children}</Body>
+          <Footer />
+        </BodyContainer>
+      </NavContextProvider>
     </AppContainer>
   );
 }


### PR DESCRIPTION
Unfortunately I couldn't find a way to break this PR down any smaller, but this is a major refactor of the new nav components which render the sidebar.

Previously, submenu state was driven purely by the configuration object. In this PR, we introduce a stateful `NavContextProvider` and manually update the state of active sidebar and submenu items. This allows us to [remove the automated detectors]() which blocked the desirec issues stream behavior.

Additionally, this PR adds [declarative submenu rendering]() which offers more control to individual product teams.

Closes [ALRT-334](https://getsentry.atlassian.net/browse/ALRT-334), [ALRT-328](https://getsentry.atlassian.net/browse/ALRT-328), [ALRT-331](https://getsentry.atlassian.net/browse/ALRT-331)

[ALRT-334]: https://getsentry.atlassian.net/browse/ALRT-334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ALRT-328]: https://getsentry.atlassian.net/browse/ALRT-328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ALRT-331]: https://getsentry.atlassian.net/browse/ALRT-331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ