### PR TITLE
feat(feedback): Add subject & body to feedback mailto links

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
@@ -55,12 +55,15 @@ export default function FeedbackItemUsername({className, feedbackIssue, style}: 
   }
 
   const mailToHref = new URL(`mailto:${email}`);
-  mailToHref.searchParams.append('subject', `Following up from ${organization.name}`);
+  mailToHref.searchParams.append(
+    'subject',
+    encodeURIComponent(`Following up from ${organization.name}`)
+  );
   mailToHref.searchParams.append(
     'body',
     feedbackIssue.metadata.message
       .split('\n')
-      .map(s => `> ${s}`)
+      .map(s => encodeURIComponent(`> ${s}`))
       .join('\n')
   );
 

--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
@@ -11,6 +11,7 @@ import {space} from 'sentry/styles/space';
 import type {FeedbackIssue} from 'sentry/utils/feedback/types';
 import {selectText} from 'sentry/utils/selectText';
 import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
+import useOrganization from 'sentry/utils/useOrganization';
 
 interface Props {
   feedbackIssue: FeedbackIssue;
@@ -22,6 +23,7 @@ export default function FeedbackItemUsername({className, feedbackIssue, style}: 
   const name = feedbackIssue.metadata.name;
   const email = feedbackIssue.metadata.contact_email;
 
+  const organization = useOrganization();
   const nameOrEmail = name || email;
   const isSameNameAndEmail = name === email;
 
@@ -52,6 +54,16 @@ export default function FeedbackItemUsername({className, feedbackIssue, style}: 
     return <strong>{t('Anonymous User')}</strong>;
   }
 
+  const mailToHref = new URL(`mailto:${email}`);
+  mailToHref.searchParams.append('subject', `Following up from ${organization.name}`);
+  mailToHref.searchParams.append(
+    'body',
+    feedbackIssue.metadata.message
+      .split('\n')
+      .map(s => `> ${s}`)
+      .join('\n')
+  );
+
   return (
     <Flex align="center" gap={space(1)} className={className} style={style}>
       <Tooltip title={t('Click to copy')} containerDisplayMode="flex">
@@ -79,7 +91,7 @@ export default function FeedbackItemUsername({className, feedbackIssue, style}: 
       {email ? (
         <Tooltip title={t(`Email %s`, user)} containerDisplayMode="flex">
           <LinkButton
-            href={`mailto:${email}`}
+            href={mailToHref.toString()}
             external
             icon={<IconMail color="gray300" />}
             aria-label={t(`Email %s`, user)}

--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
@@ -54,18 +54,10 @@ export default function FeedbackItemUsername({className, feedbackIssue, style}: 
     return <strong>{t('Anonymous User')}</strong>;
   }
 
-  const mailToHref = new URL(`mailto:${email}`);
-  mailToHref.searchParams.append(
-    'subject',
-    encodeURIComponent(`Following up from ${organization.name}`)
-  );
-  mailToHref.searchParams.append(
-    'body',
-    feedbackIssue.metadata.message
-      .split('\n')
-      .map(s => encodeURIComponent(`> ${s}`))
-      .join('\n')
-  );
+  const mailToHref = `mailto:${email}?subject=${encodeURIComponent(`Following up from ${organization.name}`)}&body=${feedbackIssue.metadata.message
+    .split('\n')
+    .map(s => encodeURIComponent(`> ${s}`))
+    .join('\n')}`;
 
   return (
     <Flex align="center" gap={space(1)} className={className} style={style}>
@@ -94,7 +86,7 @@ export default function FeedbackItemUsername({className, feedbackIssue, style}: 
       {email ? (
         <Tooltip title={t(`Email %s`, user)} containerDisplayMode="flex">
           <LinkButton
-            href={mailToHref.toString()}
+            href={mailToHref}
             external
             icon={<IconMail color="gray300" />}
             aria-label={t(`Email %s`, user)}

--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
@@ -54,10 +54,12 @@ export default function FeedbackItemUsername({className, feedbackIssue, style}: 
     return <strong>{t('Anonymous User')}</strong>;
   }
 
-  const mailToHref = `mailto:${email}?subject=${encodeURIComponent(`Following up from ${organization.name}`)}&body=${feedbackIssue.metadata.message
-    .split('\n')
-    .map(s => encodeURIComponent(`> ${s}`))
-    .join('\n')}`;
+  const mailToHref = `mailto:${email}?subject=${encodeURIComponent(`Following up from ${organization.name}`)}&body=${encodeURIComponent(
+    feedbackIssue.metadata.message
+      .split('\n')
+      .map(s => `> ${s}`)
+      .join('\n')
+  )}`;
 
   return (
     <Flex align="center" gap={space(1)} className={className} style={style}>


### PR DESCRIPTION
**Clicking this button**

![SCR-20241205-kaij](https://github.com/user-attachments/assets/6846a4fe-ee4d-4694-932a-578c981557d0)

**...will pre-fill the subject and body of the email message:**

![SCR-20241205-kajf](https://github.com/user-attachments/assets/1cd3d0e1-19bf-4af1-b02e-d1266483fdf4)
