### PR TITLE
fix(issues): Fix bug with shared issues being private

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -855,7 +855,7 @@ def handle_is_public(
     user_id = acting_user.id if acting_user else None
     share_id = None
     for group in group_list:
-        if GroupShare.objects.filter(group=group).delete():
+        if GroupShare.objects.filter(group=group).delete()[0] != 0:
             share_id = None
             Activity.objects.create(
                 project=project_lookup[group.project_id],

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -855,7 +855,7 @@ def handle_is_public(
     user_id = acting_user.id if acting_user else None
     share_id = None
     for group in group_list:
-        if GroupShare.objects.filter(group=group).delete()[0] != 0:
+        if GroupShare.objects.filter(group=group).delete()[0] > 0:
             share_id = None
             Activity.objects.create(
                 project=project_lookup[group.project_id],

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -474,6 +474,10 @@ class TestHandleIsPublic(TestCase):
         assert Activity.objects.filter(
             group=self.group, type=ActivityType.SET_PUBLIC.value
         ).exists()
+        assert not Activity.objects.filter(
+            group=self.group, type=ActivityType.SET_PRIVATE.value
+        ).exists()
+
         assert share_id == new_share.uuid
 
     def test_is_public_existing_shares(self) -> None:


### PR DESCRIPTION
this pr fixes a bug where if you shared an issue for the first time, an activity would show up setting it to be private, before one that showed it as public. this was happening because `delete` returns a tuple, which will always be truthy, even if we didn't delete the `GroupShare`. Now we are explicitly checking to see if we delete `GroupShare` before setting the activity to be private. 