### PR TITLE
fix(eap): Make p100 alias to max

### DIFF
--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -835,9 +835,7 @@ class SpansEAPDatasetConfig(SpansIndexedDatasetConfig):
                     optional_args=[
                         with_default("span.duration", NumericColumn("column", spans=True)),
                     ],
-                    snql_aggregate=lambda args, alias: self._resolve_percentile_weighted(
-                        args, alias, 1.0
-                    ),
+                    snql_aggregate=self._resolve_aggregate_if("max"),
                     result_type_fn=self.reflective_result_type(),
                     default_result_type="duration",
                     redundant_grouping=True,


### PR DESCRIPTION
There's some rounding problems that sometimes make the 2 not equal. To get a more deterministic result, just alias it to max.