### PR TITLE
fix(dashboards): Fix value units in `LineChartWidget` tooltips

### DIFF
--- a/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/lineChartWidget/lineChartWidgetVisualization.tsx
@@ -131,6 +131,9 @@ export function LineChartWidgetVisualization(props: LineChartWidgetVisualization
     return getFormatter({
       isGroupedByDate: true,
       showTimeInTooltip: true,
+      valueFormatter: value => {
+        return formatChartValue(value, type, unit);
+      },
       truncate: true,
       utc: props.utc ?? false,
     })(deDupedParams, asyncTicket);
@@ -189,9 +192,6 @@ export function LineChartWidgetVisualization(props: LineChartWidgetVisualization
           type: 'cross',
         },
         formatter,
-        valueFormatter: value => {
-          return formatChartValue(value, type, unit);
-        },
       }}
       yAxis={{
         axisLabel: {


### PR DESCRIPTION
I previously incorrectly set up the formatter, and the values were plain.

**Before:**
![Screenshot 2024-12-04 at 4 19 47 PM](https://github.com/user-attachments/assets/5d4c17fa-1d47-43c2-b954-32112af8f589)

**After:**
![Screenshot 2024-12-04 at 4 20 04 PM](https://github.com/user-attachments/assets/3776a10d-72fc-4c40-9c5e-520f980dbc31)
