### PR TITLE
chore(alerts): Remove activated alerts project subscription

### DIFF
--- a/src/sentry/incidents/models/alert_rule.py
+++ b/src/sentry/incidents/models/alert_rule.py
@@ -3,14 +3,12 @@ from __future__ import annotations
 import abc
 import logging
 from collections.abc import Callable, Collection, Iterable
-from datetime import timedelta
 from enum import Enum, IntEnum, StrEnum
-from typing import TYPE_CHECKING, Any, ClassVar, Protocol, Self
+from typing import TYPE_CHECKING, Any, ClassVar, Self
 
 from django.conf import settings
 from django.core.cache import cache
 from django.db import models
-from django.db.models import QuerySet
 from django.db.models.signals import post_delete, post_save
 from django.utils import timezone
 from django.utils.translation import gettext_lazy
@@ -28,10 +26,7 @@ from sentry.db.models import (
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.db.models.manager.base import BaseManager
 from sentry.db.models.manager.base_query_set import BaseQuerySet
-from sentry.incidents.models.alert_rule_activations import AlertRuleActivations
 from sentry.incidents.models.incident import Incident, IncidentStatus, IncidentTrigger
-from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
-from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.team import Team
@@ -42,7 +37,6 @@ from sentry.notifications.models.notificationaction import (
 )
 from sentry.seer.anomaly_detection.delete_rule import delete_rule_in_seer
 from sentry.snuba.models import QuerySubscription
-from sentry.snuba.subscriptions import bulk_create_snuba_subscriptions, delete_snuba_subscription
 from sentry.types.actor import Actor
 from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
@@ -53,34 +47,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
-
-
-class SubscriptionCallback(Protocol):
-    def __call__(self, subscription: QuerySubscription, *args: Any, **kwargs: Any) -> bool: ...
-
-
-alert_subscription_callback_registry: dict[AlertRuleMonitorTypeInt, SubscriptionCallback] = {}
-
-
-def register_alert_subscription_callback(
-    monitor_type: AlertRuleMonitorTypeInt,
-) -> Callable[[Callable], Callable]:
-    def decorator(func: Callable) -> Callable:
-        alert_subscription_callback_registry[monitor_type] = func
-        return func
-
-    return decorator
-
-
-def invoke_alert_subscription_callback(
-    monitor_type: AlertRuleMonitorTypeInt, subscription: QuerySubscription, **kwargs: Any
-) -> bool:
-    try:
-        callback = alert_subscription_callback_registry[monitor_type]
-    except KeyError:
-        return False
-
-    return callback(subscription, **kwargs)
 
 
 class AlertRuleStatus(Enum):
@@ -187,59 +153,6 @@ class AlertRuleManager(BaseManager["AlertRule"]):
                     },
                 )
 
-    def conditionally_subscribe_project_to_alert_rules(
-        self,
-        project: Project,
-        activation_condition: AlertRuleActivationConditionType,
-        query_extra: str,
-        origin: str,
-        activator: str,
-    ) -> list[QuerySubscription]:
-        """
-        Subscribes a project to an alert rule given activation condition
-        Initializes an AlertRule activation instance
-        """
-        try:
-            project_alert_rules: QuerySet[AlertRule] = self.filter(
-                projects=project,
-                monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
-            )
-            created_subscriptions = []
-            for alert_rule in project_alert_rules:
-                # an alert rule should only ever have a single condition
-                if alert_rule.activation_condition.filter(
-                    condition_type=activation_condition.value
-                ).exists():
-                    # if an activated alert rule exists with the passed condition
-                    logger.info(
-                        "Attempt subscribe project to activated alert rule",
-                        extra={
-                            "origin": origin,
-                            "query_extra": query_extra,
-                            "condition": activation_condition,
-                        },
-                    )
-                    # attempt to subscribe the alert rule
-                    created_subscriptions.extend(
-                        alert_rule.subscribe_projects(
-                            projects=[project],
-                            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
-                            query_extra=query_extra,
-                            activation_condition=activation_condition,
-                            activator=activator,
-                        )
-                    )
-            return created_subscriptions
-        except Exception as e:
-            logger.exception(
-                "Failed to subscribe project to activated alert rule",
-                extra={
-                    "origin": origin,
-                    "exception": e,
-                },
-            )
-        return []
-
 
 @region_silo_model
 class AlertRuleProjects(Model):
