### PR TITLE
chore(autofix): Remove autofix enabled check and remove write access from initial onboarding

### DIFF
--- a/static/app/components/events/autofix/autofixSetupModal.spec.tsx
+++ b/static/app/components/events/autofix/autofixSetupModal.spec.tsx
@@ -1,6 +1,6 @@
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {AutofixSetupContent} from 'sentry/components/events/autofix/autofixSetupModal';
 import {AutofixCodebaseIndexingStatus} from 'sentry/components/events/autofix/types';
@@ -40,124 +40,11 @@ describe('AutofixSetupContent', function () {
       },
     });
 
-    const onComplete = jest.fn();
-
-    render(<AutofixSetupContent groupId="1" projectId="1" onComplete={onComplete} />);
+    render(<AutofixSetupContent groupId="1" projectId="1" />);
 
     expect(await screen.findByText('Install the GitHub Integration')).toBeInTheDocument();
     expect(
       screen.getByText(/Install the GitHub integration by navigating to/)
     ).toBeInTheDocument();
-  });
-
-  it('displays successful integration text when it is installed', async function () {
-    MockApiClient.addMockResponse({
-      url: '/issues/1/autofix/setup/',
-      body: {
-        genAIConsent: {ok: false},
-        integration: {ok: true},
-        githubWriteIntegration: {
-          ok: false,
-          repos: [
-            {
-              provider: 'integrations:github',
-              owner: 'getsentry',
-              name: 'sentry',
-              external_id: '123',
-              ok: false,
-            },
-          ],
-        },
-      },
-    });
-
-    const onComplete = jest.fn();
-
-    render(<AutofixSetupContent groupId="1" projectId="1" onComplete={onComplete} />);
-
-    await screen.findByText('Install the GitHub Integration');
-
-    await userEvent.click(screen.getByRole('button', {name: 'Back'}));
-
-    expect(
-      await screen.findByText(/The GitHub integration is already installed/)
-    ).toBeInTheDocument();
-  });
-
-  it('displays pending repos for github app text', async function () {
-    MockApiClient.addMockResponse({
-      url: '/issues/1/autofix/setup/',
-      body: {
-        genAIConsent: {ok: false},
-        integration: {ok: true},
-        githubWriteIntegration: {
-          ok: false,
-          repos: [
-            {
-              provider: 'integrations:github',
-              owner: 'getsentry',
-              name: 'sentry',
-              external_id: '123',
-              ok: true,
-            },
-            {
-              provider: 'integrations:github',
-              owner: 'getsentry',
-              name: 'seer',
-              external_id: '235',
-              ok: false,
-            },
-          ],
-        },
-      },
-    });
-
-    const onComplete = jest.fn();
-
-    render(<AutofixSetupContent groupId="1" projectId="1" onComplete={onComplete} />);
-
-    expect(await screen.findByText('getsentry/sentry')).toBeInTheDocument();
-    expect(await screen.findByText('getsentry/seer')).toBeInTheDocument();
-  });
-
-  it('displays success repos for github app text', async function () {
-    MockApiClient.addMockResponse({
-      url: '/issues/1/autofix/setup/',
-      body: {
-        genAIConsent: {ok: false},
-        integration: {ok: true},
-        githubWriteIntegration: {
-          ok: false,
-          repos: [
-            {
-              provider: 'integrations:github',
-              owner: 'getsentry',
-              name: 'sentry',
-              external_id: '123',
-              ok: true,
-            },
-            {
-              provider: 'integrations:github',
-              owner: 'getsentry',
-              name: 'seer',
-              external_id: '235',
-              ok: false,
-            },
-          ],
-        },
-      },
-    });
-
-    const onComplete = jest.fn();
-
-    render(<AutofixSetupContent groupId="1" projectId="1" onComplete={onComplete} />);
-
-    await screen.findByText('Allow Autofix to Make Pull Requests');
-
-    expect(
-      await screen.findByText(/for the following repositories:/)
-    ).toBeInTheDocument();
-    expect(await screen.findByText('getsentry/sentry')).toBeInTheDocument();
-    expect(await screen.findByText('getsentry/seer')).toBeInTheDocument();
   });
 });

--- a/static/app/components/events/autofix/autofixSetupModal.tsx
+++ b/static/app/components/events/autofix/autofixSetupModal.tsx
@@ -1,13 +1,11 @@
-import {Fragment, useEffect, useMemo} from 'react';
+import {Fragment, useEffect} from 'react';
 import styled from '@emotion/styled';
 
