### PR TITLE
feat: use signed-urls for email confirmation

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -267,6 +267,13 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_REQUIRED,
 )
 
+# User Settings
+register(
+    "user-settings.signed-url-confirmation-emails",
+    default=False,
+    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Staff
 register(
     "staff.ga-rollout",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -269,6 +269,12 @@ register(
 
 # User Settings
 register(
+    "user-settings.signed-url-confirmation-emails-salt",
+    type=String,
+    default="signed-url-confirmation-emails-salt",
+    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "user-settings.signed-url-confirmation-emails",
     default=False,
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/users/api/endpoints/user_emails.py
+++ b/src/sentry/users/api/endpoints/user_emails.py
@@ -28,8 +28,6 @@ from sentry.utils.signing import sign
 
 logger = logging.getLogger("sentry.accounts")
 
-EMAIL_CONFIRMATION_SALT = options.get("user-settings.signed-url-confirmation-emails-salt")
-
 
 class InvalidEmailError(Exception):
     pass
@@ -45,6 +43,9 @@ class EmailValidator(serializers.Serializer[UserEmail]):
 
 def add_email_signed(email: str, user: User) -> None:
     """New path for adding email - uses signed URLs"""
+
+    EMAIL_CONFIRMATION_SALT = options.get("user-settings.signed-url-confirmation-emails-salt")
+
     if email is None:
         raise InvalidEmailError
 

--- a/src/sentry/users/api/endpoints/user_emails.py
+++ b/src/sentry/users/api/endpoints/user_emails.py
@@ -172,7 +172,7 @@ class UserEmailsEndpoint(UserEndpoint):
                     },
                 )
                 return self.respond(
-                    {"email": _("A verification email has been sent. Please check your inbox.")},
+                    {"detail": _("A verification email has been sent. Please check your inbox.")},
                     status=201,
                 )
             else:
@@ -192,7 +192,7 @@ class UserEmailsEndpoint(UserEndpoint):
                 )
         except DuplicateEmailError:
             return self.respond(
-                {"email": _("Email address is already associated with your account.")},
+                {"detail": _("That email address is already associated with your account.")},
                 status=409,
             )
 

--- a/src/sentry/users/api/endpoints/user_emails.py
+++ b/src/sentry/users/api/endpoints/user_emails.py
@@ -28,7 +28,7 @@ from sentry.utils.signing import sign
 
 logger = logging.getLogger("sentry.accounts")
 
-EMAIL_CONFIRMATION_SALT = "email-confirmation"
+EMAIL_CONFIRMATION_SALT = "signed-url-confirmation-emails-salt"
 
 
 class InvalidEmailError(Exception):

--- a/src/sentry/users/api/endpoints/user_emails.py
+++ b/src/sentry/users/api/endpoints/user_emails.py
@@ -2,8 +2,6 @@ import logging
 
 from django.db import IntegrityError, router, transaction
 from django.db.models import Q
-from django.http import HttpResponseRedirect
-from django.urls import reverse
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers
 from rest_framework.request import Request
@@ -155,7 +153,7 @@ class UserEmailsEndpoint(UserEndpoint):
         use_signed_urls = options.get("user-settings.signed-url-confirmation-emails")
         if use_signed_urls:
             add_email_signed(email, user)
-            return HttpResponseRedirect(reverse("sentry-account-settings-emails"))
+            return self.respond(status=201)
         else:
             try:
                 new_useremail = add_email(email, user)

--- a/src/sentry/users/api/endpoints/user_emails.py
+++ b/src/sentry/users/api/endpoints/user_emails.py
@@ -28,7 +28,7 @@ from sentry.utils.signing import sign
 
 logger = logging.getLogger("sentry.accounts")
 
-EMAIL_CONFIRMATION_SALT = "signed-url-confirmation-emails-salt"
+EMAIL_CONFIRMATION_SALT = options.get("user-settings.signed-url-confirmation-emails-salt")
 
 
 class InvalidEmailError(Exception):

--- a/src/sentry/users/api/endpoints/user_emails.py
+++ b/src/sentry/users/api/endpoints/user_emails.py
@@ -2,6 +2,7 @@ import logging
 
 from django.db import IntegrityError, router, transaction
 from django.db.models import Q
+from django.utils.translation import gettext as _
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers
 from rest_framework.request import Request
@@ -153,7 +154,10 @@ class UserEmailsEndpoint(UserEndpoint):
         use_signed_urls = options.get("user-settings.signed-url-confirmation-emails")
         if use_signed_urls:
             add_email_signed(email, user)
-            return self.respond(status=201)
+            return self.respond(
+                {"email": _("A verification email has been sent. Please check your inbox.")},
+                status=201,
+            )
         else:
             try:
                 new_useremail = add_email(email, user)
@@ -231,13 +235,13 @@ class UserEmailsEndpoint(UserEndpoint):
             .exists()
         ):
             return self.respond(
-                {"email": "That email address is already associated with another account."},
+                {"email": _("That email address is already associated with another account.")},
                 status=400,
             )
 
         if not new_useremail.is_verified:
             return self.respond(
-                {"email": "You must verify your email address before marking it as primary."},
+                {"email": _("You must verify your email address before marking it as primary.")},
                 status=400,
             )
 

