### PR TITLE
ref(grouping): Simplify security report grouping strategies

### DIFF
--- a/src/sentry/grouping/strategies/security.py
+++ b/src/sentry/grouping/strategies/security.py
@@ -8,21 +8,7 @@ from sentry.grouping.strategies.base import (
     produces_variants,
     strategy,
 )
-from sentry.interfaces.security import Csp, ExpectCT, ExpectStaple, Hpkp, SecurityReport
-
-
-def _security_v1(
-    reported_id: str, obj: SecurityReport, context: GroupingContext, **meta: Any
-) -> ReturnedVariants:
-    return {
-        context["variant"]: BaseGroupingComponent(
-            id=reported_id,
-            values=[
-                BaseGroupingComponent(id="salt", values=[reported_id]),
-                BaseGroupingComponent(id="hostname", values=[obj.hostname]),
-            ],
-        )
-    }
+from sentry.interfaces.security import Csp, ExpectCT, ExpectStaple, Hpkp
 
 
 @strategy(ids=["expect-ct:v1"], interface=ExpectCT, score=1000)
@@ -30,7 +16,15 @@ def _security_v1(
 def expect_ct_v1(
     interface: ExpectCT, event: Event, context: GroupingContext, **meta: Any
 ) -> ReturnedVariants:
-    return _security_v1("expect-ct", interface, context=context, **meta)
+    return {
+        context["variant"]: BaseGroupingComponent(
+            id="expect-ct",
+            values=[
+                BaseGroupingComponent(id="salt", values=["expect-ct"]),
+                BaseGroupingComponent(id="hostname", values=[interface.hostname]),
+            ],
+        )
+    }
 
 
 @strategy(ids=["expect-staple:v1"], interface=ExpectStaple, score=1001)
@@ -38,7 +32,15 @@ def expect_ct_v1(
 def expect_staple_v1(
     interface: ExpectStaple, event: Event, context: GroupingContext, **meta: Any
 ) -> ReturnedVariants:
-    return _security_v1("expect-staple", interface, context=context, **meta)
+    return {
+        context["variant"]: BaseGroupingComponent(
+            id="expect-staple",
+            values=[
+                BaseGroupingComponent(id="salt", values=["expect-staple"]),
+                BaseGroupingComponent(id="hostname", values=[interface.hostname]),
+            ],
+        )
+    }
 
 
 @strategy(ids=["hpkp:v1"], interface=Hpkp, score=1002)
@@ -46,7 +48,15 @@ def expect_staple_v1(
 def hpkp_v1(
     interface: Hpkp, event: Event, context: GroupingContext, **meta: Any
 ) -> ReturnedVariants:
-    return _security_v1("hpkp", interface, context=context, **meta)
+    return {
+        context["variant"]: BaseGroupingComponent(
+            id="hpkp",
+            values=[
+                BaseGroupingComponent(id="salt", values=["hpkp"]),
+                BaseGroupingComponent(id="hostname", values=[interface.hostname]),
+            ],
+        )
+    }
 
 
 @strategy(ids=["csp:v1"], interface=Csp, score=1003)


### PR DESCRIPTION
This simplifies the non-CSP security-related grouping strategies, to no longer require a helper function but instead just return their requisite components directly. (Basically, each one now inlines the helper's return value.) Doing this will allow each one to return a different subclass of `BaseGroupingComponent`, as will be done in https://github.com/getsentry/sentry/pull/80722.