### PR TITLE
feat(ai): Migrate FE ai features to use new consolidated flag

### DIFF
--- a/static/app/components/events/autofix/autofixMessageBox.spec.tsx
+++ b/static/app/components/events/autofix/autofixMessageBox.spec.tsx
@@ -206,7 +206,6 @@ describe('AutofixMessageBox', () => {
       method: 'GET',
       body: {
         genAIConsent: {ok: true},
-        codebaseIndexing: {ok: true},
         integration: {ok: true},
         githubWriteIntegration: {
           repos: [{ok: true, owner: 'owner', name: 'hello-world', id: 100}],
@@ -230,7 +229,6 @@ describe('AutofixMessageBox', () => {
       method: 'GET',
       body: {
         genAIConsent: {ok: true},
-        codebaseIndexing: {ok: true},
         integration: {ok: true},
         githubWriteIntegration: {
           repos: [{ok: true, owner: 'owner', name: 'hello-world', id: 100}],
@@ -287,7 +285,6 @@ describe('AutofixMessageBox', () => {
       method: 'GET',
       body: {
         genAIConsent: {ok: true},
-        codebaseIndexing: {ok: true},
         integration: {ok: true},
         githubWriteIntegration: {
           repos: [

--- a/static/app/components/events/autofix/autofixSetupWriteAccessModal.spec.tsx
+++ b/static/app/components/events/autofix/autofixSetupWriteAccessModal.spec.tsx
@@ -29,7 +29,6 @@ describe('AutofixSetupWriteAccessModal', function () {
             },
           ],
         },
-        codebaseIndexing: {ok: false},
       },
     });
 
@@ -80,7 +79,6 @@ describe('AutofixSetupWriteAccessModal', function () {
             },
           ],
         },
-        codebaseIndexing: {ok: false},
       },
     });
 

--- a/static/app/components/events/autofix/autofixSteps.spec.tsx
+++ b/static/app/components/events/autofix/autofixSteps.spec.tsx
@@ -149,7 +149,6 @@ describe('AutofixSteps', () => {
       url: '/issues/group1/autofix/setup/',
       body: {
         genAIConsent: {ok: true},
-        codebaseIndexing: {ok: true},
         integration: {ok: true},
         githubWriteIntegration: {
           repos: [],

--- a/static/app/views/issueDetails/groupSidebar.tsx
+++ b/static/app/views/issueDetails/groupSidebar.tsx
@@ -259,7 +259,7 @@ export default function GroupSidebar({
 
   return (
     <Container>
-      {((organization.features.includes('ai-summary') &&
+      {((organization.features.includes('gen-ai-features') &&
         issueTypeConfig.issueSummary.enabled &&
         !organization.hideAiFeatures) ||
         issueTypeConfig.resources) && (

--- a/static/app/views/issueDetails/streamline/sidebar.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar.spec.tsx
@@ -22,7 +22,7 @@ describe('StreamlinedSidebar', function () {
   const issueTrackingKey = 'issue-key';
 
   const organization = OrganizationFixture({
-    features: ['ai-summary'],
+    features: ['gen-ai-features'],
   });
   const project = ProjectFixture();
   const group = GroupFixture({

--- a/static/app/views/issueDetails/streamline/sidebar.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar.tsx
@@ -51,7 +51,7 @@ export default function StreamlinedSidebar({group, event, project}: Props) {
         <FirstLastSeenSection group={group} />
       </GuideAnchor>
       <StyledBreak />
-      {((organization.features.includes('ai-summary') &&
+      {((organization.features.includes('gen-ai-features') &&
         issueTypeConfig.issueSummary.enabled &&
         !organization.hideAiFeatures) ||
         issueTypeConfig.resources) && (

--- a/static/app/views/issueDetails/streamline/solutionsHubDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/solutionsHubDrawer.spec.tsx
@@ -19,7 +19,11 @@ import {EntryType} from 'sentry/types/event';
 import {SolutionsHubDrawer} from 'sentry/views/issueDetails/streamline/solutionsHubDrawer';
 
 describe('SolutionsHubDrawer', () => {
-  const organization = OrganizationFixture({genAIConsent: true, hideAiFeatures: false});
+  const organization = OrganizationFixture({
+    genAIConsent: true,
+    hideAiFeatures: false,
+    features: ['gen-ai-features'],
+  });
 
   const mockEvent = EventFixture({
     entries: [

--- a/static/app/views/issueDetails/streamline/solutionsHubDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/solutionsHubDrawer.tsx
@@ -103,9 +103,8 @@ function AutofixStartBox({onSend, groupId}: AutofixStartBoxProps) {
 
 const shouldDisplayAiAutofixForOrganization = (organization: Organization) => {
   return (
-    ((organization.features.includes('autofix') &&
-      organization.features.includes('issue-details-autofix-ui')) ||
-      organization.genAIConsent) &&
+    organization.features.includes('gen-ai-features') &&
+    organization.genAIConsent &&
     !organization.hideAiFeatures &&
     getRegionDataFromOrganization(organization)?.name !== 'de'
   );


### PR DESCRIPTION
Consolidates all AI functionality under 1 flag

Should merge this after https://github.com/getsentry/sentry-options-automator/pull/2700