### PR TITLE
feat(workflow_engine): Evaluate the Actions associated with a Workflow

### DIFF
--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -663,7 +663,7 @@ class Fixtures:
     def create_workflow_data_condition_group(self, *args, **kwargs):
         return Factories.create_workflow_data_condition_group(*args, **kwargs)
 
-    # workflow_engine action
+    # workflow_engine.models.action
     def create_action(self, *args, **kwargs):
         return Factories.create_action(*args, **kwargs)
 

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -661,7 +661,7 @@ class ExhaustiveFixtures(Fixtures):
             organization=org,
         )
 
-        send_notification_action = self.create_action(type=Action.Type.Notification, data="")
+        send_notification_action = self.create_action(type=Action.Type.NOTIFICATION, data="")
         self.create_data_condition_group_action(
             action=send_notification_action,
             condition_group=notification_condition_group,
@@ -689,7 +689,7 @@ class ExhaustiveFixtures(Fixtures):
         )
 
         # TODO @saponifi3d: Create or define trigger workflow action type
-        trigger_workflows_action = self.create_action(type=Action.Type.TriggerWorkflow, data="")
+        trigger_workflows_action = self.create_action(type=Action.Type.WEBHOOK, data="")
         self.create_data_condition_group_action(
             action=trigger_workflows_action, condition_group=detector_conditions
         )

--- a/src/sentry/workflow_engine/action_handlers/__init__.py
+++ b/src/sentry/workflow_engine/action_handlers/__init__.py
@@ -1,0 +1,5 @@
+__all__ = [
+    "NotificationActionHandler",
+]
+
+from .notification import NotificationActionHandler

