### PR TITLE
fix(dynamic-sampling): Bug bash papercuts

### DIFF
--- a/static/app/views/settings/dynamicSampling/index.tsx
+++ b/static/app/views/settings/dynamicSampling/index.tsx
@@ -9,9 +9,11 @@ import useOrganization from 'sentry/utils/useOrganization';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import {OrganizationSampling} from 'sentry/views/settings/dynamicSampling/organizationSampling';
 import {ProjectSampling} from 'sentry/views/settings/dynamicSampling/projectSampling';
+import {useHasDynamicSamplingWriteAccess} from 'sentry/views/settings/dynamicSampling/utils/access';
 
 export default function DynamicSamplingSettings() {
   const organization = useOrganization();
+  const hasWriteAccess = useHasDynamicSamplingWriteAccess();
 
   if (!hasDynamicSamplingCustomFeature(organization)) {
     return <Alert type="warning">{t("You don't have access to this feature")}</Alert>;
@@ -20,29 +22,34 @@ export default function DynamicSamplingSettings() {
   return (
     <Fragment>
       <SentryDocumentTitle title={t('Dynamic Sampling')} orgSlug={organization.slug} />
-      <div>
-        <SettingsPageHeader
-          title={t('Dynamic Sampling')}
-          action={
-            <LinkButton
-              external
-              href="https://docs.sentry.io/product/performance/retention-priorities/"
-            >
-              {t('Read the docs')}
-            </LinkButton>
-          }
-        />
-        <p>
+      <SettingsPageHeader
+        title={t('Dynamic Sampling')}
+        action={
+          <LinkButton
+            external
+            href="https://docs.sentry.io/product/performance/retention-priorities/"
+          >
+            {t('Read the docs')}
+          </LinkButton>
+        }
+      />
+      {!hasWriteAccess && (
+        <Alert type="warning">
           {t(
-            'Dynamic sampling adaptively reduces the number of spans stored in Sentry without changing SDK sample rates. It allows you to keep the most relevant samples and obtain accurate high-level insights while limiting redundancy and stored span volume. You can customize sample rates and priorities in these settings to control which data is stored.'
+            'These settings can only be edited by users with the organization owner or manager role.'
           )}
-        </p>
-        {organization.samplingMode === 'organization' ? (
-          <OrganizationSampling />
-        ) : (
-          <ProjectSampling />
+        </Alert>
+      )}
+      <p>
+        {t(
+          'Dynamic sampling adaptively reduces the number of spans stored in Sentry without changing SDK sample rates. It allows you to keep the most relevant samples and obtain accurate high-level insights while limiting redundancy and stored span volume. You can customize sample rates and priorities in these settings to control which data is stored.'
         )}
-      </div>
+      </p>
+      {organization.samplingMode === 'organization' ? (
+        <OrganizationSampling />
+      ) : (
+        <ProjectSampling />
+      )}
     </Fragment>
   );
 }

--- a/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsEditTable.tsx
@@ -7,6 +7,7 @@ import {Button} from 'sentry/components/button';
 import FieldGroup from 'sentry/components/forms/fieldGroup';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
+import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useProjects from 'sentry/utils/useProjects';
@@ -111,6 +112,12 @@ export function ProjectsEditTable({
     [dataByProjectId, editMode, onChange, onEditModeChange, value]
   );
 
+  const handleOrgBlur = useCallback(() => {
+    setIsBulkEditEnabled(false);
+    // Parse to ensure valid values
+    setOrgRate(rate => (parsePercent(rate, 1) * 100).toString());
+  }, []);
+
   const items = useMemo(
     () =>
       projects.map(project => {
@@ -181,7 +188,7 @@ export function ProjectsEditTable({
         {isLoading ? (
           <LoadingIndicator
             css={css`
-              margin: ${space(4)} 0;
+              margin: 60px 0;
             `}
           />
         ) : (
@@ -199,21 +206,26 @@ export function ProjectsEditTable({
               alignRight
             >
               <InputWrapper>
-                <PercentInput
-                  type="number"
-                  ref={inputRef}
-                  disabled={!hasAccess || !isBulkEditEnabled}
-                  size="sm"
-                  onChange={handleOrgChange}
-                  value={projectedOrgRate}
-                  onKeyDown={event => {
-                    if (event.key === 'Enter') {
-                      event.preventDefault();
-                      inputRef.current?.blur();
-                    }
-                  }}
-                  onBlur={() => setIsBulkEditEnabled(false)}
-                />
+                <Tooltip
+                  disabled={hasAccess}
+                  title={t('You do not have permission to change the sample rate')}
+                >
+                  <PercentInput
+                    type="number"
+                    ref={inputRef}
+                    disabled={!hasAccess || !isBulkEditEnabled}
+                    size="sm"
+                    onChange={handleOrgChange}
+                    value={projectedOrgRate}
+                    onKeyDown={event => {
+                      if (event.key === 'Enter') {
+                        event.preventDefault();
+                        inputRef.current?.blur();
+                      }
+                    }}
+                    onBlur={handleOrgBlur}
+                  />
+                </Tooltip>
                 <FlexRow>
                   <PreviousValue>
                     {initialOrgRate !== projectedOrgRate

--- a/static/app/views/settings/dynamicSampling/samplingBreakdown.tsx
+++ b/static/app/views/settings/dynamicSampling/samplingBreakdown.tsx
@@ -63,7 +63,7 @@ export function SamplingBreakdown({sampleCounts, sampleRates, ...props}: Props) 
     .reduce((acc, item) => acc + item.sampledSpans, 0);
   const total = spansWithSampleRates.reduce((acc, item) => acc + item.sampledSpans, 0);
 
-  const getSpanRate = spanCount => (total === 0 ? 1 : spanCount / total);
+  const getSpanRate = spanCount => (total === 0 ? 0 : spanCount / total);
   const otherRate = getSpanRate(otherSpanCount);
 
   return (

--- a/static/app/views/settings/dynamicSampling/samplingModeField.tsx
+++ b/static/app/views/settings/dynamicSampling/samplingModeField.tsx
@@ -4,6 +4,7 @@ import FieldGroup from 'sentry/components/forms/fieldGroup';
 import ExternalLink from 'sentry/components/links/externalLink';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {SegmentedControl} from 'sentry/components/segmentedControl';
+import {Tooltip} from 'sentry/components/tooltip';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -30,52 +31,64 @@ export function SamplingModeField({initialTargetRate}: Props) {
 
   return (
     <FieldGroup
+      disabledReason={t('You do not have permission to change this setting.')}
       disabled={!hasAccess}
       label={t('Sampling Mode')}
       help={t('The current operating mode for dynamic sampling.')}
     >
       <ControlWrapper>
-        <SegmentedControl
-          disabled={!hasAccess}
-          label={t('Sampling mode')}
-          value={samplingMode}
-          onChange={handleSwitchMode}
+        <Tooltip
+          disabled={hasAccess}
+          title={t('You do not have permission to change this setting.')}
         >
-          <SegmentedControl.Item key="organization" textValue={t('Automatic')}>
-            <LabelWrapper>
-              {t('Automatic')}
-              <QuestionTooltip
-                isHoverable
-                size="sm"
-                title={tct(
-                  'Automatic mode allows you to set a target sample rate for your organization. Sentry automatically adjusts individual project rates to boost small projects and ensure equal visibility. [link:Learn more]',
-                  {
-                    link: (
-                      <ExternalLink href="https://docs.sentry.io/product/performance/retention-priorities/" />
-                    ),
+          <SegmentedControl
+            disabled={!hasAccess}
+            label={t('Sampling mode')}
+            value={samplingMode}
+            onChange={handleSwitchMode}
+          >
+            <SegmentedControl.Item key="organization" textValue={t('Automatic')}>
+              <LabelWrapper>
+                {t('Automatic')}
+                <QuestionTooltip
+                  isHoverable
+                  size="sm"
+                  title={
+                    hasAccess &&
+                    tct(
+                      'Automatic mode allows you to set a target sample rate for your organization. Sentry automatically adjusts individual project rates to boost small projects and ensure equal visibility. [link:Learn more]',
+                      {
+                        link: (
+                          <ExternalLink href="https://docs.sentry.io/product/performance/retention-priorities/" />
+                        ),
+                      }
+                    )
                   }
-                )}
-              />
-            </LabelWrapper>
-          </SegmentedControl.Item>
-          <SegmentedControl.Item key="project" textValue={t('Manual')}>
-            <LabelWrapper>
-              {t('Manual')}
-              <QuestionTooltip
-                isHoverable
-                size="sm"
-                title={tct(
-                  'Manual mode allows you to set fixed sample rates for each project. [link:Learn more]',
-                  {
-                    link: (
-                      <ExternalLink href="https://docs.sentry.io/product/performance/retention-priorities/" />
-                    ),
+                />
+              </LabelWrapper>
+            </SegmentedControl.Item>
+            <SegmentedControl.Item key="project" textValue={t('Manual')}>
+              <LabelWrapper>
+                {t('Manual')}
+                <QuestionTooltip
+                  isHoverable
+                  size="sm"
+                  title={
+                    hasAccess &&
+                    tct(
+                      'Manual mode allows you to set fixed sample rates for each project. [link:Learn more]',
+                      {
+                        link: (
+                          <ExternalLink href="https://docs.sentry.io/product/performance/retention-priorities/" />
+                        ),
+                      }
+                    )
                   }
-                )}
-              />
-            </LabelWrapper>
-          </SegmentedControl.Item>
-        </SegmentedControl>
+                />
+              </LabelWrapper>
+            </SegmentedControl.Item>
+          </SegmentedControl>
+        </Tooltip>
       </ControlWrapper>
     </FieldGroup>
   );

--- a/static/app/views/settings/dynamicSampling/utils/useProjectSampleCounts.tsx
+++ b/static/app/views/settings/dynamicSampling/utils/useProjectSampleCounts.tsx
@@ -106,17 +106,14 @@ export function useProjectSampleCounts({period}: {period: ProjectionSamplePeriod
 
   const items = useMemo(
     () =>
-      projectEntries
-        .entries()
-        .map<ProjectSampleCount>(([key, value]) => {
-          return {
-            project: projectBySlug[key],
-            count: value.count,
-            ownCount: value.ownCount,
-            subProjects: value.subProjects.toSorted((a, b) => b.count - a.count),
-          };
-        })
-        .toArray(),
+      Array.from(projectEntries.entries()).map<ProjectSampleCount>(([key, value]) => {
+        return {
+          project: projectBySlug[key],
+          count: value.count,
+          ownCount: value.ownCount,
+          subProjects: value.subProjects.toSorted((a, b) => b.count - a.count),
+        };
+      }),
     [projectBySlug, projectEntries]
   );
 


### PR DESCRIPTION
- Display banner for insufficient permissions
- Add tooltips to all disabled inputs
- Ensure estimated org rate stays in boundaries (0-100)
- Fix Safari bug where `.map()` is  not available on a `MapIterator` instance
- Properly disable project rate inputs when permissions are missing