### PR TITLE
:recycle: ref(integrations): Add SLO for `link_all_repos` Celery Task

### DIFF
--- a/src/sentry/integrations/github/tasks/link_all_repos.py
+++ b/src/sentry/integrations/github/tasks/link_all_repos.py
@@ -2,6 +2,11 @@ import logging
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.source_code_management.metrics import (
+    LinkAllReposHaltReason,
+    SCMIntegrationInteractionEvent,
+    SCMIntegrationInteractionType,
+)
 from sentry.organizations.services.organization import organization_service
 from sentry.plugins.providers.integration_repository import (
     RepoExistsError,
@@ -35,52 +40,64 @@ def link_all_repos(
     integration_id: int,
     organization_id: int,
 ):
-    integration = integration_service.get_integration(
-        integration_id=integration_id, status=ObjectStatus.ACTIVE
-    )
-    if not integration:
-        logger.error(
-            "%s.link_all_repos.integration_missing",
-            integration_key,
-            extra={"organization_id": organization_id},
+
+    with SCMIntegrationInteractionEvent(
+        interaction_type=SCMIntegrationInteractionType.LINK_ALL_REPOS,
+        provider_key=integration_key,
+        organization=organization_id,
+    ).capture() as lifecycle:
+        integration = integration_service.get_integration(
+            integration_id=integration_id, status=ObjectStatus.ACTIVE
         )
-        metrics.incr("github.link_all_repos.error", tags={"type": "missing_integration"})
-        return
-
-    rpc_org = organization_service.get(id=organization_id)
-    if rpc_org is None:
-        logger.error(
-            "%s.link_all_repos.organization_missing",
-            integration_key,
-            extra={"organization_id": organization_id},
-        )
-        metrics.incr(
-            f"{integration_key}.link_all_repos.error",
-            tags={"type": "missing_organization"},
-        )
-        return
-
-    installation = integration.get_installation(organization_id=organization_id)
-
-    client = installation.get_client()
-
-    try:
-        repositories = client.get_repositories(fetch_max_pages=True)
-    except ApiError as e:
-        if installation.is_rate_limited_error(e):
+        if not integration:
+            # TODO: Remove this logger in favor of context manager
+            logger.error(
+                "%s.link_all_repos.integration_missing",
+                integration_key,
+                extra={"organization_id": organization_id},
+            )
+            metrics.incr("github.link_all_repos.error", tags={"type": "missing_integration"})
+            lifecycle.record_halt(str(LinkAllReposHaltReason.MISSING_INTEGRATION))
             return
 
-        metrics.incr(f"{integration_key}.link_all_repos.api_error")
-        raise
+        rpc_org = organization_service.get(id=organization_id)
+        if rpc_org is None:
+            logger.error(
+                "%s.link_all_repos.organization_missing",
+                integration_key,
+                extra={"organization_id": organization_id},
+            )
+            metrics.incr(
+                f"{integration_key}.link_all_repos.error",
+                tags={"type": "missing_organization"},
+            )
+            lifecycle.record_halt(str(LinkAllReposHaltReason.MISSING_ORGANIZATION))
+            return
 
-    integration_repo_provider = get_integration_repository_provider(integration)
+        installation = integration.get_installation(organization_id=organization_id)
 
-    for repo in repositories:
+        client = installation.get_client()
+
         try:
-            config = get_repo_config(repo, integration_id)
-            integration_repo_provider.create_repository(repo_config=config, organization=rpc_org)
-        except KeyError:
-            continue
-        except RepoExistsError:
-            metrics.incr("sentry.integration_repo_provider.repo_exists")
-            continue
+            repositories = client.get_repositories(fetch_max_pages=True)
+        except ApiError as e:
+            if installation.is_rate_limited_error(e):
+                lifecycle.record_halt(str(LinkAllReposHaltReason.RATE_LIMITED))
+                return
+
+            metrics.incr(f"{integration_key}.link_all_repos.api_error")
+            raise
+
+        integration_repo_provider = get_integration_repository_provider(integration)
+
+        for repo in repositories:
+            try:
+                config = get_repo_config(repo, integration_id)
+                integration_repo_provider.create_repository(
+                    repo_config=config, organization=rpc_org
+                )
+            except KeyError:
+                continue
+            except RepoExistsError:
+                metrics.incr("sentry.integration_repo_provider.repo_exists")
+                continue

--- a/src/sentry/integrations/github/tasks/link_all_repos.py
+++ b/src/sentry/integrations/github/tasks/link_all_repos.py
@@ -57,7 +57,7 @@ def link_all_repos(
                 extra={"organization_id": organization_id},
             )
             metrics.incr("github.link_all_repos.error", tags={"type": "missing_integration"})
-            lifecycle.record_halt(str(LinkAllReposHaltReason.MISSING_INTEGRATION))
+            lifecycle.record_failure(str(LinkAllReposHaltReason.MISSING_INTEGRATION))
             return
 
         rpc_org = organization_service.get(id=organization_id)
@@ -71,7 +71,7 @@ def link_all_repos(
                 f"{integration_key}.link_all_repos.error",
                 tags={"type": "missing_organization"},
             )
-            lifecycle.record_halt(str(LinkAllReposHaltReason.MISSING_ORGANIZATION))
+            lifecycle.record_failure(str(LinkAllReposHaltReason.MISSING_ORGANIZATION))
             return
 
         installation = integration.get_installation(organization_id=organization_id)

--- a/src/sentry/integrations/source_code_management/metrics.py
+++ b/src/sentry/integrations/source_code_management/metrics.py
@@ -46,8 +46,8 @@ class SCMIntegrationInteractionEvent(IntegrationEventLifecycleMetric):
     provider_key: str
 
     # Optional attributes to populate extras
-    organization: Organization | RpcOrganization | int | None = None
-    org_integration: OrganizationIntegration | RpcOrganizationIntegration | int | None = None
+    organization: Organization | RpcOrganization | None = None
+    org_integration: OrganizationIntegration | RpcOrganizationIntegration | None = None
 
     def get_integration_domain(self) -> IntegrationDomain:
         return IntegrationDomain.SOURCE_CODE_MANAGEMENT
@@ -59,16 +59,9 @@ class SCMIntegrationInteractionEvent(IntegrationEventLifecycleMetric):
         return str(self.interaction_type)
 
     def get_extras(self) -> Mapping[str, Any]:
-        def get_id(obj: Any) -> int | None:
-            if hasattr(obj, "id"):
-                return obj.id
-            if isinstance(obj, int):
-                return obj
-            return None
-
         return {
-            "organization_id": get_id(self.organization),
-            "org_integration_id": get_id(self.org_integration),
+            "organization_id": (self.organization.id if self.organization else None),
+            "org_integration_id": (self.org_integration.id if self.org_integration else None),
         }
 
 
@@ -78,3 +71,4 @@ class LinkAllReposHaltReason(StrEnum):
     MISSING_INTEGRATION = "missing_integration"
     MISSING_ORGANIZATION = "missing_organization"
     RATE_LIMITED = "rate_limited"
+    REPOSITORY_NOT_CREATED = "repository_not_created"

--- a/src/sentry/integrations/source_code_management/metrics.py
+++ b/src/sentry/integrations/source_code_management/metrics.py
@@ -59,21 +59,16 @@ class SCMIntegrationInteractionEvent(IntegrationEventLifecycleMetric):
         return str(self.interaction_type)
 
     def get_extras(self) -> Mapping[str, Any]:
-        organization_id = (
-            (
-                self.organization.id
-                if hasattr(self.organization, "id")
-                else self.organization if isinstance(self.organization, int) else None
-            ),
-        )
-        org_integration_id = (
-            self.org_integration.id
-            if hasattr(self.org_integration, "id")
-            else self.org_integration if isinstance(self.org_integration, int) else None
-        )
+        def get_id(obj: Any) -> int | None:
+            if hasattr(obj, "id"):
+                return obj.id
+            if isinstance(obj, int):
+                return obj
+            return None
+
         return {
-            "organization_id": organization_id,
-            "org_integration_id": org_integration_id,
+            "organization_id": get_id(self.organization),
+            "org_integration_id": get_id(self.org_integration),
         }
 
 

--- a/tests/sentry/integrations/github/tasks/test_link_all_repos.py
+++ b/tests/sentry/integrations/github/tasks/test_link_all_repos.py
@@ -7,11 +7,14 @@ from django.db import IntegrityError
 from sentry.constants import ObjectStatus
 from sentry.integrations.github.integration import GitHubIntegrationProvider
 from sentry.integrations.github.tasks.link_all_repos import link_all_repos
+from sentry.integrations.source_code_management.metrics import LinkAllReposHaltReason
+from sentry.integrations.utils.metrics import EventLifecycleOutcome
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
+from tests.sentry.integrations.utils.test_assert_metrics import assert_halt_metric
 
 
 @control_silo_test
@@ -41,8 +44,9 @@ class LinkAllReposTestCase(IntegrationTestCase):
             },
         )
 
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.integrations.github.tasks.link_all_repos.metrics")
-    def test_link_all_repos_inactive_integration(self, mock_metrics, _):
+    def test_link_all_repos_inactive_integration(self, mock_metrics, mock_record, _):
         self.integration.update(status=ObjectStatus.DISABLED)
 
         link_all_repos(
@@ -55,8 +59,14 @@ class LinkAllReposTestCase(IntegrationTestCase):
             "github.link_all_repos.error", tags={"type": "missing_integration"}
         )
 
