### PR TITLE
fix(explore): Add legends back in

### DIFF
--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -297,6 +297,7 @@ export function ExploreCharts({query, setError}: ExploreChartsProps) {
                 aggregateOutputFormat={
                   outputTypes.size === 1 ? outputTypes.keys().next().value : undefined
                 }
+                showLegend
               />
             </ChartPanel>
           </ChartContainer>

--- a/static/app/views/insights/common/components/chart.tsx
+++ b/static/app/views/insights/common/components/chart.tsx
@@ -334,6 +334,7 @@ function Chart({
     return getFormatter({
       isGroupedByDate: true,
       showTimeInTooltip: true,
+      truncate: true,
       utc: utc ?? false,
       valueFormatter: (value, seriesName) => {
         return tooltipFormatter(


### PR DESCRIPTION
We want legends back in explore and truncate the tooltip as needed.