### PR TITLE
feat(ai): New GenAI Consent Flow

### DIFF
--- a/static/app/components/events/autofix/autofixSetupModal.tsx
+++ b/static/app/components/events/autofix/autofixSetupModal.tsx
@@ -19,7 +19,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 
 const ConsentStep = HookOrDefault({
-  hookName: 'component:autofix-setup-step-consent',
+  hookName: 'component:ai-setup-data-consent',
   defaultComponent: null,
 });
 
@@ -349,7 +349,7 @@ export function AutofixSetupContent({
 
   return (
     <Fragment>
-      <Header>Set up Autofix</Header>
+      <Header>Set up Sentry AI</Header>
       <p>
         Sentry's AI-enabled Autofix uses all of the contextual data surrounding this error
         to work with you to find the root cause and create a fix.

--- a/static/app/components/events/autofix/autofixSetupModal.tsx
+++ b/static/app/components/events/autofix/autofixSetupModal.tsx
@@ -8,7 +8,6 @@ import {
   useAutofixSetup,
 } from 'sentry/components/events/autofix/useAutofixSetup';
 import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
-import HookOrDefault from 'sentry/components/hookOrDefault';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -17,11 +16,6 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
-
-const ConsentStep = HookOrDefault({
-  hookName: 'component:ai-setup-data-consent',
-  defaultComponent: null,
-});
 
 function AutofixIntegrationStep({autofixSetup}: {autofixSetup: AutofixSetupResponse}) {
   if (autofixSetup.integration.ok) {
@@ -283,7 +277,6 @@ function AutofixSetupSteps({
 }) {
   return (
     <GuidedSteps>
-      <ConsentStep hasConsented={autofixSetup.genAIConsent.ok} />
       <GuidedSteps.Step
         stepKey="integration"
         title={t('Install the GitHub Integration')}
@@ -349,7 +342,8 @@ export function AutofixSetupContent({
 
   return (
     <Fragment>
-      <Header>Set up Sentry AI</Header>
+      <Divider />
+      <Header>Set up Autofix</Header>
       <p>
         Sentry's AI-enabled Autofix uses all of the contextual data surrounding this error
         to work with you to find the root cause and create a fix.
@@ -400,4 +394,9 @@ const GithubLink = styled('div')`
   display: flex;
   align-items: center;
   gap: ${space(0.5)};
+`;
+
+const Divider = styled('div')`
+  margin: ${space(3)} 0;
+  border-bottom: 2px solid ${p => p.theme.gray100};
 `;

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -184,6 +184,7 @@ export type MembershipSettingsProps = {
  * Component wrapping hooks
  */
 export type ComponentHooks = {
+  'component:ai-setup-data-consent': () => React.ComponentType<{}>;
   'component:autofix-setup-step-consent': () => React.ComponentType<AutofixSetupConsentStepProps> | null;
   'component:codecov-integration-settings-link': () => React.ComponentType<CodecovLinkProps>;
   'component:confirm-account-close': () => React.ComponentType<AttemptCloseAttemptProps>;

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -72,6 +72,9 @@ export type RouteHooks = {
  * Component specific hooks for DateRange and SelectorItems
  * These components have plan specific overrides in getsentry
  */
+type AiSetupDataConsentProps = {
+  groupId: string;
+};
 type AutofixSetupConsentStepProps = {hasConsented: boolean};
 type DateRangeProps = React.ComponentProps<typeof DateRange>;
 
@@ -184,7 +187,7 @@ export type MembershipSettingsProps = {
  * Component wrapping hooks
  */
 export type ComponentHooks = {
-  'component:ai-setup-data-consent': () => React.ComponentType<{}>;
+  'component:ai-setup-data-consent': () => React.ComponentType<AiSetupDataConsentProps> | null;
   'component:autofix-setup-step-consent': () => React.ComponentType<AutofixSetupConsentStepProps> | null;
   'component:codecov-integration-settings-link': () => React.ComponentType<CodecovLinkProps>;
   'component:confirm-account-close': () => React.ComponentType<AttemptCloseAttemptProps>;

--- a/static/app/views/issueDetails/streamline/solutionsHubDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/solutionsHubDrawer.tsx
@@ -142,7 +142,7 @@ const AiSetupDataConsent = HookOrDefault({
 });
 
 export function SolutionsHubDrawer({group, project, event}: SolutionsHubDrawerProps) {
-  const {autofixData, triggerAutofix, reset, isPolling} = useAiAutofix(group, event);
+  const {autofixData, triggerAutofix, reset} = useAiAutofix(group, event);
   const {
     data: summaryData,
     isError,

--- a/static/app/views/issueDetails/streamline/solutionsHubDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/solutionsHubDrawer.tsx
@@ -17,6 +17,7 @@ import {DrawerBody, DrawerHeader} from 'sentry/components/globalDrawer/component
 import {GroupSummaryBody, useGroupSummary} from 'sentry/components/group/groupSummary';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import Input from 'sentry/components/input';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconDocs, IconSeer} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -89,6 +90,7 @@ function AutofixStartBox({onSend, groupId}: AutofixStartBoxProps) {
                   : 'Autofix: Start Fix Clicked'
               }
               analyticsParams={{group_id: groupId}}
+              aria-label="Start Autofix"
             >
               {t('Start Autofix')}
             </Button>
@@ -136,7 +138,7 @@ interface SolutionsHubDrawerProps {
 
 const AiSetupDataConsent = HookOrDefault({
   hookName: 'component:ai-setup-data-consent',
-  defaultComponent: null,
+  defaultComponent: () => <div data-test-id="ai-setup-data-consent" />,
 });
 
 export function SolutionsHubDrawer({group, project, event}: SolutionsHubDrawerProps) {
@@ -243,7 +245,11 @@ export function SolutionsHubDrawer({group, project, event}: SolutionsHubDrawerPr
             </ButtonBar>
           )}
         </HeaderText>
-        {!hasConsent ? (
+        {isSetupLoading ? (
+          <div data-test-id="ai-setup-loading-indicator">
+            <LoadingIndicator />
+          </div>
+        ) : !hasConsent ? (
           <AiSetupDataConsent groupId={group.id} />
         ) : (
           <Fragment>
@@ -258,7 +264,7 @@ export function SolutionsHubDrawer({group, project, event}: SolutionsHubDrawerPr
             )}
             {displayAiAutofix && (
               <Fragment>
-                {!isSetupLoading && !isAutofixSetupComplete ? (
+                {!isAutofixSetupComplete ? (
                   <AutofixSetupContent
                     groupId={group.id}
                     projectId={project.id}

--- a/static/app/views/issueDetails/streamline/solutionsHubDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/solutionsHubDrawer.tsx
@@ -15,6 +15,7 @@ import {useAiAutofix} from 'sentry/components/events/autofix/useAutofix';
 import {useAutofixSetup} from 'sentry/components/events/autofix/useAutofixSetup';
 import {DrawerBody, DrawerHeader} from 'sentry/components/globalDrawer/components';
 import {GroupSummaryBody, useGroupSummary} from 'sentry/components/group/groupSummary';
+import HookOrDefault from 'sentry/components/hookOrDefault';
 import Input from 'sentry/components/input';
 import {IconDocs, IconSeer} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -133,6 +134,11 @@ interface SolutionsHubDrawerProps {
   project: Project;
 }
 
+const AiSetupDataConsent = HookOrDefault({
+  hookName: 'component:ai-setup-data-consent',
+  defaultComponent: null,
+});
+
 export function SolutionsHubDrawer({group, project, event}: SolutionsHubDrawerProps) {
   const {autofixData, triggerAutofix, reset, isPolling} = useAiAutofix(group, event);
   const {
@@ -163,8 +169,8 @@ export function SolutionsHubDrawer({group, project, event}: SolutionsHubDrawerPr
     shouldDisplayAiAutofixForOrganization(organization) &&
     config.autofix &&
     !shouldShowCustomErrorResourceConfig(group, project) &&
-    hasStacktraceWithFrames(event) &&
-    !isSampleError;
+    hasStacktraceWithFrames(event);
+  // !isSampleError;
 
   return (
     <SolutionsDrawerContainer>
@@ -390,16 +396,6 @@ const StarLarge3 = styled(StarLarge)`
   transform: rotate(20deg);
   width: 28px;
   height: 28px;
-`;
-
-const SetupContainer = styled('div')`
-  padding: ${space(2)};
-
-  /* Override some modal-specific styles */
-  h3 {
-    font-size: ${p => p.theme.fontSizeLarge};
-    margin-bottom: ${space(2)};
-  }
 `;
 
 const StyledCard = styled('div')`


### PR DESCRIPTION
New consent flow within the drawer allowing you to consent right there.

![CleanShot 2024-11-13 at 16 18 44@2x](https://github.com/user-attachments/assets/372c96d8-d7f2-4a32-8338-0e6c733cf207)
