### PR TITLE
chore(integrations): consolidate various SCM interactions into a single Enum

### DIFF
--- a/src/sentry/integrations/bitbucket/issues.py
+++ b/src/sentry/integrations/bitbucket/issues.py
@@ -6,9 +6,7 @@ from typing import Any
 from django.urls import reverse
 
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
-from sentry.integrations.source_code_management.metrics import (
-    SourceCodeIssueIntegrationInteractionType,
-)
+from sentry.integrations.source_code_management.metrics import SCMIntegrationInteractionType
 from sentry.models.group import Group
 from sentry.shared_integrations.exceptions import ApiError, IntegrationFormError
 from sentry.silo.base import all_silo_function
@@ -122,7 +120,7 @@ class BitbucketIssuesSpec(SourceCodeIssueIntegration):
         ]
 
     def create_issue(self, data, **kwargs):
-        with self.record_event(SourceCodeIssueIntegrationInteractionType.CREATE_ISSUE).capture():
+        with self.record_event(SCMIntegrationInteractionType.CREATE_ISSUE).capture():
             client = self.get_client()
             if not data.get("repo"):
                 raise IntegrationFormError({"repo": ["Repository is required"]})

--- a/src/sentry/integrations/bitbucket/issues.py
+++ b/src/sentry/integrations/bitbucket/issues.py
@@ -6,7 +6,6 @@ from typing import Any
 from django.urls import reverse
 
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
-from sentry.integrations.source_code_management.metrics import SCMIntegrationInteractionType
 from sentry.models.group import Group
 from sentry.shared_integrations.exceptions import ApiError, IntegrationFormError
 from sentry.silo.base import all_silo_function
@@ -120,25 +119,24 @@ class BitbucketIssuesSpec(SourceCodeIssueIntegration):
         ]
 
     def create_issue(self, data, **kwargs):
-        with self.record_event(SCMIntegrationInteractionType.CREATE_ISSUE).capture():
-            client = self.get_client()
-            if not data.get("repo"):
-                raise IntegrationFormError({"repo": ["Repository is required"]})
+        client = self.get_client()
+        if not data.get("repo"):
+            raise IntegrationFormError({"repo": ["Repository is required"]})
 
-            data["content"] = {"raw": data["description"]}
-            del data["description"]
+        data["content"] = {"raw": data["description"]}
+        del data["description"]
 
-            try:
-                issue = client.create_issue(data.get("repo"), data)
-            except ApiError as e:
-                self.raise_error(e)
+        try:
+            issue = client.create_issue(data.get("repo"), data)
+        except ApiError as e:
+            self.raise_error(e)
 
-            return {
-                "key": issue["id"],
-                "title": issue["title"],
-                "description": issue["content"]["html"],  # users content rendered as html
-                "repo": data.get("repo"),
-            }
+        return {
+            "key": issue["id"],
+            "title": issue["title"],
+            "description": issue["content"]["html"],  # users content rendered as html
+            "repo": data.get("repo"),
+        }
 
     def get_issue(self, issue_id, **kwargs):
         client = self.get_client()

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -11,9 +11,7 @@ from sentry.eventstore.models import Event, GroupEvent
 from sentry.integrations.mixins.issues import MAX_CHAR
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
-from sentry.integrations.source_code_management.metrics import (
-    SourceCodeIssueIntegrationInteractionType,
-)
+from sentry.integrations.source_code_management.metrics import SCMIntegrationInteractionType
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import Group
 from sentry.organizations.services.organization.service import organization_service
@@ -173,7 +171,7 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
         ]
 
     def create_issue(self, data: Mapping[str, Any], **kwargs: Any) -> Mapping[str, Any]:
-        with self.record_event(SourceCodeIssueIntegrationInteractionType.CREATE_ISSUE).capture():
+        with self.record_event(SCMIntegrationInteractionType.CREATE_ISSUE).capture():
             client = self.get_client()
 
             repo = data.get("repo")

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -11,7 +11,6 @@ from sentry.eventstore.models import Event, GroupEvent
 from sentry.integrations.mixins.issues import MAX_CHAR
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
-from sentry.integrations.source_code_management.metrics import SCMIntegrationInteractionType
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import Group
 from sentry.organizations.services.organization.service import organization_service
@@ -171,34 +170,33 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
         ]
 
     def create_issue(self, data: Mapping[str, Any], **kwargs: Any) -> Mapping[str, Any]:
-        with self.record_event(SCMIntegrationInteractionType.CREATE_ISSUE).capture():
-            client = self.get_client()
+        client = self.get_client()
 
-            repo = data.get("repo")
+        repo = data.get("repo")
 
-            if not repo:
-                raise IntegrationError("repo kwarg must be provided")
+        if not repo:
+            raise IntegrationError("repo kwarg must be provided")
 
