### PR TITLE
chore(sentry apps): Add backwards compatbility for SentryAppCompenent errors

### DIFF
--- a/static/app/components/feedback/list/useHasLinkedIssues.tsx
+++ b/static/app/components/feedback/list/useHasLinkedIssues.tsx
@@ -1,5 +1,6 @@
 import type {ExternalIssueComponent} from 'sentry/components/group/externalIssuesList/types';
 import useIssueTrackingFilter from 'sentry/components/group/externalIssuesList/useIssueTrackingFilter';
+import {getSentryAppComponentIsDisabled} from 'sentry/components/sentryAppComponentIcon';
 import SentryAppInstallationStore from 'sentry/stores/sentryAppInstallationsStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {Event} from 'sentry/types/event';
@@ -23,8 +24,8 @@ export default function useExternalIssueData({group, event, project}: Props) {
   const renderSentryAppIssues = (): ExternalIssueComponent[] => {
     return components
       .map<ExternalIssueComponent | null>(component => {
-        const {sentryApp, error} = component;
-        const disabled = typeof error === 'string' ? !error : error;
+        const {sentryApp} = component;
+        const disabled = getSentryAppComponentIsDisabled(component);
         const installation = sentryAppInstallations.find(
           i => i.app.uuid === sentryApp.uuid
         );

--- a/static/app/components/feedback/list/useHasLinkedIssues.tsx
+++ b/static/app/components/feedback/list/useHasLinkedIssues.tsx
@@ -23,7 +23,8 @@ export default function useExternalIssueData({group, event, project}: Props) {
   const renderSentryAppIssues = (): ExternalIssueComponent[] => {
     return components
       .map<ExternalIssueComponent | null>(component => {
-        const {sentryApp, error: disabled} = component;
+        const {sentryApp, error} = component;
+        const disabled = typeof error === 'string' ? !error : error;
         const installation = sentryAppInstallations.find(
           i => i.app.uuid === sentryApp.uuid
         );

--- a/static/app/components/feedback/list/useHasLinkedIssues.tsx
+++ b/static/app/components/feedback/list/useHasLinkedIssues.tsx
@@ -1,6 +1,6 @@
 import type {ExternalIssueComponent} from 'sentry/components/group/externalIssuesList/types';
 import useIssueTrackingFilter from 'sentry/components/group/externalIssuesList/useIssueTrackingFilter';
-import {getSentryAppComponentIsDisabled} from 'sentry/components/sentryAppComponentIcon';
+import {sentryAppComponentIsDisabled} from 'sentry/components/sentryAppComponentIcon';
 import SentryAppInstallationStore from 'sentry/stores/sentryAppInstallationsStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {Event} from 'sentry/types/event';
@@ -25,7 +25,7 @@ export default function useExternalIssueData({group, event, project}: Props) {
     return components
       .map<ExternalIssueComponent | null>(component => {
         const {sentryApp} = component;
-        const disabled = getSentryAppComponentIsDisabled(component);
+        const disabled = sentryAppComponentIsDisabled(component);
         const installation = sentryAppInstallations.find(
           i => i.app.uuid === sentryApp.uuid
         );

--- a/static/app/components/group/externalIssuesList/useExternalIssueData.tsx
+++ b/static/app/components/group/externalIssuesList/useExternalIssueData.tsx
@@ -71,7 +71,8 @@ export default function useExternalIssueData({group, event, project}: Props) {
   const renderSentryAppIssues = (): ExternalIssueComponent[] => {
     return components
       .map<ExternalIssueComponent | null>(component => {
-        const {sentryApp, error: disabled} = component;
+        const {sentryApp, error} = component;
+        const disabled = typeof error === 'string' ? !error : error;
         const installation = sentryAppInstallations.find(
           i => i.app.uuid === sentryApp.uuid
         );

--- a/static/app/components/group/externalIssuesList/useExternalIssueData.tsx
+++ b/static/app/components/group/externalIssuesList/useExternalIssueData.tsx
@@ -2,6 +2,7 @@ import type {ExternalIssueComponent} from 'sentry/components/group/externalIssue
 import {useExternalIssues} from 'sentry/components/group/externalIssuesList/useExternalIssues';
 import useFetchIntegrations from 'sentry/components/group/externalIssuesList/useFetchIntegrations';
 import useIssueTrackingFilter from 'sentry/components/group/externalIssuesList/useIssueTrackingFilter';
+import {getSentryAppComponentIsDisabled} from 'sentry/components/sentryAppComponentIcon';
 import SentryAppInstallationStore from 'sentry/stores/sentryAppInstallationsStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {Event} from 'sentry/types/event';
@@ -71,8 +72,8 @@ export default function useExternalIssueData({group, event, project}: Props) {
   const renderSentryAppIssues = (): ExternalIssueComponent[] => {
     return components
       .map<ExternalIssueComponent | null>(component => {
-        const {sentryApp, error} = component;
-        const disabled = typeof error === 'string' ? !error : error;
+        const {sentryApp} = component;
+        const disabled = getSentryAppComponentIsDisabled(component);
         const installation = sentryAppInstallations.find(
           i => i.app.uuid === sentryApp.uuid
         );

--- a/static/app/components/group/externalIssuesList/useExternalIssueData.tsx
+++ b/static/app/components/group/externalIssuesList/useExternalIssueData.tsx
@@ -2,7 +2,7 @@ import type {ExternalIssueComponent} from 'sentry/components/group/externalIssue
 import {useExternalIssues} from 'sentry/components/group/externalIssuesList/useExternalIssues';
 import useFetchIntegrations from 'sentry/components/group/externalIssuesList/useFetchIntegrations';
 import useIssueTrackingFilter from 'sentry/components/group/externalIssuesList/useIssueTrackingFilter';
-import {getSentryAppComponentIsDisabled} from 'sentry/components/sentryAppComponentIcon';
+import {sentryAppComponentIsDisabled} from 'sentry/components/sentryAppComponentIcon';
 import SentryAppInstallationStore from 'sentry/stores/sentryAppInstallationsStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {Event} from 'sentry/types/event';
@@ -73,7 +73,7 @@ export default function useExternalIssueData({group, event, project}: Props) {
     return components
       .map<ExternalIssueComponent | null>(component => {
         const {sentryApp} = component;
-        const disabled = getSentryAppComponentIsDisabled(component);
+        const disabled = sentryAppComponentIsDisabled(component);
         const installation = sentryAppInstallations.find(
           i => i.app.uuid === sentryApp.uuid
         );

--- a/static/app/components/sentryAppComponentIcon.spec.tsx
+++ b/static/app/components/sentryAppComponentIcon.spec.tsx
@@ -1,24 +1,24 @@
 import {SentryAppComponentFixture} from 'sentry-fixture/sentryAppComponent';
 
-import {getSentryAppComponentIsDisabled} from 'sentry/components/sentryAppComponentIcon';
+import {sentryAppComponentIsDisabled} from 'sentry/components/sentryAppComponentIcon';
 
 describe('SentryAppComponentIcon', function () {
-  it('returns false if the error is a non empty string', () => {
+  it('sentryAppComponentIsDisabled returns false if the error is a non empty string', () => {
     const component = SentryAppComponentFixture();
     component.error = 'RIP couldnt connect to sentry :C';
-    expect(getSentryAppComponentIsDisabled(component)).toBe(false);
+    expect(sentryAppComponentIsDisabled(component)).toBe(false);
   });
 
-  it('returns true if the error is an empty string', () => {
+  it('sentryAppComponentIsDisabled returns true if the error is an empty string', () => {
     const component = SentryAppComponentFixture();
     component.error = '';
-    expect(getSentryAppComponentIsDisabled(component)).toBe(true);
+    expect(sentryAppComponentIsDisabled(component)).toBe(true);
   });
 
   // TODO: Delete after new errors are deployed
-  it('returns itself if the error is a boolean', () => {
+  it('sentryAppComponentIsDisabled returns itself if the error is a boolean', () => {
     const component = SentryAppComponentFixture();
     component.error = true;
-    expect(getSentryAppComponentIsDisabled(component)).toBe(true);
+    expect(sentryAppComponentIsDisabled(component)).toBe(true);
   });
 });

--- a/static/app/components/sentryAppComponentIcon.spec.tsx
+++ b/static/app/components/sentryAppComponentIcon.spec.tsx
@@ -1,0 +1,24 @@
+import {SentryAppComponentFixture} from 'sentry-fixture/sentryAppComponent';
+
+import {getSentryAppComponentIsDisabled} from 'sentry/components/sentryAppComponentIcon';
+
+describe('SentryAppComponentIcon', function () {
+  it('returns false if the error is a non empty string', () => {
+    const component = SentryAppComponentFixture();
+    component.error = 'RIP couldnt connect to sentry :C';
+    expect(getSentryAppComponentIsDisabled(component)).toBe(false);
+  });
+
+  it('returns true if the error is an empty string', () => {
+    const component = SentryAppComponentFixture();
+    component.error = '';
+    expect(getSentryAppComponentIsDisabled(component)).toBe(true);
+  });
+
+  // TODO: Delete after new errors are deployed
+  it('returns itself if the error is a boolean', () => {
+    const component = SentryAppComponentFixture();
+    component.error = true;
+    expect(getSentryAppComponentIsDisabled(component)).toBe(true);
+  });
+});

--- a/static/app/components/sentryAppComponentIcon.tsx
+++ b/static/app/components/sentryAppComponentIcon.tsx
@@ -18,7 +18,12 @@ function SentryAppComponentIcon({sentryAppComponent, size = 20}: Props) {
     ({color}) => color === false
   );
   const isDefault = selectedAvatar?.avatarType !== 'upload';
-  const isDisabled = sentryAppComponent.error;
+
+  // Patch for backwards compatibility as the change's truth table is inverse to the previous'
+  const isDisabled =
+    typeof sentryAppComponent.error === 'string'
+      ? !sentryAppComponent.error
+      : sentryAppComponent.error;
   return (
     <SentryAppAvatarWrapper
       isDark={ConfigStore.get('theme') === 'dark'}

--- a/static/app/components/sentryAppComponentIcon.tsx
+++ b/static/app/components/sentryAppComponentIcon.tsx
@@ -18,12 +18,8 @@ function SentryAppComponentIcon({sentryAppComponent, size = 20}: Props) {
     ({color}) => color === false
   );
   const isDefault = selectedAvatar?.avatarType !== 'upload';
+  const isDisabled = getSentryAppComponentIsDisabled(sentryAppComponent);
 
-  // Patch for backwards compatibility as the change's truth table is inverse to the previous'
-  const isDisabled =
-    typeof sentryAppComponent.error === 'string'
-      ? !sentryAppComponent.error
-      : sentryAppComponent.error;
   return (
     <SentryAppAvatarWrapper
       isDark={ConfigStore.get('theme') === 'dark'}
@@ -38,6 +34,11 @@ function SentryAppComponentIcon({sentryAppComponent, size = 20}: Props) {
     </SentryAppAvatarWrapper>
   );
 }
+
+// Patch for backwards compatibility as the change's truth table is inverse to the previous'
+export const getSentryAppComponentIsDisabled = (component: SentryAppComponent) => {
+  return typeof component.error === 'boolean' ? component.error : !component.error;
+};
 
 export default SentryAppComponentIcon;
 

--- a/static/app/components/sentryAppComponentIcon.tsx
+++ b/static/app/components/sentryAppComponentIcon.tsx
@@ -18,7 +18,7 @@ function SentryAppComponentIcon({sentryAppComponent, size = 20}: Props) {
     ({color}) => color === false
   );
   const isDefault = selectedAvatar?.avatarType !== 'upload';
-  const isDisabled = getSentryAppComponentIsDisabled(sentryAppComponent);
+  const isDisabled = sentryAppComponentIsDisabled(sentryAppComponent);
 
   return (
     <SentryAppAvatarWrapper
@@ -36,7 +36,7 @@ function SentryAppComponentIcon({sentryAppComponent, size = 20}: Props) {
 }
 
 // Patch for backwards compatibility as the change's truth table is inverse to the previous'
-export const getSentryAppComponentIsDisabled = (component: SentryAppComponent) => {
+export const sentryAppComponentIsDisabled = (component: SentryAppComponent) => {
   return typeof component.error === 'boolean' ? component.error : !component.error;
 };
 

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -254,7 +254,6 @@ export type SentryAppComponent<
     | SentryAppSchemaStacktraceLink
     | SentryAppSchemaElement,
 > = {
-  error: string | boolean;
   schema: Schema;
   sentryApp: {
     avatars: Avatar[];
@@ -264,6 +263,7 @@ export type SentryAppComponent<
   };
   type: 'issue-link' | 'alert-rule-action' | 'issue-media' | 'stacktrace-link';
   uuid: string;
+  error?: string | boolean;
 };
 
 export type SentryAppWebhookRequest = {

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -254,6 +254,7 @@ export type SentryAppComponent<
     | SentryAppSchemaStacktraceLink
     | SentryAppSchemaElement,
 > = {
+  error: string | boolean;
   schema: Schema;
   sentryApp: {
     avatars: Avatar[];
@@ -263,7 +264,6 @@ export type SentryAppComponent<
   };
   type: 'issue-link' | 'alert-rule-action' | 'issue-media' | 'stacktrace-link';
   uuid: string;
-  error?: boolean;
 };
 
 export type SentryAppWebhookRequest = {


### PR DESCRIPTION
In (#81167 ), we want to change the SentryAppComponent endpoint to return a string of the error to improve end user clarity when debugging. In the frontend, we currently expect the error response to be a boolean though, so we need to make the frontend backwards compatible (i.e handle both boolean and string)