### PR TITLE
chore(grouping): Differentiate fingerprint and enhancements class names

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -22,7 +22,7 @@ from sentry.utils.safe import get_path, set_path
 from .exceptions import InvalidEnhancerConfig
 from .matchers import create_match_frame
 from .parser import parse_enhancements
-from .rules import Rule
+from .rules import EnhancementRule
 
 logger = logging.getLogger(__name__)
 
@@ -225,7 +225,7 @@ class Enhancements:
         if version not in VERSIONS:
             raise ValueError("Unknown version")
         return cls(
-            rules=[Rule._from_config_structure(x, version=version) for x in rules],
+            rules=[EnhancementRule._from_config_structure(x, version=version) for x in rules],
             rust_enhancements=rust_enhancements,
             version=version,
             bases=bases,

--- a/src/sentry/grouping/enhancer/actions.py
+++ b/src/sentry/grouping/enhancer/actions.py
@@ -21,7 +21,7 @@ ACTION_FLAGS = {
 REVERSE_ACTION_FLAGS = {v: k for k, v in ACTION_FLAGS.items()}
 
 
-class Action:
+class EnhancementAction:
     _is_modifier: bool
     _is_updater: bool
 
@@ -60,7 +60,7 @@ class Action:
         return FlagAction(ACTIONS[val & 0xF], flag, range)
 
 
-class FlagAction(Action):
+class FlagAction(EnhancementAction):
     def __init__(self, key: str, flag: bool, range: str | None) -> None:
         self.key = key
         self._is_updater = key in {"group", "app"}
@@ -135,7 +135,7 @@ class FlagAction(Action):
                 )
 
 
-class VarAction(Action):
+class VarAction(EnhancementAction):
     range = None
 
     _VALUE_PARSERS: dict[str, Callable[[Any], Any]] = {

--- a/src/sentry/grouping/enhancer/matchers.py
+++ b/src/sentry/grouping/enhancer/matchers.py
@@ -104,7 +104,7 @@ def create_match_frame(frame_data: dict, platform: str | None) -> dict:
     return match_frame
 
 
-class Match:
+class EnhancementMatch:
     def matches_frame(self, frames, idx, exception_data, cache):
         raise NotImplementedError()
 
@@ -115,9 +115,9 @@ class Match:
     def _from_config_structure(obj, version):
         val = obj
         if val.startswith("|[") and val.endswith("]"):
-            return CalleeMatch(Match._from_config_structure(val[2:-1], version))
+            return CalleeMatch(EnhancementMatch._from_config_structure(val[2:-1], version))
         if val.startswith("[") and val.endswith("]|"):
-            return CallerMatch(Match._from_config_structure(val[1:-2], version))
+            return CallerMatch(EnhancementMatch._from_config_structure(val[1:-2], version))
 
         if val.startswith("!"):
             negated = True
@@ -136,13 +136,13 @@ class Match:
 InstanceKey = tuple[str, str, bool]
 
 
-class FrameMatch(Match):
+class FrameMatch(EnhancementMatch):
     # Global registry of matchers
-    instances: dict[InstanceKey, Match] = {}
+    instances: dict[InstanceKey, EnhancementMatch] = {}
     field: Any = None
 
     @classmethod
-    def from_key(cls, key: str, pattern: str, negated: bool) -> Match:
+    def from_key(cls, key: str, pattern: str, negated: bool) -> EnhancementMatch:
         instance_key = (key, pattern, negated)
         if instance_key in cls.instances:
             instance = cls.instances[instance_key]
@@ -153,7 +153,7 @@ class FrameMatch(Match):
         return instance
 
     @classmethod
-    def _from_key(cls, key: str, pattern: str, negated: bool) -> Match:
+    def _from_key(cls, key: str, pattern: str, negated: bool) -> EnhancementMatch:
         subclass = {
             "package": PackageMatch,
             "path": PathMatch,
@@ -315,7 +315,7 @@ class ExceptionMechanismMatch(ExceptionFieldMatch):
     field_path = ["mechanism", "type"]
 
 
-class CallerMatch(Match):
+class CallerMatch(EnhancementMatch):
     def __init__(self, inner: FrameMatch):
         self.inner = inner
 
@@ -330,7 +330,7 @@ class CallerMatch(Match):
         return idx > 0 and self.inner.matches_frame(frames, idx - 1, exception_data, cache)
 
 
-class CalleeMatch(Match):
+class CalleeMatch(EnhancementMatch):
     def __init__(self, inner: FrameMatch):
         self.inner = inner
 

--- a/src/sentry/grouping/enhancer/parser.py
+++ b/src/sentry/grouping/enhancer/parser.py
@@ -7,7 +7,7 @@ from sentry.utils.strings import unescape_string
 from .actions import FlagAction, VarAction
 from .exceptions import InvalidEnhancerConfig
 from .matchers import CalleeMatch, CallerMatch, FrameMatch
-from .rules import Rule
+from .rules import EnhancementRule
 
 # Grammar is defined in EBNF syntax.
 enhancements_grammar = Grammar(
@@ -59,7 +59,7 @@ class EnhancementsVisitor(NodeVisitor):
     visit_comment = visit_empty = lambda *a: None
     unwrapped_exceptions = (InvalidEnhancerConfig,)
 
-    def visit_enhancements(self, node, children) -> list[Rule]:
+    def visit_enhancements(self, node, children) -> list[EnhancementRule]:
         rules = []
         for child in children:
             if not isinstance(child, str) and child is not None:
@@ -75,7 +75,7 @@ class EnhancementsVisitor(NodeVisitor):
 
     def visit_rule(self, node, children):
         _, matcher, actions = children
-        return Rule(matcher, actions)
+        return EnhancementRule(matcher, actions)
 
     def visit_matchers(self, node, children):
         caller_matcher, frame_matchers, callee_matcher = children
@@ -141,7 +141,7 @@ class EnhancementsVisitor(NodeVisitor):
         return node.match.groups()[0].lstrip("!")
 
 
-def parse_enhancements(s: str) -> list[Rule]:
+def parse_enhancements(s: str) -> list[EnhancementRule]:
     try:
         tree = enhancements_grammar.parse(s)
         return EnhancementsVisitor().visit(tree)

--- a/src/sentry/grouping/enhancer/rules.py
+++ b/src/sentry/grouping/enhancer/rules.py
@@ -6,7 +6,7 @@ from .actions import Action
 from .matchers import EnhancementMatch, ExceptionFieldMatch
 
 
-class Rule:
+class EnhancementRule:
     def __init__(self, matchers, actions):
         self.matchers = matchers
 
@@ -29,17 +29,17 @@ class Rule:
             rv = f"{rv} {action}"
         return rv
 
-    def _as_modifier_rule(self) -> Rule | None:
+    def _as_modifier_rule(self) -> EnhancementRule | None:
         actions = [action for action in self.actions if action.is_modifier]
         if actions:
-            return Rule(self.matchers, actions)
+            return EnhancementRule(self.matchers, actions)
         else:
             return None
 
-    def _as_updater_rule(self) -> Rule | None:
+    def _as_updater_rule(self) -> EnhancementRule | None:
         actions = [action for action in self.actions if action.is_updater]
         if actions:
-            return Rule(self.matchers, actions)
+            return EnhancementRule(self.matchers, actions)
         else:
             return None
 
@@ -87,7 +87,7 @@ class Rule:
 
     @classmethod
     def _from_config_structure(cls, tuple, version):
-        return Rule(
+        return EnhancementRule(
             [EnhancementMatch._from_config_structure(x, version) for x in tuple[0]],
             [Action._from_config_structure(x, version) for x in tuple[1]],
         )

--- a/src/sentry/grouping/enhancer/rules.py
+++ b/src/sentry/grouping/enhancer/rules.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from .actions import Action
-from .matchers import ExceptionFieldMatch, Match
+from .matchers import EnhancementMatch, ExceptionFieldMatch
 
 
 class Rule:
@@ -88,6 +88,6 @@ class Rule:
     @classmethod
     def _from_config_structure(cls, tuple, version):
         return Rule(
-            [Match._from_config_structure(x, version) for x in tuple[0]],
+            [EnhancementMatch._from_config_structure(x, version) for x in tuple[0]],
             [Action._from_config_structure(x, version) for x in tuple[1]],
         )

--- a/src/sentry/grouping/enhancer/rules.py
+++ b/src/sentry/grouping/enhancer/rules.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from .actions import Action
+from .actions import EnhancementAction
 from .matchers import EnhancementMatch, ExceptionFieldMatch
 
 
@@ -54,7 +54,7 @@ class EnhancementRule:
         match_frames: list[dict[str, Any]],
         exception_data: dict[str, Any],
         in_memory_cache: dict[str, str],
-    ) -> list[tuple[int, Action]]:
+    ) -> list[tuple[int, EnhancementAction]]:
         """Given a frame returns all the matching actions based on this rule.
         If the rule does not match `None` is returned.
         """
@@ -89,5 +89,5 @@ class EnhancementRule:
     def _from_config_structure(cls, tuple, version):
         return EnhancementRule(
             [EnhancementMatch._from_config_structure(x, version) for x in tuple[0]],
-            [Action._from_config_structure(x, version) for x in tuple[1]],
+            [EnhancementAction._from_config_structure(x, version) for x in tuple[1]],
         )

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -337,7 +337,7 @@ MATCHERS = {
 }
 
 
-class Match:
+class FingerprintMatch:
     def __init__(self, key: str, pattern: str, negated: bool = False) -> None:
         if key.startswith("tags."):
             self.key = key
@@ -457,7 +457,7 @@ class Match:
 class Rule:
     def __init__(
         self,
-        matchers: Sequence[Match],
+        matchers: Sequence[FingerprintMatch],
         fingerprint: list[str],
         attributes: dict[str, Any],
         is_builtin: bool = False,
@@ -470,7 +470,7 @@ class Rule:
     def get_fingerprint_values_for_event_access(
         self, event_access: EventAccess
     ) -> None | tuple[list[str], dict[str, Any]]:
-        by_match_group: dict[str, list[Match]] = {}
+        by_match_group: dict[str, list[FingerprintMatch]] = {}
         for matcher in self.matchers:
             by_match_group.setdefault(matcher.match_group, []).append(matcher)
 
@@ -499,7 +499,7 @@ class Rule:
     @classmethod
     def _from_config_structure(cls, obj: dict[str, Any]) -> Self:
         return cls(
-            [Match._from_config_structure(x) for x in obj["matchers"]],
+            [FingerprintMatch._from_config_structure(x) for x in obj["matchers"]],
             obj["fingerprint"],
             obj.get("attributes") or {},
             obj.get("is_builtin") or False,
@@ -572,7 +572,7 @@ class FingerprintingVisitor(NodeVisitorBase):
         self,
         _: object,
         children: tuple[
-            object, list[Match], object, object, object, tuple[list[str], dict[str, Any]]
+            object, list[FingerprintMatch], object, object, object, tuple[list[str], dict[str, Any]]
         ],
     ) -> Rule:
         _, matcher, _, _, _, (fingerprint, attributes) = children
@@ -580,9 +580,9 @@ class FingerprintingVisitor(NodeVisitorBase):
 
     def visit_matcher(
         self, _: object, children: tuple[object, list[str], str, object, str]
-    ) -> Match:
+    ) -> FingerprintMatch:
         _, negation, ty, _, argument = children
-        return Match(ty, argument, bool(negation))
+        return FingerprintMatch(ty, argument, bool(negation))
 
     def visit_matcher_type(self, _: object, children: list[str]) -> str:
         return children[0]

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -211,7 +211,7 @@ class EventAccess:
 class FingerprintingRules:
     def __init__(
         self,
-        rules: Sequence[Rule],
+        rules: Sequence[FingerprintRule],
         changelog: Sequence[object] | None = None,
         version: int | None = None,
         bases: Sequence[str] | None = None,
@@ -223,7 +223,7 @@ class FingerprintingRules:
         self.changelog = changelog
         self.bases = bases or []
 
-    def iter_rules(self, include_builtin: bool = True) -> Generator[Rule]:
+    def iter_rules(self, include_builtin: bool = True) -> Generator[FingerprintRule]:
         if self.rules:
             yield from self.rules
         if include_builtin:
@@ -249,7 +249,7 @@ class FingerprintingRules:
         if version != VERSION:
             raise ValueError("Unknown version")
         return cls(
-            rules=[Rule._from_config_structure(x) for x in data["rules"]],
+            rules=[FingerprintRule._from_config_structure(x) for x in data["rules"]],
             version=version,
             bases=bases,
         )
@@ -454,7 +454,7 @@ class FingerprintMatch:
         )
 
 
-class Rule:
+class FingerprintRule:
     def __init__(
         self,
         matchers: Sequence[FingerprintMatch],
@@ -539,7 +539,7 @@ class FingerprintingVisitor(NodeVisitorBase):
         return node.text
 
     def visit_fingerprinting_rules(
-        self, _: object, children: list[str | Rule | None]
+        self, _: object, children: list[str | FingerprintRule | None]
     ) -> FingerprintingRules:
         changelog = []
         rules = []
@@ -560,8 +560,8 @@ class FingerprintingVisitor(NodeVisitorBase):
         )
 
     def visit_line(
-        self, _: object, children: tuple[object, list[Rule | str | None], object]
-    ) -> Rule | str | None:
+        self, _: object, children: tuple[object, list[FingerprintRule | str | None], object]
+    ) -> FingerprintRule | str | None:
         _, line, _ = children
         comment_or_rule_or_empty = line[0]
         if comment_or_rule_or_empty:
@@ -574,9 +574,9 @@ class FingerprintingVisitor(NodeVisitorBase):
         children: tuple[
             object, list[FingerprintMatch], object, object, object, tuple[list[str], dict[str, Any]]
         ],
-    ) -> Rule:
+    ) -> FingerprintRule:
         _, matcher, _, _, _, (fingerprint, attributes) = children
