### PR TITLE
ref: Improve symbolication platform logic

### DIFF
--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -7,7 +7,7 @@ import orjson
 
 from sentry.attachments import CachedAttachment, attachment_cache
 from sentry.ingest.consumer.processors import CACHE_TIMEOUT
-from sentry.lang.java.utils import get_jvm_images, get_proguard_images
+from sentry.lang.java.utils import JAVA_PLATFORMS, get_jvm_images, get_proguard_images
 from sentry.lang.native.error import SymbolicationFailed, write_error
 from sentry.lang.native.symbolicator import Symbolicator
 from sentry.models.eventerror import EventError
@@ -85,7 +85,7 @@ def _handles_frame(frame: dict[str, Any], platform: str) -> bool:
     return (
         "function" in frame
         and "module" in frame
-        and (frame.get("platform", None) or platform) == "java"
+        and (frame.get("platform", None) or platform) in JAVA_PLATFORMS
     )
 
 

--- a/src/sentry/lang/java/utils.py
+++ b/src/sentry/lang/java/utils.py
@@ -22,7 +22,7 @@ from sentry.utils.safe import get_path
 #
 # Strictly speaking, this should probably include
 # "android" too—at least we use it in profiling.
-JAVA_PLATFORMS = "java"
+JAVA_PLATFORMS = ("java",)
 
 
 def is_valid_proguard_image(image):

--- a/src/sentry/lang/java/utils.py
+++ b/src/sentry/lang/java/utils.py
@@ -11,8 +11,18 @@ from sentry.ingest.consumer.processors import CACHE_TIMEOUT
 from sentry.lang.java.proguard import open_proguard_mapper
 from sentry.models.debugfile import ProjectDebugFile
 from sentry.models.project import Project
+from sentry.stacktraces.processing import StacktraceInfo
+from sentry.utils import metrics
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.safe import get_path
+
+# Platform values that should mark an event
+# or frame as being Java for the purposes
+# of symbolication.
+#
+# Strictly speaking, this should probably include
+# "android" too—at least we use it in profiling.
+JAVA_PLATFORMS = "java"
 
 
 def is_valid_proguard_image(image):
@@ -107,10 +117,24 @@ def deobfuscation_template(data, map_type, deobfuscation_fn):
     attachment_cache.set(cache_key, attachments=new_attachments, timeout=CACHE_TIMEOUT)
 
 
-def is_jvm_event(data: Any) -> bool:
-    """Returns whether `data` is a JVM event, based on its images."""
+def is_jvm_event(data: Any, stacktraces: list[StacktraceInfo]) -> bool:
+    """Returns whether `data` is a JVM event, based on its platform,
+    the supplied stacktraces, and its images."""
+
+    platform = data.get("platform")
+
+    if platform in JAVA_PLATFORMS:
+        return True
+
+    for stacktrace in stacktraces:
+        # The platforms of a stacktrace are exactly the platforms of its frames
+        # so this is tantamount to checking if any frame has a Java platform.
+        if any(x in JAVA_PLATFORMS for x in stacktrace.platforms):
+            return True
 
     # check if there are any JVM or Proguard images
+    # TODO: Can this actually happen if the event platform
+    # is not "java"?
     images = get_path(
         data,
         "debug_meta",
@@ -118,4 +142,10 @@ def is_jvm_event(data: Any) -> bool:
         filter=lambda x: is_valid_jvm_image(x) or is_valid_proguard_image(x),
         default=(),
     )
-    return bool(images)
+
+    if images:
+        metrics.incr("process.java.symbolicate.missing_platform", tags={platform: platform})
+
+        return True
+
+    return False

--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -3,6 +3,7 @@ import re
 from typing import Any
 
 from sentry.debug_files.artifact_bundles import maybe_renew_artifact_bundles_from_processing
+from sentry.lang.javascript.utils import JAVASCRIPT_PLATFORMS
 from sentry.lang.native.error import SymbolicationFailed, write_error
 from sentry.lang.native.symbolicator import Symbolicator
 from sentry.models.eventerror import EventError
@@ -171,6 +172,11 @@ def map_symbolicator_process_js_errors(errors):
 
 def _handles_frame(frame, data):
     abs_path = frame.get("abs_path")
+    platform = frame.get("platform") or data.get("platform", "unknown")
+
+    # Skip non-JS frames
+    if platform not in JAVASCRIPT_PLATFORMS:
+        return False
 
     # Skip frames without an `abs_path` or line number
     if not abs_path or not frame.get("lineno"):
