### PR TITLE
fix(onboarding): fix messaging integration logging on project creation page

### DIFF
--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -263,7 +263,7 @@ export default function IssueAlertNotificationOptions(
       {shouldRenderSetupButton && (
         <SetupMessagingIntegrationButton
           analyticsParams={{
-            view: MessagingIntegrationAnalyticsView.ALERT_RULE_CREATION,
+            view: MessagingIntegrationAnalyticsView.PROJECT_CREATION,
           }}
         />
       )}


### PR DESCRIPTION
accidentally set the view to Alert Rule Creation instead of Project Creation 😳