### PR TITLE
ref(crons): Include clock-ticks in volume recording in serial mode

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -1013,8 +1013,7 @@ def process_single(message: Message[KafkaPayload | FilteredPayload]):
         ts = message.value.timestamp
         partition = message.value.partition.index
 
-        if wrapper["message_type"] != "clock_pulse":
-            update_check_in_volume([ts])
+        update_check_in_volume([ts])
 
         try:
             try_monitor_clock_tick(ts, partition)


### PR DESCRIPTION
This doesn't actually affect production sentry.io and is more of a consistency change.

Right now the batched consumer processor will record clock tick messages as volume, which is actually likely what we want to happen. In the case that ALL up-stream ingestion stops, we want to still have SOME volume for each tick so that we can detect the drop-off and start an incident.