### PR TITLE
fix(dynamic-sampling): round dynamic sampling rates

### DIFF
--- a/src/sentry/api/endpoints/organization_sampling_project_rates.py
+++ b/src/sentry/api/endpoints/organization_sampling_project_rates.py
@@ -36,7 +36,7 @@ class GetSerializer(Serializer):
         }
 
     def serialize(self, obj: Any, attrs: Any, user, **kwargs) -> Mapping[str, Any]:
-        return {"id": obj.id, "sampleRate": round(attrs, 4)}
+        return {"id": obj.id, "sampleRate": attrs}
 
 
 class PutSerializer(serializers.Serializer):
@@ -123,7 +123,7 @@ class OrganizationSamplingProjectRatesEndpoint(OrganizationEndpoint):
         project_ids = {int(d["id"]) for d in serializer.data}
         projects = self.get_projects(request, organization, project_ids=project_ids)
 
-        rate_by_project = {d["id"]: d["sampleRate"] for d in serializer.data}
+        rate_by_project = {d["id"]: round(d["sampleRate"], 4) for d in serializer.data}
         with transaction.atomic(router.db_for_write(ProjectOption)):
             for project in projects:
                 project.update_option(OPTION_KEY, rate_by_project[project.id])

--- a/src/sentry/api/endpoints/organization_sampling_project_rates.py
+++ b/src/sentry/api/endpoints/organization_sampling_project_rates.py
@@ -36,7 +36,7 @@ class GetSerializer(Serializer):
         }
 
     def serialize(self, obj: Any, attrs: Any, user, **kwargs) -> Mapping[str, Any]:
-        return {"id": obj.id, "sampleRate": attrs}
+        return {"id": obj.id, "sampleRate": round(attrs, 4)}
 
 
 class PutSerializer(serializers.Serializer):

--- a/tests/sentry/api/endpoints/test_organization_sampling_project_rates.py
+++ b/tests/sentry/api/endpoints/test_organization_sampling_project_rates.py
@@ -22,9 +22,7 @@ class OrganizationSamplingProjectRatesTest(APITestCase):
     def test_get(self):
         project1 = self.create_project(teams=[self.team])
         project2 = self.create_project(teams=[self.team])
-        project3 = self.create_project(teams=[self.team])
         project2.update_option("sentry:target_sample_rate", 0.2)
-        project3.update_option("sentry:target_sample_rate", 0.123456789)
 
         with self.feature(self.features):
             response = self.get_success_response(self.organization.slug)
@@ -32,7 +30,6 @@ class OrganizationSamplingProjectRatesTest(APITestCase):
         assert response.data == [
             {"id": project1.id, "sampleRate": 1.0},
             {"id": project2.id, "sampleRate": 0.2},
-            {"id": project3.id, "sampleRate": 0.1235},
         ]
 
     def test_put(self):
@@ -40,10 +37,13 @@ class OrganizationSamplingProjectRatesTest(APITestCase):
         project1.update_option("sentry:target_sample_rate", 0.2)
         project2 = self.create_project(teams=[self.team])
         project2.update_option("sentry:target_sample_rate", 0.2)
+        project3 = self.create_project(teams=[self.team])
+        project3.update_option("sentry:target_sample_rate", 0.2)
 
         data = [
             # we leave project 1 unchanged
             {"id": project2.id, "sampleRate": 0.5},
+            {"id": project3.id, "sampleRate": 0.123456789},
         ]
 
         with self.feature(self.features):
@@ -53,10 +53,12 @@ class OrganizationSamplingProjectRatesTest(APITestCase):
 
         assert response.data == [
             {"id": project2.id, "sampleRate": 0.5},
+            {"id": project3.id, "sampleRate": 0.1235},
         ]
 
         assert project1.get_option("sentry:target_sample_rate") == 0.2
         assert project2.get_option("sentry:target_sample_rate") == 0.5
+        assert project3.get_option("sentry:target_sample_rate") == 0.1235
 
     def test_put_automatic_mode(self):
         self.organization.update_option(

--- a/tests/sentry/api/endpoints/test_organization_sampling_project_rates.py
+++ b/tests/sentry/api/endpoints/test_organization_sampling_project_rates.py
@@ -22,7 +22,9 @@ class OrganizationSamplingProjectRatesTest(APITestCase):
     def test_get(self):
         project1 = self.create_project(teams=[self.team])
         project2 = self.create_project(teams=[self.team])
+        project3 = self.create_project(teams=[self.team])
         project2.update_option("sentry:target_sample_rate", 0.2)
+        project3.update_option("sentry:target_sample_rate", 0.123456789)
 
         with self.feature(self.features):
             response = self.get_success_response(self.organization.slug)
@@ -30,6 +32,7 @@ class OrganizationSamplingProjectRatesTest(APITestCase):
         assert response.data == [
             {"id": project1.id, "sampleRate": 1.0},
             {"id": project2.id, "sampleRate": 0.2},
+            {"id": project3.id, "sampleRate": 0.1235},
         ]
 
     def test_put(self):


### PR DESCRIPTION
Round the API response for the OrganizationSamplingProjectRatesEndpoint to 4 decimal place, so that the UI displays up to 2 decimal points like the UI for Automatic Mode.

Closes https://github.com/getsentry/sentry/issues/81557