### PR TITLE
chore(vsts): webhook metrics

### DIFF
--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -293,6 +293,7 @@ class IntegrationWebhookEventType(StrEnum):
     INSTALLATION = "installation"
     PUSH = "push"
     PULL_REQUEST = "pull_request"
+    INBOUND_SYNC = "inbound_sync"
 
 
 @dataclass

--- a/tests/sentry/integrations/utils/test_assert_metrics.py
+++ b/tests/sentry/integrations/utils/test_assert_metrics.py
@@ -26,7 +26,7 @@ def assert_failure_metric(mock_record, error_msg):
 
 
 def assert_success_metric(mock_record):
-    (event_success,) = (
+    event_success = (
         call for call in mock_record.mock_calls if call.args[0] == EventLifecycleOutcome.SUCCESS
     )
     assert event_success

--- a/tests/sentry/integrations/vsts/test_webhooks.py
+++ b/tests/sentry/integrations/vsts/test_webhooks.py
@@ -22,6 +22,10 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.users.models.identity import Identity
 from sentry.utils.http import absolute_uri
+from tests.sentry.integrations.utils.test_assert_metrics import (
+    assert_failure_metric,
+    assert_success_metric,
+)
 
 
 class VstsWebhookWorkItemTest(APITestCase):
@@ -94,7 +98,8 @@ class VstsWebhookWorkItemTest(APITestCase):
         return work_item
 
     @responses.activate
-    def test_workitem_change_assignee(self):
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_workitem_change_assignee(self, mock_record):
         work_item_id = 31
 
         external_issue = ExternalIssue.objects.create(
@@ -116,6 +121,24 @@ class VstsWebhookWorkItemTest(APITestCase):
             assert args["email"] == "lauryn@sentry.io"
             assert args["external_issue_key"] == work_item_id
             assert args["assign"] is True
+
+        assert_success_metric(mock_record)  # multiple success metrics being recorded
+
+    @patch("sentry.integrations.vsts.webhooks.handle_updated_workitem")
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_workitem_change_assignee_error_metric(self, mock_record, mock_handle):
+        error = Exception("oops")
+        mock_handle.side_effect = error
+
+        resp = self.client.post(
+            absolute_uri("/extensions/vsts/issue-updated/"),
+            data=WORK_ITEM_UPDATED,
+            HTTP_SHARED_SECRET=self.shared_secret,
+        )
+
+        assert resp.status_code == 500
+
+        assert_failure_metric(mock_record, error)
 
     @responses.activate
     def test_workitem_unassign(self):
@@ -141,7 +164,8 @@ class VstsWebhookWorkItemTest(APITestCase):
             assert args["assign"] is False
 
     @responses.activate
-    def test_inbound_status_sync_resolve(self):
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_inbound_status_sync_resolve(self, mock_record):
 
         header_validation = []
         if SiloMode.get_current_mode() != SiloMode.REGION:
@@ -188,6 +212,27 @@ class VstsWebhookWorkItemTest(APITestCase):
             len(Group.objects.filter(id__in=group_ids, status=GroupStatus.RESOLVED)) == num_groups
         )
         assert len(Activity.objects.filter(group_id__in=group_ids)) == num_groups
+
+        assert_success_metric(mock_record)  # multiple success metrics being recorded
+
+    @patch("sentry.integrations.vsts.webhooks.handle_updated_workitem")
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_inbound_status_sync_error_metric(self, mock_record, mock_handle):
+        error = Exception("oops")
+        mock_handle.side_effect = error
+
+        # Change so that state is changing from unresolved to resolved
+        work_item = self.set_workitem_state("Active", "Resolved")
+
+        with self.feature("organizations:integrations-issue-sync"), self.tasks():
+            resp = self.client.post(
+                absolute_uri("/extensions/vsts/issue-updated/"),
+                data=work_item,
+                HTTP_SHARED_SECRET=self.shared_secret,
+            )
+        assert resp.status_code == 500
+
+        assert_failure_metric(mock_record, error)  # multiple success metrics being recorded
 
     @responses.activate
     def test_inbound_status_sync_unresolve(self):


### PR DESCRIPTION
Simple webhook metrics for VSTS. The only thing we do is inbound sync. The webhook metric should capture anything between deciding we need to handle the incoming work item and when we actually do inbound status or assignee sync (the actual logic is already wrapped with a metric).