### PR TITLE
feat(eap): Map attributes to public names

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_spans_fields.py
+++ b/tests/sentry/api/endpoints/test_organization_spans_fields.py
@@ -35,13 +35,13 @@ class OrganizationSpansTagsEndpointTest(BaseSpansTestCase, APITestCase):
         assert response.status_code == 200, response.data
         assert response.data == []
 
-    def test_tags_list(self):
+    def test_tags_list_str(self):
         for tag in ["foo", "bar", "baz"]:
             self.store_segment(
                 self.project.id,
                 uuid4().hex,
                 uuid4().hex,
-                span_id=uuid4().hex[:15],
+                span_id=uuid4().hex[:16],
                 organization_id=self.organization.id,
                 parent_span_id=None,
                 timestamp=before_now(days=0, minutes=10).replace(microsecond=0),
@@ -86,13 +86,13 @@ class OrganizationEAPSpansTagsEndpointTest(OrganizationSpansTagsEndpointTest):
                 **kwargs,
             )
 
-    def test_tags_list(self):
+    def test_tags_list_str(self):
         for tag in ["foo", "bar", "baz"]:
             self.store_segment(
                 self.project.id,
                 uuid4().hex,
                 uuid4().hex,
-                span_id=uuid4().hex[:15],
+                span_id=uuid4().hex[:16],
                 organization_id=self.organization.id,
                 parent_span_id=None,
                 timestamp=before_now(days=0, minutes=10).replace(microsecond=0),
@@ -112,14 +112,42 @@ class OrganizationEAPSpansTagsEndpointTest(OrganizationSpansTagsEndpointTest):
             )
             assert response.status_code == 200, response.data
             assert {"key": "bar", "name": "Bar"} in response.data
-            assert {"key": "foo", "name": "Foo"} in response.data
             assert {"key": "baz", "name": "Baz"} in response.data
-            # Skipping for now
-            # assert response.data == [
-            #     {"key": "span.description", "name": "Span.Description"},
-            #     {"key": "transaction", "name": "Transaction"},
-            #     {"key": "project", "name": "Project"},
-            # ]
+            assert {"key": "foo", "name": "Foo"} in response.data
+
+    def test_tags_list_str_processed(self):
+        for tag in ["foo", "bar", "baz"]:
+            self.store_segment(
+                self.project.id,
+                uuid4().hex,
+                uuid4().hex,
+                span_id=uuid4().hex[:16],
+                organization_id=self.organization.id,
+                parent_span_id=None,
+                timestamp=before_now(days=0, minutes=10).replace(microsecond=0),
+                transaction="foo",
+                duration=100,
+                exclusive_time=100,
+                tags={tag: tag},
+                is_eap=self.is_eap,
+            )
+
+        for features in [
+            None,  # use the default features
+            ["organizations:performance-trace-explorer"],
+        ]:
+            response = self.do_request(
+                features=features, query={"dataset": "spans", "type": "string", "process": 1}
+            )
+            assert response.status_code == 200, response.data
+            assert response.data == [
+                {"key": "bar", "name": "bar"},
+                {"key": "baz", "name": "baz"},
+                {"key": "foo", "name": "foo"},
+                {"key": "span.description", "name": "span.description"},
+                {"key": "transaction", "name": "transaction"},
+                {"key": "project", "name": "project"},
+            ]
 
     def test_tags_list_nums(self):
         for tag in ["foo", "bar", "baz"]:
@@ -127,7 +155,7 @@ class OrganizationEAPSpansTagsEndpointTest(OrganizationSpansTagsEndpointTest):
                 self.project.id,
                 uuid4().hex,
                 uuid4().hex,
-                span_id=uuid4().hex[:15],
+                span_id=uuid4().hex[:16],
                 organization_id=self.organization.id,
                 parent_span_id=None,
                 timestamp=before_now(days=0, minutes=10).replace(microsecond=0),
@@ -147,8 +175,42 @@ class OrganizationEAPSpansTagsEndpointTest(OrganizationSpansTagsEndpointTest):
             )
             assert response.status_code == 200, response.data
             assert {"key": "bar", "name": "Bar"} in response.data
-            assert {"key": "foo", "name": "Foo"} in response.data
             assert {"key": "baz", "name": "Baz"} in response.data
