### PR TITLE
ref(ecosystem): Refines terminal cases for lifecycle reporting

### DIFF
--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -161,7 +161,7 @@ class EventLifecycle:
     ) -> None:
         should_record_outcome = True
         if self._state is None:
-            self._report_flow_warning("The lifecycle has not yet been entered")
+            self._report_flow_error("The lifecycle has not yet been entered")
             should_record_outcome = False
         elif self._state == EventLifecycleOutcome.SUCCESS and (
             new_state == EventLifecycleOutcome.HALTED or new_state == EventLifecycleOutcome.FAILURE


### PR DESCRIPTION
Updates lifecycle reporting for terminal cases when multiple outcomes are recorded:
1. `SUCCESS` -> `FAILURE` or `HALTED`: Now generates a specific error message and logs additional context + reports to Sentry via the error logger.
2. `FAILURE` or `HALTED` -> Another outcome: Downgraded from an error to a warning log, no longer reports these to sentry as this seems like potentially expected behavior.
3. `None` -> Anything: Left as an error, as this is likely just misuse of the context manager.


This should alleviate sentry issues like SENTRY-3JF1, while reporting any seriously erroneous cases that attempt mutually exclusive lifecycle outcomes.

