### PR TITLE
feat(explore): Ensure id column is present in samples mode

### DIFF
--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -103,8 +103,13 @@ export function SpansTable({setError}: SpansTableProps) {
     userQuery: query,
   });
 
+  const visibleFields = useMemo(
+    () => (fields.includes('id') ? fields : ['id', ...fields]),
+    [fields]
+  );
+
   const {tableStyles} = useTableStyles({
-    items: fields.map(field => {
+    items: visibleFields.map(field => {
       return {
         label: field,
         value: field,
@@ -122,7 +127,7 @@ export function SpansTable({setError}: SpansTableProps) {
       <Table style={tableStyles}>
         <TableHead>
           <TableRow>
-            {fields.map((field, i) => {
+            {visibleFields.map((field, i) => {
               // Hide column names before alignment is determined
               if (result.isPending) {
                 return <TableHeadCell key={i} isFirst={i === 0} />;
@@ -176,7 +181,7 @@ export function SpansTable({setError}: SpansTableProps) {
           ) : result.isFetched && result.data?.length ? (
             result.data?.map((row, i) => (
               <TableRow key={i}>
-                {fields.map((field, j) => {
+                {visibleFields.map((field, j) => {
                   return (
                     <TableBodyCell key={j}>
                       <FieldRenderer


### PR DESCRIPTION
It's possible for users to remove the id column in the column editor. But if they do so, the result isn't very useful since it won't link to a trace. So we ensure the id column is always present no matter what columns are selected.