### PR TITLE
chore(statistical-detectors): Do not make vroom request when not nece…

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -587,6 +587,9 @@ def emit_function_regression_issue(
             }
         )
 
+    if not payloads:
+        return 0
+
     response = get_from_profiling_service(method="POST", path="/regressed", json_data=payloads)
     if response.status != 200:
         return 0


### PR DESCRIPTION
…ssary

If there are no payloads, dont make a vroom request as it'll 400.