-            try:
-                issue = client.create_issue(
-                    repo=repo,
-                    data={
-                        "title": data["title"],
-                        "body": data["description"],
-                        "assignee": data.get("assignee"),
-                        "labels": data.get("labels"),
-                    },
-                )
-            except ApiError as e:
-                raise IntegrationError(self.message_from_error(e))
+        try:
+            issue = client.create_issue(
+                repo=repo,
+                data={
+                    "title": data["title"],
+                    "body": data["description"],
+                    "assignee": data.get("assignee"),
+                    "labels": data.get("labels"),
+                },
+            )
+        except ApiError as e:
+            raise IntegrationError(self.message_from_error(e))
 
-            return {
-                "key": issue["number"],
-                "title": issue["title"],
-                "description": issue["body"],
-                "url": issue["html_url"],
-                "repo": repo,
-            }
+        return {
+            "key": issue["number"],
+            "title": issue["title"],
+            "description": issue["body"],
+            "url": issue["html_url"],
+            "repo": repo,
+        }
 
     def get_link_issue_config(self, group: Group, **kwargs: Any) -> list[dict[str, Any]]:
         params = kwargs.pop("params", {})

--- a/src/sentry/integrations/gitlab/issues.py
+++ b/src/sentry/integrations/gitlab/issues.py
@@ -7,9 +7,7 @@ from typing import Any
 from django.urls import reverse
 
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
-from sentry.integrations.source_code_management.metrics import (
-    SourceCodeIssueIntegrationInteractionType,
-)
+from sentry.integrations.source_code_management.metrics import SCMIntegrationInteractionType
 from sentry.models.group import Group
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
 from sentry.silo.base import all_silo_function
@@ -80,7 +78,7 @@ class GitlabIssuesSpec(SourceCodeIssueIntegration):
         ]
 
     def create_issue(self, data, **kwargs):
-        with self.record_event(SourceCodeIssueIntegrationInteractionType.CREATE_ISSUE).capture():
+        with self.record_event(SCMIntegrationInteractionType.CREATE_ISSUE).capture():
             client = self.get_client()
 
             project_id = data.get("project")

--- a/src/sentry/integrations/gitlab/issues.py
+++ b/src/sentry/integrations/gitlab/issues.py
@@ -7,7 +7,6 @@ from typing import Any
 from django.urls import reverse
 
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
-from sentry.integrations.source_code_management.metrics import SCMIntegrationInteractionType
 from sentry.models.group import Group
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
 from sentry.silo.base import all_silo_function
@@ -78,32 +77,31 @@ class GitlabIssuesSpec(SourceCodeIssueIntegration):
         ]
 
     def create_issue(self, data, **kwargs):
-        with self.record_event(SCMIntegrationInteractionType.CREATE_ISSUE).capture():
-            client = self.get_client()
+        client = self.get_client()
 
-            project_id = data.get("project")
+        project_id = data.get("project")
 
-            if not project_id:
-                raise IntegrationError("project kwarg must be provided")
+        if not project_id:
+            raise IntegrationError("project kwarg must be provided")
 
-            try:
-                issue = client.create_issue(
-                    project=project_id,
-                    data={"title": data["title"], "description": data["description"]},
-                )
-                project = client.get_project(project_id)
-            except ApiError as e:
-                raise IntegrationError(self.message_from_error(e))
+        try:
+            issue = client.create_issue(
+                project=project_id,
+                data={"title": data["title"], "description": data["description"]},
+            )
+            project = client.get_project(project_id)
+        except ApiError as e:
+            raise IntegrationError(self.message_from_error(e))
 
-            project_and_issue_iid = "{}#{}".format(project["path_with_namespace"], issue["iid"])
-            return {
-                "key": project_and_issue_iid,
-                "title": issue["title"],
-                "description": issue["description"],
-                "url": issue["web_url"],
-                "project": project_id,
-                "metadata": {"display_name": project_and_issue_iid},
-            }
+        project_and_issue_iid = "{}#{}".format(project["path_with_namespace"], issue["iid"])
+        return {
+            "key": project_and_issue_iid,
+            "title": issue["title"],
+            "description": issue["description"],
+            "url": issue["web_url"],
+            "project": project_id,
+            "metadata": {"display_name": project_and_issue_iid},
+        }
 
     def after_link_issue(self, external_issue, **kwargs):
         data = kwargs["data"]

--- a/src/sentry/integrations/source_code_management/issues.py
+++ b/src/sentry/integrations/source_code_management/issues.py
@@ -6,8 +6,8 @@ from typing import Any
 
 from sentry.integrations.mixins.issues import IssueBasicIntegration
 from sentry.integrations.source_code_management.metrics import (
-    SourceCodeIssueIntegrationInteractionEvent,
-    SourceCodeIssueIntegrationInteractionType,
+    SCMIntegrationInteractionEvent,
+    SCMIntegrationInteractionType,
 )
 from sentry.integrations.source_code_management.repository import BaseRepositoryIntegration
 from sentry.models.group import Group
