### PR TITLE
fix(taskworker) Fix not_found errors being handled

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -237,6 +237,7 @@ def worker(ignore_unknown_queues: bool, **options: Any) -> None:
         run_worker(**options)
 
 
+@run.command()
 @click.option("--rpc-host", help="The hostname for the taskworker-rpc", default="127.0.0.1:50051")
 @click.option("--autoreload", is_flag=True, default=False, help="Enable autoreloading.")
 @click.option(

--- a/src/sentry/taskworker/client.py
+++ b/src/sentry/taskworker/client.py
@@ -37,8 +37,9 @@ class TaskworkerClient:
             if err.code() == grpc.StatusCode.NOT_FOUND:
                 return None
             raise
-
-        return response.task
+        if response.HasField("task"):
+            return response.task
+        return None
 
     def update_task(
         self, task_id: str, status: TaskActivationStatus.ValueType, fetch_next: bool = True
@@ -59,4 +60,6 @@ class TaskworkerClient:
             if err.code() == grpc.StatusCode.NOT_FOUND:
                 return None
             raise
-        return response.task
+        if response.HasField("task"):
+            return response.task
+        return None

--- a/tests/sentry/taskworker/test_client.py
+++ b/tests/sentry/taskworker/test_client.py
@@ -1,0 +1,119 @@
+from collections import defaultdict
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import patch
+
+import grpc
+import pytest
+from google.protobuf.message import Message
+from sentry_protos.sentry.v1.taskworker_pb2 import GetTaskResponse, TaskActivation
+
+from sentry.taskworker.client import TaskworkerClient
+
+
+class MockServiceMethod:
+    """Stub for grpc service methods"""
+
+    def __init__(
+        self,
+        path: str,
+        responses: list[Any],
+        request_serializer: Callable,
+        response_deserializer: Callable,
+    ):
+        self.path = path
+        self.request_serializer = request_serializer
+        self.response_deserializer = response_deserializer
+        self.responses = responses
+
+    def __call__(self, *args, **kwargs):
+        """Capture calls and use registered mocks"""
+        # move the head to the tail
+        res = self.responses[0]
+        tail = self.responses[1:]
+        self.responses = tail + [res]
+
+        if isinstance(res, Exception):
+            raise res
+        return res
+
+
+class MockChannel:
+    def __init__(self):
+        self._responses = defaultdict(list)
+
+    def unary_unary(
+        self, path: str, request_serializer: Callable, response_deserializer: Callable, **kwargs
+    ):
+        return MockServiceMethod(
+            path, self._responses.get(path, []), request_serializer, response_deserializer
+        )
+
+    def add_response(self, path: str, resp: Message | Exception):
+        self._responses[path].append(resp)
+
+
+class MockGrpcError(grpc.RpcError):
+    """Grpc error are elusive and this mock simulates the interface in mypy stubs"""
+
+    def __init__(self, code, message):
+        self._code = code
+        self._message = message
+
+    def code(self) -> grpc.StatusCode:
+        return self._code
+
+    def details(self) -> str:
+        return self._message
+
+
+def test_get_task_ok():
+    channel = MockChannel()
+    channel.add_response(
+        "/sentry_protos.sentry.v1.ConsumerService/GetTask",
+        GetTaskResponse(
+            task=TaskActivation(
+                id="abc123",
+                namespace="testing",
+                taskname="do_thing",
+                parameters="",
+                headers={},
+                processing_deadline_duration=10,
+            )
+        ),
+    )
+    with patch("sentry.taskworker.client.grpc.insecure_channel") as mock_channel:
+        mock_channel.return_value = channel
+        client = TaskworkerClient("localhost:50051")
+        result = client.get_task()
+
+        assert result
+        assert result.id
+        assert result.namespace == "testing"
+
+
+def test_get_task_not_found():
+    channel = MockChannel()
+    channel.add_response(
+        "/sentry_protos.sentry.v1.ConsumerService/GetTask",
+        MockGrpcError(grpc.StatusCode.NOT_FOUND, "no pending task found"),
+    )
+    with patch("sentry.taskworker.client.grpc.insecure_channel") as mock_channel:
+        mock_channel.return_value = channel
+        client = TaskworkerClient("localhost:50051")
+        result = client.get_task()
+
+        assert result is None
+
+
+def test_get_task_failure():
+    channel = MockChannel()
+    channel.add_response(
+        "/sentry_protos.sentry.v1.ConsumerService/GetTask",
+        MockGrpcError(grpc.StatusCode.INTERNAL, "something bad"),
+    )
+    with patch("sentry.taskworker.client.grpc.insecure_channel") as mock_channel:
+        mock_channel.return_value = channel
+        client = TaskworkerClient("localhost:50051")
+        with pytest.raises(grpc.RpcError):
+            client.get_task()


### PR DESCRIPTION
The taskbroker server will respond with NOT_FOUND errors when there are no pending tasks, or when an update with fetch_next cannot fetch a new task. We should catch these exceptions in our client as they aren't exceptions that the Worker needs to handle.

I've added a janky set of tests for the client. So far I've not had much luck in locating a library or package for mocking grpc requests as a client. If this isn't too unpleasant I can improve this and use it for the worker tests as well.