### PR TITLE
feat(explore): Do not reload existing charts

### DIFF
--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -1,8 +1,8 @@
 import type {Dispatch, SetStateAction} from 'react';
 import {Fragment, useCallback, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
+import isEqual from 'lodash/isEqual';
 
-import {getInterval} from 'sentry/components/charts/utils';
 import {CompactSelect} from 'sentry/components/compactSelect';
 import {Tooltip} from 'sentry/components/tooltip';
 import {CHART_PALETTE} from 'sentry/constants/chartPalette';
@@ -16,7 +16,7 @@ import {
   prettifyParsedFunction,
 } from 'sentry/utils/discover/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import usePageFilters from 'sentry/utils/usePageFilters';
+import usePrevious from 'sentry/utils/usePrevious';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import ChartContextMenu from 'sentry/views/explore/components/chartContextMenu';
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
@@ -60,7 +60,6 @@ export const EXPLORE_CHART_GROUP = 'explore-charts_group';
 
 // TODO: Update to support aggregate mode and multiple queries / visualizations
 export function ExploreCharts({query, setError}: ExploreChartsProps) {
-  const pageFilters = usePageFilters();
   const [dataset] = useDataset();
   const [visualizes, setVisualizes] = useVisualizes();
   const [interval, setInterval, intervalOptions] = useChartInterval();
@@ -93,25 +92,53 @@ export function ExploreCharts({query, setError}: ExploreChartsProps) {
     return deduped;
   }, [visualizes]);
 
-  const search = new MutableSearch(query);
+  const options = useMemo(() => {
+    const search = new MutableSearch(query);
 
-  // Filtering out all spans with op like 'ui.interaction*' which aren't
-  // embedded under transactions. The trace view does not support rendering
-  // such spans yet.
-  search.addFilterValues('!transaction.span_id', ['00']);
+    // Filtering out all spans with op like 'ui.interaction*' which aren't
+    // embedded under transactions. The trace view does not support rendering
+    // such spans yet.
+    search.addFilterValues('!transaction.span_id', ['00']);
 
-  const timeSeriesResult = useSortedTimeSeries(
-    {
+    return {
       search,
       yAxis: yAxes,
-      interval: interval ?? getInterval(pageFilters.selection.datetime, 'metrics'),
+      interval,
       fields,
       orderby,
       topEvents,
-    },
-    'api.explorer.stats',
-    dataset
-  );
+    };
+  }, [query, yAxes, interval, fields, orderby, topEvents]);
+
+  const previousQuery = usePrevious(query);
+  const previousOptions = usePrevious(options);
+  const canUsePreviousResults = useMemo(() => {
+    if (!isEqual(query, previousQuery)) {
+      return false;
+    }
+
+    if (!isEqual(options.interval, previousOptions.interval)) {
+      return false;
+    }
+
+    if (!isEqual(options.fields, previousOptions.fields)) {
+      return false;
+    }
+
+    if (!isEqual(options.orderby, previousOptions.orderby)) {
+      return false;
+    }
+
+    if (!isEqual(options.topEvents, previousOptions.topEvents)) {
+      return false;
+    }
+
+    return true;
+  }, [query, previousQuery, options, previousOptions]);
+
+  const timeSeriesResult = useSortedTimeSeries(options, 'api.explorer.stats', dataset);
+
+  const previousTimeSeriesResult = usePrevious(timeSeriesResult);
 
   useEffect(() => {
     setError(timeSeriesResult.error?.message ?? '');
@@ -119,9 +146,17 @@ export function ExploreCharts({query, setError}: ExploreChartsProps) {
 
   const getSeries = useCallback(
     (dedupedYAxes: string[], formattedYAxes: (string | undefined)[]) => {
-      return dedupedYAxes.flatMap((yAxis, i) => {
-        const series = timeSeriesResult.data[yAxis] ?? [];
-        return series.map(s => {
+      const shouldUsePreviousResults =
+        timeSeriesResult.isPending &&
+        canUsePreviousResults &&
+        dedupedYAxes.every(yAxis => previousTimeSeriesResult.data.hasOwnProperty(yAxis));
+
+      const data = dedupedYAxes.flatMap((yAxis, i) => {
+        const series = shouldUsePreviousResults
+          ? previousTimeSeriesResult.data[yAxis]
+          : timeSeriesResult.data[yAxis];
+
+        return (series ?? []).map(s => {
           // We replace the series name with the formatted series name here
           // when possible as it's cleaner to read.
           //
@@ -136,8 +171,18 @@ export function ExploreCharts({query, setError}: ExploreChartsProps) {
           return s;
         });
       });
+
+      return {
+        data,
+        error: shouldUsePreviousResults
+          ? previousTimeSeriesResult.error
+          : timeSeriesResult.error,
+        loading: shouldUsePreviousResults
+          ? previousTimeSeriesResult.isPending
+          : timeSeriesResult.isPending,
+      };
     },
-    [timeSeriesResult]
+    [canUsePreviousResults, timeSeriesResult, previousTimeSeriesResult]
   );
 
   const handleChartTypeChange = useCallback(
@@ -175,7 +220,7 @@ export function ExploreCharts({query, setError}: ExploreChartsProps) {
               ? 'area'
               : 'bar';
 
-        const data = getSeries(dedupedYAxes, formattedYAxes);
+        const {data, error, loading} = getSeries(dedupedYAxes, formattedYAxes);
 
         const outputTypes = new Set(
           formattedYAxes.filter(Boolean).map(aggregateOutputType)
@@ -236,8 +281,8 @@ export function ExploreCharts({query, setError}: ExploreChartsProps) {
                 }}
                 legendFormatter={value => formatVersion(value)}
                 data={data}
-                error={timeSeriesResult.error}
-                loading={timeSeriesResult.isPending}
+                error={error}
+                loading={loading}
                 chartGroup={EXPLORE_CHART_GROUP}
                 // TODO Abdullah: Make chart colors dynamic, with changing topN events count and overlay count.
                 chartColors={CHART_PALETTE[TOP_EVENTS_LIMIT - 1]}


### PR DESCRIPTION
When adding a new chart to explore, we should avoid showing the existing charts as loading again.