### PR TITLE
chore(grouping): Add `unsafe-eval` and `unsafe-inline` grouping test inputs

### DIFF
--- a/tests/sentry/grouping/grouping_inputs/csp-script-src-unsafe-eval.json
+++ b/tests/sentry/grouping/grouping_inputs/csp-script-src-unsafe-eval.json
@@ -1,0 +1,11 @@
+{
+  "csp": {
+    "TODO": "Remove 'unsafe-eval' from `original_policy`, `violated_directive`, and `culprit` and change `blocked_uri` to 'eval' once https://github.com/getsentry/relay/issues/4323 and https://github.com/getsentry/sentry/issues/81531 are fixed",
+    "effective_directive": "script-src",
+    "blocked_uri": "",
+    "original_policy": "default-src 'self'; script-src 'unsafe-eval' 'self'; report-uri https://o1121.ingest.us.sentry.io/api/1231/security/?sentry_key=09082013112120121231201204152013; report-to csp-endpoint",
+    "violated_directive": "script-src 'unsafe-eval' 'self'"
+  },
+  "culprit": "script-src 'unsafe-eval' 'self'",
+  "message": "Blocked unsafe eval() 'script'"
+}

--- a/tests/sentry/grouping/grouping_inputs/csp-script-src-unsafe-inline.json
+++ b/tests/sentry/grouping/grouping_inputs/csp-script-src-unsafe-inline.json
@@ -1,0 +1,11 @@
+{
+  "csp": {
+    "TODO": "Remove 'unsafe-inline' from `original_policy`, `violated_directive`, and `culprit` and change `blocked_uri` to 'inline' once https://github.com/getsentry/relay/issues/4323 and https://github.com/getsentry/sentry/issues/81531 are fixed",
+    "effective_directive": "script-src",
+    "blocked_uri": "",
+    "original_policy": "default-src 'self'; script-src 'unsafe-inline' 'self'; report-uri https://o1121.ingest.us.sentry.io/api/1231/security/?sentry_key=09082013112120121231201204152013; report-to csp-endpoint",
+    "violated_directive": "script-src 'unsafe-inline' 'self'"
+  },
+  "culprit": "script-src 'unsafe-inline' 'self'",
+  "message": "Blocked unsafe inline 'script'"
+}

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/csp_script_src_unsafe_eval.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/csp_script_src_unsafe_eval.pysnap
@@ -1,0 +1,24 @@
+---
+created: '2024-12-02T21:58:29.631100+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: unknown
+hashing_metadata: {}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "unknown"
+  }
+}
+---
+contributing variants:
+  default*
+    hash: "56c6520f35bce2f89ed2c4e725ccef65"
+    component:
+      default*
+        csp*
+          salt* (a static salt)
+            "script-src"
+          violation*
+            "'unsafe-eval'"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/csp_script_src_unsafe_inline.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/csp_script_src_unsafe_inline.pysnap
@@ -1,0 +1,24 @@
+---
+created: '2024-12-02T21:58:29.688250+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: unknown
+hashing_metadata: {}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "unknown"
+  }
+}
+---
+contributing variants:
+  default*
+    hash: "d346ee37d19a2be6587e609075ca2d57"
+    component:
+      default*
+        csp*
+          salt* (a static salt)
+            "script-src"
+          violation*
+            "'unsafe-inline'"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/csp_script_src_unsafe_eval.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/csp_script_src_unsafe_eval.pysnap
@@ -1,0 +1,24 @@
+---
+created: '2024-12-02T21:57:58.424160+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: unknown
+hashing_metadata: {}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "unknown"
+  }
+}
+---
+contributing variants:
+  default*
+    hash: "56c6520f35bce2f89ed2c4e725ccef65"
+    component:
+      default*
+        csp*
+          salt* (a static salt)
+            "script-src"
+          violation*
+            "'unsafe-eval'"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/csp_script_src_unsafe_inline.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/csp_script_src_unsafe_inline.pysnap
@@ -1,0 +1,24 @@
+---
+created: '2024-12-02T21:57:58.488332+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: unknown
+hashing_metadata: {}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "unknown"
+  }
+}
+---
+contributing variants:
+  default*
+    hash: "d346ee37d19a2be6587e609075ca2d57"
+    component:
+      default*
+        csp*
+          salt* (a static salt)
+            "script-src"
+          violation*
+            "'unsafe-inline'"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/csp_script_src_unsafe_eval.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/csp_script_src_unsafe_eval.pysnap
@@ -1,0 +1,24 @@
+---
+created: '2024-12-02T21:58:08.828837+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: unknown
+hashing_metadata: {}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "unknown"
+  }
+}
+---
+contributing variants:
+  default*
+    hash: "56c6520f35bce2f89ed2c4e725ccef65"
+    component:
+      default*
+        csp*
+          salt* (a static salt)
+            "script-src"
+          violation*
+            "'unsafe-eval'"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/csp_script_src_unsafe_inline.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/csp_script_src_unsafe_inline.pysnap
@@ -1,0 +1,24 @@
+---
+created: '2024-12-02T21:58:08.876697+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: unknown
+hashing_metadata: {}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "unknown"
+  }
+}
+---
+contributing variants:
+  default*
+    hash: "d346ee37d19a2be6587e609075ca2d57"
+    component:
+      default*
+        csp*
+          salt* (a static salt)
+            "script-src"
+          violation*
+            "'unsafe-inline'"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
@@ -1,0 +1,24 @@
+---
+created: '2024-12-02T21:58:18.348661+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: unknown
+hashing_metadata: {}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "unknown"
+  }
+}
+---
+contributing variants:
+  default*
+    hash: "56c6520f35bce2f89ed2c4e725ccef65"
+    component:
+      default*
+        csp*
+          salt* (a static salt)
+            "script-src"
+          violation*
+            "'unsafe-eval'"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
@@ -1,0 +1,24 @@
+---
+created: '2024-12-02T21:58:18.403594+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: unknown
+hashing_metadata: {}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "unknown"
+  }
+}
+---
+contributing variants:
+  default*
+    hash: "d346ee37d19a2be6587e609075ca2d57"
+    component:
+      default*
+        csp*
+          salt* (a static salt)
+            "script-src"
+          violation*
+            "'unsafe-inline'"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/csp_script_src_unsafe_eval.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/csp_script_src_unsafe_eval.pysnap
@@ -1,0 +1,18 @@
+---
+created: '2024-12-02T21:59:54.483735+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+default:
+  hash: "56c6520f35bce2f89ed2c4e725ccef65"
+  component:
+    default*
+      csp*
+        salt* (a static salt)
+          "script-src"
+        violation*
+          "'unsafe-eval'"
+        uri (violation takes precedence)
+          "'self'"
+      message (csp takes precedence)
+        "Blocked unsafe eval() 'script'"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/csp_script_src_unsafe_inline.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/csp_script_src_unsafe_inline.pysnap
@@ -1,0 +1,18 @@
+---
+created: '2024-12-02T21:59:54.519184+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+default:
+  hash: "d346ee37d19a2be6587e609075ca2d57"
+  component:
+    default*
+      csp*
+        salt* (a static salt)
+          "script-src"
+        violation*
+          "'unsafe-inline'"
+        uri (violation takes precedence)
+          "'self'"
+      message (csp takes precedence)
+        "Blocked unsafe inline 'script'"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/csp_script_src_unsafe_eval.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/csp_script_src_unsafe_eval.pysnap
@@ -1,0 +1,18 @@
+---
+created: '2024-12-02T21:59:39.975587+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+default:
+  hash: "56c6520f35bce2f89ed2c4e725ccef65"
+  component:
+    default*
+      csp*
+        salt* (a static salt)
+          "script-src"
+        violation*
+          "'unsafe-eval'"
+        uri (violation takes precedence)
+          "'self'"
+      message (csp takes precedence)
+        "Blocked unsafe eval() 'script'"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/csp_script_src_unsafe_inline.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/csp_script_src_unsafe_inline.pysnap
@@ -1,0 +1,18 @@
+---
+created: '2024-12-02T21:59:40.046341+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+default:
+  hash: "d346ee37d19a2be6587e609075ca2d57"
+  component:
+    default*
+      csp*
+        salt* (a static salt)
+          "script-src"
+        violation*
+          "'unsafe-inline'"
+        uri (violation takes precedence)
+          "'self'"
+      message (csp takes precedence)
+        "Blocked unsafe inline 'script'"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/csp_script_src_unsafe_eval.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/csp_script_src_unsafe_eval.pysnap
@@ -1,0 +1,18 @@
+---
+created: '2024-12-02T21:59:26.090063+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+default:
+  hash: "56c6520f35bce2f89ed2c4e725ccef65"
+  component:
+    default*
+      csp*
+        salt* (a static salt)
+          "script-src"
+        violation*
+          "'unsafe-eval'"
+        uri (violation takes precedence)
+          "'self'"
+      message (csp takes precedence)
+        "Blocked unsafe eval() 'script'"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/csp_script_src_unsafe_inline.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/csp_script_src_unsafe_inline.pysnap
@@ -1,0 +1,18 @@
+---
+created: '2024-12-02T21:59:26.141295+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+default:
+  hash: "d346ee37d19a2be6587e609075ca2d57"
+  component:
+    default*
+      csp*
+        salt* (a static salt)
+          "script-src"
+        violation*
+          "'unsafe-inline'"
+        uri (violation takes precedence)
+          "'self'"
+      message (csp takes precedence)
+        "Blocked unsafe inline 'script'"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
@@ -1,0 +1,18 @@
+---
+created: '2024-12-02T21:59:16.027178+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+default:
+  hash: "56c6520f35bce2f89ed2c4e725ccef65"
+  component:
+    default*
+      csp*
+        salt* (a static salt)
+          "script-src"
+        violation*
+          "'unsafe-eval'"
+        uri (violation takes precedence)
+          "'self'"
+      message (csp takes precedence)
+        "Blocked unsafe eval() 'script'"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
@@ -1,0 +1,18 @@
+---
+created: '2024-12-02T21:59:16.088248+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+default:
+  hash: "d346ee37d19a2be6587e609075ca2d57"
+  component:
+    default*
+      csp*
+        salt* (a static salt)
+          "script-src"
+        violation*
+          "'unsafe-inline'"
+        uri (violation takes precedence)
+          "'self'"
+      message (csp takes precedence)
+        "Blocked unsafe inline 'script'"


### PR DESCRIPTION
This adds two new grouping test inputs, to show how we handle CSP reports with `unsafe-eval` and `unsafe-inline` violations, which are cases we don't currently cover with our grouping tests.

Note that there are two bugs which currently affect how we handle such inputs:

- We don't currently recognize such reports for grouping metadata purposes (this is very soon to be fixed), which is why for now they're being recorded in the metadata snapshots as being grouped by an unknown method. 

- We handle such reports backwards at the ingest level, marking events which aren't either `unsafe-eval`- or `unsafe-inline`-type violations as one or the other. (Unclear how soon this will be fixed, as it went undetected for five years and no one has yet complained about it.) For now, the input data includes the necessary values to trigger the relevant handlers, but each also includes a `TODO` so that it can  be updated once the underlying bug is fixed. (See https://github.com/getsentry/relay/issues/4323 and https://github.com/getsentry/sentry/issues/81531.)

