### PR TITLE
ref(PasswordStrength): Refactor password strength to render with React.createRoot

### DIFF
--- a/static/app/bootstrap/processInitQueue.tsx
+++ b/static/app/bootstrap/processInitQueue.tsx
@@ -1,3 +1,6 @@
+import {createRoot} from 'react-dom/client';
+import throttle from 'lodash/throttle';
+
 import {exportedGlobals} from 'sentry/bootstrap/exportGlobals';
 import type {OnSentryInitConfiguration} from 'sentry/types/system';
 import {SentryInitRenderReactComponent} from 'sentry/types/system';
@@ -32,15 +35,23 @@ async function processItem(initConfig: OnSentryInitConfiguration) {
     if (!input || !element) {
       return;
     }
+    const inputElem = document.querySelector(input);
+    const rootEl = document.querySelector(element);
+    if (!inputElem || !rootEl) {
+      return;
+    }
 
-    const passwordStrength = await import(
+    const {PasswordStrength} = await import(
       /* webpackChunkName: "PasswordStrength" */ 'sentry/components/passwordStrength'
     );
 
-    passwordStrength.attachTo({
-      input: document.querySelector(input),
-      element: document.querySelector(element),
-    });
+    const root = createRoot(rootEl);
+    inputElem.addEventListener(
+      'input',
+      throttle(e => {
+        root.render(<PasswordStrength value={e.target.value} />);
+      })
+    );
 
     return;
   }

--- a/static/app/components/passwordStrength.tsx
+++ b/static/app/components/passwordStrength.tsx
@@ -1,18 +1,11 @@
 import {Fragment} from 'react';
-import {render} from 'react-dom';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
-import throttle from 'lodash/throttle';
 import zxcvbn from 'zxcvbn';
 
 import {tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import theme from 'sentry/utils/theme';
-
-/**
- * NOTE: Do not import this component synchronously. The zxcvbn library is
- * relatively large. This component should be loaded async as a split chunk.
- */
 
 /**
  * The maximum score that zxcvbn reports
@@ -34,7 +27,11 @@ type Props = {
   labels?: [string, string, string, string, string];
 };
 
-function PasswordStrength({
+/**
+ * NOTE: Do not import this component synchronously. The zxcvbn library is
+ * relatively large. This component should be loaded async as a split chunk.
+ */
+export function PasswordStrength({
   value,
   labels = ['Very Weak', 'Very Weak', 'Weak', 'Strong', 'Very Strong'],
   colors = [theme.red300, theme.red300, theme.yellow300, theme.green300, theme.green300],
@@ -96,20 +93,3 @@ const StrengthLabel = styled('div')`
 const ScoreText = styled('strong')`
   color: ${p => p.theme.black};
 `;
-
-export default PasswordStrength;
-
-/**
- * This is a shim that allows the password strength component to be used
- * outside of our main react application. Mostly useful since all of our
- * registration pages aren't in the react app.
- */
-export const attachTo = ({input, element}) =>
-  element &&
-  input &&
-  input.addEventListener(
-    'input',
-    throttle(e => {
-      render(<PasswordStrength value={e.target.value} />, element);
-    })
-  );


### PR DESCRIPTION
To test i fired up `sentry devserver` and visited `/auth/login/sentry/#register`. We can see it's still rendering when input changes:
<img width="566" alt="SCR-20241119-qiaa" src="https://github.com/user-attachments/assets/4e41706d-a188-4ee9-89a9-1fa5eba54a5a">

