### PR TITLE
feat(insights): new badge geo region selector

### DIFF
--- a/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
@@ -66,7 +66,7 @@ export default function SubregionSelector({size}: Props) {
       triggerProps={{
         prefix: (
           <Fragment>
-            <StyledFeatureBadge type="beta" />
+            <StyledFeatureBadge type="new" />
             {t('Geo region')}
           </Fragment>
         ),


### PR DESCRIPTION
Work for https://github.com/getsentry/sentry/issues/81663
The region selector is going to GA, change the beta badge to a new badge.