### PR TITLE
ref(uptime): improve typing of interval second choices

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -155,6 +155,7 @@ from sentry.types.actor import Actor
 from sentry.types.region import Region, get_local_region, get_region_by_name
 from sentry.types.token import AuthTokenType
 from sentry.uptime.models import (
+    IntervalSecondsLiteral,
     ProjectUptimeSubscription,
     ProjectUptimeSubscriptionMode,
     UptimeStatus,
@@ -1955,7 +1956,7 @@ class Factories:
         url_domain: str,
         url_domain_suffix: str,
         host_provider_id: str,
-        interval_seconds: int,
+        interval_seconds: IntervalSecondsLiteral,
         timeout_ms: int,
         method,
         headers,

--- a/src/sentry/uptime/endpoints/validators.py
+++ b/src/sentry/uptime/endpoints/validators.py
@@ -1,5 +1,4 @@
 from collections.abc import Sequence
-from datetime import timedelta
 
 import jsonschema
 from drf_spectacular.utils import extend_schema_serializer
@@ -12,7 +11,11 @@ from sentry.api.serializers.rest_framework import CamelSnakeSerializer
 from sentry.auth.superuser import is_active_superuser
 from sentry.models.environment import Environment
 from sentry.uptime.detectors.url_extraction import extract_domain_parts
-from sentry.uptime.models import ProjectUptimeSubscription, ProjectUptimeSubscriptionMode
+from sentry.uptime.models import (
+    ProjectUptimeSubscription,
+    ProjectUptimeSubscriptionMode,
+    UptimeSubscription,
+)
 from sentry.uptime.subscriptions.subscriptions import (
     MAX_MANUAL_SUBSCRIPTIONS_PER_ORG,
     MaxManualUptimeSubscriptionsReached,
@@ -36,15 +39,6 @@ public suffix list (PSL). See `extract_domain_parts` fo more details
 SUPPORTED_HTTP_METHODS = ["GET", "POST", "HEAD", "PUT", "DELETE", "PATCH", "OPTIONS"]
 MAX_REQUEST_SIZE_BYTES = 1000
 
-# This matches the jsonschema for the check config
-VALID_INTERVALS = [
-    timedelta(minutes=1),
-    timedelta(minutes=5),
-    timedelta(minutes=10),
-    timedelta(minutes=20),
-    timedelta(minutes=30),
-    timedelta(minutes=60),
-]
 
 HEADERS_LIST_SCHEMA = {
     "type": "array",
@@ -91,7 +85,7 @@ class UptimeMonitorValidator(CamelSnakeSerializer):
     )
     url = URLField(required=True, max_length=255)
     interval_seconds = serializers.ChoiceField(
-        required=True, choices=[int(i.total_seconds()) for i in VALID_INTERVALS]
+        required=True, choices=UptimeSubscription.IntervalSeconds.choices
     )
     timeout_ms = serializers.IntegerField(
         required=True,

--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -1,6 +1,6 @@
 import enum
 from datetime import timedelta
-from typing import ClassVar, Self
+from typing import ClassVar, Literal, Self
 
 from django.conf import settings
 from django.db import models
@@ -29,12 +29,22 @@ headers_json_encoder = JSONEncoder(
     sort_keys=True,
 ).encode
 
+IntervalSecondsLiteral = Literal[60, 300, 600, 1200, 1800, 3600]
+
 
 @region_silo_model
 class UptimeSubscription(BaseRemoteSubscription, DefaultFieldsModelExisting):
     # TODO: This should be included in export/import, but right now it has no relation to
     # any projects/orgs. Will fix this in a later pr
     __relocation_scope__ = RelocationScope.Excluded
+
+    class IntervalSeconds(models.IntegerChoices):
+        ONE_MINUTE = 60, "1 minute"
+        FIVE_MINUTES = 300, "5 minutes"
+        TEN_MINUTES = 600, "10 minutes"
+        TWENTY_MINUTES = 1200, "20 minutes"
+        THIRTY_MINUTES = 1800, "30 minutes"
+        ONE_HOUR = 3600, "1 hour"
 
     # The url to check
     url = models.CharField(max_length=255)
@@ -48,7 +58,9 @@ class UptimeSubscription(BaseRemoteSubscription, DefaultFieldsModelExisting):
     # The name of the provider hosting this domain
     host_provider_name = models.CharField(max_length=255, db_index=True, null=True)
     # How frequently to run the check in seconds
-    interval_seconds = models.IntegerField()
+    interval_seconds: models.IntegerField[IntervalSecondsLiteral, IntervalSecondsLiteral] = (
+        models.IntegerField(choices=IntervalSeconds)
+    )
     # How long to wait for a response from the url before we assume a timeout
     timeout_ms = models.IntegerField()
     # HTTP method to perform the check with
@@ -101,6 +113,7 @@ class UptimeStatus(enum.IntEnum):
 class ProjectUptimeSubscription(DefaultFieldsModelExisting):
     # TODO: This should be included in export/import, but right now it has no relation to
     # any projects/orgs. Will fix this in a later pr
+
     __relocation_scope__ = RelocationScope.Excluded
 
     project = FlexibleForeignKey("sentry.Project")

--- a/src/sentry/uptime/subscriptions/tasks.py
+++ b/src/sentry/uptime/subscriptions/tasks.py
@@ -91,7 +91,7 @@ def uptime_subscription_to_check_config(
     config: CheckConfig = {
         "subscription_id": subscription_id,
         "url": subscription.url,
-        "interval_seconds": subscription.interval_seconds,  # type: ignore[typeddict-item]
+        "interval_seconds": subscription.interval_seconds,
         "timeout_ms": subscription.timeout_ms,
         "request_method": subscription.method,  # type: ignore[typeddict-item]
         "request_headers": headers,

--- a/tests/sentry/migrations/test_0007_update_detected_subscription_interval.py
+++ b/tests/sentry/migrations/test_0007_update_detected_subscription_interval.py
@@ -28,7 +28,7 @@ class UpdateAutoDetectedActiveIntervalSecondsTest(TestMigrations):
         )
 
         self.uptime_subscription_unchanged_2 = self.create_uptime_subscription(
-            url="http://sontry.io", interval_seconds=120
+            url="http://sontry.io", interval_seconds=300
         )
         self.create_project_uptime_subscription(
             uptime_subscription=self.uptime_subscription_unchanged_2,
@@ -43,5 +43,5 @@ class UpdateAutoDetectedActiveIntervalSecondsTest(TestMigrations):
         assert self.uptime_subscription_unchanged.interval_seconds == 300
         assert self.uptime_subscription_unchanged.status == UptimeSubscription.Status.ACTIVE.value
         self.uptime_subscription_unchanged_2.refresh_from_db()
-        assert self.uptime_subscription_unchanged_2.interval_seconds == 120
+        assert self.uptime_subscription_unchanged_2.interval_seconds == 300
         assert self.uptime_subscription_unchanged_2.status == UptimeSubscription.Status.ACTIVE.value


### PR DESCRIPTION
- [x] use django stubs type annotation to set the literal values on the interval integer field
- [x] replace the definition in the validator with a `ChoicesField` in the model, which will also be enforced by django
- [x] remove the type-ignore in the config producer
- [x] fix one of the tests which was using an invalid interval time