### PR TITLE
[Opsgenie integration] Hit close api instead acknowledge api when resolved

### DIFF
--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -107,12 +107,12 @@ class OpsgenieClient(ApiClient):
                 notification_uuid=notification_uuid,
             )
         else:
-            # if we're acknowledging the alert—meaning that the Sentry alert was resolved
+            # if we're closing the alert—meaning that the Sentry alert was resolved
             if data.get("identifier"):
                 interaction_type = OnCallInteractionType.RESOLVE
                 alias = data["identifier"]
                 resp = self.post(
-                    f"/alerts/{alias}/acknowledge",
+                    f"/alerts/{alias}/close",
                     data={},
                     params={"identifierType": "alias"},
                     headers=headers,

--- a/tests/sentry/incidents/action_handlers/test_opsgenie.py
+++ b/tests/sentry/incidents/action_handlers/test_opsgenie.py
@@ -172,7 +172,7 @@ class OpsgenieActionHandlerTest(FireTest):
         if method == "resolve":
             responses.add(
                 responses.POST,
-                url=f"https://api.opsgenie.com/v2/alerts/{alias}/acknowledge?identifierType=alias",
+                url=f"https://api.opsgenie.com/v2/alerts/{alias}/close?identifierType=alias",
                 json={},
                 status=202,
             )


### PR DESCRIPTION
Related to: https://github.com/getsentry/sentry/issues/62261

When a Sentry Alert is resolved, the expected result is that the Opsgenie alert will close.

Steps to reproduce:
1. An alert is triggered in Sentry (For instance: Number of crashes is above 5 in the last 5 minutes).
2. The Sentry Alert triggers an Opsgenie Alert
3. The alert is acknowledged in Opsgenie by a teammate on call.
4. When the Sentry Alert is resolved (For instance: Number of crashes is now below 5 in the last 5 minutes).
5. The Opsgenie Alert stay opened.

After fix:
1. An alert is triggered in Sentry (For instance: Number of crashes is above 5 in the last 5 minutes).
2. The Sentry Alert triggers an Opsgenie Alert
3. The alert is acknowledged in Opsgenie by a teammate on call.
4. When the Sentry Alert is resolved (For instance: Number of crashes is now below 5 in the last 5 minutes).
5. The Opsgenie open alert should close


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
