### PR TITLE
fix(replay): Fix replay playback showing duped elements...

### DIFF
--- a/static/app/utils/replays/replayerStepper.tsx
+++ b/static/app/utils/replays/replayerStepper.tsx
@@ -44,7 +44,7 @@ export default function replayerStepper<
     // as well.
     const rrwebEventsWithoutMediaInteractions = rrwebEvents.filter(
       ({type, data}) =>
-        type === EventType.IncrementalSnapshot &&
+        type !== EventType.IncrementalSnapshot ||
         data.source !== IncrementalSource.MediaInteraction
     );
 


### PR DESCRIPTION
... and elements that do not disappear. Fixes regression introduced in https://github.com/getsentry/sentry/pull/80681

The filter statement is incorrect, but beyond that, there is a larger problem in that the replayStepper is somehow affecting the replayer playback instance.
