### PR TITLE
fix(widget-builder): Make slideout fixed position

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -153,10 +153,7 @@ const SampleWidgetCard = styled(motion.div)<{isTable: boolean}>`
 const ContainerWithoutSidebar = styled('div')`
   position: absolute;
   top: 0;
-  bottom: 0;
-  right: 0;
   left: 0;
-  height: 100vh;
 `;
 
 const WidgetBuilderContainer = styled('div')`

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -166,6 +166,7 @@ const WidgetBuilderContainer = styled('div')`
   justify-content: space-between;
   height: 100vh;
   position: fixed;
-  width: -webkit-fill-available;
-  width: fill-available;
+  width: -webkit-fill-available; /* Chrome */
+  width: -moz-available; /* Firefox */
+  width: fill-available; /* others */
 `;

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -52,13 +52,15 @@ function WidgetBuilderV2({
       <AnimatePresence>
         {isOpen && (
           <WidgetBuilderProvider>
-            <WidgetBuilderContainer>
-              <WidgetBuilderSlideout isOpen={isOpen} onClose={onClose} />
-              <WidgetPreviewContainer
-                dashboardFilters={dashboardFilters}
-                dashboard={dashboard}
-              />
-            </WidgetBuilderContainer>
+            <ContainerWithoutSidebar>
+              <WidgetBuilderContainer>
+                <WidgetBuilderSlideout isOpen={isOpen} onClose={onClose} />
+                <WidgetPreviewContainer
+                  dashboardFilters={dashboardFilters}
+                  dashboard={dashboard}
+                />
+              </WidgetBuilderContainer>
+            </ContainerWithoutSidebar>
           </WidgetBuilderProvider>
         )}
       </AnimatePresence>
@@ -136,7 +138,7 @@ const Backdrop = styled('div')`
 `;
 
 const SampleWidgetCard = styled(motion.div)<{isTable: boolean}>`
-  width: 35vw;
+  width: 30vw;
   min-width: 400px;
   height: ${p => (p.isTable ? 'auto' : '400px')};
   border: 2px dashed ${p => p.theme.border};
@@ -148,11 +150,22 @@ const SampleWidgetCard = styled(motion.div)<{isTable: boolean}>`
   margin: auto;
 `;
 
+const ContainerWithoutSidebar = styled('div')`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  height: 100vh;
+`;
+
 const WidgetBuilderContainer = styled('div')`
-  ${fullPageCss}
   z-index: ${p => p.theme.zIndex.widgetBuilderDrawer};
   display: flex;
   align-items: center;
   justify-content: space-between;
   height: 100vh;
+  position: fixed;
+  width: -webkit-fill-available;
+  width: fill-available;
 `;


### PR DESCRIPTION
Made the widget builder container fixed and put a container on the outside to make sure it does not overlap with the navigation sidebar. Fixes this issue:

| Before | After |
|--------|--------|
| <img width="1504" alt="image" src="https://github.com/user-attachments/assets/be956eda-a9bf-4925-bdc1-d0936b100a5d"> | <img width="1509" alt="image" src="https://github.com/user-attachments/assets/015e878f-3f87-4f33-b638-be59c7392e83"> | 
