### PR TITLE
fix(gettingstarted): clean up new profiling snippets

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/step.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/step.tsx
@@ -12,14 +12,12 @@ export enum StepType {
   INSTALL = 'install',
   CONFIGURE = 'configure',
   VERIFY = 'verify',
-  VERIFYPROFILING = 'verifyprofiling',
 }
 
 export const StepTitle = {
   [StepType.INSTALL]: t('Install'),
   [StepType.CONFIGURE]: t('Configure SDK'),
   [StepType.VERIFY]: t('Verify'),
-  [StepType.VERIFYPROFILING]: t('Verify Profiling'),
 };
 
 interface CodeSnippetTab {

--- a/static/app/components/onboarding/gettingStartedDoc/step.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/step.tsx
@@ -12,12 +12,14 @@ export enum StepType {
   INSTALL = 'install',
   CONFIGURE = 'configure',
   VERIFY = 'verify',
+  VERIFYPROFILING = 'verifyprofiling',
 }
 
 export const StepTitle = {
   [StepType.INSTALL]: t('Install'),
   [StepType.CONFIGURE]: t('Configure SDK'),
   [StepType.VERIFY]: t('Verify'),
+  [StepType.VERIFYPROFILING]: t('Verify Profiling'),
 };
 
 interface CodeSnippetTab {

--- a/static/app/components/profiling/profilingOnboardingSidebar.tsx
+++ b/static/app/components/profiling/profilingOnboardingSidebar.tsx
@@ -312,7 +312,11 @@ function ProfilingOnboardingContent(props: ProfilingOnboardingContentProps) {
   };
 
   const doc = docs.profilingOnboarding ?? docs.onboarding;
-  const steps = [...doc.install(docParams), ...doc.configure(docParams)];
+  const steps = [
+    ...doc.install(docParams),
+    ...doc.configure(docParams),
+    ...doc.verify(docParams),
+  ];
 
   return (
     <Wrapper>

--- a/static/app/gettingStartedDocs/node/awslambda.spec.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.spec.tsx
@@ -99,13 +99,5 @@ describe('awslambda onboarding docs', function () {
     expect(
       screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
-
-    // Should have start and stop profiling calls
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.startProfiler/))
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiler/))
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/azurefunctions.spec.tsx
+++ b/static/app/gettingStartedDocs/node/azurefunctions.spec.tsx
@@ -98,13 +98,5 @@ describe('express onboarding docs', function () {
     expect(
       screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
-
-    // Should have start and stop profiling calls
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.startProfiler/))
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiler/))
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/connect.spec.tsx
+++ b/static/app/gettingStartedDocs/node/connect.spec.tsx
@@ -106,13 +106,5 @@ describe('connect onboarding docs', function () {
     expect(
       screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
-
-    // Should have start and stop profiling calls
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.startProfiler/))
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiler/))
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/express.spec.tsx
+++ b/static/app/gettingStartedDocs/node/express.spec.tsx
@@ -106,13 +106,5 @@ describe('express onboarding docs', function () {
     expect(
       screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
-
-    // Should have start and stop profiling calls
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.startProfiler/))
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiler/))
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/fastify.spec.tsx
+++ b/static/app/gettingStartedDocs/node/fastify.spec.tsx
@@ -107,13 +107,5 @@ describe('fastify onboarding docs', function () {
     expect(
       screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
-
-    // Should have start and stop profiling calls
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.startProfiler/))
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiler/))
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/gcpfunctions.spec.tsx
+++ b/static/app/gettingStartedDocs/node/gcpfunctions.spec.tsx
@@ -101,13 +101,5 @@ describe('gcpfunctions onboarding docs', function () {
     expect(
       screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
-
-    // Should have start and stop profiling calls
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.startProfiler/))
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiler/))
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/hapi.spec.tsx
+++ b/static/app/gettingStartedDocs/node/hapi.spec.tsx
@@ -107,13 +107,5 @@ describe('hapi onboarding docs', function () {
     expect(
       screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
-
-    // Should have start and stop profiling calls
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.startProfiler/))
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiler/))
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/koa.spec.tsx
+++ b/static/app/gettingStartedDocs/node/koa.spec.tsx
@@ -107,13 +107,5 @@ describe('koa onboarding docs', function () {
     expect(
       screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
-
-    // Should have start and stop profiling calls
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.startProfiler/))
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiler/))
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/nestjs.spec.tsx
+++ b/static/app/gettingStartedDocs/node/nestjs.spec.tsx
@@ -107,13 +107,5 @@ describe('Nest.js onboarding docs', function () {
     expect(
       screen.queryByText(textWithMarkupMatcher(/profilesSampleRate: 1\.0/))
     ).not.toBeInTheDocument();
-
-    // Should have start and stop profiling calls
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.startProfiler/))
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/Sentry.profiler.stopProfiler/))
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -68,11 +68,11 @@ sentry_sdk.init(
 
 def slow_function():
     time.sleep(0.1)
-    return "done"
+    return
 
 def fast_function():
     time.sleep(0.05)
-    return "done"
+    return
 
 # Manually call start_profiler and stop_profiler
 # to profile the code in between

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -37,7 +37,12 @@ const getInstallSnippet = () => `pip install --upgrade sentry-sdk`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
-
+${
+  params.isProfilingSelected &&
+  params.profilingOptions?.defaultProfilingMode === 'continuous'
+    ? 'import time'
+    : ''
+}
 sentry_sdk.init(
     dsn="${params.dsn.public}",${
       params.isPerformanceSelected
@@ -62,12 +67,10 @@ sentry_sdk.init(
     ? `
 
 def slow_function():
-    import time
     time.sleep(0.1)
     return "done"
 
 def fast_function():
-    import time
     time.sleep(0.05)
     return "done"
 

--- a/static/app/utils/gettingStartedDocs/node.ts
+++ b/static/app/utils/gettingStartedDocs/node.ts
@@ -222,30 +222,7 @@ Sentry.init({
     // Set sampling rate for profiling - this is relative to tracesSampleRate
     profilesSampleRate: 1.0,`
       : ''
-  }});${
-    params.isProfilingSelected &&
-    params.profilingOptions?.defaultProfilingMode === 'continuous'
-      ? `
-// Manually call startProfiler and stopProfiler
-// to profile the code in between
-Sentry.profiler.startProfiler();
-${
-  params.isPerformanceSelected
-    ? `
-// Starts a transaction that will also be profiled
-Sentry.startSpan({
-  name: "My First Transaction",
-}, () => {
-  // the code executing inside the transaction will be wrapped in a span and profiled
-});
-`
-    : '// this code will be profiled'
-}
-// Calls to stopProfiling are optional - if you don't stop the profiler, it will keep profiling
-// your application until the process exits or stopProfiling is called.
-Sentry.profiler.stopProfiler();`
-      : ''
-  }`;
+  }});`;
 
 export function getProductIntegrations({
   productSelection,


### PR DESCRIPTION
- Move the startProfiler/stopProfiler snippets for profiling out of the Setup SDK section & delete the corresponding tests & explicitly add the profilingOnboarding for Python for rendering the verification step in the sidebar
- Modularize the snippets for node.js & python to make them more easily composable
- Add a function calling setTimeout to demonstrate profiling in node.js

Before: 
![simon-test-us sentry io_projects_node-37_getting-started__product=performance-monitoring product=profiling](https://github.com/user-attachments/assets/b077a1f1-97e2-4619-8b6c-7ef59044c59e)



After:
![simon-test-us dev getsentry net_7999_projects_node-37_getting-started__product=performance-monitoring product=profiling (2)](https://github.com/user-attachments/assets/74054468-5a60-4fbd-9638-760ab7e486b3)
