### PR TITLE
ref(flags): rm success message when modal closed

### DIFF
--- a/static/app/components/events/featureFlags/setupIntegrationModal.tsx
+++ b/static/app/components/events/featureFlags/setupIntegrationModal.tsx
@@ -2,7 +2,6 @@ import {Fragment, useCallback, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import Alert from 'sentry/components/alert';
 import {Button, LinkButton} from 'sentry/components/button';
@@ -66,7 +65,6 @@ export function SetupIntegrationModal<T extends Data>({
   const {createToken} = useGenerateAuthToken({state, orgSlug: organization?.slug});
 
   const handleDone = useCallback(() => {
-    addSuccessMessage(t('Integration set up successfully'));
     closeModal();
   }, [closeModal]);
 


### PR DESCRIPTION
clicking "done" doesn't necessarily mean the integration was set up, so remove the success message