### PR TITLE
feat(insights): add back original web vitals tab in performance landing page

### DIFF
--- a/static/app/views/performance/transactionSummary/pageLayout.tsx
+++ b/static/app/views/performance/transactionSummary/pageLayout.tsx
@@ -30,6 +30,7 @@ import {PerformanceEventViewProvider} from 'sentry/utils/performance/contexts/pe
 import {decodeScalar} from 'sentry/utils/queryString';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useRouter from 'sentry/utils/useRouter';
+import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {aggregateWaterfallRouteWithQuery} from 'sentry/views/performance/transactionSummary/aggregateSpanWaterfall/utils';
 
 import {
@@ -118,6 +119,8 @@ function PageLayout(props: Props) {
   const [transactionThresholdMetric, setTransactionThresholdMetric] = useState<
     TransactionThresholdMetric | undefined
   >();
+
+  const {isInDomainView} = useDomainViewFilters();
 
   const getNewRoute = useCallback(
     (newTab: Tab) => {
@@ -257,7 +260,7 @@ function PageLayout(props: Props) {
 
   let hasWebVitals: TransactionHeaderProps['hasWebVitals'] =
     tab === Tab.WEB_VITALS ? 'yes' : 'maybe';
-  if (organization.features.includes('insights-domain-view')) {
+  if (isInDomainView) {
     hasWebVitals = 'no';
   }
 


### PR DESCRIPTION

<img width="412" alt="image" src="https://github.com/user-attachments/assets/b2591342-9df4-4069-b6c5-5c2f7fe582a5">

Some customers enjoyed the old web vitals tab in the transaction summary page. This PR adds back the web vitals tab in the old performance landing page, so that it can still be accessed until we migrate some of the feature over to our new web vitals product.