### PR TITLE
fix(grouping): Small fingerprinting simplification

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -336,7 +336,7 @@ def get_grouping_variants_for_event(
     # a materialized fingerprint info from server side fingerprinting we forward it to the
     # variants which can export additional information about them.
     fingerprint = event.data.get("fingerprint") or ["{{ default }}"]
-    fingerprint_info = event.data.get("_fingerprint_info")
+    fingerprint_info = event.data.get("_fingerprint_info", {})
     defaults_referenced = sum(1 if is_default_fingerprint_var(d) else 0 for d in fingerprint)
 
     if config is None:
@@ -359,7 +359,7 @@ def get_grouping_variants_for_event(
             rv[key] = ComponentVariant(component, context.config)
 
         fingerprint = resolve_fingerprint_values(fingerprint, event.data)
-        if (fingerprint_info or {}).get("matched_rule", {}).get("is_builtin") is True:
+        if fingerprint_info.get("matched_rule", {}).get("is_builtin") is True:
             rv["built_in_fingerprint"] = BuiltInFingerprintVariant(fingerprint, fingerprint_info)
         else:
             rv["custom_fingerprint"] = CustomFingerprintVariant(fingerprint, fingerprint_info)

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -134,7 +134,7 @@ class ComponentVariant(BaseVariant):
         return super().__repr__() + f" contributes={self.contributes} ({self.description})"
 
 
-def expose_fingerprint_dict(values, info=None):
+def expose_fingerprint_dict(values, info):
     rv = {
         "values": values,
     }
@@ -161,7 +161,7 @@ class CustomFingerprintVariant(BaseVariant):
 
     type = "custom_fingerprint"
 
-    def __init__(self, values, fingerprint_info=None):
+    def __init__(self, values, fingerprint_info):
         self.values = values
         self.info = fingerprint_info
 
@@ -191,7 +191,7 @@ class SaltedComponentVariant(ComponentVariant):
 
     type = "salted_component"
 
-    def __init__(self, values, component, config, fingerprint_info=None):
+    def __init__(self, values, component, config, fingerprint_info):
         ComponentVariant.__init__(self, component, config)
         self.values = values
         self.info = fingerprint_info

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -139,8 +139,6 @@ def expose_fingerprint_dict(values, info):
         "values": values,
     }
 
-    from sentry.grouping.fingerprinting import FingerprintRule
-
     client_values = info.get("client_fingerprint")
     if client_values and (
         len(client_values) != 1 or not is_default_fingerprint_var(client_values[0])
@@ -149,8 +147,7 @@ def expose_fingerprint_dict(values, info):
 
     matched_rule = info.get("matched_rule")
     if matched_rule:
-        rule = FingerprintRule.from_json(matched_rule)
-        rv["matched_rule"] = rule.text
+        rv["matched_rule"] = matched_rule["text"]
 
     return rv
 

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -138,8 +138,6 @@ def expose_fingerprint_dict(values, info):
     rv = {
         "values": values,
     }
-    if not info:
-        return rv
 
     from sentry.grouping.fingerprinting import FingerprintRule
 

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -146,6 +146,7 @@ def expose_fingerprint_dict(values, info):
         len(client_values) != 1 or not is_default_fingerprint_var(client_values[0])
     ):
         rv["client_values"] = client_values
+
     matched_rule = info.get("matched_rule")
     if matched_rule:
         rule = FingerprintRule.from_json(matched_rule)


### PR DESCRIPTION
This makes four small simplifying changes to our fingerprinting code:

- In `get_grouping_variants_for_event`, default `fingerprint_info` to `{}`, thus ensuring it always has a value. This in turn means that it doesn't have to be defaulted to `None` in the `CustomFingerprintVariant` and `SaltedComponentVariant` constructors.

- Remove the default `None` value for `fingerprint_info` in `expose_fingerprint_dict` as well. (This in fact never needed the default, even before the above change, since it's called on the above classes' `.info` attribute, to which the constructors have always given a value.)

- In `expose_fingerprint_dict`, remove the `if not info:` check, since 
  a) the above changes mean `info` is never `None`, and 
  b) in fact, it's never even empty, because `expose_fingerprint_dict` is only called by the aforementioned classes, and said classes are only ever used in the presence of either a client fingerprint or a matched server fingerprint rule (the two pieces of data which `info` can contain).

- Also in `expose_fingerprint_dict`, stop creating an instance of `FingerprintRule` just to get the rule's textual form, since as of https://github.com/getsentry/sentry/pull/79231 that data is included straight in the `matched_rule` dictionary.