### PR TITLE
fix(issue-details): Fix duplicate title on event grouping

### DIFF
--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -79,7 +79,7 @@ export default function GroupingInfo({
 
   return (
     <Fragment>
-      {!hasStreamlinedUI && (
+      {hasStreamlinedUI && (
         <GroupInfoSummary event={event} group={group} projectSlug={projectSlug} />
       )}
       <ConfigHeader>


### PR DESCRIPTION
Slight bug with titles here, it's omitted on the streamlined UI, but duplicated on the legacy:

**Before**:

<img width="1200" alt="image" src="https://github.com/user-attachments/assets/61e874a7-4c03-4079-8862-538e7ac1be69">
<img width="1180" alt="image" src="https://github.com/user-attachments/assets/8d2eced6-2066-4b58-84ec-b38952e3341c">


**After**

<img width="1165" alt="image" src="https://github.com/user-attachments/assets/14d76f43-a027-457e-abea-34fe525e2d6f">
<img width="1186" alt="image" src="https://github.com/user-attachments/assets/3a0f31a5-c7c4-40b6-bf50-4ed2649e98f6">
