### PR TITLE
fix(spans): Add types to measurements on spans indexed

### DIFF
--- a/src/sentry/search/events/builder/spans_indexed.py
+++ b/src/sentry/search/events/builder/spans_indexed.py
@@ -33,23 +33,17 @@ SPAN_ID_FIELDS = {
     "segment_id",
 }
 
-
-class SpansIndexedQueryBuilderMixin:
-    meta_resolver_map: dict[str, str]
-
-    def get_field_type(self, field: str) -> str | None:
-        if field in self.meta_resolver_map:
-            return self.meta_resolver_map[field]
-        if field in ["span.duration", "span.self_time"]:
-            return "duration"
-
-        return None
+DURATION_FIELDS = {
+    "span.duration",
+    "span.self_time",
+}
 
 
-class SpansIndexedQueryBuilder(SpansIndexedQueryBuilderMixin, BaseQueryBuilder):
+class SpansIndexedQueryBuilder(BaseQueryBuilder):
     requires_organization_condition = False
     uuid_fields = SPAN_UUID_FIELDS
     span_id_fields = SPAN_ID_FIELDS
+    duration_fields = DURATION_FIELDS
     config_class = SpansIndexedDatasetConfig
 
     def __init__(self, *args, **kwargs):
@@ -59,10 +53,11 @@ class SpansIndexedQueryBuilder(SpansIndexedQueryBuilderMixin, BaseQueryBuilder):
         )
 
 
-class SpansEAPQueryBuilder(SpansIndexedQueryBuilderMixin, BaseQueryBuilder):
+class SpansEAPQueryBuilder(BaseQueryBuilder):
     requires_organization_condition = True
     uuid_fields = SPAN_UUID_FIELDS
     span_id_fields = SPAN_ID_FIELDS
+    duration_fields = DURATION_FIELDS
     config_class = SpansEAPDatasetConfig
 
     def __init__(self, *args, **kwargs):
@@ -106,10 +101,11 @@ class SpansEAPQueryBuilder(SpansIndexedQueryBuilderMixin, BaseQueryBuilder):
         return field_col
 
 
-class TimeseriesSpanIndexedQueryBuilder(SpansIndexedQueryBuilderMixin, TimeseriesQueryBuilder):
+class TimeseriesSpanIndexedQueryBuilder(TimeseriesQueryBuilder):
     config_class = SpansIndexedDatasetConfig
     uuid_fields = SPAN_UUID_FIELDS
     span_id_fields = SPAN_ID_FIELDS
+    duration_fields = DURATION_FIELDS
 
     @property
     def time_column(self) -> SelectType:
