### PR TITLE
fix(discover): Custom measurements validation in equations

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -256,7 +256,7 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer[Dashboard]):
 
         try:
             batch_features = self.get_metrics_features(
-                self.context["organization"], self.context["user"]
+                self.context.get("organization"), self.context.get("user")
             )
             use_metrics = bool(
                 (
@@ -366,12 +366,14 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
         # Update the context for the queries serializer because the display type is
         # required for validation of the queries
         queries_serializer = self.fields["queries"]
-        queries_serializer.context.update(
-            {
-                "display_type": data.get("display_type"),
-                "user": self.context["request"].user,
-            }
-        )
+        additional_context = {}
+
+        if data.get("display_type"):
+            additional_context["display_type"] = data.get("display_type")
+        if self.context.get("request") and self.context["request"].user:
+            additional_context["user"] = self.context["request"].user
+
+        queries_serializer.context.update(additional_context)
         return super().to_internal_value(data)
 
     def validate(self, data):

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -361,7 +361,7 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
         queries_serializer = self.fields["queries"]
         queries_serializer.context.update(
             {
-                "display_type": data["display_type"],
+                "display_type": data.get("display_type"),
                 "user": self.context["request"].user,
             }
         )

--- a/src/sentry/discover/endpoints/discover_homepage_query.py
+++ b/src/sentry/discover/endpoints/discover_homepage_query.py
@@ -71,7 +71,7 @@ class DiscoverHomepageQueryEndpoint(OrganizationEndpoint):
         serializer = DiscoverSavedQuerySerializer(
             # HACK: To ensure serializer data is valid, pass along a name temporarily
             data={**request.data, "name": "New Query"},
-            context={"params": params},
+            context={"params": params, "organization": organization, "user": request.user},
         )
         if not serializer.is_valid():
             raise ParseError(serializer.errors)

--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -17,6 +17,8 @@ from sentry.discover.models import (
     TeamKeyTransaction,
 )
 from sentry.exceptions import InvalidParams, InvalidSearchQuery
+from sentry.interfaces.user import User
+from sentry.models.organization import Organization
 from sentry.models.team import Team
 from sentry.search.events.builder.discover import DiscoverQueryBuilder
 from sentry.search.events.types import QueryBuilderConfig
@@ -255,7 +257,9 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
         2: {"groupby", "rollup", "aggregations", "conditions", "limit"},
     }
 
-    def get_metrics_features(self, organization, user):
+    def get_metrics_features(
+        self, organization: Organization | None, user: User | None
+    ) -> dict[str, bool]:
         feature_names = [
             "organizations:mep-rollout-flag",
             "organizations:dynamic-sampling",
@@ -330,7 +334,7 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
                 )
             try:
                 batch_features = self.get_metrics_features(
-                    self.context["organization"], self.context["user"]
+                    self.context.get("organization"), self.context.get("user")
                 )
                 use_metrics = (
                     (

--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -6,6 +6,7 @@ from drf_spectacular.utils import extend_schema_serializer
 from rest_framework import serializers
 from rest_framework.serializers import ListField
 
+from sentry import features
 from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.utils import get_date_range_from_params
 from sentry.constants import ALL_ACCESS_PROJECTS
@@ -18,6 +19,7 @@ from sentry.discover.models import (
 from sentry.exceptions import InvalidParams, InvalidSearchQuery
 from sentry.models.team import Team
 from sentry.search.events.builder.discover import DiscoverQueryBuilder
+from sentry.search.events.types import QueryBuilderConfig
 from sentry.snuba.dataset import Dataset
 from sentry.utils.dates import parse_stats_period, validate_interval
 from sentry.utils.snuba import SENTRY_SNUBA_MAP
@@ -253,6 +255,28 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
         2: {"groupby", "rollup", "aggregations", "conditions", "limit"},
     }
 
+    def get_metrics_features(self, organization, user):
+        feature_names = [
+            "organizations:mep-rollout-flag",
+            "organizations:dynamic-sampling",
+            "organizations:performance-use-metrics",
+            "organizations:dashboards-mep",
+        ]
+        batch_features = features.batch_has(
+            feature_names,
+            organization=organization,
+            actor=user,
+        )
+
+        return (
+            batch_features.get(f"organization:{organization.id}", {})
+            if batch_features is not None
+            else {
+                feature_name: features.has(feature_name, organization=organization, actor=user)
+                for feature_name in feature_names
+            }
+        )
+
     def validate_projects(self, projects):
         from sentry.api.validators import validate_project_ids
 
@@ -305,6 +329,18 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
                     0,
                 )
             try:
+                batch_features = self.get_metrics_features(
+                    self.context["organization"], self.context["user"]
+                )
+                use_metrics = (
+                    (
+                        batch_features.get("organizations:mep-rollout-flag", False)
+                        and batch_features.get("organizations:dynamic-sampling", False)
+                    )
+                    or batch_features.get("organizations:performance-use-metrics", False)
+                    or batch_features.get("organizations:dashboards-mep", False)
+                )
+
                 equations, columns = categorize_columns(query["fields"])
                 builder = DiscoverQueryBuilder(
                     dataset=Dataset.Discover,
@@ -313,6 +349,7 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
                     selected_columns=columns,
                     equations=equations,
                     orderby=query.get("orderby"),
+                    config=QueryBuilderConfig(has_metrics=use_metrics),
                 )
                 builder.get_snql_query().validate()
             except (InvalidSearchQuery, ArithmeticError) as err:

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -19,10 +19,7 @@ from sentry.models.dashboard_widget import (
 )
 from sentry.models.project import Project
 from sentry.snuba.metrics.extraction import OnDemandMetricSpecVersioning
-from sentry.testutils.cases import (
-    MetricsEnhancedPerformanceTestCase,
-    OrganizationDashboardWidgetTestCase,
-)
+from sentry.testutils.cases import BaseMetricsTestCase, OrganizationDashboardWidgetTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.skips import requires_snuba
 from sentry.users.models.user import User
@@ -645,9 +642,7 @@ class OrganizationDashboardDetailsDeleteTest(OrganizationDashboardDetailsTestCas
         assert response.status_code == 403
 
 
-class OrganizationDashboardDetailsPutTest(
-    OrganizationDashboardDetailsTestCase, MetricsEnhancedPerformanceTestCase
-):
+class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
     def setUp(self):
         super().setUp()
         self.project = self.create_project()
@@ -2332,14 +2327,13 @@ class OrganizationDashboardDetailsPutTest(
         assert sorted(response.data["projects"]) == [project1.id, project2.id]
 
     def test_save_widget_with_custom_measurement_in_equation_tables(self):
-        self.store_transaction_metric(
-            123,
-            metric="measurements.custom_duration",
-            internal_metric="d:transactions/measurements.custom_duration@millisecond",
-            entity="metrics_distributions",
-            tags={"transaction": "foo_transaction"},
-            timestamp=before_now(days=1) + timedelta(minutes=30),
-            project=self.project.id,
+        BaseMetricsTestCase.store_metric(
+            self.organization.id,
+            self.project.id,
+            "d:transactions/measurements.custom_duration@millisecond",
+            {},
+            int(before_now(days=1).timestamp()),
+            1,
         )
 
         data: dict[str, Any] = {
@@ -2385,14 +2379,13 @@ class OrganizationDashboardDetailsPutTest(
         self.assert_serialized_widget_query(data["widgets"][0]["queries"][0], queries[0])
 
     def test_save_widget_with_custom_measurement_in_equation_line_chart(self):
-        self.store_transaction_metric(
-            123,
-            metric="measurements.custom_duration",
-            internal_metric="d:transactions/measurements.custom_duration@millisecond",
-            entity="metrics_distributions",
-            tags={"transaction": "foo_transaction"},
-            timestamp=before_now(days=1) + timedelta(minutes=30),
-            project=self.project.id,
+        BaseMetricsTestCase.store_metric(
+            self.organization.id,
+            self.project.id,
+            "d:transactions/measurements.custom_duration@millisecond",
+            {},
+            int(before_now(days=1).timestamp()),
+            1,
         )
 
         data: dict[str, Any] = {

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -4,9 +4,9 @@ from datetime import datetime, timedelta
 from typing import Any
 from unittest import mock
 
+import pytest
 from django.urls import reverse
 
-from sentry import sentry_metrics
 from sentry.discover.models import DatasetSourcesTypes
 from sentry.models.dashboard import Dashboard, DashboardTombstone
 from sentry.models.dashboard_permissions import DashboardPermissions
@@ -27,7 +27,7 @@ from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.skips import requires_snuba
 from sentry.users.models.user import User
 
-pytestmark = [requires_snuba, sentry_metrics]
+pytestmark = [requires_snuba, pytest.mark.sentry_metrics]
 
 
 class OrganizationDashboardDetailsTestCase(OrganizationDashboardWidgetTestCase):

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from typing import Any
 from unittest import mock
 
+import pytest
 from django.urls import reverse
 
 from sentry.discover.models import DatasetSourcesTypes
@@ -18,12 +19,16 @@ from sentry.models.dashboard_widget import (
 )
 from sentry.models.project import Project
 from sentry.snuba.metrics.extraction import OnDemandMetricSpecVersioning
-from sentry.testutils.cases import OrganizationDashboardWidgetTestCase
+from sentry.testutils.cases import (
+    MetricsEnhancedPerformanceTestCase,
+    OrganizationDashboardWidgetTestCase,
+)
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.skips import requires_snuba
 from sentry.users.models.user import User
 
 pytestmark = [requires_snuba]
+pytestmark = pytest.mark.sentry_metrics
 
 
 class OrganizationDashboardDetailsTestCase(OrganizationDashboardWidgetTestCase):
@@ -641,7 +646,9 @@ class OrganizationDashboardDetailsDeleteTest(OrganizationDashboardDetailsTestCas
         assert response.status_code == 403
 
 
-class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
+class OrganizationDashboardDetailsPutTest(
+    OrganizationDashboardDetailsTestCase, MetricsEnhancedPerformanceTestCase
+):
     def setUp(self):
         super().setUp()
         self.project = self.create_project()
@@ -2324,6 +2331,112 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         response = self.do_request("put", self.url(dashboard.id), data=data)
         assert response.status_code == 200, response.data
         assert sorted(response.data["projects"]) == [project1.id, project2.id]
+
+    def test_save_widget_with_custom_measurement_in_equation_tables(self):
+        self.store_transaction_metric(
+            123,
+            metric="measurements.custom_duration",
+            internal_metric="d:transactions/measurements.custom_duration@millisecond",
+            entity="metrics_distributions",
+            tags={"transaction": "foo_transaction"},
+            timestamp=before_now(days=1) + timedelta(minutes=30),
+            project=self.project.id,
+        )
+
+        data: dict[str, Any] = {
+            "title": "First dashboard",
+            "widgets": [
+                {
+                    "title": "EPM table",
+                    "displayType": "table",
+                    "queries": [
+                        {
+                            "name": "",
+                            "fields": [
+                                "transaction.duration",
+                                "measurements.custom_duration",
+                                "equation|measurements.custom_duration / transaction.duration",
+                            ],
+                            "columns": [
+                                "transaction.duration",
+                                "measurements.custom_duration",
+                            ],
+                            "aggregates": [
+                                "equation|measurements.custom_duration / transaction.duration"
+                            ],
+                            "conditions": "",
+                            "orderby": "",
+                            "selectedAggregate": 1,
+                        }
+                    ],
+                },
+            ],
+        }
+        with self.feature({"organizations:performance-use-metrics": True}):
+            response = self.do_request("put", self.url(self.dashboard.id), data=data)
+        assert response.status_code == 200, response.data
+
+        widgets = self.get_widgets(self.dashboard.id)
+        assert len(widgets) == 1
+
+        self.assert_serialized_widget(data["widgets"][0], widgets[0])
+
+        queries = widgets[0].dashboardwidgetquery_set.all()
+        assert len(queries) == 1
+        self.assert_serialized_widget_query(data["widgets"][0]["queries"][0], queries[0])
+
+    def test_save_widget_with_custom_measurement_in_equation_line_chart(self):
+        self.store_transaction_metric(
+            123,
+            metric="measurements.custom_duration",
+            internal_metric="d:transactions/measurements.custom_duration@millisecond",
+            entity="metrics_distributions",
+            tags={"transaction": "foo_transaction"},
+            timestamp=before_now(days=1) + timedelta(minutes=30),
+            project=self.project.id,
+        )
+
+        data: dict[str, Any] = {
+            "title": "First dashboard",
+            "widgets": [
+                {
+                    "title": "EPM line",
+                    "displayType": "line",
+                    "queries": [
+                        {
+                            "name": "",
+                            "fields": [
+                                "transaction.duration",
+                                "measurements.custom_duration",
+                                "equation|avg(measurements.custom_duration) / avg(transaction.duration)",
+                            ],
+                            "columns": [
+                                "transaction.duration",
+                                "measurements.custom_duration",
+                            ],
+                            "aggregates": [
+                                "equation|avg(measurements.custom_duration) / avg(transaction.duration)"
+                            ],
+                            "conditions": "",
+                            "orderby": "",
+                            "selectedAggregate": 1,
+                        }
+                    ],
+                },
+            ],
+        }
+        with self.feature({"organizations:performance-use-metrics": True}):
+            response = self.do_request("put", self.url(self.dashboard.id), data=data)
+        assert response.status_code == 200, response.data
+
+        widgets = self.get_widgets(self.dashboard.id)
+        assert len(widgets) == 1
+
+        self.assert_serialized_widget(data["widgets"][0], widgets[0])
+
+        queries = widgets[0].dashboardwidgetquery_set.all()
+        assert len(queries) == 1
+        self.assert_serialized_widget_query(data["widgets"][0]["queries"][0], queries[0])
 
 
 class OrganizationDashboardDetailsOnDemandTest(OrganizationDashboardDetailsTestCase):

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -4,9 +4,9 @@ from datetime import datetime, timedelta
 from typing import Any
 from unittest import mock
 
-import pytest
 from django.urls import reverse
 
+from sentry import sentry_metrics
 from sentry.discover.models import DatasetSourcesTypes
 from sentry.models.dashboard import Dashboard, DashboardTombstone
 from sentry.models.dashboard_permissions import DashboardPermissions
@@ -27,8 +27,7 @@ from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.skips import requires_snuba
 from sentry.users.models.user import User
 
-pytestmark = [requires_snuba]
-pytestmark = pytest.mark.sentry_metrics
+pytestmark = [requires_snuba, sentry_metrics]
 
 
 class OrganizationDashboardDetailsTestCase(OrganizationDashboardWidgetTestCase):

--- a/tests/snuba/api/endpoints/test_discover_homepage_query.py
+++ b/tests/snuba/api/endpoints/test_discover_homepage_query.py
@@ -5,10 +5,8 @@ from django.urls import reverse
 
 from sentry.api.serializers import serialize
 from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryTypes
+from sentry.testutils.cases import MetricsEnhancedPerformanceTestCase
 from sentry.testutils.helpers.datetime import before_now
-from tests.sentry.snuba.metrics.test_metrics_layer.test_metrics_enhanced_performance import (
-    MetricsEnhancedPerformanceTestCase,
-)
 from tests.snuba.api.endpoints.test_discover_saved_queries import DiscoverSavedQueryBase
 
 FEATURES = ("organizations:discover-query", "organizations:performance-use-metrics")


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/80625

If a custom measurement was being used in equations, saving a discover query or dashboard widget would fail validation. This is because we don't fetch custom measurements if `has_metrics` is not defined (i.e. it's `False` by default). In other places of the app we do feature flag checks to verify if the user has metrics and can use custom measurements. I added this to the relevant parts that failed validation.

I also realized that for dashboards, we restrict the kinds of fields we can use in the equation to aggregates only if it's _not_ a table. This check actually didn't ever work because `self.context` never contained the display type. I added something to pass that down.