### PR TITLE
:sparkles: feat(integration slos): add logging for halt event lifecycle status

### DIFF
--- a/src/sentry/integrations/types.py
+++ b/src/sentry/integrations/types.py
@@ -1,4 +1,6 @@
+from dataclasses import dataclass
 from enum import Enum
+from typing import Generic, TypeVar
 
 from sentry.hybridcloud.rpc import ValueEqualityEnum
 
@@ -71,3 +73,23 @@ PERSONAL_NOTIFICATION_PROVIDERS = [
     ExternalProviderEnum.SLACK.value,
     ExternalProviderEnum.MSTEAMS.value,
 ]
+
+
+class EventLifecycleOutcome(Enum):
+    STARTED = "STARTED"
+    HALTED = "HALTED"
+    SUCCESS = "SUCCESS"
+    FAILURE = "FAILURE"
+
+    def __str__(self) -> str:
+        return self.value.lower()
+
+
+T = TypeVar("T")
+
+
+@dataclass
+class MessagingResponse(Generic[T]):
+    interaction_result: EventLifecycleOutcome
+    response: T
+    context_data: dict | None = None

--- a/src/sentry/integrations/types.py
+++ b/src/sentry/integrations/types.py
@@ -89,7 +89,7 @@ T = TypeVar("T")
 
 
 @dataclass
-class MessagingResponse(Generic[T]):
+class IntegrationResponse(Generic[T]):
     interaction_result: EventLifecycleOutcome
     response: T
     context_data: dict | None = None

--- a/tests/sentry/identity/test_oauth2.py
+++ b/tests/sentry/identity/test_oauth2.py
@@ -11,7 +11,7 @@ import sentry.identity
 from sentry.identity.oauth2 import OAuth2CallbackView, OAuth2LoginView
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.identity.providers.dummy import DummyProvider
-from sentry.integrations.utils.metrics import EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
 

--- a/tests/sentry/integrations/bitbucket/test_issues.py
+++ b/tests/sentry/integrations/bitbucket/test_issues.py
@@ -7,7 +7,7 @@ import responses
 from sentry.integrations.bitbucket.issues import ISSUE_TYPES, PRIORITIES
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.services.integration import integration_service
-from sentry.integrations.utils.metrics import EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.shared_integrations.exceptions import IntegrationFormError
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.factories import EventType

--- a/tests/sentry/integrations/bitbucket_server/test_integration.py
+++ b/tests/sentry/integrations/bitbucket_server/test_integration.py
@@ -7,7 +7,7 @@ from fixtures.bitbucket_server import EXAMPLE_PRIVATE_KEY
 from sentry.integrations.bitbucket_server.integration import BitbucketServerIntegrationProvider
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
-from sentry.integrations.utils.metrics import EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.users.models.identity import Identity, IdentityProvider

--- a/tests/sentry/integrations/discord/webhooks/test_command.py
+++ b/tests/sentry/integrations/discord/webhooks/test_command.py
@@ -4,7 +4,7 @@ from sentry.integrations.discord.message_builder.base.flags import EPHEMERAL_FLA
 from sentry.integrations.discord.requests.base import DiscordRequestTypes
 from sentry.integrations.discord.webhooks.command import HELP_MESSAGE, NOT_LINKED_MESSAGE
 from sentry.integrations.discord.webhooks.types import DiscordResponseTypes
-from sentry.integrations.utils.metrics import EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.testutils.cases import APITestCase
 
 WEBHOOK_URL = "/extensions/discord/interactions/"

--- a/tests/sentry/integrations/discord/webhooks/test_message_component.py
+++ b/tests/sentry/integrations/discord/webhooks/test_message_component.py
@@ -24,7 +24,7 @@ from sentry.integrations.discord.webhooks.message_component import (
     RESOLVED_IN_NEXT_RELEASE,
     UNRESOLVED,
 )
-from sentry.integrations.utils.metrics import EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.release import Release
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -23,7 +23,7 @@ from sentry.integrations.source_code_management.commit_context import (
     FileBlameInfo,
     SourceLineInfo,
 )
