### PR TITLE
fix(rpc): Handle invalid float in snuba rpc

### DIFF
--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -70,6 +70,7 @@ from sentry.utils.snuba import (
     is_numeric_measurement,
     is_percentage_measurement,
     is_span_op_breakdown,
+    process_value,
     raw_snql_query,
     resolve_column,
 )
@@ -1595,18 +1596,7 @@ class BaseQueryBuilder:
             def get_row(row: dict[str, Any]) -> dict[str, Any]:
                 transformed = {}
                 for key, value in row.items():
-                    if isinstance(value, float):
-                        # 0 for nan, and none for inf were chosen arbitrarily, nan and inf are invalid json
-                        # so needed to pick something valid to use instead
-                        if math.isnan(value):
-                            value = 0
-                        elif math.isinf(value):
-                            value = None
-                        value = self.handle_invalid_float(value)
-                    if isinstance(value, list):
-                        for index, item in enumerate(value):
-                            if isinstance(item, float):
-                                value[index] = self.handle_invalid_float(item)
+                    value = process_value(value)
                     if key in self.value_resolver_map:
                         new_value = self.value_resolver_map[key](value)
                     else:

--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime, timedelta
 from re import Match
@@ -1533,16 +1532,6 @@ class BaseQueryBuilder:
             flags=Flags(turbo=self.turbo),
             tenant_ids=self.tenant_ids,
         )
-
-    @classmethod
-    def handle_invalid_float(cls, value: float | None) -> float | None:
-        if value is None:
-            return value
-        elif math.isnan(value):
-            return 0
-        elif math.isinf(value):
-            return None
-        return value
 
     def run_query(
         self, referrer: str | None, use_cache: bool = False, query_source: QuerySource | None = None

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -15,7 +15,7 @@ from sentry.search.events.fields import get_function_alias, is_function
 from sentry.search.events.types import EventsMeta, SnubaData, SnubaParams
 from sentry.snuba.discover import OTHER_KEY, create_result_key, zerofill
 from sentry.utils import snuba_rpc
-from sentry.utils.snuba import SnubaTSResult
+from sentry.utils.snuba import SnubaTSResult, process_value
 
 logger = logging.getLogger("sentry.snuba.spans_rpc")
 
@@ -129,6 +129,7 @@ def run_table_query(
                 result_value = result.val_int
             elif resolved_column.proto_type == FLOAT:
                 result_value = result.val_float
+            result_value = process_value(result_value)
             final_data[index][attribute] = resolved_column.process_column(result_value)
             if has_reliability:
                 final_confidence[index][attribute] = CONFIDENCES.get(
@@ -389,7 +390,7 @@ def _process_timeseries(
             result.append({"time": bucket.seconds})
             confidence.append({"time": bucket.seconds})
     for index, data_point in enumerate(timeseries.data_points):
-        result[index][label] = data_point.data
+        result[index][label] = process_value(data_point.data)
         confidence[index][label] = CONFIDENCES.get(data_point.reliability, None)
 
     return result, confidence

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dataclasses
 import functools
 import logging
+import math
 import os
 import re
 import time
@@ -1993,3 +1994,21 @@ def get_array_column_field(array_column, internal_key):
     if array_column == "span_op_breakdowns":
         return get_span_op_breakdown_key_name(internal_key)
     return internal_key
+
+
+def process_value(value: None | str | int | float | list[str] | list[int] | list[float]):
+    if isinstance(value, float):
+        # 0 for nan, and none for inf were chosen arbitrarily, nan and inf are
+        # invalid json so needed to pick something valid to use instead
+        if math.isnan(value):
+            value = 0
+        elif math.isinf(value):
+            value = None
+
+    if isinstance(value, list):
+        for i, v in enumerate(value):
+            if isinstance(v, float):
+                value[i] = process_value(v)
+        return value
+
+    return value

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -856,6 +856,23 @@ class OrganizationEventsSpanIndexedEndpointTest(OrganizationEventsEndpointTestBa
         ]
         assert meta["dataset"] == self.dataset
 
+    def test_handle_nans_from_snuba(self):
+        self.store_spans(
+            [self.create_span({"description": "foo"}, start_ts=self.ten_mins_ago)],
+            is_eap=self.is_eap,
+        )
+
+        response = self.do_request(
+            {
+                "field": ["description", "count()"],
+                "query": "span.status:internal_error",
+                "orderby": "description",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+        assert response.status_code == 200, response.content
+
 
 class OrganizationEventsEAPSpanEndpointTest(OrganizationEventsSpanIndexedEndpointTest):
     is_eap = True

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
@@ -74,6 +74,21 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         for test in zip(event_counts, rows):
             assert test[1][1][0]["count"] == test[0]
 
+    def test_handle_nans_from_snuba(self):
+        self.store_spans(
+            [self.create_span({"description": "foo"}, start_ts=self.day_ago)],
+            is_eap=self.is_eap,
+        )
+
+        response = self._do_request(
+            data={
+                "yAxis": "avg(measurements.lcp)",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            },
+        )
+        assert response.status_code == 200, response.content
+
     def test_count_unique(self):
         event_counts = [6, 0, 6, 3, 0, 3]
         for hour, count in enumerate(event_counts):


### PR DESCRIPTION
The RPC can return nans and infs. Make sure to handle them the same way it was handled in snql.