### PR TITLE
fix(migrations): add if not exists to alter table syntax

### DIFF
--- a/src/sentry/uptime/migrations/0018_add_trace_sampling_field_to_uptime.py
+++ b/src/sentry/uptime/migrations/0018_add_trace_sampling_field_to_uptime.py
@@ -30,7 +30,7 @@ class Migration(CheckedMigration):
             database_operations=[
                 migrations.RunSQL(
                     """
-                    ALTER TABLE "uptime_uptimesubscription" ADD COLUMN "trace_sampling" boolean NOT NULL DEFAULT false;
+                    ALTER TABLE "uptime_uptimesubscription" ADD COLUMN IF NOT EXISTS "trace_sampling" boolean NOT NULL DEFAULT false;
                     """,
                     reverse_sql="""
                     ALTER TABLE "uptime_uptimesubscription" DROP COLUMN "trace_sampling";


### PR DESCRIPTION
this causes migrations to fail if the migration fails partway through and we need to retry. the migration previously failed on the add constraint line, and i think if we try again it will likely succeed
