### PR TITLE
feat(grouping): Include frames which are missing the filename

### DIFF
--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -220,14 +220,10 @@ def get_stacktrace_string(data: dict[str, Any], platform: str | None = None) -> 
 
         for frame in contributing_frames:
             frame_dict = extract_values_from_frame_values(frame.get("values", []))
-            filename = extract_filename(frame_dict)
+            filename = extract_filename(frame_dict) or "None"
 
             if not _is_snipped_context_line(frame_dict["context-line"]):
                 found_non_snipped_context_line = True
-
-            if not filename:
-                # Skip the frame if we can't figure out the filename
-                continue
 
             # Not an exhaustive list of tests we could run to detect HTML, but this is only
             # meant to be a temporary, quick-and-dirty metric

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -366,7 +366,7 @@ def get_stacktrace_string_with_metrics(
     return stacktrace_string
 
 
-def event_content_has_stacktrace(event: Event) -> bool:
+def event_content_has_stacktrace(event: GroupEvent | Event) -> bool:
     # If an event has no stacktrace, there's no data for Seer to analyze, so no point in making the
     # API call. If we ever start analyzing message-only events, we'll need to add `event.title in
     # PLACEHOLDER_EVENT_TITLES` to this check.

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -4,7 +4,7 @@ from enum import StrEnum
 from typing import Any, TypeVar
 
 from sentry import options
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.killswitches import killswitch_matches_context
 from sentry.models.project import Project
 from sentry.utils import metrics
@@ -366,7 +366,7 @@ def get_stacktrace_string_with_metrics(
     return stacktrace_string
 
 
-def event_content_has_stacktrace(event: Event) -> bool:
+def event_content_has_stacktrace(event: GroupEvent) -> bool:
     # If an event has no stacktrace, there's no data for Seer to analyze, so no point in making the
     # API call. If we ever start analyzing message-only events, we'll need to add `event.title in
     # PLACEHOLDER_EVENT_TITLES` to this check.
@@ -376,7 +376,7 @@ def event_content_has_stacktrace(event: Event) -> bool:
     return exception_stacktrace or threads_stacktrace or only_stacktrace
 
 
-def event_content_is_seer_eligible(event: Event) -> bool:
+def event_content_is_seer_eligible(event: GroupEvent) -> bool:
     """
     Determine if an event's contents makes it fit for using with Seer's similar issues model.
     """
@@ -405,7 +405,7 @@ def event_content_is_seer_eligible(event: Event) -> bool:
     return True
 
 
-def killswitch_enabled(project_id: int, event: Event | None = None) -> bool:
+def killswitch_enabled(project_id: int, event: GroupEvent | None = None) -> bool:
     """
     Check both the global and similarity-specific Seer killswitches.
     """

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -4,7 +4,7 @@ from enum import StrEnum
 from typing import Any, TypeVar
 
 from sentry import options
-from sentry.eventstore.models import GroupEvent
+from sentry.eventstore.models import Event, GroupEvent
 from sentry.killswitches import killswitch_matches_context
 from sentry.models.project import Project
 from sentry.utils import metrics
@@ -366,7 +366,7 @@ def get_stacktrace_string_with_metrics(
     return stacktrace_string
 
 
-def event_content_has_stacktrace(event: GroupEvent) -> bool:
+def event_content_has_stacktrace(event: Event) -> bool:
     # If an event has no stacktrace, there's no data for Seer to analyze, so no point in making the
     # API call. If we ever start analyzing message-only events, we'll need to add `event.title in
     # PLACEHOLDER_EVENT_TITLES` to this check.
@@ -376,7 +376,7 @@ def event_content_has_stacktrace(event: GroupEvent) -> bool:
     return exception_stacktrace or threads_stacktrace or only_stacktrace
 
 
-def event_content_is_seer_eligible(event: GroupEvent) -> bool:
+def event_content_is_seer_eligible(event: GroupEvent | Event) -> bool:
     """
     Determine if an event's contents makes it fit for using with Seer's similar issues model.
     """
@@ -405,7 +405,7 @@ def event_content_is_seer_eligible(event: GroupEvent) -> bool:
     return True
 
 
-def killswitch_enabled(project_id: int, event: GroupEvent | None = None) -> bool:
+def killswitch_enabled(project_id: int, event: GroupEvent | Event | None = None) -> bool:
     """
     Check both the global and similarity-specific Seer killswitches.
     """

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -860,7 +860,10 @@ class GetStacktraceStringTest(TestCase):
         del exception["app"]["component"]["values"][0]["values"][0]["values"][0]["values"][0]
         stacktrace_string = get_stacktrace_string(exception)
         # It only includes the exception type and value because there's no filename or module
-        assert stacktrace_string == "ZeroDivisionError: division by zero"
+        assert (
+            stacktrace_string
+            == 'ZeroDivisionError: division by zero\n  File "None", function divide_by_zero\n    divide = 1/0'
+        )
 
 
 class EventContentIsSeerEligibleTest(TestCase):

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -1,18 +1,15 @@
 import copy
 from collections.abc import Callable
 from typing import Any, Literal, cast
-from unittest.mock import patch
 from uuid import uuid1
 
 import pytest
 
-from sentry import options
 from sentry.eventstore.models import Event
 from sentry.seer.similarity.utils import (
     BASE64_ENCODED_PREFIXES,
     MAX_FRAME_COUNT,
     SEER_ELIGIBLE_PLATFORMS,
-    NoFilenameOrModuleException,
     ReferrerOptions,
     TooManyOnlySystemFramesException,
     _is_snipped_context_line,
@@ -855,29 +852,15 @@ class GetStacktraceStringTest(TestCase):
             == 'ZeroDivisionError: division by zero\n  File "__main__", function divide_by_zero\n    divide = 1/0'
         )
 
-    @patch("sentry.seer.similarity.utils.metrics")
-    def test_no_filename_or_module(self, mock_metrics):
+    def test_no_filename_or_module(self):
         exception = copy.deepcopy(self.BASE_APP_DATA)
         # delete module from the exception
         del exception["app"]["component"]["values"][0]["values"][0]["values"][0]["values"][0]
         # delete filename from the exception
         del exception["app"]["component"]["values"][0]["values"][0]["values"][0]["values"][0]
-        with pytest.raises(NoFilenameOrModuleException):
-            get_stacktrace_string(exception)
-
-        stacktrace_string = get_stacktrace_string_with_metrics(
-            exception, "python", ReferrerOptions.INGEST
-        )
-        sample_rate = options.get("seer.similarity.metrics_sample_rate")
-        assert stacktrace_string is None
-        mock_metrics.incr.assert_called_with(
-            "grouping.similarity.did_call_seer",
-            sample_rate=sample_rate,
-            tags={
-                "call_made": False,
-                "blocker": "no-module-or-filename",
-            },
-        )
+        stacktrace_string = get_stacktrace_string(exception)
+        # It only includes the exception type and value because there's no filename or module
+        assert stacktrace_string == "ZeroDivisionError: division by zero"
 
 
 class EventContentIsSeerEligibleTest(TestCase):


### PR DESCRIPTION
A stack trace may sometimes contain frames without the `filename` or the `module`. 
    
Instead of aborting the call to Seer, we want to call it including the frame with the missing `filename` and `module`.

If we look at the Grouping Information section of an issue, we can notice that the frame with just the `function` is used for grouping.

This fixes ML grouping for issues on iOS.

<img width="227" alt="image" src="https://github.com/user-attachments/assets/377630fb-db76-40b1-b959-708825ea0905">

Caption: Some of these frames used for grouping only have `function` as the means for grouping.