### PR TITLE
feat(dashboards): add 'return' to endpoint response

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboard_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_details.py
@@ -231,7 +231,7 @@ class OrganizationDashboardFavoriteEndpoint(OrganizationDashboardBase):
         elif not is_favorited and request.user.id in current_favorites:
             current_favorites.remove(request.user.id)
         else:
-            Response(status=204)
+            return Response(status=204)
 
         dashboard.favorited_by = current_favorites
 


### PR DESCRIPTION
Add 'return' to endpoint response for POST request.

Should have added it in this PR: https://github.com/getsentry/sentry/pull/81438