### PR TITLE
fix(grouping): Wrap metadata collection in try-catch

### DIFF
--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -233,9 +233,14 @@ def get_or_create_grouphashes(
         if options.get("grouping.grouphash_metadata.ingestion_writes_enabled") and features.has(
             "organizations:grouphash-metadata-creation", project.organization
         ):
-            create_or_update_grouphash_metadata_if_needed(
-                event, project, grouphash, created, grouping_config, variants
-            )
+            try:
+                # We don't expect this to throw any errors, but collecting this metadata
+                # shouldn't ever derail ingestion, so better to be safe
+                create_or_update_grouphash_metadata_if_needed(
+                    event, project, grouphash, created, grouping_config, variants
+                )
+            except Exception as exc:
+                sentry_sdk.capture_exception(exc)
 
         if grouphash.metadata:
             record_grouphash_metadata_metrics(grouphash.metadata)


### PR DESCRIPTION
In a very particular set of circumstances (an org in the 20% of EA to which grouphash metadata has been rolled out, a project in the midst of a grouping config transition, a group where two hashes are calculated for the secondary grouping config, and a pair of secondary hashes in which one hash already exists and one doesn't), it's currently possible for gathering of grouphash metadata to crash. 

That will soon be fixed, but in the meantime, it points out the fact that we should be wrapping the metadata-gathering code in a `try-except`, because regardless of the reason, we don't ever want it to derail the rest of the grouping code.