### PR TITLE
fix(api-docs): Update api docs for group hash endpoints

### DIFF
--- a/api-docs/paths/events/issue-hashes.json
+++ b/api-docs/paths/events/issue-hashes.json
@@ -23,6 +23,16 @@
         }
       },
       {
+        "in": "query",
+        "name": "full",
+        "schema": {
+          "type": "boolean",
+          "default": true
+        },
+        "description": "If this is set to true, the event payload will include the full event body, including the stacktrace. Set to 1 to enable.",
+        "required": false
+      },
+      {
         "$ref": "../../components/parameters/pagination-cursor.json#/PaginationCursor"
       }
     ],


### PR DESCRIPTION
Splitting out the docs change from https://github.com/getsentry/sentry/pull/81017.