### PR TITLE
chore: Remove Profiling from Android onboarding features

### DIFF
--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -82,7 +82,7 @@ function getDisabledProducts(organization: Organization): DisabledProducts {
 // Since the ProductSelection component is rendered in the onboarding/project creation flow only, it is ok to have this list here
 // NOTE: Please keep the prefix in alphabetical order
 export const platformProductAvailability = {
-  android: [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
+  android: [ProductSolution.PERFORMANCE_MONITORING],
   'apple-ios': [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
   'apple-macos': [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
   bun: [ProductSolution.PERFORMANCE_MONITORING],


### PR DESCRIPTION
Removes Profiling from in-product Android onboarding features. Related: https://github.com/getsentry/sentry-docs/pull/11905

I would actually prefer to keep it and similar to https://github.com/getsentry/sentry-docs/pull/11905 deactivate it by default, and show a message if user activates it, but seems like this is not easily doable - maybe @ArthurKnaus knows how to do it?