### PR TITLE
fix(autofix): Break long words in insight cards

### DIFF
--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -583,6 +583,7 @@ const UserMessageContainer = styled('div')`
 const UserMessage = styled('div')`
   margin-left: ${space(2)};
   flex-shrink: 100;
+  word-break: break-word;
 `;
 
 const NoInsightsYet = styled('div')`
@@ -732,6 +733,7 @@ const MiniHeader = styled('p')`
   padding-right: ${space(2)};
   padding-left: ${space(2)};
   width: 95%;
+  word-break: break-word;
 `;
 
 const ExpandableContext = styled('div')<{isRounded?: boolean}>`


### PR DESCRIPTION
Small styling change so that long words don't overflow in insight cards.