### PR TITLE
feat(context): Allow `geo` data to be rendered to the frontend

### DIFF
--- a/src/sentry/interfaces/user.py
+++ b/src/sentry/interfaces/user.py
@@ -69,6 +69,7 @@ class User(Interface):
             "username": self.username,
             "ip_address": self.ip_address,
             "name": self.name,
+            "geo": self.geo.to_json() if self.geo is not None else None,
             "data": self.data,
         }
 

--- a/src/sentry/interfaces/user.py
+++ b/src/sentry/interfaces/user.py
@@ -15,6 +15,7 @@ class EventUserApiContext(TypedDict, total=False):
     username: str | None
     ip_address: str | None
     name: str | None
+    geo: dict[str, str] | None
     data: dict[str, Any] | None
 
 
@@ -81,6 +82,7 @@ class User(Interface):
             "username": meta.get("username"),
             "ip_address": meta.get("ip_address"),
             "name": meta.get("name"),
+            "geo": meta.get("geo"),
             "data": meta.get("data"),
         }
 


### PR DESCRIPTION
Requires https://github.com/getsentry/sentry/pull/80704 to render on issue details.

These files are 6-8 years old, so I'm not really sure why this data wasn't  exposed to the frontend via`get_api_context` (called by`EventSerializer` on 'group_event_details.py`) and this isn't releasing any new data. This data is actually already accessible via the event JSON.

For example:
- This issue says nothing about geo data in the UI ([link](https://demo.sentry.io/issues/6051030798/events/6d1970669234406c9806913e117982da/?project=5808623))
- But the JSON (via View JSON button) for the issue does ([link](https://us.sentry.io/api/0/projects/demo/react/events/6d1970669234406c9806913e117982da/json/))
<img width="418" alt="image" src="https://github.com/user-attachments/assets/c7f16a2c-4cc3-42a2-b6d9-97ff768be368">


