### PR TITLE
fix(charts): Respect stacked prop in area chart

### DIFF
--- a/static/app/views/insights/common/components/chart.tsx
+++ b/static/app/views/insights/common/components/chart.tsx
@@ -250,8 +250,10 @@ function Chart({
         metricChartType
       );
       // this helper causes all the incomplete series to stack, here we remove the stacking
-      for (const s of ingestionSeries) {
-        delete s.stack;
+      if (!stacked) {
+        for (const s of ingestionSeries) {
+          delete s.stack;
+        }
       }
       return ingestionSeries;
     });


### PR DESCRIPTION
Not all charts are unstacked. Make sure we respect the stacked prop when deciding to remove the stacking behaviour.