### PR TITLE
ref(issues): remove duplicate view full trace button

### DIFF
--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -133,7 +133,9 @@ function IssuesTraceOverlay({event}: {event: Event}) {
         icon={<IconOpen />}
         aria-label={t('Open Trace')}
         to={traceTarget}
-      />
+      >
+        {t('View Full Trace')}
+      </LinkButton>
     </IssuesTraceOverlayContainer>
   );
 }
@@ -176,7 +178,7 @@ export function EventTraceView({group, event, organization}: EventTraceViewProps
 
   return (
     <InterimSection type={SectionKey.TRACE} title={t('Trace')}>
-      <TraceDataSection event={event} />
+      <TraceDataSection event={event} group={group} />
       {hasTracePreviewFeature && (
         <EventTraceViewInner
           event={event}

--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -133,7 +133,9 @@ function IssuesTraceOverlay({event}: {event: Event}) {
         icon={<IconOpen />}
         aria-label={t('Open Trace')}
         to={traceTarget}
-      />
+      >
+        {t('View Full Trace')}
+      </LinkButton>
     </IssuesTraceOverlayContainer>
   );
 }

--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -133,9 +133,7 @@ function IssuesTraceOverlay({event}: {event: Event}) {
         icon={<IconOpen />}
         aria-label={t('Open Trace')}
         to={traceTarget}
-      >
-        {t('View Full Trace')}
-      </LinkButton>
+      />
     </IssuesTraceOverlayContainer>
   );
 }
@@ -178,7 +176,7 @@ export function EventTraceView({group, event, organization}: EventTraceViewProps
 
   return (
     <InterimSection type={SectionKey.TRACE} title={t('Trace')}>
-      <TraceDataSection event={event} group={group} />
+      <TraceDataSection event={event} />
       {hasTracePreviewFeature && (
         <EventTraceViewInner
           event={event}

--- a/static/app/views/issueDetails/traceDataSection.tsx
+++ b/static/app/views/issueDetails/traceDataSection.tsx
@@ -4,33 +4,18 @@ import styled from '@emotion/styled';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
-import type {Group} from 'sentry/types/group';
-import {IssueCategory} from 'sentry/types/group';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
-import useOrganization from 'sentry/utils/useOrganization';
 
 import {TraceIssueEvent} from './traceTimeline/traceIssue';
 import {TraceLink} from './traceTimeline/traceLink';
 import {TraceTimeline} from './traceTimeline/traceTimeline';
 import {useTraceTimelineEvents} from './traceTimeline/useTraceTimelineEvents';
 
-export function TraceDataSection({event, group}: {event: Event; group: Group}) {
-  const organization = useOrganization();
+export function TraceDataSection({event}: {event: Event}) {
   // This is also called within the TraceTimeline component but caching will save a second call
   const {isLoading, oneOtherIssueEvent} = useTraceTimelineEvents({
     event,
   });
-
-  const hasProfilingFeature = organization.features.includes('profiling');
-  const hasIssueDetailsTrace = organization.features.includes(
-    'issue-details-always-show-trace'
-  );
-  const hasTracePreviewFeature =
-    hasProfilingFeature &&
-    hasIssueDetailsTrace &&
-    // Only display this for error or default events since performance events are handled elsewhere
-    group.issueCategory !== IssueCategory.PERFORMANCE;
-
   let params: Record<string, boolean> = {};
   if (!isLoading && oneOtherIssueEvent !== undefined) {
     params = {
@@ -50,8 +35,7 @@ export function TraceDataSection({event, group}: {event: Event; group: Group}) {
         {oneOtherIssueEvent && (
           <span>{t('One other issue appears in the same trace.')}</span>
         )}
-        {/* If the user has trace preview, they are seeing the link to the full trace there already and we wont duplicate it */}
-        {!hasTracePreviewFeature && <TraceLink event={event} />}
+        <TraceLink event={event} />
       </StyledTraceLink>
       {oneOtherIssueEvent === undefined ? (
         <TraceTimeline event={event} />

--- a/static/app/views/issueDetails/traceDataSection.tsx
+++ b/static/app/views/issueDetails/traceDataSection.tsx
@@ -4,18 +4,33 @@ import styled from '@emotion/styled';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
+import type {Group} from 'sentry/types/group';
+import {IssueCategory} from 'sentry/types/group';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
+import useOrganization from 'sentry/utils/useOrganization';
 
 import {TraceIssueEvent} from './traceTimeline/traceIssue';
 import {TraceLink} from './traceTimeline/traceLink';
 import {TraceTimeline} from './traceTimeline/traceTimeline';
 import {useTraceTimelineEvents} from './traceTimeline/useTraceTimelineEvents';
 
-export function TraceDataSection({event}: {event: Event}) {
+export function TraceDataSection({event, group}: {event: Event; group: Group}) {
+  const organization = useOrganization();
   // This is also called within the TraceTimeline component but caching will save a second call
   const {isLoading, oneOtherIssueEvent} = useTraceTimelineEvents({
     event,
   });
+
+  const hasProfilingFeature = organization.features.includes('profiling');
+  const hasIssueDetailsTrace = organization.features.includes(
+    'issue-details-always-show-trace'
+  );
+  const hasTracePreviewFeature =
+    hasProfilingFeature &&
+    hasIssueDetailsTrace &&
+    // Only display this for error or default events since performance events are handled elsewhere
+    group.issueCategory !== IssueCategory.PERFORMANCE;
+
   let params: Record<string, boolean> = {};
   if (!isLoading && oneOtherIssueEvent !== undefined) {
     params = {
@@ -35,7 +50,8 @@ export function TraceDataSection({event}: {event: Event}) {
         {oneOtherIssueEvent && (
           <span>{t('One other issue appears in the same trace.')}</span>
         )}
-        <TraceLink event={event} />
+        {/* If the user has trace preview, they are seeing the link to the full trace there already and we wont duplicate it */}
+        {!hasTracePreviewFeature && <TraceLink event={event} />}
       </StyledTraceLink>
       {oneOtherIssueEvent === undefined ? (
         <TraceTimeline event={event} />


### PR DESCRIPTION
No need to duplicate the trace link button if the user has trace preview