### PR TITLE
fix(explore): Order of options in aggregate mode

### DIFF
--- a/static/app/views/explore/tables/aggregatesTable.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.tsx
@@ -61,9 +61,25 @@ export function AggregatesTable({setError}: AggregatesTableProps) {
   const {groupBys} = useGroupBys();
   const [visualizes] = useVisualizes();
   const fields = useMemo(() => {
-    return [...groupBys, ...visualizes.flatMap(visualize => visualize.yAxes)].filter(
-      Boolean
-    );
+    const allFields: string[] = [];
+
+    for (const visualize of visualizes) {
+      for (const yAxis of visualize.yAxes) {
+        if (allFields.includes(yAxis)) {
+          continue;
+        }
+        allFields.push(yAxis);
+      }
+    }
+
+    for (const groupBy of groupBys) {
+      if (allFields.includes(groupBy)) {
+        continue;
+      }
+      allFields.push(groupBy);
+    }
+
+    return allFields.filter(Boolean);
   }, [groupBys, visualizes]);
   const [sorts, setSorts] = useSorts({fields});
   const [query] = useUserQuery();


### PR DESCRIPTION
Temporary fix to synchronize them. The real fix here is to not have `useSorts` take fields as as argument and be able to directly access fields.