### PR TITLE
feat(getting-started): add slow and fast example functions to profiling onboarding

### DIFF
--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -46,17 +46,20 @@ sentry_sdk.init(
 
 def slow_function():
     import time
-    time.sleep(2)  # sleep for 2 seconds
+    time.sleep(0.1)
     return "done"
 
 def fast_function():
+    import time
+    time.sleep(0.05)
     return "done"
 
 # Manually call start_profiler and stop_profiler
 # to profile the code in between
 sentry_sdk.profiler.start_profiler()
-slow_function()
-fast_function()
+for i in range(0, 10):
+    slow_function()
+    fast_function()
 #
 # Calls to stop_profiler are optional - if you don't stop the profiler, it will keep profiling
 # your application until the process exits or stop_profiler is called.

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -44,10 +44,19 @@ sentry_sdk.init(
   params.profilingOptions?.defaultProfilingMode === 'continuous'
     ? `
 
+def slow_function():
+    import time
+    time.sleep(2)  # sleep for 2 seconds
+    return "done"
+
+def fast_function():
+    return "done"
+
 # Manually call start_profiler and stop_profiler
 # to profile the code in between
 sentry_sdk.profiler.start_profiler()
-# this code will be profiled
+slow_function()
+fast_function()
 #
 # Calls to stop_profiler are optional - if you don't stop the profiler, it will keep profiling
 # your application until the process exits or stop_profiler is called.


### PR DESCRIPTION
- Adds a first example to the Python getting started page to better showcase the profiling functionality 

Closes https://github.com/getsentry/projects/issues/403