### PR TITLE
feat(grouping): Allow calling seer without a filename

### DIFF
--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Mapping, Sequence
 from enum import StrEnum
 from typing import Any, TypeVar
 
@@ -168,10 +169,6 @@ class TooManyOnlySystemFramesException(Exception):
     pass
 
 
-class NoFilenameOrModuleException(Exception):
-    pass
-
-
 def _get_value_if_exists(exception_value: dict[str, Any]) -> str:
     return exception_value["values"][0] if exception_value.get("values") else ""
 
@@ -199,7 +196,6 @@ def get_stacktrace_string(data: dict[str, Any], platform: str | None = None) -> 
     frame_count = 0
     html_frame_count = 0  # for a temporary metric
     is_frames_truncated = False
-    has_no_filename_or_module = False
     stacktrace_str = ""
     found_non_snipped_context_line = False
 
@@ -209,7 +205,6 @@ def get_stacktrace_string(data: dict[str, Any], platform: str | None = None) -> 
         nonlocal frame_count
         nonlocal html_frame_count
         nonlocal is_frames_truncated
-        nonlocal has_no_filename_or_module
         nonlocal found_non_snipped_context_line
         frame_strings = []
 
@@ -224,18 +219,12 @@ def get_stacktrace_string(data: dict[str, Any], platform: str | None = None) -> 
         frame_count += len(contributing_frames)
 
         for frame in contributing_frames:
-            frame_dict = {"filename": "", "function": "", "context-line": "", "module": ""}
-            for frame_values in frame.get("values", []):
-                if frame_values.get("id") in frame_dict:
-                    frame_dict[frame_values["id"]] = _get_value_if_exists(frame_values)
+            frame_dict = extract_values_from_frame_values(frame.get("values", []))
 
             if not _is_snipped_context_line(frame_dict["context-line"]):
                 found_non_snipped_context_line = True
 
-            if frame_dict["filename"] == "" and frame_dict["module"] == "":
-                has_no_filename_or_module = True
-            elif frame_dict["filename"] == "":
-                frame_dict["filename"] = frame_dict["module"]
+            filename = extract_filename(frame_dict) or "None"
 
             # Not an exhaustive list of tests we could run to detect HTML, but this is only
             # meant to be a temporary, quick-and-dirty metric
@@ -245,18 +234,11 @@ def get_stacktrace_string(data: dict[str, Any], platform: str | None = None) -> 
             if frame_dict["filename"].endswith("html") or "<html>" in frame_dict["context-line"]:
                 html_frame_count += 1
 
-            # We want to skip frames with base64 encoded filenames since they can be large
-            # and not contain any usable information
-            base64_encoded = False
-            for base64_prefix in BASE64_ENCODED_PREFIXES:
-                if frame_dict["filename"].startswith(base64_prefix):
-                    base64_encoded = True
-                    break
-            if base64_encoded:
+            if is_base64_encoded_frame(frame_dict):
                 continue
 
             frame_strings.append(
-                f'  File "{frame_dict["filename"]}", function {frame_dict["function"]}\n    {frame_dict["context-line"]}\n'
+                f'  File "{filename}", function {frame_dict["function"]}\n    {frame_dict["context-line"]}\n'
             )
 
         return frame_strings
@@ -293,8 +275,7 @@ def get_stacktrace_string(data: dict[str, Any], platform: str | None = None) -> 
             and not app_hash
         ):
             raise TooManyOnlySystemFramesException
-        if has_no_filename_or_module:
-            raise NoFilenameOrModuleException
+
         # Only exceptions have the type and value properties, so we don't need to handle the threads
         # case here
         header = f"{exc_type}: {exc_value}\n" if exception["id"] == "exception" else ""
@@ -330,6 +311,35 @@ def get_stacktrace_string(data: dict[str, Any], platform: str | None = None) -> 
     return stacktrace_str.strip()
 
 
