### PR TITLE
fix(explore): Remove hover effect on sample spans

### DIFF
--- a/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
+++ b/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
@@ -302,7 +302,6 @@ export function SpanBreakdownSliceRenderer({
   onMouseEnter,
   offset,
 }: {
-  onMouseEnter: () => void;
   sliceEnd: number;
   sliceName: string | null;
   sliceSecondaryName: string | null;
@@ -310,6 +309,7 @@ export function SpanBreakdownSliceRenderer({
   theme: Theme;
   trace: TraceResult;
   offset?: number;
+  onMouseEnter?: () => void;
   sliceDurationReal?: number;
   sliceNumberStart?: number;
   sliceNumberWidth?: number;

--- a/static/app/views/explore/tables/tracesTable/index.tsx
+++ b/static/app/views/explore/tables/tracesTable/index.tsx
@@ -175,17 +175,8 @@ function TraceRow({
   const {selection} = usePageFilters();
   const {projects} = useProjects();
   const [expanded, setExpanded] = useState<boolean>(defaultExpanded);
-  const [highlightedSliceName, _setHighlightedSliceName] = useState('');
   const location = useLocation();
   const organization = useOrganization();
-
-  const setHighlightedSliceName = useMemo(
-    () =>
-      debounce(sliceName => _setHighlightedSliceName(sliceName), 100, {
-        leading: true,
-      }),
-    [_setHighlightedSliceName]
-  );
 
   const onClickExpand = useCallback(() => setExpanded(e => !e), [setExpanded]);
 
@@ -287,16 +278,7 @@ function TraceRow({
           <Count value={trace.numSpans} />
         )}
       </StyledPanelItem>
-      <BreakdownPanelItem
-        align="right"
-        highlightedSliceName={highlightedSliceName}
-        onMouseLeave={() => setHighlightedSliceName('')}
-      >
-        <TraceBreakdownRenderer
-          trace={trace}
-          setHighlightedSliceName={setHighlightedSliceName}
-        />
-      </BreakdownPanelItem>
+      <Breakdown trace={trace} />
       <StyledPanelItem align="right">
         {defined(trace.rootDuration) ? (
           <PerformanceDuration milliseconds={trace.rootDuration} abbreviation />
@@ -307,10 +289,32 @@ function TraceRow({
       <StyledPanelItem align="right">
         <SpanTimeRenderer timestamp={trace.end} tooltipShowSeconds />
       </StyledPanelItem>
-      {expanded && (
-        <SpanTable trace={trace} setHighlightedSliceName={setHighlightedSliceName} />
-      )}
+      {expanded && <SpanTable trace={trace} />}
     </Fragment>
+  );
+}
+
+function Breakdown({trace}: {trace: TraceResult}) {
+  const [highlightedSliceName, _setHighlightedSliceName] = useState('');
+  const setHighlightedSliceName = useMemo(
+    () =>
+      debounce(sliceName => _setHighlightedSliceName(sliceName), 100, {
+        leading: true,
+      }),
+    [_setHighlightedSliceName]
+  );
+
+  return (
+    <BreakdownPanelItem
+      align="right"
+      highlightedSliceName={highlightedSliceName}
+      onMouseLeave={() => setHighlightedSliceName('')}
+    >
+      <TraceBreakdownRenderer
+        trace={trace}
+        setHighlightedSliceName={setHighlightedSliceName}
+      />
+    </BreakdownPanelItem>
   );
 }
 

--- a/static/app/views/explore/tables/tracesTable/spansTable.tsx
+++ b/static/app/views/explore/tables/tracesTable/spansTable.tsx
@@ -33,20 +33,11 @@ import {
   StyledPanelItem,
   StyledSpanPanelItem,
 } from 'sentry/views/explore/tables/tracesTable/styles';
-import {
-  getSecondaryNameFromSpan,
-  getStylingSliceName,
-} from 'sentry/views/explore/tables/tracesTable/utils';
+import {getSecondaryNameFromSpan} from 'sentry/views/explore/tables/tracesTable/utils';
 
 const ONE_MINUTE = 60 * 1000; // in milliseconds
 
-export function SpanTable({
-  trace,
-  setHighlightedSliceName,
-}: {
-  setHighlightedSliceName: (sliceName: string) => void;
-  trace: TraceResult;
-}) {
+export function SpanTable({trace}: {trace: TraceResult}) {
   const organization = useOrganization();
 
   const [dataset] = useDataset();
@@ -118,7 +109,6 @@ export function SpanTable({
               key={span.id}
               span={span}
               trace={trace}
-              setHighlightedSliceName={setHighlightedSliceName}
             />
           ))}
           {hasData && spans.length < trace.matchingSpans && (
@@ -140,10 +130,8 @@ function SpanRow({
   organization,
   span,
   trace,
-  setHighlightedSliceName,
 }: {
   organization: Organization;
-  setHighlightedSliceName: (sliceName: string) => void;
   span: SpanResult<Field>;
 
   trace: TraceResult;
@@ -169,7 +157,7 @@ function SpanRow({
       <StyledSpanPanelItem align="left" overflow>
         <SpanDescriptionRenderer span={span} />
       </StyledSpanPanelItem>
-      <StyledSpanPanelItem align="right" onMouseLeave={() => setHighlightedSliceName('')}>
+      <StyledSpanPanelItem align="right">
         <TraceBreakdownContainer>
           <SpanBreakdownSliceRenderer
             sliceName={span.project}
@@ -178,11 +166,6 @@ function SpanRow({
             sliceEnd={Math.floor(span['precise.finish_ts'] * 1000)}
             trace={trace}
             theme={theme}
-            onMouseEnter={() =>
-              setHighlightedSliceName(
-                getStylingSliceName(span.project, getSecondaryNameFromSpan(span)) ?? ''
-              )
-            }
           />
         </TraceBreakdownContainer>
       </StyledSpanPanelItem>


### PR DESCRIPTION
This hover effect required keeping state in the parent component which means each hover resulted in a re-render causing the timestamp column to refresh. This hover also didn't do very much so may as well remove it to avoid this issue.