### PR TITLE
chore(grouping): Deprecate all grouping configs but the current one

### DIFF
--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -20,7 +20,9 @@ logger = logging.getLogger("sentry.events.grouping")
 Job = MutableMapping[str, Any]
 
 # Used to migrate projects that have no activity via getsentry scripts
-CONFIGS_TO_DEPRECATE = ()
+CONFIGS_TO_DEPRECATE = set(CONFIGURATIONS.keys()) - {
+    DEFAULT_GROUPING_CONFIG,
+}
 
 
 def update_grouping_config_if_needed(project: Project, source: str) -> None:


### PR DESCRIPTION
This marks all but the current grouping config as deprecated, as a first step to using the [script in getsentry](https://github.com/getsentry/getsentry/blob/master/bin/upgrade_deprecated_grouping_configs.py) to force all inactive projects onto the current config. (Active projects are all already on the new config, because as soon as we see an event from a project, we upgrade its config.)

Once the script has been run and all projects have been migrated, we can wait the requisite 30 days (for all transition periods to end) and then we can delete the two older `newstyle` configs, along with all of their snapshots. (We'll keep the legacy config because a) we need at least one config besides the current one in order to be able to test grouping config transition, and b) we need that extra config to be different enough from the current config to predictably generate different hashes from the same data (so keeping another `newstyle` config won't do).