### PR TITLE
fix(issue-details): Ensure trace link appears for performance issues

### DIFF
--- a/static/app/components/events/interfaces/performance/eventTraceView.spec.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.spec.tsx
@@ -5,6 +5,7 @@ import {initializeData} from 'sentry-test/performance/initializePerformanceData'
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {EntryType} from 'sentry/types/event';
+import {IssueCategory, IssueTitle} from 'sentry/types/group';
 import type {TraceEventResponse} from 'sentry/views/issueDetails/traceTimeline/useTraceTimelineEvents';
 import {makeTraceError} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
 
@@ -98,6 +99,35 @@ describe('EventTraceView', () => {
     expect(await screen.findByText('Trace')).toBeInTheDocument();
     expect(
       await screen.findByText('MaybeEncodingError: Error sending result')
+    ).toBeInTheDocument();
+  });
+
+  it('still renders trace link for performance issues', async () => {
+    const perfGroup = GroupFixture({issueCategory: IssueCategory.PERFORMANCE});
+    const perfEvent = EventFixture({
+      occurrence: {
+        type: 1001,
+        issueTitle: IssueTitle.PERFORMANCE_SLOW_DB_QUERY,
+      },
+      entries: [
+        {
+          data: [],
+          type: EntryType.SPANS,
+        },
+      ],
+      contexts: {
+        trace: {
+          trace_id: traceId,
+        },
+      },
+    });
+
+    render(
+      <EventTraceView group={perfGroup} event={perfEvent} organization={organization} />
+    );
+    expect(await screen.findByText('Trace')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('link', {name: 'View Full Trace'})
     ).toBeInTheDocument();
   });
 

--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -2,7 +2,6 @@ import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from 'sentry/components/button';
-import ErrorBoundary from 'sentry/components/errorBoundary';
 import {generateTraceTarget} from 'sentry/components/quickTrace/utils';
 import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -169,25 +168,22 @@ export function EventTraceView({group, event, organization}: EventTraceViewProps
   const hasIssueDetailsTrace = organization.features.includes(
     'issue-details-always-show-trace'
   );
-  const hasTracePreviewFeature = hasProfilingFeature && hasIssueDetailsTrace;
-
-  // Only display this for error or default events since performance events are handled elsewhere
-  if (group.issueCategory === IssueCategory.PERFORMANCE) {
-    return null;
-  }
+  const hasTracePreviewFeature =
+    hasProfilingFeature &&
+    hasIssueDetailsTrace &&
+    // Only display this for error or default events since performance events are handled elsewhere
+    group.issueCategory !== IssueCategory.PERFORMANCE;
 
   return (
-    <ErrorBoundary mini>
-      <InterimSection type={SectionKey.TRACE} title={t('Trace')}>
-        <TraceDataSection event={event} />
-        {hasTracePreviewFeature && (
-          <EventTraceViewInner
-            event={event}
-            organization={organization}
-            traceId={traceId}
-          />
-        )}
-      </InterimSection>
-    </ErrorBoundary>
+    <InterimSection type={SectionKey.TRACE} title={t('Trace')}>
+      <TraceDataSection event={event} />
+      {hasTracePreviewFeature && (
+        <EventTraceViewInner
+          event={event}
+          organization={organization}
+          traceId={traceId}
+        />
+      )}
+    </InterimSection>
   );
 }


### PR DESCRIPTION
Ensures the trace link still appears on perf issues, even if we don't display the entire trace preview yet.

<img width="1181" alt="image" src="https://github.com/user-attachments/assets/4ff7efea-39c7-4b26-b13e-d10ded8ccc18">

Without this, the section is omitted entirely:
<img width="1157" alt="image" src="https://github.com/user-attachments/assets/20f393ea-e67a-454d-b057-e44196502f8c">


We must do this since the trace link appears at the top of the old UI and we don't want a regression:
<img width="1168" alt="image" src="https://github.com/user-attachments/assets/444995b6-7f3a-4f71-912b-a89e4540a60d">

