### PR TITLE
fix(debugfile): Recognize chunk-uploaded Proguard files

### DIFF
--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -338,7 +338,10 @@ def create_dif_from_id(
     return dif, True
 
 
-def _analyze_progard_filename(filename: str) -> str | None:
+def _analyze_progard_filename(filename: str | None) -> str | None:
+    if filename is None:
+        return None
+
     match = _proguard_file_re.search(filename)
     if match is None:
         return None
@@ -474,9 +477,9 @@ def detect_dif_from_path(
 
     :raises BadDif: If the file is not a valid DIF.
     """
-    # proguard files (proguard/UUID.txt) or
+    # Proguard files have a path or a name like (proguard/UUID.txt) or
     # (proguard/mapping-UUID.txt).
-    proguard_id = _analyze_progard_filename(path)
+    proguard_id = _analyze_progard_filename(path) or _analyze_progard_filename(name)
     if proguard_id is not None:
         data = {"features": ["mapping"]}
         return [


### PR DESCRIPTION
The `detect_dif_from_path` function does not correctly identify Proguard files which are chunk uploaded because these files have a randomly-assigned temporary path, and the logic tries to guess whether the file is a Proguard file based on its path. However, the `detect_dif_from_path` function also takes an optional `name` option, which for chunk-uploaded files, is the file name that is specified by the client making the assemble call. This has not been a problem yet, since Sentry CLI does not support chunk uploading Proguard files, but we are adding support in https://github.com/getsentry/sentry-cli/issues/2196, and so we need to fix the backend to allow chunk uploads of Proguard files.

Here, we update the logic to check both the `path` and the `name` for potentially matching a Proguard file.