### PR TITLE
feat(crons): Record tick decisions during clock ticks

### DIFF
--- a/src/sentry/monitors/consumers/clock_tick_consumer.py
+++ b/src/sentry/monitors/consumers/clock_tick_consumer.py
@@ -15,7 +15,11 @@ from sentry_kafka_schemas.schema_types.monitors_clock_tick_v1 import ClockTick
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.monitors.clock_tasks.check_missed import dispatch_check_missing
 from sentry.monitors.clock_tasks.check_timeout import dispatch_check_timeout
-from sentry.monitors.system_incidents import record_clock_tick_volume_metric
+from sentry.monitors.system_incidents import (
+    make_clock_tick_decision,
+    record_clock_tick_volume_metric,
+)
+from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +34,22 @@ def process_clock_tick(message: Message[KafkaPayload | FilteredPayload]):
     ts = datetime.fromtimestamp(wrapper["ts"], tz=timezone.utc)
 
     record_clock_tick_volume_metric(ts)
+    try:
+        result = make_clock_tick_decision(ts)
+
+        metrics.incr(
+            "monitors.tasks.clock_tick.tick_decision",
+            tags={"decision": result.decision},
+            sample_rate=1.0,
+        )
+        if result.transition:
+            metrics.incr(
+                "monitors.tasks.clock_tick.tick_transition",
+                tags={"transition": result.transition},
+                sample_rate=1.0,
+            )
+    except Exception:
+        logger.exception("sentry.tasks.clock_tick.clock_tick_decision_failed")
 
     logger.info(
         "process_clock_tick",


### PR DESCRIPTION
This actually uses the system_incidents `record_clock_tick_volume_metric` to record decisions and transitions as metrics.

In the future we will use these decisions to dispatch unknowns as well as use them as part of the incidents outcomes consumer to determine if an outcome can be dispatched.

Part of GH-79328