### PR TITLE
fix(toolbar): Remove closing </body> tag so extra #login_as markup is not injected

### DIFF
--- a/src/sentry/templates/sentry/toolbar/login-success.html
+++ b/src/sentry/templates/sentry/toolbar/login-success.html
@@ -41,5 +41,8 @@
       })();
     </script>
     {% endscript %}
-  </body>
-</html>
+
+{% comment %}
+No need to close `body`. If we do then middleware will inject some extra markup
+we don't need. Browsers can figure out when it missing and deal with it.
+{% endcomment %}


### PR DESCRIPTION
In getsentry we inject some login code to the bottom of rendered templates, we don't need this to happen inside our toolbar popup; and we can skip it by omitting the `</body>` tag form the template.

[`class ViewAsRenderMiddleware`](https://github.com/getsentry/getsentry/blob/3cff20a7236510b918e785e3cd50a3cd20434207/getsentry/vendor/viewas/middleware.py#L102-L133) will replace `</body>` with the content of  https://github.com/getsentry/getsentry/blob/3cff20a7236510b918e785e3cd50a3cd20434207/getsentry/templates/viewas/header.html#L1