### PR TITLE
:wrench: chore(api): Make SentryAppsStatsEndpoint Private

### DIFF
--- a/src/sentry/sentry_apps/api/endpoints/sentry_apps_stats.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_apps_stats.py
@@ -16,7 +16,7 @@ from sentry.sentry_apps.models.sentry_app_avatar import SentryAppAvatar
 class SentryAppsStatsEndpoint(SentryAppsBaseEndpoint):
     owner = ApiOwner.INTEGRATIONS
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (SuperuserOrStaffFeatureFlaggedPermission,)
 


### PR DESCRIPTION
the endpoint is only used in admin tool