### PR TITLE
fix(merges): Derive projects from group IDs

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -212,9 +212,6 @@ def update_groups(
 
     result = dict(serializer.validated_data)
 
-    # so we won't have to requery for each group
-    project_lookup = {g.project_id: g.project for g in group_list}
-
     acting_user = user if user.is_authenticated else None
 
     if search_fn and not group_ids:
@@ -231,6 +228,11 @@ def update_groups(
         group_list = list(cursor_result)
         group_ids = [g.id for g in group_list]
 
+    if not group_list:
+        return Response(detail="No groups found", status=400)
+
+    # so we won't have to requery for each group
+    project_lookup = {g.project_id: g.project for g in group_list}
     group_project_ids = {g.project_id for g in group_list}
     # filter projects down to only those that have groups in the search results
     projects = [p for p in projects if p.id in group_project_ids]

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -170,7 +170,7 @@ def update_groups(
     group_ids: Sequence[int | str] | None,
     projects: Sequence[Project],
     organization_id: int,
-    search_fn: SearchFunction | None,
+    search_fn: SearchFunction | None = None,
     user: RpcUser | User | None = None,
     data: Mapping[str, Any] | None = None,
 ) -> Response:
@@ -213,7 +213,7 @@ def update_groups(
     result = dict(serializer.validated_data)
 
     # so we won't have to requery for each group
-    project_lookup = {p.id: p for p in projects}
+    project_lookup = {g.project_id: g.project for g in group_list}
 
     acting_user = user if user.is_authenticated else None
 


### PR DESCRIPTION
The developer may be viewing multiple projects, however, they may merge issues belonging to the same project.

If all groups belong to the same project, support merging them.

Fixes #81433