### PR TITLE
fix(crons): fix check-in env styling

### DIFF
--- a/static/app/views/monitors/components/overviewTimeline/overviewRow.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/overviewRow.tsx
@@ -171,7 +171,8 @@ export function OverviewRow({
           const {name, isMuted} = env;
           return (
             <EnvRow key={name}>
-              <DropdownMenu
+              <MonitorEnvironmentLabel monitorEnv={env} />
+              <EnvDropdown
                 size="sm"
                 trigger={triggerProps => (
                   <EnvActionButton
@@ -185,7 +186,6 @@ export function OverviewRow({
                   actionCreator(name, isMuted)
                 )}
               />
-              <MonitorEnvironmentLabel monitorEnv={env} />
             </EnvRow>
           );
         })}
@@ -345,6 +345,10 @@ const MonitorEnvContainer = styled('div')`
   flex-direction: column;
   border-right: 1px solid ${p => p.theme.innerBorder};
   text-align: right;
+`;
+
+const EnvDropdown = styled(DropdownMenu)`
+  text-align: left;
 `;
 
 const EnvRow = styled('div')`


### PR DESCRIPTION
hovering over the environment looked very clunky:

https://github.com/user-attachments/assets/adcd5087-95d8-437d-84a4-823993a9a86e


moved the dropdown to the right of the environment name so that the name no longer shifts, and the text is now left-aligned:
<img width="675" alt="Screenshot 2024-12-04 at 3 13 11 PM" src="https://github.com/user-attachments/assets/3df46c0e-91b8-4246-9582-abe7614b9871">
