### PR TITLE
ref(replay): Change Logcat and Timber frames to console frames

### DIFF
--- a/static/app/utils/replays/hydrateBreadcrumbs.tsx
+++ b/static/app/utils/replays/hydrateBreadcrumbs.tsx
@@ -25,14 +25,14 @@ export default function hydrateBreadcrumbs(
             description: t('Encountered an error while hydrating'),
           };
         }
-        // Logcat and Timber are considered a console frame instead of a custom breadcrumb frame
-        if (frame.category === 'Logcat' || frame.category === 'Timber') {
-          frame.category = 'console';
-        }
         return {
           ...frame,
+          // Logcat and Timber are considered a console frame instead of a custom breadcrumb frame
           // custom frames might not have a defined category, so we need to set one
-          category: frame.category || defaultTitle(frame) || 'custom',
+          category:
+            frame.category === 'Logcat' || frame.category === 'Timber'
+              ? 'console'
+              : frame.category || defaultTitle(frame) || 'custom',
           offsetMs: Math.abs(time.getTime() - startTimestampMs),
           timestamp: time,
           timestampMs: time.getTime(),

--- a/static/app/utils/replays/hydrateBreadcrumbs.tsx
+++ b/static/app/utils/replays/hydrateBreadcrumbs.tsx
@@ -27,7 +27,7 @@ export default function hydrateBreadcrumbs(
         }
         return {
           ...frame,
-          // Logcat and Timber are considered a console frame instead of a custom breadcrumb frame
+          // Logcat and Timber are used for mobile replays and are considered a console frame instead of a custom breadcrumb frame
           // custom frames might not have a defined category, so we need to set one
           category:
             frame.category === 'Logcat' || frame.category === 'Timber'

--- a/static/app/utils/replays/hydrateBreadcrumbs.tsx
+++ b/static/app/utils/replays/hydrateBreadcrumbs.tsx
@@ -25,6 +25,10 @@ export default function hydrateBreadcrumbs(
             description: t('Encountered an error while hydrating'),
           };
         }
+        // Logcat and Timber are considered a console frame instead of a custom breadcrumb frame
+        if (frame.category === 'Logcat' || frame.category === 'Timber') {
+          frame.category = 'console';
+        }
         return {
           ...frame,
           // custom frames might not have a defined category, so we need to set one

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -41,6 +41,7 @@ import {
   getNodeIds,
   IncrementalSource,
   isCLSFrame,
+  isConsoleFrame,
   isDeadClick,
   isDeadRageClick,
   isPaintFrame,
@@ -507,7 +508,7 @@ export default class ReplayReader {
   getErrorFrames = () => this._errors;
 
   getConsoleFrames = memoize(() =>
-    this._sortedBreadcrumbFrames.filter(frame => frame.category === 'console')
+    this._sortedBreadcrumbFrames.filter(frame => isConsoleFrame(frame))
   );
 
   getNavigationFrames = memoize(() =>

--- a/static/app/views/replays/detail/console/useConsoleFilters.tsx
+++ b/static/app/views/replays/detail/console/useConsoleFilters.tsx
@@ -5,7 +5,11 @@ import type {SelectOption} from 'sentry/components/compactSelect';
 import {defined} from 'sentry/utils';
 import {decodeList, decodeScalar} from 'sentry/utils/queryString';
 import useFiltersInLocationQuery from 'sentry/utils/replays/hooks/useFiltersInLocationQuery';
-import type {BreadcrumbFrame, ConsoleFrame} from 'sentry/utils/replays/types';
+import {
+  type BreadcrumbFrame,
+  type ConsoleFrame,
+  isConsoleFrame,
+} from 'sentry/utils/replays/types';
 import {filterItems} from 'sentry/views/replays/detail/utils';
 
 export interface ConsoleSelectOption extends SelectOption<string> {
@@ -32,7 +36,7 @@ type Return = {
 };
 
 function getFilterableField(frame: BreadcrumbFrame) {
-  if (frame.category === 'console') {
+  if (isConsoleFrame(frame)) {
     const consoleFrame = frame as ConsoleFrame;
     return consoleFrame.level;
   }


### PR DESCRIPTION
For mobile replays, we use Logcat and Timber as loggers, so we want them to show up in the console tab instead of the breadcrumbs tab.

Before:
![image](https://github.com/user-attachments/assets/71f6fae6-8398-4100-a769-caa028babc78)

After:
![image](https://github.com/user-attachments/assets/12ca430a-deb5-455b-b9e8-540e94cf064d)

