### PR TITLE
feat(similarity): Add option to globally disable similarity indexing

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2933,3 +2933,11 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE | FLAG_RATE,
 )
+
+# allows us to disable indexing during maintenance events
+register(
+    "sentry.similarity.indexing.enabled",
+    default=True,
+    type=Bool,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -13,7 +13,7 @@ from django.db.models.signals import post_save
 from django.utils import timezone
 from google.api_core.exceptions import ServiceUnavailable
 
-from sentry import features, projectoptions
+from sentry import features, options, projectoptions
 from sentry.eventstream.types import EventStreamEventType
 from sentry.exceptions import PluginError
 from sentry.features.rollout import in_rollout_group
@@ -1229,6 +1229,8 @@ def process_plugins(job: PostProcessJob) -> None:
 
 
 def process_similarity(job: PostProcessJob) -> None:
+    if not options.get("sentry.similarity.indexing.enabled"):
+        return
     if job["is_reprocessed"] or job["event"].group.project.get_option(
         "sentry:similarity_backfill_completed"
     ):

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2451,6 +2451,20 @@ class ProcessSimilarityTestMixin(BasePostProgressGroupMixin):
 
         self.assert_not_called_with(mock_safe_execute)
 
+    @patch("sentry.tasks.post_process.safe_execute")
+    @override_options({"sentry.similarity.indexing.enabled": False})
+    def test_skip_process_similarity_global(self, mock_safe_execute):
+        event = self.create_event(data={}, project_id=self.project.id)
+
+        self.call_post_process_group(
+            is_new=True,
+            is_regression=False,
+            is_new_group_environment=False,
+            event=event,
+        )
+
+        self.assert_not_called_with(mock_safe_execute)
+
 
 class PostProcessGroupErrorTest(
     TestCase,


### PR DESCRIPTION
<!-- Describe your PR here. -->

During maintenance event such as Redis instance migration might be desirable to disable similarity write operations. This PR adds an option to disable indexing in the post process group task.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
