### PR TITLE
ref: remove sentry custom .json_body request attribute

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -331,7 +331,6 @@ module = [
     "tests.sentry.api.endpoints.notifications.test_notification_actions_index",
     "tests.sentry.api.endpoints.test_event_attachment_details",
     "tests.sentry.api.helpers.test_group_index",
-    "tests.sentry.api.test_authentication",
     "tests.sentry.api.test_base",
     "tests.sentry.api.test_event_search",
     "tests.sentry.eventstore.test_base",

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -293,11 +293,11 @@ class ClientIdSecretAuthentication(QuietBasicAuthentication):
     """
 
     def authenticate(self, request: Request):
-        if not request.json_body:
+        if not request.data:
             raise AuthenticationFailed("Invalid request")
 
-        client_id = request.json_body.get("client_id")
-        client_secret = request.json_body.get("client_secret")
+        client_id = request.data.get("client_id")
+        client_secret = request.data.get("client_secret")
 
         invalid_pair_error = AuthenticationFailed("Invalid Client ID / Secret pair")
 

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -9,7 +9,6 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 from urllib.parse import quote as urlquote
 
-import orjson
 import sentry_sdk
 from django.conf import settings
 from django.http import HttpResponse
@@ -342,29 +341,6 @@ class Endpoint(APIView):
     def create_audit_entry(self, request: Request, transaction_id=None, **kwargs):
         return create_audit_entry(request, transaction_id, audit_logger, **kwargs)
 
-    def load_json_body(self, request: Request):
-        """
-        Attempts to load the request body when it's JSON.
-
-        The end result is ``request.json_body`` having a value. When it can't
-        load the body as JSON, for any reason, ``request.json_body`` is None.
-
-        The request flow is unaffected and no exceptions are ever raised.
-        """
-
-        request.json_body = None
-
-        if not request.META.get("CONTENT_TYPE", "").startswith("application/json"):
-            return
-
-        if not len(request.body):
-            return
-
-        try:
-            request.json_body = orjson.loads(request.body)
-        except orjson.JSONDecodeError:
-            return
-
     def initialize_request(self, request: HttpRequest, *args: Any, **kwargs: Any) -> Request:
         # XXX: Since DRF 3.x, when the request is passed into
         # `initialize_request` it's set as an internal variable on the returned
@@ -398,7 +374,10 @@ class Endpoint(APIView):
             self.args = args
             self.kwargs = kwargs
             request = self.initialize_request(request, *args, **kwargs)
-            self.load_json_body(request)
+            # XXX: without this seemingly useless access to `.body` we are
+            # unable to access `request.body` later on due to `rest_framework`
+            # loading the request body via `request.read()`
+            request.body
             self.request = request
             self.headers = self.default_response_headers  # deprecate?
 

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -155,12 +155,6 @@ class SuperuserAccessFormInvalidJson(SentryAPIException):
     message = "The request contains invalid json"
 
 
-class EmptySuperuserAccessForm(SentryAPIException):
-    status_code = status.HTTP_400_BAD_REQUEST
-    code = "empty-superuser-access-form"
-    message = "The request contains an empty superuser access form data"
-
-
 class Superuser(ElevatedMode):
     allowed_ips = frozenset(ipaddress.ip_network(str(v), strict=False) for v in ALLOWED_IPS)
     org_id = SUPERUSER_ORG_ID
@@ -456,13 +450,6 @@ class Superuser(ElevatedMode):
                     tags={"reason": SuperuserAccessFormInvalidJson.code},
                 )
                 raise SuperuserAccessFormInvalidJson()
-            except AttributeError:
-                metrics.incr(
-                    "superuser.failure",
-                    sample_rate=1.0,
-                    tags={"reason": EmptySuperuserAccessForm.code},
-                )
-                raise EmptySuperuserAccessForm()
 
         su_access_info = SuperuserAccessSerializer(data=su_access_json)
 

--- a/src/sentry/integrations/api/bases/doc_integrations.py
+++ b/src/sentry/integrations/api/bases/doc_integrations.py
@@ -68,7 +68,7 @@ class DocIntegrationsBaseEndpoint(Endpoint):
     permission_classes = (DocIntegrationsAndStaffPermission,)
 
     def generate_incoming_metadata(self, request: Request) -> Any:
-        return {k: v for k, v in request.json_body.items() if k in METADATA_PROPERTIES}
+        return {k: v for k, v in request.data.items() if k in METADATA_PROPERTIES}
 
 
 class DocIntegrationBaseEndpoint(DocIntegrationsBaseEndpoint):

--- a/src/sentry/integrations/api/endpoints/doc_integration_details.py
+++ b/src/sentry/integrations/api/endpoints/doc_integration_details.py
@@ -31,7 +31,7 @@ class DocIntegrationDetailsEndpoint(DocIntegrationBaseEndpoint):
         return self.respond(serialize(doc_integration, request.user), status=status.HTTP_200_OK)
 
     def put(self, request: Request, doc_integration: DocIntegration) -> Response:
-        data = request.json_body
+        data = request.data
         data["metadata"] = self.generate_incoming_metadata(request)
 
         serializer = DocIntegrationSerializer(doc_integration, data=data)

--- a/src/sentry/integrations/api/endpoints/doc_integrations_index.py
+++ b/src/sentry/integrations/api/endpoints/doc_integrations_index.py
@@ -42,7 +42,7 @@ class DocIntegrationsEndpoint(DocIntegrationsBaseEndpoint):
 
     def post(self, request: Request):
         # Override any incoming JSON for these fields
-        data = request.json_body
+        data = request.data
         data["is_draft"] = True
         data["metadata"] = self.generate_incoming_metadata(request)
         serializer = DocIntegrationSerializer(data=data)

--- a/src/sentry/integrations/slack/requests/base.py
+++ b/src/sentry/integrations/slack/requests/base.py
@@ -73,7 +73,6 @@ class SlackRequest:
         """
         Ensure everything is present to properly process this request
         """
-        self.request.body
         self._log_request()
         self._get_context()
         self.authorize()

--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -120,7 +120,7 @@ class SentryAppsBaseEndpoint(IntegrationPlatformEndpoint):
     permission_classes: tuple[type[BasePermission], ...] = (SentryAppsAndStaffPermission,)
 
     def _get_organization_slug(self, request: Request):
-        organization_slug = request.json_body.get("organization")
+        organization_slug = request.data.get("organization")
         if not organization_slug or not isinstance(organization_slug, str):
             error_message = "Please provide a valid value for the 'organization' field."
             raise ValidationError({"organization": to_single_line_str(error_message)})
@@ -179,7 +179,7 @@ class SentryAppsBaseEndpoint(IntegrationPlatformEndpoint):
         objects from URI params, we're applying the same logic for a param in
         the request body.
         """
-        if not request.json_body:
+        if not request.data:
             return (args, kwargs)
 
         context = self._get_org_context(request)

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_authorizations.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_authorizations.py
@@ -46,7 +46,7 @@ class SentryAppAuthorizationsEndpoint(SentryAppAuthorizationsBaseEndpoint):
         scope.set_tag("sentry_app_slug", installation.sentry_app.slug)
 
         try:
-            if request.json_body.get("grant_type") == GrantTypes.AUTHORIZATION:
+            if request.data.get("grant_type") == GrantTypes.AUTHORIZATION:
                 auth_serializer: SentryAppAuthorizationSerializer = (
                     SentryAppAuthorizationSerializer(data=request.data)
                 )
@@ -60,7 +60,7 @@ class SentryAppAuthorizationsEndpoint(SentryAppAuthorizationsBaseEndpoint):
                     client_id=auth_serializer.validated_data.get("client_id"),
                     user=promote_request_api_user(request),
                 ).run()
