### PR TITLE
ref(profiling): remove option to control where profiles outcomes are created

### DIFF
--- a/src/sentry/ingest/billing_metrics_consumer.py
+++ b/src/sentry/ingest/billing_metrics_consumer.py
@@ -14,7 +14,6 @@ from arroyo.types import Commit, Message, Partition
 from django.core.cache import cache
 from sentry_kafka_schemas.schema_types.snuba_generic_metrics_v1 import GenericMetric
 
-from sentry import options
 from sentry.constants import DataCategory
 from sentry.models.project import Project
 from sentry.sentry_metrics.indexer.strings import (
@@ -104,13 +103,6 @@ class BillingTxCountMetricConsumerStrategy(ProcessingStrategy[KafkaPayload]):
             return {}
 
         items = {data_category: quantity}
-
-        if not options.get("profiling.emit_outcomes_in_profiling_consumer.enabled"):
-            if self._has_profile(generic_metric):
-                # The bucket is tagged with the "has_profile" tag,
-                # so we also count the quantity of this bucket towards profiles.
-                # This assumes a "1 to 0..1" relationship between transactions / spans and profiles.
-                items[DataCategory.PROFILE] = quantity
 
         return items
 

--- a/tests/sentry/ingest/billing_metrics_consumer/test_billing_metrics_consumer_kafka.py
+++ b/tests/sentry/ingest/billing_metrics_consumer/test_billing_metrics_consumer_kafka.py
@@ -266,22 +266,11 @@ def test_outcomes_consumed(track_outcome, factories):
                     category=DataCategory.TRANSACTION,
                     quantity=1,
                 ),
-                mock.call(
-                    org_id=organization.id,
-                    project_id=missing_project_id,
-                    key_id=None,
-                    outcome=Outcome.ACCEPTED,
-                    reason=None,
-                    timestamp=mock.ANY,
-                    event_id=None,
-                    category=DataCategory.PROFILE,
-                    quantity=1,
-                ),
             ]
             # We double-check that the project does not exist.
             assert not Project.objects.filter(id=2).exists()
         else:
