### PR TITLE
feat(dashboards): Enable automatic height for `LineChartWidget`

### DIFF
--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.stories.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidget.stories.tsx
@@ -5,6 +5,7 @@ import moment from 'moment-timezone';
 
 import JSXNode from 'sentry/components/stories/jsxNode';
 import SideBySide from 'sentry/components/stories/sideBySide';
+import SizingWindow from 'sentry/components/stories/sizingWindow';
 import storyBook from 'sentry/stories/storyBook';
 import type {DateString} from 'sentry/types/core';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -68,37 +69,34 @@ export default storyBook(LineChartWidget, story => {
         <p>
           The visualization of <JSXNode name="LineChartWidget" /> a line chart. It has
           some bells and whistles including automatic axes labels, and a hover tooltip.
+          Like other widgets, it automatically fills the parent element. The{' '}
+          <code>utc</code> prop controls whether the X Axis timestamps are shown in UTC or
+          not.
         </p>
-
-        <p>
-          The <code>utc</code> prop controls whether the X Axis timestamps are shown in
-          UTC or not
-        </p>
+        <SmallSizingWindow>
+          <LineChartWidget
+            title="eps()"
+            description="Number of events per second"
+            timeseries={[throughputTimeSeries]}
+            meta={{
+              fields: {
+                'eps()': 'rate',
+              },
+              units: {
+                'eps()': '1/second',
+              },
+            }}
+          />
+        </SmallSizingWindow>
 
         <p>
           The <code>dataCompletenessDelay</code> prop indicates that this data is live,
           and the last few buckets might not have complete data. The delay is a number in
           seconds. Any data bucket that happens in that delay window will be plotted with
-          a dotted line. By default the delay is <code>0</code>
+          a dotted line. By default the delay is <code>0</code>.
         </p>
 
         <SideBySide>
-          <MediumWidget>
-            <LineChartWidget
-              title="eps()"
-              description="Number of events per second"
-              timeseries={[throughputTimeSeries]}
-              meta={{
-                fields: {
-                  'eps()': 'rate',
-                },
-                units: {
-                  'eps()': '1/second',
-                },
-              }}
-            />
-          </MediumWidget>
-
           <MediumWidget>
             <LineChartWidget
               title="span.duration"
@@ -203,6 +201,11 @@ const MediumWidget = styled('div')`
 const SmallWidget = styled('div')`
   width: 360px;
   height: 160px;
+`;
+
+const SmallSizingWindow = styled(SizingWindow)`
+  width: 50%;
+  height: 300px;
 `;
 
 function toTimeSeriesSelection(

--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidgetVisualization.tsx
@@ -110,6 +110,7 @@ export function LineChartWidgetVisualization(props: LineChartWidgetVisualization
   return (
     <BaseChart
       ref={chartRef}
+      autoHeightResize
       series={[
         ...completeSeries.map(timeserie => {
           return LineSeries({


### PR DESCRIPTION
EZ.

**e.g.,**
![Screenshot 2024-11-28 at 3 19 22 PM](https://github.com/user-attachments/assets/d23f0a83-4c2f-4b7a-8d9d-eae62265b8f4)
