### PR TITLE
chore(grouping): Add fingerprinting-related types

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Sequence
+from collections.abc import MutableMapping, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, NotRequired, TypedDict
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 
 import sentry_sdk
 
@@ -239,7 +239,9 @@ def get_fingerprinting_config_for_project(
     return rv
 
 
-def apply_server_fingerprinting(event, config, allow_custom_title=True):
+def apply_server_fingerprinting(
+    event: MutableMapping[str, Any], config: FingerprintingRules, allow_custom_title: bool = True
+) -> None:
     fingerprint_info = {}
 
     client_fingerprint = event.get("fingerprint", [])

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, NotRequired, TypedDict
 
 import sentry_sdk
 
@@ -33,11 +33,16 @@ from sentry.models.grouphash import GroupHash
 
 if TYPE_CHECKING:
     from sentry.eventstore.models import Event
-    from sentry.grouping.fingerprinting import FingerprintingRules
+    from sentry.grouping.fingerprinting import FingerprintingRules, FingerprintRuleJSON
     from sentry.grouping.strategies.base import StrategyConfiguration
     from sentry.models.project import Project
 
 HASH_RE = re.compile(r"^[0-9a-f]{32}$")
+
+
+class FingerprintInfo(TypedDict):
+    client_fingerprint: NotRequired[list[str]]
+    matched_rule: NotRequired[FingerprintRuleJSON]
 
 
 @dataclass

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -4,7 +4,7 @@ import inspect
 import logging
 from collections.abc import Generator, Mapping, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NotRequired, Self, TypedDict, TypeVar
+from typing import TYPE_CHECKING, Any, NamedTuple, NotRequired, Self, TypedDict, TypeVar
 
 from django.conf import settings
 from parsimonious.exceptions import ParseError
@@ -106,6 +106,41 @@ class _FamilyInfo(TypedDict):
 
 class _ReleaseInfo(TypedDict):
     release: str | None
+
+
+class FingerprintRuleAttributes(TypedDict):
+    title: NotRequired[str]
+
+
+class FingerprintWithAttributes(NamedTuple):
+    fingerprint: list[str]
+    attributes: FingerprintRuleAttributes
+
+
+class FingerprintRuleConfig(TypedDict):
+    # Each matcher is a list of [<name of event attribute to match>, <value to match>]
+    matchers: list[list[str]]
+    fingerprint: list[str]
+    attributes: NotRequired[FingerprintRuleAttributes]
+    is_builtin: NotRequired[bool]
+
+
+# This is just `FingerprintRuleConfig` with an extra `text` entry and with `attributes` required
+# rather than optional. (Unfortunately, you can't overwrite lack of required-ness when subclassing a
+# TypedDict, so we have to create the full type independently.)
+class FingerprintRuleJSON(TypedDict):
+    text: str
+    # Each matcher is a list of [<name of event attribute to match>, <value to match>]
+    matchers: list[list[str]]
+    fingerprint: list[str]
+    attributes: FingerprintRuleAttributes
+    is_builtin: NotRequired[bool]
+
+
+class FingerprintRuleMatch(NamedTuple):
+    matched_rule: FingerprintRule
+    fingerprint: list[str]
+    attributes: FingerprintRuleAttributes
 
 
 class EventAccess:
@@ -231,14 +266,16 @@ class FingerprintingRules:
                 base_rules = FINGERPRINTING_BASES.get(base, [])
                 yield from base_rules
 
-    def get_fingerprint_values_for_event(self, event: dict[str, object]) -> None | object:
+    def get_fingerprint_values_for_event(
+        self, event: dict[str, object]
+    ) -> None | FingerprintRuleMatch:
         if not (self.bases or self.rules):
             return None
         access = EventAccess(event)
         for rule in self.iter_rules():
             new_values = rule.get_fingerprint_values_for_event_access(access)
             if new_values is not None:
-                return (rule,) + new_values
+                return FingerprintRuleMatch(rule, new_values.fingerprint, new_values.attributes)
         return None
 
     @classmethod
@@ -436,7 +473,7 @@ class FingerprintMatch:
         return [key, self.pattern]
 
     @classmethod
-    def _from_config_structure(cls, obj: Sequence[str]) -> Self:
+    def _from_config_structure(cls, obj: list[str]) -> Self:
         key = obj[0]
         if key.startswith("!"):
             key = key[1:]
@@ -459,7 +496,7 @@ class FingerprintRule:
         self,
         matchers: Sequence[FingerprintMatch],
         fingerprint: list[str],
-        attributes: dict[str, Any],
+        attributes: FingerprintRuleAttributes,
         is_builtin: bool = False,
     ) -> None:
         self.matchers = matchers