+            assert {"key": "foo", "name": "Foo"} in response.data
+
+    def test_tags_list_nums_processed(self):
+        for tag in ["foo", "bar", "baz", "lcp", "fcp"]:
+            self.store_segment(
+                self.project.id,
+                uuid4().hex,
+                uuid4().hex,
+                span_id=uuid4().hex[:16],
+                organization_id=self.organization.id,
+                parent_span_id=None,
+                timestamp=before_now(days=0, minutes=10).replace(microsecond=0),
+                transaction="foo",
+                duration=100,
+                exclusive_time=100,
+                measurements={tag: 0},
+                is_eap=self.is_eap,
+            )
+
+        for features in [
+            None,  # use the default features
+            ["organizations:performance-trace-explorer"],
+        ]:
+            response = self.do_request(
+                features=features, query={"dataset": "spans", "type": "number", "process": 1}
+            )
+            assert response.status_code == 200, response.data
+            assert response.data == [
+                {"key": "tags[bar,number]", "name": "bar"},
+                {"key": "tags[baz,number]", "name": "baz"},
+                {"key": "measurements.fcp", "name": "measurements.fcp"},
+                {"key": "tags[foo,number]", "name": "foo"},
+                {"key": "measurements.lcp", "name": "measurements.lcp"},
+                {"key": "span.duration", "name": "span.duration"},
+            ]
 
 
 class OrganizationSpansTagKeyValuesEndpointTest(BaseSpansTestCase, APITestCase):
@@ -189,7 +251,7 @@ class OrganizationSpansTagKeyValuesEndpointTest(BaseSpansTestCase, APITestCase):
                 self.project.id,
                 uuid4().hex,
                 uuid4().hex,
-                span_id=uuid4().hex[:15],
+                span_id=uuid4().hex[:16],
                 organization_id=self.organization.id,
                 parent_span_id=None,
                 timestamp=timestamp,
@@ -236,7 +298,7 @@ class OrganizationSpansTagKeyValuesEndpointTest(BaseSpansTestCase, APITestCase):
                 self.project.id,
                 uuid4().hex,
                 uuid4().hex,
-                span_id=uuid4().hex[:15],
+                span_id=uuid4().hex[:16],
                 organization_id=self.organization.id,
                 parent_span_id=None,
                 timestamp=timestamp,
@@ -284,7 +346,7 @@ class OrganizationSpansTagKeyValuesEndpointTest(BaseSpansTestCase, APITestCase):
                 self.project.id,
                 uuid4().hex,
                 uuid4().hex,
-                span_id=uuid4().hex[:15],
+                span_id=uuid4().hex[:16],
                 organization_id=self.organization.id,
                 parent_span_id=None,
                 timestamp=timestamp,
@@ -324,7 +386,7 @@ class OrganizationSpansTagKeyValuesEndpointTest(BaseSpansTestCase, APITestCase):
                 self.project.id,
                 uuid4().hex,
                 uuid4().hex,
-                span_id=uuid4().hex[:15],
+                span_id=uuid4().hex[:16],
                 organization_id=self.organization.id,
                 parent_span_id=None,
                 timestamp=timestamp,
@@ -364,7 +426,7 @@ class OrganizationSpansTagKeyValuesEndpointTest(BaseSpansTestCase, APITestCase):
                 self.project.id,
                 uuid4().hex,
                 uuid4().hex,
-                span_id=uuid4().hex[:15],
+                span_id=uuid4().hex[:16],
                 organization_id=self.organization.id,
                 parent_span_id=None,
                 timestamp=timestamp,
@@ -413,7 +475,7 @@ class OrganizationSpansTagKeyValuesEndpointTest(BaseSpansTestCase, APITestCase):
                 self.project.id,
                 uuid4().hex,
                 uuid4().hex,
-                span_id=uuid4().hex[:15],
+                span_id=uuid4().hex[:16],
                 organization_id=self.organization.id,
                 parent_span_id=None,
                 timestamp=timestamp,
@@ -454,7 +516,7 @@ class OrganizationSpansTagKeyValuesEndpointTest(BaseSpansTestCase, APITestCase):
                 self.project.id,
                 uuid4().hex,
                 uuid4().hex,
-                span_id=uuid4().hex[:15],
+                span_id=uuid4().hex[:16],
                 organization_id=self.organization.id,
                 parent_span_id=None,
                 timestamp=timestamp,
@@ -495,7 +557,7 @@ class OrganizationSpansTagKeyValuesEndpointTest(BaseSpansTestCase, APITestCase):
                 self.project.id,
                 uuid4().hex,
                 uuid4().hex,
-                span_id=uuid4().hex[:15],
+                span_id=uuid4().hex[:16],
                 organization_id=self.organization.id,
                 parent_span_id=None,
                 timestamp=timestamp,
@@ -650,7 +712,7 @@ class OrganizationSpansTagKeyValuesEndpointTest(BaseSpansTestCase, APITestCase):
                 self.project.id,
                 uuid4().hex,
                 uuid4().hex,
-                span_id=uuid4().hex[:15],
+                span_id=uuid4().hex[:16],
                 organization_id=self.organization.id,
                 parent_span_id=None,
                 timestamp=timestamp,


### PR DESCRIPTION
This postprocesses the results from the RPC call so that the what is returned matches the public names of the various attributes. For example,
- `sentry.segment_name` -> `transaction`
- `sentry.duration_ms` -> `span.duration`