### PR TITLE
feat(issues): Remove child props from all events

### DIFF
--- a/static/app/views/issueDetails/allEventsTable.tsx
+++ b/static/app/views/issueDetails/allEventsTable.tsx
@@ -1,5 +1,4 @@
 import {useEffect, useMemo, useState} from 'react';
-import type {Location} from 'history';
 
 import {getSampleEventQuery} from 'sentry/components/events/eventStatisticalDetector/eventComparison/eventDisplay';
 import LoadingError from 'sentry/components/loadingError';
@@ -20,24 +19,23 @@ import {platformToCategory} from 'sentry/utils/platform';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {decodeSorts} from 'sentry/utils/queryString';
 import {projectCanLinkToReplay} from 'sentry/utils/replays/projectSupportsReplay';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useRoutes} from 'sentry/utils/useRoutes';
 import EventsTable from 'sentry/views/performance/transactionSummary/transactionEvents/eventsTable';
 
 interface Props {
+  excludedTags: string[];
   group: Group;
-  issueId: string;
-  location: Location;
   organization: Organization;
-  excludedTags?: string[];
 }
 
 const makeGroupPreviewRequestUrl = ({groupId}: {groupId: string}) => {
   return `/issues/${groupId}/events/latest/`;
 };
 
-function AllEventsTable(props: Props) {
-  const {location, organization, issueId, excludedTags, group} = props;
-  const config = getConfigForIssueType(props.group, group.project);
+function AllEventsTable({organization, excludedTags, group}: Props) {
+  const location = useLocation();
+  const config = getConfigForIssueType(group, group.project);
   const [error, setError] = useState<string>('');
   const routes = useRoutes();
   const {fields, columnTitles} = useEventColumns(group, organization);
@@ -58,7 +56,7 @@ function AllEventsTable(props: Props) {
   // Once migration to the issue platform is complete a call to /latest should be removed
   const groupIsOccurrenceBacked = !!data?.occurrence;
 
-  const eventView: EventView = EventView.fromLocation(props.location);
+  const eventView: EventView = EventView.fromLocation(location);
   if (config.usesIssuePlatform) {
     eventView.dataset = DiscoverDatasets.ISSUE_PLATFORM;
   }
@@ -82,9 +80,9 @@ function AllEventsTable(props: Props) {
     group.issueType === IssueType.PERFORMANCE_DURATION_REGRESSION ||
     group.issueType === IssueType.PERFORMANCE_ENDPOINT_REGRESSION;
 
-  let idQuery = `issue.id:${issueId}`;
+  let idQuery = `issue.id:${group.id}`;
   if (group.issueCategory === IssueCategory.PERFORMANCE && !groupIsOccurrenceBacked) {
-    idQuery = `performance.issue_ids:${issueId} event.type:transaction`;
+    idQuery = `performance.issue_ids:${group.id} event.type:transaction`;
   } else if (isRegressionIssue && groupIsOccurrenceBacked) {
     const {transaction, aggregateRange2, breakpoint} =
       data?.occurrence?.evidenceData ?? {};
@@ -102,7 +100,7 @@ function AllEventsTable(props: Props) {
     eventView.statsPeriod = undefined;
   }
   eventView.project = [parseInt(group.project.id, 10)];
-  eventView.query = `${idQuery} ${props.location.query.query || ''}`;
+  eventView.query = `${idQuery} ${location.query.query || ''}`;
 
   if (error || isLoadingError) {
     return (
@@ -114,7 +112,7 @@ function AllEventsTable(props: Props) {
     <EventsTable
       eventView={eventView}
       location={location}
-      issueId={issueId}
+      issueId={group.id}
       isRegressionIssue={isRegressionIssue}
       organization={organization}
       routes={routes}

--- a/static/app/views/issueDetails/groupEvents.spec.tsx
+++ b/static/app/views/issueDetails/groupEvents.spec.tsx
@@ -1,8 +1,8 @@
-import type {Location} from 'history';
 import {GroupFixture} from 'sentry-fixture/group';
-import {ProjectFixture} from 'sentry-fixture/project';
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {RouterFixture} from 'sentry-fixture/routerFixture';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   render,
   screen,
@@ -11,50 +11,31 @@ import {
   waitForElementToBeRemoved,
 } from 'sentry-test/reactTestingLibrary';
 
-import {IssueCategory} from 'sentry/types/group';
+import {type Group, IssueCategory} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import GroupEvents from 'sentry/views/issueDetails/groupEvents';
 
-let location: Location;
-
 describe('groupEvents', () => {
   const requests: {[requestName: string]: jest.Mock} = {};
-  const baseProps = Object.freeze({
-    params: {orgId: 'orgId', groupId: '1'},
-    route: {},
-    routeParams: {},
-    router: {} as any,
-    routes: [],
-    location: {},
-    environments: [],
-    group: GroupFixture(),
-    project: ProjectFixture(),
-  });
-
+  let group!: Group;
   let organization: Organization;
-  let router: ReturnType<typeof initializeOrg>['router'];
+  let router: ReturnType<typeof RouterFixture>;
 
   beforeEach(() => {
-    browserHistory.push = jest.fn();
-
-    ({organization, router} = initializeOrg({
-      organization: {
-        features: ['event-attachments'],
-      },
-    } as any));
-
-    location = {
-      pathname: '/organizations/org-slug/issues/123/events/',
-      search: '',
-      hash: '',
-      action: 'REPLACE',
-      key: 'okjkey',
-      state: '',
-      query: {
-        query: '',
-      },
-    };
+    group = GroupFixture();
+    organization = OrganizationFixture({features: ['event-attachments']});
+    router = RouterFixture({
+      params: {orgId: 'org-slug', groupId: group.id},
+      location: LocationFixture({
+        pathname: '/organizations/org-slug/issues/123/events/',
+        action: 'REPLACE',
+        key: 'okjkey',
+        query: {
+          query: '',
+        },
+      }),
+    });
 
     requests.discover = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
@@ -126,6 +107,10 @@ describe('groupEvents', () => {
       url: '/organizations/org-slug/issues/1/tags/',
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/`,
+      body: group,
+    });
   });
 
   afterEach(() => {
@@ -134,10 +119,7 @@ describe('groupEvents', () => {
   });
 
   it('fetches and renders a table of events', async () => {
-    render(<GroupEvents {...baseProps} location={{...location, query: {}}} />, {
-      router,
-      organization,
-    });
+    render(<GroupEvents />, {router, organization});
 
     expect(await screen.findByText('id123')).toBeInTheDocument();
 
@@ -152,12 +134,9 @@ describe('groupEvents', () => {
   });
 
   it('pushes new query parameter when searching', async () => {
-    render(<GroupEvents {...baseProps} location={{...location, query: {}}} />, {
-      router,
-    });
+    render(<GroupEvents />, {organization, router});
 
-    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
-    const input = screen.getByPlaceholderText('Search events\u2026');
+    const input = await screen.findByPlaceholderText('Search events\u2026');
 
     await userEvent.click(input);
     await userEvent.keyboard('foo');
@@ -178,12 +157,9 @@ describe('groupEvents', () => {
       body: [{key: 'custom_tag', name: 'custom_tag', totalValues: 1}],
     });
 
-    render(<GroupEvents {...baseProps} location={{...location, query: {}}} />, {
-      router,
-    });
+    render(<GroupEvents />, {organization, router});
 
-    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
-    const input = screen.getByPlaceholderText('Search events\u2026');
+    const input = await screen.findByPlaceholderText('Search events\u2026');
 
     await userEvent.click(input);
 
@@ -200,64 +176,46 @@ describe('groupEvents', () => {
   });
 
   it('handles environment filtering', async () => {
-    render(
-      <GroupEvents
-        {...baseProps}
-        location={{...location, query: {environment: ['prod', 'staging']}}}
-      />,
-      {router, organization}
-    );
+    router.location.query.environment = ['prod', 'staging'];
+    render(<GroupEvents />, {router, organization});
+
     await waitFor(() => {
-      expect(screen.getByText('Transaction')).toBeInTheDocument();
+      expect(requests.discover).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({environment: ['prod', 'staging']}),
+        })
+      );
     });
-    expect(requests.discover).toHaveBeenCalledWith(
-      '/organizations/org-slug/events/',
-      expect.objectContaining({
-        query: expect.objectContaining({environment: ['prod', 'staging']}),
-      })
-    );
+    expect(await screen.findByText('Transaction')).toBeInTheDocument();
   });
 
   it('renders events table for performance issue', async () => {
-    const group = GroupFixture();
     group.issueCategory = IssueCategory.PERFORMANCE;
+    router.location.query.environment = ['prod', 'staging'];
 
-    render(
-      <GroupEvents
-        {...baseProps}
-        group={group}
-        location={{...location, query: {environment: ['prod', 'staging']}}}
-      />,
-      {router, organization}
-    );
-    expect(requests.discover).toHaveBeenCalledWith(
-      '/organizations/org-slug/events/',
-      expect.objectContaining({
-        query: expect.objectContaining({
-          query: 'performance.issue_ids:1 event.type:transaction ',
-        }),
-      })
-    );
+    render(<GroupEvents />, {router, organization});
+
     await waitFor(() => {
-      expect(screen.getByText('Transaction')).toBeInTheDocument();
+      expect(requests.discover).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query: 'performance.issue_ids:1 event.type:transaction ',
+          }),
+        })
+      );
     });
+    expect(await screen.findByText('Transaction')).toBeInTheDocument();
   });
 
   it('renders event and trace link correctly', async () => {
-    const group = GroupFixture();
     group.issueCategory = IssueCategory.PERFORMANCE;
+    router.location.query.environment = ['prod', 'staging'];
 
-    render(
-      <GroupEvents
-        {...baseProps}
-        group={group}
-        location={{...location, query: {environment: ['prod', 'staging']}}}
-      />,
-      {router, organization}
-    );
-    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
+    render(<GroupEvents />, {router, organization});
 
-    const eventIdATag = screen.getByText('id123').closest('a');
+    const eventIdATag = (await screen.findByText('id123')).closest('a');
     expect(eventIdATag).toHaveAttribute(
       'href',
       '/organizations/org-slug/issues/1/events/id123/'
@@ -265,13 +223,8 @@ describe('groupEvents', () => {
   });
 
   it('does not make attachments request, async when feature not enabled', async () => {
-    render(
-      <GroupEvents
-        {...baseProps}
-        location={{...location, query: {environment: ['prod', 'staging']}}}
-      />,
-      {router, organization: {...organization, features: []}}
-    );
+    router.location.query.environment = ['prod', 'staging'];
+    render(<GroupEvents />, {router, organization: {...organization, features: []}});
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
     const attachmentsColumn = screen.queryByText('Attachments');
@@ -280,13 +233,8 @@ describe('groupEvents', () => {
   });
 
   it('does not display attachments column with no attachments', async () => {
-    render(
-      <GroupEvents
-        {...baseProps}
-        location={{...location, query: {environment: ['prod', 'staging']}}}
-      />,
-      {router, organization}
-    );
+    router.location.query.environment = ['prod', 'staging'];
+    render(<GroupEvents />, {router, organization});
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
     const attachmentsColumn = screen.queryByText('Attachments');
@@ -295,13 +243,8 @@ describe('groupEvents', () => {
   });
 
   it('does not display minidump column with no minidumps', async () => {
-    render(
-      <GroupEvents
-        {...baseProps}
-        location={{...location, query: {environment: ['prod', 'staging']}}}
-      />,
-      {router, organization}
-    );
+    router.location.query.environment = ['prod', 'staging'];
+    render(<GroupEvents />, {router, organization});
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
     const minidumpColumn = screen.queryByText('Minidump');
@@ -328,15 +271,8 @@ describe('groupEvents', () => {
       ],
     });
 
-    render(
-      <GroupEvents
-        {...baseProps}
-        location={{...location, query: {environment: ['prod', 'staging']}}}
-      />,
-      {router, organization}
-    );
-    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
-    const minidumpColumn = screen.queryByText('Minidump');
+    render(<GroupEvents />, {router, organization});
+    const minidumpColumn = await screen.findByText('Minidump');
     expect(minidumpColumn).toBeInTheDocument();
   });
 
@@ -359,39 +295,31 @@ describe('groupEvents', () => {
         },
       ],
     });
+    router.location.query.environment = ['prod', 'staging'];
 
-    render(
-      <GroupEvents
-        {...baseProps}
-        location={{...location, query: {environment: ['prod', 'staging']}}}
-      />,
-      {router, organization}
-    );
+    render(<GroupEvents />, {router, organization});
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
-    const attachmentsColumn = screen.queryByText('Attachments');
-    const minidumpColumn = screen.queryByText('Minidump');
-    expect(attachmentsColumn).not.toBeInTheDocument();
+    const minidumpColumn = await screen.findByText('Minidump');
     expect(minidumpColumn).toBeInTheDocument();
+    const attachmentsColumn = screen.queryByText('Attachments');
+    expect(attachmentsColumn).not.toBeInTheDocument();
     expect(requests.attachments).toHaveBeenCalled();
   });
 
   it('renders events table for error', async () => {
-    render(
-      <GroupEvents
-        {...baseProps}
-        location={{...location, query: {environment: ['prod', 'staging']}}}
-      />,
-      {router, organization}
-    );
-    expect(requests.discover).toHaveBeenCalledWith(
-      '/organizations/org-slug/events/',
-      expect.objectContaining({
-        query: expect.objectContaining({
-          query: 'issue.id:1 ',
-          field: expect.not.arrayContaining(['attachments', 'minidump']),
-        }),
-      })
-    );
+    router.location.query.environment = ['prod', 'staging'];
+    render(<GroupEvents />, {router, organization});
+    await waitFor(() => {
+      expect(requests.discover).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query: 'issue.id:1 ',
+            field: expect.not.arrayContaining(['attachments', 'minidump']),
+          }),
+        })
+      );
+    });
 
     await waitFor(() => {
       expect(screen.getByText('Transaction')).toBeInTheDocument();
@@ -399,46 +327,39 @@ describe('groupEvents', () => {
   });
 
   it('removes sort if unsupported by the events table', async () => {
-    render(
-      <GroupEvents
-        {...baseProps}
-        location={{...location, query: {environment: ['prod', 'staging'], sort: 'user'}}}
-      />,
-      {router, organization}
-    );
-    expect(requests.discover).toHaveBeenCalledWith(
-      '/organizations/org-slug/events/',
-      expect.objectContaining({query: expect.not.objectContaining({sort: 'user'})})
-    );
+    router.location.query = {
+      ...router.location.query,
+      environment: ['prod', 'staging'],
+      sort: 'user',
+    };
+    render(<GroupEvents />, {router, organization});
+    await waitFor(() => {
+      expect(requests.discover).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({query: expect.not.objectContaining({sort: 'user'})})
+      );
+    });
     await waitFor(() => {
       expect(screen.getByText('Transaction')).toBeInTheDocument();
     });
   });
 
   it('only request for a single projectId', async () => {
-    const group = GroupFixture();
-
-    render(
-      <GroupEvents
-        {...baseProps}
-        group={group}
-        location={{
-          ...location,
-          query: {
-            environment: ['prod', 'staging'],
-            sort: 'user',
-            project: [group.project.id, '456'],
-          },
-        }}
-      />,
-      {router, organization}
-    );
-    expect(requests.discover).toHaveBeenCalledWith(
-      '/organizations/org-slug/events/',
-      expect.objectContaining({
-        query: expect.objectContaining({project: [group.project.id]}),
-      })
-    );
+    router.location.query = {
+      ...router.location.query,
+      environment: ['prod', 'staging'],
+      sort: 'user',
+      project: [group.project.id, '456'],
+    };
+    render(<GroupEvents />, {router, organization});
+    await waitFor(() => {
+      expect(requests.discover).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({project: [group.project.id]}),
+        })
+      );
+    });
     await waitFor(() => {
       expect(screen.getByText('Transaction')).toBeInTheDocument();
     });
@@ -453,14 +374,9 @@ describe('groupEvents', () => {
         errorId: '69ab396e73704cdba9342ff8dcd59795',
       },
     });
+    router.location.query.environment = ['prod', 'staging'];
 
-    render(
-      <GroupEvents
-        {...baseProps}
-        location={{...location, query: {environment: ['prod', 'staging']}}}
-      />,
-      {router, organization}
-    );
+    render(<GroupEvents />, {router, organization});
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
@@ -468,26 +384,21 @@ describe('groupEvents', () => {
   });
 
   it('requests for backend columns if backend project', async () => {
-    const group = GroupFixture();
     group.project.platform = 'node-express';
-    render(
-      <GroupEvents
-        {...baseProps}
-        group={group}
-        location={{...location, query: {environment: ['prod', 'staging']}}}
-      />,
-      {router, organization}
-    );
+    router.location.query.environment = ['prod', 'staging'];
+    render(<GroupEvents />, {router, organization});
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
-    expect(requests.discover).toHaveBeenCalledWith(
-      '/organizations/org-slug/events/',
-      expect.objectContaining({
-        query: expect.objectContaining({
-          field: expect.arrayContaining(['url', 'runtime']),
-        }),
-      })
-    );
+    await waitFor(() => {
+      expect(requests.discover).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            field: expect.arrayContaining(['url', 'runtime']),
+          }),
+        })
+      );
+    });
     expect(requests.discover).toHaveBeenCalledWith(
       '/organizations/org-slug/events/',
       expect.objectContaining({

--- a/static/app/views/issueDetails/groupEvents.tsx
+++ b/static/app/views/issueDetails/groupEvents.tsx
@@ -2,26 +2,26 @@ import {useCallback} from 'react';
 import styled from '@emotion/styled';
 
 import * as Layout from 'sentry/components/layouts/thirds';
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-import type {Project} from 'sentry/types/project';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import {ISSUE_PROPERTY_FIELDS} from 'sentry/utils/fields';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useCleanQueryParamsOnRouteLeave from 'sentry/utils/useCleanQueryParamsOnRouteLeave';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
 import {EventList} from 'sentry/views/issueDetails/streamline/eventList';
 import {EventSearch} from 'sentry/views/issueDetails/streamline/eventSearch';
-import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
+import {useGroup} from 'sentry/views/issueDetails/useGroup';
+import {
+  useEnvironmentsFromUrl,
+  useHasStreamlinedUI,
+} from 'sentry/views/issueDetails/utils';
 
 import AllEventsTable from './allEventsTable';
-
-interface Props extends RouteComponentProps<{groupId: string}, {}> {
-  environments: string[];
-  group: Group;
-  project: Project;
-}
 
 export const ALL_EVENTS_EXCLUDED_TAGS = [
   'environment',
@@ -31,28 +31,34 @@ export const ALL_EVENTS_EXCLUDED_TAGS = [
   ...ISSUE_PROPERTY_FIELDS,
 ];
 
-function GroupEvents({params, location, group, environments}: Props) {
-  const organization = useOrganization();
+interface GroupEventsProps {
+  group: Group;
+}
 
-  const {groupId} = params;
+function GroupEvents({group}: GroupEventsProps) {
+  const location = useLocation();
+  const environments = useEnvironmentsFromUrl();
+  const params = useParams<{groupId: string}>();
+  const organization = useOrganization();
 
   useCleanQueryParamsOnRouteLeave({
     fieldsToClean: ['cursor', 'query'],
-    shouldClean: newLocation => newLocation.pathname.includes(`/issues/${group.id}/`),
+    shouldClean: newLocation =>
+      newLocation.pathname.includes(`/issues/${params.groupId}/`),
   });
 
   const handleSearch = useCallback(
     (query: string) =>
       browserHistory.push(
         normalizeUrl({
-          pathname: `/organizations/${organization.slug}/issues/${groupId}/events/`,
+          pathname: `/organizations/${organization.slug}/issues/${params.groupId}/events/`,
           query: {...location.query, query},
         })
       ),
-    [location, organization, groupId]
+    [location, organization, params.groupId]
   );
 
-  const query = location.query?.query ?? '';
+  const query = (location.query?.query ?? '') as string;
 
   return (
     <Layout.Body>
@@ -66,8 +72,6 @@ function GroupEvents({params, location, group, environments}: Props) {
           />
         </AllEventsFilters>
         <AllEventsTable
-          issueId={group.id}
-          location={location}
           organization={organization}
           group={group}
           excludedTags={ALL_EVENTS_EXCLUDED_TAGS}
@@ -82,14 +86,29 @@ const AllEventsFilters = styled('div')`
 `;
 
 // TODO(streamlined-ui): Remove this file completely and change rotue to new events list
-function IssueEventsList(props: Props) {
+function IssueEventsList() {
   const hasStreamlinedUI = useHasStreamlinedUI();
+  const params = useParams<{groupId: string}>();
+  const {
+    data: group,
+    isPending: isGroupPending,
+    isError: isGroupError,
+    refetch: refetchGroup,
+  } = useGroup({groupId: params.groupId});
 
-  if (hasStreamlinedUI) {
-    return <EventList {...props} />;
+  if (isGroupPending) {
+    return <LoadingIndicator />;
   }
 
-  return <GroupEvents {...props} />;
+  if (isGroupError) {
+    return <LoadingError onRetry={refetchGroup} />;
+  }
+
+  if (hasStreamlinedUI) {
+    return <EventList group={group} />;
+  }
+
+  return <GroupEvents group={group} />;
 }
 
 export default IssueEventsList;

--- a/static/app/views/issueDetails/streamline/eventList.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventList.spec.tsx
@@ -1,4 +1,3 @@
-import {EventFixture} from 'sentry-fixture/event';
 import {EventsStatsFixture} from 'sentry-fixture/events';
 import {GroupFixture} from 'sentry-fixture/group';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
@@ -9,8 +8,6 @@ import {TagsFixture} from 'sentry-fixture/tags';
 
 import {render, renderHook, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import PageFiltersStore from 'sentry/stores/pageFiltersStore';
-import ProjectsStore from 'sentry/stores/projectsStore';
 import {useEventColumns} from 'sentry/views/issueDetails/allEventsTable';
 import {MOCK_EVENTS_TABLE_DATA} from 'sentry/views/performance/transactionSummary/transactionEvents/testUtils';
 
@@ -22,7 +19,6 @@ describe('EventList', () => {
     environments: ['production', 'staging', 'development'],
   });
   const group = GroupFixture();
-  const event = EventFixture({id: 'event-id'});
   const persistantQuery = `issue:${group.shortId}`;
   const totalCount = 100;
 
@@ -30,22 +26,7 @@ describe('EventList', () => {
   let mockEventListMeta: jest.Mock;
 
   beforeEach(() => {
-    PageFiltersStore.init();
-    PageFiltersStore.onInitializeUrlState(
-      {
-        projects: [],
-        environments: [],
-        datetime: {start: null, end: null, period: '14d', utc: null},
-      },
-      new Set(['environments'])
-    );
-    ProjectsStore.loadInitialData([project]);
     MockApiClient.clearMockResponses();
-    MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/actionable-items/`,
-      body: {errors: []},
-      method: 'GET',
-    });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/${group.id}/tags/`,
       body: TagsFixture(),
@@ -91,7 +72,7 @@ describe('EventList', () => {
   });
 
   function renderAllEvents() {
-    render(<EventList group={group} project={project} />, {
+    render(<EventList group={group} />, {
       organization,
       router: RouterFixture({
         location: LocationFixture({
@@ -148,7 +129,7 @@ describe('EventList', () => {
         query: `${tagKey}:${tagValue}`,
       },
     };
-    render(<EventList group={group} project={project} />, {
+    render(<EventList group={group} />, {
       organization,
       router: RouterFixture({
         location: LocationFixture({

--- a/static/app/views/issueDetails/streamline/eventList.tsx
+++ b/static/app/views/issueDetails/streamline/eventList.tsx
@@ -15,7 +15,6 @@ import {IconChevron} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {type Group, IssueType} from 'sentry/types/group';
-import type {Project} from 'sentry/types/project';
 import {parseCursor} from 'sentry/utils/cursor';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {decodeSorts} from 'sentry/utils/queryString';
@@ -29,7 +28,6 @@ import EventsTable from 'sentry/views/performance/transactionSummary/transaction
 
 interface EventListProps {
   group: Group;
-  project: Project;
 }
 
 export function EventList({group}: EventListProps) {


### PR DESCRIPTION
The goal is to remove cloneElement and passing untyped props from groupDetails down to child routes.

https://github.com/getsentry/sentry/blob/f4a29f737fe9e46716468934b68dadb3605f03b9/static/app/views/issueDetails/groupDetails.tsx#L651-L661
