### PR TITLE
chore(scm): metrics for derive_code_mappings

### DIFF
--- a/src/sentry/integrations/source_code_management/metrics.py
+++ b/src/sentry/integrations/source_code_management/metrics.py
@@ -42,6 +42,9 @@ class SCMIntegrationInteractionType(StrEnum):
     # Tasks
     LINK_ALL_REPOS = "LINK_ALL_REPOS"
 
+    # GitHub only
+    DERIVE_CODEMAPPINGS = "DERIVE_CODEMAPPINGS"
+
 
 @dataclass
 class SCMIntegrationInteractionEvent(IntegrationEventLifecycleMetric):

--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -9,8 +9,13 @@ from sentry_sdk import set_tag, set_user
 from sentry import features
 from sentry.constants import ObjectStatus
 from sentry.db.models.fields.node import NodeData
+from sentry.integrations.github.integration import GitHubIntegration
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.integrations.services.integration import RpcOrganizationIntegration, integration_service
+from sentry.integrations.source_code_management.metrics import (
+    SCMIntegrationInteractionEvent,
+    SCMIntegrationInteractionType,
+)
 from sentry.integrations.utils.code_mapping import CodeMapping, CodeMappingTreesHelper
 from sentry.locks import locks
 from sentry.models.organization import Organization
