### PR TITLE
chore(alerts): Remove seen_by from expand

### DIFF
--- a/static/app/views/alerts/utils/apiCalls.tsx
+++ b/static/app/views/alerts/utils/apiCalls.tsx
@@ -30,7 +30,7 @@ export function fetchIncidentsForRule(
       includeSnapshots: true,
       start,
       end,
-      expand: ['activities', 'seen_by', 'original_alert_rule'],
+      expand: ['activities', 'original_alert_rule'],
     },
   });
 }


### PR DESCRIPTION
As a part of removing the `IncidentSeen` model we must remove `seen_by` from the expansion args here. 