### PR TITLE
fix(issues): Adjust issue events table colors, padding

### DIFF
--- a/static/app/views/issueDetails/streamline/eventList.tsx
+++ b/static/app/views/issueDetails/streamline/eventList.tsx
@@ -174,7 +174,7 @@ const EventListHeader = styled('div')`
   grid-template-columns: 1fr auto auto;
   gap: ${space(1.5)};
   align-items: center;
-  padding: ${space(1)} ${space(1)} ${space(1)} ${space(2)};
+  padding: ${space(1)} ${space(1)} ${space(1)} ${space(1.5)};
   background: ${p => p.theme.background};
   border-bottom: 1px solid ${p => p.theme.translucentBorder};
   position: sticky;
@@ -234,7 +234,7 @@ const StreamlineEventsTable = styled('div')`
       border: 0;
     }
     &:first-child {
-      padding-left: ${space(2)};
+      padding-left: ${space(1.5)};
     }
   }
 
@@ -249,7 +249,7 @@ const StreamlineEventsTable = styled('div')`
 
   ${GridRow} {
     td:nth-child(2) {
-      padding-left: ${space(2)};
+      padding-left: ${space(1.5)};
     }
 
     td:not(:nth-child(2)) {

--- a/static/app/views/issueDetails/streamline/eventList.tsx
+++ b/static/app/views/issueDetails/streamline/eventList.tsx
@@ -9,6 +9,7 @@ import {
   GridHead,
   GridHeadCell,
   GridResizer,
+  GridRow,
 } from 'sentry/components/gridEditable/styles';
 import Panel from 'sentry/components/panels/panel';
 import {IconChevron} from 'sentry/icons';
@@ -116,7 +117,7 @@ export function EventList({group}: EventListProps) {
             <EventListHeader>
               <EventListTitle>{t('All Events')}</EventListTitle>
               <EventListHeaderItem>
-                {isPending
+                {isPending || pageEventsCount === 0
                   ? null
                   : tct('Showing [start]-[end] of [count] matching events', {
                       start: start.toLocaleString(),
@@ -170,10 +171,10 @@ export function EventList({group}: EventListProps) {
 
 const EventListHeader = styled('div')`
   display: grid;
-  grid-template-columns: 1fr auto auto auto;
+  grid-template-columns: 1fr auto auto;
   gap: ${space(1.5)};
   align-items: center;
-  padding: ${space(1)} ${space(2)};
+  padding: ${space(1)} ${space(1)} ${space(1)} ${space(2)};
   background: ${p => p.theme.background};
   border-bottom: 1px solid ${p => p.theme.translucentBorder};
   position: sticky;
@@ -232,6 +233,9 @@ const StreamlineEventsTable = styled('div')`
     &:last-child {
       border: 0;
     }
+    &:first-child {
+      padding-left: ${space(2)};
+    }
   }
 
   ${GridBodyCell} {
@@ -241,13 +245,19 @@ const StreamlineEventsTable = styled('div')`
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    a {
-      color: ${p => p.theme.textColor};
-    }
   }
-  a {
-    text-decoration: underline;
-    text-decoration-style: dotted;
-    text-decoration-color: ${p => p.theme.border};
+
+  ${GridRow} {
+    td:nth-child(2) {
+      padding-left: ${space(2)};
+    }
+
+    td:not(:nth-child(2)) {
+      a {
+        color: ${p => p.theme.textColor};
+        text-decoration: underline;
+        text-decoration-color: ${p => p.theme.border};
+      }
+    }
   }
 `;


### PR DESCRIPTION
- the event id will be blue and underlined, the rest should continue to be text color
- hides the pagination counts on zero because it said 1-0 events and was broken
- padding adjustments

before
![image](https://github.com/user-attachments/assets/bcbfec51-e870-41b7-a37b-1bcc01cf9ae9)

after
![image](https://github.com/user-attachments/assets/cb592154-56f8-4527-8b87-a6e48b2c7165)

