### PR TITLE
styles(explore): Only render label for multiple charts

### DIFF
--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -144,6 +144,8 @@ export function ExploreCharts({query}: ExploreChartsProps) {
     EXPLORE_CHART_GROUP
   );
 
+  const shouldRenderLabel = visualizes.length > 1;
+
   return (
     <Fragment>
       {visualizes.map((visualize, index) => {
@@ -191,7 +193,7 @@ export function ExploreCharts({query}: ExploreChartsProps) {
           <ChartContainer key={index}>
             <ChartPanel>
               <ChartHeader>
-                <ChartLabel>{label}</ChartLabel>
+                {shouldRenderLabel && <ChartLabel>{label}</ChartLabel>}
                 <ChartTitle>{formattedYAxes.join(', ')}</ChartTitle>
                 <Tooltip
                   title={t('Type of chart displayed in this visualization (ex. line)')}

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -149,6 +149,8 @@ export function ToolbarVisualize({}: ToolbarVisualizeProps) {
       .map(parsedVisualizeGroup => parsedVisualizeGroup.length)
       .reduce((a, b) => a + b, 0) <= 1;
 
+  const shouldRenderLabel = visualizes.length > 1;
+
   return (
     <ToolbarSection data-test-id="section-visualizes">
       <ToolbarHeader>
@@ -174,7 +176,7 @@ export function ToolbarVisualize({}: ToolbarVisualizeProps) {
             <Fragment key={group}>
               {parsedVisualizeGroup.map((parsedVisualize, index) => (
                 <ToolbarRow key={index}>
-                  <ChartLabel>{parsedVisualize.label}</ChartLabel>
+                  {shouldRenderLabel && <ChartLabel>{parsedVisualize.label}</ChartLabel>}
                   <CompactSelect
                     searchable
                     options={fieldOptions}


### PR DESCRIPTION
When there's only 1 chart, there's no need for the extra label as it's not ambiguous.