### PR TITLE
chore(visibility): Manually instrument tagstore cache

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1679,8 +1679,12 @@ SENTRY_TRANSACTION_PROCESSING_STORE_OPTIONS: dict[str, str] = {}
 
 # The internal Django cache is still used in many places
 # TODO(dcramer): convert uses over to Sentry's backend
-CACHES = {"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
-
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
+        "LOCATION": "/var/tmp/django_cache",
+    }
+}
 # The cache version affects both Django's internal cache (at runtime) as well
 # as Sentry's cache. This automatically overrides VERSION on the default
 # CACHES backend.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1679,12 +1679,8 @@ SENTRY_TRANSACTION_PROCESSING_STORE_OPTIONS: dict[str, str] = {}
 
 # The internal Django cache is still used in many places
 # TODO(dcramer): convert uses over to Sentry's backend
-CACHES = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
-        "LOCATION": "/var/tmp/django_cache",
-    }
-}
+CACHES = {"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
+
 # The cache version affects both Django's internal cache (at runtime) as well
 # as Sentry's cache. This automatically overrides VERSION on the default
 # CACHES backend.

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -314,7 +314,7 @@ class SnubaTagStorage(TagStorage):
             with sentry_sdk.start_span(op="cache.get", name="tagstore.cache") as span:
                 result = cache.get(cache_key, None)
 
-                span.set_data("cache.key", cache_key.split(":", 2))
+                span.set_data("cache.key", [cache_key])
 
                 if result is not None:
                     span.set_data("cache.hit", True)
@@ -341,7 +341,7 @@ class SnubaTagStorage(TagStorage):
             if should_cache:
                 with sentry_sdk.start_span(op="cache.put", name="tagstore.cache") as span:
                     cache.set(cache_key, result, 300)
-                    span.set_data("cache.key", cache_key.split(":", 2))
+                    span.set_data("cache.key", [cache_key])
                     span.set_data("cache.item_size", len(str(result)))
                     metrics.incr("testing.tagstore.cache_tag_key.len", amount=len(result))
 

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -314,7 +314,7 @@ class SnubaTagStorage(TagStorage):
             with sentry_sdk.start_span(op="cache.get", name="tagstore.cache") as span:
                 result = cache.get(cache_key, None)
 
-                span.set_data("cache.key", cache_key)
+                span.set_data("cache.key", cache_key.split(":"))
 
                 if result is not None:
                     span.set_data("cache.hit", True)
@@ -344,7 +344,7 @@ class SnubaTagStorage(TagStorage):
             if should_cache:
                 with sentry_sdk.start_span(op="cache.put", name="tagstore.cache") as span:
                     cache.set(cache_key, result, 300)
-                    span.set_data("cache.key", cache_key)
+                    span.set_data("cache.key", cache_key.split(":"))
                     span.set_data("cache.item_size", len(str(result)))
 
                 metrics.incr("testing.tagstore.cache_tag_key.len", amount=len(result))

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -311,7 +311,9 @@ class SnubaTagStorage(TagStorage):
             end = snuba.quantize_time(end, key_hash)
             cache_key += f":{duration}@{end.isoformat()}"
 
-            with sentry_sdk.start_span(op="cache.get", name="tagstore.cache") as span:
+            with sentry_sdk.start_span(
+                op="cache.get", name="sentry.tagstore.cache.__get_tag_keys_for_projects"
+            ) as span:
                 result = cache.get(cache_key, None)
 
                 span.set_data("cache.key", [cache_key])
@@ -339,7 +341,9 @@ class SnubaTagStorage(TagStorage):
                 **kwargs,
             )
             if should_cache:
-                with sentry_sdk.start_span(op="cache.put", name="tagstore.cache") as span:
+                with sentry_sdk.start_span(
+                    op="cache.put", name="sentry.tagstore.cache.__get_tag_keys_for_projects"
+                ) as span:
                     cache.set(cache_key, result, 300)
                     span.set_data("cache.key", [cache_key])
                     span.set_data("cache.item_size", len(str(result)))

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -319,12 +319,9 @@ class SnubaTagStorage(TagStorage):
                 if result is not None:
                     span.set_data("cache.hit", True)
                     span.set_data("cache.item_size", len(str(result)))
