### PR TITLE
fix(dashboards): Improve `DashboardCard` interactions

### DIFF
--- a/static/app/views/dashboards/manage/dashboardCard.tsx
+++ b/static/app/views/dashboards/manage/dashboardCard.tsx
@@ -1,7 +1,9 @@
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {ActivityAvatar} from 'sentry/components/activity/item/avatar';
 import Card from 'sentry/components/card';
+import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import type {LinkProps} from 'sentry/components/links/link';
 import Link from 'sentry/components/links/link';
 import {t} from 'sentry/locale';
@@ -33,14 +35,20 @@ function DashboardCard({
     onEventClick?.();
   }
 
+  // Fetch the theme to set the `InteractionStateLayer` color. Otherwise it will
+  // use the `currentColor` of the `Link`, which is blue, and not correct
+  const theme = useTheme();
+
   return (
-    <CardWithoutMargin interactive>
+    <CardWithoutMargin>
       <CardLink
         data-test-id={`card-${title}`}
         onClick={onClick}
         to={to}
         aria-label={title}
       >
+        <InteractionStateLayer as="div" color={theme.textColor} />
+
         <CardHeader>
           <CardContent>
             <Title>{title}</Title>
@@ -89,27 +97,33 @@ const CardWithoutMargin = styled(Card)`
   margin: 0;
 `;
 
+const Title = styled('div')`
+  ${p => p.theme.text.cardTitle};
+  color: ${p => p.theme.headingColor};
+  ${p => p.theme.overflowEllipsis};
+  font-weight: ${p => p.theme.fontWeightNormal};
+`;
+
 const CardLink = styled(Link)`
   position: relative;
   display: flex;
   flex-direction: column;
 
+  color: ${p => p.theme.textColor};
+
   &:focus,
   &:hover {
-    top: -1px;
+    color: ${p => p.theme.textColor};
+
+    ${Title} {
+      text-decoration: underline;
+    }
   }
 `;
 
 const CardHeader = styled('div')`
   display: flex;
   padding: ${space(1.5)} ${space(2)};
-`;
-
-const Title = styled('div')`
-  ${p => p.theme.text.cardTitle};
-  color: ${p => p.theme.headingColor};
-  ${p => p.theme.overflowEllipsis};
-  font-weight: ${p => p.theme.fontWeightNormal};
 `;
 
 const Detail = styled('div')`

--- a/static/app/views/dashboards/manage/dashboardCard.tsx
+++ b/static/app/views/dashboards/manage/dashboardCard.tsx
@@ -34,8 +34,13 @@ function DashboardCard({
   }
 
   return (
-    <Link data-test-id={`card-${title}`} onClick={onClick} to={to} aria-label={title}>
-      <StyledDashboardCard interactive>
+    <CardWithoutMargin interactive>
+      <CardLink
+        data-test-id={`card-${title}`}
+        onClick={onClick}
+        to={to}
+        aria-label={title}
+      >
         <CardHeader>
           <CardContent>
             <Title>{title}</Title>
@@ -60,10 +65,11 @@ function DashboardCard({
               <DateStatus />
             )}
           </DateSelected>
-          {renderContextMenu?.()}
         </CardFooter>
-      </StyledDashboardCard>
-    </Link>
+      </CardLink>
+
+      <ContextMenuWrapper>{renderContextMenu?.()}</ContextMenuWrapper>
+    </CardWithoutMargin>
   );
 }
 
@@ -79,9 +85,15 @@ const CardContent = styled('div')`
   margin-right: ${space(1)};
 `;
 
-const StyledDashboardCard = styled(Card)`
-  justify-content: space-between;
-  height: 100%;
+const CardWithoutMargin = styled(Card)`
+  margin: 0;
+`;
+
+const CardLink = styled(Link)`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+
   &:focus,
   &:hover {
     top: -1px;
@@ -122,6 +134,7 @@ const CardFooter = styled('div')`
   justify-content: space-between;
   align-items: center;
   padding: ${space(1)} ${space(2)};
+  height: 42px;
 `;
 
 const DateSelected = styled('div')`
@@ -135,6 +148,12 @@ const DateSelected = styled('div')`
 const DateStatus = styled('span')`
   color: ${p => p.theme.subText};
   padding-left: ${space(1)};
+`;
+
+const ContextMenuWrapper = styled('div')`
+  position: absolute;
+  right: ${space(2)};
+  bottom: ${space(1)};
 `;
 
 export default DashboardCard;


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/79969, and makes a few other improvements.

1. Removes the current hover state, we didn't like it. Instead of hovering up and getting a box shadown, uses `InteractionStateLayer` and adds a title underline.
2. Moves the context menu outside of the `Link`. This fixes the linked issue, and prevents problems with accidentally activating the `Link` hover and active states

**e.g.,**

https://github.com/user-attachments/assets/4b205821-0fe6-43e7-a6cc-114c6cfed855

