### PR TITLE
fix(rpc): Table request's timezone

### DIFF
--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -1,7 +1,9 @@
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Literal
 
+from dateutil.tz import tz
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeAggregation,
     AttributeKey,
@@ -147,6 +149,10 @@ def simple_measurements_field(
         internal_name=field,
         search_type=search_type,
     )
+
+
+def datetime_processor(datetime_string: str) -> str:
+    return datetime.fromisoformat(datetime_string).replace(tzinfo=tz.tzutc()).isoformat()
 
 
 SPAN_COLUMN_DEFINITIONS = {
@@ -301,6 +307,12 @@ SPAN_COLUMN_DEFINITIONS = {
             internal_name="sentry.sampling_factor",
             search_type="percentage",
         ),
+        ResolvedColumn(
+            public_alias="timestamp",
+            internal_name="sentry.timestamp",
+            search_type="string",
+            processor=datetime_processor,
+        ),
         simple_sentry_field("browser.name"),
         simple_sentry_field("environment"),
         simple_sentry_field("messaging.destination.name"),
@@ -311,7 +323,6 @@ SPAN_COLUMN_DEFINITIONS = {
         simple_sentry_field("sdk.version"),
         simple_sentry_field("span.status_code"),
         simple_sentry_field("span_id"),
-        simple_sentry_field("timestamp"),
         simple_sentry_field("trace.status"),
         simple_sentry_field("transaction.method"),
         simple_sentry_field("transaction.op"),

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import mock
 
 import pytest
@@ -815,7 +815,9 @@ class OrganizationEventsSpanIndexedEndpointTest(OrganizationEventsEndpointTestBa
             assert result["span.duration"] == 1000.0, "duration"
             assert result["span.op"] == "", "op"
             assert result["span.description"] == source["description"], "description"
-            assert datetime.fromisoformat(result["timestamp"]).timestamp() == pytest.approx(
+            ts = datetime.fromisoformat(result["timestamp"])
+            assert ts.tzinfo == timezone.utc
+            assert ts.timestamp() == pytest.approx(
                 source["end_timestamp_precise"], abs=5
             ), "timestamp"
             assert result["transaction.span_id"] == source["segment_id"], "transaction.span_id"


### PR DESCRIPTION
- This adds a timestamp processor that defaults the timestamps we get to utc.
- This used to be handled by snuba via snql, but doesn't seem to happen with RPC anymore? :shrug: