### PR TITLE
ref(similarity): Use project endpoint instead of feature flag in ui

### DIFF
--- a/static/app/components/issueDiff/index.spec.tsx
+++ b/static/app/components/issueDiff/index.spec.tsx
@@ -15,7 +15,7 @@ describe('IssueDiff', function () {
   const entries123Base = Entries123Base();
   const api = new MockApiClient();
   const organization = OrganizationFixture();
-  const project = ProjectFixture({features: ['similarity-embeddings']});
+  const project = ProjectFixture();
 
   beforeEach(function () {
     MockApiClient.addMockResponse({
@@ -92,6 +92,7 @@ describe('IssueDiff', function () {
           action: 'PUSH',
           key: 'default',
         }}
+        hasSimilarityEmbeddingsProjectFeature
       />
     );
 

--- a/static/app/components/issueDiff/index.tsx
+++ b/static/app/components/issueDiff/index.tsx
@@ -31,6 +31,7 @@ type Props = {
   targetIssueId: string;
   baseEventId?: string;
   className?: string;
+  hasSimilarityEmbeddingsProjectFeature?: boolean;
   organization?: Organization;
   shouldBeGrouped?: string;
   targetEventId?: string;
@@ -67,12 +68,12 @@ class IssueDiff extends Component<Props, State> {
       baseEventId,
       targetEventId,
       organization,
-      project,
       shouldBeGrouped,
       location,
+      hasSimilarityEmbeddingsProjectFeature,
     } = this.props;
     const hasSimilarityEmbeddingsFeature =
-      project.features.includes('similarity-embeddings') ||
+      hasSimilarityEmbeddingsProjectFeature ||
       location.query.similarityEmbeddings === '1';
 
     // Fetch component and event data

--- a/static/app/components/modals/diffModal.spec.tsx
+++ b/static/app/components/modals/diffModal.spec.tsx
@@ -28,6 +28,10 @@ describe('DiffModal', function () {
       url: '/projects/123/project-slug/events/789/',
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: `/projects/org-slug/project-slug/`,
+      body: {features: ['']},
+    });
 
     const styledWrapper = styled(c => c.children);
 

--- a/static/app/components/modals/diffModal.spec.tsx
+++ b/static/app/components/modals/diffModal.spec.tsx
@@ -30,7 +30,7 @@ describe('DiffModal', function () {
     });
     MockApiClient.addMockResponse({
       url: `/projects/org-slug/project-slug/`,
-      body: {features: ['']},
+      body: {features: []},
     });
 
     const styledWrapper = styled(c => c.children);

--- a/static/app/components/modals/diffModal.tsx
+++ b/static/app/components/modals/diffModal.tsx
@@ -14,6 +14,7 @@ function DiffModal({className, Body, CloseButton, ...props}: Props) {
     orgSlug: organization.slug,
     projectSlug: project.slug,
   });
+  // similarity-embeddings feature is only available on project details
   const similarityEmbeddingsProjectFeature = projectData?.features.includes(
     'similarity-embeddings'
   );

--- a/static/app/components/modals/diffModal.tsx
+++ b/static/app/components/modals/diffModal.tsx
@@ -1,17 +1,34 @@
+import {useState} from 'react';
 import {css} from '@emotion/react';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {Client} from 'sentry/api';
 import IssueDiff from 'sentry/components/issueDiff';
 import useOrganization from 'sentry/utils/useOrganization';
+import {fetchProjectDetails} from 'sentry/views/issueDetails/groupSimilarIssues/similarStackTrace';
 
 type Props = ModalRenderProps & React.ComponentProps<typeof IssueDiff>;
 
 function DiffModal({className, Body, CloseButton, ...props}: Props) {
   const organization = useOrganization();
+  const api = new Client();
+  const {project} = props;
+  const [similarityEmbeddingsProjectFeature, setSimilarityEmbeddingsProjectFeature] =
+    useState<boolean>(false);
+  fetchProjectDetails(api, organization?.slug, project.slug).then(response => {
+    setSimilarityEmbeddingsProjectFeature(
+      response.features.includes('similarity-embeddings')
+    );
+  });
   return (
     <Body>
       <CloseButton />
-      <IssueDiff className={className} organization={organization} {...props} />
+      <IssueDiff
+        className={className}
+        organization={organization}
+        hasSimilarityEmbeddingsProjectFeature={similarityEmbeddingsProjectFeature}
+        {...props}
+      />
     </Body>
   );
 }

--- a/static/app/components/modals/diffModal.tsx
+++ b/static/app/components/modals/diffModal.tsx
@@ -1,25 +1,23 @@
-import {useState} from 'react';
 import {css} from '@emotion/react';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import {Client} from 'sentry/api';
 import IssueDiff from 'sentry/components/issueDiff';
+import {useDetailedProject} from 'sentry/utils/useDetailedProject';
 import useOrganization from 'sentry/utils/useOrganization';
-import {fetchProjectDetails} from 'sentry/views/issueDetails/groupSimilarIssues/similarStackTrace';
 
 type Props = ModalRenderProps & React.ComponentProps<typeof IssueDiff>;
 
 function DiffModal({className, Body, CloseButton, ...props}: Props) {
   const organization = useOrganization();
-  const api = new Client();
   const {project} = props;
-  const [similarityEmbeddingsProjectFeature, setSimilarityEmbeddingsProjectFeature] =
-    useState<boolean>(false);
-  fetchProjectDetails(api, organization?.slug, project.slug).then(response => {
-    setSimilarityEmbeddingsProjectFeature(
-      response.features.includes('similarity-embeddings')
-    );
+  const {data: projectData} = useDetailedProject({
+    orgSlug: organization.slug,
+    projectSlug: project.slug,
   });
+  const similarityEmbeddingsProjectFeature = projectData?.features.includes(
+    'similarity-embeddings'
+  );
+
   return (
     <Body>
       <CloseButton />

--- a/static/app/views/issueDetails/groupSimilarIssues/similarIssues.spec.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarIssues.spec.tsx
@@ -54,7 +54,7 @@ describe('Issues Similar View', function () {
     });
     MockApiClient.addMockResponse({
       url: `/projects/org-slug/project-slug/`,
-      body: {features: []},
+      body: {features: ['similarity-view']},
     });
     ProjectsStore.init();
     ProjectsStore.loadInitialData([project]);

--- a/static/app/views/issueDetails/groupSimilarIssues/similarIssues.spec.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarIssues.spec.tsx
@@ -52,6 +52,10 @@ describe('Issues Similar View', function () {
       url: `/organizations/org-slug/issues/${group.id}/`,
       body: group,
     });
+    MockApiClient.addMockResponse({
+      url: `/projects/org-slug/project-slug/`,
+      body: {features: []},
+    });
     ProjectsStore.init();
     ProjectsStore.loadInitialData([project]);
   });
@@ -150,7 +154,7 @@ describe('Issues Similar Embeddings View', function () {
 
   const group = GroupFixture();
   const project = ProjectFixture({
-    features: ['similarity-view', 'similarity-embeddings'],
+    features: ['similarity-view'],
   });
 
   const router = RouterFixture({
@@ -165,7 +169,7 @@ describe('Issues Similar Embeddings View', function () {
   ];
 
   const mockData = {
-    simlarEmbeddings: GroupsFixture().map((issue, i) => [
+    similarEmbeddings: GroupsFixture().map((issue, i) => [
       issue,
       similarEmbeddingsScores[i],
     ]),
@@ -174,11 +178,15 @@ describe('Issues Similar Embeddings View', function () {
   beforeEach(function () {
     mock = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${group.id}/similar-issues-embeddings/?k=10&threshold=0.01&useReranking=true`,
-      body: mockData.simlarEmbeddings,
+      body: mockData.similarEmbeddings,
     });
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${group.id}/`,
       body: group,
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/org-slug/project-slug/`,
+      body: {features: ['similarity-embeddings']},
     });
     ProjectsStore.init();
     ProjectsStore.loadInitialData([project]);

--- a/static/app/views/issueDetails/groupSimilarIssues/similarIssuesDrawer.spec.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarIssuesDrawer.spec.tsx
@@ -3,7 +3,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import GroupStore from 'sentry/stores/groupStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
@@ -32,6 +32,10 @@ describe('SimilarIssuesDrawer', function () {
       url: `/organizations/${organization.slug}/issues/${group.id}/`,
       body: group,
     });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/`,
+      body: {features: []},
+    });
   });
 
   it('renders the content as expected', async function () {
@@ -43,8 +47,11 @@ describe('SimilarIssuesDrawer', function () {
     expect(
       await screen.findByRole('heading', {name: 'Similar Issues'})
     ).toBeInTheDocument();
+
     expect(screen.getByText('Issues with a similar stack trace')).toBeInTheDocument();
-    expect(mockSimilarIssues).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockSimilarIssues).toHaveBeenCalled();
+    });
     expect(screen.getByRole('button', {name: 'Close Drawer'})).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
@@ -54,6 +54,7 @@ function SimilarStackTrace({project}: Props) {
     orgSlug: organization.slug,
     projectSlug: project.slug,
   });
+  // similarity-embeddings feature is only available on project details
   const hasSimilarityEmbeddingsFeature =
     projectData?.features.includes('similarity-embeddings') ||
     location.query.similarityEmbeddings === '1';

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/item.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/item.tsx
@@ -23,6 +23,7 @@ import type {Project} from 'sentry/types/project';
 
 type Props = {
   groupId: Group['id'];
+  hasSimilarityEmbeddingsFeature: boolean;
   issue: Group;
   location: Location;
   orgId: Organization['id'];
@@ -106,11 +107,9 @@ class Item extends Component<Props, State> {
   };
 
   render() {
-    const {aggregate, scoresByInterface, issue, project, location} = this.props;
+    const {aggregate, scoresByInterface, issue, hasSimilarityEmbeddingsFeature} =
+      this.props;
     const {visible, busy} = this.state;
-    const hasSimilarityEmbeddingsFeature =
-      project.features.includes('similarity-embeddings') ||
-      location.query.similarityEmbeddings === '1';
     const similarInterfaces = hasSimilarityEmbeddingsFeature
       ? ['exception']
       : ['exception', 'message'];

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/list.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/list.tsx
@@ -24,6 +24,7 @@ type DefaultProps = {
 
 type Props = {
   groupId: string;
+  hasSimilarityEmbeddingsFeature: boolean;
   items: Array<SimilarItem>;
   location: Location;
   onMerge: () => void;
@@ -53,15 +54,13 @@ function List({
   pageLinks,
   onMerge,
   location,
+  hasSimilarityEmbeddingsFeature,
 }: Props) {
   const [showAllItems, setShowAllItems] = useState(false);
 
   const hasHiddenItems = !!filteredItems.length;
   const hasResults = items.length > 0 || hasHiddenItems;
   const itemsWithFiltered = items.concat(showAllItems ? filteredItems : []);
-  const hasSimilarityEmbeddingsFeature =
-    project.features.includes('similarity-embeddings') ||
-    location.query.similarityEmbeddings === '1';
   const organization = useOrganization();
   const itemsWouldGroup = hasSimilarityEmbeddingsFeature
     ? itemsWithFiltered.map(item => ({
@@ -97,7 +96,7 @@ function List({
           project={project}
           organization={organization}
           itemsWouldGroup={itemsWouldGroup}
-          location={location}
+          hasSimilarityEmbeddingsFeature={hasSimilarityEmbeddingsFeature}
         />
 
         <PanelBody>
@@ -108,6 +107,7 @@ function List({
               groupId={groupId}
               project={project}
               location={location}
+              hasSimilarityEmbeddingsFeature={hasSimilarityEmbeddingsFeature}
               {...item}
             />
           ))}

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/toolbar.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/toolbar.tsx
@@ -1,6 +1,5 @@
 import {Component} from 'react';
 import styled from '@emotion/styled';
-import type {Location} from 'history';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {Button} from 'sentry/components/button';
@@ -15,7 +14,7 @@ import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 
 type Props = {
-  location: Location;
+  hasSimilarityEmbeddingsFeature: boolean;
   onMerge: () => void;
   groupId?: string;
   itemsWouldGroup?: Array<{id: string; shouldBeGrouped: string | undefined}> | undefined;
@@ -78,11 +77,8 @@ class SimilarToolbar extends Component<Props, State> {
   };
 
   render() {
-    const {onMerge, project, location} = this.props;
+    const {onMerge, hasSimilarityEmbeddingsFeature} = this.props;
     const {mergeCount} = this.state;
-    const hasSimilarityEmbeddingsFeature =
-      project?.features.includes('similarity-embeddings') ||
-      location.query.similarityEmbeddings === '1';
 
     return (
       <PanelHeader hasButtons>


### PR DESCRIPTION
Use project details endpoint instead of feature flag in ui
Removing the use of the feature flag will allow us to stop serializing it in project options endpoint, which is taking a long time