### PR TITLE
ref(grouping): Make `BaseGroupingComponent` and `BaseVariant` abstract

### DIFF
--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import ABC
 from collections import Counter
 from collections.abc import Generator, Iterator, Sequence
 from typing import Any, Self
@@ -29,7 +30,7 @@ def _calculate_contributes[ValuesType](values: Sequence[ValuesType]) -> bool:
     return False
 
 
-class BaseGroupingComponent[ValuesType: str | int | BaseGroupingComponent[Any]]:
+class BaseGroupingComponent[ValuesType: str | int | BaseGroupingComponent[Any]](ABC):
     """A grouping component is a recursive structure that is flattened
     into components to make a hash for grouping purposes.
     """

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -42,13 +42,11 @@ class BaseGroupingComponent[ValuesType: str | int | BaseGroupingComponent[Any]](
 
     def __init__(
         self,
-        id: str | None = None,
         hint: str | None = None,
         contributes: bool | None = None,
         values: Sequence[ValuesType] | None = None,
         variant_provider: bool = False,
     ):
-        self.id = id or self.id
         self.variant_provider = variant_provider
 
         self.update(

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from abc import ABC
+from abc import ABC, abstractmethod
 from collections import Counter
 from collections.abc import Generator, Iterator, Sequence
 from typing import Any, Self
@@ -35,7 +35,6 @@ class BaseGroupingComponent[ValuesType: str | int | BaseGroupingComponent[Any]](
     into components to make a hash for grouping purposes.
     """
 
-    id: str = "default"
     hint: str | None = None
     contributes: bool = False
     values: Sequence[ValuesType]
@@ -54,6 +53,10 @@ class BaseGroupingComponent[ValuesType: str | int | BaseGroupingComponent[Any]](
             contributes=contributes,
             values=values or [],
         )
+
+    @property
+    @abstractmethod
+    def id(self) -> str: ...
 
     @property
     def name(self) -> str | None:

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import ABC
 from typing import TYPE_CHECKING, NotRequired, TypedDict
 
 from sentry.grouping.component import (
@@ -22,7 +23,7 @@ class FingerprintVariantMetadata(TypedDict):
     matched_rule: NotRequired[str]
 
 
-class BaseVariant:
+class BaseVariant(ABC):
     # The type of the variant that is reported to the UI.
     type: str | None = None
 

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from abc import ABC
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, NotRequired, TypedDict
 
 from sentry.grouping.component import (
@@ -24,11 +24,12 @@ class FingerprintVariantMetadata(TypedDict):
 
 
 class BaseVariant(ABC):
-    # The type of the variant that is reported to the UI.
-    type: str | None = None
-
     # This is true if `get_hash` does not return `None`.
     contributes = True
+
+    @property
+    @abstractmethod
+    def type(self) -> str: ...
 
     def get_hash(self) -> str | None:
         return None


### PR DESCRIPTION
This converts `BaseGroupingComponent` and `BaseVariant` to an abstract classes. Neither one is currently instantiated anywhere, but this guarantees neither will be in the future, either. It also converts their `id` and `type` attributes, respectively, to be abstract properties, in order to force subclasses to define them. Finally, since `BaseGroupingComponent` subclasses now all have to define `id`, this removes it from the classes' `__init__`.