### PR TITLE
feat(issues): Add ownership button to assignee dropdwn

### DIFF
--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -69,6 +69,10 @@ export interface AssigneeSelectorDropdownProps {
    */
   loading: boolean;
   /**
+   * Additional items to render in the menu footer
+   */
+  additionalMenuFooterItems?: React.ReactNode;
+  /**
    * Additional styles to apply to the dropdown
    */
   className?: string;
@@ -213,6 +217,7 @@ export default function AssigneeSelectorDropdown({
   owners,
   sizeLimit = 150,
   trigger,
+  additionalMenuFooterItems,
 }: AssigneeSelectorDropdownProps) {
   const memberLists = useLegacyStore(MemberListStore);
   const sessionUser = useUser();
@@ -536,18 +541,21 @@ export default function AssigneeSelectorDropdown({
   };
 
   const footerInviteButton = (
-    <Button
-      size="xs"
-      aria-label={t('Invite Member')}
-      disabled={loading}
-      onClick={(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-        event.preventDefault();
-        openInviteMembersModal({source: 'assignee_selector'});
-      }}
-      icon={<IconAdd isCircled />}
-    >
-      {t('Invite Member')}
-    </Button>
+    <FooterWrapper>
+      <Button
+        size="xs"
+        aria-label={t('Invite Member')}
+        disabled={loading}
+        onClick={(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+          event.preventDefault();
+          openInviteMembersModal({source: 'assignee_selector'});
+        }}
+        icon={<IconAdd isCircled />}
+      >
+        {t('Invite Member')}
+      </Button>
+      {additionalMenuFooterItems}
+    </FooterWrapper>
   );
 
   return (
@@ -610,4 +618,10 @@ const TooltipSubExternalLink = styled(ExternalLink)`
 
 const TooltipSubtext = styled('div')`
   color: ${p => p.theme.subText};
+`;
+
+const FooterWrapper = styled('div')`
+  display: flex;
+  gap: ${space(1)};
+  align-items: center;
 `;

--- a/static/app/components/group/assigneeSelector.tsx
+++ b/static/app/components/group/assigneeSelector.tsx
@@ -20,6 +20,7 @@ interface AssigneeSelectorProps {
   assigneeLoading: boolean;
   group: Group;
   handleAssigneeChange: (assignedActor: AssignableEntity | null) => void;
+  additionalMenuFooterItems?: React.ReactNode;
   memberList?: User[];
   owners?: Omit<SuggestedAssignee, 'assignee'>[];
 }
@@ -76,6 +77,7 @@ export function AssigneeSelector({
   assigneeLoading,
   handleAssigneeChange,
   owners,
+  additionalMenuFooterItems,
 }: AssigneeSelectorProps) {
   return (
     <AssigneeSelectorDropdown
@@ -107,6 +109,7 @@ export function AssigneeSelector({
           />
         </StyledDropdownButton>
       )}
+      additionalMenuFooterItems={additionalMenuFooterItems}
     />
   );
 }

--- a/static/app/views/issueDetails/streamline/header/assigneeSelector.spec.tsx
+++ b/static/app/views/issueDetails/streamline/header/assigneeSelector.spec.tsx
@@ -58,5 +58,6 @@ describe('GroupHeaderAssigneeSelector', () => {
 
     expect(screen.getByText(ownerActor.name)).toBeInTheDocument();
     expect(screen.getByText('Codeowners:/issues')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Ownership'})).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/header/assigneeSelector.tsx
+++ b/static/app/views/issueDetails/streamline/header/assigneeSelector.tsx
@@ -1,11 +1,15 @@
 import {useEffect} from 'react';
 
 import {fetchOrgMembers} from 'sentry/actionCreators/members';
+import {openIssueOwnershipRuleModal} from 'sentry/actionCreators/modal';
+import {Button} from 'sentry/components/button';
 import {getOwnerList} from 'sentry/components/group/assignedTo';
 import {
   AssigneeSelector,
   useHandleAssigneeChange,
 } from 'sentry/components/group/assigneeSelector';
+import {IconSettings} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
@@ -58,6 +62,23 @@ export function GroupHeaderAssigneeSelector({
       owners={owners}
       assigneeLoading={assigneeLoading}
       handleAssigneeChange={handleAssigneeChange}
+      additionalMenuFooterItems={
+        <Button
+          type="button"
+          onClick={() => {
+            openIssueOwnershipRuleModal({
+              project,
+              organization,
+              issueId: group.id,
+              eventData: event!,
+            });
+          }}
+          icon={<IconSettings />}
+          size="xs"
+        >
+          {t('Ownership')}
+        </Button>
+      }
     />
   );
 }


### PR DESCRIPTION
Adds ownership settings button to the assignee selector dropdown. We do have a link in the tooltip but it goes to our docs.

![image](https://github.com/user-attachments/assets/6499280d-da1f-45af-b7e6-d855aac129d7)
