### PR TITLE
ref(transactions): dont send transactions to post_process

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2664,6 +2664,12 @@ def save_transaction_events(jobs: Sequence[Job], projects: ProjectsMapping) -> S
         _nodestore_save_many(jobs=jobs, app_feature="transactions")
 
     with metrics.timer("save_transaction_events.eventstream_insert_many"):
+        for job in jobs:
+            if in_rollout_group("transactions.dont_send_to_post_process", job["event"].project_id):
+                # we don't need to send transactions to post process
+                # so set raw so we skip post_process
+                job["raw"] = True
+
         _eventstream_insert_many(jobs)
 
     with metrics.timer("save_transaction_events.track_outcome_accepted_many"):

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2919,6 +2919,7 @@ register(
     "performance.event-tracker.sample-rate.transaction",
     default=0.0,
 )
+
 register(
     "transactions.do_post_process_in_save",
     type=Bool,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2926,3 +2926,8 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE | FLAG_RATE,
 )
+register(
+    "transactions.dont_send_to_post_process",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE | FLAG_RATE,
+)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2918,12 +2918,6 @@ register(
 register(
     "performance.event-tracker.sample-rate.transaction",
     default=0.0,
-)
-
-register(
-    "transactions.do_post_process_in_save",
-    type=Bool,
-    default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2918,6 +2918,11 @@ register(
 register(
     "performance.event-tracker.sample-rate.transaction",
     default=0.0,
+)
+register(
+    "transactions.do_post_process_in_save",
+    type=Bool,
+    default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -16,6 +16,7 @@ from sentry.attachments import attachment_cache
 from sentry.constants import DEFAULT_STORE_NORMALIZER_ARGS
 from sentry.datascrubbing import scrub_data
 from sentry.eventstore import processing
+from sentry.features.rollout import in_rollout_group
 from sentry.feedback.usecases.create_feedback import FeedbackCreationSource, create_feedback_issue
 from sentry.ingest.types import ConsumerType
 from sentry.killswitches import killswitch_matches_context
@@ -582,6 +583,14 @@ def _do_save_event(
             raise
 
         finally:
+            if consumer_type == ConsumerType.Transactions and in_rollout_group(
+                "transactions.dont_send_to_post_process", project_id
+            ):
+                # we won't use the transaction data in post_process
+                # so we can delete it from the cache now.
+                if cache_key:
+                    processing_store.delete_by_key(cache_key)
+
             reprocessing2.mark_event_reprocessed(data)
             if cache_key and has_attachments:
                 attachment_cache.delete(cache_key)

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1603,8 +1603,10 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
     @override_options({"transactions.do_post_process_in_save": 1.0})
     @patch("sentry.signals.transaction_processed.send_robust")
     @patch("sentry.ingest.transaction_clusterer.datasource.redis._record_sample")
+    @patch("sentry.event_manager.eventstream.backend.insert")
     def test_transaction_sampler_and_receive_mock_called(
         self,
+        eventstream_insert: mock.MagicMock,
         mock_record_sample: mock.MagicMock,
         transaction_processed_signal_mock: mock.MagicMock,
     ) -> None:
@@ -1664,9 +1666,80 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         manager.normalize()
         manager.save(self.project.id)
         assert transaction_processed_signal_mock.call_count == 1
+        assert (
+            transaction_processed_signal_mock.call_args.kwargs["sender"]
+            == "save_transaction_events"
+        )
         assert mock_record_sample.mock_calls == [
             mock.call(ClustererNamespace.TRANSACTIONS, self.project, "wait")
         ]
+        eventstream_insert.assert_called_once()
+        assert eventstream_insert.call_args.kwargs["skip_consume"] is False
+
+    @override_options({"transactions.dont_send_to_post_process": 1.0})
+    @mock.patch("sentry.event_manager.eventstream.backend.insert")
+    def test_transaction_event_stream_insert_with_raw(
+        self, eventstream_insert: mock.MagicMock
+    ) -> None:
+        # make sure with the option on we don't get any errors
+        # and skip_consume is true
+        manager = EventManager(
+            make_event(
+                **{
+                    "transaction": "wait",
+                    "contexts": {
+                        "trace": {
+                            "parent_span_id": "bce14471e0e9654d",
+                            "op": "foobar",
+                            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                            "span_id": "bf5be759039ede9a",
+                        }
+                    },
+                    "spans": [
+                        {
+                            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                            "parent_span_id": "bf5be759039ede9a",
+                            "span_id": "a" * 16,
+                            "start_timestamp": 0,
+                            "timestamp": 1,
+                            "same_process_as_parent": True,
+                            "op": "default",
+                            "description": "span a",
+                        },
+                        {
+                            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                            "parent_span_id": "bf5be759039ede9a",
+                            "span_id": "b" * 16,
+                            "start_timestamp": 0,
+                            "timestamp": 1,
+                            "same_process_as_parent": True,
+                            "op": "default",
+                            "description": "span a",
+                        },
+                        {
+                            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                            "parent_span_id": "bf5be759039ede9a",
+                            "span_id": "c" * 16,
+                            "start_timestamp": 0,
+                            "timestamp": 1,
+                            "same_process_as_parent": True,
+                            "op": "default",
+                            "description": "span b",
+                        },
+                    ],
+                    "timestamp": "2019-06-14T14:01:40Z",
+                    "start_timestamp": "2019-06-14T14:01:40Z",
+                    "type": "transaction",
+                    "transaction_info": {
+                        "source": "url",
+                    },
+                }
+            )
+        )
+        manager.normalize()
+        manager.save(self.project.id)
+        eventstream_insert.assert_called_once()
+        assert eventstream_insert.call_args.kwargs["skip_consume"] is True
 
     def test_sdk(self) -> None:
         manager = EventManager(make_event(**{"sdk": {"name": "sentry-unity", "version": "1.0"}}))

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2734,6 +2734,41 @@ class TransactionClustererTestCase(TestCase, SnubaTestCase):
             mock.call(ClustererNamespace.TRANSACTIONS, self.project, "foo")
         ]
 
+    @patch("sentry.ingest.transaction_clusterer.datasource.redis._record_sample")
+    @override_options({"transactions.do_post_process_in_save": 1.0})
+    def test_process_transaction_event_clusterer_flag_on(
+        self,
+        mock_store_transaction_name,
+    ):
+        min_ago = before_now(minutes=1)
+        event = process_event(
+            data={
+                "project": self.project.id,
+                "event_id": "b" * 32,
+                "transaction": "foo",
+                "start_timestamp": str(min_ago),
+                "timestamp": str(min_ago),
+                "type": "transaction",
+                "transaction_info": {
+                    "source": "url",
+                },
+                "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
+            },
+            group_id=0,
+        )
+        cache_key = write_event_to_cache(event)
+        post_process_group(
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=False,
+            cache_key=cache_key,
+            group_id=None,
+            project_id=self.project.id,
+            eventstream_type=EventStreamEventType.Transaction,
+        )
+
+        assert mock_store_transaction_name.mock_calls == []
+
 
 class PostProcessGroupGenericTest(
     TestCase,

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -14,6 +14,7 @@ from sentry.tasks.store import (
     save_event,
     save_event_transaction,
 )
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 
 EVENT_ID = "cc3e6c2bb6b6498097f336d1e6979f4b"
@@ -397,3 +398,64 @@ def test_store_consumer_type(
         )
 
     mock_transaction_processing_store.get.assert_called_once_with("tx:3")
+    mock_transaction_processing_store.delete_by_key.assert_not_called()
+
+
+@django_db_all
+@override_options({"transactions.dont_send_to_post_process": 1.0})
+def test_store_consumer_type_transactions_cleanup(
+    default_project,
+    mock_save_event,
+    register_plugin,
+    mock_event_processing_store,
+    mock_transaction_processing_store,
+):
+    register_plugin(globals(), BasicPreprocessorPlugin)
+
+    data = {
+        "project": default_project.id,
+        "platform": "python",
+        "logentry": {"formatted": "test"},
+        "event_id": EVENT_ID,
+        "extra": {"foo": "bar"},
+        "timestamp": time(),
+    }
+
+    mock_event_processing_store.get.return_value = data
+    mock_event_processing_store.store.return_value = "e:2"
+
+    process_event(cache_key="e:2", start_time=1)
+
+    mock_event_processing_store.get.assert_called_once_with("e:2")
+
+    mock_save_event.delay.assert_called_once_with(
+        cache_key="e:2",
+        data=None,
+        start_time=1,
+        event_id=EVENT_ID,
+        project_id=default_project.id,
+    )
+
+    transaction_data = {
+        "project": default_project.id,
+        "platform": "transaction",
+        "event_id": EVENT_ID,
+        "extra": {"foo": "bar"},
+        "timestamp": time(),
+        "start_timestamp": time() - 1,
+    }
+
+    mock_transaction_processing_store.get.return_value = transaction_data
+    mock_transaction_processing_store.store.return_value = "tx:3"
+
+    with mock.patch("sentry.event_manager.EventManager.save", return_value=None):
+        save_event_transaction(
+            cache_key="tx:3",
+            data=None,
+            start_time=1,
+            event_id=EVENT_ID,
+            project_id=default_project.id,
+        )
+
+    mock_transaction_processing_store.get.assert_called_once_with("tx:3")
+    mock_transaction_processing_store.delete_by_key.assert_called_once_with("tx:3")


### PR DESCRIPTION
Once we've deployed https://github.com/getsentry/sentry/pull/81079, we no longer need to send transactions to post_process. 

We delete the redis key from the processing store right in save event as its no longer needed, and take advantage of the existing `raw / skip_consume` functionality to tell the event stream not to carry on the transaction to post_process after it's been inserted into snuba.
https://github.com/getsentry/sentry/blob/dce58ed72c715cd5e44e0f2a71d48e598fbfeead/src/sentry/event_manager.py#L1144

Once this is merged and the option is turned on, we can delete all of the option code, as well as code that is no longer active in post_process.

part of https://github.com/getsentry/sentry/issues/81065


note that when this is deployed, there could be some transactions that go through post_process that do not have values in the processing store. this shouldn't cause problems, and wil monitor logs from post_process here: https://github.com/getsentry/sentry/blob/dce58ed72c715cd5e44e0f2a71d48e598fbfeead/src/sentry/tasks/post_process.py#L531