### PR TITLE
ref(profiling): support stack trace rules aliases

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -35,9 +35,13 @@ LATEST_VERSION = VERSIONS[-1]
 
 VALID_PROFILING_MATCHER_PREFIXES = (
     "stack.abs_path",
+    "path",  # stack.abs_path alias
     "stack.module",
+    "module",  # stack.module alias
     "stack.function",
+    "function",  # stack.function alias
     "stack.package",
+    "package",  # stack.package
 )
 VALID_PROFILING_ACTIONS_SET = frozenset(["+app", "-app"])
 


### PR DESCRIPTION
This adds support for using valid matchers aliases as defined in the [docs](https://docs.sentry.io/concepts/data-management/event-grouping/stack-trace-rules/#stackabs_path).
