### PR TITLE
ref(insights): simplify domain view header by using tab links

### DIFF
--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
+import type {LocationDescriptor} from 'history';
 
 import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
 import ButtonBar from 'sentry/components/buttonBar';
@@ -8,7 +9,6 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import {TabList, Tabs} from 'sentry/components/tabs';
 import {IconBusiness} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useModuleTitles} from 'sentry/views/insights/common/utils/useModuleTitle';
 import {
@@ -37,6 +37,7 @@ export type Props = {
 type Tab = {
   key: string;
   label: React.ReactNode;
+  to: LocationDescriptor;
 };
 
 export function DomainViewHeader({
@@ -50,7 +51,6 @@ export function DomainViewHeader({
   domainBaseUrl,
   tabs,
 }: Props) {
-  const navigate = useNavigate();
   const organization = useOrganization();
   const moduleURLBuilder = useModuleURLBuilder();
   const moduleTitles = useModuleTitles();
@@ -78,30 +78,14 @@ export function DomainViewHeader({
 
   const showModuleTabs = organization.features.includes('insights-entry-points');
 
-  const defaultHandleTabChange = (key: ModuleName | typeof OVERVIEW_PAGE_TITLE) => {
-    if (key === selectedModule || (key === OVERVIEW_PAGE_TITLE && !module)) {
-      return;
-    }
-    if (!key) {
-      return;
-    }
-    if (key === OVERVIEW_PAGE_TITLE) {
-      navigate(domainBaseUrl);
-      return;
-    }
-    navigate(`${moduleURLBuilder(key as RoutableModuleNames)}/`);
-  };
-
   const tabValue =
     hideDefaultTabs && tabs?.value ? tabs.value : selectedModule ?? OVERVIEW_PAGE_TITLE;
-
-  const handleTabChange =
-    hideDefaultTabs && tabs ? tabs.onTabChange : defaultHandleTabChange;
 
   const tabList: Tab[] = [
     {
       key: OVERVIEW_PAGE_TITLE,
       label: OVERVIEW_PAGE_TITLE,
+      to: domainBaseUrl,
     },
   ];
 
@@ -110,6 +94,7 @@ export function DomainViewHeader({
       ...modules.map(moduleName => ({
         key: moduleName,
         label: <TabLabel moduleName={moduleName} />,
+        to: `${moduleURLBuilder(moduleName as RoutableModuleNames)}/`,
       }))
     );
   }
@@ -128,11 +113,13 @@ export function DomainViewHeader({
             <FeedbackWidgetButton />
           </ButtonBar>
         </Layout.HeaderActions>
-        <Tabs value={tabValue} onChange={handleTabChange}>
+        <Tabs value={tabValue} onChange={tabs?.onTabChange}>
           {!hideDefaultTabs && (
             <TabList hideBorder>
               {tabList.map(tab => (
-                <TabList.Item key={tab.key}>{tab.label}</TabList.Item>
+                <TabList.Item key={tab.key} to={tab.to}>
+                  {tab.label}
+                </TabList.Item>
               ))}
             </TabList>
           )}


### PR DESCRIPTION
The `TabList` component supports a `to` prop in order to link between tabs. This PR removes the default onChange handler for the tabList (which dealt with navigating when clicking between tabs), in favour of the `to` prop.  This cleans up the code and reduces duplicated and already tested logic.