### PR TITLE
styles(explore): Show tooltip for truncated cells in explore

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -302,24 +302,28 @@ export const FIELD_FORMATTERS: FieldFormatters = {
         : defined(data[field])
           ? data[field]
           : emptyValue;
+
       if (isUrl(value)) {
         return (
-          <Container>
-            <ExternalLink href={value} data-test-id="group-tag-url">
-              {value}
-            </ExternalLink>
-          </Container>
+          <Tooltip title={value} containerDisplayMode="block" showOnlyOnOverflow>
+            <Container>
+              <ExternalLink href={value} data-test-id="group-tag-url">
+                {value}
+              </ExternalLink>
+            </Container>
+          </Tooltip>
         );
       }
 
-      const content =
-        value && typeof value === 'string' ? (
-          <span title={value}>{nullableValue(value)}</span>
-        ) : (
-          nullableValue(value)
+      if (value && typeof value === 'string') {
+        return (
+          <Tooltip title={value} containerDisplayMode="block" showOnlyOnOverflow>
+            <Container>{nullableValue(value)}</Container>
+          </Tooltip>
         );
+      }
 
-      return <Container>{content}</Container>;
+      return <Container>{nullableValue(value)}</Container>;
     },
   },
   array: {

--- a/static/app/views/explore/tables/tracesTable/index.tsx
+++ b/static/app/views/explore/tables/tracesTable/index.tsx
@@ -9,6 +9,7 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Pagination from 'sentry/components/pagination';
 import PerformanceDuration from 'sentry/components/performanceDuration';
+import {Tooltip} from 'sentry/components/tooltip';
 import {DEFAULT_PER_PAGE, SPAN_PROPS_DOCS_URL} from 'sentry/constants';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {IconWarning} from 'sentry/icons/iconWarning';
@@ -223,24 +224,26 @@ function TraceRow({
         />
       </StyledPanelItem>
       <StyledPanelItem align="left" overflow>
-        <Description>
-          <ProjectBadgeWrapper>
-            <ProjectsRenderer
-              projectSlugs={
-                traceProjects.length > 0
-                  ? traceProjects
-                  : trace.project
-                    ? [trace.project]
-                    : []
-              }
-            />
-          </ProjectBadgeWrapper>
-          {trace.name ? (
-            <WrappingText>{trace.name}</WrappingText>
-          ) : (
-            <EmptyValueContainer>{t('Missing Trace Root')}</EmptyValueContainer>
-          )}
-        </Description>
+        <Tooltip title={trace.name} containerDisplayMode="block" showOnlyOnOverflow>
+          <Description>
+            <ProjectBadgeWrapper>
+              <ProjectsRenderer
+                projectSlugs={
+                  traceProjects.length > 0
+                    ? traceProjects
+                    : trace.project
+                      ? [trace.project]
+                      : []
+                }
+              />
+            </ProjectBadgeWrapper>
+            {trace.name ? (
+              <WrappingText>{trace.name}</WrappingText>
+            ) : (
+              <EmptyValueContainer>{t('Missing Trace Root')}</EmptyValueContainer>
+            )}
+          </Description>
+        </Tooltip>
       </StyledPanelItem>
       <StyledPanelItem align="right">
         {query ? (


### PR DESCRIPTION
Some cells are truncated in explore due to a lack of space. Show a tooltip for them on hover containing the full text.