### PR TITLE
feat(ai): Add new organizations:gen-ai-features flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -139,6 +139,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:escalating-metrics-backend", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable logging for failure rate subscription processor
     manager.add("organizations:failure-rate-metric-alert-logging", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable GenAI features such as Autofix and Issue Summary
+    manager.add("organizations:gen-ai-features", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable disabling gitlab integrations when broken is detected
     manager.add("organizations:gitlab-disable-on-broken", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Allow creating `GroupHashMetadata` records


### PR DESCRIPTION
Adds a new feature flag, `organizations:gen-ai-features` for all consolidated gen ai feature rollout.

This is the first needed step to smoothly transition autofix/issue summary customers to this flag.
1. Define this flag, and make sure it's deployed
2. Set the value for this flag on flagpole, exactly matching the current settings for the other flags
3. Frontend / Backend PRs for migrating to this flag on the relevant features
4. Remove the values for the old flags on flagpole
5. Remove the definitions of these flags in sentry