### PR TITLE
feat(dashboards): Add Open in Explore for Span widgets

### DIFF
--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -2,6 +2,7 @@ import ReactEchartsCore from 'echarts-for-react/lib/core';
 import {DashboardFixture} from 'sentry-fixture/dashboard';
 import {MetricsTotalCountByReleaseIn24h} from 'sentry-fixture/metrics';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {WidgetFixture} from 'sentry-fixture/widget';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -1477,6 +1478,37 @@ describe('Modals -> WidgetViewerModal', function () {
       await waitFor(() => {
         expect(metricsMock).toHaveBeenCalledTimes(2);
       });
+    });
+  });
+
+  describe('Span Widgets', function () {
+    beforeEach(function () {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/events/',
+        body: {},
+      });
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/events-stats/',
+        body: {},
+      });
+    });
+
+    it('renders the Open in Explore button', async function () {
+      const mockWidget = WidgetFixture({
+        widgetType: WidgetType.SPANS,
+        queries: [
+          {
+            fields: ['span.description', 'avg(span.duration)'],
+            aggregates: ['avg(span.duration)'],
+            columns: ['span.description'],
+            conditions: '',
+            orderby: '',
+            name: '',
+          },
+        ],
+      });
+      await renderModal({initialData, widget: mockWidget});
+      expect(await screen.findByText('Open in Explore')).toBeInTheDocument();
     });
   });
 });

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -71,6 +71,7 @@ import {
   isUsingPerformanceScore,
   performanceScoreTooltip,
 } from 'sentry/views/dashboards/utils';
+import {getWidgetExploreUrl} from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
 import {
   SESSION_DURATION_ALERT,
   WidgetDescription,
@@ -1122,6 +1123,10 @@ function OpenButton({
     case WidgetType.METRICS:
       openLabel = t('Open in Metrics');
       path = getWidgetMetricsUrl(widget, selection, organization);
+      break;
+    case WidgetType.SPANS:
+      openLabel = t('Open in Explore');
+      path = getWidgetExploreUrl(widget, selection, organization);
       break;
     case WidgetType.DISCOVER:
     default:

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
@@ -1,0 +1,58 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {WidgetFixture} from 'sentry-fixture/widget';
+
+import {DisplayType} from 'sentry/views/dashboards/types';
+import {getWidgetExploreUrl} from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
+
+describe('getWidgetExploreUrl', () => {
+  const organization = OrganizationFixture();
+  const selection = PageFiltersFixture();
+
+  it('returns the correct url for table widgets', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.TABLE,
+      queries: [
+        {
+          fields: ['span.description', 'avg(span.duration)'],
+          aggregates: ['avg(span.duration)'],
+          columns: ['span.description'],
+          conditions: '',
+          orderby: '',
+          name: '',
+        },
+      ],
+    });
+
+    const url = getWidgetExploreUrl(widget, selection, organization);
+
+    // Note: for table widgets the mode is set to samples and the fields are propagated
+    expect(url).toBe(
+      '/traces/?field=span.description&field=avg%28span.duration%29&groupBy=span.description&interval=30m&mode=samples&query=&statsPeriod=14d&visualize=%7B%22yAxes%22%3A%5B%22avg%28span.duration%29%22%5D%7D'
+    );
+  });
+
+  it('returns the correct url for timeseries widgets', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.AREA,
+      queries: [
+        {
+          fields: ['span.description', 'avg(span.duration)'],
+          aggregates: ['avg(span.duration)'],
+          columns: ['span.description'],
+          conditions: '',
+          orderby: '',
+          name: '',
+        },
+      ],
+    });
+
+    const url = getWidgetExploreUrl(widget, selection, organization);
+
+    // Note: for line widgets the mode is set to aggregate
+    // The chart type is set to 1 for area charts
+    expect(url).toBe(
+      '/traces/?field=span.description&field=avg%28span.duration%29&groupBy=span.description&interval=30m&mode=aggregate&query=&statsPeriod=14d&visualize=%7B%22yAxes%22%3A%5B%22avg%28span.duration%29%22%5D%2C%22chartType%22%3A%222%22%7D'
+    );
+  });
+});

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -1,0 +1,114 @@
+import pick from 'lodash/pick';
+import * as qs from 'query-string';
+
+import type {PageFilters} from 'sentry/types/core';
+import type {Organization} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
+import {
+  getAggregateAlias,
+  isAggregateFieldOrEquation,
+} from 'sentry/utils/discover/fields';
+import {DisplayType, type Widget} from 'sentry/views/dashboards/types';
+import {
+  eventViewFromWidget,
+  getFieldsFromEquations,
+  getWidgetInterval,
+} from 'sentry/views/dashboards/utils';
+import type {ResultMode} from 'sentry/views/explore/hooks/useResultsMode';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+
+export function getWidgetExploreUrl(
+  widget: Widget,
+  selection: PageFilters,
+  organization: Organization
+) {
+  const eventView = eventViewFromWidget(widget.title, widget.queries[0], selection);
+  const {query: locationQueryParams} = eventView.getResultsViewUrlTarget(
+    organization.slug,
+    false,
+    undefined
+  );
+
+  // Pull a max of 3 valid Y-Axis from the widget
+  const yAxisOptions = eventView.getYAxisOptions().map(({value}) => value);
+  locationQueryParams.yAxes = [
+    ...new Set(
+      widget.queries[0].aggregates.filter(aggregate => yAxisOptions.includes(aggregate))
+    ),
+  ].slice(0, 3);
+
+  // Visualization specific transforms
+  let exploreMode: ResultMode | undefined = undefined;
+  switch (widget.displayType) {
+    case DisplayType.BAR:
+      exploreMode = 'aggregate';
+      locationQueryParams.chartType = ChartType.BAR.toString();
+      break;
+    case DisplayType.LINE:
+      exploreMode = 'aggregate';
+      locationQueryParams.chartType = ChartType.LINE.toString();
+      break;
+    case DisplayType.AREA:
+      exploreMode = 'aggregate';
+      locationQueryParams.chartType = ChartType.AREA.toString();
+      break;
+    case DisplayType.TABLE:
+    case DisplayType.BIG_NUMBER:
+      exploreMode = 'samples';
+      break;
+    default:
+      break;
+  }
+
+  // Equation fields need to have their terms explicitly selected as columns in the discover table
+  const fields =
+    Array.isArray(locationQueryParams.field) || !defined(locationQueryParams.field)
+      ? locationQueryParams.field
+      : [locationQueryParams.field];
+
+  const query = widget.queries[0];
+  const queryFields = defined(query.fields)
+    ? query.fields
+    : [...query.columns, ...query.aggregates];
+
+  // Updates fields by adding any individual terms from equation fields as a column
+  getFieldsFromEquations(queryFields).forEach(term => {
+    if (Array.isArray(fields) && !fields.includes(term)) {
+      fields.unshift(term);
+    }
+  });
+  locationQueryParams.field = fields;
+
+  const queryParams = {
+    // Page filters should propagate
+    ...pick(locationQueryParams, [
+      'start',
+      'end',
+      'statsPeriod',
+      'project',
+      'environment',
+    ]),
+
+    mode: exploreMode,
+    visualize: JSON.stringify(pick(locationQueryParams, ['yAxes', 'chartType'])),
+    groupBy: fields?.filter(field => !isAggregateFieldOrEquation(field)),
+    field: locationQueryParams.field,
+    query: locationQueryParams.query,
+    sort:
+      defined(fields) && defined(locationQueryParams.sort)
+        ? _getSort(fields, locationQueryParams.sort as string)
+        : undefined,
+    interval:
+      locationQueryParams.interval ??
+      getWidgetInterval(widget.displayType, selection.datetime),
+  };
+
+  return `/traces/?${qs.stringify(queryParams)}`;
+}
+
+function _getSort(fields: string[], sort: string) {
+  const descending = sort.startsWith('-');
+  const rawSort = descending ? sort.slice(1) : sort;
+  const sortedField = fields?.find(field => getAggregateAlias(field) === rawSort);
+  return descending ? `-${sortedField}` : sortedField;
+}

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.spec.tsx
@@ -87,4 +87,26 @@ describe('WidgetCardContextMenu', () => {
     const $button = screen.getByRole('menuitemradio', {name: 'Duplicate Widget'});
     expect($button).toHaveAttribute('aria-disabled', 'true');
   });
