### PR TITLE
ref(transactions): clean up post_process transactions areas

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2518,9 +2518,6 @@ def _detect_performance_problems(
 
 @sentry_sdk.tracing.trace
 def _sample_transactions_in_save(jobs: Sequence[Job], projects: ProjectsMapping) -> None:
-    if not options.get("save_event_transactions.sample_transactions_in_save"):
-        return
-
     for job in jobs:
         project = job["event"].project
         record_transaction_name_for_clustering(project, job["event"].data)
@@ -2528,9 +2525,6 @@ def _sample_transactions_in_save(jobs: Sequence[Job], projects: ProjectsMapping)
 
 @sentry_sdk.tracing.trace
 def _send_transaction_processed_signals(jobs: Sequence[Job], projects: ProjectsMapping) -> None:
-    if not options.get("save_event_transactions.sample_transactions_in_save"):
-        return
-
     for job in jobs:
         project = job["event"].project
         with sentry_sdk.start_span(op="tasks.post_process_group.transaction_processed_signal"):
@@ -2656,10 +2650,9 @@ def save_transaction_events(jobs: Sequence[Job], projects: ProjectsMapping) -> S
 
     with metrics.timer("save_transaction_events.eventstream_insert_many"):
         for job in jobs:
-            if options.get("save_event_transactions.post_process_cleanup"):
-                # we don't need to send transactions to post process
-                # so set raw so we skip post_process
-                job["raw"] = True
+            # we don't need to send transactions to post process
+            # so set raw so we skip post_process
+            job["raw"] = True
 
         _eventstream_insert_many(jobs)
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2655,6 +2655,12 @@ def save_transaction_events(jobs: Sequence[Job], projects: ProjectsMapping) -> S
         _nodestore_save_many(jobs=jobs, app_feature="transactions")
 
     with metrics.timer("save_transaction_events.eventstream_insert_many"):
+        for job in jobs:
+            if options.get("save_event_transactions.post_process_cleanup"):
+                # we don't need to send transactions to post process
+                # so set raw so we skip post_process
+                job["raw"] = True
+
         _eventstream_insert_many(jobs)
 
     with metrics.timer("save_transaction_events.track_outcome_accepted_many"):

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2921,3 +2921,9 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "save_event_transactions.post_process_cleanup",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2915,3 +2915,9 @@ register(
     default=[],
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "save_event_transactions.sample_transactions_in_save",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -13,7 +13,7 @@ from django.db.models.signals import post_save
 from django.utils import timezone
 from google.api_core.exceptions import ServiceUnavailable
 
-from sentry import features, projectoptions
+from sentry import features, options, projectoptions
 from sentry.eventstream.types import EventStreamEventType
 from sentry.exceptions import PluginError
 from sentry.issues.grouptype import GroupCategory
@@ -611,7 +611,9 @@ def post_process_group(
         # Simplified post processing for transaction events.
         # This should eventually be completely removed and transactions
         # will not go through any post processing.
-        if is_transaction_event:
+        if is_transaction_event and not options.get(
+            "save_event_transactions.sample_transactions_in_save"
+        ):
             record_transaction_name_for_clustering(event.project, event.data)
             with sentry_sdk.start_span(op="tasks.post_process_group.transaction_processed_signal"):
                 transaction_processed.send_robust(

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -582,9 +582,7 @@ def _do_save_event(
             raise
 
         finally:
-            if consumer_type == ConsumerType.Transactions and options.get(
-                "save_event_transactions.post_process_cleanup"
-            ):
+            if consumer_type == ConsumerType.Transactions:
                 # we won't use the transaction data in post_process
                 # so we can delete it from the cache now.
                 if cache_key:

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -582,6 +582,14 @@ def _do_save_event(
             raise
 
         finally:
+            if consumer_type == ConsumerType.Transactions and options.get(
+                "save_event_transactions.post_process_cleanup"
+            ):
+                # we won't use the transaction data in post_process
+                # so we can delete it from the cache now.
+                if cache_key:
+                    processing_store.delete_by_key(cache_key)
+
             reprocessing2.mark_event_reprocessed(data)
             if cache_key and has_attachments:
                 attachment_cache.delete(cache_key)

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -49,6 +49,7 @@ from sentry.exceptions import HashDiscarded
 from sentry.grouping.api import load_grouping_config
 from sentry.grouping.utils import hash_from_values
 from sentry.ingest.inbound_filters import FilterStatKeys
+from sentry.ingest.transaction_clusterer import ClustererNamespace
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration import Integration
 from sentry.issues.grouptype import (
@@ -1539,6 +1540,133 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         spans = [{"hash": span["hash"]} for span in data["spans"]]
         # the basic strategy is to simply use the description
         assert spans == [{"hash": hash_values([span["description"]])} for span in data["spans"]]
+
+    @override_options({"save_event_transactions.sample_transactions_in_save": True})
+    def test_transaction_sampler_and_recieve(self) -> None:
+        # make sure with the option on we don't get any errors
+        manager = EventManager(
+            make_event(
+                **{
+                    "transaction": "wait",
+                    "contexts": {
+                        "trace": {
+                            "parent_span_id": "bce14471e0e9654d",
+                            "op": "foobar",
+                            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                            "span_id": "bf5be759039ede9a",
+                        }
+                    },
+                    "spans": [
+                        {
+                            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                            "parent_span_id": "bf5be759039ede9a",
+                            "span_id": "a" * 16,
+                            "start_timestamp": 0,
+                            "timestamp": 1,
+                            "same_process_as_parent": True,
+                            "op": "default",
+                            "description": "span a",
+                        },
+                        {
+                            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                            "parent_span_id": "bf5be759039ede9a",
+                            "span_id": "b" * 16,
+                            "start_timestamp": 0,
+                            "timestamp": 1,
+                            "same_process_as_parent": True,
+                            "op": "default",
+                            "description": "span a",
+                        },
+                        {
+                            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                            "parent_span_id": "bf5be759039ede9a",
+                            "span_id": "c" * 16,
+                            "start_timestamp": 0,
+                            "timestamp": 1,
+                            "same_process_as_parent": True,
+                            "op": "default",
+                            "description": "span b",
+                        },
+                    ],
+                    "timestamp": "2019-06-14T14:01:40Z",
+                    "start_timestamp": "2019-06-14T14:01:40Z",
+                    "type": "transaction",
+                    "transaction_info": {
+                        "source": "url",
+                    },
+                }
+            )
+        )
+        manager.normalize()
+        manager.save(self.project.id)
+
+    @override_options({"save_event_transactions.sample_transactions_in_save": True})
+    @patch("sentry.signals.transaction_processed.send_robust")
+    @patch("sentry.ingest.transaction_clusterer.datasource.redis._record_sample")
+    def test_transaction_sampler_and_recieve_mock_called(
+        self,
+        mock_record_sample: mock.MagicMock,
+        transaction_processed_signal_mock: mock.MagicMock,
+    ) -> None:
+        manager = EventManager(
+            make_event(
+                **{
+                    "transaction": "wait",
+                    "contexts": {
+                        "trace": {
+                            "parent_span_id": "bce14471e0e9654d",
+                            "op": "foobar",
+                            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                            "span_id": "bf5be759039ede9a",
+                        }
+                    },
+                    "spans": [
+                        {
+                            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                            "parent_span_id": "bf5be759039ede9a",
+                            "span_id": "a" * 16,
+                            "start_timestamp": 0,
+                            "timestamp": 1,
+                            "same_process_as_parent": True,
+                            "op": "default",
+                            "description": "span a",
+                        },
+                        {
+                            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                            "parent_span_id": "bf5be759039ede9a",
+                            "span_id": "b" * 16,
+                            "start_timestamp": 0,
+                            "timestamp": 1,
+                            "same_process_as_parent": True,
+                            "op": "default",
+                            "description": "span a",
+                        },
+                        {
+                            "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                            "parent_span_id": "bf5be759039ede9a",
+                            "span_id": "c" * 16,
+                            "start_timestamp": 0,
+                            "timestamp": 1,
+                            "same_process_as_parent": True,
+                            "op": "default",
+                            "description": "span b",
+                        },
+                    ],
+                    "timestamp": "2019-06-14T14:01:40Z",
+                    "start_timestamp": "2019-06-14T14:01:40Z",
+                    "type": "transaction",
+                    "transaction_info": {
+                        "source": "url",
+                    },
+                }
+            )
+        )
+        manager.normalize()
+        manager.save(self.project.id)
+        assert transaction_processed_signal_mock.call_count == 1
+        assert mock_record_sample.mock_calls == [
+            mock.call(ClustererNamespace.TRANSACTIONS, self.project, "wait")
+        ]
 
     def test_sdk(self) -> None:
         manager = EventManager(make_event(**{"sdk": {"name": "sentry-unity", "version": "1.0"}}))

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1541,7 +1541,6 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         # the basic strategy is to simply use the description
         assert spans == [{"hash": hash_values([span["description"]])} for span in data["spans"]]
 
-    @override_options({"save_event_transactions.sample_transactions_in_save": True})
     def test_transaction_sampler_and_recieve(self) -> None:
         # make sure with the option on we don't get any errors
         manager = EventManager(
@@ -1600,15 +1599,12 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         manager.normalize()
         manager.save(self.project.id)
 
-    @override_options({"save_event_transactions.sample_transactions_in_save": True})
     @patch("sentry.signals.transaction_processed.send_robust")
     @patch("sentry.ingest.transaction_clusterer.datasource.redis._record_sample")
-    @mock.patch("sentry.event_manager.eventstream.backend.insert")
     def test_transaction_sampler_and_recieve_mock_called(
         self,
         transaction_processed_signal_mock: mock.MagicMock,
         mock_record_sample: mock.MagicMock,
-        eventstream_insert: mock.MagicMock,
     ) -> None:
         manager = EventManager(
             make_event(
@@ -1669,10 +1665,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         assert mock_record_sample.mock_calls == [
             mock.call(ClustererNamespace.TRANSACTIONS, self.project, "wait")
         ]
-        eventstream_insert.assert_called_once()
-        assert "skip_consume" not in eventstream_insert.call_args.kwargs
 
-    @override_options({"save_event_transactions.post_process_cleanup": True})
     @mock.patch("sentry.event_manager.eventstream.backend.insert")
     def test_transaction_event_stream_insert_with_raw(
         self, eventstream_insert: mock.MagicMock

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2734,6 +2734,41 @@ class TransactionClustererTestCase(TestCase, SnubaTestCase):
             mock.call(ClustererNamespace.TRANSACTIONS, self.project, "foo")
         ]
 
+    @patch("sentry.ingest.transaction_clusterer.datasource.redis._record_sample")
+    @override_options({"save_event_transactions.sample_transactions_in_save": True})
+    def test_process_transaction_event_clusterer_flag_off(
+        self,
+        mock_store_transaction_name,
+    ):
+        min_ago = before_now(minutes=1)
+        event = process_event(
+            data={
+                "project": self.project.id,
+                "event_id": "b" * 32,
+                "transaction": "foo",
+                "start_timestamp": str(min_ago),
+                "timestamp": str(min_ago),
+                "type": "transaction",
+                "transaction_info": {
+                    "source": "url",
+                },
+                "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
+            },
+            group_id=0,
+        )
+        cache_key = write_event_to_cache(event)
+        post_process_group(
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=False,
+            cache_key=cache_key,
+            group_id=None,
+            project_id=self.project.id,
+            eventstream_type=EventStreamEventType.Transaction,
+        )
+
+        assert mock_store_transaction_name.mock_calls == []
+
 
 class PostProcessGroupGenericTest(
     TestCase,

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -14,7 +14,6 @@ from sentry.tasks.store import (
     save_event,
     save_event_transaction,
 )
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 
 EVENT_ID = "cc3e6c2bb6b6498097f336d1e6979f4b"
@@ -402,11 +401,9 @@ def test_store_consumer_type(
 
 
 @django_db_all
-@override_options({"save_event_transactions.post_process_cleanup": True})
 def test_store_consumer_type_transactions_cleanup(
     default_project,
     mock_save_event,
-    mock_save_event_transaction,
     register_plugin,
     mock_event_processing_store,
     mock_transaction_processing_store,
@@ -447,7 +444,6 @@ def test_store_consumer_type_transactions_cleanup(
     }
 
     mock_transaction_processing_store.get.return_value = transaction_data
-    # mock_transaction_processing_store.delete_by_key = mock.Mock()
 
     mock_transaction_processing_store.store.return_value = "tx:3"
 


### PR DESCRIPTION
after we deploy https://github.com/getsentry/sentry/pull/81085 and validate all is well, we can clean up the options used to deploy the feature, and delete code in post_process to do with transactions.

final step of https://github.com/getsentry/sentry/issues/81065