### PR TITLE
chore(similarity): Do not send over 30 system-only frames to seer (#8…

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -17,9 +17,10 @@ from sentry.models.project import Project
 from sentry.seer.similarity.similar_issues import get_similarity_data_from_seer
 from sentry.seer.similarity.types import SimilarIssuesEmbeddingsRequest
 from sentry.seer.similarity.utils import (
+    ReferrerOptions,
     event_content_is_seer_eligible,
     filter_null_from_string,
-    get_stacktrace_string,
+    get_stacktrace_string_with_metrics,
     killswitch_enabled,
 )
 from sentry.utils import metrics
@@ -187,7 +188,9 @@ def _has_empty_stacktrace_string(event: Event, variants: Mapping[str, BaseVarian
     grouping_info = get_grouping_info_from_variants(variants)
     grouping_info["project_id"] = event.project.id  # type: ignore[assignment]
     grouping_info["event_id"] = event.event_id  # type: ignore[assignment]
-    stacktrace_string = get_stacktrace_string(grouping_info)
+    stacktrace_string = get_stacktrace_string_with_metrics(
+        grouping_info, event.platform, ReferrerOptions.INGEST
+    )
     if stacktrace_string == "":
         metrics.incr(
             "grouping.similarity.did_call_seer",
@@ -222,7 +225,10 @@ def get_seer_similar_issues(
         "hash": event_hash,
         "project_id": event.project.id,
         "stacktrace": event.data.get(
-            "stacktrace_string", get_stacktrace_string(get_grouping_info_from_variants(variants))
+            "stacktrace_string",
+            get_stacktrace_string_with_metrics(
+                get_grouping_info_from_variants(variants), event.platform, ReferrerOptions.INGEST
+            ),
         ),
         "exception_type": filter_null_from_string(exception_type) if exception_type else None,
         "k": num_neighbors,

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -1,4 +1,5 @@
 import logging
+from enum import StrEnum
 from typing import Any, TypeVar
 
 from sentry import options
@@ -151,6 +152,15 @@ BASE64_ENCODED_PREFIXES = [
 ]
 
 
+class ReferrerOptions(StrEnum):
+    INGEST = "ingest"
+    BACKFILL = "backfill"
+
+
+class TooManyOnlySystemFramesException(Exception):
+    pass
+
+
 def _get_value_if_exists(exception_value: dict[str, Any]) -> str:
     return exception_value["values"][0] if exception_value.get("values") else ""
 
@@ -177,6 +187,7 @@ def get_stacktrace_string(data: dict[str, Any]) -> str:
 
     frame_count = 0
     html_frame_count = 0  # for a temporary metric
+    is_frames_truncated = False
     stacktrace_str = ""
     found_non_snipped_context_line = False
     is_frames_truncated = False
@@ -186,6 +197,7 @@ def get_stacktrace_string(data: dict[str, Any]) -> str:
     def _process_frames(frames: list[dict[str, Any]]) -> list[str]:
         nonlocal frame_count
         nonlocal html_frame_count
+        nonlocal is_frames_truncated
         nonlocal found_non_snipped_context_line
         nonlocal is_frames_truncated
         frame_strings = []
@@ -259,6 +271,14 @@ def get_stacktrace_string(data: dict[str, Any]) -> str:
                     exc_value = _get_value_if_exists(exception_value)
                 elif exception_value.get("id") == "stacktrace" and frame_count < MAX_FRAME_COUNT:
                     frame_strings = _process_frames(exception_value["values"])
+        if is_frames_truncated and not app_hash:
+            logger_extra = {
+                "project_id": data.get("project_id", ""),
+                "event_id": data.get("event_id", ""),
+                "hash": system_hash,
+            }
+            logger.info("grouping.similarity.over_threshold_system_only_frames", extra=logger_extra)
+            raise TooManyOnlySystemFramesException
         # Only exceptions have the type and value properties, so we don't need to handle the threads
         # case here
         header = f"{exc_type}: {exc_value}\n" if exception["id"] == "exception" else ""
@@ -291,15 +311,32 @@ def get_stacktrace_string(data: dict[str, Any]) -> str:
         },
     )
 
-    if is_frames_truncated and not app_hash:
-        logger_extra = {
-            "project_id": data.get("project_id", ""),
-            "event_id": data.get("event_id", ""),
-            "hash": system_hash,
-        }
-        logger.info("grouping.similarity.over_threshold_system_only_frames", extra=logger_extra)
-
     return stacktrace_str.strip()
+
+
+def get_stacktrace_string_with_metrics(
+    data: dict[str, Any], platform: str | None, referrer: ReferrerOptions
+) -> str | None:
+    try:
+        stacktrace_string = get_stacktrace_string(data)
+    except TooManyOnlySystemFramesException:
+        platform = platform if platform else "unknown"
+        metrics.incr(
+            "grouping.similarity.over_threshold_only_system_frames",
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+            tags={"platform": platform, "referrer": referrer},
+        )
+        if referrer == ReferrerOptions.INGEST:
+            metrics.incr(
+                "grouping.similarity.did_call_seer",
+                sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+                tags={
+                    "call_made": False,
+                    "blocker": "over-threshold-only-system-frames",
+                },
+            )
+        stacktrace_string = None
+    return stacktrace_string
 
 
 def event_content_has_stacktrace(event: Event) -> bool:

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -32,9 +32,10 @@ from sentry.seer.similarity.types import (
     SimilarHashNotFoundError,
 )
 from sentry.seer.similarity.utils import (
+    ReferrerOptions,
     event_content_has_stacktrace,
     filter_null_from_string,
-    get_stacktrace_string,
+    get_stacktrace_string_with_metrics,
 )
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
@@ -359,8 +360,10 @@ def get_events_from_nodestore(
             # TODO: Remove when grouping.similarity.over_threshold_system_only_frames is removed
             grouping_info["project_id"] = project.id
             grouping_info["event_id"] = event.event_id  # type: ignore[assignment]
-            stacktrace_string = get_stacktrace_string(grouping_info)
-            if stacktrace_string == "":
+            stacktrace_string = get_stacktrace_string_with_metrics(
+                grouping_info, event.platform, ReferrerOptions.BACKFILL
+            )
+            if not stacktrace_string:
                 invalid_event_group_ids.append(group_id)
                 continue
             primary_hash = event.get_primary_hash()

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -4,11 +4,14 @@ from typing import Any, Literal, cast
 from unittest.mock import patch
 from uuid import uuid1
 
+import pytest
+
 from sentry.eventstore.models import Event
 from sentry.seer.similarity.utils import (
     BASE64_ENCODED_PREFIXES,
     MAX_FRAME_COUNT,
     SEER_ELIGIBLE_PLATFORMS,
+    TooManyOnlySystemFramesException,
     _is_snipped_context_line,
     event_content_is_seer_eligible,
     filter_null_from_string,
@@ -672,7 +675,7 @@ class GetStacktraceStringTest(TestCase):
             )
 
     def test_chained_too_many_exceptions(self):
-        """Test that we restrict number of chained exceptions to 30."""
+        """Test that we restrict number of chained exceptions to MAX_FRAME_COUNT."""
         data_chained_exception = copy.deepcopy(self.CHAINED_APP_DATA)
         data_chained_exception["app"]["component"]["values"][0]["values"] = [
             self.create_exception(
@@ -680,10 +683,10 @@ class GetStacktraceStringTest(TestCase):
                 exception_value=f"exception {i} message!",
                 frames=self.create_frames(num_frames=1, context_line_factory=lambda i: f"line {i}"),
             )
-            for i in range(1, 32)
+            for i in range(1, MAX_FRAME_COUNT + 2)
         ]
         stacktrace_str = get_stacktrace_string(data_chained_exception)
-        for i in range(2, 32):
+        for i in range(2, MAX_FRAME_COUNT + 2):
             assert f"exception {i} message!" in stacktrace_str
         assert "exception 1 message!" not in stacktrace_str
 
@@ -722,7 +725,8 @@ class GetStacktraceStringTest(TestCase):
         data_system["project_id"] = self.project.id
         data_system["event_id"] = "39485673049520"
 
-        get_stacktrace_string(data_system)
+        with pytest.raises(TooManyOnlySystemFramesException):
+            get_stacktrace_string(data_system)
 
         mock_logger.info.assert_called_with(
             "grouping.similarity.over_threshold_system_only_frames",
@@ -747,7 +751,8 @@ class GetStacktraceStringTest(TestCase):
             "values"
         ] += self.create_frames(MAX_FRAME_COUNT // 2, True)
 
-        get_stacktrace_string(data_system)
+        with pytest.raises(TooManyOnlySystemFramesException):
+            get_stacktrace_string(data_system)
 
         mock_logger.info.assert_called_with(
             "grouping.similarity.over_threshold_system_only_frames",
@@ -759,8 +764,10 @@ class GetStacktraceStringTest(TestCase):
         )
 
     def test_too_many_in_app_contributing_frames(self):
-        """Check that when there are over 30 contributing frames, the last 30 are included."""
-
+        """
+        Check that when there are over MAX_FRAME_COUNT contributing frames, the last MAX_FRAME_COUNT
+        are included.
+        """
         data_frames = copy.deepcopy(self.BASE_APP_DATA)
         # Create 30 contributing frames, 1-20 -> last 10 should be included
         data_frames["app"]["component"]["values"][0]["values"][0]["values"] = self.create_frames(
@@ -787,7 +794,7 @@ class GetStacktraceStringTest(TestCase):
         for i in range(41, 61):
             num_frames += 1
             assert ("test = " + str(i) + "!") in stacktrace_str
-        assert num_frames == 30
+        assert num_frames == MAX_FRAME_COUNT
 
     def test_too_many_frames_minified_js_frame_limit(self):
         """Test that we restrict fully-minified stacktraces to 20 frames, and all other stacktraces to 30 frames."""


### PR DESCRIPTION
If an event has no in-app frames and over 30 system frames, return null formatted stacktrace string
