### PR TITLE
fix(alerts): auto-allow alert creation for org:write and org:admin permissions

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -442,10 +442,15 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint, AlertRuleIndexMix
         permission, then we must verify that the user is a team admin with "alerts:write" access to the project(s)
         in their request.
         """
-        #
-        if request.access.has_scope("alerts:write"):
+        # if the requesting user has any of these scopes, then they can create an alert
+        # if alerts: write is org-scoped, that means that member alert creation is enabled.
+        if (
+            request.access.has_scope("alerts:write")
+            or request.access.has_scope("org:admin")
+            or request.access.has_scope("org:write")
+        ):
             return
-        # team admins should be able to crete alerts for the projects they have access to
+        # team admins should be able to create alerts for the projects they have access to
         projects = self.get_projects(request, organization)
         # team admins will have alerts:write scoped to their projects, members will not
         team_admin_has_access = all(

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -442,8 +442,7 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint, AlertRuleIndexMix
         permission, then we must verify that the user is a team admin with "alerts:write" access to the project(s)
         in their request.
         """
-        # if the requesting user has any of these scopes, then they can create an alert
-        # if alerts: write is org-scoped, that means that member alert creation is enabled.
+        # if the requesting user has any of these org-level permissions, then they can create an alert
         if (
             request.access.has_scope("alerts:write")
             or request.access.has_scope("org:admin")


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/79624, I introduced a check for the `alerts:write` permission on the org/project level in order to verify that a user had access to alert creation. However, this breaks the API, because currently there is no option to grant `alerts:write` scopes to an API key, and the upper bound scopes from the API key will falsify this condition whenever it is checked. To restore the original behavior of the API and allow org admins/managers to create alert rules, also perform an org-level check for the `org:admin` and `org:write` permissions.