### PR TITLE
fix(quick-start): Do not display waiting event in 'adding second platform' task

### DIFF
--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -313,7 +313,7 @@ export function getOnboardingTasks({
       display: true,
       pendingTitle: t('Awaiting an error for this project.'),
       SupplementComponent: ({task}: OnboardingSupplementComponentProps) => {
-        if (!hasQuickStartUpdatesFeature(organization)) {
+        if (hasQuickStartUpdatesFeature(organization)) {
           return null;
         }
         if (!projects?.length || task.requisiteTasks.length > 0 || taskIsDone(task)) {


### PR DESCRIPTION
Users no longer need to send an error event. Creating a new project will complete the task, so 'waiting for event' is no longer needed in the new experience.