### PR TITLE
feat(autofix): Prompt rethink on step completion

### DIFF
--- a/static/app/components/events/autofix/autofixInsightCards.spec.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.spec.tsx
@@ -164,17 +164,29 @@ describe('AutofixInsightCards', () => {
     renderComponent();
     const rethinkButton = screen.getByRole('button', {name: 'Rethink from here'});
     await userEvent.click(rethinkButton);
-    expect(screen.getByPlaceholderText('Say something...')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(
+        'You should know X... Dive deeper into Y... Look at Z...'
+      )
+    ).toBeInTheDocument();
   });
 
   it('hides rethink input overlay when clicked outside', async () => {
     renderComponent();
     const rethinkButton = screen.getByRole('button', {name: 'Rethink from here'});
     await userEvent.click(rethinkButton);
-    expect(screen.getByPlaceholderText('Say something...')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(
+        'You should know X... Dive deeper into Y... Look at Z...'
+      )
+    ).toBeInTheDocument();
 
     await userEvent.click(document.body);
-    expect(screen.queryByPlaceholderText('Say something...')).not.toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText(
+        'You should know X... Dive deeper into Y... Look at Z...'
+      )
+    ).not.toBeInTheDocument();
   });
 
   it('submits rethink request when form is submitted', async () => {
@@ -187,7 +199,9 @@ describe('AutofixInsightCards', () => {
     const rethinkButton = screen.getByRole('button', {name: 'Rethink from here'});
     await userEvent.click(rethinkButton);
 
-    const input = screen.getByPlaceholderText('Say something...');
+    const input = screen.getByPlaceholderText(
+      'You should know X... Dive deeper into Y... Look at Z...'
+    );
     await userEvent.type(input, 'Rethink this part');
 
     const submitButton = screen.getByLabelText(
@@ -222,7 +236,9 @@ describe('AutofixInsightCards', () => {
     const rethinkButton = screen.getByRole('button', {name: 'Rethink from here'});
     await userEvent.click(rethinkButton);
 
-    const input = screen.getByPlaceholderText('Say something...');
+    const input = screen.getByPlaceholderText(
+      'You should know X... Dive deeper into Y... Look at Z...'
+    );
     await userEvent.type(input, 'Rethink this part');
 
     const submitButton = screen.getByLabelText(
@@ -246,7 +262,9 @@ describe('AutofixInsightCards', () => {
     const rethinkButton = screen.getByRole('button', {name: 'Rethink from here'});
     await userEvent.click(rethinkButton);
 
-    const input = screen.getByPlaceholderText('Say something...');
+    const input = screen.getByPlaceholderText(
+      'You should know X... Dive deeper into Y... Look at Z...'
+    );
     await userEvent.type(input, 'Rethink this part');
 
     const submitButton = screen.getByLabelText(

--- a/static/app/components/events/autofix/autofixMessageBox.spec.tsx
+++ b/static/app/components/events/autofix/autofixMessageBox.spec.tsx
@@ -80,7 +80,9 @@ describe('AutofixMessageBox', () => {
     render(<AutofixMessageBox {...defaultProps} />);
 
     expect(screen.getByText('Test display text')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('Say something...')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText('Share helpful context or feedback...')
+    ).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Send'})).toBeInTheDocument();
   });
 
@@ -88,7 +90,7 @@ describe('AutofixMessageBox', () => {
     const onSendMock = jest.fn();
     render(<AutofixMessageBox {...defaultProps} onSend={onSendMock} />);
 
-    const input = screen.getByPlaceholderText('Say something...');
+    const input = screen.getByPlaceholderText('Share helpful context or feedback...');
     await userEvent.type(input, 'Test message');
     await userEvent.click(screen.getByRole('button', {name: 'Send'}));
 
@@ -104,7 +106,7 @@ describe('AutofixMessageBox', () => {
 
     render(<AutofixMessageBox {...defaultProps} />);
 
-    const input = screen.getByPlaceholderText('Say something...');
+    const input = screen.getByPlaceholderText('Share helpful context or feedback...');
     await userEvent.type(input, 'Test message');
     await userEvent.click(screen.getByRole('button', {name: 'Send'}));
 
@@ -125,7 +127,7 @@ describe('AutofixMessageBox', () => {
 
     render(<AutofixMessageBox {...defaultProps} />);
 
-    const input = screen.getByPlaceholderText('Say something...');
+    const input = screen.getByPlaceholderText('Share helpful context or feedback...');
     await userEvent.type(input, 'Test message');
     await userEvent.click(screen.getByRole('button', {name: 'Send'}));
 
@@ -196,7 +198,9 @@ describe('AutofixMessageBox', () => {
   it('shows feedback input when "Give feedback" is selected', () => {
     render(<AutofixMessageBox {...changesStepProps} />);
 
-    expect(screen.getByPlaceholderText('Say something...')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText('Share helpful context or feedback...')
+    ).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Send'})).toBeInTheDocument();
   });
 

--- a/static/app/components/events/autofix/autofixMessageBox.tsx
+++ b/static/app/components/events/autofix/autofixMessageBox.tsx
@@ -409,7 +409,7 @@ function AutofixMessageBox({
                       onChange={e => setMessage(e.target.value)}
                       placeholder={
                         !isRootCauseSelectionStep
-                          ? 'Say something...'
+                          ? 'Share helpful context or feedback...'
                           : rootCauseMode === 'suggested_root_cause'
                             ? '(Optional) Provide any instructions for the fix...'
                             : 'Propose your own root cause...'

--- a/static/app/components/events/autofix/autofixSteps.spec.tsx
+++ b/static/app/components/events/autofix/autofixSteps.spec.tsx
@@ -190,7 +190,7 @@ describe('AutofixSteps', () => {
 
     render(<AutofixSteps {...propsWithChanges} />);
 
-    const input = screen.getByPlaceholderText('Say something...');
+    const input = screen.getByPlaceholderText('Share helpful context or feedback...');
     await userEvent.type(input, 'Feedback on changes');
     await userEvent.click(screen.getByRole('button', {name: 'Send'}));
 

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -34,6 +34,7 @@ interface StepProps {
   hasStepBelow: boolean;
   repos: AutofixRepository[];
   runId: string;
+  shouldHighlightRethink: boolean;
   step: AutofixStep;
 }
 
@@ -67,6 +68,7 @@ export function Step({
   hasStepBelow,
   hasStepAbove,
   hasErroredStepBefore,
+  shouldHighlightRethink,
 }: StepProps) {
   return (
     <StepCard>
@@ -90,6 +92,7 @@ export function Step({
                   stepIndex={step.index}
                   groupId={groupId}
                   runId={runId}
+                  shouldHighlightRethink={shouldHighlightRethink}
                 />
               )}
               {step.type === AutofixStepType.ROOT_CAUSE_ANALYSIS && (
@@ -249,6 +252,14 @@ export function AutofixSteps({data, groupId, runId}: AutofixStepsProps) {
             nextStep?.status === 'PROCESSING' &&
             nextStep?.insights?.length === 0;
 
+          const isNextStepLastStep = index === steps.length - 2;
+          const shouldHighlightRethink =
+            (nextStep?.type === AutofixStepType.ROOT_CAUSE_ANALYSIS &&
+              isNextStepLastStep) ||
+            (nextStep?.type === AutofixStepType.CHANGES &&
+              nextStep.changes.length > 0 &&
+              !nextStep.changes.every(change => change.pull_request));
+
           return (
             <div ref={el => (stepsRef.current[index] = el)} key={step.id}>
               {twoNonDefaultStepsInARow && <br />}
@@ -264,6 +275,7 @@ export function AutofixSteps({data, groupId, runId}: AutofixStepsProps) {
                 runId={runId}
                 repos={repos}
                 hasErroredStepBefore={previousStepErrored}
+                shouldHighlightRethink={shouldHighlightRethink}
               />
             </div>
           );


### PR DESCRIPTION
To make it clear to users that they can dive deeper or correct unsatisfactory results, when they reach a proposed-but-unconfirmed root cause or code change, we highlight the rethink buttons and show a message as a reminder.

This PR also updates the placeholder text to make it more clear what you can do with the rethink feature.

<img width="668" alt="Screenshot 2024-11-20 at 7 58 44 AM" src="https://github.com/user-attachments/assets/89086600-0ae4-42f0-9410-dbae11b3a5f6">
