### PR TITLE
fix(dashboards): modify team rendering in edit access selector

### DIFF
--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -271,12 +271,12 @@ function EditAccessSelector({
         setMenuOpen(!isMenuOpen);
         if (!isMenuOpen) {
           teamsToRender.sort((team1, team2) => {
-            const team1Selected = selectedOptions.includes(team1.id);
-            const team2Selected = selectedOptions.includes(team2.id);
-            if (team1Selected && !team2Selected) {
+            const isTeam1Selected = selectedOptions.includes(team1.id);
+            const isTeam2Selected = selectedOptions.includes(team2.id);
+            if (isTeam1Selected && !isTeam2Selected) {
               return -1;
             }
-            if (!team1Selected && team2Selected) {
+            if (!isTeam1Selected && isTeam2Selected) {
               return 1;
             }
             return team1.name.localeCompare(team2.name);

--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -243,7 +243,6 @@ function EditAccessSelector({
             onChangeEditAccess?.(newDashboardPermissions);
           }
           setMenuOpen(!isMenuOpen);
-          setStagedOptions(selectedOptions);
         }}
         priority="primary"
         disabled={
@@ -290,6 +289,7 @@ function EditAccessSelector({
       searchPlaceholder={t('Search Teams')}
       isOpen={isMenuOpen}
       onOpenChange={() => {
+        setStagedOptions(selectedOptions);
         setMenuOpen(!isMenuOpen);
       }}
       menuFooter={dropdownFooterButtons}

--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -231,7 +231,12 @@ function EditAccessSelector({
         priority="primary"
         disabled={
           !userCanEditDashboardPermissions ||
-          isEqual(getDashboardPermissions(), dashboard.permissions)
+          isEqual(getDashboardPermissions(), {
+            ...dashboard.permissions,
+            teamsWithEditAccess: dashboard.permissions?.teamsWithEditAccess?.sort(
+              (a, b) => a - b
+            ),
+          })
         }
       >
         {t('Save Changes')}

--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -79,7 +79,7 @@ function EditAccessSelector({
             ) ?? []),
           ];
     setSelectedOptions(selectedOptionsFromDashboard);
-  }, [dashboard, teamsToRender]);
+  }, [dashboard, teamsToRender, isMenuOpen]);
 
   // Handles state change when dropdown options are selected
   const onSelectOptions = newSelectedOptions => {
@@ -119,7 +119,8 @@ function EditAccessSelector({
         ? []
         : selectedOptions
             .filter(option => option !== '_creator')
-            .map(teamId => parseInt(teamId, 10)),
+            .map(teamId => parseInt(teamId, 10))
+            .sort((a, b) => a - b),
     };
   }
 
@@ -268,6 +269,19 @@ function EditAccessSelector({
       isOpen={isMenuOpen}
       onOpenChange={() => {
         setMenuOpen(!isMenuOpen);
+        if (!isMenuOpen) {
+          teamsToRender.sort((team1, team2) => {
+            const team1Selected = selectedOptions.includes(team1.id);
+            const team2Selected = selectedOptions.includes(team2.id);
+            if (team1Selected && !team2Selected) {
+              return -1;
+            }
+            if (!team1Selected && team2Selected) {
+              return 1;
+            }
+            return team1.name.localeCompare(team2.name);
+          });
+        }
       }}
       menuFooter={dropdownFooterButtons}
       onSearch={debounce(val => void onSearch(val), DEFAULT_DEBOUNCE_DURATION)}

--- a/static/app/views/dashboards/editAccessSelector.tsx
+++ b/static/app/views/dashboards/editAccessSelector.tsx
@@ -81,7 +81,7 @@ function EditAccessSelector({
             ) ?? []),
           ];
     setSelectedOptions(selectedOptionsFromDashboard);
-  }, [dashboard, teamsToRender, isMenuOpen]);
+  }, [dashboard, teamsToRender, isMenuOpen]); // isMenuOpen dependency ensures perms are 'refreshed'
 
   // Handles state change when dropdown options are selected
   const onSelectOptions = newSelectedOptions => {


### PR DESCRIPTION
1. Make sure the selected teams show up as the first options in the selector
2. Add `isOpenMenu` to `useEffect` dependencies so that the selected options 'refreshes' to original values every time the selector is opened (related to [this PR](https://github.com/getsentry/sentry/pull/81384))