-            elif request.json_body.get("grant_type") == GrantTypes.REFRESH:
+            elif request.data.get("grant_type") == GrantTypes.REFRESH:
                 refresh_serializer = SentryAppRefreshAuthorizationSerializer(data=request.data)
 
                 if not refresh_serializer.is_valid():
@@ -87,7 +87,7 @@ class SentryAppAuthorizationsEndpoint(SentryAppAuthorizationsBaseEndpoint):
             )
             return Response({"error": e.msg or "Unauthorized"}, status=403)
 
-        attrs = {"state": request.json_body.get("state"), "application": None}
+        attrs = {"state": request.data.get("state"), "application": None}
 
         body = ApiTokenSerializer().serialize(token, attrs, promote_request_api_user(request))
 

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
@@ -192,7 +192,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
         return Response({"detail": ["Published apps cannot be removed."]}, status=403)
 
     def _has_hook_events(self, request: Request):
-        if not request.json_body.get("events"):
+        if not request.data.get("events"):
             return False
 
-        return "error" in request.json_body["events"]
+        return "error" in request.data["events"]

--- a/src/sentry/sentry_apps/api/endpoints/sentry_apps.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_apps.py
@@ -71,22 +71,22 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
 
     def post(self, request: Request, organization) -> Response:
         data = {
-            "name": request.json_body.get("name"),
+            "name": request.data.get("name"),
             "user": request.user,
-            "author": request.json_body.get("author"),
+            "author": request.data.get("author"),
             "organization": organization,
-            "webhookUrl": request.json_body.get("webhookUrl"),
-            "redirectUrl": request.json_body.get("redirectUrl"),
-            "isAlertable": request.json_body.get("isAlertable"),
-            "isInternal": request.json_body.get("isInternal"),
-            "verifyInstall": request.json_body.get("verifyInstall"),
-            "scopes": request.json_body.get("scopes", []),
-            "events": request.json_body.get("events", []),
-            "schema": request.json_body.get("schema", {}),
-            "overview": request.json_body.get("overview"),
-            "allowedOrigins": request.json_body.get("allowedOrigins", []),
+            "webhookUrl": request.data.get("webhookUrl"),
+            "redirectUrl": request.data.get("redirectUrl"),
+            "isAlertable": request.data.get("isAlertable"),
+            "isInternal": request.data.get("isInternal"),
+            "verifyInstall": request.data.get("verifyInstall"),
+            "scopes": request.data.get("scopes", []),
+            "events": request.data.get("events", []),
+            "schema": request.data.get("schema", {}),
+            "overview": request.data.get("overview"),
+            "allowedOrigins": request.data.get("allowedOrigins", []),
             "popularity": (
-                request.json_body.get("popularity") if is_active_superuser(request) else None
+                request.data.get("popularity") if is_active_superuser(request) else None
             ),
         }
 
