### PR TITLE
fix(eap): Add missing transaction.op

### DIFF
--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -287,6 +287,7 @@ SPAN_COLUMN_DEFINITIONS = {
         simple_sentry_field("span_id"),
         simple_sentry_field("trace.status"),
         simple_sentry_field("transaction.method"),
+        simple_sentry_field("transaction.op"),
         simple_sentry_field("user"),
         simple_sentry_field("user.email"),
         simple_sentry_field("user.geo.country_code"),

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -201,6 +201,7 @@ SPAN_EAP_COLUMN_MAP = {
     "timestamp": "timestamp",
     "trace": "trace_id",
     "transaction": "segment_name",
+    "transaction.op": "attr_str[sentry.transaction.op]",
     # `transaction.id` and `segment.id` is going to be replaced by `transaction.span_id` please do not use
     # transaction.id is "wrong", its pointing to segment_id to return something for the transistion, but represents the
     # txn event id(32 char uuid). EAP will no longer be storing this.


### PR DESCRIPTION
This was missing from the EAP definitions in both SnQL and RPC.