### PR TITLE
fix(issues): Hide empty project series in team stats

### DIFF
--- a/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.tsx
@@ -135,16 +135,21 @@ function TeamIssuesBreakdown({
     .map(([projectId, {total}]) => ({projectId, total}))
     .sort((a, b) => b.total - a.total);
 
-  const allSeries = Object.keys(allReviewedByDay).map(
-    (projectId, idx): BarChartSeries => ({
-      seriesName: ProjectsStore.getById(projectId)?.slug ?? projectId,
-      data: sortSeriesByDay(convertDayValueObjectToSeries(allReviewedByDay[projectId])),
-      animationDuration: 500,
-      animationDelay: idx * 500,
-      silent: true,
-      barCategoryGap: '5%',
-    })
-  );
+  // There are projects with more than 0 results
+  const hasResults = sortedProjectIds.some(({total}) => total !== 0);
+  const allSeries = Object.keys(allReviewedByDay)
+    // Hide projects with no results when there are other projects with results
+    .filter(projectId => (hasResults ? projectTotals[projectId].total !== 0 : true))
+    .map(
+      (projectId, idx): BarChartSeries => ({
+        seriesName: ProjectsStore.getById(projectId)?.slug ?? projectId,
+        data: sortSeriesByDay(convertDayValueObjectToSeries(allReviewedByDay[projectId])),
+        animationDuration: 500,
+        animationDelay: idx * 500,
+        silent: true,
+        barCategoryGap: '5%',
+      })
+    );
 
   if (isError) {
     return <LoadingError onRetry={refetch} />;


### PR DESCRIPTION
Hides empty project series when there are other projects with data.

Some teams have 20+ projects making the tooltip impossible to read and huge.

before (all projects shown)
![image](https://github.com/user-attachments/assets/68fb4624-53bc-434a-9c47-2e9dde3c1d7e)

after (only projects with 1 or more issues are shown)
![image](https://github.com/user-attachments/assets/60cfdead-5639-4749-ba31-6f113cce3818)
