### PR TITLE
fix(explore): Allow custom ranges in date picker

### DIFF
--- a/static/app/views/explore/content.tsx
+++ b/static/app/views/explore/content.tsx
@@ -97,11 +97,12 @@ function ExploreContentImpl({}: ExploreContentProps) {
                 <EnvironmentPageFilter />
                 <DatePageFilter
                   maxPickableDays={7}
-                  relativeOptions={{
+                  relativeOptions={({arbitraryOptions}) => ({
+                    ...arbitraryOptions,
                     '1h': t('Last 1 hour'),
                     '24h': t('Last 24 hours'),
                     '7d': t('Last 7 days'),
-                  }}
+                  })}
                 />
               </StyledPageFilterBar>
               {dataset === DiscoverDatasets.SPANS_INDEXED ? (


### PR DESCRIPTION
The date picker is constrained to the last 7 days, but if the user comes from another page with a selection like 2d, it should not show as invalid.