### PR TITLE
ref(uptime): remove duplicate enum declaration

### DIFF
--- a/src/sentry/conf/types/kafka_definition.py
+++ b/src/sentry/conf/types/kafka_definition.py
@@ -48,7 +48,6 @@ class Topic(Enum):
     MONITORS_CLOCK_TICK = "monitors-clock-tick"
     MONITORS_CLOCK_TASKS = "monitors-clock-tasks"
     MONITORS_INCIDENT_OCCURRENCES = "monitors-incident-occurrences"
-    UPTIME_CONFIG = "uptime-configs"
     UPTIME_RESULTS = "uptime-results"
     UPTIME_CONFIGS = "uptime-configs"
     EVENTSTREAM_GENERIC = "generic-events"


### PR DESCRIPTION
confirmed this is not used anywhere. `UPTIME_CONFIGS` is what's used.