### PR TITLE
ref(crons): Bump to latest sentry-kafka-schemas

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -66,7 +66,7 @@ rfc3339-validator>=0.1.2
 rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo>=2.16.5
-sentry-kafka-schemas>=0.1.118
+sentry-kafka-schemas>=0.1.119
 sentry-ophio==1.0.0
 sentry-protos>=0.1.34
 sentry-redis-tools>=0.1.7

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -185,7 +185,7 @@ sentry-cli==2.16.0
 sentry-devenv==1.13.0
 sentry-forked-django-stubs==5.1.1.post1
 sentry-forked-djangorestframework-stubs==3.15.1.post2
-sentry-kafka-schemas==0.1.118
+sentry-kafka-schemas==0.1.119
 sentry-ophio==1.0.0
 sentry-protos==0.1.34
 sentry-redis-tools==0.1.7

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -125,7 +125,7 @@ rpds-py==0.20.0
 rsa==4.8
 s3transfer==0.10.0
 sentry-arroyo==2.16.5
-sentry-kafka-schemas==0.1.118
+sentry-kafka-schemas==0.1.119
 sentry-ophio==1.0.0
 sentry-protos==0.1.34
 sentry-redis-tools==0.1.7


### PR DESCRIPTION
This includes changes to remove the now unused `volume_anomaly_result`
keys from clock ticks and tasks.