### PR TITLE
feaT(crons): Add collect_metrics option to replace old option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2029,6 +2029,11 @@ register(
     default=False,
     flags=FLAG_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "crons.system_incidents.collect_metrics",
+    default=False,
+    flags=FLAG_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Enables the the crons incident occurrence consumer to consider the clock-tick
 # decision made based on volume metrics to determine if a incident occurrence


### PR DESCRIPTION
This will replace `tick_volume_anomaly_detection` since that name no longer really makes sense for what it does