### PR TITLE
ref(crons): Move resolution logic to incidents module

### DIFF
--- a/src/sentry/monitors/logic/incident_occurrence.py
+++ b/src/sentry/monitors/logic/incident_occurrence.py
@@ -11,6 +11,10 @@ from django.utils.text import get_text_list
 from django.utils.translation import gettext_lazy as _
 
 from sentry.issues.grouptype import MonitorIncidentType
+from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
+from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
+from sentry.issues.status_change_message import StatusChangeMessage
+from sentry.models.group import GroupStatus
 from sentry.monitors.models import (
     CheckInStatus,
     MonitorCheckIn,
@@ -31,9 +35,6 @@ def create_incident_occurrence(
     incident: MonitorIncident,
     received: datetime | None,
 ) -> None:
-    from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
-    from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
-
     monitor_env = failed_checkin.monitor_environment
 
     if monitor_env is None:
@@ -169,3 +170,16 @@ def get_monitor_environment_context(monitor_environment: MonitorEnvironment):
         "status": monitor_environment.get_status_display(),
         "type": monitor_environment.monitor.get_type_display(),
     }
+
+
+def resolve_incident_group(incident: MonitorIncident, project_id: int):
+    status_change = StatusChangeMessage(
+        fingerprint=[incident.grouphash],
+        project_id=project_id,
+        new_status=GroupStatus.RESOLVED,
+        new_substatus=None,
+    )
+    produce_occurrence_to_kafka(
+        payload_type=PayloadType.STATUS_CHANGE,
+        status_change=status_change,
+    )

--- a/src/sentry/monitors/logic/mark_ok.py
+++ b/src/sentry/monitors/logic/mark_ok.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import NotRequired, TypedDict
 
-from django.utils import timezone
-
-from sentry import analytics
-from sentry.monitors.models import CheckInStatus, MonitorCheckIn, MonitorEnvironment, MonitorStatus
-from sentry.monitors.tasks.detect_broken_monitor_envs import NUM_DAYS_BROKEN_PERIOD
+from sentry.monitors.logic.incidents import try_incident_resolution
+from sentry.monitors.models import MonitorCheckIn, MonitorEnvironment, MonitorStatus
 
 logger = logging.getLogger(__name__)
 
@@ -43,83 +40,11 @@ def mark_ok(checkin: MonitorCheckIn, succeeded_at: datetime) -> None:
         "next_checkin_latest": next_checkin_latest,
     }
 
-    if monitor_env.status != MonitorStatus.OK and checkin.status == CheckInStatus.OK:
-        recovery_threshold = monitor_env.monitor.config.get("recovery_threshold", 1)
-        if not recovery_threshold:
-            recovery_threshold = 1
+    incident_resolved = try_incident_resolution(checkin)
 
-        # Run incident logic if recovery threshold is set
-        if recovery_threshold > 1:
-            # Check if our incident is recovering
-            previous_checkins = (
-                MonitorCheckIn.objects.filter(monitor_environment=monitor_env)
-                .values("id", "date_added", "status")
-                .order_by("-date_added")[:recovery_threshold]
-            )
-
-            # Incident recovers when we have successive threshold check-ins
-            incident_recovering = all(
-                previous_checkin["status"] == CheckInStatus.OK
-                for previous_checkin in previous_checkins
-            )
-        else:
-            # Mark any open incidents as recovering by default
-            incident_recovering = True
-
-        # Resolve any open incidents
-        if incident_recovering:
-            params["status"] = MonitorStatus.OK
-            incident = monitor_env.active_incident
-            if incident:
-                resolve_incident_group(incident.grouphash, checkin.monitor.project_id)
-                incident.update(
-                    resolving_checkin=checkin,
-                    resolving_timestamp=checkin.date_added,
-                )
-                logger.info(
-                    "monitors.logic.mark_ok.resolving_incident",
-                    extra={
-                        "monitor_env_id": monitor_env.id,
-                        "incident_id": incident.id,
-                        "grouphash": incident.grouphash,
-                    },
-                )
-                # if incident was longer than the broken env time, check if there was a broken detection that is also now resolved
-                if (
-                    incident.starting_timestamp is not None
-                    and incident.starting_timestamp
-                    <= timezone.now() - timedelta(days=NUM_DAYS_BROKEN_PERIOD)
-                ):
-                    if incident.monitorenvbrokendetection_set.exists():
-                        analytics.record(
-                            "cron_monitor_broken_status.recovery",
-                            organization_id=monitor_env.monitor.organization_id,
-                            project_id=monitor_env.monitor.project_id,
-                            monitor_id=monitor_env.monitor.id,
-                            monitor_env_id=monitor_env.id,
-                        )
+    if incident_resolved:
+        params["status"] = MonitorStatus.OK
 
     MonitorEnvironment.objects.filter(id=monitor_env.id).exclude(
         last_checkin__gt=succeeded_at
     ).update(**params)
