### PR TITLE
feat(attachments): Allow group attachments endpoint to apply filters

### DIFF
--- a/src/sentry/api/endpoints/group_attachments.py
+++ b/src/sentry/api/endpoints/group_attachments.py
@@ -1,4 +1,3 @@
-from collections.abc import Sequence
 from datetime import datetime, timedelta
 
 from django.utils import timezone
@@ -27,7 +26,7 @@ def get_event_ids_from_filters(
     group: Group,
     start: datetime | None,
     end: datetime | None,
-) -> Sequence[str] | None:
+) -> list[str] | None:
     default_end = timezone.now()
     default_start = default_end - timedelta(days=90)
     try:
@@ -93,7 +92,7 @@ class GroupAttachmentsEndpoint(GroupEndpoint, EnvironmentMixin):
         attachments = EventAttachment.objects.filter(group_id=group.id)
 
         types = request.GET.getlist("types") or ()
-        event_ids = request.GET.getlist("event_id") or ()
+        event_ids = request.GET.getlist("event_id") or None
         screenshot = "screenshot" in request.GET
 
         try:

--- a/src/sentry/api/endpoints/group_attachments.py
+++ b/src/sentry/api/endpoints/group_attachments.py
@@ -17,7 +17,6 @@ from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import EventAttachmentSerializer, serialize
 from sentry.api.utils import get_date_range_from_params
 from sentry.exceptions import InvalidParams
-from sentry.issues.endpoints.group_events import get_event_search_query
 from sentry.models.eventattachment import EventAttachment, event_attachment_screenshot_filter
 from sentry.models.group import Group
 from sentry.search.events.types import ParamsType