-import {Button} from 'sentry/components/button';
 import {
   type AutofixSetupRepoDefinition,
   type AutofixSetupResponse,
   useAutofixSetup,
 } from 'sentry/components/events/autofix/useAutofixSetup';
-import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -24,7 +22,6 @@ function AutofixIntegrationStep({autofixSetup}: {autofixSetup: AutofixSetupRespo
         {tct('The GitHub integration is already installed, [link: view in settings].', {
           link: <ExternalLink href={`/settings/integrations/github/`} />,
         })}
-        <GuidedSteps.StepButtons />
       </Fragment>
     );
   }
@@ -50,7 +47,6 @@ function AutofixIntegrationStep({autofixSetup}: {autofixSetup: AutofixSetupRespo
             }
           )}
         </p>
-        <GuidedSteps.StepButtons />
       </Fragment>
     );
   }
@@ -76,7 +72,6 @@ function AutofixIntegrationStep({autofixSetup}: {autofixSetup: AutofixSetupRespo
             }
           )}
         </p>
-        <GuidedSteps.StepButtons />
       </Fragment>
     );
   }
@@ -101,7 +96,6 @@ function AutofixIntegrationStep({autofixSetup}: {autofixSetup: AutofixSetupRespo
           }
         )}
       </p>
-      <GuidedSteps.StepButtons />
     </Fragment>
   );
 }
@@ -128,194 +122,46 @@ export function GitRepoLink({repo}: {repo: AutofixSetupRepoDefinition}) {
   );
 }
 