@@ -469,7 +506,7 @@ class FingerprintRule:
 
     def get_fingerprint_values_for_event_access(
         self, event_access: EventAccess
-    ) -> None | tuple[list[str], dict[str, Any]]:
+    ) -> None | FingerprintWithAttributes:
         by_match_group: dict[str, list[FingerprintMatch]] = {}
         for matcher in self.matchers:
             by_match_group.setdefault(matcher.match_group, []).append(matcher)
@@ -481,10 +518,10 @@ class FingerprintRule:
             else:
                 return None
 
-        return self.fingerprint, self.attributes
+        return FingerprintWithAttributes(self.fingerprint, self.attributes)
 
-    def _to_config_structure(self) -> dict[str, Any]:
-        config_structure: dict[str, Any] = {
+    def _to_config_structure(self) -> FingerprintRuleJSON:
+        config_structure: FingerprintRuleJSON = {
             "text": self.text,
             "matchers": [x._to_config_structure() for x in self.matchers],
             "fingerprint": self.fingerprint,
@@ -497,7 +534,7 @@ class FingerprintRule:
         return config_structure
 
     @classmethod
-    def _from_config_structure(cls, obj: dict[str, Any]) -> Self:
+    def _from_config_structure(cls, obj: FingerprintRuleConfig | FingerprintRuleJSON) -> Self:
         return cls(
             [FingerprintMatch._from_config_structure(x) for x in obj["matchers"]],
             obj["fingerprint"],
@@ -505,11 +542,11 @@ class FingerprintRule:
             obj.get("is_builtin") or False,
         )
 
-    def to_json(self) -> dict[str, Any]:
+    def to_json(self) -> FingerprintRuleJSON:
         return self._to_config_structure()
 
     @classmethod
-    def from_json(cls, json: dict[str, object]) -> Self:
+    def from_json(cls, json: FingerprintRuleConfig | FingerprintRuleJSON) -> Self:
         return cls._from_config_structure(json)
 
     @property
@@ -572,7 +609,7 @@ class FingerprintingVisitor(NodeVisitorBase):
         self,
         _: object,
         children: tuple[
-            object, list[FingerprintMatch], object, object, object, tuple[list[str], dict[str, Any]]
+            object, list[FingerprintMatch], object, object, object, FingerprintWithAttributes
         ],
     ) -> FingerprintRule:
         _, matcher, _, _, _, (fingerprint, attributes) = children
@@ -594,16 +631,18 @@ class FingerprintingVisitor(NodeVisitorBase):
 
     def visit_fingerprint(
         self, _: object, children: list[str | tuple[str, str]]
-    ) -> tuple[list[str], dict[str, str]]:
+    ) -> FingerprintWithAttributes:
         fingerprint = []
-        attributes = {}
+        attributes: FingerprintRuleAttributes = {}
         for item in children:
             if isinstance(item, tuple):
-                key, value = item
-                attributes[key] = value
+                # This should always be true, because otherwise an error would have been raised when
+                # we visited the child node in `visit_fp_attribute`
+                if item[0] == "title":
+                    attributes["title"] = item[1]
             else:
                 fingerprint.append(item)
-        return fingerprint, attributes
+        return FingerprintWithAttributes(fingerprint, attributes)
 
     def visit_fp_value(self, _: object, children: tuple[object, str, object, object]) -> str:
         _, argument, _, _ = children

--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -267,7 +267,7 @@ class FingerprintingRules:
                 yield from base_rules
 
     def get_fingerprint_values_for_event(
-        self, event: dict[str, object]
+        self, event: Mapping[str, object]
     ) -> None | FingerprintRuleMatch:
         if not (self.bases or self.rules):
             return None

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NotRequired, TypedDict
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 
 from sentry.grouping.fingerprinting import FingerprintRule
 from sentry.grouping.utils import hash_from_values, is_default_fingerprint_var
@@ -8,6 +8,8 @@ from sentry.types.misc import KeyedList
 
 if TYPE_CHECKING:
     from sentry.grouping.api import FingerprintInfo
+    from sentry.grouping.component import BaseGroupingComponent
+    from sentry.grouping.strategies.base import StrategyConfiguration
 
 
 class FingerprintVariantMetadata(TypedDict):
@@ -201,7 +203,13 @@ class SaltedComponentVariant(ComponentVariant):
 
     type = "salted_component"
 
