### PR TITLE
chore(widget-builder): Remove organization props

### DIFF
--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -33,7 +33,6 @@ export type WidgetBuilderSearchBarProps = {
   getFilterWarning: SearchBarProps['getFilterWarning'];
   onClose: SearchBarProps['onClose'];
   onSearch: SearchBarProps['onSearch'];
-  organization: Organization;
   pageFilters: PageFilters;
   widgetQuery: WidgetQuery;
   dataset?: DiscoverDatasets;

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/columnsStep/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/columnsStep/index.tsx
@@ -1,9 +1,9 @@
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
 import type {TagCollection} from 'sentry/types/group';
-import type {Organization} from 'sentry/types/organization';
 import type {QueryFieldValue} from 'sentry/utils/discover/fields';
 import useCustomMeasurements from 'sentry/utils/useCustomMeasurements';
+import useOrganization from 'sentry/utils/useOrganization';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import type {DisplayType, WidgetQuery, WidgetType} from 'sentry/views/dashboards/types';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
@@ -20,7 +20,6 @@ interface Props {
   handleColumnFieldChange: (newFields: QueryFieldValue[]) => void;
   isOnDemandWidget: boolean;
   onQueryChange: (queryIndex: number, newQuery: WidgetQuery) => void;
-  organization: Organization;
   tags: TagCollection;
   widgetType: WidgetType;
   queryErrors?: Record<string, any>[];
@@ -29,7 +28,6 @@ interface Props {
 export function ColumnsStep({
   dataSet,
   displayType,
-  organization,
   widgetType,
   handleColumnFieldChange,
   queryErrors,
@@ -37,6 +35,7 @@ export function ColumnsStep({
   tags,
   isOnDemandWidget,
 }: Props) {
+  const organization = useOrganization();
   const {customMeasurements} = useCustomMeasurements();
   const datasetConfig = getDatasetConfig(widgetType);
 

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.tsx
@@ -1,28 +1,22 @@
 import type {SearchBarProps} from 'sentry/components/events/searchBar';
 import type {PageFilters} from 'sentry/types/core';
-import type {Organization} from 'sentry/types/organization';
 import {generateAggregateFields} from 'sentry/utils/discover/fields';
 import type {DiscoverDatasets} from 'sentry/utils/discover/types';
 import useCustomMeasurements from 'sentry/utils/useCustomMeasurements';
+import useOrganization from 'sentry/utils/useOrganization';
 import type {WidgetQuery} from 'sentry/views/dashboards/types';
 import {eventViewFromWidget, hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import ResultsSearchQueryBuilder from 'sentry/views/discover/resultsSearchQueryBuilder';
 
 interface Props {
   onClose: SearchBarProps['onClose'];
-  organization: Organization;
   pageFilters: PageFilters;
   widgetQuery: WidgetQuery;
   dataset?: DiscoverDatasets;
 }
 
-export function EventsSearchBar({
-  organization,
-  pageFilters,
-  onClose,
-  widgetQuery,
-  dataset,
-}: Props) {
+export function EventsSearchBar({pageFilters, onClose, widgetQuery, dataset}: Props) {
+  const organization = useOrganization();
   const {customMeasurements} = useCustomMeasurements();
   const eventView = eventViewFromWidget('', widgetQuery, pageFilters);
   const fields = eventView.hasAggregateField()

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/index.tsx
@@ -14,7 +14,6 @@ import {IconAdd, IconDelete} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types/core';
-import type {Organization} from 'sentry/types/organization';
 import {
   createOnDemandFilterWarning,
   isOnDemandQueryString,
@@ -48,7 +47,6 @@ interface Props {
   onQueryChange: (queryIndex: number, newQuery: WidgetQuery) => void;
   onQueryConditionChange: (isQueryConditionValid: boolean) => void;
   onQueryRemove: (queryIndex: number) => void;
-  organization: Organization;
   queries: WidgetQuery[];
   selection: PageFilters;
   validatedWidgetResponse: UseApiQueryResult<ValidateWidgetResponse, RequestError>;
@@ -66,7 +64,6 @@ export function FilterResultsStep({
   onQueryRemove,
   onAddSearchConditions,
   onQueryChange,
-  organization,
   hideLegendAlias,
   queryErrors,
   widgetType,
@@ -74,6 +71,7 @@ export function FilterResultsStep({
   onQueryConditionChange,
   validatedWidgetResponse,
 }: Props) {
+  const organization = useOrganization();
   const [queryConditionValidity, setQueryConditionValidity] = useState<boolean[]>([]);
 
   const handleSearch = useCallback(
@@ -174,7 +172,6 @@ export function FilterResultsStep({
                       ? getOnDemandFilterWarning
                       : undefined
                   }
-                  organization={organization}
                   pageFilters={selection}
                   onClose={handleClose(queryIndex)}
                   onSearch={handleSearch(queryIndex)}

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/issuesSearchBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/issuesSearchBar.tsx
@@ -4,17 +4,17 @@ import styled from '@emotion/styled';
 import type {SearchBarProps} from 'sentry/components/events/searchBar';
 import type {SearchQueryBuilderProps} from 'sentry/components/searchQueryBuilder';
 import {t} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
+import useOrganization from 'sentry/utils/useOrganization';
 import type {WidgetQuery} from 'sentry/views/dashboards/types';
 import IssueListSearchBar from 'sentry/views/issueList/searchBar';
 
 interface Props {
   onClose: SearchBarProps['onClose'];
-  organization: Organization;
   widgetQuery: WidgetQuery;
 }
 
-function IssuesSearchBar({onClose, widgetQuery, organization}: Props) {
+function IssuesSearchBar({onClose, widgetQuery}: Props) {
+  const organization = useOrganization();
   const onChange = useCallback<NonNullable<SearchQueryBuilderProps['onChange']>>(
     (query, state) => {
       onClose?.(query, {validSearch: state.queryIsValid});

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
@@ -7,8 +7,8 @@ import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import type {Tag, TagValue} from 'sentry/types/group';
 import {SavedSearchType} from 'sentry/types/group';
-import type {Organization} from 'sentry/types/organization';
 import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
 import type {WidgetQuery} from 'sentry/views/dashboards/types';
 
 import {SESSION_STATUSES, SESSIONS_FILTER_TAGS} from '../../releaseWidget/fields';
@@ -31,17 +31,12 @@ const invalidMessages = {
 
 interface Props {
   onClose: SearchBarProps['onClose'];
-  organization: Organization;
   pageFilters: PageFilters;
   widgetQuery: WidgetQuery;
 }
 
-export function ReleaseSearchBar({
-  organization,
-  pageFilters,
-  widgetQuery,
-  onClose,
-}: Props) {
+export function ReleaseSearchBar({pageFilters, widgetQuery, onClose}: Props) {
+  const organization = useOrganization();
   const orgSlug = organization.slug;
   const projectIds = pageFilters.projects;
 

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/index.tsx
@@ -1,9 +1,9 @@
 import {t} from 'sentry/locale';
 import type {TagCollection} from 'sentry/types/group';
-import type {Organization} from 'sentry/types/organization';
 import type {QueryFieldValue} from 'sentry/utils/discover/fields';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
+import useOrganization from 'sentry/utils/useOrganization';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import type {ValidateWidgetResponse} from 'sentry/views/dashboards/types';
 
@@ -17,7 +17,6 @@ interface Props {
   columns: QueryFieldValue[];
   dataSet: DataSet;
   onGroupByChange: (newFields: QueryFieldValue[]) => void;
-  organization: Organization;
   tags: TagCollection;
   validatedWidgetResponse: UseApiQueryResult<ValidateWidgetResponse, RequestError>;
 }
@@ -26,10 +25,10 @@ export function GroupByStep({
   dataSet,
   columns,
   onGroupByChange,
-  organization,
   tags,
   validatedWidgetResponse,
 }: Props) {
+  const organization = useOrganization();
   const datasetConfig = getDatasetConfig(DATA_SET_TO_WIDGET_TYPE[dataSet]);
 
   const groupByOptions = datasetConfig.getGroupByFieldOptions

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/index.tsx
@@ -9,7 +9,6 @@ import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {SelectValue} from 'sentry/types/core';
 import type {TagCollection} from 'sentry/types/group';
-import type {Organization} from 'sentry/types/organization';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import type {WidgetQuery, WidgetType} from 'sentry/views/dashboards/types';
 import {DisplayType} from 'sentry/views/dashboards/types';
@@ -30,7 +29,6 @@ interface Props {
   displayType: DisplayType;
   onLimitChange: (newLimit: number) => void;
   onSortByChange: (newSortBy: string) => void;
-  organization: Organization;
   queries: WidgetQuery[];
   tags: TagCollection;
   widgetType: WidgetType;

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/visualizationStep.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/visualizationStep.spec.tsx
@@ -321,7 +321,6 @@ describe('VisualizationStep', function () {
       <MEPSettingProvider>
         <DashboardsMEPProvider>
           <VisualizationStep
-            organization={organization}
             pageFilters={PageFiltersFixture()}
             displayType={DisplayType.TABLE}
             error={undefined}

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/visualizationStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/visualizationStep.tsx
@@ -14,8 +14,8 @@ import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PageFilters, SelectValue} from 'sentry/types/core';
-import type {Organization} from 'sentry/types/organization';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
+import useOrganization from 'sentry/utils/useOrganization';
 import usePrevious from 'sentry/utils/usePrevious';
 import type {DashboardFilters, Widget, WidgetType} from 'sentry/views/dashboards/types';
 import {DisplayType} from 'sentry/views/dashboards/types';
@@ -34,7 +34,6 @@ interface Props {
   isWidgetInvalid: boolean;
   location: Location;
   onChange: (displayType: DisplayType) => void;
-  organization: Organization;
   pageFilters: PageFilters;
   widget: Widget;
   widgetLegendState: WidgetLegendSelectionState;
@@ -45,7 +44,6 @@ interface Props {
 }
 
 export function VisualizationStep({
-  organization,
   pageFilters,
   displayType,
   error,
@@ -58,6 +56,7 @@ export function VisualizationStep({
   onWidgetSplitDecision,
   widgetLegendState,
 }: Props) {
+  const organization = useOrganization();
   const [debouncedWidget, setDebouncedWidget] = useState(widget);
 
   const previousWidget = usePrevious(widget);

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/yAxisStep/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/yAxisStep/index.tsx
@@ -1,6 +1,5 @@
 import {t} from 'sentry/locale';
 import type {TagCollection} from 'sentry/types/group';
-import type {Organization} from 'sentry/types/organization';
 import type {QueryFieldValue} from 'sentry/utils/discover/fields';
 import type {WidgetType} from 'sentry/views/dashboards/types';
 import {DisplayType} from 'sentry/views/dashboards/types';
@@ -15,7 +14,6 @@ interface Props {
   dataSet: DataSet;
   displayType: DisplayType;
   onYAxisChange: (newFields: QueryFieldValue[], newSelectedAggregate?: number) => void;
-  organization: Organization;
   tags: TagCollection;
   widgetType: WidgetType;
   queryErrors?: Record<string, any>[];

--- a/static/app/views/dashboards/widgetBuilder/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/index.tsx
@@ -10,8 +10,7 @@ import WidgetLegendSelectionState from '../widgetLegendSelectionState';
 
 import WidgetBuilder from './widgetBuilder';
 
-interface WidgetBuilderProps
-  extends Omit<React.ComponentProps<typeof WidgetBuilder>, 'organization'> {}
+interface WidgetBuilderProps extends React.ComponentProps<typeof WidgetBuilder> {}
 
 function WidgetBuilderContainer(props: WidgetBuilderProps) {
   const organization = useOrganization();
@@ -32,7 +31,6 @@ function WidgetBuilderContainer(props: WidgetBuilderProps) {
       >
         <WidgetBuilder
           {...props}
-          organization={organization}
           widgetLegendState={
             new WidgetLegendSelectionState({
               location: props.location,

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -23,7 +23,6 @@ import {space} from 'sentry/styles/space';
 import type {DateString, PageFilters} from 'sentry/types/core';
 import type {TagCollection} from 'sentry/types/group';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {CustomMeasurementsProvider} from 'sentry/utils/customMeasurements/customMeasurementsProvider';
@@ -48,6 +47,7 @@ import {
 import {OnRouteLeave} from 'sentry/utils/reactRouter6Compat/onRouteLeave';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
 import useTags from 'sentry/utils/useTags';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import {
@@ -142,7 +142,6 @@ interface QueryData {
 interface Props extends RouteComponentProps<RouteParams, {}> {
   dashboard: DashboardDetails;
   onSave: (widgets: Widget[]) => void;
-  organization: Organization;
   selection: PageFilters;
   widgetLegendState: WidgetLegendSelectionState;
   displayType?: DisplayType;
@@ -177,7 +176,6 @@ function WidgetBuilder({
   dashboard,
   params,
   location,
-  organization,
   selection,
   start,
   end,
@@ -187,6 +185,7 @@ function WidgetBuilder({
   updateDashboardSplitDecision,
   widgetLegendState,
 }: Props) {
+  const organization = useOrganization();
   const {widgetIndex, orgId, dashboardId} = params;
   const {source, displayType, defaultTitle, limit, dataset} = location.query;
   const defaultWidgetQuery = getParsedDefaultWidgetQuery(
@@ -341,7 +340,7 @@ function WidgetBuilder({
           displayType: newDisplayType,
           queries: widgetFromDashboard.queries,
           widgetType: widgetFromDashboard.widgetType ?? defaultWidgetType,
-          organization: organization,
+          organization,
         }).map(query => ({
           ...query,
           // Use the last aggregate because that's where the y-axis is stored
@@ -354,7 +353,7 @@ function WidgetBuilder({
           displayType: newDisplayType,
           queries: widgetFromDashboard.queries,
           widgetType: widgetFromDashboard.widgetType ?? defaultWidgetType,
-          organization: organization,
+          organization,
         });
       }
 
@@ -448,7 +447,7 @@ function WidgetBuilder({
             displayType: newDisplayType,
             queries: [{...getDatasetConfig(defaultWidgetType).defaultWidgetQuery}],
             widgetType: defaultWidgetType,
-            organization: organization,
+            organization,
           })
         );
         set(newState, 'dataSet', defaultDataset);
@@ -460,7 +459,7 @@ function WidgetBuilder({
         displayType: newDisplayType,
         queries: prevState.queries,
         widgetType: DATA_SET_TO_WIDGET_TYPE[prevState.dataSet],
-        organization: organization,
+        organization,
       });
 
       if (newDisplayType === DisplayType.TOP_N) {
@@ -1219,7 +1218,6 @@ function WidgetBuilder({
                                     onDataFetched={handleWidgetDataFetched}
                                     widget={currentWidget}
                                     dashboardFilters={dashboard.filters}
-                                    organization={organization}
                                     pageFilters={pageFilters}
                                     displayType={state.displayType}
                                     error={state.errors?.displayType}
@@ -1262,7 +1260,6 @@ function WidgetBuilder({
                                           )}
                                           explodedFields={explodedFields}
                                           tags={tags}
-                                          organization={organization}
                                           isOnDemandWidget={isOnDemandWidget}
                                         />
                                       )}
@@ -1282,14 +1279,12 @@ function WidgetBuilder({
                                         state.queries[0].selectedAggregate
                                       }
                                       tags={tags}
-                                      organization={organization}
                                     />
                                   )}
                                   <FilterResultsStep
                                     queries={state.queries}
                                     hideLegendAlias={hideLegendAlias}
                                     canAddSearchConditions={canAddSearchConditions}
-                                    organization={organization}
                                     queryErrors={state.errors?.queries}
                                     onAddSearchConditions={handleAddSearchConditions}
                                     onQueryChange={handleQueryChange}
@@ -1312,7 +1307,6 @@ function WidgetBuilder({
                                           })
                                         )}
                                       onGroupByChange={handleGroupByChange}
-                                      organization={organization}
                                       validatedWidgetResponse={validatedWidgetResponse}
                                       tags={tags}
                                       dataSet={state.dataSet}
@@ -1327,7 +1321,6 @@ function WidgetBuilder({
                                       error={state.errors?.orderby}
                                       onSortByChange={handleSortByChange}
                                       onLimitChange={handleLimitChange}
-                                      organization={organization}
                                       widgetType={widgetType}
                                       tags={tags}
                                     />
@@ -1355,7 +1348,6 @@ function WidgetBuilder({
                             </MainWrapper>
                             <Side>
                               <WidgetLibrary
-                                organization={organization}
                                 selectedWidgetId={
                                   state.userHasModified ? null : state.prebuiltWidgetId
                                 }

--- a/static/app/views/dashboards/widgetBuilder/widgetLibrary/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetLibrary/index.tsx
@@ -6,7 +6,7 @@ import {openWidgetBuilderOverwriteModal} from 'sentry/actionCreators/modal';
 import type {OverwriteWidgetModalProps} from 'sentry/components/modals/widgetBuilder/overwriteWidgetModal';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Organization} from 'sentry/types/organization';
+import useOrganization from 'sentry/utils/useOrganization';
 import {DisplayType} from 'sentry/views/dashboards/types';
 import type {WidgetTemplate} from 'sentry/views/dashboards/widgetLibrary/data';
 import {getTopNConvertedDefaultWidgets} from 'sentry/views/dashboards/widgetLibrary/data';
@@ -18,7 +18,6 @@ import {Card} from './card';
 interface Props {
   bypassOverwriteModal: boolean;
   onWidgetSelect: (widget: WidgetTemplate) => void;
-  organization: Organization;
   selectedWidgetId: string | null;
 }
 
@@ -26,9 +25,9 @@ export function WidgetLibrary({
   bypassOverwriteModal,
   onWidgetSelect,
   selectedWidgetId,
-  organization,
 }: Props) {
   const theme = useTheme();
+  const organization = useOrganization();
   const defaultWidgets = getTopNConvertedDefaultWidgets(organization);
 
   function getLibrarySelectionHandler(


### PR DESCRIPTION
These aren't necessary since we can just use hooks and get the org.

I'm going through the code and these are just unnecessary.