### PR TITLE
fix(crons): Move limit back onto QuerySet for incident detection

### DIFF
--- a/src/sentry/monitors/logic/incidents.py
+++ b/src/sentry/monitors/logic/incidents.py
@@ -70,11 +70,11 @@ def try_incident_threshold(
                     monitor_environment=monitor_env, date_added__lte=failed_checkin.date_added
                 )
                 .order_by("-date_added")
-                .values("id", "date_added", "status")
+                .values("id", "date_added", "status")[:failure_issue_threshold]
             ]
 
             # reverse the list after slicing in order to start with oldest check-in
-            previous_checkins = list(reversed(previous_checkins[:failure_issue_threshold]))
+            previous_checkins = list(reversed(previous_checkins))
 
             # If we have any successful check-ins within the threshold of
             # commits we have NOT reached an incident state


### PR DESCRIPTION
This caused a query regressions in https://github.com/getsentry/sentry/commit/f4933eee5f795d6ea6925a1b48f54ddddf5ae1c3 since the limit was moved off the QuerySet and the query was executed due to the list comprehension 