### PR TITLE
fix(eap): handle span status

### DIFF
--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -44,7 +44,7 @@ class SpansIndexedDatasetConfig(DatasetConfig):
     @property
     def search_filter_converter(
         self,
-    ) -> Mapping[str, Callable[[SearchFilter], WhereType | None]]:
+    ) -> dict[str, Callable[[SearchFilter], WhereType | None]]:
         return {
             "message": self._message_filter_converter,
             constants.PROJECT_ALIAS: self._project_slug_filter_converter,
@@ -915,6 +915,14 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
         }
         existing_field_aliases.update(field_alias_converter)
         return existing_field_aliases
+
+    @property
+    def search_filter_converter(
+        self,
+    ) -> dict[str, Callable[[SearchFilter], WhereType | None]]:
+        existing_search_filters = super().search_filter_converter
+        del existing_search_filters[constants.SPAN_STATUS]
+        return existing_search_filters
 
     def _resolve_sum_weighted(
         self,

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -730,6 +730,38 @@ class OrganizationEventsSpanIndexedEndpointTest(OrganizationEventsEndpointTestBa
         ]
         assert meta["dataset"] == self.dataset
 
+    def test_span_status(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "foo", "sentry_tags": {"status": "internal_error"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=self.is_eap,
+        )
+        response = self.do_request(
+            {
+                "field": ["description", "count()"],
+                "query": "span.status:internal_error",
+                "orderby": "description",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data == [
+            {
+                "description": "foo",
+                "count()": 1,
+            },
+        ]
+        assert meta["dataset"] == self.dataset
+
 
 class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsSpanIndexedEndpointTest):
     is_eap = True


### PR DESCRIPTION
- Span.status filters should not be special cased in eap cause we just store the converted string instead of an enum