@@ -166,7 +166,7 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
         return queryset.filter(owner_id__in=owner_ids)
 
     def _has_hook_events(self, request: Request):
-        if not request.json_body.get("events"):
+        if not request.data.get("events"):
             return False
 
-        return "error" in request.json_body["events"]
+        return "error" in request.data["events"]

--- a/tests/sentry/api/test_api_pagination_check.py
+++ b/tests/sentry/api/test_api_pagination_check.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 import pytest
-from django.http import HttpRequest
+from django.test import RequestFactory
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -17,10 +17,6 @@ class APIPaginationCheckTestCase(TestCase):
                 self.access = "read"
 
             # Required to go through the dispatch method
-            def initialize_request(self, request, *args, **kwargs) -> Request:
-                return request
-
-            # Required to go through the dispatch method
             def check_permissions(self, request: Request) -> None:
                 pass
 
@@ -30,8 +26,7 @@ class APIPaginationCheckTestCase(TestCase):
         # Test the endpoint, assert there is a MissingPaginationError
         with pytest.raises(MissingPaginationError):
             endpoint = ExampleEndpoint()
-            request = Request(HttpRequest())
-            request.method = "GET"
+            request = RequestFactory().get("/")
             request.access = "read"
             ExampleEndpoint.dispatch(endpoint, request)
 
@@ -42,10 +37,6 @@ class APIPaginationCheckTestCase(TestCase):
                 self.access = "read"
 
             # Required to go through the dispatch method
-            def initialize_request(self, request, *args, **kwargs) -> Request:
-                return request
-
-            # Required to go through the dispatch method
             def check_permissions(self, request: Request) -> None:
                 pass
 
@@ -54,20 +45,15 @@ class APIPaginationCheckTestCase(TestCase):
 
         # Test the endpoint, assert there is no MissingPaginationError
         endpoint = GroupTagsEndpoint()
