### PR TITLE
chore(dashboards): Remove dashboards releases on charts FF from temp

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -102,8 +102,6 @@ def register_temporary_features(manager: FeatureManager):
     # Enable metrics enhanced performance for AM2+ customers as they transition from AM2 to AM3
     manager.add("organizations:dashboards-metrics-transition", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:dashboards-span-metrics", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=False)
-    # Enable releases overlay on dashboard chart widgets
-    manager.add("organizations:dashboards-releases-on-charts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable table view on dashboards landing page
     manager.add("organizations:dashboards-table-view", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable access protected editing of dashboards


### PR DESCRIPTION
<!-- Describe your PR here. -->
Final step for removing the `dashboards-releases-on-charts` feature flag. https://github.com/getsentry/sentry-options-automator/pull/2765 needs to be merged before i can merge this 