@@ -15,8 +15,8 @@ from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 
 
 class SourceCodeIssueIntegration(IssueBasicIntegration, BaseRepositoryIntegration, ABC):
-    def record_event(self, event: SourceCodeIssueIntegrationInteractionType):
-        return SourceCodeIssueIntegrationInteractionEvent(
+    def record_event(self, event: SCMIntegrationInteractionType):
+        return SCMIntegrationInteractionEvent(
             interaction_type=event,
             provider_key=self.model.provider,
             organization=self.organization,
@@ -27,9 +27,7 @@ class SourceCodeIssueIntegration(IssueBasicIntegration, BaseRepositoryIntegratio
         """
         Returns the default repository and a set/subset of repositories of associated with the installation
         """
-        with self.record_event(
-            SourceCodeIssueIntegrationInteractionType.GET_REPOSITORY_CHOICES
-        ).capture():
+        with self.record_event(SCMIntegrationInteractionType.GET_REPOSITORY_CHOICES).capture():
             try:
                 repos = self.get_repositories()
             except ApiError:

--- a/src/sentry/integrations/source_code_management/metrics.py
+++ b/src/sentry/integrations/source_code_management/metrics.py
@@ -22,11 +22,8 @@ class SCMIntegrationInteractionType(Enum):
     GET_CODEOWNER_FILE = "GET_CODEOWNER_FILE"
     CHECK_FILE = "CHECK_FILE"
 
-    # SourceCodeIssueIntegration
+    # SourceCodeIssueIntegration (SCM only)
     GET_REPOSITORY_CHOICES = "GET_REPOSITORY_CHOICES"
-    CREATE_ISSUE = "CREATE_ISSUE"
-    SYNC_STATUS_OUTBOUND = "SYNC_STATUS_OUTBOUND"
-    SYNC_ASSIGNEE_OUTBOUND = "SYNC_ASSIGNEE_OUTBOUND"
 
     # CommitContextIntegration
     CREATE_COMMENT = "CREATE_COMMENT"

--- a/src/sentry/integrations/source_code_management/metrics.py
+++ b/src/sentry/integrations/source_code_management/metrics.py
@@ -12,66 +12,37 @@ from sentry.models.organization import Organization
 from sentry.organizations.services.organization import RpcOrganization
 
 
-class RepositoryIntegrationInteractionType(Enum):
+class SCMIntegrationInteractionType(Enum):
     """
-    A RepositoryIntegration feature.
+    SCM integration features
     """
 
+    # RepositoryIntegration
     GET_STACKTRACE_LINK = "GET_STACKTRACE_LINK"
     GET_CODEOWNER_FILE = "GET_CODEOWNER_FILE"
     CHECK_FILE = "CHECK_FILE"
 
-    def __str__(self) -> str:
-        return self.value.lower()
-
-
-class SourceCodeIssueIntegrationInteractionType(Enum):
-    """
-    A SourceCodeIssueIntegration feature.
-    """
-
+    # SourceCodeIssueIntegration
     GET_REPOSITORY_CHOICES = "GET_REPOSITORY_CHOICES"
     CREATE_ISSUE = "CREATE_ISSUE"
     SYNC_STATUS_OUTBOUND = "SYNC_STATUS_OUTBOUND"
     SYNC_ASSIGNEE_OUTBOUND = "SYNC_ASSIGNEE_OUTBOUND"
 
+    # CommitContextIntegration
+    CREATE_COMMENT = "CREATE_COMMENT"
+    UPDATE_COMMENT = "UPDATE_COMMENT"
+
+    def __str__(self) -> str:
+        return self.value.lower()
+
 
 @dataclass
-class RepositoryIntegrationInteractionEvent(IntegrationEventLifecycleMetric):
+class SCMIntegrationInteractionEvent(IntegrationEventLifecycleMetric):
     """
     An instance to be recorded of a RepositoryIntegration feature call.
     """
 
-    interaction_type: RepositoryIntegrationInteractionType
-    provider_key: str
-
-    # Optional attributes to populate extras
-    organization: Organization | RpcOrganization | None = None
-    org_integration: OrganizationIntegration | RpcOrganizationIntegration | None = None
-
-    def get_integration_domain(self) -> IntegrationDomain:
-        return IntegrationDomain.SOURCE_CODE_MANAGEMENT
-
-    def get_integration_name(self) -> str:
-        return self.provider_key
-
-    def get_interaction_type(self) -> str:
-        return str(self.interaction_type)
-
-    def get_extras(self) -> Mapping[str, Any]:
-        return {
-            "organization_id": (self.organization.id if self.organization else None),
-            "org_integration_id": (self.org_integration.id if self.org_integration else None),
-        }
-
-
-@dataclass
-class SourceCodeIssueIntegrationInteractionEvent(IntegrationEventLifecycleMetric):
-    """
-    An instance to be recorded of a SourceCodeIssueIntegration feature call.
-    """
-
-    interaction_type: SourceCodeIssueIntegrationInteractionType
+    interaction_type: SCMIntegrationInteractionType
     provider_key: str
 
     # Optional attributes to populate extras

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -10,8 +10,8 @@ from sentry.auth.exceptions import IdentityNotValid
 from sentry.integrations.base import IntegrationInstallation
 from sentry.integrations.services.repository import RpcRepository
 from sentry.integrations.source_code_management.metrics import (
-    RepositoryIntegrationInteractionEvent,
-    RepositoryIntegrationInteractionType,
+    SCMIntegrationInteractionEvent,
+    SCMIntegrationInteractionType,
 )
 from sentry.models.repository import Repository
 from sentry.shared_integrations.client.base import BaseApiResponseX
@@ -97,8 +97,8 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
         """
         return []
 
-    def record_event(self, event: RepositoryIntegrationInteractionType):
-        return RepositoryIntegrationInteractionEvent(
+    def record_event(self, event: SCMIntegrationInteractionType):
+        return SCMIntegrationInteractionEvent(
             interaction_type=event,
             provider_key=self.integration_name,
             organization=self.organization,
@@ -118,7 +118,7 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
         filepath: file from the stacktrace (string)
         branch: commitsha or default_branch (string)
         """
-        with self.record_event(RepositoryIntegrationInteractionType.CHECK_FILE).capture():
+        with self.record_event(SCMIntegrationInteractionType.CHECK_FILE).capture():
             filepath = filepath.lstrip("/")
             try:
                 client = self.get_client()
@@ -153,7 +153,7 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
         If no file was found return `None`, and re-raise for non-"Not Found"
         errors, like 403 "Account Suspended".
         """
-        with self.record_event(RepositoryIntegrationInteractionType.GET_STACKTRACE_LINK).capture():
+        with self.record_event(SCMIntegrationInteractionType.GET_STACKTRACE_LINK).capture():
             scope = sentry_sdk.Scope.get_isolation_scope()
             scope.set_tag("stacktrace_link.tried_version", False)
             if version:
@@ -182,7 +182,7 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
          * filepath - full path of the file i.e. CODEOWNERS, .github/CODEOWNERS, docs/CODEOWNERS
          * raw - the decoded raw contents of the codeowner file
         """
-        with self.record_event(RepositoryIntegrationInteractionType.GET_CODEOWNER_FILE).capture():
+        with self.record_event(SCMIntegrationInteractionType.GET_CODEOWNER_FILE).capture():
             if self.codeowners_locations is None:
                 raise NotImplementedError("Implement self.codeowners_locations to use this method.")
 

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -11,7 +11,6 @@ from sentry.integrations.mixins import ResolveSyncAction
 from sentry.integrations.mixins.issues import IssueSyncIntegration
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
-from sentry.integrations.source_code_management.metrics import SCMIntegrationInteractionType
 from sentry.models.activity import Activity
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
 from sentry.silo.base import all_silo_function
@@ -169,36 +168,35 @@ class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration):
         """
         Creates the issue on the remote service and returns an issue ID.
         """
-        with self.record_event(SCMIntegrationInteractionType.CREATE_ISSUE).capture():
-            project_id = data.get("project")
-            if project_id is None:
-                raise ValueError("Azure DevOps expects project")
+        project_id = data.get("project")
+        if project_id is None:
+            raise ValueError("Azure DevOps expects project")
 
-            client = self.get_client()
+        client = self.get_client()
 
-            title = data["title"]
-            description = data["description"]
-            item_type = data["work_item_type"]
+        title = data["title"]
+        description = data["description"]
+        item_type = data["work_item_type"]
 
-            try:
-                created_item = client.create_work_item(
-                    project=project_id,
-                    item_type=item_type,
-                    title=title,
-                    # Descriptions cannot easily be seen. So, a comment will be added as well.
-                    description=markdown(description),
-                    comment=markdown(description),
-                )
-            except Exception as e:
-                self.raise_error(e)
+        try:
+            created_item = client.create_work_item(
+                project=project_id,
+                item_type=item_type,
+                title=title,
+                # Descriptions cannot easily be seen. So, a comment will be added as well.
+                description=markdown(description),
+                comment=markdown(description),
+            )
+        except Exception as e:
+            self.raise_error(e)
 
-            project_name = created_item["fields"]["System.AreaPath"]
-            return {
-                "key": str(created_item["id"]),
-                "title": title,
-                "description": description,
-                "metadata": {"display_name": "{}#{}".format(project_name, created_item["id"])},
-            }
+        project_name = created_item["fields"]["System.AreaPath"]
+        return {
+            "key": str(created_item["id"]),
+            "title": title,
+            "description": description,
+            "metadata": {"display_name": "{}#{}".format(project_name, created_item["id"])},
+        }
 
     def get_issue(self, issue_id: int, **kwargs: Any) -> Mapping[str, Any]:
         client = self.get_client()
@@ -221,110 +219,100 @@ class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration):
         assign: bool = True,
         **kwargs: Any,
     ) -> None:
