### PR TITLE
ref(crons): Always pass received

### DIFF
--- a/src/sentry/monitors/clock_tasks/check_missed.py
+++ b/src/sentry/monitors/clock_tasks/check_missed.py
@@ -161,4 +161,4 @@ def mark_environment_missing(monitor_environment_id: int, ts: datetime):
         monitor.schedule,
     )
 
-    mark_failed(checkin, failed_at=most_recent_expected_ts)
+    mark_failed(checkin, failed_at=most_recent_expected_ts, received=ts)

--- a/src/sentry/monitors/clock_tasks/check_timeout.py
+++ b/src/sentry/monitors/clock_tasks/check_timeout.py
@@ -121,4 +121,4 @@ def mark_checkin_timeout(checkin_id: int, ts: datetime) -> None:
             monitor.schedule,
         )
 
-        mark_failed(checkin, failed_at=most_recent_expected_ts)
+        mark_failed(checkin, failed_at=most_recent_expected_ts, received=ts)

--- a/src/sentry/monitors/logic/incident_occurrence.py
+++ b/src/sentry/monitors/logic/incident_occurrence.py
@@ -32,7 +32,7 @@ def create_incident_occurrence(
     failed_checkin: MonitorCheckIn,
     previous_checkins: Sequence[MonitorCheckIn],
     incident: MonitorIncident,
-    received: datetime | None,
+    received: datetime,
 ) -> None:
     monitor_env = failed_checkin.monitor_environment
 
@@ -92,8 +92,10 @@ def create_incident_occurrence(
         "fingerprint": [incident.grouphash],
         "platform": "other",
         "project_id": monitor_env.monitor.project_id,
-        # We set this to the time that the checkin that triggered the occurrence was written to relay if available
-        "received": (received if received else current_timestamp).isoformat(),
+        # This is typically the time that the checkin that triggered the
+        # occurrence was written to relay, otherwise it is when we detected a
+        # missed or timeout.
+        "received": received.isoformat(),
         "sdk": None,
         "tags": {
             "monitor.id": str(monitor_env.monitor.guid),

--- a/src/sentry/monitors/logic/incidents.py
+++ b/src/sentry/monitors/logic/incidents.py
@@ -34,7 +34,7 @@ class SimpleCheckIn:
 
 def try_incident_threshold(
     failed_checkin: MonitorCheckIn,
-    received: datetime | None,
+    received: datetime,
 ) -> bool:
     """
     Determine if a monitor environment has reached it's incident threshold
@@ -115,12 +115,7 @@ def try_incident_threshold(
     if not monitor_env.monitor.is_muted and not monitor_env.is_muted and incident:
         checkins = list(MonitorCheckIn.objects.filter(id__in=[c.id for c in previous_checkins]))
         for checkin in checkins:
-            create_incident_occurrence(
-                checkin,
-                checkins,
-                incident,
-                received=received,
-            )
+            create_incident_occurrence(checkin, checkins, incident, received)
 
     monitor_environment_failed.send(monitor_environment=monitor_env, sender=type(monitor_env))
 

--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -30,6 +30,10 @@ def mark_failed(
     if monitor_env is None:
         return False
 
+    # Use the failure time as recieved if there is no received time
+    if received is None:
+        received = failed_at
+
     # Compute the next check-in time from our reference time
     next_checkin = monitor_env.monitor.get_next_expected_checkin(failed_at)
     next_checkin_latest = monitor_env.monitor.get_next_expected_checkin_latest(failed_at)


### PR DESCRIPTION
This does change behavior slightly in that issue occurrences will used the miss / timeout clock-tick time for issue occurrences for those.

Part of GH-79328