### PR TITLE
ref(trace) consolidate hooks

### DIFF
--- a/static/app/components/events/interfaces/performance/eventTraceView.spec.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.spec.tsx
@@ -93,7 +93,7 @@ describe('EventTraceView', () => {
     render(<EventTraceView group={group} event={event} organization={organization} />);
 
     expect(await screen.findByText('Trace')).toBeInTheDocument();
-    expect(await screen.findByText('2 hidden spans')).toBeInTheDocument();
+    expect(await screen.findByText('1 hidden span')).toBeInTheDocument();
   });
 
   it('does not render the trace preview if it has no transactions', async () => {

--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -53,7 +53,7 @@ function EventTraceViewInner({event, organization}: EventTraceViewInnerProps) {
   // Assuming profile exists, should be checked in the parent component
   const traceId = event.contexts.trace!.trace_id!;
   const trace = useTrace({
-    traceSlug: traceId ? traceId : undefined,
+    traceSlug: traceId,
     limit: 10000,
   });
   const meta = useTraceMeta([{traceSlug: traceId, timestamp: undefined}]);
@@ -62,7 +62,6 @@ function EventTraceViewInner({event, organization}: EventTraceViewInnerProps) {
   const shouldLoadTraceRoot = !trace.isPending && trace.data;
 
   const rootEvent = useTraceRootEvent(shouldLoadTraceRoot ? trace.data! : null);
-
   const preferences = useMemo(
     () =>
       loadTraceViewPreferences('issue-details-trace-view-preferences') ||
@@ -72,11 +71,6 @@ function EventTraceViewInner({event, organization}: EventTraceViewInnerProps) {
 
   const params = useTraceQueryParams();
   const traceEventView = useTraceEventView(traceId, params);
-
-  const scrollToNode = useMemo(() => {
-    const firstTransactionEventId = trace.data?.transactions[0]?.event_id;
-    return {eventId: firstTransactionEventId};
-  }, [trace.data]);
 
   if (trace.isPending || rootEvent.isPending || !rootEvent.data) {
     return null;
@@ -97,8 +91,8 @@ function EventTraceViewInner({event, organization}: EventTraceViewInnerProps) {
           traceEventView={traceEventView}
           meta={meta}
           source="issues"
-          scrollToNode={scrollToNode}
           replay={null}
+          event={event}
         />
       </TraceViewWaterfallWrapper>
     </TraceStateProvider>
@@ -150,9 +144,9 @@ const TraceContentWrapper = styled('div')`
 
 const ROW_HEIGHT = 24;
 const MIN_ROW_COUNT = 1;
-const MAX_HEIGHT = 12 * ROW_HEIGHT;
+const HEADER_HEIGHT = 28;
+const MAX_HEIGHT = 12 * ROW_HEIGHT + HEADER_HEIGHT;
 const MAX_ROW_COUNT = Math.floor(MAX_HEIGHT / ROW_HEIGHT);
-const HEADER_HEIGHT = 26;
 
 const TraceViewWaterfallWrapper = styled('div')<{rowCount: number}>`
   display: flex;

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -1270,7 +1270,7 @@ const TraceStylingWrapper = styled('div')`
       border-top: 1px solid ${p => p.theme.border};
 
       .TraceLeftColumn {
-        padding-left: 12px;
+        padding-left: 14px;
         width: 100%;
         color: ${p => p.theme.subText};
 

--- a/static/app/views/performance/newTraceDetails/traceModels/__snapshots__/issuesTraceTree.spec.tsx.snap
+++ b/static/app/views/performance/newTraceDetails/traceModels/__snapshots__/issuesTraceTree.spec.tsx.snap
@@ -4,7 +4,6 @@ exports[`IssuesTraceTree FromSpans collapses spans 1`] = `
 "
 trace root
   collapsed
-  transaction 1 - transaction.op
     transaction 2 - transaction.op
       collapsed
       http - GET /
@@ -24,8 +23,7 @@ trace root
 exports[`IssuesTraceTree collapses sibling collapsed nodes 1`] = `
 "
 trace root
-  transaction 1 - transaction.op
-    collapsed
+  collapsed
     transaction 2 - transaction.op
     collapsed
 "
@@ -51,7 +49,6 @@ exports[`IssuesTraceTree preserves path to child error 1`] = `
 "
 trace root
   collapsed
-  transaction 2 - transaction.op
     transaction - transaction.op
   collapsed
 "

--- a/static/app/views/performance/newTraceDetails/traceModels/issuesTraceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/issuesTraceTree.spec.tsx
@@ -80,6 +80,8 @@ describe('IssuesTraceTree', () => {
       replay: null,
     });
 
+    IssuesTraceTree.CollapseNodes(tree.root);
+
     expect(tree.build().serialize()).toMatchSnapshot();
   });
 
@@ -88,6 +90,8 @@ describe('IssuesTraceTree', () => {
       meta: null,
       replay: null,
     });
+
+    IssuesTraceTree.CollapseNodes(tree.root);
 
     expect(tree.build().serialize()).toMatchSnapshot();
   });
@@ -99,6 +103,8 @@ describe('IssuesTraceTree', () => {
       replay: null,
     });
 
+    IssuesTraceTree.CollapseNodes(tree.root);
+
     expect(tree.build().serialize()).toMatchSnapshot();
   });
 
@@ -107,6 +113,8 @@ describe('IssuesTraceTree', () => {
       meta: null,
       replay: null,
     });
+
+    IssuesTraceTree.CollapseNodes(tree.root);
 
     expect(tree.build().serialize()).toMatchSnapshot();
   });
