### PR TITLE
chore(sso): add duplicate tables to historical silo assignments

### DIFF
--- a/src/sentry/db/router.py
+++ b/src/sentry/db/router.py
@@ -71,6 +71,8 @@ class SiloRouter:
         "sentry_projectavatar": SiloMode.REGION,
         "sentry_pagerdutyservice": SiloMode.REGION,
         "sentry_notificationsetting": SiloMode.CONTROL,
+        "authprovider_duplicate": SiloMode.CONTROL,
+        "authidentity_duplicate": SiloMode.CONTROL,
     }
     """
     When we remove models, we are no longer able to resolve silo assignments


### PR DESCRIPTION
The migration to drop `authprovider_duplicate` and `authidentity_duplicate` didn't work the first time, perhaps because django routing couldn't resolve the tables. Add them to the historical routing map. 