### PR TITLE
chore(ecosystem): Clean up verbose test alert feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -588,7 +588,7 @@ def register_temporary_features(manager: FeatureManager):
 
     # Ecosystem: Enable verbose alert reporting when triggering test alerts
     manager.add("projects:verbose-test-alert-reporting", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE,
-                api_expose=False)
+                default=True, api_expose=False)
     # Project plugin features
     manager.add("projects:plugins", ProjectPluginFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
 


### PR DESCRIPTION
This feature has been GA'd for a while now, so this just removes the old deprecated code path.
