### PR TITLE
fix(explore): Compute chart type from series name

### DIFF
--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -12,11 +12,7 @@ import {IconClock, IconGraph, IconSubscribed} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {dedupeArray} from 'sentry/utils/dedupeArray';
-import {
-  aggregateOutputType,
-  formatParsedFunction,
-  parseFunction,
-} from 'sentry/utils/discover/fields';
+import {formatParsedFunction, parseFunction} from 'sentry/utils/discover/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -273,8 +269,6 @@ export function ExploreCharts({query, setError}: ExploreChartsProps) {
                 // TODO Abdullah: Make chart colors dynamic, with changing topN events count and overlay count.
                 chartColors={CHART_PALETTE[TOP_EVENTS_LIMIT - 1]}
                 type={chartType}
-                // for now, use the first y axis unit
-                aggregateOutputFormat={aggregateOutputType(dedupedYAxes[0])}
               />
             </ChartPanel>
           </ChartContainer>


### PR DESCRIPTION
The chart type can be inferred from the series name so do not hard code in the a type for the chart. This also addresses the issue where the tooltip will infer the type from the series name instead of using the hard coded type.