### PR TITLE
feat(dashboards): `WidgetSyncContext`

### DIFF
--- a/static/app/views/dashboards/contexts/widgetSyncContext.stories.tsx
+++ b/static/app/views/dashboards/contexts/widgetSyncContext.stories.tsx
@@ -1,0 +1,73 @@
+import {Fragment, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/button';
+import JSXNode from 'sentry/components/stories/jsxNode';
+import SideBySide from 'sentry/components/stories/sideBySide';
+import storyBook from 'sentry/stories/storyBook';
+
+import {LineChartWidget} from '../widgets/lineChartWidget/lineChartWidget';
+import sampleDurationTimeSeries from '../widgets/lineChartWidget/sampleDurationTimeSeries.json';
+import sampleThroughputTimeSeries from '../widgets/lineChartWidget/sampleThroughputTimeSeries.json';
+
+import {WidgetSyncContextProvider} from './widgetSyncContext';
+
+export default storyBook('WidgetSyncContext', story => {
+  story('Getting Started', () => {
+    const [visible, setVisible] = useState<boolean>(false);
+
+    return (
+      <Fragment>
+        <p>
+          <JSXNode name="WidgetSyncContext" /> is a Dashboard Widget Context. All Line
+          Chart widgets within this context will be synchronized via{' '}
+          <code>echarts.connect</code>
+        </p>
+
+        <p>
+          <Button onClick={() => setVisible(true)}>Show Second Chart</Button>{' '}
+          <Button onClick={() => setVisible(false)}>Hide Second Chart</Button>
+        </p>
+
+        <WidgetSyncContextProvider>
+          <SideBySide>
+            <MediumWidget>
+              <LineChartWidget
+                title="span.duration"
+                timeseries={[sampleDurationTimeSeries]}
+                meta={{
+                  fields: {
+                    'span.duration': 'duration',
+                  },
+                  units: {
+                    'span.duration': 'millisecond',
+                  },
+                }}
+              />
+            </MediumWidget>
+            {visible && (
+              <MediumWidget>
+                <LineChartWidget
+                  title="span.duration"
+                  timeseries={[sampleThroughputTimeSeries]}
+                  meta={{
+                    fields: {
+                      'spm()': 'rate',
+                    },
+                    units: {
+                      'spm()': '1/minute',
+                    },
+                  }}
+                />
+              </MediumWidget>
+            )}
+          </SideBySide>
+        </WidgetSyncContextProvider>
+      </Fragment>
+    );
+  });
+});
+const MediumWidget = styled('div')`
+  width: 420px;
+  height: 250px;
+`;

--- a/static/app/views/dashboards/contexts/widgetSyncContext.tsx
+++ b/static/app/views/dashboards/contexts/widgetSyncContext.tsx
@@ -1,0 +1,58 @@
+import type {ReactNode} from 'react';
+import type {EChartsType} from 'echarts';
+import * as echarts from 'echarts';
+
+import {uniqueId} from 'sentry/utils/guid';
+import {createDefinedContext} from 'sentry/utils/performance/contexts/utils';
+
+type RegistrationFunction = (chart: EChartsType) => void;
+
+interface WidgetSyncContext {
+  register: RegistrationFunction;
+}
+
+const [_WidgetSyncProvider, _useWidgetSyncContext, WidgetSyncContext] =
+  createDefinedContext<WidgetSyncContext>({
+    name: 'WidgetSyncContext',
+    strict: false,
+  });
+
+interface WidgetSyncContextProviderProps {
+  children: ReactNode;
+  groupName?: string;
+}
+
+export function WidgetSyncContextProvider({
+  children,
+  groupName = uniqueId(),
+}: WidgetSyncContextProviderProps) {
+  const register: RegistrationFunction = chart => {
+    chart.group = groupName;
+    echarts?.connect(groupName);
+  };
+
+  return (
+    <_WidgetSyncProvider
+      value={{
+        register,
+      }}
+    >
+      {children}
+    </_WidgetSyncProvider>
+  );
+}
+
+export {WidgetSyncContext};
+
+export function useWidgetSyncContext(): WidgetSyncContext {
+  const context = _useWidgetSyncContext();
+
+  if (!context) {
+    // The provider was not registered, return a dummy function
+    return {
+      register: (_p: any) => null,
+    };
+  }
+
+  return context;
+}

--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidgetVisualization.tsx
@@ -5,17 +5,19 @@ import type {
   TooltipFormatterCallback,
   TopLevelFormatterParams,
 } from 'echarts/types/dist/shared';
+import type EChartsReactCore from 'echarts-for-react/lib/core';
 
 import BaseChart from 'sentry/components/charts/baseChart';
 import {getFormatter} from 'sentry/components/charts/components/tooltip';
 import LineSeries from 'sentry/components/charts/series/lineSeries';
 import {useChartZoom} from 'sentry/components/charts/useChartZoom';
 import {isChartHovered} from 'sentry/components/charts/utils';
-import type {ReactEchartsRef, Series} from 'sentry/types/echarts';
+import type {Series} from 'sentry/types/echarts';
 import {defined} from 'sentry/utils';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOrganization from 'sentry/utils/useOrganization';
 
+import {useWidgetSyncContext} from '../../contexts/widgetSyncContext';
 import {ReleaseSeries} from '../common/releaseSeries';
 import type {Meta, Release, TimeseriesData} from '../common/types';
 
@@ -31,7 +33,8 @@ export interface LineChartWidgetVisualizationProps {
 }
 
 export function LineChartWidgetVisualization(props: LineChartWidgetVisualizationProps) {
-  const chartRef = useRef<ReactEchartsRef>(null);
+  const chartRef = useRef<EChartsReactCore | null>(null);
+  const {register: registerWithWidgetSyncContext} = useWidgetSyncContext();
   const {meta} = props;
 
   const dataCompletenessDelay = props.dataCompletenessDelay ?? 0;
@@ -135,7 +138,13 @@ export function LineChartWidgetVisualization(props: LineChartWidgetVisualization
 
   return (
     <BaseChart
-      ref={chartRef}
+      ref={e => {
+        chartRef.current = e;
+
+        if (e) {
+          registerWithWidgetSyncContext(e.getEchartsInstance());
+        }
+      }}
       autoHeightResize
       series={[
         ...completeSeries.map(timeserie => {

--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidgetVisualization.tsx
@@ -141,7 +141,7 @@ export function LineChartWidgetVisualization(props: LineChartWidgetVisualization
       ref={e => {
         chartRef.current = e;
 
-        if (e) {
+        if (e?.getEchartsInstance) {
           registerWithWidgetSyncContext(e.getEchartsInstance());
         }
       }}


### PR DESCRIPTION
Implements the first context defined in the [Widget Contexts Spec](https://www.notion.so/sentry/Widget-Contexts-Spec-62cfb66a10a6424e90f270bc32ac3614?pvs=4#1528b10e4b5d80d59fdcf435bd7bac81), the `WidgetSyncContext`.

Right now this is a thin wrapper around `echarts.connect`, and works as an alternative to `useSynchronizeCharts`. The `useSynchronizeCharts` hook is fine, though it has a slightly awkward API (why would a user need to know how many charts are on the page?)

This context only works with `LineChartWidget` for now. It's an important step because it'll allow us to _manually_ sync context if we need to. That'll be a lesser hack than how we currently unsync chart series names and tooltips.

Closes https://github.com/getsentry/sentry/issues/81668

**e.g.,**
![Screenshot 2024-12-04 at 1 04 36 PM](https://github.com/user-attachments/assets/6765bed9-fccc-40c6-b533-ff608460fea8)
