### PR TITLE
feat(insights): register flag for wip eap

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -450,6 +450,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:insights-query-date-range-limit", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Make Insights modules use EAP instead of metrics
     manager.add("organizations:insights-use-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Make Insights modules use EAP instead of metrics, but for area's that are still WIP
+    manager.add("organizations:insights-use-eap-wip", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable access to insights metrics alerts
     manager.add("organizations:insights-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Related Issues table in Insights modules


### PR DESCRIPTION
Work for https://github.com/getsentry/sentry/issues/81750

This PR adds a new flag, `insights-use-eap-wip`

Currently we have the `insights-use-eap` flag, which is used within the LLM monitoring module. This feature is enabled for a select internal devs, and internal orgs (such as sentry). LLM monitoring is feature complete with EAP, so everything works and we can enable it internally. However for modules that aren't fully supported by EAP (due to some functions that aren't available yet), we should have a separate flag so that we can have push the WIP eap+insights stuff without releasing it internally.