### PR TITLE
fix(replay): Use braces to fix operator precedence

### DIFF
--- a/static/app/views/issueDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.tsx
@@ -271,7 +271,7 @@ function GroupReplaysTable({
     <StyledLayoutPage withPadding hasStreamlinedUI={hasStreamlinedUI}>
       <ReplayCountHeader>
         <IconUser size="sm" />
-        {replayCount ?? 0 > 50
+        {(replayCount ?? 0) > 50
           ? tn(
               'There are 50+ replays for this issue across %s event',
               'There are 50+ replays for this issue across %s events',


### PR DESCRIPTION
[<!-- Describe your PR here. -->](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_precedence#table)

So in JS `>` happens before `??`

Which means that this:
```javascript
function check(value: undefined | number) {
  return value ?? 0 > 50; // returns `undefined | boolean`
}
```
is not the same as:
```javascript
function check(value: undefined | number) {
  return (value ?? 0) > 50; // returns boolean
}
```

Checkout the playground here and hover to see the real types: https://www.typescriptlang.org/play/?ssl=7&ssc=52&pln=6&pc=1#code/PTAEAsBdIBwZwFwgCYFMBuqA2B7GqAnAOgFscAvASyywEMicCBzYVAOwFoBVAZWGRwBjOMADqqAEbAAUrXS0eggpRiRgAJVQAzQu0GpgAeXwFakRiOOEzjAPowCqfWjb6AxJFoSsqAFC+tAFdXSEocNlBBcCcAa1sAdwJwpgAKeSxA1ARQYLQtSjZUZFAAH1A2QJIJQgBKUABvX1BQR0hAggj0zNAAfh7QAAZQAD5QAFYBgG5QEBbUNo64UAADXO0CotLQCRwcH1o2Zd8AX38gkLCIqNjbQUZHQUg02gysnLY8jeKyiqrahqacwWEWer16-QGdVGE2ms1a7TYSx2e1QBxOQA