### PR TITLE
feat(dynamic-sampling): Show project as active if not 100 percent

### DIFF
--- a/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
@@ -131,7 +131,6 @@ export function ProjectsEditTable({
       }),
     [dataByProjectId, error, initialValue, projects, value]
   );
-  const [activeItems, inactiveItems] = partition(items, item => item.count > 0);
 
   const totalSpanCount = useMemo(
     () => items.reduce((acc, item) => acc + item.count, 0),
@@ -167,6 +166,11 @@ export function ProjectsEditTable({
         {} as Record<string, number>
       ),
     [value]
+  );
+
+  const [activeItems, inactiveItems] = useMemo(
+    () => partition(items, item => item.count > 0 || item.initialSampleRate !== '100'),
+    [items]
   );
 
   const isLoading = fetching || isLoadingProp;


### PR DESCRIPTION
Display a project as part of the active projects if the sample rate is < 100%.

<img width="899" alt="Screenshot 2024-11-15 at 14 47 38" src="https://github.com/user-attachments/assets/4c29657b-c7eb-4487-b7d1-192974c7ae27">

closes https://github.com/getsentry/projects/issues/390