### PR TITLE
ref(transactions): option for not doing transactions sampling in post_process

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2919,6 +2919,7 @@ register(
     "performance.event-tracker.sample-rate.transaction",
     default=0.0,
 )
+
 register(
     "transactions.do_post_process_in_save",
     type=Bool,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2918,12 +2918,6 @@ register(
 register(
     "performance.event-tracker.sample-rate.transaction",
     default=0.0,
-)
-
-register(
-    "transactions.do_post_process_in_save",
-    type=Bool,
-    default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2918,6 +2918,11 @@ register(
 register(
     "performance.event-tracker.sample-rate.transaction",
     default=0.0,
+)
+register(
+    "transactions.do_post_process_in_save",
+    type=Bool,
+    default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2734,6 +2734,41 @@ class TransactionClustererTestCase(TestCase, SnubaTestCase):
             mock.call(ClustererNamespace.TRANSACTIONS, self.project, "foo")
         ]
 
+    @patch("sentry.ingest.transaction_clusterer.datasource.redis._record_sample")
+    @override_options({"transactions.do_post_process_in_save": 1.0})
+    def test_process_transaction_event_clusterer_flag_on(
+        self,
+        mock_store_transaction_name,
+    ):
+        min_ago = before_now(minutes=1)
+        event = process_event(
+            data={
+                "project": self.project.id,
+                "event_id": "b" * 32,
+                "transaction": "foo",
+                "start_timestamp": str(min_ago),
+                "timestamp": str(min_ago),
+                "type": "transaction",
+                "transaction_info": {
+                    "source": "url",
+                },
+                "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
+            },
+            group_id=0,
+        )
+        cache_key = write_event_to_cache(event)
+        post_process_group(
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=False,
+            cache_key=cache_key,
+            group_id=None,
+            project_id=self.project.id,
+            eventstream_type=EventStreamEventType.Transaction,
+        )
+
+        assert mock_store_transaction_name.mock_calls == []
+
 
 class PostProcessGroupGenericTest(
     TestCase,


### PR DESCRIPTION
in lockstep with https://github.com/getsentry/sentry/pull/81077/, stops doing work in post_process on transactions. part of https://github.com/getsentry/sentry/issues/81065