### PR TITLE
ref(crons): Only pass MonitorCheckIns to create_incident_occurrence

### DIFF
--- a/src/sentry/monitors/logic/incident_occurrence.py
+++ b/src/sentry/monitors/logic/incident_occurrence.py
@@ -17,7 +17,6 @@ from sentry.monitors.models import (
     MonitorEnvironment,
     MonitorIncident,
 )
-from sentry.monitors.types import SimpleCheckIn
 
 if TYPE_CHECKING:
     from django.utils.functional import _StrPromise
@@ -26,8 +25,8 @@ logger = logging.getLogger(__name__)
 
 
 def create_incident_occurrence(
-    failed_checkins: Sequence[SimpleCheckIn],
     failed_checkin: MonitorCheckIn,
+    previous_checkins: Sequence[MonitorCheckIn],
     incident: MonitorIncident,
     received: datetime | None,
 ) -> None:
@@ -59,7 +58,7 @@ def create_incident_occurrence(
         evidence_display=[
             IssueEvidence(
                 name="Failure reason",
-                value=str(get_failure_reason(failed_checkins)),
+                value=str(get_failure_reason(previous_checkins)),
                 important=True,
             ),
             IssueEvidence(
@@ -127,7 +126,7 @@ SINGULAR_HUMAN_FAILURE_MAP: Mapping[int, _StrPromise] = {
 }
 
 
-def get_failure_reason(failed_checkins: Sequence[SimpleCheckIn]):
+def get_failure_reason(failed_checkins: Sequence[MonitorCheckIn]):
     """
     Builds a human readable string from a list of failed check-ins.
 

--- a/src/sentry/monitors/logic/incidents.py
+++ b/src/sentry/monitors/logic/incidents.py
@@ -81,11 +81,11 @@ def try_incident_threshold(
     # - We have an active incident and fingerprint
     # - The monitor and env are not muted
     if not monitor_env.monitor.is_muted and not monitor_env.is_muted and incident:
-        checkins = MonitorCheckIn.objects.filter(id__in=[c.id for c in previous_checkins])
+        checkins = list(MonitorCheckIn.objects.filter(id__in=[c.id for c in previous_checkins]))
         for checkin in checkins:
             create_incident_occurrence(
-                previous_checkins,
                 checkin,
+                checkins,
                 incident,
                 received=received,
             )


### PR DESCRIPTION
We already have the check-in objects. There's no reason to need this SimpleCheckIn thing