### PR TITLE
feat(stats): Display total spans with stored

### DIFF
--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -125,7 +125,7 @@ describe('OrganizationStats', function () {
         groupBy: ['outcome', 'reason'],
         project: [-1],
         field: ['sum(quantity)'],
-        category: 'error',
+        category: ['error'],
       },
       UsageStatsPerMin: {
         statsPeriod: '5m',
@@ -140,7 +140,7 @@ describe('OrganizationStats', function () {
         groupBy: ['outcome', 'project'],
         project: [-1],
         field: ['sum(quantity)'],
-        category: 'error',
+        category: ['error'],
       },
     };
     for (const query of Object.values(mockExpectations)) {
@@ -325,7 +325,7 @@ describe('OrganizationStats', function () {
           groupBy: ['outcome', 'reason'],
           project: selectedProjects,
           field: ['sum(quantity)'],
-          category: 'error',
+          category: ['error'],
         },
       })
     );
@@ -367,7 +367,7 @@ describe('OrganizationStats', function () {
           groupBy: ['outcome', 'reason'],
           project: selectedProject,
           field: ['sum(quantity)'],
-          category: 'error',
+          category: ['error'],
         },
       })
     );

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -30,6 +30,7 @@ import {
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
+import {hasDynamicSamplingCustomFeature} from 'sentry/utils/dynamicSampling/features';
 import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import HeaderTabs from 'sentry/views/organizationStats/header';
@@ -75,7 +76,8 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
 
     if (
       info?.name === DataCategoryExact.SPAN &&
-      this.props.organization.features.includes('spans-usage-tracking')
+      this.props.organization.features.includes('spans-usage-tracking') &&
+      !hasDynamicSamplingCustomFeature(this.props.organization)
     ) {
       return {
         ...info,

--- a/static/app/views/organizationStats/mapSeriesToChart.ts
+++ b/static/app/views/organizationStats/mapSeriesToChart.ts
@@ -149,7 +149,7 @@ export function mapSeriesToChart({
         if (category === 'span_indexed') {
           if (outcome === Outcome.ACCEPTED) {
             usageStats[i].accepted_stored += stat;
-            updateChartSubLabels(SeriesTypes.ACCEPTED, 'stored');
+            updateChartSubLabels(SeriesTypes.ACCEPTED, 'Stored');
             return;
           }
         }

--- a/static/app/views/organizationStats/mapSeriesToChart.ts
+++ b/static/app/views/organizationStats/mapSeriesToChart.ts
@@ -28,6 +28,7 @@ export function mapSeriesToChart({
 }): {
   cardStats: {
     accepted?: string;
+    accepted_stored?: string;
     filtered?: string;
     invalid?: string;
     rateLimited?: string;
@@ -40,19 +41,21 @@ export function mapSeriesToChart({
   const cardStats = {
     total: undefined,
     accepted: undefined,
+    accepted_stored: undefined,
     filtered: undefined,
     invalid: undefined,
     rateLimited: undefined,
   };
   const chartStats: ChartStats = {
     accepted: [],
+    accepted_stored: [],
     filtered: [],
     rateLimited: [],
     invalid: [],
     clientDiscard: [],
     projected: [],
   };
-  const chartSubLabels: TooltipSubLabel[] = [];
+  let chartSubLabels: TooltipSubLabel[] = [];
 
   if (!orgStats) {
     return {cardStats, chartStats, chartSubLabels};
@@ -66,6 +69,7 @@ export function mapSeriesToChart({
         date: getDateFromMoment(dateTime, chartDateInterval, chartDateUtc),
         total: 0,
         accepted: 0,
+        accepted_stored: 0,
         filtered: 0,
         rateLimited: 0,
         invalid: 0,
@@ -85,14 +89,28 @@ export function mapSeriesToChart({
       [Outcome.ABUSE]: 0, // Combined with dropped later
     };
 
-    orgStats.groups.forEach(group => {
-      const {outcome} = group.by;
+    let countAcceptedStored = 0;
 
-      if (outcome !== Outcome.CLIENT_DISCARD) {
-        count.total += group.totals['sum(quantity)'];
+    orgStats.groups.forEach(group => {
+      const {outcome, category} = group.by;
+
+      // For spans, we additionally query for `span_indexed` data
+      // to get the `accepted_stored` count
+      if (category !== 'span_indexed') {
+        if (outcome !== Outcome.CLIENT_DISCARD) {
+          count.total += group.totals['sum(quantity)'];
+        }
+        count[outcome] += group.totals['sum(quantity)'];
+      } else {
+        if (outcome === Outcome.ACCEPTED) {
+          countAcceptedStored += group.totals['sum(quantity)'];
+        }
       }
 
-      count[outcome] += group.totals['sum(quantity)'];
+      if (category === 'span_indexed' && outcome !== Outcome.ACCEPTED) {
+        // we need `span_indexed` data for `accepted_stored` only
+        return;
+      }
 
       group.series['sum(quantity)'].forEach((stat, i) => {
         const dataObject = {name: orgStats.intervals[i], value: stat};
@@ -100,10 +118,11 @@ export function mapSeriesToChart({
         const strigfiedReason = String(group.by.reason ?? '');
         const reason = getReasonGroupName(outcome, strigfiedReason);
 
-        const label = startCase(reason.replace(/-|_/g, ' '));
-
         // Function to handle chart sub-label updates
-        const updateChartSubLabels = (parentLabel: SeriesTypes) => {
+        const updateChartSubLabels = (
+          parentLabel: SeriesTypes,
+          label = startCase(reason.replace(/-|_/g, ' '))
+        ) => {
           const existingSubLabel = chartSubLabels.find(
             subLabel => subLabel.label === label && subLabel.parentLabel === parentLabel
           );
@@ -125,6 +144,15 @@ export function mapSeriesToChart({
             });
           }
         };
+
+        // Add accepted indexed spans as sub-label to accepted
+        if (category === 'span_indexed') {
+          if (outcome === Outcome.ACCEPTED) {
+            usageStats[i].accepted_stored += stat;
+            updateChartSubLabels(SeriesTypes.ACCEPTED, 'stored');
+            return;
+          }
+        }
 
         switch (outcome) {
           case Outcome.FILTERED:
@@ -158,6 +186,11 @@ export function mapSeriesToChart({
     count[Outcome.RATE_LIMITED] +=
       count[Outcome.ABUSE] + count[Outcome.CARDINALITY_LIMITED];
 
+    const isSampled =
+      dataCategory === 'spans' &&
+      countAcceptedStored > 0 &&
+      countAcceptedStored !== count[Outcome.ACCEPTED];
+
     usageStats.forEach(stat => {
       stat.total = [
         stat.accepted,
@@ -169,7 +202,11 @@ export function mapSeriesToChart({
 
       // Chart Data
       const chartData = [
-        {key: 'accepted', value: stat.accepted},
+        {
+          key: 'accepted',
+          value: stat.accepted,
+        },
+        ...(isSampled ? [{key: 'accepted_stored', value: stat.accepted_stored}] : []),
         {key: 'filtered', value: stat.filtered},
         {key: 'rateLimited', value: stat.rateLimited},
         {key: 'invalid', value: stat.invalid},
@@ -180,6 +217,12 @@ export function mapSeriesToChart({
         (chartStats[data.key] as any[]).push({value: [stat.date, data.value]});
       });
     });
+
+    if (!isSampled) {
+      chartSubLabels = chartSubLabels.filter(
+        subLabel => subLabel.parentLabel !== SeriesTypes.ACCEPTED
+      );
+    }
 
     return {
       cardStats: {
@@ -193,6 +236,13 @@ export function mapSeriesToChart({
           dataCategory,
           getFormatUsageOptions(dataCategory)
         ),
+        accepted_stored: isSampled
+          ? formatUsageWithUnits(
+              countAcceptedStored,
+              dataCategory,
+              getFormatUsageOptions(dataCategory)
+            )
+          : undefined,
         filtered: formatUsageWithUnits(
           count[Outcome.FILTERED],
           dataCategory,

--- a/static/app/views/organizationStats/types.tsx
+++ b/static/app/views/organizationStats/types.tsx
@@ -12,6 +12,7 @@ export interface UsageSeries extends SeriesApi {
 
 export type UsageStat = {
   accepted: number;
+  accepted_stored: number;
   clientDiscard: number;
   date: string;
   filtered: number;

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -108,6 +108,7 @@ export const CHART_OPTIONS_DATA_TRANSFORM: SelectValue<ChartDataTransform>[] = [
 
 export const enum SeriesTypes {
   ACCEPTED = 'Accepted',
+  ACCEPTED_STORED = 'Accepted (stored)',
   FILTERED = 'Filtered',
   RATE_LIMITED = 'Rate Limited',
   INVALID = 'Invalid',
@@ -216,6 +217,7 @@ const getUnitYaxisFormatter =
 export type ChartStats = {
   accepted: NonNullable<BarSeriesOption['data']>;
   projected: NonNullable<BarSeriesOption['data']>;
+  accepted_stored?: NonNullable<BarSeriesOption['data']>;
   clientDiscard?: NonNullable<BarSeriesOption['data']>;
   dropped?: NonNullable<BarSeriesOption['data']>;
   filtered?: NonNullable<BarSeriesOption['data']>;
@@ -378,6 +380,10 @@ function UsageChartBody({
   function chartLegendData(): LegendComponentOption['data'] {
     const legend: LegendComponentOption['data'] = [];
 
+    // if ((chartData.accepted_stored ?? []).length > 0) {
+    //   legend.push({name: SeriesTypes.ACCEPTED_STORED});
+    // }
+
     if (!chartData.reserved || chartData.reserved.length === 0) {
       legend.push({name: SeriesTypes.ACCEPTED});
     }
@@ -432,6 +438,28 @@ function UsageChartBody({
       stack: 'usage',
       legendHoverLink: false,
     }),
+    ...(chartData.accepted_stored
+      ? [
+          barSeries({
+            name: SeriesTypes.ACCEPTED,
+            data: chartData.accepted_stored,
+            barMinHeight: 1,
+            barGap: '-100%',
+            z: 3,
+            silent: true,
+            tooltip: {show: false},
+            itemStyle: {
+              decal: {
+                color: 'rgba(255, 255, 255, 0.2)',
+                dashArrayX: [1, 0],
+                dashArrayY: [3, 5],
+                rotation: -Math.PI / 4,
+              },
+            },
+            legendHoverLink: false,
+          }),
+        ]
+      : []),
     barSeries({
       name: SeriesTypes.FILTERED,
       data: chartData.filtered,
@@ -472,6 +500,13 @@ function UsageChartBody({
   return (
     <BaseChart
       colors={colors}
+      options={{
+        aria: {
+          decal: {
+            show: true,
+          },
+        },
+      }}
       grid={{bottom: '3px', left: '3px', right: '10px', top: '40px'}}
       xAxis={xAxis({
         show: true,

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -380,10 +380,6 @@ function UsageChartBody({
   function chartLegendData(): LegendComponentOption['data'] {
     const legend: LegendComponentOption['data'] = [];
 
-    // if ((chartData.accepted_stored ?? []).length > 0) {
-    //   legend.push({name: SeriesTypes.ACCEPTED_STORED});
-    // }
-
     if (!chartData.reserved || chartData.reserved.length === 0) {
       legend.push({name: SeriesTypes.ACCEPTED});
     }

--- a/static/app/views/organizationStats/usageTable.tsx
+++ b/static/app/views/organizationStats/usageTable.tsx
@@ -13,6 +13,7 @@ import Panel from 'sentry/components/panels/panel';
 import {PanelTable} from 'sentry/components/panels/panelTable';
 import {IconGraph, IconSettings, IconWarning} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {DataCategoryInfo} from 'sentry/types/core';
 import type {WithRouterProps} from 'sentry/types/legacyReactRouter';
 import type {Project} from 'sentry/types/project';
@@ -30,10 +31,12 @@ type Props = {
   isEmpty?: boolean;
   isError?: boolean;
   isLoading?: boolean;
+  showStoredOutcome?: boolean;
 } & WithRouterProps<{}, {}>;
 
 export type TableStat = {
   accepted: number;
+  accepted_stored: number;
   filtered: number;
   invalid: number;
   project: Project;
@@ -70,8 +73,9 @@ class UsageTable extends Component<Props> {
   }
 
   renderTableRow(stat: TableStat & {project: Project}) {
-    const {dataCategory} = this.props;
-    const {project, total, accepted, filtered, invalid, rate_limited} = stat;
+    const {dataCategory, showStoredOutcome} = this.props;
+    const {project, total, accepted, accepted_stored, filtered, invalid, rate_limited} =
+      stat;
 
     return [
       <CellProject key={0}>
@@ -97,6 +101,15 @@ class UsageTable extends Component<Props> {
           accepted,
           dataCategory.plural,
           getFormatUsageOptions(dataCategory.plural)
+        )}
+        {showStoredOutcome && (
+          <SubText>
+            {`(${formatUsageWithUnits(
+              accepted_stored,
+              dataCategory.plural,
+              getFormatUsageOptions(dataCategory.plural)
+            )})`}
+          </SubText>
         )}
       </CellStat>,
       <CellStat key={3}>
@@ -168,7 +181,6 @@ export default withSentryRouter(UsageTable);
 
 const StyledPanelTable = styled(PanelTable)`
   grid-template-columns: repeat(7, auto);
-
   @media (min-width: ${p => p.theme.breakpoints.small}) {
     grid-template-columns: 1fr repeat(6, minmax(0, auto));
   }
@@ -189,4 +201,9 @@ const StyledIdBadge = styled(IdBadge)`
   overflow: hidden;
   white-space: nowrap;
   flex-shrink: 1;
+`;
+
+const SubText = styled('span')`
+  color: ${p => p.theme.subText};
+  margin-left: ${space(0.5)};
 `;


### PR DESCRIPTION
Display the amount of stored spans if the shown span outcomes are affected by dynamic sampling.

![Screenshot 2024-11-20 at 16 37 51](https://github.com/user-attachments/assets/dedf14d3-5271-471c-a9c0-667663c047c5)

Closes https://github.com/getsentry/projects/issues/196
Closes https://github.com/getsentry/projects/issues/139