### PR TITLE
feat(dashboards): Add permissions field to dashboards list endpoint

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -192,6 +192,7 @@ class DashboardListResponse(TypedDict):
     createdBy: UserSerializerResponse
     widgetDisplay: list[str]
     widgetPreview: list[dict[str, str]]
+    permissions: DashboardPermissionsResponse | None
 
 
 class DashboardListSerializer(Serializer):
@@ -250,6 +251,7 @@ class DashboardListSerializer(Serializer):
             "createdBy": attrs.get("created_by"),
             "widgetDisplay": attrs.get("widget_display", []),
             "widgetPreview": attrs.get("widget_preview", []),
+            "permissions": serialize(obj.permissions) if hasattr(obj, "permissions") else None,
         }
         return data
 

--- a/src/sentry/apidocs/examples/dashboard_examples.py
+++ b/src/sentry/apidocs/examples/dashboard_examples.py
@@ -104,6 +104,7 @@ DASHBOARDS_OBJECT = [
         },
         "widgetDisplay": [],
         "widgetPreview": [],
+        "permissions": {"isEditableByEveryone": True, "teamsWithEditAccess": []},
     },
     {
         "id": "2",
@@ -134,6 +135,7 @@ DASHBOARDS_OBJECT = [
         },
         "widgetDisplay": [],
         "widgetPreview": [],
+        "permissions": None,
     },
 ]
 

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -156,6 +156,7 @@ def get_prebuilt_dashboards(organization, user) -> list[dict[str, Any]]:
             "title": "General",
             "dateCreated": "",
             "createdBy": "",
+            "permissions": {"isEditableByEveryone": True, "teamsWithEditAccess": []},
             "widgets": [
                 {
                     "title": "Number of Errors",

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -1043,3 +1043,15 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         assert response.status_code == 201, response.content
         assert response.data["permissions"]["isEditableByEveryone"] is False
         assert response.data["permissions"]["teamsWithEditAccess"] == [team1.id, team2.id]
+
+    def test_gets_dashboard_permissions_with_dashboard_list(self):
+        response = self.do_request("get", self.url)
+        assert response.status_code == 200, response.content
+        assert len(response.data) > 1
+        # Ensure the "permissions" field exists in each dashboard
+        for dashboard in response.data:
+            assert (
+                "permissions" in dashboard
+            ), f"Permissions field not found in dashboard: {dashboard}"
+        self.assert_equal_dashboards(self.dashboard, response.data[1])
+        assert response.data[1]["permissions"] is None

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -1055,3 +1055,27 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
             ), f"Permissions field not found in dashboard: {dashboard}"
         self.assert_equal_dashboards(self.dashboard, response.data[1])
         assert response.data[1]["permissions"] is None
+
+    def test_dasboard_list_permissions_is_valid(self):
+        team1 = self.create_team(organization=self.organization)
+        team2 = self.create_team(organization=self.organization)
+
+        data = {
+            "title": "New Dashboard 7",
+            "permissions": {
+                "isEditableByEveryone": "false",
+                "teamsWithEditAccess": [str(team1.id), str(team2.id)],
+            },
+            "createdBy": {"id": "23516"},
+            "id": "7136",
+        }
+
+        with self.feature({"organizations:dashboards-edit-access": True}):
+            response = self.do_request("post", self.url, data=data)
+        assert response.status_code == 201
+
+        response = self.do_request("get", self.url)
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 4
+        assert response.data[3]["permissions"]["isEditableByEveryone"] is False
+        assert response.data[3]["permissions"]["teamsWithEditAccess"] == [team1.id, team2.id]


### PR DESCRIPTION
Adding the permissions field in the dashboard details endpoint to the dashboards list endpoint to have permissions available on dashboard landing page as a part of the dashboard list table view


