### PR TITLE
nit(integrations): replace on-call integration validation error failures with halts

### DIFF
--- a/src/sentry/integrations/on_call/metrics.py
+++ b/src/sentry/integrations/on_call/metrics.py
@@ -65,3 +65,4 @@ class OnCallIntegrationsHaltReason(StrEnum):
 
     INVALID_TEAM = "invalid_team"
     INVALID_SERVICE = "invalid_service"
+    INVALID_KEY = "invalid_key"

--- a/src/sentry/integrations/on_call/metrics.py
+++ b/src/sentry/integrations/on_call/metrics.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import Enum, StrEnum
 
 from attr import dataclass
 
@@ -56,3 +56,12 @@ class OnCallInteractionEvent(IntegrationEventLifecycleMetric):
 
     def get_interaction_type(self) -> str:
         return str(self.interaction_type)
+
+
+class OnCallIntegrationsHaltReason(StrEnum):
+    """
+    Reasons why on on call integration method may halt without success/failure.
+    """
+
+    INVALID_TEAM = "invalid_team"
+    INVALID_SERVICE = "invalid_service"

--- a/src/sentry/integrations/opsgenie/actions/form.py
+++ b/src/sentry/integrations/opsgenie/actions/form.py
@@ -6,7 +6,7 @@ from typing import Any
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
-from sentry.integrations.on_call.metrics import OnCallInteractionType
+from sentry.integrations.on_call.metrics import OnCallIntegrationsHaltReason, OnCallInteractionType
 from sentry.integrations.opsgenie.metrics import record_event
 from sentry.integrations.opsgenie.utils import get_team
 from sentry.integrations.services.integration import integration_service
@@ -65,7 +65,7 @@ class OpsgenieNotifyTeamForm(forms.Form):
         return VALID_TEAM
 
     def _validate_team(self, team_id: str | None, integration_id: int | None) -> None:
-        with record_event(OnCallInteractionType.VERIFY_TEAM).capture():
+        with record_event(OnCallInteractionType.VERIFY_TEAM).capture() as lifecyle:
             params = {
                 "account": dict(self.fields["account"].choices).get(integration_id),
                 "team": dict(self.fields["team"].choices).get(team_id),
@@ -78,6 +78,7 @@ class OpsgenieNotifyTeamForm(forms.Form):
                 organization_id=self.org_id,
             )
             if integration is None or org_integration is None:
