### PR TITLE
fix(dynamic-sampling): Prevent calculations with unclamped form values

### DIFF
--- a/static/app/views/settings/dynamicSampling/organizationSampling.tsx
+++ b/static/app/views/settings/dynamicSampling/organizationSampling.tsx
@@ -18,6 +18,7 @@ import {ProjectsPreviewTable} from 'sentry/views/settings/dynamicSampling/projec
 import {SamplingModeField} from 'sentry/views/settings/dynamicSampling/samplingModeField';
 import {useHasDynamicSamplingWriteAccess} from 'sentry/views/settings/dynamicSampling/utils/access';
 import {organizationSamplingForm} from 'sentry/views/settings/dynamicSampling/utils/organizationSamplingForm';
+import {parsePercent} from 'sentry/views/settings/dynamicSampling/utils/parsePercent';
 import {
   type ProjectionSamplePeriod,
   useProjectSampleCounts,
@@ -47,7 +48,7 @@ export function OrganizationSampling() {
   const handleSubmit = () => {
     updateOrganization(
       {
-        targetSampleRate: Number(formState.fields.targetSampleRate.value) / 100,
+        targetSampleRate: parsePercent(formState.fields.targetSampleRate.value),
       },
       {
         onSuccess: () => {

--- a/static/app/views/settings/dynamicSampling/projectSampling.tsx
+++ b/static/app/views/settings/dynamicSampling/projectSampling.tsx
@@ -18,6 +18,7 @@ import {ProjectionPeriodControl} from 'sentry/views/settings/dynamicSampling/pro
 import {ProjectsEditTable} from 'sentry/views/settings/dynamicSampling/projectsEditTable';
 import {SamplingModeField} from 'sentry/views/settings/dynamicSampling/samplingModeField';
 import {useHasDynamicSamplingWriteAccess} from 'sentry/views/settings/dynamicSampling/utils/access';
+import {parsePercent} from 'sentry/views/settings/dynamicSampling/utils/parsePercent';
 import {projectSamplingForm} from 'sentry/views/settings/dynamicSampling/utils/projectSamplingForm';
 import {
   type ProjectionSamplePeriod,
@@ -70,7 +71,7 @@ export function ProjectSampling() {
     const ratesArray = Object.entries(formState.fields.projectRates.value).map(
       ([id, rate]) => ({
         id: Number(id),
-        sampleRate: Number(rate) / 100,
+        sampleRate: parsePercent(rate),
       })
     );
     addLoadingMessage(t('Saving changes...'));

--- a/static/app/views/settings/dynamicSampling/projectSampling.tsx
+++ b/static/app/views/settings/dynamicSampling/projectSampling.tsx
@@ -161,7 +161,7 @@ export function ProjectSampling() {
           </Button>
           <Button
             priority="primary"
-            disabled={isFormActionDisabled}
+            disabled={isFormActionDisabled || !formState.isValid}
             onClick={handleSubmit}
           >
             {t('Apply Changes')}

--- a/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
@@ -15,6 +15,7 @@ import {PercentInput} from 'sentry/views/settings/dynamicSampling/percentInput';
 import {ProjectsTable} from 'sentry/views/settings/dynamicSampling/projectsTable';
 import {SamplingBreakdown} from 'sentry/views/settings/dynamicSampling/samplingBreakdown';
 import {useHasDynamicSamplingWriteAccess} from 'sentry/views/settings/dynamicSampling/utils/access';
+import {clampPercent} from 'sentry/views/settings/dynamicSampling/utils/clampNumer';
 import {projectSamplingForm} from 'sentry/views/settings/dynamicSampling/utils/projectSamplingForm';
 import {scaleSampleRates} from 'sentry/views/settings/dynamicSampling/utils/scaleSampleRates';
 import type {ProjectSampleCount} from 'sentry/views/settings/dynamicSampling/utils/useProjectSampleCounts';
@@ -80,7 +81,7 @@ export function ProjectsEditTable({
       if (editMode === 'single') {
         projectRateSnapshotRef.current = value;
       }
-      const cappedOrgRate = Math.min(100, Math.max(0, Number(newRate))) ?? 100;
+      const cappedOrgRate = clampPercent(Number(newRate) ?? 100);
 
       const scalingItems = Object.entries(projectRateSnapshotRef.current)
         .map(([projectId, rate]) => ({
@@ -142,7 +143,8 @@ export function ProjectsEditTable({
       return orgRate;
     }
     const totalSampledSpans = items.reduce(
-      (acc, item) => acc + item.count * Number(value[item.project.id] ?? 100),
+      (acc, item) =>
+        acc + item.count * clampPercent(Number(value[item.project.id] ?? 100)),
       0
     );
     return formatNumberWithDynamicDecimalPoints(totalSampledSpans / totalSpanCount, 2);

--- a/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
@@ -15,7 +15,7 @@ import {PercentInput} from 'sentry/views/settings/dynamicSampling/percentInput';
 import {ProjectsTable} from 'sentry/views/settings/dynamicSampling/projectsTable';
 import {SamplingBreakdown} from 'sentry/views/settings/dynamicSampling/samplingBreakdown';
 import {useHasDynamicSamplingWriteAccess} from 'sentry/views/settings/dynamicSampling/utils/access';
-import {clampPercent} from 'sentry/views/settings/dynamicSampling/utils/clampNumer';
+import {parsePercent} from 'sentry/views/settings/dynamicSampling/utils/parsePercent';
 import {projectSamplingForm} from 'sentry/views/settings/dynamicSampling/utils/projectSamplingForm';
 import {scaleSampleRates} from 'sentry/views/settings/dynamicSampling/utils/scaleSampleRates';
 import type {ProjectSampleCount} from 'sentry/views/settings/dynamicSampling/utils/useProjectSampleCounts';
@@ -81,12 +81,12 @@ export function ProjectsEditTable({
       if (editMode === 'single') {
         projectRateSnapshotRef.current = value;
       }
-      const cappedOrgRate = clampPercent(Number(newRate) ?? 100);
+      const cappedOrgRate = parsePercent(newRate, 1);
 
       const scalingItems = Object.entries(projectRateSnapshotRef.current)
         .map(([projectId, rate]) => ({
           id: projectId,
-          sampleRate: rate ? Number(rate) / 100 : 0,
+          sampleRate: rate ? parsePercent(rate) : 0,
           count: dataByProjectId[projectId]?.count ?? 0,
         }))
         // We do not wan't to bulk edit inactive projects as they have no effect on the outcome
@@ -94,7 +94,7 @@ export function ProjectsEditTable({
 
       const {scaledItems} = scaleSampleRates({
         items: scalingItems,
-        sampleRate: cappedOrgRate / 100,
+        sampleRate: cappedOrgRate,
       });
 
       const newProjectValues = scaledItems.reduce((acc, item) => {
@@ -143,26 +143,31 @@ export function ProjectsEditTable({
       return orgRate;
     }
     const totalSampledSpans = items.reduce(
-      (acc, item) =>
-        acc + item.count * clampPercent(Number(value[item.project.id] ?? 100)),
+      (acc, item) => acc + item.count * parsePercent(value[item.project.id], 1),
       0
     );
-    return formatNumberWithDynamicDecimalPoints(totalSampledSpans / totalSpanCount, 2);
+    return formatNumberWithDynamicDecimalPoints(
+      (totalSampledSpans / totalSpanCount) * 100,
+      2
+    );
   }, [editMode, items, orgRate, totalSpanCount, value]);
 
   const initialOrgRate = useMemo(() => {
     const totalSampledSpans = items.reduce(
-      (acc, item) => acc + item.count * Number(initialValue[item.project.id] ?? 100),
+      (acc, item) => acc + item.count * parsePercent(initialValue[item.project.id], 1),
       0
     );
-    return formatNumberWithDynamicDecimalPoints(totalSampledSpans / totalSpanCount, 2);
+    return formatNumberWithDynamicDecimalPoints(
+      (totalSampledSpans / totalSpanCount) * 100,
+      2
+    );
   }, [initialValue, items, totalSpanCount]);
 
   const breakdownSampleRates = useMemo(
     () =>
       Object.entries(value).reduce(
         (acc, [projectId, rate]) => {
-          acc[projectId] = Number(rate) / 100;
+          acc[projectId] = parsePercent(rate);
           return acc;
         },
         {} as Record<string, number>

--- a/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
@@ -9,12 +9,12 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {formatNumberWithDynamicDecimalPoints} from 'sentry/utils/number/formatNumberWithDynamicDecimalPoints';
 import useProjects from 'sentry/utils/useProjects';
 import {PercentInput} from 'sentry/views/settings/dynamicSampling/percentInput';
 import {ProjectsTable} from 'sentry/views/settings/dynamicSampling/projectsTable';
 import {SamplingBreakdown} from 'sentry/views/settings/dynamicSampling/samplingBreakdown';
 import {useHasDynamicSamplingWriteAccess} from 'sentry/views/settings/dynamicSampling/utils/access';
+import {formatPercent} from 'sentry/views/settings/dynamicSampling/utils/formatPercent';
 import {parsePercent} from 'sentry/views/settings/dynamicSampling/utils/parsePercent';
 import {projectSamplingForm} from 'sentry/views/settings/dynamicSampling/utils/projectSamplingForm';
 import {scaleSampleRates} from 'sentry/views/settings/dynamicSampling/utils/scaleSampleRates';
@@ -98,7 +98,7 @@ export function ProjectsEditTable({
       });
 
       const newProjectValues = scaledItems.reduce((acc, item) => {
-        acc[item.id] = formatNumberWithDynamicDecimalPoints(item.sampleRate * 100, 2);
+        acc[item.id] = formatPercent(item.sampleRate);
         return acc;
       }, {});
       onChange(prev => {
@@ -146,10 +146,7 @@ export function ProjectsEditTable({
       (acc, item) => acc + item.count * parsePercent(value[item.project.id], 1),
       0
     );
-    return formatNumberWithDynamicDecimalPoints(
-      (totalSampledSpans / totalSpanCount) * 100,
-      2
-    );
+    return formatPercent(totalSampledSpans / totalSpanCount);
   }, [editMode, items, orgRate, totalSpanCount, value]);
 
   const initialOrgRate = useMemo(() => {
@@ -157,10 +154,7 @@ export function ProjectsEditTable({
       (acc, item) => acc + item.count * parsePercent(initialValue[item.project.id], 1),
       0
     );
-    return formatNumberWithDynamicDecimalPoints(
-      (totalSampledSpans / totalSpanCount) * 100,
-      2
-    );
+    return formatPercent(totalSampledSpans / totalSpanCount);
   }, [initialValue, items, totalSpanCount]);
 
   const breakdownSampleRates = useMemo(

--- a/static/app/views/settings/dynamicSampling/projectsPreviewTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsPreviewTable.tsx
@@ -10,6 +10,7 @@ import {formatNumberWithDynamicDecimalPoints} from 'sentry/utils/number/formatNu
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {ProjectsTable} from 'sentry/views/settings/dynamicSampling/projectsTable';
 import {SamplingBreakdown} from 'sentry/views/settings/dynamicSampling/samplingBreakdown';
+import {clampPercent} from 'sentry/views/settings/dynamicSampling/utils/clampNumer';
 import {organizationSamplingForm} from 'sentry/views/settings/dynamicSampling/utils/organizationSamplingForm';
 import {balanceSampleRate} from 'sentry/views/settings/dynamicSampling/utils/rebalancing';
 import type {ProjectSampleCount} from 'sentry/views/settings/dynamicSampling/utils/useProjectSampleCounts';
@@ -43,7 +44,7 @@ export function ProjectsPreviewTable({isLoading, sampleCounts}: Props) {
   );
 
   const {balancedItems} = useMemo(() => {
-    const targetRate = Math.min(100, Math.max(0, Number(debouncedTargetSampleRate) || 0));
+    const targetRate = clampPercent(Number(debouncedTargetSampleRate) || 0);
     return balanceSampleRate({
       targetSampleRate: targetRate / 100,
       items: balancingItems,
@@ -51,7 +52,7 @@ export function ProjectsPreviewTable({isLoading, sampleCounts}: Props) {
   }, [debouncedTargetSampleRate, balancingItems]);
 
   const initialSampleRateById = useMemo(() => {
-    const targetRate = Math.min(100, Math.max(0, Number(initialTargetSampleRate) || 0));
+    const targetRate = clampPercent(Number(initialTargetSampleRate) || 0);
     const {balancedItems: initialBalancedItems} = balanceSampleRate({
       targetSampleRate: targetRate / 100,
       items: balancingItems,

--- a/static/app/views/settings/dynamicSampling/projectsPreviewTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsPreviewTable.tsx
@@ -10,8 +10,8 @@ import {formatNumberWithDynamicDecimalPoints} from 'sentry/utils/number/formatNu
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {ProjectsTable} from 'sentry/views/settings/dynamicSampling/projectsTable';
 import {SamplingBreakdown} from 'sentry/views/settings/dynamicSampling/samplingBreakdown';
-import {clampPercent} from 'sentry/views/settings/dynamicSampling/utils/clampNumer';
 import {organizationSamplingForm} from 'sentry/views/settings/dynamicSampling/utils/organizationSamplingForm';
+import {parsePercent} from 'sentry/views/settings/dynamicSampling/utils/parsePercent';
 import {balanceSampleRate} from 'sentry/views/settings/dynamicSampling/utils/rebalancing';
 import type {ProjectSampleCount} from 'sentry/views/settings/dynamicSampling/utils/useProjectSampleCounts';
 
@@ -44,17 +44,17 @@ export function ProjectsPreviewTable({isLoading, sampleCounts}: Props) {
   );
 
   const {balancedItems} = useMemo(() => {
-    const targetRate = clampPercent(Number(debouncedTargetSampleRate) || 0);
+    const targetRate = parsePercent(debouncedTargetSampleRate);
     return balanceSampleRate({
-      targetSampleRate: targetRate / 100,
+      targetSampleRate: targetRate,
       items: balancingItems,
     });
   }, [debouncedTargetSampleRate, balancingItems]);
 
   const initialSampleRateById = useMemo(() => {
-    const targetRate = clampPercent(Number(initialTargetSampleRate) || 0);
+    const targetRate = parsePercent(initialTargetSampleRate);
     const {balancedItems: initialBalancedItems} = balanceSampleRate({
-      targetSampleRate: targetRate / 100,
+      targetSampleRate: targetRate,
       items: balancingItems,
     });
     return initialBalancedItems.reduce((acc, item) => {

--- a/static/app/views/settings/dynamicSampling/projectsPreviewTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsPreviewTable.tsx
@@ -6,10 +6,10 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {formatNumberWithDynamicDecimalPoints} from 'sentry/utils/number/formatNumberWithDynamicDecimalPoints';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {ProjectsTable} from 'sentry/views/settings/dynamicSampling/projectsTable';
 import {SamplingBreakdown} from 'sentry/views/settings/dynamicSampling/samplingBreakdown';
+import {formatPercent} from 'sentry/views/settings/dynamicSampling/utils/formatPercent';
 import {organizationSamplingForm} from 'sentry/views/settings/dynamicSampling/utils/organizationSamplingForm';
 import {parsePercent} from 'sentry/views/settings/dynamicSampling/utils/parsePercent';
 import {balanceSampleRate} from 'sentry/views/settings/dynamicSampling/utils/rebalancing';
@@ -66,11 +66,8 @@ export function ProjectsPreviewTable({isLoading, sampleCounts}: Props) {
   const itemsWithFormattedNumbers = useMemo(() => {
     return balancedItems.map(item => ({
       ...item,
-      sampleRate: formatNumberWithDynamicDecimalPoints(item.sampleRate * 100, 2),
-      initialSampleRate: formatNumberWithDynamicDecimalPoints(
-        initialSampleRateById[item.id] * 100,
-        2
-      ),
+      sampleRate: formatPercent(item.sampleRate),
+      initialSampleRate: formatPercent(initialSampleRateById[item.id]),
     }));
   }, [balancedItems, initialSampleRateById]);
 

--- a/static/app/views/settings/dynamicSampling/projectsTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsTable.tsx
@@ -14,7 +14,7 @@ import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import oxfordizeArray from 'sentry/utils/oxfordizeArray';
 import useOrganization from 'sentry/utils/useOrganization';
 import {PercentInput} from 'sentry/views/settings/dynamicSampling/percentInput';
-import {clampPercent} from 'sentry/views/settings/dynamicSampling/utils/clampNumer';
+import {parsePercent} from 'sentry/views/settings/dynamicSampling/utils/parsePercent';
 
 interface ProjectItem {
   count: number;
@@ -255,11 +255,8 @@ const TableRow = memo(function TableRow({
     [onChange, project.id]
   );
 
-  const getStoredSpans = (rate: number) => {
-    return Math.floor((count * clampPercent(rate)) / 100);
-  };
-  const storedSpans = getStoredSpans(Number(sampleRate));
-  const initialStoredSpans = getStoredSpans(Number(initialSampleRate));
+  const storedSpans = Math.floor(count * parsePercent(sampleRate));
+  const initialStoredSpans = Math.floor(count * parsePercent(initialSampleRate));
 
   return (
     <Fragment key={project.slug}>

--- a/static/app/views/settings/dynamicSampling/projectsTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsTable.tsx
@@ -14,6 +14,7 @@ import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import oxfordizeArray from 'sentry/utils/oxfordizeArray';
 import useOrganization from 'sentry/utils/useOrganization';
 import {PercentInput} from 'sentry/views/settings/dynamicSampling/percentInput';
+import {clampPercent} from 'sentry/views/settings/dynamicSampling/utils/clampNumer';
 
 interface ProjectItem {
   count: number;
@@ -255,7 +256,7 @@ const TableRow = memo(function TableRow({
   );
 
   const getStoredSpans = (rate: number) => {
-    return Math.floor((count * rate) / 100);
+    return Math.floor((count * clampPercent(rate)) / 100);
   };
   const storedSpans = getStoredSpans(Number(sampleRate));
   const initialStoredSpans = getStoredSpans(Number(initialSampleRate));
@@ -297,7 +298,7 @@ const TableRow = memo(function TableRow({
           {formatAbbreviatedNumber(storedSpans)}
         </FirstCellLine>
         <SubSpans>
-          {sampleRate !== initialSampleRate ? (
+          {storedSpans !== initialStoredSpans ? (
             <SmallPrint>
               {t('previous: %s', formatAbbreviatedNumber(initialStoredSpans))}
             </SmallPrint>

--- a/static/app/views/settings/dynamicSampling/samplingBreakdown.tsx
+++ b/static/app/views/settings/dynamicSampling/samplingBreakdown.tsx
@@ -8,8 +8,8 @@ import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
-import {formatNumberWithDynamicDecimalPoints} from 'sentry/utils/number/formatNumberWithDynamicDecimalPoints';
 import {clampPercentRate} from 'sentry/views/settings/dynamicSampling/utils/clampNumer';
+import {formatPercent} from 'sentry/views/settings/dynamicSampling/utils/formatPercent';
 import type {ProjectSampleCount} from 'sentry/views/settings/dynamicSampling/utils/useProjectSampleCounts';
 
 const ITEMS_TO_SHOW = 5;
@@ -63,8 +63,8 @@ export function SamplingBreakdown({sampleCounts, sampleRates, ...props}: Props) 
     .reduce((acc, item) => acc + item.sampledSpans, 0);
   const total = spansWithSampleRates.reduce((acc, item) => acc + item.sampledSpans, 0);
 
-  const getSpanPercent = spanCount => (total === 0 ? 100 : (spanCount / total) * 100);
-  const otherPercent = getSpanPercent(otherSpanCount);
+  const getSpanRate = spanCount => (total === 0 ? 1 : spanCount / total);
+  const otherRate = getSpanRate(otherSpanCount);
 
   return (
     <div {...props}>
@@ -74,6 +74,7 @@ export function SamplingBreakdown({sampleCounts, sampleRates, ...props}: Props) 
       </Heading>
       <Breakdown>
         {topItems.map((item, index) => {
+          const itemPercent = getSpanRate(item.sampledSpans);
           return (
             <Tooltip
               key={item.project.id}
@@ -81,7 +82,7 @@ export function SamplingBreakdown({sampleCounts, sampleRates, ...props}: Props) 
               title={
                 <LegendItem key={item.project.id}>
                   <ProjectBadge disableLink avatarSize={16} project={item.project} />
-                  {`${formatNumberWithDynamicDecimalPoints(getSpanPercent(item.sampledSpans))}%`}
+                  {formatPercent(itemPercent, {addSymbol: true})}
                   <SubText>{formatAbbreviatedNumber(item.sampledSpans)}</SubText>
                 </LegendItem>
               }
@@ -89,7 +90,7 @@ export function SamplingBreakdown({sampleCounts, sampleRates, ...props}: Props) 
             >
               <div
                 style={{
-                  width: `${getSpanPercent(item.sampledSpans)}%`,
+                  width: `${itemPercent * 100}%`,
                   backgroundColor: palette[index],
                 }}
               />
@@ -102,7 +103,7 @@ export function SamplingBreakdown({sampleCounts, sampleRates, ...props}: Props) 
             title={
               <LegendItem>
                 <OthersBadge />
-                {`${formatNumberWithDynamicDecimalPoints(otherPercent)}%`}
+                {formatPercent(otherRate, {addSymbol: true})}
                 <SubText>{formatAbbreviatedNumber(total)}</SubText>
               </LegendItem>
             }
@@ -110,7 +111,7 @@ export function SamplingBreakdown({sampleCounts, sampleRates, ...props}: Props) 
           >
             <div
               style={{
-                width: `${otherPercent}%`,
+                width: `${otherRate * 100}%`,
                 backgroundColor: palette[palette.length - 1],
               }}
             />
@@ -119,17 +120,18 @@ export function SamplingBreakdown({sampleCounts, sampleRates, ...props}: Props) 
       </Breakdown>
       <Legend>
         {topItems.map(item => {
+          const itemPercent = getSpanRate(item.sampledSpans);
           return (
             <LegendItem key={item.project.id}>
               <ProjectBadge avatarSize={16} project={item.project} />
-              {`${formatNumberWithDynamicDecimalPoints(getSpanPercent(item.sampledSpans))}%`}
+              {formatPercent(itemPercent, {addSymbol: true})}
             </LegendItem>
           );
         })}
         {hasOthers && (
           <LegendItem>
             <OthersBadge />
-            {`${formatNumberWithDynamicDecimalPoints(otherPercent)}%`}
+            {formatPercent(otherRate, {addSymbol: true})}
           </LegendItem>
         )}
       </Legend>

--- a/static/app/views/settings/dynamicSampling/samplingBreakdown.tsx
+++ b/static/app/views/settings/dynamicSampling/samplingBreakdown.tsx
@@ -9,6 +9,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {formatNumberWithDynamicDecimalPoints} from 'sentry/utils/number/formatNumberWithDynamicDecimalPoints';
+import {clampPercentRate} from 'sentry/views/settings/dynamicSampling/utils/clampNumer';
 import type {ProjectSampleCount} from 'sentry/views/settings/dynamicSampling/utils/useProjectSampleCounts';
 
 const ITEMS_TO_SHOW = 5;
@@ -43,7 +44,8 @@ function OthersBadge() {
 export function SamplingBreakdown({sampleCounts, sampleRates, ...props}: Props) {
   const spansWithSampleRates = sampleCounts
     ?.map(item => {
-      const sampledSpans = Math.floor(item.count * (sampleRates[item.project.id] ?? 1));
+      const sampleRate = clampPercentRate(sampleRates[item.project.id] ?? 1);
+      const sampledSpans = Math.floor(item.count * sampleRate);
       return {
         project: item.project,
         sampledSpans,

--- a/static/app/views/settings/dynamicSampling/samplingModeSwitchModal.tsx
+++ b/static/app/views/settings/dynamicSampling/samplingModeSwitchModal.tsx
@@ -13,8 +13,8 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
-import {formatNumberWithDynamicDecimalPoints} from 'sentry/utils/number/formatNumberWithDynamicDecimalPoints';
 import {PercentInput} from 'sentry/views/settings/dynamicSampling/percentInput';
+import {formatPercent} from 'sentry/views/settings/dynamicSampling/utils/formatPercent';
 import {organizationSamplingForm} from 'sentry/views/settings/dynamicSampling/utils/organizationSamplingForm';
 import {parsePercent} from 'sentry/views/settings/dynamicSampling/utils/parsePercent';
 import {useUpdateOrganization} from 'sentry/views/settings/dynamicSampling/utils/useUpdateOrganization';
@@ -43,7 +43,7 @@ function SamplingModeSwitchModal({
 }: Props & ModalRenderProps) {
   const formState = useFormState({
     initialValues: {
-      targetSampleRate: formatNumberWithDynamicDecimalPoints(initialTargetRate * 100, 2),
+      targetSampleRate: formatPercent(initialTargetRate),
     },
   });
 

--- a/static/app/views/settings/dynamicSampling/samplingModeSwitchModal.tsx
+++ b/static/app/views/settings/dynamicSampling/samplingModeSwitchModal.tsx
@@ -16,6 +16,7 @@ import type {Organization} from 'sentry/types/organization';
 import {formatNumberWithDynamicDecimalPoints} from 'sentry/utils/number/formatNumberWithDynamicDecimalPoints';
 import {PercentInput} from 'sentry/views/settings/dynamicSampling/percentInput';
 import {organizationSamplingForm} from 'sentry/views/settings/dynamicSampling/utils/organizationSamplingForm';
+import {parsePercent} from 'sentry/views/settings/dynamicSampling/utils/parsePercent';
 import {useUpdateOrganization} from 'sentry/views/settings/dynamicSampling/utils/useUpdateOrganization';
 
 interface Props {
@@ -67,7 +68,7 @@ function SamplingModeSwitchModal({
       samplingMode,
     };
     if (samplingMode === 'organization') {
-      changes.targetSampleRate = Number(formState.fields.targetSampleRate.value) / 100;
+      changes.targetSampleRate = parsePercent(formState.fields.targetSampleRate.value);
     }
     updateOrganization(changes);
   };

--- a/static/app/views/settings/dynamicSampling/utils/clampNumer.tsx
+++ b/static/app/views/settings/dynamicSampling/utils/clampNumer.tsx
@@ -2,10 +2,6 @@ function clampNumber(number: number, min: number, max: number) {
   return Math.min(Math.max(number, min), max);
 }
 
-export function clampPercent(number: number) {
-  return clampNumber(number, 0, 100);
-}
-
 export function clampPercentRate(number: number) {
   return clampNumber(number, 0, 1);
 }

--- a/static/app/views/settings/dynamicSampling/utils/clampNumer.tsx
+++ b/static/app/views/settings/dynamicSampling/utils/clampNumer.tsx
@@ -1,0 +1,11 @@
+function clampNumber(number: number, min: number, max: number) {
+  return Math.min(Math.max(number, min), max);
+}
+
+export function clampPercent(number: number) {
+  return clampNumber(number, 0, 100);
+}
+
+export function clampPercentRate(number: number) {
+  return clampNumber(number, 0, 1);
+}

--- a/static/app/views/settings/dynamicSampling/utils/formContext.tsx
+++ b/static/app/views/settings/dynamicSampling/utils/formContext.tsx
@@ -54,7 +54,7 @@ export type FormValidators<
   FormFields extends Record<string, PlainValue>,
   FieldErrors extends Record<keyof FormFields, any>,
 > = {
-  [K in keyof FormFields]?: (value: FormFields[K]) => FieldErrors[K];
+  [K in keyof FormFields]?: (value: FormFields[K]) => FieldErrors[K] | undefined;
 };
 
 type InitialValues<FormFields extends Record<string, any>> = {

--- a/static/app/views/settings/dynamicSampling/utils/formatPercent.tsx
+++ b/static/app/views/settings/dynamicSampling/utils/formatPercent.tsx
@@ -1,0 +1,10 @@
+import {formatNumberWithDynamicDecimalPoints} from 'sentry/utils/number/formatNumberWithDynamicDecimalPoints';
+
+interface Options {
+  addSymbol?: boolean;
+}
+
+export function formatPercent(value: number, {addSymbol}: Options = {}) {
+  const formatedNumber = formatNumberWithDynamicDecimalPoints(value * 100, 2);
+  return addSymbol ? `${formatedNumber}%` : formatedNumber;
+}

--- a/static/app/views/settings/dynamicSampling/utils/parsePercent.spec.tsx
+++ b/static/app/views/settings/dynamicSampling/utils/parsePercent.spec.tsx
@@ -1,0 +1,28 @@
+import {parsePercent} from 'sentry/views/settings/dynamicSampling/utils/parsePercent';
+
+describe('parsePercent', () => {
+  it('parses a valid percent', () => {
+    expect(parsePercent('50')).toEqual(0.5);
+    expect(parsePercent('100')).toEqual(1);
+    expect(parsePercent('0')).toEqual(0);
+
+    expect(parsePercent('50.5')).toEqual(0.505);
+    expect(parsePercent('1.5%')).toEqual(0.015);
+  });
+
+  it('falls back to default value', () => {
+    expect(parsePercent(undefined, 0.1)).toEqual(0.1);
+    expect(parsePercent(null, 0.2)).toEqual(0.2);
+    expect(parsePercent('', 0.3)).toEqual(0.3);
+    expect(parsePercent('invalid', 0.4)).toEqual(0.4);
+  });
+
+  it('clamps to 0-1 range', () => {
+    expect(parsePercent('-1')).toEqual(0);
+    expect(parsePercent('101')).toEqual(1);
+  });
+
+  it('return 0 as default fallback', () => {
+    expect(parsePercent(null)).toEqual(0);
+  });
+});

--- a/static/app/views/settings/dynamicSampling/utils/parsePercent.tsx
+++ b/static/app/views/settings/dynamicSampling/utils/parsePercent.tsx
@@ -1,0 +1,14 @@
+import {clampPercentRate} from 'sentry/views/settings/dynamicSampling/utils/clampNumer';
+
+export function parsePercent(value: string | undefined | null, fallback: number = 0) {
+  if (!value) {
+    return fallback;
+  }
+
+  const numericValue = parseFloat(value);
+  if (Number.isNaN(numericValue)) {
+    return fallback;
+  }
+
+  return clampPercentRate(numericValue / 100);
+}

--- a/static/app/views/settings/dynamicSampling/utils/projectSamplingForm.tsx
+++ b/static/app/views/settings/dynamicSampling/utils/projectSamplingForm.tsx
@@ -29,7 +29,7 @@ export const projectSamplingForm = createForm<FormFields, FormErrors>({
         }
       });
 
-      return errors;
+      return Object.keys(errors).length === 0 ? undefined : errors;
     },
   },
 });

--- a/static/app/views/settings/dynamicSampling/utils/scaleSampleRates.tsx
+++ b/static/app/views/settings/dynamicSampling/utils/scaleSampleRates.tsx
@@ -1,3 +1,5 @@
+import {clampPercentRate} from 'sentry/views/settings/dynamicSampling/utils/clampNumer';
+
 interface ScalingItem {
   count: number;
   sampleRate: number;
@@ -50,7 +52,7 @@ export function scaleSampleRates<T extends ScalingItem>({
 
   const scaledItems: T[] = [];
   for (const item of sortedItems) {
-    const newProjectRate = Math.min(1, Math.max(0, item.sampleRate * factor));
+    const newProjectRate = clampPercentRate(item.sampleRate * factor);
     const newProjectSampleCount = item.count * newProjectRate;
 
     remainingTotal -= item.count;


### PR DESCRIPTION
Most calculations are based on the current forms state, which has to allow for invalid values to enable frictionless editing of fields. This PR clamps the values to valid percentages / rates before using them in calculations.