### PR TITLE
fix(explore): Force 7 days or less on explore

### DIFF
--- a/static/app/views/explore/content.tsx
+++ b/static/app/views/explore/content.tsx
@@ -75,9 +75,11 @@ function ExploreContentImpl({}: ExploreContentProps) {
   const [chartError, setChartError] = useState<string>('');
   const [tableError, setTableError] = useState<string>('');
 
+  const maxPickableDays = 7;
+
   return (
     <SentryDocumentTitle title={t('Traces')} orgSlug={organization.slug}>
-      <PageFiltersContainer>
+      <PageFiltersContainer maxPickableDays={maxPickableDays}>
         <Layout.Page>
           <Layout.Header>
             <Layout.HeaderContent>
@@ -100,7 +102,8 @@ function ExploreContentImpl({}: ExploreContentProps) {
                 <ProjectPageFilter />
                 <EnvironmentPageFilter />
                 <DatePageFilter
-                  maxPickableDays={7}
+                  defaultPeriod="7d"
+                  maxPickableDays={maxPickableDays}
                   relativeOptions={({arbitraryOptions}) => ({
                     ...arbitraryOptions,
                     '1h': t('Last 1 hour'),


### PR DESCRIPTION
For the time being we want to restrict explore to the last 7 days of data only. This ensures the page doesn't load more than that.