### PR TITLE
fix(issue-details): Hide solution section if no resource and AI features are hidden

### DIFF
--- a/static/app/views/issueDetails/groupSidebar.tsx
+++ b/static/app/views/issueDetails/groupSidebar.tsx
@@ -260,7 +260,8 @@ export default function GroupSidebar({
   return (
     <Container>
       {((organization.features.includes('ai-summary') &&
-        issueTypeConfig.issueSummary.enabled) ||
+        issueTypeConfig.issueSummary.enabled &&
+        !organization.hideAiFeatures) ||
         issueTypeConfig.resources) && (
         <SolutionsSectionContainer>
           <SolutionsSection group={group} project={project} event={event} />

--- a/static/app/views/issueDetails/streamline/sidebar.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar.tsx
@@ -52,7 +52,8 @@ export default function StreamlinedSidebar({group, event, project}: Props) {
       </GuideAnchor>
       <StyledBreak />
       {((organization.features.includes('ai-summary') &&
-        issueTypeConfig.issueSummary.enabled) ||
+        issueTypeConfig.issueSummary.enabled &&
+        !organization.hideAiFeatures) ||
         issueTypeConfig.resources) && (
         <Fragment>
           <SolutionsSection group={group} project={project} event={event} />


### PR DESCRIPTION
Before, if no resources were available for an issue, AI was supported, and the org had AI features disabled, we'd still show the solutions section with empty content. This PR fixes that by adding a check for the `hideAiFeatures` setting.