-        return Rule(matcher, fingerprint, attributes)
+        return FingerprintRule(matcher, fingerprint, attributes)
 
     def visit_matcher(
         self, _: object, children: tuple[object, list[str], str, object, str]
@@ -634,7 +634,7 @@ class FingerprintingVisitor(NodeVisitorBase):
         return node.match.groups()[0].lstrip("!")
 
 
-def _load_configs() -> dict[str, list[Rule]]:
+def _load_configs() -> dict[str, list[FingerprintRule]]:
     if not CONFIGS_DIR.exists():
         logger.error(
             "Failed to load Fingerprinting Configs, invalid _config_dir: %s",
@@ -645,7 +645,7 @@ def _load_configs() -> dict[str, list[Rule]]:
                 f"Failed to load Fingerprinting Configs, invalid _config_dir: '{CONFIGS_DIR}'"
             )
 
-    configs: dict[str, list[Rule]] = {}
+    configs: dict[str, list[FingerprintRule]] = {}
 
     for config_file_path in sorted(CONFIGS_DIR.glob("**/*.txt")):
         config_name = config_file_path.parent.name

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -141,7 +141,7 @@ def expose_fingerprint_dict(values, info=None):
     if not info:
         return rv
 
-    from sentry.grouping.fingerprinting import Rule
+    from sentry.grouping.fingerprinting import FingerprintRule
 
     client_values = info.get("client_fingerprint")
     if client_values and (
@@ -150,7 +150,7 @@ def expose_fingerprint_dict(values, info=None):
         rv["client_values"] = client_values
     matched_rule = info.get("matched_rule")
     if matched_rule:
-        rule = Rule.from_json(matched_rule)
+        rule = FingerprintRule.from_json(matched_rule)
         rv["matched_rule"] = rule.text
 
     return rv


### PR DESCRIPTION
Both fingerprinting rules and stacktrace rules ("enhancements") use classes called `Rule` and `Match`, and without spending time figuring out the context, it's hard to tell which of them one is dealing with. This therefore changes the names all four classes (along with the enhancements `Action` class, just to keep things standardized) to include `Fingerprint` or `Enhancement` as appropriate. No behavior changes, just a lot of find and replace.