### PR TITLE
fix(taskworker) Fix off by one in retry counts

### DIFF
--- a/src/sentry/taskworker/retry.py
+++ b/src/sentry/taskworker/retry.py
@@ -35,8 +35,10 @@ class Retry:
         self._times_exceeded = times_exceeded
 
     def should_retry(self, state: RetryState, exc: Exception) -> bool:
-        # No more attempts left
-        if state.attempts >= self._times:
+        # No more attempts left.
+        # We subtract one, as attempts starts at 0, but `times`
+        # starts at 1.
+        if state.attempts >= (self._times - 1):
             return False
 
         # Explicit RetryError with attempts left.

--- a/tests/sentry/taskworker/test_retry.py
+++ b/tests/sentry/taskworker/test_retry.py
@@ -47,7 +47,7 @@ def test_should_retry_retryerror() -> None:
     err = RetryError("something bad")
     assert retry.should_retry(state, err)
 
-    state.attempts = 5
+    state.attempts = 4
     assert not retry.should_retry(state, err)
 
 
@@ -57,6 +57,13 @@ def test_should_retry_multiprocessing_timeout() -> None:
 
     timeout = TimeoutError("timeouts should retry if there are attempts left")
     assert retry.should_retry(state, timeout)
+
+    state.attempts = 1
+    assert retry.should_retry(state, timeout)
+
+    # attempt = 2 is actually the third attempt.
+    state.attempts = 2
+    assert not retry.should_retry(state, timeout)
 
     state.attempts = 3
     assert not retry.should_retry(state, timeout)


### PR DESCRIPTION
When tasks activations are appended to kafka they have attempts=0. The `times` attribute of a task retry is expressed starting from 1, so we need to modify `times` when checking if we've exhausted retry attempts.