### PR TITLE
ref(insights): remove conditional to render module upsell

### DIFF
--- a/static/app/views/insights/browser/resources/views/resourceSummaryPage.tsx
+++ b/static/app/views/insights/browser/resources/views/resourceSummaryPage.tsx
@@ -189,11 +189,7 @@ function ResourceSummary() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders
-      moduleName="resource"
-      pageTitle={`${DATA_TYPE} ${t('Summary')}`}
-      features="insights-initial-modules"
-    >
+    <ModulePageProviders moduleName="resource" pageTitle={`${DATA_TYPE} ${t('Summary')}`}>
       <ResourceSummary />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/browser/resources/views/resourcesLandingPage.tsx
+++ b/static/app/views/insights/browser/resources/views/resourcesLandingPage.tsx
@@ -118,7 +118,6 @@ function PageWithProviders() {
   return (
     <ModulePageProviders
       moduleName="resource"
-      features="insights-initial-modules"
       analyticEventName="insight.page_loads.assets"
     >
       <ResourcesLandingPage />

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
@@ -299,7 +299,7 @@ export function PageOverview() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders moduleName="vital" features="insights-initial-modules">
+    <ModulePageProviders moduleName="vital">
       <PageOverview />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/common/components/modulePageProviders.tsx
+++ b/static/app/views/insights/common/components/modulePageProviders.tsx
@@ -1,7 +1,4 @@
-import type {ComponentProps} from 'react';
-
 import Feature from 'sentry/components/acl/feature';
-import HookOrDefault from 'sentry/components/hookOrDefault';
 import * as Layout from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
@@ -11,7 +8,6 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {NoAccess} from 'sentry/views/insights/common/components/noAccess';
 import {useHasDataTrackAnalytics} from 'sentry/views/insights/common/utils/useHasDataTrackAnalytics';
 import {useModuleTitles} from 'sentry/views/insights/common/utils/useModuleTitle';
-import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {INSIGHTS_TITLE, QUERY_DATE_RANGE_LIMIT} from 'sentry/views/insights/settings';
 import type {ModuleName} from 'sentry/views/insights/types';
 
@@ -20,7 +16,6 @@ export type TitleableModuleNames = Exclude<ModuleNameStrings, '' | 'other'>;
 
 interface Props {
   children: React.ReactNode;
-  features: ComponentProps<typeof Feature>['features'];
   moduleName: TitleableModuleNames;
   analyticEventName?: InsightEventKey;
   pageTitle?: string;
@@ -30,12 +25,10 @@ export function ModulePageProviders({
   moduleName,
   pageTitle,
   children,
-  features,
   analyticEventName,
 }: Props) {
   const organization = useOrganization();
   const moduleTitles = useModuleTitles();
-  const {isInDomainView} = useDomainViewFilters();
 
   const hasDateRangeQueryLimit = organization.features.includes(
     'insights-query-date-range-limit'
@@ -44,7 +37,6 @@ export function ModulePageProviders({
   useHasDataTrackAnalytics(moduleName as ModuleName, analyticEventName);
 
   const moduleTitle = moduleTitles[moduleName];
-  const shouldUseUpsellHook = !isInDomainView;
 
   const fullPageTitle = [pageTitle, moduleTitle, INSIGHTS_TITLE]
     .filter(Boolean)
@@ -55,39 +47,16 @@ export function ModulePageProviders({
       maxPickableDays={hasDateRangeQueryLimit ? QUERY_DATE_RANGE_LIMIT : undefined}
     >
       <SentryDocumentTitle title={fullPageTitle} orgSlug={organization.slug}>
-        {shouldUseUpsellHook && (
-          <UpsellPageHook moduleName={moduleName}>
-            <Layout.Page>
-              <Feature
-                features={features}
-                organization={organization}
-                renderDisabled={NoAccess}
-              >
-                <NoProjectMessage organization={organization}>
-                  {children}
-                </NoProjectMessage>
-              </Feature>
-            </Layout.Page>
-          </UpsellPageHook>
-        )}
-
-        {!shouldUseUpsellHook && (
-          <Layout.Page>
-            <Feature
-              features={['insights-entry-points']}
-              organization={organization}
-              renderDisabled={NoAccess}
-            >
-              <NoProjectMessage organization={organization}>{children}</NoProjectMessage>
-            </Feature>
-          </Layout.Page>
-        )}
+        <Layout.Page>
+          <Feature
+            features={['insights-entry-points']}
+            organization={organization}
+            renderDisabled={NoAccess}
+          >
+            <NoProjectMessage organization={organization}>{children}</NoProjectMessage>
+          </Feature>
+        </Layout.Page>
       </SentryDocumentTitle>
     </PageFiltersContainer>
   );
 }
-
-export const UpsellPageHook = HookOrDefault({
-  hookName: 'component:insights-upsell-page',
-  defaultComponent: ({children}) => children,
-});

--- a/static/app/views/insights/common/components/moduleUpsellHookWrapper.tsx
+++ b/static/app/views/insights/common/components/moduleUpsellHookWrapper.tsx
@@ -1,11 +1,8 @@
 import Feature from 'sentry/components/acl/feature';
+import HookOrDefault from 'sentry/components/hookOrDefault';
 import {NoAccess} from 'sentry/components/noAccess';
 import useOrganization from 'sentry/utils/useOrganization';
-import {
-  type TitleableModuleNames,
-  UpsellPageHook,
-} from 'sentry/views/insights/common/components/modulePageProviders';
-import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
+import type {TitleableModuleNames} from 'sentry/views/insights/common/components/modulePageProviders';
 import {MODULE_FEATURE_MAP} from 'sentry/views/insights/settings';
 
 // TODO - remove, This is only necessary for domain views, where we don't want to show the full upsell page.
@@ -16,21 +13,22 @@ export function ModuleBodyUpsellHook({
   children: React.ReactNode;
   moduleName: TitleableModuleNames;
 }) {
-  const {isInDomainView: shouldDisplayUpsell} = useDomainViewFilters();
   const organization = useOrganization();
 
-  if (shouldDisplayUpsell) {
-    return (
-      <UpsellPageHook moduleName={moduleName} fullPage={false}>
-        <Feature
-          features={MODULE_FEATURE_MAP[moduleName]}
-          organization={organization}
-          renderDisabled={NoAccess}
-        >
-          {children}
-        </Feature>
-      </UpsellPageHook>
-    );
-  }
-  return children;
+  return (
+    <UpsellPageHook moduleName={moduleName} fullPage={false}>
+      <Feature
+        features={MODULE_FEATURE_MAP[moduleName]}
+        organization={organization}
+        renderDisabled={NoAccess}
+      >
+        {children}
+      </Feature>
+    </UpsellPageHook>
+  );
 }
+
+const UpsellPageHook = HookOrDefault({
+  hookName: 'component:insights-upsell-page',
+  defaultComponent: ({children}) => children,
+});

--- a/static/app/views/insights/database/views/databaseLandingPage.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.tsx
@@ -279,11 +279,7 @@ const LIMIT: number = 25;
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders
-      moduleName="db"
-      features="insights-initial-modules"
-      analyticEventName="insight.page_loads.db"
-    >
+    <ModulePageProviders moduleName="db" analyticEventName="insight.page_loads.db">
       <DatabaseLandingPage />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
@@ -358,11 +358,7 @@ const DescriptionContainer = styled(ModuleLayout.Full)`
 
 function PageWithProviders(props) {
   return (
-    <ModulePageProviders
-      moduleName="db"
-      pageTitle={t('Query Summary')}
-      features="insights-initial-modules"
-    >
+    <ModulePageProviders moduleName="db" pageTitle={t('Query Summary')}>
       <DatabaseSpanSummaryPage {...props} />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/http/views/httpDomainSummaryPage.tsx
+++ b/static/app/views/insights/http/views/httpDomainSummaryPage.tsx
@@ -400,11 +400,7 @@ const TRANSACTIONS_TABLE_ROW_COUNT = 20;
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders
-      moduleName="http"
-      pageTitle={t('Domain Summary')}
-      features="insights-initial-modules"
-    >
+    <ModulePageProviders moduleName="http" pageTitle={t('Domain Summary')}>
       <HTTPDomainSummaryPage />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/http/views/httpLandingPage.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.tsx
@@ -292,11 +292,7 @@ const DOMAIN_TABLE_ROW_COUNT = 10;
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders
-      moduleName="http"
-      features="insights-initial-modules"
-      analyticEventName="insight.page_loads.http"
-    >
+    <ModulePageProviders moduleName="http" analyticEventName="insight.page_loads.http">
       <HTTPLandingPage />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/llmMonitoring/views/llmMonitoringDetailsPage.tsx
+++ b/static/app/views/insights/llmMonitoring/views/llmMonitoringDetailsPage.tsx
@@ -240,11 +240,7 @@ export function LLMMonitoringPage({params}: Props) {
 
 function PageWithProviders({params}: Props) {
   return (
-    <ModulePageProviders
-      moduleName="ai"
-      pageTitle={t('Pipeline Summary')}
-      features="insights-addon-modules"
-    >
+    <ModulePageProviders moduleName="ai" pageTitle={t('Pipeline Summary')}>
       <LLMMonitoringPage params={params} />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/llmMonitoring/views/llmMonitoringLandingPage.tsx
+++ b/static/app/views/insights/llmMonitoring/views/llmMonitoringLandingPage.tsx
@@ -110,11 +110,7 @@ export function LLMMonitoringPage() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders
-      moduleName="ai"
-      features="insights-addon-modules"
-      analyticEventName="insight.page_loads.ai"
-    >
+    <ModulePageProviders moduleName="ai" analyticEventName="insight.page_loads.ai">
       <LLMMonitoringPage />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/mobile/appStarts/views/appStartsLandingPage.tsx
+++ b/static/app/views/insights/mobile/appStarts/views/appStartsLandingPage.tsx
@@ -26,7 +26,6 @@ function PageWithProviders() {
   return (
     <ModulePageProviders
       moduleName="app_start"
-      features="insights-initial-modules"
       analyticEventName="insight.page_loads.app_start"
     >
       <InitializationModule />

--- a/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.tsx
+++ b/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.tsx
@@ -232,11 +232,7 @@ export function ScreenSummaryContentPage() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders
-      moduleName="app_start"
-      pageTitle={t('Screen Summary')}
-      features="insights-initial-modules"
-    >
+    <ModulePageProviders moduleName="app_start" pageTitle={t('Screen Summary')}>
       <ScreenSummary />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/mobile/screenRendering/screenRenderingLandingPage.tsx
+++ b/static/app/views/insights/mobile/screenRendering/screenRenderingLandingPage.tsx
@@ -14,7 +14,6 @@ import {PlatformSelector} from 'sentry/views/insights/mobile/screenload/componen
 import {ScreenRenderingContent} from 'sentry/views/insights/mobile/screenRendering/screenRenderingContent';
 import {MODULE_TITLE} from 'sentry/views/insights/mobile/screenRendering/settings';
 import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
-import {MODULE_FEATURE_MAP} from 'sentry/views/insights/settings';
 import {ModuleName} from 'sentry/views/insights/types';
 
 export function ScreenRenderingModule() {
@@ -56,7 +55,6 @@ function PageWithProviders() {
   return (
     <ModulePageProviders
       moduleName="screen_load"
-      features={MODULE_FEATURE_MAP[ModuleName.SCREEN_RENDERING]}
       analyticEventName="insight.page_loads.screen_rendering"
     >
       <ScreenRenderingModule />

--- a/static/app/views/insights/mobile/screenRendering/screenRenderingSummaryPage.tsx
+++ b/static/app/views/insights/mobile/screenRendering/screenRenderingSummaryPage.tsx
@@ -12,7 +12,6 @@ import {
 } from 'sentry/views/insights/mobile/screenRendering/settings';
 import {ScreenSummaryContent} from 'sentry/views/insights/mobile/ui/views/screenSummaryPage';
 import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
-import {MODULE_FEATURE_MAP} from 'sentry/views/insights/settings';
 import {ModuleName} from 'sentry/views/insights/types';
 
 function ScreenRenderingSummary() {
@@ -46,7 +45,6 @@ function PageWithProviders() {
     <ModulePageProviders
       moduleName={ModuleName.SCREEN_RENDERING}
       pageTitle={`${DATA_TYPE} ${t('Summary')}`}
-      features={MODULE_FEATURE_MAP[ModuleName.SCREEN_RENDERING]}
     >
       <ScreenRenderingSummary />
     </ModulePageProviders>

--- a/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.tsx
@@ -240,11 +240,7 @@ export function ScreenLoadSpansContent() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders
-      moduleName="screen_load"
-      pageTitle={t('Screen Summary')}
-      features="insights-initial-modules"
-    >
+    <ModulePageProviders moduleName="screen_load" pageTitle={t('Screen Summary')}>
       <ScreenLoadSpans />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/mobile/screenload/views/screenloadLandingPage.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenloadLandingPage.tsx
@@ -118,7 +118,6 @@ function PageWithProviders() {
   return (
     <ModulePageProviders
       moduleName="screen_load"
-      features="insights-initial-modules"
       analyticEventName="insight.page_loads.screen_load"
     >
       <PageloadModule />

--- a/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
+++ b/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
@@ -37,7 +37,6 @@ import {Referrer} from 'sentry/views/insights/mobile/screens/referrers';
 import {
   MODULE_DESCRIPTION,
   MODULE_DOC_LINK,
-  MODULE_FEATURE,
   MODULE_TITLE,
 } from 'sentry/views/insights/mobile/screens/settings';
 import {
@@ -291,7 +290,7 @@ export function ScreensLandingPage() {
   };
 
   return (
-    <ModulePageProviders moduleName="mobile-screens" features={[MODULE_FEATURE]}>
+    <ModulePageProviders moduleName="mobile-screens">
       <Layout.Page>
         <PageAlertProvider>
           {!isInDomainView && (

--- a/static/app/views/insights/mobile/ui/views/screenSummaryPage.tsx
+++ b/static/app/views/insights/mobile/ui/views/screenSummaryPage.tsx
@@ -149,11 +149,7 @@ export function ScreenSummaryContent() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders
-      moduleName="mobile-ui"
-      pageTitle={t('Screen Summary')}
-      features={['insights-addon-modules', 'starfish-mobile-ui-module']}
-    >
+    <ModulePageProviders moduleName="mobile-ui" pageTitle={t('Screen Summary')}>
       <ScreenSummary />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/mobile/ui/views/uiLandingPage.tsx
+++ b/static/app/views/insights/mobile/ui/views/uiLandingPage.tsx
@@ -22,10 +22,7 @@ export function ResponsivenessModule() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders
-      moduleName="mobile-ui"
-      features={['insights-addon-modules', 'starfish-mobile-ui-module']}
-    >
+    <ModulePageProviders moduleName="mobile-ui">
       <ResponsivenessModule />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/queues/views/destinationSummaryPage.tsx
+++ b/static/app/views/insights/queues/views/destinationSummaryPage.tsx
@@ -179,11 +179,7 @@ function DestinationSummaryPage() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders
-      moduleName="queue"
-      pageTitle={t('Destination Summary')}
-      features="insights-addon-modules"
-    >
+    <ModulePageProviders moduleName="queue" pageTitle={t('Destination Summary')}>
       <DestinationSummaryPage />
     </ModulePageProviders>
   );

--- a/static/app/views/insights/queues/views/queuesLandingPage.tsx
+++ b/static/app/views/insights/queues/views/queuesLandingPage.tsx
@@ -158,11 +158,7 @@ function QueuesLandingPage() {
 
 function PageWithProviders() {
   return (
-    <ModulePageProviders
-      moduleName="queue"
-      features="insights-addon-modules"
-      analyticEventName="insight.page_loads.queue"
-    >
+    <ModulePageProviders moduleName="queue" analyticEventName="insight.page_loads.queue">
       <QueuesLandingPage />
     </ModulePageProviders>
   );


### PR DESCRIPTION
Before domain views were released, we conditionally rendered the module upsells. If the domain views were not enabled we rendered full screen module upsells, otherwise we rendered a body upsell (so that the tabs/headers are retained).

Now that we GA'd domain views, we no longer need these conditons.