### PR TITLE
fix(autofix): Hide rethink arrow above empty processing step

### DIFF
--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -244,12 +244,22 @@ export function AutofixSteps({data, groupId, runId}: AutofixStepsProps) {
             (previousStep?.type !== AutofixStepType.DEFAULT ||
               previousStep?.insights.length === 0) &&
             step.type !== AutofixStepType.DEFAULT;
+          const stepBelowProcessingAndEmpty =
+            nextStep &&
+            nextStep?.type === AutofixStepType.DEFAULT &&
+            nextStep?.status === 'PROCESSING' &&
+            nextStep?.insights?.length === 0;
+
           return (
             <div ref={el => (stepsRef.current[index] = el)} key={step.id}>
               {twoNonDefaultStepsInARow && <br />}
               <Step
                 step={step}
-                hasStepBelow={index + 1 < steps.length && !twoInsightStepsInARow}
+                hasStepBelow={
+                  index + 1 < steps.length &&
+                  !twoInsightStepsInARow &&
+                  !stepBelowProcessingAndEmpty
+                }
                 hasStepAbove
                 groupId={groupId}
                 runId={runId}

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -245,7 +245,6 @@ export function AutofixSteps({data, groupId, runId}: AutofixStepsProps) {
               previousStep?.insights.length === 0) &&
             step.type !== AutofixStepType.DEFAULT;
           const stepBelowProcessingAndEmpty =
-            nextStep &&
             nextStep?.type === AutofixStepType.DEFAULT &&
             nextStep?.status === 'PROCESSING' &&
             nextStep?.insights?.length === 0;


### PR DESCRIPTION
If there is an insights/DEFAULT step below the current one, and it's empty and processing, don't show a rethink arrow above it.