### PR TITLE
fix(replay): Include a message that delte/merge is not supported for replay issues

### DIFF
--- a/static/app/utils/issueTypeConfig/replayConfig.tsx
+++ b/static/app/utils/issueTypeConfig/replayConfig.tsx
@@ -5,9 +5,18 @@ const replayConfig: IssueCategoryConfigMapping = {
   _categoryDefaults: {
     actions: {
       archiveUntilOccurrence: {enabled: true},
-      delete: {enabled: false},
-      deleteAndDiscard: {enabled: false},
-      merge: {enabled: false},
+      delete: {
+        enabled: false,
+        disabledReason: t('Not yet supported for replay issues'),
+      },
+      deleteAndDiscard: {
+        enabled: false,
+        disabledReason: t('Not yet supported for replay issues'),
+      },
+      merge: {
+        enabled: false,
+        disabledReason: t('Not yet supported for replay issues'),
+      },
       ignore: {enabled: true},
       resolveInRelease: {enabled: true},
       share: {enabled: true},

--- a/static/app/utils/issueTypeConfig/replayConfig.tsx
+++ b/static/app/utils/issueTypeConfig/replayConfig.tsx
@@ -15,7 +15,7 @@ const replayConfig: IssueCategoryConfigMapping = {
       },
       merge: {
         enabled: false,
-        disabledReason: t('Not yet supported for replay issues'),
+        disabledReason: t('Not supported for replay issues'),
       },
       ignore: {enabled: true},
       resolveInRelease: {enabled: true},


### PR DESCRIPTION
This is modeled after the performance config: https://github.com/getsentry/sentry/blob/38e79dd514a71d24724ce5e8725e78f98983f4ff/static/app/utils/issueTypeConfig/performanceConfig.tsx#L9-L20

ideally both Perf and Replay issues would be deletable.... and the team is checking on that. Until we get that confirmation tho... lets add the message.