-from sentry.integrations.utils.metrics import EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
 from sentry.shared_integrations.response.base import BaseApiResponse

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -30,8 +30,8 @@ from sentry.integrations.source_code_management.commit_context import (
     FileBlameInfo,
     SourceLineInfo,
 )
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.integrations.utils.code_mapping import Repo, RepoTree
-from sentry.integrations.utils.metrics import EventLifecycleOutcome
 from sentry.models.project import Project
 from sentry.models.repository import Repository
 from sentry.organizations.absolute_url import generate_organization_url

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -15,7 +15,7 @@ from sentry.integrations.github import client
 from sentry.integrations.github.integration import GitHubIntegration
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.services.integration import integration_service
-from sentry.integrations.utils.metrics import EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.issues.grouptype import FeedbackGroup
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.silo.util import PROXY_BASE_URL_HEADER, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER

--- a/tests/sentry/integrations/gitlab/test_issues.py
+++ b/tests/sentry/integrations/gitlab/test_issues.py
@@ -6,7 +6,7 @@ import responses
 from fixtures.gitlab import GitLabTestCase
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.services.integration import integration_service
-from sentry.integrations.utils.metrics import EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils.factories import EventType
 from sentry.testutils.helpers.datetime import before_now

--- a/tests/sentry/integrations/msteams/test_action_state_change.py
+++ b/tests/sentry/integrations/msteams/test_action_state_change.py
@@ -11,7 +11,7 @@ from sentry.integrations.msteams.card_builder.identity import build_linking_card
 from sentry.integrations.msteams.constants import SALT
 from sentry.integrations.msteams.link_identity import build_linking_url
 from sentry.integrations.msteams.utils import ACTION_TYPE
-from sentry.integrations.utils.metrics import EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.activity import Activity, ActivityIntegration
 from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider

--- a/tests/sentry/integrations/msteams/test_webhook.py
+++ b/tests/sentry/integrations/msteams/test_webhook.py
@@ -10,7 +10,7 @@ from django.urls import reverse
 
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.msteams.utils import ACTION_TYPE
-from sentry.integrations.utils.metrics import EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode

--- a/tests/sentry/integrations/opsgenie/test_client.py
+++ b/tests/sentry/integrations/opsgenie/test_client.py
@@ -4,7 +4,7 @@ import orjson
 import pytest
 import responses
 
-from sentry.integrations.utils.metrics import EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.rule import Rule
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.skips import requires_snuba

--- a/tests/sentry/integrations/opsgenie/test_integration.py
+++ b/tests/sentry/integrations/opsgenie/test_integration.py
@@ -12,7 +12,7 @@ from sentry.integrations.opsgenie.tasks import (
     ALERT_LEGACY_INTEGRATIONS,
     ALERT_LEGACY_INTEGRATIONS_WITH_NAME,
 )
-from sentry.integrations.utils.metrics import EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.rule import Rule
 from sentry.shared_integrations.exceptions import ApiRateLimitedError, ApiUnauthorized
 from sentry.testutils.cases import APITestCase, IntegrationTestCase

--- a/tests/sentry/integrations/opsgenie/test_notify_action.py
+++ b/tests/sentry/integrations/opsgenie/test_notify_action.py
@@ -6,7 +6,7 @@ import responses
 
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.opsgenie.actions import OpsgenieNotifyTeamAction
-from sentry.integrations.utils.metrics import EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import PerformanceIssueTestCase, RuleTestCase

--- a/tests/sentry/integrations/pagerduty/test_client.py
+++ b/tests/sentry/integrations/pagerduty/test_client.py
@@ -7,7 +7,7 @@ from responses import matchers
 
 from sentry.api.serializers import ExternalEventSerializer, serialize
 from sentry.integrations.pagerduty.utils import add_service
-from sentry.integrations.utils.metrics import EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.factories import EventType
 from sentry.testutils.helpers.datetime import before_now

