### PR TITLE
spike(aci): update and serialize project options attached to ErrorDetector

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -541,6 +541,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:widget-viewer-modal-minimap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enabled unresolved issue webhook for organization
     manager.add("organizations:webhooks-unresolved", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=True)
+    # Enable project options through a detector
+    manager.add("organizations:detector-project-options", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # Enable EventUniqueUserFrequencyConditionWithConditions special alert condition
     manager.add("organizations:event-unique-user-frequency-condition-with-conditions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Use spans instead of transactions for dynamic sampling calculations. This will become the new default.

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -74,6 +74,7 @@ class GroupingConfigLoader:
         }
 
     def _get_enhancements(self, project) -> str:
+        # project option editable via UI, will be on Error Detector page
         enhancements = project.get_option("sentry:grouping_enhancements")
 
         config_id = self._get_config_id(project)
@@ -214,6 +215,7 @@ def get_fingerprinting_config_for_project(
     from sentry.grouping.fingerprinting import FingerprintingRules, InvalidFingerprintingConfig
 
     bases = get_projects_default_fingerprinting_bases(project, config_id=config_id)
+    # project option editable via UI, will be on Error Detector page
     rules = project.get_option("sentry:fingerprinting_rules")
     if not rules:
         return FingerprintingRules([], bases=bases)

--- a/src/sentry/tasks/auto_resolve_issues.py
+++ b/src/sentry/tasks/auto_resolve_issues.py
@@ -43,6 +43,7 @@ def schedule_auto_resolution():
 
     cutoff = time() - ONE_HOUR
     for project_id, options in opts_by_project.items():
+        # project option editable via UI, will be on Error Detector page
         if not options.get("sentry:resolve_age"):
             # kill the option to avoid it coming up in the future
             ProjectOption.objects.filter(

--- a/src/sentry/workflow_engine/endpoints/validators/error_detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/error_detector.py
@@ -1,0 +1,44 @@
+from django.db import router, transaction
+from rest_framework import serializers
+
+from sentry import audit_log
+from sentry.api.fields.empty_integer import EmptyIntegerField
+from sentry.utils.audit import create_audit_entry
+from sentry.workflow_engine.endpoints.validators import BaseGroupTypeDetectorValidator
+from sentry.workflow_engine.models.detector import Detector, ErrorDetector
+
+
+class ErrorDetectorValidator(BaseGroupTypeDetectorValidator):
+    groupingEnhancements = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+    fingerprintingRules = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+    resolveAge = EmptyIntegerField(
+        required=False,
+        allow_null=True,
+        help_text="Automatically resolve an issue if it hasn't been seen for this many hours. Set to `0` to disable auto-resolve.",
+    )
+
+    def create(self, validated_data):
+        with transaction.atomic(router.db_for_write(Detector)):
+            detector: ErrorDetector = ErrorDetector.objects.create(
+                project_id=self.context["project"].id,
+                organization_id=self.context["project"].organization_id,
+                name=validated_data["name"],
+                # no workflow_condition_group
+                type=validated_data["group_type"].slug,
+            )
+
+            project = detector.project
+            # update configs, which are project options. continue using them
+            for config in validated_data:
+                project.update_option(
+                    detector.project_options_config[config], validated_data[config]
+                )
+
+            create_audit_entry(
+                request=self.context["request"],
+                organization=self.context["organization"],
+                target_object=detector.id,
+                event=audit_log.get_event_id("DETECTOR_ADD"),
+                data=detector.get_audit_log_data(),
+            )
+        return detector

--- a/src/sentry/workflow_engine/endpoints/validators/error_detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/error_detector.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 
 from sentry import audit_log
 from sentry.api.fields.empty_integer import EmptyIntegerField
+from sentry.models.project import Project
 from sentry.utils.audit import create_audit_entry
 from sentry.workflow_engine.endpoints.validators import BaseGroupTypeDetectorValidator
 from sentry.workflow_engine.models.detector import Detector, ErrorDetector
@@ -27,12 +28,13 @@ class ErrorDetectorValidator(BaseGroupTypeDetectorValidator):
                 type=validated_data["group_type"].slug,
             )
 
-            project = detector.project
-            # update configs, which are project options. continue using them
-            for config in validated_data:
-                project.update_option(
-                    detector.project_options_config[config], validated_data[config]
-                )
+            project: Project | None = detector.project
+            if project:
+                # update configs, which are project options. continue using them
+                for config in validated_data:
+                    project.update_option(
+                        detector.project_options_config[config], validated_data[config]
+                    )
 
             create_audit_entry(
                 request=self.context["request"],

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import builtins
 import logging
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from django.conf import settings
@@ -105,6 +106,14 @@ class Detector(DefaultFieldsModel, OwnerModel, JSONConfigBase):
     def get_audit_log_data(self) -> dict[str, Any]:
         # TODO: Create proper audit log data for the detector, group and conditions
         return {}
+
+    def get_option(
+        self, key: str, default: Any | None = None, validate: Callable[[object], bool] | None = None
+    ) -> Any:
+        if not self.project:
+            raise ValueError("Detector must have a project to get options")
+
+        return self.project.get_option(key, default=default, validate=validate)
 
 
 class ErrorDetector(Detector):

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -105,3 +105,20 @@ class Detector(DefaultFieldsModel, OwnerModel, JSONConfigBase):
     def get_audit_log_data(self) -> dict[str, Any]:
         # TODO: Create proper audit log data for the detector, group and conditions
         return {}
+
+
+class ErrorDetector(Detector):
+    class Meta:
+        proxy = True
+
+    @property
+    def CONFIG_SCHEMA(self) -> dict[str, Any]:
+        return {}
+
+    @property
+    def project_options_config(self) -> dict[str, str]:
+        return {
+            "groupingEnhancements": "sentry:grouping_enhancements",
+            "fingerprintingRules": "sentry:fingerprinting_rules",
+            "resolveAge": "sentry:resolve_age",
+        }


### PR DESCRIPTION
Leave the underlying usage of project options for grouping and auto-resolve. But collect them for serializing an error detector and updating an error detector via the API.