@@ -181,7 +187,7 @@ def _handles_frame(frame, data):
         return False
 
     # Skip builtin node modules
-    if _is_built_in(abs_path, data.get("platform")):
+    if _is_built_in(abs_path, platform):
         return False
 
     return True

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -58,7 +58,7 @@ def get_symbolication_platforms(
 
     platforms = []
 
-    if is_jvm_event(data):
+    if is_jvm_event(data, stacktraces):
         platforms.append(SymbolicatorPlatform.jvm)
     if is_js_event(data, stacktraces):
         platforms.append(SymbolicatorPlatform.js)

--- a/tests/relay_integration/lang/java/test_plugin.py
+++ b/tests/relay_integration/lang/java/test_plugin.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 
 from sentry.models.debugfile import ProjectDebugFile
 from sentry.models.files.file import File
+from sentry.stacktraces.processing import find_stacktraces_in_data
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.relay import RelayStoreHelper
@@ -1585,7 +1586,9 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
             },
             "timestamp": before_now(seconds=1),
         }
-        assert is_jvm_event(event)
+
+        stacktraces = find_stacktraces_in_data(event)
+        assert is_jvm_event(event, stacktraces)
 
         event = {
             "user": {"ip_address": "31.172.207.97"},
@@ -1615,7 +1618,8 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
             "timestamp": before_now(seconds=1),
         }
         # has no platform
-        assert is_jvm_event(event)
+        stacktraces = find_stacktraces_in_data(event)
+        assert is_jvm_event(event, stacktraces)
 
         event = {
             "user": {"ip_address": "31.172.207.97"},
@@ -1646,4 +1650,5 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
             "timestamp": before_now(seconds=1),
         }
         # has no modules
-        assert not is_jvm_event(event)
+        stacktraces = find_stacktraces_in_data(event)
+        assert is_jvm_event(event, stacktraces)

--- a/tests/relay_integration/lang/java/test_plugin.py
+++ b/tests/relay_integration/lang/java/test_plugin.py
@@ -1652,3 +1652,66 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
         # has no modules
         stacktraces = find_stacktraces_in_data(event)
         assert is_jvm_event(event, stacktraces)
+
+        event = {
+            "user": {"ip_address": "31.172.207.97"},
+            "extra": {},
+            "project": self.project.id,
+            "debug_meta": {},
+            "exception": {
+                "values": [
+                    {
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "platform": "java",
+                                    "function": "whoops4",
+                                    "abs_path": "SourceFile",
+                                    "module": "io.sentry.samples.MainActivity$OneMoreInnerClass",
+                                    "filename": "SourceFile",
+                                    "lineno": 38,
+                                },
+                            ]
+                        },
+                        "module": "io.sentry.samples",
+                        "type": "RuntimeException",
+                        "value": "whoops",
+                    }
+                ]
+            },
+            "timestamp": before_now(seconds=1),
+        }
+        # has a Java frame
+        stacktraces = find_stacktraces_in_data(event)
+        assert is_jvm_event(event, stacktraces)
+
+        event = {
+            "user": {"ip_address": "31.172.207.97"},
+            "extra": {},
+            "project": self.project.id,
+            "debug_meta": {},
+            "exception": {
+                "values": [
+                    {
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "function": "whoops4",
+                                    "abs_path": "SourceFile",
+                                    "module": "io.sentry.samples.MainActivity$OneMoreInnerClass",
+                                    "filename": "SourceFile",
+                                    "lineno": 38,
+                                },
+                            ]
+                        },
+                        "module": "io.sentry.samples",
+                        "type": "RuntimeException",
+                        "value": "whoops",
+                    }
+                ]
+            },
+            "timestamp": before_now(seconds=1),
+        }
+        # has no platform, frame, or modules
+        stacktraces = find_stacktraces_in_data(event)
+        assert not is_jvm_event(event, stacktraces)


### PR DESCRIPTION
There are a number of discrepancies between native, JS, and JVM regarding how events and frames that should be symbolicated are detected. For example, native and JVM check the `"platform"` field of
frames, but JS doesn't. Conversely, JVM doesn't check it for events.

This PR aims to align the logic between the platforms so that platforms are checked everywhere. We have metrics in Symbolicator showing that we don't get any frames where at least one of the platforms isn't set, but we _do_ rarely get frames with nonsensical platforms (Java, Lua, …) in the JS case, likely because the check is too lenient.

One open question is whether it is possible for an event to contain JVM/Java images, but not have a platform of `"java"`. We now emit a counter for cases like this.