### PR TITLE
fix(issues): Remove streamline=1 query parameter

### DIFF
--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
@@ -8,10 +8,6 @@ import ConfigStore from 'sentry/stores/configStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {NewIssueExperienceButton} from 'sentry/views/issueDetails/actions/newIssueExperienceButton';
 
-const mockUseNavigate = jest.fn();
-jest.mock('sentry/utils/useNavigate', () => ({
-  useNavigate: () => mockUseNavigate,
-}));
 jest.mock('sentry/utils/analytics');
 
 const mockFeedbackForm = jest.fn();
@@ -99,10 +95,6 @@ describe('NewIssueExperienceButton', function () {
         })
       );
     });
-    // Location should update
-    expect(mockUseNavigate).toHaveBeenCalledWith(
-      expect.objectContaining({query: {streamline: '1'}})
-    );
     expect(trackAnalytics).toHaveBeenCalledTimes(1);
 
     // Clicking again toggles it off
@@ -124,10 +116,6 @@ describe('NewIssueExperienceButton', function () {
         })
       );
     });
-    // Location should update again
-    expect(mockUseNavigate).toHaveBeenCalledWith(
-      expect.objectContaining({query: {streamline: '0'}})
-    );
     expect(trackAnalytics).toHaveBeenCalledTimes(2);
   });
 

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -8,16 +8,12 @@ import {IconLab} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
-import {useLocation} from 'sentry/utils/useLocation';
 import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
 export function NewIssueExperienceButton() {
   const organization = useOrganization();
-  const location = useLocation();
-  const navigate = useNavigate();
   const hasStreamlinedUIFlag = organization.features.includes('issue-details-streamline');
   const hasStreamlinedUI = useHasStreamlinedUI();
   const openForm = useFeedbackForm();
@@ -29,11 +25,7 @@ export function NewIssueExperienceButton() {
       isEnabled: !hasStreamlinedUI,
       organization: organization,
     });
-    navigate({
-      ...location,
-      query: {...location.query, streamline: hasStreamlinedUI ? '0' : '1'},
-    });
-  }, [mutate, organization, hasStreamlinedUI, location, navigate]);
+  }, [mutate, organization, hasStreamlinedUI]);
 
   if (!hasStreamlinedUIFlag) {
     return null;


### PR DESCRIPTION
When switching between the old and new interface we'll no longer set the query parameter and just update the user config.
