### PR TITLE
fix(crons): Fix correct linking to issue in crons monitorCheckIns

### DIFF
--- a/static/app/views/monitors/components/monitorCheckIns.tsx
+++ b/static/app/views/monitors/components/monitorCheckIns.tsx
@@ -169,11 +169,7 @@ function MonitorCheckIns({monitor, monitorEnvs, orgSlug}: Props) {
                               avatarSize={12}
                             />
                           }
-                          to={
-                            USING_CUSTOMER_DOMAIN
-                              ? `/issues/${id}`
-                              : `/organizations/${organization.slug}/issues/${id}`
-                          }
+                          to={`/organizations/${organization.slug}/issues/${id}/`}
                         />
                       </QuickContextHovercard>
                     ))}

--- a/static/app/views/monitors/components/monitorCheckIns.tsx
+++ b/static/app/views/monitors/components/monitorCheckIns.tsx
@@ -17,7 +17,6 @@ import {
 } from 'sentry/components/statusIndicator';
 import Text from 'sentry/components/text';
 import {Tooltip} from 'sentry/components/tooltip';
-import {USING_CUSTOMER_DOMAIN} from 'sentry/constants';
 import {IconDownload} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';

--- a/static/app/views/monitors/components/monitorCheckIns.tsx
+++ b/static/app/views/monitors/components/monitorCheckIns.tsx
@@ -17,6 +17,7 @@ import {
 } from 'sentry/components/statusIndicator';
 import Text from 'sentry/components/text';
 import {Tooltip} from 'sentry/components/tooltip';
+import {USING_CUSTOMER_DOMAIN} from 'sentry/constants';
 import {IconDownload} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -168,7 +169,11 @@ function MonitorCheckIns({monitor, monitorEnvs, orgSlug}: Props) {
                               avatarSize={12}
                             />
                           }
-                          to={`/issues/${id}`}
+                          to={
+                            USING_CUSTOMER_DOMAIN
+                              ? `/issues/${id}`
+                              : `/organizations/${organization.slug}/issues/${id}`
+                          }
                         />
                       </QuickContextHovercard>
                     ))}


### PR DESCRIPTION
When an error is thrown inside a cron it gets linked in the cronMonitor. 

![image](https://github.com/user-attachments/assets/ebdf34d3-2dd8-4e77-aaf0-7b431c2a5be6)


But the Link to the issue is wrong if the organization has a subdomain since it is hardcoded to `/issues`

Link is: `https://sentry.mydomain.com/issues/29/`

When clicking it, this navigates me to this:

![image](https://github.com/user-attachments/assets/aa3fe531-5e41-41d5-9f5e-ed091785150f)

The real issue/link would be: `https://sentry.mydomain.com/organizations/myslug/issues/29`


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
