### PR TITLE
ref(models): Include event id in `Event` repr

### DIFF
--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -572,6 +572,11 @@ class Event(BaseEvent):
         state.pop("_groups_cache", None)
         return state
 
+    def __repr__(self):
+        return "<sentry.eventstore.models.Event at 0x{:x}: event_id={}>".format(
+            id(self), self.event_id
+        )
+
     @property
     def data(self) -> NodeData:
         return self._data


### PR DESCRIPTION
Recently, when debugging a grouping error using Sentry, I wanted to know what event we'd been processing at the time the error was thrown, so I could examine its contents. Unfortunately, in the stack locals in the Sentry UI, all I saw was `<sentry.eventstore.models.Event object at 0x7930346ecce0>`. Fortunately, the project in question was low-traffic, so I was able to find the event based on timestamp, but it would have been a whole lot easier with the event id.

This fixes that problem by adding the event id to the `Event` class's `__repr__`, so now in stack locals events appear as `<sentry.eventstore.models.Event at 0x125d619a0: event_id=8c567b1d65a3486da2db52695a5320d5>`.

Note: I chose to keep the full path to the class in the repr - rather than following the `safe_repr` pattern we use with our DB models, under which it would just be <Event at 0x125d619a0: event_id=8c567b1d65a3486da2db52695a5320d5> - because `Event` _isn't_ in fact a postgres model, and therefore doesn't live where other DB models do. As a result, I always forget where the `Event` code is, and have generally found having the full path there a helpful reminder.