### PR TITLE
chore(flagpole): Adds a test flag to validate region checks in flagpole

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -545,6 +545,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:ingest-spans-in-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables EAP alerts UI use RPC
     manager.add("organizations:eap-alerts-ui-uses-rpc", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Test flag for flagpole region checking
+    manager.add("organizations:validate-region-test-flag", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 
     # NOTE: Don't add features down here! Add them to their specific group and sort
     #       them alphabetically! The order features are registered is not important.


### PR DESCRIPTION
Adds a new flag named `organizations:validate-region-test-flag` which will be used to test region checks in a couple test organizations.
