### PR TITLE
fix(anomaly detection): valid time periods for five minutes of data

### DIFF
--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -158,9 +158,7 @@ const HISTORICAL_TIME_PERIOD_MAP: TimePeriodMap = {
 };
 
 const HISTORICAL_TIME_PERIOD_MAP_FIVE_MINS: TimePeriodMap = {
-  [TimePeriod.SIX_HOURS]: '678h',
-  [TimePeriod.ONE_DAY]: '29d',
-  [TimePeriod.THREE_DAYS]: '31d',
+  ...HISTORICAL_TIME_PERIOD_MAP,
   [TimePeriod.SEVEN_DAYS]: '28d', // fetching 28 + 7 days of historical data at 5 minute increments exceeds the max number of data points that snuba can return
   [TimePeriod.FOURTEEN_DAYS]: '28d', // fetching 28 + 14 days of historical data at 5 minute increments exceeds the max number of data points that snuba can return
 };

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -157,6 +157,14 @@ const HISTORICAL_TIME_PERIOD_MAP: TimePeriodMap = {
   [TimePeriod.FOURTEEN_DAYS]: '42d',
 };
 
+const HISTORICAL_TIME_PERIOD_MAP_FIVE_MINS: TimePeriodMap = {
+  [TimePeriod.SIX_HOURS]: '678h',
+  [TimePeriod.ONE_DAY]: '29d',
+  [TimePeriod.THREE_DAYS]: '31d',
+  [TimePeriod.SEVEN_DAYS]: '28d', // fetching 28 + 7 days of historical data at 5 minute increments exceeds the max number of data points that snuba can return
+  [TimePeriod.FOURTEEN_DAYS]: '28d', // fetching 28 + 14 days of historical data at 5 minute increments exceeds the max number of data points that snuba can return
+};
+
 const noop: any = () => {};
 
 type State = {
@@ -496,6 +504,11 @@ class TriggersChart extends PureComponent<Props, State> {
             <OnDemandMetricRequest
               {...baseProps}
               api={this.historicalAPI}
+              period={
+                timeWindow === 5
+                  ? HISTORICAL_TIME_PERIOD_MAP_FIVE_MINS[period]
+                  : HISTORICAL_TIME_PERIOD_MAP[period]
+              }
               dataLoadedCallback={onHistoricalDataLoaded}
             />
           ) : null}
@@ -610,7 +623,11 @@ class TriggersChart extends PureComponent<Props, State> {
           <EventsRequest
             {...baseProps}
             api={this.historicalAPI}
-            period={HISTORICAL_TIME_PERIOD_MAP[period]}
+            period={
+              timeWindow === 5
+                ? HISTORICAL_TIME_PERIOD_MAP_FIVE_MINS[period]
+                : HISTORICAL_TIME_PERIOD_MAP[period]
+            }
             dataLoadedCallback={onHistoricalDataLoaded}
           >
             {noop}


### PR DESCRIPTION
Snuba is not able to return 35/42 days of historical data at 5 minute increments for use in preview chart anomaly detection, so pull less data for selected periods of 7/14 days when a 5 minute time window is selected.