### PR TITLE
feat(new-trace): Redesigning error drawer content

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/error.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/error.tsx
@@ -10,6 +10,7 @@ import {
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {generateIssueEventTarget} from 'sentry/components/quickTrace/utils';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {EventError} from 'sentry/types/event';
 import {useApiQuery} from 'sentry/utils/queryClient';
 
@@ -19,11 +20,61 @@ import {TraceTree} from '../../traceModels/traceTree';
 import type {TraceTreeNode} from '../../traceModels/traceTreeNode';
 import {makeTraceNodeBarColor} from '../../traceRow/traceBar';
 import {getTraceTabTitle} from '../../traceState/traceTabs';
+import {useHasTraceNewUi} from '../../useHasTraceNewUi';
 
 import {IssueList} from './issues/issues';
 import {type SectionCardKeyValueList, TraceDrawerComponents} from './styles';
 
-export function ErrorNodeDetails({
+export function ErrorNodeDetails(
+  props: TraceTreeNodeDetailsProps<TraceTreeNode<TraceTree.TraceError>>
+) {
+  const hasTraceNewUi = useHasTraceNewUi();
+  const {node, organization, onTabScrollToNode} = props;
+  const issues = useMemo(() => {
+    return [...node.errors];
+  }, [node.errors]);
+
+  if (!hasTraceNewUi) {
+    return <LegacyErrorNodeDetails {...props} />;
+  }
+
+  return (
+    <TraceDrawerComponents.DetailContainer hasNewTraceUi={hasTraceNewUi}>
+      <TraceDrawerComponents.HeaderContainer>
+        <TraceDrawerComponents.Title>
+          <TraceDrawerComponents.LegacyTitleText>
+            <TraceDrawerComponents.TitleText>
+              {t('Error')}
+            </TraceDrawerComponents.TitleText>
+            <TraceDrawerComponents.SubtitleWithCopyButton
+              text={`ID: ${props.node.value.event_id}`}
+            />
+          </TraceDrawerComponents.LegacyTitleText>
+        </TraceDrawerComponents.Title>
+        <TraceDrawerComponents.NodeActions
+          node={node}
+          organization={organization}
+          onTabScrollToNode={onTabScrollToNode}
+        />
+      </TraceDrawerComponents.HeaderContainer>
+      <Description>
+        {t(
+          'This error is related to an ongoing issue. For details about how many users this affects and more, go to the issue below.'
+        )}
+      </Description>
+      <IssueList issues={issues} node={node} organization={organization} />
+    </TraceDrawerComponents.DetailContainer>
+  );
+}
+
+const Description = styled('div')`
+  margin-bottom: ${space(2)};
+  font-size: ${p => p.theme.fontSizeLarge};
+  line-height: 1.5;
+  text-align: left;
+`;
+
+function LegacyErrorNodeDetails({
   node,
   organization,
   onTabScrollToNode,
@@ -133,7 +184,6 @@ export function ErrorNodeDetails({
     </TraceDrawerComponents.DetailContainer>
   ) : null;
 }
-
 const StackTraceWrapper = styled('div')`
   .traceback {
     margin-bottom: 0;


### PR DESCRIPTION
Designs: [link](https://www.figma.com/design/zfReOSQiHfODLLoFWpYVdW/Trace-V3?node-id=42-1924&node-type=frame&t=WGeiXNC70KIF6zWC-0)

Feature Flag: trace-view-new-ui

To summarize the changes, the current ui components are converted to `LegacyComponent` and the new code exists under `Component`. It'll make it easier to cleanup once we've reached general availability.

<img width="1308" alt="Screenshot 2024-11-27 at 2 03 34 PM" src="https://github.com/user-attachments/assets/b360d4fe-2b60-49df-a221-f00c4e490be1">
