### PR TITLE
chore(autofix): Pre expand relevant code context

### DIFF
--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -86,13 +86,15 @@ export function ExpandableInsightContext({
   title,
   icon,
   rounded,
+  expandByDefault,
 }: {
   children: React.ReactNode;
   title: string;
+  expandByDefault?: boolean;
   icon?: React.ReactNode;
   rounded?: boolean;
 }) {
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(expandByDefault ?? false);
 
   const toggleExpand = () => {
     setExpanded(oldState => !oldState);

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -94,7 +94,7 @@ export function ExpandableInsightContext({
   icon?: React.ReactNode;
   rounded?: boolean;
 }) {
-  const [expanded, setExpanded] = useState(expandByDefault ?? false);
+  const [expanded, setExpanded] = useState(expandByDefault);
 
   const toggleExpand = () => {
     setExpanded(oldState => !oldState);

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -86,7 +86,7 @@ export function ExpandableInsightContext({
   title,
   icon,
   rounded,
-  expandByDefault,
+  expandByDefault = false,
 }: {
   children: React.ReactNode;
   title: string;

--- a/static/app/components/events/autofix/autofixRootCause.spec.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.spec.tsx
@@ -13,7 +13,7 @@ describe('AutofixRootCause', function () {
     repos: [],
   };
 
-  it('can view a relevant code snippet', async function () {
+  it('can view a relevant code snippet', function () {
     render(<AutofixRootCause {...defaultProps} />);
 
     // Displays all root cause and code context info
@@ -23,11 +23,6 @@ describe('AutofixRootCause', function () {
       screen.getByText('This is the description of a root cause.')
     ).toBeInTheDocument();
 
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: 'Relevant code',
-      })
-    );
     expect(
       screen.getByText('Snippet #1: This is the title of a relevant code snippet.')
     ).toBeInTheDocument();
@@ -53,7 +48,7 @@ describe('AutofixRootCause', function () {
     ).toBeInTheDocument();
   });
 
-  it('shows hyperlink when matching GitHub repo available', async function () {
+  it('shows hyperlink when matching GitHub repo available', function () {
     render(
       <AutofixRootCause
         {...{
@@ -69,12 +64,6 @@ describe('AutofixRootCause', function () {
           ],
         }}
       />
-    );
-
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: 'Relevant code',
-      })
     );
 
     expect(screen.queryByRole('link', {name: 'GitHub'})).toBeInTheDocument();

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -230,6 +230,7 @@ function RootCauseContext({
           icon={<IconCode size="sm" color="subText" />}
           title={'Relevant code'}
           rounded
+          expandByDefault
         >
           <AutofixRootCauseCodeContexts codeContext={cause.code_context} repos={repos} />
         </ExpandableInsightContext>


### PR DESCRIPTION
Users often missed the Relevant Code section of the Root Cause output and complained that we didn't go in deep enough. So now we just have it expanded by default so that they don't miss the important info it contains.

<img width="688" alt="Screenshot 2024-12-03 at 10 02 10 AM" src="https://github.com/user-attachments/assets/e819b769-9452-4fe5-a03f-1ea6c9e54a32">
<img width="711" alt="Screenshot 2024-12-03 at 10 02 20 AM" src="https://github.com/user-attachments/assets/79662cc1-f827-4629-96cc-a4ceb6dba332">
