### PR TITLE
:wrench: chore(slo): Add slos for "View Submission" for Slack

### DIFF
--- a/src/sentry/integrations/messaging/metrics.py
+++ b/src/sentry/integrations/messaging/metrics.py
@@ -34,6 +34,7 @@ class MessagingInteractionType(StrEnum):
     UNRESOLVE = "UNRESOLVE"
     IGNORE = "IGNORE"
     MARK_ONGOING = "MARK_ONGOING"
+    VIEW_SUBMISSION = "VIEW_SUBMISSION"
 
     # Automatic behaviors
     UNFURL_ISSUES = "UNFURL_ISSUES"
@@ -84,9 +85,6 @@ class MessageCommandHaltReason(StrEnum):
     TEAM_NOT_LINKED = "team_not_linked"
     INSUFFICIENT_ROLE = "insufficient_role"
 
-    def __str__(self) -> str:
-        return self.value
-
 
 class MessageCommandFailureReason(StrEnum):
     """Common reasons why a messaging command may fail."""
@@ -94,5 +92,8 @@ class MessageCommandFailureReason(StrEnum):
     MISSING_DATA = "missing_data"
     INVALID_STATE = "invalid_state"
 
-    def __str__(self) -> str:
-        return self.value
+
+class MessageInteractionFailureReason(StrEnum):
+    """Common reasons why a messaging interaction may fail."""
+
+    MISSING_ACTION = "missing_action"

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -255,10 +255,12 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert "via" not in blocks[4]["elements"][0]["text"]
         assert ":white_circle:" in blocks[0]["text"]["text"]
 
-        assert len(mock_record.mock_calls) == 2
-        start, halt = mock_record.mock_calls
-        assert start.args[0] == EventLifecycleOutcome.STARTED
-        assert halt.args[0] == EventLifecycleOutcome.SUCCESS
+        assert len(mock_record.mock_calls) == 4
+        start_1, success_1, start_2, success_2 = mock_record.mock_calls
+        assert start_1.args[0] == EventLifecycleOutcome.STARTED
+        assert success_1.args[0] == EventLifecycleOutcome.SUCCESS
+        assert start_2.args[0] == EventLifecycleOutcome.STARTED
+        assert success_2.args[0] == EventLifecycleOutcome.SUCCESS
 
     @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
     def test_archive_issue_until_escalating_through_unfurl(self, mock_tags):

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -195,7 +195,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         # resp so that the tests can assert the response blocks looked as expected
         return resp
 
-    def resolve_issue(self, original_message, selected_option, payload_data=None):
+    def resolve_issue(self, original_message, selected_option, payload_data=None, mock_record=None):
         status_action = self.get_resolve_status_action()
         resp = self.post_webhook_block_kit(
             action_data=[status_action], original_message=original_message, data=payload_data
@@ -221,6 +221,15 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         )
 
         assert resp.status_code == 200, resp.content
+
+        # 4 lifecycle events are recorded: 2 for the view submission and 2 for the view update
+        if mock_record:
+            assert len(mock_record.mock_calls) == 4
+            start_1, success_1, start_2, success_2 = mock_record.mock_calls
+            assert start_1.args[0] == EventLifecycleOutcome.STARTED
+            assert success_1.args[0] == EventLifecycleOutcome.SUCCESS
+            assert start_2.args[0] == EventLifecycleOutcome.STARTED
+            assert success_2.args[0] == EventLifecycleOutcome.SUCCESS
 
     @freeze_time("2021-01-14T12:27:28.303Z")
     def test_ask_linking(self):
@@ -708,10 +717,11 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.notification_text in blocks[1]["text"]["text"]
         assert blocks[2]["text"]["text"].endswith(expect_status), text
 
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
-    def test_resolve_issue(self, mock_tags):
+    def test_resolve_issue(self, mock_tags, mock_record):
         original_message = self.get_original_message(self.group.id)
-        self.resolve_issue(original_message, "resolved")
+        self.resolve_issue(original_message, "resolved", mock_record)
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.RESOLVED
@@ -725,8 +735,9 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert blocks[2]["text"]["text"] == expect_status
         assert ":white_circle:" in blocks[0]["text"]["text"]
 
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
-    def test_resolve_perf_issue(self, mock_tags):
+    def test_resolve_perf_issue(self, mock_tags, mock_record):
         group_fingerprint = f"{PerformanceNPlusOneGroupType.type_id}-group1"
 
         event_data_2 = load_data("transaction-n-plus-one", fingerprint=[group_fingerprint])
@@ -741,7 +752,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.group
 
         original_message = self.get_original_message(self.group.id)
-        self.resolve_issue(original_message, "resolved")
+        self.resolve_issue(original_message, "resolved", mock_record)
 
         self.group.refresh_from_db()
         assert self.group.get_status() == GroupStatus.RESOLVED
@@ -775,8 +786,9 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.notification_text in blocks[1]["text"]["text"]
         assert blocks[2]["text"]["text"] == expect_status
 
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
-    def test_resolve_issue_in_current_release(self, mock_tags):
+    def test_resolve_issue_in_current_release(self, mock_tags, mock_record):
         release = Release.objects.create(
             organization_id=self.organization.id,
             version="1.0",
@@ -784,7 +796,7 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         release.add_project(self.project)
 
         original_message = self.get_original_message(self.group.id)
-        self.resolve_issue(original_message, "resolved:inCurrentRelease")
+        self.resolve_issue(original_message, "resolved:inCurrentRelease", mock_record)
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.RESOLVED
@@ -824,15 +836,16 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
         assert self.notification_text in blocks[1]["text"]["text"]
         assert blocks[2]["text"]["text"].endswith(expect_status)
 
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.integrations.slack.message_builder.issues.get_tags", return_value=[])
-    def test_resolve_in_next_release(self, mock_tags):
+    def test_resolve_in_next_release(self, mock_tags, mock_record):
         release = Release.objects.create(
             organization_id=self.organization.id,
             version="1.0",
         )
         release.add_project(self.project)
         original_message = self.get_original_message(self.group.id)
-        self.resolve_issue(original_message, "resolved:inNextRelease")
+        self.resolve_issue(original_message, "resolved:inNextRelease", mock_record)
 
         self.group = Group.objects.get(id=self.group.id)
         assert self.group.get_status() == GroupStatus.RESOLVED


### PR DESCRIPTION
"View Submission" Represents the user finishing the "Resolve" or "Archive" modal. we currently don't have slos for this and its affecting my ability to debug issues with the modal.