### PR TITLE
feat(oauth): Adding org to ApiAuthorizationSerializer

### DIFF
--- a/src/sentry/api/serializers/models/apiauthorization.py
+++ b/src/sentry/api/serializers/models/apiauthorization.py
@@ -1,5 +1,6 @@
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models.apiauthorization import ApiAuthorization
+from sentry.organizations.services.organization import organization_service
 
 
 @register(ApiAuthorization)
@@ -23,4 +24,9 @@ class ApiAuthorizationSerializer(Serializer):
             "scopes": obj.get_scopes(),
             "application": attrs["application"],
             "dateCreated": obj.date_added,
+            "organization": (
+                organization_service.serialize_organization(id=obj.organization_id)
+                if obj.organization_id
+                else None
+            ),
         }

--- a/tests/sentry/api/endpoints/test_api_authorizations.py
+++ b/tests/sentry/api/endpoints/test_api_authorizations.py
@@ -25,6 +25,18 @@ class ApiAuthorizationsListTest(ApiAuthorizationsTest):
         response = self.get_success_response()
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(auth.id)
+        assert response.data[0]["organization"] is None
+
+    def test_org_level_auth(self):
+        org = self.create_organization(owner=self.user, slug="test-org-slug")
+        app = ApiApplication.objects.create(
+            name="test", owner=self.user, requires_org_level_access=True
+        )
+        ApiAuthorization.objects.create(application=app, user=self.user, organization_id=org.id)
+
+        response = self.get_success_response()
+        assert len(response.data) == 1
+        assert response.data[0]["organization"]["slug"] == org.slug
 
 
 @control_silo_test


### PR DESCRIPTION
As part of latest partnership oauth changes now we have ApiAuthorizations that are specific to an org. We want to display this org in the frontend to the user because user can have multiple one for each org. Adding org to the serializer.

Frontend PR: https://github.com/getsentry/sentry/pull/81383
<img width="1016" alt="Screenshot 2024-11-27 at 11 41 01 AM" src="https://github.com/user-attachments/assets/d579cd40-5aea-4d6f-b4d6-b72f6c80cec6">

