### PR TITLE
feat(explore): Disable sort by for traces table

### DIFF
--- a/static/app/views/explore/hooks/useTab.tsx
+++ b/static/app/views/explore/hooks/useTab.tsx
@@ -1,0 +1,39 @@
+import {useCallback, useMemo} from 'react';
+
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+
+export enum Tab {
+  SPAN = 'span',
+  TRACE = 'trace',
+}
+
+export function useTab(): [Tab, (tab: Tab) => void] {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const tab = useMemo(() => {
+    const rawTab = decodeScalar(location.query.table);
+    if (rawTab === 'trace') {
+      return Tab.TRACE;
+    }
+    return Tab.SPAN;
+  }, [location.query.table]);
+
+  const setTab = useCallback(
+    (newTab: Tab) => {
+      navigate({
+        ...location,
+        query: {
+          ...location.query,
+          table: newTab,
+          cursor: undefined,
+        },
+      });
+    },
+    [location, navigate]
+  );
+
+  return [tab, setTab];
+}

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -1,5 +1,5 @@
 import type {Dispatch, SetStateAction} from 'react';
-import {Fragment, useCallback, useMemo} from 'react';
+import {Fragment, useCallback} from 'react';
 import styled from '@emotion/styled';
 
 import {openModal} from 'sentry/actionCreators/modal';
@@ -8,52 +8,14 @@ import {TabList, Tabs} from 'sentry/components/tabs';
 import {IconTable} from 'sentry/icons/iconTable';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {decodeScalar} from 'sentry/utils/queryString';
-import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
+import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {useResultMode} from 'sentry/views/explore/hooks/useResultsMode';
 import {useSampleFields} from 'sentry/views/explore/hooks/useSampleFields';
-
-import {useSpanTags} from '../contexts/spanTagsContext';
-
-import {TracesTable} from './tracesTable/index';
-import {AggregatesTable} from './aggregatesTable';
-import {ColumnEditorModal} from './columnEditorModal';
-import {SpansTable} from './spansTable';
-
-enum Tab {
-  SPAN = 'span',
-  TRACE = 'trace',
-}
-
-function useTab(): [Tab, (tab: Tab) => void] {
-  const location = useLocation();
-  const navigate = useNavigate();
-
-  const tab = useMemo(() => {
-    const rawTab = decodeScalar(location.query.table);
-    if (rawTab === 'trace') {
-      return Tab.TRACE;
-    }
-    return Tab.SPAN;
-  }, [location.query.table]);
-
-  const setTab = useCallback(
-    (newTab: Tab) => {
-      navigate({
-        ...location,
-        query: {
-          ...location.query,
-          table: newTab,
-          cursor: undefined,
-        },
-      });
-    },
-    [location, navigate]
-  );
-
-  return [tab, setTab];
-}
+import {Tab, useTab} from 'sentry/views/explore/hooks/useTab';
+import {AggregatesTable} from 'sentry/views/explore/tables/aggregatesTable';
+import {ColumnEditorModal} from 'sentry/views/explore/tables/columnEditorModal';
+import {SpansTable} from 'sentry/views/explore/tables/spansTable';
+import {TracesTable} from 'sentry/views/explore/tables/tracesTable/index';
 
 interface ExploreTablesProps {
   setError: Dispatch<SetStateAction<string>>;

--- a/static/app/views/explore/toolbar/toolbarSortBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarSortBy.tsx
@@ -9,7 +9,9 @@ import type {Sort} from 'sentry/utils/discover/fields';
 import {formatParsedFunction, parseFunction} from 'sentry/utils/discover/fields';
 import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useResultMode} from 'sentry/views/explore/hooks/useResultsMode';
 import type {Field} from 'sentry/views/explore/hooks/useSampleFields';
+import {Tab, useTab} from 'sentry/views/explore/hooks/useTab';
 
 import {ToolbarHeader, ToolbarLabel, ToolbarRow, ToolbarSection} from './styles';
 
@@ -19,7 +21,59 @@ interface ToolbarSortByProps {
   sorts: Sort[];
 }
 
-export function ToolbarSortBy({fields, setSorts, sorts}: ToolbarSortByProps) {
+export function ToolbarSortBy(props: ToolbarSortByProps) {
+  const [resultMode] = useResultMode();
+  const [tab] = useTab();
+
+  if (resultMode === 'samples' && tab === Tab.TRACE) {
+    return <ToolbarSortByTraces />;
+  }
+
+  return <ToolbarSortBySelectors {...props} />;
+}
+
+function ToolbarSortByTraces() {
+  const fieldOptions: SelectOption<Field>[] = useMemo(() => {
+    return [
+      {
+        label: 'timestamp',
+        value: 'timestamp',
+        textValue: t('timestamp'),
+      },
+    ];
+  }, []);
+
+  const kindOptions: SelectOption<Sort['kind']>[] = useMemo(() => {
+    return [
+      {
+        label: 'Desc',
+        value: 'desc',
+        textValue: t('Descending'),
+      },
+    ];
+  }, []);
+
+  return (
+    <ToolbarSection data-test-id="section-sort-by">
+      <ToolbarHeader>
+        <Tooltip
+          position="right"
+          title={t('Results you see first and last in your samples or aggregates.')}
+        >
+          <ToolbarLabel disabled>{t('Sort By')}</ToolbarLabel>
+        </Tooltip>
+      </ToolbarHeader>
+      <div>
+        <ToolbarRow>
+          <ColumnCompactSelect options={fieldOptions} value="timestamp" disabled />
+          <DirectionCompactSelect options={kindOptions} value="desc" disabled />
+        </ToolbarRow>
+      </div>
+    </ToolbarSection>
+  );
+}
+
+function ToolbarSortBySelectors({fields, setSorts, sorts}: ToolbarSortByProps) {
   const numberTags = useSpanTags('number');
   const stringTags = useSpanTags('string');
 


### PR DESCRIPTION
Traces are currently only sortable by timestamp. So when switching to the traces table, disable all sort by options and force it to render `timestamp desc`. There may be additional sorts for the slowest trace but that's to be determined.