### PR TITLE
feat(processing): add electron symbol server to default for electron projects

### DIFF
--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -223,7 +223,7 @@ class TeamProjectsEndpoint(TeamEndpoint, EnvironmentMixin):
                 project.update_option("sentry:similarity_backfill_completed", int(time.time()))
 
             # Add electron symbol server by default to both electron and javascript-electron projects
-            if project.platform and project.platform.endswith("electron"):
+            if project.platform and project.platform in ["electron", "javascript-electron"]:
                 project.update_option(
                     "sentry:builtin_symbol_sources", ["ios", "microsoft", "electron"]
                 )

--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -13,6 +13,7 @@ from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.team import TeamEndpoint, TeamPermission
 from sentry.api.fields.sentry_slug import SentrySerializerSlugField
 from sentry.api.helpers.default_inbound_filters import set_default_inbound_filters
+from sentry.api.helpers.default_symbol_sources import set_default_symbol_sources
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import ProjectSummarySerializer, serialize
 from sentry.api.serializers.models.project import OrganizationProjectResponse, ProjectSerializer
@@ -203,6 +204,8 @@ class TeamProjectsEndpoint(TeamEndpoint, EnvironmentMixin):
             if project.platform and project.platform.startswith("javascript"):
                 set_default_inbound_filters(project, team.organization)
 
+            set_default_symbol_sources(project)
+
             self.create_audit_entry(
                 request=request,
                 organization=team.organization,
@@ -221,11 +224,5 @@ class TeamProjectsEndpoint(TeamEndpoint, EnvironmentMixin):
             # Create project option to turn on ML similarity feature for new EA projects
             if project_is_seer_eligible(project):
                 project.update_option("sentry:similarity_backfill_completed", int(time.time()))
-
-            # Add electron symbol server by default to both electron and javascript-electron projects
-            if project.platform and project.platform in ["electron", "javascript-electron"]:
-                project.update_option(
-                    "sentry:builtin_symbol_sources", ["ios", "microsoft", "electron"]
-                )
 
         return Response(serialize(project, request.user), status=201)

--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -22,7 +22,6 @@ from sentry.apidocs.examples.team_examples import TeamExamples
 from sentry.apidocs.parameters import CursorQueryParam, GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import PROJECT_SLUG_MAX_LENGTH, RESERVED_PROJECT_SLUGS, ObjectStatus
-from sentry.models.options.project_option import ProjectOption
 from sentry.models.project import Project
 from sentry.models.team import Team
 from sentry.seer.similarity.utils import project_is_seer_eligible
@@ -225,10 +224,8 @@ class TeamProjectsEndpoint(TeamEndpoint, EnvironmentMixin):
 
             # Add electron symbol server by default to both electron and javascript-electron projects
             if project.platform and project.platform.endswith("electron"):
-                symbol_sources = ProjectOption.objects.get_value(
-                    project=project, key="sentry:builtin_symbol_sources"
+                project.update_option(
+                    "sentry:builtin_symbol_sources", ["ios", "microsoft", "electron"]
                 )
-                symbol_sources.append("electron")
-                project.update_option("sentry:builtin_symbol_sources", symbol_sources)
 
         return Response(serialize(project, request.user), status=201)

--- a/src/sentry/api/helpers/default_symbol_sources.py
+++ b/src/sentry/api/helpers/default_symbol_sources.py
@@ -1,0 +1,14 @@
+from sentry.models.project import Project
+from sentry.projects.services.project import RpcProject
+
+DEFAULT_SYMBOL_SOURCES = {
+    "electron": ["ios", "microsoft", "electron"],
+    "javascript-electron": ["ios", "microsoft", "electron"],
+}
+
+
+def set_default_symbol_sources(project: Project | RpcProject):
+    if project.platform and project.platform in DEFAULT_SYMBOL_SOURCES:
+        project.update_option(
+            "sentry:builtin_symbol_sources", DEFAULT_SYMBOL_SOURCES[project.platform]
+        )

--- a/src/sentry/projects/services/project/impl.py
+++ b/src/sentry/projects/services/project/impl.py
@@ -133,12 +133,10 @@ class DatabaseBackedProjectService(ProjectService):
                 user_id=user_id,
             )
             # Add electron symbol server by default to both electron and javascript-electron projects
-            if platform and platform.endswith("electron"):
-                symbol_sources = ProjectOption.objects.get_value(
-                    project=project, key="sentry:builtin_symbol_sources"
+            if project.platform and project.platform.endswith("electron"):
+                project.update_option(
+                    "sentry:builtin_symbol_sources", ["ios", "microsoft", "electron"]
                 )
-                symbol_sources.append("electron")
-                project.update_option("sentry:builtin_symbol_sources", symbol_sources)
 
             return serialize_project(project)
 

--- a/src/sentry/projects/services/project/impl.py
+++ b/src/sentry/projects/services/project/impl.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from django.db import router, transaction
 
+from sentry.api.helpers.default_symbol_sources import set_default_symbol_sources
 from sentry.api.serializers import ProjectSerializer
 from sentry.auth.services.auth import AuthenticationContext
 from sentry.constants import ObjectStatus
@@ -126,17 +127,14 @@ class DatabaseBackedProjectService(ProjectService):
                 if team:
                     project.add_team(team)
 
+            set_default_symbol_sources(project)
+
             project_created.send(
                 project=project,
                 default_rules=True,
                 sender=self.create_project_for_organization,
                 user_id=user_id,
             )
-            # Add electron symbol server by default to both electron and javascript-electron projects
-            if project.platform and project.platform in ["electron", "javascript-electron"]:
-                project.update_option(
-                    "sentry:builtin_symbol_sources", ["ios", "microsoft", "electron"]
-                )
 
             return serialize_project(project)
 

--- a/src/sentry/projects/services/project/impl.py
+++ b/src/sentry/projects/services/project/impl.py
@@ -133,7 +133,7 @@ class DatabaseBackedProjectService(ProjectService):
                 user_id=user_id,
             )
             # Add electron symbol server by default to both electron and javascript-electron projects
-            if project.platform and project.platform.endswith("electron"):
+            if project.platform and project.platform in ["electron", "javascript-electron"]:
                 project.update_option(
                     "sentry:builtin_symbol_sources", ["ios", "microsoft", "electron"]
                 )

--- a/src/sentry/projects/services/project/impl.py
+++ b/src/sentry/projects/services/project/impl.py
@@ -132,6 +132,13 @@ class DatabaseBackedProjectService(ProjectService):
                 sender=self.create_project_for_organization,
                 user_id=user_id,
             )
