### PR TITLE
feat(autofix): Write access is optional in setup via query

### DIFF
--- a/src/sentry/api/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/api/endpoints/group_autofix_setup_check.py
@@ -119,8 +119,14 @@ class GroupAutofixSetupCheck(GroupEndpoint):
                 organization=org, project=group.project
             )
 
-        repos = get_repos_and_access(group.project)
-        write_access_ok = len(repos) > 0 and all(repo["ok"] for repo in repos)
+        write_integration_check = None
+        if request.query_params.get("check_write_access", False):
+            repos = get_repos_and_access(group.project)
+            write_access_ok = len(repos) > 0 and all(repo["ok"] for repo in repos)
+            write_integration_check = {
+                "ok": write_access_ok,
+                "repos": repos,
+            }
 
         return Response(
             {
@@ -132,9 +138,6 @@ class GroupAutofixSetupCheck(GroupEndpoint):
                     "ok": integration_check is None,
                     "reason": integration_check,
                 },
-                "githubWriteIntegration": {
-                    "ok": write_access_ok,
-                    "repos": repos,
-                },
+                "githubWriteIntegration": write_integration_check,
             }
         )

--- a/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
@@ -32,19 +32,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
         )
         self.organization.update_option("sentry:gen_ai_consent_v2024_11_14", True)
 
-    @patch(
-        "sentry.api.endpoints.group_autofix_setup_check.get_repos_and_access",
-        return_value=[
-            {
-                "provider": "github",
-                "owner": "getsentry",
-                "name": "seer",
-                "external_id": "123",
-                "ok": True,
-            }
-        ],
-    )
-    def test_successful_setup(self, mock_get_repos_and_access):
+    def test_successful_setup(self):
         """
         Everything is set up correctly, should respond with OKs.
         """
@@ -63,18 +51,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
                 "ok": True,
                 "reason": None,
             },
-            "githubWriteIntegration": {
-                "ok": True,
-                "repos": [
-                    {
-                        "provider": "github",
-                        "owner": "getsentry",
-                        "name": "seer",
-                        "external_id": "123",
-                        "ok": True,
-                    }
-                ],
-            },
+            "githubWriteIntegration": None,
         }
 
     @patch(
@@ -89,13 +66,13 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
             }
         ],
     )
-    def test_successful_with_codebase_indexing_disabled_flag(self, mock_get_repos_and_access):
+    def test_successful_with_write_access(self, mock_get_repos_and_access):
         """
         Everything is set up correctly, should respond with OKs.
         """
         group = self.create_group()
         self.login_as(user=self.user)
-        url = f"/api/0/issues/{group.id}/autofix/setup/"
+        url = f"/api/0/issues/{group.id}/autofix/setup/?check_write_access=true"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
@@ -192,7 +169,7 @@ class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
     def test_repo_write_access_not_ready(self, mock_get_repos_and_access):
         group = self.create_group()
         self.login_as(user=self.user)
-        url = f"/api/0/issues/{group.id}/autofix/setup/"
+        url = f"/api/0/issues/{group.id}/autofix/setup/?check_write_access=true"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
@@ -223,7 +200,7 @@ class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
     def test_repo_write_access_no_repos(self, mock_get_repos_and_access):
         group = self.create_group()
         self.login_as(user=self.user)
-        url = f"/api/0/issues/{group.id}/autofix/setup/"
+        url = f"/api/0/issues/{group.id}/autofix/setup/?check_write_access=true"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200


### PR DESCRIPTION
Only call seer for the write access check for when Autofix is ready to create a PR