### PR TITLE
feat(grouping): Tally frame types while building exception grouping components

### DIFF
--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -306,6 +306,17 @@ ExceptionGroupingComponentChildren = (
 
 class ExceptionGroupingComponent(BaseGroupingComponent[ExceptionGroupingComponentChildren]):
     id: str = "exception"
+    frame_counts: Counter[str]
+
+    def __init__(
+        self,
+        values: Sequence[ExceptionGroupingComponentChildren] | None = None,
+        hint: str | None = None,
+        contributes: bool | None = None,
+        frame_counts: Counter[str] | None = None,
+    ):
+        super().__init__(hint=hint, contributes=contributes, values=values)
+        self.frame_counts = frame_counts or Counter()
 
 
 class ChainedExceptionGroupingComponent(BaseGroupingComponent[ExceptionGroupingComponent]):

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -321,6 +321,17 @@ class ExceptionGroupingComponent(BaseGroupingComponent[ExceptionGroupingComponen
 
 class ChainedExceptionGroupingComponent(BaseGroupingComponent[ExceptionGroupingComponent]):
     id: str = "chained-exception"
+    frame_counts: Counter[str]
+
+    def __init__(
+        self,
+        values: Sequence[ExceptionGroupingComponent] | None = None,
+        hint: str | None = None,
+        contributes: bool | None = None,
+        frame_counts: Counter[str] | None = None,
+    ):
+        super().__init__(hint=hint, contributes=contributes, values=values)
+        self.frame_counts = frame_counts or Counter()
 
 
 class ThreadsGroupingComponent(BaseGroupingComponent[StacktraceGroupingComponent]):

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -228,16 +228,17 @@ class SymbolGroupingComponent(BaseGroupingComponent[str]):
     id: str = "symbol"
 
 
-class FrameGroupingComponent(
-    BaseGroupingComponent[
-        ContextLineGroupingComponent
-        | FilenameGroupingComponent
-        | FunctionGroupingComponent
-        | LineNumberGroupingComponent  # only in legacy config
-        | ModuleGroupingComponent
-        | SymbolGroupingComponent  # only in legacy config
-    ]
-):
+FrameGroupingComponentChildren = (
+    ContextLineGroupingComponent
+    | FilenameGroupingComponent
+    | FunctionGroupingComponent
+    | LineNumberGroupingComponent  # only in legacy config
+    | ModuleGroupingComponent
+    | SymbolGroupingComponent  # only in legacy config
+)
+
+
+class FrameGroupingComponent(BaseGroupingComponent[FrameGroupingComponentChildren]):
     id: str = "frame"
 
 

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -240,6 +240,17 @@ FrameGroupingComponentChildren = (
 
 class FrameGroupingComponent(BaseGroupingComponent[FrameGroupingComponentChildren]):
     id: str = "frame"
+    in_app: bool
+
+    def __init__(
+        self,
+        values: Sequence[FrameGroupingComponentChildren],
+        in_app: bool,
+        hint: str | None = None,  # only passed in legacy
+        contributes: bool | None = None,  # only passed in legacy
+    ):
+        super().__init__(hint=hint, contributes=contributes, values=values)
+        self.in_app = in_app
 
 
 # Security-related inner components

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -296,14 +296,15 @@ class StacktraceGroupingComponent(BaseGroupingComponent[FrameGroupingComponent])
         self.frame_counts = frame_counts or Counter()
 
 
-class ExceptionGroupingComponent(
-    BaseGroupingComponent[
-        ErrorTypeGroupingComponent
-        | ErrorValueGroupingComponent
-        | NSErrorGroupingComponent
-        | StacktraceGroupingComponent
-    ]
-):
+ExceptionGroupingComponentChildren = (
+    ErrorTypeGroupingComponent
+    | ErrorValueGroupingComponent
+    | NSErrorGroupingComponent
+    | StacktraceGroupingComponent
+)
+
+
+class ExceptionGroupingComponent(BaseGroupingComponent[ExceptionGroupingComponentChildren]):
     id: str = "exception"
 
 

--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import Counter
 from collections.abc import Generator, Iterator, Sequence
 from typing import Any, Self
 
@@ -282,6 +283,17 @@ class MessageGroupingComponent(BaseGroupingComponent[str]):
 
 class StacktraceGroupingComponent(BaseGroupingComponent[FrameGroupingComponent]):
     id: str = "stacktrace"
+    frame_counts: Counter[str]
+
+    def __init__(
+        self,
+        values: Sequence[FrameGroupingComponent] | None = None,
+        hint: str | None = None,
+        contributes: bool | None = None,
+        frame_counts: Counter[str] | None = None,
+    ):
+        super().__init__(hint=hint, contributes=contributes, values=values)
+        self.frame_counts = frame_counts or Counter()
 
 
 class ExceptionGroupingComponent(

--- a/src/sentry/grouping/strategies/legacy.py
+++ b/src/sentry/grouping/strategies/legacy.py
@@ -392,6 +392,7 @@ def frame_legacy(
             ],
             contributes=contributes,
             hint=hint,
+            in_app=interface.in_app,
         )
     }
 

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -594,7 +594,9 @@ def single_exception(
 
             values.append(value_component)
 
-        rv[variant] = ExceptionGroupingComponent(values=values)
+        rv[variant] = ExceptionGroupingComponent(
+            values=values, frame_counts=stacktrace_component.frame_counts
+        )
 
     return rv
 

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -341,7 +341,7 @@ def frame(
     if context_line_component is not None:
         values.append(context_line_component)
 
-    rv = FrameGroupingComponent(values=values)
+    rv = FrameGroupingComponent(values=values, in_app=frame.in_app)
 
     # if we are in javascript fuzzing mode we want to disregard some
     # frames consistently.  These force common bad stacktraces together

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import itertools
 import logging
 import re
+from collections import Counter
 from collections.abc import Generator
 from typing import Any
 
@@ -646,7 +647,16 @@ def chained_exception(
     rv = {}
 
     for name, component_list in by_name.items():
-        rv[name] = ChainedExceptionGroupingComponent(values=component_list)
+        # Calculate an aggregate tally of the different types of frames (in-app vs system,
+        # contributing or not) across all of the exceptions in the chain
+        total_frame_counts: Counter[str] = Counter()
+        for exception_component in component_list:
+            total_frame_counts += exception_component.frame_counts
+
+        rv[name] = ChainedExceptionGroupingComponent(
+            values=component_list,
+            frame_counts=total_frame_counts,
+        )
 
     return rv
 

--- a/tests/sentry/grouping/test_components.py
+++ b/tests/sentry/grouping/test_components.py
@@ -1,0 +1,238 @@
+from collections import Counter
+from typing import Any
+
+from sentry.eventstore.models import Event
+from sentry.grouping.component import (
+    BaseGroupingComponent,
+    ChainedExceptionGroupingComponent,
+    ExceptionGroupingComponent,
+    FunctionGroupingComponent,
+    StacktraceGroupingComponent,
+)
+from sentry.testutils.cases import TestCase
+from sentry.utils.types import NonNone
+
+
+def find_given_child_component[
+    T
+](parent_component: BaseGroupingComponent[Any], child_component_type: type[T]) -> T | None:
+    """
+    Finds the first instance of the given type of child component in the parent component's `values`
+    list. Works best in cases where only one instance of the given type is expected.
+    """
+    for child_component in parent_component.values:
+        if isinstance(child_component, child_component_type):
+            return child_component
+
+    return None
+
+
+class ComponentTest(TestCase):
+    def setUp(self):
+        self.contributing_system_frame = {
+            "function": "handleRequest",
+            "filename": "/node_modules/express/router.js",
+            "context_line": "return handler(request);",
+        }
+        self.non_contributing_system_frame = {
+            "function": "runApp",
+            "filename": "/node_modules/express/app.js",
+            "context_line": "return server.serve(port);",
+        }
+        self.contributing_in_app_frame = {
+            "function": "playFetch",
+            "filename": "/dogApp/dogpark.js",
+            "context_line": "raise FailedToFetchError('Charlie didn't bring the ball back');",
+        }
+        self.non_contributing_in_app_frame = {
+            "function": "recordMetrics",
+            "filename": "/dogApp/metrics.js",
+            "context_line": "return withMetrics(handler, metricName, tags);",
+        }
+        self.exception_value = {
+            "type": "FailedToFetchError",
+            "value": "Charlie didn't bring the ball back",
+        }
+        self.event = Event(
+            event_id="12312012041520130908201311212012",
+            project_id=self.project.id,
+            data={
+                "title": "FailedToFetchError('Charlie didn't bring the ball back')",
+                "exception": {"values": [self.exception_value]},
+            },
+        )
+        self.project.update_option(
+            "sentry:grouping_enhancements",
+            "\n".join(
+                [
+                    "stack.function:runApp -app -group",
+                    "stack.function:handleRequest -app +group",
+                    "stack.function:recordMetrics +app -group",
+                    "stack.function:playFetch +app +group",
+                ]
+            ),
+        )
+
+    def test_frame_components_record_in_app(self):
+        self.event.data["exception"]["values"][0]["stacktrace"] = {
+            "frames": [
+                self.contributing_system_frame,
+                self.contributing_in_app_frame,
+            ]
+        }
+
+        # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
+        variants = self.event.get_grouping_variants(normalize_stacktraces=True)
+
+        for variant_name in ["app", "system"]:
+            exception_component = variants[variant_name].component.values[0]
+            assert isinstance(exception_component, ExceptionGroupingComponent)
+            stacktrace_component = find_given_child_component(
+                exception_component, StacktraceGroupingComponent
+            )
+            assert stacktrace_component
+
+            frame_components = stacktrace_component.values
+            assert [
+                NonNone(
+                    find_given_child_component(frame_component, FunctionGroupingComponent)
+                ).values[0]
+                for frame_component in frame_components
+            ] == ["handleRequest", "playFetch"]
+
+            assert [frame_component.in_app for frame_component in frame_components] == [False, True]
+
+    def test_stacktrace_component_tallies_frame_types_simple(self):
+        self.event.data["exception"]["values"][0]["stacktrace"] = {
+            "frames": (
+                [self.non_contributing_system_frame] * 11
+                + [self.contributing_system_frame] * 21
+                + [self.non_contributing_in_app_frame] * 12
+                + [self.contributing_in_app_frame] * 31
+            )
+        }
+
+        # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
+        variants = self.event.get_grouping_variants(normalize_stacktraces=True)
+
+        for variant_name in ["app", "system"]:
+            exception_component = variants[variant_name].component.values[0]
+            assert isinstance(exception_component, ExceptionGroupingComponent)
+            stacktrace_component = find_given_child_component(
+                exception_component, StacktraceGroupingComponent
+            )
+            assert stacktrace_component
+
+            assert stacktrace_component.frame_counts == Counter(
+                system_non_contributing_frames=11,
+                system_contributing_frames=21,
+                in_app_non_contributing_frames=12,
+                in_app_contributing_frames=31,
+            )
+
+    def test_stacktrace_component_tallies_frame_types_not_all_types_present(self):
+        self.event.data["exception"]["values"][0]["stacktrace"] = {
+            "frames": (
+                [self.contributing_system_frame] * 20 + [self.contributing_in_app_frame] * 13
+            )
+        }
+
+        # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
+        variants = self.event.get_grouping_variants(normalize_stacktraces=True)
+
+        for variant_name in ["app", "system"]:
+            exception_component = variants[variant_name].component.values[0]
+            assert isinstance(exception_component, ExceptionGroupingComponent)
+            stacktrace_component = find_given_child_component(
+                exception_component, StacktraceGroupingComponent
+            )
+            assert stacktrace_component
+
+            assert stacktrace_component.frame_counts == Counter(
+                system_non_contributing_frames=0,
+                system_contributing_frames=20,
+                in_app_non_contributing_frames=0,
+                in_app_contributing_frames=13,
+            )
+
+    def test_exception_component_uses_stacktrace_frame_counts(self):
+        self.event.data["exception"]["values"][0]["stacktrace"] = {
+            "frames": (
+                [self.non_contributing_system_frame] * 4
+                + [self.contributing_system_frame] * 15
+                + [self.non_contributing_in_app_frame] * 9
+                + [self.contributing_in_app_frame] * 8
+            )
+        }
+
+        # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
+        variants = self.event.get_grouping_variants(normalize_stacktraces=True)
+
+        for variant_name in ["app", "system"]:
+            exception_component = variants[variant_name].component.values[0]
+            assert isinstance(exception_component, ExceptionGroupingComponent)
+            stacktrace_component = find_given_child_component(
+                exception_component, StacktraceGroupingComponent
+            )
+            assert stacktrace_component
+
+            assert stacktrace_component.frame_counts == Counter(
+                system_non_contributing_frames=4,
+                system_contributing_frames=15,
+                in_app_non_contributing_frames=9,
+                in_app_contributing_frames=8,
+            )
+            assert exception_component.frame_counts == stacktrace_component.frame_counts
+
+    def test_chained_exception_component_sums_stacktrace_frame_counts(self):
+        self.event.data["exception"]["values"] = [
+            {**self.exception_value},
+            {**self.exception_value},
+        ]
+        self.event.data["exception"]["values"][0]["stacktrace"] = {
+            "frames": (
+                [self.non_contributing_system_frame] * 11
+                + [self.contributing_system_frame] * 21
+                + [self.non_contributing_in_app_frame] * 12
+                + [self.contributing_in_app_frame] * 31
+            )
+        }
+        self.event.data["exception"]["values"][1]["stacktrace"] = {
+            "frames": (
+                [self.non_contributing_system_frame] * 4
+                + [self.contributing_system_frame] * 15
+                + [self.non_contributing_in_app_frame] * 9
+                + [self.contributing_in_app_frame] * 8
+            )
+        }
+
+        # `normalize_stacktraces=True` forces the custom stacktrace enhancements to run
+        variants = self.event.get_grouping_variants(normalize_stacktraces=True)
+
+        for variant_name in ["app", "system"]:
+            chained_exception_component = variants[variant_name].component.values[0]
+            assert isinstance(chained_exception_component, ChainedExceptionGroupingComponent)
+            exception_components = chained_exception_component.values
+            assert [
+                exception_component.frame_counts for exception_component in exception_components
+            ] == [
+                Counter(
+                    system_non_contributing_frames=11,
+                    system_contributing_frames=21,
+                    in_app_non_contributing_frames=12,
+                    in_app_contributing_frames=31,
+                ),
+                Counter(
+                    system_non_contributing_frames=4,
+                    system_contributing_frames=15,
+                    in_app_non_contributing_frames=9,
+                    in_app_contributing_frames=8,
+                ),
+            ]
+
+            assert chained_exception_component.frame_counts == Counter(
+                system_non_contributing_frames=15,
+                system_contributing_frames=36,
+                in_app_non_contributing_frames=21,
+                in_app_contributing_frames=39,
+            )


### PR DESCRIPTION
This adds a tally of the four possible types of frames (in-app vs system, each of which can be contributing or not) to exception and chained exception grouping components created by the newstyle config. To make this work:

- First, each `FrameGroupingComponent` stores on itself whether it's in-app or not.*
- Then, as we're walking through the frames when building the `StacktraceGroupingComponent`, we note each frame component's `in_app` and `contributing` values, and keep a running tally of the different frame types, which we then store on the stacktrace component.
- Next, when creating an `ExceptionGroupingComponent`, we read the frame tally from the stacktrace component and store it on the exception component.
- Finally, if we have a chained exception, we add up the tallies from the individual exception components and store a combined tally on the `ChainedExceptionGroupingComponent`.

Having this data will enable us to do a few different things (in follow-up PRs, if and when we choose to):

- Gather metrics on the precise mix of frames. Right now we have a separately-calculated `in_app_frame_mix` metric, which just records the presence, or lack thereof, of in-app and system frames in the initial event in a group; should we choose, this will allow us to gather more detailed metrics. (One place this might be useful is as we start automatically adding code-mappings-based stacktrace rules to projects, to see the change in percentage of in-app vs system frame.) We also could consider switching the frame mix metric to rely on these counts, as it would make the code quite a bit simpler.
- Store this information in grouphash metadata.
- Use the information when deciding whether to send events to Seer.

*Note: Though in general this PR only applies to newstyle grouping, I did add in-app tracking to legacy frame components, too, to make them compatible with the newly-modified `assemble_stacktrace_component` helper both configs use.