### PR TITLE
fix(grouping): Add `violation` as recognized description for grouphash metadata

### DIFF
--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -71,6 +71,8 @@ GROUPING_METHODS_BY_DESCRIPTION = {
     # Security reports (CSP, expect-ct, and the like)
     "URL": HashBasis.SECURITY_VIOLATION,
     "hostname": HashBasis.SECURITY_VIOLATION,
+    # CSP reports of `unsafe-inline` and `unsafe-eval` violations
+    "violation": HashBasis.SECURITY_VIOLATION,
     # Django template errors, which don't report a full stacktrace
     "template": HashBasis.TEMPLATE,
     # Hash set directly on the event by the client, under the key `checksum`

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -175,7 +175,7 @@ def get_hash_basis_and_metadata(
         logger.exception(
             "Encountered unknown grouping method '%s'.",
             contributing_variant.description,
-            extra={"project": project.id, "event": event.event_id},
+            extra={"project": project.id, "event_id": event.event_id},
         )
         return (HashBasis.UNKNOWN, {})
 

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/csp_script_src_unsafe_eval.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/csp_script_src_unsafe_eval.pysnap
@@ -1,14 +1,23 @@
 ---
-created: '2024-12-02T21:58:29.631100+00:00'
+created: '2024-12-02T22:04:01.043471+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
-hash_basis: unknown
-hashing_metadata: {}
+hash_basis: violation
+hashing_metadata: {
+  "blocked_host": "self",
+  "csp_directive": "script-src",
+  "csp_script_violation": "unsafe-eval",
+  "security_report_type": "csp"
+}
 ---
 metrics with tags: {
   "grouping.grouphashmetadata.event_hash_basis": {
-    "hash_basis": "unknown"
+    "hash_basis": "violation",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.violation": {
+    "security_report_type": "csp"
   }
 }
 ---

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/csp_script_src_unsafe_inline.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/csp_script_src_unsafe_inline.pysnap
@@ -1,14 +1,23 @@
 ---
-created: '2024-12-02T21:58:29.688250+00:00'
+created: '2024-12-02T22:04:02.308585+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
-hash_basis: unknown
-hashing_metadata: {}
+hash_basis: violation
+hashing_metadata: {
+  "blocked_host": "self",
+  "csp_directive": "script-src",
+  "csp_script_violation": "unsafe-inline",
+  "security_report_type": "csp"
+}
 ---
 metrics with tags: {
   "grouping.grouphashmetadata.event_hash_basis": {
-    "hash_basis": "unknown"
+    "hash_basis": "violation",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.violation": {
+    "security_report_type": "csp"
   }
 }
 ---

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/csp_script_src_unsafe_eval.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/csp_script_src_unsafe_eval.pysnap
@@ -1,14 +1,23 @@
 ---
-created: '2024-12-02T21:57:58.424160+00:00'
+created: '2024-12-02T22:04:08.965328+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
-hash_basis: unknown
-hashing_metadata: {}
+hash_basis: violation
+hashing_metadata: {
+  "blocked_host": "self",
+  "csp_directive": "script-src",
+  "csp_script_violation": "unsafe-eval",
+  "security_report_type": "csp"
+}
 ---
 metrics with tags: {
   "grouping.grouphashmetadata.event_hash_basis": {
-    "hash_basis": "unknown"
+    "hash_basis": "violation",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.violation": {
+    "security_report_type": "csp"
   }
 }
 ---

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/csp_script_src_unsafe_inline.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/csp_script_src_unsafe_inline.pysnap
@@ -1,14 +1,23 @@
 ---
-created: '2024-12-02T21:57:58.488332+00:00'
+created: '2024-12-02T22:04:10.035038+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
-hash_basis: unknown
-hashing_metadata: {}
+hash_basis: violation
+hashing_metadata: {
+  "blocked_host": "self",
+  "csp_directive": "script-src",
+  "csp_script_violation": "unsafe-inline",
+  "security_report_type": "csp"
+}
 ---
 metrics with tags: {
   "grouping.grouphashmetadata.event_hash_basis": {
-    "hash_basis": "unknown"
+    "hash_basis": "violation",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.violation": {
+    "security_report_type": "csp"
   }
 }
 ---

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/csp_script_src_unsafe_eval.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/csp_script_src_unsafe_eval.pysnap
@@ -1,14 +1,23 @@
 ---
-created: '2024-12-02T21:58:08.828837+00:00'
+created: '2024-12-02T22:04:02.951839+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
-hash_basis: unknown
-hashing_metadata: {}
+hash_basis: violation
+hashing_metadata: {
+  "blocked_host": "self",
+  "csp_directive": "script-src",
+  "csp_script_violation": "unsafe-eval",
+  "security_report_type": "csp"
+}
 ---
 metrics with tags: {
   "grouping.grouphashmetadata.event_hash_basis": {
-    "hash_basis": "unknown"
+    "hash_basis": "violation",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.violation": {
+    "security_report_type": "csp"
   }
 }
 ---

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/csp_script_src_unsafe_inline.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_10_29/csp_script_src_unsafe_inline.pysnap
@@ -1,14 +1,23 @@
 ---
-created: '2024-12-02T21:58:08.876697+00:00'
+created: '2024-12-02T22:04:05.851532+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
-hash_basis: unknown
-hashing_metadata: {}
+hash_basis: violation
+hashing_metadata: {
+  "blocked_host": "self",
+  "csp_directive": "script-src",
+  "csp_script_violation": "unsafe-inline",
+  "security_report_type": "csp"
+}
 ---
 metrics with tags: {
   "grouping.grouphashmetadata.event_hash_basis": {
-    "hash_basis": "unknown"
+    "hash_basis": "violation",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.violation": {
+    "security_report_type": "csp"
   }
 }
 ---

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
@@ -1,14 +1,23 @@
 ---
-created: '2024-12-02T21:58:18.348661+00:00'
+created: '2024-12-02T22:04:06.906409+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
-hash_basis: unknown
-hashing_metadata: {}
+hash_basis: violation
+hashing_metadata: {
+  "blocked_host": "self",
+  "csp_directive": "script-src",
+  "csp_script_violation": "unsafe-eval",
+  "security_report_type": "csp"
+}
 ---
 metrics with tags: {
   "grouping.grouphashmetadata.event_hash_basis": {
-    "hash_basis": "unknown"
+    "hash_basis": "violation",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.violation": {
+    "security_report_type": "csp"
   }
 }
 ---

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
@@ -1,14 +1,23 @@
 ---
-created: '2024-12-02T21:58:18.403594+00:00'
+created: '2024-12-02T22:04:08.131452+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
-hash_basis: unknown
-hashing_metadata: {}
+hash_basis: violation
+hashing_metadata: {
+  "blocked_host": "self",
+  "csp_directive": "script-src",
+  "csp_script_violation": "unsafe-inline",
+  "security_report_type": "csp"
+}
 ---
 metrics with tags: {
   "grouping.grouphashmetadata.event_hash_basis": {
-    "hash_basis": "unknown"
+    "hash_basis": "violation",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.violation": {
+    "security_report_type": "csp"
   }
 }
 ---


### PR DESCRIPTION
The initial implementation of grouphash metadata was missing a possible value for variant description (`"violation"`), which is what it uses to determine the overall grouping method. Events with this variant description have therefore been being recorded as having been grouped by an unknown method. This fixes that by adding `"violation"` to the `GROUPING_METHODS_BY_DESCRIPTION` lookup. (It won't fix existing records, but thankfully there are only 4, and they will eventually get taken care of once we implement grouphash metadata backfilling/update.)

This also makes a small change to the logging we do when we hit an unknown grouping method, changing the tag name from `event` to `event_id`. (In GCP, the `event` tag doesn't show up because it thinks of `event` as the name of the first argument passed to the log function. IOW, in something like `logger.info("stuff happened", tags={"event": event.event_id})`, it will ignore the tag because the name `event` is already assigned to `"stuff happened"`.) This should make it easier to debug future instances of unknown grouping, if any.