### PR TITLE
fix: flatten searchable os distribution fields

### DIFF
--- a/src/sentry/rules/conditions/event_attribute.py
+++ b/src/sentry/rules/conditions/event_attribute.py
@@ -63,8 +63,8 @@ ATTR_CHOICES = {
     "stacktrace.package": Columns.STACK_PACKAGE,
     "unreal.crashtype": Columns.UNREAL_CRASH_TYPE,
     "app.in_foreground": Columns.APP_IN_FOREGROUND,
-    "os.distribution.name": Columns.OS_DISTRIBUTION_NAME,
-    "os.distribution.version": Columns.OS_DISTRIBUTION_VERSION,
+    "os.distribution_name": Columns.OS_DISTRIBUTION_NAME,
+    "os.distribution_version": Columns.OS_DISTRIBUTION_VERSION,
 }
 
 
@@ -418,21 +418,14 @@ class AppAttributeHandler(AttributeHandler):
 
 @attribute_registry.register("os")
 class OsAttributeHandler(AttributeHandler):
-    minimum_path_length = 3
+    minimum_path_length = 2
 
     @classmethod
     def _handle(cls, path: list[str], event: GroupEvent) -> list[str]:
-        if path[1] in ("distribution"):
-            if path[2] in ("name", "version"):
-                contexts = event.data.get("contexts", {})
-                os_context = contexts.get("os")
-                if os_context is None:
-                    os_context = {}
-
-                distribution = os_context.get(path[1])
-                if distribution is None:
-                    distribution = {}
-
-                return [distribution.get(path[2])]
-            return []
+        if path[1] in ("distribution_name", "distribution_version"):
+            contexts = event.data.get("contexts", {})
+            os_context = contexts.get("os")
+            if os_context is None:
+                os_context = {}
+            return [os_context.get(path[1])]
         return []

--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -601,20 +601,20 @@ class Columns(Enum):
         alias="app.in_foreground",
     )
     OS_DISTRIBUTION_NAME = Column(
-        group_name="events.contexts[os.distribution.name]",
-        event_name="contexts[os.distribution.name]",
-        transaction_name="contexts[os.distribution.name]",
-        discover_name="contexts[os.distribution.name]",
-        issue_platform_name="contexts[os.distribution.name]",
-        alias="os.distribution.name",
+        group_name="events.contexts[os.distribution_name]",
+        event_name="contexts[os.distribution_name]",
+        transaction_name="contexts[os.distribution_name]",
+        discover_name="contexts[os.distribution_name]",
+        issue_platform_name="contexts[os.distribution_name]",
+        alias="os.distribution_name",
     )
     OS_DISTRIBUTION_VERSION = Column(
-        group_name="events.contexts[os.distribution.version]",
-        event_name="contexts[os.distribution.version]",
-        transaction_name="contexts[os.distribution.version]",
-        discover_name="contexts[os.distribution.version]",
-        issue_platform_name="contexts[os.distribution.version]",
-        alias="os.distribution.version",
+        group_name="events.contexts[os.distribution_version]",
+        event_name="contexts[os.distribution_version]",
+        transaction_name="contexts[os.distribution_version]",
+        discover_name="contexts[os.distribution_version]",
+        issue_platform_name="contexts[os.distribution_version]",
+        alias="os.distribution_version",
     )
     # Transactions specific columns
     TRANSACTION_OP = Column(

--- a/tests/sentry/rules/conditions/test_event_attribute.py
+++ b/tests/sentry/rules/conditions/test_event_attribute.py
@@ -64,12 +64,7 @@ class EventAttributeConditionTest(RuleTestCase):
                 "unreal": {
                     "crash_type": "crash",
                 },
-                "os": {
-                    "distribution": {
-                        "name": "ubuntu",
-                        "version": "22.04",
-                    }
-                },
+                "os": {"distribution_name": "ubuntu", "distribution_version": "22.04"},
             },
             "threads": {
                 "values": [
@@ -824,24 +819,21 @@ class EventAttributeConditionTest(RuleTestCase):
         )
         self.assertDoesNotPass(rule, event)
 
-    def test_os_distribution_only(self):
-        event = self.get_event()
-        rule = self.get_rule(
-            data={"match": MatchType.EQUAL, "attribute": "os.distribution", "value": "irrelevant"}
-        )
-        self.assertDoesNotPass(rule, event)
-
     def test_os_distribution_name_and_version(self):
         event = self.get_event()
         rule = self.get_rule(
-            data={"match": MatchType.EQUAL, "attribute": "os.distribution.name", "value": "ubuntu"}
+            data={
+                "match": MatchType.EQUAL,
+                "attribute": "os.distribution_name",
+                "value": "ubuntu",
+            }
         )
         self.assertPasses(rule, event)
 
         rule = self.get_rule(
             data={
                 "match": MatchType.EQUAL,
-                "attribute": "os.distribution.version",
+                "attribute": "os.distribution_version",
                 "value": "22.04",
             }
         )
@@ -850,7 +842,7 @@ class EventAttributeConditionTest(RuleTestCase):
         rule = self.get_rule(
             data={
                 "match": MatchType.EQUAL,
-                "attribute": "os.distribution.name",
+                "attribute": "os.distribution_name",
                 "value": "slackware",
             }
         )
@@ -859,7 +851,7 @@ class EventAttributeConditionTest(RuleTestCase):
         rule = self.get_rule(
             data={
                 "match": MatchType.EQUAL,
-                "attribute": "os.distribution.version",
+                "attribute": "os.distribution_version",
                 "value": "20.04",
             }
         )

--- a/tests/sentry/rules/conditions/test_event_attribute.py
+++ b/tests/sentry/rules/conditions/test_event_attribute.py
@@ -857,6 +857,16 @@ class EventAttributeConditionTest(RuleTestCase):
         )
         self.assertDoesNotPass(rule, event)
 
+        event["contexts"]["os"] = {}  # missing distribution_name and distribution_version
+        rule = self.get_rule(
+            data={
+                "match": MatchType.EQUAL,
+                "attribute": "os.distribution_name",
+                "value": "ubuntu",
+            }
+        )
+        self.assertDoesNotPass(rule, event)
+
     def test_unreal_crash_type(self):
         event = self.get_event()
         rule = self.get_rule(

--- a/tests/sentry/rules/conditions/test_event_attribute.py
+++ b/tests/sentry/rules/conditions/test_event_attribute.py
@@ -857,16 +857,6 @@ class EventAttributeConditionTest(RuleTestCase):
         )
         self.assertDoesNotPass(rule, event)
 
-        event["contexts"]["os"] = {}  # missing distribution_name and distribution_version
-        rule = self.get_rule(
-            data={
-                "match": MatchType.EQUAL,
-                "attribute": "os.distribution_name",
-                "value": "ubuntu",
-            }
-        )
-        self.assertDoesNotPass(rule, event)
-
     def test_unreal_crash_type(self):
         event = self.get_event()
         rule = self.get_rule(


### PR DESCRIPTION
<!-- Describe your PR here. -->
update to https://github.com/getsentry/sentry/pull/69865
To search the distribution fields, we cannot have them in a hierarchy `os.distribution.name`, we instead need them flattened to `os.distribution_name`

This is part of reworking the following native-SDK PR: https://github.com/getsentry/sentry-native/pull/963

The update is also tracked on the docs side: https://github.com/getsentry/sentry-docs/pull/11936
And on Relay: https://github.com/getsentry/relay/pull/4292