--- a/src/sentry/workflow_engine/action_handlers/notification.py
+++ b/src/sentry/workflow_engine/action_handlers/notification.py
@@ -8,7 +8,6 @@ from sentry.workflow_engine.types import ActionHandler
 class NotificationActionHandler(ActionHandler[GroupEvent]):
     @staticmethod
     def execute(
-        self,
         data: GroupEvent,
         action: Action,
         detector: Detector,

--- a/src/sentry/workflow_engine/action_handlers/notification.py
+++ b/src/sentry/workflow_engine/action_handlers/notification.py
@@ -1,0 +1,17 @@
+from sentry.eventstore.models import GroupEvent
+from sentry.workflow_engine.models import Action, Detector
+from sentry.workflow_engine.registry import action_handler_registry
+from sentry.workflow_engine.types import ActionHandler
+
+
+@action_handler_registry.register(Action.Type.NOTIFICATION)
+class NotificationActionHandler(ActionHandler[GroupEvent]):
+    @staticmethod
+    def execute(
+        self,
+        data: GroupEvent,
+        action: Action,
+        detector: Detector,
+    ) -> None:
+        # TODO: Implment this in milestone 2
+        pass

--- a/src/sentry/workflow_engine/action_handlers/notification.py
+++ b/src/sentry/workflow_engine/action_handlers/notification.py
@@ -5,10 +5,10 @@ from sentry.workflow_engine.types import ActionHandler
 
 
 @action_handler_registry.register(Action.Type.NOTIFICATION)
-class NotificationActionHandler(ActionHandler[GroupEvent]):
+class NotificationActionHandler(ActionHandler):
     @staticmethod
     def execute(
-        data: GroupEvent,
+        evt: GroupEvent,
         action: Action,
         detector: Detector,
     ) -> None:

--- a/src/sentry/workflow_engine/apps.py
+++ b/src/sentry/workflow_engine/apps.py
@@ -6,5 +6,6 @@ class Config(AppConfig):
 
     def ready(self):
         # Import our base DataConditionHandlers for the workflow engine platform
+        import sentry.workflow_engine.action_handlers  # NOQA
         import sentry.workflow_engine.condition_handlers  # NOQA
         from sentry.workflow_engine.endpoints import serializers  # NOQA

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -57,8 +57,7 @@ class Action(DefaultFieldsModel):
 
     def get_handler(self) -> ActionHandler[Any]:
         action_type = Action.Type(self.type)
-        handler_class = action_handler_registry.get(action_type)
-        return handler_class()
+        return action_handler_registry.get(action_type)
 
     def trigger(self, evt: GroupEvent, detector: Detector) -> bool:
         triggered = False

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -1,9 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from django.db import models
 
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import DefaultFieldsModel, region_silo_model, sane_repr
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
+from sentry.eventstore.models import GroupEvent
 from sentry.notifications.models.notificationaction import ActionTarget
+from sentry.workflow_engine.registry import action_handler_registry
+from sentry.workflow_engine.types import ActionHandler
+
+if TYPE_CHECKING:
+    from sentry.workflow_engine.models import Detector
 
 
 @region_silo_model
@@ -19,10 +29,9 @@ class Action(DefaultFieldsModel):
     __relocation_scope__ = RelocationScope.Excluded
     __repr__ = sane_repr("id", "type")
 
-    # TODO (@saponifi3d): Don't hardcode these values, and these are incomplete values
     class Type(models.TextChoices):
-        Notification = "SendNotificationAction"
-        TriggerWorkflow = "TriggerWorkflowAction"
+        NOTIFICATION = "notification"
+        WEBHOOK = "webhook"
 
     # The type field is used to denote the type of action we want to trigger
     type = models.TextField(choices=Type.choices)
@@ -45,3 +54,17 @@ class Action(DefaultFieldsModel):
 
     # LEGACY: This is used to denote if the Notification is going to a user, team, sentry app, etc
     target_type = models.SmallIntegerField(choices=ActionTarget.as_choices(), null=True)
+
+    def get_handler(self) -> ActionHandler[Any]:
+        action_type = Action.Type(self.type)
+        handler_class = action_handler_registry.get(action_type)
+        return handler_class()
+
+    def trigger(self, evt: GroupEvent, detector: Detector) -> bool:
+        triggered = False
+
+        # get the handler for the action type
+        handler = self.get_handler()
+        handler.execute(evt, self, detector)
+
+        return triggered

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from django.db import models
 
@@ -55,7 +55,7 @@ class Action(DefaultFieldsModel):
     # LEGACY: This is used to denote if the Notification is going to a user, team, sentry app, etc
     target_type = models.SmallIntegerField(choices=ActionTarget.as_choices(), null=True)
 
-    def get_handler(self) -> ActionHandler[Any]:
+    def get_handler(self) -> ActionHandler:
         action_type = Action.Type(self.type)
         return action_handler_registry.get(action_type)
 

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -17,7 +17,7 @@ class Action(DefaultFieldsModel):
     """
 
     __relocation_scope__ = RelocationScope.Excluded
-    __repr__ = sane_repr("workflow_id", "type")
+    __repr__ = sane_repr("id", "type")
 
     # TODO (@saponifi3d): Don't hardcode these values, and these are incomplete values
     class Type(models.TextChoices):

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -59,11 +59,7 @@ class Action(DefaultFieldsModel):
         action_type = Action.Type(self.type)
         return action_handler_registry.get(action_type)
 
-    def trigger(self, evt: GroupEvent, detector: Detector) -> bool:
-        triggered = False
-
+    def trigger(self, evt: GroupEvent, detector: Detector) -> None:
         # get the handler for the action type
         handler = self.get_handler()
         handler.execute(evt, self, detector)
-
-        return triggered

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -60,3 +60,21 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
 
         evaluation, _ = evaluate_condition_group(self.when_condition_group, evt)
         return evaluation
+
+    def get_filtered_actions(self, evt: GroupEvent) -> bool:
+        """
+        Evaluate the conditions for the workflow action filters and return the results.
+        If there isn't a filter_condition_group, the workflow should always trigger.
+        """
+        actions = self.workflowdataconditiongroup_set.all()
+        filtered_actions = set()
+
+        for action in actions:
+            evaluation, result = evaluate_condition_group(action, evt)
+
+            print("Action: ", action, "evaluation: ", evaluation, "result: ", result)
+
+            if evaluation:
+                filtered_actions.add(action)
+
+        return filtered_actions

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -60,21 +60,3 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
 
         evaluation, _ = evaluate_condition_group(self.when_condition_group, evt)
         return evaluation
-
-    def get_filtered_actions(self, evt: GroupEvent) -> bool:
-        """
-        Evaluate the conditions for the workflow action filters and return the results.
-        If there isn't a filter_condition_group, the workflow should always trigger.
-        """
-        actions = self.workflowdataconditiongroup_set.all()
-        filtered_actions = set()
-
-        for action in actions:
-            evaluation, result = evaluate_condition_group(action, evt)
-
-            print("Action: ", action, "evaluation: ", evaluation, "result: ", result)
-
-            if evaluation:
-                filtered_actions.add(action)
-
-        return filtered_actions

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -1,0 +1,28 @@
+from sentry.db.models.manager.base_query_set import BaseQuerySet
+from sentry.eventstore.models import GroupEvent
+from sentry.workflow_engine.models import Action, DataConditionGroup, Workflow
+from sentry.workflow_engine.processors.data_condition_group import evaluate_condition_group
+
+
+def evaluate_workflow_action_filters(
+    workflows: set[Workflow], evt: GroupEvent
+) -> BaseQuerySet[Action]:
+    filtered_action_groups: set[DataConditionGroup] = set()
+
+    # gets the list of the workflow ids, and then get the workflow_data_condition_groups for those workflows
+    workflow_ids = {workflow.id for workflow in workflows}
+
+    action_conditions = DataConditionGroup.objects.filter(
+        workflowdataconditiongroup__workflow_id__in=workflow_ids
+    ).distinct()
+
+    for action_condition in action_conditions:
+        evaluation, result = evaluate_condition_group(action_condition, evt)
+
+        if evaluation:
+            filtered_action_groups.add(action_condition)
+
+    # get the actions for any of the triggered data condition groups
+    return Action.objects.filter(
+        dataconditiongroupaction__condition_group__in=filtered_action_groups
+    ).distinct()

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -5,6 +5,7 @@ from sentry.workflow_engine.types import DetectorType
 
 
 # TODO - cache these by evt.group_id? :thinking:
+# TODO - Move to process_detector
 def get_detector_by_event(evt: GroupEvent) -> Detector:
     issue_occurrence = evt.occurrence
 

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -26,6 +26,16 @@ def evaluate_workflow_triggers(workflows: set[Workflow], evt: GroupEvent) -> set
     return triggered_workflows
 
 
+def evaluate_workflow_action_filters(workflows: set[Workflow], evt: GroupEvent) -> set[Workflow]:
+    triggered_workflows: set[Workflow] = set()
+
+    for workflow in workflows:
+        if workflow.evaluate_action_filters(evt):
+            triggered_workflows.add(workflow)
+
+    return triggered_workflows
+
+
 def process_workflows(evt: GroupEvent):
     # Check to see if the GroupEvent has an issue occurrence
     detector = get_detector_by_event(evt)
@@ -33,11 +43,7 @@ def process_workflows(evt: GroupEvent):
     workflows = set(Workflow.objects.filter(detectorworkflow__detector_id=detector.id).distinct())
     triggered_workflows = evaluate_workflow_triggers(workflows, evt)
 
-    # get all the data_condition_group_ids from the triggered_workflows <=> workflow_data_condition_groups
-
-    # TODO - create processors/action.py: evaluate_actions(data_condition_group_ids, evt)
-    # TODO - decide if this should iterate the actions and call action.trigger
-    #         or just return the list of actions
-    #         or just return the trigger
+    # get all the triggered_workflow_groups from the triggered_workflows <=> workflow_data_condition_groups
+    # call `evaluate_workflow_actions` on the triggered groups, more or less the same as this stuff, but not triggered by an event.. is it?
 
     return triggered_workflows

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -30,7 +30,6 @@ def evaluate_workflow_triggers(workflows: set[Workflow], evt: GroupEvent) -> set
 def evaluate_workflow_action_filters(
     workflows: set[Workflow], evt: GroupEvent
 ) -> BaseQuerySet[Action]:
-    # TODO - decide if this should live here, or in procesors/action.py
     filtered_action_groups: set[DataConditionGroup] = set()
 
     # gets the list of the workflow ids, and then get the workflow_data_condition_groups for those workflows
@@ -52,7 +51,7 @@ def evaluate_workflow_action_filters(
     ).distinct()
 
 
-def process_workflows(evt: GroupEvent):
+def process_workflows(evt: GroupEvent) -> set[Workflow]:
     # Check to see if the GroupEvent has an issue occurrence
     detector = get_detector_by_event(evt)
 
@@ -61,7 +60,10 @@ def process_workflows(evt: GroupEvent):
 
     # get all the triggered_workflow_groups from the triggered_workflows <=> workflow_data_condition_groups
     # call `evaluate_workflow_actions` on the triggered groups, more or less the same as this stuff, but not triggered by an event.. is it?
-    # triggered_actions = evaluate_workflow_action_filters(triggered_workflows, evt)
+    actions = set(evaluate_workflow_action_filters(triggered_workflows, evt))
 
-    # TODO - return the triggered_workflows or triggered_actions, decide on the location of the processing
+    for action in actions:
+        action.trigger(evt, detector)
+
+    # TODO decide if this should return a tuple or not.
     return triggered_workflows

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -1,7 +1,6 @@
-from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.eventstore.models import GroupEvent
-from sentry.workflow_engine.models import Action, DataConditionGroup, Detector, Workflow
-from sentry.workflow_engine.processors.data_condition_group import evaluate_condition_group
+from sentry.workflow_engine.models import Detector, Workflow
+from sentry.workflow_engine.processors.action import evaluate_workflow_action_filters
 from sentry.workflow_engine.types import DetectorType
 
 
@@ -25,30 +24,6 @@ def evaluate_workflow_triggers(workflows: set[Workflow], evt: GroupEvent) -> set
             triggered_workflows.add(workflow)
 
     return triggered_workflows
-
-
-def evaluate_workflow_action_filters(
-    workflows: set[Workflow], evt: GroupEvent
-) -> BaseQuerySet[Action]:
-    filtered_action_groups: set[DataConditionGroup] = set()
-
-    # gets the list of the workflow ids, and then get the workflow_data_condition_groups for those workflows
-    workflow_ids = {workflow.id for workflow in workflows}
-
-    action_conditions = DataConditionGroup.objects.filter(
-        workflowdataconditiongroup__workflow_id__in=workflow_ids
-    ).distinct()
-
-    for action_condition in action_conditions:
-        evaluation, result = evaluate_condition_group(action_condition, evt)
-
-        if evaluation:
-            filtered_action_groups.add(action_condition)
-
-    # get the actions for any of the triggered data condition groups
-    return Action.objects.filter(
-        dataconditiongroupaction__condition_group__in=filtered_action_groups
-    ).distinct()
 
 
 def process_workflows(evt: GroupEvent) -> set[Workflow]:

--- a/src/sentry/workflow_engine/registry.py
+++ b/src/sentry/workflow_engine/registry.py
@@ -1,7 +1,8 @@
 from typing import Any
 
 from sentry.utils.registry import Registry
-from sentry.workflow_engine.types import DataConditionHandler, DataSourceTypeHandler
+from sentry.workflow_engine.types import ActionHandler, DataConditionHandler, DataSourceTypeHandler
 
 data_source_type_registry = Registry[type[DataSourceTypeHandler]]()
 condition_handler_registry = Registry[DataConditionHandler[Any]]()
+action_handler_registry = Registry[type[ActionHandler]]()

--- a/src/sentry/workflow_engine/registry.py
+++ b/src/sentry/workflow_engine/registry.py
@@ -5,4 +5,4 @@ from sentry.workflow_engine.types import ActionHandler, DataConditionHandler, Da
 
 data_source_type_registry = Registry[type[DataSourceTypeHandler]]()
 condition_handler_registry = Registry[DataConditionHandler[Any]]()
-action_handler_registry = Registry[type[ActionHandler]]()
+action_handler_registry = Registry[ActionHandler]()

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from enum import IntEnum, StrEnum
-from typing import Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from sentry.types.group import PriorityLevel
+
+if TYPE_CHECKING:
+    from sentry.workflow_engine.models import Action, Detector
 
 T = TypeVar("T")
 
@@ -22,6 +25,12 @@ DetectorGroupKey = str | None
 
 DataConditionResult = DetectorPriorityLevel | int | float | bool | None
 ProcessedDataConditionResult = tuple[bool, list[DataConditionResult]]
+
+
+class ActionHandler(Generic[T]):
+    @staticmethod
+    def execute(self, data: T, action: Action, detector: Detector) -> None:
+        raise NotImplementedError
 
 
 class DataSourceTypeHandler(Generic[T]):

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -29,7 +29,7 @@ ProcessedDataConditionResult = tuple[bool, list[DataConditionResult]]
 
 class ActionHandler(Generic[T]):
     @staticmethod
-    def execute(self, data: T, action: Action, detector: Detector) -> None:
+    def execute(data: T, action: Action, detector: Detector) -> None:
         raise NotImplementedError
 
 

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar
 from sentry.types.group import PriorityLevel
 
 if TYPE_CHECKING:
+    from sentry.eventstore.models import GroupEvent
     from sentry.workflow_engine.models import Action, Detector
 
 T = TypeVar("T")
@@ -27,9 +28,9 @@ DataConditionResult = DetectorPriorityLevel | int | float | bool | None
 ProcessedDataConditionResult = tuple[bool, list[DataConditionResult]]
 
 
-class ActionHandler(Generic[T]):
+class ActionHandler:
     @staticmethod
-    def execute(data: T, action: Action, detector: Detector) -> None:
+    def execute(group_event: GroupEvent, action: Action, detector: Detector) -> None:
         raise NotImplementedError
 
 

--- a/tests/sentry/workflow_engine/models/test_action.py
+++ b/tests/sentry/workflow_engine/models/test_action.py
@@ -26,13 +26,15 @@ class TestAction(TestCase):
             assert handler == mock_handler
 
     def test_get_handler_webhook_type(self):
+        self.action = Action(type=Action.Type.WEBHOOK)
+
         with patch("sentry.workflow_engine.registry.action_handler_registry.get") as mock_get:
             mock_handler = Mock(spec=ActionHandler)
             mock_get.return_value = mock_handler
 
             handler = self.action.get_handler()
 
-            mock_get.assert_called_once_with(Action.Type.NOTIFICATION)
+            mock_get.assert_called_once_with(Action.Type.WEBHOOK)
             assert handler == mock_handler
 
     def test_get_handler_unregistered_type(self):

--- a/tests/sentry/workflow_engine/models/test_action.py
+++ b/tests/sentry/workflow_engine/models/test_action.py
@@ -1,0 +1,68 @@
+from unittest.mock import Mock, patch
+
+import pytest
+from django.test import TestCase
+
+from sentry.eventstore.models import GroupEvent
+from sentry.utils.registry import NoRegistrationExistsError
+from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.types import ActionHandler
+
+
+class TestAction(TestCase):
+    def setUp(self):
+        self.mock_event = Mock(spec=GroupEvent)
+        self.mock_detector = Mock(name="detector")
+        self.action = Action(type=Action.Type.NOTIFICATION)
+
+    def test_get_handler_notification_type(self):
+        with patch("sentry.workflow_engine.registry.action_handler_registry.get") as mock_get:
+            mock_handler = Mock(spec=ActionHandler)
+            mock_get.return_value = mock_handler
+
+            handler = self.action.get_handler()
+
+            mock_get.assert_called_once_with(Action.Type.NOTIFICATION)
+            assert handler == mock_handler
+
+    def test_get_handler_webhook_type(self):
+        with patch("sentry.workflow_engine.registry.action_handler_registry.get") as mock_get:
+            mock_handler = Mock(spec=ActionHandler)
+            mock_get.return_value = mock_handler
+
+            handler = self.action.get_handler()
+
+            mock_get.assert_called_once_with(Action.Type.NOTIFICATION)
+            assert handler == mock_handler
+
+    def test_get_handler_unregistered_type(self):
+        with patch("sentry.workflow_engine.registry.action_handler_registry.get") as mock_get:
+            mock_get.side_effect = NoRegistrationExistsError(
+                "No handler registered for notification type"
+            )
+
+            with pytest.raises(
+                NoRegistrationExistsError, match="No handler registered for notification type"
+            ):
+                self.action.get_handler()
+
+            # Verify the registry was queried with the correct action type
+            mock_get.assert_called_once_with(Action.Type.NOTIFICATION)
+
+    def test_trigger_calls_handler_execute(self):
+        mock_handler = Mock(spec=ActionHandler)
+
+        with patch.object(self.action, "get_handler", return_value=mock_handler):
+            self.action.trigger(self.mock_event, self.mock_detector)
+
+            mock_handler.execute.assert_called_once_with(
+                self.mock_event, self.action, self.mock_detector
+            )
+
+    def test_trigger_with_failing_handler(self):
+        mock_handler = Mock(spec=ActionHandler)
+        mock_handler.execute.side_effect = Exception("Handler failed")
+
+        with patch.object(self.action, "get_handler", return_value=mock_handler):
+            with pytest.raises(Exception, match="Handler failed"):
+                self.action.trigger(self.mock_event, self.mock_detector)

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -1,0 +1,47 @@
+from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.processors.action import evaluate_workflow_action_filters
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
+
+
+class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
+    def setUp(self):
+        (
+            self.workflow,
+            self.detector,
+            self.detector_workflow,
+            self.workflow_triggers,
+        ) = self.create_detector_and_workflow()
+
+        self.action_group, self.action = self.create_workflow_action(workflow=self.workflow)
+
+        self.group, self.event, self.group_event = self.create_group_event(
+            occurrence=self.build_occurrence_data(evidence_data={"detector_id": self.detector.id})
+        )
+
+    def test_basic__no_filter(self):
+        triggered_actions = evaluate_workflow_action_filters({self.workflow}, self.group_event)
+        assert set(triggered_actions) == {self.action}
+
+    def test_basic__with_filter__passes(self):
+        self.create_data_condition(
+            condition_group=self.action_group,
+            type=Condition.GROUP_EVENT_ATTR_COMPARISON,
+            condition="group.times_seen",
+            comparison=1,
+            condition_result=True,
+        )
+
+        triggered_actions = evaluate_workflow_action_filters({self.workflow}, self.group_event)
+        assert set(triggered_actions) == {self.action}
+
+    def test_basic__with_filter__filtered(self):
+        # Add a filter to the action's group
+        self.create_data_condition(
+            condition_group=self.action_group,
+            type=Condition.GROUP_EVENT_ATTR_COMPARISON,
+            condition="occurrence.evidence_data.detector_id",
+            comparison=self.detector.id + 1,
+        )
+
+        triggered_actions = evaluate_workflow_action_filters({self.workflow}, self.group_event)
+        assert not triggered_actions

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -9,9 +9,13 @@ from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 class TestProcessWorkflows(BaseWorkflowTest):
     def setUp(self):
-        self.workflow, self.detector, self.detector_workflow, self.workflow_triggers = (
-            self.create_detector_and_workflow()
-        )
+        (
+            self.workflow,
+            self.detector,
+            self.detector_workflow,
+            self.workflow_triggers,
+        ) = self.create_detector_and_workflow()
+
         self.error_workflow, self.error_detector, self.detector_workflow_error, _ = (
             self.create_detector_and_workflow(
                 name_prefix="error",
@@ -36,20 +40,14 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
 class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
     def setUp(self):
-        self.workflow, self.detector, self.detector_workflow, self.workflow_triggers = (
-            self.create_detector_and_workflow()
-        )
+        (
+            self.workflow,
+            self.detector,
+            self.detector_workflow,
+            self.workflow_triggers,
+        ) = self.create_detector_and_workflow()
 
-        self.action_group = self.create_data_condition_group(logic_type="any-short")
-        self.workflow_action_group = self.create_workflow_data_condition_group(
-            self.workflow, self.action_group
-        )
-
-        self.action = self.create_action(type="SendNotificationAction", data={"message": "test"})
-        self.create_data_condition_group_action(
-            condition_group=self.action_group,
-            action=self.action,
-        )
+        self.action_group, self.action = self.create_workflow_action(workflow=self.workflow)
 
         self.group, self.event, self.group_event = self.create_group_event(
             occurrence=self.build_occurrence_data(evidence_data={"detector_id": self.detector.id})
@@ -72,6 +70,7 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
         assert set(triggered_actions) == {self.action}
 
     def test_basic__with_filter__filtered(self):
+        # Add a filter to the action's group
         self.create_data_condition(
             condition_group=self.action_group,
             type=Condition.GROUP_EVENT_ATTR_COMPARISON,

--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -94,7 +94,7 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
 
         return workflow, detector, detector_workflow, workflow_triggers
 
-    def create_group_event(self, project=None, **kwargs) -> tuple[Group, Event, GroupEvent]:
+    def create_group_event(self, project=None, occurrence=None) -> tuple[Group, Event, GroupEvent]:
         project = project or self.project
         group = self.create_group(project)
         event = self.create_event(
@@ -109,6 +109,7 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
             group,
             event.data,
             event._snuba_data,
+            occurrence,
         )
 
         return group, event, group_event


### PR DESCRIPTION
## Description
This PR adds:
- `evaluate_workflow_action_filters`. This method takes a set of Workflows, and the GroupEvent that triggered the workflow. It then processes the Workflow conditions with the GroupEvent to see if the action conditions are met. (*NOTE* This isn't fully setup, we will need to take into account more kinds of conditions, but waiting until we have more examples to make this more generic).
- `Action.trigger` and helper methods, to invoke an action with all the pertinent data.
- `create_workflow_action` to `BaseWorkflowTest`, allowing us to easily add an action to a workflow.