@@ -122,10 +118,11 @@ class TimeseriesSpanEAPIndexedQueryBuilder(SpansEAPQueryBuilder, TimeseriesQuery
     pass
 
 
-class TopEventsSpanIndexedQueryBuilder(SpansIndexedQueryBuilderMixin, TopEventsQueryBuilder):
+class TopEventsSpanIndexedQueryBuilder(TopEventsQueryBuilder):
     config_class = SpansIndexedDatasetConfig
     uuid_fields = SPAN_UUID_FIELDS
     span_id_fields = SPAN_ID_FIELDS
+    duration_fields = DURATION_FIELDS
 
     @property
     def time_column(self) -> SelectType:

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1922,8 +1922,6 @@ def is_duration_measurement(key):
         "measurements.fid",
         "measurements.ttfb",
         "measurements.ttfb.requesttime",
-        "measurements.time_to_initial_display",
-        "measurements.time_to_full_display",
         "measurements.app_start_cold",
         "measurements.app_start_warm",
         "measurements.time_to_full_display",

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -1372,3 +1372,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
     @pytest.mark.xfail(reason="rate not implemented yet")
     def test_spm(self):
         super().test_spm()
+
+    @pytest.mark.xfail(reason="units not implemented yet")
+    def test_simple_measurements(self):
+        super().test_simple_measurements()

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -564,45 +564,45 @@ class OrganizationEventsSpanIndexedEndpointTest(OrganizationEventsEndpointTestBa
 
     def test_simple_measurements(self):
         keys = [
-            "app_start_cold",
-            "app_start_warm",
-            "frames_frozen",
-            "frames_frozen_rate",
-            "frames_slow",
-            "frames_slow_rate",
-            "frames_total",
-            "time_to_initial_display",
-            "time_to_full_display",
-            "stall_count",
-            "stall_percentage",
-            "stall_stall_longest_time",
-            "stall_stall_total_time",
-            "cls",
-            "fcp",
-            "fid",
-            "fp",
-            "inp",
-            "lcp",
-            "ttfb",
-            "ttfb.requesttime",
-            "score.cls",
-            "score.fcp",
-            "score.fid",
-            "score.inp",
-            "score.lcp",
-            "score.ttfb",
-            "score.total",
-            "score.weight.cls",
-            "score.weight.fcp",
-            "score.weight.fid",
-            "score.weight.inp",
-            "score.weight.lcp",
-            "score.weight.ttfb",
-            "cache.item_size",
-            "messaging.message.body.size",
-            "messaging.message.receive.latency",
-            "messaging.message.retry.count",
-            "http.response_content_length",
+            ("app_start_cold", "duration", "millisecond"),
+            ("app_start_warm", "duration", "millisecond"),
+            ("frames_frozen", "number", None),
+            ("frames_frozen_rate", "percentage", None),
+            ("frames_slow", "number", None),
+            ("frames_slow_rate", "percentage", None),
+            ("frames_total", "number", None),
+            ("time_to_initial_display", "duration", "millisecond"),
+            ("time_to_full_display", "duration", "millisecond"),
+            ("stall_count", "number", None),
+            ("stall_percentage", "percentage", None),
+            ("stall_stall_longest_time", "number", None),
+            ("stall_stall_total_time", "number", None),
+            ("cls", "number", None),
+            ("fcp", "duration", "millisecond"),
+            ("fid", "duration", "millisecond"),
+            ("fp", "duration", "millisecond"),
+            ("inp", "duration", "millisecond"),
+            ("lcp", "duration", "millisecond"),
+            ("ttfb", "duration", "millisecond"),
+            ("ttfb.requesttime", "duration", "millisecond"),
+            ("score.cls", "number", None),
+            ("score.fcp", "number", None),
+            ("score.fid", "number", None),
+            ("score.inp", "number", None),
+            ("score.lcp", "number", None),
+            ("score.ttfb", "number", None),
+            ("score.total", "number", None),
+            ("score.weight.cls", "number", None),
+            ("score.weight.fcp", "number", None),
+            ("score.weight.fid", "number", None),
+            ("score.weight.inp", "number", None),
+            ("score.weight.lcp", "number", None),
+            ("score.weight.ttfb", "number", None),
+            ("cache.item_size", "number", None),
+            ("messaging.message.body.size", "number", None),
+            ("messaging.message.receive.latency", "number", None),
+            ("messaging.message.retry.count", "number", None),
+            ("http.response_content_length", "number", None),
         ]
 
         self.store_spans(
@@ -613,14 +613,14 @@ class OrganizationEventsSpanIndexedEndpointTest(OrganizationEventsEndpointTestBa
                         "sentry_tags": {"status": "success"},
                         "tags": {"bar": "bar2"},
                     },
-                    measurements={k: {"value": i + 1} for i, k in enumerate(keys)},
+                    measurements={k: {"value": i + 1} for i, (k, _, _) in enumerate(keys)},
                     start_ts=self.ten_mins_ago,
                 ),
             ],
             is_eap=self.is_eap,
         )
 
-        for i, k in enumerate(keys):
+        for i, (k, type, unit) in enumerate(keys):
             key = f"measurements.{k}"
             response = self.do_request(
                 {
@@ -631,6 +631,23 @@ class OrganizationEventsSpanIndexedEndpointTest(OrganizationEventsEndpointTestBa
                 }
             )
             assert response.status_code == 200, response.content
+            assert response.data["meta"] == {
+                "dataset": mock.ANY,
+                "datasetReason": "unchanged",
+                "fields": {
+                    key: type,
+                    "id": "string",
+                    "project.name": "string",
+                },
+                "isMetricsData": False,
+                "isMetricsExtractedData": False,
+                "tips": {},
+                "units": {
+                    key: unit,
+                    "id": None,
+                    "project.name": None,
+                },
+            }
             assert response.data["data"] == [
                 {
                     key: i + 1,


### PR DESCRIPTION
This overrode the implementation from the base class which already handled all this correctly if `duration_fields` was set correctly.