### PR TITLE
chore(deps): bump requests

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -60,7 +60,7 @@ rb>=1.9.0
 redis-py-cluster>=2.1.0
 redis>=3.4.1
 requests-oauthlib>=1.2.0
-requests>=2.25.1
+requests>=2.32.0
 # [start] jsonschema format validators
 rfc3339-validator>=0.1.2
 rfc3986-validator>=0.1.1

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -60,7 +60,7 @@ rb>=1.9.0
 redis-py-cluster>=2.1.0
 redis>=3.4.1
 requests-oauthlib>=1.2.0
-requests>=2.32.0
+requests>=2.32.3
 # [start] jsonschema format validators
 rfc3339-validator>=0.1.2
 rfc3986-validator>=0.1.1

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -170,7 +170,7 @@ redis-py-cluster==2.1.0
 referencing==0.30.2
 regex==2022.9.13
 reportlab==4.0.7
-requests==2.31.0
+requests==2.32.3
 requests-file==2.1.0
 requests-oauthlib==1.2.0
 responses==0.23.1
@@ -226,7 +226,7 @@ types-python-dateutil==2.8.19
 types-pytz==2022.1.2
 types-pyyaml==6.0.11
 types-redis==3.5.18
-types-requests==2.31.0.20240406
+types-requests==2.32.0.20241016
 types-setuptools==69.0.0.0
 types-simplejson==3.17.7.2
 typing-extensions==4.12.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -45,7 +45,7 @@ django-csp==3.8
 django-pg-zero-downtime-migrations==0.13
 django-stubs-ext==5.1.1
 djangorestframework==3.15.2
-docker==6.1.3
+docker==7.1.0
 drf-spectacular==0.26.3
 email-reply-parser==0.5.12
 execnet==1.9.0
@@ -238,7 +238,6 @@ urllib3==2.2.2
 vine==5.1.0
 virtualenv==20.25.0
 wcwidth==0.2.10
-websocket-client==1.3.2
 werkzeug==3.0.3
 wheel==0.38.4
 wrapt==1.17.0rc1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -55,6 +55,6 @@ types-pytz
 types-pyyaml
 # make sure to match close-enough to redis==
 types-redis<4
-types-requests>=2.31.0.20240406
+types-requests>=2.32.0.20241016
 types-setuptools>=68
 types-simplejson>=3.17.7.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ sentry-devenv>=1.13.0
 devservices>=1.0.2
 
 covdefaults>=2.3.0
-docker>=6
+docker>=7
 time-machine>=2.16.0
 honcho>=2
 openapi-core>=0.18.2

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -116,7 +116,7 @@ redis-py-cluster==2.1.0
 referencing==0.30.2
 regex==2022.9.13
 reportlab==4.0.7
-requests==2.31.0
+requests==2.32.3
 requests-file==2.1.0
 requests-oauthlib==1.2.0
 rfc3339-validator==0.1.2


### PR DESCRIPTION
- Bumps `requests` to the latest available version to resolve known vulnerabilities.
- Bumps `docker` dev dependency in order to maintain compatibility with the newest version of `requests`.