+            # Add electron symbol server by default to both electron and javascript-electron projects
+            if platform and platform.endswith("electron"):
+                symbol_sources = ProjectOption.objects.get_value(
+                    project=project, key="sentry:builtin_symbol_sources"
+                )
+                symbol_sources.append("electron")
+                project.update_option("sentry:builtin_symbol_sources", symbol_sources)
 
             return serialize_project(project)
 

--- a/tests/sentry/api/endpoints/test_team_projects.py
+++ b/tests/sentry/api/endpoints/test_team_projects.py
@@ -305,7 +305,7 @@ class TeamProjectsCreateTest(APITestCase, TestCase):
         symbol_sources = ProjectOption.objects.get_value(
             project=electron_project, key="sentry:builtin_symbol_sources"
         )
-        assert "electron" in symbol_sources
+        assert symbol_sources == ["ios", "microsoft", "electron"]
 
     def test_builtin_symbol_sources_not_electron(self):
         # Test non-Electron project (e.g. Python)

--- a/tests/sentry/api/endpoints/test_team_projects.py
+++ b/tests/sentry/api/endpoints/test_team_projects.py
@@ -284,3 +284,44 @@ class TeamProjectsCreateTest(APITestCase, TestCase):
             )
             is None
         )
+
+    def test_builtin_symbol_sources_electron(self):
+        """
+        Test that project option for builtin symbol sources contains ["electron"] when creating
+        an Electron project, but uses defaults for other platforms.
+        """
+        # Test Electron project
+        response = self.get_success_response(
+            self.organization.slug,
+            self.team.slug,
+            name="electron-app",
+            slug="electron-app",
+            platform="electron",
+            status_code=201,
+        )
+
+        electron_project = Project.objects.get(id=response.data["id"])
+        assert electron_project.platform == "electron"
+        symbol_sources = ProjectOption.objects.get_value(
+            project=electron_project, key="sentry:builtin_symbol_sources"
+        )
+        assert "electron" in symbol_sources
+
+    def test_builtin_symbol_sources_not_electron(self):
+        # Test non-Electron project (e.g. Python)
+        response = self.get_success_response(
+            self.organization.slug,
+            self.team.slug,
+            name="python-app",
+            slug="python-app",
+            platform="python",
+            status_code=201,
+        )
+
+        python_project = Project.objects.get(id=response.data["id"])
+        assert python_project.platform == "python"
+        # Should use default value, not ["electron"]
+        symbol_sources = ProjectOption.objects.get_value(
+            project=python_project, key="sentry:builtin_symbol_sources"
+        )
+        assert "electron" not in symbol_sources


### PR DESCRIPTION
For projects with platforms `electron` and `javascript-electron`, add the public electron symbol server to the list of default symbol servers during project creation.

Closes https://github.com/getsentry/sentry/issues/80891