### PR TITLE
fix(crons): Missing `,` in example

### DIFF
--- a/static/app/views/monitors/components/quickStartEntries.tsx
+++ b/static/app/views/monitors/components/quickStartEntries.tsx
@@ -167,7 +167,7 @@ $checkInId = \\Sentry\\captureCheckIn(
   const checkInFailCode = `// 🔴 Notify Sentry your job has failed:
 \\Sentry\\captureCheckIn(
     slug: '${slug}',
-    status: CheckInStatus::error()
+    status: CheckInStatus::error(),
     checkInId: $checkInId,
 );`;
 


### PR DESCRIPTION
Fixes [JAVASCRIPT-2WTQ](https://sentry.sentry.io/feedback/?feedbackSlug=javascript%3A6082610710&project=11276)