### PR TITLE
test(dashboards): Replace flaky acceptance test

### DIFF
--- a/tests/acceptance/test_organization_dashboards.py
+++ b/tests/acceptance/test_organization_dashboards.py
@@ -360,43 +360,6 @@ class OrganizationDashboardsAcceptanceTest(AcceptanceTestCase):
 
             self.page.wait_until_loaded()
 
-    @pytest.mark.skip(reason="Flaky")
-    def test_duplicate_widget_in_view_mode(self):
-        existing_widget = DashboardWidget.objects.create(
-            dashboard=self.dashboard,
-            order=0,
-            title="Big Number Widget",
-            display_type=DashboardWidgetDisplayTypes.BIG_NUMBER,
-            widget_type=DashboardWidgetTypes.DISCOVER,
-            interval="1d",
-        )
-        DashboardWidgetQuery.objects.create(
-            widget=existing_widget,
-            fields=["count_unique(issue)"],
-            columns=[],
-            aggregates=["count_unique(issue)"],
-            order=0,
-        )
-        with self.feature(FEATURE_NAMES + EDIT_FEATURE):
-            self.page.visit_dashboard_detail()
-
-            # Hover over the widget to show widget actions
-            self.browser.move_to('[aria-label="Widget panel"]')
-
-            self.browser.element('[aria-label="Widget actions"]').click()
-            self.browser.element('[data-test-id="duplicate-widget"]').click()
-            self.page.wait_until_loaded()
-
-            self.browser.element('[aria-label="Widget actions"]').click()
-            self.browser.element('[data-test-id="duplicate-widget"]').click()
-            self.page.wait_until_loaded()
-
-            # Should not trigger alert
-            self.page.enter_edit_state()
-            self.page.click_cancel_button()
-            wait = WebDriverWait(self.browser.driver, 5)
-            wait.until_not(EC.alert_is_present())
-
     def test_delete_widget_in_view_mode(self):
         existing_widget = DashboardWidget.objects.create(
             dashboard=self.dashboard,


### PR DESCRIPTION
Removes a flaky dashboard test and tests the functionality in jest. We can validate that the API is called with the correct props and the other tests handle rendering the dashboard.