### PR TITLE
ref(stats): Rename CORS to disallowed domain

### DIFF
--- a/static/app/views/organizationStats/getReasonGroupName.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.ts
@@ -108,7 +108,7 @@ const invalidReasonsGroup: Record<string, DiscardReason[]> = {
   minidump: [DiscardReason.MISSING_MINIDUMP_UPLOAD, DiscardReason.INVALID_MINIDUMP],
   security_report: [DiscardReason.SECURITY_REPORT, DiscardReason.SECURITY_REPORT_TYPE],
   unreal: [DiscardReason.PROCESS_UNREAL],
-  cors: [DiscardReason.CORS],
+  disallowed_domain: [DiscardReason.CORS],
   empty: [
     DiscardReason.NO_EVENT_PAYLOAD,
     DiscardReason.EMPTY_ENVELOPE,


### PR DESCRIPTION
The "CORS" category on the stats page refers to the disallowed domain settings in the project. It would be clearer to rename it to "Disallowed Domain"