### PR TITLE
feat(widget-builder): Add fields to hook

### DIFF
--- a/static/app/utils/url/useLocationQuery.tsx
+++ b/static/app/utils/url/useLocationQuery.tsx
@@ -10,7 +10,7 @@ import {
 import {useLocation} from 'sentry/utils/useLocation';
 
 type Scalar = string | boolean | number | undefined;
-type Decoder =
+export type Decoder =
   | typeof decodeInteger
   | typeof decodeList
   | typeof decodeScalar

--- a/static/app/views/dashboards/widgetBuilder/components/devBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/devBuilder.tsx
@@ -4,7 +4,11 @@ import RadioGroup from 'sentry/components/forms/controls/radioGroup';
 import SelectField from 'sentry/components/forms/fields/selectField';
 import Input from 'sentry/components/input';
 import {space} from 'sentry/styles/space';
+import {type Column, generateFieldAsString} from 'sentry/utils/discover/fields';
+import useOrganization from 'sentry/utils/useOrganization';
+import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import {ColumnFields} from 'sentry/views/dashboards/widgetBuilder/buildSteps/columnsStep/columnFields';
 import useWidgetBuilderState, {
   BuilderStateAction,
 } from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
@@ -78,7 +82,54 @@ function DevBuilder() {
           }
         />
       </Section>
+      <Section>
+        <h1>Fields:</h1>
+        <div>{state.fields?.map(generateFieldAsString).join(', ')}</div>
+        <ColumnSelector
+          displayType={state.displayType ?? DisplayType.TABLE}
+          dataset={state.dataset ?? WidgetType.DISCOVER}
+          fields={state.fields ?? [{field: '', kind: 'field'}]}
+          onChange={newFields => {
+            dispatch({
+              type: BuilderStateAction.SET_FIELDS,
+              payload: newFields,
+            });
+          }}
+        />
+      </Section>
     </Body>
+  );
+}
+
+function ColumnSelector({
+  displayType,
+  fields,
+  dataset,
+  onChange,
+}: {
+  dataset: WidgetType;
+  displayType: DisplayType;
+  fields: Column[];
+  onChange: (newFields: Column[]) => void;
+}) {
+  const organization = useOrganization();
+  const datasetConfig = getDatasetConfig(dataset);
+
+  const fieldOptions = datasetConfig.getTableFieldOptions(organization);
+
+  return (
+    <ColumnFields
+      displayType={displayType ?? DisplayType.TABLE}
+      organization={organization}
+      widgetType={dataset ?? WidgetType.DISCOVER}
+      fields={fields ?? []}
+      errors={[]}
+      fieldOptions={fieldOptions}
+      isOnDemandWidget={false}
+      filterAggregateParameters={() => true}
+      filterPrimaryOptions={() => true}
+      onChange={onChange}
+    />
   );
 }
 

