### PR TITLE
ref(flags): update settings page to include webhook url

### DIFF
--- a/static/app/views/settings/featureFlags/newProviderForm.spec.tsx
+++ b/static/app/views/settings/featureFlags/newProviderForm.spec.tsx
@@ -5,6 +5,6 @@ import NewProviderForm from 'sentry/views/settings/featureFlags/newProviderForm'
 describe('NewProviderForm', () => {
   it('renders', () => {
     const callback = ({}) => {};
-    render(<NewProviderForm onCreatedSecret={callback} />);
+    render(<NewProviderForm onSetProvider={callback} onCreatedSecret={callback} />);
   });
 });

--- a/static/app/views/settings/featureFlags/newProviderForm.tsx
+++ b/static/app/views/settings/featureFlags/newProviderForm.tsx
@@ -111,8 +111,6 @@ export default function NewProviderForm({
             onChange={setSelectedProvider}
             value={selectedProvider}
             placeholder={t('Select a provider')}
-            defaultValue={'Launchdarkly'}
-            defaultChecked
             name="provider"
             options={[{value: 'LaunchDarkly', label: 'LaunchDarkly'}]}
             help={t(

--- a/static/app/views/settings/featureFlags/newProviderForm.tsx
+++ b/static/app/views/settings/featureFlags/newProviderForm.tsx
@@ -110,7 +110,7 @@ export default function NewProviderForm({
             label={t('Provider')}
             onChange={setSelectedProvider}
             value={selectedProvider}
-            placeholder="Select a provider"
+            placeholder={t('Select a provider')}
             defaultValue={'Launchdarkly'}
             defaultChecked
             name="provider"

--- a/static/app/views/settings/featureFlags/newProviderForm.tsx
+++ b/static/app/views/settings/featureFlags/newProviderForm.tsx
@@ -1,4 +1,5 @@
-import {useCallback} from 'react';
+import {useCallback, useState} from 'react';
+import styled from '@emotion/styled';
 
 import {
   addErrorMessage,
@@ -6,10 +7,15 @@ import {
   addSuccessMessage,
 } from 'sentry/actionCreators/indicator';
 import Access from 'sentry/components/acl/access';
+import {PROVIDER_OPTION_TO_URLS} from 'sentry/components/events/featureFlags/utils';
+import FieldGroup from 'sentry/components/forms/fieldGroup';
 import SelectField from 'sentry/components/forms/fields/selectField';
 import TextField from 'sentry/components/forms/fields/textField';
 import Form from 'sentry/components/forms/form';
-import {t} from 'sentry/locale';
+import ExternalLink from 'sentry/components/links/externalLink';
+import TextCopyInput from 'sentry/components/textCopyInput';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
 import {useMutation, useQueryClient} from 'sentry/utils/queryClient';
@@ -28,17 +34,20 @@ export type CreateSecretResponse = string;
 
 export default function NewProviderForm({
   onCreatedSecret,
+  onSetProvider,
 }: {
   onCreatedSecret: (secret: string) => void;
+  onSetProvider: (provider: string) => void;
 }) {
   const initialData = {
     provider: '',
     secret: '',
   };
   const organization = useOrganization();
-
   const api = useApi();
   const queryClient = useQueryClient();
+
+  const [selectedProvider, setSelectedProvider] = useState('<provider_name>');
 
   const handleGoBack = useCallback(() => {
     browserHistory.push(normalizeUrl(`/settings/${organization.slug}/feature-flags/`));
@@ -56,16 +65,17 @@ export default function NewProviderForm({
         {
           method: 'POST',
           data: {
-            provider,
+            provider: provider.toLowerCase(),
             secret,
           },
         }
       );
     },
 
-    onSuccess: (_response, {secret}) => {
+    onSuccess: (_response, {secret, provider}) => {
       addSuccessMessage(t('Added provider and secret.'));
       onCreatedSecret(secret);
+      onSetProvider(provider);
       queryClient.invalidateQueries({
         queryKey: makeFetchSecretQueryKey({orgSlug: organization.slug}),
       });
@@ -98,13 +108,32 @@ export default function NewProviderForm({
           <SelectField
             required
             label={t('Provider')}
+            onChange={setSelectedProvider}
+            value={selectedProvider}
+            placeholder="Select a provider"
+            defaultValue={'Launchdarkly'}
+            defaultChecked
             name="provider"
-            options={[{value: 'launchdarkly', label: 'LaunchDarkly'}]}
-            placeholder={t('Select one')}
+            options={[{value: 'LaunchDarkly', label: 'LaunchDarkly'}]}
             help={t(
               'If you have already linked this provider, pasting a new secret will override the existing secret.'
             )}
           />
+          <StyledFieldGroup
+            label={t('Webhook URL')}
+            help={tct(
+              "Create a webhook integration with your [link:feature flag service]. When you do so, you'll need to enter this URL.",
+              {
+                link: <ExternalLink href={PROVIDER_OPTION_TO_URLS[selectedProvider]} />,
+              }
+            )}
+            inline
+            flexibleControlStateSize
+          >
+            <TextCopyInput
+              aria-label={t('Webhook URL')}
+            >{`https://sentry.io/api/0/organizations/sentry/flags/hooks/provider/${selectedProvider.toLowerCase()}/`}</TextCopyInput>
+          </StyledFieldGroup>
           <TextField
             name="secret"
             label={t('Secret')}
@@ -120,3 +149,7 @@ export default function NewProviderForm({
     </Access>
   );
 }
+
+const StyledFieldGroup = styled(FieldGroup)`
+  padding: ${space(2)};
+`;

--- a/static/app/views/settings/featureFlags/newSecretHandler.spec.tsx
+++ b/static/app/views/settings/featureFlags/newSecretHandler.spec.tsx
@@ -7,6 +7,12 @@ import NewSecretHandler from 'sentry/views/settings/featureFlags/newSecretHandle
 describe('NewSecretHandler', () => {
   it('renders', () => {
     const callback = ({}) => {};
-    render(<NewSecretHandler secret={SecretFixture().secret} onGoBack={callback} />);
+    render(
+      <NewSecretHandler
+        secret={SecretFixture().secret}
+        onGoBack={callback}
+        provider={SecretFixture().provider}
+      />
+    );
   });
 });

--- a/static/app/views/settings/featureFlags/newSecretHandler.tsx
+++ b/static/app/views/settings/featureFlags/newSecretHandler.tsx
@@ -3,28 +3,49 @@ import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';
 import {Button} from 'sentry/components/button';
+import {PROVIDER_OPTION_TO_URLS} from 'sentry/components/events/featureFlags/utils';
 import FieldGroup from 'sentry/components/forms/fieldGroup';
+import ExternalLink from 'sentry/components/links/externalLink';
 import PanelItem from 'sentry/components/panels/panelItem';
 import TextCopyInput from 'sentry/components/textCopyInput';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 function NewSecretHandler({
   secret,
+  provider,
   onGoBack,
 }: {
   onGoBack: MouseEventHandler;
+  provider: string;
   secret: string;
 }) {
   return (
     <div>
-      <Alert type="warning" showIcon system>
+      <StyledAlert type="warning" showIcon system>
         {t('The secret has been posted.')}
-      </Alert>
+      </StyledAlert>
 
-      <PanelItem>
+      <StyledPanelItem>
         <InputWrapper>
-          <FieldGroupNoPadding
+          <StyledFieldGroup
+            label={t('Webhook URL')}
+            help={tct(
+              "Create a webhook integration with your [link:feature flag service]. When you do so, you'll need to enter this URL.",
+              {
+                link: (
+                  <ExternalLink href={PROVIDER_OPTION_TO_URLS[provider.toLowerCase()]} />
+                ),
+              }
+            )}
+            inline
+            flexibleControlStateSize
+          >
+            <TextCopyInput
+              aria-label={t('Webhook URL')}
+            >{`https://sentry.io/api/0/organizations/sentry/flags/hooks/provider/${provider.toLowerCase()}/`}</TextCopyInput>
+          </StyledFieldGroup>
+          <StyledFieldGroup
             label={t('Secret')}
             help={t(
               'The secret should not be shared and will not be retrievable once you leave this page.'
@@ -33,17 +54,17 @@ function NewSecretHandler({
             flexibleControlStateSize
           >
             <TextCopyInput aria-label={t('Secret')}>{secret}</TextCopyInput>
-          </FieldGroupNoPadding>
+          </StyledFieldGroup>
         </InputWrapper>
-      </PanelItem>
+      </StyledPanelItem>
 
-      <PanelItem>
+      <StyledPanelItem>
         <ButtonWrapper>
           <Button onClick={onGoBack} priority="primary">
             {t('Done')}
           </Button>
         </ButtonWrapper>
-      </PanelItem>
+      </StyledPanelItem>
     </div>
   );
 }
@@ -52,8 +73,8 @@ const InputWrapper = styled('div')`
   flex: 1;
 `;
 
-const FieldGroupNoPadding = styled(FieldGroup)`
-  padding: 0;
+const StyledFieldGroup = styled(FieldGroup)`
+  padding: ${space(1)};
 `;
 
 const ButtonWrapper = styled('div')`
@@ -65,4 +86,11 @@ const ButtonWrapper = styled('div')`
   gap: ${space(1)};
 `;
 
+const StyledPanelItem = styled(PanelItem)`
+  padding: ${space(1.5)};
+`;
+
+const StyledAlert = styled(Alert)`
+  margin: 0;
+`;
 export default NewSecretHandler;

--- a/static/app/views/settings/featureFlags/organizationFeatureFlagsNewSecret.tsx
+++ b/static/app/views/settings/featureFlags/organizationFeatureFlagsNewSecret.tsx
@@ -16,6 +16,7 @@ import NewSecretHandler from 'sentry/views/settings/featureFlags/newSecretHandle
 
 export function OrganizationFeatureFlagsNewSecet() {
   const [newSecret, setNewSecret] = useState<string | null>(null);
+  const [provider, setProvider] = useState<string>('');
   const organization = useOrganization();
 
   const handleGoBack = useCallback(() => {
@@ -45,12 +46,15 @@ export function OrganizationFeatureFlagsNewSecet() {
 
       <Panel>
         <PanelHeader>{t('Add New Provider')}</PanelHeader>
-
         <PanelBody>
           {newSecret ? (
-            <NewSecretHandler onGoBack={handleGoBack} secret={newSecret} />
+            <NewSecretHandler
+              onGoBack={handleGoBack}
+              secret={newSecret}
+              provider={provider}
+            />
           ) : (
-            <NewProviderForm onCreatedSecret={setNewSecret} />
+            <NewProviderForm onCreatedSecret={setNewSecret} onSetProvider={setProvider} />
           )}
         </PanelBody>
       </Panel>


### PR DESCRIPTION
webhook appears in 2 spots, before the secret is created and also after.

https://github.com/user-attachments/assets/d291dae4-6931-4598-87b2-6d3e3220e0f2

<img width="699" alt="SCR-20241204-obux" src="https://github.com/user-attachments/assets/e0b58844-0cae-414c-a9ae-3a0c9d65a364">

closes https://github.com/getsentry/team-replay/issues/507#event-15533439554