### PR TITLE
ref(widget-builder): Add common component for section header

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
@@ -33,7 +33,7 @@ function WidgetBuilderDatasetSelector() {
 
   return (
     <Fragment>
-      <SectionHeader
+      <StyledSectionHeader
         title={t('Dataset')}
         tooltipText={tct(
           `This reflects the type of information you want to use. To learn more, [link: read the docs].`,
@@ -73,4 +73,8 @@ const FeatureBadgeAlignmentWrapper = styled('div')`
     position: relative;
     top: -1px;
   }
+`;
+
+const StyledSectionHeader = styled(SectionHeader)`
+  margin-bottom: ${space(2)};
 `;

--- a/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
@@ -4,11 +4,11 @@ import styled from '@emotion/styled';
 import FeatureBadge from 'sentry/components/badge/featureBadge';
 import RadioGroup, {type RadioOption} from 'sentry/components/forms/controls/radioGroup';
 import ExternalLink from 'sentry/components/links/externalLink';
-import {Tooltip} from 'sentry/components/tooltip';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 import {WidgetType} from 'sentry/views/dashboards/types';
+import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/sectionHeader';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 
@@ -33,8 +33,9 @@ function WidgetBuilderDatasetSelector() {
 
   return (
     <Fragment>
-      <Tooltip
-        title={tct(
+      <SectionHeader
+        title={t('Dataset')}
+        tooltipText={tct(
           `This reflects the type of information you want to use. To learn more, [link: read the docs].`,
           {
             link: (
@@ -42,13 +43,7 @@ function WidgetBuilderDatasetSelector() {
             ),
           }
         )}
-        position="right-end"
-        delay={200}
-        isHoverable
-        showUnderline
-      >
-        <Header>{t('Dataset')}</Header>
-      </Tooltip>
+      />
       <DatasetChoices
         label={t('Dataset')}
         value={state.dataset ?? WidgetType.ERRORS}
@@ -78,9 +73,4 @@ const FeatureBadgeAlignmentWrapper = styled('div')`
     position: relative;
     top: -1px;
   }
-`;
-
-const Header = styled('h6')`
-  font-size: ${p => p.theme.fontSizeLarge};
-  margin-bottom: ${space(2)};
 `;

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
@@ -6,6 +6,7 @@ import TextArea from 'sentry/components/forms/controls/textarea';
 import Input from 'sentry/components/input';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/sectionHeader';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 
@@ -15,7 +16,7 @@ function WidgetBuilderNameAndDescription() {
 
   return (
     <Fragment>
-      <Header>{t('Widget Name & Description')}</Header>
+      <SectionHeader title={t('Widget Name & Description')} />
       <StyledInput
         size="md"
         placeholder={t('Name')}
@@ -56,11 +57,6 @@ function WidgetBuilderNameAndDescription() {
 }
 
 export default WidgetBuilderNameAndDescription;
-
-const Header = styled('h6')`
-  font-size: ${p => p.theme.fontSizeLarge};
-  margin-bottom: ${space(1)};
-`;
 
 const StyledInput = styled(Input)`
   margin-bottom: ${space(1)};

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
@@ -29,19 +29,17 @@ function WidgetBuilderQueryFilterBuilder() {
 
   return (
     <Fragment>
-      <HeaderWrapper>
-        <SectionHeader
-          title={t('Filter')}
-          tooltipText={
-            canAddSearchConditions
-              ? t(
-                  'Filter down your search here. You can add multiple queries to compare data for each overlay'
-                )
-              : t('Filter down your search here')
-          }
-          optional
-        />
-      </HeaderWrapper>
+      <SectionHeader
+        title={t('Filter')}
+        tooltipText={
+          canAddSearchConditions
+            ? t(
+                'Filter down your search here. You can add multiple queries to compare data for each overlay'
+              )
+            : t('Filter down your search here')
+        }
+        optional
+      />
       {!state.query?.length ? (
         <QueryFieldRowWrapper key={0}>
           <QueryField
@@ -155,10 +153,4 @@ const QueryFieldRowWrapper = styled('div')`
 
 const LegendAliasInput = styled(Input)`
   width: 33%;
-`;
-
-const HeaderWrapper = styled('div')`
-  display: flex;
-  flex-direction: row;
-  gap: ${space(0.5)};
 `;

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
@@ -4,11 +4,11 @@ import styled from '@emotion/styled';
 import {Button} from 'sentry/components/button';
 import Input from 'sentry/components/input';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
-import {Tooltip} from 'sentry/components/tooltip';
 import {IconAdd, IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DisplayType} from 'sentry/views/dashboards/types';
+import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/sectionHeader';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 
@@ -30,22 +30,17 @@ function WidgetBuilderQueryFilterBuilder() {
   return (
     <Fragment>
       <HeaderWrapper>
-        <Tooltip
-          title={
+        <SectionHeader
+          title={t('Filter')}
+          tooltipText={
             canAddSearchConditions
               ? t(
                   'Filter down your search here. You can add multiple queries to compare data for each overlay'
                 )
               : t('Filter down your search here')
           }
-          position="right"
-          delay={200}
-          isHoverable
-          showUnderline
-        >
-          <Header>{t('Filter')}</Header>
-        </Tooltip>
-        <OptionalHeader>{t('(optional)')}</OptionalHeader>
+          optional
+        />
       </HeaderWrapper>
       {!state.query?.length ? (
         <QueryFieldRowWrapper key={0}>
@@ -160,18 +155,6 @@ const QueryFieldRowWrapper = styled('div')`
 
 const LegendAliasInput = styled(Input)`
   width: 33%;
-`;
-
-const Header = styled('h6')`
-  font-size: ${p => p.theme.fontSizeLarge};
-  margin-bottom: ${space(1)};
-`;
-
-const OptionalHeader = styled('h6')`
-  font-size: ${p => p.theme.fontSizeLarge};
-  color: ${p => p.theme.subText};
-  font-weight: ${p => p.theme.fontWeightNormal};
-  margin-bottom: ${space(1)};
 `;
 
 const HeaderWrapper = styled('div')`

--- a/static/app/views/dashboards/widgetBuilder/components/sectionHeader.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sectionHeader.tsx
@@ -1,4 +1,3 @@
-import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Tooltip} from 'sentry/components/tooltip';
@@ -7,13 +6,19 @@ import {space} from 'sentry/styles/space';
 
 interface SectionHeaderProps {
   title: React.ReactNode;
+  className?: string;
   optional?: boolean;
   tooltipText?: React.ReactNode;
 }
 
-export function SectionHeader({tooltipText, title, optional}: SectionHeaderProps) {
+export function SectionHeader({
+  tooltipText,
+  title,
+  optional,
+  className,
+}: SectionHeaderProps) {
   return (
-    <Fragment>
+    <HeaderWrapper>
       <Tooltip
         title={tooltipText}
         disabled={!tooltipText}
@@ -22,10 +27,10 @@ export function SectionHeader({tooltipText, title, optional}: SectionHeaderProps
         isHoverable
         showUnderline
       >
-        <StyledHeader>{title}</StyledHeader>
+        <StyledHeader className={className}>{title}</StyledHeader>
       </Tooltip>
       {optional && <OptionalHeader>{t('(optional)')}</OptionalHeader>}
-    </Fragment>
+    </HeaderWrapper>
   );
 }
 
@@ -39,4 +44,10 @@ const OptionalHeader = styled('h6')`
   color: ${p => p.theme.subText};
   font-weight: ${p => p.theme.fontWeightNormal};
   margin-bottom: ${space(1)};
+`;
+
+const HeaderWrapper = styled('div')`
+  display: flex;
+  flex-direction: row;
+  gap: ${space(0.5)};
 `;

--- a/static/app/views/dashboards/widgetBuilder/components/sectionHeader.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sectionHeader.tsx
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+
+import {Tooltip} from 'sentry/components/tooltip';
+import {space} from 'sentry/styles/space';
+
+interface SectionHeaderProps {
+  title: React.ReactNode;
+  tooltipText?: React.ReactNode;
+}
+
+export function SectionHeader({tooltipText, title}: SectionHeaderProps) {
+  return (
+    <Tooltip
+      title={tooltipText}
+      disabled={!tooltipText}
+      position="right-end"
+      delay={200}
+      isHoverable
+      showUnderline
+    >
+      <StyledHeader>{title}</StyledHeader>
+    </Tooltip>
+  );
+}
+
+const StyledHeader = styled('h6')`
+  font-size: ${p => p.theme.fontSizeLarge};
+  margin-bottom: ${space(1)};
+`;

--- a/static/app/views/dashboards/widgetBuilder/components/sectionHeader.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sectionHeader.tsx
@@ -1,29 +1,42 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Tooltip} from 'sentry/components/tooltip';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 interface SectionHeaderProps {
   title: React.ReactNode;
+  optional?: boolean;
   tooltipText?: React.ReactNode;
 }
 
-export function SectionHeader({tooltipText, title}: SectionHeaderProps) {
+export function SectionHeader({tooltipText, title, optional}: SectionHeaderProps) {
   return (
-    <Tooltip
-      title={tooltipText}
-      disabled={!tooltipText}
-      position="right-end"
-      delay={200}
-      isHoverable
-      showUnderline
-    >
-      <StyledHeader>{title}</StyledHeader>
-    </Tooltip>
+    <Fragment>
+      <Tooltip
+        title={tooltipText}
+        disabled={!tooltipText}
+        position="right-end"
+        delay={200}
+        isHoverable
+        showUnderline
+      >
+        <StyledHeader>{title}</StyledHeader>
+      </Tooltip>
+      {optional && <OptionalHeader>{t('(optional)')}</OptionalHeader>}
+    </Fragment>
   );
 }
 
 const StyledHeader = styled('h6')`
   font-size: ${p => p.theme.fontSizeLarge};
+  margin-bottom: ${space(1)};
+`;
+
+const OptionalHeader = styled('h6')`
+  font-size: ${p => p.theme.fontSizeLarge};
+  color: ${p => p.theme.subText};
+  font-weight: ${p => p.theme.fontWeightNormal};
   margin-bottom: ${space(1)};
 `;

--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
@@ -3,11 +3,11 @@ import {components} from 'react-select';
 import styled from '@emotion/styled';
 
 import SelectControl from 'sentry/components/forms/controls/selectControl';
-import {Tooltip} from 'sentry/components/tooltip';
 import {IconGraph, IconNumber, IconTable} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DisplayType} from 'sentry/views/dashboards/types';
+import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/sectionHeader';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 
@@ -32,15 +32,10 @@ function WidgetBuilderTypeSelector() {
 
   return (
     <Fragment>
-      <Tooltip
-        title={t('This is the type of visualization (ex. line chart)')}
-        position="right-end"
-        delay={200}
-        isHoverable
-        showUnderline
-      >
-        <Header>{t('Type')}</Header>
-      </Tooltip>
+      <SectionHeader
+        tooltipText={t('This is the type of visualization (ex. line chart)')}
+        title={t('Type')}
+      />
       <SelectControl
         name="displayType"
         value={state.displayType}
@@ -88,9 +83,4 @@ export default WidgetBuilderTypeSelector;
 const SelectionWrapper = styled('div')`
   display: flex;
   gap: ${space(1)};
-`;
-
-const Header = styled('h6')`
-  font-size: ${p => p.theme.fontSizeLarge};
-  margin-bottom: ${space(1)};
 `;


### PR DESCRIPTION
Just avoids some duplicate code and makes the section header with the tooltip reusable.