### PR TITLE
fix(dynamic-sampling): round dynamic sampling rates when switching from org to project mode

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -1036,7 +1036,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                 error_sample_rate_fallback=None,
             )
             if current_rate:
-                project.update_option("sentry:target_sample_rate", current_rate)
+                project.update_option("sentry:target_sample_rate", round(current_rate, 4))
 
     def handle_delete(self, request: Request, organization: Organization):
         """

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -752,8 +752,12 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             if project.update_option("sentry:origins", result["allowedDomains"]):
                 changed_proj_settings["sentry:origins"] = result["allowedDomains"]
         if result.get("targetSampleRate") is not None:
-            if project.update_option("sentry:target_sample_rate", result["targetSampleRate"]):
-                changed_proj_settings["sentry:target_sample_rate"] = result["targetSampleRate"]
+            if project.update_option(
+                "sentry:target_sample_rate", round(result["targetSampleRate"]), 4
+            ):
+                changed_proj_settings["sentry:target_sample_rate"] = round(
+                    result["targetSampleRate"], 4
+                )
         if "dynamicSamplingBiases" in result:
             updated_biases = get_user_biases(user_set_biases=result["dynamicSamplingBiases"])
             if project.update_option("sentry:dynamic_sampling_biases", updated_biases):

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -753,7 +753,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                 changed_proj_settings["sentry:origins"] = result["allowedDomains"]
         if result.get("targetSampleRate") is not None:
             if project.update_option(
-                "sentry:target_sample_rate", round(result["targetSampleRate"]), 4
+                "sentry:target_sample_rate", round(result["targetSampleRate"], 4)
             ):
                 changed_proj_settings["sentry:target_sample_rate"] = round(
                     result["targetSampleRate"], 4


### PR DESCRIPTION
- Rounds the project rates when switching from organization mode to project mode to 4 digits via the OrganizationDetailsEndpoint
- Rounds the project rate when updated via the ProjectDetailsEndpoint

Contributes to https://github.com/getsentry/sentry/issues/81557