### PR TITLE
fix(dashboards): Remove fullscreen from Add to Dashboard

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -310,6 +310,7 @@ function AddToDashboardModal({
                         ? {selected: unselectedReleasesForCharts}
                         : undefined
                     }
+                    disableFullscreen
                   />
 
                   <IndexedEventsSelectionAlert widget={widget} />

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/visualizationStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/visualizationStep.tsx
@@ -146,6 +146,7 @@ export function VisualizationStep({
               : undefined
           }
           widgetLegendState={widgetLegendState}
+          disableFullscreen
         />
 
         <IndexedEventsSelectionAlert widget={widget} />

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -68,6 +68,7 @@ type Props = WithRouterProps & {
   widgetLegendState: WidgetLegendSelectionState;
   widgetLimitReached: boolean;
   dashboardFilters?: DashboardFilters;
+  disableFullscreen?: boolean;
   hasEditAccess?: boolean;
   index?: string;
   isEditingWidget?: boolean;
@@ -129,6 +130,7 @@ function WidgetCard(props: Props) {
     onSetTransactionsDataset,
     legendOptions,
     widgetLegendState,
+    disableFullscreen,
   } = props;
 
   if (widget.displayType === DisplayType.TOP_N) {
@@ -289,7 +291,9 @@ function WidgetCard(props: Props) {
                   actionsDisabled={actionsDisabled}
                   actionsMessage={actionsMessage}
                   actions={actions}
-                  onFullScreenViewClick={onFullScreenViewClick}
+                  onFullScreenViewClick={
+                    disableFullscreen ? undefined : onFullScreenViewClick
+                  }
                   isLoading={loading}
                   thresholds={widget.thresholds ?? undefined}
                   value={value}
@@ -311,7 +315,7 @@ function WidgetCard(props: Props) {
             error={widgetQueryError}
             actionsMessage={actionsMessage}
             actions={actions}
-            onFullScreenViewClick={onFullScreenViewClick}
+            onFullScreenViewClick={disableFullscreen ? undefined : onFullScreenViewClick}
           >
             <WidgetCardChartContainer
               location={location}


### PR DESCRIPTION
The add to dashboard modal shouldn't have the fullscreen option. Also disable it in the widget builder.