### PR TITLE
fix(visibility): Improve `LineChartWidget` padding

### DIFF
--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidgetVisualization.tsx
@@ -170,10 +170,21 @@ export function LineChartWidgetVisualization(props: LineChartWidgetVisualization
           }),
       ].filter(defined)}
       utc={props.utc}
-      legend={{
-        top: 0,
+      grid={{
         left: 0,
+        top: props.timeseries.length > 1 ? 25 : 10,
+        right: 1,
+        bottom: 0,
+        containLabel: true,
       }}
+      legend={
+        props.timeseries.length > 1
+          ? {
+              top: 0,
+              left: 0,
+            }
+          : undefined
+      }
       tooltip={{
         trigger: 'axis',
         axisPointer: {


### PR DESCRIPTION
- hide legend if only one series is rendered
- flexibly position the grid

This is more akin to how we render these in dashboards, and is a pretty good approach. This'll get better once we render custom legends.
