### PR TITLE
feat(dashboards): Implement "Releases" feature for `LineChartWidget`

### DIFF
--- a/static/app/views/dashboards/widgets/common/releaseSeries.tsx
+++ b/static/app/views/dashboards/widgets/common/releaseSeries.tsx
@@ -1,0 +1,67 @@
+import type {Theme} from '@emotion/react';
+
+import MarkLine from 'sentry/components/charts/components/markLine';
+import {t} from 'sentry/locale';
+import type {Series} from 'sentry/types/echarts';
+import {escape} from 'sentry/utils';
+import {getFormattedDate} from 'sentry/utils/dates';
+import {formatVersion} from 'sentry/utils/versions/formatVersion';
+
+import type {Release} from './types';
+
+export function ReleaseSeries(
+  theme: Theme,
+  releases: Release[],
+  onClick: (release: Release) => void,
+  utc: boolean
+): Series {
+  return {
+    seriesName: t('Releases'),
+    color: theme.purple200,
+    data: [],
+    markLine: MarkLine({
+      animation: false,
+      lineStyle: {
+        color: theme.purple300,
+        opacity: 0.3,
+        type: 'solid',
+      },
+      label: {
+        show: false,
+      },
+      data: releases.map(release => ({
+        xAxis: new Date(release.timestamp).getTime(),
+        name: formatVersion(release.version, true),
+        value: formatVersion(release.version, true),
+        onClick: () => {
+          onClick(release);
+        },
+        label: {
+          formatter: () => formatVersion(release.version, true),
+        },
+      })),
+      tooltip: {
+        trigger: 'item',
+        formatter: function (params: any) {
+          const time = getFormattedDate(params.value, 'MMM D, YYYY LT', {
+            local: utc,
+          });
+
+          const version = escape(formatVersion(params.name, true));
+
+          return [
+            '<div class="tooltip-series">',
+            `<div><span class="tooltip-label"><strong>${t(
+              'Release'
+            )}</strong></span> ${version}</div>`,
+            '</div>',
+            '<div class="tooltip-footer">',
+            time,
+            '</div>',
+            '<div class="tooltip-arrow"></div>',
+          ].join('');
+        },
+      },
+    }),
+  };
+}

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -28,3 +28,8 @@ export interface StateProps {
 }
 
 export type Thresholds = ThresholdsConfig;
+
+export type Release = {
+  timestamp: string;
+  version: string;
+};

--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.stories.tsx
@@ -9,7 +9,7 @@ import storyBook from 'sentry/stories/storyBook';
 import type {DateString} from 'sentry/types/core';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
-import type {TimeseriesData} from '../common/types';
+import type {Release, TimeseriesData} from '../common/types';
 
 import {LineChartWidget} from './lineChartWidget';
 import sampleDurationTimeSeries from './sampleDurationTimeSeries.json';
@@ -193,6 +193,50 @@ export default storyBook(LineChartWidget, story => {
       </Fragment>
     );
   });
+
+  story('Releases', () => {
+    const releases = [
+      {
+        version: 'ui@0.1.2',
+        timestamp: sampleThroughputTimeSeries.data.at(2)?.timestamp,
+      },
+      {
+        version: 'ui@0.1.3',
+        timestamp: sampleThroughputTimeSeries.data.at(20)?.timestamp,
+      },
+    ].filter(hasTimestamp);
+
+    return (
+      <Fragment>
+        <p>
+          <JSXNode name="LineChartWidget" /> supports the <code>releases</code> prop. If
+          passed in, the widget will plot every release as a vertical line that overlays
+          the chart data. Clicking on a release line will open the release details page.
+        </p>
+
+        <MediumWidget>
+          <LineChartWidget
+            title="error_rate()"
+            timeseries={[
+              {
+                ...sampleThroughputTimeSeries,
+                field: 'error_rate()',
+              } as unknown as TimeseriesData,
+            ]}
+            releases={releases}
+            meta={{
+              fields: {
+                'error_rate()': 'rate',
+              },
+              units: {
+                'error_rate()': '1/second',
+              },
+            }}
+          />
+        </MediumWidget>
+      </Fragment>
+    );
+  });
 });
 
 const MediumWidget = styled('div')`
@@ -224,4 +268,8 @@ function toTimeSeriesSelection(
       return true;
     }),
   };
+}
+
+function hasTimestamp(release: Partial<Release>): release is Release {
+  return Boolean(release?.timestamp);
 }

--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.tsx
@@ -54,6 +54,7 @@ export function LineChartWidget(props: Props) {
         <LineChartWrapper>
           <LineChartWidgetVisualization
             timeseries={timeseries}
+            releases={props.releases}
             utc={props.utc}
             meta={props.meta}
             dataCompletenessDelay={props.dataCompletenessDelay}


### PR DESCRIPTION
This is a slightly simplified version of what's available in current charts. I will tweak this more when I start integrating it. Adapted from the current release series code.

**e.g.,**
![Screenshot 2024-11-28 at 2 58 12 PM](https://github.com/user-attachments/assets/cb871584-8b26-4088-aecd-3c0fd1e04ae5)
