### PR TITLE
ref(insights): remove insights-domain-view flag part 1

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.spec.tsx
@@ -147,7 +147,7 @@ describe('PagePerformanceTable', function () {
     expect(screen.getByRole('cell', {name: '/insights/browser/'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: '/insights/browser/'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/insights/pageloads/overview/?project=11276&transaction=%2Finsights%2Fbrowser%2F'
+      '/organizations/org-slug/insights/frontend/pageloads/overview/?project=11276&transaction=%2Finsights%2Fbrowser%2F'
     );
 
     expect(screen.getByRole('cell', {name: 'View Project Details'})).toBeInTheDocument();

--- a/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
+++ b/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
@@ -253,7 +253,7 @@ describe('CacheLandingPage', function () {
     expect(screen.getByRole('cell', {name: 'my-transaction'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'my-transaction'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/insights/caches/?project=123&statsPeriod=10d&transaction=my-transaction'
+      '/organizations/org-slug/insights/backend/caches/?project=123&statsPeriod=10d&transaction=my-transaction'
     );
 
     expect(screen.getByRole('columnheader', {name: 'Project'})).toBeInTheDocument();

--- a/static/app/views/insights/common/utils/useModuleURL.tsx
+++ b/static/app/views/insights/common/utils/useModuleURL.tsx
@@ -18,7 +18,6 @@ import {
 } from 'sentry/views/insights/pages/useFilters';
 import {getModuleView} from 'sentry/views/insights/pages/utils';
 import {BASE_URL as QUEUE_BASE_URL} from 'sentry/views/insights/queues/settings';
-import {INSIGHTS_BASE_URL} from 'sentry/views/insights/settings';
 import {ModuleName} from 'sentry/views/insights/types';
 
 export const MODULE_BASE_URLS: Record<ModuleName, string> = {
@@ -66,7 +65,6 @@ export function useModuleURLBuilder(
   detectDomainView: boolean = true
 ): URLBuilder {
   const organization = useOrganization({allowNull: true}); // Some parts of the app, like the main sidebar, render even if the organization isn't available (during loading, or at all).
-  const hasDomainViewFeature = organization?.features.includes('insights-domain-view');
   const {view: currentView} = useDomainViewFilters();
 
   if (!organization) {
@@ -76,28 +74,17 @@ export function useModuleURLBuilder(
 
   const {slug} = organization;
 
-  if (hasDomainViewFeature) {
-    return function (moduleName: RoutableModuleNames, domainView?: DomainView) {
-      let view = detectDomainView ? currentView : currentView ?? domainView;
+  return function (moduleName: RoutableModuleNames, domainView?: DomainView) {
+    let view = detectDomainView ? currentView : currentView ?? domainView;
 
-      if (!view) {
-        view = getModuleView(moduleName as ModuleName);
-      }
+    if (!view) {
+      view = getModuleView(moduleName as ModuleName);
+    }
 
-      return bare
-        ? `${DOMAIN_VIEW_BASE_URL}/${view}/${MODULE_BASE_URLS[moduleName]}`
-        : normalizeUrl(
-            `/organizations/${slug}/${DOMAIN_VIEW_BASE_URL}/${view}/${MODULE_BASE_URLS[moduleName]}`
-          );
-    };
-  }
-
-  // TODO - delete this block once the domain view feature is fully rolled out
-  return function (moduleName: RoutableModuleNames) {
     return bare
-      ? `${INSIGHTS_BASE_URL}/${MODULE_BASE_URLS[moduleName]}`
+      ? `${DOMAIN_VIEW_BASE_URL}/${view}/${MODULE_BASE_URLS[moduleName]}`
       : normalizeUrl(
-          `/organizations/${slug}/${INSIGHTS_BASE_URL}/${MODULE_BASE_URLS[moduleName]}`
+          `/organizations/${slug}/${DOMAIN_VIEW_BASE_URL}/${view}/${MODULE_BASE_URLS[moduleName]}`
         );
   };
 }

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
@@ -348,7 +348,7 @@ describe('DatabaseSpanSummaryPage', function () {
     expect(screen.getByRole('cell', {name: 'GET /api/users'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'GET /api/users'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/insights/database/spans/span/1756baf8fd19c116?statsPeriod=10d&transaction=%2Fapi%2Fusers&transactionMethod=GET&transactionsCursor=0%3A25%3A0'
+      '/organizations/org-slug/insights/backend/database/spans/span/1756baf8fd19c116?statsPeriod=10d&transaction=%2Fapi%2Fusers&transactionMethod=GET&transactionsCursor=0%3A25%3A0'
     );
     expect(screen.getByRole('cell', {name: '17.9/s'})).toBeInTheDocument();
     expect(screen.getByRole('cell', {name: '204.50ms'})).toBeInTheDocument();

--- a/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
@@ -275,7 +275,7 @@ describe('HTTPSummaryPage', function () {
     expect(screen.getByRole('cell', {name: 'GET /api/users'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'GET /api/users'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/insights/http/domains/?domain=%2A.sentry.dev&project=8&statsPeriod=10d&transaction=%2Fapi%2Fusers&transactionMethod=GET&transactionsCursor=0%3A20%3A0'
+      '/organizations/org-slug/insights/backend/http/domains/?domain=%2A.sentry.dev&project=8&statsPeriod=10d&transaction=%2Fapi%2Fusers&transactionMethod=GET&transactionsCursor=0%3A20%3A0'
     );
     expect(screen.getByRole('cell', {name: '17.9/s'})).toBeInTheDocument();
     expect(screen.getByRole('cell', {name: '97%'})).toBeInTheDocument();

--- a/static/app/views/insights/http/views/httpLandingPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.spec.tsx
@@ -300,7 +300,7 @@ describe('HTTPLandingPage', function () {
     expect(screen.getByRole('cell', {name: '*.sentry.io'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: '*.sentry.io'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/insights/http/domains/?domain=%2A.sentry.io&project=1&statsPeriod=10d'
+      '/organizations/org-slug/insights/backend/http/domains/?domain=%2A.sentry.io&project=1&statsPeriod=10d'
     );
     expect(
       screen.getAllByRole('cell', {name: 'View Project Details'})[0]

--- a/static/app/views/insights/mobile/appStarts/components/tables/spanOperationTable.spec.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/tables/spanOperationTable.spec.tsx
@@ -94,7 +94,7 @@ describe('SpanOpSelector', function () {
 
     expect(screen.getByRole('link', {name: 'Application Init'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/insights/app-startup/spans/?spanDescription=Application%20Init&spanGroup=7f4be68f08c0455f&spanOp=app.start.warm&transaction=foo-bar'
+      '/organizations/org-slug/insights/mobile/app-startup/spans/?spanDescription=Application%20Init&spanGroup=7f4be68f08c0455f&spanOp=app.start.warm&transaction=foo-bar'
     );
   });
 

--- a/static/app/views/insights/mobile/screenRendering/settings.ts
+++ b/static/app/views/insights/mobile/screenRendering/settings.ts
@@ -14,4 +14,4 @@ export const SUMMARY_PAGE_BASE_URL = 'details';
 
 export const SUMMARY_PAGE_TITLE = t('Render Summary');
 
-export const MODULE_FEATURES = ['insights-addon-modules', 'insights-domain-view'];
+export const MODULE_FEATURES = ['insights-addon-modules'];

--- a/static/app/views/insights/pages/ai/aiOverviewPage.tsx
+++ b/static/app/views/insights/pages/ai/aiOverviewPage.tsx
@@ -134,7 +134,7 @@ function AiOverviewPage() {
 
   return (
     <Feature
-      features="insights-domain-view"
+      features="performance-view"
       organization={organization}
       renderDisabled={NoAccess}
     >

--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -166,7 +166,7 @@ function BackendOverviewPage() {
 
   return (
     <Feature
-      features="insights-domain-view"
+      features="performance-view"
       organization={organization}
       renderDisabled={NoAccess}
     >

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -157,7 +157,7 @@ function FrontendOverviewPage() {
 
   return (
     <Feature
-      features="insights-domain-view"
+      features="performance-view"
       organization={organization}
       renderDisabled={NoAccess}
     >

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -180,7 +180,7 @@ function MobileOverviewPage() {
 
   return (
     <Feature
-      features="insights-domain-view"
+      features="performance-view"
       organization={organization}
       renderDisabled={NoAccess}
     >

--- a/static/app/views/insights/pages/useFilters.spec.tsx
+++ b/static/app/views/insights/pages/useFilters.spec.tsx
@@ -23,16 +23,7 @@ describe('useDomainViewFilters', () => {
     mockUseLocation.mockReturnValue(
       LocationFixture({pathname: `/${DOMAIN_VIEW_BASE_URL}/${FRONTEND_LANDING_SUB_PATH}`})
     );
-    mockUseOrganization.mockReturnValue(
-      OrganizationFixture({features: ['insights-domain-view']})
-    );
-  });
-
-  it('should return isInDomainView as false without feature', function () {
     mockUseOrganization.mockReturnValue(OrganizationFixture());
-    const {isInDomainView, view} = useDomainViewFilters();
-    expect(isInDomainView).toBe(false);
-    expect(view).toBeUndefined();
   });
 
   it('should return correct domain view based on the url', function () {

--- a/static/app/views/insights/pages/useFilters.tsx
+++ b/static/app/views/insights/pages/useFilters.tsx
@@ -1,7 +1,6 @@
 import type {ModuleName} from 'webpack-cli';
 
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import {AI_LANDING_SUB_PATH} from 'sentry/views/insights/pages/ai/settings';
 import {BACKEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/backend/settings';
 import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
@@ -32,15 +31,12 @@ export type Filters = {
 
 export const useDomainViewFilters = () => {
   const location = useLocation();
-  const organization = useOrganization({allowNull: true});
-
-  const hasDomainViewFeature = organization?.features.includes('insights-domain-view');
   const pathSegments = location.pathname.split('/').filter(Boolean);
   const indexOfPerformance = pathSegments.indexOf(DOMAIN_VIEW_BASE_URL);
   const isInDomainView = indexOfPerformance !== -1;
   const view = pathSegments[indexOfPerformance + 1] as DomainViewFilters['view'];
 
-  if (!domainViews.includes(view || '') || !hasDomainViewFeature) {
+  if (!domainViews.includes(view || '')) {
     return {isInDomainView: false};
   }
 

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -126,9 +126,11 @@ export function PerformanceLanding(props: Props) {
   const landingDisplay = paramLandingDisplay ?? defaultLandingDisplayForProjects;
   const showOnboarding = onboardingProject !== undefined;
 
-  if (performanceMovingAlert && pageAlert?.message !== performanceMovingAlert) {
-    setPageInfo(performanceMovingAlert);
-  }
+  useEffect(() => {
+    if (performanceMovingAlert && pageAlert?.message !== performanceMovingAlert) {
+      setPageInfo(performanceMovingAlert);
+    }
+  }, [pageAlert?.message, performanceMovingAlert, setPageInfo]);
 
   useEffect(() => {
     if (hasMounted.current) {

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -95,7 +95,6 @@ export function PerformanceLanding(props: Props) {
   const {setPageInfo, pageAlert} = usePageAlert();
   const {teams, initiallyLoaded} = useTeams({provideUserTeams: true});
   const {slug} = organization;
-  const hasDomainViews = organization.features.includes('insights-domain-view');
 
   const performanceMovingAlert = useMemo(() => {
     if (!slug) {
@@ -127,11 +126,7 @@ export function PerformanceLanding(props: Props) {
   const landingDisplay = paramLandingDisplay ?? defaultLandingDisplayForProjects;
   const showOnboarding = onboardingProject !== undefined;
 
-  if (
-    hasDomainViews &&
-    performanceMovingAlert &&
-    pageAlert?.message !== performanceMovingAlert
-  ) {
+  if (performanceMovingAlert && pageAlert?.message !== performanceMovingAlert) {
     setPageInfo(performanceMovingAlert);
   }
 

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -869,7 +869,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
     );
     expect(await screen.findByRole('button', {name: 'View All'})).toHaveAttribute(
       'href',
-      '/insights/database/'
+      '/insights/backend/database/'
     );
     expect(eventsMock).toHaveBeenCalledTimes(1);
     expect(eventsMock).toHaveBeenNthCalledWith(
@@ -915,7 +915,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
     );
     expect(await screen.findByRole('button', {name: 'View All'})).toHaveAttribute(
       'href',
-      '/insights/http/'
+      '/insights/backend/http/'
     );
     expect(eventsMock).toHaveBeenCalledTimes(1);
     expect(eventsMock).toHaveBeenNthCalledWith(
@@ -959,7 +959,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
     );
     expect(await screen.findByRole('button', {name: 'View All'})).toHaveAttribute(
       'href',
-      '/insights/assets/'
+      '/insights/frontend/assets/'
     );
     expect(eventsMock).toHaveBeenCalledTimes(1);
     expect(eventsMock).toHaveBeenNthCalledWith(
@@ -1008,7 +1008,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
     );
     expect(await screen.findByRole('button', {name: 'View All'})).toHaveAttribute(
       'href',
-      '/insights/caches/'
+      '/insights/backend/caches/'
     );
     expect(eventsMock).toHaveBeenCalledTimes(1);
     expect(eventsMock).toHaveBeenNthCalledWith(

--- a/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
@@ -52,7 +52,6 @@ function UserStats({
   const webVitalsUrl = useModuleURL(ModuleName.VITAL, false, 'frontend');
 
   const hasWebVitalsFlag = organization.features.includes('insights-initial-modules');
-  const hasDomainViewFlag = organization.features.includes('insights-domain-view');
 
   let userMisery = error !== null ? <div>{'\u2014'}</div> : <Placeholder height="34px" />;
 
@@ -84,7 +83,7 @@ function UserStats({
     query: location.query,
   });
 
-  if (hasWebVitalsFlag && hasDomainViewFlag) {
+  if (hasWebVitalsFlag) {
     webVitalsTarget = {
       pathname: `${webVitalsUrl}/overview/`,
       query: {
@@ -93,7 +92,7 @@ function UserStats({
     };
   }
 
-  const showLink = !hasDomainViewFlag || (hasDomainViewFlag && hasWebVitalsFlag);
+  const showLink = hasWebVitalsFlag;
 
   const mepSetting = useMEPSettingContext();
   const mepCardinalityContext = useMetricsCardinalityContext();


### PR DESCRIPTION
Now that domain views have been in GA for about a week, we can remove the flag that controls it.

This is part 1 of the flag removal, i'm splitting this up to make it easier to review.
In this part we remove the flag in all the associated utils and the domain view landing pages.
In the domain view landing pages, we also replace the flag from `insights-domain-view` to `performance-view`, as performance view is a pre-requisite of the insights views.