### PR TITLE
fix(alerts): fixes delete eap subscriptions

### DIFF
--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -671,6 +671,9 @@ def get_entity_key_from_snuba_query(
     project_id: int,
     skip_field_validation_for_entity_subscription_deletion: bool = False,
 ) -> EntityKey:
+    query_dataset = Dataset(snuba_query.dataset)
+    if query_dataset == Dataset.EventsAnalyticsPlatform:
+        return EntityKey.EAPSpans
     entity_subscription = get_entity_subscription_from_snuba_query(
         snuba_query,
         organization_id,


### PR DESCRIPTION
Updates `get_entity_key_from_snuba_query` to handle EAP subscriptions by checking the dataset param. This is needed because the EAP "entity" doesn't have a `build_query_builder` function. This fixes subscription deletes and updates from EAP Alerts not functioning properly. Also fixes tests for delete not properly testing entire flow.