### PR TITLE
fix(dashboards): change the ordering of team and user badges

### DIFF
--- a/static/app/components/avatar/avatarList.tsx
+++ b/static/app/components/avatar/avatarList.tsx
@@ -17,6 +17,7 @@ type Props = {
   className?: string;
   maxVisibleAvatars?: number;
   renderTooltip?: UserAvatarProps['renderTooltip'];
+  renderUsersFirst?: boolean;
   teams?: Team[];
   tooltipOptions?: UserAvatarProps['tooltipOptions'];
   typeAvatars?: string;
@@ -51,6 +52,7 @@ function AvatarList({
   className,
   users = [],
   teams = [],
+  renderUsersFirst = false,
   renderTooltip,
 }: Props) {
   const numTeams = teams.length;
@@ -87,25 +89,48 @@ function AvatarList({
           </CollapsedAvatars>
         </Tooltip>
       )}
-      {visibleUserAvatars.map(user => (
-        <StyledUserAvatar
-          key={`${user.id}-${user.email}`}
-          user={user}
-          size={avatarSize}
-          renderTooltip={renderTooltip}
-          tooltipOptions={tooltipOptions}
-          hasTooltip
-        />
-      ))}
-      {visibleTeamAvatars.map(team => (
-        <StyledTeamAvatar
-          key={`${team.id}-${team.name}`}
-          team={team}
-          size={avatarSize}
-          tooltipOptions={tooltipOptions}
-          hasTooltip
-        />
-      ))}
+
+      {renderUsersFirst
+        ? visibleTeamAvatars.map(team => (
+            <StyledTeamAvatar
+              key={`${team.id}-${team.name}`}
+              team={team}
+              size={avatarSize}
+              tooltipOptions={tooltipOptions}
+              hasTooltip
+            />
+          ))
+        : visibleUserAvatars.map(user => (
+            <StyledUserAvatar
+              key={user.id}
+              user={user}
+              size={avatarSize}
+              tooltipOptions={tooltipOptions}
+              renderTooltip={renderTooltip}
+              hasTooltip
+            />
+          ))}
+
+      {!renderUsersFirst
+        ? visibleTeamAvatars.map(team => (
+            <StyledTeamAvatar
+              key={`${team.id}-${team.name}`}
+              team={team}
+              size={avatarSize}
+              tooltipOptions={tooltipOptions}
+              hasTooltip
+            />
+          ))
+        : visibleUserAvatars.map(user => (
+            <StyledUserAvatar
+              key={user.id}
+              user={user}
+              size={avatarSize}
+              tooltipOptions={tooltipOptions}
+              renderTooltip={renderTooltip}
+              hasTooltip
+            />
+          ))}
     </AvatarListWrapper>
   );
 }

--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -128,7 +128,7 @@ function EditAccessSelector({dashboard, onChangeEditAccess}: EditAccessSelectorP
     ) : selectedOptions.length === 2 ? (
       // Case where we display 1 Creator Avatar + 1 Team Avatar
       <StyledAvatarList
-        key="avatar-list"
+        key="avatar-list-2-badges"
         typeAvatars="users"
         users={[dashboardCreator]}
         teams={[teams.find(team => team.id === selectedOptions[1])!]}
@@ -139,7 +139,7 @@ function EditAccessSelector({dashboard, onChangeEditAccess}: EditAccessSelectorP
     ) : (
       // Case where we display 1 Creator Avatar + a Badge with no. of teams selected
       <StyledAvatarList
-        key="avatar-list"
+        key="avatar-list-many-teams"
         typeAvatars="users"
         users={Array(selectedOptions.length).fill(dashboardCreator)}
         maxVisibleAvatars={1}

--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -134,6 +134,7 @@ function EditAccessSelector({dashboard, onChangeEditAccess}: EditAccessSelectorP
         teams={[teams.find(team => team.id === selectedOptions[1])!]}
         maxVisibleAvatars={1}
         avatarSize={25}
+        renderUsersFirst
       />
     ) : (
       // Case where we display 1 Creator Avatar + a Badge with no. of teams selected


### PR DESCRIPTION
Change the ordering of team and user badges so that the creator's badge is ordered first. 

before:
<img width="219" alt="Screenshot 2024-11-19 at 2 22 47 PM" src="https://github.com/user-attachments/assets/424fbc88-28eb-4c3c-85a2-f9242be62126">
after:
<img width="227" alt="Screenshot 2024-11-19 at 2 22 30 PM" src="https://github.com/user-attachments/assets/4613fb50-ea9c-4042-a918-b8886e90da74">
