### PR TITLE
chore(explore): margin tweaks

### DIFF
--- a/static/app/views/explore/toolbar/styles.tsx
+++ b/static/app/views/explore/toolbar/styles.tsx
@@ -33,14 +33,15 @@ export const ToolbarFooterButton = styled(Button)<{disabled?: boolean}>`
   color: ${p => (p.disabled ? p.theme.gray300 : p.theme.linkColor)};
 `;
 
-export const ToolbarFooter = styled('div')<{disabled?: boolean}>`
-  margin: ${space(0.5)} 0;
-`;
+export const ToolbarFooter = styled('div')<{disabled?: boolean}>``;
 
 export const ToolbarRow = styled('div')`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   gap: ${space(0.5)};
-  margin-bottom: ${space(0.5)};
+
+  :not(:last-child) {
+    margin-bottom: ${space(0.5)};
+  }
 `;

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -11,7 +11,6 @@ import {IconAdd} from 'sentry/icons/iconAdd';
 import {IconDelete} from 'sentry/icons/iconDelete';
 import {IconGrabbable} from 'sentry/icons/iconGrabbable';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import {useGroupBys} from 'sentry/views/explore/hooks/useGroupBys';
 
@@ -96,7 +95,7 @@ export function ToolbarGroupBy({disabled}: ToolbarGroupByProps) {
 
         return (
           <ToolbarSection data-test-id="section-group-by">
-            <StyledToolbarHeader>
+            <ToolbarHeader>
               <Tooltip
                 position="right"
                 title={t(
@@ -115,7 +114,7 @@ export function ToolbarGroupBy({disabled}: ToolbarGroupByProps) {
                   icon={<IconAdd />}
                 />
               </Tooltip>
-            </StyledToolbarHeader>
+            </ToolbarHeader>
             {columnEditorRows}
           </ToolbarSection>
         );
@@ -126,10 +125,6 @@ export function ToolbarGroupBy({disabled}: ToolbarGroupByProps) {
 
 const FullWidthTooltip = styled(Tooltip)`
   width: 100%;
-`;
-
-const StyledToolbarHeader = styled(ToolbarHeader)`
-  margin-bottom: ${space(1)};
 `;
 
 interface ColumnEditorRowProps {
@@ -165,7 +160,7 @@ function ColumnEditorRow({
   }, [column.column, options]);
 
   return (
-    <RowContainer
+    <ToolbarRow
       key={column.id}
       ref={setNodeRef}
       style={{
@@ -204,15 +199,9 @@ function ColumnEditorRow({
         icon={<IconDelete size="sm" />}
         onClick={() => onColumnDelete()}
       />
-    </RowContainer>
+    </ToolbarRow>
   );
 }
-
-const RowContainer = styled(ToolbarRow)`
-  :not(:first-child) {
-    margin-top: ${space(1)};
-  }
-`;
 
 const StyledCompactSelect = styled(CompactSelect)`
   flex-grow: 1;

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -246,7 +246,7 @@ const ChartLabel = styled('div')`
   background-color: ${p => p.theme.purple100};
   border-radius: ${p => p.theme.borderRadius};
   text-align: center;
-  width: 32px;
+  width: 38px;
   color: ${p => p.theme.purple400};
   white-space: nowrap;
   font-weight: ${p => p.theme.fontWeightBold};


### PR DESCRIPTION
When Samples and Aggregates are toggled, the margin under Group By changes. This fixes that.

**Before:**
![Screenshot 2024-12-04 at 10 17 25 AM](https://github.com/user-attachments/assets/0f48359a-9ebb-42a6-bfab-cb30857edbf0)

**After:**
![Screenshot 2024-12-04 at 10 18 52 AM](https://github.com/user-attachments/assets/f486361f-2e1b-4071-8627-25912002ac79)

