### PR TITLE
feat(crons): Respect tick decisions in incident occurrence consumer

### DIFF
--- a/src/sentry/monitors/consumers/incident_occurrences_consumer.py
+++ b/src/sentry/monitors/consumers/incident_occurrences_consumer.py
@@ -6,22 +6,36 @@ from datetime import UTC, datetime
 from typing import TypeGuard
 
 from arroyo.backends.kafka.consumer import KafkaPayload
+from arroyo.processing.strategies import MessageRejected
 from arroyo.processing.strategies.abstract import ProcessingStrategy, ProcessingStrategyFactory
 from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.processing.strategies.run_task import RunTask
 from arroyo.types import BrokerValue, Commit, FilteredPayload, Message, Partition
+from cachetools.func import ttl_cache
 from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.monitors_incident_occurrences_v1 import IncidentOccurrence
 
+from sentry import options
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.monitors.logic.incident_occurrence import send_incident_occurrence
 from sentry.monitors.models import MonitorCheckIn, MonitorIncident
+from sentry.monitors.system_incidents import TickAnomalyDecision, get_clock_tick_decision
 
 logger = logging.getLogger(__name__)
 
 MONITORS_INCIDENT_OCCURRENCES: Codec[IncidentOccurrence] = get_topic_codec(
     Topic.MONITORS_INCIDENT_OCCURRENCES
 )
+
+
+@ttl_cache(ttl=5)
+def memoized_tick_decision(tick: datetime) -> TickAnomalyDecision | None:
+    """
+    Memoized version of get_clock_tick_decision. Used in
+    process_incident_occurrence to avoid stampeding calls when waiting for a
+    tick decision to resolve.
+    """
+    return get_clock_tick_decision(tick)
 
 
 def process_incident_occurrence(message: Message[KafkaPayload | FilteredPayload]):
