### PR TITLE
fix(insights): filter out ui.action in backend, and add to mobile

### DIFF
--- a/static/app/views/insights/pages/mobile/settings.ts
+++ b/static/app/views/insights/pages/mobile/settings.ts
@@ -9,6 +9,7 @@ export const OVERVIEW_PAGE_ALLOWED_OPS = [
   'ui.action.swipe',
   'ui.action.scroll',
   'ui.action.click',
+  'ui.action',
   'ui.load',
   'app.lifecycle',
   // navigation and pageload are seen in react-native


### PR DESCRIPTION
This PR filters out `ui.action` transactions on the backend page, and adds it to the mobile page. 
`ui.action` is only applicable in mobile 
(The backend page just displays whatever mobile and frontend do not, that's why we just add it to the mobile settings.ts)