--- a/static/app/views/dashboards/widgetBuilder/hooks/useQueryParamState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useQueryParamState.spec.tsx
@@ -68,12 +68,39 @@ describe('useQueryParamState', () => {
       LocationFixture({query: {testField: 'initial state'}})
     );
 
-    const testDecoder = (value: string) => `${value.toUpperCase()} - decoded`;
+    const testDeserializer = (value: string) => `${value.toUpperCase()} - decoded`;
 
     const {result} = renderHook(() =>
-      useQueryParamState({fieldName: 'testField', decoder: testDecoder})
+      useQueryParamState({fieldName: 'testField', deserializer: testDeserializer})
     );
 
     expect(result.current[0]).toBe('INITIAL STATE - decoded');
+  });
+
+  it('can take any kind of value and serialize it to a string compatible with query params', () => {
+    type TestType = {
+      count: number;
+      isActive: boolean;
+      value: string;
+    };
+
+    const mockedNavigate = jest.fn();
+    mockedUseNavigate.mockReturnValue(mockedNavigate);
+
+    const testSerializer = (value: TestType) =>
+      `${value.value} - ${value.count} - ${value.isActive}`;
+
+    const {result} = renderHook(() =>
+      useQueryParamState({fieldName: 'testField', serializer: testSerializer})
+    );
+
+    act(() => {
+      result.current[1]({value: 'newValue', count: 2, isActive: true});
+    });
+
+    expect(mockedNavigate).toHaveBeenCalledWith({
+      ...LocationFixture(),
+      query: {testField: 'newValue - 2 - true'},
+    });
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/hooks/useQueryParamState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useQueryParamState.tsx
@@ -1,27 +1,52 @@
 import {useCallback, useMemo, useState} from 'react';
+import * as Sentry from '@sentry/react';
 import debounce from 'lodash/debounce';
 
 import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
-import {decodeScalar} from 'sentry/utils/queryString';
+import {defined} from 'sentry/utils';
+import {type decodeList, decodeScalar} from 'sentry/utils/queryString';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 
-interface UseQueryParamStateProps<T> {
+interface UseQueryParamStateWithScalarDecoder {
   fieldName: string;
-  decoder?: (value: string) => T;
+  decoder?: typeof decodeScalar;
+  deserializer?: undefined;
+  serializer?: undefined;
 }
+
+interface UseQueryParamStateWithScalarDecoderSerializers<T> {
+  fieldName: string;
+  decoder?: typeof decodeScalar;
+  deserializer?: (value: ReturnType<typeof decodeScalar>) => T;
+  serializer?: (value: T) => string;
+}
+
+interface UseQueryParamStateWithListDecoder<T> {
+  decoder: typeof decodeList;
+  deserializer: (value: ReturnType<typeof decodeList>) => T;
+  fieldName: string;
+  serializer: (value: T) => string[];
+}
+
+type UseQueryParamStateProps<T> =
+  | UseQueryParamStateWithScalarDecoder
+  | UseQueryParamStateWithScalarDecoderSerializers<T>
+  | UseQueryParamStateWithListDecoder<T>;
 
 /**
  * Hook to manage a state that is synced with a query param in the URL
  *
  * @param fieldName - The name of the query param to sync with the state
- * @param decoder - A function to decode the query param value into the desired type
+ * @param deserializer - A function to transform the query param value into the desired type
  * @returns A tuple containing the current state and a function to update the state
  */
 export function useQueryParamState<T = string>({
   fieldName,
   decoder,
+  deserializer,
+  serializer,
 }: UseQueryParamStateProps<T>): [T | undefined, (newField: T | undefined) => void] {
   const navigate = useNavigate();
   const location = useLocation();
@@ -29,26 +54,32 @@ export function useQueryParamState<T = string>({
   // The URL query params give us our initial state
   const parsedQueryParams = useLocationQuery({
     fields: {
-      [fieldName]: decodeScalar,
+      [fieldName]: decoder ?? decodeScalar,
     },
   });
   const [localState, setLocalState] = useState<T | undefined>(() => {
-    return decoder
-      ? decoder(parsedQueryParams[fieldName])
+    const decodedValue = parsedQueryParams[fieldName];
+
+    if (!defined(decodedValue)) {
+      return undefined;
+    }
+
+    return deserializer
+      ? deserializer(decodedValue as any)
       : // TODO(nar): This is a temporary fix to avoid type errors
-        // When the decoder isn't provided, we should return the value
+        // When the deserializer isn't provided, we should return the value
         // if T is a string, or else return undefined
-        (parsedQueryParams[fieldName] as T);
+        (decodedValue as T);
   });
 
   // Debounce the update to the URL query params
   // to avoid unnecessary re-renders
   const updateQueryParam = useMemo(
     () =>
-      debounce((newField: T | undefined) => {
+      debounce((newURLParamValues: string | string[] | undefined) => {
         navigate({
           ...location,
-          query: {...location.query, [fieldName]: newField},
+          query: {...location.query, [fieldName]: newURLParamValues},
         });
       }, DEFAULT_DEBOUNCE_DURATION),
     [location, navigate, fieldName]
@@ -57,9 +88,29 @@ export function useQueryParamState<T = string>({
   const updateField = useCallback(
     (newField: T | undefined) => {
       setLocalState(newField);
-      updateQueryParam(newField);
+
+      if (!defined(newField)) {
+        updateQueryParam(undefined);
+      } else if (serializer) {
+        updateQueryParam(serializer(newField));
+      } else {
+        // At this point, only update the query param if the new field is a string, number, boolean, or array
+        if (
+          ['string', 'number', 'boolean'].includes(typeof newField) ||
+          Array.isArray(newField)
+        ) {
+          updateQueryParam(newField as any);
+        } else {
+          Sentry.captureException(
+            new Error(
+              'useQueryParamState: newField is not a primitive value and not provided a serializer'
+            )
+          );
+          updateQueryParam(undefined);
+        }
+      }
     },
-    [updateQueryParam]
+    [updateQueryParam, serializer]
   );
 
   return [localState, updateField];

--- a/static/app/views/dashboards/widgetBuilder/hooks/useQueryParamState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useQueryParamState.tsx
@@ -9,14 +9,7 @@ import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 
-interface UseQueryParamStateWithScalarDecoder {
-  fieldName: string;
-  decoder?: typeof decodeScalar;
-  deserializer?: undefined;
-  serializer?: undefined;
-}
-
-interface UseQueryParamStateWithScalarDecoderSerializers<T> {
+interface UseQueryParamStateWithScalarDecoder<T> {
   fieldName: string;
   decoder?: typeof decodeScalar;
   deserializer?: (value: ReturnType<typeof decodeScalar>) => T;
@@ -31,8 +24,7 @@ interface UseQueryParamStateWithListDecoder<T> {
 }
 
 type UseQueryParamStateProps<T> =
-  | UseQueryParamStateWithScalarDecoder
-  | UseQueryParamStateWithScalarDecoderSerializers<T>
+  | UseQueryParamStateWithScalarDecoder<T>
   | UseQueryParamStateWithListDecoder<T>;
 
 /**

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -161,4 +161,24 @@ describe('useWidgetBuilderState', () => {
       expect(result.current.state.dataset).toBe(WidgetType.ERRORS);
     });
   });
+
+  describe('fields', () => {
+    it('returns the fields from the query params', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({query: {field: ['event.type', 'potato', 'count()']}})
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState());
+
+      expect(result.current.state.fields).toEqual([
+        {field: 'event.type', alias: undefined, kind: 'field'},
+        {field: 'potato', alias: undefined, kind: 'field'},
+        {
+          alias: undefined,
+          kind: 'function',
+          function: ['count', '', undefined, undefined],
+        },
+      ]);
+    });
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -1,5 +1,11 @@
 import {useCallback, useMemo} from 'react';
 
+import {
+  type Column,
+  explodeField,
+  generateFieldAsString,
+} from 'sentry/utils/discover/fields';
+import {decodeList} from 'sentry/utils/queryString';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import {useQueryParamState} from 'sentry/views/dashboards/widgetBuilder/hooks/useQueryParamState';
 
@@ -8,18 +14,21 @@ export const BuilderStateAction = {
   SET_DESCRIPTION: 'SET_DESCRIPTION',
   SET_DISPLAY_TYPE: 'SET_DISPLAY_TYPE',
   SET_DATASET: 'SET_DATASET',
+  SET_FIELDS: 'SET_FIELDS',
 } as const;
 
 type WidgetAction =
   | {payload: string; type: typeof BuilderStateAction.SET_TITLE}
   | {payload: string; type: typeof BuilderStateAction.SET_DESCRIPTION}
   | {payload: DisplayType; type: typeof BuilderStateAction.SET_DISPLAY_TYPE}
-  | {payload: WidgetType; type: typeof BuilderStateAction.SET_DATASET};
+  | {payload: WidgetType; type: typeof BuilderStateAction.SET_DATASET}
+  | {payload: Column[]; type: typeof BuilderStateAction.SET_FIELDS};
 
 interface WidgetBuilderState {
   dataset?: WidgetType;
   description?: string;
   displayType?: DisplayType;
+  fields?: Column[];
   title?: string;
 }
 
@@ -33,16 +42,22 @@ function useWidgetBuilderState(): {
   });
   const [displayType, setDisplayType] = useQueryParamState<DisplayType>({
     fieldName: 'displayType',
-    decoder: decodeDisplayType,
+    deserializer: deserializeDisplayType,
   });
   const [dataset, setDataset] = useQueryParamState<WidgetType>({
     fieldName: 'dataset',
-    decoder: decodeDataset,
+    deserializer: deserializeDataset,
+  });
+  const [fields, setFields] = useQueryParamState<Column[]>({
+    fieldName: 'field',
+    decoder: decodeList,
+    deserializer: deserializeFields,
+    serializer: serializeFields,
   });
 
   const state = useMemo(
-    () => ({title, description, displayType, dataset}),
-    [title, description, displayType, dataset]
+    () => ({title, description, displayType, dataset, fields}),
+    [title, description, displayType, dataset, fields]
   );
 
   const dispatch = useCallback(
@@ -60,11 +75,14 @@ function useWidgetBuilderState(): {
         case BuilderStateAction.SET_DATASET:
           setDataset(action.payload);
           break;
+        case BuilderStateAction.SET_FIELDS:
+          setFields(action.payload);
+          break;
         default:
           break;
       }
     },
-    [setTitle, setDescription, setDisplayType, setDataset]
+    [setTitle, setDescription, setDisplayType, setDataset, setFields]
   );
 
   return {
@@ -77,7 +95,7 @@ function useWidgetBuilderState(): {
  * Decodes the display type from the query params
  * Returns the default display type if the value is not a valid display type
  */
-function decodeDisplayType(value: string): DisplayType {
+function deserializeDisplayType(value: string): DisplayType {
   if (Object.values(DisplayType).includes(value as DisplayType)) {
     return value as DisplayType;
   }
@@ -88,11 +106,27 @@ function decodeDisplayType(value: string): DisplayType {
  * Decodes the dataset from the query params
  * Returns the default dataset if the value is not a valid dataset
  */
-function decodeDataset(value: string): WidgetType {
+function deserializeDataset(value: string): WidgetType {
   if (Object.values(WidgetType).includes(value as WidgetType)) {
     return value as WidgetType;
   }
   return WidgetType.ERRORS;
+}
+
+/**
+ * Takes fields from the query params in list form and converts
+ * them into a list of fields and functions
+ */
+function deserializeFields(fields: string[]): Column[] {
+  return fields.map(field => explodeField({field}));
+}
+
+/**
+ * Takes fields in the field and function format and coverts
+ * them into a list of strings compatible with query params
+ */
+function serializeFields(fields: Column[]): string[] {
+  return fields.map(generateFieldAsString);
 }
 
 export default useWidgetBuilderState;


### PR DESCRIPTION
Support the fields object in the hook. This requires us to "explode" the fields into Column type objects which we can use inside Widget Builder, and serialize them back into a query params compatible type.

To do this, I change the `useQueryParamState` hook to optionally take a decoder to decode scalars or lists from the URL params. If it's a list, then I added serializer and deserializer props to convert to and from more complex objects.