### PR TITLE
fix(issue-stream): Show tooltip when hovering over events column for new layout

### DIFF
--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -844,6 +844,7 @@ const CheckboxLabel = styled('label')<{hasNewLayout: boolean}>`
 `;
 
 const CountsWrapper = styled('div')`
+  position: relative;
   display: flex;
   flex-direction: column;
 `;


### PR DESCRIPTION
Needs position:relative for hover events to not be swallowed up by the full-row hover overlay.

![CleanShot 2024-12-04 at 14 54 55](https://github.com/user-attachments/assets/91dbdca6-0d24-4baf-8924-ee0ddaf9b2db)
