### PR TITLE
ref(trace) adjust height of container for trace view

### DIFF
--- a/static/app/components/events/interfaces/performance/eventTraceView.spec.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.spec.tsx
@@ -6,6 +6,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {EntryType} from 'sentry/types/event';
 import type {TraceEventResponse} from 'sentry/views/issueDetails/traceTimeline/useTraceTimelineEvents';
+import {makeTraceError} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
 
 import {EventTraceView} from './eventTraceView';
 
@@ -72,7 +73,7 @@ describe('EventTraceView', () => {
             errors: [],
           },
         ],
-        orphan_errors: [],
+        orphan_errors: [makeTraceError()],
       },
     });
     MockApiClient.addMockResponse({
@@ -92,7 +93,7 @@ describe('EventTraceView', () => {
     render(<EventTraceView group={group} event={event} organization={organization} />);
 
     expect(await screen.findByText('Trace')).toBeInTheDocument();
-    expect(await screen.findByText('transaction')).toBeInTheDocument();
+    expect(await screen.findByText('2 hidden spans')).toBeInTheDocument();
   });
 
   it('does not render the trace preview if it has no transactions', async () => {

--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -11,10 +11,10 @@ import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 import {TraceDataSection} from 'sentry/views/issueDetails/traceDataSection';
 import {IssuesTraceWaterfall} from 'sentry/views/performance/newTraceDetails/issuesTraceWaterfall';
+import {useIssuesTraceTree} from 'sentry/views/performance/newTraceDetails/traceApi/useIssuesTraceTree';
 import {useTrace} from 'sentry/views/performance/newTraceDetails/traceApi/useTrace';
 import {useTraceMeta} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceMeta';
 import {useTraceRootEvent} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
-import {useTraceTree} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceTree';
 import {
   loadTraceViewPreferences,
   type TracePreferencesState,
@@ -57,7 +57,7 @@ function EventTraceViewInner({event, organization}: EventTraceViewInnerProps) {
     limit: 10000,
   });
   const meta = useTraceMeta([{traceSlug: traceId, timestamp: undefined}]);
-  const tree = useTraceTree({trace, meta, replay: null});
+  const tree = useIssuesTraceTree({trace, meta, replay: null});
 
   const hasNoTransactions = meta.data?.transactions === 0;
   const shouldLoadTraceRoot = !trace.isPending && trace.data && !hasNoTransactions;
@@ -153,7 +153,7 @@ const ROW_HEIGHT = 24;
 const MIN_ROW_COUNT = 1;
 const MAX_HEIGHT = 500;
 const MAX_ROW_COUNT = Math.floor(MAX_HEIGHT / ROW_HEIGHT);
-const HEADER_HEIGHT = 32;
+const HEADER_HEIGHT = 26;
 
 const TraceViewWaterfallWrapper = styled('div')<{rowCount: number}>`
   display: flex;

--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -151,11 +151,7 @@ const TraceContentWrapper = styled('div')`
 
 const ROW_HEIGHT = 24;
 const MIN_ROW_COUNT = 1;
-<<<<<<< HEAD
-const MAX_HEIGHT = 400;
-=======
 const MAX_HEIGHT = 500;
->>>>>>> 1850b577422 (ref(trace) adjust height of container for trace view)
 const MAX_ROW_COUNT = Math.floor(MAX_HEIGHT / ROW_HEIGHT);
 const HEADER_HEIGHT = 32;
 

--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -151,7 +151,11 @@ const TraceContentWrapper = styled('div')`
 
 const ROW_HEIGHT = 24;
 const MIN_ROW_COUNT = 1;
+<<<<<<< HEAD
 const MAX_HEIGHT = 400;
+=======
+const MAX_HEIGHT = 500;
+>>>>>>> 1850b577422 (ref(trace) adjust height of container for trace view)
 const MAX_ROW_COUNT = Math.floor(MAX_HEIGHT / ROW_HEIGHT);
 const HEADER_HEIGHT = 32;
 

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -31,6 +31,7 @@ import {
 } from './traceRenderers/traceVirtualizedList';
 import type {VirtualizedViewManager} from './traceRenderers/virtualizedViewManager';
 import {TraceAutogroupedRow} from './traceRow/traceAutogroupedRow';
+import {TraceCollapsedRow} from './traceRow/traceCollapsedRow';
 import {TraceErrorRow} from './traceRow/traceErrorRow';
 import {TraceLoadingRow} from './traceRow/traceLoadingRow';
 import {TraceMissingInstrumentationRow} from './traceRow/traceMissingInstrumentationRow';
@@ -51,6 +52,7 @@ import {
 import {useTraceState, useTraceStateDispatch} from './traceState/traceStateProvider';
 import {
   isAutogroupedNode,
+  isCollapsedNode,
   isMissingInstrumentationNode,
   isSpanNode,
   isTraceErrorNode,
@@ -630,6 +632,10 @@ function RenderTraceRow(props: {
 
   if (isTraceNode(node)) {
     return <TraceRootRow {...rowProps} node={node} />;
+  }
+
+  if (isCollapsedNode(node)) {
+    return <TraceCollapsedRow {...rowProps} node={node} />;
   }
 
   return null;
@@ -1254,6 +1260,22 @@ const TraceStylingWrapper = styled('div')`
             color: ${p => p.theme.white};
             background-color: ${p => p.theme.red300};
           }
+        }
+      }
+    }
+
+    &.Collapsed {
+      background-color: ${p => p.theme.backgroundSecondary};
+      border-bottom: 1px solid ${p => p.theme.border};
+      border-top: 1px solid ${p => p.theme.border};
+
+      .TraceLeftColumn {
+        padding-left: 12px;
+        width: 100%;
+        color: ${p => p.theme.subText};
+
+        .TraceLeftColumnInner {
+          padding-left: 0 !important;
         }
       }
     }

