### PR TITLE
fix(insights): use ModulePageFilterBar in module summary pages

### DIFF
--- a/static/app/views/insights/browser/resources/views/resourceSummaryPage.tsx
+++ b/static/app/views/insights/browser/resources/views/resourceSummaryPage.tsx
@@ -4,10 +4,6 @@ import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import ButtonBar from 'sentry/components/buttonBar';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
-import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {t, tct} from 'sentry/locale';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -24,6 +20,7 @@ import {ResourceSpanOps} from 'sentry/views/insights/browser/resources/types';
 import {useResourceModuleFilters} from 'sentry/views/insights/browser/resources/utils/useResourceFilters';
 import {HeaderContainer} from 'sentry/views/insights/common/components/headerContainer';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
+import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModuleBodyUpsellHook} from 'sentry/views/insights/common/components/moduleUpsellHookWrapper';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
@@ -139,12 +136,7 @@ function ResourceSummary() {
               <ModuleLayout.Full>
                 <HeaderContainer>
                   <ToolRibbon>
-                    <PageFilterBar condensed>
-                      <ProjectPageFilter />
-                      <EnvironmentPageFilter />
-                      <DatePageFilter />
-                    </PageFilterBar>
-
+                    <ModulePageFilterBar moduleName={ModuleName.RESOURCE} />
                     <RenderBlockingSelector
                       value={filters[RESOURCE_RENDER_BLOCKING_STATUS] || ''}
                     />

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
@@ -9,10 +9,6 @@ import ButtonBar from 'sentry/components/buttonBar';
 import {AggregateSpans} from 'sentry/components/events/interfaces/spans/aggregateSpans';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
-import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {TabList, Tabs} from 'sentry/components/tabs';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -35,6 +31,7 @@ import {calculatePerformanceScoreFromStoredTableDataRow} from 'sentry/views/insi
 import {useProjectWebVitalsScoresQuery} from 'sentry/views/insights/browser/webVitals/queries/storedScoreQueries/useProjectWebVitalsScoresQuery';
 import type {WebVitals} from 'sentry/views/insights/browser/webVitals/types';
 import decodeBrowserTypes from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
+import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModuleBodyUpsellHook} from 'sentry/views/insights/common/components/moduleUpsellHookWrapper';
 import {useModuleBreadcrumbs} from 'sentry/views/insights/common/utils/useModuleBreadcrumbs';