--- a/tests/sentry/integrations/pagerduty/test_notify_action.py
+++ b/tests/sentry/integrations/pagerduty/test_notify_action.py
@@ -6,7 +6,7 @@ import responses
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.pagerduty.actions.notification import PagerDutyNotifyServiceAction
 from sentry.integrations.pagerduty.utils import add_service
-from sentry.integrations.utils.metrics import EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import PerformanceIssueTestCase, RuleTestCase
 from sentry.testutils.helpers.datetime import before_now

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -14,7 +14,7 @@ from sentry.integrations.slack.webhooks.action import (
     LINK_IDENTITY_MESSAGE,
     UNLINK_IDENTITY_MESSAGE,
 )
-from sentry.integrations.utils.metrics import EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType
 from sentry.models.activity import Activity, ActivityIntegration
 from sentry.models.authidentity import AuthIdentity

--- a/tests/sentry/integrations/slack/webhooks/commands/test_link_team.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/test_link_team.py
@@ -11,7 +11,7 @@ from sentry.integrations.slack.webhooks.command import (
     LINK_USER_FIRST_MESSAGE,
     TEAM_NOT_LINKED_MESSAGE,
 )
-from sentry.integrations.utils.metrics import EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.silo.base import SiloMode
 from sentry.testutils.helpers import get_response_text, link_user
 from sentry.testutils.helpers.features import with_feature

--- a/tests/sentry/integrations/slack/webhooks/commands/test_link_user.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/test_link_user.py
@@ -7,7 +7,7 @@ from sentry.integrations.slack.views.unlink_identity import (
     build_unlinking_url,
 )
 from sentry.integrations.slack.webhooks.base import NOT_LINKED_MESSAGE
-from sentry.integrations.utils.metrics import EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.testutils.helpers import get_response_text
 from sentry.testutils.silo import control_silo_test
 from sentry.users.models.identity import Identity

--- a/tests/sentry/integrations/slack/webhooks/events/test_message_im.py
+++ b/tests/sentry/integrations/slack/webhooks/events/test_message_im.py
@@ -4,7 +4,7 @@ import orjson
 import pytest
 from slack_sdk.web import SlackResponse
 
-from sentry.integrations.utils.metrics import EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import IntegratedApiTestCase
 from sentry.testutils.helpers import get_response_text

--- a/tests/sentry/integrations/test_issues.py
+++ b/tests/sentry/integrations/test_issues.py
@@ -6,7 +6,7 @@ from sentry.integrations.example.integration import AliasedIntegrationProvider, 
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.integration import integration_service
-from sentry.integrations.utils.metrics import EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.activity import Activity
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouplink import GroupLink

--- a/tests/sentry/integrations/utils/test_lifecycle_metrics.py
+++ b/tests/sentry/integrations/utils/test_lifecycle_metrics.py
@@ -1,7 +1,8 @@
 from unittest import mock
 
 from sentry.integrations.base import IntegrationDomain
-from sentry.integrations.types import EventLifecycleOutcome, IntegrationEventLifecycleMetric
+from sentry.integrations.types import EventLifecycleOutcome
+from sentry.integrations.utils.metrics import IntegrationEventLifecycleMetric
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import no_silo_test
 

--- a/tests/sentry/integrations/utils/test_lifecycle_metrics.py
+++ b/tests/sentry/integrations/utils/test_lifecycle_metrics.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 from sentry.integrations.base import IntegrationDomain
-from sentry.integrations.utils.metrics import EventLifecycleOutcome, IntegrationEventLifecycleMetric
+from sentry.integrations.types import EventLifecycleOutcome, IntegrationEventLifecycleMetric
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import no_silo_test
 

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -21,7 +21,7 @@ from sentry.integrations.mixins import ResolveSyncAction
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration_external_project import IntegrationExternalProject
 from sentry.integrations.services.integration import integration_service
-from sentry.integrations.utils.metrics import EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.integrations.vsts.integration import VstsIntegration
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.silo.base import SiloMode


### PR DESCRIPTION
adding support for passing extras when recording a halt so we can log. 

also introduced MessagingResponse type to encapsulate SLOs for messaging commands