### PR TITLE
feat(devservices): Support migrations in devenv sync for new devservices

### DIFF
--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -255,8 +255,6 @@ def main(context: dict[str, str]) -> int:
         print("Skipping python migrations since SENTRY_DEVENV_FRONTEND_ONLY is set.")
         return 0
 
-    postgres_container_name = "sentry_postgres"
-
     if USE_NEW_DEVSERVICES:
         # Ensure old sentry devservices is not being used, otherwise ports will conflict
         proc.run(
@@ -290,6 +288,7 @@ def main(context: dict[str, str]) -> int:
             pathprepend=f"{reporoot}/.devenv/bin",
             exit=True,
         )
+        postgres_container_name = "sentry_postgres"
 
     if not run_procs(
         repo,

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -258,6 +258,16 @@ def main(context: dict[str, str]) -> int:
     postgres_container_name = "sentry_postgres"
 
     if USE_NEW_DEVSERVICES:
+        # Ensure old sentry devservices is not being used, otherwise ports will conflict
+        proc.run(
+            (
+                f"{venv_dir}/bin/{repo}",
+                "devservices",
+                "down",
+            ),
+            pathprepend=f"{reporoot}/.devenv/bin",
+            exit=True,
+        )
         proc.run(
             (
                 f"{venv_dir}/bin/devservices",


### PR DESCRIPTION
For users using the new devservices, they should set the `USE_NEW_DEVSERVICES` in their .env file. 

devenv sync will bring up new devservices in preparation for migrations. It will also bring down services brought up with `sentry devservices` since those will conflict with new devservices ports.