### PR TITLE
feat(dashbaords): Add confirmation pop-up for duplicating dashboards

### DIFF
--- a/static/app/views/dashboards/manage/dashboardGrid.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.spec.tsx
@@ -244,9 +244,16 @@ describe('Dashboards - DashboardGrid', function () {
         rowCount={3}
       />
     );
+    renderGlobalModal();
 
     await userEvent.click(screen.getAllByRole('button', {name: /dashboard actions/i})[1]);
     await userEvent.click(screen.getByTestId('dashboard-duplicate'));
+
+    expect(createMock).not.toHaveBeenCalled();
+
+    await userEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', {name: /confirm/i})
+    );
 
     await waitFor(() => {
       expect(createMock).toHaveBeenCalled();
@@ -271,9 +278,16 @@ describe('Dashboards - DashboardGrid', function () {
         rowCount={3}
       />
     );
+    renderGlobalModal();
 
     await userEvent.click(screen.getAllByRole('button', {name: /dashboard actions/i})[1]);
     await userEvent.click(screen.getByTestId('dashboard-duplicate'));
+
+    expect(createMock).not.toHaveBeenCalled();
+
+    await userEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', {name: /confirm/i})
+    );
 
     await waitFor(() => {
       expect(postMock).toHaveBeenCalled();

--- a/static/app/views/dashboards/manage/dashboardGrid.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.spec.tsx
@@ -283,7 +283,7 @@ describe('Dashboards - DashboardGrid', function () {
     await userEvent.click(screen.getAllByRole('button', {name: /dashboard actions/i})[1]);
     await userEvent.click(screen.getByTestId('dashboard-duplicate'));
 
-    expect(createMock).not.toHaveBeenCalled();
+    expect(postMock).not.toHaveBeenCalled();
 
     await userEvent.click(
       within(screen.getByRole('dialog')).getByRole('button', {name: /confirm/i})

--- a/static/app/views/dashboards/manage/dashboardGrid.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.tsx
@@ -104,7 +104,13 @@ function DashboardGrid({
       {
         key: 'dashboard-duplicate',
         label: t('Duplicate'),
-        onAction: () => handleDuplicate(dashboard),
+        onAction: () => {
+          openConfirmModal({
+            message: t('Are you sure you want to duplicate this dashboard?'),
+            priority: 'primary',
+            onConfirm: () => handleDuplicate(dashboard),
+          });
+        },
       },
       {
         key: 'dashboard-delete',

--- a/static/app/views/dashboards/manage/dashboardTable.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.spec.tsx
@@ -269,7 +269,7 @@ describe('Dashboards - DashboardTable', function () {
 
     await userEvent.click(screen.getAllByTestId('dashboard-duplicate')[1]);
 
-    expect(createMock).not.toHaveBeenCalled();
+    expect(postMock).not.toHaveBeenCalled();
 
     await userEvent.click(
       within(screen.getByRole('dialog')).getByRole('button', {name: /confirm/i})

--- a/static/app/views/dashboards/manage/dashboardTable.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.spec.tsx
@@ -234,8 +234,15 @@ describe('Dashboards - DashboardTable', function () {
         onDashboardsChange={dashboardUpdateMock}
       />
     );
+    renderGlobalModal();
 
     await userEvent.click(screen.getAllByTestId('dashboard-duplicate')[1]);
+
+    expect(createMock).not.toHaveBeenCalled();
+
+    await userEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', {name: /confirm/i})
+    );
 
     await waitFor(() => {
       expect(createMock).toHaveBeenCalled();
@@ -258,8 +265,15 @@ describe('Dashboards - DashboardTable', function () {
         onDashboardsChange={dashboardUpdateMock}
       />
     );
+    renderGlobalModal();
 
     await userEvent.click(screen.getAllByTestId('dashboard-duplicate')[1]);
+
+    expect(createMock).not.toHaveBeenCalled();
+
+    await userEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', {name: /confirm/i})
+    );
 
     await waitFor(() => {
       expect(postMock).toHaveBeenCalled();

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -144,7 +144,11 @@ function DashboardTable({
             <StyledButton
               onClick={e => {
                 e.stopPropagation();
-                handleDuplicate(dataRow);
+                openConfirmModal({
+                  message: t('Are you sure you want to duplicate this dashboard?'),
+                  priority: 'primary',
+                  onConfirm: () => handleDuplicate(dataRow),
+                });
               }}
               aria-label={t('Duplicate Dashboard')}
               data-test-id={'dashboard-duplicate'}


### PR DESCRIPTION
As per Vasudha's request, adding a confirmation pop-up for duplicating dashboards as well (on both grid and table view)

![image](https://github.com/user-attachments/assets/976ab4aa-816a-408c-a62e-78c279425ab5)