--- a/static/app/views/performance/newTraceDetails/traceApi/useIssuesTraceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useIssuesTraceTree.tsx
@@ -1,0 +1,107 @@
+import {useEffect, useState} from 'react';
+
+import type {TraceSplitResults} from 'sentry/utils/performance/quickTrace/types';
+import type {QueryStatus, UseApiQueryResult} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
+import {IssuesTraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/issuesTraceTree';
+import type {ReplayRecord} from 'sentry/views/replays/types';
+
+import {TraceTree} from '../traceModels/traceTree';
+
+import type {TraceMetaQueryResults} from './useTraceMeta';
+
+type UseTraceTreeParams = {
+  meta: TraceMetaQueryResults;
+  replay: ReplayRecord | null;
+  trace: UseApiQueryResult<TraceSplitResults<TraceTree.Transaction> | undefined, any>;
+  traceSlug?: string;
+};
+
+function getTraceViewQueryStatus(
+  traceQueryStatus: QueryStatus,
+  traceMetaQueryStatus: QueryStatus
+): QueryStatus {
+  if (traceQueryStatus === 'error' || traceMetaQueryStatus === 'error') {
+    return 'error';
+  }
+
+  if (traceQueryStatus === 'pending' || traceMetaQueryStatus === 'pending') {
+    return 'pending';
+  }
+
+  return 'success';
+}
+
+export function useIssuesTraceTree({
+  trace,
+  meta,
+  replay,
+  traceSlug,
+}: UseTraceTreeParams): TraceTree {
+  const api = useApi();
+  const {projects} = useProjects();
+  const organization = useOrganization();
+
+  const [tree, setTree] = useState<TraceTree>(TraceTree.Empty());
+
+  useEffect(() => {
+    const status = getTraceViewQueryStatus(trace.status, meta.status);
+
+    if (status === 'error') {
+      setTree(t =>
+        t.type === 'error'
+          ? t
+          : TraceTree.Error({
+              project_slug: projects?.[0]?.slug ?? '',
+              event_id: traceSlug,
+            })
+      );
+      return;
+    }
+
+    if (
+      trace?.data?.transactions.length === 0 &&
+      trace?.data?.orphan_errors.length === 0
+    ) {
+      setTree(t => (t.type === 'empty' ? t : TraceTree.Empty()));
+      return;
+    }
+
+    if (status === 'pending') {
+      setTree(t =>
+        t.type === 'loading'
+          ? t
+          : TraceTree.Loading({
+              project_slug: projects?.[0]?.slug ?? '',
+              event_id: traceSlug,
+            })
+      );
+      return;
+    }
+
+    if (trace.data && meta.data) {
+      const newTree = IssuesTraceTree.FromTrace(trace.data, {
+        meta: meta.data,
+        replay: replay,
+      });
+
+      setTree(newTree);
+      newTree.build();
+      return;
+    }
+  }, [
+    api,
+    organization,
+    projects,
+    replay,
+    meta.status,
+    trace.status,
+    trace.data,
+    meta.data,
+    traceSlug,
+  ]);
+
+  return tree;
+}

--- a/static/app/views/performance/newTraceDetails/traceGuards.tsx
+++ b/static/app/views/performance/newTraceDetails/traceGuards.tsx
@@ -1,6 +1,7 @@
 import {MissingInstrumentationNode} from './traceModels/missingInstrumentationNode';
 import {ParentAutogroupNode} from './traceModels/parentAutogroupNode';
 import {SiblingAutogroupNode} from './traceModels/siblingAutogroupNode';
+import {CollapsedNode} from './traceModels/traceCollapsedNode';
 import type {TraceTree} from './traceModels/traceTree';
 import type {TraceTreeNode} from './traceModels/traceTreeNode';
 
@@ -42,6 +43,12 @@ export function isAutogroupedNode(
   node: TraceTreeNode<TraceTree.NodeValue>
 ): node is ParentAutogroupNode | SiblingAutogroupNode {
   return node instanceof ParentAutogroupNode || node instanceof SiblingAutogroupNode;
+}
+
+export function isCollapsedNode(
+  node: TraceTreeNode<TraceTree.NodeValue>
+): node is CollapsedNode {
+  return node instanceof CollapsedNode;
 }
 
 export function isTraceErrorNode(

--- a/static/app/views/performance/newTraceDetails/traceModels/__snapshots__/issuesTraceTree.spec.tsx.snap
+++ b/static/app/views/performance/newTraceDetails/traceModels/__snapshots__/issuesTraceTree.spec.tsx.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`IssuesTraceTree collapsed nodes without errors 1`] = `
+"
+trace root
+  collapsed
+  transaction 3 - transaction.op
+  collapsed
+"
+`;
+
+exports[`IssuesTraceTree preserves path to child error 1`] = `
+"
+trace root
+  collapsed
+  transaction 2 - transaction.op
+    transaction - transaction.op
+  collapsed
+"
+`;

--- a/static/app/views/performance/newTraceDetails/traceModels/issuesTraceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/issuesTraceTree.spec.tsx
@@ -1,0 +1,43 @@
+import {IssuesTraceTree} from './issuesTraceTree';
+import {makeTrace, makeTraceError, makeTransaction} from './traceTreeTestUtils';
+
+const traceWithErrorInMiddle = makeTrace({
+  transactions: [
+    makeTransaction({transaction: 'transaction 1'}),
+    makeTransaction({transaction: 'transaction 2'}),
+    makeTransaction({transaction: 'transaction 3', errors: [makeTraceError({})]}),
+    makeTransaction({transaction: 'transaction 4'}),
+    makeTransaction({transaction: 'transaction 5'}),
+  ],
+});
+
+const traceWithChildError = makeTrace({
+  transactions: [
+    makeTransaction({transaction: 'transaction 1'}),
+    makeTransaction({
+      transaction: 'transaction 2',
+      children: [makeTransaction({errors: [makeTraceError({})]})],
+    }),
+    makeTransaction({transaction: 'transaction 4'}),
+  ],
+});
+
+describe('IssuesTraceTree', () => {
+  it('collapsed nodes without errors', () => {
+    const tree = IssuesTraceTree.FromTrace(traceWithErrorInMiddle, {
+      meta: null,
+      replay: null,
+    });
+
+    expect(tree.build().serialize()).toMatchSnapshot();
+  });
+
+  it('preserves path to child error', () => {
+    const tree = IssuesTraceTree.FromTrace(traceWithChildError, {
+      meta: null,
+      replay: null,
+    });
+
+    expect(tree.build().serialize()).toMatchSnapshot();
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceModels/issuesTraceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/issuesTraceTree.tsx
@@ -1,3 +1,4 @@
+import {isTraceErrorNode} from 'sentry/views/performance/newTraceDetails/traceGuards';
 import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
@@ -20,7 +21,11 @@ export class IssuesTraceTree extends TraceTree {
     // Collect all nodes with errors and their path to the root. None of these nodes should be collapsed
     // because we want to preserve the path to the error node so that the user can see the chain that lead
     // to it.
-    const errorNodes = TraceTree.FindAll(tree.root, node => node.hasErrors);
+    const errorNodes = TraceTree.FindAll(
+      tree.root,
+      node => node.hasErrors || isTraceErrorNode(node)
+    );
+
     const preservePaths = new Set<TraceTreeNode>();
     for (const node of errorNodes) {
       let current: TraceTreeNode | null = node;

--- a/static/app/views/performance/newTraceDetails/traceModels/issuesTraceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/issuesTraceTree.tsx
@@ -1,0 +1,91 @@
+import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import type {ReplayRecord} from 'sentry/views/replays/types';
+
+import type {TraceMetaQueryResults} from '../traceApi/useTraceMeta';
+import {CollapsedNode} from '../traceModels/traceCollapsedNode';
+
+import type {TraceTreeNode} from './traceTreeNode';
+
+export class IssuesTraceTree extends TraceTree {
+  static FromTrace(
+    trace: TraceTree.Trace,
+    options: {
+      meta: TraceMetaQueryResults['data'] | null;
+      replay: ReplayRecord | null;
+    }
+  ): IssuesTraceTree {
+    const tree = TraceTree.FromTrace(trace, options);
+    const issuesTree = new IssuesTraceTree();
+
+    // Collect all nodes with errors and their path to the root. None of these nodes should be collapsed
+    // because we want to preserve the path to the error node so that the user can see the chain that lead
+    // to it.
+    const errorNodes = TraceTree.FindAll(tree.root, node => node.hasErrors);
+    const preservePaths = new Set<TraceTreeNode>();
+    for (const node of errorNodes) {
+      let current: TraceTreeNode | null = node;
+      while (current) {
+        preservePaths.add(current);
+        current = current.parent;
+      }
+    }
+
+    const queue: TraceTreeNode[] = [tree.root];
+
+    while (queue.length > 0) {
+      const node = queue.pop();
+
+      if (!node) {
+        continue;
+      }
+
+      for (const child of node.children) {
+        queue.push(child);
+      }
+
+      let index = 0;
+      while (index < node.children.length) {
+        const start = index;
+
+        while (
+          node.children[index] &&
+          !node.children[index]?.hasErrors &&
+          !preservePaths.has(node.children[index])
+        ) {
+          index++;
+        }
+
+        if (index - start > 0) {
+          const collapsedNode = new CollapsedNode(
+            node,
+            {type: 'collapsed'},
+            node.metadata
+          );
+
+          collapsedNode.children = node.children.splice(
+            start,
+            index - start,
+            collapsedNode
+          );
+
+          for (const child of collapsedNode.children) {
+            child.parent = collapsedNode;
+          }
+
+          // Skip the section we collapsed so we dont collapse or process it again
+          index = start + 1;
+        } else {
+          index++;
+        }
+      }
+    }
+
+    issuesTree.root = tree.root;
+    return issuesTree;
+  }
+
+  build() {
+    super.build();
+    return this;
+  }
+}

--- a/static/app/views/performance/newTraceDetails/traceModels/traceCollapsedNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceCollapsedNode.tsx
@@ -1,0 +1,13 @@
+import type {TraceTree} from './traceTree';
+import {TraceTreeNode} from './traceTreeNode';
+
+export class CollapsedNode extends TraceTreeNode<TraceTree.CollapsedNode> {
+  constructor(
+    parent: TraceTreeNode<TraceTree.NodeValue>,
+    node: TraceTree.CollapsedNode,
+    metadata: TraceTree.Metadata
+  ) {
+    super(parent, node, metadata);
+    this.expanded = false;
+  }
+}

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -24,6 +24,7 @@ import {
   getPageloadTransactionChildCount,
   isAutogroupedNode,
   isBrowserRequestSpan,
+  isCollapsedNode,
   isJavascriptSDKTransaction,
   isMissingInstrumentationNode,
   isPageloadTransactionNode,
@@ -146,7 +147,12 @@ export declare namespace TraceTree {
     | MissingInstrumentationSpan
     | SiblingAutogroup
     | ChildrenAutogroup
+    | CollapsedNode
     | Root;
+
+  interface CollapsedNode {
+    type: 'collapsed';
+  }
 
   // Node types
   interface MissingInstrumentationSpan {
@@ -1014,7 +1020,8 @@ export class TraceTree extends TraceTreeEventDispatcher {
       const node = queue.pop()!;
 
       visibleChildren.push(node);
-      // iterate in reverseto ensure nodes are processed in order
+
+      // iterate in reverse to ensure nodes are processed in order
       if (node.expanded || isParentAutogroupedNode(node)) {
         const children = TraceTree.DirectVisibleChildren(node);
 
@@ -1511,7 +1518,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
         // This is very wasteful as it performs O(n^2) search each time we expand a node...
         // In most cases though, we should be operating on a tree with sub 10k elements and hopefully
         // a low autogrouped node count.
-        index = node ? tree.list.findIndex(n => n === node) : -1;
+        index = node ? tree.list.indexOf(node) : -1;
         if (index !== -1) {
           break;
         }
@@ -1959,6 +1966,10 @@ function printTraceTreeNode(
 
   if (isTraceErrorNode(t)) {
     return padding + (t.value.event_id || t.value.level) || 'unknown trace error';
+  }
+
+  if (isCollapsedNode(t)) {
+    return padding + 'collapsed';
   }
 
   return 'unknown node';

--- a/static/app/views/performance/newTraceDetails/traceRow/traceCollapsedRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceCollapsedRow.tsx
@@ -24,7 +24,8 @@ export function TraceCollapsedRow(props: TraceRowProps<CollapsedNode>) {
     >
       <div className="TraceLeftColumn" ref={props.registerListColumnRef}>
         <div className="TraceLeftColumnInner" style={props.listColumnStyle}>
-          {collapsedChildrenCount} {t('hidden spans')}
+          {collapsedChildrenCount}{' '}
+          {collapsedChildrenCount === 1 ? t('hidden span') : t('hidden spans')}
         </div>
       </div>
     </div>

--- a/static/app/views/performance/newTraceDetails/traceRow/traceCollapsedRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceCollapsedRow.tsx
@@ -1,0 +1,32 @@
+import {useMemo} from 'react';
+
+import {t} from 'sentry/locale';
+
+import type {CollapsedNode} from '../traceModels/traceCollapsedNode';
+import {TraceTree} from '../traceModels/traceTree';
+import type {TraceRowProps} from '../traceRow/traceRow';
+
+export function TraceCollapsedRow(props: TraceRowProps<CollapsedNode>) {
+  const collapsedChildrenCount = useMemo(() => {
+    let count = 1;
+    TraceTree.ForEachChild(props.node, () => count++);
+    return count;
+  }, [props.node]);
+
+  return (
+    <div
+      key={props.index}
+      tabIndex={props.tabIndex}
+      className="Collapsed TraceRow"
+      onPointerDown={props.onRowClick}
+      onKeyDown={props.onRowKeyDown}
+      style={props.style}
+    >
+      <div className="TraceLeftColumn" ref={props.registerListColumnRef}>
+        <div className="TraceLeftColumnInner" style={props.listColumnStyle}>
+          {collapsedChildrenCount} {t('hidden spans')}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds collapsing functionality to trace tree. Currently just persists all errors in a trace, so next step is to make it only focus on top n

![CleanShot 2024-11-21 at 11 23 52@2x](https://github.com/user-attachments/assets/7e72f6fd-4943-4d6b-b18f-b11ca6366855)
