### PR TITLE
fix(insights): Fix text overflows within mobile screen rendering tables

### DIFF
--- a/static/app/views/insights/mobile/ui/components/tables/spanOperationTable.tsx
+++ b/static/app/views/insights/mobile/ui/components/tables/spanOperationTable.tsx
@@ -175,9 +175,11 @@ export function SpanOperationTable({
       };
 
       return (
-        <Link to={`${pathname}?${qs.stringify(query)}`}>
-          <OverflowEllipsisTextContainer>{label}</OverflowEllipsisTextContainer>
-        </Link>
+        <OverflowEllipsisTextContainer>
+          <Link to={`${pathname}?${qs.stringify(query)}`}>
+            <OverflowEllipsisTextContainer>{label}</OverflowEllipsisTextContainer>
+          </Link>
+        </OverflowEllipsisTextContainer>
       );
     }
 

--- a/static/app/views/insights/mobile/ui/components/tables/uiScreensTable.tsx
+++ b/static/app/views/insights/mobile/ui/components/tables/uiScreensTable.tsx
@@ -13,6 +13,7 @@ import {
   PRIMARY_RELEASE_ALIAS,
   SECONDARY_RELEASE_ALIAS,
 } from 'sentry/views/insights/common/components/releaseSelector';
+import {OverflowEllipsisTextContainer} from 'sentry/views/insights/common/components/textAlign';
 import {useReleaseSelection} from 'sentry/views/insights/common/queries/useReleases';
 import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
 import {ScreensTable} from 'sentry/views/insights/mobile/common/components/tables/screensTable';
@@ -102,19 +103,21 @@ export function UIScreensTable({data, eventView, isLoading, pageLinks}: Props) {
     if (field === 'transaction') {
       return (
         <Fragment>
-          <TopResultsIndicator count={TOP_SCREENS} index={index} />
-          <Link
-            to={`${moduleURL}/spans/?${qs.stringify({
-              ...location.query,
-              project: row['project.id'],
-              transaction: row.transaction,
-              primaryRelease,
-              secondaryRelease,
-            })}`}
-            style={{display: `block`, width: `100%`}}
-          >
-            {row.transaction}
-          </Link>
+          <OverflowEllipsisTextContainer>
+            <TopResultsIndicator count={TOP_SCREENS} index={index} />
+            <Link
+              to={`${moduleURL}/spans/?${qs.stringify({
+                ...location.query,
+                project: row['project.id'],
+                transaction: row.transaction,
+                primaryRelease,
+                secondaryRelease,
+              })}`}
+              style={{display: `block`, width: `100%`}}
+            >
+              {row.transaction}
+            </Link>
+          </OverflowEllipsisTextContainer>
         </Fragment>
       );
     }


### PR DESCRIPTION
Wrap txn/span descriptions, so they don't overflow the tables.

Before:
<img width="705" alt="image" src="https://github.com/user-attachments/assets/16cec345-cb65-4ab6-ba05-4d3e72e106dd">


After: 
<img width="635" alt="image" src="https://github.com/user-attachments/assets/2f945969-224e-4266-b725-19d8167ae71e">
