### PR TITLE
feat(auth): Return auth error if application is requesting a wrong org

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -426,7 +426,7 @@ class UserAuthTokenAuthentication(StandardAuthentication):
             # We need to make sure the organization to which the token has access is the same as the one in the URL
             organization = None
             organization_context = organization_service.get_organization_by_id(
-                id=token.organization_id
+                id=token.organization_id, include_projects=False, include_teams=False
             )
             if organization_context:
                 organization = organization_context.organization

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -443,9 +443,11 @@ class UserAuthTokenAuthentication(StandardAuthentication):
                         raise AuthenticationFailed("Unauthorized organization access.")
                 else:
                     # We want to limit org scoped tokens access to org level endpoints only
-                    raise AuthenticationFailed(
-                        "This token access is limited to organization endpoints."
-                    )
+                    # Or none org level endpoints that we added special treatments for
+                    if resolved_url.url_name not in ["sentry-api-0-organizations"]:
+                        raise AuthenticationFailed(
+                            "This token access is limited to organization endpoints."
+                        )
             else:
                 sentry_sdk.capture_message(
                     "Could not resolve organization for organization scoped token", level="warning"


### PR DESCRIPTION
If an application is organization scope application, their tokens will only have access to one organization of a user. So we should return auth error if:
1. They're calling an API on an organization that is not the same as the org in the token
2. They're calling an API that is not limited to one organization, for example list all user's project

[In a previous PR](https://github.com/getsentry/sentry/pull/80012) I added some logging to make sure this doesn't break other integrations.  It actually does, so I have to limit this to token.scoping_organization_id vs token.organization_id