@@ -336,56 +249,6 @@ class AlertRule(Model):
 
     def get_audit_log_data(self) -> dict[str, Any]:
         return {"label": self.name}
-
-    def subscribe_projects(
-        self,
-        projects: Iterable[Project],
-        monitor_type: AlertRuleMonitorTypeInt = AlertRuleMonitorTypeInt.CONTINUOUS,
-        query_extra: str | None = None,
-        activation_condition: AlertRuleActivationConditionType | None = None,
-        activator: str | None = None,
-    ) -> list[QuerySubscription]:
-        """
-        Subscribes a list of projects to the alert rule instance
-        :return: The list of created subscriptions
-        """
-
-        logger.info(
-            "Subscribing projects to alert rule",
-            extra={
-                "alert_rule.monitor_type": self.monitor_type,
-                "conditional_monitor_type": monitor_type,
-                "query_extra": query_extra,
-            },
-        )
-        # NOTE: AlertRuleMonitorTypeInt.ACTIVATED will be conditionally subscribed given activation triggers
-        # On activated subscription, additional query parameters will be added to the constructed query in Snuba
-        created_subscriptions = []
-        if self.monitor_type == monitor_type:
-            # NOTE: QuerySubscriptions hold reference to Projects which should match the AlertRule's project reference
-            created_subscriptions = bulk_create_snuba_subscriptions(
-                projects,
-                INCIDENTS_SNUBA_SUBSCRIPTION_TYPE,
-                self.snuba_query,
-                query_extra=query_extra,
-            )
-            if self.monitor_type == AlertRuleMonitorTypeInt.ACTIVATED:
-                # NOTE: Activated Alert Rules are conditionally subscribed
-                # Meaning at time of subscription, the rule must have been activated
-                if not activator or activation_condition is None:
-                    raise Exception(
-                        "Alert activations require an activation condition and activator reference"
-                    )
-
-                for subscription in created_subscriptions:
-                    AlertRuleActivations.objects.create(
-                        alert_rule=self,
-                        query_subscription=subscription,
-                        condition_type=activation_condition.value,
-                        activator=activator,
-                    )
-
-        return created_subscriptions
 
 
 class AlertRuleTriggerManager(BaseManager["AlertRuleTrigger"]):
@@ -728,41 +591,6 @@ class AlertRuleActivity(Model):
     class Meta:
         app_label = "sentry"
         db_table = "sentry_alertruleactivity"
-
-
-@register_alert_subscription_callback(AlertRuleMonitorTypeInt.ACTIVATED)
-def update_alert_activations(
-    subscription: QuerySubscription, alert_rule: AlertRule, value: float
-) -> bool:
-    if subscription.snuba_query is None:
-        return False
-
-    now = timezone.now()
-    subscription_end = subscription.date_added + timedelta(
-        seconds=subscription.snuba_query.time_window
-    )
-
-    if now > subscription_end:
-        logger.info(
-            "alert activation monitor finishing",
-            extra={
-                "subscription_window": subscription.snuba_query.time_window,
-                "date_added": subscription.date_added,
-                "now": now,
-            },
-        )
-
-        alert_rule.activations.filter(finished_at=None, query_subscription=subscription).update(
-            metric_value=value, finished_at=now
-        )
-        # NOTE: QuerySubscription deletion will set fk to null on the activation
-        delete_snuba_subscription(subscription)
-    else:
-        alert_rule.activations.filter(finished_at=None, query_subscription=subscription).update(
-            metric_value=value
-        )
-
-    return True
 
 
 post_delete.connect(AlertRuleManager.clear_subscription_cache, sender=QuerySubscription)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -10,7 +10,6 @@ from django.utils.functional import cached_property
 
 from sentry.eventstore.models import Event
 from sentry.incidents.models.alert_rule import AlertRule
-from sentry.incidents.models.incident import IncidentActivityType
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.issues.grouptype import ErrorGroupType

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Mapping
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -9,7 +9,8 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 
 from sentry.eventstore.models import Event
-from sentry.incidents.models.alert_rule import AlertRule, AlertRuleMonitorTypeInt
+from sentry.incidents.models.alert_rule import AlertRule
+from sentry.incidents.models.incident import IncidentActivityType
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.issues.grouptype import ErrorGroupType
@@ -26,7 +27,6 @@ from sentry.models.team import Team
 from sentry.monitors.models import Monitor, MonitorType, ScheduleType
 from sentry.organizations.services.organization import RpcOrganization
 from sentry.silo.base import SiloMode