@@ -35,7 +34,7 @@ def get_event_ids_from_filters(
         environments = get_environments(request, group.project.organization)
     except ResourceDoesNotExist:
         environments = []
-    query = get_event_search_query(request, group, environments)
+    query = request.GET.get("query", "")
 
     # Exit early if no query or environment is specified
     if not query and not environments:
@@ -52,7 +51,7 @@ def get_event_ids_from_filters(
         params["environment"] = [env.name for env in environments]
 
     snuba_query = get_query_builder_for_group(
-        query=query if query else "",
+        query=query,
         snuba_params=params,
         group=group,
         limit=10000,

--- a/src/sentry/api/endpoints/group_attachments.py
+++ b/src/sentry/api/endpoints/group_attachments.py
@@ -77,6 +77,11 @@ class GroupAttachmentsEndpoint(GroupEndpoint, EnvironmentMixin):
 
         :pparam string issue_id: the ID of the issue to retrieve.
         :pparam list   types:    a list of attachment types to filter for.
+        :qparam string start: Beginning date. You must also provide ``end``.
+        :qparam string end: End date. You must also provide ``start``.
+        :qparam string statsPeriod: An optional stat period (defaults to ``"90d"``).
+        :qparam string query: If set, will filter to only attachments from events matching that query.
+        :qparam string environment: If set, will filter to only attachments from events within a specific environment.
         :auth: required
         """
 

--- a/src/sentry/issues/endpoints/group_events.py
+++ b/src/sentry/issues/endpoints/group_events.py
@@ -50,20 +50,6 @@ class GroupEventsError(Exception):
     pass
 
 
-def get_event_search_query(
-    request: Request, group: Group, environments: Sequence[Environment]
-) -> str | None:
-    raw_query = request.GET.get("query")
-
-    if raw_query:
-        query_kwargs = parse_query([group.project], raw_query, request.user, environments)
-        query = query_kwargs.pop("query", None)
-    else:
-        query = None
-
-    return query
-
-
 @extend_schema(tags=["Events"])
 @region_silo_endpoint
 class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
@@ -122,7 +108,7 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
 
         try:
             environments = get_environments(request, group.project.organization)
-            query = get_event_search_query(request, group, environments)
+            query = self._get_search_query(request, group, environments)
         except InvalidQuery as exc:
             return Response({"detail": str(exc)}, status=400)
         except (NoResults, ResourceDoesNotExist):
@@ -211,3 +197,16 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
             on_results=lambda results: serialize(results, request.user, serializer),
             paginator=GenericOffsetPaginator(data_fn=data_fn),
         )
+
+    def _get_search_query(
+        self, request: Request, group: Group, environments: Sequence[Environment]
+    ) -> str | None:
+        raw_query = request.GET.get("query")
+
+        if raw_query:
+            query_kwargs = parse_query([group.project], raw_query, request.user, environments)
+            query = query_kwargs.pop("query", None)
+        else:
+            query = None
+
+        return query

--- a/src/sentry/issues/endpoints/group_events.py
+++ b/src/sentry/issues/endpoints/group_events.py
@@ -51,7 +51,7 @@ class GroupEventsError(Exception):
 
 
 def get_event_search_query(
-    self, request: Request, group: Group, environments: Sequence[Environment]
+    request: Request, group: Group, environments: Sequence[Environment]
 ) -> str | None:
     raw_query = request.GET.get("query")
 

--- a/tests/sentry/api/endpoints/test_group_attachments.py
+++ b/tests/sentry/api/endpoints/test_group_attachments.py
@@ -4,13 +4,14 @@ from urllib.parse import urlencode
 from sentry.models.eventattachment import EventAttachment
 from sentry.models.files.file import File
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.skips import requires_snuba
 
 pytestmark = [requires_snuba]
 
 
 class GroupEventAttachmentsTest(APITestCase):
-    def create_attachment(self, type=None, event_id=None, file_name="hello.png"):
+    def create_attachment(self, type=None, event_id=None, file_name="hello.png", group_id=None):
         if type is None:
             type = "event.attachment"
 
@@ -20,7 +21,7 @@ class GroupEventAttachmentsTest(APITestCase):
         self.attachment = EventAttachment.objects.create(
             event_id=event_id or self.event.event_id,
             project_id=self.event.project_id,
-            group_id=self.group.id,
+            group_id=group_id or self.group.id,
             file_id=self.file.id,
             type=self.file.type,
             name=file_name,
@@ -127,3 +128,86 @@ class GroupEventAttachmentsTest(APITestCase):
         assert len(response.data) == 2
         assert response.data[0]["event_id"] == attachment2.event_id
         assert response.data[1]["event_id"] == attachment.event_id
+
+    def test_date_range_filter(self):
+        self.login_as(user=self.user)
+
+        old_attachment = self.create_attachment(event_id="b" * 32)
+        old_attachment.date_added = before_now(days=28).isoformat()
+        old_attachment.save()
+
+        newer_attachment = self.create_attachment(event_id="c" * 32)
+
+        with self.feature("organizations:event-attachments"):
+            all_response = self.client.get(f"/api/0/issues/{self.group.id}/attachments/")
+        assert len(all_response.data) == 2
+
+        with self.feature("organizations:event-attachments"):
+            range_response = self.client.get(
+                f"/api/0/issues/{self.group.id}/attachments/?statsPeriod=14d"
+            )
+
+        assert range_response.status_code == 200, range_response.content
+        assert len(range_response.data) == 1
+        assert range_response.data[0]["id"] == str(newer_attachment.id)
+        assert range_response.data[0]["event_id"] == newer_attachment.event_id
+
+    def test_event_environment_filter(self):
+        self.login_as(user=self.user)
+        data = {}
+
+        for env in ["production", "development"]:
+            event = self.store_event(
+                data={
+                    "fingerprint": ["same-group"],
+                    "timestamp": before_now(days=1).isoformat(),
+                    "environment": env,
+                },
+                project_id=self.project.id,
+            )
+            attachment = self.create_attachment(event_id=event.event_id, group_id=event.group_id)
+            data[env] = (event, attachment)
+
+        prod_event, prod_attachment = data["production"]
+
+        with self.feature("organizations:event-attachments"):
+            all_response = self.client.get(f"/api/0/issues/{prod_event.group.id}/attachments/")
+        assert len(all_response.data) == 2
+
+        with self.feature("organizations:event-attachments"):
+            prod_response = self.client.get(
+                f"/api/0/issues/{prod_event.group.id}/attachments/?environment=production"
+            )
+        assert len(prod_response.data) == 1
+        assert prod_response.data[0]["id"] == str(prod_attachment.id)
+        assert prod_response.data[0]["event_id"] == prod_attachment.event_id
+
+    def test_event_query_filter(self):
+        self.login_as(user=self.user)
+        data = {}
+
+        for org in ["sentry", "not-sentry"]:
+            event = self.store_event(
+                data={
+                    "fingerprint": ["same-group"],
+                    "timestamp": before_now(days=1).isoformat(),
+                    "tags": {"organization": org},
+                },
+                project_id=self.project.id,
+            )
+            attachment = self.create_attachment(event_id=event.event_id, group_id=event.group_id)
+            data[org] = (event, attachment)
+
+        sentry_event, sentry_attachment = data["sentry"]
+
+        with self.feature("organizations:event-attachments"):
+            all_response = self.client.get(f"/api/0/issues/{sentry_event.group.id}/attachments/")
+        assert len(all_response.data) == 2
+
+        with self.feature("organizations:event-attachments"):
+            prod_response = self.client.get(
+                f"/api/0/issues/{sentry_event.group.id}/attachments/?query=organization:sentry"
+            )
+        assert len(prod_response.data) == 1
+        assert prod_response.data[0]["id"] == str(sentry_attachment.id)
+        assert prod_response.data[0]["event_id"] == sentry_attachment.event_id

--- a/tests/sentry/api/endpoints/test_group_attachments.py
+++ b/tests/sentry/api/endpoints/test_group_attachments.py
@@ -169,6 +169,7 @@ class GroupEventAttachmentsTest(APITestCase):
             data[env] = (event, attachment)
 
         prod_event, prod_attachment = data["production"]
+        assert prod_event.group is not None
 
         with self.feature("organizations:event-attachments"):
             all_response = self.client.get(f"/api/0/issues/{prod_event.group.id}/attachments/")
@@ -199,6 +200,7 @@ class GroupEventAttachmentsTest(APITestCase):
             data[org] = (event, attachment)
 
         sentry_event, sentry_attachment = data["sentry"]
+        assert sentry_event.group is not None
 
         with self.feature("organizations:event-attachments"):
             all_response = self.client.get(f"/api/0/issues/{sentry_event.group.id}/attachments/")


### PR DESCRIPTION
Allow filter attachments by date, environment and event query. Date queries should be simple enough, but environment/query will be expensive. This will only be computed if one of those are provided though.

- [x] Fix tests
- [x] Add new tests.