### PR TITLE
fix(dynamic-sampling): set dynamic sampling project span count mql query limit

### DIFF
--- a/src/sentry/api/endpoints/organization_sampling_project_span_counts.py
+++ b/src/sentry/api/endpoints/organization_sampling_project_span_counts.py
@@ -43,7 +43,7 @@ class OrganizationSamplingProjectSpanCountsEndpoint(OrganizationEndpoint):
             Project.objects.filter(organization=organization, status=ObjectStatus.ACTIVE)
         )
         mql = f"sum({SpanMRI.COUNT_PER_ROOT_PROJECT.value}) by (project,target_project_id)"
-        query = MQLQuery(mql=mql, order=QueryOrder.DESC)
+        query = MQLQuery(mql=mql, order=QueryOrder.DESC, limit=10000)
         results = run_queries(
             mql_queries=[query],
             start=start,


### PR DESCRIPTION
- The query layer seems to have a dynamic limit if the limit is not set in the MQL Query
- This PR fixes that the number of returned elements is dynamically changed depending on 24h vs 30d

Contributes to https://github.com/getsentry/projects/issues/353