### PR TITLE
fix(grouping): Return 400 when trying to merge across projects

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -816,7 +816,9 @@ def prepare_response(
     if result.get("merge") and len(group_list) > 1:
         # don't allow merging cross project
         if len(project_lookup) > 1:
-            return Response({"detail": "Merging across multiple projects is not supported"})
+            return Response(
+                {"detail": "Merging across multiple projects is not supported"}, status=400
+            )
         result["merge"] = merge_groups(
             group_list,
             project_lookup,

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -323,6 +323,7 @@ class MergeGroupsTest(TestCase):
         )
 
         assert response.data == {"detail": "Merging across multiple projects is not supported"}
+        assert response.status_code == 400
         assert mock_handle_merge.call_count == 0
 
     @patch("sentry.api.helpers.group_index.update.handle_merge")


### PR DESCRIPTION
Merging of issues isn't supported across projects, and we have various safeguards in place, in both the backend and front end, to make sure we don't try it. Before the latest of those safeguards existed, however, we were running into a problem where the backend would correctly return an error if you tried, but would also return a 200, confusing the front end and causing it not to show the error. 

Thanks to recent fixes by @armenzg, requests from the UI should no longer make it far enough to hit the error. Nonetheless, it would be good to return an error status rather than a success status if we ever do, so this changes the response code in that case from a 200 to a 400.