-from sentry.snuba.models import QuerySubscription
 from sentry.tempest.models import TempestCredentials
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers.datetime import before_now
@@ -388,36 +388,6 @@ class Fixtures:
         if projects is None:
             projects = [self.project]
         return Factories.create_alert_rule(organization, projects, *args, **kwargs)
-
-    def create_alert_rule_activation(
-        self,
-        alert_rule: AlertRule | None = None,
-        query_subscriptions: Iterable[QuerySubscription] | None = None,
-        project=None,
-        monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
-        activator=None,
-        activation_condition=None,
-        *args,
-        **kwargs,
-    ):
-        if not alert_rule:
-            alert_rule = self.create_alert_rule(monitor_type=monitor_type)
-        if not query_subscriptions:
-            projects = [project] if project else [self.project]
-            # subscribing an activated alert rule will create an activation
-            query_subscriptions = alert_rule.subscribe_projects(
-                projects=projects,
-                monitor_type=monitor_type,
-                activation_condition=activation_condition,
-                activator=activator,
-            )
-
-        created_activations = []
-        for sub in query_subscriptions:
-            created_activations.append(
-                Factories.create_alert_rule_activation(alert_rule, sub, *args, **kwargs)
-            )
-        return created_activations
 
     def create_alert_rule_trigger(self, alert_rule=None, *args, **kwargs):
         if not alert_rule:

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -44,11 +44,6 @@ from sentry.backup.scopes import ExportScope
 from sentry.backup.validate import validate
 from sentry.data_secrecy.models import DataSecrecyWaiver
 from sentry.db.models.paranoia import ParanoidModel
