### PR TITLE
feat(issues): Disable search and date filter on routes

### DIFF
--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.spec.tsx
@@ -11,6 +11,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
+import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
 
 import {EventDetailsHeader} from './eventDetailsHeader';
 
@@ -111,5 +112,21 @@ describe('EventDetailsHeader', () => {
     expect(mockUseNavigate).toHaveBeenCalledWith(expect.objectContaining(locationQuery), {
       replace: true,
     });
+  });
+
+  it('disables search when not on the events tab', async function () {
+    const allEventsRouter = RouterFixture({
+      params: {groupId: group.id},
+      routes: [{path: TabPaths[Tab.ATTACHMENTS]}],
+      location: LocationFixture({
+        pathname: `/organizations/${organization.slug}/issues/${group.id}/${TabPaths[Tab.ATTACHMENTS]}`,
+      }),
+    });
+    render(<EventDetailsHeader {...defaultProps} />, {
+      organization,
+      router: allEventsRouter,
+    });
+    expect(await screen.findByTestId('event-graph-loading')).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search events\u2026')).toBeDisabled();
   });
 });

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -1,4 +1,3 @@
-import {useParams} from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import {LinkButton} from 'sentry/components/button';
@@ -38,7 +37,6 @@ export function EventDetailsHeader({
   project: Project;
 }) {
   const organization = useOrganization();
-  const params = useParams<{groupId: string}>();
   const navigate = useNavigate();
   const location = useLocation();
   const environments = useEnvironmentsFromUrl();
@@ -77,7 +75,7 @@ export function EventDetailsHeader({
             handleSearch={query => {
               navigate(
                 {
-                  pathname: `/organizations/${organization.slug}/issues/${params.groupId}/events/`,
+                  pathname: `/organizations/${organization.slug}/issues/${group.id}/events/`,
                   query: {...location.query, query},
                 },
                 {replace: true}

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -1,3 +1,4 @@
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from 'sentry/components/button';
@@ -36,6 +37,7 @@ export function EventDetailsHeader({
   group: Group;
   project: Project;
 }) {
+  const theme = useTheme();
   const organization = useOrganization();
   const navigate = useNavigate();
   const location = useLocation();
@@ -69,7 +71,14 @@ export function EventDetailsHeader({
           }}
           disabled={!TABS_WITH_DATE_FILTER.includes(currentTab)}
         />
-        <Flex style={{gridArea: 'search'}}>
+        <Flex
+          style={{
+            gridArea: 'search',
+            backgroundColor: TABS_WITH_DATE_FILTER.includes(currentTab)
+              ? undefined
+              : theme.backgroundSecondary,
+          }}
+        >
           <SearchFilter
             group={group}
             handleSearch={query => {

--- a/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetailsHeader.tsx
@@ -1,3 +1,4 @@
+import {useParams} from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import {LinkButton} from 'sentry/components/button';
@@ -13,6 +14,7 @@ import type {Project} from 'sentry/types/project';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
 import {EventGraph} from 'sentry/views/issueDetails/streamline/eventGraph';
 import {
   EventSearch,
@@ -23,6 +25,9 @@ import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
 import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
 import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 
+const TABS_WITH_SEARCH = [Tab.DETAILS, Tab.EVENTS];
+const TABS_WITH_DATE_FILTER = [Tab.DETAILS, Tab.EVENTS];
+
 export function EventDetailsHeader({
   group,
   event,
@@ -32,11 +37,13 @@ export function EventDetailsHeader({
   group: Group;
   project: Project;
 }) {
+  const organization = useOrganization();
+  const params = useParams<{groupId: string}>();
   const navigate = useNavigate();
   const location = useLocation();
   const environments = useEnvironmentsFromUrl();
   const searchQuery = useEventQuery({group});
-  const {baseUrl} = useGroupDetailsRoute();
+  const {baseUrl, currentTab} = useGroupDetailsRoute();
 
   const issueTypeConfig = getConfigForIssueType(group, project);
 
@@ -62,17 +69,25 @@ export function EventDetailsHeader({
               borderRadius: 0,
             },
           }}
+          disabled={!TABS_WITH_DATE_FILTER.includes(currentTab)}
         />
         <Flex style={{gridArea: 'search'}}>
           <SearchFilter
             group={group}
             handleSearch={query => {
-              navigate({...location, query: {...location.query, query}}, {replace: true});
+              navigate(
+                {
+                  pathname: `/organizations/${organization.slug}/issues/${params.groupId}/events/`,
+                  query: {...location.query, query},
+                },
+                {replace: true}
+              );
             }}
             environments={environments}
             query={searchQuery}
             queryBuilderProps={{
               disallowFreeText: true,
+              disabled: !TABS_WITH_SEARCH.includes(currentTab),
             }}
           />
           <ToggleSidebar />


### PR DESCRIPTION
- searching will now take you to the all events page
- date and search are disabled unless viewing the events or issue details pages

![image](https://github.com/user-attachments/assets/09efb0c0-180a-425a-92d6-558326b9a544)
