### PR TITLE
fix(autofix): Add loading placeholder, rethink buttons for empty state, and move Autofix button bar

### DIFF
--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -401,9 +401,9 @@ function ChainLink({
   stepIndex: number;
 }) {
   const [showOverlay, setShowOverlay] = useState(false);
-  const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(
-    null
-  );
+  const [referenceElement, setReferenceElement] = useState<
+    HTMLAnchorElement | HTMLButtonElement | null
+  >(null);
   const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
   const [comment, setComment] = useState('');
   const {mutate: send} = useUpdateInsightCard({groupId, runId});
@@ -448,7 +448,7 @@ function ChainLink({
     <ArrowContainer>
       <IconArrow direction={'down'} className="arrow-icon" />
       <RethinkButton
-        ref={(instance: HTMLButtonElement | null) => setReferenceElement(instance)}
+        ref={setReferenceElement}
         icon={<IconEdit size="xs" />}
         size="zero"
         className="rethink-button"

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -1,4 +1,6 @@
-import {useEffect, useRef, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
+import {createPortal} from 'react-dom';
+import {usePopper} from 'react-popper';
 import styled from '@emotion/styled';
 import {AnimatePresence, type AnimationProps, motion} from 'framer-motion';
 
@@ -343,12 +345,14 @@ function AutofixInsightCards({
           </p>
         </NoInsightsYet>
       ) : hasStepBelow ? (
-        <ChainLink
-          insightCardAboveIndex={null}
-          stepIndex={stepIndex}
-          groupId={groupId}
-          runId={runId}
-        />
+        <EmptyResultsContainer>
+          <ChainLink
+            insightCardAboveIndex={null}
+            stepIndex={stepIndex}
+            groupId={groupId}
+            runId={runId}
+          />
+        </EmptyResultsContainer>
       ) : null}
     </InsightsContainer>
   );
@@ -397,15 +401,37 @@ function ChainLink({
   stepIndex: number;
 }) {
   const [showOverlay, setShowOverlay] = useState(false);
-  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(
+    null
+  );
+  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
   const [comment, setComment] = useState('');
   const {mutate: send} = useUpdateInsightCard({groupId, runId});
 
-  const handleClickOutside = event => {
-    if (overlayRef.current && !overlayRef.current.contains(event.target)) {
+  const {styles, attributes} = usePopper(referenceElement, popperElement, {
+    placement: insightCardAboveIndex === null ? 'right-start' : 'right-start',
+    modifiers: [
+      {
+        name: 'offset',
+        options: {
+          offset: [-16, 4],
+        },
+      },
+    ],
+  });
+
+  const handleClickOutside = useCallback(
+    (event: MouseEvent) => {
+      if (
+        referenceElement?.contains(event.target as Node) ||
+        popperElement?.contains(event.target as Node)
+      ) {
+        return;
+      }
       setShowOverlay(false);
-    }
-  };
+    },
+    [popperElement, referenceElement]
+  );
 
   useEffect(() => {
     if (showOverlay) {
@@ -416,15 +442,13 @@ function ChainLink({
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, [showOverlay]);
-
-  // Determine if this is the first chain link (before first insight)
-  const isFirstLink = insightCardAboveIndex === null || insightCardAboveIndex < 0;
+  }, [showOverlay, handleClickOutside]);
 
   return (
     <ArrowContainer>
       <IconArrow direction={'down'} className="arrow-icon" />
       <RethinkButton
+        ref={(instance: HTMLButtonElement | null) => setReferenceElement(instance)}
         icon={<IconEdit size="xs" />}
         size="zero"
         className="rethink-button"
@@ -433,40 +457,52 @@ function ChainLink({
         onClick={() => setShowOverlay(true)}
       />
 
-      {showOverlay && (
-        <RethinkInput $isFirstLink={isFirstLink} ref={overlayRef}>
-          <form
-            onSubmit={e => {
-              e.preventDefault();
-              setShowOverlay(false);
-              setComment('');
-              send({
-                message: comment,
-                step_index: stepIndex,
-                retain_insight_card_index: insightCardAboveIndex,
-              });
-            }}
-            className="row-form"
+      {showOverlay &&
+        createPortal(
+          <RethinkInput
+            ref={setPopperElement}
+            style={styles.popper}
+            {...attributes.popper}
+            id="autofix-rethink-input"
           >
-            <Input
-              type="text"
-              placeholder="Say something..."
-              value={comment}
-              onChange={e => setComment(e.target.value)}
-              size="md"
-              autoFocus
-            />
-            <Button
-              type="submit"
-              icon={<IconRefresh />}
-              title="Restart analysis from this point in the chain"
-              aria-label="Restart analysis from this point in the chain"
-              priority="primary"
-              size="md"
-            />
-          </form>
-        </RethinkInput>
-      )}
+            <form
+              onSubmit={e => {
+                e.preventDefault();
+                e.stopPropagation();
+                setShowOverlay(false);
+                setComment('');
+                send({
+                  message: comment,
+                  step_index: stepIndex,
+                  retain_insight_card_index: insightCardAboveIndex,
+                });
+              }}
+              className="row-form"
+              onClick={e => e.stopPropagation()}
+              id="autofix-rethink-input"
+            >
+              <Input
+                type="text"
+                placeholder="Say something..."
+                value={comment}
+                onChange={e => setComment(e.target.value)}
+                size="md"
+                autoFocus
+                id="autofix-rethink-input"
+              />
+              <Button
+                type="submit"
+                icon={<IconRefresh />}
+                title="Restart analysis from this point in the chain"
+                aria-label="Restart analysis from this point in the chain"
+                priority="primary"
+                size="md"
+                id="autofix-rethink-input"
+              />
+            </form>
+          </RethinkInput>,
+          document.body
+        )}
     </ArrowContainer>
   );
 }
@@ -518,6 +554,11 @@ const NoInsightsYet = styled('div')`
   padding-top: ${space(4)};
 `;
 
+const EmptyResultsContainer = styled('div')`
+  position: relative;
+  bottom: -${space(1)};
+`;
+
 const InsightsContainer = styled('div')``;
 
 const InsightContainer = styled(motion.div)`
@@ -566,17 +607,14 @@ const RethinkButton = styled(Button)`
   transition: color 0.2s ease-in-out;
 `;
 
-const RethinkInput = styled('div')<{$isFirstLink: boolean}>`
-  position: absolute;
+const RethinkInput = styled('div')`
   box-shadow: ${p => p.theme.dropShadowHeavy};
   border: 1px solid ${p => p.theme.border};
-  width: 95%;
+  width: 45%;
   background: ${p => p.theme.backgroundElevated};
   padding: ${space(0.5)};
   border-radius: ${p => p.theme.borderRadius};
-  margin: 0 ${space(1.5)} 0 ${space(1.5)};
-  z-index: 10000;
-  transform: translateY(${p => (p.$isFirstLink ? '25%' : '-25%')});
+  z-index: ${p => p.theme.zIndex.tooltip};
 
   .row-form {
     display: flex;

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -85,9 +85,11 @@ function GroupSummaryFeatureBadge() {
 export function GroupSummaryBody({
   data,
   isError,
+  isPending,
 }: {
   data: GroupSummaryData | undefined;
   isError: boolean;
+  isPending: boolean;
 }) {
   const insightCards = [
     {
@@ -113,24 +115,34 @@ export function GroupSummaryBody({
   return (
     <Body>
       {isError ? <div>{t('Error loading summary')}</div> : null}
-      {data && (
+      {isPending ? (
         <Content>
           <InsightGrid>
-            {insightCards.map(card => (
-              <InsightCard key={card.id}>
-                <CardTitle>
-                  <CardTitleIcon>{card.icon}</CardTitleIcon>
-                  <CardTitleText>{card.title}</CardTitleText>
-                </CardTitle>
-                <CardContent
-                  dangerouslySetInnerHTML={{
-                    __html: marked(card.insight ?? ''),
-                  }}
-                />
-              </InsightCard>
-            ))}
+            <InsightCard>
+              <Placeholder height="96px" />
+            </InsightCard>
           </InsightGrid>
         </Content>
+      ) : (
+        data && (
+          <Content>
+            <InsightGrid>
+              {insightCards.map(card => (
+                <InsightCard key={card.id}>
+                  <CardTitle>
+                    <CardTitleIcon>{card.icon}</CardTitleIcon>
+                    <CardTitleText>{card.title}</CardTitleText>
+                  </CardTitle>
+                  <CardContent
+                    dangerouslySetInnerHTML={{
+                      __html: marked(card.insight ?? ''),
+                    }}
+                  />
+                </InsightCard>
+              ))}
+            </InsightGrid>
+          </Content>
+        )
       )}
     </Body>
   );
@@ -193,7 +205,7 @@ export function GroupSummary({groupId, groupCategory}: GroupSummaryProps) {
       </StyledTitleRow>
       {expanded && (
         <Fragment>
-          <GroupSummaryBody data={data} isError={isError} />
+          <GroupSummaryBody data={data} isError={isError} isPending={isPending} />
           {openForm && !isPending && (
             <ButtonContainer>
               <Button

--- a/static/app/views/issueDetails/streamline/solutionsHubDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/solutionsHubDrawer.tsx
@@ -134,8 +134,12 @@ interface SolutionsHubDrawerProps {
 }
 
 export function SolutionsHubDrawer({group, project, event}: SolutionsHubDrawerProps) {
-  const {autofixData, triggerAutofix, reset} = useAiAutofix(group, event);
-  const {data: summaryData, isError} = useGroupSummary(group.id, group.issueCategory);
+  const {autofixData, triggerAutofix, reset, isPolling} = useAiAutofix(group, event);
+  const {
+    data: summaryData,
+    isError,
+    isPending: isSummaryLoading,
+  } = useGroupSummary(group.id, group.issueCategory);
   const {
     data: setupData,
     isPending: isSetupLoading,
@@ -182,22 +186,6 @@ export function SolutionsHubDrawer({group, project, event}: SolutionsHubDrawerPr
       </SolutionsDrawerHeader>
       <SolutionsDrawerNavigator>
         <Header>{t('Solutions Hub')}</Header>
-        {autofixData && (
-          <ButtonBar gap={1}>
-            <AutofixFeedback />
-            <Button
-              size="xs"
-              onClick={reset}
-              title={
-                autofixData.created_at
-                  ? `Last run at ${autofixData.created_at.split('T')[0]}`
-                  : null
-              }
-            >
-              {t('Start Over')}
-            </Button>
-          </ButtonBar>
-        )}
       </SolutionsDrawerNavigator>
       <SolutionsDrawerBody>
         {config.resources && (
@@ -216,21 +204,43 @@ export function SolutionsHubDrawer({group, project, event}: SolutionsHubDrawerPr
           </ResourcesContainer>
         )}
         <HeaderText>
-          <IconSeer size="lg" />
-          {t('Sentry AI')}
-          <StyledFeatureBadge
-            type="beta"
-            title={tct(
-              'This feature is in beta. Try it out and let us know your feedback at [email:autofix@sentry.io].',
-              {
-                email: <a href="mailto:autofix@sentry.io" />,
-              }
-            )}
-          />
+          <div style={{display: 'flex', alignItems: 'center', gap: space(0.5)}}>
+            <IconSeer size="lg" />
+            {t('Sentry AI')}
+            <StyledFeatureBadge
+              type="beta"
+              title={tct(
+                'This feature is in beta. Try it out and let us know your feedback at [email:autofix@sentry.io].',
+                {
+                  email: <a href="mailto:autofix@sentry.io" />,
+                }
+              )}
+            />
+          </div>
+          {autofixData && (
+            <ButtonBar gap={1}>
+              <AutofixFeedback />
+              <Button
+                size="xs"
+                onClick={reset}
+                title={
+                  autofixData.created_at
+                    ? `Last run at ${autofixData.created_at.split('T')[0]}`
+                    : null
+                }
+              >
+                {t('Start Over')}
+              </Button>
+            </ButtonBar>
+          )}
         </HeaderText>
         {hasSummary && (
           <StyledCard>
-            <GroupSummaryBody data={summaryData} isError={isError} />
+            <GroupSummaryBody
+              data={summaryData}
+              isError={isError}
+              isPending={isSummaryLoading}
+            />
           </StyledCard>
         )}
         {displayAiAutofix && (
@@ -243,16 +253,16 @@ export function SolutionsHubDrawer({group, project, event}: SolutionsHubDrawerPr
                   onComplete={refetchSetup}
                 />
               </SetupContainer>
-            ) : !autofixData ? (
+            ) : !autofixData && isPolling ? (
               <AutofixStartBox onSend={triggerAutofix} groupId={group.id} />
-            ) : (
+            ) : autofixData ? (
               <AutofixSteps
                 data={autofixData}
                 groupId={group.id}
                 runId={autofixData.run_id}
                 onRetry={reset}
               />
-            )}
+            ) : null}
           </Fragment>
         )}
       </SolutionsDrawerBody>
@@ -301,9 +311,8 @@ const SolutionsDrawerHeader = styled(DrawerHeader)`
 
 const SolutionsDrawerNavigator = styled('div')`
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: 1fr;
   align-items: center;
-  column-gap: ${space(1)};
   padding: ${space(0.75)} 24px;
   background: ${p => p.theme.background};
   z-index: 1;
@@ -409,6 +418,7 @@ const HeaderText = styled('div')`
   align-items: center;
   gap: ${space(0.5)};
   padding-bottom: ${space(2)};
+  justify-content: space-between;
 `;
 
 const StyledFeatureBadge = styled(FeatureBadge)`

--- a/static/app/views/issueDetails/streamline/solutionsHubDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/solutionsHubDrawer.tsx
@@ -204,7 +204,7 @@ export function SolutionsHubDrawer({group, project, event}: SolutionsHubDrawerPr
           </ResourcesContainer>
         )}
         <HeaderText>
-          <div style={{display: 'flex', alignItems: 'center', gap: space(0.5)}}>
+          <HeaderContainer>
             <IconSeer size="lg" />
             {t('Sentry AI')}
             <StyledFeatureBadge
@@ -216,7 +216,7 @@ export function SolutionsHubDrawer({group, project, event}: SolutionsHubDrawerPr
                 }
               )}
             />
-          </div>
+          </HeaderContainer>
           {autofixData && (
             <ButtonBar gap={1}>
               <AutofixFeedback />
@@ -451,4 +451,10 @@ const TrailStar = styled('img')<{index: number; offset: number; size: number}>`
   transform: translateX(${p => p.offset}px) rotate(${p => p.index * 40}deg);
   opacity: ${p => Math.min(1, 0.2 + p.index * 0.1)};
   filter: sepia(1) saturate(3) hue-rotate(290deg);
+`;
+
+const HeaderContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
 `;

--- a/static/app/views/issueDetails/streamline/solutionsHubDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/solutionsHubDrawer.tsx
@@ -89,7 +89,7 @@ function AutofixStartBox({onSend, groupId}: AutofixStartBoxProps) {
               }
               analyticsParams={{group_id: groupId}}
             >
-              {message ? 'Start' : 'Start Autofix'}
+              {t('Start Autofix')}
             </Button>
           </ButtonWithStars>
         </Row>

--- a/static/app/views/issueDetails/streamline/solutionsSection.tsx
+++ b/static/app/views/issueDetails/streamline/solutionsSection.tsx
@@ -54,7 +54,8 @@ export default function SolutionsSection({
           const viewAllButton = openButtonRef.current;
           if (
             viewAllButton?.contains(element) ||
-            document.getElementById('sentry-feedback')?.contains(element)
+            document.getElementById('sentry-feedback')?.contains(element) ||
+            document.getElementById('autofix-rethink-input')?.contains(element)
           ) {
             return false;
           }


### PR DESCRIPTION
1. Adds a placeholder for the loading summary
2. Adds a rethink button if there are no insight cards
3. Moves the start over and feedback buttons down to the Sentry AI section