### PR TITLE
chore(devservices): Bumping the version of devservices to latest

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -36,7 +36,7 @@ cryptography==43.0.1
 cssselect==1.0.3
 cssutils==2.9.0
 datadog==0.49.1
-devservices==1.0.3
+devservices==1.0.4
 distlib==0.3.8
 distro==1.8.0
 django==5.1.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 
 sentry-devenv>=1.13.0
-devservices>=1.0.3
+devservices>=1.0.4
 
 covdefaults>=2.3.0
 sentry-covdefaults-disable-branch-coverage>=1.0.2


### PR DESCRIPTION
https://github.com/getsentry/devservices/releases/tag/1.0.4
Fixes some bugs with bring up order of services and uses an external network.