### PR TITLE
fix(insights): view query summary button broken

### DIFF
--- a/static/app/components/events/interfaces/spans/spanDetail.spec.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.spec.tsx
@@ -164,7 +164,7 @@ describe('SpanDetail', function () {
       ).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'View Query Summary'})).toHaveAttribute(
         'href',
-        '/organizations/org-slug/insights/database/spans/span/a7ebd21614897/?project=2'
+        '/organizations/org-slug/insights/backend/database/spans/span/a7ebd21614897/?project=2'
       );
     });
   });

--- a/static/app/components/events/interfaces/spans/spanSummaryButton.tsx
+++ b/static/app/components/events/interfaces/spans/spanSummaryButton.tsx
@@ -23,6 +23,7 @@ interface Props {
 function SpanSummaryButton(props: Props) {
   const location = useLocation();
   const resourceBaseUrl = useModuleURL(ModuleName.RESOURCE);
+  const queryBaseUrl = useModuleURL(ModuleName.DB);
 
   const {event, organization, span} = props;
 
@@ -41,7 +42,7 @@ function SpanSummaryButton(props: Props) {
       <LinkButton
         size="xs"
         to={querySummaryRouteWithQuery({
-          orgSlug: organization.slug,
+          base: queryBaseUrl,
           query: location.query,
           group: sentryTags.group,
           projectID: event.projectID,

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/utils.tsx
@@ -53,28 +53,28 @@ export function spanDetailsRouteWithQuery({
 }
 
 export function generateQuerySummaryRoute({
-  orgSlug,
+  base,
   group,
 }: {
+  base: string;
   group: string;
-  orgSlug: string;
 }): string {
-  return `/organizations/${orgSlug}/insights/database/spans/span/${group}/`;
+  return `${base}/spans/span/${group}/`;
 }
 
 export function querySummaryRouteWithQuery({
-  orgSlug,
+  base,
   query,
   group,
   projectID,
 }: {
+  base: string;
   group: string;
-  orgSlug: string;
   query: Query;
   projectID?: string | string[];
 }) {
   const pathname = generateQuerySummaryRoute({
-    orgSlug,
+    base,
     group,
   });
 


### PR DESCRIPTION
The view query summary button should be using `useModuleUrl`, this is a shared function that returns the appropriate module url. Previously the button did not use this hook, and when we updated the module urls, the old url was left here.