### PR TITLE
feat(devservices): Add restart setting and use devservices external network

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -53,10 +53,12 @@ services:
       - 127.0.0.1:5432:5432
     extra_hosts:
       - host.docker.internal:host-gateway
+    restart: unless-stopped
 
 networks:
   devservices:
     name: devservices
+    external: true
 
 volumes:
   postgres-data:


### PR DESCRIPTION
add restart setting to automatically restart unless explicitly stopped for postgres, and also make containers use devservices external network