### PR TITLE
feat(widget-builder): Add sort field to hook

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/hooks/useQueryParamState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useQueryParamState.tsx
@@ -4,7 +4,7 @@ import debounce from 'lodash/debounce';
 
 import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import {defined} from 'sentry/utils';
-import {type decodeList, decodeScalar} from 'sentry/utils/queryString';
+import {type decodeList, decodeScalar, type decodeSorts} from 'sentry/utils/queryString';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -23,9 +23,17 @@ interface UseQueryParamStateWithListDecoder<T> {
   serializer?: (value: T) => string[];
 }
 
+interface UseQueryParamStateWithSortsDecoder<T> {
+  decoder: typeof decodeSorts;
+  fieldName: string;
+  serializer: (value: T) => string[];
+  deserializer?: (value: ReturnType<typeof decodeSorts>) => T;
+}
+
 type UseQueryParamStateProps<T> =
   | UseQueryParamStateWithScalarDecoder<T>
-  | UseQueryParamStateWithListDecoder<T>;
+  | UseQueryParamStateWithListDecoder<T>
+  | UseQueryParamStateWithSortsDecoder<T>;
 
 /**
  * Hook to manage a state that is synced with a query param in the URL

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -218,4 +218,29 @@ describe('useWidgetBuilderState', () => {
       ]);
     });
   });
+
+  describe('sort', () => {
+    it('can decode and update sorts', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            sort: ['-testField'],
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState());
+
+      expect(result.current.state.sort).toEqual([{field: 'testField', kind: 'desc'}]);
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_SORT,
+          payload: [{field: 'testField', kind: 'asc'}],
+        });
+      });
+
+      expect(result.current.state.sort).toEqual([{field: 'testField', kind: 'asc'}]);
+    });
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -4,10 +4,12 @@ import {
   type Column,
   explodeField,
   generateFieldAsString,
+  type Sort,
 } from 'sentry/utils/discover/fields';
-import {decodeList} from 'sentry/utils/queryString';
+import {decodeList, decodeSorts} from 'sentry/utils/queryString';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import {useQueryParamState} from 'sentry/views/dashboards/widgetBuilder/hooks/useQueryParamState';
+import {formatSort} from 'sentry/views/explore/tables/aggregatesTable';
 
 export type WidgetBuilderStateQueryParams = {
   dataset?: WidgetType;
@@ -15,6 +17,7 @@ export type WidgetBuilderStateQueryParams = {
   displayType?: DisplayType;
   field?: (string | undefined)[];
   query?: string[];
+  sort?: string[];
   title?: string;
   yAxis?: string[];
 };
@@ -27,6 +30,7 @@ export const BuilderStateAction = {
   SET_FIELDS: 'SET_FIELDS',
   SET_Y_AXIS: 'SET_Y_AXIS',
   SET_QUERY: 'SET_QUERY',
+  SET_SORT: 'SET_SORT',
 } as const;
 
 type WidgetAction =
@@ -36,7 +40,8 @@ type WidgetAction =
   | {payload: WidgetType; type: typeof BuilderStateAction.SET_DATASET}
   | {payload: Column[]; type: typeof BuilderStateAction.SET_FIELDS}
   | {payload: Column[]; type: typeof BuilderStateAction.SET_Y_AXIS}
-  | {payload: string[]; type: typeof BuilderStateAction.SET_QUERY};
+  | {payload: string[]; type: typeof BuilderStateAction.SET_QUERY}
+  | {payload: Sort[]; type: typeof BuilderStateAction.SET_SORT};
 
 export interface WidgetBuilderState {
   dataset?: WidgetType;
@@ -44,6 +49,7 @@ export interface WidgetBuilderState {
   displayType?: DisplayType;
   fields?: Column[];
   query?: string[];
+  sort?: Sort[];
   title?: string;
   yAxis?: Column[];
 }
@@ -80,10 +86,15 @@ function useWidgetBuilderState(): {
     fieldName: 'query',
     decoder: decodeList,
   });
+  const [sort, setSort] = useQueryParamState<Sort[]>({
+    fieldName: 'sort',
+    decoder: decodeSorts,
+    serializer: serializeSorts,
+  });
 
   const state = useMemo(
-    () => ({title, description, displayType, dataset, fields, yAxis, query}),
-    [title, description, displayType, dataset, fields, yAxis, query]
+    () => ({title, description, displayType, dataset, fields, yAxis, query, sort}),
+    [title, description, displayType, dataset, fields, yAxis, query, sort]
   );
 
   const dispatch = useCallback(
@@ -110,11 +121,23 @@ function useWidgetBuilderState(): {
         case BuilderStateAction.SET_QUERY:
           setQuery(action.payload);
           break;
+        case BuilderStateAction.SET_SORT:
+          setSort(action.payload);
+          break;
         default:
           break;
       }
     },
-    [setTitle, setDescription, setDisplayType, setDataset, setFields, setYAxis, setQuery]
+    [
+      setTitle,
+      setDescription,
+      setDisplayType,
+      setDataset,
+      setFields,
+      setYAxis,
+      setQuery,
+      setSort,
+    ]
   );
 
   return {
@@ -159,6 +182,10 @@ function deserializeFields(fields: string[]): Column[] {
  */
 function serializeFields(fields: Column[]): string[] {
   return fields.map(generateFieldAsString);
+}
+
+function serializeSorts(sorts: Sort[]): string[] {
+  return sorts.map(formatSort);
 }
 
 export default useWidgetBuilderState;

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
@@ -97,4 +97,16 @@ describe('convertBuilderStateToWidget', function () {
       ],
     });
   });
