### PR TITLE
feat(widget-builder): Open widget builder slideout when adding widget

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1064,7 +1064,7 @@ function buildRoutes() {
       <Fragment>
         {USING_CUSTOMER_DOMAIN && (
           <Route
-            path="/dashboards/new/"
+            path="/dashboards/new/*"
             component={withDomainRequired(
               make(() => import('sentry/views/dashboards/create'))
             )}
@@ -1081,7 +1081,7 @@ function buildRoutes() {
           </Route>
         )}
         <Route
-          path="/organizations/:orgId/dashboards/new/"
+          path="/organizations/:orgId/dashboards/new/*"
           component={withDomainRedirect(
             make(() => import('sentry/views/dashboards/create'))
           )}
@@ -1133,21 +1133,10 @@ function buildRoutes() {
         <Redirect from="/dashboards/:dashboardId/" to="/dashboard/:dashboardId/" />
       )}
       <Route
-        path="/dashboard/:dashboardId/"
+        path="/dashboard/:dashboardId/*"
         component={make(() => import('sentry/views/dashboards/view'))}
         withOrgPath
       >
-        {/* New widget builder routes */}
-        <Route
-          path="widget-builder/widget/:widgetIndex/edit/"
-          component={make(() => import('sentry/views/dashboards/view'))}
-        />
-        <Route
-          path="widget-builder/widget/new/"
-          component={make(() => import('sentry/views/dashboards/view'))}
-        />
-
-        {/* Old widget builder routes */}
         <Route
           path="widget/:widgetIndex/edit/"
           component={make(() => import('sentry/views/dashboards/widgetBuilder'))}

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1064,12 +1064,23 @@ function buildRoutes() {
       <Fragment>
         {USING_CUSTOMER_DOMAIN && (
           <Route
-            path="/dashboards/new/*"
+            path="/dashboards/new/"
             component={withDomainRequired(
               make(() => import('sentry/views/dashboards/create'))
             )}
             key="orgless-dashboards-new-route"
           >
+            {/* New widget builder routes */}
+            <Route
+              path="widget-builder/widget/:widgetIndex/edit/"
+              component={make(() => import('sentry/views/dashboards/view'))}
+            />
+            <Route
+              path="widget-builder/widget/new/"
+              component={make(() => import('sentry/views/dashboards/view'))}
+            />
+
+            {/* Old widget builder routes */}
             <Route
               path="widget/:widgetIndex/edit/"
               component={make(() => import('sentry/views/dashboards/widgetBuilder'))}
@@ -1081,12 +1092,23 @@ function buildRoutes() {
           </Route>
         )}
         <Route
-          path="/organizations/:orgId/dashboards/new/*"
+          path="/organizations/:orgId/dashboards/new/"
           component={withDomainRedirect(
             make(() => import('sentry/views/dashboards/create'))
           )}
           key="org-dashboards-new"
         >
+          {/* New widget builder routes */}
+          <Route
+            path="widget-builder/widget/:widgetIndex/edit/"
+            component={make(() => import('sentry/views/dashboards/view'))}
+          />
+          <Route
+            path="widget-builder/widget/new/"
+            component={make(() => import('sentry/views/dashboards/view'))}
+          />
+
+          {/* Old widget builder routes */}
           <Route
             path="widget/:widgetIndex/edit/"
             component={make(() => import('sentry/views/dashboards/widgetBuilder'))}
@@ -1133,10 +1155,21 @@ function buildRoutes() {
         <Redirect from="/dashboards/:dashboardId/" to="/dashboard/:dashboardId/" />
       )}
       <Route
-        path="/dashboard/:dashboardId/*"
+        path="/dashboard/:dashboardId/"
         component={make(() => import('sentry/views/dashboards/view'))}
         withOrgPath
       >
+        {/* New widget builder routes */}
+        <Route
+          path="widget-builder/widget/:widgetIndex/edit/"
+          component={make(() => import('sentry/views/dashboards/view'))}
+        />
+        <Route
+          path="widget-builder/widget/new/"
+          component={make(() => import('sentry/views/dashboards/view'))}
+        />
+
+        {/* Old widget builder routes */}
         <Route
           path="widget/:widgetIndex/edit/"
           component={make(() => import('sentry/views/dashboards/widgetBuilder'))}

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1137,6 +1137,17 @@ function buildRoutes() {
         component={make(() => import('sentry/views/dashboards/view'))}
         withOrgPath
       >
+        {/* New widget builder routes */}
+        <Route
+          path="widget-builder/widget/:widgetIndex/edit/"
+          component={make(() => import('sentry/views/dashboards/view'))}
+        />
+        <Route
+          path="widget-builder/widget/new/"
+          component={make(() => import('sentry/views/dashboards/view'))}
+        />
+
+        {/* Old widget builder routes */}
         <Route
           path="widget/:widgetIndex/edit/"
           component={make(() => import('sentry/views/dashboards/widgetBuilder'))}

--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -95,6 +95,7 @@ type Props = {
   handleChangeSplitDataset?: (widget: Widget, index: number) => void;
   isPreview?: boolean;
   newWidget?: Widget;
+  onAddWidget?: (dataset?: DataSet) => void;
   onSetNewWidget?: () => void;
   paramDashboardId?: string;
   paramTemplateId?: string;
@@ -222,18 +223,38 @@ class Dashboard extends Component<Props, State> {
   }
 
   handleStartAdd = (dataset?: DataSet) => {
-    const {organization, router, location, paramDashboardId, handleAddMetricWidget} =
-      this.props;
+    const {
+      organization,
+      router,
+      location,
+      paramDashboardId,
+      handleAddMetricWidget,
+      onAddWidget,
+    } = this.props;
 
     if (dataset === DataSet.METRICS) {
       handleAddMetricWidget?.({...this.addWidgetLayout, ...METRIC_WIDGET_MIN_SIZE});
       return;
     }
 
-    if (paramDashboardId) {
+    if (!organization.features.includes('dashboards-widget-builder-redesign')) {
+      if (paramDashboardId) {
+        router.push(
+          normalizeUrl({
+            pathname: `/organizations/${organization.slug}/dashboard/${paramDashboardId}/widget/new/`,
+            query: {
+              ...location.query,
+              source: DashboardWidgetSource.DASHBOARDS,
+              dataset,
+            },
+          })
+        );
+        return;
+      }
+
       router.push(
         normalizeUrl({
-          pathname: `/organizations/${organization.slug}/dashboard/${paramDashboardId}/widget/new/`,
+          pathname: `/organizations/${organization.slug}/dashboards/new/widget/new/`,
           query: {
             ...location.query,
             source: DashboardWidgetSource.DASHBOARDS,
@@ -241,20 +262,11 @@ class Dashboard extends Component<Props, State> {
           },
         })
       );
+
       return;
     }
 
-    router.push(
-      normalizeUrl({
-        pathname: `/organizations/${organization.slug}/dashboards/new/widget/new/`,
-        query: {
-          ...location.query,
-          source: DashboardWidgetSource.DASHBOARDS,
-          dataset,
-        },
-      })
-    );
-
+    onAddWidget?.();
     return;
   };
 

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -25,9 +25,12 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import CreateDashboard from 'sentry/views/dashboards/create';
-import {handleUpdateDashboardSplit} from 'sentry/views/dashboards/detail';
+import DashboardDetail, {
+  handleUpdateDashboardSplit,
+} from 'sentry/views/dashboards/detail';
 import EditAccessSelector from 'sentry/views/dashboards/editAccessSelector';
 import * as types from 'sentry/views/dashboards/types';
+import {DashboardState} from 'sentry/views/dashboards/types';
 import ViewEditDashboard from 'sentry/views/dashboards/view';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
@@ -2015,6 +2018,57 @@ describe('Dashboards > Detail', function () {
         'aria-disabled',
         'true'
       );
+    });
+
+    describe('widget builder redesign', function () {
+      beforeEach(function () {
+        initialData = initializeOrg({
+          organization: OrganizationFixture({
+            features: [
+              'global-views',
+              'dashboards-basic',
+              'dashboards-edit',
+              'discover-query',
+              'performance-discover-dataset-selector',
+              'dashboards-widget-builder-redesign',
+            ],
+          }),
+        });
+      });
+
+      it('opens the widget builder slideout when clicking add widget', async function () {
+        render(
+          <DashboardDetail
+            {...RouteComponentPropsFixture()}
+            initialState={DashboardState.VIEW}
+            dashboard={DashboardFixture([])}
+            dashboards={[]}
+            onDashboardUpdate={jest.fn()}
+            newWidget={undefined}
+            onSetNewWidget={() => {}}
+          />,
+          {organization: initialData.organization}
+        );
+        await userEvent.click(await screen.findByRole('button', {name: 'Add Widget'}));
+        expect(await screen.findByText('Create Custom Widget')).toBeInTheDocument();
+      });
+
+      it('opens the widget builder slideout when clicking add widget in edit mode', async function () {
+        render(
+          <DashboardDetail
+            {...RouteComponentPropsFixture()}
+            initialState={DashboardState.EDIT}
+            dashboard={DashboardFixture([])}
+            dashboards={[]}
+            onDashboardUpdate={jest.fn()}
+            newWidget={undefined}
+            onSetNewWidget={() => {}}
+          />,
+          {organization: initialData.organization}
+        );
+        await userEvent.click(await screen.findByTestId('widget-add'));
+        expect(await screen.findByText('Create Custom Widget')).toBeInTheDocument();
+      });
     });
 
     describe('discover split', function () {

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -250,7 +250,7 @@ class DashboardDetail extends Component<Props, State> {
       location: this.props.location,
       router: this.props.router,
     }),
-    isWidgetBuilderOpen: this.isWidgetBuilderRouter,
+    isWidgetBuilderOpen: this.isRedesignedWidgetBuilder,
   };
 
   componentDidMount() {
@@ -406,27 +406,34 @@ class DashboardDetail extends Component<Props, State> {
     const {location, params, organization} = this.props;
     const {dashboardId, widgetIndex} = params;
 
+    const widgetBuilderRoutes = [
+      `/organizations/${organization.slug}/dashboards/new/widget/new/`,
+      `/organizations/${organization.slug}/dashboard/${dashboardId}/widget/new/`,
+      `/organizations/${organization.slug}/dashboards/new/widget/${widgetIndex}/edit/`,
+      `/organizations/${organization.slug}/dashboard/${dashboardId}/widget/${widgetIndex}/edit/`,
+    ];
+
+    if (USING_CUSTOMER_DOMAIN) {
+      // TODO: replace with url generation later on.
+      widgetBuilderRoutes.push(
+        ...[
+          `/dashboards/new/widget/new/`,
+          `/dashboard/${dashboardId}/widget/new/`,
+          `/dashboards/new/widget/${widgetIndex}/edit/`,
+          `/dashboard/${dashboardId}/widget/${widgetIndex}/edit/`,
+        ]
+      );
+    }
+
+    return widgetBuilderRoutes.includes(location.pathname);
+  }
+
+  get isRedesignedWidgetBuilder() {
+    const {organization, location, params} = this.props;
+    const {dashboardId, widgetIndex} = params;
+
     if (!organization.features.includes('dashboards-widget-builder-redesign')) {
-      const widgetBuilderRoutes = [
-        `/organizations/${organization.slug}/dashboards/new/widget/new/`,
-        `/organizations/${organization.slug}/dashboard/${dashboardId}/widget/new/`,
-        `/organizations/${organization.slug}/dashboards/new/widget/${widgetIndex}/edit/`,
-        `/organizations/${organization.slug}/dashboard/${dashboardId}/widget/${widgetIndex}/edit/`,
-      ];
-
-      if (USING_CUSTOMER_DOMAIN) {
-        // TODO: replace with url generation later on.
-        widgetBuilderRoutes.push(
-          ...[
-            `/dashboards/new/widget/new/`,
-            `/dashboard/${dashboardId}/widget/new/`,
-            `/dashboards/new/widget/${widgetIndex}/edit/`,
-            `/dashboard/${dashboardId}/widget/${widgetIndex}/edit/`,
-          ]
-        );
-      }
-
-      return widgetBuilderRoutes.includes(location.pathname);
+      return false;
     }
 
     const widgetBuilderRoutes = [
@@ -1265,10 +1272,7 @@ class DashboardDetail extends Component<Props, State> {
       return this.renderDevWidgetBuilder();
     }
 
-    if (
-      this.isWidgetBuilderRouter &&
-      !organization.features.includes('dashboards-widget-builder-redesign')
-    ) {
+    if (this.isWidgetBuilderRouter) {
       return this.renderWidgetBuilder();
     }
 

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -335,11 +335,6 @@ class DashboardDetail extends Component<Props, State> {
             });
           },
           onEdit: () => {
-            if (organization.features.includes('dashboards-widget-builder-redesign')) {
-              this.setState({isWidgetBuilderOpen: true});
-              return;
-            }
-
             const widgetIndex = dashboard.widgets.indexOf(widget);
             if (dashboardId) {
               const query = omit(location.query, Object.values(WidgetViewerQueryField));


### PR DESCRIPTION
Under the `dashboards-widget-builder-redesign` feature flag, when the "Add Widget" button is clicked (either in the header bar or the edit dashboard state) then open up the widget builder.

This is achieved by:
- Add routes specifically for the new widget builder
  - These aren't permanent and mostly for dev. We need to find a way to transition this URL to the old widget builder at some point
- Handle URL management for the redesign in the `detail.tsx` component
  - Required me to pass down `onAddWidget`
- When cancelling/closing the modal, the URL should go back to the dashboard with the right params from the page filters.

⚠️ This doesn't support Edit Widget yet.