@@ -163,6 +171,8 @@ describe('IssuesTraceTree', () => {
         organization: OrganizationFixture(),
         preferences: DEFAULT_TRACE_VIEW_PREFERENCES,
       });
+
+      IssuesTraceTree.CollapseNodes(tree.root);
 
       expect(tree.build().serialize()).toMatchSnapshot();
     });

--- a/static/app/views/performance/newTraceDetails/traceModels/parentAutogroupNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/parentAutogroupNode.tsx
@@ -1,5 +1,3 @@
-import {isSpanNode} from '../traceGuards';
-
 import type {TraceTree} from './traceTree';
 import {TraceTreeNode} from './traceTreeNode';
 
@@ -57,10 +55,6 @@ export function computeCollapsedBarSpace(
 
   const first = nodes[0];
 
-  if (!isSpanNode(first)) {
-    throw new Error('Autogrouped node must have span children');
-  }
-
   const segments: [number, number][] = [];
 
   let start = first.space[0];
@@ -69,10 +63,6 @@ export function computeCollapsedBarSpace(
 
   while (i < nodes.length) {
     const next = nodes[i];
-
-    if (!isSpanNode(next)) {
-      throw new Error('Autogrouped node must have span children');
-    }
 
     if (next.space[0] > end) {
       segments.push([start, end - start]);

--- a/static/app/views/performance/newTraceDetails/traceRow/traceCollapsedRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceCollapsedRow.tsx
@@ -1,39 +1,56 @@
 import {useMemo} from 'react';
 
 import {t} from 'sentry/locale';
-import {isTraceErrorNode} from 'sentry/views/performance/newTraceDetails/traceGuards';
+import {
+  isCollapsedNode,
+  isTraceErrorNode,
+} from 'sentry/views/performance/newTraceDetails/traceGuards';
 
 import type {CollapsedNode} from '../traceModels/traceCollapsedNode';
 import {TraceTree} from '../traceModels/traceTree';
 import type {TraceRowProps} from '../traceRow/traceRow';
 
 export function TraceCollapsedRow(props: TraceRowProps<CollapsedNode>) {
-  const collapsedNodeType = useMemo(() => {
-    let type: 'issues only' | '' = 'issues only';
-    let count = 1;
+  const stats = useMemo(() => {
+    const childStatistics = {issues: 0, events: 0};
 
     TraceTree.ForEachChild(props.node, c => {
-      count++;
+      // Dont count collapsed nodes
+      if (isCollapsedNode(c)) {
+        return;
+      }
+
       if (!isTraceErrorNode(c)) {
-        type = '';
+        childStatistics.events++;
+      } else {
+        childStatistics.issues++;
       }
     });
-    return {count, type};
+    return childStatistics;
   }, [props.node]);
 
   return (
     <div
       key={props.index}
       tabIndex={props.tabIndex}
-      className={`Collapsed ${collapsedNodeType.type === 'issues only' ? 'IssuesOnly' : ''} TraceRow`}
+      className={`Collapsed TraceRow`}
       onPointerDown={props.onRowClick}
       onKeyDown={props.onRowKeyDown}
       style={props.style}
     >
       <div className="TraceLeftColumn" ref={props.registerListColumnRef}>
         <div className="TraceLeftColumnInner" style={props.listColumnStyle}>
-          {collapsedNodeType.count}{' '}
-          {collapsedNodeType.count === 1 ? t('hidden span') : t('hidden spans')}
+          {stats.issues + stats.events}{' '}
+          {stats.events > 0
+            ? stats.events === 1
+              ? t('hidden span')
+              : t('hidden spans')
+            : null}
+          {stats.issues > 0
+            ? stats.issues === 1
+              ? t('hidden issue')
+              : t('hidden issues')
+            : null}
         </div>
       </div>
     </div>


### PR DESCRIPTION
When the trace view loads, fetch the spans of the transaction that has the issue associated to it so that we can try and find a more precise child node/span that is associated to the error. 

![CleanShot 2024-11-24 at 19 27 59@2x](https://github.com/user-attachments/assets/6e631da1-e7fd-4457-88ff-dfbc290cfc76)
