### PR TITLE
feat(trace) scroll to event

### DIFF
--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -49,11 +49,17 @@ interface EventTraceViewInnerProps {
 }
 
 function EventTraceViewInner({event, organization, traceId}: EventTraceViewInnerProps) {
+  const timestamp = new Date(event.dateReceived).getTime() / 1e3;
+
   const trace = useTrace({
+    timestamp,
     traceSlug: traceId,
     limit: 10000,
   });
-  const meta = useTraceMeta([{traceSlug: traceId, timestamp: undefined}]);
+  const params = useTraceQueryParams({
+    timestamp,
+  });
+  const meta = useTraceMeta([{traceSlug: traceId, timestamp}]);
   const tree = useIssuesTraceTree({trace, meta, replay: null});
 
   const shouldLoadTraceRoot = !trace.isPending && trace.data;
@@ -66,7 +72,6 @@ function EventTraceViewInner({event, organization, traceId}: EventTraceViewInner
     []
   );
 
-  const params = useTraceQueryParams();
   const traceEventView = useTraceEventView(traceId, params);
 
   if (!traceId) {

--- a/static/app/views/performance/newTraceDetails/useTraceQueryParams.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceQueryParams.tsx
@@ -12,7 +12,9 @@ export interface TraceViewQueryParams {
   useSpans: number;
 }
 
-export function useTraceQueryParams(): TraceViewQueryParams {
+export function useTraceQueryParams(
+  params?: Partial<TraceViewQueryParams>
+): TraceViewQueryParams {
   return useMemo(() => {
     const normalizedParams = normalizeDateTimeParams(qs.parse(location.search), {
       allowAbsolutePageDatetime: true,
@@ -23,6 +25,12 @@ export function useTraceQueryParams(): TraceViewQueryParams {
     const statsPeriod = decodeScalar(normalizedParams.statsPeriod);
     const numberTimestamp = timestamp ? Number(timestamp) : undefined;
 
-    return {start, end, statsPeriod, timestamp: numberTimestamp, useSpans: 1};
-  }, []);
+    return {
+      start: start ?? params?.start,
+      end: end ?? params?.end,
+      statsPeriod: statsPeriod ?? params?.statsPeriod,
+      timestamp: numberTimestamp ?? params?.timestamp,
+      useSpans: 1,
+    };
+  }, [params]);
 }


### PR DESCRIPTION
Not using a timestamp query param when fetching the trace was causing a number of traces to fail to load. This change infers the param from the issue and queries the trace view with a timestamp that is inferred from dateReceived