### PR TITLE
feat(uptime): Make consumer able to run in parallel

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -135,6 +135,37 @@ def ingest_monitors_options() -> list[click.Option]:
     return options
 
 
+def uptime_options() -> list[click.Option]:
+    """Return a list of uptime-results options."""
+    options = [
+        click.Option(
+            ["--mode", "mode"],
+            type=click.Choice(["serial", "parallel"]),
+            default="serial",
+            help="The mode to process results in. Parallel uses multithreading.",
+        ),
+        click.Option(
+            ["--max-batch-size", "max_batch_size"],
+            type=int,
+            default=500,
+            help="Maximum number of results to batch before processing in parallel.",
+        ),
+        click.Option(
+            ["--max-batch-time", "max_batch_time"],
+            type=int,
+            default=1,
+            help="Maximum time spent batching results to batch before processing in parallel.",
+        ),
+        click.Option(
+            ["--max-workers", "max_workers"],
+            type=int,
+            default=None,
+            help="The maximum number of threads to spawn in parallel mode.",
+        ),
+    ]
+    return options
+
+
 def ingest_events_options() -> list[click.Option]:
     """
     Options for the "events"-like consumers: `events`, `attachments`, `transactions`.
@@ -263,6 +294,7 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
     "uptime-results": {
         "topic": Topic.UPTIME_RESULTS,
         "strategy_factory": "sentry.uptime.consumers.results_consumer.UptimeResultsStrategyFactory",
+        "click_options": uptime_options(),
     },
     "billing-metrics-consumer": {
         "topic": Topic.SNUBA_GENERIC_METRICS,

--- a/src/sentry/remote_subscriptions/consumers/result_consumer.py
+++ b/src/sentry/remote_subscriptions/consumers/result_consumer.py
@@ -2,17 +2,23 @@ from __future__ import annotations
 
 import abc
 import logging
+from collections import defaultdict
 from collections.abc import Mapping
-from typing import Generic, TypeVar
+from concurrent.futures import ThreadPoolExecutor, wait
+from typing import Generic, Literal, TypeVar
 
+import sentry_sdk
 from arroyo.backends.kafka.consumer import KafkaPayload
+from arroyo.processing.strategies import BatchStep
 from arroyo.processing.strategies.abstract import ProcessingStrategy, ProcessingStrategyFactory
+from arroyo.processing.strategies.batching import ValuesBatch
 from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.processing.strategies.run_task import RunTask
-from arroyo.types import Commit, FilteredPayload, Message, Partition
+from arroyo.types import BrokerValue, Commit, FilteredPayload, Message, Partition
 
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.remote_subscriptions.models import BaseRemoteSubscription
+from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +60,39 @@ class ResultProcessor(abc.ABC, Generic[T, U]):
 
 
 class ResultsStrategyFactory(ProcessingStrategyFactory[KafkaPayload], Generic[T, U]):
-    def __init__(self) -> None:
+    parallel_executor: ThreadPoolExecutor | None = None
+
+    parallel = False
+    """
+    Does the consumer process unrelated messages in parallel?
+    """
+
+    max_batch_size = 500
+    """
+    How many messages will be batched at once when in parallel mode.
+    """
+
+    max_batch_time = 10
+    """
+    The maximum time in seconds to accumulate a bach of check-ins.
+    """
+
+    def __init__(
+        self,
+        mode: Literal["parallel", "serial"] = "serial",
+        max_batch_size: int | None = None,
+        max_batch_time: int | None = None,
+        max_workers: int | None = None,
+    ) -> None:
+        if mode == "parallel":
+            self.parallel = True
+            self.parallel_executor = ThreadPoolExecutor(max_workers=max_workers)
+
+        if max_batch_size is not None:
+            self.max_batch_size = max_batch_size
+        if max_batch_time is not None:
+            self.max_batch_time = max_batch_time
+
         self.result_processor = self.result_processor_cls()
         self.codec = get_topic_codec(self.topic_for_codec)
 
@@ -68,6 +106,19 @@ class ResultsStrategyFactory(ProcessingStrategyFactory[KafkaPayload], Generic[T,
     def result_processor_cls(self) -> type[ResultProcessor[T, U]]:
         pass
 
+    @abc.abstractmethod
+    def build_payload_grouping_key(self, result: T) -> str:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def identifier(self) -> str:
+        pass
+
+    def shutdown(self) -> None:
+        if self.parallel_executor:
+            self.parallel_executor.shutdown()
+
     def decode_payload(self, payload: KafkaPayload | FilteredPayload) -> T | None:
         assert not isinstance(payload, FilteredPayload)
         try:
@@ -79,10 +130,15 @@ class ResultsStrategyFactory(ProcessingStrategyFactory[KafkaPayload], Generic[T,
             )
         return None
 
-    def process_single(self, message: Message[KafkaPayload | FilteredPayload]):
-        result = self.decode_payload(message.payload)
-        if result is not None:
-            self.result_processor(result)
+    def create_with_partitions(
+        self,
+        commit: Commit,
+        partitions: Mapping[Partition, int],
+    ) -> ProcessingStrategy[KafkaPayload]:
+        if self.parallel:
+            return self.create_parallel_worker(commit)
+        else:
+            return self.create_serial_worker(commit)
 
     def create_serial_worker(self, commit: Commit) -> ProcessingStrategy[KafkaPayload]:
         return RunTask(
@@ -90,9 +146,71 @@ class ResultsStrategyFactory(ProcessingStrategyFactory[KafkaPayload], Generic[T,
             next_step=CommitOffsets(commit),
         )
 
-    def create_with_partitions(
-        self,
-        commit: Commit,
-        partitions: Mapping[Partition, int],
-    ) -> ProcessingStrategy[KafkaPayload]:
-        return self.create_serial_worker(commit)
+    def process_single(self, message: Message[KafkaPayload | FilteredPayload]):
+        result = self.decode_payload(message.payload)
+        if result is not None:
+            self.result_processor(result)
+
+    def create_parallel_worker(self, commit: Commit) -> ProcessingStrategy[KafkaPayload]:
+        assert self.parallel_executor is not None
+        batch_processor = RunTask(
+            function=self.process_batch,
+            next_step=CommitOffsets(commit),
+        )
+        return BatchStep(
+            max_batch_size=self.max_batch_size,
+            max_batch_time=self.max_batch_time,
+            next_step=batch_processor,
+        )
+
+    def process_batch(self, message: Message[ValuesBatch[KafkaPayload]]):
+        """
+        Receives batches of messages. This function will take the batch and group them together
+        using `build_payload_grouping_key`, which ensures order is preserved. Each group is then
+        executed using a ThreadPoolWorker.
+
+        By batching we're able to process messages in parallel while guaranteeing that no messages
+        are processed out of order.
+        """
+        assert self.parallel_executor is not None
+        batch = message.payload
+
+        batch_mapping: Mapping[str, list[T]] = defaultdict(list)
+
+        for item in batch:
+            assert isinstance(item, BrokerValue)
+
+            result = self.decode_payload(item.payload)
+            if result is None:
+                continue
+
+            key = self.build_payload_grouping_key(result)
+            batch_mapping[key].append(result)
+
+        # Number of messages that are being processed in this batch
+        metrics.gauge(
+            "result_consumer.process_batch.parallel_batch_count",
+            len(batch),
+            tags={"identifier": self.identifier},
+        )
+        # Number of groups we've collected to be processed in parallel
+        metrics.gauge(
+            "result_consumer.process_batch.parallel_batch_groups",
+            len(batch_mapping),
+            tags={"identifier": self.identifier},
+        )
+
+        # Submit groups for processing
+        with sentry_sdk.start_transaction(op="process_batch", name="monitors.monitor_consumer"):
+            futures = [
+                self.parallel_executor.submit(self.process_group, group)
+                for group in batch_mapping.values()
+            ]
+            wait(futures)
+
+    def process_group(self, items: list[T]):
+        """
+        Process a group of related messages serially.
+        """
+        for item in items:
+            self.result_processor(item)

--- a/src/sentry/remote_subscriptions/consumers/result_consumer.py
+++ b/src/sentry/remote_subscriptions/consumers/result_consumer.py
@@ -4,7 +4,7 @@ import abc
 import logging
 from collections import defaultdict
 from collections.abc import Generator, Mapping
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, wait
+from concurrent.futures import ThreadPoolExecutor, wait
 from typing import Generic, Literal, TypeVar
 
 import sentry_sdk
@@ -87,7 +87,7 @@ class ResultsStrategyFactory(ProcessingStrategyFactory[KafkaPayload], Generic[T,
         self.mode = mode
         if mode == "parallel":
             self.parallel = True
-            self.parallel_executor = ProcessPoolExecutor(max_workers=max_workers)
+            self.parallel_executor = ThreadPoolExecutor(max_workers=max_workers)
 
         if max_batch_size is not None:
             self.max_batch_size = max_batch_size

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -333,3 +333,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
 class UptimeResultsStrategyFactory(ResultsStrategyFactory[CheckResult, UptimeSubscription]):
     result_processor_cls = UptimeResultProcessor
     topic_for_codec = Topic.UPTIME_RESULTS
+    identifier = "uptime"
+
+    def build_payload_grouping_key(self, result: CheckResult) -> str:
+        return self.result_processor.get_subscription_id(result)


### PR DESCRIPTION
This adds thread pool parallelization to the uptime consumer. We should potentially consider process parallelisation as well, so that we can take advantage of all cores. Alternatively, it could be worth experimenting with disabling the GIL so we can avoid the complexity of figuring out processes.