+
+  it('injects the orderby from the sort state into the widget queries', function () {
+    const mockState: WidgetBuilderState = {
+      query: ['transaction.duration:>100', 'transaction.duration:>50'],
+      sort: [{field: 'geo.country', kind: 'desc'}],
+    };
+
+    const widget = convertBuilderStateToWidget(mockState);
+
+    expect(widget.queries[0].orderby).toEqual('-geo.country');
+    expect(widget.queries[1].orderby).toEqual('-geo.country');
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -7,6 +7,7 @@ import {
   type WidgetQuery,
   WidgetType,
 } from 'sentry/views/dashboards/types';
+import {formatSort} from 'sentry/views/explore/tables/aggregatesTable';
 
 import type {WidgetBuilderState} from '../hooks/useWidgetBuilderState';
 
@@ -22,6 +23,13 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
     ?.filter(field => 'kind' in field && field.kind === 'field')
     .map(generateFieldAsString);
 
+  // If there's no sort, use the first field as the default sort
+  const defaultSort = fields?.[0] ?? defaultQuery.orderby;
+  const sort =
+    defined(state.sort) && state.sort.length > 0
+      ? formatSort(state.sort[0])
+      : defaultSort;
+
   const widgetQueries: WidgetQuery[] = queries.map(query => {
     return {
       ...defaultQuery,
@@ -32,9 +40,7 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
           : defaultQuery.aggregates,
       columns: defined(columns) && columns.length > 0 ? columns : defaultQuery.columns,
       conditions: query,
-      // TODO: This will be read from the state under a separate key, not derived
-      // from the fields. This is only to satisfy the type interface for now.
-      orderby: defined(fields) && fields.length > 0 ? fields[0] : defaultQuery.orderby,
+      orderby: sort,
     };
   });
 

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
@@ -11,6 +11,7 @@ export function convertWidgetToBuilderStateParams(
   const yAxis = widget.queries.flatMap(q => q.aggregates);
   const field = widget.queries.flatMap(q => q.fields);
   const query = widget.queries.flatMap(q => q.conditions);
+  const sort = widget.queries.flatMap(q => q.orderby);
 
   return {
     title: widget.title,
@@ -20,5 +21,6 @@ export function convertWidgetToBuilderStateParams(
     field,
     yAxis,
     query,
+    sort,
   };
 }


### PR DESCRIPTION
Adds a sort field to the hook. Also makes sure that it's passed around through the the widget conversion helpers to go from builder state -> widget and vice versa.

Opening widgets for edit now should show a basic sort component and the sort should be propagated to the widget preview.