### PR TITLE
fix(insights): add missing slash on performance moving banner

### DIFF
--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -105,13 +105,19 @@ export function PerformanceLanding(props: Props) {
         {t(
           `To make it easier to see what's relevant for you, Sentry's Performance landing page is now being split into separate `
         )}
-        <Link to={getPerformanceBaseUrl(slug, 'frontend')}>{FRONTEND_SIDEBAR_LABEL}</Link>
+        <Link to={`${getPerformanceBaseUrl(slug, 'frontend')}/`}>
+          {FRONTEND_SIDEBAR_LABEL}
+        </Link>
         {`, `}
-        <Link to={getPerformanceBaseUrl(slug, 'backend')}>{BACKEND_SIDEBAR_LABEL}</Link>
+        <Link to={`${getPerformanceBaseUrl(slug, 'backend')}/`}>
+          {BACKEND_SIDEBAR_LABEL}
+        </Link>
         {`, `}
-        <Link to={getPerformanceBaseUrl(slug, 'mobile')}>{MOBILE_SIDEBAR_LABEL}</Link>
+        <Link to={`${getPerformanceBaseUrl(slug, 'mobile')}/`}>
+          {MOBILE_SIDEBAR_LABEL}
+        </Link>
         {t(', and ')}
-        <Link to={getPerformanceBaseUrl(slug, 'ai')}>{AI_SIDEBAR_LABEL}</Link>
+        <Link to={`${getPerformanceBaseUrl(slug, 'ai')}/`}>{AI_SIDEBAR_LABEL}</Link>
         {t(' performance pages. They can all be found in the Insights tab.')}
       </Fragment>
     );


### PR DESCRIPTION
On the following banner in the performance landing page
<img width="1264" alt="image" src="https://github.com/user-attachments/assets/5200632d-7014-4279-b702-a9ce6a356fa0">

We have links that take them to the frontend, backend, mobile and ai domain views. These links were missing a trailing slash, which means when they are clicked, the sidebar did not correctly indicate what page they were on.
| Before | After |
|--------|--------|
| <img width="693" alt="image" src="https://github.com/user-attachments/assets/205ab416-2d5f-4b56-b4f4-a355a9fc5c64"> | <img width="679" alt="image" src="https://github.com/user-attachments/assets/addef79e-b3af-4052-b75f-d604879db0d9"> | 

