### PR TITLE
feat(devservices): Support new devservices for devenv sync

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -19,8 +19,15 @@ x-sentry-service-config:
         mode: containerized
     postgres:
       description: Database used to store Sentry data
+    redis:
+      description: Shared instance of redis used by sentry services
+      remote:
+        repo_name: sentry-shared-redis
+        branch: main
+        repo_link: git@github.com:getsentry/sentry-shared-redis.git
   modes:
     default: [snuba, postgres, relay]
+    migrations: [postgres, redis]
 
 services:
   postgres:

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -36,7 +36,7 @@ cryptography==43.0.1
 cssselect==1.0.3
 cssutils==2.9.0
 datadog==0.49.1
-devservices==1.0.2
+devservices==1.0.3
 distlib==0.3.8
 distro==1.8.0
 django==5.1.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 
 sentry-devenv>=1.13.0
-devservices>=1.0.2
+devservices>=1.0.3
 
 covdefaults>=2.3.0
 docker>=7


### PR DESCRIPTION
bumps devservices to 1.0.3 and supports new devservices for devenv sync as long as `USE_NEW_DEVSERVICES` is set to `1`