### PR TITLE
fix(ecosystem): Removes double SLO reporting issue for ticket creation utils

### DIFF
--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -135,6 +135,10 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
                     # Most of the time, these aren't explicit failures, they're
                     # some misconfiguration of an issue field - typically Jira.
                     lifecycle.record_halt(str(e))
+                else:
+                    # Don't pass the full exception here, as it can contain a
+                    # massive request response along with its stacktrace
+                    lifecycle.record_failure(str(e))
 
                 metrics.incr(
                     f"{provider}.rule_trigger.create_ticket.failure",
@@ -142,10 +146,6 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
                         "provider": provider,
                     },
                 )
-
-                # Don't pass the full exception here, as it can contain a
-                # massive request response along with its stacktrace
-                lifecycle.record_failure(str(e))
 
                 raise
 


### PR DESCRIPTION
Fixes SENTRY-3JF1

Removes double reporting issue from ticket creation utils, which is causing this error to be logged.
