### PR TITLE
fix(insights): link to module from breadcrumbs broken

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
@@ -229,7 +229,6 @@ function getInsightsModuleBreadcrumbs(
     moduleName = TRACE_SOURCE_TO_MODULE[location.query.source] as RoutableModuleNames;
     crumbs.push({
       label: MODULE_TITLES[moduleName],
-      preservePageFilters: false,
       to: getBreadCrumbTarget(
         `${moduleURLBuilder(moduleName, view)}/`,
         location.query,

--- a/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
@@ -229,7 +229,12 @@ function getInsightsModuleBreadcrumbs(
     moduleName = TRACE_SOURCE_TO_MODULE[location.query.source] as RoutableModuleNames;
     crumbs.push({
       label: MODULE_TITLES[moduleName],
-      to: moduleURLBuilder(moduleName),
+      preservePageFilters: false,
+      to: getBreadCrumbTarget(
+        `${moduleURLBuilder(moduleName, view)}/`,
+        location.query,
+        organization
+      ),
     });
   }
 


### PR DESCRIPTION
When you click on a module in the breadcrumbs, i.e "Network Requests" in the example below, it would take you to blank page and some weird url (`/performance/trace/{id}/insights/http` instead of `/insights/http`).

<img width="988" alt="image" src="https://github.com/user-attachments/assets/0a2eb277-d347-4034-b0b7-2dbb58db69ce">

This PR fixes that issue, and takes you to the correct module url
