### PR TITLE
ref: disable branch coverage

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -182,6 +182,7 @@ s3transfer==0.10.0
 selenium==4.16.0
 sentry-arroyo==2.16.5
 sentry-cli==2.16.0
+sentry-covdefaults-disable-branch-coverage==1.0.2
 sentry-devenv==1.13.0
 sentry-forked-django-stubs==5.1.1.post1
 sentry-forked-djangorestframework-stubs==3.15.1.post2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ sentry-devenv>=1.13.0
 devservices>=1.0.3
 
 covdefaults>=2.3.0
+sentry-covdefaults-disable-branch-coverage>=1.0.2
 docker>=7
 time-machine>=2.16.0
 honcho>=2

--- a/setup.cfg
+++ b/setup.cfg
@@ -112,7 +112,9 @@ extension =
 [coverage:run]
 omit =
     src/sentry/migrations/*
-plugins = covdefaults
+plugins =
+    covdefaults
+    sentry_covdefaults_disable_branch_coverage
 
 [coverage:report]
 # Setting this to 0 makes it falsy, and it gets ignored, so we set it to


### PR DESCRIPTION
this disables branch coverage (coverage of jumps for loops / if statements / lambdas / try-except / etc.) but drastically improves CI time

we can revert this out once https://github.com/nedbat/coveragepy/issues/1746 is resolved and we're on a sufficiently new-enough version of coverage

<!-- Describe your PR here. -->