### PR TITLE
fix(issue-details): Convert IconLock to IconGlobe for public issues

### DIFF
--- a/static/app/views/issueDetails/streamline/groupActivityIcons.tsx
+++ b/static/app/views/issueDetails/streamline/groupActivityIcons.tsx
@@ -11,6 +11,7 @@ import {
   IconFlag,
   IconGithub,
   IconGitlab,
+  IconGlobe,
   IconGraph,
   IconJira,
   IconLock,
@@ -53,7 +54,7 @@ export const groupActivityTypeIconMapping: Record<
   },
   [GroupActivityType.SET_UNRESOLVED]: {Component: IconClose, defaultProps: {}},
   [GroupActivityType.SET_IGNORED]: {Component: IconMute, defaultProps: {}},
-  [GroupActivityType.SET_PUBLIC]: {Component: IconLock, defaultProps: {}},
+  [GroupActivityType.SET_PUBLIC]: {Component: IconGlobe, defaultProps: {}},
   [GroupActivityType.SET_PRIVATE]: {Component: IconLock, defaultProps: {locked: true}},
   [GroupActivityType.SET_REGRESSION]: {Component: IconFire, defaultProps: {}},
   [GroupActivityType.CREATE_ISSUE]: {

--- a/static/app/views/issueDetails/streamline/header.tsx
+++ b/static/app/views/issueDetails/streamline/header.tsx
@@ -14,7 +14,7 @@ import UnhandledTag from 'sentry/components/group/inboxBadges/unhandledTag';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
 import {Tooltip} from 'sentry/components/tooltip';
-import {IconLock} from 'sentry/icons';
+import {IconGlobe} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
@@ -101,8 +101,7 @@ export default function StreamlinedGroupHeader({
                 })}
                 tooltipProps={{isHoverable: true}}
                 icon={
-                  <IconLock
-                    locked={false}
+                  <IconGlobe
                     size="xs"
                     color="subText"
                     onClick={() =>


### PR DESCRIPTION
**Before**

<img width="308" alt="image" src="https://github.com/user-attachments/assets/9af752e7-1cca-4a81-924e-d33f4eb77a61">
<img width="203" alt="image" src="https://github.com/user-attachments/assets/97b70ae7-9b51-4189-a8eb-8ec4378cbcc6">


**After**

<img width="295" alt="image" src="https://github.com/user-attachments/assets/96e293f0-db78-447f-a5d3-beca368280a3">
<img width="170" alt="image" src="https://github.com/user-attachments/assets/3bacd188-3359-4cdf-b0c9-41ac5918a1e0">
