### PR TITLE
feat(trace) issues only collapse trace

### DIFF
--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -59,8 +59,7 @@ function EventTraceViewInner({event, organization}: EventTraceViewInnerProps) {
   const meta = useTraceMeta([{traceSlug: traceId, timestamp: undefined}]);
   const tree = useIssuesTraceTree({trace, meta, replay: null});
 
-  const hasNoTransactions = meta.data?.transactions === 0;
-  const shouldLoadTraceRoot = !trace.isPending && trace.data && !hasNoTransactions;
+  const shouldLoadTraceRoot = !trace.isPending && trace.data;
 
   const rootEvent = useTraceRootEvent(shouldLoadTraceRoot ? trace.data! : null);
 
@@ -79,7 +78,7 @@ function EventTraceViewInner({event, organization}: EventTraceViewInnerProps) {
     return {eventId: firstTransactionEventId};
   }, [trace.data]);
 
-  if (trace.isPending || rootEvent.isPending || !rootEvent.data || hasNoTransactions) {
+  if (trace.isPending || rootEvent.isPending || !rootEvent.data) {
     return null;
   }
 
@@ -151,7 +150,7 @@ const TraceContentWrapper = styled('div')`
 
 const ROW_HEIGHT = 24;
 const MIN_ROW_COUNT = 1;
-const MAX_HEIGHT = 500;
+const MAX_HEIGHT = 12 * ROW_HEIGHT;
 const MAX_ROW_COUNT = Math.floor(MAX_HEIGHT / ROW_HEIGHT);
 const HEADER_HEIGHT = 26;
 

--- a/static/app/views/performance/newTraceDetails/issuesTraceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/issuesTraceWaterfall.tsx
@@ -164,7 +164,6 @@ export function IssuesTraceWaterfall(props: IssuesTraceWaterfallProps) {
       (eventId && TraceTree.FindByID(props.tree.root, eventId)) ||
       null;
 
-    // @TODO Scrolling to a node is not yet supported for issues, so always pin to the top
     const index = -1;
 
     if (index === -1 || !node) {
@@ -239,18 +238,20 @@ export function IssuesTraceWaterfall(props: IssuesTraceWaterfallProps) {
         organization={organization}
       />
       <IssuesTraceGrid layout={traceState.preferences.layout}>
-        <Trace
-          trace={props.tree}
-          rerender={rerender}
-          trace_id={props.traceSlug}
-          onRowClick={onRowClick}
-          onTraceSearch={noopTraceSearch}
-          previouslyFocusedNodeRef={previouslyFocusedNodeRef}
-          manager={viewManager}
-          scheduler={traceScheduler}
-          forceRerender={forceRender}
-          isLoading={props.tree.type === 'loading' || onLoadScrollStatus === 'pending'}
-        />
+        <IssuesPointerDisabled>
+          <Trace
+            trace={props.tree}
+            rerender={rerender}
+            trace_id={props.traceSlug}
+            onRowClick={onRowClick}
+            onTraceSearch={noopTraceSearch}
+            previouslyFocusedNodeRef={previouslyFocusedNodeRef}
+            manager={viewManager}
+            scheduler={traceScheduler}
+            forceRerender={forceRender}
+            isLoading={props.tree.type === 'loading' || onLoadScrollStatus === 'pending'}
+          />
+        </IssuesPointerDisabled>
 
         {props.tree.type === 'loading' || onLoadScrollStatus === 'pending' ? (
           <TraceWaterfallState.Loading />
@@ -263,6 +264,12 @@ export function IssuesTraceWaterfall(props: IssuesTraceWaterfallProps) {
     </Fragment>
   );
 }
+
+const IssuesPointerDisabled = styled('div')`
+  position: relative;
+  height: 100%;
+  width: 100%;
+`;
 
 const IssuesTraceGrid = styled(TraceGrid)<{
   layout: 'drawer bottom' | 'drawer left' | 'drawer right';

--- a/static/app/views/performance/newTraceDetails/traceModels/__snapshots__/issuesTraceTree.spec.tsx.snap
+++ b/static/app/views/performance/newTraceDetails/traceModels/__snapshots__/issuesTraceTree.spec.tsx.snap
@@ -9,19 +9,19 @@ trace root
 "
 `;
 
+exports[`IssuesTraceTree collapses sibling collapsed nodes 1`] = `
+"
+trace root
+  transaction 1 - transaction.op
+    collapsed
+    transaction 2 - transaction.op
+    collapsed
+"
+`;
+
 exports[`IssuesTraceTree errors only 1`] = `
 "
 trace root
-  error
-  error
-  error
-  error
-  error
-  error
-  error
-  error
-  error
-  error
   error
   error
   error

--- a/static/app/views/performance/newTraceDetails/traceModels/__snapshots__/issuesTraceTree.spec.tsx.snap
+++ b/static/app/views/performance/newTraceDetails/traceModels/__snapshots__/issuesTraceTree.spec.tsx.snap
@@ -9,6 +9,32 @@ trace root
 "
 `;
 
+exports[`IssuesTraceTree errors only 1`] = `
+"
+trace root
+  error
+  error
+  error
+  error
+  error
+  error
+  error
+  error
+  error
+  error
+  error
+  error
+  error
+  error
+  error
+  error
+  error
+  error
+  error
+  collapsed
+"
+`;
+
 exports[`IssuesTraceTree preserves path to child error 1`] = `
 "
 trace root

--- a/static/app/views/performance/newTraceDetails/traceModels/issuesTraceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/issuesTraceTree.spec.tsx
@@ -22,6 +22,11 @@ const traceWithChildError = makeTrace({
   ],
 });
 
+const errorsOnlyTrace = makeTrace({
+  transactions: [],
+  orphan_errors: new Array(30).fill(null).map(() => makeTraceError({})),
+});
+
 describe('IssuesTraceTree', () => {
   it('collapsed nodes without errors', () => {
     const tree = IssuesTraceTree.FromTrace(traceWithErrorInMiddle, {
@@ -34,6 +39,15 @@ describe('IssuesTraceTree', () => {
 
   it('preserves path to child error', () => {
     const tree = IssuesTraceTree.FromTrace(traceWithChildError, {
+      meta: null,
+      replay: null,
+    });
+
+    expect(tree.build().serialize()).toMatchSnapshot();
+  });
+
+  it('errors only', () => {
+    const tree = IssuesTraceTree.FromTrace(errorsOnlyTrace, {
       meta: null,
       replay: null,
     });

--- a/static/app/views/performance/newTraceDetails/traceModels/issuesTraceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/issuesTraceTree.spec.tsx
@@ -24,7 +24,23 @@ const traceWithChildError = makeTrace({
 
 const errorsOnlyTrace = makeTrace({
   transactions: [],
-  orphan_errors: new Array(30).fill(null).map(() => makeTraceError({})),
+  orphan_errors: new Array(20).fill(null).map(() => makeTraceError({})),
+});
+
+const traceWithSiblingCollapsedNodes = makeTrace({
+  transactions: [
+    makeTransaction({
+      transaction: 'transaction 1',
+      children: [
+        makeTransaction({}),
+        makeTransaction({}),
+        makeTransaction({transaction: 'transaction 2', errors: [makeTraceError({})]}),
+        makeTransaction({}),
+      ],
+    }),
+    makeTransaction({transaction: 'transaction 3'}),
+    makeTransaction({transaction: 'transaction 4'}),
+  ],
 });
 
 describe('IssuesTraceTree', () => {
@@ -47,7 +63,17 @@ describe('IssuesTraceTree', () => {
   });
 
   it('errors only', () => {
+    // has +100 issues at the end
     const tree = IssuesTraceTree.FromTrace(errorsOnlyTrace, {
+      meta: null,
+      replay: null,
+    });
+
+    expect(tree.build().serialize()).toMatchSnapshot();
+  });
+
+  it('collapses sibling collapsed nodes', () => {
+    const tree = IssuesTraceTree.FromTrace(traceWithSiblingCollapsedNodes, {
       meta: null,
       replay: null,
     });

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -1149,8 +1149,8 @@ export class TraceTree extends TraceTreeEventDispatcher {
       if (isParentAutogroupedNode(next)) {
         queue.push(next.head);
       } else {
-        for (const child of next.children) {
-          queue.push(child);
+        for (let i = next.children.length - 1; i >= 0; i--) {
+          queue.push(next.children[i]);
         }
       }
     }

--- a/static/app/views/performance/newTraceDetails/traceRow/traceCollapsedRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceCollapsedRow.tsx
@@ -1,31 +1,39 @@
 import {useMemo} from 'react';
 
 import {t} from 'sentry/locale';
+import {isTraceErrorNode} from 'sentry/views/performance/newTraceDetails/traceGuards';
 
 import type {CollapsedNode} from '../traceModels/traceCollapsedNode';
 import {TraceTree} from '../traceModels/traceTree';
 import type {TraceRowProps} from '../traceRow/traceRow';
 
 export function TraceCollapsedRow(props: TraceRowProps<CollapsedNode>) {
-  const collapsedChildrenCount = useMemo(() => {
+  const collapsedNodeType = useMemo(() => {
+    let type: 'issues only' | '' = 'issues only';
     let count = 1;
-    TraceTree.ForEachChild(props.node, () => count++);
-    return count;
+
+    TraceTree.ForEachChild(props.node, c => {
+      count++;
+      if (!isTraceErrorNode(c)) {
+        type = '';
+      }
+    });
+    return {count, type};
   }, [props.node]);
 
   return (
     <div
       key={props.index}
       tabIndex={props.tabIndex}
-      className="Collapsed TraceRow"
+      className={`Collapsed ${collapsedNodeType.type === 'issues only' ? 'IssuesOnly' : ''} TraceRow`}
       onPointerDown={props.onRowClick}
       onKeyDown={props.onRowKeyDown}
       style={props.style}
     >
       <div className="TraceLeftColumn" ref={props.registerListColumnRef}>
         <div className="TraceLeftColumnInner" style={props.listColumnStyle}>
-          {collapsedChildrenCount}{' '}
-          {collapsedChildrenCount === 1 ? t('hidden span') : t('hidden spans')}
+          {collapsedNodeType.count}{' '}
+          {collapsedNodeType.count === 1 ? t('hidden span') : t('hidden spans')}
         </div>
       </div>
     </div>


### PR DESCRIPTION
We bfs to find collapsed nodes, because we want to preserve the tree structure, this means that it is possible to have consecutive collapsed nodes at different levels in the tree. We can fix this by doing a second pass over the list of the nodes in the tree and collapse any siblings. I also removed the condition to not render the errors only trace view as this seems to be a case that we handle in our new design.