### PR TITLE
fix(auth): add 401 response to member invite

### DIFF
--- a/src/sentry/api/endpoints/accept_organization_invite.py
+++ b/src/sentry/api/endpoints/accept_organization_invite.py
@@ -111,10 +111,13 @@ class AcceptOrganizationInvite(Endpoint):
         return Response(status=status.HTTP_400_BAD_REQUEST, data={"details": "Invalid invite code"})
 
     @staticmethod
-    def respond_unauthorized() -> Response:
+    def respond_unauthorized(email: str) -> Response:
         return Response(
             status=status.HTTP_401_UNAUTHORIZED,
-            data={"details": "Active session account is not authorized to accept invite"},
+            data={
+                "details": "Active session account is not authorized to accept invite",
+                "user_email": email,
+            },
         )
 
     def get_helper(
@@ -155,7 +158,7 @@ class AcceptOrganizationInvite(Endpoint):
             # not matching the invited user, and the token is definitely not expired (which is what the
             # error message suggests). Prompt the user to sign out and try again.
             if organization_member.user_id and not organization_member.token_expired:
-                return self.respond_unauthorized()
+                return self.respond_unauthorized(organization_member.email)
             return self.respond_invalid()
 
         # Keep track of the invite details in the request session

--- a/src/sentry/api/endpoints/accept_organization_invite.py
+++ b/src/sentry/api/endpoints/accept_organization_invite.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping
 
+from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest
 from django.urls import reverse
 from rest_framework import status
@@ -26,7 +27,6 @@ from sentry.organizations.services.organization import (
 )
 from sentry.types.region import RegionResolutionError, get_region_by_name
 from sentry.utils import auth
-from sudo.forms import AnonymousUser
 
 logger = logging.getLogger(__name__)
 

--- a/tests/sentry/api/endpoints/test_accept_organization_invite.py
+++ b/tests/sentry/api/endpoints/test_accept_organization_invite.py
@@ -97,7 +97,7 @@ class AcceptInviteTest(TestCase, HybridCloudTestMixin):
         om = Factories.create_member(token="abc", organization=self.organization, user=user)
         for path in self._get_paths([om.id, om.token]):
             resp = self.client.get(path)
-            assert resp.status_code == 401
+            assert resp.status_code == 400
 
     def test_invite_unapproved(self):
         om = Factories.create_member(

--- a/tests/sentry/api/endpoints/test_accept_organization_invite.py
+++ b/tests/sentry/api/endpoints/test_accept_organization_invite.py
@@ -97,7 +97,7 @@ class AcceptInviteTest(TestCase, HybridCloudTestMixin):
         om = Factories.create_member(token="abc", organization=self.organization, user=user)
         for path in self._get_paths([om.id, om.token]):
             resp = self.client.get(path)
-            assert resp.status_code == 400
+            assert resp.status_code == 401
 
     def test_invite_unapproved(self):
         om = Factories.create_member(


### PR DESCRIPTION
In the event that a user is logged into Sentry with an account that is different than the account invited to join an organization, we wish to prompt them to log out and try again. To do this, we introduce a 401 UNAUTHORIZED response if the requesting user's email does not match the email in the invite context.

This does not result in any changes on the user side, because the same warning message is rendered for all errors. Frontend changes will come in a subsequent PR.