### PR TITLE
ref(grouping): Small refactor of the `GroupingComponent` class

### DIFF
--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -23,7 +23,7 @@ KNOWN_MAJOR_COMPONENT_NAMES = {
 }
 
 
-def _calculate_contributes(values: Sequence[str | GroupingComponent]) -> bool:
+def _calculate_contributes(values: Sequence[str | int | GroupingComponent]) -> bool:
     for value in values or ():
         if not isinstance(value, GroupingComponent) or value.contributes:
             return True
@@ -38,14 +38,14 @@ class GroupingComponent:
     id: str = "default"
     hint: str | None = None
     contributes: bool = False
-    values: Sequence[str | GroupingComponent]
+    values: Sequence[str | int | GroupingComponent]
 
     def __init__(
         self,
         id: str,
         hint: str | None = None,
         contributes: bool | None = None,
-        values: Sequence[str | GroupingComponent] | None = None,
+        values: Sequence[str | int | GroupingComponent] | None = None,
         variant_provider: bool = False,
     ):
         self.id = id
@@ -99,13 +99,13 @@ class GroupingComponent:
 
     def get_subcomponent(
         self, id: str, only_contributing: bool = False
-    ) -> str | GroupingComponent | None:
+    ) -> str | int | GroupingComponent | None:
         """Looks up a subcomponent by the id and returns the first or `None`."""
         return next(self.iter_subcomponents(id=id, only_contributing=only_contributing), None)
 
     def iter_subcomponents(
         self, id: str, recursive: bool = False, only_contributing: bool = False
-    ) -> Iterator[str | GroupingComponent | None]:
+    ) -> Iterator[str | int | GroupingComponent | None]:
         """Finds all subcomponents matching an id, optionally recursively."""
         for value in self.values:
             if isinstance(value, GroupingComponent):
@@ -123,7 +123,7 @@ class GroupingComponent:
         self,
         hint: str | None = None,
         contributes: bool | None = None,
-        values: Sequence[str | GroupingComponent] | None = None,
+        values: Sequence[str | int | GroupingComponent] | None = None,
     ) -> None:
         """Updates an already existing component with new values."""
         if hint is not None:
@@ -142,7 +142,7 @@ class GroupingComponent:
         rv.values = list(self.values)
         return rv
 
-    def iter_values(self) -> Generator[str | GroupingComponent]:
+    def iter_values(self) -> Generator[str | int | GroupingComponent]:
         """Recursively walks the component and flattens it into a list of
         values.
         """

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -49,17 +49,12 @@ class GroupingComponent:
         variant_provider: bool = False,
     ):
         self.id = id
-
-        # Default values
-        self.hint = DEFAULT_HINTS.get(id)
-        self.contributes = contributes
         self.variant_provider = variant_provider
-        self.values: Sequence[str | GroupingComponent] = []
 
         self.update(
-            hint=hint,
+            hint=hint or DEFAULT_HINTS.get(self.id),
             contributes=contributes,
-            values=values,
+            values=values or [],
         )
 
     @property

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -180,4 +180,4 @@ class GroupingComponent:
         return rv
 
     def __repr__(self) -> str:
-        return f"GroupingComponent({self.id!r}, hint={self.hint!r}, contributes={self.contributes!r}, values={self.values!r})"
+        return f"{self.__class__.__name__}({self.id!r}, hint={self.hint!r}, contributes={self.contributes!r}, values={self.values!r})"

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -35,6 +35,11 @@ class GroupingComponent:
     into components to make a hash for grouping purposes.
     """
 
+    id: str = "default"
+    hint: str | None = None
+    contributes: bool = False
+    values: Sequence[str | GroupingComponent]
+
     def __init__(
         self,
         id: str,


### PR DESCRIPTION
This makes a few small changes to the `GroupingComponent` class, in preparation for the creation of a more detailed taxonomy of subclasses, which will happen in https://github.com/getsentry/sentry/pull/80722.

- Add class-level type declarations, with defaults.
- Use the class name (rather than hardcoded `GroupingComponent`) in `__repr__`.
- Add `int` to the `values` list type. (This is more of a bug fix, though it's also a necessary for the upcoming changes. In fact, `values` has always been able to contain ints, but the incoming data isn't super strictly typed, so typechecking has passed even with this missing.)
- Simplify the way that values are set in `__init__`.