### PR TITLE
feat(issue-details): Make support link easier to find

### DIFF
--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -100,19 +100,6 @@ export function NewIssueExperienceButton() {
           onAction: handleToggle,
         },
         {
-          key: 'learn-more',
-          label: t('Learn more about the new UI'),
-          onAction: () => {
-            trackAnalytics('issue_details.streamline_ui_learn_more', {
-              organization,
-            });
-            window.open(
-              'https://sentry.zendesk.com/hc/en-us/articles/30882241712795',
-              '_blank'
-            );
-          },
-        },
-        {
           key: 'give-feedback',
           label: t('Give feedback on new UI'),
           hidden: !openForm,

--- a/static/app/views/issueDetails/streamline/header/header.tsx
+++ b/static/app/views/issueDetails/streamline/header/header.tsx
@@ -5,7 +5,8 @@ import Color from 'color';
 import {openModal} from 'sentry/actionCreators/modal';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
-import {Button} from 'sentry/components/button';
+import {Button, LinkButton} from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
 import {Flex} from 'sentry/components/container/flex';
 import Count from 'sentry/components/count';
 import ErrorLevel from 'sentry/components/events/errorLevel';
@@ -14,7 +15,7 @@ import UnhandledTag from 'sentry/components/group/inboxBadges/unhandledTag';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
 import {Tooltip} from 'sentry/components/tooltip';
-import {IconGlobe} from 'sentry/icons';
+import {IconGlobe, IconQuestion} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
@@ -124,7 +125,22 @@ export default function StreamlinedGroupHeader({
               />
             ) : null}
           </Flex>
-          <NewIssueExperienceButton />
+          <ButtonBar gap={0.5}>
+            <LinkButton
+              size="xs"
+              external
+              title={t('Learn more about the new UI')}
+              aria-label={t('Learn more about the new UI')}
+              href={`https://sentry.zendesk.com/hc/en-us/articles/30882241712795`}
+              icon={<IconQuestion />}
+              onClick={() => {
+                trackAnalytics('issue_details.streamline_ui_learn_more', {
+                  organization,
+                });
+              }}
+            />
+            <NewIssueExperienceButton />
+          </ButtonBar>
         </Flex>
         <HeaderGrid>
           <Flex gap={space(0.75)} align="baseline">


### PR DESCRIPTION
this pr moves the support page out of the dropdown and into it's own button on issue details. 
<img width="131" alt="Screenshot 2024-12-04 at 4 08 08 PM" src="https://github.com/user-attachments/assets/feab41c2-26ee-4b2d-9058-ff611e1827d9">