-        with self.record_event(
-            SCMIntegrationInteractionType.SYNC_ASSIGNEE_OUTBOUND
-        ).capture() as lifecycle:
-            client = self.get_client()
-            assignee = None
+        client = self.get_client()
+        assignee = None
 
-            if user and assign is True:
-                sentry_emails = [email.lower() for email in user.emails]
-                continuation_token = None
-                while True:
-                    vsts_users = client.get_users(self.model.name, continuation_token)
-                    continuation_token = vsts_users.headers.get("X-MS-ContinuationToken")
-                    for vsts_user in vsts_users["value"]:
-                        vsts_email = vsts_user.get("mailAddress")
-                        if vsts_email and vsts_email.lower() in sentry_emails:
-                            assignee = vsts_user["mailAddress"]
-                            break
-
-                    if not continuation_token:
+        if user and assign is True:
+            sentry_emails = [email.lower() for email in user.emails]
+            continuation_token = None
+            while True:
+                vsts_users = client.get_users(self.model.name, continuation_token)
+                continuation_token = vsts_users.headers.get("X-MS-ContinuationToken")
+                for vsts_user in vsts_users["value"]:
+                    vsts_email = vsts_user.get("mailAddress")
+                    if vsts_email and vsts_email.lower() in sentry_emails:
+                        assignee = vsts_user["mailAddress"]
                         break
 
