### PR TITLE
chore(dashboards): Add view_type to delete+duplicate analytics

### DIFF
--- a/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
@@ -1,3 +1,5 @@
+import type {DashboardsLayout} from 'sentry/views/dashboards/manage';
+
 // Used in the full-page widget builder
 type DashboardsEventParametersWidgetBuilder = {
   'dashboards_views.widget_builder.change': {
@@ -39,8 +41,8 @@ export type DashboardsEventParameters = {
     sort: string;
   };
   'dashboards_manage.create.start': {};
-  'dashboards_manage.delete': {dashboard_id: number};
-  'dashboards_manage.duplicate': {dashboard_id: number};
+  'dashboards_manage.delete': {dashboard_id: number; view_type: DashboardsLayout};
+  'dashboards_manage.duplicate': {dashboard_id: number; view_type: DashboardsLayout};
   'dashboards_manage.paginate': {};
   'dashboards_manage.search': {};
   'dashboards_manage.templates.add': {

--- a/static/app/views/dashboards/manage/dashboardGrid.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.tsx
@@ -73,6 +73,7 @@ function DashboardGrid({
         trackAnalytics('dashboards_manage.delete', {
           organization,
           dashboard_id: parseInt(dashboard.id, 10),
+          view_type: 'grid',
         });
         onDashboardsChange();
         addSuccessMessage(t('Dashboard deleted'));
@@ -91,6 +92,7 @@ function DashboardGrid({
       trackAnalytics('dashboards_manage.duplicate', {
         organization,
         dashboard_id: parseInt(dashboard.id, 10),
+        view_type: 'grid',
       });
       onDashboardsChange();
       addSuccessMessage(t('Dashboard duplicated'));

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -65,6 +65,7 @@ function DashboardTable({
         trackAnalytics('dashboards_manage.delete', {
           organization,
           dashboard_id: parseInt(dashboard.id, 10),
+          view_type: 'table',
         });
         onDashboardsChange();
         addSuccessMessage(t('Dashboard deleted'));
@@ -83,6 +84,7 @@ function DashboardTable({
       trackAnalytics('dashboards_manage.duplicate', {
         organization,
         dashboard_id: parseInt(dashboard.id, 10),
+        view_type: 'table',
       });
       onDashboardsChange();
       addSuccessMessage(t('Dashboard duplicated'));

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -70,9 +70,9 @@ const SHOW_TEMPLATES_KEY = 'dashboards-show-templates';
 export const LAYOUT_KEY = 'dashboards-overview-layout';
 
 const GRID = 'grid';
-const LIST = 'list';
+const TABLE = 'table';
 
-type DashboardsLayout = 'grid' | 'list';
+export type DashboardsLayout = 'grid' | 'table';
 
 function shouldShowTemplates(): boolean {
   const shouldShow = localStorage.getItem(SHOW_TEMPLATES_KEY);
@@ -81,7 +81,9 @@ function shouldShowTemplates(): boolean {
 
 function getDashboardsOverviewLayout(): DashboardsLayout {
   const dashboardsLayout = localStorage.getItem(LAYOUT_KEY);
-  return dashboardsLayout === GRID || dashboardsLayout === LIST ? dashboardsLayout : GRID;
+  return dashboardsLayout === GRID || dashboardsLayout === TABLE
+    ? dashboardsLayout
+    : GRID;
 }
 
 function ManageDashboards() {


### PR DESCRIPTION
There was [a comment](https://github.com/getsentry/sentry/pull/80945/files#r1850778551) that @narsaynorath made on a previous PR stating that it would be interesting to see which dashboards view generates more deletes/duplicates

https://github.com/getsentry/sentry/issues/81057