### PR TITLE
:wrench: chore(slos): Update Halt to Success for Bot Commands

### DIFF
--- a/src/sentry/integrations/discord/webhooks/command.py
+++ b/src/sentry/integrations/discord/webhooks/command.py
@@ -80,7 +80,7 @@ class DiscordCommandDispatcher(MessagingIntegrationCommandDispatcher[str]):
     def link_user_handler(self, _: CommandInput) -> IntegrationResponse[str]:
         if self.request.has_identity():
             return IntegrationResponse(
-                interaction_result=EventLifecycleOutcome.HALTED,
+                interaction_result=EventLifecycleOutcome.SUCCESS,
                 response=ALREADY_LINKED_MESSAGE.format(email=self.request.get_identity_str()),
                 outcome_reason=str(MessageCommandHaltReason.ALREADY_LINKED),
                 context_data={
@@ -120,7 +120,7 @@ class DiscordCommandDispatcher(MessagingIntegrationCommandDispatcher[str]):
     def unlink_user_handler(self, input: CommandInput) -> IntegrationResponse[str]:
         if not self.request.has_identity():
             return IntegrationResponse(
-                interaction_result=EventLifecycleOutcome.HALTED,
+                interaction_result=EventLifecycleOutcome.SUCCESS,
                 response=NOT_LINKED_MESSAGE,
                 outcome_reason=str(MessageCommandHaltReason.NOT_LINKED),
             )

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -669,7 +669,7 @@ class MsTeamsCommandDispatcher(MessagingIntegrationCommandDispatcher[AdaptiveCar
 
         if has_linked_identity:
             return IntegrationResponse(
-                interaction_result=EventLifecycleOutcome.HALTED,
+                interaction_result=EventLifecycleOutcome.SUCCESS,
                 response=build_already_linked_identity_command_card(),
                 outcome_reason=str(MessageCommandHaltReason.ALREADY_LINKED),
                 context_data={

--- a/src/sentry/integrations/slack/webhooks/base.py
+++ b/src/sentry/integrations/slack/webhooks/base.py
@@ -166,7 +166,7 @@ class SlackCommandDispatcher(MessagingIntegrationCommandDispatcher[Response]):
         response = self.endpoint.link_user(self.request)
         if ALREADY_LINKED_MESSAGE.format(username=self.request.identity_str) in str(response.data):
             return IntegrationResponse(
-                interaction_result=EventLifecycleOutcome.HALTED,
+                interaction_result=EventLifecycleOutcome.SUCCESS,
                 response=response,
                 outcome_reason=str(MessageCommandHaltReason.ALREADY_LINKED),
                 context_data={
@@ -182,7 +182,7 @@ class SlackCommandDispatcher(MessagingIntegrationCommandDispatcher[Response]):
         response = self.endpoint.unlink_user(self.request)
         if NOT_LINKED_MESSAGE in str(response.data):
             return IntegrationResponse(
-                interaction_result=EventLifecycleOutcome.HALTED,
+                interaction_result=EventLifecycleOutcome.SUCCESS,
                 response=response,
                 outcome_reason=str(MessageCommandHaltReason.NOT_LINKED),
                 context_data={
@@ -200,7 +200,7 @@ class SlackCommandDispatcher(MessagingIntegrationCommandDispatcher[Response]):
         for message, reason in self.TEAM_HALT_MAPPINGS.items():
             if message in str(response.data):
                 return IntegrationResponse(
-                    interaction_result=EventLifecycleOutcome.HALTED,
+                    interaction_result=EventLifecycleOutcome.SUCCESS,
                     response=response,
                     outcome_reason=str(reason),
                 )
@@ -215,7 +215,7 @@ class SlackCommandDispatcher(MessagingIntegrationCommandDispatcher[Response]):
         for message, reason in self.TEAM_HALT_MAPPINGS.items():
             if message in str(response.data):
                 return IntegrationResponse(
-                    interaction_result=EventLifecycleOutcome.HALTED,
+                    interaction_result=EventLifecycleOutcome.SUCCESS,
                     response=response,
                     outcome_reason=str(reason),
                 )

--- a/tests/sentry/integrations/discord/webhooks/test_command.py
+++ b/tests/sentry/integrations/discord/webhooks/test_command.py
@@ -4,16 +4,10 @@ from sentry.integrations.discord.message_builder.base.flags import EPHEMERAL_FLA
 from sentry.integrations.discord.requests.base import DiscordRequestTypes
 from sentry.integrations.discord.webhooks.command import HELP_MESSAGE, NOT_LINKED_MESSAGE
 from sentry.integrations.discord.webhooks.types import DiscordResponseTypes
-from sentry.integrations.messaging.metrics import (
-    MessageCommandFailureReason,
-    MessageCommandHaltReason,
-)
+from sentry.integrations.messaging.metrics import MessageCommandFailureReason
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.testutils.cases import APITestCase
-from tests.sentry.integrations.utils.test_assert_metrics import (
-    assert_failure_metric,
-    assert_halt_metric,
-)
+from tests.sentry.integrations.utils.test_assert_metrics import assert_failure_metric
 
 WEBHOOK_URL = "/extensions/discord/interactions/"
 
@@ -211,10 +205,9 @@ class DiscordCommandInteractionTest(APITestCase):
             assert data["data"]["flags"] == EPHEMERAL_FLAG
             assert response.status_code == 200
 
-        start, halt = mock_record.mock_calls
+        start, success = mock_record.mock_calls
         assert start.args[0] == EventLifecycleOutcome.STARTED
-        assert halt.args[0] == EventLifecycleOutcome.HALTED
-        assert_halt_metric(mock_record, MessageCommandHaltReason.ALREADY_LINKED.value)
+        assert success.args[0] == EventLifecycleOutcome.SUCCESS
 
     @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_unlink_no_identity(self, mock_record):
@@ -239,10 +232,9 @@ class DiscordCommandInteractionTest(APITestCase):
             assert data["data"]["flags"] == EPHEMERAL_FLAG
             assert response.status_code == 200
 
-        start, halt = mock_record.mock_calls
+        start, success = mock_record.mock_calls
         assert start.args[0] == EventLifecycleOutcome.STARTED
-        assert halt.args[0] == EventLifecycleOutcome.HALTED
-        assert_halt_metric(mock_record, MessageCommandHaltReason.NOT_LINKED.value)
+        assert success.args[0] == EventLifecycleOutcome.SUCCESS
 
     @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_unlink(self, mock_record):

--- a/tests/sentry/integrations/msteams/test_webhook.py
+++ b/tests/sentry/integrations/msteams/test_webhook.py
@@ -8,7 +8,6 @@ import responses
 from django.test import override_settings
 from django.urls import reverse
 
-from sentry.integrations.messaging.metrics import MessageCommandHaltReason
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.msteams.utils import ACTION_TYPE
 from sentry.integrations.types import EventLifecycleOutcome
@@ -17,7 +16,6 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.users.models.identity import Identity
 from sentry.utils import jwt
-from tests.sentry.integrations.utils.test_assert_metrics import assert_halt_metric
 
 from .test_helpers import (
     DECODED_TOKEN,
@@ -546,10 +544,9 @@ class MsTeamsWebhookTest(APITestCase):
         )
         assert "Bearer my_token" in responses.calls[3].request.headers["Authorization"]
 
-        start, halt = mock_record.mock_calls
+        start, success = mock_record.mock_calls
         assert start.args[0] == EventLifecycleOutcome.STARTED
-        assert halt.args[0] == EventLifecycleOutcome.HALTED
-        assert_halt_metric(mock_record, MessageCommandHaltReason.ALREADY_LINKED.value)
+        assert success.args[0] == EventLifecycleOutcome.SUCCESS
 
     @responses.activate
     @mock.patch("sentry.utils.jwt.decode")

--- a/tests/sentry/integrations/slack/webhooks/commands/test_link_user.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/test_link_user.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch
 
-from sentry.integrations.messaging.metrics import MessageCommandHaltReason
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.slack.views.link_identity import SUCCESS_LINKED_MESSAGE, build_linking_url
 from sentry.integrations.slack.views.unlink_identity import (
@@ -13,7 +12,6 @@ from sentry.testutils.helpers import get_response_text
 from sentry.testutils.silo import control_silo_test
 from sentry.users.models.identity import Identity
 from tests.sentry.integrations.slack.webhooks.commands import SlackCommandsTest
-from tests.sentry.integrations.utils.test_assert_metrics import assert_halt_metric
 
 
 @control_silo_test
@@ -51,10 +49,9 @@ class SlackCommandsLinkUserTest(SlackCommandsTest):
         data = self.send_slack_message("link")
         assert "You are already linked as" in get_response_text(data)
 
-        start, halt = mock_record.mock_calls
+        start, success = mock_record.mock_calls
         assert start.args[0] == EventLifecycleOutcome.STARTED
-        assert halt.args[0] == EventLifecycleOutcome.HALTED
-        assert_halt_metric(mock_record, MessageCommandHaltReason.ALREADY_LINKED.value)
+        assert success.args[0] == EventLifecycleOutcome.SUCCESS
 
 
 @control_silo_test
@@ -134,7 +131,6 @@ class SlackCommandsUnlinkUserTest(SlackCommandsTest):
         data = self.send_slack_message("unlink")
         assert NOT_LINKED_MESSAGE in get_response_text(data)
 
-        start, halt = mock_record.mock_calls
+        start, success = mock_record.mock_calls
         assert start.args[0] == EventLifecycleOutcome.STARTED
-        assert halt.args[0] == EventLifecycleOutcome.HALTED
-        assert_halt_metric(mock_record, MessageCommandHaltReason.NOT_LINKED.value)
+        assert success.args[0] == EventLifecycleOutcome.SUCCESS


### PR DESCRIPTION
user errors such as: trying to link identity when identity is already linked, unlinking when there was no identity to begin with was currently recorded as a halt, leading to "bad events" in our SLO. Updating these states to success.