### PR TITLE
ref(crons): Improve logging in system_incidents module

### DIFF
--- a/src/sentry/monitors/system_incidents.py
+++ b/src/sentry/monitors/system_incidents.py
@@ -22,7 +22,7 @@ from django.conf import settings
 from sentry import options
 from sentry.utils import metrics, redis
 
-logger = logging.getLogger("sentry")
+logger = logging.getLogger(__name__)
 
 # This key is used to record historical date about the volume of check-ins.
 MONITOR_VOLUME_HISTORY = "sentry.monitors.volume_history:{ts}"
@@ -90,7 +90,7 @@ def process_clock_tick_for_system_incidents(tick: datetime) -> DecisionResult:
     result = make_clock_tick_decision(tick)
 
     logger.info(
-        "monitors.system_incidents.process_clock_tick",
+        "process_clock_tick",
         extra={"decision": result.decision, "transition": result.transition},
     )
 
@@ -116,7 +116,7 @@ def process_clock_tick_for_system_incidents(tick: datetime) -> DecisionResult:
         if start := get_last_incident_ts():
             prune_incident_check_in_volume(start, result.ts)
         else:
-            logger.error("monitors.system_incidents.recovered_without_start_ts")
+            logger.error("recovered_without_start_ts")
 
     return result
 
@@ -207,10 +207,12 @@ def record_clock_tick_volume_metric(tick: datetime) -> None:
 
     # Can't make any decisions if we didn't have data for the past minute
     if past_minute_volume is None:
+        logger.info("past_minute_volume_missing", extra={"reference_datetime": tick})
         return
 
     # We need AT LEAST two data points to calculate standard deviation
     if len(historic_volume) < 2:
+        logger.info("history_volume_low", extra={"reference_datetime": tick})
         return
 
     # Record some statistics about the past_minute_volume volume in comparison
@@ -242,7 +244,7 @@ def record_clock_tick_volume_metric(tick: datetime) -> None:
     metrics.gauge("monitors.task.volume_history.pct_deviation", pct_deviation, sample_rate=1.0)
 
     logger.info(
-        "monitors.system_incidents.volume_history",
+        "volume_history",
         extra={
             "reference_datetime": str(tick),
             "evaluation_minute": past_ts.strftime("%H:%M"),
@@ -511,7 +513,7 @@ def make_clock_tick_decision(tick: datetime) -> DecisionResult:
         pipeline.execute()
 
         logger.info(
-            "monitors.system_incidents.decision",
+            "clock_tick_decision",
             extra={
                 "reference_datetime": str(tick),
                 "decision": decision,
@@ -631,7 +633,7 @@ def _make_backfill(start: datetime, until_not: TickAnomalyDecision) -> Generator
 
     # If we've iterated through the entire BACKFILL_CUTOFF we have a
     # "decision runaway" and should report this as an error
-    logger.error("sentry.system_incidents.decision_backfill_runaway")
+    logger.error("decision_backfill_runaway")
 
 
 def _backfill_decisions(

--- a/tests/sentry/monitors/test_system_incidents.py
+++ b/tests/sentry/monitors/test_system_incidents.py
@@ -133,7 +133,7 @@ def test_process_clock_tick_for_system_incident(
 
     # Metrics and logs are recorded
     assert mock_logger.info.call_args_list[0] == mock.call(
-        "monitors.system_incidents.process_clock_tick",
+        "process_clock_tick",
         extra={
             "decision": TickAnomalyDecision.ABNORMAL,
             "transition": AnomalyTransition.ABNORMALITY_STARTED,
@@ -195,7 +195,7 @@ def test_record_clock_tick_volume_metric_simple(metrics, logger):
     record_clock_tick_volume_metric(tick)
 
     logger.info.assert_called_with(
-        "monitors.system_incidents.volume_history",
+        "volume_history",
         extra={
             "reference_datetime": str(tick),
             "evaluation_minute": past_ts.strftime("%H:%M"),
@@ -249,7 +249,7 @@ def test_record_clock_tick_volume_metric_volume_drop(metrics, logger):
 
     # Note that the pct_deviation and z_score are extremes
     logger.info.assert_called_with(
-        "monitors.system_incidents.volume_history",
+        "volume_history",
         extra={
             "reference_datetime": str(tick),
             "evaluation_minute": past_ts.strftime("%H:%M"),
@@ -296,8 +296,12 @@ def test_record_clock_tick_volume_metric_low_history(metrics, logger):
 
     # We should do nothing because there was not enough daata to make any
     # calculation
-    assert not logger.info.called
+    logger.info.assert_called_with(
+        "history_volume_low",
+        extra={"reference_datetime": tick},
+    )
     assert not metrics.gauge.called
+
     assert get_clock_tick_volume_metric(past_ts) is None
 
 
@@ -324,7 +328,7 @@ def test_record_clock_tick_volume_metric_uniform(metrics, logger):
     record_clock_tick_volume_metric(tick)
 
     logger.info.assert_called_with(
-        "monitors.system_incidents.volume_history",
+        "volume_history",
         extra={
             "reference_datetime": str(tick),
             "evaluation_minute": past_ts.strftime("%H:%M"),


### PR DESCRIPTION
- Uses the `__name__` as the logger name so we can shorten up the logs themselves.
- Adds two more logs during volume metric computations
