### PR TITLE
fix(insights): Styling of Web Vitals cards

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/webVitalMeters.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalMeters.tsx
@@ -199,6 +199,7 @@ const MeterBarBody = styled('div')`
 
 const MeterHeader = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
+  font-weight: ${p => p.theme.fontWeightBold};
   color: ${p => p.theme.textColor};
   display: inline-block;
   text-align: center;
@@ -233,7 +234,7 @@ const MeterBarFooterContainer = styled('div')<{status: string}>`
   color: ${p => p.theme[PERFORMANCE_SCORE_COLORS[p.status].normal]};
   border-radius: 0 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius};
   background-color: ${p => p.theme[PERFORMANCE_SCORE_COLORS[p.status].light]};
-  border: solid 1px ${p => p.theme[PERFORMANCE_SCORE_COLORS[p.status].light]};
+  border: solid 1px ${p => p.theme[PERFORMANCE_SCORE_COLORS[p.status].border]};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   padding: ${space(0.5)};
   text-align: center;

--- a/static/app/views/insights/browser/webVitals/utils/performanceScoreColors.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/performanceScoreColors.tsx
@@ -2,17 +2,21 @@ export const PERFORMANCE_SCORE_COLORS = {
   good: {
     light: 'green100',
     normal: 'green300',
+    border: 'green200',
   },
   needsImprovement: {
     light: 'yellow100',
     normal: 'yellow400',
+    border: 'yellow200',
   },
   bad: {
     light: 'red100',
     normal: 'red300',
+    border: 'red200',
   },
   none: {
     light: 'gray100',
     normal: 'gray300',
+    border: 'gray200',
   },
 };


### PR DESCRIPTION
Touches up the styling of the web vitals cards so they are consistent with what is found in the designs

## Before
![image](https://github.com/user-attachments/assets/17afcea7-4ea5-4f07-a75b-ea962e1d53aa)

## After
![image](https://github.com/user-attachments/assets/f1743288-bd82-4f1e-bb85-32b0c3712092)
