### PR TITLE
fix(security): ensure user views are isolated

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -118,7 +118,6 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
 def bulk_update_views(
     org: Organization, user_id: int, views: list[GroupSearchViewValidatorResponse]
 ) -> None:
-
     existing_view_ids = [view["id"] for view in views if "id" in view]
 
     _delete_missing_views(org, user_id, view_ids_to_keep=existing_view_ids)
@@ -140,7 +139,7 @@ def _update_existing_view(
     org: Organization, user_id: int, view: GroupSearchViewValidatorResponse, position: int
 ) -> None:
     try:
-        GroupSearchView.objects.get(id=view["id"]).update(
+        GroupSearchView.objects.get(id=view["id"], user_id=user_id).update(
             name=view["name"],
             query=view["query"],
             query_sort=view["querySort"],

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -332,3 +332,82 @@ class OrganizationGroupSearchViewsPutTest(APITestCase):
         assert response.data[1]["query"] == view_one["query"]
         assert response.data[1]["querySort"] == view_one["querySort"]
         assert response.data[2] == views[2]
+
+
+class OrganizationGroupSearchViewsPutRegressionTest(APITestCase):
+    endpoint = "sentry-api-0-organization-group-search-views"
+    method = "put"
+
+    def setUp(self) -> None:
+        self.user_2 = self.create_user()
+        self.create_member(organization=self.organization, user=self.user_2)
+
+        self.url = reverse(
+            "sentry-api-0-organization-group-search-views",
+            kwargs={"organization_id_or_slug": self.organization.slug},
+        )
+
+    @with_feature({"organizations:issue-stream-custom-views": True})
+    def test_cannot_rename_other_users_views(self) -> None:
+        self.login_as(user=self.user)
+        views = self.client.get(self.url).data
+        view = views[0]
+
+        # ensure we only have the default view
+        assert len(views) == 1
+        assert view["name"] == "Prioritized"
+        assert view["query"] == "is:unresolved issue.priority:[high, medium]"
+        assert view["querySort"] == "date"
+        assert view["position"] == 0
+
+        # create a new custom view
+        views.append(
+            {
+                "name": "Custom View Two",
+                "query": "is:unresolved",
+                "query_sort": "date",
+            }
+        )
+
+        response = self.get_success_response(self.organization.slug, views=views)
+
+        assert len(response.data) == 2  # 1 existing default view + 1 new view
+        assert response.data[1]["name"] == "Custom View Two"
+        assert response.data[1]["query"] == "is:unresolved"
+        assert response.data[1]["querySort"] == "date"
+
+        # now "delete" the custom view so the default view gets a proper ID
+        views = self.client.get(self.url).data
+        views.pop(1)
+
+        response = self.get_success_response(self.organization.slug, views=views)
+
+        # we should only have the default view now
+        assert len(response.data) == 1
+        assert response.data[0]["name"] == "Prioritized"
+        assert response.data[0]["id"]  # and it should now have an ID
+
+        # attempt to change user's 1 view from user 2
+        views = self.client.get(self.url).data
+        default_view = views[0]
+        default_view["name"] = "New Name"
+
+        self.login_as(user=self.user_2)
+        response = self.get_success_response(self.organization.slug, views=views)
+
+        # instead of editing the original view, it should create a new view for user 2
+        assert len(response.data) == 1
+        assert (
+            response.data[0]["id"] == "3"
+        )  # should be 3 because user 1 created a view (2) and then deleted it
+        assert response.data[0]["name"] == "New Name"
+
+        # as user 1, verify the name has not been changed
+        self.login_as(user=self.user)
+        response = self.client.get(self.url)
+
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == "1"
+        assert response.data[0]["name"] == "Prioritized"
+        assert response.data[0]["query"] == view["query"]
+        assert response.data[0]["querySort"] == view["querySort"]

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -397,9 +397,7 @@ class OrganizationGroupSearchViewsPutRegressionTest(APITestCase):
 
         # instead of editing the original view, it should create a new view for user 2
         assert len(response.data) == 1
-        assert (
-            response.data[0]["id"] == "3"
-        )  # should be 3 because user 1 created a view (2) and then deleted it
+        assert response.data[0]["id"] != default_view["id"]
         assert response.data[0]["name"] == "New Name"
 
         # as user 1, verify the name has not been changed
@@ -407,7 +405,7 @@ class OrganizationGroupSearchViewsPutRegressionTest(APITestCase):
         response = self.client.get(self.url)
 
         assert len(response.data) == 1
-        assert response.data[0]["id"] == "1"
+        assert response.data[0]["id"] == default_view["id"]
         assert response.data[0]["name"] == "Prioritized"
         assert response.data[0]["query"] == view["query"]
         assert response.data[0]["querySort"] == view["querySort"]


### PR DESCRIPTION
All operations on group search views should be isolated to the requesting user.
