### PR TITLE
feat(widget-builder): Add query in state -> widget conversion

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/devBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/devBuilder.tsx
@@ -3,20 +3,18 @@ import styled from '@emotion/styled';
 import RadioGroup from 'sentry/components/forms/controls/radioGroup';
 import SelectField from 'sentry/components/forms/fields/selectField';
 import Input from 'sentry/components/input';
+import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import {space} from 'sentry/styles/space';
 import {CustomMeasurementsProvider} from 'sentry/utils/customMeasurements/customMeasurementsProvider';
 import {type Column, generateFieldAsString} from 'sentry/utils/discover/fields';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import {ColumnFields} from 'sentry/views/dashboards/widgetBuilder/buildSteps/columnsStep/columnFields';
 import {YAxisSelector} from 'sentry/views/dashboards/widgetBuilder/buildSteps/yAxisStep/yAxisSelector';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
-import {getDiscoverDatasetFromWidgetType} from 'sentry/views/dashboards/widgetBuilder/utils';
-import ResultsSearchQueryBuilder from 'sentry/views/discover/resultsSearchQueryBuilder';
 
 function DevBuilder() {
   const {state, dispatch} = useWidgetBuilderContext();
@@ -124,15 +122,14 @@ function DevBuilder() {
       </Section>
       <Section>
         <h1>Query:</h1>
-        <ol>{state.query?.map((query, index) => <li key={index}>{query}</li>)}</ol>
+        <ol style={{overflow: 'auto'}}>
+          {state.query?.map((query, index) => <li key={index}>{query}</li>)}
+        </ol>
         <div>
           {state.query?.map((query, index) => (
             <div key={index} style={{display: 'flex', flexDirection: 'row'}}>
               <QueryField
                 query={query}
-                widgetType={state.dataset ?? WidgetType.DISCOVER}
-                fields={state.fields ?? []}
-                key={index}
                 onSearch={queryString => {
                   dispatch({
                     type: BuilderStateAction.SET_QUERY,
@@ -230,26 +227,21 @@ function YAxis({
 
 function QueryField({
   query,
-  widgetType,
-  fields,
   onSearch,
 }: {
-  fields: Column[];
   onSearch: (query: string) => void;
   query: string;
-  widgetType: WidgetType;
 }) {
-  const pageFilters = usePageFilters();
-
   return (
-    <ResultsSearchQueryBuilder
-      projectIds={pageFilters.selection.projects}
-      query={query}
-      fields={fields as any}
+    <SearchQueryBuilder
+      placeholder={'Search'}
+      filterKeys={{}}
+      initialQuery={query ?? ''}
       onSearch={onSearch}
-      dataset={getDiscoverDatasetFromWidgetType(widgetType)}
-      includeTransactions
-      searchSource="widget_builder"
+      searchSource={'widget_builder'}
+      filterKeySections={[]}
+      getTagValues={() => Promise.resolve([])}
+      showUnsubmittedIndicator
     />
   );
 }

--- a/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
@@ -39,10 +39,8 @@ function WidgetPreview({dashboard, dashboardFilters}: WidgetPreviewProps) {
   // TODO: The way we create the widget here does not propagate a widget ID
   // to pass to the legend encoder decoder.
   const unselectedReleasesForCharts = {
-    [WidgetLegendNameEncoderDecoder.encodeSeriesNameForLegend(
-      'Releases',
-      'widget-builder'
-    )]: false,
+    [WidgetLegendNameEncoderDecoder.encodeSeriesNameForLegend('Releases', undefined)]:
+      false,
   };
 
   return (

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -14,6 +14,7 @@ export type WidgetBuilderStateQueryParams = {
   description?: string;
   displayType?: DisplayType;
   field?: (string | undefined)[];
+  query?: string[];
   title?: string;
   yAxis?: string[];
 };

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
@@ -10,6 +10,7 @@ export function convertWidgetToBuilderStateParams(
 ): WidgetBuilderStateQueryParams {
   const yAxis = widget.queries.flatMap(q => q.aggregates);
   const field = widget.queries.flatMap(q => q.fields);
+  const query = widget.queries.flatMap(q => q.conditions);
 
   return {
     title: widget.title,
@@ -18,5 +19,6 @@ export function convertWidgetToBuilderStateParams(
     displayType: widget.displayType ?? DisplayType.TABLE,
     field,
     yAxis,
+    query,
   };
 }


### PR DESCRIPTION
Forgot to account for putting the queries into the URL, so editing a widget wasn't picking up on query even though we did add support for it.