### PR TITLE
chore(issue-details): Update inactive color for event chart

### DIFF
--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -209,6 +209,7 @@ export function EventGraph({group, event, ...styleProps}: EventGraphProps) {
     data: hasFeatureFlagFeature ? ['Feature Flags', 'Releases'] : ['Releases'],
     selected: legendSelected,
     zlevel: 10,
+    inactiveColor: theme.gray200,
   });
 
   const onLegendSelectChanged = useMemo(


### PR DESCRIPTION
this pr updates the inactive color in the legend so it is more clear that it is not currently selected 