### PR TITLE
feat(rpc): Add confidence to the events stats response

### DIFF
--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -128,17 +128,8 @@ class SnubaTSResultSerializer(BaseSnubaSerializer):
                         item[self.lookup.name] = (attrs.get(value),)
                     result_row.append(item)
                 confidence_values.append((key, result_row))
-            res["confidence"] = (
-                zerofill(
-                    confidence_values,
-                    result.start,
-                    result.end,
-                    result.rollup,
-                    allow_partial_buckets=allow_partial_buckets,
-                )
-                if zerofill_results
-                else confidence_values
-            )
+            # confidence only comes from the RPC which already helps us zerofill by returning all buckets
+            res["confidence"] = confidence_values
 
         if result.data.get("totals"):
             res["totals"] = {"count": result.data["totals"][column]}

--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -114,6 +114,32 @@ class SnubaTSResultSerializer(BaseSnubaSerializer):
             )
         }
 
+        confidence_values = []
+        if "confidence" in result.data:
+            for key, group in itertools.groupby(result.data["confidence"], key=lambda r: r["time"]):
+                result_row = []
+                for confidence_row in group:
+                    item = {"count": confidence_row.get(column, None)}
+                    if extra_columns is not None:
+                        for extra_column in extra_columns:
+                            item[extra_column] = confidence_row.get(extra_column, 0)
+                    if self.lookup:
+                        value = value_from_row(confidence_row, self.lookup.columns)
+                        item[self.lookup.name] = (attrs.get(value),)
+                    result_row.append(item)
+                confidence_values.append((key, result_row))
+            res["confidence"] = (
+                zerofill(
+                    confidence_values,
+                    result.start,
+                    result.end,
+                    result.rollup,
+                    allow_partial_buckets=allow_partial_buckets,
+                )
+                if zerofill_results
+                else confidence_values
+            )
+
         if result.data.get("totals"):
             res["totals"] = {"count": result.data["totals"][column]}
         # If order is passed let that overwrite whats in data since its order for multi-axis

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -1478,8 +1478,9 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
         assert data[0]["count()"] == 10
         assert confidence[0]["count()"] == "low"
         assert data[1]["count()"] == 1
-        # Skipping this assert for now, IMO confidence for "bar" should be high, but checking with sns
-        # assert confidence[1]["count()"] == "high"
+        # While logically the confidence for 1 event at 100% sample rate should be high, we're going with low until we
+        # get customer feedback
+        assert confidence[1]["count()"] == "low"
 
     def test_span_duration(self):
         spans = [

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
@@ -518,6 +518,148 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsEAPSpanEndpoint
     is_eap = True
     is_rpc = True
 
+    def test_extrapolation(self):
+        event_counts = [6, 0, 6, 3, 0, 3]
+        for hour, count in enumerate(event_counts):
+            for minute in range(count):
+                self.store_spans(
+                    [
+                        self.create_span(
+                            {
+                                "description": "foo",
+                                "sentry_tags": {"status": "success"},
+                                "measurements": {"client_sample_rate": {"value": 0.1}},
+                            },
+                            start_ts=self.day_ago + timedelta(hours=hour, minutes=minute),
+                        ),
+                    ],
+                    is_eap=self.is_eap,
+                )
+
+        response = self._do_request(
+            data={
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(hours=6),
+                "interval": "1h",
+                "yAxis": "count()",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            },
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        confidence = response.data["confidence"]
+        assert len(data) == 6
+        assert response.data["meta"]["dataset"] == self.dataset
+
+        for expected, actual in zip(event_counts, data[0:6]):
+            assert actual[1][0]["count"] == expected * 10
+
+        for expected, actual in zip(event_counts, confidence[0:6]):
+            if expected != 0:
+                assert actual[1][0]["count"] == "low"
+            else:
+                assert actual[1][0]["count"] is None
+
+    def test_extrapolation_with_multiaxis(self):
+        event_counts = [6, 0, 6, 3, 0, 3]
+        for hour, count in enumerate(event_counts):
+            for minute in range(count):
+                self.store_spans(
+                    [
+                        self.create_span(
+                            {
+                                "description": "foo",
+                                "sentry_tags": {"status": "success"},
+                                "measurements": {"client_sample_rate": {"value": 0.1}},
+                            },
+                            duration=count,
+                            start_ts=self.day_ago + timedelta(hours=hour, minutes=minute),
+                        ),
+                    ],
+                    is_eap=self.is_eap,
+                )
+
+        response = self._do_request(
+            data={
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(hours=6),
+                "interval": "1h",
+                "yAxis": ["count()", "p95()"],
+                "project": self.project.id,
+                "dataset": self.dataset,
+            },
+        )
+        assert response.status_code == 200, response.content
+        count_data = response.data["count()"]["data"]
+        p95_data = response.data["p95()"]["data"]
+        assert len(count_data) == len(p95_data) == 6
+
+        count_rows = count_data[0:6]
+        for test in zip(event_counts, count_rows):
+            assert test[1][1][0]["count"] == test[0] * 10
+
+        for expected, actual in zip(event_counts, response.data["count()"]["confidence"][0:6]):
+            if expected != 0:
+                assert actual[1][0]["count"] == "low"
+            else:
+                assert actual[1][0]["count"] is None
+
+        p95_rows = p95_data[0:6]
+        for test in zip(event_counts, p95_rows):
+            assert test[1][1][0]["count"] == test[0]
+
+        for actual in response.data["p95()"]["confidence"][0:6]:
+            assert actual[1][0]["count"] is None
+
+    def test_top_events_with_extrapolation(self):
+        # Each of these denotes how many events to create in each minute
+        for transaction in ["foo", "bar"]:
+            self.store_spans(
+                [
+                    self.create_span(
+                        {"sentry_tags": {"transaction": transaction, "status": "success"}},
+                        start_ts=self.day_ago + timedelta(minutes=1),
+                        duration=2000,
+                    ),
+                ],
+                is_eap=self.is_eap,
+            )
+        self.store_spans(
+            [
+                self.create_span(
+                    {"segment_name": "baz", "sentry_tags": {"status": "success"}},
+                    start_ts=self.day_ago + timedelta(minutes=1),
+                ),
+            ],
+            is_eap=self.is_eap,
+        )
+
+        response = self._do_request(
+            data={
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(minutes=6),
+                "interval": "1m",
+                "yAxis": "count()",
+                "field": ["transaction", "sum(span.self_time)"],
+                "orderby": ["-sum_span_self_time"],
+                "project": self.project.id,
+                "dataset": self.dataset,
+                "excludeOther": 0,
+                "topEvents": 2,
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert "Other" in response.data
+        assert "foo" in response.data
+        assert "bar" in response.data
+        assert len(response.data["Other"]["data"]) == 6
+        for key in ["Other", "foo", "bar"]:
+            rows = response.data[key]["data"][0:6]
+            for expected, result in zip([0, 1, 0, 0, 0, 0], rows):
+                assert result[1][0]["count"] == expected, key
+        assert response.data["Other"]["meta"]["dataset"] == self.dataset
+
     @pytest.mark.xfail(reason="epm not implemented yet")
     def test_throughput_epm_hour_rollup(self):
         super().test_throughput_epm_hour_rollup()


### PR DESCRIPTION
- This updates the events-stats response for single/multi axis as well as top events to include the confidences when available.