### PR TITLE
fix(issues): Release authors type incorrect

### DIFF
--- a/static/app/components/avatar/avatarList.tsx
+++ b/static/app/components/avatar/avatarList.tsx
@@ -1,11 +1,12 @@
 import {forwardRef} from 'react';
-import {css} from '@emotion/react';
+import {css, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import TeamAvatar from 'sentry/components/avatar/teamAvatar';
 import UserAvatar from 'sentry/components/avatar/userAvatar';
 import {Tooltip} from 'sentry/components/tooltip';
 import {space} from 'sentry/styles/space';
+import type {Actor} from 'sentry/types/core';
 import type {Team} from 'sentry/types/organization';
 import type {AvatarUser} from 'sentry/types/user';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
@@ -21,7 +22,7 @@ type Props = {
   teams?: Team[];
   tooltipOptions?: UserAvatarProps['tooltipOptions'];
   typeAvatars?: string;
-  users?: AvatarUser[];
+  users?: Array<Actor | AvatarUser>;
 };
 
 const CollapsedAvatars = forwardRef(function CollapsedAvatars(
@@ -144,7 +145,7 @@ export const AvatarListWrapper = styled('div')`
   flex-direction: row-reverse;
 `;
 
-const AvatarStyle = p => css`
+const AvatarStyle = (p: {theme: Theme}) => css`
   border: 2px solid ${p.theme.background};
   margin-left: -8px;
   cursor: default;

--- a/static/app/components/versionHoverCard.spec.tsx
+++ b/static/app/components/versionHoverCard.spec.tsx
@@ -47,4 +47,29 @@ describe('VersionHoverCard', () => {
 
     expect(await screen.findByText(deploy.environment)).toBeInTheDocument();
   });
+
+  it('renders authors without ids', async () => {
+    const noIdAuthorRelease = ReleaseFixture({
+      authors: [
+        {name: 'Test Author', email: 'test@sentry.io'},
+        {name: 'Test Author 2', email: 'test2@sentry.io'},
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/releases/${encodeURIComponent(noIdAuthorRelease.version)}/`,
+      body: noIdAuthorRelease,
+    });
+
+    render(
+      <VersionHoverCard
+        organization={organization}
+        projectSlug={project.slug}
+        releaseVersion={release.version}
+      >
+        <div>{release.version}</div>
+      </VersionHoverCard>
+    );
+
+    expect(await screen.findByText(release.version)).toBeInTheDocument();
+  });
 });

--- a/static/app/components/versionHoverCard.tsx
+++ b/static/app/components/versionHoverCard.tsx
@@ -1,3 +1,4 @@
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import AvatarList from 'sentry/components/avatar/avatarList';
@@ -13,8 +14,11 @@ import TimeSince from 'sentry/components/timeSince';
 import Version from 'sentry/components/version';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {Actor} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
+import type {User} from 'sentry/types/user';
 import {defined} from 'sentry/utils';
+import {uniqueId} from 'sentry/utils/guid';
 import {useDeploys} from 'sentry/utils/useDeploys';
 import {useRelease} from 'sentry/utils/useRelease';
 import {useRepositories} from 'sentry/utils/useRepositories';
@@ -74,6 +78,19 @@ function VersionHoverCard({
     };
   }
 
+  const authors = useMemo(
+    () =>
+      release?.authors.map<Actor | User>(author =>
+        // Add a unique id if missing
+        ({
+          ...author,
+          type: 'user',
+          id: 'id' in author ? author.id : uniqueId(),
+        })
+      ),
+    [release?.authors]
+  );
+
   function getBody() {
     if (release === undefined || !defined(deploys)) {
       return {header: null, body: null};
@@ -103,7 +120,7 @@ function VersionHoverCard({
                 {release.authors.length !== 1 ? t('authors') : t('author')}{' '}
               </h6>
               <AvatarList
-                users={release.authors}
+                users={authors}
                 avatarSize={25}
                 tooltipOptions={{container: 'body'} as any}
                 typeAvatars="authors"

--- a/static/app/types/release.tsx
+++ b/static/app/types/release.tsx
@@ -76,7 +76,7 @@ export interface ReleaseWithHealth extends BaseRelease, ReleaseData {
 }
 
 interface ReleaseData {
-  authors: User[];
+  authors: Array<User | {email: string; name: string}>;
   commitCount: number;
   currentProjectMeta: {
     firstReleaseVersion: string | null;

--- a/static/app/views/releases/list/releaseCard/releaseCardCommits.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardCommits.tsx
@@ -1,9 +1,13 @@
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import AvatarList from 'sentry/components/avatar/avatarList';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {Actor} from 'sentry/types/core';
 import type {Release} from 'sentry/types/release';
+import type {User} from 'sentry/types/user';
+import {uniqueId} from 'sentry/utils/guid';
 
 type Props = {
   release: Release;
@@ -13,6 +17,20 @@ type Props = {
 function ReleaseCardCommits({release, withHeading = true}: Props) {
   const commitCount = release.commitCount || 0;
   const authorCount = release.authors?.length || 0;
+
+  const authors = useMemo(
+    () =>
+      release.authors.map<Actor | User>(author =>
+        // Add a unique id if missing
+        ({
+          ...author,
+          type: 'user',
+          id: 'id' in author ? author.id : uniqueId(),
+        })
+      ),
+    [release.authors]
+  );
+
   if (commitCount === 0) {
     return null;
   }
@@ -27,7 +45,7 @@ function ReleaseCardCommits({release, withHeading = true}: Props) {
     <div className="release-stats">
       {withHeading && <ReleaseSummaryHeading>{releaseSummary}</ReleaseSummaryHeading>}
       <span style={{display: 'inline-block'}}>
-        <AvatarList users={release.authors} avatarSize={25} typeAvatars="authors" />
+        <AvatarList users={authors} avatarSize={25} typeAvatars="authors" />
       </span>
     </div>
   );


### PR DESCRIPTION
Release authors can be sentry users or they can be `{name: string; email: string}` if no user can be matched.

Fixes react error when iterating over users with no unique id for the key
