### PR TITLE
fix(discover): Persist environment on next event view

### DIFF
--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -369,6 +369,9 @@ export class Results extends Component<Props, State> {
     if (nextEventView.project.length === 0 && selection.projects) {
       nextEventView.project = selection.projects;
     }
+    if (nextEventView.environment.length === 0 && selection.environments) {
+      nextEventView.environment = selection.environments;
+    }
     if (selection.datetime) {
       const {period, utc, start, end} = selection.datetime;
       nextEventView.statsPeriod = period ?? undefined;


### PR DESCRIPTION
Navigation to discover doesn't keep the environment query in the url
this fixes the issue.

Fixes https://github.com/getsentry/sentry/issues/81360