+                lifecyle.record_halt(str(OnCallIntegrationsHaltReason.INVALID_TEAM))
                 raise forms.ValidationError(
                     _("The Opsgenie integration does not exist."),
                     code="invalid_integration",
@@ -86,6 +87,7 @@ class OpsgenieNotifyTeamForm(forms.Form):
 
             team_status = self._get_team_status(team_id=team_id, org_integration=org_integration)
             if team_status == INVALID_TEAM:
+                lifecyle.record_halt(str(OnCallIntegrationsHaltReason.INVALID_TEAM))
                 raise forms.ValidationError(
                     _('The team "%(team)s" does not belong to the %(account)s Opsgenie account.'),
                     code="invalid_team",

--- a/src/sentry/integrations/opsgenie/actions/form.py
+++ b/src/sentry/integrations/opsgenie/actions/form.py
@@ -78,7 +78,7 @@ class OpsgenieNotifyTeamForm(forms.Form):
                 organization_id=self.org_id,
             )
             if integration is None or org_integration is None:
-                lifecyle.record_halt(str(OnCallIntegrationsHaltReason.INVALID_TEAM))
+                lifecyle.record_halt(OnCallIntegrationsHaltReason.INVALID_TEAM)
                 raise forms.ValidationError(
                     _("The Opsgenie integration does not exist."),
                     code="invalid_integration",
@@ -87,7 +87,7 @@ class OpsgenieNotifyTeamForm(forms.Form):
 
             team_status = self._get_team_status(team_id=team_id, org_integration=org_integration)
             if team_status == INVALID_TEAM:
-                lifecyle.record_halt(str(OnCallIntegrationsHaltReason.INVALID_TEAM))
+                lifecyle.record_halt(OnCallIntegrationsHaltReason.INVALID_TEAM)
                 raise forms.ValidationError(
                     _('The team "%(team)s" does not belong to the %(account)s Opsgenie account.'),
                     code="invalid_team",

--- a/src/sentry/integrations/opsgenie/integration.py
+++ b/src/sentry/integrations/opsgenie/integration.py
@@ -20,7 +20,7 @@ from sentry.integrations.base import (
 )
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
-from sentry.integrations.on_call.metrics import OnCallInteractionType
+from sentry.integrations.on_call.metrics import OnCallIntegrationsHaltReason, OnCallInteractionType
 from sentry.integrations.opsgenie.metrics import record_event
 from sentry.integrations.opsgenie.tasks import migrate_opsgenie_plugin
 from sentry.organizations.services.organization import RpcOrganizationSummary
@@ -183,7 +183,7 @@ class OpsgenieIntegration(IntegrationInstallation):
             team["id"] = str(self.org_integration.id) + "-" + team["team"]
 
         invalid_keys = []
-        with record_event(OnCallInteractionType.VERIFY_KEYS).capture():
+        with record_event(OnCallInteractionType.VERIFY_KEYS).capture() as lifecycle:
             for team in teams:
                 # skip if team, key pair already exist in config
                 if (team["team"], team["integration_key"]) in existing_team_key_pairs:
@@ -213,6 +213,7 @@ class OpsgenieIntegration(IntegrationInstallation):
                         raise
 
             if invalid_keys:
+                lifecycle.record_halt(OnCallIntegrationsHaltReason.INVALID_KEY)
                 raise ApiUnauthorized(f"Invalid integration key: {str(invalid_keys)}")
 
         return super().update_organization_config(data)

--- a/src/sentry/integrations/opsgenie/integration.py
+++ b/src/sentry/integrations/opsgenie/integration.py
@@ -213,7 +213,10 @@ class OpsgenieIntegration(IntegrationInstallation):
                         raise
 
             if invalid_keys:
-                lifecycle.record_halt(OnCallIntegrationsHaltReason.INVALID_KEY)
+                lifecycle.record_halt(
+                    OnCallIntegrationsHaltReason.INVALID_KEY,
+                    extra={"invalid_keys": invalid_keys, "integration_id": integration.id},
+                )
                 raise ApiUnauthorized(f"Invalid integration key: {str(invalid_keys)}")
 
         return super().update_organization_config(data)

--- a/src/sentry/integrations/pagerduty/actions/form.py
+++ b/src/sentry/integrations/pagerduty/actions/form.py
@@ -66,7 +66,7 @@ class PagerDutyNotifyServiceForm(forms.Form):
             ):
                 # We need to make sure that the service actually belongs to that integration,
                 # meaning that it belongs under the appropriate account in PagerDuty.
-                lifecycle.record_halt(str(OnCallIntegrationsHaltReason.INVALID_SERVICE))
+                lifecycle.record_halt(OnCallIntegrationsHaltReason.INVALID_SERVICE)
                 raise forms.ValidationError(
                     _(
                         'The service "%(service)s" has not been granted access in the %(account)s Pagerduty account.'

--- a/src/sentry/integrations/pagerduty/actions/form.py
+++ b/src/sentry/integrations/pagerduty/actions/form.py
@@ -6,7 +6,7 @@ from typing import Any
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
-from sentry.integrations.on_call.metrics import OnCallInteractionType
+from sentry.integrations.on_call.metrics import OnCallIntegrationsHaltReason, OnCallInteractionType
 from sentry.integrations.pagerduty.metrics import record_event
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import ExternalProviders
@@ -47,7 +47,7 @@ class PagerDutyNotifyServiceForm(forms.Form):
         self.fields["service"].widget.choices = self.fields["service"].choices
 
     def _validate_service(self, service_id: int, integration_id: int) -> None:
-        with record_event(OnCallInteractionType.VALIDATE_SERVICE).capture():
+        with record_event(OnCallInteractionType.VALIDATE_SERVICE).capture() as lifecycle:
             params = {
                 "account": dict(self.fields["account"].choices).get(integration_id),
                 "service": dict(self.fields["service"].choices).get(service_id),
@@ -66,6 +66,7 @@ class PagerDutyNotifyServiceForm(forms.Form):
             ):
                 # We need to make sure that the service actually belongs to that integration,
                 # meaning that it belongs under the appropriate account in PagerDuty.
+                lifecycle.record_halt(str(OnCallIntegrationsHaltReason.INVALID_SERVICE))
                 raise forms.ValidationError(
                     _(
                         'The service "%(service)s" has not been granted access in the %(account)s Pagerduty account.'

--- a/tests/sentry/integrations/pagerduty/test_notify_action.py
+++ b/tests/sentry/integrations/pagerduty/test_notify_action.py
@@ -4,6 +4,7 @@ import orjson
 import responses
 
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.on_call.metrics import OnCallIntegrationsHaltReason
 from sentry.integrations.pagerduty.actions.notification import PagerDutyNotifyServiceAction
 from sentry.integrations.pagerduty.utils import add_service
 from sentry.integrations.types import EventLifecycleOutcome
@@ -13,6 +14,7 @@ from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
+from tests.sentry.integrations.utils.test_assert_metrics import assert_halt_metric
 
 pytestmark = [requires_snuba]
 
@@ -330,4 +332,5 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
         assert len(mock_record.mock_calls) == 2
         start, halt = mock_record.mock_calls
         assert start.args[0] == EventLifecycleOutcome.STARTED
-        assert halt.args[0] == EventLifecycleOutcome.FAILURE
+        assert halt.args[0] == EventLifecycleOutcome.HALTED
+        assert_halt_metric(mock_record, OnCallIntegrationsHaltReason.INVALID_SERVICE.value)


### PR DESCRIPTION
`VALIDATE_SERVICE` and `VERIFY_TEAM` only fail due to user error, so we should record halts and not failures if they raise a validation error.