### PR TITLE
feat(rollback): Display dismissable banner in sidebar

### DIFF
--- a/static/app/actionCreators/prompts.tsx
+++ b/static/app/actionCreators/prompts.tsx
@@ -2,6 +2,7 @@ import {useCallback} from 'react';
 
 import type {Client} from 'sentry/api';
 import type {Organization, OrganizationSummary} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
 import {promptIsDismissed} from 'sentry/utils/promptIsDismissed';
 import type {ApiQueryKey, UseApiQueryOptions} from 'sentry/utils/queryClient';
 import {setApiQueryData, useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
@@ -41,7 +42,7 @@ type PromptCheckParams = {
    * The prompt feature name
    */
   feature: string | string[];
-  organization: OrganizationSummary;
+  organization: OrganizationSummary | null;
   /**
    * The numeric project ID as a string
    */
@@ -89,10 +90,10 @@ export async function promptsCheck(
 ): Promise<PromptData> {
   const query = {
     feature: params.feature,
-    organization_id: params.organization.id,
+    organization_id: params.organization?.id,
     ...(params.projectId === undefined ? {} : {project_id: params.projectId}),
   };
-  const url = `/organizations/${params.organization.slug}/prompts-activity/`;
+  const url = `/organizations/${params.organization?.slug}/prompts-activity/`;
   const response: PromptResponse = await api.requestPromise(url, {
     query,
   });
@@ -112,22 +113,23 @@ export const makePromptsCheckQueryKey = ({
   organization,
   projectId,
 }: PromptCheckParams): ApiQueryKey => {
-  const url = `/organizations/${organization.slug}/prompts-activity/`;
+  const url = `/organizations/${organization?.slug}/prompts-activity/`;
   return [
     url,
-    {query: {feature, organization_id: organization.id, project_id: projectId}},
+    {query: {feature, organization_id: organization?.id, project_id: projectId}},
   ];
 };
 
 export function usePromptsCheck(
   {feature, organization, projectId}: PromptCheckParams,
-  options: Partial<UseApiQueryOptions<PromptResponse>> = {}
+  {enabled = true, ...options}: Partial<UseApiQueryOptions<PromptResponse>> = {}
 ) {
   return useApiQuery<PromptResponse>(
     makePromptsCheckQueryKey({feature, organization, projectId}),
     {
       staleTime: 120000,
       retry: false,
+      enabled: defined(organization) && enabled,
       ...options,
     }
   );
@@ -141,7 +143,7 @@ export function usePrompt({
   options,
 }: {
   feature: string;
-  organization: Organization;
+  organization: Organization | null;
   daysToSnooze?: number;
   options?: Partial<UseApiQueryOptions<PromptResponse>>;
   projectId?: string;
@@ -162,6 +164,9 @@ export function usePrompt({
       : undefined;
 
   const dismissPrompt = useCallback(() => {
+    if (!organization) {
+      return;
+    }
     promptsUpdate(api, {
       organization,
       projectId,
@@ -189,6 +194,9 @@ export function usePrompt({
   }, [api, feature, organization, projectId, queryClient]);
 
   const snoozePrompt = useCallback(() => {
+    if (!organization) {
+      return;
+    }
     promptsUpdate(api, {
       organization,
       projectId,
@@ -216,6 +224,9 @@ export function usePrompt({
   }, [api, feature, organization, projectId, queryClient]);
 
   const showPrompt = useCallback(() => {
+    if (!organization) {
+      return;
+    }
     promptsUpdate(api, {
       organization,
       projectId,

--- a/static/app/components/sidebar/index.spec.tsx
+++ b/static/app/components/sidebar/index.spec.tsx
@@ -11,6 +11,7 @@ import {logout} from 'sentry/actionCreators/account';
 import {OnboardingContextProvider} from 'sentry/components/onboarding/onboardingContext';
 import SidebarContainer from 'sentry/components/sidebar';
 import ConfigStore from 'sentry/stores/configStore';
+import PreferenceStore from 'sentry/stores/preferencesStore';
 import type {Organization} from 'sentry/types/organization';
 import type {StatuspageIncident} from 'sentry/types/system';
 import localStorage from 'sentry/utils/localStorage';
@@ -440,6 +441,10 @@ describe('Sidebar', function () {
   });
 
   describe('Rollback prompts', () => {
+    beforeEach(() => {
+      PreferenceStore.showSidebar();
+    });
+
     it('should render the sidebar banner with no dismissed prompts and an existing rollback', async () => {
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/prompts-activity/`,
@@ -470,6 +475,26 @@ describe('Sidebar', function () {
       renderSidebarWithFeatures(['sentry-rollback-2024']);
 
       await screen.findByText('OS');
+
+      await waitFor(() => {
+        expect(screen.queryByText(/Your 2024 Rollback/)).not.toBeInTheDocument();
+      });
+    });
+
+    it('will not render sidebar banner when collapsed', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/prompts-activity/`,
+        body: {data: {}},
+      });
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/user-rollback/`,
+        body: {data: {}},
+      });
+
+      renderSidebarWithFeatures(['sentry-rollback-2024']);
+
+      await userEvent.click(screen.getByTestId('sidebar-collapse'));
 
       await waitFor(() => {
         expect(screen.queryByText(/Your 2024 Rollback/)).not.toBeInTheDocument();

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -721,7 +721,12 @@ function Sidebar() {
             )}
           </DropdownSidebarSection>
 
-          {!collapsed ? <DismissableRollbackBanner /> : null}
+          {organization ? (
+            <DismissableRollbackBanner
+              organization={organization}
+              collapsed={collapsed}
+            />
+          ) : null}
 
           <PrimaryItems>
             {hasOrganization && (

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -18,6 +18,7 @@ import {
   ExpandedContextProvider,
 } from 'sentry/components/sidebar/expandedContextProvider';
 import {NewOnboardingStatus} from 'sentry/components/sidebar/newOnboardingStatus';
+import {DismissableRollbackBanner} from 'sentry/components/sidebar/rollback/dismissableBanner';
 import {isDone} from 'sentry/components/sidebar/utils';
 import {
   IconDashboard,
@@ -719,6 +720,8 @@ function Sidebar() {
               <Hook name="component:superuser-warning" organization={organization} />
             )}
           </DropdownSidebarSection>
+
+          {!collapsed ? <DismissableRollbackBanner /> : null}
 
           <PrimaryItems>
             {hasOrganization && (

--- a/static/app/components/sidebar/rollback/banner.tsx
+++ b/static/app/components/sidebar/rollback/banner.tsx
@@ -2,24 +2,22 @@ import styled from '@emotion/styled';
 
 import {Button, LinkButton} from 'sentry/components/button';
 import Panel from 'sentry/components/panels/panel';
-import {useRollbackPrompts} from 'sentry/components/sidebar/rollback/useRollbackPrompts';
 import {IconClose, IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import useOrganization from 'sentry/utils/useOrganization';
+import type {Organization} from 'sentry/types/organization';
 
-type RollbackBannerProps = {className?: string; dismissable?: boolean};
+type RollbackBannerProps = {
+  organization: Organization;
+  className?: string;
+  handleDismiss?: () => void;
+};
 
-export function RollbackBanner({className, dismissable}: RollbackBannerProps) {
-  const organization = useOrganization();
-  const {shouldShowSidebarBanner, onDismissSidebarBanner} = useRollbackPrompts({
-    collapsed: false,
-  });
-
-  if (!shouldShowSidebarBanner) {
-    return null;
-  }
-
+export function RollbackBanner({
+  className,
+  handleDismiss,
+  organization,
+}: RollbackBannerProps) {
   return (
     <StyledPanel className={className}>
       <Title>🥳 {t('Your 2024 Rollback')}</Title>
@@ -37,17 +35,17 @@ export function RollbackBanner({className, dismissable}: RollbackBannerProps) {
       >
         {t('View My Rollback')}
       </RollbackButton>
-      {dismissable && (
+      {handleDismiss ? (
         <DismissButton
           icon={<IconClose />}
           aria-label={t('Dismiss')}
-          onClick={onDismissSidebarBanner}
+          onClick={handleDismiss}
           size="xs"
           borderless
           analyticsEventKey="rollback.sidebar_dismiss_clicked"
           analyticsEventName="Rollback: Sidebar Dismiss Clicked"
         />
-      )}
+      ) : null}
     </StyledPanel>
   );
 }

--- a/static/app/components/sidebar/rollback/banner.tsx
+++ b/static/app/components/sidebar/rollback/banner.tsx
@@ -3,24 +3,13 @@ import styled from '@emotion/styled';
 import {usePrompt} from 'sentry/actionCreators/prompts';
 import {Button, LinkButton} from 'sentry/components/button';
 import Panel from 'sentry/components/panels/panel';
+import {useRollback} from 'sentry/components/sidebar/rollback/useRollback';
 import {IconClose, IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
 type RollbackBannerProps = {className?: string; dismissable?: boolean};
-
-function useRollback() {
-  const organization = useOrganization();
-
-  return useApiQuery([`/organizations/${organization.slug}/user-rollback/`], {
-    staleTime: Infinity,
-    retry: false,
-    enabled: organization.features.includes('sentry-rollback-2024'),
-    retryOnMount: false,
-  });
-}
 
 export function RollbackBanner({className, dismissable}: RollbackBannerProps) {
   const organization = useOrganization();

--- a/static/app/components/sidebar/rollback/banner.tsx
+++ b/static/app/components/sidebar/rollback/banner.tsx
@@ -1,9 +1,8 @@
 import styled from '@emotion/styled';
 
-import {usePrompt} from 'sentry/actionCreators/prompts';
 import {Button, LinkButton} from 'sentry/components/button';
 import Panel from 'sentry/components/panels/panel';
-import {useRollback} from 'sentry/components/sidebar/rollback/useRollback';
+import {useRollbackPrompts} from 'sentry/components/sidebar/rollback/useRollbackPrompts';
 import {IconClose, IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -13,14 +12,11 @@ type RollbackBannerProps = {className?: string; dismissable?: boolean};
 
 export function RollbackBanner({className, dismissable}: RollbackBannerProps) {
   const organization = useOrganization();
-  const {data} = useRollback();
-
-  const {dismissPrompt, isPromptDismissed} = usePrompt({
-    feature: 'rollback_2024_sidebar',
-    organization,
+  const {shouldShowSidebarBanner, onDismissSidebarBanner} = useRollbackPrompts({
+    collapsed: false,
   });
 
-  if (!data || (dismissable && isPromptDismissed)) {
+  if (!shouldShowSidebarBanner) {
     return null;
   }
 
@@ -45,7 +41,7 @@ export function RollbackBanner({className, dismissable}: RollbackBannerProps) {
         <DismissButton
           icon={<IconClose />}
           aria-label={t('Dismiss')}
-          onClick={dismissPrompt}
+          onClick={onDismissSidebarBanner}
           size="xs"
           borderless
           analyticsEventKey="rollback.sidebar_dismiss_clicked"

--- a/static/app/components/sidebar/rollback/dismissableBanner.tsx
+++ b/static/app/components/sidebar/rollback/dismissableBanner.tsx
@@ -1,18 +1,38 @@
 import styled from '@emotion/styled';
 
 import {RollbackBanner} from 'sentry/components/sidebar/rollback/banner';
+import {useRollbackPrompts} from 'sentry/components/sidebar/rollback/useRollbackPrompts';
 import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {space} from 'sentry/styles/space';
+import type {Organization} from 'sentry/types/organization';
 
-export function DismissableRollbackBanner() {
+type DismissableRollbackBannerProps = {collapsed: boolean; organization: Organization};
+
+export function DismissableRollbackBanner({
+  collapsed,
+  organization,
+}: DismissableRollbackBannerProps) {
   const config = useLegacyStore(ConfigStore);
 
   const isDarkMode = config.theme === 'dark';
 
+  const {shouldShowSidebarBanner, onDismissSidebarBanner} = useRollbackPrompts({
+    collapsed,
+    organization,
+  });
+
+  if (!shouldShowSidebarBanner || !organization) {
+    return null;
+  }
+
   return (
     <Wrapper>
-      <TranslucentBackgroundBanner dismissable isDarkMode={isDarkMode} />
+      <TranslucentBackgroundBanner
+        organization={organization}
+        isDarkMode={isDarkMode}
+        handleDismiss={onDismissSidebarBanner}
+      />
     </Wrapper>
   );
 }

--- a/static/app/components/sidebar/rollback/dismissableBanner.tsx
+++ b/static/app/components/sidebar/rollback/dismissableBanner.tsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+
+import {RollbackBanner} from 'sentry/components/sidebar/rollback/banner';
+import ConfigStore from 'sentry/stores/configStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import {space} from 'sentry/styles/space';
+
+type Props = {};
+
+export function DismissableRollbackBanner({}: Props) {
+  const config = useLegacyStore(ConfigStore);
+
+  const isDarkMode = config.theme === 'dark';
+
+  return (
+    <Wrapper>
+      <TranslucentBackgroundBanner dismissable isDarkMode={isDarkMode} />
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled('div')`
+  padding: 0 ${space(1)};
+`;
+
+const TranslucentBackgroundBanner = styled(RollbackBanner)<{isDarkMode: boolean}>`
+  position: relative;
+  background: rgba(245, 243, 247, ${p => (p.isDarkMode ? 0.05 : 0.1)});
+  border: 1px solid rgba(245, 243, 247, ${p => (p.isDarkMode ? 0.1 : 0.15)});
+  color: ${p => (p.isDarkMode ? p.theme.textColor : '#ebe6ef')};
+  margin: ${space(0.5)} ${space(1)};
+`;

--- a/static/app/components/sidebar/rollback/dismissableBanner.tsx
+++ b/static/app/components/sidebar/rollback/dismissableBanner.tsx
@@ -5,9 +5,7 @@ import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {space} from 'sentry/styles/space';
 
-type Props = {};
-
-export function DismissableRollbackBanner({}: Props) {
+export function DismissableRollbackBanner() {
   const config = useLegacyStore(ConfigStore);
 
   const isDarkMode = config.theme === 'dark';

--- a/static/app/components/sidebar/rollback/notificationDot.tsx
+++ b/static/app/components/sidebar/rollback/notificationDot.tsx
@@ -1,19 +1,7 @@
 import styled from '@emotion/styled';
 
-import {useRollbackPrompts} from 'sentry/components/sidebar/rollback/useRollbackPrompts';
-
-type RollbackNotificationDotProps = {
-  collapsed: boolean;
-};
-
-export function RollbackNotificationDot({collapsed}: RollbackNotificationDotProps) {
-  const {shouldShowDot} = useRollbackPrompts({collapsed});
-
-  if (!shouldShowDot) {
-    return null;
-  }
-
-  return <Dot />;
+export function RollbackNotificationDot() {
+  return <Dot data-test-id="rollback-notification-dot" />;
 }
 
 const Dot = styled('div')`

--- a/static/app/components/sidebar/rollback/notificationDot.tsx
+++ b/static/app/components/sidebar/rollback/notificationDot.tsx
@@ -1,0 +1,40 @@
+import styled from '@emotion/styled';
+
+import {usePrompt} from 'sentry/actionCreators/prompts';
+import {useRollback} from 'sentry/components/sidebar/rollback/useRollback';
+import useOrganization from 'sentry/utils/useOrganization';
+
+type RollbackNotificationDotProps = {
+  collapsed: boolean;
+};
+
+export function RollbackNotificationDot({collapsed}: RollbackNotificationDotProps) {
+  const organization = useOrganization();
+  const {data} = useRollback();
+
+  const {isPromptDismissed: isSidebarPromptDismissed} = usePrompt({
+    feature: 'rollback_2024_sidebar',
+    organization,
+  });
+
+  const {isPromptDismissed: isDropdownPromptDismissed} = usePrompt({
+    feature: 'rollback_2024_dropdown',
+    organization,
+  });
+
+  if (!data || isDropdownPromptDismissed || (!collapsed && !isSidebarPromptDismissed)) {
+    return null;
+  }
+
+  return <Dot />;
+}
+
+const Dot = styled('div')`
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  position: absolute;
+  background-color: #ff45a8;
+  left: 25px;
+  top: -2px;
+`;

--- a/static/app/components/sidebar/rollback/notificationDot.tsx
+++ b/static/app/components/sidebar/rollback/notificationDot.tsx
@@ -1,28 +1,15 @@
 import styled from '@emotion/styled';
 
-import {usePrompt} from 'sentry/actionCreators/prompts';
-import {useRollback} from 'sentry/components/sidebar/rollback/useRollback';
-import useOrganization from 'sentry/utils/useOrganization';
+import {useRollbackPrompts} from 'sentry/components/sidebar/rollback/useRollbackPrompts';
 
 type RollbackNotificationDotProps = {
   collapsed: boolean;
 };
 
 export function RollbackNotificationDot({collapsed}: RollbackNotificationDotProps) {
-  const organization = useOrganization();
-  const {data} = useRollback();
+  const {shouldShowDot} = useRollbackPrompts({collapsed});
 
-  const {isPromptDismissed: isSidebarPromptDismissed} = usePrompt({
-    feature: 'rollback_2024_sidebar',
-    organization,
-  });
-
-  const {isPromptDismissed: isDropdownPromptDismissed} = usePrompt({
-    feature: 'rollback_2024_dropdown',
-    organization,
-  });
-
-  if (!data || isDropdownPromptDismissed || (!collapsed && !isSidebarPromptDismissed)) {
+  if (!shouldShowDot) {
     return null;
   }
 

--- a/static/app/components/sidebar/rollback/useRollback.tsx
+++ b/static/app/components/sidebar/rollback/useRollback.tsx
@@ -1,0 +1,13 @@
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export function useRollback() {
+  const organization = useOrganization();
+
+  return useApiQuery([`/organizations/${organization.slug}/user-rollback/`], {
+    staleTime: Infinity,
+    retry: false,
+    enabled: organization.features.includes('sentry-rollback-2024'),
+    retryOnMount: false,
+  });
+}

--- a/static/app/components/sidebar/rollback/useRollback.tsx
+++ b/static/app/components/sidebar/rollback/useRollback.tsx
@@ -1,13 +1,11 @@
+import type {Organization} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import useOrganization from 'sentry/utils/useOrganization';
 
-export function useRollback() {
-  const organization = useOrganization();
-
-  return useApiQuery([`/organizations/${organization.slug}/user-rollback/`], {
+export function useRollback({organization}: {organization: Organization | null}) {
+  return useApiQuery([`/organizations/${organization?.slug}/user-rollback/`], {
     staleTime: Infinity,
     retry: false,
-    enabled: organization.features.includes('sentry-rollback-2024'),
+    enabled: organization?.features.includes('sentry-rollback-2024') ?? false,
     retryOnMount: false,
   });
 }

--- a/static/app/components/sidebar/rollback/useRollbackPrompts.tsx
+++ b/static/app/components/sidebar/rollback/useRollbackPrompts.tsx
@@ -1,0 +1,46 @@
+import {usePrompt} from 'sentry/actionCreators/prompts';
+import {useRollback} from 'sentry/components/sidebar/rollback/useRollback';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export function useRollbackPrompts({collapsed}: {collapsed: boolean}) {
+  const organization = useOrganization();
+  const hasRollback = organization.features.includes('sentry-rollback-2024');
+  const {data} = useRollback();
+
+  const {
+    isPromptDismissed: isSidebarPromptDismissed,
+    dismissPrompt: dismissSidebarPrompt,
+  } = usePrompt({
+    feature: 'rollback_2024_sidebar',
+    organization,
+    options: {enabled: hasRollback},
+  });
+
+  const {
+    isPromptDismissed: isDropdownPromptDismissed,
+    dismissPrompt: dismissDropdownPrompt,
+  } = usePrompt({
+    feature: 'rollback_2024_dropdown',
+    organization,
+    options: {enabled: hasRollback},
+  });
+
+  return {
+    shouldShowSidebarBanner: hasRollback && data && !isSidebarPromptDismissed,
+    shouldShowDot:
+      hasRollback &&
+      data &&
+      isDropdownPromptDismissed === false &&
+      (collapsed || isSidebarPromptDismissed),
+    onOpenOrgDropdown: () => {
+      if (
+        hasRollback &&
+        isSidebarPromptDismissed === true &&
+        isDropdownPromptDismissed === false
+      ) {
+        dismissDropdownPrompt();
+      }
+    },
+    onDismissSidebarBanner: dismissSidebarPrompt,
+  };
+}

--- a/static/app/components/sidebar/rollback/useRollbackPrompts.tsx
+++ b/static/app/components/sidebar/rollback/useRollbackPrompts.tsx
@@ -31,7 +31,8 @@ export function useRollbackPrompts({
   });
 
   return {
-    shouldShowSidebarBanner: hasRollback && data && isSidebarPromptDismissed === false,
+    shouldShowSidebarBanner:
+      hasRollback && data && !collapsed && isSidebarPromptDismissed === false,
     shouldShowDropdownBanner: hasRollback && data,
     shouldShowDot:
       hasRollback &&

--- a/static/app/components/sidebar/rollback/useRollbackPrompts.tsx
+++ b/static/app/components/sidebar/rollback/useRollbackPrompts.tsx
@@ -1,11 +1,16 @@
 import {usePrompt} from 'sentry/actionCreators/prompts';
 import {useRollback} from 'sentry/components/sidebar/rollback/useRollback';
-import useOrganization from 'sentry/utils/useOrganization';
+import type {Organization} from 'sentry/types/organization';
 
-export function useRollbackPrompts({collapsed}: {collapsed: boolean}) {
-  const organization = useOrganization();
-  const hasRollback = organization.features.includes('sentry-rollback-2024');
-  const {data} = useRollback();
+export function useRollbackPrompts({
+  collapsed,
+  organization,
+}: {
+  collapsed: boolean;
+  organization: Organization | null;
+}) {
+  const hasRollback = organization?.features.includes('sentry-rollback-2024') ?? false;
+  const {data} = useRollback({organization});
 
   const {
     isPromptDismissed: isSidebarPromptDismissed,
@@ -26,7 +31,8 @@ export function useRollbackPrompts({collapsed}: {collapsed: boolean}) {
   });
 
   return {
-    shouldShowSidebarBanner: hasRollback && data && !isSidebarPromptDismissed,
+    shouldShowSidebarBanner: hasRollback && data && isSidebarPromptDismissed === false,
+    shouldShowDropdownBanner: hasRollback && data,
     shouldShowDot:
       hasRollback &&
       data &&

--- a/static/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {logout} from 'sentry/actionCreators/account';
+import {usePrompt} from 'sentry/actionCreators/prompts';
 import DemoModeGate from 'sentry/components/acl/demoModeGate';
 import Avatar from 'sentry/components/avatar';
 import {Chevron} from 'sentry/components/chevron';
@@ -10,6 +11,7 @@ import Hook from 'sentry/components/hook';
 import IdBadge from 'sentry/components/idBadge';
 import Link from 'sentry/components/links/link';
 import {RollbackBanner} from 'sentry/components/sidebar/rollback/banner';
+import {RollbackNotificationDot} from 'sentry/components/sidebar/rollback/notificationDot';
 import SidebarDropdownMenu from 'sentry/components/sidebar/sidebarDropdownMenu.styled';
 import SidebarMenuItem, {menuItemStyles} from 'sentry/components/sidebar/sidebarMenuItem';
 import SidebarOrgSummary from 'sentry/components/sidebar/sidebarOrgSummary';
@@ -39,6 +41,7 @@ type Props = Pick<CommonSidebarProps, 'orientation' | 'collapsed'> & {
 
 export default function SidebarDropdown({orientation, collapsed, hideOrgLinks}: Props) {
   const api = useApi();
+  const organization = useOrganization();
 
   const config = useLegacyStore(ConfigStore);
   const org = useOrganization({allowNull: true});
@@ -54,6 +57,11 @@ export default function SidebarDropdown({orientation, collapsed, hideOrgLinks}: 
   const hasMemberRead = org?.access?.includes('member:read');
   const hasTeamRead = org?.access?.includes('team:read');
   const canCreateOrg = ConfigStore.get('features').has('organizations:create');
+
+  const {dismissPrompt} = usePrompt({
+    feature: 'rollback_2024_dropdown',
+    organization,
+  });
 
   function handleLogout() {
     logout(api);
@@ -76,7 +84,7 @@ export default function SidebarDropdown({orientation, collapsed, hideOrgLinks}: 
     );
 
   return (
-    <DeprecatedDropdownMenu>
+    <DeprecatedDropdownMenu onOpen={dismissPrompt}>
       {({isOpen, getRootProps, getActorProps, getMenuProps}) => (
         <SidebarDropdownRoot {...getRootProps()}>
           <SidebarDropdownActor
@@ -84,7 +92,10 @@ export default function SidebarDropdown({orientation, collapsed, hideOrgLinks}: 
             data-test-id="sidebar-dropdown"
             {...getActorProps({})}
           >
-            {avatar}
+            <AvatarWrapper>
+              {avatar}
+              <RollbackNotificationDot collapsed={collapsed} />
+            </AvatarWrapper>
             {!collapsed && orientation !== 'top' && (
               <OrgAndUserWrapper>
                 <OrgOrUserName>
@@ -264,4 +275,8 @@ const OrgAndUserMenu = styled('div')`
 
 const StyledChevron = styled(Chevron)`
   transform: translateY(${space(0.25)});
+`;
+
+const AvatarWrapper = styled('div')`
+  position: relative;
 `;

--- a/static/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.tsx
@@ -2,7 +2,6 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {logout} from 'sentry/actionCreators/account';
-import {usePrompt} from 'sentry/actionCreators/prompts';
 import DemoModeGate from 'sentry/components/acl/demoModeGate';
 import Avatar from 'sentry/components/avatar';
 import {Chevron} from 'sentry/components/chevron';
@@ -12,6 +11,7 @@ import IdBadge from 'sentry/components/idBadge';
 import Link from 'sentry/components/links/link';
 import {RollbackBanner} from 'sentry/components/sidebar/rollback/banner';
 import {RollbackNotificationDot} from 'sentry/components/sidebar/rollback/notificationDot';
+import {useRollbackPrompts} from 'sentry/components/sidebar/rollback/useRollbackPrompts';
 import SidebarDropdownMenu from 'sentry/components/sidebar/sidebarDropdownMenu.styled';
 import SidebarMenuItem, {menuItemStyles} from 'sentry/components/sidebar/sidebarMenuItem';
 import SidebarOrgSummary from 'sentry/components/sidebar/sidebarOrgSummary';
@@ -41,7 +41,6 @@ type Props = Pick<CommonSidebarProps, 'orientation' | 'collapsed'> & {
 
 export default function SidebarDropdown({orientation, collapsed, hideOrgLinks}: Props) {
   const api = useApi();
-  const organization = useOrganization();
 
   const config = useLegacyStore(ConfigStore);
   const org = useOrganization({allowNull: true});
@@ -58,9 +57,8 @@ export default function SidebarDropdown({orientation, collapsed, hideOrgLinks}: 
   const hasTeamRead = org?.access?.includes('team:read');
   const canCreateOrg = ConfigStore.get('features').has('organizations:create');
 
-  const {dismissPrompt} = usePrompt({
-    feature: 'rollback_2024_dropdown',
-    organization,
+  const {onOpenOrgDropdown} = useRollbackPrompts({
+    collapsed,
   });
 
   function handleLogout() {
@@ -84,7 +82,7 @@ export default function SidebarDropdown({orientation, collapsed, hideOrgLinks}: 
     );
 
   return (
-    <DeprecatedDropdownMenu onOpen={dismissPrompt}>
+    <DeprecatedDropdownMenu onOpen={onOpenOrgDropdown}>
       {({isOpen, getRootProps, getActorProps, getMenuProps}) => (
         <SidebarDropdownRoot {...getRootProps()}>
           <SidebarDropdownActor

--- a/static/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.tsx
@@ -57,9 +57,12 @@ export default function SidebarDropdown({orientation, collapsed, hideOrgLinks}: 
   const hasTeamRead = org?.access?.includes('team:read');
   const canCreateOrg = ConfigStore.get('features').has('organizations:create');
 
-  const {onOpenOrgDropdown} = useRollbackPrompts({
-    collapsed,
-  });
+  const {onOpenOrgDropdown, shouldShowDropdownBanner, shouldShowDot} = useRollbackPrompts(
+    {
+      collapsed,
+      organization: org,
+    }
+  );
 
   function handleLogout() {
     logout(api);
@@ -92,7 +95,7 @@ export default function SidebarDropdown({orientation, collapsed, hideOrgLinks}: 
           >
             <AvatarWrapper>
               {avatar}
-              <RollbackNotificationDot collapsed={collapsed} />
+              {shouldShowDot ? <RollbackNotificationDot /> : null}
             </AvatarWrapper>
             {!collapsed && orientation !== 'top' && (
               <OrgAndUserWrapper>
@@ -112,7 +115,9 @@ export default function SidebarDropdown({orientation, collapsed, hideOrgLinks}: 
               {hasOrganization && (
                 <Fragment>
                   <SidebarOrgSummary organization={org} projectCount={projects.length} />
-                  <RollbackBanner />
+                  {org && shouldShowDropdownBanner ? (
+                    <RollbackBanner organization={org} />
+                  ) : null}
                   {!hideOrgLinks && (
                     <Fragment>
                       {hasOrgRead && (


### PR DESCRIPTION
With the rollback flag, displays a banner on the sidebar itself to draw attention to the feature. When dismissed, it will display a dot on the org dropdown to show the user that the rollback is still available in the dropdown. Once that is opened, the dot will go away.

https://github.com/user-attachments/assets/9099bd39-3047-4927-8360-ef968954f6d2

