### PR TITLE
ci(coverage) only run coverage on master

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -129,7 +129,11 @@ jobs:
           # This quiets up the logs quite a bit.
           DEBUG_PRINT_LIMIT: 0
         run: |
-          JEST_TESTS=$(yarn -s jest --listTests --json) yarn test-ci --forceExit
+          if [ ${{ github.ref }} = 'refs/heads/master' ]; then
+            JEST_TESTS=$(yarn -s jest --listTests --json) yarn test-ci --forceExit --coverage
+          else
+            JEST_TESTS=$(yarn -s jest --listTests --json) yarn test-ci --forceExit
+          fi
 
       # We only upload coverage data for FE changes since it conflicts with
       # codecov's carry forward functionality.

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,6 +4,7 @@ coverage:
     project: false
     patch:
       frontend:
+        informational: true
         branches:
           - master
         flags:

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,10 +4,8 @@ coverage:
     project: false
     patch:
       frontend:
-        # codecov will not fail status checks for master
-        only_pulls: true
-        informational: false # Fail the check
-        target: 60%
+        branches:
+          - master
         flags:
           - frontend
       backend:

--- a/package.json
+++ b/package.json
@@ -227,7 +227,7 @@
   "proxyURL": "http://localhost:8000",
   "scripts": {
     "test": "node scripts/test.js --watch",
-    "test-ci": "node scripts/test.js --ci --coverage --maxWorkers=100% --colors",
+    "test-ci": "node scripts/test.js --ci --maxWorkers=100% --colors",
     "test-debug": "node --inspect-brk scripts/test.js --runInBand",
     "test-precommit": "node scripts/test.js --bail --findRelatedTests -u",
     "test-staged": "node scripts/test.js --findRelatedTests $(git diff --name-only --cached)",


### PR DESCRIPTION
Running coverage doubles our CI times and causes PRs to be marked as failing in Github UI. In addition, since it is not enforced, it just means it goes entirely dismisses (last 10 PRs with failed merged coverage checks were merged anyways).

The following change would preserve coverage reporting from master branch so that we can monitor coverage of the repo over time, or until we decide to enforce it.

I have only followed codecov docs, but I would appreciate someone familiar with Codecov to review the change.