### PR TITLE
feat(issue-details): Allow jumping to Threads entry

### DIFF
--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -326,7 +326,7 @@ export function Threads({data, event, projectSlug, groupingCurrentLevel, group}:
         </Fragment>
       )}
       <TraceEventDataSection
-        type={EntryType.THREADS}
+        type={SectionKey.THREADS}
         projectSlug={projectSlug}
         eventId={event.id}
         recentFirst={isStacktraceNewestFirst()}

--- a/static/app/views/issueDetails/streamline/context.tsx
+++ b/static/app/views/issueDetails/streamline/context.tsx
@@ -25,6 +25,7 @@ export const enum SectionKey {
 
   EXCEPTION = 'exception',
   STACKTRACE = 'stacktrace',
+  THREADS = 'threads',
   SPANS = 'spans',
   EVIDENCE = 'evidence',
   MESSAGE = 'message',

--- a/static/app/views/issueDetails/streamline/eventTitle.tsx
+++ b/static/app/views/issueDetails/streamline/eventTitle.tsx
@@ -46,13 +46,14 @@ type EventNavigationProps = {
 const sectionLabels = {
   [SectionKey.HIGHLIGHTS]: t('Highlights'),
   [SectionKey.STACKTRACE]: t('Stack Trace'),
-  [SectionKey.TRACE]: t('Trace'),
   [SectionKey.EXCEPTION]: t('Stack Trace'),
+  [SectionKey.THREADS]: t('Stack Trace'),
+  [SectionKey.REPLAY]: t('Replay'),
   [SectionKey.BREADCRUMBS]: t('Breadcrumbs'),
+  [SectionKey.TRACE]: t('Trace'),
   [SectionKey.TAGS]: t('Tags'),
   [SectionKey.CONTEXTS]: t('Context'),
   [SectionKey.USER_FEEDBACK]: t('User Feedback'),
-  [SectionKey.REPLAY]: t('Replay'),
   [SectionKey.FEATURE_FLAGS]: t('Flags'),
 };
 


### PR DESCRIPTION
Reorders the sections to match what we have, and add threads to the known section labels to allow jumping to it.