### PR TITLE
feat(insights): add transaction action buttons to transaction summary

### DIFF
--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -281,6 +281,42 @@ function TransactionHeader({
         },
         view,
       }),
+      headerActions: (
+        <Fragment>
+          <Feature organization={organization} features="incidents">
+            {({hasFeature}) =>
+              hasFeature && !metricsCardinality?.isLoading ? (
+                <CreateAlertFromViewButton
+                  size="sm"
+                  eventView={eventView}
+                  organization={organization}
+                  projects={projects}
+                  onClick={handleCreateAlertSuccess}
+                  referrer="performance"
+                  alertType="trans_duration"
+                  aria-label={t('Create Alert')}
+                  disableMetricDataset={
+                    metricsCardinality?.outcome?.forceTransactionsOnly
+                  }
+                />
+              ) : null
+            }
+          </Feature>
+          <TeamKeyTransactionButton
+            eventView={eventView}
+            organization={organization}
+            transactionName={transactionName}
+          />
+          <GuideAnchor target="project_transaction_threshold_override" position="bottom">
+            <TransactionThresholdButton
+              organization={organization}
+              transactionName={transactionName}
+              eventView={eventView}
+              onChangeThreshold={onChangeThreshold}
+            />
+          </GuideAnchor>
+        </Fragment>
+      ),
     };
     if (view === FRONTEND_LANDING_SUB_PATH) {
       return <FrontendHeader {...headerProps} />;


### PR DESCRIPTION
This PR adds the transaction action buttons to the top right of the domain view transaction summary

(Create alert, starred for team, etc)
<img width="1282" alt="image" src="https://github.com/user-attachments/assets/52259327-9aaf-41c3-8cb9-b91060b8c621">
