### PR TITLE
fix(trace) disable missing instrumentation for nuxt

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceGuards.tsx
+++ b/static/app/views/performance/newTraceDetails/traceGuards.tsx
@@ -82,6 +82,7 @@ export function shouldAddMissingInstrumentationSpan(sdk: string | undefined): bo
     case 'sentry.javascript.angular':
     case 'sentry.javascript.angular-ivy':
     case 'sentry.javascript.nextjs':
+    case 'sentry.javascript.nuxt':
     case 'sentry.javascript.electron':
     case 'sentry.javascript.remix':
     case 'sentry.javascript.svelte':


### PR DESCRIPTION
Force disabling of missing instrumentation span detection for nuxtjs SDK