### PR TITLE
fix(widget-builder): Pass along proper fields depending on display

### DIFF
--- a/static/app/views/dashboards/datasetConfig/utils/getSeriesRequestData.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/utils/getSeriesRequestData.spec.tsx
@@ -160,5 +160,59 @@ describe('utils', () => {
         topEvents: 5,
       });
     });
+
+    it('does not add the orderby field if it is in alias format but the query is not', () => {
+      const widget = WidgetFixture({
+        displayType: DisplayType.LINE,
+        queries: [
+          WidgetQueryFixture({
+            fields: ['title', 'count_unique(user)'],
+            aggregates: ['count_unique(user)'],
+            columns: ['title'],
+            orderby: 'count_unique_user',
+          }),
+        ],
+      });
+      const pageFilters = PageFiltersFixture();
+      const organization = OrganizationFixture();
+
+      const requestData = getSeriesRequestData(
+        widget,
+        0,
+        organization,
+        pageFilters,
+        DiscoverDatasets.ERRORS,
+        'test-referrer'
+      );
+
+      expect(requestData.field).not.toContain('count_unique_user');
+    });
+
+    it('adds the orderby to fields if it is not in fields, columns, or aggregates', () => {
+      const widget = WidgetFixture({
+        displayType: DisplayType.LINE,
+        queries: [
+          WidgetQueryFixture({
+            fields: ['test'],
+            aggregates: [],
+            columns: ['test'],
+            orderby: 'count_unique_user',
+          }),
+        ],
+      });
+      const pageFilters = PageFiltersFixture();
+      const organization = OrganizationFixture();
+
+      const requestData = getSeriesRequestData(
+        widget,
+        0,
+        organization,
+        pageFilters,
+        DiscoverDatasets.ERRORS,
+        'test-referrer'
+      );
+
+      expect(requestData.field).toContain('count_unique_user');
+    });
   });
 });

--- a/static/app/views/dashboards/datasetConfig/utils/getSeriesRequestData.tsx
+++ b/static/app/views/dashboards/datasetConfig/utils/getSeriesRequestData.tsx
@@ -3,7 +3,11 @@ import trimStart from 'lodash/trimStart';
 import type {EventsStatsOptions} from 'sentry/actionCreators/events';
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
-import {isEquation, isEquationAlias} from 'sentry/utils/discover/fields';
+import {
+  getAggregateAlias,
+  isEquation,
+  isEquationAlias,
+} from 'sentry/utils/discover/fields';
 import type {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {TOP_N} from 'sentry/utils/discover/types';
 import {DisplayType, type Widget} from 'sentry/views/dashboards/types';
@@ -83,7 +87,7 @@ export function getSeriesRequestData(
       if (
         widgetQuery.orderby &&
         !isEquationAlias(orderby) &&
-        !requestData.field.includes(orderby)
+        !requestData.field.map(getAggregateAlias).includes(getAggregateAlias(orderby))
       ) {
         requestData.field.push(orderby);
       }

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
@@ -9,9 +9,18 @@ export function convertWidgetToBuilderStateParams(
   widget: Widget
 ): WidgetBuilderStateQueryParams {
   const yAxis = widget.queries.flatMap(q => q.aggregates);
-  const field = widget.queries.flatMap(q => q.fields);
   const query = widget.queries.flatMap(q => q.conditions);
   const sort = widget.queries.flatMap(q => q.orderby);
+
+  let field: string[] = [];
+  if (
+    widget.displayType === DisplayType.TABLE ||
+    widget.displayType === DisplayType.BIG_NUMBER
+  ) {
+    field = widget.queries.flatMap(q => q.fields ?? []);
+  } else {
+    field = widget.queries.flatMap(q => q.columns);
+  }
 
   return {
     title: widget.title,


### PR DESCRIPTION
Tables and big numbers should prioritize the `fields` property because they're tabular and order matters. For timeseries we should just pass along the columns for `fields` because there's a y-axis prop that uses aggregates.

Also modifies the helper that makes timeseries requests to compare the flattened alias version of aggregates because we still use those forms in places. This is safe because `getAggregateAlias` just returns the input string if the input doesn't seem like a function (i.e. regular fields/tags pass through and things like `p95_transaction_duration` also pass through)