### PR TITLE
ref(grouping): Make `GroupingComponent` generic and add subclasses

### DIFF
--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -42,13 +42,13 @@ class BaseGroupingComponent[ValuesType: str | int | BaseGroupingComponent[Any]]:
 
     def __init__(
         self,
-        id: str,
+        id: str | None = None,
         hint: str | None = None,
         contributes: bool | None = None,
         values: Sequence[ValuesType] | None = None,
         variant_provider: bool = False,
     ):
-        self.id = id
+        self.id = id or self.id
         self.variant_provider = variant_provider
 
         self.update(

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -183,3 +183,139 @@ class BaseGroupingComponent[ValuesType: str | int | BaseGroupingComponent[Any]]:
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.id!r}, hint={self.hint!r}, contributes={self.contributes!r}, values={self.values!r})"
+
+
+# NOTE: In all of the classes below, the type(s) passed to `BaseGroupingComponent` represent
+# the type(s) which can appear in the `values` attribute
+
+
+# Error-related inner components
+
+
+class ContextLineGroupingComponent(BaseGroupingComponent[str]):
+    id: str = "context-line"
+
+
+class ErrorTypeGroupingComponent(BaseGroupingComponent[str]):
+    id: str = "type"
+
+
+class ErrorValueGroupingComponent(BaseGroupingComponent[str]):
+    id: str = "value"
+
+
+class FilenameGroupingComponent(BaseGroupingComponent[str]):
+    id: str = "filename"
+
+
+class FunctionGroupingComponent(BaseGroupingComponent[str]):
+    id: str = "function"
+
+
+class LineNumberGroupingComponent(BaseGroupingComponent[str]):
+    id: str = "lineno"
+
+
+class ModuleGroupingComponent(BaseGroupingComponent[str]):
+    id: str = "module"
+
+
+class NSErrorGroupingComponent(BaseGroupingComponent[str | int]):
+    id: str = "ns-error"
+
+
+class SymbolGroupingComponent(BaseGroupingComponent[str]):
+    id: str = "symbol"
+
+
+class FrameGroupingComponent(
+    BaseGroupingComponent[
+        ContextLineGroupingComponent
+        | FilenameGroupingComponent
+        | FunctionGroupingComponent
+        | LineNumberGroupingComponent  # only in legacy config
+        | ModuleGroupingComponent
+        | SymbolGroupingComponent  # only in legacy config
+    ]
+):
+    id: str = "frame"
+
+
+# Security-related inner components
+
+
+class HostnameGroupingComponent(BaseGroupingComponent[str]):
+    id: str = "hostname"
+
+
+class SaltGroupingComponent(BaseGroupingComponent[str]):
+    id: str = "salt"
+    hint: str = "a static salt"
+
+
+class ViolationGroupingComponent(BaseGroupingComponent[str]):
+    id: str = "violation"
+
+
+class URIGroupingComponent(BaseGroupingComponent[str]):
+    id: str = "uri"
+
+
+# Top-level components
+
+
+class MessageGroupingComponent(BaseGroupingComponent[str]):
+    id: str = "message"
+
+
+class StacktraceGroupingComponent(BaseGroupingComponent[FrameGroupingComponent]):
+    id: str = "stacktrace"
+
+
+class ExceptionGroupingComponent(
+    BaseGroupingComponent[
+        ErrorTypeGroupingComponent
+        | ErrorValueGroupingComponent
+        | NSErrorGroupingComponent
+        | StacktraceGroupingComponent
+    ]
+):
+    id: str = "exception"
+
+
+class ChainedExceptionGroupingComponent(BaseGroupingComponent[ExceptionGroupingComponent]):
+    id: str = "chained-exception"
+
+
+class ThreadsGroupingComponent(BaseGroupingComponent[StacktraceGroupingComponent]):
+    id: str = "threads"
+
+
+class CSPGroupingComponent(
+    BaseGroupingComponent[SaltGroupingComponent | ViolationGroupingComponent | URIGroupingComponent]
+):
+    id: str = "csp"
+
+
+class ExpectCTGroupingComponent(
+    BaseGroupingComponent[HostnameGroupingComponent | SaltGroupingComponent]
+):
+    id: str = "expect-ct"
+
+
+class ExpectStapleGroupingComponent(
+    BaseGroupingComponent[HostnameGroupingComponent | SaltGroupingComponent]
+):
+    id: str = "expect-staple"
+
+
+class HPKPGroupingComponent(
+    BaseGroupingComponent[HostnameGroupingComponent | SaltGroupingComponent]
+):
+    id: str = "hpkp"
+
+
+class TemplateGroupingComponent(
+    BaseGroupingComponent[ContextLineGroupingComponent | FilenameGroupingComponent]
+):
+    id: str = "template"

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -164,11 +164,11 @@ class Enhancements:
 
     def assemble_stacktrace_component(
         self,
-        components: list[BaseGroupingComponent],
+        components: list[BaseGroupingComponent[BaseGroupingComponent[str]]],
         frames: list[dict[str, Any]],
         platform: str | None,
         exception_data: dict[str, Any] | None = None,
-    ) -> tuple[BaseGroupingComponent, bool]:
+    ) -> tuple[BaseGroupingComponent[BaseGroupingComponent[BaseGroupingComponent[str]]], bool]:
         """
         This assembles a `stacktrace` grouping component out of the given
         `frame` components and source frames.
@@ -186,11 +186,13 @@ class Enhancements:
         for py_component, rust_component in zip(components, rust_components):
             py_component.update(contributes=rust_component.contributes, hint=rust_component.hint)
 
-        component = BaseGroupingComponent(
-            id="stacktrace",
-            values=components,
-            hint=rust_results.hint,
-            contributes=rust_results.contributes,
+        component: BaseGroupingComponent[BaseGroupingComponent[BaseGroupingComponent[str]]] = (
+            BaseGroupingComponent(
+                id="stacktrace",
+                values=components,
+                hint=rust_results.hint,
+                contributes=rust_results.contributes,
+            )
         )
 
         return component, rust_results.invert_stacktrace

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -15,7 +15,7 @@ from sentry_ophio.enhancers import Component as RustComponent
 from sentry_ophio.enhancers import Enhancements as RustEnhancements
 
 from sentry import projectoptions
-from sentry.grouping.component import BaseGroupingComponent
+from sentry.grouping.component import FrameGroupingComponent, StacktraceGroupingComponent
 from sentry.stacktraces.functions import set_in_app
 from sentry.utils.safe import get_path, set_path
 
@@ -164,11 +164,11 @@ class Enhancements:
 
     def assemble_stacktrace_component(
         self,
-        components: list[BaseGroupingComponent[BaseGroupingComponent[str]]],
+        components: list[FrameGroupingComponent],
         frames: list[dict[str, Any]],
         platform: str | None,
         exception_data: dict[str, Any] | None = None,
-    ) -> tuple[BaseGroupingComponent[BaseGroupingComponent[BaseGroupingComponent[str]]], bool]:
+    ) -> tuple[StacktraceGroupingComponent, bool]:
         """
         This assembles a `stacktrace` grouping component out of the given
         `frame` components and source frames.
