### PR TITLE
ref(seer grouping): Add `platform` to `did_call_seer` metric

### DIFF
--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -345,11 +345,11 @@ def killswitch_enabled(project_id: int, event: Event | None = None) -> bool:
             "should_call_seer_for_grouping.seer_global_killswitch_enabled",
             extra=logger_extra,
         )
-        metrics.incr(
-            "grouping.similarity.did_call_seer",
-            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-            tags={"call_made": False, "blocker": "global-killswitch"},
-        )
+        # `event` will be defined when we're calling this from ingest, which is really what the
+        # `did_call_seer` is meant to track
+        if event:
+            record_did_call_seer_metric(event, called=False, blocker="global-killswitch")
+
         return True
 
     if options.get("seer.similarity-killswitch.enabled"):
@@ -357,11 +357,8 @@ def killswitch_enabled(project_id: int, event: Event | None = None) -> bool:
             "should_call_seer_for_grouping.seer_similarity_killswitch_enabled",
             extra=logger_extra,
         )
-        metrics.incr(
-            "grouping.similarity.did_call_seer",
-            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-            tags={"call_made": False, "blocker": "similarity-killswitch"},
-        )
+        if event:
+            record_did_call_seer_metric(event, called=False, blocker="similarity-killswitch")
         return True
 
     if killswitch_matches_context(
@@ -371,11 +368,8 @@ def killswitch_enabled(project_id: int, event: Event | None = None) -> bool:
             "should_call_seer_for_grouping.seer_similarity_project_killswitch_enabled",
             extra=logger_extra,
         )
-        metrics.incr(
-            "grouping.similarity.did_call_seer",
-            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-            tags={"call_made": False, "blocker": "project-killswitch"},
-        )
+        if event:
+            record_did_call_seer_metric(event, called=False, blocker="project-killswitch")
         return True
 
     return False

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -421,3 +421,11 @@ def project_is_seer_eligible(project: Project) -> bool:
     is_region_enabled = options.get("similarity.new_project_seer_grouping.enabled")
 
     return not is_backfill_completed and is_seer_eligible_platform and is_region_enabled
+
+
+def record_did_call_seer_metric(event: Event, called: bool, blocker: str) -> None:
+    metrics.incr(
+        "grouping.similarity.did_call_seer",
+        sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+        tags={"call_made": called, "blocker": blocker, "platform": event.platform},
+    )


### PR DESCRIPTION
This adds the event's platform as a tag on the `did_call_seer` metric. In order to streamline things a bit, it also adds a new helper, `record_did_call_seer_metric`, to make the actual datadog call. (This saves a lot of repetition of sample rate, tags, etc.) 

Other than the new tag, the only behavior change is that we've been (in theory) also recording `did_call_seer` during backfill, in cases where the killswitch is enabled. This is a mistake, though a harmless one as we haven't actually had to engage the killswitches in the last few months, so all our current DD data should be legit. Regardless, this fixes that, and only calls the new helper when we have an event (which we only do during ingest, not backfill).

Note: Leaving this in draft because it won't typecheck until some other PRs have gone through, and in order to wait for new `did_call_seer` calls to be merged, at which point I'll rebase and include them.