-    def __init__(self, values: list[str], component, config, fingerprint_info: FingerprintInfo):
+    def __init__(
+        self,
+        values: list[str],
+        component: BaseGroupingComponent[Any],
+        config: StrategyConfiguration,
+        fingerprint_info: FingerprintInfo,
+    ):
         ComponentVariant.__init__(self, component, config)
         self.values = values
         self.info = fingerprint_info

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -135,7 +135,7 @@ class ComponentVariant(BaseVariant):
         return super().__repr__() + f" contributes={self.contributes} ({self.description})"
 
 
-def expose_fingerprint_dict(values, info):
+def expose_fingerprint_dict(values: list[str], info):
     rv = {
         "values": values,
     }
@@ -162,7 +162,7 @@ class CustomFingerprintVariant(BaseVariant):
 
     type = "custom_fingerprint"
 
-    def __init__(self, values, fingerprint_info):
+    def __init__(self, values: list[str], fingerprint_info):
         self.values = values
         self.info = fingerprint_info
 
@@ -192,7 +192,7 @@ class SaltedComponentVariant(ComponentVariant):
 
     type = "salted_component"
 
-    def __init__(self, values, component, config, fingerprint_info):
+    def __init__(self, values: list[str], component, config, fingerprint_info):
         ComponentVariant.__init__(self, component, config)
         self.values = values
         self.info = fingerprint_info

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 from sentry.grouping.fingerprinting import FingerprintRule
 from sentry.grouping.utils import hash_from_values, is_default_fingerprint_var
 from sentry.types.misc import KeyedList
+
+if TYPE_CHECKING:
+    from sentry.grouping.api import FingerprintInfo
 
 
 class BaseVariant:
@@ -135,7 +138,7 @@ class ComponentVariant(BaseVariant):
         return super().__repr__() + f" contributes={self.contributes} ({self.description})"
 
 
-def expose_fingerprint_dict(values: list[str], info):
+def expose_fingerprint_dict(values: list[str], info: FingerprintInfo):
     rv = {
         "values": values,
     }
@@ -162,7 +165,7 @@ class CustomFingerprintVariant(BaseVariant):
 
     type = "custom_fingerprint"
 
-    def __init__(self, values: list[str], fingerprint_info):
+    def __init__(self, values: list[str], fingerprint_info: FingerprintInfo):
         self.values = values
         self.info = fingerprint_info
 
@@ -192,7 +195,7 @@ class SaltedComponentVariant(ComponentVariant):
 
     type = "salted_component"
 
-    def __init__(self, values: list[str], component, config, fingerprint_info):
+    def __init__(self, values: list[str], component, config, fingerprint_info: FingerprintInfo):
         ComponentVariant.__init__(self, component, config)
         self.values = values
         self.info = fingerprint_info

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, NotRequired, TypedDict
 
 from sentry.grouping.fingerprinting import FingerprintRule
 from sentry.grouping.utils import hash_from_values, is_default_fingerprint_var
@@ -8,6 +8,12 @@ from sentry.types.misc import KeyedList
 
 if TYPE_CHECKING:
     from sentry.grouping.api import FingerprintInfo
+
+
+class FingerprintVariantMetadata(TypedDict):
+    values: list[str]
+    client_values: NotRequired[list[str]]
+    matched_rule: NotRequired[str]
 
 
 class BaseVariant:
@@ -138,8 +144,8 @@ class ComponentVariant(BaseVariant):
         return super().__repr__() + f" contributes={self.contributes} ({self.description})"
 
 
-def expose_fingerprint_dict(values: list[str], info: FingerprintInfo):
-    rv = {
+def expose_fingerprint_dict(values: list[str], info: FingerprintInfo) -> FingerprintVariantMetadata:
+    rv: FingerprintVariantMetadata = {
         "values": values,
     }
 
@@ -176,7 +182,7 @@ class CustomFingerprintVariant(BaseVariant):
     def get_hash(self) -> str | None:
         return hash_from_values(self.values)
 
-    def _get_metadata_as_dict(self):
+    def _get_metadata_as_dict(self) -> FingerprintVariantMetadata:
         return expose_fingerprint_dict(self.values, self.info)
 
 


### PR DESCRIPTION
This adds a handful of types to our fingerprinting-related code.

Note: The type added to `list_values` in `ComponentVariant.get_hash` to make mypy happy is currently `Any` just as a stop gap until it can be made more specific in https://github.com/getsentry/sentry/pull/80959.