### PR TITLE
fix(profiling) hint to opening aggregate flamegraph

### DIFF
--- a/static/app/components/profiling/billing/alerts.tsx
+++ b/static/app/components/profiling/billing/alerts.tsx
@@ -20,7 +20,7 @@ export const ProfilingAM1OrMMXUpgrade = HookOrDefault({
       <h3>{t('Function level insights')}</h3>
       <p>
         {t(
-          'Discover slow-to-execute or resource intensive functions within your application'
+          'Discover slow-to-execute or resource intensive functions within your application.'
         )}
       </p>
     </Fragment>

--- a/static/app/utils/analytics/profilingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/profilingAnalyticsEvents.tsx
@@ -40,6 +40,8 @@ export type ProfilingEventParameters = {
     source: ProfilingEventSource;
   };
   'profiling_views.landing': {};
+  'profiling_views.missing_transactions_banner.flamegraph_clicked': {};
+  'profiling_views.missing_transactions_banner.viewed': {};
   'profiling_views.onboarding': {};
   'profiling_views.onboarding_action': {
     action: 'done' | 'dismissed';
@@ -63,6 +65,10 @@ export const profilingEventMap: Record<EventKey, string> = {
   'profiling_views.onboarding_action': 'Profiling Actions: Onboarding Action',
   'profiling_views.give_feedback_action': 'Profiling Actions: Feedback Action',
   'profiling_views.visit_discord_channel': 'Profiling Actions: Visit Discord Channel',
+  'profiling_views.missing_transactions_banner.viewed':
+    'Profiling Views: Missing Transactions Banner Viewed',
+  'profiling_views.missing_transactions_banner.flamegraph_clicked':
+    'Profiling Views: Missing Transactions Banner Flamegraph Clicked',
   'profiling_ui_events.transaction_hovercard_view':
     'Profiling Actions: Viewed Transaction Hovercard',
 };

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -607,12 +607,13 @@ function ProfilingMissingTransactionsAlert(props: {
     });
   }, [organization]);
 
+  const onSeeFlamegraphTabClick = props.onSeeFlamegraphTabClick;
   const onViewFlamegraphClick = useCallback(() => {
     trackAnalytics('profiling_views.missing_transactions_banner.flamegraph_clicked', {
       organization,
     });
-    props.onSeeFlamegraphTabClick?.();
-  }, [organization, props]);
+    onSeeFlamegraphTabClick?.();
+  }, [organization, onSeeFlamegraphTabClick]);
 
   return (
     <Alert
@@ -624,10 +625,18 @@ function ProfilingMissingTransactionsAlert(props: {
         </Button>
       }
     >
-      {t('Looks like you are only sending us profiling data.')}{' '}
+      {t(
+        'Looks like you are only sending us continuous profiling data and not tracing data.'
+      )}{' '}
       {tct('Learn why this happens [docsLink].', {
         docsLink: (
-          <Link to={'https://docs.sentry.io/product/profiling/'}>{t('here')}</Link>
+          <Link
+            to={
+              'https://docs.sentry.io/product/explore/profiling/transaction-vs-continuous-profiling/#missing-transaction-data'
+            }
+          >
+            {t('here')}
+          </Link>
         ),
       })}
     </Alert>

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -598,11 +598,19 @@ function ProfilingOnboardingCTA(props: {
             organization={organization}
             fallback={
               <Fragment>
-                <h3>{t('Function level insights')}</h3>
+                <h3>
+                  {hintToAggregateFlamegraph
+                    ? t('Function level insights')
+                    : t('View Aggregate Flamegraph')}
+                </h3>
                 <p>
-                  {t(
-                    'Discover slow-to-execute or resource intensive functions within your application.'
-                  )}
+                  {hintToAggregateFlamegraph
+                    ? t(
+                        'It seems like you have continuous profiling enabled but have not sent any transactions. Open the aggregate flamegraph to see function-level insights.'
+                      )
+                    : t(
+                        'Discover slow-to-execute or resource intensive functions within your application.'
+                      )}
                 </p>
               </Fragment>
             }

--- a/static/app/views/profiling/landing/profilesChartWidget.tsx
+++ b/static/app/views/profiling/landing/profilesChartWidget.tsx
@@ -8,7 +8,7 @@ import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
 import {axisLabelFormatter, tooltipFormatter} from 'sentry/utils/discover/charts';
-import {useProfileEventsStats} from 'sentry/utils/profiling/hooks/useProfileEventsStats';
+import type {useProfileEventsStats} from 'sentry/utils/profiling/hooks/useProfileEventsStats';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import {
@@ -20,11 +20,9 @@ import {
 
 interface ProfilesChartWidgetProps {
   chartHeight: number;
-  referrer: string;
-  continuousProfilingCompat?: boolean;
+  profileStats: ReturnType<typeof useProfileEventsStats>;
   header?: ReactNode;
   selection?: PageFilters;
-  userQuery?: string;
   widgetHeight?: string;
 }
 
@@ -32,23 +30,13 @@ const SERIES_ORDER = ['p99()', 'p95()', 'p75()', 'p50()'] as const;
 
 export function ProfilesChartWidget({
   chartHeight,
-  continuousProfilingCompat,
   header,
-  referrer,
   selection,
-  userQuery,
   widgetHeight,
+  profileStats,
 }: ProfilesChartWidgetProps) {
   const theme = useTheme();
   const organization = useOrganization();
-
-  const profileStats = useProfileEventsStats({
-    dataset: 'profiles',
-    query: userQuery,
-    referrer,
-    yAxes: SERIES_ORDER,
-    continuousProfilingCompat,
-  });
 
   const series: Series[] = useMemo(() => {
     if (profileStats.status !== 'success') {

--- a/static/app/views/profiling/profilingOnboardingPanel.tsx
+++ b/static/app/views/profiling/profilingOnboardingPanel.tsx
@@ -22,7 +22,7 @@ export function ProfilingOnboardingPanel(props: ProfilingOnboardingPanelProps) {
           <h3>{t('Function level insights')}</h3>
           <p>
             {t(
-              'Discover slow-to-execute or resource intensive functions within your application'
+              'Discover slow-to-execute or resource intensive functions within your application.'
             )}
           </p>
         </Fragment>


### PR DESCRIPTION
Add a banner that links to docs and hints to users that they should open the flamegraph tab in the off change that they are only sending us profiling data and no tracing data.

@shellmayr this would also help with the case that encountered where profiling data was empty, but it was all just on the flamegraph tab :)