### PR TITLE
ref(crons): Move SimpleCheckIn back to just incident module

### DIFF
--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -37,7 +37,7 @@ from sentry.db.models.utils import slugify_instance
 from sentry.locks import locks
 from sentry.models.environment import Environment
 from sentry.models.rule import Rule, RuleSource
-from sentry.monitors.types import CrontabSchedule, IntervalSchedule, SimpleCheckIn
+from sentry.monitors.types import CrontabSchedule, IntervalSchedule
 from sentry.types.actor import Actor
 from sentry.utils.retries import TimedRetryPolicy
 
@@ -580,9 +580,6 @@ class MonitorCheckIn(Model):
     # what we want to happen, so kill it here
     def _update_timestamps(self):
         pass
-
-    def as_simple_checkin(self) -> SimpleCheckIn:
-        return SimpleCheckIn(self.id, self.date_added, self.status)
 
 
 def delete_file_for_monitorcheckin(instance: MonitorCheckIn, **kwargs):

--- a/src/sentry/monitors/types.py
+++ b/src/sentry/monitors/types.py
@@ -101,17 +101,6 @@ class CheckinItem:
         )
 
 
-@dataclass
-class SimpleCheckIn:
-    """
-    A stripped down check in object
-    """
-
-    id: int
-    date_added: datetime
-    status: int
-
-
 IntervalUnit = Literal["year", "month", "week", "day", "hour", "minute"]
 
 


### PR DESCRIPTION
Turns out we actually really don't need to expose this type more
broadly, and can just use it only in this module.

Part of GH-79328