### PR TITLE
feat(insights): Placeholders for Web Vitals boxes

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/webVitalMeters.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalMeters.tsx
@@ -116,27 +116,51 @@ export default function WebVitalMeters({
             </Fragment>
           );
           return (
-            <MeterBarContainer
+            <VitalContainer
               key={webVital}
-              onClick={() => webVitalExists && onClick?.(webVital)}
-              clickable={webVitalExists}
-            >
-              {webVitalExists && <InteractionStateLayer />}
-              {webVitalExists && meterBody}
-              {!webVitalExists && (
-                <StyledTooltip
-                  title={tct('No [webVital] data found in this project.', {
-                    webVital: webVital.toUpperCase(),
-                  })}
-                >
-                  {meterBody}
-                </StyledTooltip>
-              )}
-            </MeterBarContainer>
+              webVital={webVital}
+              webVitalExists={webVitalExists}
+              meterBody={meterBody}
+              onClick={onClick}
+            />
           );
         })}
       </Flex>
     </Container>
+  );
+}
+
+type VitalContainerProps = {
+  meterBody: React.ReactNode;
+  webVital: WebVitals;
+  webVitalExists: boolean;
+  onClick?: (webVital: WebVitals) => void;
+};
+
+function VitalContainer({
+  webVital,
+  webVitalExists,
+  meterBody,
+  onClick,
+}: VitalContainerProps) {
+  return (
+    <MeterBarContainer
+      key={webVital}
+      onClick={() => webVitalExists && onClick?.(webVital)}
+      clickable={webVitalExists}
+    >
+      {webVitalExists && <InteractionStateLayer />}
+      {webVitalExists && meterBody}
+      {!webVitalExists && (
+        <StyledTooltip
+          title={tct('No [webVital] data found in this project.', {
+            webVital: webVital.toUpperCase(),
+          })}
+        >
+          {meterBody}
+        </StyledTooltip>
+      )}
+    </MeterBarContainer>
   );
 }
 

--- a/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
+++ b/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
@@ -44,6 +44,8 @@ import {
   type SubregionCode,
 } from 'sentry/views/insights/types';
 
+const WEB_VITALS_COUNT = 5;
+
 export function WebVitalsLandingPage() {
   const location = useLocation();
   const {isInDomainView} = useDomainViewFilters();
@@ -135,6 +137,7 @@ export function WebVitalsLandingPage() {
                   />
                 </PerformanceScoreChartContainer>
                 <WebVitalMetersContainer>
+                  {(isPending || isProjectScoresLoading) && <WebVitalMetersPlaceholder />}
                   <WebVitalMeters
                     projectData={projectData}
                     projectScore={projectScore}
@@ -188,6 +191,16 @@ export function WebVitalsLandingPage() {
   );
 }
 
+function WebVitalMetersPlaceholder() {
+  return (
+    <LoadingBoxContainer>
+      {[...Array(WEB_VITALS_COUNT)].map((_, index) => (
+        <LoadingBox key={index} />
+      ))}
+    </LoadingBoxContainer>
+  );
+}
+
 function PageWithProviders() {
   return (
     <ModulePageProviders
@@ -217,6 +230,26 @@ const MainContentContainer = styled('div')`
 
 const WebVitalMetersContainer = styled('div')`
   margin-bottom: ${space(2)};
+`;
+
+const LoadingBoxContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+  gap: ${space(1)};
+  align-items: center;
+  flex-wrap: wrap;
+
+  margin-bottom: ${space(1)};
+`;
+
+const LoadingBox = styled('div')`
+  flex: 1;
+  min-width: 140px;
+  height: 90px;
+  background-color: ${p => p.theme.gray100};
+  border-radius: ${p => p.theme.borderRadius};
 `;
 
 export const AlertContent = styled('div')`


### PR DESCRIPTION
This improves the experience by adding placeholder cards for the web vitals while the data is loading. Previously, the vitals cards would be invisible and pop in after the data loaded, causing a very jarring layout shift.

### Before

https://github.com/user-attachments/assets/4a7e4292-c568-4352-b159-9aa81d1452e3

### After

https://github.com/user-attachments/assets/80d06ac4-b27d-45db-9e15-5f40932cc625



