### PR TITLE
feat(ui): Support customizing help tooltip in FieldGroup

### DIFF
--- a/static/app/components/forms/fieldGroup/index.tsx
+++ b/static/app/components/forms/fieldGroup/index.tsx
@@ -96,7 +96,12 @@ function FieldGroup({
             </span>
             {helpElement && showHelpInTooltip && (
               <FieldQuestion>
-                <QuestionTooltip position="top" size="sm" title={helpElement} />
+                <QuestionTooltip
+                  position="top"
+                  size="sm"
+                  {...(showHelpInTooltip !== true ? showHelpInTooltip : {})}
+                  title={helpElement}
+                />
               </FieldQuestion>
             )}
           </FieldLabel>

--- a/static/app/components/forms/fieldGroup/types.tsx
+++ b/static/app/components/forms/fieldGroup/types.tsx
@@ -1,3 +1,5 @@
+import type {TooltipProps} from 'sentry/components/tooltip';
+
 /**
  * Props that control UI elements that are part of a Form Group
  */
@@ -91,9 +93,10 @@ export interface FieldGroupProps {
    */
   required?: boolean;
   /**
-   * Displays the help element in the tooltip
+   * Displays the help element in the tooltip. Tooltip props may be passed to
+   * customize the help tooltip.
    */
-  showHelpInTooltip?: boolean;
+  showHelpInTooltip?: boolean | Omit<TooltipProps, 'title'>;
   /**
    * When stacking forms the bottom border is hidden and padding is adjusted
    * for form elements to be stacked on each other.


### PR DESCRIPTION
need to be able to make the tooltip hoverable for a link in the help tooltip