### PR TITLE
feat(insights): add http module to mobile domain view

### DIFF
--- a/static/app/views/insights/common/utils/moduleTitles.tsx
+++ b/static/app/views/insights/common/utils/moduleTitles.tsx
@@ -4,6 +4,7 @@ import {MODULE_TITLE as CACHE_MODULE_TITLE} from 'sentry/views/insights/cache/se
 import {MODULE_TITLE as DB_MODULE_TITLE} from 'sentry/views/insights/database/settings';
 import {
   FRONTEND_MODULE_TITLE as HTTP_FRONTEND_MODULE_TITLE,
+  MOBILE_MODULE_TITLE as HTTP_MOBILE_MODULE_TITLE,
   MODULE_TITLE as HTTP_MODULE_TITLE,
 } from 'sentry/views/insights/http/settings';
 import {MODULE_TITLE as AI_MODULE_TITLE} from 'sentry/views/insights/llmMonitoring/settings';
@@ -42,7 +43,9 @@ export const DOMAIN_VIEW_MODULE_TITLES: Record<
 > = {
   ai: {},
   backend: {},
-  mobile: {},
+  mobile: {
+    [ModuleName.HTTP]: HTTP_MOBILE_MODULE_TITLE,
+  },
   frontend: {
     [ModuleName.HTTP]: HTTP_FRONTEND_MODULE_TITLE,
   },

--- a/static/app/views/insights/http/settings.ts
+++ b/static/app/views/insights/http/settings.ts
@@ -3,6 +3,7 @@ import {ModuleName} from 'sentry/views/insights/types';
 
 export const MODULE_TITLE = t('Outbound API Requests');
 export const FRONTEND_MODULE_TITLE = t('Network Requests');
+export const MOBILE_MODULE_TITLE = t('Network Requests');
 export const MODULE_SIDEBAR_TITLE = t('Requests');
 export const DATA_TYPE = t('Request');
 export const DATA_TYPE_PLURAL = t('Requests');

--- a/static/app/views/insights/http/views/httpDomainSummaryPage.tsx
+++ b/static/app/views/insights/http/views/httpDomainSummaryPage.tsx
@@ -51,6 +51,8 @@ import {BackendHeader} from 'sentry/views/insights/pages/backend/backendPageHead
 import {BACKEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/backend/settings';
 import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
 import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
+import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
+import {MOBILE_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mobile/settings';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import type {SpanMetricsQueryFilters} from 'sentry/views/insights/types';
 import {ModuleName, SpanFunction, SpanMetricsField} from 'sentry/views/insights/types';
@@ -180,45 +182,27 @@ export function HTTPDomainSummaryPage() {
     !isThroughputDataLoading && !isDurationDataLoading && !isResponseCodeDataLoading
   );
 
-  const headerTitle = (
-    <Fragment>
-      {project && <ProjectAvatar project={project} size={36} />}
-      {domain || NULL_DOMAIN_DESCRIPTION}
-      <DomainStatusLink domain={domain} />
-    </Fragment>
-  );
+  const headerProps = {
+    headerTitle: (
+      <Fragment>
+        {project && <ProjectAvatar project={project} size={36} />}
+        {domain || NULL_DOMAIN_DESCRIPTION}
+        <DomainStatusLink domain={domain} />
+      </Fragment>
+    ),
+    breadcrumbs: [
+      {
+        label: t('Domain Summary'),
+      },
+    ],
+    module: ModuleName.HTTP,
+  };
 
   return (
     <React.Fragment>
-      {view === FRONTEND_LANDING_SUB_PATH && (
-        <FrontendHeader
-          headerTitle={
-            <Fragment>
-              {project && <ProjectAvatar project={project} size={36} />}
-              {domain || NULL_DOMAIN_DESCRIPTION}
-              <DomainStatusLink domain={domain} />
-            </Fragment>
-          }
-          breadcrumbs={[
-            {
-              label: 'Domain Summary',
-            },
-          ]}
-          module={ModuleName.HTTP}
-        />
-      )}
-
-      {view === BACKEND_LANDING_SUB_PATH && (
-        <BackendHeader
-          headerTitle={headerTitle}
-          module={ModuleName.HTTP}
-          breadcrumbs={[
-            {
-              label: t('Domain Summary'),
-            },
-          ]}
-        />
-      )}
+      {view === FRONTEND_LANDING_SUB_PATH && <FrontendHeader {...headerProps} />}
+      {view === BACKEND_LANDING_SUB_PATH && <BackendHeader {...headerProps} />}
+      {view === MOBILE_LANDING_SUB_PATH && <MobileHeader {...headerProps} />}
 
       <ModuleBodyUpsellHook moduleName={ModuleName.HTTP}>
         <Layout.Body>

--- a/static/app/views/insights/http/views/httpLandingPage.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.tsx
@@ -40,6 +40,8 @@ import {BackendHeader} from 'sentry/views/insights/pages/backend/backendPageHead
 import {BACKEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/backend/settings';
 import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
 import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
+import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
+import {MOBILE_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mobile/settings';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {ModuleName, SpanMetricsField} from 'sentry/views/insights/types';
 
@@ -167,15 +169,16 @@ export function HTTPLandingPage() {
     </Fragment>
   );
 
+  const headerProps = {
+    headerTitle,
+    module: ModuleName.HTTP,
+  };
+
   return (
     <React.Fragment>
-      {view === FRONTEND_LANDING_SUB_PATH && (
-        <FrontendHeader headerTitle={headerTitle} module={ModuleName.HTTP} />
-      )}
-
-      {view === BACKEND_LANDING_SUB_PATH && (
-        <BackendHeader headerTitle={headerTitle} module={ModuleName.HTTP} />
-      )}
+      {view === FRONTEND_LANDING_SUB_PATH && <FrontendHeader {...headerProps} />}
+      {view === BACKEND_LANDING_SUB_PATH && <BackendHeader {...headerProps} />}
+      {view === MOBILE_LANDING_SUB_PATH && <MobileHeader {...headerProps} />}
 
       <ModuleBodyUpsellHook moduleName={ModuleName.HTTP}>
         <Layout.Body>

--- a/static/app/views/insights/pages/mobile/mobilePageHeader.tsx
+++ b/static/app/views/insights/pages/mobile/mobilePageHeader.tsx
@@ -40,7 +40,12 @@ export function MobileHeader({
 
   const modules = hasMobileScreens
     ? [ModuleName.MOBILE_SCREENS]
-    : [ModuleName.APP_START, ModuleName.SCREEN_LOAD, ModuleName.SCREEN_RENDERING];
+    : [
+        ModuleName.APP_START,
+        ModuleName.SCREEN_LOAD,
+        ModuleName.SCREEN_RENDERING,
+        ModuleName.HTTP,
+      ];
 
   if (!hasMobileScreens && hasMobileUi) {
     modules.push(ModuleName.MOBILE_UI);


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/80862

Adds the http module under mobile. For now, it's called "Network Requests", these seems to be a term mobile developers used, but if anyone knows more lmk!
<img width="840" alt="image" src="https://github.com/user-attachments/assets/41332d2b-69c9-4ac2-b697-d26ff1919997">