-function AutofixGithubIntegrationStep({
-  autofixSetup,
-  canStartAutofix,
-  onComplete,
-  isLastStep,
+function SetupStep({
+  title,
+  isCompleted,
+  children,
 }: {
-  autofixSetup: AutofixSetupResponse;
-  canStartAutofix: boolean;
-  isLastStep?: boolean;
-  onComplete?: () => void;
+  children: React.ReactNode;
+  isCompleted: boolean;
+  title: string;
 }) {
-  const handleClose = () => {
-    onComplete?.();
-  };
-
-  const sortedRepos = useMemo(
-    () =>
-      autofixSetup.githubWriteIntegration.repos.toSorted((a, b) => {
-        if (a.ok === b.ok) {
-          return `${a.owner}/${a.name}`.localeCompare(`${b.owner}/${b.name}`);
-        }
-        return a.ok ? -1 : 1;
-      }),
-    [autofixSetup.githubWriteIntegration.repos]
-  );
-
-  if (autofixSetup.githubWriteIntegration.ok) {
-    return (
-      <Fragment>
-        <p>
-          {tct(
-            'The [link:Sentry Autofix GitHub App] has been installed on all required repositories:',
-            {
-              link: (
-                <ExternalLink href="https://github.com/apps/sentry-autofix-experimental" />
-              ),
-            }
-          )}
-        </p>
-        <RepoLinkUl>
-          {sortedRepos.map(repo => (
-            <GitRepoLink key={`${repo.owner}/${repo.name}`} repo={repo} />
-          ))}
-        </RepoLinkUl>
-        <GuidedSteps.StepButtons>
-          {isLastStep && (
-            <Button
-              priority="primary"
-              size="sm"
-              disabled={!canStartAutofix}
-              onClick={handleClose}
-              analyticsEventName="Autofix Setup Enable Autofix"
-              analyticsEventKey="autofix.setup_enable_autofix"
-            >
-              {t('Enable Autofix')}
-            </Button>
-          )}
-        </GuidedSteps.StepButtons>
-      </Fragment>
-    );
-  }
-
-  if (autofixSetup.githubWriteIntegration.repos.length > 0) {
-    return (
-      <Fragment>
-        <p>
-          {tct(
-            'Install and grant write access to the [link:Sentry Autofix Github App] for the following repositories:',
-            {
-              link: (
-                <ExternalLink
-                  href={`https://github.com/apps/sentry-autofix/installations/new`}
-                />
-              ),
-            }
-          )}
-        </p>
-        <RepoLinkUl>
-          {sortedRepos.map(repo => (
-            <GitRepoLink key={`${repo.owner}/${repo.name}`} repo={repo} />
-          ))}
-        </RepoLinkUl>
-        <p>
-          {t(
-            'Without this, Autofix can still provide root analysis and suggested code changes.'
-          )}
-        </p>
-        <GuidedSteps.StepButtons>
-          {isLastStep && (
-            <Button
-              priority="primary"
-              size="sm"
-              disabled={!canStartAutofix}
-              onClick={handleClose}
-            >
-              {t('Skip & Enable Autofix')}
-            </Button>
-          )}
-        </GuidedSteps.StepButtons>
-      </Fragment>
-    );
-  }
-
   return (
-    <Fragment>
-      <p>
-        {tct(
-          'Install and grant write access to the [link:Sentry Autofix Github App] for the relevant repositories.',
-          {
-            link: (
-              <ExternalLink
-                href={`https://github.com/apps/sentry-autofix/installations/new`}
-              />
-            ),
-          }
-        )}
-      </p>
-      <p>
-        {t(
-          'Without this, Autofix can still provide root analysis and suggested code changes.'
-        )}
-      </p>
-      <GuidedSteps.StepButtons>
-        {isLastStep && (
-          <Button
-            priority="primary"
-            size="sm"
-            disabled={!canStartAutofix}
-            onClick={handleClose}
-            analyticsEventName="Autofix Setup Skip & Enable Autofix"
-            analyticsEventKey="autofix.setup_skip_enable_autofix"
-          >
-            {t('Skip & Enable Autofix')}
-          </Button>
-        )}
-      </GuidedSteps.StepButtons>
-    </Fragment>
+    <StepWrapper>
+      <StepHeader>
+        <StepTitle>{title}</StepTitle>
+        {isCompleted && <IconCheckmark color="success" size="sm" />}
+      </StepHeader>
+      <div>{children}</div>
+    </StepWrapper>
   );
 }
 
-function AutofixSetupSteps({
-  autofixSetup,
-  canStartAutofix,
-  onComplete,
-}: {
-  autofixSetup: AutofixSetupResponse;
-  canStartAutofix: boolean;
-  groupId: string;
-  projectId: string;
-  onComplete?: () => void;
-}) {
+function AutofixSetupSteps({autofixSetup}: {autofixSetup: AutofixSetupResponse}) {
   return (
-    <GuidedSteps>
-      <GuidedSteps.Step
-        stepKey="integration"
-        title={t('Install the GitHub Integration')}
-        isCompleted={autofixSetup.integration.ok}
-      >
-        <AutofixIntegrationStep autofixSetup={autofixSetup} />
-      </GuidedSteps.Step>
-      <GuidedSteps.Step
-        stepKey="repoWriteAccess"
-        title={t('Allow Autofix to Make Pull Requests')}
-        isCompleted={autofixSetup.githubWriteIntegration.ok}
-        optional
-      >
-        <AutofixGithubIntegrationStep
-          autofixSetup={autofixSetup}
-          canStartAutofix={canStartAutofix}
-          isLastStep
-          onComplete={onComplete}
-        />
-      </GuidedSteps.Step>
-    </GuidedSteps>
+    <SetupStep
+      title={t('Install the GitHub Integration')}
+      isCompleted={autofixSetup.integration.ok}
+    >
+      <AutofixIntegrationStep autofixSetup={autofixSetup} />
+    </SetupStep>
   );
 }
 
 export function AutofixSetupContent({
   projectId,
   groupId,
-  onComplete,
 }: {
   groupId: string;
   projectId: string;
-  onComplete?: () => void;
 }) {
   const organization = useOrganization();
-  const {data, canStartAutofix, isPending, isError} = useAutofixSetup(
+  const {data, isPending, isError} = useAutofixSetup(
     {groupId},
     // Want to check setup status whenever the user comes back to the tab
     {refetchOnWindowFocus: true}
@@ -352,14 +198,8 @@ export function AutofixSetupContent({
         Sentry's AI-enabled Autofix uses all of the contextual data surrounding this error
         to work with you to find the root cause and create a fix.
       </p>
-      <p>A few additional steps are needed before you can use Autofix.</p>
-      <AutofixSetupSteps
-        groupId={groupId}
-        projectId={projectId}
-        autofixSetup={data}
-        canStartAutofix={canStartAutofix}
-        onComplete={onComplete}
-      />
+      <p>To use Autofix, please follow the instructions below.</p>
+      <AutofixSetupSteps autofixSetup={data} />
     </Fragment>
   );
 }
@@ -381,13 +221,6 @@ const Header = styled('p')`
   margin-top: ${space(2)};
 `;
 
-const RepoLinkUl = styled('ul')`
-  display: flex;
-  flex-direction: column;
-  gap: ${space(0.5)};
-  padding: 0;
-`;
-
 const RepoLinkItem = styled('li')`
   display: flex;
   align-items: center;
@@ -403,4 +236,23 @@ const GithubLink = styled('div')`
 const Divider = styled('div')`
   margin: ${space(3)} 0;
   border-bottom: 2px solid ${p => p.theme.gray100};
+`;
+
+const StepWrapper = styled('div')`
+  margin-top: ${space(3)};
+  padding-left: ${space(2)};
+  border-left: 2px solid ${p => p.theme.border};
+`;
+
+const StepHeader = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
+  margin-bottom: ${space(1)};
+`;
+
+const StepTitle = styled('p')`
+  font-size: ${p => p.theme.fontSizeMedium};
+  font-weight: 600;
+  margin: 0;
 `;

--- a/static/app/components/events/autofix/useAutofixSetup.tsx
+++ b/static/app/components/events/autofix/useAutofixSetup.tsx
@@ -11,9 +11,6 @@ export interface AutofixSetupRepoDefinition extends AutofixRepoDefinition {
 }
 
 export type AutofixSetupResponse = {
-  autofixEnabled: {
-    ok: boolean;
-  };
   genAIConsent: {
     ok: boolean;
   };

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -19,7 +19,6 @@ import type {User} from './user';
  */
 export interface OrganizationSummary {
   aiSuggestedSolution: boolean;
-  autofixEnabled: boolean;
   avatar: Avatar;
   codecovAccess: boolean;
   dateCreated: string;

--- a/static/app/views/issueDetails/streamline/solutionsHubDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/solutionsHubDrawer.spec.tsx
@@ -208,8 +208,6 @@ describe('SolutionsHubDrawer', () => {
 
     expect(screen.queryByRole('button', {name: 'Start Autofix'})).not.toBeInTheDocument();
 
-    expect(
-      screen.getByRole('heading', {name: 'Install the GitHub Integration'})
-    ).toBeInTheDocument();
+    expect(await screen.findByText('Install the GitHub Integration')).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/solutionsHubDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/solutionsHubDrawer.spec.tsx
@@ -43,7 +43,6 @@ describe('SolutionsHubDrawer', () => {
         genAIConsent: {ok: true},
         integration: {ok: true},
         githubWriteIntegration: {ok: true},
-        autofixEnabled: {ok: true},
       },
     });
     MockApiClient.addMockResponse({
@@ -65,7 +64,6 @@ describe('SolutionsHubDrawer', () => {
         genAIConsent: {ok: false},
         integration: {ok: false},
         githubWriteIntegration: {ok: false},
-        autofixEnabled: {ok: false},
       },
     });
     MockApiClient.addMockResponse({
@@ -181,14 +179,13 @@ describe('SolutionsHubDrawer', () => {
     });
   });
 
-  it('continues to show setup if autofix is not enabled', async () => {
+  it('shows setup if not complete', async () => {
     MockApiClient.addMockResponse({
       url: `/issues/${mockGroup.id}/autofix/setup/`,
       body: {
         genAIConsent: {ok: true},
-        integration: {ok: true},
+        integration: {ok: false},
         githubWriteIntegration: {ok: false, repos: []},
-        autofixEnabled: {ok: false},
       },
     });
     MockApiClient.addMockResponse({
@@ -212,7 +209,7 @@ describe('SolutionsHubDrawer', () => {
     expect(screen.queryByRole('button', {name: 'Start Autofix'})).not.toBeInTheDocument();
 
     expect(
-      screen.getByRole('button', {name: 'Skip & Enable Autofix'})
+      screen.getByRole('heading', {name: 'Install the GitHub Integration'})
     ).toBeInTheDocument();
   });
 });

--- a/tests/js/fixtures/organization.ts
+++ b/tests/js/fixtures/organization.ts
@@ -64,7 +64,6 @@ export function OrganizationFixture( params: Partial<Organization> = {}): Organi
     githubOpenPRBot: false,
     githubPRBot: false,
     hideAiFeatures: false,
-    autofixEnabled: false,
     isDefault: false,
     isDynamicallySampled: true,
     isEarlyAdopter: false,


### PR DESCRIPTION
Since not all users could hit "Enable Autofix", we're removing the check for that setting. That also means that the write access setup step wouldn't be seen by the user since it's optional, so that step is removed from the initial setup flow (it's still accessible when the user tries to create a PR).

I will follow up with a backend PR to cleanup the unused setting.

<img width="698" alt="Screenshot 2024-11-18 at 12 58 04 PM" src="https://github.com/user-attachments/assets/b14400ff-abdb-4be5-b2b1-1dc451f0e8ea">