+
+  it('renders the Open in Explore button for span widgets', async function () {
+    render(
+      <MEPSettingProvider>
+        <DashboardsMEPProvider>
+          <WidgetCardContextMenu
+            location={LocationFixture()}
+            organization={OrganizationFixture({})}
+            router={RouterFixture()}
+            selection={PageFiltersFixture()}
+            widget={WidgetFixture({widgetType: WidgetType.SPANS})}
+            widgetLimitReached={false}
+            showContextMenu
+          />
+        </DashboardsMEPProvider>
+      </MEPSettingProvider>
+    );
+
+    await userEvent.click(await screen.findByLabelText('Widget actions'));
+
+    expect(await screen.findByText('Open in Explore')).toBeInTheDocument();
+  });
 });

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -33,6 +33,7 @@ import {
   isUsingPerformanceScore,
   performanceScoreTooltip,
 } from 'sentry/views/dashboards/utils';
+import {getWidgetExploreUrl} from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
 
 import type {Widget} from '../types';
 import {WidgetType} from '../types';
@@ -325,6 +326,14 @@ export function getMenuOptions(
         },
       });
     }
+  }
+
+  if (widget.widgetType === WidgetType.SPANS) {
+    menuOptions.push({
+      key: 'open-in-explore',
+      label: t('Open in Explore'),
+      to: getWidgetExploreUrl(widget, selection, organization),
+    });
   }
 
   if (widget.widgetType === WidgetType.ISSUE) {


### PR DESCRIPTION
When there's a spans typed widget, it will allow you to click an Open in Explore button to see the query there.

- The action is viewable in the widget viewer and the context menu that opens up on a widget
- Tables and big numbers open up in the samples mode and modify the table with the correct columns, similar to what happens in discover. The chart visualizes the first 3 aggregates
- Line charts open up in aggregate mode
- All "Open in Explore" actions carry over the page filters and query

Contributes to [#79745](https://github.com/getsentry/sentry/issues/79745)