### PR TITLE
fix(flags): fix flag context type

### DIFF
--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
-import ErrorBoundary from 'sentry/components/errorBoundary';
 import {
   CardContainer,
   FeatureFlagDrawer,
@@ -242,28 +241,26 @@ export function EventFeatureFlagList({
   }
 
   return (
-    <ErrorBoundary mini message={t('There was a problem loading feature flags.')}>
-      <InterimSection
-        help={t(
-          "The last 100 flags evaluated in the user's session leading up to this event."
-        )}
-        isHelpHoverable
-        title={t('Feature Flags')}
-        type={SectionKey.FEATURE_FLAGS}
-        actions={actions}
-      >
-        {hasFlags ? (
-          <CardContainer numCols={columnTwo.length ? 2 : 1}>
-            <KeyValueData.Card expandLeft contentItems={columnOne} />
-            <KeyValueData.Card expandLeft contentItems={columnTwo} />
-          </CardContainer>
-        ) : (
-          <StyledEmptyStateWarning withIcon>
-            {t('No feature flags were found for this event')}
-          </StyledEmptyStateWarning>
-        )}
-      </InterimSection>
-    </ErrorBoundary>
+    <InterimSection
+      help={t(
+        "The last 100 flags evaluated in the user's session leading up to this event."
+      )}
+      isHelpHoverable
+      title={t('Feature Flags')}
+      type={SectionKey.FEATURE_FLAGS}
+      actions={actions}
+    >
+      {hasFlags ? (
+        <CardContainer numCols={columnTwo.length ? 2 : 1}>
+          <KeyValueData.Card expandLeft contentItems={columnOne} />
+          <KeyValueData.Card expandLeft contentItems={columnTwo} />
+        </CardContainer>
+      ) : (
+        <StyledEmptyStateWarning withIcon>
+          {t('No feature flags were found for this event')}
+        </StyledEmptyStateWarning>
+      )}
+    </InterimSection>
   );
 }
 

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -91,7 +91,9 @@ export function EventFeatureFlagList({
   });
 
   const hasFlagContext = Boolean(event.contexts?.flags?.values);
-  const flagValues = event.contexts?.flags?.values ?? [];
+  const flagValues = useMemo(() => {
+    return event.contexts?.flags?.values ?? [];
+  }, [event]);
   const hasFlags = hasFlagContext && flagValues.length > 0;
 
   const showCTA =
@@ -108,7 +110,7 @@ export function EventFeatureFlagList({
   const hydratedFlags = useMemo(() => {
     // Transform the flags array into something readable by the key-value component
     // Reverse the flags to show newest at the top by default
-    const rawFlags: FeatureFlag[] = event.contexts?.flags?.values?.toReversed() ?? [];
+    const rawFlags: FeatureFlag[] = flagValues.toReversed() ?? [];
 
     // Filter out ill-formatted flags, which come from SDK developer error or user-provided contexts.
     const flags = rawFlags.filter(
@@ -132,7 +134,7 @@ export function EventFeatureFlagList({
         isSuspectFlag: suspectFlagNames.has(f.flag),
       };
     });
-  }, [event, suspectFlagNames]);
+  }, [suspectFlagNames, flagValues]);
 
   const onViewAllFlags = useCallback(
     (focusControl?: FlagControlOptions) => {

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -91,8 +91,10 @@ export function EventFeatureFlagList({
     event,
   });
 
-  const hasFlagContext = !!event.contexts?.flags?.values;
-  const hasFlags = Boolean(hasFlagContext && event?.contexts?.flags?.values?.length);
+  const hasFlagContext = Boolean(event.contexts?.flags?.values);
+  const flagValues = event.contexts?.flags?.values ?? [];
+  const hasFlags = hasFlagContext && flagValues.length > 0;
+
   const showCTA =
     !hasFlagContext &&
     featureFlagOnboardingPlatforms.includes(project.platform ?? 'other') &&
@@ -111,7 +113,7 @@ export function EventFeatureFlagList({
 
     // Filter out ill-formatted flags, which come from SDK developer error or user-provided contexts.
     const flags = rawFlags.filter(
-      f => f && typeof f === 'object' && 'flag' in f && 'result' in f
+      (f): f is Required<FeatureFlag> => f && 'flag' in f && 'result' in f
     );
 
     return flags.map(f => {

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -92,7 +92,7 @@ export function EventFeatureFlagList({
   });
 
   const hasFlagContext = !!event.contexts.flags;
-  const hasFlags = Boolean(hasFlagContext && event?.contexts?.flags?.values.length);
+  const hasFlags = Boolean(hasFlagContext && event?.contexts?.flags?.values?.length);
   const showCTA =
     !hasFlagContext &&
     featureFlagOnboardingPlatforms.includes(project.platform ?? 'other') &&
@@ -107,7 +107,7 @@ export function EventFeatureFlagList({
   const hydratedFlags = useMemo(() => {
     // Transform the flags array into something readable by the key-value component
     // Reverse the flags to show newest at the top by default
-    const rawFlags: FeatureFlag[] = event.contexts?.flags?.values.toReversed() ?? [];
+    const rawFlags: FeatureFlag[] = event.contexts?.flags?.values?.toReversed() ?? [];
 
     // Filter out ill-formatted flags, which come from SDK developer error or user-provided contexts.
     const flags = rawFlags.filter(

--- a/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagList.tsx
@@ -91,7 +91,7 @@ export function EventFeatureFlagList({
     event,
   });
 
-  const hasFlagContext = !!event.contexts.flags;
+  const hasFlagContext = !!event.contexts?.flags?.values;
   const hasFlags = Boolean(hasFlagContext && event?.contexts?.flags?.values?.length);
   const showCTA =
     !hasFlagContext &&

--- a/static/app/components/events/featureFlags/testUtils.tsx
+++ b/static/app/components/events/featureFlags/testUtils.tsx
@@ -4,7 +4,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import type {FeatureFlag} from 'sentry/types/event';
 
-export const MOCK_FLAGS: FeatureFlag[] = [
+export const MOCK_FLAGS: Required<FeatureFlag>[] = [
   {
     flag: 'mobile-replay-ui',
     result: false,

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -643,7 +643,7 @@ export interface ResponseContext {
 }
 
 export type FeatureFlag = {flag: string; result: boolean};
-export type Flags = {values: FeatureFlag[]};
+export type Flags = {values?: FeatureFlag[]};
 
 export type EventContexts = {
   'Current Culture'?: CultureContext;

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -642,8 +642,10 @@ export interface ResponseContext {
   type: 'response';
 }
 
-export type FeatureFlag = {flag: string; result: boolean};
+// event.contexts.flags can be overriden by the user so the type is not strict
+export type FeatureFlag = {flag?: string; result?: boolean};
 export type Flags = {values?: FeatureFlag[]};
+export type NonNullableFeatureFlag = Required<FeatureFlag>;
 
 export type EventContexts = {
   'Current Culture'?: CultureContext;

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -645,7 +645,6 @@ export interface ResponseContext {
 // event.contexts.flags can be overriden by the user so the type is not strict
 export type FeatureFlag = {flag?: string; result?: boolean};
 export type Flags = {values?: FeatureFlag[]};
-export type NonNullableFeatureFlag = Required<FeatureFlag>;
 
 export type EventContexts = {
   'Current Culture'?: CultureContext;

--- a/static/app/utils/featureObserver.ts
+++ b/static/app/utils/featureObserver.ts
@@ -1,4 +1,5 @@
-import type {Flags} from 'sentry/types/event';
+import type {FeatureFlagContext} from '@sentry/types/build/types/context';
+
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 
@@ -22,7 +23,7 @@ export default class FeatureObserver {
   }
 
   private _bufferSize = 0;
-  private FEATURE_FLAGS: Flags = {values: []};
+  private FEATURE_FLAGS: FeatureFlagContext = {values: []};
 
   constructor({bufferSize}: {bufferSize: number}) {
     this._bufferSize = bufferSize;

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -419,7 +419,9 @@ export function EventDetailsContent({
         </Fragment>
       ) : null}
       <EventContexts group={group} event={event} />
-      <EventFeatureFlagList group={group} project={project} event={event} />
+      <ErrorBoundary mini message={t('There was a problem loading feature flags.')}>
+        <EventFeatureFlagList group={group} project={project} event={event} />
+      </ErrorBoundary>
       <EventExtraData event={event} />
       <EventPackageData event={event} />
       <EventDevice event={event} />

--- a/static/app/views/issueDetails/streamline/hooks/useFlagSeries.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useFlagSeries.tsx
@@ -34,7 +34,7 @@ export default function useFlagSeries({query = {}, event}: FlagSeriesProps) {
   }
 
   const hydratedFlagData = hydrateToFlagSeries(rawFlagData);
-  const evaluatedFlagNames = event?.contexts.flags?.values?.map(f => f.flag);
+  const evaluatedFlagNames = event?.contexts?.flags?.values?.map(f => f.flag);
   const intersectionFlags = hydratedFlagData.filter(f =>
     evaluatedFlagNames?.includes(f.name)
   );

--- a/static/app/views/issueDetails/streamline/hooks/useFlagSeries.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useFlagSeries.tsx
@@ -34,7 +34,7 @@ export default function useFlagSeries({query = {}, event}: FlagSeriesProps) {
   }
 
   const hydratedFlagData = hydrateToFlagSeries(rawFlagData);
-  const evaluatedFlagNames = event?.contexts.flags?.values.map(f => f.flag);
+  const evaluatedFlagNames = event?.contexts.flags?.values?.map(f => f.flag);
   const intersectionFlags = hydratedFlagData.filter(f =>
     evaluatedFlagNames?.includes(f.name)
   );

--- a/static/app/views/issueDetails/streamline/hooks/useSuspectFlags.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useSuspectFlags.tsx
@@ -28,7 +28,7 @@ export default function useSuspectFlags({
 
   // map flag data to arrays of flag names
   const auditLogFlagNames = hydratedFlagData.map(f => f.name);
-  const evaluatedFlagNames = event?.contexts.flags?.values?.map(f => f.flag);
+  const evaluatedFlagNames = event?.contexts?.flags?.values?.map(f => f.flag);
   const intersectionFlags = useMemo(
     () => intersection(auditLogFlagNames, evaluatedFlagNames),
     [auditLogFlagNames, evaluatedFlagNames]

--- a/static/app/views/issueDetails/streamline/hooks/useSuspectFlags.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useSuspectFlags.tsx
@@ -28,7 +28,7 @@ export default function useSuspectFlags({
 
   // map flag data to arrays of flag names
   const auditLogFlagNames = hydratedFlagData.map(f => f.name);
-  const evaluatedFlagNames = event?.contexts.flags?.values.map(f => f.flag);
+  const evaluatedFlagNames = event?.contexts.flags?.values?.map(f => f.flag);
   const intersectionFlags = useMemo(
     () => intersection(auditLogFlagNames, evaluatedFlagNames),
     [auditLogFlagNames, evaluatedFlagNames]


### PR DESCRIPTION
fixes JAVASCRIPT-2WYM

the error boundary already exists, but move it up to the group level.

we also need to guard against unsafe access to a user-set `flags` property on the event context. we can't always assume the `flags` property comes from sentry (e.g. `flags.values` might not always exist)