--- a/src/sentry/users/models/user.py
+++ b/src/sentry/users/models/user.py
@@ -276,7 +276,9 @@ class User(Model, AbstractBaseUser):
     def get_actor_identifier(self) -> str:
         return f"user:{self.id}"
 
-    def send_signed_url_confirm_email_singular(self, email: str, signed_data: str) -> None:
+    def send_signed_url_confirm_email_singular(
+        self, email: str, signed_data: str, is_new_user: bool = False
+    ) -> None:
         from sentry import options
         from sentry.utils.email import MessageBuilder
 
@@ -284,7 +286,7 @@ class User(Model, AbstractBaseUser):
             "user": self,
             "url": absolute_uri(reverse("sentry-account-confirm-signed-email", args=[signed_data])),
             "confirm_email": email,
-            "is_new_user": False,
+            "is_new_user": is_new_user,
         }
 
         msg = MessageBuilder(

--- a/src/sentry/users/models/user.py
+++ b/src/sentry/users/models/user.py
@@ -276,6 +276,26 @@ class User(Model, AbstractBaseUser):
     def get_actor_identifier(self) -> str:
         return f"user:{self.id}"
 
+    def send_signed_url_confirm_email_singular(self, email: str, signed_data: str) -> None:
+        from sentry import options
+        from sentry.utils.email import MessageBuilder
+
+        context = {
+            "user": self,
+            "url": absolute_uri(reverse("sentry-account-confirm-signed-email", args=[signed_data])),
+            "confirm_email": email,
+            "is_new_user": False,
+        }
+
+        msg = MessageBuilder(
+            subject="{}Confirm Email".format(options.get("mail.subject-prefix")),
+            template="sentry/emails/confirm_email.txt",
+            html_template="sentry/emails/confirm_email.html",
+            type="user.confirm_email",
+            context=context,
+        )
+        msg.send_async([email.email])
+
     def send_confirm_email_singular(self, email: UserEmail, is_new_user: bool = False) -> None:
         from sentry import options
         from sentry.utils.email import MessageBuilder

--- a/src/sentry/users/models/user.py
+++ b/src/sentry/users/models/user.py
@@ -294,7 +294,7 @@ class User(Model, AbstractBaseUser):
             type="user.confirm_email",
             context=context,
         )
-        msg.send_async([email.email])
+        msg.send_async([email])
 
     def send_confirm_email_singular(self, email: UserEmail, is_new_user: bool = False) -> None:
         from sentry import options

--- a/src/sentry/users/web/accounts.py
+++ b/src/sentry/users/web/accounts.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 from functools import partial
 
