### PR TITLE
fix(oauth): only remove the related tokens

### DIFF
--- a/src/sentry/api/endpoints/api_authorizations.py
+++ b/src/sentry/api/endpoints/api_authorizations.py
@@ -50,7 +50,9 @@ class ApiAuthorizationsEndpoint(Endpoint):
 
         with outbox_context(transaction.atomic(using=router.db_for_write(ApiToken)), flush=False):
             for token in ApiToken.objects.filter(
-                user_id=request.user.id, application=auth.application_id
+                user_id=request.user.id,
+                application=auth.application_id,
+                scoping_organization_id=auth.organization_id,
             ):
                 token.delete()
 

--- a/tests/sentry/api/endpoints/test_api_authorizations.py
+++ b/tests/sentry/api/endpoints/test_api_authorizations.py
@@ -51,3 +51,29 @@ class ApiAuthorizationsDeleteTest(ApiAuthorizationsTest):
         self.get_success_response(authorization=auth.id, status_code=204)
         assert not ApiAuthorization.objects.filter(id=auth.id).exists()
         assert not ApiToken.objects.filter(id=token.id).exists()
+
+    def test_with_org(self):
+        org1 = self.organization
+        org2 = self.create_organization(owner=self.user, slug="test-org-2")
+        app_with_org = ApiApplication.objects.create(
+            name="test-app", owner=self.user, requires_org_level_access=True
+        )
+        org1_auth = ApiAuthorization.objects.create(
+            application=app_with_org, user=self.user, organization_id=org1.id
+        )
+        org2_auth = ApiAuthorization.objects.create(
+            application=app_with_org, user=self.user, organization_id=org2.id
+        )
+        org1_token = ApiToken.objects.create(
+            application=app_with_org, user=self.user, scoping_organization_id=org1.id
+        )
+        org2_token = ApiToken.objects.create(
+            application=app_with_org, user=self.user, scoping_organization_id=org2.id
+        )
+
+        self.get_success_response(authorization=org1_auth.id, status_code=204)
+        assert not ApiAuthorization.objects.filter(id=org1_auth.id).exists()
+        assert not ApiToken.objects.filter(id=org1_token.id).exists()
+
+        assert ApiAuthorization.objects.filter(id=org2_auth.id).exists()
+        assert ApiToken.objects.filter(id=org2_token.id).exists()


### PR DESCRIPTION
Before this fix, if someone deleted 1 authorization for one org we would delete all tokens for that app even if they're related to another org. This was not an issue before because our application authorization was user level, and becomes a problem now that some of them become (org, user) level.