+        start, halt = mock_record.mock_calls
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.HALTED
+        assert_halt_metric(mock_record, LinkAllReposHaltReason.MISSING_INTEGRATION.value)
+
     @responses.activate
-    def test_link_all_repos(self, _):
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_link_all_repos(self, mock_record, _):
         self._add_responses()
 
         link_all_repos(
@@ -76,8 +86,13 @@ class LinkAllReposTestCase(IntegrationTestCase):
         assert repos[0].name == "getsentry/sentry"
         assert repos[1].name == "getsentry/snuba"
 
+        start, halt = mock_record.mock_calls
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.SUCCESS
+
     @responses.activate
-    def test_link_all_repos_api_response_keyerror(self, _):
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_link_all_repos_api_response_keyerror(self, mock_record, _):
 
         responses.add(
             responses.GET,
@@ -112,8 +127,13 @@ class LinkAllReposTestCase(IntegrationTestCase):
 
         assert repos[0].name == "getsentry/snuba"
 
+        start, halt = mock_record.mock_calls
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.SUCCESS
+
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.integrations.github.tasks.link_all_repos.metrics")
-    def test_link_all_repos_missing_integration(self, mock_metrics, _):
+    def test_link_all_repos_missing_integration(self, mock_metrics, mock_record, _):
         link_all_repos(
             integration_key=self.key,
             integration_id=0,
@@ -123,8 +143,14 @@ class LinkAllReposTestCase(IntegrationTestCase):
             "github.link_all_repos.error", tags={"type": "missing_integration"}
         )
 
+        start, halt = mock_record.mock_calls
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.HALTED
+        assert_halt_metric(mock_record, LinkAllReposHaltReason.MISSING_INTEGRATION.value)
+
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.integrations.github.tasks.link_all_repos.metrics")
-    def test_link_all_repos_missing_organization(self, mock_metrics, _):
+    def test_link_all_repos_missing_organization(self, mock_metrics, mock_record, _):
         link_all_repos(
             integration_key=self.key,
             integration_id=self.integration.id,
@@ -134,9 +160,15 @@ class LinkAllReposTestCase(IntegrationTestCase):
             "github.link_all_repos.error", tags={"type": "missing_organization"}
         )
 
+        start, halt = mock_record.mock_calls
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.HALTED
+        assert_halt_metric(mock_record, LinkAllReposHaltReason.MISSING_ORGANIZATION.value)
+
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.integrations.github.tasks.link_all_repos.metrics")
     @responses.activate
-    def test_link_all_repos_api_error(self, mock_metrics, _):
+    def test_link_all_repos_api_error(self, mock_metrics, mock_record, _):
 
         responses.add(
             responses.GET,
@@ -150,11 +182,16 @@ class LinkAllReposTestCase(IntegrationTestCase):
                 integration_id=self.integration.id,
                 organization_id=self.organization.id,
             )
-            mock_metrics.incr.assert_called_with("github.link_all_repos.api_error")
+        mock_metrics.incr.assert_called_with("github.link_all_repos.api_error")
 
+        start, halt = mock_record.mock_calls
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.FAILURE
+
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.integrations.github.integration.metrics")
     @responses.activate
-    def test_link_all_repos_api_error_rate_limited(self, mock_metrics, _):
+    def test_link_all_repos_api_error_rate_limited(self, mock_metrics, mock_record, _):
 
         responses.add(
             responses.GET,
@@ -173,10 +210,16 @@ class LinkAllReposTestCase(IntegrationTestCase):
         )
         mock_metrics.incr.assert_called_with("github.link_all_repos.rate_limited_error")
 
+        start, halt = mock_record.mock_calls
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.HALTED
+        assert_halt_metric(mock_record, LinkAllReposHaltReason.RATE_LIMITED.value)
+
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.models.Repository.objects.create")
     @patch("sentry.integrations.github.tasks.link_all_repos.metrics")
     @responses.activate
-    def test_link_all_repos_repo_creation_error(self, mock_metrics, mock_repo, _):
+    def test_link_all_repos_repo_creation_error(self, mock_metrics, mock_repo, mock_record, _):
         mock_repo.side_effect = IntegrityError
 
         self._add_responses()
@@ -189,11 +232,16 @@ class LinkAllReposTestCase(IntegrationTestCase):
 
         mock_metrics.incr.assert_called_with("sentry.integration_repo_provider.repo_exists")
 
+        start, halt = mock_record.mock_calls
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.SUCCESS
+
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.integrations.services.repository.repository_service.create_repository")
     @patch("sentry.plugins.providers.IntegrationRepositoryProvider.on_delete_repository")
     @responses.activate
     def test_link_all_repos_repo_creation_exception(
-        self, mock_delete_repo, mock_create_repository, _
+        self, mock_delete_repo, mock_create_repository, mock_record, _
     ):
         mock_create_repository.return_value = None
         mock_delete_repo.side_effect = Exception
@@ -206,3 +254,7 @@ class LinkAllReposTestCase(IntegrationTestCase):
                 integration_id=self.integration.id,
                 organization_id=self.organization.id,
             )
+
+        start, halt = mock_record.mock_calls
+        assert start.args[0] == EventLifecycleOutcome.STARTED
+        assert halt.args[0] == EventLifecycleOutcome.FAILURE

--- a/tests/sentry/integrations/github/tasks/test_link_all_repos.py
+++ b/tests/sentry/integrations/github/tasks/test_link_all_repos.py
@@ -14,7 +14,10 @@ from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
-from tests.sentry.integrations.utils.test_assert_metrics import assert_halt_metric
+from tests.sentry.integrations.utils.test_assert_metrics import (
+    assert_failure_metric,
+    assert_halt_metric,
+)
 
 
 @control_silo_test
@@ -61,8 +64,8 @@ class LinkAllReposTestCase(IntegrationTestCase):
 
         start, halt = mock_record.mock_calls
         assert start.args[0] == EventLifecycleOutcome.STARTED
-        assert halt.args[0] == EventLifecycleOutcome.HALTED
-        assert_halt_metric(mock_record, LinkAllReposHaltReason.MISSING_INTEGRATION.value)
+        assert halt.args[0] == EventLifecycleOutcome.FAILURE
+        assert_failure_metric(mock_record, LinkAllReposHaltReason.MISSING_INTEGRATION.value)
 
     @responses.activate
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
@@ -180,8 +183,8 @@ class LinkAllReposTestCase(IntegrationTestCase):
 
         start, halt = mock_record.mock_calls
         assert start.args[0] == EventLifecycleOutcome.STARTED
-        assert halt.args[0] == EventLifecycleOutcome.HALTED
-        assert_halt_metric(mock_record, LinkAllReposHaltReason.MISSING_INTEGRATION.value)
+        assert halt.args[0] == EventLifecycleOutcome.FAILURE
+        assert_failure_metric(mock_record, LinkAllReposHaltReason.MISSING_INTEGRATION.value)
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.integrations.github.tasks.link_all_repos.metrics")
@@ -197,8 +200,8 @@ class LinkAllReposTestCase(IntegrationTestCase):
 
         start, halt = mock_record.mock_calls
         assert start.args[0] == EventLifecycleOutcome.STARTED
-        assert halt.args[0] == EventLifecycleOutcome.HALTED
-        assert_halt_metric(mock_record, LinkAllReposHaltReason.MISSING_ORGANIZATION.value)
+        assert halt.args[0] == EventLifecycleOutcome.FAILURE
+        assert_failure_metric(mock_record, LinkAllReposHaltReason.MISSING_ORGANIZATION.value)
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.integrations.github.tasks.link_all_repos.metrics")

--- a/tests/sentry/integrations/github/tasks/test_link_all_repos.py
+++ b/tests/sentry/integrations/github/tasks/test_link_all_repos.py
@@ -8,7 +8,7 @@ from sentry.constants import ObjectStatus
 from sentry.integrations.github.integration import GitHubIntegrationProvider
 from sentry.integrations.github.tasks.link_all_repos import link_all_repos
 from sentry.integrations.source_code_management.metrics import LinkAllReposHaltReason
-from sentry.integrations.utils.metrics import EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode


### PR DESCRIPTION
`link_all_repos` is only for Github at the moment, but added observability on the task here.

also updated the `SCMIntegrationInteractionEvent` to accept org_id