### PR TITLE
fix(relocation): Indentation error

### DIFF
--- a/src/sentry/tasks/relocation.py
+++ b/src/sentry/tasks/relocation.py
@@ -1521,7 +1521,7 @@ def postprocessing(uuid: UUID) -> None:
             except Exception as e:
                 capture_exception(e)
 
-    notifying_unhide.apply_async(args=[uuid])
+        notifying_unhide.apply_async(args=[uuid])
 
 
 @instrumented_task(


### PR DESCRIPTION
Want this to run inside of the `start_relocation_task`'s scope.