### PR TITLE
ref(issue-details): Allow event endpoint results to filter by query, date and environment

### DIFF
--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -164,7 +164,7 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
         """
         environments = [e for e in get_environments(request, group.project.organization)]
         environment_names = [e.name for e in environments]
-        # # The enforced streamlined UI doesn't want a fallback event if the filters yield no results.
+        # The enforced streamlined UI doesn't want a fallback event if the filters yield no results.
         request.GET.get("no_fallback") is not None or features.has(
             "organizations:issue-details-streamline-enforce",
             group.organization,
@@ -225,8 +225,6 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
                 event = eventstore.backend.get_event_by_id(
                     group.project.id, event_id, group_id=group.id
                 )
-            # TODO: Remove `for_group` check once performance issues are moved to the issue platform
-
             if event is not None and event.group:
                 event = event.for_group(event.group)
 

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -792,16 +792,22 @@ class Group(Model):
         self,
         environments: Sequence[Environment] = (),
         conditions: Sequence[Condition] | None = None,
+        *,
+        always_return_event: bool = True,
     ) -> GroupEvent | None:
         maybe_event = get_recommended_event_for_environments(
             environments,
             self,
             conditions,
         )
+
+        if maybe_event:
+            return maybe_event
+
         return (
-            maybe_event
-            if maybe_event
-            else self.get_latest_event_for_environments([env.name for env in environments])
+            self.get_latest_event_for_environments([env.name for env in environments])
+            if always_return_event
+            else None
         )
 
     def get_suspect_commit(self) -> Commit | None:

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -798,7 +798,9 @@ class Group(Model):
         Legacy special case of `self.get_latest_event` for environments and no date range.
         Kept for compatability, but it's advised to use `self.get_latest_event` directly.
         """