-            assert track_outcome.mock_calls[3:] == [
+            assert track_outcome.mock_calls[2:] == [
                 mock.call(
                     org_id=organization.id,
                     project_id=project_2.id,

--- a/tests/sentry/profiles/test_task.py
+++ b/tests/sentry/profiles/test_task.py
@@ -833,33 +833,23 @@ def test_get_metrics_dsn(default_project):
     assert get_metrics_dsn(default_project.id) == key1.get_dsn(public=True)
 
 
-@patch("sentry.options.get")
 @patch("sentry.profiles.task._track_outcome")
-@patch("sentry.profiles.task._track_outcome_legacy")
 @patch("sentry.profiles.task._track_duration_outcome")
 @patch("sentry.profiles.task._symbolicate_profile")
 @patch("sentry.profiles.task._deobfuscate_profile")
 @patch("sentry.profiles.task._push_profile_to_vroom")
 @django_db_all
 @pytest.mark.parametrize(
-    "profile,outcomes_in_consumer",
-    [
-        ("sample_v1_profile", True),
-        ("sample_v2_profile", True),
-        ("sample_v1_profile", False),
-        ("sample_v2_profile", False),
-    ],
+    "profile",
+    ["sample_v1_profile", "sample_v2_profile"],
 )
 def test_process_profile_task_should_emit_profile_duration_outcome(
     _push_profile_to_vroom,
     _deobfuscate_profile,
     _symbolicate_profile,
     _track_duration_outcome,
-    _track_outcome_legacy,
     _track_outcome,
-    options_get,
     profile,
-    outcomes_in_consumer,
     organization,
     project,
     request,
@@ -867,11 +857,6 @@ def test_process_profile_task_should_emit_profile_duration_outcome(
     _push_profile_to_vroom.return_value = True
     _deobfuscate_profile.return_value = True
     _symbolicate_profile.return_value = True
-    options_get.side_effect = lambda name: (
-        outcomes_in_consumer
-        if name == "profiling.emit_outcomes_in_profiling_consumer.enabled"
-        else None
-    )
 
     profile = request.getfixturevalue(profile)
     profile["organization_id"] = organization.id
@@ -882,58 +867,40 @@ def test_process_profile_task_should_emit_profile_duration_outcome(
     assert _track_duration_outcome.call_count == 1
 
     if "profiler_id" not in profile:
-        if outcomes_in_consumer:
-            assert _track_outcome.call_count == 1
-            _track_outcome.assert_called_with(
-                profile=profile,
-                project=project,
-                categories=[DataCategory.PROFILE, DataCategory.PROFILE_INDEXED],
-                outcome=Outcome.ACCEPTED,
-            )
-        else:
-            assert _track_outcome_legacy.call_count == 1
+        assert _track_outcome.call_count == 1
+        _track_outcome.assert_called_with(
+            profile=profile,
+            project=project,
+            categories=[DataCategory.PROFILE, DataCategory.PROFILE_INDEXED],
+            outcome=Outcome.ACCEPTED,
+        )
     else:
-        assert _track_outcome_legacy.call_count == 0
+        assert _track_outcome.call_count == 0
 
 
-@patch("sentry.options.get")
 @patch("sentry.quotas.backend.should_emit_profile_duration_outcome")
 @patch("sentry.profiles.task._track_outcome")
-@patch("sentry.profiles.task._track_outcome_legacy")
 @patch("sentry.profiles.task._track_duration_outcome")
 @patch("sentry.profiles.task._symbolicate_profile")
 @patch("sentry.profiles.task._deobfuscate_profile")
 @patch("sentry.profiles.task._push_profile_to_vroom")
 @django_db_all
 @pytest.mark.parametrize(
-    "profile,outcomes_in_consumer",
-    [
-        ("sample_v1_profile", True),
-        ("sample_v2_profile", True),
-        ("sample_v1_profile", False),
-        ("sample_v2_profile", False),
-    ],
+    "profile",
+    ["sample_v1_profile", "sample_v2_profile"],
 )
 def test_process_profile_task_should_not_emit_profile_duration_outcome(
     _push_profile_to_vroom,
     _deobfuscate_profile,
     _symbolicate_profile,
     _track_duration_outcome,
-    _track_outcome_legacy,
     _track_outcome,
     should_emit_profile_duration_outcome,
-    options_get,
     profile,
-    outcomes_in_consumer,
     organization,
     project,
     request,
 ):
-    options_get.side_effect = lambda name: (
-        outcomes_in_consumer
-        if name == "profiling.emit_outcomes_in_profiling_consumer.enabled"
-        else None
-    )
     _push_profile_to_vroom.return_value = True
     _deobfuscate_profile.return_value = True
     _symbolicate_profile.return_value = True
@@ -952,15 +919,13 @@ def test_process_profile_task_should_not_emit_profile_duration_outcome(
     )
 
     if "profiler_id" not in profile:
-        if outcomes_in_consumer:
-            assert _track_outcome.call_count == 1
-            _track_outcome.assert_called_with(
-                profile=profile,
-                project=project,
-                categories=[DataCategory.PROFILE, DataCategory.PROFILE_INDEXED],
-                outcome=Outcome.ACCEPTED,
-            )
-        else:
-            assert _track_outcome_legacy.call_count == 1
+        assert _track_outcome.call_count == 1
+        _track_outcome.assert_called_with(
+            profile=profile,
+            project=project,
+            categories=[DataCategory.PROFILE, DataCategory.PROFILE_INDEXED],
+            outcome=Outcome.ACCEPTED,
+        )
+
     else:
-        assert _track_outcome_legacy.call_count == 0
+        assert _track_outcome.call_count == 0


### PR DESCRIPTION
Following up on https://github.com/getsentry/sentry/pull/80189 this removes the option and finalises emitting outcomes in the profiling consumer.