### PR TITLE
styles(explore): Misaligned column editor labels

### DIFF
--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -238,7 +238,7 @@ const StyledCompactSelect = styled(CompactSelect)`
 const TriggerLabel = styled('span')`
   ${p => p.theme.overflowEllipsis}
   text-align: left;
-  line-height: normal;
+  line-height: 20px;
   display: flex;
   justify-content: space-between;
 `;


### PR DESCRIPTION
# Before

![image](https://github.com/user-attachments/assets/728e15ec-ae74-4211-81da-b1e12349932d)

# After

![image](https://github.com/user-attachments/assets/d8b2324b-1a40-45dc-b83b-9b117b2e1f47)