### PR TITLE
fix(grouping): Only collect metadata timing metric when actually getting metadata

### DIFF
--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -41,6 +41,7 @@ from sentry.types.grouphash_metadata import (
     TemplateHashingMetadata,
 )
 from sentry.utils import metrics
+from sentry.utils.metrics import MutableTags
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +106,12 @@ def create_or_update_grouphash_metadata(
     # we'll have to override the metadata creation date for them.
 
     if created:
-        hash_basis, hashing_metadata = get_hash_basis_and_metadata(event, project, variants)
+        with metrics.timer(
+            "grouping.grouphashmetadata.get_hash_basis_and_metadata"
+        ) as metrics_timer_tags:
+            hash_basis, hashing_metadata = get_hash_basis_and_metadata(
+                event, project, variants, metrics_timer_tags
+            )
 
         GroupHashMetadata.objects.create(
             grouphash=grouphash,
@@ -121,7 +127,10 @@ def create_or_update_grouphash_metadata(
 
 
 def get_hash_basis_and_metadata(
-    event: Event, project: Project, variants: dict[str, BaseVariant]
+    event: Event,
+    project: Project,
+    variants: dict[str, BaseVariant],
+    metrics_timer_tags: MutableTags,
 ) -> tuple[HashBasis, HashingMetadata]:
     hashing_metadata: HashingMetadata = {}
 
@@ -167,6 +176,8 @@ def get_hash_basis_and_metadata(
             extra={"project": project.id, "event": event.event_id},
         )
         return (HashBasis.UNKNOWN, {})
+
+    metrics_timer_tags["hash_basis"] = hash_basis
 
     # Gather different metadata depending on the grouping method
 

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -94,7 +94,7 @@ METRICS_TAGS_BY_HASH_BASIS = {
 }
 
 
-def create_or_update_grouphash_metadata(
+def create_or_update_grouphash_metadata_if_needed(
     event: Event,
     project: Project,
     grouphash: GroupHash,

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -22,7 +22,7 @@ from sentry.grouping.api import (
 )
 from sentry.grouping.ingest.config import is_in_transition
 from sentry.grouping.ingest.grouphash_metadata import (
-    create_or_update_grouphash_metadata,
+    create_or_update_grouphash_metadata_if_needed,
     record_grouphash_metadata_metrics,
 )
 from sentry.grouping.variants import BaseVariant
@@ -233,7 +233,7 @@ def get_or_create_grouphashes(
         if options.get("grouping.grouphash_metadata.ingestion_writes_enabled") and features.has(
             "organizations:grouphash-metadata-creation", project.organization
         ):
-            create_or_update_grouphash_metadata(
+            create_or_update_grouphash_metadata_if_needed(
                 event, project, grouphash, created, grouping_config, variants
             )
 

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -233,10 +233,9 @@ def get_or_create_grouphashes(
         if options.get("grouping.grouphash_metadata.ingestion_writes_enabled") and features.has(
             "organizations:grouphash-metadata-creation", project.organization
         ):
-            with metrics.timer("grouping.grouphashmetadata.create_or_update_grouphash_metadata"):
-                create_or_update_grouphash_metadata(
-                    event, project, grouphash, created, grouping_config, variants
-                )
+            create_or_update_grouphash_metadata(
+                event, project, grouphash, created, grouping_config, variants
+            )
 
         if grouphash.metadata:
             record_grouphash_metadata_metrics(grouphash.metadata)

--- a/tests/sentry/grouping/test_grouphash_metadata.py
+++ b/tests/sentry/grouping/test_grouphash_metadata.py
@@ -135,7 +135,7 @@ def _assert_and_snapshot_results(
     lines: list[str] = []
     variants = event.get_grouping_variants()
 
-    hash_basis, hashing_metadata = get_hash_basis_and_metadata(event, project, variants)
+    hash_basis, hashing_metadata = get_hash_basis_and_metadata(event, project, variants, {})
 
     with patch("sentry.grouping.ingest.grouphash_metadata.metrics.incr") as mock_metrics_incr:
         record_grouphash_metadata_metrics(


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/81070, a metric was added to time the gathering of grouphash metadata. Unfortunately, it's also timing all the cases in which we don't have to gather such data as well (which are the vast, vast majority of cases - for example, in the last 24 hours, we’ve hit roughly 2.5 million cases where the function it's timing has no-opped and only about 400 in which the function's actually had to do any work). As a result, the actual timing data we care about is being utterly drowned out.

This fixes that by moving the timer from timing `create_or_update_grouphash_metadata` to timing it's helper, `get_hash_basis_and_metadata`, which only runs when the calculation is needed. It also renames the function we have been timing from `create_or_update_grouphash_metadata` to `create_or_update_grouphash_metadata_if_needed`, to make it clearer that it's just a wrapper which may no-op. (It's this unclear naming on my part which led to the confusion in the first place.)