### PR TITLE
ref(devservices): Updating code to support new postgres container names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ all: develop
 
 PIP := python -m pip --disable-pip-version-check
 WEBPACK := yarn build-acceptance
-POSTGRES_CONTAINER := sentry_postgres
 
 freeze-requirements:
 	@python3 -S -m tools.freeze_requirements

--- a/bin/split-silo-database
+++ b/bin/split-silo-database
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import os
+
 import click
 from django.apps import apps
 
@@ -30,7 +32,12 @@ def split_database(tables: list[str], source: str, destination: str, reset: bool
     command.extend([">", f"/tmp/{destination}-tables.sql"])
 
     with get_docker_client() as client:
-        postgres = client.containers.get("sentry_postgres")
+        postgres_container = (
+            "sentry_postgres"
+            if os.environ.get("USE_NEW_DEVSERVICES") != "1"
+            else "sentry-postgres-1"
+        )
+        postgres = client.containers.get(postgres_container)
 
         if verbose:
             click.echo(f">> Running {' '.join(command)}")

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -281,12 +281,16 @@ def main(context: dict[str, str]) -> int:
     ):
         return 1
 
+    postgres_container = (
+        "sentry_postgres" if os.environ.get("USE_NEW_DEVSERVICES") != "1" else "sentry-postgres-1"
+    )
+
     # faster prerequisite check than starting up sentry and running createuser idempotently
     stdout = proc.run(
         (
             "docker",
             "exec",
-            "sentry_postgres",
+            postgres_container,
             "psql",
             "sentry",
             "postgres",

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -8,7 +8,8 @@
 # shellcheck disable=SC2001 # https://github.com/koalaman/shellcheck/wiki/SC2001
 
 POSTGRES_CONTAINER="sentry_postgres"
-if [ "$USE_NEW_DEVSERVICES" == 1 ]; then
+USE_NEW_DEVSERVICES=${USE_NEW_DEVSERVICES:-"0"}
+if [ "$USE_NEW_DEVSERVICES" == "1" ]; then
 POSTGRES_CONTAINER="sentry-postgres-1"
 fi
 

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -7,6 +7,11 @@
 # shellcheck disable=SC2034 # Unused variables
 # shellcheck disable=SC2001 # https://github.com/koalaman/shellcheck/wiki/SC2001
 
+POSTGRES_CONTAINER="sentry_postgres"
+if [ "$USE_NEW_DEVSERVICES" == 1 ]; then
+POSTGRES_CONTAINER="sentry-postgres-1"
+fi
+
 # This block is a safe-guard since in CI calling tput will fail and abort scripts
 if [ -z "${CI+x}" ]; then
     bold="$(tput bold)"
@@ -87,7 +92,7 @@ run-dependent-services() {
 }
 
 create-db() {
-    container_name=${POSTGRES_CONTAINER:-sentry_postgres}
+    container_name=${POSTGRES_CONTAINER}
     echo "--> Creating 'sentry' database"
     docker exec "${container_name}" createdb -h 127.0.0.1 -U postgres -E utf-8 sentry || true
     echo "--> Creating 'control', 'region' and 'secondary' database"
@@ -132,7 +137,7 @@ clean() {
 }
 
 drop-db() {
-    container_name=${POSTGRES_CONTAINER:-sentry_postgres}
+    container_name=${POSTGRES_CONTAINER}
     echo "--> Dropping existing 'sentry' database"
     docker exec "${container_name}" dropdb --if-exists -h 127.0.0.1 -U postgres sentry
     echo "--> Dropping 'control' and 'region' database"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -10,7 +10,7 @@
 POSTGRES_CONTAINER="sentry_postgres"
 USE_NEW_DEVSERVICES=${USE_NEW_DEVSERVICES:-"0"}
 if [ "$USE_NEW_DEVSERVICES" == "1" ]; then
-POSTGRES_CONTAINER="sentry-postgres-1"
+    POSTGRES_CONTAINER="sentry-postgres-1"
 fi
 
 # This block is a safe-guard since in CI calling tput will fail and abort scripts

--- a/scripts/upgrade-postgres.sh
+++ b/scripts/upgrade-postgres.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+POSTGRES_CONTAINER="sentry_postgres"
+if [ "$USE_NEW_DEVSERVICES" == 1 ]; then
+POSTGRES_CONTAINER="sentry-postgres-1"
+fi
+
 OLD_VERSION="9.6"
 NEW_VERSION="14"
 PG_IMAGE="ghcr.io/getsentry/image-mirror-library-postgres:${NEW_VERSION}-alpine"
@@ -10,7 +15,7 @@ TMP_VOLUME_NAME="${VOLUME_NAME}_${NEW_VERSION}"
 TMP_CONTAINER="${PROJECT}_pg_migration"
 
 echo "Stop the container"
-docker stop sentry_postgres
+docker stop "${POSTGRES_CONTAINER}"
 
 echo "Check existence of a volume"
 if [[ -z "$(docker volume ls -q --filter name="^${VOLUME_NAME}$")" ]]

--- a/scripts/upgrade-postgres.sh
+++ b/scripts/upgrade-postgres.sh
@@ -3,7 +3,7 @@
 POSTGRES_CONTAINER="sentry_postgres"
 USE_NEW_DEVSERVICES=${USE_NEW_DEVSERVICES:-"0"}
 if [ "$USE_NEW_DEVSERVICES" == "1" ]; then
-POSTGRES_CONTAINER="sentry-postgres-1"
+    POSTGRES_CONTAINER="sentry-postgres-1"
 fi
 
 OLD_VERSION="9.6"

--- a/scripts/upgrade-postgres.sh
+++ b/scripts/upgrade-postgres.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 POSTGRES_CONTAINER="sentry_postgres"
-if [ "$USE_NEW_DEVSERVICES" == 1 ]; then
+USE_NEW_DEVSERVICES=${USE_NEW_DEVSERVICES:-"0"}
+if [ "$USE_NEW_DEVSERVICES" == "1" ]; then
 POSTGRES_CONTAINER="sentry-postgres-1"
 fi
 

--- a/scripts/use-colima.sh
+++ b/scripts/use-colima.sh
@@ -3,7 +3,7 @@
 POSTGRES_CONTAINER="sentry_postgres"
 USE_NEW_DEVSERVICES=${USE_NEW_DEVSERVICES:-"0"}
 if [ "$USE_NEW_DEVSERVICES" == "1" ]; then
-POSTGRES_CONTAINER="sentry-postgres-1"
+    POSTGRES_CONTAINER="sentry-postgres-1"
 fi
 
 if ! [[ -x ~/.local/share/sentry-devenv/bin/colima ]]; then

--- a/scripts/use-colima.sh
+++ b/scripts/use-colima.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 POSTGRES_CONTAINER="sentry_postgres"
-if [ "$USE_NEW_DEVSERVICES" == 1 ]; then
+USE_NEW_DEVSERVICES=${USE_NEW_DEVSERVICES:-"0"}
+if [ "$USE_NEW_DEVSERVICES" == "1" ]; then
 POSTGRES_CONTAINER="sentry-postgres-1"
 fi
 

--- a/scripts/use-colima.sh
+++ b/scripts/use-colima.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+POSTGRES_CONTAINER="sentry_postgres"
+if [ "$USE_NEW_DEVSERVICES" == 1 ]; then
+POSTGRES_CONTAINER="sentry-postgres-1"
+fi
+
 if ! [[ -x ~/.local/share/sentry-devenv/bin/colima ]]; then
     echo "You need to install devenv! https://github.com/getsentry/devenv/#install"
     exit 1
@@ -18,7 +23,7 @@ fi
 echo "Copying your postgres volume for use with colima. Will take a few minutes."
 tmpdir=$(mktemp -d)
 docker context use desktop-linux
-docker run --rm -v sentry_postgres:/from -v "${tmpdir}:/to" alpine ash -c "cd /from ; cp -a . /to" || { echo "You need to start Docker Desktop."; exit 1; }
+docker run --rm -v $POSTGRES_CONTAINER:/from -v "${tmpdir}:/to" alpine ash -c "cd /from ; cp -a . /to" || { echo "You need to start Docker Desktop."; exit 1; }
 
 echo "Stopping Docker.app. If a 'process terminated unexpectedly' dialog appears, dismiss it."
 osascript - <<'EOF' || exit
@@ -58,8 +63,8 @@ echo "Starting colima."
 devenv colima start
 
 echo "Recreating your postgres volume for use with colima. May take a few minutes."
-docker volume create --name sentry_postgres
-docker run --rm -v "${tmpdir}:/from" -v sentry_postgres:/to alpine ash -c "cd /from ; cp -a . /to"
+docker volume create --name $POSTGRES_CONTAINER
+docker run --rm -v "${tmpdir}:/from" -v $POSTGRES_CONTAINER:/to alpine ash -c "cd /from ; cp -a . /to"
 rm -rf "$tmpdir"
 
 echo "-----------------------------------------------"


### PR DESCRIPTION
This change enables the Makefile and other logic to work with new devservices by conditionally setting the postgres container name. This enables beta users of the new devservices to perform actions such as make create-db and make drop-db among other things.