### PR TITLE
feat(widget-builder): Add context for synchronized state

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/devBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/devBuilder.tsx
@@ -13,14 +13,13 @@ import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import {ColumnFields} from 'sentry/views/dashboards/widgetBuilder/buildSteps/columnsStep/columnFields';
 import {YAxisSelector} from 'sentry/views/dashboards/widgetBuilder/buildSteps/yAxisStep/yAxisSelector';
-import useWidgetBuilderState, {
-  BuilderStateAction,
-} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
+import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {getDiscoverDatasetFromWidgetType} from 'sentry/views/dashboards/widgetBuilder/utils';
 import ResultsSearchQueryBuilder from 'sentry/views/discover/resultsSearchQueryBuilder';
 
 function DevBuilder() {
-  const {state, dispatch} = useWidgetBuilderState();
+  const {state, dispatch} = useWidgetBuilderContext();
   const [showDevBuilder] = useLocalStorageState('showDevBuilder', false);
 
   if (!showDevBuilder) {

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
@@ -6,12 +6,11 @@ import TextArea from 'sentry/components/forms/controls/textarea';
 import Input from 'sentry/components/input';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import useWidgetBuilderState, {
-  BuilderStateAction,
-} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
+import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 
 function WidgetBuilderNameAndDescription() {
-  const {state, dispatch} = useWidgetBuilderState();
+  const {state, dispatch} = useWidgetBuilderContext();
   const [isDescSelected, setIsDescSelected] = useState(state.description ? true : false);
 
   return (

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -5,6 +5,7 @@ import {AnimatePresence, motion} from 'framer-motion';
 
 import useKeyPress from 'sentry/utils/useKeyPress';
 import WidgetBuilderSlideout from 'sentry/views/dashboards/widgetBuilder/components/widgetBuilderSlideout';
+import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 
 type DevWidgetBuilderProps = {
   isOpen: boolean;
@@ -27,21 +28,23 @@ function DevWidgetBuilder({isOpen, onClose}: DevWidgetBuilderProps) {
       {isOpen && <Backdrop style={{opacity: 0.5, pointerEvents: 'auto'}} />}
       <AnimatePresence>
         {isOpen && (
-          <WidgetBuilderContainer>
-            <WidgetBuilderSlideout isOpen={isOpen} onClose={onClose} />
-            <SampleWidgetCard
-              initial={{opacity: 0, x: '50%', y: 0}}
-              animate={{opacity: 1, x: 0, y: 0}}
-              exit={{opacity: 0, x: '50%', y: 0}}
-              transition={{
-                type: 'spring',
-                stiffness: 500,
-                damping: 50,
-              }}
-            >
-              {'TEST WIDGET'}
-            </SampleWidgetCard>
-          </WidgetBuilderContainer>
+          <WidgetBuilderProvider>
+            <WidgetBuilderContainer>
+              <WidgetBuilderSlideout isOpen={isOpen} onClose={onClose} />
+              <SampleWidgetCard
+                initial={{opacity: 0, x: '50%', y: 0}}
+                animate={{opacity: 1, x: 0, y: 0}}
+                exit={{opacity: 0, x: '50%', y: 0}}
+                transition={{
+                  type: 'spring',
+                  stiffness: 500,
+                  damping: 50,
+                }}
+              >
+                {'TEST WIDGET'}
+              </SampleWidgetCard>
+            </WidgetBuilderContainer>
+          </WidgetBuilderProvider>
         )}
       </AnimatePresence>
     </Fragment>

--- a/static/app/views/dashboards/widgetBuilder/contexts/widgetBuilderContext.tsx
+++ b/static/app/views/dashboards/widgetBuilder/contexts/widgetBuilderContext.tsx
@@ -1,0 +1,37 @@
+import type React from 'react';
+import {createContext, useContext} from 'react';
+
+import useWidgetBuilderState from '../hooks/useWidgetBuilderState';
+
+const WidgetBuilderContext = createContext<
+  ReturnType<typeof useWidgetBuilderState> | undefined
+>(undefined);
+
+interface WidgetBuilderProviderProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Provider for maintaining a single source of truth for the widget builder state.
+ */
+export function WidgetBuilderProvider({children}: WidgetBuilderProviderProps) {
+  const widgetBuilderState = useWidgetBuilderState();
+  return (
+    <WidgetBuilderContext.Provider value={widgetBuilderState}>
+      {children}
+    </WidgetBuilderContext.Provider>
+  );
+}
+
+/**
+ * Custom hook to get state and dispatch from the WidgetBuilderContext
+ */
+export const useWidgetBuilderContext = () => {
+  const context = useContext(WidgetBuilderContext);
+  if (!context) {
+    throw new Error(
+      'useWidgetBuilderContext must be used within a WidgetBuilderProvider'
+    );
+  }
+  return context;
+};


### PR DESCRIPTION
Adds a provider and hook so we can get the same state across any component under the provider.

We'll have to use `useWidgetBuilderContext` instead of `useWidgetBuilderState` now!