@@ -115,24 +120,35 @@ def derive_code_mappings(
     # Acquire the lock for a maximum of 10 minutes
     lock = locks.get(key=f"get_trees_for_org:{org.slug}", duration=60 * 10, name="process_pending")
 
-    try:
-        with lock.acquire():
-            # This method is specific to the GithubIntegration
-            trees = installation.get_trees_for_org()  # type: ignore[attr-defined]
-    except ApiError as error:
-        process_error(error, extra)
-        return
-    except UnableToAcquireLock as error:
-        extra["error"] = error
-        logger.warning("derive_code_mappings.getting_lock_failed", extra=extra)
-        return
-    except Exception:
-        logger.exception("Unexpected error type while calling `get_trees_for_org()`.", extra=extra)
-        return
+    with SCMIntegrationInteractionEvent(
+        SCMIntegrationInteractionType.DERIVE_CODEMAPPINGS, provider_key=installation.model.provider
+    ).capture() as lifecycle:
+        try:
+            with lock.acquire():
+                # This method is specific to the GithubIntegration
+                if not isinstance(installation, GitHubIntegration):
+                    return
+                trees = installation.get_trees_for_org()
+        except ApiError as error:
+            process_error(error, extra)
+            lifecycle.record_halt(error, extra)
+            return
+        except UnableToAcquireLock as error:
+            extra["error"] = error
+            logger.warning("derive_code_mappings.getting_lock_failed", extra=extra)
+            lifecycle.record_failure(error, extra)
+            return
+        except Exception:
+            logger.exception(
+                "Unexpected error type while calling `get_trees_for_org()`.", extra=extra
+            )
+            lifecycle.record_failure(extra=extra)
+            return
 
-    if not trees:
-        logger.warning("The trees are empty.", extra=extra)
-        return
+        if not trees:
+            logger.warning("The trees are empty.", extra=extra)
+            lifecycle.record_halt(extra=extra)
+            return
 
     trees_helper = CodeMappingTreesHelper(trees)
     code_mappings = trees_helper.generate_code_mappings(stacktrace_paths)

--- a/tests/sentry/tasks/test_derive_code_mappings.py
+++ b/tests/sentry/tasks/test_derive_code_mappings.py
@@ -9,6 +9,7 @@ import responses
 from sentry.db.models.fields.node import NodeData
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
+from sentry.integrations.types import EventLifecycleOutcome
 from sentry.integrations.utils.code_mapping import CodeMapping, Repo, RepoTree
 from sentry.models.organization import OrganizationStatus
 from sentry.models.repository import Repository
@@ -42,19 +43,24 @@ class BaseDeriveCodeMappings(TestCase):
         test_data = {"platform": platform or self.platform, "stacktrace": {"frames": frames}}
         return self.store_event(data=test_data, project_id=self.project.id).data
 
+    def assert_slo_metric(self, mock_record, outcome=EventLifecycleOutcome.FAILURE, error_msg=None):
+        (events,) = (call for call in mock_record.mock_calls if call.args[0] == outcome)
+        if error_msg:
+            assert events.args[1] == error_msg
 
+
+@patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
 class TestTaskBehavior(BaseDeriveCodeMappings):
     """Test task behavior that is not language specific."""
 
     def setUp(self):
         super().setUp()
-        self.platform = "any"
         self.event_data = self.generate_data(
             [{"filename": "foo.py", "in_app": True}],
-            platform="any",
+            platform="javascript",
         )
 
-    def test_does_not_raise_installation_removed(self):
+    def test_does_not_raise_installation_removed(self, mock_record):
         with patch(
             "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org",
             side_effect=ApiError(
@@ -62,39 +68,40 @@ class TestTaskBehavior(BaseDeriveCodeMappings):
             ),
         ):
             assert derive_code_mappings(self.project.id, self.event_data) is None
+            self.assert_slo_metric(mock_record, EventLifecycleOutcome.HALTED)
 
     @patch("sentry.tasks.derive_code_mappings.logger")
-    def test_raises_other_api_errors(self, mock_logger):
-        with patch("sentry.tasks.derive_code_mappings.SUPPORTED_LANGUAGES", ["other"]):
-            with patch(
-                "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org",
-                side_effect=ApiError("foo"),
-            ):
-                derive_code_mappings(self.project.id, self.event_data)
-                assert mock_logger.error.call_count == 1
+    def test_raises_other_api_errors(self, mock_logger, mock_record):
+        with patch(
+            "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org",
+            side_effect=ApiError("foo"),
+        ):
+            derive_code_mappings(self.project.id, self.event_data)
+            assert mock_logger.error.call_count == 1
+            self.assert_slo_metric(mock_record, EventLifecycleOutcome.HALTED)
 
-    def test_unable_to_get_lock(self):
-        with patch("sentry.tasks.derive_code_mappings.SUPPORTED_LANGUAGES", ["other"]):
-            with patch(
-                "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org",
-                side_effect=UnableToAcquireLock,
-            ):
-                derive_code_mappings(self.project.id, self.event_data)
-                assert not RepositoryProjectPathConfig.objects.exists()
+    def test_unable_to_get_lock(self, mock_record):
+        with patch(
+            "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org",
+            side_effect=UnableToAcquireLock,
+        ):
+            derive_code_mappings(self.project.id, self.event_data)
+            assert not RepositoryProjectPathConfig.objects.exists()
+            self.assert_slo_metric(mock_record, EventLifecycleOutcome.FAILURE)
 
     @patch("sentry.tasks.derive_code_mappings.logger")
-    def test_raises_generic_errors(self, mock_logger):
-        with patch("sentry.tasks.derive_code_mappings.SUPPORTED_LANGUAGES", ["other"]):
-            with patch(
-                "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org",
-                side_effect=Exception("foo"),
-            ):
-                derive_code_mappings(self.project.id, self.event_data)
-                assert mock_logger.exception.call_count == 1
-                assert (
-                    mock_logger.exception.call_args.args[0]
-                    == "Unexpected error type while calling `get_trees_for_org()`."
-                )
+    def test_raises_generic_errors(self, mock_logger, mock_record):
+        with patch(
+            "sentry.integrations.github.client.GitHubBaseClient.get_trees_for_org",
+            side_effect=Exception("foo"),
+        ):
+            derive_code_mappings(self.project.id, self.event_data)
+            assert mock_logger.exception.call_count == 1
+            assert (
+                mock_logger.exception.call_args.args[0]
+                == "Unexpected error type while calling `get_trees_for_org()`."
+            )
+            self.assert_slo_metric(mock_record, EventLifecycleOutcome.FAILURE)
 
 
 class TestBackSlashDeriveCodeMappings(BaseDeriveCodeMappings):


### PR DESCRIPTION
Adds SLO tracking for the `derive_code_mappings` task, which is currently only used for GitHub integrations.