### PR TITLE
fix(prompts): Properly return false instead of undefined when prompt data is null

### DIFF
--- a/static/app/actionCreators/prompts.tsx
+++ b/static/app/actionCreators/prompts.tsx
@@ -152,16 +152,15 @@ export function usePrompt({
   const prompt = usePromptsCheck({feature, organization, projectId}, options);
   const queryClient = useQueryClient();
 
-  const isPromptDismissed =
-    prompt.isSuccess && prompt.data.data
-      ? promptIsDismissed(
-          {
-            dismissedTime: prompt.data.data.dismissed_ts,
-            snoozedTime: prompt.data.data.snoozed_ts,
-          },
-          daysToSnooze
-        )
-      : undefined;
+  const isPromptDismissed = prompt.isSuccess
+    ? promptIsDismissed(
+        {
+          dismissedTime: prompt.data?.data?.dismissed_ts,
+          snoozedTime: prompt.data?.data?.snoozed_ts,
+        },
+        daysToSnooze
+      )
+    : undefined;
 
   const dismissPrompt = useCallback(() => {
     if (!organization) {

--- a/static/app/components/sidebar/index.spec.tsx
+++ b/static/app/components/sidebar/index.spec.tsx
@@ -427,12 +427,12 @@ describe('Sidebar', function () {
     it('should render the sidebar banner with no dismissed prompts and an existing rollback', async () => {
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/prompts-activity/`,
-        body: {data: {}},
+        body: {data: null},
       });
 
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/user-rollback/`,
-        body: {data: {}},
+        body: {data: null},
       });
 
       renderSidebarWithFeatures(['sentry-rollback-2024']);
@@ -443,7 +443,7 @@ describe('Sidebar', function () {
     it('will not render anything if the user does not have a rollback', async () => {
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/prompts-activity/`,
-        body: {data: {}},
+        body: {data: null},
       });
 
       MockApiClient.addMockResponse({
@@ -463,12 +463,12 @@ describe('Sidebar', function () {
     it('will not render sidebar banner when collapsed', async () => {
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/prompts-activity/`,
-        body: {data: {}},
+        body: {data: null},
       });
 
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/user-rollback/`,
-        body: {data: {}},
+        body: {data: null},
       });
 
       renderSidebarWithFeatures(['sentry-rollback-2024']);
@@ -483,12 +483,12 @@ describe('Sidebar', function () {
     it('should show dot on org dropdown after dismissing sidebar banner', async () => {
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/prompts-activity/`,
-        body: {data: {}},
+        body: {data: null},
       });
 
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/user-rollback/`,
-        body: {data: {}},
+        body: {data: null},
       });
 
       const dismissMock = MockApiClient.addMockResponse({


### PR DESCRIPTION
`usePrompt` was checking for `data.data`, but that may be `null` if the prompt has never been dismissed. It used to return `undefined`, but it should have been returning `false`. This doesn't affect other usages of `usePrompt` because they were just checking truthiness, whereas the Rollback prompt was checking specifically for `false`.