### PR TITLE
ref(crons): Handle errors when dispatching send_incident_occurrence

### DIFF
--- a/src/sentry/monitors/consumers/incident_occurrences_consumer.py
+++ b/src/sentry/monitors/consumers/incident_occurrences_consumer.py
@@ -96,7 +96,10 @@ def process_incident_occurrence(message: Message[KafkaPayload | FilteredPayload]
         # as unknown.
         pass
 
-    send_incident_occurrence(failed_checkin, previous_checkins, incident, received)
+    try:
+        send_incident_occurrence(failed_checkin, previous_checkins, incident, received)
+    except Exception:
+        logger.exception("failed_send_incident_occurrence")
 
 
 class MonitorIncidentOccurenceStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):


### PR DESCRIPTION
This helps us handle things like [SENTRY-3J3R](https://sentry.sentry.io/issues/6073039699/)