-        request = Request(HttpRequest())
-        request.method = "GET"
+        request = RequestFactory().get("/")
         request.access = "read"
         GroupTagsEndpoint.dispatch(endpoint, request)
 
     def test_empty_payload_with_pagination(self) -> None:
-        class ExampleEndpoint(TestCase, Endpoint):
+        class ExampleEndpoint(Endpoint):
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
                 self.access = "read"
-
-            # Required to go through the dispatch method
-            def initialize_request(self, request, *args, **kwargs) -> Request:
-                return request
 
             # Required to go through the dispatch method
             def check_permissions(self, request: Request) -> None:
@@ -84,7 +70,6 @@ class APIPaginationCheckTestCase(TestCase):
 
         # Test the endpoint, assert there is no MissingPaginationError
         endpoint = ExampleEndpoint()
-        request = Request(HttpRequest())
-        request.method = "GET"
+        request = RequestFactory().get("/")
         request.access = "read"
         ExampleEndpoint.dispatch(endpoint, request)

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -2,10 +2,11 @@ import uuid
 from datetime import UTC, datetime
 
 import pytest
-from django.http import HttpRequest
+from django.http.request import HttpRequest
 from django.test import RequestFactory, override_settings
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.request import Request
+from rest_framework.views import APIView
 from sentry_relay.auth import generate_key_pair
 
 from sentry.api.authentication import (
@@ -36,6 +37,15 @@ from sentry.types.token import AuthTokenType
 from sentry.utils.security.orgauthtoken_token import hash_token
 
 
+def _drf_request_from_request(request: HttpRequest) -> Request:
+    return APIView().initialize_request(request)
+
+
+def _drf_request(data: dict[str, str] | None = None) -> Request:
+    req = RequestFactory().post("/example", data, format="json")
+    return _drf_request_from_request(req)
+
+
 @control_silo_test
 class TestClientIdSecretAuthentication(TestCase):
     def setUp(self):
@@ -49,53 +59,53 @@ class TestClientIdSecretAuthentication(TestCase):
         self.api_app = self.sentry_app.application
 
     def test_authenticate(self):
-        request = HttpRequest()
-        request.json_body = {
-            "client_id": self.api_app.client_id,
-            "client_secret": self.api_app.client_secret,
-        }
+        request = _drf_request(
+            {
+                "client_id": self.api_app.client_id,
+                "client_secret": self.api_app.client_secret,
+            }
+        )
 
         user, _ = self.auth.authenticate(request)
 
         assert user.id == self.sentry_app.proxy_user.id
 
     def test_without_json_body(self):
-        request = HttpRequest()
-        request.json_body = None
+        request = _drf_request()
 
         with pytest.raises(AuthenticationFailed):
             self.auth.authenticate(request)
 
     def test_missing_client_id(self):
-        request = HttpRequest()
-        request.json_body = {"client_secret": self.api_app.client_secret}
+        request = _drf_request({"client_secret": self.api_app.client_secret})
 
         with pytest.raises(AuthenticationFailed):
             self.auth.authenticate(request)
 
     def test_missing_client_secret(self):
-        request = HttpRequest()
-        request.json_body = {"client_id": self.api_app.client_id}
+        request = _drf_request({"client_id": self.api_app.client_id})
 
         with pytest.raises(AuthenticationFailed):
             self.auth.authenticate(request)
 
     def test_incorrect_client_id(self):
-        request = HttpRequest()
-        request.json_body = {
-            "client_id": "notit",
-            "client_secret": self.api_app.client_secret,
-        }
+        request = _drf_request(
+            {
+                "client_id": "notit",
+                "client_secret": self.api_app.client_secret,
+            }
+        )
 
         with pytest.raises(AuthenticationFailed):
             self.auth.authenticate(request)
 
     def test_incorrect_client_secret(self):
-        request = HttpRequest()
-        request.json_body = {
-            "client_id": self.api_app.client_id,
-            "client_secret": "notit",
-        }
+        request = _drf_request(
+            {
+                "client_id": self.api_app.client_id,
+                "client_secret": "notit",
+            }
+        )
 
         with pytest.raises(AuthenticationFailed):
             self.auth.authenticate(request)
@@ -111,7 +121,7 @@ class TestDSNAuthentication(TestCase):
         self.project_key = self.create_project_key(project=self.project)
 
     def test_authenticate(self):
-        request = HttpRequest()
+        request = _drf_request()
         request.META["HTTP_AUTHORIZATION"] = f"DSN {self.project_key.dsn_public}"
 
         result = self.auth.authenticate(request)
@@ -123,7 +133,7 @@ class TestDSNAuthentication(TestCase):
 
     def test_inactive_key(self):
         self.project_key.update(status=ProjectKeyStatus.INACTIVE)
-        request = HttpRequest()
+        request = _drf_request()
         request.META["HTTP_AUTHORIZATION"] = f"DSN {self.project_key.dsn_public}"
 
         with pytest.raises(AuthenticationFailed):
@@ -149,7 +159,7 @@ class TestOrgAuthTokenAuthentication(TestCase):
         )
 
     def test_authenticate(self):
