### PR TITLE
chore(insights): Remove insights alerts progress

### DIFF
--- a/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
+++ b/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
@@ -5,7 +5,6 @@ import {hasCustomMetrics} from 'sentry/utils/metrics/features';
 import {hasOnDemandMetricAlertFeature} from 'sentry/utils/onDemandMetrics/features';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {getMEPAlertsDataset} from 'sentry/views/alerts/wizard/options';
-import {hasInsightsAlerts} from 'sentry/views/insights/common/utils/hasInsightsAlerts';
 
 import {Dataset, type MetricRule} from '../types';
 
@@ -32,8 +31,7 @@ export function getMetricDatasetQueryExtras({
     hasOnDemandMetricAlertFeature(organization) ||
     hasCustomMetrics(organization) ||
     organization.features.includes('mep-rollout-flag') ||
-    organization.features.includes('dashboards-metrics-transition') ||
-    hasInsightsAlerts(organization);
+    organization.features.includes('dashboards-metrics-transition');
   const disableMetricDataset =
     decodeScalar(location?.query?.disableMetricDataset) === 'true';
 

--- a/static/app/views/alerts/rules/metric/wizardField.tsx
+++ b/static/app/views/alerts/rules/metric/wizardField.tsx
@@ -25,7 +25,6 @@ import {QueryField} from 'sentry/views/discover/table/queryField';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 import {generateFieldOptions} from 'sentry/views/discover/utils';
 import {hasEAPAlerts} from 'sentry/views/insights/common/utils/hasEAPAlerts';
-import {hasInsightsAlerts} from 'sentry/views/insights/common/utils/hasInsightsAlerts';
 
 import {getFieldOptionConfig} from './metricField';
 
@@ -118,14 +117,6 @@ export default function WizardField({
               {
                 label: AlertWizardAlertNames.custom_transactions,
                 value: 'custom_transactions' as const,
-              },
-            ]
-          : []),
-        ...(hasInsightsAlerts(organization)
-          ? [
-              {
-                label: AlertWizardAlertNames.insights_metrics,
-                value: 'insights_metrics' as const,
               },
             ]
           : []),

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -29,7 +29,6 @@ import {
   SessionsAggregate,
 } from 'sentry/views/alerts/rules/metric/types';
 import {hasEAPAlerts} from 'sentry/views/insights/common/utils/hasEAPAlerts';
-import {hasInsightsAlerts} from 'sentry/views/insights/common/utils/hasInsightsAlerts';
 import {MODULE_TITLE as LLM_MONITORING_MODULE_TITLE} from 'sentry/views/insights/llmMonitoring/settings';
 
 export type AlertType =
@@ -140,7 +139,6 @@ export const getAlertWizardCategories = (org: Organization) => {
         'fid',
         'cls',
         ...(hasCustomMetrics(org) ? (['custom_transactions'] satisfies AlertType[]) : []),
-        ...(hasInsightsAlerts(org) ? ['insights_metrics' as const] : []),
         ...(hasEAPAlerts(org) ? ['eap_metrics' as const] : []),
       ],
     });

--- a/static/app/views/insights/common/components/chartPanel.spec.tsx
+++ b/static/app/views/insights/common/components/chartPanel.spec.tsx
@@ -1,5 +1,5 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import ChartPanel from 'sentry/views/insights/common/components/chartPanel';
 
