### PR TITLE
fix(issues): Text overflow on avatar hover card

### DIFF
--- a/static/app/components/hovercard.tsx
+++ b/static/app/components/hovercard.tsx
@@ -177,6 +177,7 @@ const Header = styled('div')`
 const Body = styled('div')`
   padding: ${space(2)};
   min-height: 30px;
+  word-wrap: break-word;
 `;
 
 const Divider = styled('div')`


### PR DESCRIPTION
<!-- Describe your PR here. -->
I noticed that when the email is long on the hover card for the suspect commit avatar on the issue details page, the text overflows and is outside the hover card. I put in a `break-word` for the body text to fix that.

Before
![issues-detail-before](https://github.com/user-attachments/assets/2ec0e1a9-ede4-41dd-b061-25b96e4764c6)

After
 ![issues-detail-after](https://github.com/user-attachments/assets/34b10d95-2bc6-4dfe-b3b0-d2e49efb307b) 
<!--

  Sentry employees and contractors can delete or ignore the following.

-->
