### PR TITLE
ref: fix monkeypatching of stderr

### DIFF
--- a/tests/sentry/management/commands/test_generate_controlsilo_urls.py
+++ b/tests/sentry/management/commands/test_generate_controlsilo_urls.py
@@ -11,7 +11,7 @@ from sentry.testutils.cases import TestCase
 class TestGenerateControlsiloUrls(TestCase):
     def call_command(self, *args, **kwargs):
         out = StringIO()
-        call_command("generate_controlsilo_urls", *args, stdout=out, stderr=StringIO, **kwargs)
+        call_command("generate_controlsilo_urls", *args, stdout=out, stderr=StringIO(), **kwargs)
         return out.getvalue()
 
     def test_skip_includes(self):


### PR DESCRIPTION
something different about python 3.13 causes this to fail on .flush()

<!-- Describe your PR here. -->