### PR TITLE
fix(issues): Update prefix for issues endpoints

### DIFF
--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -135,13 +135,13 @@
     "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/issues/": {
       "$ref": "paths/events/project-issues.json"
     },
-    "/api/0/issues/{issue_id}/tags/{key}/values/": {
+    "/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/tags/{key}/values/": {
       "$ref": "paths/events/tag-values.json"
     },
-    "/api/0/issues/{issue_id}/hashes/": {
+    "/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/hashes/": {
       "$ref": "paths/events/issue-hashes.json"
     },
-    "/api/0/issues/{issue_id}/": {
+    "/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/": {
       "$ref": "paths/events/issue-details.json"
     },
     "/api/0/organizations/{organization_id_or_slug}/releases/": {

--- a/api-docs/paths/events/issue-hashes.json
+++ b/api-docs/paths/events/issue-hashes.json
@@ -5,6 +5,15 @@
     "operationId": "List an Issue's Hashes",
     "parameters": [
       {
+        "name": "organization_id_or_slug",
+        "in": "path",
+        "description": "The ID or slug of the organization the event belongs to.",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
         "name": "issue_id",
         "in": "path",
         "description": "The ID of the issue to retrieve.",

--- a/api-docs/paths/events/tag-values.json
+++ b/api-docs/paths/events/tag-values.json
@@ -5,6 +5,15 @@
     "operationId": "List a Tag's Values Related to an Issue",
     "parameters": [
       {
+        "name": "organization_id_or_slug",
+        "in": "path",
+        "description": "The ID or slug of the organization the event belongs to.",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
         "name": "issue_id",
         "in": "path",
         "description": "The ID of the issue to retrieve.",

--- a/tests/apidocs/endpoints/events/test_group_hashes.py
+++ b/tests/apidocs/endpoints/events/test_group_hashes.py
@@ -8,7 +8,7 @@ class ProjectGroupHashesDocs(APIDocsTestCase):
         self.create_event("a")
         event = self.create_event("b")
 
-        self.url = f"/api/0/issues/{event.group_id}/hashes/"
+        self.url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group_id}/hashes/"
 
         self.login_as(user=self.user)
 

--- a/tests/apidocs/endpoints/events/test_group_issue_details.py
+++ b/tests/apidocs/endpoints/events/test_group_issue_details.py
@@ -24,7 +24,7 @@ class ProjectGroupIssueDetailsDocs(APIDocsTestCase):
         for timestamp in last_release.values():
             event = self.create_event("c", release="1.0a", timestamp=timestamp.isoformat())
 
-        self.url = f"/api/0/issues/{event.group.id}/"
+        self.url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/"
 
         self.login_as(user=self.user)
 

--- a/tests/apidocs/endpoints/events/test_group_tagkey_values.py
+++ b/tests/apidocs/endpoints/events/test_group_tagkey_values.py
@@ -10,7 +10,7 @@ class GroupTagKeyValuesDocs(APIDocsTestCase):
 
         self.login_as(user=self.user)
 
-        self.url = f"/api/0/issues/{event.group_id}/tags/{key}/values/"
+        self.url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group_id}/tags/{key}/values/"
 
     def test_get(self):
         response = self.client.get(self.url)


### PR DESCRIPTION
The docs themselves already reference the organization id parameter, this updates the paths to actually use it. This is required unless accessing these endpoints via a direct route to the region so that the control silo can proxy on the request to the correct region.