### PR TITLE
feat(autofix): Add line numbers to github links

### DIFF
--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -280,7 +280,11 @@ export function SuggestedFixSnippet({
     if (!repo) {
       return undefined;
     }
-    return `${repo.url}/blob/${repo.default_branch}/${snippet.file_path}`;
+    return `${repo.url}/blob/${repo.default_branch}/${snippet.file_path}${
+      snippet.start_line && snippet.end_line
+        ? `#L${snippet.start_line}-L${snippet.end_line}`
+        : ''
+    }`;
   }
   const extension = getFileExtension(snippet.file_path);
   const language = extension ? getPrismLanguage(extension) : undefined;
@@ -299,7 +303,7 @@ export function SuggestedFixSnippet({
       </StyledCodeSnippet>
       {sourceLink && (
         <CodeLinkWrapper>
-          <Tooltip title={t('Open this file in GitHub')} skipWrapper>
+          <Tooltip title={t('Open in GitHub')} skipWrapper>
             <OpenInLink href={sourceLink} openInNewTab aria-label={t('GitHub')}>
               <StyledIconWrapper>{getIntegrationIcon('github', 'sm')}</StyledIconWrapper>
             </OpenInLink>

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -93,6 +93,8 @@ export type CodeSnippetContext = {
   file_path: string;
   repo_name: string;
   snippet: string;
+  end_line?: number;
+  start_line?: number;
 };
 
 export type StacktraceContext = {


### PR DESCRIPTION
If a range of line numbers is provided in the root cause output's relevant code snippets, add them to the GitHub link that we give to users.

Wait for the Seer PR before merging.