### PR TITLE
fix(visibility): Allow mapping meta aliases back to input format in timeseries results

### DIFF
--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -337,6 +337,9 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                         use_aggregate_conditions=False,
                     ),
                 )
+
+            transform_alias_to_input_format = request.GET.get("transformAliasToInputFormat") == "1"
+
             return scoped_dataset.timeseries_query(
                 selected_columns=query_columns,
                 query=query,
@@ -366,6 +369,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                     organization,
                     actor=request.user,
                 ),
+                transform_alias_to_input_format=transform_alias_to_input_format,
             )
 
         def get_event_stats_factory(scoped_dataset):

--- a/src/sentry/search/events/builder/profile_functions.py
+++ b/src/sentry/search/events/builder/profile_functions.py
@@ -120,9 +120,13 @@ class ProfileFunctionsTimeseriesQueryBuilder(
     def process_results(self, results: Any) -> EventsResponse:
         # Calling `super().process_results(results)` on the timeseries data
         # mutates the data in such a way that breaks the zerofill later such
-        # as applying `transform_alias_to_input_format` setting.  So skip it.
+        # as applying `transform_alias_to_input_format` setting.  So only run
+        # it to get the correct meta.
         for row in results["data"]:
             self.process_profiling_function_columns(row)
+
+        results["meta"] = super().process_results(results)["meta"]
+
         return results
 
 

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -20,12 +20,7 @@ from sentry.search.events.builder.discover import (
     TimeseriesQueryBuilder,
     TopEventsQueryBuilder,
 )
-from sentry.search.events.fields import (
-    FIELD_ALIASES,
-    get_function_alias,
-    get_json_meta_type,
-    is_function,
-)
+from sentry.search.events.fields import FIELD_ALIASES, get_function_alias, is_function
 from sentry.search.events.types import (
     EventsResponse,
     HistogramParams,
@@ -411,20 +406,10 @@ def timeseries_query(
             compared_value = compared_row.get(col_name, 0)
             row["comparisonCount"] = compared_value
 
-    result = results[0]
+    result = base_builder.process_results(results[0])
 
     return SnubaTSResult(
-        {
-            "data": result["data"],
-            "meta": {
-                "fields": {
-                    value["name"]: get_json_meta_type(
-                        value["name"], value.get("type"), base_builder
-                    )
-                    for value in result["meta"]
-                }
-            },
-        },
+        {"data": result["data"], "meta": result["meta"]},
         snuba_params.start_date,
         snuba_params.end_date,
         rollup,

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -307,6 +307,7 @@ def timeseries_query(
     dataset: Dataset = Dataset.Discover,
     query_source: QuerySource | None = None,
     fallback_to_transactions: bool = False,
+    transform_alias_to_input_format: bool = False,
 ) -> SnubaTSResult:
     """
     High-level API for doing arbitrary user timeseries queries against events.
@@ -332,6 +333,8 @@ def timeseries_query(
     allow_metric_aggregates - Ignored here, only used in metric enhanced performance
     fallback_to_transactions - Whether to fallback to the transactions dataset if the query
                     fails in metrics enhanced requests. To be removed once the discover dataset is split.
+    transform_alias_to_input_format - Whether aggregate columns should be returned in the originally
+                                requested function format.
     """
     assert dataset in [
         Dataset.Discover,
@@ -351,6 +354,7 @@ def timeseries_query(
             config=QueryBuilderConfig(
                 functions_acl=functions_acl,
                 has_metrics=has_metrics,
+                transform_alias_to_input_format=transform_alias_to_input_format,
             ),
         )
         query_list = [base_builder]

--- a/src/sentry/snuba/errors.py
+++ b/src/sentry/snuba/errors.py
@@ -14,7 +14,6 @@ from sentry.search.events.builder.errors import (
     ErrorsTimeseriesQueryBuilder,
     ErrorsTopEventsQueryBuilder,
 )
-from sentry.search.events.fields import get_json_meta_type
 from sentry.search.events.types import EventsResponse, QueryBuilderConfig, SnubaParams
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.discover import OTHER_KEY, create_result_key, transform_tips, zerofill
@@ -175,19 +174,12 @@ def timeseries_query(
             cmp_result_val = cmp_result.get(col_name, 0)
             result["comparisonCount"] = cmp_result_val
 
-    result = results[0]
+    result = base_builder.process_results(results[0])
 
     return SnubaTSResult(
         {
             "data": result["data"],
-            "meta": {
-                "fields": {
-                    value["name"]: get_json_meta_type(
-                        value["name"], value.get("type"), base_builder
-                    )
-                    for value in result["meta"]
-                }
-            },
+            "meta": result["meta"],
         },
         snuba_params.start_date,
         snuba_params.end_date,

--- a/src/sentry/snuba/errors.py
+++ b/src/sentry/snuba/errors.py
@@ -104,6 +104,7 @@ def timeseries_query(
     on_demand_metrics_type: MetricSpecType | None = None,
     query_source: QuerySource | None = None,
     fallback_to_transactions: bool = False,
+    transform_alias_to_input_format: bool = False,
 ):
 
     with sentry_sdk.start_span(op="errors", name="timeseries.filter_transform"):
@@ -120,6 +121,7 @@ def timeseries_query(
                 functions_acl=functions_acl,
                 has_metrics=has_metrics,
                 parser_config_overrides=PARSER_CONFIG_OVERRIDES,
+                transform_alias_to_input_format=transform_alias_to_input_format,
             ),
         )
         query_list = [base_builder]

--- a/src/sentry/snuba/functions.py
+++ b/src/sentry/snuba/functions.py
@@ -10,7 +10,6 @@ from sentry.search.events.builder.profile_functions import (
     ProfileFunctionsTimeseriesQueryBuilder,
     ProfileTopFunctionsTimeseriesQueryBuilder,
 )
-from sentry.search.events.fields import get_json_meta_type
 from sentry.search.events.types import QueryBuilderConfig, SnubaParams
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.discover import transform_tips, zerofill
@@ -271,14 +270,7 @@ def format_top_events_timeseries_results(
                         else item["data"]
                     ),
                     "order": item["order"],
-                    "meta": {
-                        "fields": {
-                            value["name"]: get_json_meta_type(
-                                value["name"], value.get("type"), query_builder
-                            )
-                            for value in result["meta"]
-                        }
-                    },
+                    "meta": result["meta"],
                 },
                 snuba_params.start_date,
                 snuba_params.end_date,

--- a/src/sentry/snuba/functions.py
+++ b/src/sentry/snuba/functions.py
@@ -121,12 +121,7 @@ def timeseries_query(
                 if zerofill_results
                 else results["data"]
             ),
-            "meta": {
-                "fields": {
-                    value["name"]: get_json_meta_type(value["name"], value.get("type"), builder)
-                    for value in results["meta"]
-                }
-            },
+            "meta": results["meta"],
         },
         snuba_params.start_date,
         snuba_params.end_date,

--- a/src/sentry/snuba/functions.py
+++ b/src/sentry/snuba/functions.py
@@ -91,6 +91,7 @@ def timeseries_query(
     on_demand_metrics_type: MetricSpecType | None = None,
     query_source: QuerySource | None = None,
     fallback_to_transactions: bool = False,
+    transform_alias_to_input_format: bool = False,
 ) -> Any:
 
     builder = ProfileFunctionsTimeseriesQueryBuilder(
@@ -102,6 +103,7 @@ def timeseries_query(
         selected_columns=selected_columns,
         config=QueryBuilderConfig(
             functions_acl=functions_acl,
+            transform_alias_to_input_format=transform_alias_to_input_format,
         ),
     )
     results = builder.run_query(referrer=referrer, query_source=query_source)

--- a/src/sentry/snuba/issue_platform.py
+++ b/src/sentry/snuba/issue_platform.py
@@ -120,6 +120,7 @@ def timeseries_query(
     on_demand_metrics_type: MetricSpecType | None = None,
     query_source: QuerySource | None = None,
     fallback_to_transactions: bool = False,
+    transform_alias_to_input_format: bool = False,
 ):
     """
     High-level API for doing arbitrary user timeseries queries against events.
@@ -158,6 +159,7 @@ def timeseries_query(
             config=QueryBuilderConfig(
                 functions_acl=functions_acl,
                 has_metrics=has_metrics,
+                transform_alias_to_input_format=transform_alias_to_input_format,
             ),
         )
         query_list = [base_builder]

--- a/src/sentry/snuba/issue_platform.py
+++ b/src/sentry/snuba/issue_platform.py
@@ -7,7 +7,6 @@ from sentry.discover.arithmetic import categorize_columns
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.events.builder.discover import DiscoverQueryBuilder
 from sentry.search.events.builder.issue_platform import IssuePlatformTimeseriesQueryBuilder
-from sentry.search.events.fields import get_json_meta_type
 from sentry.search.events.types import EventsResponse, QueryBuilderConfig, SnubaParams
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.discover import transform_tips, zerofill
@@ -211,19 +210,12 @@ def timeseries_query(
             cmp_result_val = cmp_result.get(col_name, 0)
             result["comparisonCount"] = cmp_result_val
 
-    result = results[0]
+    result = base_builder.process_results(results[0])
 
     return SnubaTSResult(
         {
             "data": result["data"],
-            "meta": {
-                "fields": {
-                    value["name"]: get_json_meta_type(
-                        value["name"], value.get("type"), base_builder
-                    )
-                    for value in result["meta"]
-                }
-            },
+            "meta": result["meta"],
         },
         snuba_params.start_date,
         snuba_params.end_date,

--- a/src/sentry/snuba/metrics_enhanced_performance.py
+++ b/src/sentry/snuba/metrics_enhanced_performance.py
@@ -191,6 +191,7 @@ def timeseries_query(
             functions_acl=functions_acl,
             has_metrics=has_metrics,
             query_source=query_source,
+            transform_alias_to_input_format=transform_alias_to_input_format,
         )
     return SnubaTSResult(
         {

--- a/src/sentry/snuba/metrics_enhanced_performance.py
+++ b/src/sentry/snuba/metrics_enhanced_performance.py
@@ -139,6 +139,7 @@ def timeseries_query(
     on_demand_metrics_type=None,
     query_source: QuerySource | None = None,
     fallback_to_transactions: bool = False,
+    transform_alias_to_input_format: bool = False,
 ) -> SnubaTSResult:
     """
     High-level API for doing arbitrary user timeseries queries against events.
@@ -163,6 +164,7 @@ def timeseries_query(
                 on_demand_metrics_enabled=on_demand_metrics_enabled,
                 on_demand_metrics_type=on_demand_metrics_type,
                 query_source=query_source,
+                transform_alias_to_input_format=transform_alias_to_input_format,
             )
         # raise Invalid Queries since the same thing will happen with discover
         except InvalidSearchQuery:

--- a/src/sentry/snuba/metrics_performance.py
+++ b/src/sentry/snuba/metrics_performance.py
@@ -258,6 +258,7 @@ def timeseries_query(
     groupby: Column | None = None,
     query_source: QuerySource | None = None,
     fallback_to_transactions: bool = False,
+    transform_alias_to_input_format: bool = False,
 ) -> SnubaTSResult:
     """
     High-level API for doing arbitrary user timeseries queries against events.
@@ -282,6 +283,7 @@ def timeseries_query(
                     use_metrics_layer=use_metrics_layer,
                     on_demand_metrics_enabled=on_demand_metrics_enabled,
                     on_demand_metrics_type=on_demand_metrics_type,
+                    transform_alias_to_input_format=transform_alias_to_input_format,
                 ),
             )
             metrics_referrer = referrer + ".metrics-enhanced"

--- a/src/sentry/snuba/profiles.py
+++ b/src/sentry/snuba/profiles.py
@@ -6,7 +6,6 @@ from sentry.search.events.builder.profiles import (
     ProfilesQueryBuilder,
     ProfilesTimeseriesQueryBuilder,
 )
-from sentry.search.events.fields import get_json_meta_type
 from sentry.search.events.types import QueryBuilderConfig, SnubaParams
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.discover import transform_tips, zerofill
@@ -91,6 +90,7 @@ def timeseries_query(
         ),
     )
     results = builder.run_query(referrer=referrer, query_source=query_source)
+    results = builder.process_results(results)
 
     return SnubaTSResult(
         {
@@ -105,12 +105,7 @@ def timeseries_query(
                 if zerofill_results
                 else results["data"]
             ),
-            "meta": {
-                "fields": {
-                    value["name"]: get_json_meta_type(value["name"], value.get("type"), builder)
-                    for value in results["meta"]
-                }
-            },
+            "meta": results["meta"],
         },
         snuba_params.start_date,
         snuba_params.end_date,

--- a/src/sentry/snuba/profiles.py
+++ b/src/sentry/snuba/profiles.py
@@ -77,6 +77,7 @@ def timeseries_query(
     on_demand_metrics_type: MetricSpecType | None = None,
     query_source: QuerySource | None = None,
     fallback_to_transactions: bool = False,
+    transform_alias_to_input_format: bool = False,
 ) -> Any:
     builder = ProfilesTimeseriesQueryBuilder(
         dataset=Dataset.Profiles,
@@ -87,6 +88,7 @@ def timeseries_query(
         selected_columns=selected_columns,
         config=QueryBuilderConfig(
             functions_acl=functions_acl,
+            transform_alias_to_input_format=transform_alias_to_input_format,
         ),
     )
     results = builder.run_query(referrer=referrer, query_source=query_source)

--- a/src/sentry/snuba/spans_eap.py
+++ b/src/sentry/snuba/spans_eap.py
@@ -97,6 +97,7 @@ def timeseries_query(
     dataset: Dataset = Dataset.Discover,
     query_source: QuerySource | None = None,
     fallback_to_transactions: bool = False,
+    transform_alias_to_input_format: bool = False,
 ) -> SnubaTSResult:
     """
     High-level API for doing arbitrary user timeseries queries against events.
@@ -114,6 +115,7 @@ def timeseries_query(
             selected_columns=columns,
             config=QueryBuilderConfig(
                 functions_acl=functions_acl,
+                transform_alias_to_input_format=transform_alias_to_input_format,
             ),
         )
         result = querybuilder.run_query(referrer, query_source=query_source)

--- a/src/sentry/snuba/spans_indexed.py
+++ b/src/sentry/snuba/spans_indexed.py
@@ -92,6 +92,7 @@ def timeseries_query(
     on_demand_metrics_type: MetricSpecType | None = None,
     query_source: QuerySource | None = None,
     fallback_to_transactions: bool = False,
+    transform_alias_to_input_format: bool = False,
 ) -> SnubaTSResult:
     """
     High-level API for doing arbitrary user timeseries queries against events.
@@ -109,6 +110,7 @@ def timeseries_query(
             selected_columns=columns,
             config=QueryBuilderConfig(
                 functions_acl=functions_acl,
+                transform_alias_to_input_format=transform_alias_to_input_format,
             ),
         )
         result = query.run_query(referrer, query_source=query_source)

--- a/src/sentry/snuba/spans_metrics.py
+++ b/src/sentry/snuba/spans_metrics.py
@@ -93,6 +93,7 @@ def timeseries_query(
     groupby: Column | None = None,
     query_source: QuerySource | None = None,
     fallback_to_transactions: bool = False,
+    transform_alias_to_input_format: bool = False,
 ) -> SnubaTSResult:
     """
     High-level API for doing arbitrary user timeseries queries against events.
@@ -111,6 +112,7 @@ def timeseries_query(
             functions_acl=functions_acl,
             allow_metric_aggregates=allow_metric_aggregates,
             use_metrics_layer=use_metrics_layer,
+            transform_alias_to_input_format=transform_alias_to_input_format,
         ),
     )
     result = metrics_query.run_query(referrer=referrer, query_source=query_source)

--- a/src/sentry/snuba/transactions.py
+++ b/src/sentry/snuba/transactions.py
@@ -89,6 +89,7 @@ def timeseries_query(
     on_demand_metrics_type=None,
     query_source: QuerySource | None = None,
     fallback_to_transactions: bool = False,
+    transform_alias_to_input_format: bool = False,
 ) -> SnubaTSResult:
     """
     High-level API for doing arbitrary user timeseries queries against events.
@@ -110,6 +111,7 @@ def timeseries_query(
         on_demand_metrics_type=on_demand_metrics_type,
         dataset=Dataset.Transactions,
         query_source=query_source,
+        transform_alias_to_input_format=transform_alias_to_input_format,
     )
 
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -519,6 +519,13 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
             data = response.data["data"]
             assert len(data) == 6
 
+            meta = response.data["meta"]
+            assert meta["fields"] == {
+                "time": "date",
+                axis: "rate",
+            }
+            assert meta["units"] == {"time": None, axis: "1/minute"}
+
             rows = data[0:6]
             for test in zip(event_counts, rows):
                 assert test[1][1][0]["count"] == test[0] / (3600.0 / 60.0)
@@ -590,6 +597,13 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
             assert response.status_code == 200, response.content
             data = response.data["data"]
             assert len(data) == 6
+
+            meta = response.data["meta"]
+            assert meta["fields"] == {
+                "time": "date",
+                axis: "rate",
+            }
+            assert meta["units"] == {"time": None, axis: "1/second"}
 
             rows = data[0:6]
             for test in zip(event_counts, rows):

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -486,6 +486,45 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
         )
         assert response.status_code == 400, response.content
 
+    def test_throughput_meta(self):
+        project = self.create_project()
+
+        for axis in ["epm()", "tpm()"]:
+            response = self.do_request(
+                data={
+                    "transformAliasToInputFormat": 1,
+                    "start": self.day_ago,
+                    "end": self.day_ago + timedelta(hours=6),
+                    "interval": "1h",
+                    "yAxis": axis,
+                    "project": project.id,
+                },
+            )
+            meta = response.data["meta"]
+            assert meta["fields"] == {
+                "time": "date",
+                axis: "rate",
+            }
+            assert meta["units"] == {"time": None, axis: "1/minute"}
+
+        for axis in ["eps()", "tps()"]:
+            response = self.do_request(
+                data={
+                    "transformAliasToInputFormat": 1,
+                    "start": self.day_ago,
+                    "end": self.day_ago + timedelta(hours=6),
+                    "interval": "1h",
+                    "yAxis": axis,
+                    "project": project.id,
+                },
+            )
+            meta = response.data["meta"]
+            assert meta["fields"] == {
+                "time": "date",
+                axis: "rate",
+            }
+            assert meta["units"] == {"time": None, axis: "1/second"}
+
     def test_throughput_epm_hour_rollup(self):
         project = self.create_project()
         # Each of these denotes how many events to create in each hour
@@ -518,13 +557,6 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
             assert response.status_code == 200, response.content
             data = response.data["data"]
             assert len(data) == 6
-
-            meta = response.data["meta"]
-            assert meta["fields"] == {
-                "time": "date",
-                axis: "rate",
-            }
-            assert meta["units"] == {"time": None, axis: "1/minute"}
 
             rows = data[0:6]
             for test in zip(event_counts, rows):
@@ -597,13 +629,6 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
             assert response.status_code == 200, response.content
             data = response.data["data"]
             assert len(data) == 6
-
-            meta = response.data["meta"]
-            assert meta["fields"] == {
-                "time": "date",
-                axis: "rate",
-            }
-            assert meta["units"] == {"time": None, axis: "1/second"}
 
             rows = data[0:6]
             for test in zip(event_counts, rows):


### PR DESCRIPTION
## Context

Discover endpoint results include event meta, it looks like this:

```json
{
  "fields": { "time": "date", "count()": "integer" },
  "units": { "time": null, "count()": null },
  "isMetricsData": false,
  "dataset": "profileFunctions"
}
```

Conspicuously, for _timeseries_ results, the meta looks a little different:

```json
{
  "fields": { "time": "date", "count": "integer" },
  "units": { "time": null, "count": null },
  "isMetricsData": false,
  "dataset": "profileFunctions"
}
```

You'll notice that `"count"` is missing the parentheses. This is because the field is _aliased_ to a simplified form. Something like `p95(transaction.duration)` would be aliased to `"p95_transaction_duration"`. This is an old behaviour and it's been removed in most places.

This PR makes this change possible for timeseries events.

## Changes

1. Run timeseries results through `BaseEventBuilder.process_results`. I noticed that some dataset timeseries results already do this, but other do not! `process_results` is the function that maps aliases back for table results. The first change is to run _all_ dataset results through that function. This let me delete some downstream code that processed event meta and got the field types, since `process_results` already did it
2. Pass `transform_alias_to_input_format` through to all `QueryBuilderConfig` instances. Otherwise, that setting will not be respected
3. Add a new URL parameter to `/events-stats/` called `transformAliasToInputFormat`. If enabled, meta aliases are transformed back to their original forms