-                else:
-                    span.set_data("cache.hit", False)
-
-                if result is not None:
                     metrics.incr("testing.tagstore.cache_tag_key.hit")
                 else:
+                    span.set_data("cache.hit", False)
                     metrics.incr("testing.tagstore.cache_tag_key.miss")
 
         if result is None:
@@ -346,8 +343,7 @@ class SnubaTagStorage(TagStorage):
                     cache.set(cache_key, result, 300)
                     span.set_data("cache.key", cache_key.split(":", 2))
                     span.set_data("cache.item_size", len(str(result)))
-
-                metrics.incr("testing.tagstore.cache_tag_key.len", amount=len(result))
+                    metrics.incr("testing.tagstore.cache_tag_key.len", amount=len(result))
 
         if group is None:
             ctor = TagKey

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable, Sequence
 from datetime import timedelta, timezone
 from typing import Any
 
+import sentry_sdk
 from dateutil.parser import parse as parse_datetime
 from django.core.cache import cache
 from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
@@ -309,11 +310,22 @@ class SnubaTagStorage(TagStorage):
             # Cause there's rounding to create this cache suffix, we want to update the query end so results match
             end = snuba.quantize_time(end, key_hash)
             cache_key += f":{duration}@{end.isoformat()}"
-            result = cache.get(cache_key, None)
-            if result is not None:
-                metrics.incr("testing.tagstore.cache_tag_key.hit")
-            else:
-                metrics.incr("testing.tagstore.cache_tag_key.miss")
+
+            with sentry_sdk.start_span(op="cache.get", name="tagstore.cache") as span:
+                result = cache.get(cache_key, None)
+
+                span.set_data("cache.key", cache_key)
+
+                if result is not None:
+                    span.set_data("cache.hit", True)
+                    span.set_data("cache.item_size", len(str(result)))
+                else:
+                    span.set_data("cache.hit", False)
+
+                if result is not None:
+                    metrics.incr("testing.tagstore.cache_tag_key.hit")
+                else:
+                    metrics.incr("testing.tagstore.cache_tag_key.miss")
 
         if result is None:
             result = snuba.query(
@@ -330,7 +342,11 @@ class SnubaTagStorage(TagStorage):
                 **kwargs,
             )
             if should_cache:
-                cache.set(cache_key, result, 300)
+                with sentry_sdk.start_span(op="cache.put", name="tagstore.cache") as span:
+                    cache.set(cache_key, result, 300)
+                    span.set_data("cache.key", cache_key)
+                    span.set_data("cache.item_size", len(str(result)))
+
                 metrics.incr("testing.tagstore.cache_tag_key.len", amount=len(result))
 
         if group is None:

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -314,7 +314,7 @@ class SnubaTagStorage(TagStorage):
             with sentry_sdk.start_span(op="cache.get", name="tagstore.cache") as span:
                 result = cache.get(cache_key, None)
 
-                span.set_data("cache.key", cache_key.split(":"))
+                span.set_data("cache.key", cache_key.split(":", 2))
 
                 if result is not None:
                     span.set_data("cache.hit", True)
@@ -344,7 +344,7 @@ class SnubaTagStorage(TagStorage):
             if should_cache:
                 with sentry_sdk.start_span(op="cache.put", name="tagstore.cache") as span:
                     cache.set(cache_key, result, 300)
-                    span.set_data("cache.key", cache_key.split(":"))
+                    span.set_data("cache.key", cache_key.split(":", 2))
                     span.set_data("cache.item_size", len(str(result)))
 
                 metrics.incr("testing.tagstore.cache_tag_key.len", amount=len(result))


### PR DESCRIPTION
We have Django cache instrumentation turned off, but I want to track the cache hit rate for tagstore in Sentry itself if I can. Firstly to dogfood, and secondly to help with some caching improvements I'm thinking of making.

**e.g.,**

![Screenshot 2024-11-26 at 2 17 56 PM](https://github.com/user-attachments/assets/f342685c-a2fb-4e0b-bec7-92b32d30d939)