@@ -388,7 +389,10 @@ def confirm_email(request: HttpRequest, user_id: int, hash: str) -> HttpResponse
             extra={
                 "user_id": user_id,
                 "ip_address": request.META["REMOTE_ADDR"],
-                "email": email.email,
+                "useremail_id": email.id,
+                "email_sha256_hash": hashlib.sha256(
+                    email.email.lower().encode("utf-8")
+                ).hexdigest(),
             },
         )
     messages.add_message(request, level, msg)

--- a/src/sentry/users/web/accounts.py
+++ b/src/sentry/users/web/accounts.py
@@ -415,7 +415,7 @@ def confirm_signed_email(
 
     try:
         data = unsign(
-            signed_data, salt=EMAIL_CONFIRMATION_SALT, max_age=172800
+            signed_data, salt=EMAIL_CONFIRMATION_SALT, max_age=2 * 24 * 60 * 60
         )  # max age is 2 days in seconds
 
         # is the currently logged in user the one that

--- a/src/sentry/users/web/accounts.py
+++ b/src/sentry/users/web/accounts.py
@@ -1,4 +1,3 @@
-import hashlib
 import logging
 from functools import partial
 
@@ -390,9 +389,7 @@ def confirm_email(request: HttpRequest, user_id: int, hash: str) -> HttpResponse
                 "user_id": user_id,
                 "ip_address": request.META["REMOTE_ADDR"],
                 "useremail_id": email.id,
-                "email_sha256_hash": hashlib.sha256(
-                    email.email.lower().encode("utf-8")
-                ).hexdigest(),
+                "email": email.email.lower(),
             },
         )
     messages.add_message(request, level, msg)

--- a/src/sentry/users/web/accounts.py
+++ b/src/sentry/users/web/accounts.py
@@ -6,7 +6,7 @@ from django.contrib.auth import authenticate
 from django.contrib.auth import login as login_user
 from django.core.signing import BadSignature, SignatureExpired
 from django.db import router, transaction
