### PR TITLE
fix(toolbar): Force the correct, subdomained, url when navigating to the toolbar popup

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -427,7 +427,7 @@ def register_temporary_features(manager: FeatureManager):
     # Enable replay web vital breadcrumbs
     manager.add("organizations:session-replay-web-vitals", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=True)
     # Enable Dev Toolbar frontend features (ex project settings page)
-    manager.add("organizations:dev-toolbar-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=True, api_expose=True)
+    manager.add("organizations:dev-toolbar-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=True)
     # Lets organizations manage grouping configs
     manager.add("organizations:set-grouping-config", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enable description field in Slack metric alerts

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -427,7 +427,7 @@ def register_temporary_features(manager: FeatureManager):
     # Enable replay web vital breadcrumbs
     manager.add("organizations:session-replay-web-vitals", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=True)
     # Enable Dev Toolbar frontend features (ex project settings page)
-    manager.add("organizations:dev-toolbar-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=True)
+    manager.add("organizations:dev-toolbar-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=True, api_expose=True)
     # Lets organizations manage grouping configs
     manager.add("organizations:set-grouping-config", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enable description field in Slack metric alerts

--- a/src/sentry/templates/sentry/toolbar/iframe.html
+++ b/src/sentry/templates/sentry/toolbar/iframe.html
@@ -60,7 +60,7 @@ Required context variables:
             log('window.onMessage', messageEvent.data, messageEvent);
             if (messageEvent.data.message === 'did-login') {
               saveAccessToken(messageEvent.data);
-              sendStateMessage('logged-in');
+              window.location.reload();
             }
           });
         }

--- a/src/sentry/templates/sentry/toolbar/iframe.html
+++ b/src/sentry/templates/sentry/toolbar/iframe.html
@@ -20,7 +20,7 @@ Required context variables:
     <script>
       (function() {
         const referrer = '{{ referrer|escapejs }}';
-        const state = '{{ state|escapejs }}';
+        const state = '{{ state|escapejs }}'; // enum of: logged-out, missing-project, invalid-domain, logged-in
         const logging = '{{ logging|escapejs }}';
         const organizationSlug = '{{ organization_slug|escapejs }}';
         const projectIdOrSlug = '{{ project_id_or_slug|escapejs }}';
@@ -43,6 +43,12 @@ Required context variables:
           );
         }
 
+        /**
+         * This should only be called on pageload, which is when the server has
+         * checked for auth, project validity, and domain config first.
+         *
+         * Also to be called when we clear auth tokens.
+         */
         function sendStateMessage(state) {
           log('sendStateMessage(state)', { state });
           window.parent.postMessage({
@@ -163,8 +169,7 @@ Required context variables:
 
         setupMessageChannel();
         listenForLoginSuccess();
-        // enum of: logged-out, missing-project, invalid-domain, logged-in
-        sendStateMessage(state === 'success' ? 'logged-in' : state);
+        sendStateMessage(state);
       })();
     </script>
     {% endscript %}

--- a/src/sentry/templates/sentry/toolbar/login-success.html
+++ b/src/sentry/templates/sentry/toolbar/login-success.html
@@ -24,7 +24,7 @@
         if (window.location.origin === 'https://sentry.io') {
           // User was already logged in and didn't get a redirect to the
           // subdomained origin. Do that redirect now.
-          window.location.replace(`https://${orgSlub}.sentry.io${window.location.pathname}${window.location.search}`);
+          window.location.replace(`https://${orgSlug}.sentry.io${window.location.pathname}${window.location.search}`);
           return;
         }
 

--- a/src/sentry/templates/sentry/toolbar/login-success.html
+++ b/src/sentry/templates/sentry/toolbar/login-success.html
@@ -25,6 +25,7 @@
           // User was already logged in and didn't get a redirect to the
           // subdomained origin. Do that redirect now.
           window.location.replace(`https://${orgSlub}.sentry.io${window.location.pathname}${window.location.search}`);
+          return;
         }
 
         document.getElementById('close-popup').addEventListener('click', () => {

--- a/src/sentry/templates/sentry/toolbar/login-success.html
+++ b/src/sentry/templates/sentry/toolbar/login-success.html
@@ -16,9 +16,16 @@
     {% script %}
     <script>
       (function() {
+        const orgSlug = '{{ organization_slug|escape }}';
         const delay = {{ delay_ms|escapejs }};
         const cookie = '{{ cookie|escapejs }}';
         const token = '{{ token|escapejs }}';
+
+        if (window.location.origin === 'https://sentry.io') {
+          // User was already logged in and didn't get a redirect to the
+          // subdomained origin. Do that redirect now.
+          window.location.replace(`https://${orgSlub}.sentry.io${window.location.pathname}${window.location.search}`);
+        }
 
         document.getElementById('close-popup').addEventListener('click', () => {
           window.close();

--- a/src/sentry/toolbar/views/iframe_view.py
+++ b/src/sentry/toolbar/views/iframe_view.py
@@ -47,7 +47,7 @@ class IframeView(ProjectView):
         allowed_origins: list[str] = project.get_option("sentry:toolbar_allowed_origins")
 
         if referrer and is_origin_allowed(referrer, allowed_origins):
-            return self._respond_with_state("success")
+            return self._respond_with_state("logged-in")
 
         return self._respond_with_state("invalid-domain")
 

--- a/src/sentry/toolbar/views/login_success_view.py
+++ b/src/sentry/toolbar/views/login_success_view.py
@@ -18,6 +18,7 @@ class LoginSuccessView(OrganizationView):
             TEMPLATE,
             status=200,
             context={
+                "organization_slug": organization.slug,
                 "delay_sec": int(delay_ms / 1000),
                 "delay_ms": delay_ms,
                 "cookie": f"{session_cookie_name}={request.COOKIES.get(session_cookie_name)}",

--- a/tests/sentry/toolbar/views/test_iframe_view.py
+++ b/tests/sentry/toolbar/views/test_iframe_view.py
@@ -1,5 +1,6 @@
 from django.test import override_settings
 from django.urls import reverse
+from django.utils.html import escapejs
 
 from sentry.testutils.cases import APITestCase
 from sentry.toolbar.views.iframe_view import TEMPLATE
@@ -26,8 +27,7 @@ class IframeViewTest(APITestCase):
 
         self.assertTemplateUsed(res, TEMPLATE)
         assert f"const referrer = '{referrer}';" in res.content.decode("utf-8")
-        # TODO: 'missing-project' is the full string to check for
-        assert "const state = 'missing" in res.content.decode("utf-8")
+        assert f"const state = '{escapejs('missing-project')}';" in res.content.decode("utf-8")
 
     @override_settings(CSP_REPORT_ONLY=False)
     def test_default_no_allowed_origins(self):
@@ -41,8 +41,7 @@ class IframeViewTest(APITestCase):
 
         self.assertTemplateUsed(res, TEMPLATE)
         assert f"const referrer = '{referrer}';" in res.content.decode("utf-8")
-        # TODO: 'invalid-domain' is the full string to check for
-        assert "const state = 'invalid" in res.content.decode("utf-8")
+        assert f"const state = '{escapejs('invalid-domain')}';" in res.content.decode("utf-8")
 
     @override_settings(CSP_REPORT_ONLY=False)
     def test_allowed_origins_basic(self):
@@ -57,7 +56,7 @@ class IframeViewTest(APITestCase):
 
         self.assertTemplateUsed(res, TEMPLATE)
         assert f"const referrer = '{referrer}';" in res.content.decode("utf-8")
-        assert "const state = 'success';" in res.content.decode("utf-8")
+        assert f"const state = '{escapejs('logged-in')}';" in res.content.decode("utf-8")
 
     @override_settings(CSP_REPORT_ONLY=False)
     def test_allowed_origins_wildcard_subdomain(self):
@@ -72,7 +71,7 @@ class IframeViewTest(APITestCase):
 
         self.assertTemplateUsed(res, TEMPLATE)
         assert f"const referrer = '{referrer}';" in res.content.decode("utf-8")
-        assert "const state = 'success';" in res.content.decode("utf-8")
+        assert f"const state = '{escapejs('logged-in')}';" in res.content.decode("utf-8")
 
     @override_settings(CSP_REPORT_ONLY=False)
     def test_only_single_wildcard_subdomain(self):
@@ -87,8 +86,7 @@ class IframeViewTest(APITestCase):
 
         self.assertTemplateUsed(res, TEMPLATE)
         assert f"const referrer = '{referrer}';" in res.content.decode("utf-8")
-        # TODO: 'invalid-domain' is the full string to check for
-        assert "const state = 'invalid" in res.content.decode("utf-8")
+        assert f"const state = '{escapejs('invalid-domain')}';" in res.content.decode("utf-8")
 
     @override_settings(CSP_REPORT_ONLY=False)
     def test_no_referrer(self):
@@ -102,8 +100,7 @@ class IframeViewTest(APITestCase):
 
         self.assertTemplateUsed(res, TEMPLATE)
         assert "const referrer = '';" in res.content.decode("utf-8")
-        # TODO: 'invalid-domain' is the full string to check for
-        assert "const state = 'invalid" in res.content.decode("utf-8")
+        assert f"const state = '{escapejs('invalid-domain')}';" in res.content.decode("utf-8")
 
 
 def _get_csp_parts(response):


### PR DESCRIPTION
This is a followup to https://github.com/getsentry/sentry/pull/80003

In #80003 all the redirect and url stuff is still true... but we only do the redirect hop at the end when the user was logged out to begin with. If the user starts off logged in then there's no redirect on the server side and the url that the toolbar asked for inside the popup (`https://sentry.io/toolbar/$org/$project/login-success/`) will just load.

What's going to happen now:
If the user **is not logged into** sentry already:
1. Open a popup with url = `https://sentry.io/toolbar/$org/$project/login-success/`
2. User redirected into login flow, with `?redirect=....` appended
3. Login flow completes, user taken to `https://$org.sentry.io/toolbar/$org/$project/login-success/` inside the popup
4. Popup can communicate with the iframe ✅ 

If the user **is already** logged into sentry:
1. Open a popup with url = `https://sentry.io/toolbar/$org/$project/login-success/`
2. `https://sentry.io/toolbar/$org/$project/login-success/` loads as requested
3. NEW-> javascript redirect to `https://$org.sentry.io/toolbar/$org/$project/login-success/` inside the popup
4. Popup can communicate with the iframe ✅ 