### PR TITLE
fix(rollback): Hide banner when sidebar is horizontal

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -531,7 +531,7 @@ function Sidebar() {
           {organization ? (
             <DismissableRollbackBanner
               organization={organization}
-              collapsed={collapsed}
+              collapsed={collapsed || horizontal}
             />
           ) : null}
 

--- a/static/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.tsx
@@ -59,7 +59,7 @@ export default function SidebarDropdown({orientation, collapsed, hideOrgLinks}: 
 
   const {onOpenOrgDropdown, shouldShowDropdownBanner, shouldShowDot} = useRollbackPrompts(
     {
-      collapsed,
+      collapsed: collapsed || orientation === 'top',
       organization: org,
     }
   );


### PR DESCRIPTION
The banner was being hidden when collapsed, but not at small screen sizes:

![CleanShot 2024-12-02 at 09 06 42@2x](https://github.com/user-attachments/assets/aa69c51d-1492-4986-aa87-ef28daab0e9b)
