### PR TITLE
fix(settings): Disable data scrub settings w/o permissions

### DIFF
--- a/static/app/views/settings/projectSecurityAndPrivacy/index.spec.tsx
+++ b/static/app/views/settings/projectSecurityAndPrivacy/index.spec.tsx
@@ -87,4 +87,22 @@ describe('projectSecurityAndPrivacy', function () {
       screen.getByRole('checkbox', {name: 'Enable server-side data scrubbing'})
     ).toBeChecked();
   });
+
+  it('disables fields when missing project:write access', function () {
+    const {organization} = initializeOrg({
+      organization: {
+        access: [], // Remove all access
+      },
+    });
+    const project = ProjectFixture();
+
+    render(<ProjectSecurityAndPrivacy project={project} organization={organization} />);
+
+    // Check that the data scrubber toggle is disabled
+    expect(
+      screen.getByRole('checkbox', {
+        name: 'Enable server-side data scrubbing',
+      })
+    ).toBeDisabled();
+  });
 });

--- a/static/app/views/settings/projectSecurityAndPrivacy/index.tsx
+++ b/static/app/views/settings/projectSecurityAndPrivacy/index.tsx
@@ -53,7 +53,7 @@ export default function ProjectSecurityAndPrivacy({organization, project}: Props
         onSubmitError={() => addErrorMessage('Unable to save change')}
       >
         <JsonForm
-          additionalFieldProps={{organization}}
+          additionalFieldProps={{organization, project}}
           features={features}
           disabled={!hasAccess}
           forms={projectSecurityAndPrivacyGroups}


### PR DESCRIPTION
these form fields can be set at the organization or the project level and the organization level takes priority. But we also want to check user permissions to edit.

This adds the check for the user permissions back since the fields override the global disabled state

fixes #81621