### PR TITLE
feat(event tracker) add logging everywhere in transaction ingestion

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -138,7 +138,6 @@ from sentry.utils.safe import get_path, safe_execute, setdefault_path, trim
 from sentry.utils.sdk import set_measurement
 from sentry.utils.tag_normalization import normalized_sdk_tag_from_event
 
-from .ingest.types import ConsumerType
 from .utils.event_tracker import TransactionStageStatus, track_sampled_event
 
 if TYPE_CHECKING:
@@ -2614,6 +2613,8 @@ def _send_occurrence_to_platform(jobs: Sequence[Job], projects: ProjectsMapping)
 
 @sentry_sdk.tracing.trace
 def save_transaction_events(jobs: Sequence[Job], projects: ProjectsMapping) -> Sequence[Job]:
+    from .ingest.types import ConsumerType
+
     organization_ids = {project.organization_id for project in projects.values()}
     organizations = {o.id: o for o in Organization.objects.get_many_from_cache(organization_ids)}
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -561,9 +561,10 @@ def post_process_group(
             with metrics.timer("tasks.post_process.delete_event_cache"):
                 processing_store.delete_by_key(cache_key)
             if eventstream_type == EventStreamEventType.Transaction.value:
-                event_id = _get_event_id_from_cache_key(cache_key)
                 track_sampled_event(
-                    event_id, ConsumerType.Transactions, TransactionStageStatus.REDIS_DELETED
+                    data["event_id"],
+                    ConsumerType.Transactions,
+                    TransactionStageStatus.REDIS_DELETED,
                 )
             occurrence = None
             event = process_event(data, group_id)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -650,9 +650,10 @@ def post_process_group(
                     project=event.project,
                     event=event,
                 )
-            event_id = _get_event_id_from_cache_key(cache_key)
             track_sampled_event(
-                event_id, ConsumerType.Transactions, TransactionStageStatus.POST_PROCESS_STARTED
+                data["event_id"],
+                ConsumerType.Transactions,
+                TransactionStageStatus.POST_PROCESS_STARTED,
             )
 
         metric_tags = {}

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -653,7 +653,7 @@ def post_process_group(
             track_sampled_event(
                 event.event_id,
                 ConsumerType.Transactions,
-                TransactionStageStatus.POST_PROCESS_STARTED,
+                TransactionStageStatus.POST_PROCESS_FINISHED,
             )
 
         metric_tags = {}

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -651,7 +651,7 @@ def post_process_group(
                     event=event,
                 )
             track_sampled_event(
-                data["event_id"],
+                event.event_id,
                 ConsumerType.Transactions,
                 TransactionStageStatus.POST_PROCESS_STARTED,
             )

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -27,7 +27,6 @@ from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.signals import event_processed, issue_unignored, transaction_processed
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.tasks.store import ConsumerType
 from sentry.types.group import GroupSubStatus
 from sentry.utils import json, metrics
 from sentry.utils.cache import cache
@@ -515,6 +514,7 @@ def post_process_group(
     """
     Fires post processing hooks for a group.
     """
+    from sentry.tasks.store import ConsumerType
     from sentry.utils import snuba
 
     with snuba.options_override({"consistent": True}):

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -514,7 +514,7 @@ def post_process_group(
     """
     Fires post processing hooks for a group.
     """
-    from sentry.tasks.store import ConsumerType
+    from sentry.ingest.types import ConsumerType
     from sentry.utils import snuba
 
     with snuba.options_override({"consistent": True}):

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -27,6 +27,7 @@ from sentry.silo.base import SiloMode
 from sentry.stacktraces.processing import process_stacktraces, should_process_for_stacktraces
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
+from sentry.utils.event_tracker import TransactionStageStatus, track_sampled_event
 from sentry.utils.safe import safe_execute
 from sentry.utils.sdk import set_current_event_project
 
@@ -650,6 +651,9 @@ def save_event_transaction(
     project_id: int | None = None,
     **kwargs: Any,
 ) -> None:
+    track_sampled_event(
+        event_id, ConsumerType.Transactions, TransactionStageStatus.SAVE_TXN_STARTED
+    )
     _do_save_event(
         cache_key,
         data,
@@ -658,6 +662,9 @@ def save_event_transaction(
         project_id,
         consumer_type=ConsumerType.Transactions,
         **kwargs,
+    )
+    track_sampled_event(
+        event_id, ConsumerType.Transactions, TransactionStageStatus.SAVE_TXN_FINISHED
     )
 
 

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -651,9 +651,10 @@ def save_event_transaction(
     project_id: int | None = None,
     **kwargs: Any,
 ) -> None:
-    track_sampled_event(
-        event_id, ConsumerType.Transactions, TransactionStageStatus.SAVE_TXN_STARTED
-    )
+    if event_id:
+        track_sampled_event(
+            event_id, ConsumerType.Transactions, TransactionStageStatus.SAVE_TXN_STARTED
+        )
     _do_save_event(
         cache_key,
         data,
@@ -663,9 +664,10 @@ def save_event_transaction(
         consumer_type=ConsumerType.Transactions,
         **kwargs,
     )
-    track_sampled_event(
-        event_id, ConsumerType.Transactions, TransactionStageStatus.SAVE_TXN_FINISHED
-    )
+    if event_id:
+        track_sampled_event(
+            event_id, ConsumerType.Transactions, TransactionStageStatus.SAVE_TXN_FINISHED
+        )
 
 
 @instrumented_task(

--- a/src/sentry/utils/event_tracker.py
+++ b/src/sentry/utils/event_tracker.py
@@ -18,9 +18,6 @@ class TransactionStageStatus(StrEnum):
     # the transaction is published to the `events` topic for snuba/sbc consumers to consume
     SNUBA_TOPIC_PUT = "snuba_topic_put"
 
-    # the transaction is published to the `snuba-commit-log` topic
-    COMMIT_LOG_TOPIC_PUT = "commit_log_topic_put"
-
     # a post_process task is kicked off
     POST_PROCESS_STARTED = "post_process_started"
 

--- a/src/sentry/utils/event_tracker.py
+++ b/src/sentry/utils/event_tracker.py
@@ -18,11 +18,11 @@ class TransactionStageStatus(StrEnum):
     # the transaction is published to the `events` topic for snuba/sbc consumers to consume
     SNUBA_TOPIC_PUT = "snuba_topic_put"
 
-    # a post_process task is kicked off
-    POST_PROCESS_STARTED = "post_process_started"
-
     # the transaction is deleted from rc-transactions
     REDIS_DELETED = "redis_deleted"
+
+    # a post_process task is finished
+    POST_PROCESS_FINISHED = "post_process_finished"
 
 
 logger = logging.getLogger("EventTracker")


### PR DESCRIPTION
add logging everywhere in the transaction ingestion pipeline.

There might be more stages that need to be added later in the `TransactionStageStatus` class, but for now let's see what these stages output first

Next immediate steps after this PR is merged:
1. built a Google log sink
2. turn on the option so these loggings start working

