### PR TITLE
fix(tags): Fallback to user value if user items are malformed

### DIFF
--- a/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.tsx
@@ -241,7 +241,11 @@ function TagDetailsValue({
 }) {
   const valueComponent =
     tagKey === 'user' ? (
-      <UserBadge user={{...tagValue, id: tagValue.id ?? ''}} avatarSize={20} hideEmail />
+      <UserBadge
+        user={{...tagValue, id: tagValue.id ?? tagValue.value}}
+        avatarSize={20}
+        hideEmail
+      />
     ) : (
       <DeviceName value={tagValue.value} />
     );


### PR DESCRIPTION
Display something rather than nothing. The problem is that the endpoint is returning `user` tag values that aren't matching the format we're expecting, but in any case we should have a fallback.

![image](https://github.com/user-attachments/assets/1502e3d3-a769-4f9a-b4a8-445ebde88012)

![image](https://github.com/user-attachments/assets/c255d0b4-4311-4c71-917f-9d4fd4b75f35)
