### PR TITLE
chore(dashboards): Remove releases on widget charts ff

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -97,6 +97,11 @@ describe('add to dashboard modal', () => {
       body: testDashboard,
     });
 
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/stats/',
+      body: [],
+    });
+
     eventsStatsMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-stats/',
       body: [],

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -306,7 +306,6 @@ function AddToDashboardModal({
                     widgetLegendState={widgetLegendState}
                     onLegendSelectChanged={() => {}}
                     legendOptions={
-                      organization.features.includes('dashboards-releases-on-charts') &&
                       widgetLegendState.widgetRequiresLegendUnselection(widget)
                         ? {selected: unselectedReleasesForCharts}
                         : undefined

--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -131,6 +131,11 @@ describe('Modals -> WidgetViewerModal', function () {
       body: [],
     });
 
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/stats/',
+      body: [],
+    });
+
     eventsMetaMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-meta/',
       body: {count: 33323612},

--- a/static/app/views/dashboards/dashboard.spec.tsx
+++ b/static/app/views/dashboards/dashboard.spec.tsx
@@ -87,6 +87,10 @@ describe('Dashboards > Dashboard', () => {
       body: [],
     });
     MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/releases/stats/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-stats/',
       method: 'GET',
       body: [],

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -101,6 +101,10 @@ describe('Dashboards > Detail', function () {
         body: [],
       });
       MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/releases/stats/',
+        body: [],
+      });
+      MockApiClient.addMockResponse({
         url: '/organizations/org-slug/metrics/meta/',
         body: [],
       });
@@ -366,6 +370,10 @@ describe('Dashboards > Detail', function () {
       });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/releases/',
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/releases/stats/',
         body: [],
       });
       MockApiClient.addMockResponse({

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/visualizationStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/visualizationStep.tsx
@@ -141,7 +141,6 @@ export function VisualizationStep({
           shouldResize={false}
           onLegendSelectChanged={() => {}}
           legendOptions={
-            organization.features.includes('dashboards-releases-on-charts') &&
             widgetLegendState.widgetRequiresLegendUnselection(widget)
               ? {selected: unselectedReleasesForCharts}
               : undefined

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
@@ -266,6 +266,10 @@ describe('WidgetBuilder', function () {
       body: [],
     });
     MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/stats/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: `/organizations/org-slug/spans/fields/`,
       body: [],
     });

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilderDataset.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilderDataset.spec.tsx
@@ -277,6 +277,10 @@ describe('WidgetBuilder', function () {
       body: [],
     });
     MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/stats/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: `/organizations/org-slug/spans/fields/`,
       body: [],
     });

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilderSortBy.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilderSortBy.spec.tsx
@@ -237,6 +237,10 @@ describe('WidgetBuilder', function () {
       body: [],
     });
     MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/stats/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: `/organizations/org-slug/spans/fields/`,
       body: [],
     });

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -297,7 +297,6 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
       chartZoomOptions,
       timeseriesResultsTypes,
       shouldResize,
-      organization,
     } = this.props;
 
     if (widget.displayType === 'table') {
@@ -524,8 +523,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
 
           const forwardedRef = this.props.chartGroup ? this.handleRef : undefined;
 
-          return organization.features.includes('dashboards-releases-on-charts') &&
-            widgetLegendState.widgetRequiresLegendUnselection(widget) ? (
+          return widgetLegendState.widgetRequiresLegendUnselection(widget) ? (
             <ReleaseSeries
               end={end}
               start={start}

--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -104,6 +104,10 @@ describe('Dashboards > WidgetCard', function () {
         data: [{title: 'title'}],
       },
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/stats/',
+      body: [],
+    });
   });
 
   afterEach(function () {

--- a/static/app/views/dashboards/widgetLegendSelectionState.spec.tsx
+++ b/static/app/views/dashboards/widgetLegendSelectionState.spec.tsx
@@ -49,7 +49,6 @@ describe('WidgetLegend functions util', () => {
       };
       organization = {
         ...OrganizationFixture(),
-        features: ['dashboards-releases-on-charts'],
       };
 
       dashboard = {

--- a/static/app/views/dashboards/widgetLegendSelectionState.tsx
+++ b/static/app/views/dashboards/widgetLegendSelectionState.tsx
@@ -121,8 +121,7 @@ class WidgetLegendSelectionState {
 
     return location.query.unselectedSeries
       ? this.decodeLegendQueryParam(widget)
-      : this.widgetRequiresLegendUnselection(widget) &&
-          this.organization.features.includes('dashboards-releases-on-charts')
+      : this.widgetRequiresLegendUnselection(widget)
         ? {
             [WidgetLegendNameEncoderDecoder.encodeSeriesNameForLegend(
               'Releases',
@@ -148,8 +147,7 @@ class WidgetLegendSelectionState {
   }
 
   formatLegendDefaultQuery(widget: Widget) {
-    return this.organization.features.includes('dashboards-releases-on-charts') &&
-      this.widgetRequiresLegendUnselection(widget)
+    return this.widgetRequiresLegendUnselection(widget)
       ? `${widget.id}${WIDGET_ID_DELIMITER}Releases`
       : undefined;
   }


### PR DESCRIPTION
<!-- Describe your PR here. -->
removing all instances of the `dashboards-releases-on-charts` ff because it has been fully rolled out.
