### PR TITLE
fix(alerts): EAP alerts default to minimum 24h timerange when coming from 1h timerange in explore

### DIFF
--- a/static/app/views/insights/common/utils/getAlertsUrl.tsx
+++ b/static/app/views/insights/common/utils/getAlertsUrl.tsx
@@ -51,6 +51,8 @@ function getStatsPeriod(pageFilters: PageFilters) {
     case '7d':
     case '14d':
       return period;
+    case '1h':
+      return '24h'; // Explore allows 1h, but alerts only allows 24h minimum
     default:
       return '7d';
   }


### PR DESCRIPTION
Explore allows 1h timeranges, but alerts only allow a minimum of 24h timerange queries.