### PR TITLE
fix(ecosystem): Remove halt SLOs from outbound sync tasks for non-sync integrations

### DIFF
--- a/src/sentry/integrations/project_management/metrics.py
+++ b/src/sentry/integrations/project_management/metrics.py
@@ -22,8 +22,6 @@ class ProjectManagementActionType(StrEnum):
 
 class ProjectManagementHaltReason(StrEnum):
     SYNC_INBOUND_ASSIGNEE_NOT_FOUND = "inbound-assignee-not-found"
-    SYNC_NON_SYNC_INTEGRATION_PROVIDED = "sync-non-sync-integration-provided"
-    SYNC_INBOUND_SYNC_SKIPPED = "sync-skipped"
     SYNC_INBOUND_MISSING_CHANGELOG_STATUS = "missing-changelog-status"
 
 

--- a/src/sentry/integrations/project_management/metrics.py
+++ b/src/sentry/integrations/project_management/metrics.py
@@ -22,6 +22,7 @@ class ProjectManagementActionType(StrEnum):
 
 class ProjectManagementHaltReason(StrEnum):
     SYNC_INBOUND_ASSIGNEE_NOT_FOUND = "inbound-assignee-not-found"
+    SYNC_NON_SYNC_INTEGRATION_PROVIDED = "sync-non-sync-integration-provided"
     SYNC_INBOUND_MISSING_CHANGELOG_STATUS = "missing-changelog-status"
 
 

--- a/src/sentry/integrations/tasks/sync_assignee_outbound.py
+++ b/src/sentry/integrations/tasks/sync_assignee_outbound.py
@@ -7,7 +7,6 @@ from sentry.integrations.models.integration import Integration
 from sentry.integrations.project_management.metrics import (
     ProjectManagementActionType,
     ProjectManagementEvent,
-    ProjectManagementHaltReason,
 )
 from sentry.integrations.services.assignment_source import AssignmentSource
 from sentry.integrations.services.integration import integration_service
@@ -61,13 +60,6 @@ def sync_assignee_outbound(
         if not (
             hasattr(installation, "should_sync") and hasattr(installation, "sync_assignee_outbound")
         ):
-            lifecycle.record_halt(
-                ProjectManagementHaltReason.SYNC_NON_SYNC_INTEGRATION_PROVIDED,
-                extra={
-                    "organization_id": external_issue.organization_id,
-                    "external_issue_id": external_issue_id,
-                },
-            )
             return
 
         parsed_assignment_source = (
@@ -84,12 +76,4 @@ def sync_assignee_outbound(
                 provider=integration.provider,
                 id=integration.id,
                 organization_id=external_issue.organization_id,
-            )
-        else:
-            lifecycle.record_halt(
-                ProjectManagementHaltReason.SYNC_INBOUND_SYNC_SKIPPED,
-                extra={
-                    "organization_id": external_issue.organization_id,
-                    "external_issue_id": external_issue_id,
-                },
             )

--- a/src/sentry/integrations/tasks/sync_status_outbound.py
+++ b/src/sentry/integrations/tasks/sync_status_outbound.py
@@ -5,7 +5,6 @@ from sentry.integrations.models.integration import Integration
 from sentry.integrations.project_management.metrics import (
     ProjectManagementActionType,
     ProjectManagementEvent,
-    ProjectManagementHaltReason,
 )
 from sentry.integrations.services.integration import integration_service
 from sentry.models.group import Group, GroupStatus
@@ -62,14 +61,5 @@ def sync_status_outbound(group_id: int, external_issue_id: int) -> bool | None:
                 provider=integration.provider,
                 id=integration.id,
                 organization_id=external_issue.organization_id,
-            )
-        else:
-            # Find a way to pass further context to this in the future
-            lifecycle.record_halt(
-                ProjectManagementHaltReason.SYNC_INBOUND_SYNC_SKIPPED,
-                extra={
-                    "organization_id": external_issue.organization_id,
-                    "group_id": group.id,
-                },
             )
     return None


### PR DESCRIPTION
Removes all sync related halts, as these occur for a few main reasons:
1. The The integration queried does not support outbound issue syncing in any form.
2. The customer has not enabled the sync features in their integration, and does not have the correct sync flag in their integration config.
3. The integration was the source of the sync, and we skip syncing these outbound to prevent assignment/status change cycles.

None of these seem worthy of "halts", as it is expected behavior to skip syncs in these scenarios.