+def extract_values_from_frame_values(values: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    frame_dict = {"filename": "", "function": "", "context-line": "", "module": ""}
+    for frame_values in values:
+        if frame_values.get("id") in frame_dict:
+            frame_dict[frame_values["id"]] = _get_value_if_exists(frame_values)
+    return frame_dict
+
+
+def extract_filename(frame_dict: Mapping[str, Any]) -> str:
+    """
+    Extract the filename from the frame dictionary. Fallback to module if filename is not present.
+    """
+    filename = frame_dict["filename"]
+    if filename == "" and frame_dict["module"] != "":
+        filename = frame_dict["module"]
+    return filename
+
+
+def is_base64_encoded_frame(frame_dict: Mapping[str, Any]) -> bool:
+    # We want to skip frames with base64 encoded filenames since they can be large
+    # and not contain any usable information
+    base64_encoded = False
+    for base64_prefix in BASE64_ENCODED_PREFIXES:
+        if frame_dict["filename"].startswith(base64_prefix):
+            base64_encoded = True
+            break
+    return base64_encoded
+
+
 def get_stacktrace_string_with_metrics(
     data: dict[str, Any], platform: str | None, referrer: ReferrerOptions
 ) -> str | None:
@@ -349,17 +359,6 @@ def get_stacktrace_string_with_metrics(
                 tags={
                     "call_made": False,
                     "blocker": "over-threshold-only-system-frames",
-                },
-            )
-        stacktrace_string = None
-    except NoFilenameOrModuleException:
-        if referrer == ReferrerOptions.INGEST:
-            metrics.incr(
-                "grouping.similarity.did_call_seer",
-                sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-                tags={
-                    "call_made": False,
-                    "blocker": "no-module-or-filename",
                 },
             )
         stacktrace_string = None

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -1,18 +1,15 @@
 import copy
 from collections.abc import Callable
 from typing import Any, Literal, cast
-from unittest.mock import patch
 from uuid import uuid1
 
 import pytest
 
-from sentry import options
 from sentry.eventstore.models import Event
 from sentry.seer.similarity.utils import (
     BASE64_ENCODED_PREFIXES,
     MAX_FRAME_COUNT,
     SEER_ELIGIBLE_PLATFORMS,
-    NoFilenameOrModuleException,
     ReferrerOptions,
     TooManyOnlySystemFramesException,
     _is_snipped_context_line,
@@ -855,28 +852,16 @@ class GetStacktraceStringTest(TestCase):
             == 'ZeroDivisionError: division by zero\n  File "__main__", function divide_by_zero\n    divide = 1/0'
         )
 
-    @patch("sentry.seer.similarity.utils.metrics")
-    def test_no_filename_or_module(self, mock_metrics):
+    def test_no_filename_or_module(self):
         exception = copy.deepcopy(self.BASE_APP_DATA)
         # delete module from the exception
         del exception["app"]["component"]["values"][0]["values"][0]["values"][0]["values"][0]
         # delete filename from the exception
         del exception["app"]["component"]["values"][0]["values"][0]["values"][0]["values"][0]
-        with pytest.raises(NoFilenameOrModuleException):
-            get_stacktrace_string(exception)
-
-        stacktrace_string = get_stacktrace_string_with_metrics(
-            exception, "python", ReferrerOptions.INGEST
-        )
-        sample_rate = options.get("seer.similarity.metrics_sample_rate")
-        assert stacktrace_string is None
-        mock_metrics.incr.assert_called_with(
-            "grouping.similarity.did_call_seer",
-            sample_rate=sample_rate,
-            tags={
-                "call_made": False,
-                "blocker": "no-module-or-filename",
-            },
+        stacktrace_string = get_stacktrace_string(exception)
+        assert (
+            stacktrace_string
+            == 'ZeroDivisionError: division by zero\n  File "None", function divide_by_zero\n    divide = 1/0'
         )
 
 


### PR DESCRIPTION
In some cases, a frame does not include the `filename` nor the `module`.

More details to add.

The original work in #81272 added support to falling back to the `module` but this PR also enables the case when we cannot fallback.