### PR TITLE
fix(flags): fix flag series suffix

### DIFF
--- a/static/app/views/issueDetails/streamline/hooks/useFlagSeries.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useFlagSeries.tsx
@@ -57,6 +57,10 @@ export default function useFlagSeries({query = {}, event}: FlagSeriesProps) {
         const time = getFormattedDate(data.xAxis, 'MMM D, YYYY LT z', {
           local: !selection.datetime.utc,
         });
+
+        const eventIsBefore = moment(event?.dateCreated).isBefore(moment(time));
+        const suffix = eventIsBefore ? t('after this event') : t('before this event');
+
         return [
           '<div class="tooltip-series">',
           `<div><span class="tooltip-label"><strong>${t(
@@ -67,7 +71,7 @@ export default function useFlagSeries({query = {}, event}: FlagSeriesProps) {
           '<div class="tooltip-footer">',
           time,
           event?.dateCreated &&
-            ` (${moment(time).from(event.dateCreated, true)} ${t('before this event')})`,
+            ` (${moment(time).from(event.dateCreated, true)} ${suffix})`,
           '</div>',
           '<div class="tooltip-arrow"></div>',
         ].join('');

--- a/static/app/views/issueDetails/streamline/hooks/useFlagSeries.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useFlagSeries.tsx
@@ -59,7 +59,10 @@ export default function useFlagSeries({query = {}, event}: FlagSeriesProps) {
         });
 
         const eventIsBefore = moment(event?.dateCreated).isBefore(moment(time));
-        const suffix = eventIsBefore ? t('after this event') : t('before this event');
+        const formattedDate = moment(time).from(event?.dateCreated, true);
+        const suffix = eventIsBefore
+          ? t(' (%s after this event)', formattedDate)
+          : t(' (%s before this event)', formattedDate);
 
         return [
           '<div class="tooltip-series">',
@@ -70,8 +73,7 @@ export default function useFlagSeries({query = {}, event}: FlagSeriesProps) {
           '</div>',
           '<div class="tooltip-footer">',
           time,
-          event?.dateCreated &&
-            ` (${moment(time).from(event.dateCreated, true)} ${suffix})`,
+          event?.dateCreated && suffix,
           '</div>',
           '<div class="tooltip-arrow"></div>',
         ].join('');


### PR DESCRIPTION
if the flag got changed after the event, show that in the suffix:


https://github.com/user-attachments/assets/3e68f9e3-b883-4c68-8f29-c1adb681b2b2

<img width="422" alt="SCR-20241202-lpmn" src="https://github.com/user-attachments/assets/6bff3023-cfb1-47eb-acf9-fb091369d36f">


<img width="374" alt="SCR-20241202-lplq" src="https://github.com/user-attachments/assets/3b46bd01-e754-4eaf-ac41-5cec66dd5610">

relates to https://github.com/getsentry/team-replay/issues/506