@@ -240,11 +237,7 @@ export function PageOverview() {
             <Layout.Body>
               <Layout.Main>
                 <TopMenuContainer>
-                  <PageFilterBar condensed>
-                    <ProjectPageFilter />
-                    <EnvironmentPageFilter />
-                    <DatePageFilter />
-                  </PageFilterBar>
+                  <ModulePageFilterBar moduleName={ModuleName.VITAL} />
                   <BrowserTypeSelector />
                 </TopMenuContainer>
                 <Flex>

--- a/static/app/views/insights/common/components/modulePageFilterBar.tsx
+++ b/static/app/views/insights/common/components/modulePageFilterBar.tsx
@@ -21,6 +21,7 @@ import type {ModuleName} from 'sentry/views/insights/types';
 
 type Props = {
   moduleName: ModuleName;
+  disableProjectFilter?: boolean; // This is used primarily for module summary pages when a project can't be selected
   extraFilters?: React.ReactNode;
   onProjectChange?: ComponentProps<typeof ProjectPageFilter>['onChange'];
 };
@@ -28,7 +29,12 @@ type Props = {
 const CHANGE_PROJECT_TEXT = t('Make sure you have the correct project selected.');
 const DISABLED_OPTIONS = ['14d', '30d', '90d'];
 
-export function ModulePageFilterBar({moduleName, onProjectChange, extraFilters}: Props) {
+export function ModulePageFilterBar({
+  moduleName,
+  onProjectChange,
+  extraFilters,
+  disableProjectFilter,
+}: Props) {
   const {projects: allProjects} = useProjects();
   const organization = useOrganization();
 
@@ -90,6 +96,7 @@ export function ModulePageFilterBar({moduleName, onProjectChange, extraFilters}:
 
   return (
     <Fragment>
+      TEST
       <PageFilterBar condensed>
         <Tooltip
           title={CHANGE_PROJECT_TEXT}
@@ -101,7 +108,7 @@ export function ModulePageFilterBar({moduleName, onProjectChange, extraFilters}:
           otherwise two clicks are required because of some rerendering/event propogation issues into the children */}
           <div style={{width: '100px', position: 'absolute', height: '100%'}} />
         </Tooltip>
-        <ProjectPageFilter onChange={onProjectChange} />
+        {!disableProjectFilter && <ProjectPageFilter onChange={onProjectChange} />}
         <EnvironmentPageFilter />
         <DatePageFilter {...dateFilterProps} />
       </PageFilterBar>

--- a/static/app/views/insights/common/components/modulePageFilterBar.tsx
+++ b/static/app/views/insights/common/components/modulePageFilterBar.tsx
@@ -96,7 +96,6 @@ export function ModulePageFilterBar({
 
   return (
     <Fragment>
-      TEST
       <PageFilterBar condensed>
         <Tooltip
           title={CHANGE_PROJECT_TEXT}

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
@@ -6,9 +6,6 @@ import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import ButtonBar from 'sentry/components/buttonBar';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
-import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
@@ -21,6 +18,7 @@ import {HeaderContainer} from 'sentry/views/insights/common/components/headerCon
 import InsightIssuesList from 'sentry/views/insights/common/components/issues';
 import {MetricReadout} from 'sentry/views/insights/common/components/metricReadout';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
+import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModuleBodyUpsellHook} from 'sentry/views/insights/common/components/moduleUpsellHookWrapper';
 import {ReadoutRibbon, ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
@@ -227,10 +225,10 @@ export function DatabaseSpanSummaryPage({params}: Props) {
               <ModuleLayout.Full>
                 <HeaderContainer>
                   <ToolRibbon>
-                    <PageFilterBar condensed>
-                      <EnvironmentPageFilter />
-                      <DatePageFilter />
-                    </PageFilterBar>
+                    <ModulePageFilterBar
+                      moduleName={ModuleName.DB}
+                      disableProjectFilter
+                    />
                   </ToolRibbon>
 
                   <ReadoutRibbon>

--- a/static/app/views/insights/http/views/httpDomainSummaryPage.tsx
+++ b/static/app/views/insights/http/views/httpDomainSummaryPage.tsx
@@ -7,9 +7,6 @@ import ButtonBar from 'sentry/components/buttonBar';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
-import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
-import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {t, tct} from 'sentry/locale';
 import {DurationUnit, RateUnit} from 'sentry/utils/discover/fields';
 import {decodeList, decodeScalar, decodeSorts} from 'sentry/utils/queryString';
@@ -25,6 +22,7 @@ import {useSynchronizeCharts} from 'sentry/views/insights/common/components/char
 import {HeaderContainer} from 'sentry/views/insights/common/components/headerContainer';
 import {MetricReadout} from 'sentry/views/insights/common/components/metricReadout';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
+import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModuleBodyUpsellHook} from 'sentry/views/insights/common/components/moduleUpsellHookWrapper';
 import {ReadoutRibbon, ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
@@ -273,10 +271,10 @@ export function HTTPDomainSummaryPage() {
               <ModuleLayout.Full>
                 <HeaderContainer>
                   <ToolRibbon>
-                    <PageFilterBar condensed>
-                      <EnvironmentPageFilter />
-                      <DatePageFilter />
-                    </PageFilterBar>
+                    <ModulePageFilterBar
+                      moduleName={ModuleName.HTTP}
+                      disableProjectFilter
+                    />
                     <SubregionSelector />
                   </ToolRibbon>
 

--- a/static/app/views/insights/llmMonitoring/views/llmMonitoringDetailsPage.tsx
+++ b/static/app/views/insights/llmMonitoring/views/llmMonitoringDetailsPage.tsx
@@ -4,10 +4,6 @@ import FeatureBadge from 'sentry/components/badge/featureBadge';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import * as Layout from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
-import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
-import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {t} from 'sentry/locale';
 import {CurrencyUnit, DurationUnit, RateUnit} from 'sentry/utils/discover/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
@@ -17,6 +13,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {HeaderContainer} from 'sentry/views/insights/common/components/headerContainer';
 import {MetricReadout} from 'sentry/views/insights/common/components/metricReadout';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
+import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModuleBodyUpsellHook} from 'sentry/views/insights/common/components/moduleUpsellHookWrapper';
 import {ReadoutRibbon, ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
@@ -170,11 +167,7 @@ export function LLMMonitoringPage({params}: Props) {
                 <ModuleLayout.Full>
                   <HeaderContainer>
                     <ToolRibbon>
-                      <PageFilterBar condensed>
-                        <ProjectPageFilter />
-                        <EnvironmentPageFilter />
-                        <DatePageFilter />
-                      </PageFilterBar>
+                      <ModulePageFilterBar moduleName={ModuleName.AI} />
                     </ToolRibbon>
 
                     <ReadoutRibbon>

--- a/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.tsx
+++ b/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.tsx
@@ -5,9 +5,6 @@ import omit from 'lodash/omit';
 import Breadcrumbs from 'sentry/components/breadcrumbs';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
-import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {browserHistory} from 'sentry/utils/browserHistory';
@@ -18,6 +15,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
 import {HeaderContainer} from 'sentry/views/insights/common/components/headerContainer';
+import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {
   PRIMARY_RELEASE_ALIAS,
@@ -136,10 +134,7 @@ export function ScreenSummaryContentPage() {
     <Fragment>
       <HeaderContainer>
         <ToolRibbon>
-          <PageFilterBar condensed>
-            <EnvironmentPageFilter />
-            <DatePageFilter />
-          </PageFilterBar>
+          <ModulePageFilterBar moduleName={ModuleName.APP_START} disableProjectFilter />
           <ReleaseComparisonSelector />
           <StartTypeSelector />
         </ToolRibbon>

--- a/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.tsx
@@ -7,9 +7,6 @@ import ButtonBar from 'sentry/components/buttonBar';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
-import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DurationUnit} from 'sentry/utils/discover/fields';
@@ -19,6 +16,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
 import {HeaderContainer} from 'sentry/views/insights/common/components/headerContainer';
+import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {
   PRIMARY_RELEASE_ALIAS,
@@ -135,10 +133,7 @@ export function ScreenLoadSpansContent() {
       <HeaderContainer>
         <ToolRibbon>
           <FilterContainer>
-            <PageFilterBar condensed>
-              <EnvironmentPageFilter />
-              <DatePageFilter />
-            </PageFilterBar>
+            <ModulePageFilterBar moduleName={ModuleName.APP_START} disableProjectFilter />
             <ReleaseComparisonSelector />
           </FilterContainer>
         </ToolRibbon>

--- a/static/app/views/insights/mobile/ui/views/screenSummaryPage.tsx
+++ b/static/app/views/insights/mobile/ui/views/screenSummaryPage.tsx
@@ -4,9 +4,6 @@ import omit from 'lodash/omit';
 
 import Breadcrumbs from 'sentry/components/breadcrumbs';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
-import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
@@ -14,6 +11,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
 import {HeaderContainer} from 'sentry/views/insights/common/components/headerContainer';
+import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ReleaseComparisonSelector} from 'sentry/views/insights/common/components/releaseSelector';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
@@ -104,10 +102,10 @@ export function ScreenSummaryContent() {
     <Fragment>
       <HeaderContainer>
         <ToolRibbon>
-          <PageFilterBar condensed>
-            <EnvironmentPageFilter />
-            <DatePageFilter />
-          </PageFilterBar>
+          <ModulePageFilterBar
+            moduleName={ModuleName.SCREEN_RENDERING}
+            disableProjectFilter
+          />
           <ReleaseComparisonSelector />
         </ToolRibbon>
       </HeaderContainer>

--- a/static/app/views/insights/queues/views/destinationSummaryPage.tsx
+++ b/static/app/views/insights/queues/views/destinationSummaryPage.tsx
@@ -5,10 +5,6 @@ import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import ButtonBar from 'sentry/components/buttonBar';
 import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
-import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DurationUnit} from 'sentry/utils/discover/fields';
@@ -18,6 +14,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {HeaderContainer} from 'sentry/views/insights/common/components/headerContainer';
 import {MetricReadout} from 'sentry/views/insights/common/components/metricReadout';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
+import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModuleBodyUpsellHook} from 'sentry/views/insights/common/components/moduleUpsellHookWrapper';
 import {ReadoutRibbon, ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
@@ -95,11 +92,7 @@ function DestinationSummaryPage() {
               <ModuleLayout.Full>
                 <HeaderContainer>
                   <ToolRibbon>
-                    <PageFilterBar condensed>
-                      <ProjectPageFilter />
-                      <EnvironmentPageFilter />
-                      <DatePageFilter />
-                    </PageFilterBar>
+                    <ModulePageFilterBar moduleName={ModuleName.QUEUE} />
                   </ToolRibbon>
 
                   {!onboardingProject && (


### PR DESCRIPTION
Replaces the individual page filters with the `ModulePageFilterBar` component in the module summary pages (they already are used in the landing pages)

 We should be using these instead because it provides the ui 7 day date enforcement in the date picker component for AM3 team. it also makes it easier to stay consitent