### PR TITLE
fix(autofix): Hide Open Autofix button on errors without a stacktrace

### DIFF
--- a/static/app/views/issueDetails/streamline/solutionsHubDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/solutionsHubDrawer.tsx
@@ -112,7 +112,7 @@ const shouldDisplayAiAutofixForOrganization = (organization: Organization) => {
 };
 
 // Autofix requires the event to have stack trace frames in order to work correctly.
-function hasStacktraceWithFrames(event: Event) {
+export function hasStacktraceWithFrames(event: Event) {
   for (const entry of event.entries) {
     if (entry.type === EntryType.EXCEPTION) {
       if (entry.data.values?.some(value => value.stacktrace?.frames?.length)) {

--- a/static/app/views/issueDetails/streamline/solutionsSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/solutionsSection.spec.tsx
@@ -1,10 +1,12 @@
 import {EventFixture} from 'sentry-fixture/event';
+import {FrameFixture} from 'sentry-fixture/frame';
 import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {EntryType} from 'sentry/types/event';
 import {IssueCategory} from 'sentry/types/group';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import SolutionsSection from 'sentry/views/issueDetails/streamline/solutionsSection';
@@ -12,7 +14,14 @@ import SolutionsSection from 'sentry/views/issueDetails/streamline/solutionsSect
 jest.mock('sentry/utils/issueTypeConfig');
 
 describe('SolutionsSection', () => {
-  const mockEvent = EventFixture();
+  const mockEvent = EventFixture({
+    entries: [
+      {
+        type: EntryType.EXCEPTION,
+        data: {values: [{stacktrace: {frames: [FrameFixture()]}}]},
+      },
+    ],
+  });
   const mockGroup = GroupFixture();
   const mockProject = ProjectFixture();
   const organization = OrganizationFixture({genAIConsent: true, hideAiFeatures: false});

--- a/static/app/views/issueDetails/streamline/solutionsSection.tsx
+++ b/static/app/views/issueDetails/streamline/solutionsSection.tsx
@@ -19,7 +19,10 @@ import {getRegionDataFromOrganization} from 'sentry/utils/regions';
 import useOrganization from 'sentry/utils/useOrganization';
 import Resources from 'sentry/views/issueDetails/streamline/resources';
 import {SidebarSectionTitle} from 'sentry/views/issueDetails/streamline/sidebar';
-import {SolutionsHubDrawer} from 'sentry/views/issueDetails/streamline/solutionsHubDrawer';
+import {
+  hasStacktraceWithFrames,
+  SolutionsHubDrawer,
+} from 'sentry/views/issueDetails/streamline/solutionsHubDrawer';
 import {useHasStreamlinedUI, useIsSampleEvent} from 'sentry/views/issueDetails/utils';
 
 export default function SolutionsSection({
@@ -74,6 +77,7 @@ export default function SolutionsSection({
   });
 
   const isSampleError = useIsSampleEvent();
+  const hasStacktrace = event && hasStacktraceWithFrames(event);
 
   const issueTypeConfig = getConfigForIssueType(group, group.project);
 
@@ -86,7 +90,8 @@ export default function SolutionsSection({
   const hasResources = issueTypeConfig.resources;
 
   const hasSummary = hasGenAIConsent && isSummaryEnabled && areAiFeaturesAllowed;
-  const hasAutofix = isAutofixEnabled && areAiFeaturesAllowed && !isSampleError;
+  const hasAutofix =
+    isAutofixEnabled && areAiFeaturesAllowed && hasStacktrace && !isSampleError;
 
   const needsGenAIConsent =
     !hasGenAIConsent && (isSummaryEnabled || isAutofixEnabled) && areAiFeaturesAllowed;


### PR DESCRIPTION
Adds a check that hides Autofix in the Solutions Hub for errors with no stacktrace.