### PR TITLE
fix(auth): handle uniqueness of ApiAuthorization per org

### DIFF
--- a/tests/sentry/web/frontend/test_oauth_authorize.py
+++ b/tests/sentry/web/frontend/test_oauth_authorize.py
@@ -419,3 +419,33 @@ class OAuthAuthorizeOrgScopedTest(TestCase):
 
         assert resp.status_code == 302
         assert resp["Location"] == "https://example.com?error=invalid_scope&state=foo"
+
+    def test_second_time(self):
+        self.login_as(self.owner)
+
+        resp = self.client.get(
+            f"{self.path}?response_type=code&client_id={self.application.client_id}&scope=org:read&state=foo"
+        )
+
+        assert resp.status_code == 200
+        self.assertTemplateUsed("sentry/oauth-authorize.html")
+        assert resp.context["application"] == self.application
+
+        resp = self.client.post(
+            self.path, {"op": "approve", "selected_organization_id": self.organization.id}
+        )
+
+        grant = ApiGrant.objects.get(user=self.owner)
+        assert grant.redirect_uri == self.application.get_default_redirect_uri()
+        # There is only one ApiAuthorization for this user and app which is related to the right organization
+        api_auth = ApiAuthorization.objects.get(user=self.owner, application=self.application)
+        assert api_auth.organization_id == self.organization.id
+
+        resp = self.client.get(
+            f"{self.path}?response_type=code&client_id={self.application.client_id}&scope=org:read&state=foo"
+        )
+        assert resp.status_code == 200
+        self.assertTemplateUsed("sentry/oauth-authorize.html")
+        assert resp.context["application"] == self.application
+        new_api_auth = ApiAuthorization.objects.get(user=self.owner, application=self.application)
+        assert api_auth.id == new_api_auth.id


### PR DESCRIPTION
I added a new unique index in https://github.com/getsentry/sentry/pull/80996 and this PR is using it in code.

Basically:
1. If organization id is null then ApiAuthorization of an app must be unique per user
2. If organization id is not null then ApiAuthorization of an app must be unique per user and org (per organization member)

Why is this a bug today?
1. App with org level scope goes through authorize once. Users chooses one of their orgs. We create ApiAuthorize(user1, org1, app1)
2. Same app goes through authorize again with the same user. We find ApiAuthorize(user1, org1, app1) so we go through autoapprove. But in autoapprove we don't know what org user chose (because they weren't involve at all) and create ApiAuthorize(user1, app1, org=None).

This is against the way we defined our unique index so it breaks the code.

