### PR TITLE
fix(autofix): Fix buggy rethink input portal

### DIFF
--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -409,12 +409,18 @@ function ChainLink({
   const {mutate: send} = useUpdateInsightCard({groupId, runId});
 
   const {styles, attributes} = usePopper(referenceElement, popperElement, {
-    placement: insightCardAboveIndex === null ? 'right-start' : 'right-start',
+    placement: 'left-start',
     modifiers: [
       {
         name: 'offset',
         options: {
-          offset: [-16, 4],
+          offset: [-16, 8],
+        },
+      },
+      {
+        name: 'flip',
+        options: {
+          fallbackPlacements: ['right-start', 'bottom-start'],
         },
       },
     ],
@@ -501,7 +507,7 @@ function ChainLink({
               />
             </form>
           </RethinkInput>,
-          document.body
+          document.querySelector('.solutions-drawer-container') ?? document.body
         )}
     </ArrowContainer>
   );
@@ -608,9 +614,10 @@ const RethinkButton = styled(Button)`
 `;
 
 const RethinkInput = styled('div')`
+  position: fixed;
   box-shadow: ${p => p.theme.dropShadowHeavy};
   border: 1px solid ${p => p.theme.border};
-  width: 45%;
+  width: 90%;
   background: ${p => p.theme.backgroundElevated};
   padding: ${space(0.5)};
   border-radius: ${p => p.theme.borderRadius};

--- a/static/app/components/events/autofix/autofixMessageBox.tsx
+++ b/static/app/components/events/autofix/autofixMessageBox.tsx
@@ -297,7 +297,7 @@ function AutofixMessageBox({
     let text = message;
     if (isChangesStep && changesMode === 'add_tests') {
       text =
-        'Please write a unit test that reproduces the issue to make sure it is fixed.';
+        'Please write a unit test that reproduces the issue to make sure it is fixed. Put it in the appropriate test file in the codebase. If there is none, create one.';
     }
 
     if (text.trim() !== '' || allowEmptyMessage) {

--- a/static/app/views/issueDetails/streamline/solutionsHubDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/solutionsHubDrawer.tsx
@@ -174,7 +174,7 @@ export function SolutionsHubDrawer({group, project, event}: SolutionsHubDrawerPr
     !isSampleError;
 
   return (
-    <SolutionsDrawerContainer>
+    <SolutionsDrawerContainer className="solutions-drawer-container">
       <SolutionsDrawerHeader>
         <NavigationCrumbs
           crumbs={[
@@ -311,6 +311,7 @@ const SolutionsDrawerContainer = styled('div')`
   height: 100%;
   display: grid;
   grid-template-rows: auto auto 1fr;
+  position: relative;
 `;
 
 const SolutionsDrawerHeader = styled(DrawerHeader)`


### PR DESCRIPTION
Corrects bugs with the rethink input popup caused by `createPortal`. Before it could reset the scroll of the main page or started jittering if the main page scrolled.

Also tacks on a prompt change for unit test gen that seems to work better.