### PR TITLE
fix(replay): fix platform option bug

### DIFF
--- a/static/app/components/replaysOnboarding/platformOptionDropdown.tsx
+++ b/static/app/components/replaysOnboarding/platformOptionDropdown.tsx
@@ -1,7 +1,10 @@
+import {Fragment} from 'react';
+
 import type {SelectOption} from 'sentry/components/compactSelect';
 import {CompactSelect} from 'sentry/components/compactSelect';
 import type {PlatformOption} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {useUrlPlatformOptions} from 'sentry/components/onboarding/platformOptionsControl';
+import {t} from 'sentry/locale';
 import useRouter from 'sentry/utils/useRouter';
 
 export type OptionControlProps = {
@@ -73,12 +76,15 @@ export function PlatformOptionDropdown({
   }
 
   return (
-    <OptionControl
-      key="platformOption"
-      option={platforms}
-      value={urlOptionValues.siblingOption ?? platforms.items[0]?.label}
-      onChange={v => handleChange('siblingOption', v.value)}
-      disabled={disabled}
-    />
+    <Fragment>
+      {t('with')}
+      <OptionControl
+        key="platformOption"
+        option={platforms}
+        value={urlOptionValues.siblingOption ?? platforms.items[0]?.label}
+        onChange={v => handleChange('siblingOption', v.value)}
+        disabled={disabled}
+      />
+    </Fragment>
   );
 }

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -259,15 +259,12 @@ function OnboardingContent({
                       />
                     ),
                   })}
-                  {jsFrameworkDocs?.platformOptions &&
-                    tct('[optionSelect]', {
-                      optionSelect: (
-                        <PlatformOptionDropdown
-                          platformOptions={jsFrameworkDocs?.platformOptions}
-                          disabled={setupMode() === 'jsLoader'}
-                        />
-                      ),
-                    })}
+                  {jsFrameworkDocs?.platformOptions && (
+                    <PlatformOptionDropdown
+                      platformOptions={jsFrameworkDocs?.platformOptions}
+                      disabled={setupMode() === 'jsLoader'}
+                    />
+                  )}
                 </PlatformSelect>
               ) : (
                 t('I use NPM or Yarn')

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -260,7 +260,7 @@ function OnboardingContent({
                     ),
                   })}
                   {jsFrameworkDocs?.platformOptions &&
-                    tct('with [optionSelect]', {
+                    tct('[optionSelect]', {
                       optionSelect: (
                         <PlatformOptionDropdown
                           platformOptions={jsFrameworkDocs?.platformOptions}


### PR DESCRIPTION
onboarding docs changed which caused a bug with the platform option dropdown showing an extra "with"

before: 
<img width="510" alt="SCR-20241118-lqgb" src="https://github.com/user-attachments/assets/2c15a2cb-c6ea-4c0a-bfcc-c612cdacfa7a">
<img width="518" alt="SCR-20241118-lqhb" src="https://github.com/user-attachments/assets/97a23244-2698-4ef0-8f9c-fce57b7c78a1">
after:
<img width="470" alt="SCR-20241118-lqer" src="https://github.com/user-attachments/assets/a2d82441-fb3d-48c3-bac1-56e1bd37112e">
<img width="465" alt="SCR-20241118-lqfg" src="https://github.com/user-attachments/assets/cdd6b3b0-a90f-4b90-918b-8d99f77d73a9">