-                if assignee is None:
-                    # TODO(lb): Email people when this happens
-                    self.logger.info(
-                        "vsts.assignee-not-found",
-                        extra={
-                            "integration_id": external_issue.integration_id,
-                            "user_id": user.id,
-                            "issue_key": external_issue.key,
-                        },
-                    )
-                    lifecycle.record_halt()
-                    return
+                if not continuation_token:
+                    break
 
-            try:
-                client.update_work_item(external_issue.key, assigned_to=assignee)
-            except (ApiUnauthorized, ApiError):
+            if assignee is None:
+                # TODO(lb): Email people when this happens
                 self.logger.info(
-                    "vsts.failed-to-assign",
+                    "vsts.assignee-not-found",
                     extra={
                         "integration_id": external_issue.integration_id,
-                        "user_id": user.id if user else None,
+                        "user_id": user.id,
                         "issue_key": external_issue.key,
                     },
                 )
-                lifecycle.record_halt()
+                return
+
+        try:
+            client.update_work_item(external_issue.key, assigned_to=assignee)
+        except (ApiUnauthorized, ApiError):
+            self.logger.info(
+                "vsts.failed-to-assign",
+                extra={
+                    "integration_id": external_issue.integration_id,
+                    "user_id": user.id if user else None,
+                    "issue_key": external_issue.key,
+                },
+            )
 
     def sync_status_outbound(
         self, external_issue: "ExternalIssue", is_resolved: bool, project_id: int, **kwargs: Any
     ) -> None:
-        with self.record_event(
-            SCMIntegrationInteractionType.SYNC_STATUS_OUTBOUND
-        ).capture() as lifecycle:
-            client = self.get_client()
-            work_item = client.get_work_item(external_issue.key)
-            # For some reason, vsts doesn't include the project id
-            # in the work item response.
-            # TODO(jess): figure out if there's a better way to do this
-            vsts_project_name = work_item["fields"]["System.TeamProject"]
+        client = self.get_client()
+        work_item = client.get_work_item(external_issue.key)
+        # For some reason, vsts doesn't include the project id
+        # in the work item response.
+        # TODO(jess): figure out if there's a better way to do this
+        vsts_project_name = work_item["fields"]["System.TeamProject"]
 
-            vsts_projects = client.get_projects()
+        vsts_projects = client.get_projects()
 
-            vsts_project_id = None
-            for p in vsts_projects:
-                if p["name"] == vsts_project_name:
-                    vsts_project_id = p["id"]
-                    break
+        vsts_project_id = None
+        for p in vsts_projects:
+            if p["name"] == vsts_project_name:
+                vsts_project_id = p["id"]
+                break
 
