### PR TITLE
fix(stats): fix partial rendering on stats page

### DIFF
--- a/static/app/views/organizationStats/usageChart/utils.tsx
+++ b/static/app/views/organizationStats/usageChart/utils.tsx
@@ -55,8 +55,12 @@ export function getXAxisDates(
   interval: IntervalPeriod = '1d'
 ): string[] {
   const range: string[] = [];
-  const start = moment(dateStart).startOf('h');
-  const end = moment(dateEnd).startOf('h');
+  let startOfUnit: moment.unitOfTime.StartOf = 'h';
+  if (interval <= '6h') {
+    startOfUnit = 'm';
+  }
+  const start = moment(dateStart).startOf(startOfUnit);
+  const end = moment(dateEnd).startOf(startOfUnit);
 
   if (!start.isValid() || !end.isValid()) {
     return range;


### PR DESCRIPTION
- Charts currently get pinned to the start of an hour, even when looking at the last hour of data, this makes it appear as if there is data missing. 
- This PR pins the charts to the start of a minute for all durations that are affected, which is anything `less than or equal to 6h`.

Closes https://github.com/getsentry/sentry/issues/81114


**Before** 
![Screenshot 2024-11-28 at 16 46 14](https://github.com/user-attachments/assets/1fe710ef-9748-47d6-9566-246270c095d3)


**After**
![Screenshot 2024-11-28 at 16 46 48](https://github.com/user-attachments/assets/0895a8b0-0cde-4fbb-8c42-7a303fc81482)

