### PR TITLE
fix(issues): Switch to runtime.name for event_runtime

### DIFF
--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -386,7 +386,7 @@ export function getAnalyticsDataForEvent(event?: Event | null): BaseEventAnalyti
     num_in_app_stack_frames: event ? getNumberOfInAppStackFrames(event) : 0,
     num_threads_with_names: event ? getNumberOfThreadsWithNames(event) : 0,
     event_platform: event?.platform,
-    event_runtime: event?.tags?.find(tag => tag.key === 'runtime')?.value,
+    event_runtime: event?.tags?.find(tag => tag.key === 'runtime.name')?.value,
     event_type: event?.type,
     has_release: !!event?.release,
     has_exception_group: event ? eventHasExceptionGroup(event) : false,


### PR DESCRIPTION
Runtime is a bit too granular and includes the version info which would need to be parsed out if we were to actually try to use it for analytics. https://app.amplitude.com/analytics/sentry/chart/new/xsiha36a