### PR TITLE
feat(rpc): Add SearchResolver cache

### DIFF
--- a/src/sentry/search/eap/spans.py
+++ b/src/sentry/search/eap/spans.py
@@ -47,7 +47,12 @@ class SearchResolver:
 
     params: SnubaParams
     config: SearchResolverConfig
-    resolved_columns: dict[str, ResolvedColumn] = field(default_factory=dict)
+    _resolved_attribute_cache: dict[str, tuple[ResolvedColumn, VirtualColumnContext | None]] = (
+        field(default_factory=dict)
+    )
+    _resolved_function_cache: dict[str, tuple[ResolvedFunction, VirtualColumnContext | None]] = (
+        field(default_factory=dict)
+    )
 
     def resolve_meta(self, referrer: str) -> RequestMeta:
         if self.params.organization_id is None:
@@ -366,10 +371,6 @@ class SearchResolver:
         else:
             return self.resolve_attribute(column)
 
-        # TODO: Cache the column
-        # self.resolved_coluumn[alias] = ResolvedColumn()
-        # return ResolvedColumn()
-
     def get_field_type(self, column: str) -> str:
         resolved_column, _ = self.resolve_column(column)
         return resolved_column.search_type
@@ -390,6 +391,8 @@ class SearchResolver:
         """Attributes are columns that aren't 'functions' or 'aggregates', usually this means string or numeric
         attributes (aka. tags), but can also refer to fields like span.description"""
         # If a virtual context is defined the column definition is always the same
+        if column in self._resolved_attribute_cache:
+            return self._resolved_attribute_cache[column]
         if column in VIRTUAL_CONTEXTS:
             column_context = VIRTUAL_CONTEXTS[column](self.params)
             column_definition = ResolvedColumn(
@@ -426,7 +429,8 @@ class SearchResolver:
             column_context = None
 
         if column_definition:
-            return column_definition, column_context
+            self._resolved_attribute_cache[column] = (column_definition, column_context)
+            return self._resolved_attribute_cache[column]
         else:
             raise InvalidSearchQuery(f"Could not parse {column}")
 
@@ -444,6 +448,8 @@ class SearchResolver:
     def resolve_aggregate(
         self, column: str, match: Match | None = None
     ) -> tuple[ResolvedFunction, VirtualColumnContext | None]:
+        if column in self._resolved_function_cache:
+            return self._resolved_function_cache[column]
         # Check if this is a valid function, parse the function name and args out
         if match is None:
             match = fields.is_function(column)
@@ -502,15 +508,15 @@ class SearchResolver:
         else:
             resolved_argument = None
 
-        return (
-            ResolvedFunction(
-                public_alias=alias,
-                internal_name=function_definition.internal_function,
-                search_type=function_definition.search_type,
-                internal_type=function_definition.internal_type,
-                processor=function_definition.processor,
-                extrapolation=function_definition.extrapolation,
-                argument=resolved_argument,
-            ),
-            None,
+        resolved_function = ResolvedFunction(
+            public_alias=alias,
+            internal_name=function_definition.internal_function,
+            search_type=function_definition.search_type,
+            internal_type=function_definition.internal_type,
+            processor=function_definition.processor,
+            extrapolation=function_definition.extrapolation,
+            argument=resolved_argument,
         )
+        resolved_context = None
+        self._resolved_function_cache[column] = (resolved_function, resolved_context)
+        return self._resolved_function_cache[column]


### PR DESCRIPTION
- Implements the resolved cache for the search resolver so we're not re-running a bunch of the code again when we encounter the same attribute or column repeatedly