### PR TITLE
fix(ui): use marked superclass renderers for images and links

### DIFF
--- a/static/app/utils/marked.spec.tsx
+++ b/static/app/utils/marked.spec.tsx
@@ -12,6 +12,10 @@ describe('marked', function () {
       ['[x](http://example.com)', '<a href="http://example.com">x</a>'],
       ['[x](https://example.com)', '<a href="https://example.com">x</a>'],
       ['[x](mailto:foo@example.com)', '<a href="mailto:foo@example.com">x</a>'],
+      [
+        '[x](https://example.com "Example Title")',
+        '<a href="https://example.com" title="Example Title">x</a>',
+      ],
     ]) {
       expectMarkdown(test);
     }
@@ -44,13 +48,19 @@ describe('marked', function () {
     }
   });
 
-  it('escapes XSS and removes invalid attributes on img', function () {
+  it('escapes injections', function () {
     [
       [
-        `[test](http://example.com\""#><img/onerror='alert\(location\)'/src=>)
-![test](http://example.com"/onerror='alert\(location\)'/)`,
-        `<a href="http://example.com"><img src="">"&gt;test</a>
-<img alt="test" src="http://example.com">`,
+        '[x<b>Bold</b>](https://evil.example.com)',
+        '<a href="https://evil.example.com">x&lt;b&gt;Bold&lt;/b&gt;</a>',
+      ],
+      [
+        '[x](https://evil.example.com"class="foo)',
+        '<a href="https://evil.example.com%22class=%22foo">x</a>',
+      ],
+      [
+        '[x](https://evil.example.com "class=\\"bar")',
+        '<a href="https://evil.example.com" title="class=&quot;bar">x</a>',
       ],
       [
         '<script> <img <script> src=x onerror=alert(1) />',

--- a/static/app/utils/marked.tsx
+++ b/static/app/utils/marked.tsx
@@ -39,7 +39,7 @@ class SafeRenderer extends marked.Renderer {
       return '';
     }
 
-    return `<img src="${href}" alt="${text}"${title ? ` title="${title}"` : ''} />`;
+    return super.image(href, title, text);
   }
 }
 

--- a/static/app/utils/marked.tsx
+++ b/static/app/utils/marked.tsx
@@ -29,7 +29,7 @@ class SafeRenderer extends marked.Renderer {
       return href;
     }
 
-    const out = `<a href="${href}"${title ? ` title="${title}"` : ''}>${text}</a>`;
+    const out = super.link(href, title, text);
     return dompurify.sanitize(out);
   }
 


### PR DESCRIPTION
Use marked superclass renderers instead of creating html manually.

Thank you @a2256014 for discovering the bug.