### PR TITLE
chore(issue-details): Add analytics about sidebar/sections

### DIFF
--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -486,18 +486,18 @@ function useGetAnalyticsDataStreamlinedUI(): StreamlinedUIAnalyticsData {
     return {};
   }
 
-  const sidebarOpenSections: SectionKey[] = [];
+  const sidebarOpenSections: Record<string, boolean> = {};
   for (const sectionKey of Object.values(SectionKey)) {
     const foldSectionKey = getFoldSectionKey(sectionKey);
     const isOpen = localStorage.getItem(foldSectionKey) === 'true';
     if (isOpen) {
-      sidebarOpenSections.push(sectionKey);
+      sidebarOpenSections[`sidebar_${sectionKey}_open`] = true;
     }
   }
 
   return {
     sidebar_open: localStorage.getItem('issue-details-sidebar-open') === 'true',
-    fold_sections_open: sidebarOpenSections.join(','),
+    ...sidebarOpenSections,
   };
 }
 

--- a/static/app/views/issueDetails/streamline/context.tsx
+++ b/static/app/views/issueDetails/streamline/context.tsx
@@ -7,7 +7,7 @@ import {
   useReducer,
 } from 'react';
 
-export const enum SectionKey {
+export enum SectionKey {
   /**
    * Trace timeline or linked error
    */


### PR DESCRIPTION
this pr updates the `issue_details.viewed` event with info about if the sidebar was open and what fold sections are open.