### PR TITLE
fix(oauth): Add investigative logging

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -5,7 +5,6 @@ import logging
 from collections.abc import Callable, Iterable
 from typing import Any, ClassVar
 
-import sentry_sdk
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.urls import resolve

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -5,6 +5,7 @@ import logging
 from collections.abc import Callable, Iterable
 from typing import Any, ClassVar
 
+import sentry_sdk
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.urls import resolve


### PR DESCRIPTION
Ideally organization index endpoint should only return data limited to the organization that is on the token. But today it does not if the user is authenticated. I want to limit this usecase to return only the organization on the token but before making the change adding logging to see what I'll break.