-from django.http import HttpRequest, HttpResponse, HttpResponseNotFound, HttpResponseRedirect
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
@@ -405,7 +405,10 @@ def confirm_signed_email(
 
     use_signed_urls = options.get("user-settings.signed-url-confirmation-emails")
     if not use_signed_urls:
-        return HttpResponseNotFound()
+        msg = ERR_CONFIRMING_EMAIL
+        level = messages.ERROR
+        messages.add_message(request, level, msg)
+        return HttpResponseRedirect(reverse("sentry-account-settings-emails"))
 
     msg = _("Thanks for confirming your email")
     level = messages.SUCCESS

--- a/src/sentry/users/web/accounts.py
+++ b/src/sentry/users/web/accounts.py
@@ -411,7 +411,9 @@ def confirm_signed_email(
     level = messages.SUCCESS
 
     try:
-        data = unsign(signed_data, salt=EMAIL_CONFIRMATION_SALT)
+        data = unsign(
+            signed_data, salt=EMAIL_CONFIRMATION_SALT, max_age=172800
+        )  # max age is 2 days in seconds
 
         # is the currently logged in user the one that
         # wants to add the email to their account

--- a/src/sentry/users/web/accounts.py
+++ b/src/sentry/users/web/accounts.py
@@ -46,7 +46,7 @@ ERR_SIGNATURE_EXPIRED = _(
     "Settings to resend the verification email."
 )
 
-WARN_EMAIL_ALREADY_VERIFIED = _("The email you are trying to verify has already been verified.")
+INFO_EMAIL_ALREADY_VERIFIED = _("The email you are trying to verify has already been verified.")
 
 
 class InvalidRequest(Exception):
@@ -432,7 +432,7 @@ def confirm_signed_email(
             # user email does not exist, so we can create it
             pass
     except VerifiedEmailAlreadyExists:
-        msg = WARN_EMAIL_ALREADY_VERIFIED
+        msg = INFO_EMAIL_ALREADY_VERIFIED
         level = messages.INFO
         messages.add_message(request, level, msg)
         return HttpResponseRedirect(reverse("sentry-account-settings-emails"))

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -322,6 +322,11 @@ urlpatterns += [
                     name="sentry-account-confirm-email",
                 ),
                 re_path(
+                    r"^account/confirm-signed-email/(?P<signed_data>[-A-Za-z0-9_]+)/$",
+                    accounts.confirm_signed_email,
+                    name="sentry-account-confirm-signed-email",
+                ),
+                re_path(
                     r"^user-confirm/(?P<key>[^\/]+)/$",
                     AccountConfirmationView.as_view(),
                     name="sentry-idp-email-verification",

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -322,7 +322,7 @@ urlpatterns += [
                     name="sentry-account-confirm-email",
                 ),
                 re_path(
-                    r"^account/confirm-signed-email/(?P<signed_data>[-A-Za-z0-9_]+)/$",
+                    r"^confirm-signed-email/(?P<signed_data>[-A-Za-z0-9_]+)/$",
                     accounts.confirm_signed_email,
                     name="sentry-account-confirm-signed-email",
                 ),

--- a/tests/sentry/users/api/endpoints/test_user_emails.py
+++ b/tests/sentry/users/api/endpoints/test_user_emails.py
@@ -42,16 +42,16 @@ class UserEmailsTest(APITestCase):
         assert response.status_code == 201, response.data
         assert UserEmail.objects.filter(user=self.user, email="altemail1@example.com").exists()
 
-        # duplicate email allows still succeeds, but has a diff response code
+        # duplicate email returns 409
         response = self.client.post(self.url, data={"email": "altemail1@example.com"})
-        assert response.status_code == 200, response.data
+        assert response.status_code == 409, response.data
 
     def test_cant_have_same_email_with_different_casing(self):
         user = self.create_user(email="FOOBAR@example.com")
         self.login_as(user=user)
         url = reverse("sentry-api-0-user-emails", kwargs={"user_id": user.id})
         response = self.client.post(url, data={"email": "foobar@example.com"})
-        assert response.status_code == 200, response.data
+        assert response.status_code == 409, response.data
 
     def test_change_verified_secondary_to_primary(self):
         UserEmail.objects.create(user=self.user, email="altemail1@example.com", is_verified=True)

--- a/tests/sentry/users/api/endpoints/test_user_emails_confirm.py
+++ b/tests/sentry/users/api/endpoints/test_user_emails_confirm.py
@@ -192,3 +192,23 @@ class UserEmailsConfirmTest(APITestCase):
             messages[0].message
             == "The confirmation link has expired. Please visit your Account Settings to resend the verification email."
         )
+
+    @override_options(
+        {
+            "user-settings.signed-url-confirmation-emails": False,
+            "user-settings.signed-url-confirmation-emails-salt": "signed-url-confirmation-emails-salt",
+        }
+    )
+    def test_confirm_email_signed_urls_disabled(self):
+        self.login_as(self.user)
+
+        new_email = "newemailfromsignedurl@example.com"
+        signed_data = sign(
+            user_id=self.user.id,
+            email=new_email,
+            salt="signed-url-confirmation-emails-salt",
+        )
+        resp = self.client.get(
+            reverse("sentry-account-confirm-signed-email", args=[signed_data]), follow=True
+        )
+        assert resp.status_code == 404

--- a/tests/sentry/users/api/endpoints/test_user_emails_confirm.py
+++ b/tests/sentry/users/api/endpoints/test_user_emails_confirm.py
@@ -211,4 +211,11 @@ class UserEmailsConfirmTest(APITestCase):
         resp = self.client.get(
             reverse("sentry-account-confirm-signed-email", args=[signed_data]), follow=True
         )
-        assert resp.status_code == 404
+        assert resp.status_code == 200
+
+        messages = list(resp.context["messages"])
+        assert len(messages) == 1
+        assert (
+            messages[0].message
+            == "There was an error confirming your email. Please try again or visit your Account Settings to resend the verification email."
+        )

--- a/tests/sentry/users/api/endpoints/test_user_emails_confirm.py
+++ b/tests/sentry/users/api/endpoints/test_user_emails_confirm.py
@@ -1,8 +1,12 @@
 from unittest import mock
 
+from django.urls import reverse
+
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers import override_options
 from sentry.testutils.silo import control_silo_test
 from sentry.users.models.useremail import UserEmail
+from sentry.utils.signing import sign
 
 
 @control_silo_test
@@ -42,3 +46,149 @@ class UserEmailsConfirmTest(APITestCase):
     def test_validate_email(self, send_confirm_email):
         self.get_error_response(self.user.id, email="", status_code=400)
         assert send_confirm_email.call_count == 0
+
+    @override_options(
+        {
+            "user-settings.signed-url-confirmation-emails": True,
+            "user-settings.signed-url-confirmation-emails-salt": "signed-url-confirmation-emails-salt",
+        }
+    )
+    def test_confirm_email_signed_url(self):
+        from sentry import options
+
+        EMAIL_CONFIRMATION_SALT = options.get("user-settings.signed-url-confirmation-emails-salt")
+
+        self.login_as(self.user)
+
+        new_email = "newemailfromsignedurl@example.com"
+
+        signed_data = sign(
+            user_id=self.user.id,
+            email=new_email,
+            salt=EMAIL_CONFIRMATION_SALT,
+        )
+
+        signed_url = reverse("sentry-account-confirm-signed-email", args=[signed_data])
+
+        resp = self.client.get(signed_url, follow=True)
+        assert resp.status_code == 200
+        assert resp.redirect_chain == [(reverse("sentry-account-settings-emails"), 302)]
+
+        new_user_email = UserEmail.objects.get(user=self.user, email=new_email)
+        assert new_user_email.is_verified
+
+        messages = list(resp.context["messages"])
+        assert len(messages) == 1
+        assert messages[0].message == "Thanks for confirming your email"
+
+    @override_options(
+        {
+            "user-settings.signed-url-confirmation-emails": True,
+            "user-settings.signed-url-confirmation-emails-salt": "signed-url-confirmation-emails-salt",
+        }
+    )
+    def test_confirm_email_invalid_signed_url(self):
+        self.login_as(self.user)
+
+        new_email = "newemailfromsignedurl@example.com"
+
+        signed_data = sign(
+            user_id=self.user.id,
+            email=new_email,
+            salt="invalid-salt",
+        )
+
+        signed_url = reverse("sentry-account-confirm-signed-email", args=[signed_data])
+
+        resp = self.client.get(signed_url, follow=True)
+        assert resp.status_code == 200
+        assert resp.redirect_chain == [(reverse("sentry-account-settings-emails"), 302)]
+
+        # the email should not be added
+        user_email_counts = UserEmail.objects.filter(user=self.user).count()
+        assert user_email_counts == 1
+
+        messages = list(resp.context["messages"])
+        assert len(messages) == 1
+        assert (
+            messages[0].message
+            == "There was an error confirming your email. Please try again or visit your Account Settings to resend the verification email."
+        )
+
+    @override_options(
+        {
+            "user-settings.signed-url-confirmation-emails": True,
+            "user-settings.signed-url-confirmation-emails-salt": "signed-url-confirmation-emails-salt",
+        }
+    )
+    def test_confirm_email_already_verified(self):
+        from sentry import options
+
+        EMAIL_CONFIRMATION_SALT = options.get("user-settings.signed-url-confirmation-emails-salt")
+
+        self.login_as(self.user)
+
+        new_email = "newemailfromsignedurl@example.com"
+
+        # Create already verified email
+        UserEmail.objects.create(
+            user=self.user,
+            email=new_email,
+            is_verified=True,
+        )
+
+        signed_data = sign(
+            user_id=self.user.id,
+            email=new_email,
+            salt=EMAIL_CONFIRMATION_SALT,
+        )
+
+        signed_url = reverse("sentry-account-confirm-signed-email", args=[signed_data])
+
+        resp = self.client.get(signed_url, follow=True)
+        assert resp.status_code == 200
+        assert resp.redirect_chain == [(reverse("sentry-account-settings-emails"), 302)]
+
+        messages = list(resp.context["messages"])
+        assert len(messages) == 1
+        assert (
+            messages[0].message == "The email you are trying to verify has already been verified."
+        )
+
+    @override_options(
+        {
+            "user-settings.signed-url-confirmation-emails": True,
+            "user-settings.signed-url-confirmation-emails-salt": "signed-url-confirmation-emails-salt",
+        }
+    )
+    def test_confirm_email_expired_signature(self):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        self.login_as(self.user)
+
+        new_email = "newemailfromsignedurl@example.com"
+
+        with mock.patch("django.core.signing.time.time") as mock_time:
+            past_time = timezone.now() - timedelta(days=7)
+            mock_time.return_value = past_time.timestamp()
+
+            signed_data = sign(
+                user_id=self.user.id,
+                email=new_email,
+                salt="signed-url-confirmation-emails-salt",
+            )
+
+        signed_url = reverse("sentry-account-confirm-signed-email", args=[signed_data])
+        resp = self.client.get(signed_url, follow=True)
+
+        assert resp.status_code == 200
+        assert resp.redirect_chain == [(reverse("sentry-account-settings-emails"), 302)]
+
+        messages = list(resp.context["messages"])
+        assert len(messages) == 1
+        assert (
+            messages[0].message
+            == "The confirmation link has expired. Please visit your Account Settings to resend the verification email."
+        )

--- a/tests/sentry/users/web/test_accounts.py
+++ b/tests/sentry/users/web/test_accounts.py
@@ -9,13 +9,11 @@ from django.utils import timezone
 
 from sentry.organizations.services.organization import organization_service
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.task_runner import BurstTaskRunner
 from sentry.testutils.silo import control_silo_test
 from sentry.users.models.lostpasswordhash import LostPasswordHash
 from sentry.users.models.useremail import UserEmail
 from sentry.users.web.accounts import recover_confirm
-from sentry.utils.signing import sign
 
 
 @control_silo_test
@@ -551,23 +549,3 @@ class TestAccounts(TestCase):
         assert resp.status_code == 302
         assert resp.headers["location"] == "/auth/login/"
         assert self.client.session["_next"] == url
-
-    @override_options({"user-settings.signed-url-confirmation-emails": True})
-    def test_confirm_email_signed_url(self):
-        from sentry.users.api.endpoints.user_emails import EMAIL_CONFIRMATION_SALT
-
-        self.login_as(self.user)
-
-        signed_data = sign(
-            user_id=self.user.id,
-            email="newemailfromsignedurl@example.com",
-            salt=EMAIL_CONFIRMATION_SALT,
-        )
-
-        signed_url = reverse("sentry-account-confirm-signed-email", args=[signed_data])
-
-        resp = self.client.get(signed_url, follow=True)
-        assert resp.status_code == 200
-
-        useremail = UserEmail.objects.get(user=self.user, email="newemailfromsignedurl@example.com")
-        assert useremail.is_verified


### PR DESCRIPTION
We currently allow secondary emails to be added to accounts without verification. This leads to subtle bugs, some with security implications.

This PR adds an option to transition use to signed URLs to add secondary emails on accounts. Instead of adding the email address immediately to the account in an unverified state, a signed URL is generated and emailed to the email address. The secondary email is not added to the account. 

Once clicked, the signed URL is verified and if valid, the secondary email is added to the user's account as a verified address.

Here's what it will look like in the frontend after submitting the form with a new email:
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/6f06e89b-a1d2-40eb-a4a4-1e860e07d57d" />

If you submit it with one that's already on your account:
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/57daad3f-e129-4176-ba9a-fc36c73b11ea" />

Frontend PR will follow. The option that gates this functionality will not be enabled until the frontend PR is deployed.
