### PR TITLE
chore(alerts): Remove fe code for activated alerts

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -36,7 +36,6 @@ import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import {InvalidReason} from 'sentry/components/searchSyntax/parser';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {ActivationConditionType, MonitorType} from 'sentry/types/alerts';
 import type {SelectValue} from 'sentry/types/core';
 import type {Tag, TagCollection} from 'sentry/types/group';
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
@@ -105,12 +104,6 @@ type Props = {
   isEditing: boolean;
   onComparisonDeltaChange: (value: number) => void;
   onFilterSearch: (query: string, isQueryValid) => void;
-  onMonitorTypeSelect: (activatedAlertFields: {
-    activationCondition?: ActivationConditionType | undefined;
-    monitorType?: MonitorType;
-    monitorWindowSuffix?: string | undefined;
-    monitorWindowValue?: number | undefined;
-  }) => void;
   onTimeWindowChange: (value: number) => void;
   organization: Organization;
   project: Project;
@@ -120,7 +113,6 @@ type Props = {
   thresholdChart: React.ReactNode;
   timeWindow: number;
   // optional props
-  activationCondition?: ActivationConditionType;
   allowChangeEventTypes?: boolean;
   comparisonDelta?: number;
   disableProjectSelector?: boolean;
@@ -130,7 +122,6 @@ type Props = {
   isLowConfidenceChartData?: boolean;
   isTransactionMigration?: boolean;
   loadingProjects?: boolean;
-  monitorType?: number;
 };
 
 type State = {
@@ -486,16 +477,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
   }
 
   renderInterval() {
-    const {
-      organization,
-      disabled,
-      alertType,
-      timeWindow,
-      onTimeWindowChange,
-      project,
-      monitorType,
-      isForLlmMetric,
-    } = this.props;
+    const {organization, disabled, alertType, project, isForLlmMetric} = this.props;
 
     return (
       <Fragment>
@@ -523,118 +505,6 @@ class RuleConditionsForm extends PureComponent<Props, State> {
               required
             />
           )}
-
-          {monitorType !== MonitorType.ACTIVATED && (
-            <SelectControl
-              name="timeWindow"
-              styles={this.selectControlStyles}
-              options={this.timeWindowOptions}
-              required={monitorType === MonitorType.CONTINUOUS}
-              isDisabled={disabled}
-              value={timeWindow}
-              onChange={({value}) => onTimeWindowChange(value)}
-              inline={false}
-              flexibleControlStateSize
-            />
-          )}
-        </FormRow>
-      </Fragment>
-    );
-  }
-
-  renderMonitorTypeSelect() {
-    // TODO: disable select on edit
-    const {
-      activationCondition,
-      isEditing,
-      monitorType,
-      onMonitorTypeSelect,
-      onTimeWindowChange,
-      timeWindow,
-    } = this.props;
-
-    return (
-      <Fragment>
-        <StyledListItem>
-          <StyledListTitle>
-            <div>{t('Select Monitor Type')}</div>
-          </StyledListTitle>
-        </StyledListItem>
-        <FormRow>
-          <MonitorSelect>
-            <MonitorCard
-              disabled={isEditing}
-              position="left"
-              isSelected={monitorType === MonitorType.CONTINUOUS}
-              onClick={() =>
-                isEditing
-                  ? null
-                  : onMonitorTypeSelect({
-                      monitorType: MonitorType.CONTINUOUS,
-                    })
-              }
-            >
-              <strong>{t('Continuous')}</strong>
-              <div>{t('Continuously monitor trends for the metrics outlined below')}</div>
-            </MonitorCard>
-            <MonitorCard
-              disabled={isEditing}
-              position="right"
-              isSelected={monitorType === MonitorType.ACTIVATED}
-              onClick={() =>
-                isEditing
-                  ? null
-                  : onMonitorTypeSelect({
-                      monitorType: MonitorType.ACTIVATED,
-                    })
-              }
-            >
-              <strong>Conditional</strong>
-              {monitorType === MonitorType.ACTIVATED ? (
-                <ActivatedAlertFields>
-                  {`${t('Monitor')} `}
-                  <SelectControl
-                    name="activationCondition"
-                    styles={this.selectControlStyles}
-                    disabled={isEditing}
-                    options={[
-                      {
-                        value: ActivationConditionType.RELEASE_CREATION,
-                        label: t('New Release'),
-                      },
-                      {
-                        value: ActivationConditionType.DEPLOY_CREATION,
-                        label: t('New Deploy'),
-                      },
-                    ]}
-                    required
-                    value={activationCondition}
-                    onChange={({value}) =>
-                      onMonitorTypeSelect({activationCondition: value})
-                    }
-                    inline={false}
-                    flexibleControlStateSize
-                    size="xs"
-                  />
-                  {` ${t('for')} `}
-                  <SelectControl
-                    name="timeWindow"
-                    styles={this.selectControlStyles}
-                    options={this.timeWindowOptions}
-                    value={timeWindow}
-                    onChange={({value}) => onTimeWindowChange(value)}
-                    inline={false}
-                    flexibleControlStateSize
-                    size="xs"
-                  />
-                </ActivatedAlertFields>
-              ) : (
-                <div>
-                  {t('Temporarily monitor specified query given activation condition')}
-                </div>
-              )}
-            </MonitorCard>
-          </MonitorSelect>
         </FormRow>
       </Fragment>
     );
@@ -658,8 +528,6 @@ class RuleConditionsForm extends PureComponent<Props, State> {
     } = this.props;
 
     const {environments, filterKeys} = this.state;
-    const hasActivatedAlerts = organization.features.includes('activated-alert-rules');
-
     const environmentOptions: SelectValue<string | null>[] = [
       {
         value: null,
@@ -705,7 +573,6 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                   )}
                 </Alert>
               )}