-        conditions = [["environment", "IN", environments]] if len(environments) > 0 else []
+        conditions = (
+            [Condition(Column("environment"), Op.IN, environments)] if len(environments) > 0 else []
+        )
         return self.get_latest_event(conditions=conditions)
 
     def get_oldest_event(
@@ -826,7 +828,9 @@ class Group(Model):
         Legacy special case of `self.get_oldest_event` for environments and no date range.
         Kept for compatability, but it's advised to use `self.get_oldest_event` directly.
         """
-        conditions = [["environment", "IN", environments]] if len(environments) > 0 else []
+        conditions = (
+            [Condition(Column("environment"), Op.IN, environments)] if len(environments) > 0 else []
+        )
         return self.get_oldest_event(conditions=conditions)
 
     def get_recommended_event(

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -861,7 +861,7 @@ class Group(Model):
         Legacy special case of `self.get_recommended_event` for environments and no date range.
         Kept for compatability, but it's advised to use `self.get_recommended_event` directly.
         """
-        all_conditions = conditions if conditions else []
+        all_conditions: list[Condition] = list(conditions) if conditions else []
         if len(environments) > 0:
             all_conditions.append(
                 Condition(Column("environment"), Op.IN, [e.name for e in environments])

--- a/tests/sentry/issues/endpoints/test_group_event_details.py
+++ b/tests/sentry/issues/endpoints/test_group_event_details.py
@@ -377,7 +377,7 @@ class GroupEventDetailsHelpfulEndpointTest(
         issue_title = "king of england"
         occurrence, group_info = self.process_occurrence(
             project_id=self.project.id,
-            title=issue_title,
+            issue_title=issue_title,
             event_data={"level": "info"},
         )
 

--- a/tests/snuba/models/test_group.py
+++ b/tests/snuba/models/test_group.py
@@ -246,7 +246,7 @@ class GroupTestSnubaErrorIssue(TestCase, SnubaTestCase):
         conditions = [Condition(Column("environment"), Op.IN, ["production"])]
         assert _get_recommended(self.group, conditions=conditions).event_id == self.event_b.event_id
         conditions = [Condition(Column("environment"), Op.IN, ["development"])]
-        assert _get_recommended(self.group, conditions=conditions) is None
+        assert self.group.get_recommended_event(conditions=conditions) is None
 
         # Filter by query
         conditions = [Condition(Column("tags[organization.slug]"), Op.EQ, "sentry")]
@@ -278,7 +278,7 @@ class GroupTestSnubaErrorIssue(TestCase, SnubaTestCase):
         conditions = [Condition(Column("environment"), Op.IN, ["production"])]
         assert _get_latest(self.group, conditions=conditions).event_id == self.event_b.event_id
         conditions = [Condition(Column("environment"), Op.IN, ["development"])]
-        assert _get_latest(self.group, conditions=conditions) is None
+        assert self.group.get_latest_event(conditions=conditions) is None
 
         # Filter by query
         conditions = [Condition(Column("tags[organization.slug]"), Op.EQ, "sentry")]
@@ -308,7 +308,7 @@ class GroupTestSnubaErrorIssue(TestCase, SnubaTestCase):
         conditions = [Condition(Column("environment"), Op.IN, ["production"])]
         assert _get_oldest(self.group, conditions=conditions).event_id == self.event_b.event_id
         conditions = [Condition(Column("environment"), Op.IN, ["development"])]
-        assert _get_oldest(self.group, conditions=conditions) is None
+        assert self.group.get_oldest_event(conditions=conditions) is None
 
         # Filter by query
         conditions = [Condition(Column("tags[organization.slug]"), Op.EQ, "sentry")]
@@ -381,7 +381,7 @@ class GroupTestSnubaPerformanceIssue(TestCase, SnubaTestCase, PerformanceIssueTe
             event_data=event_data_c, fingerprint=group_fingerprint
         )
 
-        self.group = Group.objects.get()
+        self.group: Group = Group.objects.get()
         assert isinstance(self.group, Group)
 
     def test_recommended_event(self):
@@ -394,7 +394,7 @@ class GroupTestSnubaPerformanceIssue(TestCase, SnubaTestCase, PerformanceIssueTe
         conditions = [Condition(Column("environment"), Op.IN, ["production"])]
         assert _get_recommended(self.group, conditions=conditions).event_id == self.event_b.event_id
         conditions = [Condition(Column("environment"), Op.IN, ["development"])]
-        assert _get_recommended(self.group, conditions=conditions) is None
+        assert self.group.get_recommended_event(conditions=conditions) is None
 
         # Filter by query
         conditions = [Condition(Column("tags[organization.slug]"), Op.EQ, "sentry")]
@@ -426,7 +426,7 @@ class GroupTestSnubaPerformanceIssue(TestCase, SnubaTestCase, PerformanceIssueTe
         conditions = [Condition(Column("environment"), Op.IN, ["production"])]
         assert _get_latest(self.group, conditions=conditions).event_id == self.event_b.event_id
         conditions = [Condition(Column("environment"), Op.IN, ["development"])]
-        assert _get_latest(self.group, conditions=conditions) is None
+        assert self.group.get_latest_event(conditions=conditions) is None
 
         # Filter by query
         conditions = [Condition(Column("tags[organization.slug]"), Op.EQ, "sentry")]
@@ -456,7 +456,7 @@ class GroupTestSnubaPerformanceIssue(TestCase, SnubaTestCase, PerformanceIssueTe
         conditions = [Condition(Column("environment"), Op.IN, ["production"])]
         assert _get_oldest(self.group, conditions=conditions).event_id == self.event_b.event_id
         conditions = [Condition(Column("environment"), Op.IN, ["development"])]
-        assert _get_oldest(self.group, conditions=conditions) is None
+        assert self.group.get_oldest_event(conditions=conditions) is None
 
         # Filter by query
         conditions = [Condition(Column("tags[organization.slug]"), Op.EQ, "sentry")]
@@ -537,7 +537,6 @@ class GroupTestSnubaOccurrenceIssue(TestCase, SnubaTestCase, OccurrenceTestMixin
 
     def test_recommended_event(self):
         # No filter
-
         self.assert_occurrences_identical(_get_recommended(self.group).occurrence, self.issue_occ_b)
 
         # Filter by environment
@@ -552,7 +551,7 @@ class GroupTestSnubaOccurrenceIssue(TestCase, SnubaTestCase, OccurrenceTestMixin
             == self.issue_occ_b.event_id
         )
         conditions = [Condition(Column("environment"), Op.IN, ["development"])]
-        assert _get_recommended(self.group, conditions=conditions) is None
+        assert self.group.get_recommended_event(conditions=conditions) is None
 
         # Filter by query
         conditions = [Condition(Column("tags[organization.slug]"), Op.EQ, "sentry")]
@@ -590,7 +589,7 @@ class GroupTestSnubaOccurrenceIssue(TestCase, SnubaTestCase, OccurrenceTestMixin
         conditions = [Condition(Column("environment"), Op.IN, ["production"])]
         assert _get_latest(self.group, conditions=conditions).event_id == self.issue_occ_b.event_id
         conditions = [Condition(Column("environment"), Op.IN, ["development"])]
-        assert _get_latest(self.group, conditions=conditions) is None
+        assert self.group.get_latest_event(conditions=conditions) is None
 
         # Filter by query
         conditions = [Condition(Column("tags[organization.slug]"), Op.EQ, "sentry")]
@@ -620,7 +619,7 @@ class GroupTestSnubaOccurrenceIssue(TestCase, SnubaTestCase, OccurrenceTestMixin
         conditions = [Condition(Column("environment"), Op.IN, ["production"])]
         assert _get_oldest(self.group, conditions=conditions).event_id == self.issue_occ_b.event_id
         conditions = [Condition(Column("environment"), Op.IN, ["development"])]
-        assert _get_oldest(self.group, conditions=conditions) is None
+        assert self.group.get_oldest_event(conditions=conditions) is None
 
         # Filter by query
         conditions = [Condition(Column("tags[organization.slug]"), Op.EQ, "sentry")]

--- a/tests/snuba/models/test_group.py
+++ b/tests/snuba/models/test_group.py
@@ -34,14 +34,11 @@ def _get_oldest_non_null(g: Group, environments: Sequence[str] = ()) -> GroupEve
 class GroupTestSnuba(TestCase, SnubaTestCase, PerformanceIssueTestCase, OccurrenceTestMixin):
     def test_get_oldest_latest_for_environments(self):
         project = self.create_project()
-
-        min_ago = iso_format(before_now(minutes=1))
-
         self.store_event(
             data={
                 "event_id": "a" * 32,
                 "environment": "production",
-                "timestamp": min_ago,
+                "timestamp": iso_format(before_now(minutes=3)),
                 "fingerprint": ["group-1"],
             },
             project_id=project.id,
@@ -50,13 +47,17 @@ class GroupTestSnuba(TestCase, SnubaTestCase, PerformanceIssueTestCase, Occurren
             data={
                 "event_id": "b" * 32,
                 "environment": "production",
-                "timestamp": min_ago,
+                "timestamp": iso_format(before_now(minutes=2)),
                 "fingerprint": ["group-1"],
             },
             project_id=project.id,
         )
         self.store_event(
-            data={"event_id": "c" * 32, "timestamp": min_ago, "fingerprint": ["group-1"]},
+            data={
+                "event_id": "c" * 32,
+                "timestamp": iso_format(before_now(minutes=1)),
+                "fingerprint": ["group-1"],
+            },
             project_id=project.id,
         )
 
@@ -98,13 +99,12 @@ class GroupTestSnuba(TestCase, SnubaTestCase, PerformanceIssueTestCase, Occurren
 
     def test_error_issue_get_helpful_for_environments(self):
         project = self.create_project()
-        min_ago = iso_format(before_now(minutes=1))
         replay_id = uuid.uuid4().hex
 
         event_all_helpful_params = self.store_event(
             data={
                 "event_id": "a" * 32,
-                "timestamp": min_ago,
+                "timestamp": iso_format(before_now(minutes=3)),
                 "fingerprint": ["group-1"],
                 "contexts": {
                     "replay": {"replay_id": replay_id},
@@ -122,7 +122,7 @@ class GroupTestSnuba(TestCase, SnubaTestCase, PerformanceIssueTestCase, Occurren
         self.store_event(
             data={
                 "event_id": "b" * 32,
-                "timestamp": min_ago,
+                "timestamp": iso_format(before_now(minutes=2)),
                 "fingerprint": ["group-1"],
                 "contexts": {
                     "replay": {"replay_id": replay_id},
@@ -133,7 +133,11 @@ class GroupTestSnuba(TestCase, SnubaTestCase, PerformanceIssueTestCase, Occurren
             assert_no_errors=False,
         )
         event_none_helpful_params = self.store_event(
-            data={"event_id": "c" * 32, "timestamp": min_ago, "fingerprint": ["group-1"]},
+            data={
+                "event_id": "c" * 32,
+                "timestamp": iso_format(before_now(minutes=1)),
+                "fingerprint": ["group-1"],
+            },
             project_id=project.id,
         )
 


### PR DESCRIPTION
This will allow the new UI to filter the recommended, last, and first events by queries, dates, and environment. It also ensures the logic applies to the other issue types.

**todo**
- [x] Update tests
- [x] Add tests for different issue types 