-        request = HttpRequest()
+        request = _drf_request()
         request.META["HTTP_AUTHORIZATION"] = f"Bearer {self.token}"
 
         result = self.auth.authenticate(request)
@@ -162,7 +172,7 @@ class TestOrgAuthTokenAuthentication(TestCase):
         )
 
     def test_no_match(self):
-        request = HttpRequest()
+        request = _drf_request()
         request.META["HTTP_AUTHORIZATION"] = "Bearer sntrys_abc"
 
         with pytest.raises(AuthenticationFailed):
@@ -170,7 +180,7 @@ class TestOrgAuthTokenAuthentication(TestCase):
 
     def test_inactive_key(self):
         self.org_auth_token.update(date_deactivated=datetime.now(UTC))
-        request = HttpRequest()
+        request = _drf_request()
         request.META["HTTP_AUTHORIZATION"] = f"Bearer {self.token}"
 
         with pytest.raises(AuthenticationFailed):
@@ -191,7 +201,7 @@ class TestTokenAuthentication(TestCase):
         self.token = self.api_token.plaintext_token
 
     def test_authenticate(self):
-        request = HttpRequest()
+        request = _drf_request()
         request.META["HTTP_AUTHORIZATION"] = f"Bearer {self.token}"
 
         result = self.auth.authenticate(request)
@@ -203,7 +213,7 @@ class TestTokenAuthentication(TestCase):
         assert AuthenticatedToken.from_token(auth) == AuthenticatedToken.from_token(self.api_token)
 
     def test_no_match(self):
-        request = HttpRequest()
+        request = _drf_request()
         request.META["HTTP_AUTHORIZATION"] = "Bearer abc"
 
         with pytest.raises(AuthenticationFailed):
@@ -226,7 +236,7 @@ class TestOrgScopedAppTokenAuthentication(TestCase):
         self.token = self.api_token.plaintext_token
 
     def test_authenticate_correct_org(self):
-        request = HttpRequest()
+        request = _drf_request()
         request.META["HTTP_AUTHORIZATION"] = f"Bearer {self.token}"
         request.path_info = f"/api/0/organizations/{self.org.slug}/projects/"
 
@@ -239,7 +249,7 @@ class TestOrgScopedAppTokenAuthentication(TestCase):
         assert AuthenticatedToken.from_token(auth) == AuthenticatedToken.from_token(self.api_token)
 
     def test_authenticate_incorrect_org(self):
-        request = HttpRequest()
+        request = _drf_request()
         request.META["HTTP_AUTHORIZATION"] = f"Bearer {self.token}"
         request.path_info = f"/api/0/organizations/{self.another_org}/projects/"
 
@@ -247,7 +257,7 @@ class TestOrgScopedAppTokenAuthentication(TestCase):
             self.auth.authenticate(request)
 
     def test_authenticate_user_level_endpoints(self):
-        request = HttpRequest()
+        request = _drf_request()
         request.META["HTTP_AUTHORIZATION"] = f"Bearer {self.token}"
         request.path_info = "/api/0/projects/"
 
