### PR TITLE
feat(widget-builder): Add useWidgetBuilderState hook with title

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -40,6 +40,7 @@ import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metr
 import {MetricsResultsMetaProvider} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {OnDemandControlProvider} from 'sentry/utils/performance/contexts/onDemandControl';
+import {decodeScalar} from 'sentry/utils/queryString';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -54,6 +55,7 @@ import {
   isWidgetUsingTransactionName,
   resetPageFilters,
 } from 'sentry/views/dashboards/utils';
+import DevBuilder from 'sentry/views/dashboards/widgetBuilder/components/devBuilder';
 import {DataSet} from 'sentry/views/dashboards/widgetBuilder/utils';
 import WidgetLegendNameEncoderDecoder from 'sentry/views/dashboards/widgetLegendNameEncoderDecoder';
 import {MetricsDataSwitcherAlert} from 'sentry/views/performance/landing/metricsDataSwitcherAlert';
@@ -1135,8 +1137,22 @@ class DashboardDetail extends Component<Props, State> {
     );
   }
 
+  /**
+   * This is a temporary component to test the new widget builder hook during development.
+   */
+  renderDevWidgetBuilder() {
+    return <DevBuilder />;
+  }
+
   render() {
-    const {organization} = this.props;
+    const {organization, location} = this.props;
+
+    if (
+      organization.features.includes('dashboards-widget-builder-redesign') &&
+      decodeScalar(location.query?.devBuilder) === 'true'
+    ) {
+      return this.renderDevWidgetBuilder();
+    }
 
     if (this.isWidgetBuilderRouter) {
       return this.renderWidgetBuilder();

--- a/static/app/views/dashboards/widgetBuilder/components/devBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/devBuilder.tsx
@@ -1,0 +1,46 @@
+import styled from '@emotion/styled';
+
+import Input from 'sentry/components/input';
+import {space} from 'sentry/styles/space';
+import useWidgetBuilderState, {
+  BuilderStateAction,
+} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
+
+function DevBuilder() {
+  const {state, dispatch} = useWidgetBuilderState();
+
+  return (
+    <Body>
+      <Section>
+        <h1>Title:</h1>
+        <div style={{flex: 1}}>{state.title}</div>
+        <TitleInput
+          value={state.title}
+          onChange={e =>
+            dispatch({type: BuilderStateAction.SET_TITLE, payload: e.target.value})
+          }
+        />
+      </Section>
+    </Body>
+  );
+}
+
+const Body = styled('div')`
+  margin: ${space(2)};
+  padding: ${space(2)};
+`;
+
+const Section = styled('section')`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  border: 1px solid ${p => p.theme.border};
+  align-items: center;
+`;
+
+const TitleInput = styled(Input)`
+  width: 100%;
+  flex: 1;
+`;
+
+export default DevBuilder;

--- a/static/app/views/dashboards/widgetBuilder/hooks/useTitle.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useTitle.spec.tsx
@@ -1,0 +1,36 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+
+import {renderHook} from 'sentry-test/reactTestingLibrary';
+
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useTitle} from 'sentry/views/dashboards/widgetBuilder/hooks/useTitle';
+
+jest.mock('sentry/utils/useLocation');
+
+jest.mock('sentry/utils/useNavigate');
+
+const mockedUsedLocation = jest.mocked(useLocation);
+const mockedUseNavigate = jest.mocked(useNavigate);
+
+describe('useTitle', () => {
+  it('returns the title from the query params', () => {
+    mockedUsedLocation.mockReturnValue(LocationFixture({query: {title: 'test'}}));
+
+    const {result} = renderHook(() => useTitle());
+
+    expect(result.current[0]).toBe('test');
+  });
+
+  it('sets the new title in the query params', () => {
+    const mockNavigate = jest.fn();
+    mockedUseNavigate.mockReturnValue(mockNavigate);
+
+    const {result} = renderHook(() => useTitle());
+    result.current[1]('new title');
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({query: expect.objectContaining({title: 'new title'})})
+    );
+  });
+});

--- a/static/app/views/dashboards/widgetBuilder/hooks/useTitle.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useTitle.tsx
@@ -1,0 +1,32 @@
+import {useCallback} from 'react';
+
+import {decodeScalar} from 'sentry/utils/queryString';
+import useLocationQuery from 'sentry/utils/url/useLocationQuery';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+
+export function useTitle(): [string | undefined, (newTitle: string) => void] {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const {title} = useLocationQuery({
+    fields: {
+      title: decodeScalar,
+    },
+  });
+
+  const setTitle = useCallback(
+    (newTitle: string) => {
+      navigate({
+        ...location,
+        query: {
+          ...location.query,
+          title: newTitle,
+        },
+      });
+    },
+    [location, navigate]
+  );
+
+  return [title, setTitle];
+}

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -1,0 +1,42 @@
+import {useCallback, useMemo} from 'react';
+
+import {useTitle} from 'sentry/views/dashboards/widgetBuilder/hooks/useTitle';
+
+export const BuilderStateAction = {
+  SET_TITLE: 'SET_TITLE',
+} as const;
+
+type WidgetAction = {payload: string; type: typeof BuilderStateAction.SET_TITLE};
+
+interface WidgetBuilderState {
+  title?: string;
+}
+
+function useWidgetBuilderState(): {
+  dispatch: (action: WidgetAction) => void;
+  state: WidgetBuilderState;
+} {
+  const [title, setTitle] = useTitle();
+
+  const state = useMemo(() => ({title}), [title]);
+
+  const dispatch = useCallback(
+    (action: WidgetAction) => {
+      switch (action.type) {
+        case BuilderStateAction.SET_TITLE:
+          setTitle(action.payload);
+          break;
+        default:
+          throw new Error(`Unknown action type: ${action.type}`);
+      }
+    },
+    [setTitle]
+  );
+
+  return {
+    state,
+    dispatch,
+  };
+}
+
+export default useWidgetBuilderState;


### PR DESCRIPTION
Exposes a title field in the widget builder. Also adds a feature flagged dev page that will be used as a quick sandbox to test this hook more broadly with simple UI. The hidden page can be accessed on any dashboard page with the feature flag and adding `devBuilder=true` to the URL.

I just added `title` so far to keep this smaller. The title is read from the URL params and when updates are made to the hook, the URL params are updated. i.e. the URL params are the source of truth.