### PR TITLE
chore(streamline): Allow new flag to enforce the UI

### DIFF
--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
@@ -35,6 +35,21 @@ describe('NewIssueExperienceButton', function () {
     expect(screen.getByTestId('test-id')).toBeEmptyDOMElement();
   });
 
+  it('does not appear when an organization has the enforce flag', function () {
+    render(
+      <div data-test-id="test-id">
+        <NewIssueExperienceButton />
+      </div>,
+      {
+        organization: {
+          ...organization,
+          features: [...organization.features, 'issue-details-streamline-enforce'],
+        },
+      }
+    );
+    expect(screen.getByTestId('test-id')).toBeEmptyDOMElement();
+  });
+
   it('appears when organization has flag', function () {
     render(
       <div data-test-id="test-id">

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -19,6 +19,9 @@ export function NewIssueExperienceButton() {
   const user = useUser();
   const organization = useOrganization();
   const hasStreamlinedUIFlag = organization.features.includes('issue-details-streamline');
+  const hasEnforceStreamlinedUIFlag = organization.features.includes(
+    'issue-details-streamline-enforce'
+  );
   const hasStreamlinedUI = useHasStreamlinedUI();
   const openForm = useFeedbackForm();
   const {mutate} = useMutateUserOptions();
@@ -31,7 +34,8 @@ export function NewIssueExperienceButton() {
     });
   }, [mutate, organization, hasStreamlinedUI]);
 
-  if (!hasStreamlinedUIFlag) {
+  // We hide the toggle if the org doesn't have the 'opt-in' flag, or has the 'remove opt-out' flag.
+  if (!hasStreamlinedUIFlag || hasEnforceStreamlinedUIFlag) {
     return null;
   }
 


### PR DESCRIPTION
This PR allows the `issue-details-streamline-enforce` flag to force users of an organization into the streamline UI without the ability to opt out. [Only my test org](https://github.com/getsentry/sentry-options-automator/pull/2730) will receive this change, but eventually it'll apply to more people.