@@ -7,28 +7,13 @@ describe('chartPanel', function () {
   const {organization} = initializeOrg({
     organization: {features: ['insights-alerts', 'insights-initial-modules']},
   });
-
-  it('should render create alert options', async function () {
-    const alertConfigs = [
-      {
-        aggregate: 'avg(d:spans/duration@millisecond)',
-        query: 'span.module:db has:span.description',
-        name: 'Average DB Duration',
-      },
-      {
-        aggregate: 'spm()',
-        query: 'span.module:db has:span.description',
-        name: 'DB Spans per minute',
-      },
-    ];
+  it('should render', function () {
     render(
-      <ChartPanel title="Avg Latency" alertConfigs={alertConfigs}>
+      <ChartPanel title="Avg Latency">
         <div />
       </ChartPanel>,
       {organization}
     );
-    await userEvent.click(screen.getByLabelText('Chart Actions'));
-    screen.getByText('Average DB Duration');
-    screen.getByText('DB Spans per minute');
+    expect(screen.getByText('Avg Latency')).toBeInTheDocument();
   });
 });

--- a/static/app/views/insights/common/components/chartPanel.tsx
+++ b/static/app/views/insights/common/components/chartPanel.tsx
@@ -1,20 +1,11 @@
-import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {openInsightChartModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/button';
-import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import Panel from 'sentry/components/panels/panel';
-import {IconEllipsis, IconExpand} from 'sentry/icons';
+import {IconExpand} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {trackAnalytics} from 'sentry/utils/analytics';
-import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
-import useProjects from 'sentry/utils/useProjects';
-import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
-import {hasInsightsAlerts} from 'sentry/views/insights/common/utils/hasInsightsAlerts';
-import {useModuleNameFromUrl} from 'sentry/views/insights/common/utils/useModuleNameFromUrl';
 import {Subtitle} from 'sentry/views/performance/landing/widgets/widgets/singleFieldAreaWidget';
 
 export type AlertConfig = {
@@ -37,65 +28,8 @@ export default function ChartPanel({
   children,
   button,
   subtitle,
-  alertConfigs,
   className,
 }: Props) {
-  const organization = useOrganization();
-  const {selection} = usePageFilters();
-  const {projects} = useProjects();
-  const project = useMemo(
-    () =>
-      selection.projects.length === 1
-        ? projects.find(p => p.id === `${selection.projects[0]}`)
-        : undefined,
-    [projects, selection.projects]
-  );
-  const moduleName = useModuleNameFromUrl();
-  const alertsUrls =
-    alertConfigs?.map(alertConfig => {
-      // Alerts only support single project selection and one or all environment
-      const singleProject = selection.projects.length === 1 && project;
-      const singleEnvironment = selection.environments.length <= 1;
-      const alertsUrl =
-        alertConfig && singleProject && singleEnvironment
-          ? getAlertsUrl({
-              project,
-              orgSlug: organization.slug,
-              pageFilters: selection,
-              name: typeof title === 'string' ? title : undefined,
-              ...alertConfig,
-            })
-          : undefined;
-      const name = alertConfig.name ?? 'Create Alert';
-      const disabled = !singleProject || !singleEnvironment;
-      const tooltip = !singleProject
-        ? t(
-            'Alerts are only available for single project selection. Update your project filter to create an alert.'
-          )
-        : !singleEnvironment
-          ? t(
-              'Alerts are only available with at most one environment selection. Update your environment filter to create an alert.'
-            )
-          : undefined;
-      return {
-        key: name,
-        label: name,
-        to: alertsUrl,
-        disabled,
-        tooltip,
-        onClick: () => {
-          trackAnalytics('insight.general.create_alert', {
-            organization,
-            chart_name: typeof title === 'string' ? title : undefined,
-            alert_name: name,
-            source: moduleName ?? undefined,
-          });
-        },
-      };
-    }) ?? [];
-
-  const dropdownMenuItems = hasInsightsAlerts(organization) ? alertsUrls : [];
-
   return (
     <PanelWithNoPadding className={className}>
       <PanelBody>
@@ -112,19 +46,6 @@ export default function ChartPanel({
             )}
             <MenuContainer>
               {button}
-              {dropdownMenuItems.length > 0 && (
-                <DropdownMenu
-                  triggerProps={{
-                    'aria-label': t('Chart Actions'),
-                    size: 'xs',
-                    borderless: true,
-                    showChevron: false,
-                    icon: <IconEllipsis direction="down" size="sm" />,
-                  }}
-                  position="bottom-end"
-                  items={dropdownMenuItems}
-                />
-              )}
               <Button
                 aria-label={t('Expand Insight Chart')}
                 borderless

--- a/static/app/views/insights/common/utils/hasInsightsAlerts.tsx
+++ b/static/app/views/insights/common/utils/hasInsightsAlerts.tsx
@@ -1,8 +1,0 @@
-import type {Organization} from 'sentry/types/organization';
-
-export function hasInsightsAlerts(organization: Organization): boolean {
-  return (
-    organization.features.includes('insights-initial-modules') &&
-    organization.features.includes('insights-alerts')
-  );
-}


### PR DESCRIPTION
Removes areas that use insights alert flag checks and control display in the UI, since they will be replaced by eap alerts.