### PR TITLE
ref: fix flaky digests test

### DIFF
--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -163,7 +163,7 @@ class DigestSlackNotification(SlackActivityNotificationTest):
         backend = RedisBackend()
         digests.backend.digest = backend.digest
         digests.enabled.return_value = True
-        timestamp_raw = before_now(days=1)
+        timestamp_raw = before_now(days=1).replace(microsecond=0)
         timestamp_secs = int(timestamp_raw.timestamp())
         timestamp = timestamp_raw.isoformat()
         key = f"slack:p:{self.project.id}:IssueOwners::AllMembers"


### PR DESCRIPTION
relay [rounds timestamps](https://github.com/getsentry/relay/blob/0459abec0ee79f773d163f35e742cebd34134793/relay-event-schema/src/protocol/types.rs#L896) whereas the test truncates

I first forced the test to fail with:

```diff
diff --git a/tests/sentry/notifications/notifications/test_digests.py b/tests/sentry/notifications/notifications/test_digests.py
index be02406aa1..2943b1875e 100644
--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -163,7 +163,10 @@ class DigestSlackNotification(SlackActivityNotificationTest):
         backend = RedisBackend()
         digests.backend.digest = backend.digest
         digests.enabled.return_value = True
-        timestamp_raw = before_now(days=1)
+        while True:
+            timestamp_raw = before_now(days=1)
+            if int(timestamp_raw.timestamp()) != round(timestamp_raw.timestamp()):
+                break
         timestamp_secs = int(timestamp_raw.timestamp())
         timestamp = timestamp_raw.isoformat()
         key = f"slack:p:{self.project.id}:IssueOwners::AllMembers"
```

<!-- Describe your PR here. -->