-
-
-def resolve_incident_group(
-    fingerprint: str,
-    project_id: int,
-):
-    from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
-    from sentry.issues.status_change_message import StatusChangeMessage
-    from sentry.models.group import GroupStatus
-
-    status_change = StatusChangeMessage(
-        fingerprint=[fingerprint],
-        project_id=project_id,
-        new_status=GroupStatus.RESOLVED,
-        new_substatus=None,
-    )
-
-    produce_occurrence_to_kafka(
-        payload_type=PayloadType.STATUS_CHANGE,
-        status_change=status_change,
-    )

--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -23,7 +23,7 @@ from sentry.testutils.cases import TestCase
 
 
 class MarkFailedTestCase(TestCase):
-    @patch("sentry.issues.producer.produce_occurrence_to_kafka")
+    @patch("sentry.monitors.logic.incident_occurrence.produce_occurrence_to_kafka")
     def test_mark_failed_default_params(self, mock_produce_occurrence_to_kafka):
         monitor = Monitor.objects.create(
             name="test monitor",
@@ -144,7 +144,7 @@ class MarkFailedTestCase(TestCase):
             },
         ) == dict(event)
 
-    @patch("sentry.issues.producer.produce_occurrence_to_kafka")
+    @patch("sentry.monitors.logic.incident_occurrence.produce_occurrence_to_kafka")
     def test_mark_failed_muted(self, mock_produce_occurrence_to_kafka):
         monitor = Monitor.objects.create(
             name="test monitor",
@@ -181,7 +181,7 @@ class MarkFailedTestCase(TestCase):
         assert len(mock_produce_occurrence_to_kafka.mock_calls) == 0
         assert monitor_environment.active_incident is not None
 
-    @patch("sentry.issues.producer.produce_occurrence_to_kafka")
+    @patch("sentry.monitors.logic.incident_occurrence.produce_occurrence_to_kafka")
     def test_mark_failed_env_muted(self, mock_produce_occurrence_to_kafka):
         monitor = Monitor.objects.create(
             name="test monitor",
@@ -220,7 +220,7 @@ class MarkFailedTestCase(TestCase):
         assert len(mock_produce_occurrence_to_kafka.mock_calls) == 0
         assert monitor_environment.active_incident is not None
 
-    @patch("sentry.issues.producer.produce_occurrence_to_kafka")
+    @patch("sentry.monitors.logic.incident_occurrence.produce_occurrence_to_kafka")
     def test_mark_failed_issue_threshold(self, mock_produce_occurrence_to_kafka):
         failure_issue_threshold = 8
         monitor = Monitor.objects.create(
@@ -364,7 +364,7 @@ class MarkFailedTestCase(TestCase):
 
     # Test to make sure that timeout mark_failed (which occur in the past)
     # correctly create issues once passing the failure_issue_threshold
-    @patch("sentry.issues.producer.produce_occurrence_to_kafka")
+    @patch("sentry.monitors.logic.incident_occurrence.produce_occurrence_to_kafka")
     def test_mark_failed_issue_threshold_timeout(self, mock_produce_occurrence_to_kafka):
         failure_issue_threshold = 8
         monitor = Monitor.objects.create(
@@ -443,7 +443,7 @@ class MarkFailedTestCase(TestCase):
         assert occurrence["evidence_display"][0]["value"] == "8 timeout check-ins detected"
 
     # we are duplicating this test as the code paths are different, for now
-    @patch("sentry.issues.producer.produce_occurrence_to_kafka")
+    @patch("sentry.monitors.logic.incident_occurrence.produce_occurrence_to_kafka")
     def test_mark_failed_issue_threshold_disabled(self, mock_produce_occurrence_to_kafka):
         failure_issue_threshold = 8
         monitor = Monitor.objects.create(

--- a/tests/sentry/monitors/logic/test_mark_ok.py
+++ b/tests/sentry/monitors/logic/test_mark_ok.py
@@ -110,7 +110,7 @@ class MarkOkTestCase(TestCase):
         assert monitor_environment.next_checkin_latest == now + timedelta(minutes=2)
         assert monitor_environment.last_checkin == now
 
-    @patch("sentry.issues.producer.produce_occurrence_to_kafka")
+    @patch("sentry.monitors.logic.incident_occurrence.produce_occurrence_to_kafka")
     def test_mark_ok_recovery_threshold(self, mock_produce_occurrence_to_kafka):
         now = timezone.now().replace(second=0, microsecond=0)
 


### PR DESCRIPTION
We already moved the incident creation logic into the incidents and
incident_occurrence modules, move the recovery logic into these modules
for consistency as well.

Part of GH-79328