### PR TITLE
fix(tagstore): Allow flag to overwrite logic

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -442,14 +442,13 @@ class SnubaTagStorage(TagStorage):
         organization = Organization.objects.get_from_cache(id=organization_id)
         if features.has("organizations:tag-key-sample-n", organization):
             optimize_kwargs["sample"] = options.get("visibility.tag-key-sample-size")
-
         # If we are fetching less than max_unsampled_projects, then disable
         # the sampling that turbo enables so that we get more accurate results.
         # We only want sampling when we have a large number of projects, so
         # that we don't cause performance issues for Snuba.
         # We also see issues with long timeranges in large projects,
         # So only disable sampling if the timerange is short enough.
-        if len(projects) <= max_unsampled_projects and end - start <= timedelta(days=14):
+        elif len(projects) <= max_unsampled_projects and end - start <= timedelta(days=14):
             optimize_kwargs["sample"] = 1
 
         # Replays doesn't support sampling.


### PR DESCRIPTION
- The existing small # of projects & short date range should not overwrite the feature flag that samples, since the numeric sample rate should still work fine for smaller orgs