@@ -255,7 +265,7 @@ class TestOrgScopedAppTokenAuthentication(TestCase):
             self.auth.authenticate(request)
 
     def test_authenticate_allowlist_endpoint(self):
-        request = HttpRequest()
+        request = _drf_request()
         request.META["HTTP_AUTHORIZATION"] = f"Bearer {self.token}"
         request.path_info = "/api/0/organizations/"
 
@@ -268,7 +278,7 @@ class TestOrgScopedAppTokenAuthentication(TestCase):
         assert AuthenticatedToken.from_token(auth) == AuthenticatedToken.from_token(self.api_token)
 
     def test_no_match(self):
-        request = HttpRequest()
+        request = _drf_request()
         request.META["HTTP_AUTHORIZATION"] = "Bearer abc"
         request.path_info = f"/api/0/organizations/{self.another_org}/projects/"
 
@@ -284,7 +294,9 @@ def test_registered_relay(internal):
 
     data = {"some_data": "hello"}
     packed, signature = sk.pack(data)
-    request = RequestFactory().post("/", data=packed, content_type="application/json")
+    request = _drf_request_from_request(
+        RequestFactory().post("/", data=packed, content_type="application/json")
+    )
     request.META["HTTP_X_SENTRY_RELAY_SIGNATURE"] = signature
     request.META["HTTP_X_SENTRY_RELAY_ID"] = relay_id
     request.META["REMOTE_ADDR"] = "200.200.200.200"  # something that is NOT local network
@@ -315,7 +327,9 @@ def test_statically_configured_relay(settings, internal):
 
     data = {"some_data": "hello"}
     packed, signature = sk.pack(data)
-    request = RequestFactory().post("/", data=packed, content_type="application/json")
+    request = _drf_request_from_request(
+        RequestFactory().post("/", data=packed, content_type="application/json")
+    )
     request.META["HTTP_X_SENTRY_RELAY_SIGNATURE"] = signature
     request.META["HTTP_X_SENTRY_RELAY_ID"] = relay_id
     request.META["REMOTE_ADDR"] = "200.200.200.200"  # something that is NOT local network
@@ -345,8 +359,9 @@ class TestRpcSignatureAuthentication(TestCase):
     @override_settings(RPC_SHARED_SECRET=["a-long-secret-key"])
     def test_authenticate_success(self):
         data = b'{"meta":{},"args":{"id":1}'
-        request = RequestFactory().post("/", data=data, content_type="application/json")
-        request = Request(request=request)
+        request = _drf_request_from_request(
+            RequestFactory().post("/", data=data, content_type="application/json")
+        )
 
         signature = generate_request_signature(request.path_info, request.body)
         request.META["HTTP_AUTHORIZATION"] = f"rpcsignature {signature}"
@@ -356,12 +371,12 @@ class TestRpcSignatureAuthentication(TestCase):
         assert token == signature
 
     def test_authenticate_old_key_validates(self):
-        request = RequestFactory().post("/", data="", content_type="application/json")
+        request = _drf_request_from_request(
+            RequestFactory().post("/", data="", content_type="application/json")
+        )
         with override_settings(RPC_SHARED_SECRET=["an-old-key"]):
             signature = generate_request_signature(request.path_info, request.body)
             request.META["HTTP_AUTHORIZATION"] = f"rpcsignature {signature}"
-
-        request = Request(request=request)
 
         # Update settings so that we have a new key
         with override_settings(RPC_SHARED_SECRET=["a-long-secret-key", "an-old-key"]):
@@ -371,28 +386,28 @@ class TestRpcSignatureAuthentication(TestCase):
         assert token == signature
 
     def test_authenticate_without_signature(self):
-        request = RequestFactory().post("/", data="", content_type="application/json")
+        request = _drf_request_from_request(
+            RequestFactory().post("/", data="", content_type="application/json")
+        )
         request.META["HTTP_AUTHORIZATION"] = "Bearer abcdef"
-
-        request = Request(request=request)
 
         assert self.auth.authenticate(request) is None
 
     @override_settings(RPC_SHARED_SECRET=["a-long-secret-key"])
     def test_authenticate_invalid_signature(self):
