### PR TITLE
feat(issue-details): Small UI Fixes

### DIFF
--- a/static/app/views/issueDetails/streamline/eventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.tsx
@@ -474,6 +474,7 @@ const DropdownCountWrapper = styled('div')<{isCurrentTab: boolean}>`
   align-items: center;
   justify-content: space-between;
   gap: ${space(3)};
+  font-variant-numeric: tabular-nums;
   font-weight: ${p =>
     p.isCurrentTab ? p.theme.fontWeightBold : p.theme.fontWeightNormal};
 `;

--- a/static/app/views/issueDetails/streamline/sidebar/activitySection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/activitySection.tsx
@@ -63,7 +63,7 @@ function TimelineItem({
     <ActivityTimelineItem
       title={
         <Flex gap={space(0.5)} align="center" justify="flex-start">
-          <TitleTooltip title={title} showOnlyOnOverflow skipWrapper>
+          <TitleTooltip title={title} showOnlyOnOverflow>
             {title}
           </TitleTooltip>
           {item.type === GroupActivityType.NOTE && (
@@ -265,6 +265,7 @@ export default function StreamlinedActivitySection({
 }
 
 const TitleTooltip = styled(Tooltip)`
+  flex: 1;
   justify-self: start;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/static/app/views/issueDetails/streamline/sidebar/activitySection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/activitySection.tsx
@@ -265,7 +265,6 @@ export default function StreamlinedActivitySection({
 }
 
 const TitleTooltip = styled(Tooltip)`
-  flex: 1;
   justify-self: start;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
Activity title overlaps with timestamp (needed wrapper):
<img width="308" alt="image" src="https://github.com/user-attachments/assets/7b4864ba-4a41-4766-b636-c67f94b89365">


Tabular Nums:
<img width="374" alt="image" src="https://github.com/user-attachments/assets/0afbf535-979b-407a-ba1d-6da89ec97010">
