### PR TITLE
chore(spans): Update exact category info for indexed spans

### DIFF
--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -95,13 +95,14 @@ export enum DataCategoryExact {
   ATTACHMENT = 'attachment',
   PROFILE = 'profile',
   REPLAY = 'replay',
+  // TODO: Update processed and indexed transactions to camel case"
   TRANSACTION_PROCESSED = 'transaction_processed',
   TRANSACTION_INDEXED = 'transaction_indexed',
   MONITOR = 'monitor',
   MONITOR_SEAT = 'monitorSeat',
   PROFILE_DURATION = 'profileDuration',
   SPAN = 'span',
-  SPAN_INDEXED = 'span_indexed',
+  SPAN_INDEXED = 'spanIndexed',
 }
 
 export interface DataCategoryInfo {


### PR DESCRIPTION
In order to keep billing category info consistently cased, the "DataCategoryExact" enum should be updated to use camel case for indexed spans: "spanIndexed"

Future PR will update the processed and indexed transaction values. 