### PR TITLE
fix(isues): Sort unresolved issue count result

### DIFF
--- a/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.spec.tsx
@@ -11,6 +11,7 @@ describe('TeamUnresolvedIssues', () => {
     const team = TeamFixture();
     const project = ProjectFixture();
     const organization = OrganizationFixture();
+    const lastDayCount = 37;
     const issuesApi = MockApiClient.addMockResponse({
       url: `/teams/${organization.slug}/${team.slug}/all-unresolved-issues/`,
       body: {
@@ -26,9 +27,9 @@ describe('TeamUnresolvedIssues', () => {
           '2021-12-18T00:00:00+00:00': {unresolved: 44},
           '2021-12-19T00:00:00+00:00': {unresolved: 43},
           '2021-12-20T00:00:00+00:00': {unresolved: 40},
-          '2021-12-21T00:00:00+00:00': {unresolved: 37},
+          '2021-12-21T00:00:00+00:00': {unresolved: 38},
           '2021-12-22T00:00:00+00:00': {unresolved: 36},
-          '2021-12-23T00:00:00+00:00': {unresolved: 37},
+          '2021-12-23T00:00:00+00:00': {unresolved: lastDayCount},
         },
       },
     });
@@ -44,6 +45,7 @@ describe('TeamUnresolvedIssues', () => {
     // Project
     expect(await screen.findByText('project-slug')).toBeInTheDocument();
     expect(screen.getByText('-14%')).toBeInTheDocument();
+    expect(screen.getByText(lastDayCount)).toBeInTheDocument();
     expect(issuesApi).toHaveBeenCalledTimes(1);
   });
 });

--- a/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.tsx
@@ -66,6 +66,9 @@ export function TeamUnresolvedIssues({
   function getTotalUnresolved(projectId: number): number {
     const entries = Object.values(periodIssues?.[projectId] ?? {});
     const total = entries.reduce((acc, current) => acc + current.unresolved, 0);
+    if (total === 0) {
+      return 0;
+    }
 
     return Math.round(total / entries.length);
   }
@@ -76,8 +79,10 @@ export function TeamUnresolvedIssues({
   > = {};
   for (const projectId of Object.keys(periodIssues)) {
     const periodAvg = getTotalUnresolved(Number(projectId));
-    const projectPeriodEntries = Object.values(periodIssues?.[projectId] ?? {});
-    const today = projectPeriodEntries[projectPeriodEntries.length - 1]?.unresolved ?? 0;
+    const projectPeriodEntries = Object.entries(periodIssues?.[projectId] ?? {}).sort(
+      (a, b) => new Date(b[0]).getTime() - new Date(a[0]).getTime()
+    );
+    const today = projectPeriodEntries[0]?.[1]?.unresolved ?? 0;
     const percentChange = (today - periodAvg) / periodAvg;
     projectTotals[projectId] = {
       projectId,


### PR DESCRIPTION
It was using the last item in the results which maybe was "today" in the past, but now isn't. fixes a division by zero NaN error
