### PR TITLE
fix(issues): Revert to app external issue name

### DIFF
--- a/static/app/components/group/externalIssuesList/hooks/useSentryAppExternalIssues.tsx
+++ b/static/app/components/group/externalIssuesList/hooks/useSentryAppExternalIssues.tsx
@@ -51,16 +51,21 @@ export function useSentryAppExternalIssues({
     const externalIssue = externalIssues.find(
       i => i.serviceType === component.sentryApp.slug
     );
-    const displayName = component.sentryApp.name;
+    const appDisplayName = component.sentryApp.name;
     const displayIcon = (
       <SentryAppComponentIcon sentryAppComponent={component} size={14} />
     );
     if (externalIssue) {
       result.linkedIssues.push({
         key: externalIssue.id,
-        displayName: `${displayName} Issue`,
+        displayName: externalIssue.displayName,
         url: externalIssue.webUrl,
-        title: externalIssue.displayName,
+        // Some display names look like PROJ#1234
+        // Others look like ClickUp: Title
+        // Add the integration name if it's not already included
+        title: externalIssue.displayName.includes(appDisplayName)
+          ? externalIssue.displayName
+          : `${appDisplayName}: ${externalIssue.displayName}`,
         displayIcon,
         onUnlink: () => {
           deleteExternalIssue(api, group.id, externalIssue.id)
@@ -76,10 +81,10 @@ export function useSentryAppExternalIssues({
     } else {
       result.integrations.push({
         key: component.sentryApp.slug,
-        displayName,
+        displayName: appDisplayName,
         displayIcon,
         disabled: Boolean(component.error),
-        disabledText: t('Unable to connect to %s', displayName),
+        disabledText: t('Unable to connect to %s', appDisplayName),
         actions: [
           {
             id: component.sentryApp.slug,

--- a/static/app/components/group/externalIssuesList/streamlinedExternalIssueList.spec.tsx
+++ b/static/app/components/group/externalIssuesList/streamlinedExternalIssueList.spec.tsx
@@ -126,14 +126,14 @@ describe('StreamlinedExternalIssueList', () => {
     );
 
     expect(
-      await screen.findByRole('button', {name: 'Clickup Issue'})
+      await screen.findByRole('button', {name: 'ClickUp: hello#1'})
     ).toBeInTheDocument();
-    await userEvent.hover(screen.getByRole('button', {name: 'Clickup Issue'}));
+    await userEvent.hover(screen.getByRole('button', {name: 'ClickUp: hello#1'}));
     await userEvent.click(await screen.findByRole('button', {name: 'Unlink issue'}));
 
     await waitFor(() => {
       expect(
-        screen.queryByRole('button', {name: 'Clickup Issue'})
+        screen.queryByRole('button', {name: 'ClickUp: hello#1'})
       ).not.toBeInTheDocument();
     });
     expect(unlinkMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
The new designs were displaying "Linear Issue" for a linked issue. Will now display "PROJ#123" like jira and others. This does depend on how the app is setup, since some will display the entire title since that is what they set as the display name.

This is closer to how it worked previously.