-            integration_external_project = integration_service.get_integration_external_project(
-                organization_id=external_issue.organization_id,
-                integration_id=external_issue.integration_id,
-                external_id=vsts_project_id,
+        integration_external_project = integration_service.get_integration_external_project(
+            organization_id=external_issue.organization_id,
+            integration_id=external_issue.integration_id,
+            external_id=vsts_project_id,
+        )
+        if integration_external_project is None:
+            self.logger.info(
+                "vsts.external-project-not-found",
+                extra={
+                    "integration_id": external_issue.integration_id,
+                    "is_resolved": is_resolved,
+                    "issue_key": external_issue.key,
+                },
             )
-            if integration_external_project is None:
-                self.logger.info(
-                    "vsts.external-project-not-found",
-                    extra={
-                        "integration_id": external_issue.integration_id,
-                        "is_resolved": is_resolved,
-                        "issue_key": external_issue.key,
-                    },
-                )
-                lifecycle.record_halt()
-                return
+            return
 
-            status = (
-                integration_external_project.resolved_status
-                if is_resolved
-                else integration_external_project.unresolved_status
+        status = (
+            integration_external_project.resolved_status
+            if is_resolved
+            else integration_external_project.unresolved_status
+        )
+
+        try:
+            client.update_work_item(external_issue.key, state=status)
+        except (ApiUnauthorized, ApiError) as error:
+            self.logger.info(
+                "vsts.failed-to-change-status",
+                extra={
+                    "integration_id": external_issue.integration_id,
+                    "is_resolved": is_resolved,
+                    "issue_key": external_issue.key,
+                    "exception": error,
+                },
             )
-
-            try:
-                client.update_work_item(external_issue.key, state=status)
-            except (ApiUnauthorized, ApiError) as error:
-                self.logger.info(
-                    "vsts.failed-to-change-status",
-                    extra={
-                        "integration_id": external_issue.integration_id,
-                        "is_resolved": is_resolved,
-                        "issue_key": external_issue.key,
-                        "exception": error,
-                    },
-                )
-                lifecycle.record_halt()
 
     def get_resolve_sync_action(self, data: Mapping[str, Any]) -> ResolveSyncAction:
         done_states = self._get_done_statuses(data["project"])

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -11,9 +11,7 @@ from sentry.integrations.mixins import ResolveSyncAction
 from sentry.integrations.mixins.issues import IssueSyncIntegration
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
-from sentry.integrations.source_code_management.metrics import (
-    SourceCodeIssueIntegrationInteractionType,
-)
+from sentry.integrations.source_code_management.metrics import SCMIntegrationInteractionType
 from sentry.models.activity import Activity
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
 from sentry.silo.base import all_silo_function
@@ -171,7 +169,7 @@ class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration):
         """
         Creates the issue on the remote service and returns an issue ID.
         """
-        with self.record_event(SourceCodeIssueIntegrationInteractionType.CREATE_ISSUE).capture():
+        with self.record_event(SCMIntegrationInteractionType.CREATE_ISSUE).capture():
             project_id = data.get("project")
             if project_id is None:
                 raise ValueError("Azure DevOps expects project")
@@ -224,7 +222,7 @@ class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration):
         **kwargs: Any,
     ) -> None:
         with self.record_event(
-            SourceCodeIssueIntegrationInteractionType.SYNC_ASSIGNEE_OUTBOUND
+            SCMIntegrationInteractionType.SYNC_ASSIGNEE_OUTBOUND
         ).capture() as lifecycle:
             client = self.get_client()
             assignee = None
@@ -274,7 +272,7 @@ class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration):
         self, external_issue: "ExternalIssue", is_resolved: bool, project_id: int, **kwargs: Any
     ) -> None:
         with self.record_event(
-            SourceCodeIssueIntegrationInteractionType.SYNC_STATUS_OUTBOUND
+            SCMIntegrationInteractionType.SYNC_STATUS_OUTBOUND
         ).capture() as lifecycle:
             client = self.get_client()
             work_item = client.get_work_item(external_issue.key)

--- a/tests/sentry/integrations/gitlab/test_issues.py
+++ b/tests/sentry/integrations/gitlab/test_issues.py
@@ -1,12 +1,9 @@
-from unittest import mock
-
 import pytest
 import responses
 
 from fixtures.gitlab import GitLabTestCase
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.services.integration import integration_service
-from sentry.integrations.types import EventLifecycleOutcome
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils.factories import EventType
 from sentry.testutils.helpers.datetime import before_now
@@ -140,8 +137,7 @@ class GitlabIssuesTest(GitLabTestCase):
         ]
 
     @responses.activate
-    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
-    def test_create_issue(self, mock_record):
+    def test_create_issue(self):
         issue_iid = "1"
         project_id = "10"
         project_name = "getsentry/sentry"
@@ -176,29 +172,6 @@ class GitlabIssuesTest(GitLabTestCase):
             "project": project_id,
             "metadata": {"display_name": key},
         }
