### PR TITLE
fix(autofix): Change rethink icon, fix summary padding

### DIFF
--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -29,7 +29,6 @@ import {
   IconArrow,
   IconChevron,
   IconCode,
-  IconEdit,
   IconFire,
   IconRefresh,
   IconSpan,
@@ -455,7 +454,7 @@ function ChainLink({
       <IconArrow direction={'down'} className="arrow-icon" />
       <RethinkButton
         ref={setReferenceElement}
-        icon={<IconEdit size="xs" />}
+        icon={<IconRefresh size="xs" />}
         size="zero"
         className="rethink-button"
         title={t('Rethink from here')}

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -185,7 +185,7 @@ const CardTitleIcon = styled('div')`
 const CardContent = styled('div')`
   overflow-wrap: break-word;
   word-break: break-word;
-  padding-left: ${space(1.5)};
+  padding-left: 14px;
   border-left: 1px solid ${p => p.theme.border};
   margin-left: ${space(0.75)};
   p {


### PR DESCRIPTION
Changes to  a refresh icon for clarity instead of an edit icon. Also fixes the text alignment in the summary.
