### PR TITLE
chore(rollback): Add FE org setting for rollback

### DIFF
--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
@@ -120,6 +120,16 @@ function OrganizationSettingsForm({initialData, onSave}: Props) {
           </PoweredByCodecov>
         ),
       },
+      ...(organization.features.includes('sentry-rollback-settings')
+        ? [
+            {
+              name: 'rollbackEnabled',
+              type: 'boolean',
+              label: t('2024 Sentry Rollback'),
+              help: t('Allow organization members to view their year in review'),
+            } as FieldObject,
+          ]
+        : []),
     ];
     return formsConfig;
   }, [access, organization]);


### PR DESCRIPTION
Adds the setting for enabling or disabling rollback, gated behind the `sentry-rollback-settings` flag. 

(The PR registering the deployment is still in flight, so it will not show up in the vercel deployment for a few more minutes)

![image](https://github.com/user-attachments/assets/851a64b7-d66a-4422-8bdb-606107dc2237)
