### PR TITLE
chore(ai-consent): Use a new gen_ai_consent_v2024_11_14

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -163,7 +163,7 @@ class GroupAutofixEndpoint(GroupEndpoint):
         if not (
             features.has("projects:ai-autofix", group.project)
             or features.has("organizations:autofix", group.organization)
-            or group.organization.get_option("sentry:gen_ai_consent", False)
+            or group.organization.get_option("sentry:gen_ai_consent_v2024_11_14", False)
         ):
             return self._respond_with_error("AI Autofix is not enabled for this project.", 403)
 

--- a/src/sentry/api/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/api/endpoints/group_autofix_setup_check.py
@@ -109,7 +109,7 @@ class GroupAutofixSetupCheck(GroupEndpoint):
         Checks if we are able to run Autofix on the given group.
         """
         org: Organization = request.organization
-        has_gen_ai_consent = org.get_option("sentry:gen_ai_consent", False)
+        has_gen_ai_consent = org.get_option("sentry:gen_ai_consent_v2024_11_14", False)
 
         is_codebase_indexing_disabled = features.has(
             "organizations:autofix-disable-codebase-indexing",

--- a/src/sentry/api/endpoints/seer_rpc.py
+++ b/src/sentry/api/endpoints/seer_rpc.py
@@ -153,7 +153,7 @@ def get_organization_slug(*, org_id: int) -> dict:
 
 def get_organization_autofix_consent(*, org_id: int) -> dict:
     org: Organization = Organization.objects.get(id=org_id)
-    consent = org.get_option("sentry:gen_ai_consent", False)
+    consent = org.get_option("sentry:gen_ai_consent_v2024_11_14", False)
     github_extension_enabled = org_id in options.get("github-extension.enabled-orgs")
     return {
         "consent": consent or github_extension_enabled,

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -614,7 +614,9 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
                 "githubNudgeInvite": bool(
                     obj.get_option("sentry:github_nudge_invite", GITHUB_COMMENT_BOT_DEFAULT)
                 ),
-                "genAIConsent": bool(obj.get_option("sentry:gen_ai_consent", DATA_CONSENT_DEFAULT)),
+                "genAIConsent": bool(
+                    obj.get_option("sentry:gen_ai_consent_v2024_11_14", DATA_CONSENT_DEFAULT)
+                ),
                 "aggregatedDataConsent": bool(
                     obj.get_option("sentry:aggregated_data_consent", DATA_CONSENT_DEFAULT)
                 ),

--- a/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
@@ -30,7 +30,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
             stack_root="sentry/",
             source_root="sentry/",
         )
-        self.organization.update_option("sentry:gen_ai_consent", True)
+        self.organization.update_option("sentry:gen_ai_consent_v2024_11_14", True)
 
     @patch(
         "sentry.api.endpoints.group_autofix_setup_check.get_repos_and_access",
@@ -143,7 +143,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
 @apply_feature_flag_on_cls("organizations:autofix")
 class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
     def test_no_gen_ai_consent(self):
-        self.organization.update_option("sentry:gen_ai_consent", False)
+        self.organization.update_option("sentry:gen_ai_consent_v2024_11_14", False)
 
         group = self.create_group()
         self.login_as(user=self.user)


### PR DESCRIPTION
Uses a new gen ai consent option which will be defined in https://github.com/getsentry/getsentry/pull/15719

Needs to go in after https://github.com/getsentry/getsentry/pull/15719 but before https://github.com/getsentry/getsentry/pull/15714 and https://github.com/getsentry/sentry/pull/80717