-<<<<<<< HEAD
-from sentry.incidents.models.alert_rule import AlertRuleMonitorTypeInt
-=======
-from sentry.incidents.models.alert_rule import AlertRuleExcludedProjects, AlertRuleTriggerExclusion
->>>>>>> e126adc39ca (remove from fixtures)
 from sentry.incidents.models.incident import (
     IncidentActivity,
     IncidentSnapshot,

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -44,7 +44,11 @@ from sentry.backup.scopes import ExportScope
 from sentry.backup.validate import validate
 from sentry.data_secrecy.models import DataSecrecyWaiver
 from sentry.db.models.paranoia import ParanoidModel
+<<<<<<< HEAD
 from sentry.incidents.models.alert_rule import AlertRuleMonitorTypeInt
+=======
+from sentry.incidents.models.alert_rule import AlertRuleExcludedProjects, AlertRuleTriggerExclusion
+>>>>>>> e126adc39ca (remove from fixtures)
 from sentry.incidents.models.incident import (
     IncidentActivity,
     IncidentSnapshot,
@@ -52,7 +56,6 @@ from sentry.incidents.models.incident import (
     PendingIncidentSnapshot,
     TimeSeriesSnapshot,
 )
-from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.models.project_integration import ProjectIntegration
@@ -523,21 +526,6 @@ class ExhaustiveFixtures(Fixtures):
         trigger = self.create_alert_rule_trigger(alert_rule=alert)
         assert alert.snuba_query is not None
         self.create_alert_rule_trigger_action(alert_rule_trigger=trigger)
-        activated_alert = self.create_alert_rule(
-            organization=org,
-            projects=[project],
-            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
-            activation_condition=AlertRuleActivationConditionType.RELEASE_CREATION,
-        )
-        self.create_alert_rule_activation(
-            alert_rule=activated_alert,
-            project=project,
-            metric_value=100,
-            activator="testing exhaustive",
-            activation_condition=AlertRuleActivationConditionType.RELEASE_CREATION,
-        )
-        activated_trigger = self.create_alert_rule_trigger(alert_rule=activated_alert)
-        self.create_alert_rule_trigger_action(alert_rule_trigger=activated_trigger)
 
         # Incident*
         incident = self.create_incident(org, [project])

--- a/tests/sentry/incidents/models/test_alert_rule.py
+++ b/tests/sentry/incidents/models/test_alert_rule.py
@@ -1,28 +1,20 @@
 import unittest
-from datetime import timedelta
 from unittest import mock
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 from django.core.cache import cache
-from django.utils import timezone
 
 from sentry.incidents.logic import delete_alert_rule, update_alert_rule
 from sentry.incidents.models.alert_rule import (
     AlertRule,
     AlertRuleActivity,
     AlertRuleActivityType,
-    AlertRuleMonitorTypeInt,
     AlertRuleStatus,
     AlertRuleTrigger,
     AlertRuleTriggerAction,
-    alert_subscription_callback_registry,
-    register_alert_subscription_callback,
-    update_alert_activations,
 )
 from sentry.incidents.models.incident import IncidentStatus
-from sentry.incidents.utils.types import AlertRuleActivationConditionType
-from sentry.snuba.models import QuerySubscription
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.alert_rule import TemporaryAlertRuleTriggerActionRegistry
 from sentry.users.services.user.service import user_service
@@ -145,74 +137,6 @@ class IncidentAlertRuleRelationTest(TestCase):
         all_alert_rules = list(AlertRule.objects.all())
         assert self.alert_rule not in all_alert_rules
         assert self.incident.alert_rule.id == self.alert_rule.id
-
-
-class AlertRuleTest(TestCase):
-    @patch("sentry.incidents.models.alert_rule.bulk_create_snuba_subscriptions")
-    def test_subscribes_projects_to_alert_rule(self, mock_bulk_create_snuba_subscriptions):
-        # eg. creates QuerySubscription's/SnubaQuery's for AlertRule + Project
-        alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorTypeInt.ACTIVATED)
-        assert mock_bulk_create_snuba_subscriptions.call_count == 0
-
-        alert_rule.subscribe_projects(
-            projects=[self.project],
-            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
-            activator="testing",
-            activation_condition=AlertRuleActivationConditionType.RELEASE_CREATION,
-        )
-        assert mock_bulk_create_snuba_subscriptions.call_count == 1
-
-    def test_conditionally_subscribe_project_to_alert_rules(self):
-        query_extra = "foo:bar"
-        project = self.create_project(name="foo")
-        self.create_alert_rule(
-            projects=[project],
-            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
-            activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
-        )
-        with self.tasks():
-            created_subscriptions = (
-                AlertRule.objects.conditionally_subscribe_project_to_alert_rules(
-                    project=project,
-                    activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
-                    query_extra=query_extra,
-                    origin="test",
-                    activator="testing",
-                )
-            )
-            assert len(created_subscriptions) == 1
-
-            sub = created_subscriptions[0]
-            fetched_sub = QuerySubscription.objects.get(id=sub.id)
-            assert fetched_sub.subscription_id is not None
-
-    def test_conditionally_subscribing_project_initializes_activation(self):
-        query_extra = "foo:bar"
-        project = self.create_project(name="foo")
-        alert_rule = self.create_alert_rule(
-            projects=[project],
-            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
-            activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
-        )
-
-        with self.tasks():
-            created_subscriptions = (
-                AlertRule.objects.conditionally_subscribe_project_to_alert_rules(
-                    project=project,
-                    activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
-                    query_extra=query_extra,
-                    origin="test",
-                    activator="testing",
-                )
-            )
-            assert len(created_subscriptions) == 1
-
-            sub = created_subscriptions[0]
-            activations = alert_rule.activations.all()
-            assert len(activations) == 1
-            current_activation = activations[0]
-            assert current_activation.query_subscription == sub
-            assert current_activation.is_complete() is False
 
 
 class AlertRuleFetchForOrganizationTest(TestCase):
@@ -406,82 +330,6 @@ class AlertRuleActivityTest(TestCase):
         assert AlertRuleActivity.objects.filter(
             alert_rule=self.alert_rule, type=AlertRuleActivityType.UPDATED.value
         ).exists()
-
-
-class UpdateAlertActivationsTest(TestCase):
-    def test_updates_non_expired_alerts(self):
-        with self.tasks():
-            alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorTypeInt.ACTIVATED)
-            alert_rule.subscribe_projects(
-                projects=[self.project],
-                monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
-                activation_condition=AlertRuleActivationConditionType.RELEASE_CREATION,
-                activator="testing",
-            )
-            assert alert_rule.snuba_query is not None
-            subscription = alert_rule.snuba_query.subscriptions.get()
-            activation = alert_rule.activations.get()
-            assert activation.finished_at is None
-            assert activation.metric_value is None
-
-            expected_value = 10
-            result = update_alert_activations(
-                subscription=subscription, alert_rule=alert_rule, value=expected_value
-            )
-            assert result is True
-            assert QuerySubscription.objects.filter(id=subscription.id).exists()
-            activation = alert_rule.activations.get()
-            # assert activation.is_complete() is True # TODO: enable once we've implemented is_complete()
-            assert activation.finished_at is None
-            assert activation.metric_value == expected_value
-
-    def test_cleans_expired_alerts(self):
-        with self.tasks():
-            alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorTypeInt.ACTIVATED)
-            alert_rule.subscribe_projects(
-                projects=[self.project],
-                monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
-                activation_condition=AlertRuleActivationConditionType.RELEASE_CREATION,
-                activator="testing",
-            )
-
-            assert alert_rule.snuba_query is not None
-            subscription = alert_rule.snuba_query.subscriptions.get()
-            subscription.date_added = timezone.now() - timedelta(days=21)
-
-            expected_value = 10
-            result = update_alert_activations(
-                subscription=subscription, alert_rule=alert_rule, value=expected_value
-            )
-
-            assert result is True
-            assert subscription.status == QuerySubscription.Status.DELETING.value
-            assert not QuerySubscription.objects.filter(id=subscription.id).exists()
-            activation = alert_rule.activations.get()
-            # assert activation.is_complete() is True # TODO: enable once we've implemented is_complete()
-            assert activation.finished_at is not None
-            assert activation.metric_value == expected_value
-
-    def test_update_alerts_add_processor(self):
-        @register_alert_subscription_callback(AlertRuleMonitorTypeInt.CONTINUOUS)
-        def mock_processor(_subscription, alert_rule, value):
-            # everything other than subscription is passed as a kwarg
-            return True
-
-        assert AlertRuleMonitorTypeInt.CONTINUOUS in alert_subscription_callback_registry
-        assert (
-            alert_subscription_callback_registry[AlertRuleMonitorTypeInt.CONTINUOUS]
-            == mock_processor
-        )
-
-    def test_update_alerts_execute_processor(self):
-        alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorTypeInt.CONTINUOUS)
-        assert alert_rule.snuba_query is not None
-        subscription = alert_rule.snuba_query.subscriptions.get()
-
-        callback = alert_subscription_callback_registry[AlertRuleMonitorTypeInt.CONTINUOUS]
-        result = callback(subscription, alert_rule=alert_rule, value=10)
-        assert result is True
 
 
 class AlertRuleFetchForProjectTest(TestCase):

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -24,14 +24,12 @@ from sentry.incidents.logic import (
 from sentry.incidents.models.alert_rule import (
     AlertRule,
     AlertRuleDetectionType,
-    AlertRuleMonitorTypeInt,
     AlertRuleSeasonality,
     AlertRuleSensitivity,
     AlertRuleStatus,
     AlertRuleThresholdType,
     AlertRuleTrigger,
     AlertRuleTriggerAction,
-    alert_subscription_callback_registry,
 )
 from sentry.incidents.models.incident import (
     Incident,
@@ -218,10 +216,6 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         return self.rule.snuba_query.subscriptions.filter(project=self.project).get()
 
     @cached_property
-    def activated_sub(self):
-        return self.activated_rule.snuba_query.subscriptions.filter(project=self.project).get()
-
-    @cached_property
     def other_sub(self):
         return self.rule.snuba_query.subscriptions.filter(project=self.other_project).get()
 
@@ -235,7 +229,6 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             threshold_type=AlertRuleThresholdType.ABOVE,
             resolve_threshold=10,
             threshold_period=1,
-            monitor_type=AlertRuleMonitorTypeInt.CONTINUOUS,
             event_types=[
                 SnubaQueryEventType.EventType.ERROR,
                 SnubaQueryEventType.EventType.DEFAULT,
@@ -254,40 +247,6 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
     @cached_property
     def rule(self):
         return self.create_rule_trigger_and_action(projects=[self.project, self.other_project])
-
-    @cached_property
-    def activated_rule(self):
-        rule = self.create_alert_rule(
-            projects=[self.project, self.other_project],
-            name="some rule",
-            query="",
-            aggregate="count()",
-            time_window=1,
-            threshold_type=AlertRuleThresholdType.ABOVE,
-            resolve_threshold=10,
-            threshold_period=1,
-            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
-            activation_condition=AlertRuleActivationConditionType.RELEASE_CREATION,
-            event_types=[
-                SnubaQueryEventType.EventType.ERROR,
-                SnubaQueryEventType.EventType.DEFAULT,
-            ],
-        )
-        rule.subscribe_projects(
-            projects=[self.project],
-            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
-            activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
-            activator="testing",
-        )
-        # Make sure the trigger exists
-        trigger = create_alert_rule_trigger(rule, CRITICAL_TRIGGER_LABEL, 100)
-        create_alert_rule_trigger_action(
-            trigger,
-            AlertRuleTriggerAction.Type.EMAIL,
-            AlertRuleTriggerAction.TargetType.USER,
-            str(self.user.id),
-        )
-        return rule
 
     @cached_property
     def comparison_rule_above(self):
@@ -328,16 +287,8 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         return self.rule.alertruletrigger_set.get()
 
     @cached_property
-    def activated_trigger(self):
-        return self.activated_rule.alertruletrigger_set.get()
-
-    @cached_property
     def action(self):
         return self.trigger.alertruletriggeraction_set.get()
-
-    @cached_property
-    def activated_action(self):
-        return self.activated_trigger.alertruletriggeraction_set.get()
 
     def build_subscription_update(self, subscription, time_delta=None, value=EMPTY):
         if time_delta is not None:
@@ -974,33 +925,6 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             [(trigger.alert_threshold + 1, IncidentStatus.CRITICAL, uuid)],
         )
         create_metric_issue_mock.assert_not_called()
-
-    def test_activated_alert(self):
-        # Verify that an alert rule that only expects a single update to be over the
-        # alert threshold triggers correctly
-        rule = self.activated_rule
-        trigger = self.activated_trigger
-        subscription = self.activated_sub
-        processor = self.send_update(
-            rule=rule, value=trigger.alert_threshold + 1, subscription=subscription
-        )
-        self.assert_trigger_counts(processor, self.activated_trigger, 0, 0)
-        incident = self.assert_active_incident(rule=rule, subscription=subscription)
-        assert incident.date_started == (
-            timezone.now().replace(microsecond=0) - timedelta(seconds=rule.snuba_query.time_window)
-        )
-        self.assert_trigger_exists_with_status(
-            incident, self.activated_trigger, TriggerStatus.ACTIVE
-        )
-        latest_activity = self.latest_activity(incident)
-        uuid = str(latest_activity.notification_uuid)
-        self.assert_actions_fired_for_incident(
-            incident,
-            [self.activated_action],
-            [(trigger.alert_threshold + 1, IncidentStatus.CRITICAL, uuid)],
-        )
-        # assert that an incident was created _with_ an activation!
-        assert incident.activation
 
     def test_alert_dedupe(self):
         # Verify that an alert rule that only expects a single update to be over the
@@ -2958,15 +2882,6 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         new_incident = self.assert_active_incident(rule)
         self.assert_trigger_exists_with_status(new_incident, trigger, TriggerStatus.ACTIVE)
         self.assert_incident_is_latest_for_rule(new_incident)
-
-    def test_invoke_alert_subscription_callback(self):
-        mock = Mock()
-        alert_subscription_callback_registry[AlertRuleMonitorTypeInt.CONTINUOUS] = mock
-
-        self.send_update(self.rule, 1, subscription=self.sub)
-
-        assert mock.call_count == 1
-        assert mock.call_args[0][0] == self.sub
 
     @with_feature("organizations:metric-issue-poc")
     @mock.patch("sentry.incidents.utils.metric_issue_poc.produce_occurrence_to_kafka")

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -49,10 +49,7 @@ from sentry.incidents.subscription_processor import (
     partition,
     update_alert_rule_stats,
 )
-from sentry.incidents.utils.types import (
-    DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION,
-    AlertRuleActivationConditionType,
-)
+from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
 from sentry.issues.grouptype import MetricIssuePOC
 from sentry.models.project import Project
 from sentry.seer.anomaly_detection.get_anomaly_data import get_anomaly_data_from_seer

--- a/tests/sentry/models/releases/test_release_project.py
+++ b/tests/sentry/models/releases/test_release_project.py
@@ -2,12 +2,9 @@ from unittest.mock import call as mock_call
 from unittest.mock import patch
 
 from sentry.dynamic_sampling import ProjectBoostedReleases
-from sentry.incidents.models.alert_rule import AlertRule, AlertRuleMonitorTypeInt
-from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.models.release import Release
 from sentry.models.releases.release_project import ReleaseProject, ReleaseProjectModelManager
 from sentry.signals import receivers_raise_on_send
-from sentry.snuba.models import QuerySubscription
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.helpers import Feature
 
@@ -17,8 +14,7 @@ class ReleaseProjectManagerTestCase(TransactionTestCase):
         self.assertIsInstance(ReleaseProject.objects, ReleaseProjectModelManager)
 
     @receivers_raise_on_send()
-    @patch.object(ReleaseProjectModelManager, "subscribe_project_to_alert_rule")
-    def test_post_save_signal_runs_if_dynamic_sampling_is_disabled(self, _):
+    def test_post_save_signal_runs_if_dynamic_sampling_is_disabled(self):
         project = self.create_project(name="foo")
         release = Release.objects.create(organization_id=project.organization_id, version="42")
 
@@ -29,10 +25,8 @@ class ReleaseProjectManagerTestCase(TransactionTestCase):
             assert mock_task.mock_calls == []
 
     @receivers_raise_on_send()
-    @patch.object(ReleaseProjectModelManager, "subscribe_project_to_alert_rule")
     def test_post_save_signal_runs_if_dynamic_sampling_is_enabled_and_latest_release_rule_does_not_exist(
         self,
-        _,
     ):
         with Feature(
             {
@@ -49,10 +43,8 @@ class ReleaseProjectManagerTestCase(TransactionTestCase):
                 assert mock_task.mock_calls == []
 
     @receivers_raise_on_send()
-    @patch.object(ReleaseProjectModelManager, "subscribe_project_to_alert_rule")
     def test_post_save_signal_runs_if_dynamic_sampling_is_enabled_and_latest_release_rule_exists(
         self,
-        _,
     ):
         with Feature(
             {
@@ -73,62 +65,3 @@ class ReleaseProjectManagerTestCase(TransactionTestCase):
                 assert mock_task.mock_calls == [
                     mock_call(project_id=project.id, trigger="releaseproject.post_save")
                 ]
-
-    @receivers_raise_on_send()
-    @patch("sentry.models.releases.release_project.schedule_invalidate_project_config")
-    @patch.object(ReleaseProjectModelManager, "subscribe_project_to_alert_rule")
-    def test_post_save_subscribes_project_to_alert_rule_if_created(
-        self, mock_subscribe_project_to_alert_rule, _
-    ):
-        project = self.create_project(name="foo")
-        release = Release.objects.create(organization_id=project.organization_id, version="42")
-
-        release.add_project(project)
-
-        assert mock_subscribe_project_to_alert_rule.call_count == 1
-        # models.signals.post_save.send(instance=inst, sender=type(inst), created=False)
-
-    @patch(
-        "sentry.incidents.models.alert_rule.AlertRule.objects.conditionally_subscribe_project_to_alert_rules"
-    )
-    def test_subscribe_project_to_alert_rule_constructs_query(self, mock_conditionally_subscribe):
-        project = self.create_project(name="foo")
-        release = Release.objects.create(organization_id=project.organization_id, version="42")
-        ReleaseProjectModelManager.subscribe_project_to_alert_rule(
-            project=project, release=release, trigger="test"
-        )
-
-        assert mock_conditionally_subscribe.call_count == 1
-        assert mock_conditionally_subscribe.mock_calls == [
-            mock_call(
-                project=project,
-                activation_condition=AlertRuleActivationConditionType.RELEASE_CREATION,
-                query_extra="release:42",
-                origin="test",
-                activator="42",
-            )
-        ]
-
-    def test_unmocked_subscribe_project_to_alert_rule_constructs_query(self):
-        # Let the logic flow through to snuba and see whether we properly construct the snuba query
-        project = self.create_project(name="foo")
-        release = Release.objects.create(organization_id=project.organization_id, version="42")
-        self.create_alert_rule(
-            projects=[project],
-            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
-            activation_condition=AlertRuleActivationConditionType.RELEASE_CREATION,
-        )
-
-        subscribe_project = AlertRule.objects.conditionally_subscribe_project_to_alert_rules
-        with patch(
-            "sentry.incidents.models.alert_rule.AlertRule.objects.conditionally_subscribe_project_to_alert_rules",
-            wraps=subscribe_project,
-        ) as wrapped_subscribe_project:
-            with self.tasks():
-                _, created = release.add_project(project)
-
-                assert created
-                assert wrapped_subscribe_project.call_count == 1
-
-                sub = QuerySubscription.objects.filter(project=project).get()
-                assert sub.subscription_id is not None

--- a/tests/sentry/models/test_releaseprojectenvironment.py
+++ b/tests/sentry/models/test_releaseprojectenvironment.py
@@ -1,19 +1,10 @@
 from datetime import timedelta
-from unittest.mock import call as mock_call
-from unittest.mock import patch
 
 from django.utils import timezone
 
-from sentry.incidents.models.alert_rule import AlertRule, AlertRuleMonitorTypeInt
-from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.models.environment import Environment
 from sentry.models.release import Release
-from sentry.models.releaseprojectenvironment import (
-    ReleaseProjectEnvironment,
-    ReleaseProjectEnvironmentManager,
-)
-from sentry.signals import receivers_raise_on_send
-from sentry.snuba.models import QuerySubscription
+from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 from sentry.testutils.cases import TestCase
 
 
@@ -92,65 +83,3 @@ class GetOrCreateTest(TestCase):
         )
         assert release_project_env.first_seen == self.datetime_now
         assert release_project_env.last_seen == self.datetime_now
-
-    @receivers_raise_on_send()
-    @patch.object(ReleaseProjectEnvironmentManager, "subscribe_project_to_alert_rule")
-    def test_post_save_subscribes_project_to_alert_rule_if_created(
-        self, mock_subscribe_project_to_alert_rule
-    ):
-        ReleaseProjectEnvironment.get_or_create(
-            project=self.project,
-            release=self.release,
-            environment=self.environment,
-            datetime=self.datetime_now,
-        )
-
-        assert mock_subscribe_project_to_alert_rule.call_count == 1
-
-    @patch(
-        "sentry.incidents.models.alert_rule.AlertRule.objects.conditionally_subscribe_project_to_alert_rules"
-    )
-    def test_subscribe_project_to_alert_rule_constructs_query(self, mock_conditionally_subscribe):
-        ReleaseProjectEnvironmentManager.subscribe_project_to_alert_rule(
-            project=self.project, release=self.release, environment=self.environment, trigger="test"
-        )
-
-        assert mock_conditionally_subscribe.call_count == 1
-        assert mock_conditionally_subscribe.mock_calls == [
-            mock_call(
-                project=self.project,
-                activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
-                query_extra=f"release:{self.release.version} and environment:{self.environment.name}",
-                origin="test",
-                activator=f"release:{self.release.version} and environment:{self.environment.name}",
-            )
-        ]
-
-    def test_unmocked_subscribe_project_to_alert_rule_constructs_query(self):
-        # Let the logic flow through to snuba and see whether we properly construct the snuba query
-        # project = self.create_project(name="foo")
-        # release = Release.objects.create(organization_id=project.organization_id, version="42")
-        self.create_alert_rule(
-            projects=[self.project],
-            monitor_type=AlertRuleMonitorTypeInt.ACTIVATED,
-            activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
-        )
-
-        subscribe_project = AlertRule.objects.conditionally_subscribe_project_to_alert_rules
-        with patch(
-            "sentry.incidents.models.alert_rule.AlertRule.objects.conditionally_subscribe_project_to_alert_rules",
-            wraps=subscribe_project,
-        ) as wrapped_subscribe_project:
-            with self.tasks():
-                rpe = ReleaseProjectEnvironmentManager.subscribe_project_to_alert_rule(
-                    project=self.project,
-                    release=self.release,
-                    environment=self.environment,
-                    trigger="test",
-                )
-
-                assert rpe
-                assert wrapped_subscribe_project.call_count == 1
-
-                sub = QuerySubscription.objects.get(project=self.project)
-                assert sub.subscription_id is not None


### PR DESCRIPTION
Another chunk of https://github.com/getsentry/sentry/pull/81095 that removes the code for activated alerts that subscribes the rule to a project.