### PR TITLE
fix(grouping): `BaseGroupingCompoent` types cleanup

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -8,7 +8,12 @@ from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 import sentry_sdk
 
 from sentry import options
-from sentry.grouping.component import BaseGroupingComponent
+from sentry.grouping.component import (
+    AppGroupingComponent,
+    BaseGroupingComponent,
+    DefaultGroupingComponent,
+    SystemGroupingComponent,
+)
 from sentry.grouping.enhancer import LATEST_VERSION, Enhancements
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.grouping.strategies.base import DEFAULT_GROUPING_ENHANCEMENTS_BASE, GroupingContext
@@ -271,7 +276,7 @@ def apply_server_fingerprinting(
 
 def _get_calculated_grouping_variants_for_event(
     event: Event, context: GroupingContext
-) -> dict[str, BaseGroupingComponent]:
+) -> dict[str, AppGroupingComponent | SystemGroupingComponent | DefaultGroupingComponent]:
     winning_strategy: str | None = None
     precedence_hint: str | None = None
     per_variant_components: dict[str, list[BaseGroupingComponent]] = {}
@@ -299,7 +304,12 @@ def _get_calculated_grouping_variants_for_event(
 
     rv = {}
     for variant, components in per_variant_components.items():
-        component = BaseGroupingComponent(id=variant, values=components)
+        component_class_by_variant = {
+            "app": AppGroupingComponent,
+            "default": DefaultGroupingComponent,
+            "system": SystemGroupingComponent,
+        }
+        component = component_class_by_variant[variant](values=components)
         if not component.contributes and precedence_hint:
             component.update(hint=precedence_hint)
         rv[variant] = component

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -213,7 +213,7 @@ class FunctionGroupingComponent(BaseGroupingComponent[str]):
     id: str = "function"
 
 
-class LineNumberGroupingComponent(BaseGroupingComponent[str]):
+class LineNumberGroupingComponent(BaseGroupingComponent[int]):
     id: str = "lineno"
 
 

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -6,8 +6,6 @@ from typing import Any, Self
 
 from sentry.grouping.utils import hash_from_values
 
-DEFAULT_HINTS = {"salt": "a static salt"}
-
 # When a component ID appears here it has a human readable name which also
 # makes it a major component.  A major component is described as such for
 # the UI.
@@ -53,7 +51,7 @@ class BaseGroupingComponent[ValuesType: str | int | BaseGroupingComponent[Any]]:
         self.variant_provider = variant_provider
 
         self.update(
-            hint=hint or DEFAULT_HINTS.get(self.id),
+            hint=hint,
             contributes=contributes,
             values=values or [],
         )

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -145,7 +145,7 @@ class BaseGroupingComponent[ValuesType: str | int | BaseGroupingComponent[Any]]:
         rv.values = list(self.values)
         return rv
 
-    def iter_values(self) -> Generator[str | int | BaseGroupingComponent[Any]]:
+    def iter_values(self) -> Generator[str | int]:
         """Recursively walks the component and flattens it into a list of
         values.
         """

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -364,3 +364,41 @@ class TemplateGroupingComponent(
     BaseGroupingComponent[ContextLineGroupingComponent | FilenameGroupingComponent]
 ):
     id: str = "template"
+
+
+# Wrapper components used to link component trees to variants
+
+
+class DefaultGroupingComponent(
+    BaseGroupingComponent[
+        CSPGroupingComponent
+        | ExpectCTGroupingComponent
+        | ExpectStapleGroupingComponent
+        | HPKPGroupingComponent
+        | MessageGroupingComponent
+        | TemplateGroupingComponent
+    ]
+):
+    id: str = "default"
+
+
+class AppGroupingComponent(
+    BaseGroupingComponent[
+        ChainedExceptionGroupingComponent
+        | ExceptionGroupingComponent
+        | StacktraceGroupingComponent
+        | ThreadsGroupingComponent
+    ]
+):
+    id: str = "app"
+
+
+class SystemGroupingComponent(
+    BaseGroupingComponent[
+        ChainedExceptionGroupingComponent
+        | ExceptionGroupingComponent
+        | StacktraceGroupingComponent
+        | ThreadsGroupingComponent
+    ]
+):
+    id: str = "system"

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -221,7 +221,7 @@ class SaltedComponentVariant(ComponentVariant):
     def get_hash(self) -> str | None:
         if not self.component.contributes:
             return None
-        final_values = []
+        final_values: list[str | int] = []
         for value in self.values:
             if is_default_fingerprint_var(value):
                 final_values.extend(self.component.iter_values())

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
+from typing import TYPE_CHECKING, NotRequired, TypedDict
 
+from sentry.grouping.component import (
+    AppGroupingComponent,
+    DefaultGroupingComponent,
+    SystemGroupingComponent,
+)
 from sentry.grouping.fingerprinting import FingerprintRule
 from sentry.grouping.utils import hash_from_values, is_default_fingerprint_var
 from sentry.types.misc import KeyedList
 
 if TYPE_CHECKING:
     from sentry.grouping.api import FingerprintInfo
-    from sentry.grouping.component import BaseGroupingComponent
     from sentry.grouping.strategies.base import StrategyConfiguration
 
 
@@ -124,7 +128,11 @@ class ComponentVariant(BaseVariant):
 
     type = "component"
 
-    def __init__(self, component, config):
+    def __init__(
+        self,
+        component: AppGroupingComponent | SystemGroupingComponent | DefaultGroupingComponent,
+        config: StrategyConfiguration,
+    ):
         self.component = component
         self.config = config
 
@@ -206,7 +214,7 @@ class SaltedComponentVariant(ComponentVariant):
     def __init__(
         self,
         values: list[str],
-        component: BaseGroupingComponent[Any],
+        component: AppGroupingComponent | SystemGroupingComponent | DefaultGroupingComponent,
         config: StrategyConfiguration,
         fingerprint_info: FingerprintInfo,
     ):


### PR DESCRIPTION
The fixes a few small issues with the recently-introduced grouping component types:

- Line numbers in `LineNumberGroupingComponent` are stored as ints, not strings, so fix the type to reflect that.

- `BaseGroupingComponent.iter_values()` only gathers values from the leaves of the grouping component tree, which are all literals, so fix the return type not to include grouping components.

- There is a root level of grouping component not accounted for in the current implementation: For each `ComponentVariant`, we create a grouping component which doesn't correspond to any event data but is merely there to wrap the grouping component tree and connect it to the variant. (So for a message grouping component tree, for example, it's not `component_variant.component = message_grouping_component`, it's instead `component_variant.component = extra_wrapper_component` and `extra_wrapper_component.values = [message_grouping_component]`.) Add those missing component types.

- The only component type which uses `DEFAULT_HINTS` is `SaltGroupingComponent`, which already has the hint included at the class level, so remove `DEFAULT_HINTS` as it's redundant.