### PR TITLE
fix(issue-details): Add viewer/particpant last seen back

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/participantList.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/participantList.spec.tsx
@@ -7,8 +7,18 @@ import ParticipantList from 'sentry/views/issueDetails/streamline/sidebar/partic
 
 describe('ParticipantList', () => {
   const users = [
-    UserFixture({id: '1', name: 'John Doe', email: 'john.doe@example.com'}),
-    UserFixture({id: '2', name: 'Bob Alice', email: 'bob.alice@example.com'}),
+    UserFixture({
+      id: '1',
+      name: 'John Doe',
+      email: 'john.doe@example.com',
+      lastSeen: '2024-01-01T00:00:00.000Z',
+    }),
+    UserFixture({
+      id: '2',
+      name: 'Bob Alice',
+      email: 'bob.alice@example.com',
+      lastSeen: '2024-01-02T00:00:00.000Z',
+    }),
   ];
 
   const teams = [
@@ -46,5 +56,17 @@ describe('ParticipantList', () => {
     await userEvent.click(screen.getByText('J'), {skipHover: true});
     // Would find two elements if it was duplicated
     expect(await screen.findByText('john.doe@example.com')).toBeInTheDocument();
+  });
+
+  it('displays information about last seen, if available', async () => {
+    render(<ParticipantList users={users} teams={teams} />);
+    await userEvent.click(screen.getByText('JD'), {skipHover: true});
+    expect(await screen.findByText('John Doe')).toBeInTheDocument();
+    expect(await screen.findByText('Jan 1, 2024 12:00 AM')).toBeInTheDocument();
+    expect(await screen.findByText('Bob Alice')).toBeInTheDocument();
+    expect(await screen.findByText('Jan 2, 2024 12:00 AM')).toBeInTheDocument();
+    // Still display teams/users without timestamps
+    expect(await screen.findByText('#team-1')).toBeInTheDocument();
+    expect(await screen.findByText('#team-2')).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/sidebar/participantList.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/participantList.spec.tsx
@@ -3,7 +3,7 @@ import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import ParticipantList from 'sentry/components/group/streamlinedParticipantList';
+import ParticipantList from 'sentry/views/issueDetails/streamline/sidebar/participantList';
 
 describe('ParticipantList', () => {
   const users = [

--- a/static/app/views/issueDetails/streamline/sidebar/participantList.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/participantList.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -5,11 +6,13 @@ import Avatar from 'sentry/components/avatar';
 import AvatarList from 'sentry/components/avatar/avatarList';
 import TeamAvatar from 'sentry/components/avatar/teamAvatar';
 import {Button} from 'sentry/components/button';
+import {DateTime} from 'sentry/components/dateTime';
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Team} from 'sentry/types/organization';
-import type {User} from 'sentry/types/user';
+import type {AvatarUser, User} from 'sentry/types/user';
+import {userDisplayName} from 'sentry/utils/formatters';
 import useOverlay from 'sentry/utils/useOverlay';
 
 interface DropdownListProps {
@@ -35,6 +38,13 @@ export default function ParticipantList({users, teams}: DropdownListProps) {
           users={users}
           avatarSize={24}
           maxVisibleAvatars={3}
+          renderTooltip={user => (
+            <Fragment>
+              {userDisplayName(user)}
+              <br />
+              <LastSeen date={(user as AvatarUser).lastSeen} />
+            </Fragment>
+          )}
         />
       </Button>
       {isOpen && (
@@ -66,6 +76,7 @@ export default function ParticipantList({users, teams}: DropdownListProps) {
                     {user.email !== user.name ? (
                       <SmallText>{user.email}</SmallText>
                     ) : null}
+                    <LastSeen date={(user as AvatarUser).lastSeen} />
                   </NameWrapper>
                 </UserRow>
               ))}
@@ -127,4 +138,9 @@ const SmallText = styled('div')`
 const StyledAvatarList = styled(AvatarList)`
   justify-content: flex-end;
   padding-left: ${space(0.75)};
+`;
+
+const LastSeen = styled(DateTime)`
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeExtraSmall};
 `;

--- a/static/app/views/issueDetails/streamline/sidebar/peopleSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/peopleSection.tsx
@@ -1,9 +1,9 @@
 import {Flex} from 'sentry/components/container/flex';
-import ParticipantList from 'sentry/components/group/streamlinedParticipantList';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {TeamParticipant, UserParticipant} from 'sentry/types/group';
 import type {User} from 'sentry/types/user';
+import ParticipantList from 'sentry/views/issueDetails/streamline/sidebar/participantList';
 import {SidebarSectionTitle} from 'sentry/views/issueDetails/streamline/sidebar/sidebar';
 
 export default function PeopleSection({


### PR DESCRIPTION
Minor regression, we began omitting the last time a viewer/participant were seen as part of the issue details page redesign.
Fixes that and adds a test for it.

Hover:
<img width="307" alt="image" src="https://github.com/user-attachments/assets/da678ec3-0cb0-4077-a9cc-3f29cb6e3273">

Dropdown:
<img width="312" alt="image" src="https://github.com/user-attachments/assets/93f7a843-202f-468c-841e-ae70ccea395f">
