### PR TITLE
fix(explore): Preserve sort when adding group by

### DIFF
--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -179,7 +179,7 @@ export function SpansTable({setError}: SpansTableProps) {
               <IconWarning data-test-id="error-indicator" color="gray300" size="lg" />
             </TableStatus>
           ) : result.isFetched && result.data?.length ? (
-            result.data?.slice(0, 50)?.map((row, i) => (
+            result.data?.map((row, i) => (
               <TableRow key={i}>
                 {visibleFields.map((field, j) => {
                   return (

--- a/static/app/views/explore/toolbar/index.tsx
+++ b/static/app/views/explore/toolbar/index.tsx
@@ -32,7 +32,7 @@ export function ExploreToolbar({extras}: ExploreToolbarProps) {
       return sampleFields;
     }
 
-    const allFields = [...groupBys];
+    const allFields: string[] = [];
 
     for (const visualize of visualizes) {
       for (const yAxis of visualize.yAxes) {
@@ -41,6 +41,13 @@ export function ExploreToolbar({extras}: ExploreToolbarProps) {
         }
         allFields.push(yAxis);
       }
+    }
+
+    for (const groupBy of groupBys) {
+      if (allFields.includes(groupBy)) {
+        continue;
+      }
+      allFields.push(groupBy);
     }
 
     return allFields.filter(Boolean);


### PR DESCRIPTION
We use the first available option to sort when there's no sort specified. In aggregate mode, when adding a group by, the first option changes from the aggregate function to the group by field thus implicitly changing the sort. This ensures that the aggregate functions are higher in the list so the default sort doesnt change when the group by changes.