### PR TITLE
fix(anomaly detection): fix key rewrite error in historical anomaly data logger

### DIFF
--- a/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
+++ b/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
@@ -71,7 +71,7 @@ def handle_seer_error_responses(response, config, context, log_params):
         return True
 
     if not results.get("success"):
-        extra_data = {"message": results.get("message", "")}
+        extra_data = {"response_data": results.get("message", "")}
         log_statement("error", "Error when hitting Seer detect anomalies endpoint", extra_data)
         return True
 

--- a/tests/sentry/api/endpoints/test_organization_events_anomalies.py
+++ b/tests/sentry/api/endpoints/test_organization_events_anomalies.py
@@ -304,7 +304,7 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
         mock_logger.error.assert_called_with(
             "Error when hitting Seer detect anomalies endpoint",
             extra={
-                "message": "I have revolted against my human overlords",
+                "response_data": "I have revolted against my human overlords",
                 "organization_id": self.organization.id,
                 "project_id": 1,
                 "config": self.config,


### PR DESCRIPTION
We were rewriting the "message" key in the logger for the historical anomaly data endpoint. Change this to be "response_data" instead.