### PR TITLE
fix(issue summary): Hide trace section when loading

### DIFF
--- a/static/app/components/group/groupSummary.spec.tsx
+++ b/static/app/components/group/groupSummary.spec.tsx
@@ -26,7 +26,7 @@ describe('GroupSummary', function () {
     render(<GroupSummary data={undefined} isError={false} isPending />);
 
     // Should show loading placeholders
-    expect(screen.getAllByTestId('loading-placeholder')).toHaveLength(3); // 3 placeholder cards
+    expect(screen.getAllByTestId('loading-placeholder')).toHaveLength(2);
   });
 
   it('shows error state', function () {

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -68,18 +68,21 @@ export function GroupSummary({
       title: t("What's wrong"),
       insight: data?.whatsWrong,
       icon: <IconFatal size="sm" />,
+      showWhenLoading: true,
     },
     {
       id: 'trace',
       title: t('In the trace'),
       insight: data?.trace,
       icon: <IconSpan size="sm" />,
+      showWhenLoading: false,
     },
     {
       id: 'possible_cause',
       title: t('Possible cause'),
       insight: data?.possibleCause,
       icon: <IconFocus size="sm" />,
+      showWhenLoading: true,
     },
   ];
 
@@ -90,7 +93,8 @@ export function GroupSummary({
         <InsightGrid>
           {insightCards.map(card => {
             // Hide the card if we're not loading and there's no insight
-            if (!isPending && !card.insight) {
+            // Also hide if we're loading and the card shouldn't show when loading
+            if ((!isPending && !card.insight) || (isPending && !card.showWhenLoading)) {
               return null;
             }
 

--- a/static/app/views/issueDetails/streamline/sidebar/solutionsSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/solutionsSection.spec.tsx
@@ -96,7 +96,7 @@ describe('SolutionsSection', () => {
     );
 
     expect(screen.getByText('Solutions Hub')).toBeInTheDocument();
-    expect(screen.getAllByTestId('loading-placeholder')).toHaveLength(4);
+    expect(screen.getAllByTestId('loading-placeholder')).toHaveLength(3);
   });
 
   it('renders summary when AI features are enabled and data is available', async () => {


### PR DESCRIPTION
Hide the "in the trace" section in the summary when loading, and only show it if we get data for it.

<img width="365" alt="Screenshot 2024-12-03 at 2 44 58 PM" src="https://github.com/user-attachments/assets/53ebf9c5-af23-4efe-8b13-7fe0bff8cfb3">
<img width="352" alt="Screenshot 2024-12-03 at 2 45 04 PM" src="https://github.com/user-attachments/assets/487198ab-61cb-406d-b2b6-69eafcad7c93">