-              {hasActivatedAlerts && this.renderMonitorTypeSelect()}
               {!isErrorMigration && this.renderInterval()}
               <StyledListItem>{t('Filter events')}</StyledListItem>
               <FormRow noMargin columns={1 + (allowChangeEventTypes ? 1 : 0) + 1}>
@@ -933,60 +800,6 @@ const FormRow = styled('div')<{columns?: number; noMargin?: boolean}>`
       display: grid;
       grid-template-columns: repeat(${p.columns}, auto);
     `}
-`;
-
-const MonitorSelect = styled('div')`
-  border-radius: ${p => p.theme.borderRadius};
-  border: 1px solid ${p => p.theme.border};
-  width: 100%;
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  height: 5rem;
-`;
-
-type MonitorCardProps = {
-  isSelected: boolean;
-  /**
-   * Adds hover and focus states to the card
-   */
-  position: 'left' | 'right';
-  disabled?: boolean;
-};
-
-const MonitorCard = styled('div')<MonitorCardProps>`
-  padding: ${space(1)} ${space(2)};
-  display: flex;
-  flex-grow: 1;
-  flex-direction: column;
-  cursor: ${p => (p.disabled || p.isSelected ? 'default' : 'pointer')};
-  justify-content: center;
-  background-color: ${p =>
-    p.disabled && !p.isSelected ? p.theme.backgroundSecondary : p.theme.background};
-
-  &:focus,
-  &:hover {
-    ${p =>
-      p.disabled || p.isSelected
-        ? ''
-        : `
-        outline: 1px solid ${p.theme.purple200};
-        background-color: ${p.theme.backgroundSecondary};
-        `}
-  }
-
-  border-top-left-radius: ${p => (p.position === 'left' ? p.theme.borderRadius : 0)};
-  border-bottom-left-radius: ${p => (p.position === 'left' ? p.theme.borderRadius : 0)};
-  border-top-right-radius: ${p => (p.position !== 'left' ? p.theme.borderRadius : 0)};
-  border-bottom-right-radius: ${p => (p.position !== 'left' ? p.theme.borderRadius : 0)};
-  margin: ${p =>
-    p.isSelected ? (p.position === 'left' ? '1px 2px 1px 0' : '1px 0 1px 2px') : 0};
-  outline: ${p => (p.isSelected ? `2px solid ${p.theme.purple400}` : 'none')};
-`;
-
-const ActivatedAlertFields = styled('div')`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
 `;
 
 export default withApi(withProjects(withTags(RuleConditionsForm)));

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -150,12 +150,6 @@ describe('Incident Rules Form', () => {
       expect(await screen.findByLabelText('Save Rule')).toBeEnabled();
       expect(screen.queryByText(permissionAlertText)).not.toBeInTheDocument();
     });
-
-    it('renders time window', async () => {
-      createWrapper({rule});
-
-      expect(await screen.findByText('1 hour interval')).toBeInTheDocument();
-    });
   });
 
   describe('Creating a new rule', () => {

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -9,7 +9,6 @@ import selectEvent from 'sentry-test/selectEvent';
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import type FormModel from 'sentry/components/forms/model';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {ActivationConditionType, MonitorType} from 'sentry/types/alerts';
 import {metric} from 'sentry/utils/analytics';
 import RuleFormContainer from 'sentry/views/alerts/rules/metric/ruleForm';
 import {
@@ -157,17 +156,6 @@ describe('Incident Rules Form', () => {
 
       expect(await screen.findByText('1 hour interval')).toBeInTheDocument();
     });
-
-    it('renders time window for activated alerts', async () => {
-      createWrapper({
-        rule: {
-          ...rule,
-          monitorType: MonitorType.CONTINUOUS,
-        },
-      });
-
-      expect(await screen.findByText('1 hour interval')).toBeInTheDocument();
-    });
   });
 
   describe('Creating a new rule', () => {
@@ -272,84 +260,6 @@ describe('Incident Rules Form', () => {
     it('creates a rule with generic_metrics dataset', async () => {
       organization.features = [...organization.features, 'mep-rollout-flag'];
       const rule = MetricRuleFixture();
-      createWrapper({
-        rule: {
-          ...rule,
-          id: undefined,
-          aggregate: 'count()',
-          eventTypes: ['transaction'],
-          dataset: 'transactions',
-        },
-      });
-
-      expect(await screen.findByTestId('alert-total-events')).toHaveTextContent('Total5');
-
-      await userEvent.click(screen.getByLabelText('Save Rule'));
-
-      expect(createRule).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({
-          data: expect.objectContaining({
-            name: 'My Incident Rule',
-            projects: ['project-slug'],
-            aggregate: 'count()',
-            eventTypes: ['transaction'],
-            dataset: 'generic_metrics',
-            thresholdPeriod: 1,
-          }),
-        })
-      );
-    });
-
-    // Activation condition
-    it('creates a rule with an activation condition', async () => {
-      organization.features = [
-        ...organization.features,
-        'mep-rollout-flag',
-        'activated-alert-rules',
-      ];
-      const rule = MetricRuleFixture({
-        monitorType: MonitorType.ACTIVATED,
-        activationCondition: ActivationConditionType.RELEASE_CREATION,
-      });
-      createWrapper({
-        rule: {
-          ...rule,
-          id: undefined,
-          aggregate: 'count()',
-          eventTypes: ['transaction'],
-          dataset: 'transactions',
-        },
-      });
-
-      expect(await screen.findByTestId('alert-total-events')).toHaveTextContent('Total5');
-
-      await userEvent.click(screen.getByLabelText('Save Rule'));
-
-      expect(createRule).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({
-          data: expect.objectContaining({
-            name: 'My Incident Rule',
-            projects: ['project-slug'],
-            aggregate: 'count()',
-            eventTypes: ['transaction'],
-            dataset: 'generic_metrics',
-            thresholdPeriod: 1,
-          }),
-        })
-      );
-    });
-
-    it('creates a continuous rule with activated rules enabled', async () => {
-      organization.features = [
-        ...organization.features,
-        'mep-rollout-flag',
-        'activated-alert-rules',
-      ];
-      const rule = MetricRuleFixture({
-        monitorType: MonitorType.CONTINUOUS,
-      });
       createWrapper({
         rule: {
           ...rule,

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -1366,7 +1366,6 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
               ].includes(aggregate)}
               isTransactionMigration={isMigration && !showErrorMigrationWarning}
               isLowConfidenceChartData={isLowConfidenceChartData}
-              monitorType={monitorType}
               onComparisonDeltaChange={value =>
                 this.handleFieldChange('comparisonDelta', value)
               }

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -256,6 +256,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
           : AlertRuleComparisonType.COUNT,
       project: this.props.project,
       owner: rule.owner,
+      alertType: getAlertTypeFromAggregateDataset({aggregate, dataset}),
     };
   }
 


### PR DESCRIPTION
Remove the front end for activated alerts as it's being deprecated. I can't merge this until we clean up a couple live alerts but I wanted to get the PRs ready. The gigantic backend counterpart is here https://github.com/getsentry/sentry/pull/81095

**Before**
<img width="1096" alt="Screenshot 2024-11-25 at 1 25 54 PM" src="https://github.com/user-attachments/assets/8d3fdbc2-59d9-4c38-9032-cf89f56e9153">


**After**
<img width="1078" alt="Screenshot 2024-11-25 at 1 27 26 PM" src="https://github.com/user-attachments/assets/6d7d5191-285d-465a-9eda-a8441958e8bd">
