### PR TITLE
chore(grouping): Add test for merging when no projects sent

### DIFF
--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -332,12 +332,13 @@ class MergeGroupsTest(TestCase):
         proj1 = projects[0]
         groups = [self.create_group(proj1), self.create_group(proj1)]
         group_ids = [g.id for g in groups]
-        project_ids = [g.project_id for g in groups]
+        project_ids = [p.id for p in projects]
 
         request = self.make_request(method="PUT")
         request.user = self.user
         request.data = {"merge": 1}
-        # The two groups belong to the same project, so we should be able to merge them
+        # The two groups belong to the same project, so we should be able to merge them, even though
+        # we're passing multiple project ids
         request.GET = {"id": group_ids, "project": project_ids}
 
         update_groups(request, group_ids, projects, self.organization.id)


### PR DESCRIPTION
Recent work done by @armenzg has fixed https://github.com/getsentry/sentry/issues/81115 (wherein selecting 'All Projects' in the issue stream meant you couldn't merge issues, even from the same project, because no project ids are sent in the request), and this adds a test demonstrating the fix. 

This also fixes a related test, testing that sending multiple project ids also doesn't block merging so long as the merged issues belong to the same project. (In the current version of the test, we're not actually sending multiple ids, so it doesn't show what it's designed to.)