### PR TITLE
fix(ui): Avoid passing maxWidth to tooltip overlay

### DIFF
--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -1,5 +1,6 @@
 import {createContext, Fragment, useContext, useEffect} from 'react';
 import {createPortal} from 'react-dom';
+import isPropValid from '@emotion/is-prop-valid';
 import type {SerializedStyles} from '@emotion/react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -91,7 +92,9 @@ function Tooltip({
   );
 }
 
-const TooltipContent = styled(Overlay)<{maxWidth?: number}>`
+const TooltipContent = styled(Overlay, {shouldForwardProp: isPropValid})<{
+  maxWidth?: number;
+}>`
   padding: ${space(1)} ${space(1.5)};
   overflow-wrap: break-word;
   max-width: ${p => p.maxWidth ?? 225}px;


### PR DESCRIPTION
filter out maxWidth since overlay attempts to pass this to `motion.div` which errors
