### PR TITLE
feat(billing): Add profile chunks to usage stats page

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -584,8 +584,10 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /tests/snuba/search/                                        @getsentry/issues
 ## End of Issues
 
-## Billing
-/src/sentry/api/endpoints/check_am2_compatibility.py    @getsentry/revenue
+## Billing/Revenue
+/src/sentry/api/endpoints/check_am2_compatibility.py              @getsentry/revenue
+/static/app/views/organizationStats                               @getsentry/revenue
+## End of Billing/Revenue
 
 ## ML & AI
 *autofix*.py                                                @getsentry/machine-learning-ai

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -368,6 +368,16 @@ export const DATA_CATEGORY_INFO = {
     uid: 17,
     isBilledCategory: false, // TODO(Continuous Profiling GA): make true for launch to show spend notification toggle
   },
+  [DataCategoryExact.PROFILE_CHUNK]: {
+    name: DataCategoryExact.PROFILE_CHUNK,
+    apiName: 'profile_chunk',
+    plural: 'profileChunks',
+    displayName: 'profile chunk',
+    titleName: t('Profile Chunks'),
+    productName: t('Continuous Profiling'),
+    uid: 18,
+    isBilledCategory: false,
+  },
 } as const satisfies Record<DataCategoryExact, DataCategoryInfo>;
 
 // Special Search characters

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -102,6 +102,7 @@ export enum DataCategoryExact {
   PROFILE_DURATION = 'profileDuration',
   SPAN = 'span',
   SPAN_INDEXED = 'span_indexed',
+  PROFILE_CHUNK = 'profileChunk',
 }
 
 export interface DataCategoryInfo {

--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -435,6 +435,10 @@ describe('OrganizationStats', function () {
     expect(screen.getByRole('option', {name: 'Profile Hours'})).toBeInTheDocument();
     // Should not show Profiles (transaction) option
     expect(screen.queryByRole('option', {name: 'Profiles'})).not.toBeInTheDocument();
+    // Should not show Profile Chunks option
+    expect(
+      screen.queryByRole('option', {name: 'Profile Chunks'})
+    ).not.toBeInTheDocument();
   });
 
   it('shows both profile hours and profiles categories with continuous-profiling feature', async () => {
@@ -454,6 +458,8 @@ describe('OrganizationStats', function () {
     expect(screen.getByRole('option', {name: 'Profile Hours'})).toBeInTheDocument();
     // Should show Profiles (transaction) option
     expect(screen.queryByRole('option', {name: 'Profiles'})).toBeInTheDocument();
+    // Should show Profile Chunks option
+    expect(screen.getByRole('option', {name: 'Profile Chunks'})).toBeInTheDocument();
   });
 
   it('shows only profile duration category when both profiling features are enabled', async () => {
@@ -478,6 +484,8 @@ describe('OrganizationStats', function () {
     expect(screen.getByRole('option', {name: 'Profile Hours'})).toBeInTheDocument();
     // Should not show Profiles (transaction) option
     expect(screen.queryByRole('option', {name: 'Profiles'})).not.toBeInTheDocument();
+    // Should show Profile Chunks option
+    expect(screen.getByRole('option', {name: 'Profile Chunks'})).toBeInTheDocument();
   });
 
   it('shows only Profiles category without profiling features', async () => {
@@ -493,10 +501,14 @@ describe('OrganizationStats', function () {
 
     await userEvent.click(await screen.findByText('Category'));
 
-    // Should show Profile Hours option
+    // Should not show Profile Hours option
     expect(screen.queryByRole('option', {name: 'Profile Hours'})).not.toBeInTheDocument();
     // Should show Profiles (transaction) option
     expect(screen.getByRole('option', {name: 'Profiles'})).toBeInTheDocument();
+    // Should not show Profile Chunks option
+    expect(
+      screen.queryByRole('option', {name: 'Profile Chunks'})
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -245,6 +245,8 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
 
     const isSelfHostedErrorsOnly = ConfigStore.get('isSelfHostedErrorsOnly');
 
+    // Some data categories are not applicable to some subscription plans.
+    // So we filter them out depending on if the organization has the necessary features.
     const options = CHART_OPTIONS_DATACATEGORY.filter(opt => {
       if (isSelfHostedErrorsOnly) {
         return opt.value === DATA_CATEGORY_INFO.error.plural;
@@ -263,6 +265,9 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
           organization.features.includes('continuous-profiling-stats') ||
           organization.features.includes('continuous-profiling')
         );
+      }
+      if (DATA_CATEGORY_INFO.profileChunk.plural === opt.value) {
+        return organization.features.includes('continuous-profiling');
       }
       if (DATA_CATEGORY_INFO.profile.plural === opt.value) {
         return !organization.features.includes('continuous-profiling-stats');

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -86,6 +86,12 @@ export const CHART_OPTIONS_DATACATEGORY: CategoryOption[] = [
     disabled: false,
     yAxisMinInterval: 100,
   },
+  {
+    label: DATA_CATEGORY_INFO.profileChunk.titleName,
+    value: DATA_CATEGORY_INFO.profileChunk.plural,
+    disabled: false,
+    yAxisMinInterval: 100,
+  },
 ];
 
 export enum ChartDataTransform {


### PR DESCRIPTION
Add profile chunks to usage stats page.

<img width="2060" alt="Screenshot 2024-11-29 at 4 52 02 PM" src="https://github.com/user-attachments/assets/fad0c23f-5b6b-47c3-a8c7-73d4c5409193">
