### PR TITLE
chore(sentryapps) Remove option for sentryapp RPC transition

### DIFF
--- a/src/sentry/hybridcloud/options.py
+++ b/src/sentry/hybridcloud/options.py
@@ -1,5 +1,5 @@
 from sentry.options import FLAG_AUTOMATOR_MODIFIABLE, register
-from sentry.utils.types import Bool, Float, Int, Sequence
+from sentry.utils.types import Bool, Int, Sequence
 
 register(
     "outbox_replication.sentry_organizationmember.replication_version",
@@ -159,12 +159,5 @@ register(
     "hybrid_cloud.authentication.disabled_user_shards",
     type=Sequence,
     default=[],
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-register(
-    "app_service.installations_for_org.cached",
-    type=Float,
-    default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )


### PR DESCRIPTION
This option is no longer being read and was unset in getsentry/sentry-options-automator#2757
