### PR TITLE
fix(traces): Click on trace id should not expand traces row

### DIFF
--- a/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
+++ b/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
@@ -433,7 +433,7 @@ interface TraceIdRendererProps {
   location: Location;
   timestamp: number; // in milliseconds
   traceId: string;
-  onClick?: () => void;
+  onClick?: React.ComponentProps<typeof Link>['onClick'];
   transactionId?: string;
 }
 

--- a/static/app/views/explore/tables/tracesTable/index.tsx
+++ b/static/app/views/explore/tables/tracesTable/index.tsx
@@ -244,12 +244,13 @@ function TraceRow({
         <TraceIdRenderer
           traceId={trace.trace}
           timestamp={trace.end}
-          onClick={() =>
+          onClick={event => {
+            event.stopPropagation();
             trackAnalytics('trace_explorer.open_trace', {
               organization,
               source: 'new explore',
-            })
-          }
+            });
+          }}
           location={location}
         />
       </StyledPanelItem>

--- a/static/app/views/traces/fieldRenderers.tsx
+++ b/static/app/views/traces/fieldRenderers.tsx
@@ -444,7 +444,7 @@ interface TraceIdRendererProps {
   location: Location;
   timestamp: number; // in milliseconds
   traceId: string;
-  onClick?: () => void;
+  onClick?: React.ComponentProps<typeof Link>['onClick'];
   transactionId?: string;
 }
 

--- a/static/app/views/traces/tracesTable.tsx
+++ b/static/app/views/traces/tracesTable.tsx
@@ -202,12 +202,13 @@ function TraceRow({defaultExpanded, trace}: {defaultExpanded; trace: TraceResult
         <TraceIdRenderer
           traceId={trace.trace}
           timestamp={trace.end}
-          onClick={() =>
+          onClick={event => {
+            event.stopPropagation();
             trackAnalytics('trace_explorer.open_trace', {
               organization,
               source: 'trace explorer',
-            })
-          }
+            });
+          }}
           location={location}
         />
       </StyledPanelItem>


### PR DESCRIPTION
When cmd clicking on the trace id, it should not toggle the expanded state of the trace row as that is jarring behaviour opening a link in a new tab and the current tab changes slightly.