### PR TITLE
feat(autofix): Check specific autofix enabled option

### DIFF
--- a/static/app/components/events/autofix/autofixSetupModal.tsx
+++ b/static/app/components/events/autofix/autofixSetupModal.tsx
@@ -179,8 +179,10 @@ function AutofixGithubIntegrationStep({
               size="sm"
               disabled={!canStartAutofix}
               onClick={handleClose}
+              analyticsEventName="Autofix Setup Enable Autofix"
+              analyticsEventKey="autofix.setup_enable_autofix"
             >
-              {t("Let's Go!")}
+              {t('Enable Autofix')}
             </Button>
           )}
         </GuidedSteps.StepButtons>
@@ -255,6 +257,8 @@ function AutofixGithubIntegrationStep({
             size="sm"
             disabled={!canStartAutofix}
             onClick={handleClose}
+            analyticsEventName="Autofix Setup Skip & Enable Autofix"
+            analyticsEventKey="autofix.setup_skip_enable_autofix"
           >
             {t('Skip & Enable Autofix')}
           </Button>

--- a/static/app/components/events/autofix/useAutofixSetup.tsx
+++ b/static/app/components/events/autofix/useAutofixSetup.tsx
@@ -11,6 +11,9 @@ export interface AutofixSetupRepoDefinition extends AutofixRepoDefinition {
 }
 
 export type AutofixSetupResponse = {
+  autofixEnabled: {
+    ok: boolean;
+  };
   genAIConsent: {
     ok: boolean;
   };

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -19,6 +19,7 @@ import type {User} from './user';
  */
 export interface OrganizationSummary {
   aiSuggestedSolution: boolean;
+  autofixEnabled: boolean;
   avatar: Avatar;
   codecovAccess: boolean;
   dateCreated: string;

--- a/static/app/views/issueDetails/streamline/solutionsHubDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/solutionsHubDrawer.spec.tsx
@@ -43,6 +43,7 @@ describe('SolutionsHubDrawer', () => {
         genAIConsent: {ok: true},
         integration: {ok: true},
         githubWriteIntegration: {ok: true},
+        autofixEnabled: {ok: true},
       },
     });
     MockApiClient.addMockResponse({
@@ -64,6 +65,7 @@ describe('SolutionsHubDrawer', () => {
         genAIConsent: {ok: false},
         integration: {ok: false},
         githubWriteIntegration: {ok: false},
+        autofixEnabled: {ok: false},
       },
     });
     MockApiClient.addMockResponse({
@@ -105,8 +107,6 @@ describe('SolutionsHubDrawer', () => {
     await waitForElementToBeRemoved(() =>
       screen.queryByTestId('ai-setup-loading-indicator')
     );
-
-    expect(screen.getByText(mockEvent.id)).toBeInTheDocument();
 
     expect(screen.getByRole('heading', {name: 'Solutions Hub'})).toBeInTheDocument();
 
@@ -179,5 +179,40 @@ describe('SolutionsHubDrawer', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', {name: 'Start Autofix'})).toBeInTheDocument();
     });
+  });
+
+  it('continues to show setup if autofix is not enabled', async () => {
+    MockApiClient.addMockResponse({
+      url: `/issues/${mockGroup.id}/autofix/setup/`,
+      body: {
+        genAIConsent: {ok: true},
+        integration: {ok: true},
+        githubWriteIntegration: {ok: false, repos: []},
+        autofixEnabled: {ok: false},
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/issues/${mockGroup.id}/autofix/`,
+      body: {autofix: null},
+    });
+
+    render(
+      <SolutionsHubDrawer event={mockEvent} group={mockGroup} project={mockProject} />,
+      {organization}
+    );
+
+    expect(screen.getByTestId('ai-setup-loading-indicator')).toBeInTheDocument();
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('ai-setup-loading-indicator')
+    );
+
+    expect(screen.getByRole('heading', {name: 'Solutions Hub'})).toBeInTheDocument();
+
+    expect(screen.queryByRole('button', {name: 'Start Autofix'})).not.toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {name: 'Skip & Enable Autofix'})
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/solutionsHubDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/solutionsHubDrawer.tsx
@@ -147,7 +147,7 @@ const AiSetupDataConsent = HookOrDefault({
 });
 
 const useEnableAutofix = (groupId: string) => {
-  const api = useApi();
+  const api = useApi({persistInFlight: true});
   const queryClient = useQueryClient();
 
   const organization = useOrganization();

--- a/static/app/views/issueDetails/streamline/solutionsHubDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/solutionsHubDrawer.tsx
@@ -12,7 +12,10 @@ import AutofixFeedback from 'sentry/components/events/autofix/autofixFeedback';
 import {AutofixSetupContent} from 'sentry/components/events/autofix/autofixSetupModal';
 import {AutofixSteps} from 'sentry/components/events/autofix/autofixSteps';
 import {useAiAutofix} from 'sentry/components/events/autofix/useAutofix';
-import {useAutofixSetup} from 'sentry/components/events/autofix/useAutofixSetup';
+import {
+  makeAutofixSetupQueryKey,
+  useAutofixSetup,
+} from 'sentry/components/events/autofix/useAutofixSetup';
 import {DrawerBody, DrawerHeader} from 'sentry/components/globalDrawer/components';
 import {GroupSummaryBody, useGroupSummary} from 'sentry/components/group/groupSummary';
 import HookOrDefault from 'sentry/components/hookOrDefault';
@@ -30,8 +33,10 @@ import {
   getConfigForIssueType,
   shouldShowCustomErrorResourceConfig,
 } from 'sentry/utils/issueTypeConfig';
+import {useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import {getRegionDataFromOrganization} from 'sentry/utils/regions';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
+import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import {MIN_NAV_HEIGHT} from 'sentry/views/issueDetails/streamline/eventTitle';
 import Resources from 'sentry/views/issueDetails/streamline/resources';
@@ -141,6 +146,26 @@ const AiSetupDataConsent = HookOrDefault({
   defaultComponent: () => <div data-test-id="ai-setup-data-consent" />,
 });
 
+const useEnableAutofix = (groupId: string) => {
+  const api = useApi();
+  const queryClient = useQueryClient();
+
+  const organization = useOrganization();
+  return useMutation({
+    mutationFn: () => {
+      return api.requestPromise(`/organizations/${organization.slug}/`, {
+        method: 'PUT',
+        data: {
+          autofixEnabled: true,
+        },
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({queryKey: makeAutofixSetupQueryKey(groupId)});
+    },
+  });
+};
+
 export function SolutionsHubDrawer({group, project, event}: SolutionsHubDrawerProps) {
   const {autofixData, triggerAutofix, reset} = useAiAutofix(group, event);
   const {
@@ -148,13 +173,10 @@ export function SolutionsHubDrawer({group, project, event}: SolutionsHubDrawerPr
     isError,
     isPending: isSummaryLoading,
   } = useGroupSummary(group.id, group.issueCategory);
-  const {
-    data: setupData,
-    isPending: isSetupLoading,
-    refetch: refetchSetup,
-  } = useAutofixSetup({
+  const {data: setupData, isPending: isSetupLoading} = useAutofixSetup({
     groupId: group.id,
   });
+  const enableAutofixMutation = useEnableAutofix(group.id);
 
   useRouteAnalyticsParams({
     autofix_status: autofixData?.status ?? 'none',
@@ -164,6 +186,7 @@ export function SolutionsHubDrawer({group, project, event}: SolutionsHubDrawerPr
 
   const hasConsent = Boolean(setupData?.genAIConsent.ok);
   const isAutofixSetupComplete = setupData?.integration.ok && hasConsent;
+  const autofixEnabled = setupData?.autofixEnabled.ok;
 
   const hasSummary = summaryData && !isError && hasConsent;
 
@@ -245,7 +268,7 @@ export function SolutionsHubDrawer({group, project, event}: SolutionsHubDrawerPr
             </ButtonBar>
           )}
         </HeaderText>
-        {isSetupLoading ? (
+        {isSetupLoading || enableAutofixMutation.isPending ? (
           <div data-test-id="ai-setup-loading-indicator">
             <LoadingIndicator />
           </div>
@@ -264,11 +287,13 @@ export function SolutionsHubDrawer({group, project, event}: SolutionsHubDrawerPr
             )}
             {displayAiAutofix && (
               <Fragment>
-                {!isAutofixSetupComplete ? (
+                {!isAutofixSetupComplete || !autofixEnabled ? (
                   <AutofixSetupContent
                     groupId={group.id}
                     projectId={project.id}
-                    onComplete={refetchSetup}
+                    onComplete={() => {
+                      enableAutofixMutation.mutate();
+                    }}
                   />
                 ) : !autofixData ? (
                   <AutofixStartBox onSend={triggerAutofix} groupId={group.id} />

--- a/tests/js/fixtures/organization.ts
+++ b/tests/js/fixtures/organization.ts
@@ -64,6 +64,7 @@ export function OrganizationFixture( params: Partial<Organization> = {}): Organi
     githubOpenPRBot: false,
     githubPRBot: false,
     hideAiFeatures: false,
+    autofixEnabled: false,
     isDefault: false,
     isDynamicallySampled: true,
     isEarlyAdopter: false,


### PR DESCRIPTION
Should be merged after #80717 to avoid conflicts.

Before, the autofix setup steps will disappear once the required steps are completed. Now we check for a specific option that autofix is enabled. This way the steps don't disappear until you enable it.