### PR TITLE
ref(dashboards): Move widget type to parameter when adding to dashboard

### DIFF
--- a/static/app/views/discover/queryList.tsx
+++ b/static/app/views/discover/queryList.tsx
@@ -26,6 +26,7 @@ import withApi from 'sentry/utils/withApi';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 
 import {
+  getSavedQueryDataset,
   getSavedQueryWithDataset,
   handleCreateQuery,
   handleDeleteQuery,
@@ -33,7 +34,11 @@ import {
 } from './savedQuery/utils';
 import MiniGraph from './miniGraph';
 import QueryCard from './querycard';
-import {getPrebuiltQueries, handleAddQueryToDashboard} from './utils';
+import {
+  getPrebuiltQueries,
+  handleAddQueryToDashboard,
+  SAVED_QUERY_DATASET_TO_WIDGET_TYPE,
+} from './utils';
 
 type Props = {
   api: Client;
@@ -185,6 +190,11 @@ class QueryList extends Component<Props> {
               organization,
               yAxis: view?.yAxis,
               router,
+              widgetType: hasDatasetSelector(organization)
+                ? SAVED_QUERY_DATASET_TO_WIDGET_TYPE[
+                    getSavedQueryDataset(organization, location, newQuery)
+                  ]
+                : undefined,
             }),
         },
         {
@@ -275,6 +285,11 @@ class QueryList extends Component<Props> {
                     organization,
                     yAxis: savedQuery?.yAxis ?? eventView.yAxis,
                     router,
+                    widgetType: hasDatasetSelector(organization)
+                      ? SAVED_QUERY_DATASET_TO_WIDGET_TYPE[
+                          getSavedQueryDataset(organization, location, savedQuery)
+                        ]
+                      : undefined,
                   }),
               },
             ]

--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -36,12 +36,16 @@ import useOverlay from 'sentry/utils/useOverlay';
 import withApi from 'sentry/utils/withApi';
 import withProjects from 'sentry/utils/withProjects';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
-import {handleAddQueryToDashboard} from 'sentry/views/discover/utils';
+import {
+  handleAddQueryToDashboard,
+  SAVED_QUERY_DATASET_TO_WIDGET_TYPE,
+} from 'sentry/views/discover/utils';
 
 import {DEFAULT_EVENT_VIEW} from '../data';
 
 import {
   getDatasetFromLocationOrSavedQueryDataset,
+  getSavedQueryDataset,
   handleCreateQuery,
   handleDeleteQuery,
   handleResetHomepageQuery,
@@ -449,6 +453,11 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
             query: savedQuery,
             yAxis,
             router,
+            widgetType: hasDatasetSelector(organization)
+              ? SAVED_QUERY_DATASET_TO_WIDGET_TYPE[
+                  getSavedQueryDataset(organization, location, savedQuery)
+                ]
+              : undefined,
           })
         }
       >

--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -577,6 +577,11 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
             query: savedQuery,
             yAxis,
             router,
+            widgetType: hasDatasetSelector(organization)
+              ? SAVED_QUERY_DATASET_TO_WIDGET_TYPE[
+                  getSavedQueryDataset(organization, location, savedQuery)
+                ]
+              : undefined,
           });
         },
       });

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -48,7 +48,6 @@ import {getTitle} from 'sentry/utils/events';
 import {DISCOVER_FIELDS, FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
 import localStorage from 'sentry/utils/localStorage';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 
 import {
   DashboardWidgetSource,
@@ -58,7 +57,7 @@ import {
 } from '../dashboards/types';
 import {transactionSummaryRouteWithQuery} from '../performance/transactionSummary/utils';
 
-import {displayModeToDisplayType, getSavedQueryDataset} from './savedQuery/utils';
+import {displayModeToDisplayType} from './savedQuery/utils';
 import type {FieldValue, TableColumn} from './table/types';
 import {FieldValueKind} from './table/types';
 import {getAllViews, getTransactionViews, getWebVitalsViews} from './data';
@@ -688,12 +687,14 @@ export function handleAddQueryToDashboard({
   organization,
   router,
   yAxis,
+  widgetType,
 }: {
   eventView: EventView;
   location: Location;
   organization: Organization;
   router: InjectedRouter;
   query?: NewQuery;
+  widgetType?: WidgetType;
   yAxis?: string | string[];
 }) {
   const displayType = displayModeToDisplayType(eventView.display as DisplayModes);
@@ -703,14 +704,13 @@ export function handleAddQueryToDashboard({
     yAxis,
   });
 
-  const dataset = getSavedQueryDataset(organization, location, query);
-
   const {query: widgetAsQueryParams} = constructAddQueryToDashboardLink({
     eventView,
     query,
     organization,
     yAxis,
     location,
+    widgetType,
   });
   openAddToDashboardModal({
     organization,
@@ -738,9 +738,7 @@ export function handleAddQueryToDashboard({
         displayType === DisplayType.TOP_N
           ? Number(eventView.topEvents) || TOP_N
           : undefined,
-      widgetType: hasDatasetSelector(organization)
-        ? SAVED_QUERY_DATASET_TO_WIDGET_TYPE[dataset]
-        : undefined,
+      widgetType,
     },
     router,
     widgetAsQueryParams,
@@ -792,11 +790,13 @@ export function constructAddQueryToDashboardLink({
   organization,
   yAxis,
   location,
+  widgetType,
 }: {
   eventView: EventView;
   organization: Organization;
   location?: Location;
   query?: NewQuery;
+  widgetType?: WidgetType;
   yAxis?: string | string[];
 }) {
   const displayType = displayModeToDisplayType(eventView.display as DisplayModes);
@@ -806,7 +806,6 @@ export function constructAddQueryToDashboardLink({
     displayType,
     yAxis,
   });
-  const dataset = getSavedQueryDataset(organization, location, query);
 
   const defaultTitle =
     query?.name ?? (eventView.name !== 'All Events' ? eventView.name : undefined);
@@ -823,9 +822,7 @@ export function constructAddQueryToDashboardLink({
       defaultTableColumns: defaultTableFields,
       defaultTitle,
       displayType: displayType === DisplayType.TOP_N ? DisplayType.AREA : displayType,
-      dataset: hasDatasetSelector(organization)
-        ? SAVED_QUERY_DATASET_TO_WIDGET_TYPE[dataset]
-        : undefined,
+      dataset: widgetType,
       limit:
         displayType === DisplayType.TOP_N
           ? Number(eventView.topEvents) || TOP_N

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -693,8 +693,8 @@ export function handleAddQueryToDashboard({
   location: Location;
   organization: Organization;
   router: InjectedRouter;
+  widgetType: WidgetType | undefined;
   query?: NewQuery;
-  widgetType?: WidgetType;
   yAxis?: string | string[];
 }) {
   const displayType = displayModeToDisplayType(eventView.display as DisplayModes);


### PR DESCRIPTION
This modal is coupled strongly with discover saved queries. Moving this up to a param so I could integrate it properly with Explore