### PR TITLE
fix(insights): broken screen rendering doc link

### DIFF
--- a/static/app/views/insights/browser/resources/settings.ts
+++ b/static/app/views/insights/browser/resources/settings.ts
@@ -19,6 +19,6 @@ export const DEFAULT_RESOURCE_TYPES = [
   ResourceSpanOps.IMAGE,
 ];
 
-export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/assets/';
+export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/frontend/assets/';
 
 export const MODULE_FEATURES = ['insights-initial-modules'];

--- a/static/app/views/insights/browser/webVitals/settings.ts
+++ b/static/app/views/insights/browser/webVitals/settings.ts
@@ -8,7 +8,8 @@ export const DATA_TYPE_PLURAL = t('Web Vitals');
 export const MODULE_DESCRIPTION = t(
   'Measure the quality of real user experience in your web applications using industry standard quality signals.'
 );
-export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/web-vitals/';
+export const MODULE_DOC_LINK =
+  'https://docs.sentry.io/product/insights/frontend/web-vitals/';
 
 export const DEFAULT_QUERY_FILTER =
   'transaction.op:[pageload,""] span.op:[ui.interaction.click,ui.interaction.hover,ui.interaction.drag,ui.interaction.press,ui.webvital.cls,""] !transaction:"<< unparameterized >>"';