-        assert len(mock_record.mock_calls) == 2
-        start, halt = mock_record.mock_calls
-        assert start.args[0] == EventLifecycleOutcome.STARTED
-        assert halt.args[0] == EventLifecycleOutcome.SUCCESS
-
-    @responses.activate
-    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
-    def test_create_issue_failure(self, mock_record):
-        """
-        Test that metrics are being correctly emitted on failure.
-        """
-        form_data = {
-            "title": "rip",
-            "description": "Goodnight, sweet prince",
-        }
-
-        with pytest.raises(IntegrationError):
-            self.installation.create_issue(form_data)
-
-        assert len(mock_record.mock_calls) == 2
-        start, halt = mock_record.mock_calls
-        assert start.args[0] == EventLifecycleOutcome.STARTED
-        assert halt.args[0] == EventLifecycleOutcome.FAILURE
 
     @responses.activate
     def test_get_issue(self):

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -199,6 +199,16 @@ class VstsIssueSyncTest(VstsIssueBase):
         ]
 
     @responses.activate
+    def test_create_issue_failure(self):
+        form_data = {
+            "title": "rip",
+            "description": "Goodnight, sweet prince",
+        }
+
+        with pytest.raises(ValueError):
+            self.integration.create_issue(form_data)
+
+    @responses.activate
     def test_get_issue(self):
         responses.add(
             responses.GET,

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -21,7 +21,6 @@ from sentry.integrations.mixins import ResolveSyncAction
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration_external_project import IntegrationExternalProject
 from sentry.integrations.services.integration import integration_service
-from sentry.integrations.types import EventLifecycleOutcome
 from sentry.integrations.vsts.integration import VstsIntegration
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.silo.base import SiloMode
@@ -168,8 +167,7 @@ class VstsIssueSyncTest(VstsIssueBase):
         responses.reset()
 
     @responses.activate
-    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
-    def test_create_issue(self, mock_record):
+    def test_create_issue(self):
         responses.add(
             responses.PATCH,
             "https://fabrikam-fiber-inc.visualstudio.com/0987654321/_apis/wit/workitems/$Microsoft.VSTS.WorkItemTypes.Task",
@@ -199,29 +197,6 @@ class VstsIssueSyncTest(VstsIssueBase):
             {"op": "add", "path": "/fields/System.Description", "value": "<p>Fix this.</p>\n"},
             {"op": "add", "path": "/fields/System.History", "value": "<p>Fix this.</p>\n"},
         ]
-        assert len(mock_record.mock_calls) == 2
-        start, halt = mock_record.mock_calls
-        assert start.args[0] == EventLifecycleOutcome.STARTED
-        assert halt.args[0] == EventLifecycleOutcome.SUCCESS
-
-    @responses.activate
-    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
-    def test_create_issue_failure(self, mock_record):
-        """
-        Test that metrics are being correctly emitted on failure.
-        """
-        form_data = {
-            "title": "rip",
-            "description": "Goodnight, sweet prince",
-        }
-
-        with pytest.raises(ValueError):
-            self.integration.create_issue(form_data)
-
-        assert len(mock_record.mock_calls) == 2
-        start, halt = mock_record.mock_calls
-        assert start.args[0] == EventLifecycleOutcome.STARTED
-        assert halt.args[0] == EventLifecycleOutcome.FAILURE
 
     @responses.activate
     def test_get_issue(self):
@@ -242,8 +217,7 @@ class VstsIssueSyncTest(VstsIssueBase):
 
     @responses.activate
     @patch("sentry.integrations.vsts.client.VstsApiClient._use_proxy_url_for_tests")
-    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
-    def test_sync_assignee_outbound(self, mock_record, use_proxy_url_for_tests):
+    def test_sync_assignee_outbound(self, use_proxy_url_for_tests):
         use_proxy_url_for_tests.return_value = True
         vsts_work_item_id = 5
         generate_mock_response(
@@ -288,55 +262,6 @@ class VstsIssueSyncTest(VstsIssueBase):
         assert request_body[0]["value"] == "ftotten@vscsi.us"
         assert request_body[0]["op"] == "replace"
         assert responses.calls[1].response.status_code == 200
-
-        assert len(mock_record.mock_calls) == 2
-        start, halt = mock_record.mock_calls
-        assert start.args[0] == EventLifecycleOutcome.STARTED
-        assert halt.args[0] == EventLifecycleOutcome.SUCCESS
-
-    @responses.activate
-    @patch("sentry.integrations.vsts.client.VstsApiClient._use_proxy_url_for_tests")
-    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
-    def test_sync_assignee_outbound_error(self, mock_record, use_proxy_url_for_tests):
-        """
-        Test that halt metrics are being properly emitted.
-        """
-        use_proxy_url_for_tests.return_value = True
-        vsts_work_item_id = 5
-        generate_mock_response(
-            method=responses.PATCH,
-            body=WORK_ITEM_RESPONSE,
-            content_type="application/json",
-            path=f"_apis/wit/workitems/{vsts_work_item_id}",
-            non_region_url=f"https://fabrikam-fiber-inc.visualstudio.com/_apis/wit/workitems/{vsts_work_item_id}",
-        )
-        generate_mock_response(
-            method=responses.GET,
-            json={
-                "value": [
-                    {"mailAddress": "example1@example.com"},
-                    {"mailAddress": "example2@example.com"},
-                    {"mailAddress": "example3@example.com"},
-                ]
-            },
-            headers={},  # removing the continuation token takes us into the 'assignee is None' code path
-            path="_apis/graph/users",
-            non_region_url="https://fabrikam-fiber-inc.vssps.visualstudio.com/_apis/graph/users",
-        )
-        user = user_service.get_user(user_id=self.create_user("mifu@mifen.io").id)
-        external_issue = ExternalIssue.objects.create(
-            organization_id=self.organization.id,
-            integration_id=self.integration.model.id,
-            key=vsts_work_item_id,
-            title="The Little Prince",
-            description="The most beautiful things in the world cannot be seen or touched, they are felt with the heart.",
-        )
-        self.integration.sync_assignee_outbound(external_issue, user, assign=True)
-
-        assert len(mock_record.mock_calls) == 2
-        start, halt = mock_record.mock_calls
-        assert start.args[0] == EventLifecycleOutcome.STARTED
-        assert halt.args[0] == EventLifecycleOutcome.HALTED
 
     @responses.activate
     @patch("sentry.integrations.vsts.client.VstsApiClient._use_proxy_url_for_tests")
@@ -402,8 +327,7 @@ class VstsIssueSyncTest(VstsIssueBase):
         assert responses.calls[2].response.status_code == 200
 
     @responses.activate
-    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
-    def test_sync_status_outbound(self, mock_record):
+    def test_sync_status_outbound(self):
         vsts_work_item_id = 5
         responses.add(
             responses.PATCH,
@@ -456,57 +380,6 @@ class VstsIssueSyncTest(VstsIssueBase):
             {"path": "/fields/System.State", "value": "Resolved", "op": "replace"}
         ]
         assert responses.calls[2].response.status_code == 200
-
-        assert len(mock_record.mock_calls) == 2
-        start, halt = mock_record.mock_calls
-        assert start.args[0] == EventLifecycleOutcome.STARTED
-        assert halt.args[0] == EventLifecycleOutcome.SUCCESS
-
-    @responses.activate
-    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
-    def test_sync_status_outbound_error(self, mock_record):
-        """
-        Test that halt metrics are being properly emitted.
-        """
-        vsts_work_item_id = 5
-        responses.add(
-            responses.PATCH,
-            f"https://fabrikam-fiber-inc.visualstudio.com/_apis/wit/workitems/{vsts_work_item_id}",
-            body=WORK_ITEM_RESPONSE,
-            content_type="application/json",
-        )
-        responses.add(
-            responses.GET,
-            "https://fabrikam-fiber-inc.vssps.visualstudio.com/_apis/graph/users",
-            body=GET_USERS_RESPONSE,
-            content_type="application/json",
-        )
-        responses.add(
-            responses.GET,
-            f"https://fabrikam-fiber-inc.visualstudio.com/_apis/wit/workitems/{vsts_work_item_id}",
-            body=WORK_ITEM_RESPONSE,
-            content_type="application/json",
-        )
-        responses.add(
-            responses.GET,
-            "https://fabrikam-fiber-inc.visualstudio.com/_apis/projects",
-            body=GET_PROJECTS_RESPONSE,
-            content_type="application/json",
-        )
-        external_issue = ExternalIssue.objects.create(
-            organization_id=self.organization.id,
-            integration_id=self.integration.model.id,
-            key=vsts_work_item_id,
-            title="The Little Prince",
-            description="The most beautiful things in the world cannot be seen or touched, they are felt with the heart.",
-        )
-        self.integration.sync_status_outbound(
-            external_issue, True, self.project.id
-        )  # no external project will be found
-        assert len(mock_record.mock_calls) == 2
-        start, halt = mock_record.mock_calls
-        assert start.args[0] == EventLifecycleOutcome.STARTED
-        assert halt.args[0] == EventLifecycleOutcome.HALTED
 
     def test_get_issue_url(self):
         work_id = 345


### PR DESCRIPTION
We have a couple of source code management Enums to denote the specific interaction type, since there is a lot of complex inheritance going on for SCM integrations. I was about to add another ABC-related Enum when I realized my life would be a lot easier if we just used a single Enum. We can also look at all the SCM features at once with a single Enum.