### PR TITLE
ref(transactions): add functionality to sample transactions in save_event_transaction

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2920,3 +2920,9 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+register(
+    "transactions.do_post_process_in_save",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE | FLAG_RATE,
+)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2926,9 +2926,3 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE | FLAG_RATE,
 )
-
-register(
-    "transactions.dont_do_transactions_logic_in_post_process",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE | FLAG_RATE,
-)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2926,3 +2926,9 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE | FLAG_RATE,
 )
+
+register(
+    "transactions.dont_do_transactions_logic_in_post_process",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE | FLAG_RATE,
+)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -613,7 +613,7 @@ def post_process_group(
         # This should eventually be completely removed and transactions
         # will not go through any post processing.
         if is_transaction_event and not in_rollout_group(
-            "transactions.do_post_process_in_save", event.project_id
+            "transactions.dont_do_transactions_logic_in_post_process", event.project_id
         ):
             record_transaction_name_for_clustering(event.project, event.data)
             with sentry_sdk.start_span(op="tasks.post_process_group.transaction_processed_signal"):

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -16,7 +16,6 @@ from google.api_core.exceptions import ServiceUnavailable
 from sentry import features, projectoptions
 from sentry.eventstream.types import EventStreamEventType
 from sentry.exceptions import PluginError
-from sentry.features.rollout import in_rollout_group
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.killswitches import killswitch_matches_context
@@ -612,9 +611,7 @@ def post_process_group(
         # Simplified post processing for transaction events.
         # This should eventually be completely removed and transactions
         # will not go through any post processing.
-        if is_transaction_event and not in_rollout_group(
-            "transactions.dont_do_transactions_logic_in_post_process", event.project_id
-        ):
+        if is_transaction_event:
             record_transaction_name_for_clustering(event.project, event.data)
             with sentry_sdk.start_span(op="tasks.post_process_group.transaction_processed_signal"):
                 transaction_processed.send_robust(

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -16,6 +16,7 @@ from sentry.attachments import attachment_cache
 from sentry.constants import DEFAULT_STORE_NORMALIZER_ARGS
 from sentry.datascrubbing import scrub_data
 from sentry.eventstore import processing
+from sentry.features.rollout import in_rollout_group
 from sentry.feedback.usecases.create_feedback import FeedbackCreationSource, create_feedback_issue
 from sentry.ingest.types import ConsumerType
 from sentry.killswitches import killswitch_matches_context
@@ -582,6 +583,14 @@ def _do_save_event(
             raise
 
         finally:
+            if consumer_type == ConsumerType.Transactions and in_rollout_group(
+                "transactions.do_post_process_in_save", project_id
+            ):
+                # we won't use the transaction data in post_process
+                # so we can delete it from the cache now.
+                if cache_key:
+                    processing_store.delete_by_key(cache_key)
+
             reprocessing2.mark_event_reprocessed(data)
             if cache_key and has_attachments:
                 attachment_cache.delete(cache_key)

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -583,8 +583,10 @@ def _do_save_event(
             raise
 
         finally:
-            if consumer_type == ConsumerType.Transactions and in_rollout_group(
-                "transactions.do_post_process_in_save", project_id
+            if (
+                consumer_type == ConsumerType.Transactions
+                and event_id
+                and in_rollout_group("transactions.do_post_process_in_save", event_id)
             ):
                 # we won't use the transaction data in post_process
                 # so we can delete it from the cache now.

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -49,6 +49,7 @@ from sentry.exceptions import HashDiscarded
 from sentry.grouping.api import load_grouping_config
 from sentry.grouping.utils import hash_from_values
 from sentry.ingest.inbound_filters import FilterStatKeys
+from sentry.ingest.transaction_clusterer import ClustererNamespace
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration import Integration
 from sentry.issues.grouptype import (
@@ -1539,6 +1540,133 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         spans = [{"hash": span["hash"]} for span in data["spans"]]
         # the basic strategy is to simply use the description
         assert spans == [{"hash": hash_values([span["description"]])} for span in data["spans"]]
+
+    @override_options({"transactions.do_post_process_in_save": 1.0})
+    def test_transaction_sampler_and_receive(self) -> None:
+        # make sure with the option on we don't get any errors
+        manager = EventManager(
+            make_event(
+                **{
+                    "transaction": "wait",
+                    "contexts": {
+                        "trace": {
+                            "parent_span_id": "bce14471e0e9654d",
+                            "op": "foobar",
+                            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                            "span_id": "bf5be759039ede9a",
+                        }
+                    },
+                    "spans": [
+                        {
+                            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                            "parent_span_id": "bf5be759039ede9a",
+                            "span_id": "a" * 16,
+                            "start_timestamp": 0,
+                            "timestamp": 1,
+                            "same_process_as_parent": True,
+                            "op": "default",
+                            "description": "span a",
+                        },
+                        {
+                            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                            "parent_span_id": "bf5be759039ede9a",
+                            "span_id": "b" * 16,
+                            "start_timestamp": 0,
+                            "timestamp": 1,
+                            "same_process_as_parent": True,
+                            "op": "default",
+                            "description": "span a",
+                        },
+                        {
+                            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                            "parent_span_id": "bf5be759039ede9a",
+                            "span_id": "c" * 16,
+                            "start_timestamp": 0,
+                            "timestamp": 1,
+                            "same_process_as_parent": True,
+                            "op": "default",
+                            "description": "span b",
+                        },
+                    ],
+                    "timestamp": "2019-06-14T14:01:40Z",
+                    "start_timestamp": "2019-06-14T14:01:40Z",
+                    "type": "transaction",
+                    "transaction_info": {
+                        "source": "url",
+                    },
+                }
+            )
+        )
+        manager.normalize()
+        manager.save(self.project.id)
+
+    @override_options({"transactions.do_post_process_in_save": 1.0})
+    @patch("sentry.signals.transaction_processed.send_robust")
+    @patch("sentry.ingest.transaction_clusterer.datasource.redis._record_sample")
+    def test_transaction_sampler_and_receive_mock_called(
+        self,
+        mock_record_sample: mock.MagicMock,
+        transaction_processed_signal_mock: mock.MagicMock,
+    ) -> None:
+        manager = EventManager(
+            make_event(
+                **{
+                    "transaction": "wait",
+                    "contexts": {
+                        "trace": {
+                            "parent_span_id": "bce14471e0e9654d",
+                            "op": "foobar",
+                            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                            "span_id": "bf5be759039ede9a",
+                        }
+                    },
+                    "spans": [
+                        {
+                            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                            "parent_span_id": "bf5be759039ede9a",
+                            "span_id": "a" * 16,
+                            "start_timestamp": 0,
+                            "timestamp": 1,
+                            "same_process_as_parent": True,
+                            "op": "default",
+                            "description": "span a",
+                        },
+                        {
+                            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                            "parent_span_id": "bf5be759039ede9a",
+                            "span_id": "b" * 16,
+                            "start_timestamp": 0,
+                            "timestamp": 1,
+                            "same_process_as_parent": True,
+                            "op": "default",
+                            "description": "span a",
+                        },
+                        {
+                            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                            "parent_span_id": "bf5be759039ede9a",
+                            "span_id": "c" * 16,
+                            "start_timestamp": 0,
+                            "timestamp": 1,
+                            "same_process_as_parent": True,
+                            "op": "default",
+                            "description": "span b",
+                        },
+                    ],
+                    "timestamp": "2019-06-14T14:01:40Z",
+                    "start_timestamp": "2019-06-14T14:01:40Z",
+                    "type": "transaction",
+                    "transaction_info": {
+                        "source": "url",
+                    },
+                }
+            )
+        )
+        manager.normalize()
+        manager.save(self.project.id)
+        assert transaction_processed_signal_mock.call_count == 1
+        assert mock_record_sample.mock_calls == [
+            mock.call(ClustererNamespace.TRANSACTIONS, self.project, "wait")
+        ]
 
     def test_sdk(self) -> None:
         manager = EventManager(make_event(**{"sdk": {"name": "sentry-unity", "version": "1.0"}}))

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -60,6 +60,7 @@ from sentry.tasks.merge import merge_groups
 from sentry.tasks.post_process import (
     HIGHER_ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT,
     ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT,
+    _get_event_id_from_cache_key,
     feedback_filter_decorator,
     locks,
     post_process_group,
@@ -2733,6 +2734,60 @@ class TransactionClustererTestCase(TestCase, SnubaTestCase):
         assert mock_store_transaction_name.mock_calls == [
             mock.call(ClustererNamespace.TRANSACTIONS, self.project, "foo")
         ]
+
+
+class ProcessingStoreTransactionEmptyTestcase(TestCase):
+    @patch("sentry.tasks.post_process.logger")
+    def test_logger_called_when_empty(self, mock_logger):
+        post_process_group(
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=False,
+            cache_key="e:1:2",
+            group_id=None,
+            project_id=self.project.id,
+            eventstream_type=EventStreamEventType.Transaction,
+        )
+        assert mock_logger.info.called
+        mock_logger.info.assert_called_with(
+            "post_process.skipped", extra={"cache_key": "e:1:2", "reason": "missing_cache"}
+        )
+
+    @patch("sentry.tasks.post_process.logger")
+    @patch("sentry.utils.metrics.incr")
+    @override_options({"transactions.do_post_process_in_save": 1.0})
+    def test_logger_called_when_empty_option_on(self, mock_metric_incr, mock_logger):
+        post_process_group(
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=False,
+            cache_key="e:1:2",
+            group_id=None,
+            project_id=self.project.id,
+            eventstream_type=EventStreamEventType.Transaction,
+        )
+        assert not mock_logger.info.called
+        mock_metric_incr.assert_called_with("post_process.skipped_do_post_process_in_save")
+
+    @patch("sentry.tasks.post_process.logger")
+    @override_options({"transactions.do_post_process_in_save": 1.0})
+    def test_logger_called_when_empty_option_on_invalid_cache_key(self, mock_logger):
+        post_process_group(
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=False,
+            cache_key="invalidhehe",
+            group_id=None,
+            project_id=self.project.id,
+            eventstream_type=EventStreamEventType.Transaction,
+        )
+        mock_logger.info.assert_called_with(
+            "post_process.skipped", extra={"cache_key": "invalidhehe", "reason": "missing_cache"}
+        )
+
+    def test_get_event_id_from_cache_key(self):
+        assert _get_event_id_from_cache_key("e:1:2") == "1"
+        assert _get_event_id_from_cache_key("invalid") is None
 
 
 class PostProcessGroupGenericTest(

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2735,7 +2735,7 @@ class TransactionClustererTestCase(TestCase, SnubaTestCase):
         ]
 
     @patch("sentry.ingest.transaction_clusterer.datasource.redis._record_sample")
-    @override_options({"transactions.do_post_process_in_save": 1.0})
+    @override_options({"transactions.dont_do_transactions_logic_in_post_process": 1.0})
     def test_process_transaction_event_clusterer_flag_on(
         self,
         mock_store_transaction_name,

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2734,41 +2734,6 @@ class TransactionClustererTestCase(TestCase, SnubaTestCase):
             mock.call(ClustererNamespace.TRANSACTIONS, self.project, "foo")
         ]
 
-    @patch("sentry.ingest.transaction_clusterer.datasource.redis._record_sample")
-    @override_options({"transactions.dont_do_transactions_logic_in_post_process": 1.0})
-    def test_process_transaction_event_clusterer_flag_on(
-        self,
-        mock_store_transaction_name,
-    ):
-        min_ago = before_now(minutes=1)
-        event = process_event(
-            data={
-                "project": self.project.id,
-                "event_id": "b" * 32,
-                "transaction": "foo",
-                "start_timestamp": str(min_ago),
-                "timestamp": str(min_ago),
-                "type": "transaction",
-                "transaction_info": {
-                    "source": "url",
-                },
-                "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
-            },
-            group_id=0,
-        )
-        cache_key = write_event_to_cache(event)
-        post_process_group(
-            is_new=False,
-            is_regression=False,
-            is_new_group_environment=False,
-            cache_key=cache_key,
-            group_id=None,
-            project_id=self.project.id,
-            eventstream_type=EventStreamEventType.Transaction,
-        )
-
-        assert mock_store_transaction_name.mock_calls == []
-
 
 class PostProcessGroupGenericTest(
     TestCase,

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2734,6 +2734,41 @@ class TransactionClustererTestCase(TestCase, SnubaTestCase):
             mock.call(ClustererNamespace.TRANSACTIONS, self.project, "foo")
         ]
 
+    @patch("sentry.ingest.transaction_clusterer.datasource.redis._record_sample")
+    @override_options({"transactions.do_post_process_in_save": 1.0})
+    def test_process_transaction_event_clusterer_flag_on(
+        self,
+        mock_store_transaction_name,
+    ):
+        min_ago = before_now(minutes=1)
+        event = process_event(
+            data={
+                "project": self.project.id,
+                "event_id": "b" * 32,
+                "transaction": "foo",
+                "start_timestamp": str(min_ago),
+                "timestamp": str(min_ago),
+                "type": "transaction",
+                "transaction_info": {
+                    "source": "url",
+                },
+                "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
+            },
+            group_id=0,
+        )
+        cache_key = write_event_to_cache(event)
+        post_process_group(
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=False,
+            cache_key=cache_key,
+            group_id=None,
+            project_id=self.project.id,
+            eventstream_type=EventStreamEventType.Transaction,
+        )
+
+        assert mock_store_transaction_name.mock_calls == []
+
 
 class PostProcessGroupGenericTest(
     TestCase,

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -398,6 +398,7 @@ def test_store_consumer_type(
         )
 
     mock_transaction_processing_store.get.assert_called_once_with("tx:3")
+    mock_transaction_processing_store.delete_by_key.assert_not_called()
 
 
 @django_db_all

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -14,6 +14,7 @@ from sentry.tasks.store import (
     save_event,
     save_event_transaction,
 )
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 
 EVENT_ID = "cc3e6c2bb6b6498097f336d1e6979f4b"
@@ -397,3 +398,34 @@ def test_store_consumer_type(
         )
 
     mock_transaction_processing_store.get.assert_called_once_with("tx:3")
+
+
+@django_db_all
+@override_options({"transactions.do_post_process_in_save": 1.0})
+def test_transactions_do_post_process_in_save_deletes_from_processing_store(
+    default_project,
+    mock_transaction_processing_store,
+):
+    transaction_data = {
+        "project": default_project.id,
+        "platform": "transaction",
+        "event_id": EVENT_ID,
+        "extra": {"foo": "bar"},
+        "timestamp": time(),
+        "start_timestamp": time() - 1,
+    }
+
+    mock_transaction_processing_store.get.return_value = transaction_data
+    mock_transaction_processing_store.store.return_value = "tx:3"
+
+    with mock.patch("sentry.event_manager.EventManager.save", return_value=None):
+        save_event_transaction(
+            cache_key="tx:3",
+            data=None,
+            start_time=1,
+            event_id=EVENT_ID,
+            project_id=default_project.id,
+        )
+
+    mock_transaction_processing_store.get.assert_called_once_with("tx:3")
+    mock_transaction_processing_store.delete_by_key.assert_called_once_with("tx:3")


### PR DESCRIPTION
first PR of https://github.com/getsentry/sentry/issues/81065

no behavior changes until option is turned on. need to change post_process as well before we can turn the option on. equivalent of https://github.com/getsentry/sentry/blob/b84d3d9238ab75822b076d16de1111c3035fe073/src/sentry/tasks/post_process.py#L614 in post_process