@@ -33,6 +47,22 @@ def process_incident_occurrence(message: Message[KafkaPayload | FilteredPayload]
     assert isinstance(message.value, BrokerValue)
 
     wrapper: IncidentOccurrence = MONITORS_INCIDENT_OCCURRENCES.decode(message.payload.value)
+    clock_tick = datetime.fromtimestamp(wrapper["clock_tick_ts"], UTC)
+
+    # May be used as a killswitch if system incident decisions become incorrect
+    # for any reason
+    use_decision = options.get("crons.system_incidents.use_decisions")
+    tick_decision = memoized_tick_decision(clock_tick)
+
+    if use_decision and tick_decision and tick_decision.is_pending():
+        # The decision is pending resolution. We need to stop consuming until
+        # the tick decision is resolved so we can know if it's OK to dispatch the
+        # incident occurrence, or if we should drop the occurrence and mark the
+        # associated check-ins as UNKNOWN due to a system incident.
+
+        # XXX(epurkhiser): MessageRejected tells arroyo that we can't process
+        # this message right now and it should try again
+        raise MessageRejected()
 
     try:
         incident = MonitorIncident.objects.get(id=int(wrapper["incident_id"]))
@@ -56,6 +86,15 @@ def process_incident_occurrence(message: Message[KafkaPayload | FilteredPayload]
         return
 
     received = datetime.fromtimestamp(wrapper["received_ts"], UTC)
+
+    if use_decision and tick_decision and tick_decision.is_incident():
+        # TODO(epurkhiser): We are in a system incident. Mark the check-in
+        # which triggerd this incident occurrence as unknown
+        #
+        # We may need some additional logic do determine if one of the
+        # previous_checkins was part of the incident to decide if we can mark that
+        # as unknown.
+        pass
 
     send_incident_occurrence(failed_checkin, previous_checkins, incident, received)
 

--- a/src/sentry/monitors/system_incidents.py
+++ b/src/sentry/monitors/system_incidents.py
@@ -223,6 +223,16 @@ class TickAnomalyDecision(StrEnum):
     either NORMAL or back into INCIDENT.
     """
 
+    def is_pending(self) -> bool:
+        """
+        Returns True when the decision is ABNORMAL or RECOVERING, indicating
+        that we are currently pending resolution of this decision.
+        """
+        return self in [TickAnomalyDecision.ABNORMAL, TickAnomalyDecision.RECOVERING]
+
+    def is_incident(self) -> bool:
+        return self == TickAnomalyDecision.INCIDENT
+
     @classmethod
     def from_str(cls, st: str) -> TickAnomalyDecision:
         return cls[st.upper()]

--- a/tests/sentry/monitors/consumers/test_incident_occurrence_consumer.py
+++ b/tests/sentry/monitors/consumers/test_incident_occurrence_consumer.py
@@ -1,9 +1,9 @@
-import uuid
 from datetime import datetime
 from unittest import mock
 
+import pytest
 from arroyo.backends.kafka import KafkaPayload
-from arroyo.processing.strategies import ProcessingStrategy
+from arroyo.processing.strategies import MessageRejected, ProcessingStrategy
 from arroyo.types import BrokerValue, Message, Partition, Topic
 from django.utils import timezone
 from sentry_kafka_schemas.schema_types.monitors_incident_occurrences_v1 import IncidentOccurrence
@@ -19,7 +19,9 @@ from sentry.monitors.models import (
     MonitorIncident,
     MonitorStatus,
 )
+from sentry.monitors.system_incidents import TickAnomalyDecision
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import override_options
 
 partition = Partition(Topic("test"), 0)
 
@@ -30,7 +32,7 @@ def create_consumer() -> ProcessingStrategy[KafkaPayload]:
     return factory.create_with_partitions(commit, {partition: 0})
 
 
-def sned_incident_occurrence(
+def send_incident_occurrence(
     consumer: ProcessingStrategy[KafkaPayload],
     ts: datetime,
     incident_occurrence: IncidentOccurrence,
@@ -45,125 +47,135 @@ def sned_incident_occurrence(
 
 
 class MonitorsIncidentOccurrenceConsumerTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.monitor = self.create_monitor()
+        self.monitor_environment = MonitorEnvironment.objects.create(
+            monitor=self.monitor,
+            environment_id=self.environment.id,
+            status=MonitorStatus.ERROR,
+        )
+        self.failed_checkin = MonitorCheckIn.objects.create(
+            monitor=self.monitor,
+            monitor_environment=self.monitor_environment,
+            project_id=self.project.id,
+            status=CheckInStatus.ERROR,
+            date_added=timezone.now(),
+        )
+        self.incident = MonitorIncident.objects.create(
+            monitor=self.monitor,
+            monitor_environment=self.monitor_environment,
+            starting_checkin=self.failed_checkin,
+            starting_timestamp=self.failed_checkin.date_added,
+        )
+
     @mock.patch("sentry.monitors.consumers.incident_occurrences_consumer.send_incident_occurrence")
     def test_simple(self, mock_send_incident_occurrence):
         ts = timezone.now().replace(second=0, microsecond=0)
 
-        monitor = self.create_monitor()
-        monitor_environment = MonitorEnvironment.objects.create(
-            monitor=monitor,
-            environment_id=self.environment.id,
-            status=MonitorStatus.ERROR,
-        )
-
-        last_checkin = timezone.now()
-        trace_id = uuid.uuid4()
-
-        failed_checkin = MonitorCheckIn.objects.create(
-            monitor=monitor,
-            monitor_environment=monitor_environment,
-            project_id=self.project.id,
-            status=CheckInStatus.ERROR,
-            trace_id=trace_id,
-            date_added=last_checkin,
-        )
-        incident = MonitorIncident.objects.create(
-            monitor=monitor,
-            monitor_environment=monitor_environment,
-            starting_checkin=failed_checkin,
-            starting_timestamp=last_checkin,
-        )
-
         consumer = create_consumer()
-        sned_incident_occurrence(
+        send_incident_occurrence(
             consumer,
             ts,
             {
                 "clock_tick_ts": int(ts.timestamp()),
-                "received_ts": int(last_checkin.timestamp()),
-                "incident_id": incident.id,
-                "failed_checkin_id": failed_checkin.id,
-                "previous_checkin_ids": [failed_checkin.id],
+                "received_ts": int(self.failed_checkin.date_added.timestamp()),
+                "incident_id": self.incident.id,
+                "failed_checkin_id": self.failed_checkin.id,
+                "previous_checkin_ids": [self.failed_checkin.id],
             },
         )
 
         assert mock_send_incident_occurrence.call_count == 1
         assert mock_send_incident_occurrence.mock_calls[0] == mock.call(
-            failed_checkin,
-            [failed_checkin],
-            incident,
-            last_checkin.replace(microsecond=0),
+            self.failed_checkin,
+            [self.failed_checkin],
+            self.incident,
+            self.failed_checkin.date_added.replace(microsecond=0),
         )
 
     @mock.patch("sentry.monitors.consumers.incident_occurrences_consumer.logger")
     def test_missing_data(self, mock_logger):
         ts = timezone.now().replace(second=0, microsecond=0)
 
-        monitor = self.create_monitor()
-        monitor_environment = MonitorEnvironment.objects.create(
-            monitor=monitor,
-            environment_id=self.environment.id,
-            status=MonitorStatus.ERROR,
-        )
-
-        last_checkin = timezone.now()
-        trace_id = uuid.uuid4()
-
-        failed_checkin = MonitorCheckIn.objects.create(
-            monitor=monitor,
-            monitor_environment=monitor_environment,
-            project_id=self.project.id,
-            status=CheckInStatus.ERROR,
-            trace_id=trace_id,
-            date_added=last_checkin,
-        )
-        incident = MonitorIncident.objects.create(
-            monitor=monitor,
-            monitor_environment=monitor_environment,
-            starting_checkin=failed_checkin,
-            starting_timestamp=last_checkin,
-        )
-
         consumer = create_consumer()
 
         # Send with bad incident id
-        sned_incident_occurrence(
+        send_incident_occurrence(
             consumer,
             ts,
             {
                 "clock_tick_ts": int(ts.timestamp()),
-                "received_ts": int(last_checkin.timestamp()),
+                "received_ts": int(self.failed_checkin.date_added.timestamp()),
                 "incident_id": 1234,
-                "failed_checkin_id": failed_checkin.id,
-                "previous_checkin_ids": [failed_checkin.id],
+                "failed_checkin_id": self.failed_checkin.id,
+                "previous_checkin_ids": [self.failed_checkin.id],
             },
         )
         mock_logger.exception.assert_called_with("missing_incident")
 
         # Send with bad failed_checkin_id
-        sned_incident_occurrence(
+        send_incident_occurrence(
             consumer,
             ts,
             {
                 "clock_tick_ts": int(ts.timestamp()),
-                "received_ts": int(last_checkin.timestamp()),
-                "incident_id": incident.id,
+                "received_ts": int(self.failed_checkin.date_added.timestamp()),
+                "incident_id": self.incident.id,
                 "failed_checkin_id": 1234,
-                "previous_checkin_ids": [failed_checkin.id],
+                "previous_checkin_ids": [self.failed_checkin.id],
             },
         )
         mock_logger.error.assert_called_with("missing_check_ins")
 
         # Send with bad previous_checkin_ids
-        sned_incident_occurrence(
+        send_incident_occurrence(
             consumer,
             ts,
             {
                 "clock_tick_ts": int(ts.timestamp()),
-                "received_ts": int(last_checkin.timestamp()),
-                "incident_id": incident.id,
-                "failed_checkin_id": failed_checkin.id,
+                "received_ts": int(self.failed_checkin.date_added.timestamp()),
+                "incident_id": self.incident.id,
+                "failed_checkin_id": self.failed_checkin.id,
                 "previous_checkin_ids": [123],
             },
         )
         mock_logger.error.assert_called_with("missing_check_ins")
+
+    @mock.patch("sentry.monitors.consumers.incident_occurrences_consumer.send_incident_occurrence")
+    @mock.patch("sentry.monitors.consumers.incident_occurrences_consumer.memoized_tick_decision")
+    @override_options({"crons.system_incidents.use_decisions": True})
+    def test_delayed_decision_dispatch(
+        self,
+        mock_memoized_tick_decision,
+        mock_send_incident_occurrence,
+    ):
+        """
+        Tests that the consumer does NOT send an incident occurrence when the
+        clock tick decision is marked as ABNORMAL or RECOVERING. In these cases
+        we expect the consumer to just keep checking the decision until it
+        resolve to INCIDENT or NORMAL
+        """
+        mock_memoized_tick_decision.return_value = TickAnomalyDecision.ABNORMAL
+
+        ts = timezone.now().replace(second=0, microsecond=0)
+
+        consumer = create_consumer()
+
+        message: IncidentOccurrence = {
+            "clock_tick_ts": int(ts.timestamp()),
+            "received_ts": int(self.failed_checkin.date_added.timestamp()),
+            "incident_id": self.incident.id,
+            "failed_checkin_id": self.failed_checkin.id,
+            "previous_checkin_ids": [self.failed_checkin.id],
+        }
+
+        # Raises a message rejected and does not send the occurrence
+        with pytest.raises(MessageRejected):
+            send_incident_occurrence(consumer, ts, message)
+            assert mock_send_incident_occurrence.call_count == 0
+
+        # Tick decision resolves to OK
+        mock_memoized_tick_decision.return_value = TickAnomalyDecision.NORMAL
+        send_incident_occurrence(consumer, ts, message)
+        assert mock_send_incident_occurrence.call_count == 1


### PR DESCRIPTION
This adds the logic to delay dispatching an incident occurrence based on if we're in an abnormal or recovering state.

Part of GH-79328