### PR TITLE
feat(crons): Add queue_incident_occurrence

### DIFF
--- a/tests/sentry/monitors/logic/test_incident_occurrence.py
+++ b/tests/sentry/monitors/logic/test_incident_occurrence.py
@@ -1,11 +1,20 @@
 import uuid
 from datetime import timedelta
-from unittest.mock import patch
+from unittest import mock
 
+from arroyo import Topic
+from arroyo.backends.kafka import KafkaPayload
+from django.test import override_settings
 from django.utils import timezone
+from sentry_kafka_schemas.schema_types.monitors_incident_occurrences_v1 import IncidentOccurrence
 
 from sentry.issues.grouptype import MonitorIncidentType
-from sentry.monitors.logic.incident_occurrence import get_failure_reason, send_incident_occurrence
+from sentry.monitors.logic.incident_occurrence import (
+    MONITORS_INCIDENT_OCCURRENCES,
+    get_failure_reason,
+    queue_incident_occurrence,
+    send_incident_occurrence,
+)
 from sentry.monitors.models import (
     CheckInStatus,
     Monitor,
@@ -20,7 +29,7 @@ from sentry.testutils.cases import TestCase
 
 
 class IncidentOccurrenceTestCase(TestCase):
-    @patch("sentry.monitors.logic.incident_occurrence.produce_occurrence_to_kafka")
+    @mock.patch("sentry.monitors.logic.incident_occurrence.produce_occurrence_to_kafka")
     def test_send_incident_occurrence(self, mock_produce_occurrence_to_kafka):
         monitor = Monitor.objects.create(
             name="test monitor",
@@ -187,4 +196,62 @@ class IncidentOccurrenceTestCase(TestCase):
         assert (
             get_failure_reason([miss_checkin, timeout_checkin])
             == "1 missed and 1 timeout check-ins detected"
+        )
+
+    @override_settings(
+        KAFKA_TOPIC_OVERRIDES={"monitors-incident-occurrences": "monitors-test-topic"}
+    )
+    @mock.patch("sentry.monitors.logic.incident_occurrence._incident_occurrence_produer")
+    def test_queue_incident_occurrence(self, mock_producer):
+        tick = timezone.now().replace(second=0, microsecond=0)
+
+        monitor = self.create_monitor()
+        monitor_environment = MonitorEnvironment.objects.create(
+            monitor=monitor,
+            environment_id=self.environment.id,
+            status=MonitorStatus.ERROR,
+        )
+
+        last_checkin = timezone.now()
+        trace_id = uuid.uuid4()
+
+        failed_checkin = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            project_id=self.project.id,
+            status=CheckInStatus.ERROR,
+            trace_id=trace_id,
+            date_added=last_checkin,
+        )
+        incident = MonitorIncident.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            starting_checkin=failed_checkin,
+            starting_timestamp=last_checkin,
+        )
+
+        queue_incident_occurrence(
+            failed_checkin,
+            [failed_checkin],
+            incident,
+            last_checkin,
+            tick,
+        )
+
+        incident_occurrence: IncidentOccurrence = {
+            "incident_id": incident.id,
+            "failed_checkin_id": failed_checkin.id,
+            "previous_checkin_ids": [failed_checkin.id],
+            "received_ts": int(last_checkin.timestamp()),
+            "clock_tick_ts": int(tick.timestamp()),
+        }
+        test_payload = KafkaPayload(
+            str(monitor_environment.id).encode(),
+            MONITORS_INCIDENT_OCCURRENCES.encode(incident_occurrence),
+            [],
+        )
+
+        assert mock_producer.produce.call_count == 1
+        assert mock_producer.produce.mock_calls[0] == mock.call(
+            Topic("monitors-test-topic"), test_payload
         )


### PR DESCRIPTION
Produces an `IncidentOccurrence` message into the monitors-incident-occurrences topic for later issue occurrence dispatching.

Part of GH-79328