### PR TITLE
feat(relocation): Add GCP-backed export checkpointer

### DIFF
--- a/src/sentry/backup/crypto.py
+++ b/src/sentry/backup/crypto.py
@@ -216,10 +216,6 @@ class Decryptor(ABC):
     """
 
     @abstractmethod
-    def read(self) -> bytes:
-        pass
-
-    @abstractmethod
     def decrypt_data_encryption_key(self, unwrapped: UnwrappedEncryptedExportTarball) -> bytes:
         pass
 
@@ -235,9 +231,6 @@ class LocalFileDecryptor(Decryptor):
     @classmethod
     def from_bytes(cls, b: bytes) -> LocalFileDecryptor:
         return cls(io.BytesIO(b))
-
-    def read(self) -> bytes:
-        return self.__key
 
     def decrypt_data_encryption_key(self, unwrapped: UnwrappedEncryptedExportTarball) -> bytes:
         """
@@ -287,9 +280,6 @@ class GCPKMSDecryptor(Decryptor):
     @classmethod
     def from_bytes(cls, b: bytes) -> GCPKMSDecryptor:
         return cls(io.BytesIO(b))
-
-    def read(self) -> bytes:
-        return self.__key
 
     def decrypt_data_encryption_key(self, unwrapped: UnwrappedEncryptedExportTarball) -> bytes:
         gcp_kms_config_bytes = self.__key


### PR DESCRIPTION
This builds on the work of #80711 to add a GCP-backed `ExportCheckpointer` implementation. Now, when exporting, we save (always encrypted!) copies of the progress on each model kind seen so far. If the export fails halfway through, we can use these checkpoints to recover much more quickly then if we had to redo all of that work, ensuring a higher chance of success on the retry.