### PR TITLE
feat(oauth): Display org name for org scoped authorizations

### DIFF
--- a/static/app/views/settings/account/accountAuthorizations.tsx
+++ b/static/app/views/settings/account/accountAuthorizations.tsx
@@ -15,6 +15,7 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconDelete} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {Organization} from 'sentry/types/organization';
 import type {ApiApplication} from 'sentry/types/user';
 import {setApiQueryData, useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
@@ -24,6 +25,7 @@ type Authorization = {
   application: ApiApplication;
   homepageUrl: string;
   id: string;
+  organization: Organization | null;
   scopes: string[];
 };
 
@@ -94,7 +96,13 @@ function AccountAuthorizations() {
                         </ExternalLink>
                       </Url>
                     )}
-                    <Scopes>{authorization.scopes.join(', ')}</Scopes>
+                    <DetailRow>{authorization.scopes.join(', ')}</DetailRow>
+                    {authorization.organization && (
+                      <DetailRow>
+                        {t('scopes are limitted to ')}
+                        {authorization.organization.slug}
+                      </DetailRow>
+                    )}
                   </ApplicationDetails>
                   <Button
                     size="sm"
@@ -144,7 +152,7 @@ const Url = styled('div')`
   font-size: ${p => p.theme.fontSizeRelativeSmall};
 `;
 
-const Scopes = styled('div')`
+const DetailRow = styled('div')`
   color: ${p => p.theme.gray300};
   font-size: ${p => p.theme.fontSizeRelativeSmall};
 `;


### PR DESCRIPTION
<img width="1016" alt="Screenshot 2024-11-27 at 11 41 01 AM" src="https://github.com/user-attachments/assets/26f09420-0857-404f-839c-4eacf9920094">
