### PR TITLE
styles(explore): Abbreviate y axis labels

### DIFF
--- a/static/app/views/insights/common/components/chart.tsx
+++ b/static/app/views/insights/common/components/chart.tsx
@@ -286,7 +286,7 @@ function Chart({
           return axisLabelFormatter(
             value,
             aggregateOutputFormat ?? aggregateOutputType(data[0].seriesName),
-            undefined,
+            true,
             durationUnit ?? getDurationUnit(data),
             rateUnit
           );


### PR DESCRIPTION
On charts, we should always abbreviate the y axis labels.