@@ -186,13 +186,10 @@ class Enhancements:
         for py_component, rust_component in zip(components, rust_components):
             py_component.update(contributes=rust_component.contributes, hint=rust_component.hint)
 
-        component: BaseGroupingComponent[BaseGroupingComponent[BaseGroupingComponent[str]]] = (
-            BaseGroupingComponent(
-                id="stacktrace",
-                values=components,
-                hint=rust_results.hint,
-                contributes=rust_results.contributes,
-            )
+        component = StacktraceGroupingComponent(
+            values=components,
+            hint=rust_results.hint,
+            contributes=rust_results.contributes,
         )
 
         return component, rust_results.invert_stacktrace

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -1,12 +1,19 @@
 import inspect
 from collections.abc import Callable, Iterator, Sequence
-from typing import Any, Generic, Protocol, TypeVar
+from typing import Any, Generic, Protocol, TypeVar, overload
 
 from sentry import projectoptions
 from sentry.eventstore.models import Event
-from sentry.grouping.component import BaseGroupingComponent
+from sentry.grouping.component import (
+    BaseGroupingComponent,
+    ExceptionGroupingComponent,
+    FrameGroupingComponent,
+    StacktraceGroupingComponent,
+)
 from sentry.grouping.enhancer import Enhancements
 from sentry.interfaces.base import Interface
+from sentry.interfaces.exception import SingleException
+from sentry.interfaces.stacktrace import Frame, Stacktrace
 
 STRATEGIES: dict[str, "Strategy[Any]"] = {}
 
@@ -117,6 +124,21 @@ class GroupingContext:
         configured a fallback grouping component is returned.
         """
         return self._get_strategy_dict(interface, event=event, **kwargs)
+
+    @overload
+    def get_single_grouping_component(
+        self, interface: Frame, *, event: Event, **kwargs: Any
+    ) -> FrameGroupingComponent: ...
+
+    @overload
+    def get_single_grouping_component(
+        self, interface: SingleException, *, event: Event, **kwargs: Any
+    ) -> ExceptionGroupingComponent: ...
+
+    @overload
+    def get_single_grouping_component(
+        self, interface: Stacktrace, *, event: Event, **kwargs: Any
+    ) -> StacktraceGroupingComponent: ...
 
     def get_single_grouping_component(
         self, interface: Interface, *, event: Event, **kwargs: Any

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -24,7 +24,10 @@ ContextDict = dict[str, ContextValue]
 DEFAULT_GROUPING_ENHANCEMENTS_BASE = "common:2019-03-23"
 DEFAULT_GROUPING_FINGERPRINTING_BASES: list[str] = []
 
-ReturnedVariants = dict[str, BaseGroupingComponent]
+# TODO: Hack to make `ReturnedVariants` (no pun intended) covariant. At some point we should
+# probably turn `ReturnedVariants` into a Mapping (immutable), since in practice it's read-only.
+GroupingComponent = TypeVar("GroupingComponent", bound=BaseGroupingComponent[Any])
+ReturnedVariants = dict[str, GroupingComponent]
 ConcreteInterface = TypeVar("ConcreteInterface", bound=Interface, contravariant=True)
 
 

--- a/src/sentry/grouping/strategies/legacy.py
+++ b/src/sentry/grouping/strategies/legacy.py
@@ -3,7 +3,21 @@ import re
 from typing import Any
 
 from sentry.eventstore.models import Event
-from sentry.grouping.component import BaseGroupingComponent
+from sentry.grouping.component import (
+    ChainedExceptionGroupingComponent,
+    ContextLineGroupingComponent,
+    ErrorTypeGroupingComponent,
+    ErrorValueGroupingComponent,
+    ExceptionGroupingComponent,
+    FilenameGroupingComponent,
+    FrameGroupingComponent,
+    FunctionGroupingComponent,
+    LineNumberGroupingComponent,
+    ModuleGroupingComponent,
+    StacktraceGroupingComponent,
+    SymbolGroupingComponent,
+    ThreadsGroupingComponent,
+)
 from sentry.grouping.strategies.base import (
     GroupingContext,
     ReturnedVariants,
@@ -164,17 +178,15 @@ def single_exception_legacy(
     interface: SingleException, event: Event, context: GroupingContext, **meta: Any
 ) -> ReturnedVariants:
 
-    type_component = BaseGroupingComponent(
-        id="type",
+    type_component = ErrorTypeGroupingComponent(
         values=[interface.type] if interface.type else [],
         contributes=False,
     )
-    value_component = BaseGroupingComponent(
-        id="value",
+    value_component = ErrorValueGroupingComponent(
         values=[interface.value] if interface.value else [],
         contributes=False,
     )
-    stacktrace_component = BaseGroupingComponent(id="stacktrace")
+    stacktrace_component = StacktraceGroupingComponent()
 
     if interface.stacktrace is not None:
         stacktrace_component = context.get_single_grouping_component(
@@ -195,8 +207,8 @@ def single_exception_legacy(
             value_component.update(contributes=True)
 
     return {
-        context["variant"]: BaseGroupingComponent(
-            id="exception", values=[stacktrace_component, type_component, value_component]
+        context["variant"]: ExceptionGroupingComponent(
+            values=[stacktrace_component, type_component, value_component]
         )
     }
 
@@ -231,7 +243,7 @@ def chained_exception_legacy(
             if stacktrace_component is None or not stacktrace_component.contributes:
                 value.update(contributes=False, hint="exception has no stacktrace")
 
-    return {context["variant"]: BaseGroupingComponent(id="chained-exception", values=values)}
+    return {context["variant"]: ChainedExceptionGroupingComponent(values=values)}
 
 
 @chained_exception_legacy.variant_processor
@@ -262,7 +274,7 @@ def frame_legacy(
     # Safari throws [native code] frames in for calls like ``forEach``
     # whereas Chrome ignores these. Let's remove it from the hashing algo
     # so that they're more likely to group together
-    filename_component = BaseGroupingComponent(id="filename")
+    filename_component = FilenameGroupingComponent()
     if interface.filename == "<anonymous>":
         filename_component.update(
             contributes=False, values=[interface.filename], hint="anonymous filename discarded"
@@ -293,7 +305,7 @@ def frame_legacy(
     # if we have a module we use that for grouping.  This will always
     # take precedence over the filename, even if the module is
     # considered unhashable.
-    module_component = BaseGroupingComponent(id="module")
+    module_component = ModuleGroupingComponent()
     if interface.module:
         if is_unhashable_module_legacy(interface, platform):
             module_component.update(values=["<module>"], hint="normalized generated module name")
@@ -306,7 +318,7 @@ def frame_legacy(
             )
 
     # Context line when available is the primary contributor
-    context_line_component = BaseGroupingComponent(id="context-line")
+    context_line_component = ContextLineGroupingComponent()
     if interface.context_line is not None:
         if len(interface.context_line) > 120:
             context_line_component.update(hint="discarded because line too long")
@@ -315,9 +327,9 @@ def frame_legacy(
         else:
             context_line_component.update(values=[interface.context_line])
 
-    symbol_component = BaseGroupingComponent(id="symbol")
-    function_component = BaseGroupingComponent(id="function")
-    lineno_component = BaseGroupingComponent(id="lineno")
+    symbol_component = SymbolGroupingComponent()
+    function_component = FunctionGroupingComponent()
+    lineno_component = LineNumberGroupingComponent()
 
     # The context line grouping information is the most reliable one.
     # If we did not manage to find some information there, we want to
@@ -369,8 +381,7 @@ def frame_legacy(
             )
 
     return {
-        context["variant"]: BaseGroupingComponent(
-            id="frame",
+        context["variant"]: FrameGroupingComponent(
             values=[
                 module_component,
                 filename_component,
@@ -450,8 +461,7 @@ def threads_legacy(
     thread_count = len(interface.values)
     if thread_count != 1:
         return {
-            context["variant"]: BaseGroupingComponent(
-                id="threads",
+            context["variant"]: ThreadsGroupingComponent(
                 contributes=False,
                 hint="ignored because contains %d threads" % thread_count,
             )
@@ -460,14 +470,13 @@ def threads_legacy(
     stacktrace: Stacktrace = interface.values[0].get("stacktrace")
     if not stacktrace:
         return {
-            context["variant"]: BaseGroupingComponent(
-                id="threads", contributes=False, hint="thread has no stacktrace"
+            context["variant"]: ThreadsGroupingComponent(
+                contributes=False, hint="thread has no stacktrace"
             )
         }
 
     return {
-        context["variant"]: BaseGroupingComponent(
-            id="threads",
+        context["variant"]: ThreadsGroupingComponent(
             values=[context.get_single_grouping_component(stacktrace, event=event, **meta)],
         )
     }

--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -4,7 +4,7 @@ from typing import Any
 from sentry import analytics
 from sentry.eventstore.models import Event
 from sentry.features.rollout import in_rollout_group
-from sentry.grouping.component import BaseGroupingComponent
+from sentry.grouping.component import MessageGroupingComponent
 from sentry.grouping.parameterization import Parameterizer, UniqueIdExperiment
 from sentry.grouping.strategies.base import (
     GroupingContext,
@@ -108,17 +108,10 @@ def message_v1(
         raw = interface.message or interface.formatted or ""
         normalized = normalize_message_for_grouping(raw, event)
         hint = "stripped event-specific values" if raw != normalized else None
-        return {
-            context["variant"]: BaseGroupingComponent(
-                id="message",
-                values=[normalized],
-                hint=hint,
-            )
-        }
+        return {context["variant"]: MessageGroupingComponent(values=[normalized], hint=hint)}
     else:
         return {
-            context["variant"]: BaseGroupingComponent(
-                id="message",
+            context["variant"]: MessageGroupingComponent(
                 values=[interface.message or interface.formatted or ""],
             )
         }

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -7,7 +7,20 @@ from collections.abc import Generator
 from typing import Any
 
 from sentry.eventstore.models import Event
-from sentry.grouping.component import BaseGroupingComponent
+from sentry.grouping.component import (
+    ChainedExceptionGroupingComponent,
+    ContextLineGroupingComponent,
+    ErrorTypeGroupingComponent,
+    ErrorValueGroupingComponent,
+    ExceptionGroupingComponent,
+    FilenameGroupingComponent,
+    FrameGroupingComponent,
+    FunctionGroupingComponent,
+    ModuleGroupingComponent,
+    NSErrorGroupingComponent,
+    StacktraceGroupingComponent,
+    ThreadsGroupingComponent,
+)
 from sentry.grouping.strategies.base import (
     GroupingContext,
     ReturnedVariants,
@@ -116,20 +129,17 @@ def get_filename_component(
     filename: str | None,
     platform: str | None,
     allow_file_origin: bool = False,
-) -> BaseGroupingComponent:
+) -> FilenameGroupingComponent:
     """Attempt to normalize filenames by detecting special filenames and by
     using the basename only.
     """
     if filename is None:
-        return BaseGroupingComponent(id="filename")
+        return FilenameGroupingComponent()
 
     # Only use the platform independent basename for grouping and
     # lowercase it
     filename = _basename_re.split(filename)[-1].lower()
-    filename_component = BaseGroupingComponent(
-        id="filename",
-        values=[filename],
-    )
+    filename_component = FilenameGroupingComponent(values=[filename])
 
     if has_url_origin(abs_path, allow_file_origin=allow_file_origin):
         filename_component.update(contributes=False, hint="ignored because frame points to a URL")
@@ -151,17 +161,14 @@ def get_module_component(
     module: str | None,
     platform: str | None,
     context: GroupingContext,
-) -> BaseGroupingComponent:
+) -> ModuleGroupingComponent:
     """Given an absolute path, module and platform returns the module component
     with some necessary cleaning performed.
     """
     if module is None:
-        return BaseGroupingComponent(id="module")
+        return ModuleGroupingComponent()
 
-    module_component = BaseGroupingComponent(
-        id="module",
-        values=[module],
-    )
+    module_component = ModuleGroupingComponent(values=[module])
 
     if platform == "javascript" and "/" in module and abs_path and abs_path.endswith(module):
         module_component.update(contributes=False, hint="ignored bad javascript module")
@@ -200,7 +207,7 @@ def get_function_component(
     platform: str | None,
     sourcemap_used: bool = False,
     context_line_available: bool = False,
-) -> BaseGroupingComponent:
+) -> FunctionGroupingComponent:
     """
     Attempt to normalize functions by removing common platform outliers.
 
@@ -230,12 +237,9 @@ def get_function_component(
             func = trim_function_name(func, platform)
 
     if not func:
-        return BaseGroupingComponent(id="function")
+        return FunctionGroupingComponent()
 
-    function_component = BaseGroupingComponent(
-        id="function",
-        values=[func],
-    )
+    function_component = FunctionGroupingComponent(values=[func])
 
     if platform == "ruby":
         if func.startswith("block "):
@@ -328,11 +332,16 @@ def frame(
         context_line_available=context_line_available,
     )
 
-    values = [module_component, filename_component, function_component]
+    values: list[
+        ContextLineGroupingComponent
+        | FilenameGroupingComponent
+        | FunctionGroupingComponent
+        | ModuleGroupingComponent
+    ] = [module_component, filename_component, function_component]
     if context_line_component is not None:
         values.append(context_line_component)
 
-    rv = BaseGroupingComponent(id="frame", values=values)
+    rv = FrameGroupingComponent(values=values)
 
     # if we are in javascript fuzzing mode we want to disregard some
     # frames consistently.  These force common bad stacktraces together
@@ -368,7 +377,7 @@ def frame(
 
 def get_contextline_component(
     frame: Frame, platform: str | None, function: str, context: GroupingContext
-) -> BaseGroupingComponent:
+) -> ContextLineGroupingComponent:
     """Returns a contextline component.  The caller's responsibility is to
     make sure context lines are only used for platforms where we trust the
     quality of the sourcecode.  It does however protect against some bad
@@ -376,12 +385,9 @@ def get_contextline_component(
     """
     line = " ".join((frame.context_line or "").expandtabs(2).split())
     if not line:
-        return BaseGroupingComponent(id="context-line")
+        return ContextLineGroupingComponent()
 
-    component = BaseGroupingComponent(
-        id="context-line",
-        values=[line],
-    )
+    component = ContextLineGroupingComponent(values=[line])
     if line:
         if len(frame.context_line) > 120:
             component.update(hint="discarded because line too long", contributes=False)
@@ -498,8 +504,7 @@ def stacktrace_variant_processor(
 def single_exception(
     interface: SingleException, event: Event, context: GroupingContext, **meta: Any
 ) -> ReturnedVariants:
-    type_component = BaseGroupingComponent(
-        id="type",
+    type_component = ErrorTypeGroupingComponent(
         values=[interface.type] if interface.type else [],
     )
     system_type_component = type_component.shallow_copy()
@@ -522,8 +527,7 @@ def single_exception(
                 contributes=False, hint="ignored because exception is synthetic"
             )
         if interface.mechanism.meta and "ns_error" in interface.mechanism.meta:
-            ns_error_component = BaseGroupingComponent(
-                id="ns-error",
+            ns_error_component = NSErrorGroupingComponent(
                 values=[
                     interface.mechanism.meta["ns_error"].get("domain"),
                     interface.mechanism.meta["ns_error"].get("code"),
@@ -533,18 +537,23 @@ def single_exception(
     if interface.stacktrace is not None:
         with context:
             context["exception_data"] = interface.to_json()
-            stacktrace_variants = context.get_grouping_component(
-                interface.stacktrace, event=event, **meta
+            stacktrace_variants: dict[str, StacktraceGroupingComponent] = (
+                context.get_grouping_component(interface.stacktrace, event=event, **meta)
             )
     else:
         stacktrace_variants = {
-            "app": BaseGroupingComponent(id="stacktrace"),
+            "app": StacktraceGroupingComponent(),
         }
 
     rv = {}
 
     for variant, stacktrace_component in stacktrace_variants.items():
-        values = [
+        values: list[
+            ErrorTypeGroupingComponent
+            | ErrorValueGroupingComponent
+            | NSErrorGroupingComponent
+            | StacktraceGroupingComponent
+        ] = [
             stacktrace_component,
             system_type_component if variant == "system" else type_component,
         ]
@@ -553,9 +562,7 @@ def single_exception(
             values.append(ns_error_component)
 
         if context["with_exception_value_fallback"]:
-            value_component = BaseGroupingComponent(
-                id="value",
-            )
+            value_component = ErrorValueGroupingComponent()
 
             raw = interface.value
             if raw is not None:
@@ -587,7 +594,7 @@ def single_exception(
 
             values.append(value_component)
 
-        rv[variant] = BaseGroupingComponent(id="exception", values=values)
+        rv[variant] = ExceptionGroupingComponent(values=values)
 
     return rv
 
@@ -628,7 +635,7 @@ def chained_exception(
         return exception_components[id(exceptions[0])]
 
     # Case 2: produce a component for each chained exception
-    by_name: dict[str, list[BaseGroupingComponent]] = {}
+    by_name: dict[str, list[ExceptionGroupingComponent]] = {}
 
     for exception in exceptions:
         for name, component in exception_components[id(exception)].items():
@@ -637,10 +644,7 @@ def chained_exception(
     rv = {}
 
     for name, component_list in by_name.items():
-        rv[name] = BaseGroupingComponent(
-            id="chained-exception",
-            values=component_list,
-        )
+        rv[name] = ChainedExceptionGroupingComponent(values=component_list)
 
     return rv
 
@@ -777,8 +781,7 @@ def threads(
         return thread_variants
 
     return {
-        "app": BaseGroupingComponent(
-            id="threads",
+        "app": ThreadsGroupingComponent(
             contributes=False,
             hint=(
                 "ignored because does not contain exactly one crashing, "
@@ -797,18 +800,14 @@ def _filtered_threads(
 
     stacktrace = threads[0].get("stacktrace")
     if not stacktrace:
-        return {
-            "app": BaseGroupingComponent(
-                id="threads", contributes=False, hint="thread has no stacktrace"
-            )
-        }
+        return {"app": ThreadsGroupingComponent(contributes=False, hint="thread has no stacktrace")}
 
     rv = {}
 
     for name, stacktrace_component in context.get_grouping_component(
         stacktrace, event=event, **meta
     ).items():
-        rv[name] = BaseGroupingComponent(id="threads", values=[stacktrace_component])
+        rv[name] = ThreadsGroupingComponent(values=[stacktrace_component])
 
     return rv
 

--- a/src/sentry/grouping/strategies/security.py
+++ b/src/sentry/grouping/strategies/security.py
@@ -62,8 +62,8 @@ def hpkp_v1(
 @strategy(ids=["csp:v1"], interface=Csp, score=1003)
 @produces_variants(["default"])
 def csp_v1(interface: Csp, event: Event, context: GroupingContext, **meta: Any) -> ReturnedVariants:
-    violation_component = BaseGroupingComponent(id="violation")
-    uri_component = BaseGroupingComponent(id="uri")
+    violation_component: BaseGroupingComponent[str] = BaseGroupingComponent(id="violation")
+    uri_component: BaseGroupingComponent[str] = BaseGroupingComponent(id="uri")
 
     if interface.local_script_violation_type:
         violation_component.update(values=["'%s'" % interface.local_script_violation_type])

--- a/src/sentry/grouping/strategies/security.py
+++ b/src/sentry/grouping/strategies/security.py
@@ -1,7 +1,16 @@
 from typing import Any
 
 from sentry.eventstore.models import Event
-from sentry.grouping.component import BaseGroupingComponent
+from sentry.grouping.component import (
+    CSPGroupingComponent,
+    ExpectCTGroupingComponent,
+    ExpectStapleGroupingComponent,
+    HostnameGroupingComponent,
+    HPKPGroupingComponent,
+    SaltGroupingComponent,
+    URIGroupingComponent,
+    ViolationGroupingComponent,
+)
 from sentry.grouping.strategies.base import (
     GroupingContext,
     ReturnedVariants,
@@ -17,11 +26,10 @@ def expect_ct_v1(
     interface: ExpectCT, event: Event, context: GroupingContext, **meta: Any
 ) -> ReturnedVariants:
     return {
-        context["variant"]: BaseGroupingComponent(
-            id="expect-ct",
+        context["variant"]: ExpectCTGroupingComponent(
             values=[
-                BaseGroupingComponent(id="salt", values=["expect-ct"]),
-                BaseGroupingComponent(id="hostname", values=[interface.hostname]),
+                SaltGroupingComponent(values=["expect-ct"]),
+                HostnameGroupingComponent(values=[interface.hostname]),
             ],
         )
     }
@@ -33,11 +41,10 @@ def expect_staple_v1(
     interface: ExpectStaple, event: Event, context: GroupingContext, **meta: Any
 ) -> ReturnedVariants:
     return {
-        context["variant"]: BaseGroupingComponent(
-            id="expect-staple",
+        context["variant"]: ExpectStapleGroupingComponent(
             values=[
-                BaseGroupingComponent(id="salt", values=["expect-staple"]),
-                BaseGroupingComponent(id="hostname", values=[interface.hostname]),
+                SaltGroupingComponent(values=["expect-staple"]),
+                HostnameGroupingComponent(values=[interface.hostname]),
             ],
         )
     }
@@ -49,11 +56,10 @@ def hpkp_v1(
     interface: Hpkp, event: Event, context: GroupingContext, **meta: Any
 ) -> ReturnedVariants:
     return {
-        context["variant"]: BaseGroupingComponent(
-            id="hpkp",
+        context["variant"]: HPKPGroupingComponent(
             values=[
-                BaseGroupingComponent(id="salt", values=["hpkp"]),
-                BaseGroupingComponent(id="hostname", values=[interface.hostname]),
+                SaltGroupingComponent(values=["hpkp"]),
+                HostnameGroupingComponent(values=[interface.hostname]),
             ],
         )
     }
@@ -62,8 +68,8 @@ def hpkp_v1(
 @strategy(ids=["csp:v1"], interface=Csp, score=1003)
 @produces_variants(["default"])
 def csp_v1(interface: Csp, event: Event, context: GroupingContext, **meta: Any) -> ReturnedVariants:
-    violation_component: BaseGroupingComponent[str] = BaseGroupingComponent(id="violation")
-    uri_component: BaseGroupingComponent[str] = BaseGroupingComponent(id="uri")
+    violation_component = ViolationGroupingComponent()
+    uri_component = URIGroupingComponent()
 
     if interface.local_script_violation_type:
         violation_component.update(values=["'%s'" % interface.local_script_violation_type])
@@ -77,10 +83,9 @@ def csp_v1(interface: Csp, event: Event, context: GroupingContext, **meta: Any) 
         uri_component.update(values=[interface.normalized_blocked_uri])
 
     return {
-        context["variant"]: BaseGroupingComponent(
-            id="csp",
+        context["variant"]: CSPGroupingComponent(
             values=[
-                BaseGroupingComponent(id="salt", values=[interface.effective_directive]),
+                SaltGroupingComponent(values=[interface.effective_directive]),
                 violation_component,
                 uri_component,
             ],

--- a/src/sentry/grouping/strategies/template.py
+++ b/src/sentry/grouping/strategies/template.py
@@ -1,7 +1,11 @@
 from typing import Any
 
 from sentry.eventstore.models import Event
-from sentry.grouping.component import BaseGroupingComponent
+from sentry.grouping.component import (
+    ContextLineGroupingComponent,
+    FilenameGroupingComponent,
+    TemplateGroupingComponent,
+)
 from sentry.grouping.strategies.base import (
     GroupingContext,
     ReturnedVariants,
@@ -16,16 +20,16 @@ from sentry.interfaces.template import Template
 def template_v1(
     interface: Template, event: Event, context: GroupingContext, **meta: Any
 ) -> ReturnedVariants:
-    filename_component: BaseGroupingComponent[str] = BaseGroupingComponent(id="filename")
+    filename_component = FilenameGroupingComponent()
     if interface.filename is not None:
         filename_component.update(values=[interface.filename])
 
-    context_line_component: BaseGroupingComponent[str] = BaseGroupingComponent(id="context-line")
+    context_line_component = ContextLineGroupingComponent()
     if interface.context_line is not None:
         context_line_component.update(values=[interface.context_line])
 
     return {
-        context["variant"]: BaseGroupingComponent(
-            id="template", values=[filename_component, context_line_component]
+        context["variant"]: TemplateGroupingComponent(
+            values=[filename_component, context_line_component]
         )
     }

--- a/src/sentry/grouping/strategies/template.py
+++ b/src/sentry/grouping/strategies/template.py
@@ -16,11 +16,11 @@ from sentry.interfaces.template import Template
 def template_v1(
     interface: Template, event: Event, context: GroupingContext, **meta: Any
 ) -> ReturnedVariants:
-    filename_component = BaseGroupingComponent(id="filename")
+    filename_component: BaseGroupingComponent[str] = BaseGroupingComponent(id="filename")
     if interface.filename is not None:
         filename_component.update(values=[interface.filename])
 
-    context_line_component = BaseGroupingComponent(id="context-line")
+    context_line_component: BaseGroupingComponent[str] = BaseGroupingComponent(id="context-line")
     if interface.context_line is not None:
         context_line_component.update(values=[interface.context_line])
 


### PR DESCRIPTION
This adds a full taxonomy of `BaseGroupingCompontent` subclasses, partially just as a form of documentation (we create this deeply nested `variants` structure when grouping, and it's helpful to understand what kind of data is in each part), and partially so that it's easier to write helpers dealing with different kinds of components and not have to constantly be checking for the presence of this or that attribute.

Key changes:

- Make `BaseGroupingComponent` generic, so that subclasses can specify the types allowed in `values`.
- Allow `id` to be a class attribute (no longer require it to be passed to `__init__`), so that it can be specified in each subclass.
- Add overloads of `get_single_grouping_component`.
- Use a `TypeVar` to make `ReturnedVariants` covaraint. This is a bit of a hack, but fixing it will require a larger change than felt reasonable here. (Basically, we'll have to make everywhere it's used treat it as read-only.) I left a TODO.