### PR TITLE
feat(crons): Add `system_incidents.use_decisions` option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2018,6 +2018,15 @@ register(
     flags=FLAG_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Enables the the crons incident occurrence consumer to consider the clock-tick
+# decision made based on volume metrics to determine if a incident occurrence
+# should be processed, delayed, or dropped entirely.
+register(
+    "crons.system_incidents.use_decisions",
+    default=False,
+    flags=FLAG_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # The threshold that the tick metric must surpass for a tick to be determined
 # as anomalous. This value should be negative, since we will only determine an
 # incident based on a decrease in volume.


### PR DESCRIPTION
Will be used to determine if the incident occurrence consumer will delay
sending incident occurrences by using clock tick decisions.

This will be a killswitch we can use in the scenario where we falsely
start delaying incident occurrences

Part of GH-79328