### PR TITLE
feat(symbolication): Pass event & frame platforms

### DIFF
--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -89,7 +89,7 @@ def _handles_frame(frame: dict[str, Any], platform: str) -> bool:
     )
 
 
-FRAME_FIELDS = ("abs_path", "lineno", "function", "module", "filename", "in_app")
+FRAME_FIELDS = ("platform", "abs_path", "lineno", "function", "module", "filename", "in_app")
 
 
 def _normalize_frame(raw_frame: dict[str, Any], index: int) -> dict[str, Any]:
@@ -287,6 +287,7 @@ def process_jvm_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
     release_package = _get_release_package(symbolicator.project, data.get("release"))
     metrics.incr("process.java.symbolicate.request")
     response = symbolicator.process_jvm(
+        platform=data.get("platform"),
         exceptions=[
             {"module": exc["module"], "type": exc["type"]} for exc in processable_exceptions
         ],

--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -205,7 +205,7 @@ def _normalize_nonhandled_frame(frame, data):
     return frame
 
 
-FRAME_FIELDS = ("abs_path", "lineno", "colno", "function")
+FRAME_FIELDS = ("platform", "abs_path", "lineno", "colno", "function")
 
 
 def _normalize_frame(raw_frame: Any) -> dict:
@@ -240,6 +240,7 @@ def process_js_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
 
     metrics.incr("process.javascript.symbolicate.request")
     response = symbolicator.process_js(
+        platform=data.get("platform"),
         stacktraces=stacktraces,
         modules=modules,
         release=data.get("release"),

--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -285,7 +285,7 @@ def process_minidump(symbolicator: Symbolicator, data: Any) -> Any:
         return
 
     metrics.incr("process.native.symbolicate.request")
-    response = symbolicator.process_minidump(minidump.data)
+    response = symbolicator.process_minidump(data.get("platform"), minidump.data)
 
     if _handle_response_status(data, response):
         _merge_full_response(data, response)
@@ -308,7 +308,7 @@ def process_applecrashreport(symbolicator: Symbolicator, data: Any) -> Any:
         return
 
     metrics.incr("process.native.symbolicate.request")
-    response = symbolicator.process_applecrashreport(report.data)
+    response = symbolicator.process_applecrashreport(data.get("platform"), report.data)
 
     if _handle_response_status(data, response):
         _merge_full_response(data, response)
@@ -423,7 +423,9 @@ def process_native_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
     signal = signal_from_data(data)
 
     metrics.incr("process.native.symbolicate.request")
-    response = symbolicator.process_payload(stacktraces=stacktraces, modules=modules, signal=signal)
+    response = symbolicator.process_payload(
+        platform=data.get("platform"), stacktraces=stacktraces, modules=modules, signal=signal
+    )
 
     if not _handle_response_status(data, response):
         return data

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -160,7 +160,7 @@ class Symbolicator:
         (sources, process_response) = sources_for_symbolication(self.project)
         scraping_config = get_scraping_config(self.project)
         data = {
-            "platform": f'"{platform}"',
+            "platform": orjson.dumps(platform).decode(),
             "sources": orjson.dumps(sources).decode(),
             "scraping": orjson.dumps(scraping_config).decode(),
             "options": '{"dif_candidates": true}',
@@ -178,7 +178,7 @@ class Symbolicator:
         (sources, process_response) = sources_for_symbolication(self.project)
         scraping_config = get_scraping_config(self.project)
         data = {
-            "platform": f'"{platform}"',
+            "platform": orjson.dumps(platform).decode(),
             "sources": orjson.dumps(sources).decode(),
             "scraping": orjson.dumps(scraping_config).decode(),
             "options": '{"dif_candidates": true}',
@@ -198,7 +198,7 @@ class Symbolicator:
         (sources, process_response) = sources_for_symbolication(self.project)
         scraping_config = get_scraping_config(self.project)
         json = {
-            "platform": f'"{platform}"',
+            "platform": platform,
             "sources": sources,
             "options": {
                 "dif_candidates": True,
@@ -220,7 +220,7 @@ class Symbolicator:
         scraping_config = get_scraping_config(self.project)
 
         json = {
-            "platform": f'"{platform}"',
+            "platform": platform,
             "source": source,
             "stacktraces": stacktraces,
             "modules": modules,
@@ -261,7 +261,7 @@ class Symbolicator:
         source = get_internal_source(self.project)
 
         json = {
-            "platform": f'"{platform}"',
+            "platform": platform,
             "sources": [source],
             "exceptions": exceptions,
             "stacktraces": stacktraces,

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -156,10 +156,11 @@ class Symbolicator:
                 # Otherwise, we are done processing, yay
                 return json_response
 
-    def process_minidump(self, minidump):
+    def process_minidump(self, platform, minidump):
         (sources, process_response) = sources_for_symbolication(self.project)
         scraping_config = get_scraping_config(self.project)
         data = {
+            "platform": platform,
             "sources": orjson.dumps(sources).decode(),
             "scraping": orjson.dumps(scraping_config).decode(),
             "options": '{"dif_candidates": true}',
@@ -173,10 +174,11 @@ class Symbolicator:
         )
         return process_response(res)
 
-    def process_applecrashreport(self, report):
+    def process_applecrashreport(self, platform, report):
         (sources, process_response) = sources_for_symbolication(self.project)
         scraping_config = get_scraping_config(self.project)
         data = {
+            "platform": platform,
             "sources": orjson.dumps(sources).decode(),
             "scraping": orjson.dumps(scraping_config).decode(),
             "options": '{"dif_candidates": true}',
@@ -190,10 +192,13 @@ class Symbolicator:
         )
         return process_response(res)
 
-    def process_payload(self, stacktraces, modules, signal=None, apply_source_context=True):
+    def process_payload(
+        self, platform, stacktraces, modules, signal=None, apply_source_context=True
+    ):
         (sources, process_response) = sources_for_symbolication(self.project)
         scraping_config = get_scraping_config(self.project)
         json = {
+            "platform": platform,
             "sources": sources,
             "options": {
                 "dif_candidates": True,
@@ -210,11 +215,12 @@ class Symbolicator:
         res = self._process("symbolicate_stacktraces", "symbolicate", json=json)
         return process_response(res)
 
-    def process_js(self, stacktraces, modules, release, dist, apply_source_context=True):
+    def process_js(self, platform, stacktraces, modules, release, dist, apply_source_context=True):
         source = get_internal_artifact_lookup_source(self.project)
         scraping_config = get_scraping_config(self.project)
 
         json = {
+            "platform": platform,
             "source": source,
             "stacktraces": stacktraces,
             "modules": modules,
@@ -231,6 +237,7 @@ class Symbolicator:
 
     def process_jvm(
         self,
+        platform,
         exceptions,
         stacktraces,
         modules,
@@ -242,6 +249,7 @@ class Symbolicator:
         Process a JVM event by remapping its frames and exceptions with
         ProGuard.
 
+        :param platform: The event's platform. This should be either unset or "java".
         :param exceptions: The event's exceptions. These must contain a `type` and a `module`.
         :param stacktraces: The event's stacktraces. Frames must contain a `function` and a `module`.
         :param modules: ProGuard modules and source bundles. They must contain a `uuid` and have a
@@ -253,6 +261,7 @@ class Symbolicator:
         source = get_internal_source(self.project)
 
         json = {
+            "platform": platform,
             "sources": [source],
             "exceptions": exceptions,
             "stacktraces": stacktraces,

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -160,7 +160,7 @@ class Symbolicator:
         (sources, process_response) = sources_for_symbolication(self.project)
         scraping_config = get_scraping_config(self.project)
         data = {
-            "platform": platform,
+            "platform": f'"{platform}"',
             "sources": orjson.dumps(sources).decode(),
             "scraping": orjson.dumps(scraping_config).decode(),
             "options": '{"dif_candidates": true}',
@@ -178,7 +178,7 @@ class Symbolicator:
         (sources, process_response) = sources_for_symbolication(self.project)
         scraping_config = get_scraping_config(self.project)
         data = {
-            "platform": platform,
+            "platform": f'"{platform}"',
             "sources": orjson.dumps(sources).decode(),
             "scraping": orjson.dumps(scraping_config).decode(),
             "options": '{"dif_candidates": true}',
@@ -198,7 +198,7 @@ class Symbolicator:
         (sources, process_response) = sources_for_symbolication(self.project)
         scraping_config = get_scraping_config(self.project)
         json = {
-            "platform": platform,
+            "platform": f'"{platform}"',
             "sources": sources,
             "options": {
                 "dif_candidates": True,
@@ -220,7 +220,7 @@ class Symbolicator:
         scraping_config = get_scraping_config(self.project)
 
         json = {
-            "platform": platform,
+            "platform": f'"{platform}"',
             "source": source,
             "stacktraces": stacktraces,
             "modules": modules,
@@ -261,7 +261,7 @@ class Symbolicator:
         source = get_internal_source(self.project)
 
         json = {
-            "platform": platform,
+            "platform": f'"{platform}"',
             "sources": [source],
             "exceptions": exceptions,
             "stacktraces": stacktraces,

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -499,6 +499,7 @@ def symbolicate(
 ) -> Any:
     if platform in SHOULD_SYMBOLICATE_JS:
         return symbolicator.process_js(
+            platform=platform,
             stacktraces=stacktraces,
             modules=modules,
             release=profile.get("release"),
@@ -507,6 +508,7 @@ def symbolicate(
         )
     elif platform == "android":
         return symbolicator.process_jvm(
+            platform=platform,
             exceptions=[],
             stacktraces=stacktraces,
             modules=modules,
@@ -515,7 +517,7 @@ def symbolicate(
             classes=[],
         )
     return symbolicator.process_payload(
-        stacktraces=stacktraces, modules=modules, apply_source_context=False
+        platform=platform, stacktraces=stacktraces, modules=modules, apply_source_context=False
     )
 
 


### PR DESCRIPTION
This threads the `platform` fields of events and stack frames through to Symbolicator.

Background on why we want to do this: We are working on restructuring Symbolicator so that it will take mixed stacktraces directly without Sentry having to split them up and send them piecemeal. But in order for that to work we need to be able to tell native, JS, and JVM stack frames apart. The platform field seems like our best bet to do this, and for now we want to send it to Symbolicator and collect some metrics.