-        request = RequestFactory().post("/", data="", content_type="application/json")
+        request = _drf_request_from_request(
+            RequestFactory().post("/", data="", content_type="application/json")
+        )
         request.META["HTTP_AUTHORIZATION"] = "rpcsignature abcdef"
-
-        request = Request(request=request)
 
         with pytest.raises(AuthenticationFailed):
             self.auth.authenticate(request)
 
     def test_authenticate_no_shared_secret(self):
-        request = RequestFactory().post("/", data="", content_type="application/json")
+        request = _drf_request_from_request(
+            RequestFactory().post("/", data="", content_type="application/json")
+        )
         request.META["HTTP_AUTHORIZATION"] = "rpcsignature abcdef"
-
-        request = Request(request=request)
 
         with override_settings(RPC_SHARED_SECRET=None):
             with pytest.raises(RpcAuthenticationSetupException):
@@ -405,6 +420,7 @@ class TestAuthTokens(TestCase):
         sys_token = SystemToken()
         auth_token = AuthenticatedToken.from_token(sys_token)
 
+        assert auth_token is not None
         assert auth_token.entity_id is None
         assert auth_token.user_id is None
         assert is_system_auth(sys_token) and is_system_auth(auth_token)
@@ -429,6 +445,7 @@ class TestAuthTokens(TestCase):
         for token in [at, atr]:
             auth_token = AuthenticatedToken.from_token(token)
 
+            assert auth_token is not None
             assert auth_token.entity_id == at.id
             assert auth_token.user_id == app.proxy_user_id
             assert is_api_token_auth(token) and is_api_token_auth(auth_token)
@@ -446,6 +463,7 @@ class TestAuthTokens(TestCase):
         for token in [ak, akr]:
             auth_token = AuthenticatedToken.from_token(token)
 
+            assert auth_token is not None
             assert auth_token.entity_id == ak.id
             assert auth_token.user_id is None
             assert is_api_key_auth(token) and is_api_key_auth(auth_token)
@@ -467,9 +485,10 @@ class TestAuthTokens(TestCase):
         with assume_test_silo_mode(SiloMode.REGION):
             oatr = OrgAuthTokenReplica.objects.get(orgauthtoken_id=oat.id)
 
-        for token in [oat, oatr]:
+        for token in (oat, oatr):
             auth_token = AuthenticatedToken.from_token(token)
 
+            assert auth_token is not None
             assert auth_token.entity_id == oat.id
             assert auth_token.user_id is None
             assert is_org_auth_token_auth(token) and is_org_auth_token_auth(auth_token)

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from unittest import mock
 from unittest.mock import MagicMock
 
-from django.http import HttpRequest, QueryDict, StreamingHttpResponse
+from django.http import QueryDict, StreamingHttpResponse
 from django.test import override_settings
 from pytest import raises
 from rest_framework.permissions import AllowAny
@@ -498,43 +498,6 @@ class PaginateTest(APITestCase):
         assert response.status_code == 200
         assert isinstance(response, StreamingHttpResponse)
         assert response.has_header("content-type")
-
-
-class EndpointJSONBodyTest(APITestCase):
-    def setUp(self):
-        super().setUp()
-
-        self.request = HttpRequest()
-        self.request.method = "GET"
-        self.request.META["CONTENT_TYPE"] = "application/json"
-
-    def test_json(self):
-        self.request._body = b'{"foo":"bar"}'
-
-        Endpoint().load_json_body(self.request)
-
-        assert self.request.json_body == {"foo": "bar"}
-
-    def test_invalid_json(self):
-        self.request._body = b"hello"
-
-        Endpoint().load_json_body(self.request)
-
-        assert not self.request.json_body
-
-    def test_empty_request_body(self):
-        self.request._body = b""
-
-        Endpoint().load_json_body(self.request)
-
-        assert not self.request.json_body
-
-    def test_non_json_content_type(self):
-        self.request.META["CONTENT_TYPE"] = "text/plain"
-
-        Endpoint().load_json_body(self.request)
-
-        assert not self.request.json_body
 
 
 @all_silo_test(regions=create_test_regions("us", "eu"))


### PR DESCRIPTION
request.data works just fine!

(and the type checker understands request.data properly)

<!-- Describe your PR here. -->