--- a/static/app/views/insights/cache/settings.ts
+++ b/static/app/views/insights/cache/settings.ts
@@ -17,6 +17,6 @@ export const BASE_FILTERS: SpanMetricsQueryFilters = {
 export const MODULE_DESCRIPTION = t(
   'Discover whether your application is utilizing caching effectively and understand the latency associated with cache misses.'
 );
-export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/caches/';
+export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/backend/caches/';
 
 export const MODULE_FEATURES = ['insights-addon-modules'];

--- a/static/app/views/insights/database/settings.ts
+++ b/static/app/views/insights/database/settings.ts
@@ -59,6 +59,6 @@ export const DISTRIBUTION_GRANULARITIES = new GranularityLadder([
 export const MODULE_DESCRIPTION = t(
   'Investigate the performance of database queries and get the information necessary to improve them.'
 );
-export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/queries/';
+export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/backend/queries/';
 
 export const MODULE_FEATURES = ['insights-initial-modules'];

--- a/static/app/views/insights/http/settings.ts
+++ b/static/app/views/insights/http/settings.ts
@@ -21,6 +21,7 @@ export const BASE_FILTERS = {
 export const MODULE_DESCRIPTION = t(
   'Monitor outgoing HTTP requests and investigate errors and performance bottlenecks tied to domains.'
 );
-export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/requests/';
+export const MODULE_DOC_LINK =
+  'https://docs.sentry.io/product/insights/backend/requests/';
 
 export const MODULE_FEATURES = ['insights-initial-modules'];

--- a/static/app/views/insights/llmMonitoring/settings.ts
+++ b/static/app/views/insights/llmMonitoring/settings.ts
@@ -9,6 +9,7 @@ export const DATA_TYPE_PLURAL = t('LLMs');
 
 export const RELEASE_LEVEL: BadgeType = 'beta';
 
-export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/llm-monitoring/';
+export const MODULE_DOC_LINK =
+  'https://docs.sentry.io/product/insights/ai/llm-monitoring/';
 
 export const MODULE_FEATURES = ['insights-addon-modules'];

--- a/static/app/views/insights/mobile/appStarts/settings.ts
+++ b/static/app/views/insights/mobile/appStarts/settings.ts
@@ -9,6 +9,6 @@ export const MODULE_DESCRIPTION = t(
   'Improve the latency associated with your application starting up. '
 );
 export const MODULE_DOC_LINK =
-  'https://docs.sentry.io/product/insights/mobile-vitals/app-starts/';
+  'https://docs.sentry.io/product/insights/mobile/app-starts/';
 
 export const MODULE_FEATURES = ['insights-initial-modules'];

--- a/static/app/views/insights/mobile/screenRendering/settings.ts
+++ b/static/app/views/insights/mobile/screenRendering/settings.ts
@@ -6,8 +6,10 @@ export const DATA_TYPE_PLURAL = t('Screen Renders');
 
 export const CHART_HEIGHT = 160;
 
-export const MODULE_DESCRIPTION = t('TODO');
-export const MODULE_DOC_LINK = 'TODO';
+export const MODULE_DESCRIPTION = t(
+  'Screen Rendering identifies slow and frozen interactions, helping you find and fix problems that might cause users to complain, or uninstall.'
+);
+export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/mobile/';
 
 export const BASE_URL = 'screen-rendering';
 export const SUMMARY_PAGE_BASE_URL = 'details';

--- a/static/app/views/insights/mobile/screenload/settings.ts
+++ b/static/app/views/insights/mobile/screenload/settings.ts
@@ -9,6 +9,6 @@ export const MODULE_DESCRIPTION = t(
   'View the most active screens in your mobile application and monitor your releases for TTID and TTFD regressions.'
 );
 export const MODULE_DOC_LINK =
-  'https://docs.sentry.io/product/insights/mobile-vitals/screen-loads/';
+  'https://docs.sentry.io/product/insights/mobile/screen-loads/';
 
 export const MODULE_FEATURES = ['insights-initial-modules'];

--- a/static/app/views/insights/mobile/screens/settings.ts
+++ b/static/app/views/insights/mobile/screens/settings.ts
@@ -11,5 +11,4 @@ export const MODULE_FEATURE = t('insights-mobile-screens-module');
 export const DATA_TYPE = t('Mobile Screens');
 export const DATA_TYPE_PLURAL = t('Mobile Screens');
 
-// TODO: Update this link once we have the proper docs.
 export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/mobile/';

--- a/static/app/views/insights/mobile/screens/settings.ts
+++ b/static/app/views/insights/mobile/screens/settings.ts
@@ -12,4 +12,4 @@ export const DATA_TYPE = t('Mobile Screens');
 export const DATA_TYPE_PLURAL = t('Mobile Screens');
 
 // TODO: Update this link once we have the proper docs.
-export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/mobile-vitals/';
+export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/mobile/';

--- a/static/app/views/insights/mobile/ui/settings.ts
+++ b/static/app/views/insights/mobile/ui/settings.ts
@@ -6,6 +6,6 @@ export const BASE_URL = 'ui';
 export const MODULE_DESCRIPTION = t("Improve your application's responsiveness.");
 
 // TODO: Update this link once we have the proper docs.
-export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/mobile-vitals/';
+export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/mobile/';
 
 export const MODULE_FEATURES = ['insights-addon-modules', 'starfish-mobile-ui-module'];

--- a/static/app/views/insights/mobile/ui/settings.ts
+++ b/static/app/views/insights/mobile/ui/settings.ts
@@ -5,7 +5,6 @@ export const BASE_URL = 'ui';
 
 export const MODULE_DESCRIPTION = t("Improve your application's responsiveness.");
 
-// TODO: Update this link once we have the proper docs.
 export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/mobile/';
 
 export const MODULE_FEATURES = ['insights-addon-modules', 'starfish-mobile-ui-module'];

--- a/static/app/views/insights/queues/settings.ts
+++ b/static/app/views/insights/queues/settings.ts
@@ -44,7 +44,7 @@ export const MODULE_DESCRIPTION = t(
   'Understand the health and performance impact that queues have on your application and diagnose errors tied to jobs.'
 );
 export const MODULE_DOC_LINK =
-  'https://docs.sentry.io/product/insights/queue-monitoring/';
+  'https://docs.sentry.io/product/insights/backend/queue-monitoring/';
 
 export const TABLE_ROWS_LIMIT = 25;
 


### PR DESCRIPTION
1. Update the screen rendering module doc link and module description. Previous it was set as `TODO`, and now we have the correct link
2. Update all other module doc links to match our domain view docs, we did have redirects so this wasn't broken, but it's always better to not rely on redirects if possible. So might as well update them to be the correct url