### PR TITLE
fix(rpc): Disable zerofill for rpc

### DIFF
--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -547,6 +547,11 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
             return fn
 
         get_event_stats = get_event_stats_factory(dataset)
+        zerofill_results = not (
+            request.GET.get("withoutZerofill") == "1" and has_chart_interpolation
+        )
+        if use_rpc:
+            zerofill_results = False
 
         try:
             return Response(
@@ -556,9 +561,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                     get_event_stats,
                     top_events,
                     allow_partial_buckets=allow_partial_buckets,
-                    zerofill_results=not (
-                        request.GET.get("withoutZerofill") == "1" and has_chart_interpolation
-                    ),
+                    zerofill_results=zerofill_results,
                     comparison_delta=comparison_delta,
                     dataset=dataset,
                 ),

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -551,6 +551,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
             request.GET.get("withoutZerofill") == "1" and has_chart_interpolation
         )
         if use_rpc:
+            # The rpc will usually zerofill for us so we don't need to do it ourselves
             zerofill_results = False
 
         try:

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -206,6 +206,7 @@ def run_timeseries_query(
             for existing, new in zip(confidences, confidence):
                 existing.update(new)
     if len(result) == 0:
+        # The rpc only zerofills for us when there are results, if there aren't any we have to do it ourselves
         result = zerofill(
             [],
             params.start_date,

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -13,7 +13,7 @@ from sentry.search.eap.spans import SearchResolver
 from sentry.search.eap.types import CONFIDENCES, ConfidenceData, EAPResponse, SearchResolverConfig
 from sentry.search.events.fields import get_function_alias, is_function
 from sentry.search.events.types import EventsMeta, SnubaData, SnubaParams
-from sentry.snuba.discover import OTHER_KEY, create_result_key
+from sentry.snuba.discover import OTHER_KEY, create_result_key, zerofill
 from sentry.utils import snuba_rpc
 from sentry.utils.snuba import SnubaTSResult
 
@@ -205,6 +205,14 @@ def run_timeseries_query(
                 existing.update(new)
             for existing, new in zip(confidences, confidence):
                 existing.update(new)
+    if len(result) == 0:
+        result = zerofill(
+            [],
+            params.start_date,
+            params.end_date,
+            granularity_secs,
+            ["time"],
+        )
     return SnubaTSResult(
         {"data": result, "confidence": confidences}, params.start, params.end, granularity_secs
     )


### PR DESCRIPTION
- Because the rpc now returns all the buckets for us, avoid any bugs where we might zerofill unintentionally