### PR TITLE
feat(widget-builder): Widget builder slideout

### DIFF
--- a/static/app/components/slideOverPanel.tsx
+++ b/static/app/components/slideOverPanel.tsx
@@ -13,11 +13,13 @@ const PANEL_HEIGHT = '50vh';
 const OPEN_STYLES = {
   bottom: {opacity: 1, x: 0, y: 0},
   right: {opacity: 1, x: 0, y: 0},
+  left: {opacity: 1, x: 0, y: 0},
 };
 
 const COLLAPSED_STYLES = {
   bottom: {opacity: 0, x: 0, y: PANEL_HEIGHT},
   right: {opacity: 0, x: PANEL_WIDTH, y: 0},
+  left: {opacity: 0, x: -200, y: 0},
 };
 
 type SlideOverPanelProps = {
@@ -26,7 +28,7 @@ type SlideOverPanelProps = {
   ariaLabel?: string;
   className?: string;
   onOpen?: () => void;
-  slidePosition?: 'right' | 'bottom';
+  slidePosition?: 'right' | 'bottom' | 'left';
   transitionProps?: AnimationProps['transition'];
 };
 
@@ -84,7 +86,7 @@ const _SlideOverPanel = styled(motion.div, {
     ['initial', 'animate', 'exit', 'transition'].includes(prop) ||
     (prop !== 'collapsed' && isPropValid(prop)),
 })<{
-  slidePosition?: 'right' | 'bottom';
+  slidePosition?: 'right' | 'bottom' | 'left';
 }>`
   position: fixed;
 
@@ -118,16 +120,28 @@ const _SlideOverPanel = styled(motion.div, {
             bottom: 0;
             left: 0;
           `
-        : css`
-            position: fixed;
+        : p.slidePosition === 'right'
+          ? css`
+              position: fixed;
 
-            width: ${PANEL_WIDTH};
-            height: 100%;
+              width: ${PANEL_WIDTH};
+              height: 100%;
 
-            top: 0;
-            right: 0;
-            bottom: 0;
-            left: auto;
-          `}
+              top: 0;
+              right: 0;
+              bottom: 0;
+              left: auto;
+            `
+          : css`
+              position: relative;
+
+              width: ${PANEL_WIDTH};
+              height: 100%;
+
+              top: 0;
+              right: auto;
+              bottom: 0;
+              left: auto;
+            `}
   }
 `;

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -743,6 +743,9 @@ const commonTheme = {
 
     globalSelectionHeader: 1009,
 
+    // needs to be below sidebar
+    widgetBuilderDrawer: 1016,
+
     settingsSidebarNavMask: 1017,
     settingsSidebarNav: 1018,
     sidebarPanel: 1019,

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -15,6 +15,7 @@ import {openWidgetViewerModal} from 'sentry/actionCreators/modal';
 import type {Client} from 'sentry/api';
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
+import {Button} from 'sentry/components/button';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {
@@ -56,6 +57,7 @@ import {
   resetPageFilters,
 } from 'sentry/views/dashboards/utils';
 import DevBuilder from 'sentry/views/dashboards/widgetBuilder/components/devBuilder';
+import DevWidgetBuilder from 'sentry/views/dashboards/widgetBuilder/components/newWidgetBuilder';
 import {DataSet} from 'sentry/views/dashboards/widgetBuilder/utils';
 import WidgetLegendNameEncoderDecoder from 'sentry/views/dashboards/widgetLegendNameEncoderDecoder';
 import {MetricsDataSwitcherAlert} from 'sentry/views/performance/landing/metricsDataSwitcherAlert';
@@ -126,6 +128,7 @@ type Props = RouteComponentProps<RouteParams, {}> & {
 
 type State = {
   dashboardState: DashboardState;
+  isWidgetBuilderOpen: boolean;
   modifiedDashboard: DashboardDetails | null;
   widgetLegendState: WidgetLegendSelectionState;
   widgetLimitReached: boolean;
@@ -213,6 +216,7 @@ class DashboardDetail extends Component<Props, State> {
       location: this.props.location,
       router: this.props.router,
     }),
+    isWidgetBuilderOpen: false,
   };
 
   componentDidMount() {
@@ -1144,6 +1148,28 @@ class DashboardDetail extends Component<Props, State> {
     return <DevBuilder />;
   }
 
+  renderDevWidgetBuilderUI() {
+    return (
+      <Fragment>
+        <Button
+          aria-label="new widget builder"
+          onClick={() => {
+            this.setState({isWidgetBuilderOpen: true});
+          }}
+          style={{maxWidth: '250px', alignSelf: 'center'}}
+        >
+          {'Open Widget Builder'}
+        </Button>
+        <DevWidgetBuilder
+          isOpen={this.state.isWidgetBuilderOpen}
+          onClose={() => {
+            this.setState({isWidgetBuilderOpen: false});
+          }}
+        />
+      </Fragment>
+    );
+  }
+
   render() {
     const {organization, location} = this.props;
 
@@ -1152,6 +1178,13 @@ class DashboardDetail extends Component<Props, State> {
       decodeScalar(location.query?.devBuilder) === 'true'
     ) {
       return this.renderDevWidgetBuilder();
+    }
+
+    if (
+      organization.features.includes('dashboards-widget-builder-redesign') &&
+      decodeScalar(location.query?.devBuilderUI) === 'true'
+    ) {
+      return this.renderDevWidgetBuilderUI();
     }
 
     if (this.isWidgetBuilderRouter) {

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
@@ -1,0 +1,14 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import DevWidgetBuilder from 'sentry/views/dashboards/widgetBuilder/components/newWidgetBuilder';
+
+describe('NewWidgetBuiler', function () {
+  const onCloseMock = jest.fn();
+  it('renders', async function () {
+    render(<DevWidgetBuilder isOpen onClose={onCloseMock} />);
+
+    expect(await screen.findByText('Create Custom Widget')).toBeInTheDocument();
+
+    expect(await screen.findByLabelText('Close Widget Builder')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import {AnimatePresence, motion} from 'framer-motion';
 
 import useKeyPress from 'sentry/utils/useKeyPress';
-import WidgetBuilderSlideout from 'sentry/views/dashboards/widgetBuilder/components/newWidgetBuilderSlideout';
+import WidgetBuilderSlideout from 'sentry/views/dashboards/widgetBuilder/components/widgetBuilderSlideout';
 
 type DevWidgetBuilderProps = {
   isOpen: boolean;

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -52,23 +52,6 @@ function DevWidgetBuilder({isOpen, onClose}: DevWidgetBuilderProps) {
 
 export default DevWidgetBuilder;
 
-// const CloseButton = styled(Button)`
-//   color: ${p => p.theme.gray300};
-//   height: fit-content;
-//   &:hover {
-//     color: ${p => p.theme.gray400};
-//   }
-//   z-index: 100;
-// `;
-
-// const SlideoutTitle = styled('h5')``;
-
-// const SlideoutHeaderWrapper = styled('div')`
-//   padding: ${space(4)};
-//   display: flex;
-//   justify-content: space-between;
-// `;
-
 const fullPageCss = css`
   position: absolute;
   top: 0;

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -1,0 +1,110 @@
+import {Fragment, useEffect} from 'react';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+import {AnimatePresence, motion} from 'framer-motion';
+
+import useKeyPress from 'sentry/utils/useKeyPress';
+import WidgetBuilderSlideout from 'sentry/views/dashboards/widgetBuilder/components/newWidgetBuilderSlideout';
+
+type DevWidgetBuilderProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+function DevWidgetBuilder({isOpen, onClose}: DevWidgetBuilderProps) {
+  const escapeKeyPressed = useKeyPress('Escape');
+
+  // TODO(nikki): be able to handle clicking outside widget to close
+
+  useEffect(() => {
+    if (escapeKeyPressed) {
+      if (isOpen) {
+        onClose?.();
+      }
+    }
+  }, [escapeKeyPressed, isOpen, onClose]);
+
+  return (
+    <Fragment>
+      {isOpen && <Backdrop style={{opacity: 0.5, pointerEvents: 'auto'}} />}
+      <AnimatePresence>
+        {isOpen && (
+          <WidgetBuilderContainer>
+            <WidgetBuilderSlideout isOpen={isOpen} onClose={onClose} />
+            <SampleWidgetCard
+              initial={{opacity: 0, x: '50%', y: 0}}
+              animate={{opacity: 1, x: 0, y: 0}}
+              exit={{opacity: 0, x: '50%', y: 0}}
+              transition={{
+                type: 'spring',
+                stiffness: 500,
+                damping: 50,
+              }}
+            >
+              {'TEST WIDGET'}
+            </SampleWidgetCard>
+          </WidgetBuilderContainer>
+        )}
+      </AnimatePresence>
+    </Fragment>
+  );
+}
+
+export default DevWidgetBuilder;
+
+// const CloseButton = styled(Button)`
+//   color: ${p => p.theme.gray300};
+//   height: fit-content;
+//   &:hover {
+//     color: ${p => p.theme.gray400};
+//   }
+//   z-index: 100;
+// `;
+
+// const SlideoutTitle = styled('h5')``;
+
+// const SlideoutHeaderWrapper = styled('div')`
+//   padding: ${space(4)};
+//   display: flex;
+//   justify-content: space-between;
+// `;
+
+const fullPageCss = css`
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+`;
+
+const Backdrop = styled('div')`
+  ${fullPageCss};
+  z-index: ${p => p.theme.zIndex.widgetBuilderDrawer};
+  background: ${p => p.theme.black};
+  will-change: opacity;
+  transition: opacity 200ms;
+  pointer-events: none;
+  opacity: 0;
+`;
+
+// TODO: Make this centered
+const SampleWidgetCard = styled(motion.div)`
+  width: 400px;
+  height: 300px;
+  border: 2px dashed ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+  background-color: ${p => p.theme.background};
+  align-content: center;
+  text-align: center;
+  z-index: ${p => p.theme.zIndex.widgetBuilderDrawer};
+  position: relative;
+  margin-right: 2%;
+`;
+
+const WidgetBuilderContainer = styled('div')`
+  ${fullPageCss}
+  z-index: ${p => p.theme.zIndex.widgetBuilderDrawer};
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilderSlideout.tsx
@@ -1,0 +1,51 @@
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/button';
+import SlideOverPanel from 'sentry/components/slideOverPanel';
+import {IconClose} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+type WidgetBuilderSlideoutProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export default WidgetBuilderSlideout;
+
+function WidgetBuilderSlideout({isOpen, onClose}: WidgetBuilderSlideoutProps) {
+  return (
+    <SlideOverPanel collapsed={!isOpen} slidePosition="left">
+      <SlideoutHeaderWrapper>
+        <SlideoutTitle>{t('Create Custom Widget')}</SlideoutTitle>
+        <CloseButton
+          priority="link"
+          size="zero"
+          borderless
+          aria-label={t('Close Widget Builder')}
+          icon={<IconClose size="sm" />}
+          onClick={onClose}
+        >
+          {t('Close')}
+        </CloseButton>
+      </SlideoutHeaderWrapper>
+    </SlideOverPanel>
+  );
+}
+
+const CloseButton = styled(Button)`
+  color: ${p => p.theme.gray300};
+  height: fit-content;
+  &:hover {
+    color: ${p => p.theme.gray400};
+  }
+  z-index: 100;
+`;
+
+const SlideoutTitle = styled('h5')``;
+
+const SlideoutHeaderWrapper = styled('div')`
+  padding: ${space(4)};
+  display: flex;
+  justify-content: space-between;
+`;

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -39,7 +39,6 @@ const CloseButton = styled(Button)`
   &:hover {
     color: ${p => p.theme.gray400};
   }
-  z-index: 100;
 `;
 
 const SlideoutTitle = styled('h5')``;


### PR DESCRIPTION
Just the bare bones of the widget builder UI. This adds the slide-out functionality and a placeholder widget. You can see it on any dashboard page with the url parameter `devBuilderUI=true`. It looks like this so far:

![image](https://github.com/user-attachments/assets/ae4d5792-3ed5-4c0a-ad81-f87af80be9c6)
