### PR TITLE
fix(issue-details): Minor style fixes

### DIFF
--- a/static/app/views/issueDetails/streamline/eventTitle.tsx
+++ b/static/app/views/issueDetails/streamline/eventTitle.tsx
@@ -263,7 +263,7 @@ const EventInfoJumpToWrapper = styled('div')`
   @media (min-width: ${p => p.theme.breakpoints.small}) {
     flex-wrap: nowrap;
   }
-  box-shadow: ${p => p.theme.translucentBorder} 0 1px;
+  border-bottom: 1px solid ${p => p.theme.translucentBorder};
 `;
 
 const EventInfo = styled('div')`

--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -184,7 +184,8 @@ const SectionExpander = styled('div')<{preventCollapse: boolean}>`
   display: grid;
   grid-template-columns: 1fr auto;
   align-items: center;
-  padding: ${space(1)} ${space(0.75)};
+  padding: ${space(0.5)} ${space(1.5)};
+  margin: 0 -${space(0.75)};
   border-radius: ${p => p.theme.borderRadius};
   cursor: ${p => (p.preventCollapse ? 'initial' : 'pointer')};
   position: relative;


### PR DESCRIPTION
Section headings margin adjustments:
<img width="1180" alt="image" src="https://github.com/user-attachments/assets/9f4986d4-ec33-43c1-8cd9-494d42154431">


Align headers in/out of drawers:
<img width="603" alt="image" src="https://github.com/user-attachments/assets/596488d6-a6e4-4715-8867-6ef3b8c5dbe2">
