### PR TITLE
fix(performance): No table overflow + glitchy behaviour

### DIFF
--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -570,6 +570,7 @@ class _Table extends Component<Props, State> {
                           data={tableData ? tableData.data : []}
                           columnOrder={columnOrder}
                           columnSortBy={columnSortBy}
+                          bodyStyle={{overflow: 'visible'}}
                           grid={{
                             onResizeColumn: this.handleResizeColumn,
                             renderHeadCell: this.renderHeadCellWithMeta(


### PR DESCRIPTION
Fixes glitchy behaviour when table does not allow overflow. Now the overflow is visible outside the table.
Feedback link: https://sentry.sentry.io/feedback/?feedbackSlug=javascript%3A6094894234&project=11276

Before
<img width="395" alt="image" src="https://github.com/user-attachments/assets/f0a27839-3c5b-47d3-be55-d6edb244281c">

After
<img width="464" alt="image" src="https://github.com/user-attachments/assets/9b4d2f49-5a75-449c-9da7-73cb035001c5">

