### PR TITLE
chore(slack): Better Logging for Incident Alert Notifications

### DIFF
--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -140,6 +140,8 @@ def send_incident_alert_notification(
             "incident_id": incident.id,
             "incident_status": new_status,
             "attachments": attachments,
+            "channel_id": channel,
+            "channel_name": action.target_display,
         }
         _logger.info("slack.metric_alert.error", exc_info=True, extra=log_params)
         metrics.incr(


### PR DESCRIPTION
when  trying to debug out why a notification wasn't sent out properly, we ran into a problem that we couldn't verify the channel_id or name that we were send the notification out to. lets log that as well on failures so we can cross reference with the customer.