### PR TITLE
fix(billing): Fix org stats continuous profiling feature

### DIFF
--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -414,6 +414,90 @@ describe('OrganizationStats', function () {
       expect(screen.queryByText('My Projects')).not.toBeInTheDocument();
     }
   });
+
+  /**
+   * Feature Flagging - Continuous Profiling
+   */
+  it('shows only profile duration category with continuous-profiling-stats feature', async () => {
+    const newOrg = initializeOrg({
+      organization: {
+        features: ['global-views', 'team-insights', 'continuous-profiling-stats'],
+      },
+    });
+
+    render(<OrganizationStats {...defaultProps} organization={newOrg.organization} />, {
+      router: newOrg.router,
+    });
+
+    await userEvent.click(await screen.findByText('Category'));
+
+    // Should show Profile Hours option
+    expect(screen.getByRole('option', {name: 'Profile Hours'})).toBeInTheDocument();
+    // Should not show Profiles (transaction) option
+    expect(screen.queryByRole('option', {name: 'Profiles'})).not.toBeInTheDocument();
+  });
+
+  it('shows both profile hours and profiles categories with continuous-profiling feature', async () => {
+    const newOrg = initializeOrg({
+      organization: {
+        features: ['global-views', 'team-insights', 'continuous-profiling'],
+      },
+    });
+
+    render(<OrganizationStats {...defaultProps} organization={newOrg.organization} />, {
+      router: newOrg.router,
+    });
+
+    await userEvent.click(await screen.findByText('Category'));
+
+    // Should show Profile Hours option
+    expect(screen.getByRole('option', {name: 'Profile Hours'})).toBeInTheDocument();
+    // Should show Profiles (transaction) option
+    expect(screen.queryByRole('option', {name: 'Profiles'})).toBeInTheDocument();
+  });
+
+  it('shows only profile duration category when both profiling features are enabled', async () => {
+    const newOrg = initializeOrg({
+      organization: {
+        features: [
+          'global-views',
+          'team-insights',
+          'continuous-profiling-stats',
+          'continuous-profiling',
+        ],
+      },
+    });
+
+    render(<OrganizationStats {...defaultProps} organization={newOrg.organization} />, {
+      router: newOrg.router,
+    });
+
+    await userEvent.click(await screen.findByText('Category'));
+
+    // Should show Profile Hours option
+    expect(screen.getByRole('option', {name: 'Profile Hours'})).toBeInTheDocument();
+    // Should not show Profiles (transaction) option
+    expect(screen.queryByRole('option', {name: 'Profiles'})).not.toBeInTheDocument();
+  });
+
+  it('shows only Profiles category without profiling features', async () => {
+    const newOrg = initializeOrg({
+      organization: {
+        features: ['global-views', 'team-insights'],
+      },
+    });
+
+    render(<OrganizationStats {...defaultProps} organization={newOrg.organization} />, {
+      router: newOrg.router,
+    });
+
+    await userEvent.click(await screen.findByText('Category'));
+
+    // Should show Profile Hours option
+    expect(screen.queryByRole('option', {name: 'Profile Hours'})).not.toBeInTheDocument();
+    // Should show Profiles (transaction) option
+    expect(screen.getByRole('option', {name: 'Profiles'})).toBeInTheDocument();
+  });
 });
 
 const mockStatsResponse = {

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -257,7 +257,10 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
         return !organization.features.includes('spans-usage-tracking');
       }
       if (DATA_CATEGORY_INFO.profileDuration.plural === opt.value) {
-        return organization.features.includes('continuous-profiling-stats');
+        return (
+          organization.features.includes('continuous-profiling-stats') ||
+          organization.features.includes('continuous-profiling')
+        );
       }
       if (DATA_CATEGORY_INFO.profile.plural === opt.value) {
         return !organization.features.includes('continuous-profiling-stats');


### PR DESCRIPTION
We will be using `continuous-profiling` feature flag to gate continuous profiling. This allows the "Profile Hours" dropdown to show up on the Org stats page for both AM2 and AM3 plans.

We will later clean up `continuous-profiling-stats` feature. This feature is currently injected for AM3 plans.