### PR TITLE
ref(insights): group all module routes under one constant

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1543,6 +1543,180 @@ function buildRoutes() {
     </Route>
   );
 
+  const moduleRoutes = [
+    <Route key={ModuleName.HTTP} path={`${MODULE_BASE_URLS[ModuleName.HTTP]}/`}>
+      <IndexRoute
+        component={make(() => import('sentry/views/insights/http/views/httpLandingPage'))}
+      />
+      <Route
+        path="domains/"
+        component={make(
+          () => import('sentry/views/insights/http/views/httpDomainSummaryPage')
+        )}
+      />
+    </Route>,
+    <Route key={ModuleName.VITAL} path={`${MODULE_BASE_URLS[ModuleName.VITAL]}/`}>
+      <IndexRoute
+        component={make(
+          () =>
+            import('sentry/views/insights/browser/webVitals/views/webVitalsLandingPage')
+        )}
+      />
+      <Route
+        path="overview/"
+        component={make(
+          () => import('sentry/views/insights/browser/webVitals/views/pageOverview')
+        )}
+      />
+    </Route>,
+    <Route key={ModuleName.RESOURCE} path={`${MODULE_BASE_URLS[ModuleName.RESOURCE]}/`}>
+      <IndexRoute
+        component={make(
+          () =>
+            import('sentry/views/insights/browser/resources/views/resourcesLandingPage')
+        )}
+      />
+      <Route
+        path="spans/span/:groupId/"
+        component={make(
+          () =>
+            import('sentry/views/insights/browser/resources/views/resourceSummaryPage')
+        )}
+      />
+    </Route>,
+    <Route key={ModuleName.DB} path={`${MODULE_BASE_URLS[ModuleName.DB]}/`}>
+      <IndexRoute
+        component={make(
+          () => import('sentry/views/insights/database/views/databaseLandingPage')
+        )}
+      />
+      <Route
+        path="spans/span/:groupId/"
+        component={make(
+          () => import('sentry/views/insights/database/views/databaseSpanSummaryPage')
+        )}
+      />
+    </Route>,
+    <Route key={ModuleName.CACHE} path={`${MODULE_BASE_URLS[ModuleName.CACHE]}/`}>
+      <IndexRoute
+        component={make(
+          () => import('sentry/views/insights/cache/views/cacheLandingPage')
+        )}
+      />
+    </Route>,
+    <Route key={ModuleName.QUEUE} path={`${MODULE_BASE_URLS[ModuleName.QUEUE]}/`}>
+      <IndexRoute
+        component={make(
+          () => import('sentry/views/insights/queues/views/queuesLandingPage')
+        )}
+      />
+      <Route
+        path="destination/"
+        component={make(
+          () => import('sentry/views/insights/queues/views/destinationSummaryPage')
+        )}
+      />
+    </Route>,
+    <Route
+      key={ModuleName.MOBILE_SCREENS}
+      path={`${MODULE_BASE_URLS[ModuleName.MOBILE_SCREENS]}/`}
+    >
+      <IndexRoute
+        component={make(
+          () => import('sentry/views/insights/mobile/screens/views/screensLandingPage')
+        )}
+      />
+      <Route
+        path="details/"
+        component={make(
+          () => import('sentry/views/insights/mobile/screens/views/screenDetailsPage')
+        )}
+      />
+    </Route>,
+    <Route
+      key={ModuleName.SCREEN_RENDERING}
+      path={`${MODULE_BASE_URLS[ModuleName.SCREEN_RENDERING]}/`}
+    >
+      <IndexRoute
+        component={make(
+          () =>
+            import(
+              'sentry/views/insights/mobile/screenRendering/screenRenderingLandingPage'
+            )
+        )}
+      />
+      <Route
+        path={`${SUMMARY_PAGE_BASE_URL}/`}
+        component={make(
+          () =>
+            import(
+              'sentry/views/insights/mobile/screenRendering/screenRenderingSummaryPage'
+            )
+        )}
+      />
+    </Route>,
+    <Route key={ModuleName.APP_START} path={`${MODULE_BASE_URLS[ModuleName.APP_START]}/`}>
+      <IndexRoute
+        component={make(
+          () =>
+            import('sentry/views/insights/mobile/appStarts/views/appStartsLandingPage')
+        )}
+      />
+      <Route
+        path="spans/"
+        component={make(
+          () => import('sentry/views/insights/mobile/appStarts/views/screenSummaryPage')
+        )}
+      />
+    </Route>,
+    <Route key={ModuleName.MOBILE_UI} path={`${MODULE_BASE_URLS[ModuleName.MOBILE_UI]}/`}>
+      <IndexRoute
+        component={make(
+          () => import('sentry/views/insights/mobile/ui/views/uiLandingPage')
+        )}
+      />
+      <Route
+        path="spans/"
+        component={make(
+          () => import('sentry/views/insights/mobile/ui/views/screenSummaryPage')
+        )}
+      />
+    </Route>,
+    <Route
+      key={ModuleName.SCREEN_LOAD}
+      path={`${MODULE_BASE_URLS[ModuleName.SCREEN_LOAD]}/`}
+    >
+      <IndexRoute
+        component={make(
+          () =>
+            import('sentry/views/insights/mobile/screenload/views/screenloadLandingPage')
+        )}
+      />
+      <Route
+        path="spans/"
+        component={make(
+          () =>
+            import('sentry/views/insights/mobile/screenload/views/screenLoadSpansPage')
+        )}
+      />
+    </Route>,
+    <Route key={ModuleName.AI} path={`${MODULE_BASE_URLS[ModuleName.AI]}/`}>
+      <IndexRoute
+        component={make(
+          () =>
+            import('sentry/views/insights/llmMonitoring/views/llmMonitoringLandingPage')
+        )}
+      />
+      <Route
+        path="pipeline-type/:groupId/"
+        component={make(
+          () =>
+            import('sentry/views/insights/llmMonitoring/views/llmMonitoringDetailsPage')
+        )}
+      />
+    </Route>,
+  ];
+
   const domainViewRoutes = (
     <Route path={`/${DOMAIN_VIEW_BASE_URL}/`} withOrgPath>
       <Route path={`${FRONTEND_LANDING_SUB_PATH}/`}>
@@ -1560,54 +1734,7 @@ function buildRoutes() {
           path="trends/"
           component={make(() => import('sentry/views/performance/trends'))}
         />
-        <Route path={`${MODULE_BASE_URLS[ModuleName.HTTP]}/`}>
-          <IndexRoute
-            component={make(
-              () => import('sentry/views/insights/http/views/httpLandingPage')
-            )}
-          />
-          <Route
-            path="domains/"
-            component={make(
-              () => import('sentry/views/insights/http/views/httpDomainSummaryPage')
-            )}
-          />
-        </Route>
-        <Route path={`${MODULE_BASE_URLS[ModuleName.VITAL]}/`}>
-          <IndexRoute
-            component={make(
-              () =>
-                import(
-                  'sentry/views/insights/browser/webVitals/views/webVitalsLandingPage'
-                )
-            )}
-          />
-          <Route
-            path="overview/"
-            component={make(
-              () => import('sentry/views/insights/browser/webVitals/views/pageOverview')
-            )}
-          />
-        </Route>
-        <Route path={`${MODULE_BASE_URLS[ModuleName.RESOURCE]}/`}>
-          <IndexRoute
-            component={make(
-              () =>
-                import(
-                  'sentry/views/insights/browser/resources/views/resourcesLandingPage'
-                )
-            )}
-          />
-          <Route
-            path="spans/span/:groupId/"
-            component={make(
-              () =>
-                import(
-                  'sentry/views/insights/browser/resources/views/resourceSummaryPage'
-                )
-            )}
-          />
-        </Route>
+        {moduleRoutes}
       </Route>
       <Route path={`${BACKEND_LANDING_SUB_PATH}/`}>
         <IndexRoute
@@ -1624,52 +1751,7 @@ function buildRoutes() {
           path="trends/"
           component={make(() => import('sentry/views/performance/trends'))}
         />
-        <Route path={`${MODULE_BASE_URLS[ModuleName.DB]}/`}>
-          <IndexRoute
-            component={make(
-              () => import('sentry/views/insights/database/views/databaseLandingPage')
-            )}
-          />
-          <Route
-            path="spans/span/:groupId/"
-            component={make(
-              () => import('sentry/views/insights/database/views/databaseSpanSummaryPage')
-            )}
-          />
-        </Route>
-        <Route path={`${MODULE_BASE_URLS[ModuleName.HTTP]}/`}>
-          <IndexRoute
-            component={make(
-              () => import('sentry/views/insights/http/views/httpLandingPage')
-            )}
-          />
-          <Route
-            path="domains/"
-            component={make(
-              () => import('sentry/views/insights/http/views/httpDomainSummaryPage')
-            )}
-          />
-        </Route>
-        <Route path={`${MODULE_BASE_URLS[ModuleName.CACHE]}/`}>
-          <IndexRoute
-            component={make(
-              () => import('sentry/views/insights/cache/views/cacheLandingPage')
-            )}
-          />
-        </Route>
-        <Route path={`${MODULE_BASE_URLS[ModuleName.QUEUE]}/`}>
-          <IndexRoute
-            component={make(
-              () => import('sentry/views/insights/queues/views/queuesLandingPage')
-            )}
-          />
-          <Route
-            path="destination/"
-            component={make(
-              () => import('sentry/views/insights/queues/views/destinationSummaryPage')
-            )}
-          />
-        </Route>
+        {moduleRoutes}
       </Route>
       <Route path={`${MOBILE_LANDING_SUB_PATH}/`}>
         <IndexRoute
@@ -1686,88 +1768,7 @@ function buildRoutes() {
           path="trends/"
           component={make(() => import('sentry/views/performance/trends'))}
         />
-        <Route path={`${MODULE_BASE_URLS[ModuleName.MOBILE_SCREENS]}/`}>
-          <IndexRoute
-            component={make(
-              () =>
-                import('sentry/views/insights/mobile/screens/views/screensLandingPage')
-            )}
-          />
-          <Route
-            path="details/"
-            component={make(
-              () => import('sentry/views/insights/mobile/screens/views/screenDetailsPage')
-            )}
-          />
-        </Route>
-        <Route path={`${MODULE_BASE_URLS[ModuleName.SCREEN_RENDERING]}/`}>
-          <IndexRoute
-            component={make(
-              () =>
-                import(
-                  'sentry/views/insights/mobile/screenRendering/screenRenderingLandingPage'
-                )
-            )}
-          />
-          <Route
-            path={`${SUMMARY_PAGE_BASE_URL}/`}
-            component={make(
-              () =>
-                import(
-                  'sentry/views/insights/mobile/screenRendering/screenRenderingSummaryPage'
-                )
-            )}
-          />
-        </Route>
-        <Route path={`${MODULE_BASE_URLS[ModuleName.APP_START]}/`}>
-          <IndexRoute
-            component={make(
-              () =>
-                import(
-                  'sentry/views/insights/mobile/appStarts/views/appStartsLandingPage'
-                )
-            )}
-          />
-          <Route
-            path="spans/"
-            component={make(
-              () =>
-                import('sentry/views/insights/mobile/appStarts/views/screenSummaryPage')
-            )}
-          />
-        </Route>
-        <Route path={`${MODULE_BASE_URLS[ModuleName.MOBILE_UI]}/`}>
-          <IndexRoute
-            component={make(
-              () => import('sentry/views/insights/mobile/ui/views/uiLandingPage')
-            )}
-          />
-          <Route
-            path="spans/"
-            component={make(
-              () => import('sentry/views/insights/mobile/ui/views/screenSummaryPage')
-            )}
-          />
-        </Route>
-        <Route path={`${MODULE_BASE_URLS[ModuleName.SCREEN_LOAD]}/`}>
-          <IndexRoute
-            component={make(
-              () =>
-                import(
-                  'sentry/views/insights/mobile/screenload/views/screenloadLandingPage'
-                )
-            )}
-          />
-          <Route
-            path="spans/"
-            component={make(
-              () =>
-                import(
-                  'sentry/views/insights/mobile/screenload/views/screenLoadSpansPage'
-                )
-            )}
-          />
-        </Route>
+        {moduleRoutes}
       </Route>
       <Route path={`${AI_LANDING_SUB_PATH}/`}>
         <IndexRoute
@@ -1782,25 +1783,7 @@ function buildRoutes() {
           path="trends/"
           component={make(() => import('sentry/views/performance/trends'))}
         />
-        <Route path={`${MODULE_BASE_URLS[ModuleName.AI]}/`}>
-          <IndexRoute
-            component={make(
-              () =>
-                import(
-                  'sentry/views/insights/llmMonitoring/views/llmMonitoringLandingPage'
-                )
-            )}
-          />
-          <Route
-            path="pipeline-type/:groupId/"
-            component={make(
-              () =>
-                import(
-                  'sentry/views/insights/llmMonitoring/views/llmMonitoringDetailsPage'
-                )
-            )}
-          />
-        </Route>
+        {moduleRoutes}
       </Route>
     </Route>
   );


### PR DESCRIPTION
This PR groups all module routes under one `moduleRoutes` constant. And then this constant is used within the frontend,backend,mobile and ai domain view routes. There's two motivations behind this
1. Simplifies adding new modules, you only have to add routes in one place
2. We have had a couple internal and external feedback, that certain modules belong in certain domains. For example some users requested http module should be under `mobile` as well. And we may add the `assets` module to `mobile` at some point too. This PR means we never have to worry about adding new routes when moving modules to new domains, we just have to update the header tabs to link to the module.

One drawback is that there will be some unused routes, but I don't see this being a problem, and it simplifies things a little.