### PR TITLE
feat(crons): Prune check-in volume at incident end

### DIFF
--- a/src/sentry/monitors/consumers/clock_tick_consumer.py
+++ b/src/sentry/monitors/consumers/clock_tick_consumer.py
@@ -15,11 +15,7 @@ from sentry_kafka_schemas.schema_types.monitors_clock_tick_v1 import ClockTick
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.monitors.clock_tasks.check_missed import dispatch_check_missing
 from sentry.monitors.clock_tasks.check_timeout import dispatch_check_timeout
-from sentry.monitors.system_incidents import (
-    make_clock_tick_decision,
-    record_clock_tick_volume_metric,
-)
-from sentry.utils import metrics
+from sentry.monitors.system_incidents import process_clock_tick_for_system_incidents
 
 logger = logging.getLogger(__name__)
 
@@ -33,28 +29,15 @@ def process_clock_tick(message: Message[KafkaPayload | FilteredPayload]):
     wrapper: ClockTick = MONITORS_CLOCK_TICK_CODEC.decode(message.payload.value)
     ts = datetime.fromtimestamp(wrapper["ts"], tz=timezone.utc)
 
-    record_clock_tick_volume_metric(ts)
-    try:
-        result = make_clock_tick_decision(ts)
-
-        metrics.incr(
-            "monitors.tasks.clock_tick.tick_decision",
-            tags={"decision": result.decision},
-            sample_rate=1.0,
-        )
-        if result.transition:
-            metrics.incr(
-                "monitors.tasks.clock_tick.tick_transition",
-                tags={"transition": result.transition},
-                sample_rate=1.0,
-            )
-    except Exception:
-        logger.exception("sentry.tasks.clock_tick.clock_tick_decision_failed")
-
     logger.info(
         "process_clock_tick",
         extra={"reference_datetime": str(ts)},
     )
+
+    try:
+        process_clock_tick_for_system_incidents(ts)
+    except Exception:
+        logger.exception("failed_process_clock_tick_for_system_incidents")
 
     dispatch_check_missing(ts)
     dispatch_check_timeout(ts)

--- a/tests/sentry/monitors/consumers/test_clock_tick_consumer.py
+++ b/tests/sentry/monitors/consumers/test_clock_tick_consumer.py
@@ -38,9 +38,9 @@ def create_consumer():
 
 @mock.patch("sentry.monitors.consumers.clock_tick_consumer.dispatch_check_missing")
 @mock.patch("sentry.monitors.consumers.clock_tick_consumer.dispatch_check_timeout")
-@mock.patch("sentry.monitors.consumers.clock_tick_consumer.record_clock_tick_volume_metric")
+@mock.patch("sentry.monitors.consumers.clock_tick_consumer.process_clock_tick_for_system_incidents")
 def test_simple(
-    mock_record_clock_tick_volume_metric,
+    mock_process_clock_tick_for_system_incidents,
     mock_dispatch_check_timeout,
     mock_dispatch_check_missing,
 ):
@@ -56,8 +56,8 @@ def test_simple(
     )
     consumer.submit(Message(value))
 
-    assert mock_record_clock_tick_volume_metric.call_count == 1
-    assert mock_record_clock_tick_volume_metric.mock_calls[0] == mock.call(ts)
+    assert mock_process_clock_tick_for_system_incidents.call_count == 1
+    assert mock_process_clock_tick_for_system_incidents.mock_calls[0] == mock.call(ts)
 
     assert mock_dispatch_check_timeout.call_count == 1
     assert mock_dispatch_check_timeout.mock_calls[0] == mock.call(ts)


### PR DESCRIPTION
When a system incident recovers we need to prune volume data recorded during the incident, since this data will be a large outlier and will skew future metric calculations for these minutes.

Part of GH-79328