### PR TITLE
fix(alerts): add alerts permission selector to API key generation page

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -121,8 +121,8 @@ export type PermissionChoice = {
 
 type PermissionObj = {
   choices: {
-    admin: PermissionChoice;
     'no-access': PermissionChoice;
+    admin?: PermissionChoice;
     read?: PermissionChoice;
     write?: PermissionChoice;
   };
@@ -197,6 +197,15 @@ export const SENTRY_APP_PERMISSIONS: PermissionObj[] = [
       read: {label: 'Read', scopes: ['member:read']},
       write: {label: 'Read & Write', scopes: ['member:read', 'member:write']},
       admin: {label: 'Admin', scopes: ['member:read', 'member:write', 'member:admin']},
+    },
+  },
+  {
+    resource: 'Alerts',
+    help: 'Manage Alerts',
+    choices: {
+      'no-access': {label: 'No Access', scopes: []},
+      read: {label: 'Read', scopes: ['alerts:read']},
+      write: {label: 'Read & Write', scopes: ['alerts:read', 'alerts:write']},
     },
   },
 ];

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -17,6 +17,7 @@ import type {User} from './user';
 export type PermissionValue = 'no-access' | 'read' | 'write' | 'admin';
 
 export type Permissions = {
+  Alerts: PermissionValue;
   Event: PermissionValue;
   Member: PermissionValue;
   Organization: PermissionValue;

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -17,13 +17,13 @@ import type {User} from './user';
 export type PermissionValue = 'no-access' | 'read' | 'write' | 'admin';
 
 export type Permissions = {
-  Alerts: PermissionValue;
   Event: PermissionValue;
   Member: PermissionValue;
   Organization: PermissionValue;
   Project: PermissionValue;
   Release: PermissionValue;
   Team: PermissionValue;
+  Alerts?: PermissionValue;
 };
 
 export type PermissionResource = keyof Permissions;

--- a/static/app/views/settings/account/apiNewToken.tsx
+++ b/static/app/views/settings/account/apiNewToken.tsx
@@ -37,6 +37,7 @@ export default class ApiNewToken extends Component<{}, State> {
         Project: 'no-access',
         Release: 'no-access',
         Organization: 'no-access',
+        Alerts: 'no-access',
       },
       newToken: null,
     };


### PR DESCRIPTION
As I mentioned in https://github.com/getsentry/sentry/pull/81002, there is no option to select the alerts:write permission when generating an API key, so members are not able to create alert rules if the member alert creation feature is turned on (team admins are also unable to create alert rules if the member alert creation feature is turned off). Introduce the ability to grant this scope to API keys. 