### PR TITLE
ref(post-process): Use similarity project option instead of flag

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1205,8 +1205,8 @@ def process_plugins(job: PostProcessJob) -> None:
 
 
 def process_similarity(job: PostProcessJob) -> None:
-    if job["is_reprocessed"] or features.has(
-        "projects:similarity-embeddings", job["event"].group.project
+    if job["is_reprocessed"] or job["event"].group.project.get_option(
+        "sentry:similarity_backfill_completed"
     ):
         return
 

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2436,9 +2436,9 @@ class ProcessSimilarityTestMixin(BasePostProgressGroupMixin):
             return
         raise AssertionError("Expected safe_execute to not be called with similarity.record")
 
-    @with_feature("projects:similarity-embeddings")
     @patch("sentry.tasks.post_process.safe_execute")
     def test_skip_process_similarity(self, mock_safe_execute):
+        self.project.update_option("sentry:similarity_backfill_completed", int(time.time()))
         event = self.create_event(data={}, project_id=self.project.id)
 
         self.call_post_process_group(


### PR DESCRIPTION
Replace feature flag check with project option check
The feature flag handler checks the project option anyways, and was created to be used by the FE